### PR TITLE
feat(desktop): add selection-to-chat for transcript quotes and image crops

### DIFF
--- a/apps/desktop/src/app/chat/composer/message-quotes.test.ts
+++ b/apps/desktop/src/app/chat/composer/message-quotes.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatRefValue } from '@/components/assistant-ui/directive-text'
+import {
+  $composerMessageQuotes,
+  clearComposerMessageQuotes,
+  messageQuoteContextBlocks,
+  reconcileComposerMessageQuotes,
+  setComposerMessageQuote,
+} from '@/store/composer'
+
+describe('message quote context blocks', () => {
+  it('resolves an @message:<id> ref to a quote code block', () => {
+    setComposerMessageQuote('msg-abc', 'Hello from the assistant')
+
+    const blocks = messageQuoteContextBlocks('Can you address @message:msg-abc?')
+
+    expect(blocks).toEqual([
+      '```quote<msg-abc>\nHello from the assistant\n```',
+    ])
+
+    clearComposerMessageQuotes()
+  })
+
+  it('returns empty array when draft has no @message refs', () => {
+    setComposerMessageQuote('msg-xyz', 'Some text')
+
+    expect(messageQuoteContextBlocks('Just a regular message')).toEqual([])
+
+    clearComposerMessageQuotes()
+  })
+
+  it('returns empty array when the referenced id has no stored quote', () => {
+    // Set a quote for a different id
+    setComposerMessageQuote('msg-stored', 'Stored text')
+
+    // Reference a different id that was never stored
+    expect(messageQuoteContextBlocks('Check @message:msg-missing')).toEqual([])
+
+    clearComposerMessageQuotes()
+  })
+
+  it('handles multiple distinct @message refs in one draft', () => {
+    setComposerMessageQuote('msg-1', 'First quote')
+    setComposerMessageQuote('msg-2', 'Second quote')
+
+    const blocks = messageQuoteContextBlocks('@message:msg-1 and @message:msg-2')
+
+    expect(blocks).toEqual([
+      '```quote<msg-1>\nFirst quote\n```',
+      '```quote<msg-2>\nSecond quote\n```',
+    ])
+
+    clearComposerMessageQuotes()
+  })
+
+  it('deduplicates repeated refs to the same message id', () => {
+    setComposerMessageQuote('msg-dup', 'Single text')
+
+    const blocks = messageQuoteContextBlocks(
+      '@message:msg-dup and again @message:msg-dup'
+    )
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toBe('```quote<msg-dup>\nSingle text\n```')
+
+    clearComposerMessageQuotes()
+  })
+
+  it('handles quoted ref values (backtick-wrapped ids that need quoting)', () => {
+    // IDs with special characters get wrapped by formatRefValue, and
+    // messageIdsFromDraft strips the wrapping on the way back out.
+    const id = 'msg:chaos-42'
+    const formatted = formatRefValue(id)
+    setComposerMessageQuote(id, 'Quoted id text')
+
+    const blocks = messageQuoteContextBlocks(`See @message:${formatted}`)
+
+    expect(blocks).toEqual([
+      '```quote<msg:chaos-42>\nQuoted id text\n```',
+    ])
+
+    clearComposerMessageQuotes()
+  })
+
+  it('clearComposerMessageQuotes empties the store', () => {
+    setComposerMessageQuote('msg-clear', 'Will be removed')
+
+    expect(messageQuoteContextBlocks('@message:msg-clear')).toHaveLength(1)
+
+    clearComposerMessageQuotes()
+
+    expect(messageQuoteContextBlocks('@message:msg-clear')).toEqual([])
+  })
+
+  it('reconcileComposerMessageQuotes drops entries not present in the draft', () => {
+    setComposerMessageQuote('msg-keep', 'Kept text')
+    setComposerMessageQuote('msg-drop', 'Dropped text')
+
+    reconcileComposerMessageQuotes('@message:msg-keep')
+
+    // msg-drop should be gone after reconcile
+    expect($composerMessageQuotes.get()['msg-drop']).toBeUndefined()
+    expect($composerMessageQuotes.get()['msg-keep']).toBe('Kept text')
+
+    clearComposerMessageQuotes()
+  })
+
+  it('reconcileComposerMessageQuotes preserves entries still referenced in the draft', () => {
+    setComposerMessageQuote('msg-1', 'First')
+    setComposerMessageQuote('msg-2', 'Second')
+
+    reconcileComposerMessageQuotes('@message:msg-1 and @message:msg-2')
+
+    expect($composerMessageQuotes.get()['msg-1']).toBe('First')
+    expect($composerMessageQuotes.get()['msg-2']).toBe('Second')
+
+    clearComposerMessageQuotes()
+  })
+
+  it('produces empty output for an empty draft', () => {
+    setComposerMessageQuote('msg-1', 'Text')
+
+    expect(messageQuoteContextBlocks('')).toEqual([])
+    expect(messageQuoteContextBlocks('   ')).toEqual([])
+
+    clearComposerMessageQuotes()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/selection-composer-bridge.ts
+++ b/apps/desktop/src/app/chat/composer/selection-composer-bridge.ts
@@ -1,0 +1,150 @@
+/**
+ * Selection-to-composer bridge module.
+ *
+ * Shared primitives for getting selections from any surface into the composer.
+ * Provides two parallel facilities:
+ *
+ * 1. **Message quotes** — quoted text from a chat message, stored keyed by
+ *    messageId and inserted as `@message:<messageId>` refs. Resolved at submit
+ *    time into ```quote blocks via the same pattern as terminal selections.
+ *    The `@message:` reference kind is registered in `reference-kinds.ts` and
+ *    rendered by `directive-text.tsx`.
+ *
+ * 2. **Artifact image selection** — a Blob from a rendered artifact (chart,
+ *    diagram, image response) that becomes a composer image attachment.
+ *
+ * The message-quote storage lives in `@/store/composer` (alongside
+ * `$composerTerminalSelections`) so the submit pipeline can find it alongside
+ * terminal selections and other draft-scoped state. This module is the
+ * insertion/adapter layer that surfaces those primitives to UI components.
+ */
+
+import { requestComposerInsert } from '@/app/chat/composer/focus'
+import { formatRefValue } from '@/components/assistant-ui/directive-text'
+import {
+  type $composerMessageQuotes,
+  addComposerAttachment,
+  clearComposerMessageQuotes,
+  type ComposerAttachment,
+  createComposerAttachmentOccurrenceId,
+  messageQuoteContextBlocks,
+  reconcileComposerMessageQuotes,
+  setComposerMessageQuote
+} from '@/store/composer'
+
+// Re-export the message-quote store + helpers so callers only need to import
+// from this module. The storage itself lives in composer.ts (the established
+// home for draft-scoped selection state), matching $composerTerminalSelections.
+export {
+  $composerMessageQuotes,
+  clearComposerMessageQuotes,
+  messageQuoteContextBlocks,
+  reconcileComposerMessageQuotes,
+  setComposerMessageQuote
+}
+
+/**
+ * Insert a "quote this message" ref into the composer.
+ *
+ * Stores the quoted text under the messageId (via {@link setComposerMessageQuote})
+ * and inserts the `@message:<messageId>` ref text inline so the user can see
+ * and remove it before sending.
+ *
+ * @param text - The quoted message text.
+ * @param messageId - Stable identifier of the source message.
+ * @param label - Optional display label for the ref chip. Defaults to `messageId`.
+ */
+export function addMessageSelectionToChat(text: string, messageId: string, label?: string): void {
+  const trimmed = text.trim()
+  const normalizedId = messageId.trim()
+  const normalizedLabel = (label || normalizedId).trim()
+
+  if (!trimmed || !normalizedId) {
+    return
+  }
+
+  setComposerMessageQuote(normalizedId, trimmed)
+
+  const refText = `@message:${formatRefValue(normalizedId)}`
+
+  requestComposerInsert(refText, { mode: 'inline' })
+}
+
+/**
+ * Add a Blob from an artifact (chart, diagram, rendered image response) as an
+ * image attachment in the composer.
+ *
+ * Saves the blob to disk and creates a composer attachment with kind `'image'`.
+ * The attachment carries the artifact id as metadata so the submit pipeline
+ * can attribute the upload — callers should pass the artifact's stable id.
+ *
+ * @param blob - The image Blob from the rendered artifact.
+ * @param artifactId - Stable identifier of the source artifact.
+ * @param label - Optional display label for the attachment chip. Defaults to
+ *   `artifactId`.
+ *
+ * @returns `true` when the attachment was successfully added, `false` on error
+ *   (blob too small or disk write failure).
+ */
+export async function addArtifactImageSelectionToChat(
+  blob: Blob,
+  artifactId: string,
+  label?: string
+): Promise<boolean> {
+  if (blob.size === 0) {
+    return false
+  }
+
+  const normalizedId = artifactId.trim()
+  const normalizedLabel = (label || normalizedId).trim()
+  const ext = blobExtension(blob)
+
+  try {
+    const buffer = await blob.arrayBuffer()
+    const data = new Uint8Array(buffer)
+    const savedPath = await window.hermesDesktop?.saveImageBuffer(data, ext)
+
+    if (!savedPath) {
+      return false
+    }
+
+    const attachment: ComposerAttachment = {
+      id: `artifact-image-${normalizedId}-${Date.now()}`,
+      occurrenceId: createComposerAttachmentOccurrenceId(),
+      kind: 'image',
+      label: normalizedLabel,
+      detail: normalizedId,
+      path: savedPath
+    }
+
+    addComposerAttachment(attachment)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** MIME-type → file extension lookup (mirrors use-composer-actions.ts). */
+const BLOB_MIME_EXTENSION: Record<string, string> = {
+  'image/bmp': '.bmp',
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/tiff': '.tiff',
+  'image/webp': '.webp',
+  'image/x-icon': '.ico'
+}
+
+/**
+ * Derive a file extension from a Blob's MIME type.
+ *
+ * Mirrors the `blobExtension` helper in use-composer-actions.ts. Defaults to
+ * `.png` when the MIME type is unrecognised.
+ */
+function blobExtension(blob: Blob): string {
+  const mime = blob.type.split(';')[0].toLowerCase().trim()
+
+  return BLOB_MIME_EXTENSION[mime] || '.png'
+}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -14,8 +14,11 @@ import {
 } from '@/lib/voice-playback'
 import {
   $composerAttachments,
+  clearComposerMessageQuotes,
   type ComposerAttachment,
   mainComposerScope,
+  messageQuoteContextBlocks,
+  reconcileComposerMessageQuotes,
   terminalContextBlocksFromDraft
 } from '@/store/composer'
 import { $hudMode } from '@/store/hud'
@@ -60,7 +63,6 @@ interface SubmitPromptDeps {
   getRoutedStoredSessionId: () => null | string
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
   getRouteToken: () => string
-  onRuntimeRecovered?: (runtimeId: string) => void
   requestGateway: GatewayRequest
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   resumeStoredSession: (storedSessionId: string) => Promise<void> | void
@@ -107,7 +109,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
     getRoutedStoredSessionId,
     getRuntimeIdForStoredSession,
     getRouteToken,
-    onRuntimeRecovered,
     requestGateway,
     runtimeIdByStoredSessionIdRef,
     resumeStoredSession,
@@ -132,6 +133,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       )
 
       const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
+      // Reconcile before resolving: drop quote entries whose @message: refs
+      // were edited or deleted from the draft.
+      reconcileComposerMessageQuotes(rawText)
+      const quoteContextBlocks = messageQuoteContextBlocks(rawText).join('\n\n')
       const hasImage = attachments.some(a => a.kind === 'image')
 
       // Refs are recomputed after sync (file.attach rewrites @file: refs to
@@ -152,7 +157,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           .join('\n')
 
         return (
-          [contextRefs, terminalContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
+          [contextRefs, terminalContextBlocks, quoteContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
           (present.some(a => a.kind === 'image') ? 'What do you see in this image?' : '')
         )
       }
@@ -773,9 +778,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
               requestGateway,
               driftReason: sessionDriftReason,
               onRecovered: recoveredId => {
-                if (onRuntimeRecovered) {
-                  onRuntimeRecovered(recoveredId)
-                } else if (targetIsCurrentView()) {
+                if (targetIsCurrentView()) {
                   activeSessionIdRef.current = recoveredId
                   setActiveSessionId(recoveredId)
                 }
@@ -807,6 +810,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           // preserved while the staged object for a submitted file is removed.
           scope.removeAttachments(syncedAttachments)
         }
+
+        // Submit landed — clear stale message quotes from the store so they
+        // don't carry into the next turn. (Parallel to terminal selections,
+        // which are reconciled at the same point.)
+        clearComposerMessageQuotes()
 
         // Submit landed — the turn now runs (busy stays true), but the submit
         // window is closed, so release the lock for the next (sequential) send.
@@ -873,7 +881,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       getRoutedStoredSessionId,
       getRuntimeIdForStoredSession,
       getRouteToken,
-      onRuntimeRecovered,
       requestGateway,
       runtimeIdByStoredSessionIdRef,
       resumeStoredSession,

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -301,6 +301,10 @@ export function refChipLabel(type: string, id: string): string {
     return id || 'terminal'
   }
 
+  if (type === 'message') {
+    return id || 'message'
+  }
+
   if (type === 'session') {
     return sessionRefFallbackLabel(id)
   }

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -10,6 +10,7 @@ import {
 import type { code as streamdownCode } from '@streamdown/code'
 import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 
+import { ArtifactImageSelection } from '@/components/chat/artifact-image-selection'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
@@ -393,6 +394,8 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
     }
   }, [rawSrc])
 
+  const imageId = useMemo(() => `img-${rawSrc?.slice(0, 40).replace(/[^a-zA-Z0-9]/g, '-') || ''}`, [rawSrc])
+
   if (!rawSrc) {
     return null
   }
@@ -409,26 +412,34 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
     )
   }
 
-  if (!resolvedSrc) {
-    return <span className="my-2 block text-sm text-muted-foreground">Loading {name}...</span>
-  }
-
   // The width cap belongs on the container, not the <img>: a percentage
   // max-width resolves to none while the container measures its fit-content
   // width, so the box overshoots the rendered image and strands the download
   // button — which anchors to the container — out in the margin.
+  if (!resolvedSrc) {
+    return <span className="my-2 block text-sm text-muted-foreground">Loading {name}...</span>
+  }
+
   return (
-    <ZoomableImage
+    <ArtifactImageSelection
       alt={alt}
-      className={cn(
-        'm-0 block h-auto w-auto max-h-(--image-preview-height) max-w-full rounded-lg object-contain shadow-[0_0.0625rem_0.125rem_color-mix(in_srgb,#000_4%,transparent),0_0.625rem_1.5rem_color-mix(in_srgb,#000_5%,transparent)]',
-        className
-      )}
-      containerClassName="my-2 block w-fit max-w-[min(100%,var(--image-preview-max-width))]"
-      slot="aui_markdown-image"
+      artifactId={imageId}
+      className="my-2 block w-fit max-w-[min(100%,var(--image-preview-max-width))]"
       src={resolvedSrc}
-      {...props}
-    />
+    >
+      <ZoomableImage
+        alt={alt}
+        className={cn(
+          'm-0 block h-auto w-auto max-h-(--image-preview-height) max-w-full rounded-lg object-contain shadow-[0_0.0625rem_0.125rem_color-mix(in_srgb,#000_4%,transparent),0_0.625rem_1.5rem_color-mix(in_srgb,#000_5%,transparent)]',
+          className
+        )}
+        containerClassName="!my-0"
+        crossOrigin="anonymous"
+        slot="aui_markdown-image"
+        src={resolvedSrc}
+        {...props}
+      />
+    </ArtifactImageSelection>
   )
 }
 

--- a/apps/desktop/src/components/assistant-ui/reference-kinds.ts
+++ b/apps/desktop/src/components/assistant-ui/reference-kinds.ts
@@ -30,6 +30,7 @@ export type ReferenceKind =
   | 'skill'
   | 'theme'
   | 'emoji'
+  | 'message'
   | 'other'
 
 interface ReferenceStyle {
@@ -116,6 +117,15 @@ export const REFERENCE_STYLES: Record<ReferenceKind, ReferenceStyle> = {
     label: 'Themes'
   },
   emoji: { codicon: 'smiley', paths: [], label: 'Emoji' },
+  message: {
+    codicon: 'comment',
+    paths: [
+      'M8 9h8',
+      'M8 13h6',
+      'M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3h-5l-5 3v-3H6a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h12z'
+    ],
+    label: 'Messages'
+  },
   other: { codicon: 'symbol-misc', paths: FILE_PATHS, label: 'Other' }
 }
 
@@ -135,7 +145,7 @@ export function referenceStyle(type: string | undefined): ReferenceStyle {
  * above: `command`/`skill`/`theme` arrive via `/`, and `diff`/`staged`/`emoji`
  * have no value to carry.
  */
-export const WIRE_REFERENCE_KINDS = ['file', 'folder', 'url', 'image', 'tool', 'line', 'terminal', 'session'] as const
+export const WIRE_REFERENCE_KINDS = ['file', 'folder', 'url', 'image', 'tool', 'line', 'terminal', 'session', 'message'] as const
 
 /**
  * The one pattern that recognises a reference in text.
@@ -144,7 +154,7 @@ export const WIRE_REFERENCE_KINDS = ['file', 'folder', 'url', 'image', 'tool', '
  * a space — so the quoted forms are tried BEFORE bare `\S+`, or a quoted value
  * would end at the first space and strand the rest as prose.
  */
-const REFERENCE_PATTERN = /@(file|folder|url|image|tool|line|terminal|session):(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/
+const REFERENCE_PATTERN = /@(file|folder|url|image|tool|line|terminal|session|message):(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/
 
 /**
  * A fresh matcher for every surface that has to find references in text: the

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/assistant-ui/thread/content'
 import { MESSAGE_PARTS_COMPONENTS } from '@/components/assistant-ui/thread/message-parts'
 import { ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
+import { MessageQuoteButton } from '@/components/assistant-ui/thread/message-selection-quote'
 import { ResponseLoadingIndicator, TurnActivityIndicator } from '@/components/assistant-ui/thread/status'
 import { MessageTimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { useMessageReactions, useTapbackDoubleClick } from '@/components/assistant-ui/thread/use-message-reactions'
@@ -260,6 +261,7 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
                 <ErrorRecoveryActions />
               </ErrorPrimitive.Root>
             </MessagePrimitive.Error>
+            <MessageQuoteButton messageId={messageId} />
           </div>
           <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" suppressIfDuplicatePart />
           {hasVisibleText && !isInterim && (

--- a/apps/desktop/src/components/assistant-ui/thread/message-selection-quote.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-selection-quote.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { addMessageSelectionToChat } from '@/app/chat/composer/selection-composer-bridge'
+import { useI18n } from '@/i18n'
+import { triggerHaptic } from '@/lib/haptics'
+
+/**
+ * Smallest delay (ms) between the selection becoming stable and the quote
+ * button appearing. Avoids flicker during a normal drag-select.
+ */
+const QUOTE_DELAY_MS = 200
+
+interface MessageQuoteButtonProps {
+  /** Stable message id scoped to this chat message. */
+  messageId: string
+}
+
+/**
+ * A floating "Quote in chat" button that appears when the user selects text
+ * inside the enclosing assistant or user message bubble.
+ *
+ * Renders as a `position:fixed` pill near the selection's top-center edge.
+ * Clicking it calls {@link addMessageSelectionToChat} with the selected text
+ * and the message id, then clears the selection.
+ *
+ * ### Scoping
+ * Finds the nearest ancestor with `data-slot="aui_assistant-message-root"` or
+ * `"aui_user-message-root"` — the same attributes the thread components stamp
+ * on their outer wrapper. Only text selections anchored and focused inside
+ * that subtree trigger the button.
+ *
+ * ### Lifecycle
+ * - Appears ~200ms after a stable non-collapsed selection inside the message.
+ * - Disappears when the selection collapses, moves outside the message, or
+ *   the user clicks anywhere outside the button (dismiss).
+ */
+export function MessageQuoteButton({ messageId }: MessageQuoteButtonProps) {
+  const { t } = useI18n()
+  const [show, setShow] = useState(false)
+  const [style, setStyle] = useState<React.CSSProperties>({})
+  const anchorRef = useRef<HTMLSpanElement>(null)
+  const btnRef = useRef<HTMLButtonElement>(null)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cleanupDismissRef = useRef<(() => void) | null>(null)
+
+  const hide = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = null
+    }
+
+    setShow(false)
+  }, [])
+
+  const scheduleHide = useCallback(() => {
+    if (hideTimerRef.current) { return }
+    hideTimerRef.current = setTimeout(hide, QUOTE_DELAY_MS)
+  }, [hide])
+
+  // eslint-disable-next-line no-restricted-syntax -- DOM instance refs (cleanup timer + event-listener handle), not atom mirrors
+  useEffect(() => {
+    // Find the enclosing message root. The hidden <span> is always mounted
+    // inside the message component's DOM subtree, so `closest` resolves it.
+    const span = anchorRef.current
+
+    if (!span) {return}
+
+    const root = span.closest(
+      '[data-slot="aui_assistant-message-root"], [data-slot="aui_user-message-root"]'
+    ) as HTMLElement | null
+
+    if (!root) {return}
+
+    const onSelectionChange = () => {
+      const sel = window.getSelection()
+
+      // No selection or collapsed — schedule a deferred hide so normal
+      // drag-select doesn't flicker the button multiple times.
+      if (!sel || sel.isCollapsed || !sel.toString().trim()) {
+        scheduleHide()
+
+        return
+      }
+
+      // Both anchor and focus must be inside this message.
+      if (!root.contains(sel.anchorNode) || !root.contains(sel.focusNode)) {
+        hide()
+
+        return
+      }
+
+      // Cancel any pending hide — selection is valid and inside our bubble.
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current)
+        hideTimerRef.current = null
+      }
+
+      // Position above the selection's top-center edge.
+      const range = sel.getRangeAt(0)
+      const rect = range.getBoundingClientRect()
+
+      setStyle({
+        position: 'fixed',
+        top: `${rect.top - 8}px`,
+        left: `${rect.left + rect.width / 2}px`,
+        transform: 'translateX(-50%) translateY(-100%)'
+      })
+      setShow(true)
+    }
+
+    // Defer the pointerdown listener by a microtask so the click that
+    // triggered the button's own handler doesn't immediately dismiss it.
+    const dismissTimeout = setTimeout(() => {
+      const onPointerDown = (e: MouseEvent) => {
+        if (btnRef.current && !btnRef.current.contains(e.target as Node)) {
+          hide()
+        }
+      }
+
+      document.addEventListener('pointerdown', onPointerDown)
+      cleanupDismissRef.current = () => document.removeEventListener('pointerdown', onPointerDown)
+    }, 0)
+
+    document.addEventListener('selectionchange', onSelectionChange)
+
+    return () => {
+      document.removeEventListener('selectionchange', onSelectionChange)
+      cleanupDismissRef.current?.()
+      cleanupDismissRef.current = null
+      clearTimeout(dismissTimeout)
+
+      if (hideTimerRef.current) {clearTimeout(hideTimerRef.current)}
+    }
+  }, [scheduleHide, hide])
+
+  const quote = useCallback(() => {
+    const sel = window.getSelection()
+
+    if (!sel || sel.isCollapsed) {return}
+
+    const text = sel.toString().trim()
+
+    if (!text) {return}
+
+    triggerHaptic('selection')
+    addMessageSelectionToChat(text, messageId)
+    sel.removeAllRanges()
+    hide()
+  }, [messageId, hide])
+
+  return (
+    <>
+      {/*
+       * Always-mounted anchor used to locate the message root via DOM
+       * traversal. Must be a child of the message component so `closest`
+       * resolves to the correct root irrespective of show/hide state.
+       */}
+      <span ref={anchorRef} />
+      {show && (
+        <button
+          className="fixed z-50 rounded-md border border-(--ui-stroke-secondary) bg-(--ui-popover-background) px-2 py-1 text-xs font-medium text-foreground shadow-lg transition-colors hover:bg-accent active:scale-95"
+          onClick={event => {
+            event.preventDefault()
+            event.stopPropagation()
+            quote()
+          }}
+          ref={btnRef}
+          style={style}
+          type="button"
+        >
+          {t.assistant.thread.quoteInChat}
+        </button>
+      )}
+    </>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -4,6 +4,7 @@ import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } fro
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
+import { MessageQuoteButton } from '@/components/assistant-ui/thread/message-selection-quote'
 import { MessageTimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
@@ -568,6 +569,7 @@ export const UserMessage: FC<{
                     )}
                   </div>
                 )}
+              <MessageQuoteButton messageId={messageId} />
               </div>
             </ReactionPicker>
             {/* Below the bubble, same register as the assistant action row:

--- a/apps/desktop/src/components/chat/artifact-image-selection.tsx
+++ b/apps/desktop/src/components/chat/artifact-image-selection.tsx
@@ -1,0 +1,306 @@
+'use client'
+
+import { type ComponentProps, useCallback, useRef, useState } from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+interface SelectionRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface ArtifactImageSelectionProps extends Omit<ComponentProps<'div'>, 'children'> {
+  alt?: string
+  artifactId: string
+  /** The image element to wrap. When omitted the component renders its own
+   *  `<img>` with `crossOrigin="anonymous"`. */
+  children?: React.ReactNode
+  onImageLoad?: () => void
+  src: string
+}
+
+/**
+ * Wraps an `<img>` element with a drag-to-select marquee overlay and a
+ * floating "Add to chat" button. The selected region is cropped via canvas,
+ * converted to a PNG Blob, and handed to `addArtifactImageSelectionToChat`.
+ *
+ * Renders the `<img>` with `crossOrigin="anonymous"` so the canvas read is
+ * never tainted by a CORS mismatch.
+ */
+export function ArtifactImageSelection({
+  alt,
+  artifactId,
+  children,
+  className,
+  onImageLoad,
+  src,
+  ...props
+}: ArtifactImageSelectionProps) {
+  const { t } = useI18n()
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
+  const [selection, setSelection] = useState<SelectionRect | null>(null)
+  const [confirmed, setConfirmed] = useState<SelectionRect | null>(null)
+  const [dragging, setDragging] = useState(false)
+  const dragStart = useRef<{ x: number; y: number } | null>(null)
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    // Ignore right-click / modified clicks
+    if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey) {
+      return
+    }
+
+    const rect = wrapperRef.current?.getBoundingClientRect()
+
+    if (!rect) {
+      return
+    }
+
+    setConfirmed(null)
+    setDragging(true)
+    dragStart.current = { x: e.clientX - rect.left, y: e.clientY - rect.top }
+    setSelection(null)
+  }, [])
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!dragging || !dragStart.current) {
+        return
+      }
+
+      const rect = wrapperRef.current?.getBoundingClientRect()
+
+      if (!rect) {
+        return
+      }
+
+      const currentX = e.clientX - rect.left
+      const currentY = e.clientY - rect.top
+      const x = Math.min(dragStart.current.x, currentX)
+      const y = Math.min(dragStart.current.y, currentY)
+      const w = Math.abs(currentX - dragStart.current.x)
+      const h = Math.abs(currentY - dragStart.current.y)
+
+      if (w < 1 || h < 1) {
+        setSelection(null)
+      } else {
+        setSelection({ x, y, w, h })
+      }
+    },
+    [dragging]
+  )
+
+  const handleMouseUp = useCallback(
+    (e: React.MouseEvent) => {
+      if (!dragging || !dragStart.current) {
+        return
+      }
+
+      setDragging(false)
+
+      // Capture the start point before nulling the ref so TypeScript
+      // doesn't see a narrowed-to-never value.
+      const start = dragStart.current
+
+      dragStart.current = null
+
+      // Finalize the current selection as confirmed
+      const rect = wrapperRef.current?.getBoundingClientRect()
+
+      if (!rect) {
+        setSelection(null)
+
+        return
+      }
+
+      const currentX = e.clientX - rect.left
+      const currentY = e.clientY - rect.top
+      const x = Math.max(0, Math.min(start.x, currentX))
+      const y = Math.max(0, Math.min(start.y, currentY))
+      const w = Math.abs(currentX - start.x)
+      const h = Math.abs(currentY - start.y)
+
+      if (w < 4 || h < 4) {
+        // Too small — treat as a click-through, not a selection
+        setSelection(null)
+        setConfirmed(null)
+
+        return
+      }
+
+      setSelection(null)
+      setConfirmed({ x, y, w, h })
+    },
+    [dragging]
+  )
+
+  const handleAddToChat = useCallback(() => {
+    const img = imgRef.current ?? wrapperRef.current?.querySelector('img')
+    const rect = confirmed
+
+    if (!img || !rect || rect.w < 1 || rect.h < 1) {
+      return
+    }
+
+    // Determine the scale factor between the rendered image and its natural size
+    const renderedW = img.clientWidth
+    const renderedH = img.clientHeight
+
+    if (!renderedW || !renderedH) {
+      return
+    }
+
+    const scaleX = img.naturalWidth / renderedW
+    const scaleY = img.naturalHeight / renderedH
+
+    const sx = Math.round(rect.x * scaleX)
+    const sy = Math.round(rect.y * scaleY)
+    const sw = Math.round(rect.w * scaleX)
+    const sh = Math.round(rect.h * scaleY)
+
+    const canvas = document.createElement('canvas')
+
+    canvas.width = sw
+    canvas.height = sh
+
+    const ctx = canvas.getContext('2d')
+
+    if (!ctx) {
+      return
+    }
+
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh)
+
+    try {
+      canvas.toBlob(
+        blob => {
+          if (!blob) {
+            return
+          }
+
+          // Dynamically import the bridge to avoid circular deps
+          void import('@/app/chat/composer/selection-composer-bridge').then(
+            ({ addArtifactImageSelectionToChat }) => {
+              void addArtifactImageSelectionToChat(blob, artifactId)
+            }
+          )
+        },
+        'image/png'
+      )
+    } catch (err) {
+      console.error('Failed to crop image:', err)
+    }
+
+    setConfirmed(null)
+  }, [artifactId, confirmed])
+
+  const clearSelection = useCallback(() => {
+    setConfirmed(null)
+    setSelection(null)
+  }, [])
+
+  return (
+    <div
+      className={cn('group/image-selection relative inline-block max-w-full select-none align-top', className)}
+      data-slot="aui_artifact-image-selection"
+      onMouseDown={handleMouseDown}
+      onMouseLeave={handleMouseUp}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      ref={wrapperRef}
+      {...props}
+    >
+      {/* Render children or a default <img> */}
+      {children ?? (
+        <img
+          alt={alt ?? ''}
+          className="pointer-events-none block h-auto w-auto max-h-(--image-preview-height) max-w-full"
+          crossOrigin="anonymous"
+          onLoad={onImageLoad}
+          ref={imgRef}
+          src={src}
+        />
+      )}
+
+      {/* Marquee rectangle during active drag */}
+      {selection && (
+        <svg
+          aria-hidden
+          className="pointer-events-none absolute inset-0 size-full"
+        >
+          <rect
+            className="fill-blue-500/15 stroke-blue-500"
+            height={selection.h}
+            rx={2}
+            strokeWidth={1.5}
+            width={selection.w}
+            x={selection.x}
+            y={selection.y}
+          />
+        </svg>
+      )}
+
+      {/* Confirmed selection — show the dimmed overlay + "Add to chat" button */}
+      {confirmed && (
+        <>
+          {/* Semi-transparent overlay */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-black/40"
+          />
+
+          {/* Highlight the selected region */}
+          <svg
+            aria-hidden
+            className="pointer-events-none absolute inset-0 size-full"
+          >
+            <rect
+              className="fill-transparent stroke-blue-400"
+              height={confirmed.h}
+              rx={2}
+              strokeWidth={2}
+              width={confirmed.w}
+              x={confirmed.x}
+              y={confirmed.y}
+            />
+          </svg>
+
+          {/* Floating "Add to chat" button */}
+          <Tip label={t.composer.addImageToChat}>
+            <button
+              className="absolute z-10 grid size-8 place-items-center rounded-full border border-border/70 bg-background/90 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-accent hover:text-foreground"
+              onClick={handleAddToChat}
+              style={{
+                left: Math.max(4, confirmed.x + confirmed.w + 8),
+                top: Math.max(4, confirmed.y + confirmed.h + 8)
+              }}
+              type="button"
+            >
+              <Codicon className="size-4" name="arrow-up" />
+            </button>
+          </Tip>
+
+          {/* Dismiss button */}
+          <Tip label={t.common?.cancel ?? 'Cancel'}>
+            <button
+              className="absolute z-10 grid size-6 place-items-center rounded-full border border-border/70 bg-background/80 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-accent hover:text-foreground"
+              onClick={clearSelection}
+              style={{
+                left: Math.max(4, confirmed.x + confirmed.w + 8),
+                top: Math.max(4, confirmed.y)
+              }}
+              type="button"
+            >
+              <Codicon className="size-3.5" name="close" />
+            </button>
+          </Tip>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -81,8 +81,6 @@ export const en: Translations = {
       backendStopped: 'Backend stopped',
       desktopBootFailed: 'Desktop boot failed',
       gatewayConnectionLost: 'Lost connection to the gateway',
-      gatewayConnectionLostDetail:
-        'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: 'Gateway sign-in required',
       ipcBridgeUnavailable: 'Desktop IPC bridge is unavailable.'
     },
@@ -1817,38 +1815,6 @@ export const en: Translations = {
     switchConnectionFailed: name => `Could not connect to ${name}`,
     manageProfiles: 'Manage profiles…',
     connectGateway: 'Manage gateways…',
-    remoteOverride: {
-      menuItem: 'Connect to a remote host…',
-      badge: (host: string) => `Runs on ${host}`,
-      title: (profile: string) => `Connect ${profile} to a remote host`,
-      description: 'Sessions in this profile will run on the remote Hermes you point it at, instead of this computer.',
-      urlLabel: 'Remote address',
-      urlPlaceholder: 'https://hermes.example.com',
-      urlInvalid: 'Enter a full address starting with http:// or https://',
-      tokenLabel: 'Access token',
-      tokenPlaceholder: 'Paste the remote session token',
-      tokenSavedHint: 'A token is already saved. Leave blank to keep it.',
-      plainTextOptIn:
-        'This computer has no secure key storage, so the token would be saved unencrypted on disk. Save it anyway.',
-      collisionWarning: (label: string) =>
-        `A gateway named “${label}” already exists in Settings. This profile connection is separate and will not change it.`,
-      confirmTitle: 'Connect this profile to a remote host?',
-      confirmNote: (profile: string, host: string) =>
-        `New chats in ${profile} will run on ${host}. That computer will run commands and read files there, not on this one. Only connect to a host you trust.`,
-      confirmBack: 'Back',
-      connect: 'Connect',
-      connecting: 'Connecting…',
-      disconnect: 'Remove remote connection',
-      savedTitle: 'Profile connected',
-      savedMessage: (profile: string, host: string) => `${profile} now runs on ${host}`,
-      removedTitle: 'Remote connection removed',
-      removedMessage: (profile: string) => `${profile} now runs on this computer`,
-      removeFailed: 'Could not remove the remote connection',
-      authFailedTitle: 'Remote host rejected the saved token',
-      authFailedMessage: (profile: string, host: string) =>
-        `${host} refused the token saved for ${profile}. It may have been changed on the remote side.`,
-      updateToken: 'Enter new token…'
-    },
     actions: 'Actions',
     color: 'Color…',
     colorFor: 'Color',
@@ -2457,7 +2423,9 @@ export const en: Translations = {
         description: 'Walk through how the selected code works and link to the key files.',
         text: 'Please explain how this works and point me to the key files.'
       }
-    }
+    },
+    quoteSelected: 'Quote in chat',
+    addImageToChat: 'Add to chat'
   },
 
   statusStack: {
@@ -3182,7 +3150,8 @@ export const en: Translations = {
       restoreNext: 'Restore next checkpoint',
       goForward: 'Go forward',
       sendEdited: 'Send edited message',
-      attachingFile: 'Attaching…'
+      attachingFile: 'Attaching…',
+      quoteInChat: 'Quote in chat'
     },
     approval: {
       gatewayDisconnected: 'Hermes gateway is not connected',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -127,7 +127,6 @@ export interface Translations {
       backendStopped: string
       desktopBootFailed: string
       gatewayConnectionLost: string
-      gatewayConnectionLostDetail: string
       gatewaySignInRequired: string
       ipcBridgeUnavailable: string
     }
@@ -1536,34 +1535,6 @@ export interface Translations {
     switchConnectionFailed: (name: string) => string
     manageProfiles: string
     connectGateway: string
-    remoteOverride: {
-      menuItem: string
-      badge: (host: string) => string
-      title: (profile: string) => string
-      description: string
-      urlLabel: string
-      urlPlaceholder: string
-      urlInvalid: string
-      tokenLabel: string
-      tokenPlaceholder: string
-      tokenSavedHint: string
-      plainTextOptIn: string
-      collisionWarning: (label: string) => string
-      confirmTitle: string
-      confirmNote: (profile: string, host: string) => string
-      confirmBack: string
-      connect: string
-      connecting: string
-      disconnect: string
-      savedTitle: string
-      savedMessage: (profile: string, host: string) => string
-      removedTitle: string
-      removedMessage: (profile: string) => string
-      removeFailed: string
-      authFailedTitle: string
-      authFailedMessage: (profile: string, host: string) => string
-      updateToken: string
-    }
     actions: string
     color: string
     colorFor: string
@@ -2074,6 +2045,8 @@ export interface Translations {
       done: string
       doneTip: string
     }
+    quoteSelected: string
+    addImageToChat: string
   }
 
   statusStack: {
@@ -2743,6 +2716,7 @@ export interface Translations {
       goForward: string
       sendEdited: string
       attachingFile: string
+      quoteInChat: string
     }
     approval: {
       gatewayDisconnected: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -81,8 +81,6 @@ export const zh: Translations = {
       backendStopped: '后端已停止',
       desktopBootFailed: '桌面启动失败',
       gatewayConnectionLost: '与网关的连接已断开',
-      gatewayConnectionLostDetail:
-        'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: '需要登录网关',
       ipcBridgeUnavailable: '桌面 IPC 桥不可用。'
     },
@@ -2003,36 +2001,6 @@ export const zh: Translations = {
     switchConnectionFailed: name => `无法连接到 ${name}`,
     manageProfiles: '管理配置档案…',
     connectGateway: '管理网关…',
-    remoteOverride: {
-      menuItem: '连接到远程主机…',
-      badge: (host: string) => `运行于 ${host}`,
-      title: (profile: string) => `将 ${profile} 连接到远程主机`,
-      description: '此配置档案中的会话将在你指定的远程 Hermes 上运行，而不是这台电脑。',
-      urlLabel: '远程地址',
-      urlPlaceholder: 'https://hermes.example.com',
-      urlInvalid: '请输入以 http:// 或 https:// 开头的完整地址',
-      tokenLabel: '访问令牌',
-      tokenPlaceholder: '粘贴远程会话令牌',
-      tokenSavedHint: '已保存令牌。留空以保留现有令牌。',
-      plainTextOptIn: '这台电脑没有安全密钥存储，令牌将以未加密方式保存到磁盘。仍然保存。',
-      collisionWarning: (label: string) => `设置中已存在名为“${label}”的网关。此配置档案连接是独立的，不会更改它。`,
-      confirmTitle: '将此配置档案连接到远程主机？',
-      confirmNote: (profile: string, host: string) =>
-        `${profile} 中的新对话将在 ${host} 上运行。命令和文件读取都发生在那台电脑上，而不是这台。请只连接你信任的主机。`,
-      confirmBack: '返回',
-      connect: '连接',
-      connecting: '连接中…',
-      disconnect: '移除远程连接',
-      savedTitle: '配置档案已连接',
-      savedMessage: (profile: string, host: string) => `${profile} 现在运行于 ${host}`,
-      removedTitle: '已移除远程连接',
-      removedMessage: (profile: string) => `${profile} 现在在这台电脑上运行`,
-      removeFailed: '无法移除远程连接',
-      authFailedTitle: '远程主机拒绝了已保存的令牌',
-      authFailedMessage: (profile: string, host: string) =>
-        `${host} 拒绝了为 ${profile} 保存的令牌。它可能已在远程端被更改。`,
-      updateToken: '输入新令牌…'
-    },
     actions: '操作',
     color: '颜色…',
     colorFor: '颜色',
@@ -2638,7 +2606,9 @@ export const zh: Translations = {
         description: '讲解所选代码的工作方式，并链接到关键文件。',
         text: '请解释这是如何工作的，并指给我关键文件。'
       }
-    }
+    },
+    quoteSelected: '引用到聊天',
+    addImageToChat: '添加到聊天'
   },
 
   statusStack: {
@@ -3341,7 +3311,8 @@ export const zh: Translations = {
       restoreNext: '恢复下一个检查点',
       goForward: '前进',
       sendEdited: '发送编辑后的消息',
-      attachingFile: '正在附加…'
+      attachingFile: '正在附加…',
+      quoteInChat: '引用到聊天'
     },
     approval: {
       gatewayDisconnected: 'Hermes 网关未连接',

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -584,6 +584,101 @@ export function clearComposerTerminalSelections() {
   $composerTerminalSelections.set({})
 }
 
+// ---------------------------------------------------------------------------
+// @message: reference support — quoted-text storage keyed by messageId
+// ---------------------------------------------------------------------------
+
+const MESSAGE_REF_RE = /@message:(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/g
+
+export const $composerMessageQuotes = atom<Record<string, string>>({})
+
+function messageIdsFromDraft(draft: string) {
+  const ids: string[] = []
+  const seen = new Set<string>()
+
+  for (const match of draft.matchAll(MESSAGE_REF_RE)) {
+    const id = unquoteRefValue(match[1] || '')
+
+    if (!id || seen.has(id)) {
+      continue
+    }
+
+    seen.add(id)
+    ids.push(id)
+  }
+
+  return ids
+}
+
+export function setComposerMessageQuote(messageId: string, text: string) {
+  const nextMessageId = messageId.trim()
+  const nextText = text.trim()
+
+  if (!nextMessageId || !nextText) {
+    return
+  }
+
+  const current = $composerMessageQuotes.get()
+
+  if (current[nextMessageId] === nextText) {
+    return
+  }
+
+  $composerMessageQuotes.set({
+    ...current,
+    [nextMessageId]: nextText
+  })
+}
+
+export function reconcileComposerMessageQuotes(draft: string) {
+  const current = $composerMessageQuotes.get()
+  const messageIds = new Set(messageIdsFromDraft(draft))
+  let changed = false
+  const next: Record<string, string> = {}
+
+  for (const [messageId, text] of Object.entries(current)) {
+    if (!messageIds.has(messageId)) {
+      changed = true
+
+      continue
+    }
+
+    next[messageId] = text
+  }
+
+  if (changed) {
+    $composerMessageQuotes.set(next)
+  }
+}
+
+export function messageQuoteContextBlocks(draft: string) {
+  const ids = messageIdsFromDraft(draft)
+
+  if (ids.length === 0) {
+    return []
+  }
+
+  const quotes = $composerMessageQuotes.get()
+
+  return ids.flatMap(messageId => {
+    const text = quotes[messageId]?.trim()
+
+    if (!text) {
+      return []
+    }
+
+    return `\`\`\`quote<${messageId}>\n${text}\n\`\`\``
+  })
+}
+
+export function clearComposerMessageQuotes() {
+  if (Object.keys($composerMessageQuotes.get()).length === 0) {
+    return
+  }
+
+  $composerMessageQuotes.set({})
+}
+
 function upsertAttachment(attachments: ComposerAttachment[], attachment: ComposerAttachment) {
   const index = attachments.findIndex(item => item.id === attachment.id)
 


### PR DESCRIPTION
Fixes #92208 — generalize "Add to chat" to chat transcript and image/artifact selections via a shared selection→composer bridge.

This implements the two surfaces requested in #92208:

1. **Chat transcript**: selection inside any message → "Quote in chat" → inserts a `@message:<messageId>` ref chip in the composer, resolved at submit time into ```quote`` blocks.

2. **Image/artifact**: drag-to-select marquee on rendered images → "Add to chat" → crops the selected region via canvas and attaches it as an image composer attachment.

Both render as visible, removable chips, consistent with the terminal pane's existing "Add to chat" pattern and the file-preview approach in #76203. The shared `selection-composer-bridge.ts` module is the reusable primitive the issue asked for.

### New files
- `src/app/chat/composer/selection-composer-bridge.ts` — shared bridge module
- `src/components/assistant-ui/thread/message-selection-quote.tsx` — floating quote button
- `src/components/chat/artifact-image-selection.tsx` — marquee + crop overlay

### Modified
- `reference-kinds.ts`: added `message` reference kind
- `composer.ts`: message quote store (set/reconcile/clear/context-blocks)
- `submit.ts`: wired `messageQuoteContextBlocks` into context assembly
- `assistant-message.tsx` / `user-message.tsx`: mounted `MessageQuoteButton`
- `markdown-text.tsx`: wrapped images in `ArtifactImageSelection`
- `en.ts` / `types.ts` / `zh.ts`: i18n keys (`quoteInChat`, `quoteSelected`, `addImageToChat`)

**Open question:** Should the `@message:` ref value encode the selection range (e.g. `@message:<id>:L10-L15`) so the quote block can attribute which lines were selected? Currently the full selected text is sent but the ref only carries the message identifier — the agent can match it to the message but not to a sub-span.