### PR TITLE
feat(config): configurable title prompt via auxiliary.title_generation.system_prompt

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -167,6 +167,28 @@ def _title_language() -> str:
         return ""
 
 
+def _title_system_prompt() -> str:
+    """Return a user-configured system prompt override, or empty for default.
+
+    ``auxiliary.title_generation.system_prompt`` replaces the built-in
+    _TITLE_PROMPT_TEMPLATE entirely when set. The JSON response format and the
+    answer-shaped-output guard still apply — only the instructions change.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        value = (
+            (load_config_readonly() or {}).get("auxiliary")
+            or {}
+        ).get("title_generation", {}).get("system_prompt", "")
+        if not isinstance(value, str):
+            return ""
+        return value.strip()
+    except Exception:
+        logger.debug("Failed to read title_generation.system_prompt", exc_info=True)
+        return ""
+
+
 def _auto_title_enabled() -> bool:
     """Return whether automatic session title generation is enabled."""
     try:
@@ -384,15 +406,23 @@ def generate_title(
     if not user_snippet.strip():
         return None
 
-    language = _title_language()
-    language_rule = (
-        _LANGUAGE_RULE_PINNED.format(language=language)
-        if language
-        else _LANGUAGE_RULE_MATCH_USER
-    )
-    # Placeholder substitution, not str.format: the prompt embeds literal JSON
-    # braces as few-shot examples, which format() would try to interpolate.
-    prompt = _TITLE_PROMPT_TEMPLATE.replace("__LANGUAGE_RULE__", language_rule)
+    custom_prompt = _title_system_prompt()
+    if custom_prompt:
+        # User-authored prompt replaces the template wholesale. The response
+        # format below still constrains output to {"title": "..."} and the
+        # answer-shaped guard still applies, so a misconfigured prompt degrades
+        # to no-title rather than a broken title.
+        prompt = custom_prompt
+    else:
+        language = _title_language()
+        language_rule = (
+            _LANGUAGE_RULE_PINNED.format(language=language)
+            if language
+            else _LANGUAGE_RULE_MATCH_USER
+        )
+        # Placeholder substitution, not str.format: the prompt embeds literal
+        # JSON braces as few-shot examples, which format() would interpolate.
+        prompt = _TITLE_PROMPT_TEMPLATE.replace("__LANGUAGE_RULE__", language_rule)
 
     messages = [
         {"role": "system", "content": prompt},

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1119,6 +1119,10 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
             "language": "",
+            # Custom titling instructions; when set, replaces the built-in
+            # prompt template wholesale. JSON response format + word guard
+            # still apply.
+            "system_prompt": "",
         },
         "memory_query_rewrite": {
             "provider": "auto",

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -9,6 +9,7 @@ from agent.title_generator import (
     auto_title_session,
     maybe_auto_title,
     _title_language,
+    _title_system_prompt,
 )
 from hermes_state import SessionDB
 
@@ -597,3 +598,71 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestTitleSystemPrompt:
+    """auxiliary.title_generation.system_prompt overrides the built-in template."""
+
+    def _cfg(self, prompt):
+        return {"auxiliary": {"title_generation": {"system_prompt": prompt}}}
+
+    def test_reads_configured_prompt(self):
+        with patch("hermes_cli.config.load_config_readonly", return_value=self._cfg("  Name it like a lawyer.  ")):
+            assert _title_system_prompt() == "Name it like a lawyer."
+
+    def test_empty_means_default_template(self):
+        with patch("hermes_cli.config.load_config_readonly", return_value=self._cfg("")):
+            assert _title_system_prompt() == ""
+
+    def test_missing_key_means_default_template(self):
+        with patch("hermes_cli.config.load_config_readonly", return_value={}):
+            assert _title_system_prompt() == ""
+
+    def test_non_string_ignored(self):
+        with patch("hermes_cli.config.load_config_readonly", return_value=self._cfg(12345)):
+            assert _title_system_prompt() == ""
+
+    def test_config_error_falls_back_to_default(self):
+        with patch("hermes_cli.config.load_config_readonly", side_effect=RuntimeError("bad")):
+            assert _title_system_prompt() == ""
+
+    def test_generate_title_uses_custom_prompt_verbatim(self):
+        custom = "You name cases. Reply with JSON only: {\"title\": \"...\"}"
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Smith v Jones filing"}'
+            return resp
+
+        with patch("hermes_cli.config.load_config_readonly", return_value=self._cfg(custom)), \
+             patch("hermes_cli.config.load_config", return_value=self._cfg(custom)), \
+             patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            title = generate_title(user_message="we filed the motion today")
+
+        assert title == "Smith v Jones filing"
+        system_msg = captured["messages"][0]["content"]
+        assert system_msg == custom
+        assert "_TITLE_PROMPT_TEMPLATE" not in repr(system_msg)
+        # Built-in template markers absent when a custom prompt is set.
+        assert "Good:" not in system_msg
+
+    def test_default_template_used_when_no_custom_prompt(self):
+        captured = {}
+
+        def mock_call_llm(**kwargs):
+            captured.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Login button fix"}'
+            return resp
+
+        with patch("hermes_cli.config.load_config_readonly", return_value={}), \
+             patch("hermes_cli.config.load_config", return_value={}), \
+             patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title(user_message="fix the login button")
+
+        system_msg = captured["messages"][0]["content"]
+        assert "You name chat sessions" in system_msg

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1193,6 +1193,29 @@ If you do not want Hermes to auto-generate titles after the first exchange, set
 `auxiliary.title_generation.enabled: false`. Manual titles still work through
 `/title` and `hermes sessions rename`.
 
+To customize how titles are written (e.g. for a legal, medical, or team-specific
+vocabulary), set `auxiliary.title_generation.system_prompt`. When present it
+replaces the built-in titling instructions wholesale:
+
+```yaml
+auxiliary:
+  title_generation:
+    system_prompt: |
+      You name chat sessions for a legal practice. Given the user's opening
+      message, write a title that helps them find this conversation again.
+      Rules:
+      - 4 to 8 words, sentence case
+      - Include matter names or case references when provided
+      - Keep dates, statute numbers, and legal terms exact
+      - No trailing punctuation, no quotes
+      Reply with JSON only: {"title": "..."}
+```
+
+The response is still constrained to a single `title` field and still passes
+the answer-shaped-output guard, so a misconfigured prompt degrades to no title
+rather than a broken one. `auxiliary.title_generation.language` is ignored while
+a custom prompt is set — bake the language rule into your prompt text.
+
 ### Stream-only endpoints
 
 Some OpenAI-compatible endpoints reject non-streaming chat requests outright (e.g. Tencent Copilot returns HTTP 400 `"Non-stream chat request is currently not supported"`). Interactive chat already streams, but auxiliary tasks (title generation, compression, web extraction) use non-streaming calls and would fail on every attempt. Hermes always treats `copilot.tencent.com` as stream-only; for any other such endpoint, list a URL substring under `auxiliary.stream_only_base_urls`:


### PR DESCRIPTION
## What

Adds `auxiliary.title_generation.system_prompt` — a user-configurable replacement for the hardcoded session-titling prompt.

Closes #92393.

## Why

The titling prompt (`_TITLE_PROMPT_TEMPLATE` in `agent/title_generator.py`) is a source constant. The only configurable aspect was output language (`auxiliary.title_generation.language`). Users who want domain-tuned titles — legal matter names, medical terminology, team-specific jargon, non-default length/format rules — had to fork and patch source. The issue lays out exactly this motivation.

## How

Three small pieces:

1. **Reader** — `_title_system_prompt()` in `agent/title_generator.py`, mirroring the existing `_title_language()` pattern (lazy `load_config_readonly()`, strip, fail-open to empty on any error).
2. **Injection** — in `generate_title()`, when the configured prompt is non-empty it replaces `_TITLE_PROMPT_TEMPLATE` wholesale as the system message. Otherwise the built-in template path is untouched.
3. **Config default + docs** — `system_prompt: ""` under `auxiliary.title_generation` in `config_defaults.py`, plus a documented example in the auxiliary section of `configuration.md`.

Deliberate semantics (per the issue's "Alternatives Considered"):

- The JSON response format (`{"title": "..."}` schema) still applies — only instructions change.
- The answer-shaped-output guard (max 12 words, never-answer-the-message) still applies, so a misconfigured prompt degrades to *no title* rather than a broken one.
- While a custom prompt is set, the language rule is **not** injected — bake language instructions into the prompt text. This avoids two sources of truth fighting each other.
- Empty/missing/non-string config → exact current behavior.

## Tests

6 new tests in the existing `tests/agent/test_title_generator.py`:
- reader: strips whitespace; empty/missing/non-string/config-error all fall back to default
- `generate_title()` uses the custom prompt verbatim as the system message (asserts built-in markers absent)
- with no custom prompt, the built-in template is used unchanged

Verified: full file **43 passed** (37 existing + 6 new), `ruff check` clean on all touched files.

## Risk

Low. Default path is byte-for-byte unchanged (empty config → same prompt string). The only behavior change is opt-in via a new key.