### PR TITLE
fix(security): stop blocking Persian context and memory as injection

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -168,6 +168,17 @@ class TestScanFile:
         findings = scan_file(f, "safe.py")
         assert findings == []
 
+    def test_persian_zwnj_is_allowed(self, tmp_path):
+        persian = tmp_path / "persian.md"
+        persian.write_text("می\u200cرود\n", encoding="utf-8")
+        assert scan_file(persian, "persian.md") == []
+
+    def test_zwnj_cannot_hide_injection(self, tmp_path):
+        injected = tmp_path / "injected.md"
+        injected.write_text("system prompt over\u200cride\n", encoding="utf-8")
+        findings = scan_file(injected, "injected.md")
+        assert any(f.pattern_id == "sys_prompt_override" for f in findings)
+
 
     def test_detect_gitlab_pat(self, tmp_path):
         f = tmp_path / "leak.md"

--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -260,3 +260,15 @@ class TestNFKCNormalisation:
 
     def test_benign_content_not_flagged_by_normalisation(self):
         assert scan_for_threats("Refactor the parser module.", scope="context") == []
+
+
+    @pytest.mark.parametrize("scope", ["context", "strict"])
+    def test_persian_zwnj_is_allowed(self, scope):
+        assert scan_for_threats("می\u200cرود", scope=scope) == []
+
+    def test_zwnj_cannot_hide_injection(self):
+        findings = scan_for_threats(
+            "system prompt over\u200cride",
+            scope="strict",
+        )
+        assert "sys_prompt_override" in findings

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -567,6 +567,12 @@ INVISIBLE_CHARS = {
     '\u2069',  # pop directional isolate
 }
 
+# U+200C is required orthography in scripts such as Persian.  Do not flag it
+# by itself, but delete it from the regex scan copy so it cannot split an
+# otherwise detectable injection keyword.
+_ORTHOGRAPHIC_JOINERS = {'\u200c'}
+_REGEX_SCAN_TRANSLATION = {ord(ch): None for ch in _ORTHOGRAPHIC_JOINERS}
+
 
 # ---------------------------------------------------------------------------
 # Scanning functions
@@ -603,7 +609,7 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
         for i, line in enumerate(lines, start=1):
             if (pid, i) in seen:
                 continue
-            if pattern.search(line):
+            if pattern.search(line.translate(_REGEX_SCAN_TRANSLATION)):
                 seen.add((pid, i))
                 matched_text = line.strip()
                 if len(matched_text) > 120:
@@ -620,7 +626,7 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
 
     # Invisible unicode character detection
     for i, line in enumerate(lines, start=1):
-        for char in INVISIBLE_CHARS:
+        for char in INVISIBLE_CHARS - _ORTHOGRAPHIC_JOINERS:
             if char in line:
                 char_name = _unicode_char_name(char)
                 findings.append(Finding(

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -158,6 +158,13 @@ INVISIBLE_CHARS = frozenset({
     '\u2069',  # pop directional isolate
 })
 
+# U+200C is an orthographic half-space in scripts such as Persian.  It may
+# separate attack keywords too, so retain it in the canonical candidate set
+# (used by stricter consumers) but remove it from the regex scan copy instead
+# of reporting it as malicious by itself.
+_ORTHOGRAPHIC_JOINERS = frozenset({'\u200c'})
+_REGEX_SCAN_TRANSLATION = {ord(ch): None for ch in _ORTHOGRAPHIC_JOINERS}
+
 
 # Compiled pattern sets, indexed by scope.  Compiled once at import time;
 # scan_for_threats() looks them up.
@@ -232,7 +239,7 @@ def scan_for_threats(content: str, scope: str = "context") -> List[str]:
     # ``in`` lookups.  Run this on the RAW content before NFKC normalisation,
     # since normalisation can strip some of these codepoints.
     char_set = set(content)
-    invisible_hits = char_set & INVISIBLE_CHARS
+    invisible_hits = char_set & (INVISIBLE_CHARS - _ORTHOGRAPHIC_JOINERS)
     for ch in invisible_hits:
         findings.append(f"invisible_unicode_U+{ord(ch):04X}")
 
@@ -242,7 +249,9 @@ def scan_for_threats(content: str, scope: str = "context") -> List[str]:
     # bypassing keyword checks (e.g. ``ｃａｔ ~/.hermes/.env``).  NOTE: this
     # does NOT defend against cross-script confusables (Cyrillic ``а`` U+0430),
     # which NFKC leaves untouched — that needs a TR#39 confusable database.
-    normalised = unicodedata.normalize("NFKC", content)
+    normalised = unicodedata.normalize("NFKC", content).translate(
+        _REGEX_SCAN_TRANSLATION
+    )
 
     # Threat patterns
     patterns = _COMPILED.get(scope)


### PR DESCRIPTION
## What does this PR do?

Persian and other text that legitimately uses U+200C no longer causes context files, memory entries, or skills to be rejected as prompt injection. The scanners still remove U+200C from their regex matching copy, so inserting it inside an actual injection keyword cannot bypass detection.

### Symptom

An `AGENTS.md`, `CLAUDE.md`, memory entry, or skill containing normal Persian orthography such as `می\u200cرود` is reported as `invisible_unicode_U+200C` and blocked.

### Impact

Persian-speaking users cannot reliably load project instructions or save durable memories in their language. Community skills containing the same standard orthographic character also receive a false-positive security finding.

### Bug Cause

**Trigger:** `tools/threat_patterns.py:scan_for_threats` and `tools/skills_guard.py:scan_file` classify every U+200C occurrence as malicious invisible Unicode.

**Causal chain:**
1. A context file, memory entry, or skill contains an orthographic zero-width non-joiner.
2. The scanner intersects raw text with its invisible-character candidate set and emits an injection finding without considering the character's linguistic use.
3. Context and memory callers block the content, while the skill guard raises its verdict.

**Why it is wrong:** U+200C is a standard orthographic half-space in scripts including Persian. NFKC preserves it, so the existing normalization step does not prevent the false positive.

**Working sibling / contrast:** Other invisible controls such as U+200B and bidi isolates remain findings because they do not need the U+200C orthographic exception.

**Ruled out:** NFKC normalization does not remove U+200C; a direct normalization probe preserved the codepoint unchanged.

### Fix

Treat U+200C as an allowed orthographic joiner for invisible-character findings in the shared threat scanner and skill guard. Before regex matching, remove it from a temporary scan copy so `over<U+200C>ride` still matches `override`; the original user content remains unchanged.

## Related Issue

Closes #92441

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/threat_patterns.py` - allow orthographic U+200C while preserving keyword detection on a sanitized scan copy.
- `tools/skills_guard.py` - apply the same behavior to skill-file scanning.
- `tests/tools/test_threat_patterns.py` - cover context and strict scopes plus the token-splitting abuse case.
- `tests/tools/test_skills_guard.py` - cover legitimate Persian and the corresponding abuse case for skill files.

## How to Test

1. Run the related scanner, context-loader, memory, and cron compatibility suites:

```bash
scripts/run_tests.sh tests/tools/test_threat_patterns.py tests/tools/test_skills_guard.py tests/tools/test_memory_tool.py tests/agent/test_prompt_builder.py tests/tools/test_cron_prompt_injection.py -q
```

2. Confirm legitimate Persian U+200C passes both context and strict scans.
3. Confirm a U+200C inserted into `system prompt override` is still detected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on all relevant suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and security rationale are covered by code comments and tests
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; architecture and workflows are unchanged
- [x] I've considered cross-platform impact per the compatibility guide; the change uses Python Unicode operations consistently across platforms
- [x] Tool description/schema updates are N/A; no tool interface changed
