### PR TITLE
fix(desktop): pause animations and timers on invisibility, not blur

### DIFF
--- a/apps/desktop/electron/stream-throttle.ts
+++ b/apps/desktop/electron/stream-throttle.ts
@@ -25,6 +25,10 @@ const RETHROTTLE_DELAY_MS = 5_000
 
 export interface ThrottleWindowLike {
   isDestroyed(): boolean
+  /** Optional window-state probes. When absent the window is treated as
+   * off-screen, which preserves the pre-existing busy-only semantics. */
+  isMinimized?(): boolean
+  isVisible?(): boolean
   webContents?: {
     isDestroyed(): boolean
     setBackgroundThrottling(allowed: boolean): void
@@ -54,6 +58,20 @@ export function createStreamThrottle(
   let unthrottled = false
   let trailing: unknown = null
 
+  /** A window the user can actually see. Chromium throttles rAF on a
+   * throttled webContents, so an on-screen-but-blurred window stops animating
+   * while IPC-driven DOM updates still land -- it reads as a freeze. Anything
+   * on screen therefore never gets throttled, regardless of the busy dial.
+   * Missing probes mean "not on screen" so injected test fakes keep their
+   * busy-only behaviour. */
+  function isOnScreen(win: ThrottleWindowLike): boolean {
+    try {
+      return win.isVisible?.() === true && win.isMinimized?.() !== true
+    } catch {
+      return false
+    }
+  }
+
   function apply(win: ThrottleWindowLike) {
     if (win.isDestroyed()) {
       windows.delete(win)
@@ -68,7 +86,7 @@ export function createStreamThrottle(
     }
 
     try {
-      contents.setBackgroundThrottling(!unthrottled)
+      contents.setBackgroundThrottling(!unthrottled && !isOnScreen(win))
     } catch {
       // A window mid-teardown can throw; it's about to leave the set anyway.
     }
@@ -86,6 +104,13 @@ export function createStreamThrottle(
     register(win) {
       windows.add(win)
       win.on?.('closed', () => windows.delete(win))
+
+      // Visibility transitions change the throttling verdict on their own, so
+      // re-apply rather than waiting for the next busy edge.
+      for (const event of ['minimize', 'restore', 'show', 'hide']) {
+        win.on?.(event, () => apply(win))
+      }
+
       apply(win)
     },
 

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -210,7 +210,11 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
             scheduleMeasure('ancestor-mutation')
           })
 
-    pauseController = createRendererLoopPauseController(handleVisibilityChange)
+    // Opts into blur-pausing explicitly. Unlike the decorative animations, this
+    // drives overlay rect measurement: parking it on blur is a deliberate perf
+    // choice, and it is what hides a stale overlay when a tab switch happens
+    // while the window is unfocused.
+    pauseController = createRendererLoopPauseController(handleVisibilityChange, { pauseWhenUnfocused: true })
 
     if (measure('initial')) {
       scheduleMeasure('settle')

--- a/apps/desktop/src/components/chat/activity-timer.test.tsx
+++ b/apps/desktop/src/components/chat/activity-timer.test.tsx
@@ -75,7 +75,10 @@ describe('useElapsedSeconds', () => {
     expect(screen.getByTestId('elapsed').textContent).toBe('0')
   })
 
-  it('pauses UI ticks without focus and catches up immediately on return', () => {
+  it('keeps ticking while unfocused, since the window is still on screen', () => {
+    // Regression: gating on focus froze the elapsed clock the moment the user
+    // clicked another window, so a turn that was still running looked hung.
+    // Only a hidden document may pause it -- asserted below.
     render(<Probe active timerKey="tool:background" />)
     vi.mocked(document.hasFocus).mockReturnValue(false)
     window.dispatchEvent(new Event('blur'))
@@ -83,10 +86,23 @@ describe('useElapsedSeconds', () => {
     act(() => {
       vi.advanceTimersByTime(5_000)
     })
+    expect(screen.getByTestId('elapsed').textContent).toBe('5')
+  })
+
+  it('pauses UI ticks while hidden and catches up immediately on return', () => {
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    render(<Probe active timerKey="tool:background" />)
+
+    visibility.mockReturnValue('hidden')
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
     expect(screen.getByTestId('elapsed').textContent).toBe('0')
 
-    vi.mocked(document.hasFocus).mockReturnValue(true)
-    act(() => window.dispatchEvent(new Event('focus')))
+    visibility.mockReturnValue('visible')
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
     expect(screen.getByTestId('elapsed').textContent).toBe('5')
   })
 })

--- a/apps/desktop/src/components/pet/use-pet-roam.test.tsx
+++ b/apps/desktop/src/components/pet/use-pet-roam.test.tsx
@@ -98,14 +98,16 @@ describe('usePetRoam RAF scheduling', () => {
     expect(vi.getTimerCount()).toBe(1)
   })
 
-  it('suspends idle movement while unfocused and cleans up its wake timer on unmount', () => {
+  it('keeps roaming while unfocused and cleans up its wake timer on unmount', () => {
     const raf = installRaf()
 
     mount.render(<RoamHarness />)
     expect(vi.getTimerCount()).toBe(1)
 
+    // Blur alone leaves the window visible, so the roam loop keeps running.
+    // Minimize/hide still parks it -- covered by the windowState test above.
     act(() => window.dispatchEvent(new Event('blur')))
-    expect(vi.getTimerCount()).toBe(0)
+    expect(vi.getTimerCount()).toBe(1)
 
     act(() => window.dispatchEvent(new Event('focus')))
     expect(vi.getTimerCount()).toBe(1)

--- a/apps/desktop/src/hooks/use-viewed-interval.ts
+++ b/apps/desktop/src/hooks/use-viewed-interval.ts
@@ -2,10 +2,14 @@ import { useEffect, useRef } from 'react'
 
 /** Run a UI-only clock while this document is actually being viewed.
  *
- * macOS can leave an occluded BrowserWindow `visible`, and active streaming
- * deliberately disables Chromium's background timer throttling. Pairing focus
- * with visibility avoids waking React for elapsed labels nobody can see while
- * a leading tick on return catches the UI up immediately.
+ * "Viewed" is visibility ONLY, deliberately not focus. An unfocused window is
+ * usually still fully on screen -- on a multi-monitor desktop it is normal to
+ * watch one window while typing in another -- and stopping an elapsed clock
+ * there makes a working turn look hung, which is the exact bug this used to
+ * cause. Focus was standing in for occlusion (macOS can leave an occluded
+ * window `visible`), but a 1s interval is far too cheap to be worth showing a
+ * frozen timer to everyone whose window is merely unfocused. A hidden document
+ * still stops the clock, and the leading tick on return catches the UI up.
  */
 export function useViewedInterval(callback: () => void, intervalMs: number, enabled = true): void {
   const callbackRef = useRef(callback)
@@ -30,7 +34,7 @@ export function useViewedInterval(callback: () => void, intervalMs: number, enab
     }
 
     const sync = () => {
-      const viewed = document.visibilityState === 'visible' && document.hasFocus()
+      const viewed = document.visibilityState === 'visible'
 
       if (!viewed) {
         stop()
@@ -44,15 +48,11 @@ export function useViewedInterval(callback: () => void, intervalMs: number, enab
       }
     }
 
-    window.addEventListener('focus', sync)
-    window.addEventListener('blur', sync)
     document.addEventListener('visibilitychange', sync)
     sync()
 
     return () => {
       stop()
-      window.removeEventListener('focus', sync)
-      window.removeEventListener('blur', sync)
       document.removeEventListener('visibilitychange', sync)
     }
   }, [enabled, intervalMs])

--- a/apps/desktop/src/lib/renderer-loop-pause.test.ts
+++ b/apps/desktop/src/lib/renderer-loop-pause.test.ts
@@ -2,30 +2,53 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { installRendererAnimationPauseState, RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE } from './renderer-loop-pause'
 
+const paused = () => document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)
+
 describe('installRendererAnimationPauseState', () => {
   afterEach(() => {
     document.documentElement.removeAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)
     vi.restoreAllMocks()
   })
 
-  it('pauses on blur, resumes on focus, and cleans up its root state', () => {
+  it('keeps animating while merely unfocused, since the window is still visible', () => {
+    // Regression: pausing on blur froze every continuous animation whenever the
+    // user clicked another window, which on a multi-monitor desktop leaves a
+    // fully visible window looking hung. Only real invisibility may pause.
     let focused = true
     vi.spyOn(document, 'hasFocus').mockImplementation(() => focused)
 
     const dispose = installRendererAnimationPauseState()
-    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(false)
+
+    expect(paused()).toBe(false)
 
     focused = false
     window.dispatchEvent(new Event('blur'))
-    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(true)
+    expect(paused()).toBe(false)
 
     focused = true
     window.dispatchEvent(new Event('focus'))
-    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(false)
+    expect(paused()).toBe(false)
 
-    focused = false
-    window.dispatchEvent(new Event('blur'))
     dispose()
-    expect(document.documentElement.hasAttribute(RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE)).toBe(false)
+    expect(paused()).toBe(false)
+  })
+
+  it('pauses when the document is actually hidden, and cleans up its root state', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false)
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+
+    const dispose = installRendererAnimationPauseState()
+    expect(paused()).toBe(true)
+
+    visibility.mockReturnValue('visible')
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(paused()).toBe(false)
+
+    visibility.mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(paused()).toBe(true)
+
+    dispose()
+    expect(paused()).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/renderer-loop-pause.ts
+++ b/apps/desktop/src/lib/renderer-loop-pause.ts
@@ -5,7 +5,13 @@ interface WindowStatePayload {
 
 export const RENDERER_ANIMATIONS_PAUSED_ATTRIBUTE = 'data-renderer-animations-paused'
 
-export function createRendererLoopPauseController(onChange: () => void, { pauseWhenUnfocused = true } = {}) {
+// `pauseWhenUnfocused` defaults to false. Blur is not "not being looked at":
+// on a multi-monitor desktop an unfocused window is usually still fully
+// visible, and pausing its animations there reads as the app having frozen.
+// Real invisibility (document hidden, or the main process reporting
+// minimized/not-visible) still pauses, which is where the renderer-wake saving
+// actually mattered. Callers that want blur to pause opt in explicitly.
+export function createRendererLoopPauseController(onChange: () => void, { pauseWhenUnfocused = false } = {}) {
   let windowPaused = false
   let windowFocused = document.hasFocus()
 
@@ -53,8 +59,10 @@ export function createRendererLoopPauseController(onChange: () => void, { pauseW
 
 /**
  * Mirrors the main window's observability onto :root so continuous decorative
- * CSS animations can sleep with the JS renderer loops. The caller owns the
- * returned cleanup; overlay windows intentionally do not install this state.
+ * CSS animations can sleep with the JS renderer loops. Sleeping is keyed to the
+ * window being genuinely invisible (hidden/minimized), never to mere blur.
+ * The caller owns the returned cleanup; overlay windows intentionally do not
+ * install this state.
  */
 export function installRendererAnimationPauseState(): () => void {
   const root = document.documentElement


### PR DESCRIPTION
## What changed

Hermes was pausing renderer work whenever a window lost focus. That is fine for a single maximised window, but wrong when two windows are visible side by side or on separate monitors.

This PR makes visibility the boundary instead:

- Renderer animations pause when the window is hidden or minimised, not merely unfocused.
- Viewed intervals keep running in a visible background window.
- Electron background throttling is reapplied on minimise, restore, show, and hide.
- The terminal overlay keeps its existing blur-sensitive behaviour through an explicit opt-in.

## Why

On a multi-monitor setup, clicking another window froze the thinking shimmer and elapsed timer while streamed content continued to arrive. The app looked stuck even though the turn was still running.

The existing comments already describe the intended rule: stop producing frames when nobody can see them. A visible, unfocused window does not meet that condition.

## How to test

1. Put two Hermes windows side by side or on separate monitors.
2. Start a turn in one window.
3. Focus the other window.
4. Confirm the thinking animation and elapsed timer keep moving.
5. Minimise the first window and confirm its renderer work pauses.

## Verification

Rebased onto current `main` at `a70d2ffce`.

- Focused UI tests: 15 passed
- Electron stream-throttle tests: 5 passed
- Renderer, Electron, and E2E TypeScript checks: passed
- `git diff --check`: passed

Tested on CachyOS with KDE Plasma Wayland and two monitors.

## Related work

#93904 also changes `stream-throttle.ts`, but for per-window busy state. If it lands first, this PR still needs to preserve the visibility rule: a window that is visible and not minimised should not be background-throttled.
