### PR TITLE
feat(dashboard): add policy-pinned embedded chat

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1546,6 +1546,13 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
+        # Optional cross-origin chat-only embeds. Each embed ID pins the PTY to
+        # one profile server-side; the browser cannot switch it by editing
+        # ``?profile=``. External framing and lifecycle postMessage events are
+        # limited to exact origins in ``embed_parent_origins``. Empty defaults
+        # keep third-party embedding disabled.
+        "embed_parent_origins": [],
+        "embed_profiles": {},
         # OAuth gate configuration (engaged when ``--host`` is set and
         # ``--insecure`` is not). The bundled Nous Portal plugin reads
         # both keys at startup; they are the canonical surface for these

--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -230,3 +230,16 @@ def resolve_public_url() -> str:
     if not cfg_clean:
         _warn_if_malformed("dashboard.public_url in config.yaml", cfg_raw)
     return cfg_clean
+
+
+def public_url_path_prefix() -> str:
+    """Return the path prefix declared by ``dashboard.public_url``.
+
+    ``public_url`` is the authoritative external address.  Reverse proxies
+    often strip its path before forwarding, so callback redirects cannot
+    recover that path from ``request.url`` alone.
+    """
+    public_url = resolve_public_url()
+    if not public_url:
+        return ""
+    return normalise_prefix(urllib.parse.urlparse(public_url).path)

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -588,6 +588,19 @@ async def auth_callback(
     # that lets attacker-controlled bytes into the cookie would otherwise
     # produce an open redirect.
     landing = _validate_post_login_target(next_from_cookie) or "/"
+    # Keep the browser inside a reverse-proxy mount after the OAuth callback.
+    # APIM/nginx commonly strip the external prefix before forwarding, so a
+    # bare ``Location: /`` escapes the mapped dashboard and lands on the
+    # public host root.  Prefer the configured public URL (the operator's
+    # source of truth), with X-Forwarded-Prefix as the compatibility fallback.
+    from hermes_cli.dashboard_auth.prefix import public_url_path_prefix
+
+    external_prefix = public_url_path_prefix() or _prefix(request)
+    if external_prefix and not (
+        landing == external_prefix
+        or landing.startswith(f"{external_prefix}/")
+    ):
+        landing = f"{external_prefix}{landing}"
     resp = RedirectResponse(url=landing, status_code=302)
     set_session_cookies(
         resp,

--- a/hermes_cli/dashboard_embed.py
+++ b/hermes_cli/dashboard_embed.py
@@ -1,0 +1,100 @@
+"""Security policy helpers for embedding the dashboard chat surface."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+
+_EMBED_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_PROFILE_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_ORIGIN_NETLOC_RE = re.compile(r"^(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::[0-9]{1,5})?$")
+
+
+class EmbedPolicyError(ValueError):
+    """The requested embedded-chat scope is not allowed by dashboard config."""
+
+
+def _dashboard(config: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = config.get("dashboard")
+    return value if isinstance(value, Mapping) else {}
+
+
+def configured_embed_parent_origins(config: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return unique exact HTTP(S) origins accepted as embed parents."""
+    raw = _dashboard(config).get("embed_parent_origins")
+    if not isinstance(raw, list):
+        return ()
+
+    result: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        candidate = item.strip()
+        # This value is interpolated into a CSP response header. Keep the
+        # accepted surface ASCII-origin-only and reject percent-encoded control
+        # sequences rather than relying on downstream header normalization.
+        if "%" in candidate or any(ord(ch) < 0x21 or ord(ch) > 0x7E for ch in candidate):
+            continue
+        try:
+            parsed = urlsplit(candidate)
+        except ValueError:
+            continue
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            continue
+        if not _ORIGIN_NETLOC_RE.fullmatch(parsed.netloc):
+            continue
+        try:
+            _ = parsed.port
+        except ValueError:
+            continue
+        if parsed.path or parsed.query or parsed.fragment or parsed.username or parsed.password:
+            continue
+        origin = f"{parsed.scheme}://{parsed.netloc}"
+        if origin == candidate and origin not in result:
+            result.append(origin)
+    return tuple(result)
+
+
+def configured_embed_profiles(config: Mapping[str, Any]) -> dict[str, str]:
+    """Return validated embed IDs mapped to normalized profile scopes."""
+    raw = _dashboard(config).get("embed_profiles")
+    if not isinstance(raw, Mapping):
+        return {}
+    result: dict[str, str] = {}
+    for raw_id, raw_profile in raw.items():
+        if not isinstance(raw_id, str) or not _EMBED_ID_RE.fullmatch(raw_id):
+            continue
+        if not isinstance(raw_profile, str):
+            continue
+        profile = raw_profile.strip().lower()
+        if profile == "default":
+            profile = ""
+        elif not _PROFILE_RE.fullmatch(profile):
+            continue
+        result[raw_id] = profile
+    return result
+
+
+def resolve_embedded_profile(
+    config: Mapping[str, Any], embed_id: str, requested_profile: str | None
+) -> str | None:
+    """Resolve an embed ID to its configured immutable profile scope."""
+    embed_id = (embed_id or "").strip()
+    if not _EMBED_ID_RE.fullmatch(embed_id):
+        raise EmbedPolicyError("embed id is invalid")
+
+    profiles = configured_embed_profiles(config)
+    if embed_id not in profiles:
+        raise EmbedPolicyError(f"embed id {embed_id!r} is not configured")
+
+    pinned = profiles[embed_id]
+
+    requested = (requested_profile or "").strip().lower()
+    if requested == "default":
+        requested = ""
+    if requested != pinned:
+        raise EmbedPolicyError(
+            f"embed id {embed_id!r} does not permit profile {requested_profile or 'default'!r}"
+        )
+    return pinned or None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -523,6 +523,18 @@ def _apply_ssh_owner_nonce(nonce: Optional[str]) -> None:
 # injection share a single, testable seam.
 _DASHBOARD_EMBEDDED_CHAT_ENABLED = True
 
+
+def _resolve_pty_embed_profile(
+    embed_id: Optional[str], requested_profile: Optional[str]
+) -> Optional[str]:
+    """Resolve a configured chat embed to its immutable profile scope."""
+    if not embed_id:
+        return requested_profile
+    from hermes_cli.dashboard_embed import resolve_embedded_profile
+
+    return resolve_embedded_profile(load_config(), embed_id, requested_profile)
+
+
 # Desktop's file.attach compatibility transport sends a complete base64 data
 # URL in one JSON-RPC frame. Uvicorn defaults to 16 MiB, which rejects files at
 # the preview ceiling before the dispatcher sees them. Keep the gateway
@@ -17027,6 +17039,15 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=4408, reason=_ws_close_reason(client_reason))
         return
 
+    raw_profile = ws.query_params.get("profile") or None
+    embed_id = ws.query_params.get("embed") or None
+    try:
+        profile = _resolve_pty_embed_profile(embed_id, raw_profile)
+    except ValueError as exc:
+        _log.warning("pty refused: embed policy rejected peer=%s reason=%s", peer, exc)
+        await ws.close(code=4403, reason=_ws_close_reason("embed policy rejected"))
+        return
+
     await ws.accept()
     _log.info("pty accepted peer=%s mode=%s cred=%s", peer, mode, cred)
 
@@ -17045,7 +17066,6 @@ async def pty_ws(ws: WebSocket) -> None:
     # --- spawn PTY ------------------------------------------------------
     raw_resume = ws.query_params.get("resume") or None
     resume = raw_resume
-    profile = ws.query_params.get("profile") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
     force_fresh = (ws.query_params.get("fresh") or "").strip().lower() in {
@@ -17415,7 +17435,7 @@ def mount_spa(application: FastAPI):
 
     _index_path = WEB_DIST / "index.html"
 
-    def _serve_index(prefix: str = ""):
+    def _serve_index(prefix: str = "", *, embedded_request: bool = False):
         """Return index.html with the session token + base-path injected.
 
         ``prefix`` is the normalised ``X-Forwarded-Prefix`` (e.g. ``/hermes``)
@@ -17442,12 +17462,24 @@ def mount_spa(application: FastAPI):
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         gated = bool(getattr(app.state, "auth_required", False))
         gated_js = "true" if gated else "false"
+        from hermes_cli.dashboard_embed import (
+            configured_embed_parent_origins,
+            configured_embed_profiles,
+        )
+
+        dashboard_config = load_config()
+        embed_parent_origins = configured_embed_parent_origins(dashboard_config)
+        embed_profiles = configured_embed_profiles(dashboard_config)
+        embed_origins_js = json.dumps(list(embed_parent_origins), separators=(",", ":"))
+        embed_profiles_js = json.dumps(embed_profiles, separators=(",", ":"))
         if gated:
             bootstrap_script = (
                 f"<script>"
                 f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
                 f'window.__HERMES_BASE_PATH__="{prefix}";'
                 f"window.__HERMES_AUTH_REQUIRED__={gated_js};"
+                f"window.__HERMES_DASHBOARD_EMBED_PARENT_ORIGINS__={embed_origins_js};"
+                f"window.__HERMES_DASHBOARD_EMBED_PROFILES__={embed_profiles_js};"
                 f"</script>"
             )
         else:
@@ -17456,6 +17488,8 @@ def mount_spa(application: FastAPI):
                 f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
                 f'window.__HERMES_BASE_PATH__="{prefix}";'
                 f"window.__HERMES_AUTH_REQUIRED__={gated_js};"
+                f"window.__HERMES_DASHBOARD_EMBED_PARENT_ORIGINS__={embed_origins_js};"
+                f"window.__HERMES_DASHBOARD_EMBED_PROFILES__={embed_profiles_js};"
                 f"</script>"
             )
         if prefix:
@@ -17478,10 +17512,11 @@ def mount_spa(application: FastAPI):
         if theme_bootstrap:
             html = html.replace("</head>", f"{theme_bootstrap}</head>", 1)
         html = html.replace("</head>", f"{bootstrap_script}</head>", 1)
-        return HTMLResponse(
-            html,
-            headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
-        )
+        headers = {"Cache-Control": "no-store, no-cache, must-revalidate"}
+        if embedded_request:
+            ancestors = " ".join(("'self'", *embed_parent_origins))
+            headers["Content-Security-Policy"] = f"frame-ancestors {ancestors}"
+        return HTMLResponse(html, headers=headers)
 
     # When served behind a path-prefix proxy, the built CSS contains
     # absolute ``url(/fonts/...)`` and ``url(/ds-assets/...)`` references.
@@ -17554,7 +17589,7 @@ def mount_spa(application: FastAPI):
             and file_path.is_file()
         ):
             return FileResponse(file_path)
-        return _serve_index(prefix)
+        return _serve_index(prefix, embedded_request=bool(request.query_params.get("embed")))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_401_reauth.py
+++ b/tests/hermes_cli/test_dashboard_auth_401_reauth.py
@@ -483,6 +483,23 @@ class TestAuthCallbackNext:
         assert r.status_code == 302
         assert r.headers["location"] == "/sessions"
 
+    def test_callback_uses_public_url_path_prefix(
+        self, gated_app, monkeypatch
+    ):
+        """A prefixed public_url is the redirect source of truth.
+
+        Reverse proxies commonly strip the external prefix before the request
+        reaches FastAPI.  The callback must still land inside that prefix,
+        rather than emitting ``Location: /`` and escaping the mapped API.
+        """
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_PUBLIC_URL",
+            "https://dashboard.example.test/hermes",
+        )
+        r = self._drive_oauth_via_login(gated_app)
+        assert r.status_code == 302
+        assert r.headers["location"] == "/hermes/"
+
 
     def test_attacker_callback_next_param_is_ignored(self, gated_app):
         """Hardening: even if an attacker crafts a callback URL with a

--- a/tests/hermes_cli/test_dashboard_embed.py
+++ b/tests/hermes_cli/test_dashboard_embed.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.dashboard_embed import (
+    EmbedPolicyError,
+    configured_embed_parent_origins,
+    resolve_embedded_profile,
+)
+
+
+def _config():
+    return {
+        "dashboard": {
+            "embed_parent_origins": ["https://console.runi.services"],
+            "embed_profiles": {
+                "console-hermes": "default",
+                "console-wolf": "wolf",
+            },
+        }
+    }
+
+
+def test_embed_profile_is_pinned_by_server_policy():
+    assert resolve_embedded_profile(_config(), "console-wolf", "wolf") == "wolf"
+    assert resolve_embedded_profile(_config(), "console-hermes", None) is None
+
+    with pytest.raises(EmbedPolicyError, match="does not permit profile"):
+        resolve_embedded_profile(_config(), "console-wolf", "torkil")
+
+
+def test_unknown_embed_id_fails_closed():
+    with pytest.raises(EmbedPolicyError, match="not configured"):
+        resolve_embedded_profile(_config(), "console-torkil", "torkil")
+
+
+def test_parent_origins_are_exact_http_origins():
+    config = _config()
+    config["dashboard"]["embed_parent_origins"].extend(
+        [
+            "https://console.runi.services/path",
+            "javascript:alert(1)",
+            "https://evil.example%0d%0aX-Frame-Options:ALLOWALL",
+            "https://evil.example;frame-ancestors*",
+            "https://console.runi.services",
+        ]
+    )
+    assert configured_embed_parent_origins(config) == (
+        "https://console.runi.services",
+    )
+
+
+def test_websocket_embed_scope_uses_live_dashboard_config(monkeypatch):
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(web_server, "load_config", _config)
+    assert web_server._resolve_pty_embed_profile("console-wolf", "wolf") == "wolf"
+    with pytest.raises(EmbedPolicyError):
+        web_server._resolve_pty_embed_profile("console-wolf", "torkil")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import {
   Navigate,
   useLocation,
   useNavigate,
+  useSearchParams,
 } from "react-router";
 import {
   Activity,
@@ -73,6 +74,8 @@ import { useProfileScope } from "@/contexts/useProfileScope";
 import { ProfileSwitcher } from "@/components/ProfileSwitcher";
 import { ProfileScopeBanner } from "@/components/ProfileScopeBanner";
 import { MemoryPressureBanner } from "@/components/MemoryPressureBanner";
+import { EmbeddedChatHost } from "@/components/EmbeddedChatHost";
+import { parseDashboardEmbedRequest } from "@/lib/dashboard-embed";
 import { useSystemActions } from "@/contexts/useSystemActions";
 import type { SystemAction } from "@/contexts/system-actions-context";
 // Route pages are lazy-loaded so the initial dashboard shell does not pay for
@@ -372,6 +375,7 @@ const SIDEBAR_COLLAPSED_KEY = "hermes-sidebar-collapsed";
 export default function App() {
   const { t } = useI18n();
   const { pathname } = useLocation();
+  const [searchParams] = useSearchParams();
   const { manifests, loading: pluginsLoading } = usePlugins();
   const { theme } = useTheme();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -508,6 +512,29 @@ export default function App() {
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);
   }, []);
+
+  const embedRequested = isChatRoute && searchParams.has("embed");
+  const embedRequest = embedRequested
+    ? parseDashboardEmbedRequest(
+        searchParams,
+        window.__HERMES_DASHBOARD_EMBED_PARENT_ORIGINS__ ?? [],
+        window.__HERMES_DASHBOARD_EMBED_PROFILES__ ?? {},
+      )
+    : null;
+
+  if (embedRequested) {
+    return (
+      <PageHeaderProvider pluginTabs={[]}>
+        {embedRequest ? (
+          <EmbeddedChatHost request={embedRequest} />
+        ) : (
+          <main className="flex h-dvh items-center justify-center bg-black px-6 text-center text-sm text-white/75">
+            This embedded chat request is not allowed by the dashboard policy.
+          </main>
+        )}
+      </PageHeaderProvider>
+    );
+  }
 
   return (
     <ProfileProvider>

--- a/web/src/components/EmbeddedChatHost.test.tsx
+++ b/web/src/components/EmbeddedChatHost.test.tsx
@@ -46,6 +46,25 @@ afterEach(async () => {
 });
 
 describe("EmbeddedChatHost", () => {
+  it("posts ready to the parent origin once the authenticated iframe mounts", async () => {
+    const postMessage = vi.fn();
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      value: { postMessage },
+    });
+
+    await render(request);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: "hermes.dashboard.embed",
+        event: "ready",
+        embedId: "console-wolf",
+      },
+      "https://console.runi.services",
+    );
+  });
+
   it("renders the stripped terminal and announces readiness", async () => {
     const postMessage = vi.fn();
     Object.defineProperty(window, "parent", {
@@ -58,13 +77,17 @@ describe("EmbeddedChatHost", () => {
       .toContain('"embedded":true');
     expect(node.querySelector('[data-testid="chat-page"]')?.getAttribute("data-profile"))
       .toBe("wolf");
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: "hermes.dashboard.embed",
+        event: "ready",
+        embedId: "console-wolf",
+      },
+      "https://console.runi.services",
+    );
     await act(async () => {
       (chatMock.props?.onPtyStateChange as ((state: string) => void))("open");
     });
-    expect(postMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ event: "ready", embedId: "console-wolf" }),
-      "https://console.runi.services",
-    );
 
     await act(async () => {
       (chatMock.props?.onPtyStateChange as ((state: string) => void))("reconnecting");

--- a/web/src/components/EmbeddedChatHost.test.tsx
+++ b/web/src/components/EmbeddedChatHost.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { DashboardEmbedRequest } from "@/lib/dashboard-embed";
+import { useProfileScope } from "@/contexts/useProfileScope";
+
+const chatMock = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+
+vi.mock("@/pages/ChatPage", () => {
+  function MockChatPage(props: Record<string, unknown>) {
+    chatMock.props = props;
+    const { profile } = useProfileScope();
+    return <div data-testid="chat-page" data-profile={profile} data-props={JSON.stringify(props)} />;
+  }
+  return { default: MockChatPage };
+});
+
+import { EmbeddedChatHost } from "./EmbeddedChatHost";
+
+const request: DashboardEmbedRequest = {
+  authBridge: false,
+  embedId: "console-wolf",
+  parentOrigin: "https://console.runi.services",
+  profile: "wolf",
+};
+
+const mounted: Array<{ root: ReturnType<typeof createRoot>; node: HTMLDivElement }> = [];
+
+async function render(requestValue: DashboardEmbedRequest) {
+  const node = document.createElement("div");
+  document.body.append(node);
+  const root = createRoot(node);
+  mounted.push({ root, node });
+  await act(async () => root.render(<EmbeddedChatHost request={requestValue} />));
+  return node;
+}
+
+afterEach(async () => {
+  for (const { root, node } of mounted.splice(0)) {
+    await act(async () => root.unmount());
+    node.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("EmbeddedChatHost", () => {
+  it("renders the stripped terminal and announces readiness", async () => {
+    const postMessage = vi.fn();
+    Object.defineProperty(window, "parent", {
+      configurable: true,
+      value: { postMessage },
+    });
+
+    const node = await render(request);
+    expect(node.querySelector('[data-testid="chat-page"]')?.getAttribute("data-props"))
+      .toContain('"embedded":true');
+    expect(node.querySelector('[data-testid="chat-page"]')?.getAttribute("data-profile"))
+      .toBe("wolf");
+    await act(async () => {
+      (chatMock.props?.onPtyStateChange as ((state: string) => void))("open");
+    });
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "ready", embedId: "console-wolf" }),
+      "https://console.runi.services",
+    );
+
+    await act(async () => {
+      (chatMock.props?.onPtyStateChange as ((state: string) => void))("reconnecting");
+    });
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "reconnecting", embedId: "console-wolf" }),
+      "https://console.runi.services",
+    );
+  });
+
+  it("uses the OAuth bridge only to notify the opener and close", async () => {
+    const postMessage = vi.fn();
+    const close = vi.spyOn(window, "close").mockImplementation(() => {});
+    Object.defineProperty(window, "opener", {
+      configurable: true,
+      value: { postMessage },
+    });
+
+    const node = await render({ ...request, authBridge: true });
+    expect(node.querySelector('[data-testid="chat-page"]')).toBeNull();
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "authenticated" }),
+      "https://console.runi.services",
+    );
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/EmbeddedChatHost.tsx
+++ b/web/src/components/EmbeddedChatHost.tsx
@@ -38,6 +38,16 @@ export function EmbeddedChatHost({ request }: { request: DashboardEmbedRequest }
     window.close();
   }, [request.authBridge, request.embedId, request.parentOrigin]);
 
+  useEffect(() => {
+    if (request.authBridge) return;
+    postDashboardEmbedEvent(
+      window.parent,
+      request.parentOrigin,
+      "ready",
+      request.embedId,
+    );
+  }, [request.authBridge, request.embedId, request.parentOrigin]);
+
   const announcePtyState = useCallback(
     (state: PtyConnectionState) => {
       postDashboardEmbedEvent(

--- a/web/src/components/EmbeddedChatHost.tsx
+++ b/web/src/components/EmbeddedChatHost.tsx
@@ -1,0 +1,78 @@
+import { lazy, Suspense, useCallback, useEffect, useMemo } from "react";
+
+import type {
+  DashboardEmbedEvent,
+  DashboardEmbedRequest,
+} from "@/lib/dashboard-embed";
+import { postDashboardEmbedEvent } from "@/lib/dashboard-embed";
+import type { PtyConnectionState } from "@/lib/pty-reconnect";
+import { ProfileContext } from "@/contexts/profile-context";
+
+const ChatPage = lazy(() => import("@/pages/ChatPage"));
+
+function embedEventForPtyState(state: PtyConnectionState): DashboardEmbedEvent {
+  if (state === "open") return "ready";
+  if (state === "closed") return "disconnected";
+  return state;
+}
+
+export function EmbeddedChatHost({ request }: { request: DashboardEmbedRequest }) {
+  const profileScope = useMemo(
+    () => ({
+      profile: request.profile,
+      currentProfile: request.profile || "default",
+      profiles: [request.profile || "default"],
+      setProfile: () => {},
+    }),
+    [request.profile],
+  );
+
+  useEffect(() => {
+    if (!request.authBridge) return;
+    postDashboardEmbedEvent(
+      window.opener,
+      request.parentOrigin,
+      "authenticated",
+      request.embedId,
+    );
+    window.close();
+  }, [request.authBridge, request.embedId, request.parentOrigin]);
+
+  const announcePtyState = useCallback(
+    (state: PtyConnectionState) => {
+      postDashboardEmbedEvent(
+        window.parent,
+        request.parentOrigin,
+        embedEventForPtyState(state),
+        request.embedId,
+      );
+    },
+    [request.embedId, request.parentOrigin],
+  );
+
+  if (request.authBridge) {
+    return (
+      <div className="flex h-dvh items-center justify-center bg-black text-sm text-white/75">
+        Sign-in complete. You can close this window.
+      </div>
+    );
+  }
+
+  return (
+    <ProfileContext.Provider value={profileScope}>
+      <main
+        className="flex h-dvh max-h-dvh min-h-0 min-w-0 overflow-hidden bg-black"
+        data-dashboard-embed={request.embedId}
+      >
+        <Suspense fallback={<div className="h-full w-full bg-black" aria-label="Loading chat" />}>
+          <ChatPage
+            isActive
+            embedded
+            embedId={request.embedId}
+            onPtyStateChange={announcePtyState}
+          />
+        </Suspense>
+      </main>
+    </ProfileContext.Provider>
+  );
+}

--- a/web/src/lib/dashboard-embed.test.ts
+++ b/web/src/lib/dashboard-embed.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  parseDashboardEmbedRequest,
+  postDashboardEmbedEvent,
+} from "./dashboard-embed";
+
+describe("dashboard embedded chat contract", () => {
+  it("accepts only configured parent origins and keeps the embed id opaque", () => {
+    const request = parseDashboardEmbedRequest(
+      new URLSearchParams(
+        "embed=console-wolf&profile=wolf&parent_origin=https%3A%2F%2Fconsole.runi.services",
+      ),
+      ["https://console.runi.services"],
+      { "console-wolf": "wolf" },
+    );
+
+    expect(request).toEqual({
+      authBridge: false,
+      embedId: "console-wolf",
+      parentOrigin: "https://console.runi.services",
+      profile: "wolf",
+    });
+    expect(
+      parseDashboardEmbedRequest(
+        new URLSearchParams(
+          "embed=console-wolf&parent_origin=https%3A%2F%2Fevil.example",
+        ),
+        ["https://console.runi.services"],
+        { "console-wolf": "wolf" },
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects unknown embed ids and client profile drift", () => {
+    const origins = ["https://console.runi.services"];
+    const profiles = { "console-wolf": "wolf" };
+    expect(
+      parseDashboardEmbedRequest(
+        new URLSearchParams(
+          "embed=console-other&profile=wolf&parent_origin=https%3A%2F%2Fconsole.runi.services",
+        ),
+        origins,
+        profiles,
+      ),
+    ).toBeNull();
+    expect(
+      parseDashboardEmbedRequest(
+        new URLSearchParams(
+          "embed=console-wolf&profile=torkil&parent_origin=https%3A%2F%2Fconsole.runi.services",
+        ),
+        origins,
+        profiles,
+      ),
+    ).toBeNull();
+    expect(
+      parseDashboardEmbedRequest(
+        new URLSearchParams(
+          "embed=console-default&profile=default&parent_origin=https%3A%2F%2Fconsole.runi.services",
+        ),
+        origins,
+        { "console-default": "" },
+      )?.profile,
+    ).toBe("");
+  });
+
+  it("posts bounded lifecycle events only to the validated parent", () => {
+    const postMessage = vi.fn();
+    postDashboardEmbedEvent(
+      { postMessage },
+      "https://console.runi.services",
+      "ready",
+      "console-wolf",
+    );
+
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: "hermes.dashboard.embed",
+        event: "ready",
+        embedId: "console-wolf",
+      },
+      "https://console.runi.services",
+    );
+  });
+
+  it("marks the OAuth return bridge without starting a terminal", () => {
+    expect(
+      parseDashboardEmbedRequest(
+        new URLSearchParams(
+          "embed=console-hugin&auth_bridge=1&parent_origin=https%3A%2F%2Fconsole.runi.services",
+        ),
+        ["https://console.runi.services"],
+        { "console-hugin": "" },
+      )?.authBridge,
+    ).toBe(true);
+  });
+});

--- a/web/src/lib/dashboard-embed.ts
+++ b/web/src/lib/dashboard-embed.ts
@@ -1,0 +1,86 @@
+export type DashboardEmbedEvent =
+  | "authenticated"
+  | "ready"
+  | "connecting"
+  | "reconnecting"
+  | "disconnected"
+  | "ended";
+
+export interface DashboardEmbedRequest {
+  authBridge: boolean;
+  embedId: string;
+  parentOrigin: string;
+  profile: string;
+}
+
+type MessageTarget = {
+  postMessage(message: unknown, targetOrigin: string): void;
+};
+
+function normalizedOrigin(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if ((url.protocol !== "https:" && url.protocol !== "http:") || url.origin !== raw) {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function parseDashboardEmbedRequest(
+  searchParams: URLSearchParams,
+  allowedParentOrigins: readonly string[],
+  configuredProfiles: Readonly<Record<string, string>>,
+): DashboardEmbedRequest | null {
+  const embedId = (searchParams.get("embed") ?? "").trim();
+  const requestedOrigin = normalizedOrigin(
+    (searchParams.get("parent_origin") ?? "").trim(),
+  );
+  const allowed = new Set(
+    allowedParentOrigins
+      .map((origin) => normalizedOrigin(origin))
+      .filter((origin): origin is string => Boolean(origin)),
+  );
+
+  if (!embedId || !/^[a-z0-9][a-z0-9_-]{0,63}$/.test(embedId)) return null;
+  if (!requestedOrigin || !allowed.has(requestedOrigin)) return null;
+  if (!Object.prototype.hasOwnProperty.call(configuredProfiles, embedId)) return null;
+
+  const rawProfile = (searchParams.get("profile") ?? "").trim().toLowerCase();
+  const rawPinnedProfile = (configuredProfiles[embedId] ?? "").trim().toLowerCase();
+  const profile = rawProfile === "default" ? "" : rawProfile;
+  const pinnedProfile = rawPinnedProfile === "default" ? "" : rawPinnedProfile;
+  if (profile !== pinnedProfile) return null;
+
+  return {
+    authBridge: searchParams.get("auth_bridge") === "1",
+    embedId,
+    parentOrigin: requestedOrigin,
+    profile,
+  };
+}
+
+export function postDashboardEmbedEvent(
+  target: MessageTarget | null | undefined,
+  parentOrigin: string,
+  event: DashboardEmbedEvent,
+  embedId: string,
+): void {
+  target?.postMessage(
+    {
+      type: "hermes.dashboard.embed",
+      event,
+      embedId,
+    },
+    parentOrigin,
+  );
+}
+
+declare global {
+  interface Window {
+    __HERMES_DASHBOARD_EMBED_PARENT_ORIGINS__?: string[];
+    __HERMES_DASHBOARD_EMBED_PROFILES__?: Record<string, string>;
+  }
+}

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -275,6 +275,25 @@ describe("ChatPage", () => {
     expect(maybeReloadForLoopbackWsAuthFailure).toHaveBeenCalledWith(4401);
   });
 
+  it("renders only the terminal viewport and binds the PTY to the embed policy", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat?profile=wolf"]}>
+        <ChatPage isActive embedded embedId="console-wolf" />
+      </MemoryRouter>,
+    );
+
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+    expect(apiMocks.buildWsUrl).toHaveBeenCalledWith(
+      "/api/pty",
+      expect.objectContaining({ embed: "console-wolf" }),
+    );
+    expect(container.querySelector('[role="complementary"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Copy last assistant response"]')).toBeNull();
+    expect(container.querySelector('[data-hermes-embedded-chat="true"]')).not.toBeNull();
+  });
+
   it("attaches visualViewport keyboard-inset listeners only while the chat tab is active", async () => {
     // NS-434 follow-up: ChatPage stays mounted (hidden) on every dashboard
     // route. The keyboard-inset/scroll-pin listeners must only be live while

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -173,7 +173,19 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
   return layoutWidthPx < 1024 ? 1.02 : 1.15;
 }
 
-export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
+interface ChatPageProps {
+  embedId?: string;
+  embedded?: boolean;
+  isActive?: boolean;
+  onPtyStateChange?: (state: PtyConnectionState) => void;
+}
+
+export default function ChatPage({
+  embedId,
+  embedded = false,
+  isActive = true,
+  onPtyStateChange,
+}: ChatPageProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termWrapRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -248,7 +260,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const [reconnectNonce, setReconnectNonce] = useState(0);
   useEffect(() => {
     ptyStateRef.current = ptyState;
-  }, [ptyState]);
+    onPtyStateChange?.(ptyState);
+  }, [ptyState, onPtyStateChange]);
   const clearReconnectTimer = useCallback(() => {
     if (reconnectTimerRef.current) {
       clearTimeout(reconnectTimerRef.current);
@@ -1166,6 +1179,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // selected profile, so the conversation runs with that profile's model,
       // skills, memory, and sessions (see web_server._resolve_chat_argv).
       if (scopedProfile) params.profile = scopedProfile;
+      if (embedId) params.embed = embedId;
 
       ticketTimer = setTimeout(() => {
         ticketTimer = null;
@@ -1519,6 +1533,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     clearReconnectTimer,
     resumeParam,
     scopedProfile,
+    embedId,
     reconnectNonce,
   ]);
 
@@ -1684,6 +1699,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     hydrating: resumeHydrating,
   });
   const mobileModelToolsPortal =
+    !embedded &&
     isActive &&
     narrow &&
     portalRoot &&
@@ -1770,8 +1786,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     );
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-2">
-      <PluginSlot name="chat:top" />
+    <div
+      className={cn(
+        "flex min-h-0 flex-1 flex-col",
+        embedded ? "gap-0" : "gap-2",
+      )}
+      data-hermes-embedded-chat={embedded ? "true" : undefined}
+    >
+      {!embedded && <PluginSlot name="chat:top" />}
       {mobileModelToolsPortal}
 
       {visibleBanner && (
@@ -1780,12 +1802,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         </div>
       )}
 
-      <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
+      <div
+        className={cn(
+          "flex min-h-0 flex-1 flex-col",
+          !embedded && "gap-2 lg:flex-row lg:gap-3",
+        )}
+      >
         <div
           ref={termWrapRef}
           className={cn(
-            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg",
-            "p-2 sm:p-3",
+            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+            embedded ? "rounded-none p-0" : "rounded-lg p-2 sm:p-3",
           )}
           style={{
             backgroundColor: terminalBg,
@@ -1849,6 +1876,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             </div>
           )}
 
+          {!embedded && (
           <Button
             ghost
             onClick={handleCopyLast}
@@ -1873,8 +1901,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               </span>
             </span>
           </Button>
+          )}
 
-          {chatPanelCollapsed && (
+          {!embedded && chatPanelCollapsed && (
             <Button
               ghost
               onClick={toggleChatPanel}
@@ -1901,7 +1930,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           )}
         </div>
 
-        {!narrow && !chatPanelCollapsed && (
+        {!embedded && !narrow && !chatPanelCollapsed && (
           <div
             id="chat-side-panel"
             role="complementary"
@@ -1941,7 +1970,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           </div>
         )}
       </div>
-      <PluginSlot name="chat:bottom" />
+      {!embedded && <PluginSlot name="chat:bottom" />}
     </div>
   );
 }

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -620,7 +620,7 @@ Then frame:
 
 The parent and dashboard must be on the same schemeful site (for example `console.example.com` and `api.example.com` over HTTPS), because gated dashboard sessions use `SameSite=Lax` cookies. Cross-site embedding is deliberately unsupported; deploy a same-site dashboard hostname instead of weakening cookie policy. The `embed` ID must exist in `embed_profiles`, and the requested `profile` must match that mapping. The PTY WebSocket validates the mapping again before accepting, so changing the query cannot retarget the frame. Empty configuration disables external embedding. Only the chat document is frameable; OAuth remains a top-level popup flow.
 
-For OAuth, open the same URL in a top-level popup with `auth_bridge=1`. After the authenticated callback, the page posts a bounded `hermes.dashboard.embed` / `authenticated` event to the configured parent origin and closes. The framed chat posts `connecting`, `ready`, `reconnecting`, `disconnected`, and `ended` lifecycle events. Hosts must verify `event.origin`, `event.source`, `type`, and `embedId` before acting.
+For OAuth, open the same URL in a top-level popup with `auth_bridge=1`. After the authenticated callback, the page posts a bounded `hermes.dashboard.embed` / `authenticated` event to the configured parent origin and closes. The framed chat posts `ready` to `window.parent` once the authenticated chat is mounted, then `connecting`, `reconnecting`, `disconnected`, and `ended` for the PTY. Hosts must verify `event.origin`, `event.source`, `type`, and `embedId` before acting. Never post to `*`.
 
 ## Authentication (gated mode)
 

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -599,6 +599,29 @@ same auth gate as the rest of `/api/`.
 | `POST /api/sessions/prune` | Delete ended sessions older than N days |
 | `PUT /api/cron/jobs/{id}` | Edit a cron job's prompt / schedule / name / deliver |
 
+## Embedded chat hosts
+
+The dashboard can expose its real xterm/TUI chat as a bounded iframe without the dashboard navigation chrome. Configure exact parent origins and a server-pinned profile for each host:
+
+```yaml
+dashboard:
+  embed_parent_origins:
+    - https://console.example.com
+  embed_profiles:
+    console-default: default
+    console-research: research
+```
+
+Then frame:
+
+```text
+/chat?embed=console-research&profile=research&parent_origin=https%3A%2F%2Fconsole.example.com
+```
+
+The parent and dashboard must be on the same schemeful site (for example `console.example.com` and `api.example.com` over HTTPS), because gated dashboard sessions use `SameSite=Lax` cookies. Cross-site embedding is deliberately unsupported; deploy a same-site dashboard hostname instead of weakening cookie policy. The `embed` ID must exist in `embed_profiles`, and the requested `profile` must match that mapping. The PTY WebSocket validates the mapping again before accepting, so changing the query cannot retarget the frame. Empty configuration disables external embedding. Only the chat document is frameable; OAuth remains a top-level popup flow.
+
+For OAuth, open the same URL in a top-level popup with `auth_bridge=1`. After the authenticated callback, the page posts a bounded `hermes.dashboard.embed` / `authenticated` event to the configured parent origin and closes. The framed chat posts `connecting`, `ready`, `reconnecting`, `disconnected`, and `ended` lifecycle events. Hosts must verify `event.origin`, `event.source`, `type`, and `embedId` before acting.
+
 ## Authentication (gated mode)
 
 When the dashboard is bound to a public or non-loopback address — anything other than `127.0.0.1` / `localhost` — Hermes Agent engages an auth gate. Every request must carry a verified session cookie or it's bounced to the login page. Three providers ship in the box:


### PR DESCRIPTION
## Summary

- add an official chat-only dashboard embed surface using the real xterm/Ink TUI
- pin every embed ID to one profile server-side before the PTY WebSocket is accepted
- restrict frame parents and lifecycle `postMessage` events to exact configured origins
- add a top-level OAuth popup bridge for automatic host activation
- publish PTY lifecycle events and keep the ordinary dashboard lazy-load behavior intact
- document the schemeful same-site cookie requirement

## Verification

- `cd web && npm run check` — 282 tests passed; lint has only the existing warning baseline
- `cd web && npm run build` — passed
- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_embed.py tests/hermes_cli/test_web_server.py -q` — 169 passed
- browser: chat-only page rendered xterm with no dashboard/sidebar/model rail, no horizontal overflow, no console errors
- live-policy probe: mismatched `embed=console-wolf&profile=torkil` rejected before WebSocket accept (HTTP 403)

The repository-wide Python suite was attempted but the canonical clean runner lacks its async pytest plugin on this checkout, producing broad `PytestUnknownMarkWarning` / unsupported-async failures unrelated to this patch. Focused changed-path and web suites are green.
