### PR TITLE
fix(model): recover legacy named-custom-provider routes from model field

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -775,6 +775,36 @@ def init_agent(
     except Exception:
         pass  # Non-fatal — transport may not exist for all modes yet
 
+    # Older Desktop sessions could persist a named custom route inside the
+    # model field as ``<provider-name>:<model>`` while retaining only the
+    # generic ``custom`` provider.  OpenAI-compatible endpoints receive the
+    # model field verbatim, so e.g. ``qwen-token-plan:qwen3.8-max`` reaches
+    # the Token Plan API and is rejected with HTTP 404 "Model not exist".
+    #
+    # Recover this legacy serialization only when the prefix matches the
+    # configured custom provider that owns the active endpoint.  This keeps
+    # genuine colon-bearing model IDs intact for other custom endpoints.
+    if agent.provider == "custom" and ":" in str(agent.model or ""):
+        try:
+            from hermes_cli.runtime_provider import canonical_custom_identity
+
+            legacy_prefix, legacy_model = str(agent.model).split(":", 1)
+            identity = canonical_custom_identity(
+                base_url=agent.base_url,
+                model=legacy_model,
+            )
+            if (
+                identity
+                and legacy_model.strip()
+                and identity.split(":", 1)[-1].lower() == legacy_prefix.strip().lower()
+            ):
+                agent.model = legacy_model.strip()
+                agent.provider = identity
+                if agent.requested_provider == "custom":
+                    agent.requested_provider = identity
+        except Exception:
+            pass
+
     try:
         from hermes_cli.model_normalize import (
             _AGGREGATOR_PROVIDERS,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1500,6 +1500,28 @@ def switch_model(
     target_provider = current_provider
     resolved_moa_preset = False
 
+    # Named custom providers also accept the compact triple form used by the
+    # model parser: ``custom:<provider-name>:<model-id>``.  Without this
+    # normalization, the CLI slash worker could report a successful switch
+    # while the Desktop gateway attempted to validate the entire triple as a
+    # model ID on the *previous* provider.  Keep unknown triples untouched so
+    # they retain the normal, useful validation error.
+    if not explicit_provider and new_model.lower().startswith("custom:"):
+        custom_spec = new_model[len("custom:") :]
+        custom_name, separator, custom_model = custom_spec.partition(":")
+        candidate_provider = f"custom:{custom_name.strip()}" if custom_name.strip() else ""
+        if separator and custom_model.strip() and candidate_provider:
+            try:
+                if resolve_provider_full(
+                    candidate_provider, user_providers, custom_providers
+                ) is not None:
+                    explicit_provider = candidate_provider
+                    new_model = custom_model.strip()
+            except Exception:
+                # Leave malformed/unresolvable input to the regular switch
+                # pipeline below, which owns the user-facing error copy.
+                pass
+
     # =================================================================
     # PATH A: Explicit --provider given
     # =================================================================


### PR DESCRIPTION
## Bug Description

Older Desktop sessions could persist a **named custom provider route inside the model field** as `<provider-name>:<model>` while retaining only the generic `custom` provider. OpenAI-compatible endpoints receive the model field verbatim, so e.g. `qwen-token-plan:qwen3.8-max` reaches the Token Plan API and is rejected with **HTTP 404 "Model not exist"** — even though the model itself exists.

A related path: the CLI slash command accepts the compact triple form `custom:<provider-name>:<model-id>` for named custom providers. Without normalization, the switch could report success while the Desktop gateway validated the *entire triple* as a model ID on the **previous** provider.

## Root Cause

Legacy serialization conflated provider identity with the model string. The request builder sends the model field verbatim to OpenAI-compatible endpoints, and neither `init_agent` nor `switch_model` split the legacy `<name>:<model>` compound back apart.

## Fix

- **`agent/agent_init.py`** — when the provider is bare `custom` and the model carries a colon prefix that matches the configured custom provider owning the active endpoint, recover the route via `canonical_custom_identity` (restores `provider = custom:<name>`, `model = <model-id>`). Genuine colon-bearing model IDs on other endpoints are left intact; recovery only fires on an exact provider-name match.
- **`hermes_cli/model_switch.py`** — normalize the compact `custom:<name>:<model>` triple *before* validation: resolve the provider via `resolve_provider_full`, then switch with a clean provider/model pair. Unknown or malformed triples are deliberately left untouched so they still produce the regular, useful validation error.

## How to Verify

1. Configure a named custom provider (e.g. `custom:qwen-token-plan` pointing at an OpenAI-compatible Token Plan endpoint).
2. Simulate the legacy Desktop state: provider `custom`, model `qwen-token-plan:qwen3.8-max`. Before the fix: HTTP 404 "Model not exist". After: agent starts and routes to `custom:qwen-token-plan` / `qwen3.8-max`.
3. Run `switch_model("custom:qwen-token-plan:qwen3.8-max")` with no explicit provider — the switch now validates against the named provider, not the previous one.

## Test Plan

- [x] Manual verification of the fix
- [ ] Existing tests still pass

## Risk Assessment

Low — both recoveries are guarded: `agent_init` only fires for provider `custom` with a prefix that exactly matches the configured custom provider for the active endpoint (other colon-bearing model IDs untouched), and `model_switch` only normalizes triples whose provider resolves, delegating everything else to the existing error path.
