### PR TITLE
fix(desktop): probe disk-plugin entries with a listing, not a throwing read

### DIFF
--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -80,14 +80,19 @@ describe('scanDiskPlugins (#66899)', () => {
         ? { entries: [{ isDirectory: true, name: 'my-feature', path: '/local/.hermes/plugins/my-feature' }] }
         : { entries: [] }
     )
-    // No desktop half in this package — probe must target desktop/plugin.js.
+    // No desktop half in this package. The probe is a directory listing, not a
+    // read: readFileText is a hardened handler that throws for a missing path,
+    // and Electron logs a full stack for every rejection -- which spammed the
+    // console once per 5s poll for every Python-only plugin folder.
     readFileText.mockRejectedValue(new Error('ENOENT'))
 
     await discoverRuntimePlugins()
 
-    expect(readFileText).toHaveBeenCalledWith('/local/.hermes/plugins/my-feature/desktop/plugin.js')
-    // The Python half's files must never be probed as a desktop entry.
-    expect(readFileText).not.toHaveBeenCalledWith('/local/.hermes/plugins/my-feature/plugin.js')
+    // Probe targets the desktop half's directory, never the package root.
+    expect(readDir).toHaveBeenCalledWith('/local/.hermes/plugins/my-feature/desktop')
+    expect(readDir).not.toHaveBeenCalledWith('/local/.hermes/plugins/my-feature')
+    // A miss must cost no read at all, so nothing reaches the throwing handler.
+    expect(readFileText).not.toHaveBeenCalled()
   })
 
   it('still scans the standalone root when agentPluginsRoot is absent (older shell)', async () => {
@@ -104,11 +109,23 @@ describe('scanDiskPlugins (#66899)', () => {
   it('loads a unified desktop half OPT-IN: inventoried but not activated by default', async () => {
     desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
     agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
-    readDir.mockImplementation(async dir =>
-      dir === '/local/.hermes/plugins'
-        ? { entries: [{ isDirectory: true, name: 'uni', path: '/local/.hermes/plugins/uni' }] }
-        : { entries: [] }
-    )
+    // Two levels: the root lists the package, and the package's desktop/ dir
+    // lists the entry file the probe looks for.
+    readDir.mockImplementation(async dir => {
+      if (dir === '/local/.hermes/plugins') {
+        return { entries: [{ isDirectory: true, name: 'uni', path: '/local/.hermes/plugins/uni' }] }
+      }
+
+      if (dir === '/local/.hermes/plugins/uni/desktop') {
+        return {
+          entries: [
+            { isDirectory: false, name: 'plugin.js', path: '/local/.hermes/plugins/uni/desktop/plugin.js' }
+          ]
+        }
+      }
+
+      return { entries: [] }
+    })
 
     const register = vi.fn()
 

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -366,10 +366,34 @@ async function scanDiskPlugins(): Promise<void> {
           continue
         }
 
+        // Probe with a directory listing, not a read. `readFileText` is a
+        // hardened handler that THROWS for a missing path, and Electron logs a
+        // full "Error occurred in handler" stack for every rejection -- so the
+        // ordinary case (a folder in this root that is not a desktop plugin)
+        // spammed the console on every pass of the 5s poll. The unified root
+        // `~/.hermes/plugins` is full of such folders: its Python plugins
+        // (mnemosyne, vaultwarden, quota, ...) legitimately have no plugin.js.
+        // A listing answers the same question and cannot throw for a miss.
+        // Derive the listing target from the entry path, not from dir.path:
+        // the unified root's entry is `<folder>/desktop/plugin.js`, so the
+        // directory to list is the entry's own parent, which may be a level
+        // deeper than the scanned folder. A missing `desktop/` throws here and
+        // is treated as "no desktop half", same as a missing entry file.
+        const slash = file.lastIndexOf('/')
+        const entryDir = file.slice(0, slash)
+        const wanted = file.slice(slash + 1)
+        let hasEntry = false
+
         try {
-          await desktop.readFileText(file)
+          const { entries: inner } = await desktop.readDir(entryDir)
+
+          hasEntry = inner.some(candidate => !candidate.isDirectory && candidate.name === wanted)
         } catch {
-          continue // No entry file (yet) — not a plugin folder for this root.
+          continue // No such directory — not a plugin folder for this root.
+        }
+
+        if (!hasEntry) {
+          continue // Not a plugin folder for this root.
         }
 
         const record: DiskPlugin = {


### PR DESCRIPTION

Branch: `fix/disk-plugin-probe` (1 commit, 2 files, based on 13f4cfebf)

## What

`scanDiskPlugins` used `readFileText` to test whether a plugin entry file
exists. It now uses `readDir`, which does not throw when the path is missing.

## Why

The probe was:

```ts
try {
  await desktop.readFileText(file)
} catch {
  continue // No entry file (yet) — not a plugin folder for this root.
}
```

That `catch` is the expected path for any folder which is not a desktop plugin.
But `readFileText` is a hardened handler that throws when the path is missing,
and Electron logs a full `Error occurred in handler for 'hermes:readFileText'`
stack for every `ipcMain.handle` rejection. Failed probes are not remembered, so
each miss logs again on every pass of the 5 second poll.

The unified root `<hermes home>/plugins` makes that the normal case rather than
an edge case, because it is the Python plugin directory and its packages have no
`desktop/plugin.js`. On my machine four folders there (mnemosyne, vaultwarden,
quota and an Android companion app) produced four ENOENT stacks every five
seconds, indefinitely, on a healthy install. Real errors get lost in it. While
debugging something unrelated today I missed a GPU crash and a failed sudo call
because both scrolled past inside this.

## The fix

`readDirForIpc` catches and returns `{ entries: [], error }` instead of throwing
(`electron/fs-read-dir.ts`), so a miss costs no rejection and writes no log
line.

Two details worth noting for review. The directory listed is the entry path's
parent, not the scanned folder, because the unified root's entry sits at
`<folder>/desktop/plugin.js`, one level deeper than the standalone root's
`<folder>/plugin.js`. Listing the scanned folder would never match. And entries
are `stat`ed rather than `lstat`ed in `fs-read-dir.ts`, so a symlink pointing at
a directory is reported as a directory and excluded by the `isDirectory` check.

## How to test

Put a folder with no `desktop/plugin.js` into `<hermes home>/plugins`, or just
install any Python-side Hermes plugin, which is the ordinary case. Run the app
and watch the main process log.

Before the change you get one `hermes:readFileText` ENOENT stack per such
folder, repeating every 5 seconds. After it the log is quiet and any real
desktop plugin still loads.

On my install this went from four every five seconds to zero across roughly 46
poll cycles, with the one genuine desktop plugin still discovered and loaded.

## Tests

`src/contrib/runtime-loader.test.ts` is updated. The existing test asserted the
probe hit `desktop/plugin.js` through `readFileText`. It now asserts the probe
lists `<folder>/desktop` and that a miss performs no read at all, so nothing
reaches the throwing handler. The happy-path fake gained a second level so it
serves the `desktop/` directory the probe now lists.

Desktop suite: 7024 passed, 3 skipped. Both typechecks clean.

This branch touches no Python, so the pytest suite is unaffected.

## Platforms

Affects all platforms. `runtime-loader.ts` has no platform branches, and the
unified plugin root behaves the same everywhere, so anyone with a Python-side
Hermes plugin installed gets this log spam regardless of OS.

Tested on Linux only: CachyOS (Arch), KDE Plasma 6.7.4 Wayland, Electron
40.10.2.
