### PR TITLE
feat(plugins): add API server run dispatch hook

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -269,6 +269,14 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+API_RUN_TARGET_KEYS = (
+    "target_profile",
+    "targetProfile",
+    "target_agent",
+    "targetAgent",
+    "agent_id",
+    "agentId",
+)
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 
@@ -7768,6 +7776,147 @@ class APIServerAdapter(BasePlatformAdapter):
         self, request: "web.Request", run_id: str
     ) -> Dict[str, Any] | None:
         return _api_runs._durable_run_status(self, request, run_id)
+
+    @staticmethod
+    def _json_safe_payload(value: Any) -> Any:
+        """Return a JSON-safe copy of plugin-facing data."""
+        try:
+            return json.loads(json.dumps(value))
+        except (TypeError, ValueError):
+            return str(value)
+
+    @staticmethod
+    def _api_run_urls(run_id: str) -> Dict[str, str]:
+        return {
+            "status_url": f"/v1/runs/{run_id}",
+            "events_url": f"/v1/runs/{run_id}/events",
+        }
+
+    @staticmethod
+    def _api_run_target_aliases(body: Dict[str, Any]) -> Dict[str, str]:
+        aliases: Dict[str, str] = {}
+        for key in API_RUN_TARGET_KEYS:
+            if key not in body or body.get(key) is None:
+                continue
+            value = body.get(key)
+            cleaned = value.strip() if isinstance(value, str) else str(value)
+            if cleaned:
+                aliases[key] = cleaned
+        return aliases
+
+    def _api_run_dispatch_capabilities(self) -> Dict[str, Any]:
+        return {
+            "object": "hermes.api_server.run_dispatch.capabilities",
+            "hook": "api_server_run_dispatch",
+            "default_local_run": True,
+            "accepted_run_status": "accepted",
+            "endpoints": {
+                "runs": {"method": "POST", "path": "/v1/runs"},
+                "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
+                "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
+            },
+            "return_actions": {
+                "pass": ["pass", "allow", "continue"],
+                "accept": ["accept", "accepted", "handled", "handle", "routed", "route"],
+                "reject": ["reject", "rejected", "error", "block", "blocked"],
+            },
+        }
+
+    def _api_run_dispatch_payload(
+        self,
+        *,
+        body: Dict[str, Any],
+        raw_input: Any,
+        instructions: Any,
+        conversation_history: List[Dict[str, str]],
+        previous_response_id: Any,
+        session_id: str,
+        run_id: str,
+        agent_overrides: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        metadata: Dict[str, Any] = {}
+        for key in ("metadata", "source"):
+            value = body.get(key)
+            if isinstance(value, dict):
+                metadata[key] = self._json_safe_payload(value)
+
+        target_aliases = self._api_run_target_aliases(body)
+        requested_model = agent_overrides.get("requested_model") or body.get("model") or self._model_name
+        return {
+            "run_id": run_id,
+            "session_id": session_id,
+            "input": self._json_safe_payload(raw_input),
+            "instructions": self._json_safe_payload(instructions),
+            "conversation_history": self._json_safe_payload(conversation_history),
+            "previous_response_id": self._json_safe_payload(previous_response_id),
+            "requested_model": requested_model,
+            "requested_provider": agent_overrides.get("requested_provider"),
+            "target_aliases": target_aliases,
+            "metadata": metadata,
+            "capabilities": self._api_run_dispatch_capabilities(),
+            **self._api_run_urls(run_id),
+        }
+
+    def _has_api_run_dispatch_hook(self) -> bool:
+        """Return True when the API run dispatch hook has a real consumer."""
+        try:
+            from hermes_cli.lifecycle import has_hook
+        except Exception as exc:
+            logger.warning("[%s] API run dispatch hook inspection unavailable: %s", self.name, exc)
+            return False
+        return has_hook("api_server_run_dispatch")
+
+    def _dispatch_api_run(self, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Give plugins first refusal for a sanitized /v1/runs dispatch payload."""
+        try:
+            from hermes_cli.lifecycle import invoke_hook
+        except Exception as exc:
+            logger.warning("[%s] API run dispatch hook unavailable: %s", self.name, exc)
+            return None
+
+        results = invoke_hook("api_server_run_dispatch", **payload)
+        for result in results:
+            if result is None:
+                continue
+            if isinstance(result, str):
+                result = {"action": result}
+            if not isinstance(result, dict):
+                logger.warning(
+                    "[%s] API run dispatch hook returned unsupported decision %r; rejecting run",
+                    self.name,
+                    result,
+                )
+                return {
+                    "action": "rejected",
+                    "status_code": 400,
+                    "error": "API run dispatch hook returned an unsupported decision",
+                }
+            action = str(result.get("action") or "").strip().lower()
+            if action in {"pass", "allow", "continue"}:
+                continue
+            if action in {"accept", "accepted", "handled", "handle", "routed", "route"}:
+                dispatch = result.get("dispatch") or result.get("decision") or result.get("routing")
+                return {
+                    "action": "accepted",
+                    "dispatch": self._json_safe_payload(dispatch) if dispatch is not None else {},
+                }
+            if action in {"reject", "rejected", "error", "block", "blocked"}:
+                return {
+                    "action": "rejected",
+                    "status_code": result.get("status_code", 400),
+                    "error": str(result.get("error") or result.get("message") or "Run dispatch rejected"),
+                }
+            logger.warning(
+                "[%s] API run dispatch hook returned unknown action %r; rejecting run",
+                self.name,
+                result.get("action"),
+            )
+            return {
+                "action": "rejected",
+                "status_code": 400,
+                "error": "API run dispatch hook returned an unknown action",
+            }
+        return None
 
     @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -619,6 +619,33 @@ async def _handle_runs(
         or self._declared_conversation_session(gateway_session_key)
         or run_id
     )
+    dispatch_decision = None
+    if self._has_api_run_dispatch_hook():
+        dispatch_payload = self._api_run_dispatch_payload(
+            body=body,
+            raw_input=raw_input,
+            instructions=instructions,
+            conversation_history=conversation_history,
+            previous_response_id=previous_response_id,
+            session_id=session_id,
+            run_id=run_id,
+            agent_overrides=agent_overrides,
+        )
+        dispatch_decision = await asyncio.to_thread(
+            self._dispatch_api_run, dispatch_payload
+        )
+    if dispatch_decision and dispatch_decision.get("action") == "rejected":
+        try:
+            status_code = int(dispatch_decision.get("status_code", 400))
+        except (TypeError, ValueError):
+            status_code = 400
+        if status_code < 400 or status_code > 599:
+            status_code = 400
+        return web.json_response(
+            _openai_error(str(dispatch_decision.get("error") or "Run dispatch rejected")),
+            status=status_code,
+        )
+
     # Approval queues gate host-side tool execution and must be isolated
     # per API run. Client-provided session IDs and memory session keys are
     # conversation/memory scopes, not authorization namespaces: multiple
@@ -704,6 +731,38 @@ async def _handle_runs(
                 headers=headers,
             )
         self._run_idempotency_ids.add(run_id)
+
+    if dispatch_decision and dispatch_decision.get("action") == "accepted":
+        dispatch = dispatch_decision.get("dispatch") or {}
+        accepted_event = {
+            "event": "run.dispatch_accepted",
+            "run_id": run_id,
+            "timestamp": time.time(),
+            "dispatch": dispatch,
+        }
+        q.put_nowait(accepted_event)
+        q.put_nowait(None)
+        self._run_approval_sessions.pop(run_id, None)
+        self._set_run_status(
+            run_id,
+            "accepted",
+            session_id=session_id,
+            dispatch=dispatch,
+            last_event="run.dispatch_accepted",
+        )
+        response_headers = (
+            {"X-Hermes-Session-Key": gateway_session_key} if gateway_session_key else {}
+        )
+        return web.json_response(
+            {
+                "run_id": run_id,
+                "status": "accepted",
+                **self._api_run_urls(run_id),
+                "dispatch": dispatch,
+            },
+            status=202,
+            headers=response_headers,
+        )
 
     # Background task outlives the HTTP response (and thus the middleware
     # profile scope). Capture now and re-enter inside the task/executor.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -233,6 +233,25 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # API Server run dispatch hook. Fired by POST /v1/runs after auth/body
+    # validation and session/run_id allocation, before local _create_agent().
+    # Call sites short-circuit on has_hook(), so when nothing subscribes no
+    # dispatch payload is built. Hook callbacks are invoked off the event-loop
+    # thread; callbacks may perform blocking routing I/O without stalling other
+    # gateway requests.
+    # The payload is sanitized: no request objects, auth headers, environment,
+    # secrets, or mutable adapter state are exposed. Plugins should accept
+    # **kwargs for forward compatibility. Return values influence flow:
+    #   {"action": "accept"|"handled", "dispatch": {...}} -> externally handled
+    #   {"action": "reject"|"error", "error": "...", "status_code": 400} -> fail
+    #   {"action": "pass"} / None -> normal local API-server run
+    # Unknown non-None decisions fail closed with a 400 instead of silently
+    # falling through to local execution.
+    # Kwargs include: run_id, session_id, input, instructions,
+    #   conversation_history, previous_response_id, requested_model,
+    #   requested_provider, target_aliases, metadata, capabilities, status_url,
+    #   events_url.
+    "api_server_run_dispatch",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.
@@ -396,6 +415,7 @@ VALID_HOOKS: Set[str] = {
 # Support for a shell response shape can lift an event out of this set.
 SHELL_UNSUPPORTED_HOOKS: Set[str] = {
     "transform_api_error_classification",
+    "api_server_run_dispatch",
 }
 
 # Timeout coverage is an allowlist for the agent-turn hot path, not every

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -284,6 +284,166 @@ class TestStartRun:
         mock_create.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_run_dispatch_hook_accepts_sanitized_payload_not_local_agent(self, adapter, monkeypatch):
+        app = _create_runs_app(adapter)
+        dispatch_decision = {"target_profile": "martina", "task_id": "task-martina-1"}
+        seen = {}
+
+        def _invoke_hook(hook_name, **kwargs):
+            seen["thread_id"] = threading.get_ident()
+            seen["hook_name"] = hook_name
+            seen["payload"] = kwargs
+            return [{"action": "accepted", "dispatch": dispatch_decision}]
+
+        event_loop_thread_id = threading.get_ident()
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", _invoke_hook)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "show my workspace queue",
+                        "instructions": "stay concise",
+                        "conversation_history": [{"role": "user", "content": "previous"}],
+                        "previous_response_id": "resp_previous",
+                        "model": "gpt-test",
+                        "provider": "openai",
+                        "target_agent": "martina",
+                        "metadata": {"client": "mobile"},
+                        "source": {"surface": "test"},
+                    },
+                    headers={"Authorization": "Bearer secret-token"},
+                )
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+                assert data["status"] == "accepted"
+                assert data["status_url"] == f"/v1/runs/{run_id}"
+                assert data["events_url"] == f"/v1/runs/{run_id}/events"
+                assert data["dispatch"] == dispatch_decision
+                mock_create.assert_not_called()
+
+                status_resp = await cli.get(f"/v1/runs/{run_id}")
+                status_data = await status_resp.json()
+                assert status_data["status"] == "accepted"
+                assert status_data["dispatch"] == dispatch_decision
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                events_body = await events_resp.text()
+                assert "run.dispatch_accepted" in events_body
+                assert "task-martina-1" in events_body
+
+        payload = seen["payload"]
+        assert seen["thread_id"] != event_loop_thread_id
+        assert seen["hook_name"] == "api_server_run_dispatch"
+        assert payload["run_id"].startswith("run_")
+        assert payload["session_id"] == payload["run_id"]
+        assert payload["input"] == "show my workspace queue"
+        assert payload["instructions"] == "stay concise"
+        assert payload["conversation_history"] == [{"role": "user", "content": "previous"}]
+        assert payload["previous_response_id"] == "resp_previous"
+        assert payload["requested_model"] == "gpt-test"
+        assert payload["requested_provider"] == "openai"
+        assert payload["target_aliases"] == {"target_agent": "martina"}
+        assert "history" not in payload
+        assert "model" not in payload
+        assert "target" not in payload
+        assert payload["metadata"] == {
+            "metadata": {"client": "mobile"},
+            "source": {"surface": "test"},
+        }
+        assert payload["capabilities"]["hook"] == "api_server_run_dispatch"
+        assert payload["status_url"] == f"/v1/runs/{payload['run_id']}"
+        assert payload["events_url"] == f"/v1/runs/{payload['run_id']}/events"
+        for forbidden in ("request", "headers", "authorization", "auth", "adapter", "body", "gateway_session_key"):
+            assert forbidden not in payload
+
+    @pytest.mark.asyncio
+    async def test_run_dispatch_hook_pass_allows_default_local_execution(self, adapter, monkeypatch):
+        app = _create_runs_app(adapter)
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", lambda _name, **_kwargs: [{"action": "pass"}])
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello", "agent_id": "ghost"})
+                assert resp.status == 202
+                data = await resp.json()
+                assert data["status"] == "started"
+
+                for _ in range(40):
+                    if mock_create.called:
+                        break
+                    await asyncio.sleep(0.05)
+                mock_create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_run_dispatch_hook_rejects_without_local_execution(self, adapter, monkeypatch):
+        app = _create_runs_app(adapter)
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda _name, **_kwargs: [{"action": "reject", "status_code": 409, "error": "no route available"}],
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post("/v1/runs", json={"input": "hello", "agent_id": "ghost"})
+                assert resp.status == 409
+                data = await resp.json()
+                assert "no route available" in data["error"]["message"]
+                mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_dispatch_hook_unknown_action_fails_closed(self, adapter, monkeypatch):
+        app = _create_runs_app(adapter)
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda _name, **_kwargs: [{"action": "aczept"}],
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                resp = await cli.post("/v1/runs", json={"input": "hello", "agent_id": "ghost"})
+                assert resp.status == 400
+                data = await resp.json()
+                assert "unknown action" in data["error"]["message"]
+                mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_dispatch_payload_not_built_when_hook_absent(self, adapter, monkeypatch):
+        app = _create_runs_app(adapter)
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda _name: False)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            MagicMock(side_effect=AssertionError("hook should not be invoked")),
+        )
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_api_run_dispatch_payload") as mock_payload,
+                patch.object(adapter, "_create_agent") as mock_create,
+            ):
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello", "agent_id": "ghost"})
+                assert resp.status == 202
+                data = await resp.json()
+                assert data["status"] == "started"
+                mock_payload.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_start_passes_request_model_provider_options_to_create_agent(self, adapter):
         app = _create_runs_app(adapter)
         model_options = {"reasoning_effort": "medium", "service_tier": "priority"}

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -13,6 +13,7 @@ import yaml
 
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
+    SHELL_UNSUPPORTED_HOOKS,
     VALID_HOOKS,
     PluginContext,
     PluginManager,
@@ -807,6 +808,46 @@ class TestPluginHooks:
         )
         assert len(results) == 1
         assert results[0] == {"action": "skip", "reason": "test"}
+
+    def test_api_server_run_dispatch_hook_is_valid_and_additive(self, tmp_path, monkeypatch):
+        """Run dispatch hook is validated and keeps additive **kwargs compatibility."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "api_run_dispatcher",
+            register_body=(
+                'ctx.register_hook("api_server_run_dispatch", '
+                'lambda target_aliases, **kw: {"action": "accept", '
+                '"dispatch": {"target": target_aliases.get("target_agent"), '
+                '"run_id": kw.get("run_id")}})'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "api_server_run_dispatch" in VALID_HOOKS
+        assert "api_server_run_dispatch" in SHELL_UNSUPPORTED_HOOKS
+        assert mgr.has_hook("api_server_run_dispatch") is True
+        results = mgr.invoke_hook(
+            "api_server_run_dispatch",
+            run_id="run_123",
+            session_id="run-session",
+            input="queue",
+            instructions=None,
+            conversation_history=[],
+            previous_response_id=None,
+            requested_model="gpt-test",
+            requested_provider="openai",
+            target_aliases={"target_agent": "martina"},
+            metadata={"source": {"surface": "test"}},
+            capabilities={"hook": "api_server_run_dispatch"},
+            status_url="/v1/runs/run_123",
+            events_url="/v1/runs/run_123/events",
+            future_field="accepted because callback has **kw",
+        )
+        assert results == [{"action": "accept", "dispatch": {"target": "martina", "run_id": "run_123"}}]
 
 
 


### PR DESCRIPTION
## Problem

API server run creation currently has no plugin-level extension point for local/private routing behavior. Integrations that need to observe or redirect run dispatch have to patch core API server paths instead of living behind a narrow plugin hook.

## Approach

- Add an `api_server_run_dispatch` plugin hook invoked from the API server run creation path.
- Add plugin-manager support for the hook without expanding the model tool surface.
- Cover the hook behavior and no-plugin fallback with targeted gateway and plugin tests.

## Current proof snapshot

- PR: #92459, open, not draft, live mergeability from GitHub: `MERGEABLE`.
- Live PR baseRefOid from GitHub: `13f4cfebfafbce8ac9d1bf29f66731858ed638b5`.
- Current fetched `NousResearch/main`: `057dcdf236f8a6a26721c10fcc6ccb72726e272a`.
- PR head: `7c785637dc473b81fd8fb820a5a147562459a67f` (`feat(plugins): add API server run dispatch hook`).
- Current-main-to-PR unique commit count: `1`.
- Review/comments snapshot: `0` formal reviews, `0` review threads, `1` automated reference issue comment.
- Checks snapshot: GitHub reports no status checks/check runs on the PR branch.

## Changed files

- `gateway/platforms/api_server.py`
- `hermes_cli/plugins.py`
- `tests/gateway/test_api_server_runs.py`
- `tests/hermes_cli/test_plugins.py`

## Validation

- `git diff --check refs/remotes/nous/main...HEAD`
  - Result: passed with no whitespace errors.
- From detached isolated worktree at head `7c785637dc473b81fd8fb820a5a147562459a67f`:
  - `/Volumes/MIRZA/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_plugins.py tests/gateway/test_api_server_runs.py`
  - Result: `91 passed, 22 warnings in 20.19s`.

## Risks / Non-goals

- This PR only adds the narrow core extension point.
- The Fleet Router worker bridge/plugin consumer is intentionally split to a later private/plugin PR.
- No PR2 worker-bridge scope creep is included in this PR file list.
- Unrelated local dirty `contributors/emails/...`, package, and report artifacts are not part of this PR.
- No active config, process manager, secret, keychain, runtime, or plugin repo changes are included.

## Remaining state

- No code push was made in this rescue pass.
- No CI polling is in progress; PR is parked awaiting human review / maintainer checks.
