### PR TITLE
fix(config): recognize agent.reasoning_effort in validator schema

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -350,6 +350,7 @@ DEFAULT_CONFIG = {
         "image_input_mode": "auto",
         "disabled_toolsets": [],
 
+        "reasoning_effort": "",
         # Per-model reasoning effort overrides (spelling-tolerant).
         # Dict mapping model names (any reasonable spelling) to effort levels.
         # Takes precedence over agent.reasoning_effort when the current model

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -522,6 +522,7 @@ class TestValidateConfigKey:
         "model",
         "terminal.backend",
         "agent.max_turns",
+        "agent.reasoning_effort",
         "discord.gateway_restart_notification",
         "telegram.bot_token",
         "mcp_servers.foo.command",


### PR DESCRIPTION
# fix(config): recognize `agent.reasoning_effort` in validator schema

*Prepared by Philipp's bot-fleet pilot (coder lane, card t_ef269e14). Not yet submitted — awaiting operator go-ahead.*

## Problem

`hermes config set agent.reasoning_effort <level>` saves the value but prints:

```
⚠ 'agent.reasoning_effort' is not a recognized config key — it was saved anyway,
but Hermes may not read it.
  Did you mean: agent.reasoning_echo
```

The key is real: `resolve_reasoning_config()` in `hermes_constants.py` reads
`agent_cfg.get("reasoning_effort")` (global fallback after per-model overrides), the
CLI help text documents it ("the persistent level lives there"), and the runtime's own
fallback semantics treat an empty value as "provider default". Only the
`config set` validator's `DEFAULT_CONFIG['agent']` lacks the leaf — schema drift.

## Fix

Two lines:

1. `hermes_cli/config_defaults.py`: add `"reasoning_effort": ""` to
   `DEFAULT_CONFIG["agent"]` (empty string = unset = provider default, matching
   `resolve_reasoning_config()`'s fallback).
2. `tests/hermes_cli/test_set_config_value.py`: add `agent.reasoning_effort` to the
   known-keys parametrization of `TestValidateConfigKey`.

## Verification

- RED→GREEN proven against throwaway `HERMES_HOME`s: current main prints the warning;
  with this change the warning is gone and the written config is correct.
- Targeted suite: `python3 -m pytest tests/hermes_cli/test_set_config_value.py -q`
  → **86 passed** (12/12 in the validator parametrization).
- Post-merge on local main: suite green, live symptom absent.
- Sibling keys checked: `reasoning_echo` and `reasoning_overrides` already present.

## Notes

- Found while provisioning isolated kanban worker profiles; all six pre-existing
  profiles carried the key. Fix authored by an automated coder lane + independent
  review lane; happy to adjust attribution/comments to project convention.
