### PR TITLE
fix(agent): bound consecutive outer-loop errors

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8405,6 +8405,7 @@ def run_conversation(
                     consecutive_outer_loop_errors
                     >= _MAX_CONSECUTIVE_OUTER_LOOP_ERRORS
                 ):
+                    failed = True
                     _turn_exit_reason = (
                         "outer_loop_error_retry_exhausted"
                         f"({error_msg[:80]})"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -8398,6 +8398,7 @@ def run_conversation(
                 >= _MAX_CONSECUTIVE_OUTER_LOOP_ERRORS
                 or api_call_count >= agent.max_iterations - 1
             ):
+                failed = True
                 if _is_local_processing_error:
                     _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
                     final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
@@ -8405,7 +8406,6 @@ def run_conversation(
                     consecutive_outer_loop_errors
                     >= _MAX_CONSECUTIVE_OUTER_LOOP_ERRORS
                 ):
-                    failed = True
                     _turn_exit_reason = (
                         "outer_loop_error_retry_exhausted"
                         f"({error_msg[:80]})"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -277,6 +277,11 @@ _API_CALL_MODULES = frozenset({
 _MAX_CONSECUTIVE_OUTER_LOOP_ERRORS = 3
 
 
+def _sleep_outer_loop_error_backoff(seconds: int) -> None:
+    """Pause between outer-loop retries without exposing global sleep to tests."""
+    time.sleep(seconds)
+
+
 def _moa_client_consumes_prepared_request(client: Any) -> bool:
     """True when ``client`` is the in-process MoA facade.
 
@@ -8420,7 +8425,7 @@ def run_conversation(
                 consecutive_outer_loop_errors,
                 _MAX_CONSECUTIVE_OUTER_LOOP_ERRORS,
             )
-            time.sleep(_outer_error_delay)
+            _sleep_outer_loop_error_backoff(_outer_error_delay)
         finally:
             if not _outer_loop_failed:
                 consecutive_outer_loop_errors = 0

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -271,6 +271,11 @@ _API_CALL_MODULES = frozenset({
     "chat_completion_helpers",
 })
 
+# The post-response outer handler is deliberately independent from the useful
+# tool-iteration budget. Successful turns may be unlimited, but retrying the
+# same unclassified processing failure forever is never useful (#92450).
+_MAX_CONSECUTIVE_OUTER_LOOP_ERRORS = 3
+
 
 def _moa_client_consumes_prepared_request(client: Any) -> bool:
     """True when ``client`` is the in-process MoA facade.
@@ -1899,6 +1904,7 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
+    consecutive_outer_loop_errors = 0
     # One resolved per-turn compression attempt cap, shared by every site that
     # consumes ``compression_attempts``: the pre-API pressure gate, the
     # overflow/413 retry handlers, and the post-tool compaction gate. The
@@ -6636,6 +6642,7 @@ def run_conversation(
             agent._persist_session(messages, conversation_history)
             break
 
+        _outer_loop_failed = False
         try:
             _transport = agent._get_transport()
             _normalize_kwargs = {}
@@ -8298,9 +8305,11 @@ def run_conversation(
                 break
             
         except Exception as e:
-            # Phase-aware error classification. The huge outer try/except spans
-            # both the actual API request and all local post-processing of the
-            # returned assistant message. Deterministic local bugs (e.g.
+            _outer_loop_failed = True
+            consecutive_outer_loop_errors += 1
+            # Phase-aware error classification. This outer try/except starts
+            # after a provider response and spans response normalization plus
+            # local post-processing. Deterministic local bugs (e.g.
             # passing a multimodal content list into a regex helper after a
             # vision turn or context compaction) should not be retried: they
             # will fail identically on every iteration and only burn the
@@ -8374,16 +8383,28 @@ def run_conversation(
             # message pollutes history, burns tokens, and risks violating
             # role-alternation invariants.
 
-            # If we're near the limit, break to avoid infinite loops.
-            # Local processing errors are deterministic — stop immediately
-            # rather than retrying until the budget is exhausted.
+            # Local processing errors are deterministic, so stop immediately.
+            # Unclassified errors get a separate consecutive-failure ceiling:
+            # max_iterations may be sys.maxsize for unlimited useful turns and
+            # must not license an infinite traceback-writing error loop.
             if (
                 _is_local_processing_error
+                or consecutive_outer_loop_errors
+                >= _MAX_CONSECUTIVE_OUTER_LOOP_ERRORS
                 or api_call_count >= agent.max_iterations - 1
             ):
                 if _is_local_processing_error:
                     _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
                     final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
+                elif (
+                    consecutive_outer_loop_errors
+                    >= _MAX_CONSECUTIVE_OUTER_LOOP_ERRORS
+                ):
+                    _turn_exit_reason = (
+                        "outer_loop_error_retry_exhausted"
+                        f"({error_msg[:80]})"
+                    )
+                    final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                 else:
                     _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
                     final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
@@ -8391,6 +8412,18 @@ def run_conversation(
                 # session resume (avoids consecutive user messages).
                 append_message(messages, {"role": "assistant", "content": final_response})
                 break
+            _outer_error_delay = 2 ** (consecutive_outer_loop_errors - 1)
+            logger.warning(
+                "Retrying outer loop after post-response error in %ss "
+                "(failure %d/%d)",
+                _outer_error_delay,
+                consecutive_outer_loop_errors,
+                _MAX_CONSECUTIVE_OUTER_LOOP_ERRORS,
+            )
+            time.sleep(_outer_error_delay)
+        finally:
+            if not _outer_loop_failed:
+                consecutive_outer_loop_errors = 0
     
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled

--- a/tests/run_agent/test_outer_loop_error_retry.py
+++ b/tests/run_agent/test_outer_loop_error_retry.py
@@ -158,3 +158,39 @@ def test_successful_tool_iteration_resets_outer_loop_error_streak():
     assert api_call.call_count == 5
     assert result["final_response"] == "recovered after progress"
     assert sleep.call_args_list == [call(1), call(1), call(2)]
+
+
+def test_outer_loop_error_near_iteration_limit_is_failed_not_completed():
+    """A terminal outer-loop error must not be reported as a successful turn."""
+    agent = _make_agent()
+    agent.max_iterations = 2
+    response = _mock_response("ignored")
+    transport = agent._get_transport()
+    original_normalize = transport.normalize_response
+    normalize_calls = 0
+
+    def fail_outer_normalization(raw_response, **kwargs):
+        nonlocal normalize_calls
+        normalize_calls += 1
+        if normalize_calls == 2:
+            raise RuntimeError("normalization failed near iteration limit")
+        return original_normalize(raw_response, **kwargs)
+
+    with (
+        patch.object(agent, "_interruptible_api_call", return_value=response),
+        patch.object(
+            transport,
+            "normalize_response",
+            side_effect=fail_outer_normalization,
+        ),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("agent.conversation_loop._sleep_outer_loop_error_backoff") as sleep,
+    ):
+        result = agent.run_conversation("hello")
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["turn_exit_reason"].startswith("error_near_max_iterations(")
+    sleep.assert_not_called()

--- a/tests/run_agent/test_outer_loop_error_retry.py
+++ b/tests/run_agent/test_outer_loop_error_retry.py
@@ -100,6 +100,8 @@ def test_persistent_outer_loop_error_is_bounded_and_backed_off():
     assert outer_failures == 3
     assert "encountered repeated errors" in result["final_response"]
     assert "permanent normalization failure" in result["final_response"]
+    assert result["failed"] is True
+    assert result["completed"] is False
     assert sleep.call_args_list == [call(1), call(2)]
 
 

--- a/tests/run_agent/test_outer_loop_error_retry.py
+++ b/tests/run_agent/test_outer_loop_error_retry.py
@@ -1,0 +1,158 @@
+"""Regression coverage for bounded post-response error retries (#92450)."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+from run_agent import AIAgent
+
+
+def _make_agent() -> AIAgent:
+    tool_definition = {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[tool_definition]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai-compat",
+            model="test-model",
+            max_iterations=sys.maxsize,
+            enabled_toolsets=[],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    return agent
+
+
+def _mock_response(content: str):
+    message = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test-model", usage=None)
+
+
+def _mock_tool_response():
+    tool_call = SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments="{}"),
+    )
+    message = SimpleNamespace(
+        content=None,
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=[tool_call],
+    )
+    choice = SimpleNamespace(message=message, finish_reason="tool_calls")
+    return SimpleNamespace(choices=[choice], model="test-model", usage=None)
+
+
+def test_persistent_outer_loop_error_is_bounded_and_backed_off():
+    """Unlimited useful turns must not imply unlimited post-response failures."""
+    agent = _make_agent()
+    response = _mock_response("eventually recovered")
+    transport = agent._get_transport()
+    original_normalize = transport.normalize_response
+    normalize_calls = 0
+    outer_failures = 0
+
+    def fail_four_outer_normalizations(raw_response, **kwargs):
+        nonlocal normalize_calls, outer_failures
+        normalize_calls += 1
+        # The retry layer first normalizes once to inspect finish_reason. The
+        # outer post-response block normalizes the same response again. Fail
+        # only that second call so the exception reaches the handler under
+        # test instead of the separately bounded provider retry path.
+        if normalize_calls % 2 == 0 and outer_failures < 4:
+            outer_failures += 1
+            raise RuntimeError("permanent normalization failure")
+        return original_normalize(raw_response, **kwargs)
+
+    with (
+        patch.object(agent, "_interruptible_api_call", return_value=response) as api_call,
+        patch.object(
+            transport,
+            "normalize_response",
+            side_effect=fail_four_outer_normalizations,
+        ),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("agent.conversation_loop.time.sleep") as sleep,
+    ):
+        result = agent.run_conversation("hello")
+
+    assert api_call.call_count == 3
+    assert normalize_calls == 6
+    assert outer_failures == 3
+    assert "encountered repeated errors" in result["final_response"]
+    assert "permanent normalization failure" in result["final_response"]
+    assert sleep.call_args_list == [call(1), call(2)]
+
+
+def test_successful_tool_iteration_resets_outer_loop_error_streak():
+    """A successful useful iteration starts a fresh failure episode."""
+    agent = _make_agent()
+    transport = agent._get_transport()
+    original_normalize = transport.normalize_response
+    response_by_attempt = [
+        _mock_response("ignored"),
+        _mock_tool_response(),
+        _mock_response("ignored"),
+        _mock_response("ignored"),
+        _mock_response("recovered after progress"),
+    ]
+    normalize_calls_by_attempt: dict[int, int] = {}
+
+    def fail_selected_outer_normalizations(raw_response, **kwargs):
+        attempt = agent._api_call_count
+        normalize_calls_by_attempt[attempt] = normalize_calls_by_attempt.get(attempt, 0) + 1
+        if attempt in {1, 3, 4} and normalize_calls_by_attempt[attempt] == 2:
+            raise RuntimeError("episode-scoped normalization failure")
+        return original_normalize(raw_response, **kwargs)
+
+    def append_tool_result(_assistant_message, messages, *_args):
+        messages.append(
+            {
+                "role": "tool",
+                "name": "web_search",
+                "tool_call_id": "call_1",
+                "content": "ok",
+            }
+        )
+
+    with (
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            side_effect=response_by_attempt,
+        ) as api_call,
+        patch.object(
+            transport,
+            "normalize_response",
+            side_effect=fail_selected_outer_normalizations,
+        ),
+        patch.object(agent, "_execute_tool_calls", side_effect=append_tool_result),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch("agent.conversation_loop.time.sleep") as sleep,
+    ):
+        result = agent.run_conversation("hello")
+
+    assert api_call.call_count == 5
+    assert result["final_response"] == "recovered after progress"
+    assert sleep.call_args_list == [call(1), call(1), call(2)]

--- a/tests/run_agent/test_outer_loop_error_retry.py
+++ b/tests/run_agent/test_outer_loop_error_retry.py
@@ -91,7 +91,7 @@ def test_persistent_outer_loop_error_is_bounded_and_backed_off():
         patch.object(agent, "_persist_session"),
         patch.object(agent, "_save_trajectory"),
         patch.object(agent, "_cleanup_task_resources"),
-        patch("agent.conversation_loop.time.sleep") as sleep,
+        patch("agent.conversation_loop._sleep_outer_loop_error_backoff") as sleep,
     ):
         result = agent.run_conversation("hello")
 
@@ -149,7 +149,7 @@ def test_successful_tool_iteration_resets_outer_loop_error_streak():
         patch.object(agent, "_persist_session"),
         patch.object(agent, "_save_trajectory"),
         patch.object(agent, "_cleanup_task_resources"),
-        patch("agent.conversation_loop.time.sleep") as sleep,
+        patch("agent.conversation_loop._sleep_outer_loop_error_backoff") as sleep,
     ):
         result = agent.run_conversation("hello")
 


### PR DESCRIPTION
## Summary

- cap consecutive post-response outer-loop failures independently of the unlimited useful-turn budget
- reset the failure streak after any successful tool iteration
- back off for 1s and 2s before the terminal third consecutive failure
- add full-loop regressions for both bounded failure and streak reset after progress

## Test plan

- `scripts/run_tests.sh tests/run_agent/test_outer_loop_error_retry.py -q`

## Related Issue

Fixes #92450
