### PR TITLE
fix(desktop): stop the edit composer's timers from outliving it

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -118,6 +118,24 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const slash = useSlashCompletions({ gateway })
   const emoji = useEmojiCompletions()
 
+  // Timers this composer schedules must not outlive it. Every callback below
+  // touches component state, a ref or the composer core, and this is the one
+  // composer that routinely unmounts mid-flight: confirming an edit tears it
+  // down while the 200ms submit latch is still pending, so the latch resumes
+  // against an unmounted tree. Two of the callbacks already carry defensive
+  // try/catch for the racing-teardown case; clearing the timers removes the
+  // race instead of surviving it.
+  const pendingTimeoutsRef = useRef<Set<number>>(new Set())
+
+  const scheduleTimeout = useCallback((run: () => void, delayMs: number): void => {
+    const id = window.setTimeout(() => {
+      pendingTimeoutsRef.current.delete(id)
+      run()
+    }, delayMs)
+
+    pendingTimeoutsRef.current.add(id)
+  }, [])
+
   // This is the one composer that routinely unmounts, so it is where the focus
   // bus leaks: confirming or cancelling an edit tears the composer down while
   // `'edit'` is still the active target. Release it alongside the thread-scroll
@@ -126,6 +144,12 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
     () => () => {
       notifyThreadEditClose()
       releaseActiveComposer('edit')
+
+      for (const id of pendingTimeoutsRef.current) {
+        window.clearTimeout(id)
+      }
+
+      pendingTimeoutsRef.current.clear()
     },
     []
   )
@@ -341,7 +365,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         draftRef.current = composerPlainText(editor)
         aui.composer().setText(draftRef.current)
         requestEditFocus()
-        starter ? window.setTimeout(refreshTrigger, 0) : closeTrigger()
+        starter ? scheduleTimeout(refreshTrigger, 0) : closeTrigger()
       }
 
       // In place first, spanning Chromium's split text nodes (see
@@ -360,7 +384,16 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
 
       finish()
     },
-    [aui, closeTrigger, recordUndoPoint, refreshTrigger, rememberInitialDraft, requestEditFocus, trigger]
+    [
+      aui,
+      closeTrigger,
+      recordUndoPoint,
+      refreshTrigger,
+      rememberInitialDraft,
+      requestEditFocus,
+      scheduleTimeout,
+      trigger
+    ]
   )
 
   const insertRefStrings = useCallback(
@@ -526,11 +559,11 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
 
       rememberInitialDraft()
       const nextDraft = syncDraftFromEditor(editor)
-      window.setTimeout(refreshTrigger, 0)
+      scheduleTimeout(refreshTrigger, 0)
 
       return nextDraft
     },
-    [refreshTrigger, rememberInitialDraft, syncDraftFromEditor]
+    [refreshTrigger, rememberInitialDraft, scheduleTimeout, syncDraftFromEditor]
   )
 
   const handleInput = (event: FormEvent<HTMLDivElement>) => {
@@ -602,7 +635,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
       // Clear latch after cooldown to allow re-submission. This prevents rapid
       // double-Enter but doesn't require tracking when onEdit settles (which may
       // be synchronous or async, and whose promise we don't have access to).
-      window.setTimeout(() => {
+      scheduleTimeout(() => {
         setSubmitting(false)
       }, 200)
     } catch {
@@ -618,7 +651,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         return
       }
 
-      window.setTimeout(() => {
+      scheduleTimeout(() => {
         const root = rootRef.current
         const active = document.activeElement
 
@@ -653,7 +686,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
         }
       }, 80)
     },
-    [aui, closeTrigger, submitting, syncDraftFromEditor]
+    [aui, closeTrigger, scheduleTimeout, submitting, syncDraftFromEditor]
   )
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -810,7 +843,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               data-placeholder={copy.editMessage}
               data-slot={RICH_INPUT_SLOT}
               onBeforeInput={handleBeforeInput}
-              onBlur={() => window.setTimeout(closeTrigger, 80)}
+              onBlur={() => scheduleTimeout(closeTrigger, 80)}
               onCompositionEnd={event => {
                 composingRef.current = false
                 flushEditorToDraft(event.currentTarget)

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -140,6 +140,11 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   // bus leaks: confirming or cancelling an edit tears the composer down while
   // `'edit'` is still the active target. Release it alongside the thread-scroll
   // cleanup so keyboard routing falls back to the visible chat composer.
+  //
+  // It also drains whatever `scheduleTimeout` still has pending, which is a
+  // second concern under the same heading rather than a separate one: both
+  // are "this composer is going away", they unmount together by definition,
+  // and a sibling unmount-only effect would only be a second place to forget.
   useEffect(
     () => () => {
       notifyThreadEditClose()

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -233,6 +233,63 @@ describe('Enter submission and latch behavior', () => {
     })
   })
 
+  // Confirming an edit unmounts the composer while its 200ms submit latch is
+  // still pending. Left running, the callback resumes on an unmounted tree and
+  // calls setSubmitting, which React turns into work against a torn-down
+  // renderer. Under vitest that surfaces after the test file finishes, as
+  // "ReferenceError: window is not defined" out of resolveUpdatePriority, an
+  // unhandled error that fails a run in which every test passed. The delay is
+  // matched explicitly so unrelated library timers cannot make this pass.
+  it('clears the submit latch timer when confirming the edit unmounts the composer', async () => {
+    const LATCH_MS = 200
+    // jsdom under node hands back a Timeout object rather than a numeric id,
+    // so these are compared by identity rather than by value.
+    const scheduled: unknown[] = []
+    const cleared: unknown[] = []
+    const realSetTimeout = window.setTimeout.bind(window)
+    const realClearTimeout = window.clearTimeout.bind(window)
+
+    vi.spyOn(window, 'setTimeout').mockImplementation(((
+      handler: TimerHandler,
+      timeout?: number,
+      ...args: unknown[]
+    ) => {
+      const id = realSetTimeout(handler, timeout, ...args)
+
+      if (timeout === LATCH_MS) {
+        scheduled.push(id)
+      }
+
+      return id
+    }) as typeof window.setTimeout)
+
+    vi.spyOn(window, 'clearTimeout').mockImplementation(((id?: number) => {
+      cleared.push(id)
+      realClearTimeout(id)
+    }) as typeof window.clearTimeout)
+
+    const onEdit = vi.fn(async () => {})
+    const view = render(<IncrementalHarness onEdit={onEdit} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+
+    const editor = await screen.findByRole('textbox', { name: 'Edit message' })
+
+    editor.textContent = 'an edit whose composer goes away before the latch expires'
+    fireEvent.input(editor)
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(onEdit).toHaveBeenCalledTimes(1)
+    })
+
+    expect(scheduled).toHaveLength(1)
+
+    view.unmount()
+
+    expect(cleared).toContain(scheduled[0])
+  })
+
   it('inserts a newline on Shift+Enter without submitting', async () => {
     const onEdit = vi.fn(async () => {})
     render(<IncrementalHarness onEdit={onEdit} />)

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -263,9 +263,13 @@ describe('Enter submission and latch behavior', () => {
       return id
     }) as typeof window.setTimeout)
 
-    vi.spyOn(window, 'clearTimeout').mockImplementation(((id?: number) => {
+    // `id` is typed `unknown` for the same reason the arrays above are: what
+    // actually arrives is whatever `setTimeout` returned, and under jsdom that
+    // is a Timeout object rather than the `number` the DOM lib promises.
+    // Declaring it `number` would have documented a shape this never sees.
+    vi.spyOn(window, 'clearTimeout').mockImplementation(((id?: unknown) => {
       cleared.push(id)
-      realClearTimeout(id)
+      realClearTimeout(id as number | undefined)
     }) as typeof window.clearTimeout)
 
     const onEdit = vi.fn(async () => {})


### PR DESCRIPTION
## What does this PR do?

`UserEditComposer` schedules five timers and clears none of them on unmount. Confirming an inline edit tears the composer down while its 200ms submit latch is still pending, so the callback resumes on an unmounted tree and calls `setSubmitting`:

```ts
aui.composer().send()          // confirms the edit, which unmounts this composer

window.setTimeout(() => {
  setSubmitting(false)         // ...200ms later, on a component that is gone
}, 200)
```

In the running app that stray state update is an invisible no-op, which is why it has survived. Under vitest it can land after the test file's jsdom environment has been torn down, and React reaches for a `window` that no longer exists.

### The symptom is worse than the bug

From [run 32591595888](https://github.com/NousResearch/hermes-agent/actions/runs/32591595888/job/97076206899):

```
Test Files  570 passed (570)
     Tests  5434 passed (5434)
    Errors  1 error

Uncaught Exception
ReferenceError: window is not defined
 ❯ resolveUpdatePriority   react-dom-client.development.js:1308:7
 ❯ requestUpdateLane       react-dom-client.development.js:16345:11
 ❯ dispatchSetState        react-dom-client.development.js:9126:14
 ❯ Timeout._onTimeout      src/components/assistant-ui/thread/user-edit-composer.tsx:606:9
 ❯ listOnTimeout           node:internal/timers:685:17

This error originated in "src/components/assistant-ui/thread/user-message-edit.test.tsx"
```

Every test passes and the job still exits 1. That combination is indistinguishable from infrastructure noise, so the honest reading ("something is wrong") and the convenient reading ("flake, re-run") point in opposite directions. It also lands on whichever PR happens to be running rather than on anything related: I hit it on #92299, a test-only change of 43 lines to a *different vitest project*, which cost a while to rule out before I found the real cause.

### The component already knew

Its unmount effect opens with:

> `// This is the one composer that routinely unmounts, so it is where the focus bus leaks: confirming or cancelling an edit tears the composer down while 'edit' is still the active target.`

and two of its other timer callbacks already carry defensive `try/catch` for the composer core being torn down underneath them. So "my timers outlive me" was known and worked around twice. The timers were just never cancelled. This cancels them, which removes the race rather than surviving it.

## Related Issue

Fixes #92462

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

All in `apps/desktop/src/components/assistant-ui/thread/`.

- **`scheduleTimeout(run, delayMs)`** (new, in `user-edit-composer.tsx`). Records the id in a ref and drops it when the callback runs, so the set only ever holds genuinely pending timers rather than growing for the life of the component.
- **The existing unmount effect** clears whatever is left. Deliberately extended rather than given its own effect: it is already the place this component tidies up after itself, and the two concerns unmount together by definition.
- **All five `window.setTimeout` sites** route through it: the submit latch (200ms), the blur-cancel guard (80ms), the trigger-close blur (80ms) and two `refreshTrigger` hops (0ms). The latch is the one with CI evidence, but the argument applies to each: every callback touches state, a ref, or the composer core, and 0ms is not 0 when the event loop is busy.
- **Two `useCallback` dep arrays** gained `scheduleTimeout`. It is `useCallback`-stable with an empty dep list, so no identity churn: this satisfies `react-hooks/exhaustive-deps` rather than working around it.

## How to Test

```bash
cd apps/desktop
npx vitest run --project ui src/components/assistant-ui/thread/user-message-edit.test.tsx
# 10 passed
```

One regression test, placed in the file the CI error originated in: spy on `setTimeout`/`clearTimeout`, submit an edit, unmount, assert the latch's id was cleared.

Two details in it are load-bearing and are commented as such:

1. It matches on the **200ms delay** so that unrelated library timers (RTL, assistant-ui internals) cannot make it pass by accident. A test that just asserted "some timer was cleared" would pass on unpatched code.
2. Ids are compared **by identity, not value**, because jsdom under node hands back a `Timeout` object rather than a numeric id. My first version asserted on numbers and failed for that reason rather than for the reason it was testing.

**Sabotage proof.** Keeping the id tracking but removing the clear loop from the unmount effect:

```
× clears the submit latch timer when confirming the edit unmounts the composer
  Tests  1 failed | 9 passed (10)
```

Nothing else in the file notices, which is the point: this behaviour had no coverage at all.

**Wider suites.** `user-message-edit.test.tsx`, `user-message-edit-gesture.test.tsx` and `edit-context.test.tsx`: 14 passed. `eslint` clean on both changed files.

Full `--project ui` locally on Windows: 26 failures across 9 files, all in `src/app/**` and `src/store/**`, none in a file this PR touches. I stashed the two changed files and re-ran the same set: **identical failures on the unpatched tree**, so they are pre-existing and local. They are also load-dependent (running those 9 files alone gives 3 failures, not 26), which is why CI sees 570/570 and my machine does not. Linux CI on this PR is the authority.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (26200), Node 24, vitest 4.1.10

<sub>The Python box is left unticked rather than ticked dishonestly: this PR touches no Python, and `pytest tests/ -q` does not collect on Windows at all (`tests/hermes_cli/test_doctor_journal_modes.py` raises `AttributeError: module 'os' has no attribute 'geteuid'` at import and aborts the run). The relevant suite here is the JS one, run as above.</sub>

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): the new helper and the extended cleanup carry the reasoning inline, including why the delay match and the identity comparison in the test are deliberate
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A, no config surface
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): none. `setTimeout`/`clearTimeout` and React unmount ordering are identical everywhere; the bug was found on Linux CI and fixed and verified on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

## Notes for a reviewer

Two things I would want checked:

1. **Is clearing the 0ms `refreshTrigger` hops the right call?** They are the two sites with no CI evidence against them. I included them because the rule is easier to keep than the exception, and because a 0ms timer that fires after unmount is the same bug with a smaller window. If you would rather keep the diff to the latch alone, that is a two-line reduction and I will make it.
2. **`scheduleTimeout` does not return the id.** No caller currently cancels an individual timer, so returning one would be unused surface. If a future caller needs to cancel early, returning the id and exposing a matching `cancelTimeout` is the natural extension; I have left it out rather than guess at the shape.
