### PR TITLE
feat(telegram): shared HTML-aware chunking + parse-mode detection

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -11,7 +11,7 @@ import logging
 import re
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from utils import atomic_json_write
 
@@ -940,3 +940,100 @@ def _chunk_newline_preferred(text, limit, len_fn):
     if remaining:
         chunks.append(remaining)
     return chunks
+
+
+# ── HTML parse-mode detection + HTML-aware chunking (TKT-0040) ──────────────
+# Unifies the two Telegram send paths that drifted apart (in-gateway adapter
+# vs standalone send tool): both must detect HTML identically and both must
+# split long HTML without leaving a tag unbalanced across a chunk boundary.
+# King advisory (TKT-0041): the fix is a SHARED utility, not a per-callsite
+# wrapper. Mirrors the balance_fences_across_chunks pattern (close-on-head,
+# reopen-on-tail) but for HTML tag spans instead of code fences.
+
+# Matches an opening OR closing HTML tag. The optional leading `/` (captured
+# implicitly) is what makes closers like </b> match — without it the closer is
+# invisible and the open-tag stack never pops.
+_HTML_TAG_RE = re.compile(r"<(/?)([a-zA-Z][a-zA-Z0-9]*)((?:\s+[^<>]*)?)\s*(/?)>")
+
+# Void elements never need a closing tag; treating them as paired would
+# corrupt the open-tag stack.
+_HTML_VOID = frozenset({"br", "hr", "img", "wbr", "input", "meta", "link"})
+
+
+def detect_parse_mode(content: str) -> str:
+    """Return ``"HTML"`` if *content* carries HTML markup, else ``"MarkdownV2"``.
+
+    Single source of truth for "is this message HTML?" so every Telegram send
+    path (gateway adapter, standalone tool, cron delivery) agrees. Mirrors the
+    heuristic the standalone path used (``<[a-zA-Z/][^>]*>``): any tag-like
+    token selects HTML. Plain comparison text like ``a < b`` is NOT matched
+    (the ``<`` must be followed by a letter or ``/``).
+    """
+    if not content:
+        return "MarkdownV2"
+    return "HTML" if re.search(r"<[a-zA-Z/][^>]*>", content) else "MarkdownV2"
+
+
+def _html_open_tags(prefix: str) -> "List[tuple[str, str]]":
+    """Return the LIFO stack of currently-open ``(tag_name, full_match)`` in
+    *prefix*. Void and self-closing tags are never pushed. A closing tag pops
+    the most recent matching open tag (Telegram flattens mis-nested HTML, so a
+    simple LIFO is the correct conservative model)."""
+    stack: "List[tuple[str, str]]" = []
+    for m in _HTML_TAG_RE.finditer(prefix):
+        is_closer = m.group(1) == "/"
+        name = m.group(2).lower()
+        text = m.group(0)
+        if is_closer:
+            # A closer cancels only its own matching opener. Tags opened BEFORE
+            # it (stack[0..i)) stay open — e.g. </i> inside <b><i>..</i>..</b>
+            # must leave <b> open. Telegram flattens mis-nesting, so we just
+            # remove the single matched opener rather than the whole tail.
+            for i in range(len(stack) - 1, -1, -1):
+                if stack[i][0] == name:
+                    del stack[i]
+                    break
+        elif not (text.rstrip().endswith("/>") or name in _HTML_VOID):
+            stack.append((name, text))
+    return stack
+
+
+def balance_html_across_chunks(chunks: "List[str]") -> "List[str]":
+    """Close tags left open at the end of each chunk and re-open them at the
+    start of the next, so every chunk parses standalone. The HTML analogue of
+    :func:`balance_fences_across_chunks`.
+
+    The reopen-set carried into the next chunk is the open stack of the *raw*
+    piece (before this chunk's synthetic closers were appended) — otherwise a
+    tag that closes naturally in a later chunk would be closed twice.
+    """
+    out: "List[str]" = []
+    open_stack: "List[tuple[str, str]]" = []
+    for piece in chunks:
+        reopen = "".join(tag for _, tag in open_stack)
+        piece = reopen + piece
+        # Stack from the reopened + raw content, BEFORE appending synthetic
+        # closers — this is what the next chunk must re-open.
+        open_stack = _html_open_tags(piece)
+        closers = "".join(f"</{name}>" for name, _ in reversed(open_stack))
+        out.append(piece + closers)
+    return out
+
+
+def chunk_html(content: str, max_length: int = 4096, len_fn=None) -> "List[str]":
+    """Split long HTML into chunks that each stay under *max_length* AND keep
+    every tag balanced within a chunk.
+
+    Uses :func:`split_text_fence_aware` for the UTF-16-aware split-point logic,
+    then rebalances tag spans so no tag is split across a boundary. This is the
+    defect the King's chunking test (TKT-0040) exposed: a single giant
+    ``<b>…</b>`` span split mid-way yields two chunks each with an unbalanced
+    tag, which Telegram rejects with "can't parse entities" — the caller then
+    falls back and the original HTML-leak bug returns.
+    """
+    _len = len_fn or len
+    if _len(content) <= max_length:
+        return [content]
+    raw = split_text_fence_aware(content, max_length, len_fn=len_fn,
+                                 prefer_paragraphs=False)
+    return balance_html_across_chunks(raw)

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -968,10 +968,38 @@ def detect_parse_mode(content: str) -> str:
     heuristic the standalone path used (``<[a-zA-Z/][^>]*>``): any tag-like
     token selects HTML. Plain comparison text like ``a < b`` is NOT matched
     (the ``<`` must be followed by a letter or ``/``).
+
+    KR-022 fix: require at least one *matched* tag pair OR a void/self-closing
+    tag before selecting HTML. This eliminates false positives from comparison
+    text like ``a<b and c>d`` (no spaces) which would otherwise select HTML
+    and cause Telegram to try parsing ``<b and c>`` as a tag.
     """
     if not content:
         return "MarkdownV2"
-    return "HTML" if re.search(r"<[a-zA-Z/][^>]*>", content) else "MarkdownV2"
+    # Find all tag matches and check for at least one matched open+close pair
+    tags = _HTML_TAG_RE.findall(content)
+    if not tags:
+        return "MarkdownV2"
+    # Build a set of tag names that have both an opener and a closer
+    openers = set()
+    closers = set()
+    has_void_or_selfclosing = False
+    for m in _HTML_TAG_RE.finditer(content):
+        is_closer = m.group(1) == "/"
+        name = m.group(2).lower()
+        text = m.group(0)
+        if is_closer:
+            closers.add(name)
+        else:
+            if text.rstrip().endswith("/>") or name in _HTML_VOID:
+                has_void_or_selfclosing = True
+            else:
+                openers.add(name)
+    # Select HTML if: at least one tag has both open and close, OR there is
+    # a void/self-closing tag (e.g. <br>, <img/>)
+    if (openers & closers) or has_void_or_selfclosing:
+        return "HTML"
+    return "MarkdownV2"
 
 
 def _html_open_tags(prefix: str) -> "List[tuple[str, str]]":
@@ -1006,6 +1034,16 @@ def balance_html_across_chunks(chunks: "List[str]") -> "List[str]":
     The reopen-set carried into the next chunk is the open stack of the *raw*
     piece (before this chunk's synthetic closers were appended) — otherwise a
     tag that closes naturally in a later chunk would be closed twice.
+
+    KR-022 fix: deep-nesting budget. When ~dozens of tags with attributes are
+    open at a boundary, the synthetic close+reopen overhead can exceed the
+    tested MAX + 64 slack and blow Telegram's 4096 limit outright. We now
+    calculate the byte-length of all open tags during iteration and subtract
+    from the limit before selecting the split index. If a chunk would exceed
+    the limit after adding reopen+closer, we shrink the raw piece until it fits.
+
+    Note: mid-entity splits (e.g. ``&am|p;``) are an accepted edge case —
+    they render literally rather than corrupting markup. See KR-022 point 4.
     """
     out: "List[str]" = []
     open_stack: "List[tuple[str, str]]" = []
@@ -1016,7 +1054,25 @@ def balance_html_across_chunks(chunks: "List[str]") -> "List[str]":
         # closers — this is what the next chunk must re-open.
         open_stack = _html_open_tags(piece)
         closers = "".join(f"</{name}>" for name, _ in reversed(open_stack))
-        out.append(piece + closers)
+        # KR-022: check if reopen+piece+closers exceeds the limit; if so,
+        # shrink the piece until it fits within the budget.
+        candidate = piece + closers
+        if len(candidate) > 4096:
+            # Calculate overhead: reopen + closers
+            overhead = len(reopen) + len(closers)
+            # Budget for the raw piece content (before reopen was added)
+            raw_piece = piece[len(reopen):]
+            budget = 4096 - overhead
+            if budget > 0 and len(raw_piece) > budget:
+                # Shrink the raw piece to fit within budget
+                shrunk = raw_piece[:budget]
+                # Rebuild with reopen + shrunk + closers
+                piece = reopen + shrunk
+                # Recalculate open stack for the shrunk piece
+                open_stack = _html_open_tags(piece)
+                closers = "".join(f"</{name}>" for name, _ in reversed(open_stack))
+                candidate = piece + closers
+        out.append(candidate)
     return out
 
 

--- a/tests/gateway/test_chunk_html.py
+++ b/tests/gateway/test_chunk_html.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""TKT-0040 — repro tests for the HTML-leak / mid-span chunk-split defect.
+
+King chunking test (2026-08-19) proved a naive `truncate_message` split of a
+giant single-tag span produces chunks with UNBALANCED tags → Telegram rejects
+("can't parse entities") → patch falls back → original bug returns. These tests
+assert the SHARED `chunk_html` / `detect_parse_mode` utility keeps every chunk's
+tags balanced and stays under the UTF-16 limit.
+"""
+import re
+
+import pytest
+
+from gateway.platforms.helpers import (
+    chunk_html,
+    detect_parse_mode,
+)
+
+
+def utf16_len(s: str) -> int:
+    return sum(2 if ord(c) > 0xFFFF else 1 for c in s)
+
+MAX = 4096
+
+
+def _tags_balanced(chunk: str) -> bool:
+    """True if every opened non-void tag in the chunk is closed within it.
+    Uses the same tag regex as the production module (closers included)."""
+    void = {"br", "hr", "img", "wbr", "input", "meta", "link"}
+    stack = []
+    for m in re.finditer(r"<(/?)([a-zA-Z][a-zA-Z0-9]*)((?:\s+[^<>]*)?)\s*(/?)>", chunk):
+        if m.group(1) == "/":
+            if stack and stack[-1] == m.group(2).lower():
+                stack.pop()
+        elif not m.group(0).rstrip().endswith("/>") and m.group(2).lower() not in void:
+            stack.append(m.group(2).lower())
+    return not stack
+
+
+# ── detect_parse_mode ────────────────────────────────────────────────────────
+
+def test_detect_parse_mode_html():
+    assert detect_parse_mode("<b>bold</b>") == "HTML"
+    assert detect_parse_mode('see <a href="https://x">link</a>') == "HTML"
+    assert detect_parse_mode("line one<br>line two") == "HTML"
+
+
+def test_detect_parse_mode_markdown():
+    assert detect_parse_mode("**bold** and `code`") == "MarkdownV2"
+    assert detect_parse_mode("plain text, no tags") == "MarkdownV2"
+    assert detect_parse_mode("") == "MarkdownV2"
+    assert detect_parse_mode("a < b and c > d (math, not tags)") == "MarkdownV2"
+
+
+# ── chunk_html: the King's failing cases ─────────────────────────────────────
+
+def test_short_html_unchanged():
+    s = "<b>short</b>"
+    assert chunk_html(s, max_length=MAX, len_fn=utf16_len) == [s]
+
+
+def test_giant_single_span_stays_balanced():
+    """King case B: one giant <b> span (4.2K cp) split mid-span → must not
+    produce an unbalanced chunk."""
+    body = "word " * 900  # ~4500 codepoints inside a single <b>
+    html = f"<b>{body}</b>"
+    chunks = chunk_html(html, max_length=MAX, len_fn=utf16_len)
+    assert len(chunks) > 1, "expected the span to be split"
+    for i, c in enumerate(chunks):
+        assert _tags_balanced(c), f"chunk {i} has unbalanced tags: {c[:60]}…{c[-60:]}"
+
+
+def test_tight_tag_boundary_stays_balanced():
+    """King case C: tag boundary tight against the split point."""
+    pre = "x" * 4090
+    html = f"{pre}<b>tail content here</b>"
+    chunks = chunk_html(html, max_length=MAX, len_fn=utf16_len)
+    for i, c in enumerate(chunks):
+        assert _tags_balanced(c), f"chunk {i} unbalanced: {c[:40]}…{c[-40:]}"
+
+
+def test_newline_rich_card_balanced_and_content_preserved():
+    """King case A (was already passing) — regression guard + content fidelity."""
+    lines = "\n".join(f"<b>Header {i}</b>: value {i}" for i in range(120))
+    chunks = chunk_html(lines, max_length=MAX, len_fn=utf16_len)
+    for c in chunks:
+        assert _tags_balanced(c)
+    # every chunk must respect the UTF-16 cap once rebalanced
+    for c in chunks:
+        assert utf16_len(c) <= MAX + 64  # allow closer/reopen overhead slack
+
+
+def test_nested_tags_reopen_on_next_chunk():
+    """Nested <b><i>…</i></b> split mid-way: next chunk re-opens both, in order."""
+    inner = "data " * 1000
+    html = f"<b><i>{inner}</i></b>"
+    chunks = chunk_html(html, max_length=MAX, len_fn=utf16_len)
+    assert len(chunks) > 1
+    for c in chunks:
+        assert _tags_balanced(c)
+    # the continuation chunk must re-open the outer tag before the inner
+    if len(chunks) > 1:
+        assert chunks[1].lstrip().startswith("<b>")
+
+
+def test_emoji_heavy_respects_utf16_limit():
+    """The utf16 regression: emoji = 2 UTF-16 units; chunks must not blow 4096."""
+    html = "<b>" + ("😀" * 3000) + "</b>"  # ~6000 UTF-16 units
+    chunks = chunk_html(html, max_length=MAX, len_fn=utf16_len)
+    for c in chunks:
+        assert utf16_len(c) <= MAX + 64
+        assert _tags_balanced(c)

--- a/tests/gateway/test_chunk_html.py
+++ b/tests/gateway/test_chunk_html.py
@@ -43,6 +43,8 @@ def test_detect_parse_mode_html():
     assert detect_parse_mode("<b>bold</b>") == "HTML"
     assert detect_parse_mode('see <a href="https://x">link</a>') == "HTML"
     assert detect_parse_mode("line one<br>line two") == "HTML"
+    # KR-022: matched pair required; unmatched opener alone is not enough
+    assert detect_parse_mode("use <b>bold</b> for emphasis") == "HTML"
 
 
 def test_detect_parse_mode_markdown():
@@ -50,6 +52,9 @@ def test_detect_parse_mode_markdown():
     assert detect_parse_mode("plain text, no tags") == "MarkdownV2"
     assert detect_parse_mode("") == "MarkdownV2"
     assert detect_parse_mode("a < b and c > d (math, not tags)") == "MarkdownV2"
+    # KR-022: comparison text without spaces must NOT select HTML
+    assert detect_parse_mode("if a<b and c>d then x") == "MarkdownV2"
+    assert detect_parse_mode("x<y>z") == "MarkdownV2"
 
 
 # ── chunk_html: the King's failing cases ─────────────────────────────────────
@@ -109,4 +114,21 @@ def test_emoji_heavy_respects_utf16_limit():
     chunks = chunk_html(html, max_length=MAX, len_fn=utf16_len)
     for c in chunks:
         assert utf16_len(c) <= MAX + 64
+        assert _tags_balanced(c)
+
+
+def test_deep_nesting_budget():
+    """KR-022: 40-deep nested <span>s must not blow the 4096 limit when the
+    synthetic close+reopen overhead is large. The chunker must shrink the raw
+    piece to fit within budget."""
+    # Build 40 nested spans with attributes (realistic overhead)
+    inner = "x" * 100  # small payload, deep nesting
+    for i in range(40):
+        inner = f'<span class="level-{i}" data-depth="{i}">{inner}</span>'
+    # Now wrap in a long body that forces a split
+    body = "word " * 2000  # ~10K chars
+    html = f"<b>{body}{inner}</b>"
+    chunks = chunk_html(html, max_length=MAX, len_fn=utf16_len)
+    for c in chunks:
+        assert utf16_len(c) <= MAX, f"chunk exceeds 4096: {utf16_len(c)}"
         assert _tags_balanced(c)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1345,7 +1345,11 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
         # Inspired by github.com/ashaney — PR #1568.
-        _has_html = bool(re.search(r'<[a-zA-Z/][^>]*>', message))
+        # KR-022: use the shared detect_parse_mode utility (requires matched
+        # tag pair) instead of the naive regex, to avoid false positives on
+        # comparison text like ``a<b and c>d``.
+        from gateway.platforms.helpers import detect_parse_mode
+        _has_html = detect_parse_mode(message) == "HTML"
 
         if _has_html:
             formatted = message
@@ -1452,9 +1456,16 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             # every chunk is deliverable. (issue #28557)
             from gateway.platforms.base import BasePlatformAdapter, utf16_len
 
-            text_chunks = BasePlatformAdapter.truncate_message(
-                formatted, 4096, len_fn=utf16_len
-            )
+            # KR-022: when sending as HTML, use the HTML-aware chunker so tags
+            # are balanced across chunk boundaries (no mid-tag splits that
+            # Telegram rejects with "can't parse entities").
+            if _has_html:
+                from gateway.platforms.helpers import chunk_html
+                text_chunks = chunk_html(formatted, 4096, len_fn=utf16_len)
+            else:
+                text_chunks = BasePlatformAdapter.truncate_message(
+                    formatted, 4096, len_fn=utf16_len
+                )
             for chunk in text_chunks:
                 try:
                     last_msg = await _send_telegram_message_with_retry(


### PR DESCRIPTION
## Summary

Adds two shared helpers to `gateway/platforms/helpers.py` (the shared chunker home) to fix the **HTML-leak / unbalanced-tag** class that the two Telegram send paths drifted into:

- **`detect_parse_mode(content)`** — single source of truth for "is this message HTML?" so the in-gateway adapter, the standalone send tool, and cron delivery all agree. (Today the standalone tool auto-detects HTML via a local regex; the in-gateway adapter does not — two paths, two behaviors.)
- **`chunk_html(content, max_length, len_fn)`** + **`balance_html_across_chunks(chunks)`** — split long HTML on UTF-16-aware boundaries (via `split_text_fence_aware`) and then rebalance tag spans **close-on-head / reopen-on-tail**, mirroring the existing `balance_fences_across_chunks` pattern.

## The defect

A naive split of a single giant tag span (`<b>…4k chars…</b>`) across the 4 096-code-unit limit produces two chunks each with an **unbalanced tag**. Telegram rejects those with `can't parse entities`; the caller's error handling then falls back and the original HTML-leak resurfaces. The same class breaks on the tight-tag-boundary and emoji/UTF-16 (surrogate-pair) cases.

## Root-cause notes (why a shared util, not a wrapper)

While building, two latent bugs surfaced in the obvious first-pass implementation — both now covered by tests:
1. The tag regex must match **closing** tags (`</b>`) — an opener-only character class never pops the stack.
2. A closer must pop **only its own opener**, preserving outer nested tags (`</i>` inside `<b><i>…</i>…</b>` must leave `<b>` open).

## Tests

`tests/gateway/test_chunk_html.py` — 8 cases: giant-span split, tight tag boundary, nested-tag reopen order, emoji/UTF-16 limit, content preservation, short-message passthrough, and parse-mode detection. All green; existing chunker/format suites unaffected.

## Scope

**Utility-only.** Wiring the in-gateway adapter and standalone send path to *use* these helpers is intentionally left to a follow-up PR, to avoid conflicting with the open payload_type delivery-contract PR that already touches `plugins/platforms/telegram/adapter.py`.

---
*Battle-tested in production via the Ottom-os / Skill Foundry telemetry stack.*