### PR TITLE
fix(memory): serialize Honcho session flushes

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -149,6 +149,7 @@ class HonchoSessionManager:
         self._runtime_user_peer_name_alt = runtime_user_peer_name_alt
         self._cache: dict[str, HonchoSession] = {}
         self._cache_lock = threading.RLock()
+        self._flush_locks: dict[str, threading.Lock] = {}
         self._peers_cache: dict[str, Any] = {}
         self._sessions_cache: dict[str, Any] = {}
         # Bumped (under _cache_lock) whenever _force_reauth rebuilds the client.
@@ -659,6 +660,13 @@ class HonchoSessionManager:
 
     def _flush_session(self, session: HonchoSession) -> bool:
         """Internal: write unsynced messages to Honcho synchronously."""
+        with self._cache_lock:
+            flush_lock = self._flush_locks.setdefault(session.key, threading.Lock())
+        with flush_lock:
+            return self._flush_session_locked(session)
+
+    def _flush_session_locked(self, session: HonchoSession) -> bool:
+        """Write unsynced messages while holding the session's flush lock."""
         if not session.messages:
             return True
 

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -229,6 +229,44 @@ class TestSaveRouting:
 # ---------------------------------------------------------------------------
 
 class TestFlushAll:
+    def test_same_session_flushes_are_serialized(self, make_manager):
+        mgr = make_manager(write_frequency="turn")
+        session = _make_session()
+        session.add_message("user", "once")
+
+        user_peer = MagicMock()
+        user_peer.message.return_value = "honcho-message"
+        assistant_peer = MagicMock()
+        honcho_session = MagicMock()
+        mgr._get_or_create_peer = MagicMock(
+            side_effect=lambda peer_id: (
+                user_peer if peer_id == session.user_peer_id else assistant_peer
+            )
+        )
+        mgr._sessions_cache[session.honcho_session_id] = honcho_session
+        auth_barrier = threading.Barrier(2)
+
+        def synchronize_flushes(_operation, call):
+            try:
+                auth_barrier.wait(timeout=0.2)
+            except threading.BrokenBarrierError:
+                pass
+            return call()
+
+        mgr._authed_call = MagicMock(side_effect=synchronize_flushes)
+
+        first = threading.Thread(target=mgr._flush_session, args=(session,))
+        second = threading.Thread(target=mgr._flush_session, args=(session,))
+        first.start()
+        second.start()
+        first.join(timeout=2)
+        second.join(timeout=2)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        honcho_session.add_messages.assert_called_once_with(["honcho-message"])
+        assert session.messages[0]["_synced"] is True
+
     def test_flushes_all_cached_sessions(self, make_manager):
         mgr = make_manager(write_frequency="session")
         s1 = _make_session(key="s1", honcho_session_id="s1")
@@ -600,4 +638,3 @@ class TestPrefetchCacheAccessors:
 
         assert mgr.pop_context_result("cli:test") == payload
         assert mgr.pop_context_result("cli:test") == {}
-


### PR DESCRIPTION
## Summary

- serialize the read/send/mark sequence per Honcho session
- keep flushes for distinct sessions independent
- cover the async-writer versus shutdown race with a deterministic two-thread regression

Fixes #92458.

## Evidence

Base: `13f4cfebfafbce8ac9d1bf29f66731858ed638b5`
Head: `9ba2d4c021f4bb24ccb9afc7ccdd3f210bb32755`

On the unmodified base, the regression forces both flushers past the unsynced read before either sends and fails with two identical `add_messages` calls. On this head, the second same-session flusher enters only after the first marks the message synced, so the batch is sent once.

```text
uv run --with pytest pytest tests/honcho_plugin/test_async_memory.py tests/honcho_plugin/test_session.py -q
94 passed in 0.87s

uvx ruff check plugins/memory/honcho/session.py tests/honcho_plugin/test_async_memory.py
All checks passed!

git diff --check
passed
```

Publication-time searches for the issue title, `_flush_session`, flush locks, duplicate messages, and double writes found no same-root open PR.