### PR TITLE
fix(agent): validate malformed patch retries before approval

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3093,6 +3093,16 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     # Check plugin hooks for a block or approval directive before executing.
     block_message: Optional[str] = None
     if not pre_tool_block_checked:
+        contract_result: Optional[str] = None
+
+        def _validate_final_args(args: Dict[str, Any]) -> Optional[str]:
+            nonlocal contract_result
+            if function_name == "patch":
+                from tools.file_tools import _validate_patch_contract
+
+                contract_result = _validate_patch_contract(args)
+            return contract_result
+
         try:
             from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
             block_message, modified_args = _dispatch_pre_tool_call_hooks(
@@ -3102,13 +3112,18 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 middleware_trace=list(_tool_middleware_trace),
+                final_args_validator=_validate_final_args,
             )
             if modified_args is not None:
                 function_args = modified_args
         except Exception:
             block_message = None
     if block_message is not None:
-        result = json.dumps({"error": block_message}, ensure_ascii=False)
+        result = (
+            contract_result
+            if contract_result is not None
+            else json.dumps({"error": block_message}, ensure_ascii=False)
+        )
         try:
             from model_tools import _emit_post_tool_call_hook
             _emit_post_tool_call_hook(
@@ -3121,7 +3136,9 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 status="blocked",
-                error_type="plugin_block",
+                error_type=(
+                    "malformed_input" if contract_result is not None else "plugin_block"
+                ),
                 error_message=block_message,
                 middleware_trace=list(_tool_middleware_trace),
             )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -617,9 +617,61 @@ def _run_agent_tool_execution_middleware(
             begin_execution(callback)
 
         block_message = scope_block
-        block_error_type = "tool_scope_block"
-        if block_message is None:
-            block_error_type = "plugin_block"
+        block_error_type = "tool_scope_block" if scope_block is not None else "plugin_block"
+        validation_result = None
+        guardrail_decision = None
+        terminal_result = None
+        terminal_error_type = None
+        terminal_error_message = None
+
+        def _validate_final_args(args: dict[str, Any]) -> str | None:
+            nonlocal validation_result, guardrail_decision
+            nonlocal terminal_result, terminal_error_type, terminal_error_message
+
+            # Provider-portable schemas cannot express every mode-dependent
+            # contract. Observe the post-hook args before directive resolution,
+            # approvals, checkpoints, or handlers.
+            if function_name == "patch":
+                from tools.file_tools import _validate_patch_contract
+
+                validation_result = _validate_patch_contract(args)
+            malformed_decision = agent._tool_guardrails.before_validated_call(
+                function_name, args, validation_result
+            )
+            if not malformed_decision.allows_execution:
+                guardrail_decision = malformed_decision
+                terminal_result = agent._guardrail_block_result(malformed_decision)
+                terminal_error_type = "guardrail_block"
+                terminal_error_message = (
+                    malformed_decision.message or "Tool blocked by guardrail policy"
+                )
+                return terminal_result
+            if validation_result is not None:
+                terminal_result = validation_result
+                terminal_error_type = "malformed_input"
+                parsed_validation = json.loads(validation_result)
+                terminal_error_message = parsed_validation.get(
+                    "error", "Invalid tool arguments"
+                )
+                return terminal_result
+
+            guardrail_decision = agent._tool_guardrails.before_call(
+                function_name, args
+            )
+            if not guardrail_decision.allows_execution:
+                terminal_result = agent._guardrail_block_result(guardrail_decision)
+                terminal_error_type = "guardrail_block"
+                terminal_error_message = (
+                    guardrail_decision.message or "Tool blocked by guardrail policy"
+                )
+                return terminal_result
+            guardrail_decision = None
+            return None
+
+        def _resolve_policy_and_begin() -> None:
+            nonlocal block_message, final_args
+            if block_message is not None:
+                return
 
             def _resolve_pre_tool_block():
                 nonlocal final_args
@@ -636,6 +688,7 @@ def _run_agent_tool_execution_middleware(
                         api_request_id=getattr(agent, "_current_api_request_id", "")
                         or "",
                         middleware_trace=list(state["middleware_trace"]),
+                        final_args_validator=_validate_final_args,
                     )
                     if modified_args is not None:
                         final_args = modified_args
@@ -644,55 +697,33 @@ def _run_agent_tool_execution_middleware(
                 except Exception:
                     return None
 
-            block_message = (
+            resolved = (
                 _resolve_pre_tool_block()
                 if authorization_gate is None
                 else authorization_gate.run(_resolve_pre_tool_block)
             )
+            if terminal_result is None:
+                block_message = resolved
+                if block_message is None:
+                    _begin()
 
-        validation_result = None
-        guardrail_decision = None
-        if block_message is None:
-            # Provider-portable schemas cannot express every mode-dependent
-            # contract. Run built-in validation at the shared pre-dispatch
-            # boundary, then let the generic controller classify/reset its
-            # malformed-input streak before approvals, checkpoints, or handlers.
-            if function_name == "patch":
-                from tools.file_tools import _validate_patch_contract
+        # The existing concurrent start-order gate is the serialization point
+        # for final-argument validation and guardrail streak transitions. This
+        # keeps policy state in model/tool-call order instead of worker order.
+        _advance_start_order(_resolve_policy_and_begin)
 
-                validation_result = _validate_patch_contract(final_args)
-            malformed_decision = agent._tool_guardrails.before_validated_call(
-                function_name, final_args, validation_result
-            )
-            if not malformed_decision.allows_execution:
-                guardrail_decision = malformed_decision
-            elif validation_result is None:
-                guardrail_decision = agent._tool_guardrails.before_call(
-                    function_name, final_args
-                )
-                if guardrail_decision.allows_execution:
-                    guardrail_decision = None
-
-        if block_message is not None or guardrail_decision is not None or validation_result is not None:
-            _advance_start_order()
+        if block_message is not None or terminal_result is not None:
             state["blocked"] = True
-            if block_message is not None:
+            if terminal_result is not None:
+                result = terminal_result
+                error_type = terminal_error_type
+                error_message = terminal_error_message
+            elif validation_result is None:
                 result = json.dumps({"error": block_message}, ensure_ascii=False)
                 error_type = block_error_type
                 error_message = block_message
-            elif guardrail_decision is not None:
-                result = agent._guardrail_block_result(guardrail_decision)
-                error_type = "guardrail_block"
-                error_message = (
-                    getattr(guardrail_decision, "message", None)
-                    or "Tool blocked by guardrail policy"
-                )
             else:
-                assert validation_result is not None
-                result = validation_result
-                error_type = "malformed_input"
-                parsed_validation = json.loads(validation_result)
-                error_message = parsed_validation.get("error", "Invalid tool arguments")
+                raise AssertionError("blocked tool call has no terminal result")
             _emit_terminal_post_tool_call(
                 agent,
                 function_name=function_name,
@@ -711,8 +742,6 @@ def _run_agent_tool_execution_middleware(
             agent._turns_since_memory = 0
         elif function_name == "skill_manage":
             agent._iters_since_skill = 0
-
-        _advance_start_order(_begin)
 
         # Keep the gateway turn-inactivity watchdog from abandoning a turn
         # whose tool call runs silently for longer than the inactivity

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -599,16 +599,6 @@ def _run_agent_tool_execution_middleware(
             state["blocked"] = False
             state["args"] = final_args
 
-        # Built-in mode-dependent contracts cannot be expressed portably in
-        # provider JSON schemas. Validate them before plugin approvals,
-        # checkpoints, path resolution, or handler execution.
-        if function_name == "patch":
-            from tools.file_tools import _validate_patch_contract
-
-            contract_error = _validate_patch_contract(final_args)
-            if contract_error:
-                return contract_error
-
         def _begin() -> None:
             _begin_tool_execution(
                 agent,
@@ -660,28 +650,49 @@ def _run_agent_tool_execution_middleware(
                 else authorization_gate.run(_resolve_pre_tool_block)
             )
 
+        validation_result = None
         guardrail_decision = None
         if block_message is None:
-            guardrail_decision = agent._tool_guardrails.before_call(
-                function_name, final_args
-            )
-            if guardrail_decision.allows_execution:
-                guardrail_decision = None
+            # Provider-portable schemas cannot express every mode-dependent
+            # contract. Run built-in validation at the shared pre-dispatch
+            # boundary, then let the generic controller classify/reset its
+            # malformed-input streak before approvals, checkpoints, or handlers.
+            if function_name == "patch":
+                from tools.file_tools import _validate_patch_contract
 
-        if block_message is not None or guardrail_decision is not None:
+                validation_result = _validate_patch_contract(final_args)
+            malformed_decision = agent._tool_guardrails.before_validated_call(
+                function_name, final_args, validation_result
+            )
+            if not malformed_decision.allows_execution:
+                guardrail_decision = malformed_decision
+            elif validation_result is None:
+                guardrail_decision = agent._tool_guardrails.before_call(
+                    function_name, final_args
+                )
+                if guardrail_decision.allows_execution:
+                    guardrail_decision = None
+
+        if block_message is not None or guardrail_decision is not None or validation_result is not None:
             _advance_start_order()
             state["blocked"] = True
             if block_message is not None:
                 result = json.dumps({"error": block_message}, ensure_ascii=False)
                 error_type = block_error_type
                 error_message = block_message
-            else:
+            elif guardrail_decision is not None:
                 result = agent._guardrail_block_result(guardrail_decision)
                 error_type = "guardrail_block"
                 error_message = (
                     getattr(guardrail_decision, "message", None)
                     or "Tool blocked by guardrail policy"
                 )
+            else:
+                assert validation_result is not None
+                result = validation_result
+                error_type = "malformed_input"
+                parsed_validation = json.loads(validation_result)
+                error_message = parsed_validation.get("error", "Invalid tool arguments")
             _emit_terminal_post_tool_call(
                 agent,
                 function_name=function_name,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -599,6 +599,16 @@ def _run_agent_tool_execution_middleware(
             state["blocked"] = False
             state["args"] = final_args
 
+        # Built-in mode-dependent contracts cannot be expressed portably in
+        # provider JSON schemas. Validate them before plugin approvals,
+        # checkpoints, path resolution, or handler execution.
+        if function_name == "patch":
+            from tools.file_tools import _validate_patch_contract
+
+            contract_error = _validate_patch_contract(final_args)
+            if contract_error:
+                return contract_error
+
         def _begin() -> None:
             _begin_tool_execution(
                 agent,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -723,7 +723,16 @@ def _run_agent_tool_execution_middleware(
                 error_type = block_error_type
                 error_message = block_message
             else:
-                raise AssertionError("blocked tool call has no terminal result")
+                # Validation normally always sets terminal_result. Degrade to a
+                # generic tool error if a plugin integration violates that
+                # invariant instead of raising from a worker thread.
+                logger.error(
+                    "blocked %s tool call had validation state but no terminal result",
+                    function_name,
+                )
+                error_message = "Tool call was blocked during final argument validation"
+                result = json.dumps({"error": error_message}, ensure_ascii=False)
+                error_type = "validation_block"
             _emit_terminal_post_tool_call(
                 agent,
                 function_name=function_name,

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -300,20 +300,6 @@ def canonical_tool_args(args: Mapping[str, Any]) -> str:
     )
 
 
-def _structural_args_hash(args: Mapping[str, Any]) -> str:
-    """Hash argument keys/container shapes and scalar types, never values."""
-    def shape(value: Any) -> Any:
-        if isinstance(value, Mapping):
-            return {str(key): shape(child) for key, child in sorted(value.items(), key=lambda item: str(item[0]))}
-        if isinstance(value, list):
-            return [shape(child) for child in value]
-        if value is None:
-            return "null"
-        return type(value).__name__
-
-    return _sha256(json.dumps(shape(args), sort_keys=True, separators=(",", ":")))
-
-
 def _malformed_failure_identity(result: str | None) -> tuple[str, str] | None:
     """Read an explicit deterministic malformed-input class from a tool result."""
     data = safe_json_loads(result or "")
@@ -381,7 +367,7 @@ class ToolCallGuardrailController:
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
-        self._malformed_failure_counts: dict[tuple[str, str, str, str], int] = {}
+        self._malformed_failure_counts: dict[tuple[str, str], int] = {}
         # Identical-call loop-breaker state (agent.stall_guards): tracks the
         # CONSECUTIVE streak of identical (tool, canonical args) calls whose
         # results were also identical. Any different call — or a different
@@ -412,6 +398,57 @@ class ToolCallGuardrailController:
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
 
+    def before_validated_call(
+        self,
+        tool_name: str,
+        args: Mapping[str, Any] | None,
+        validation_result: str | None,
+    ) -> ToolGuardrailDecision:
+        """Observe pre-dispatch contract validation and gate malformed retries.
+
+        A valid corrected call clears this tool's malformed streak. An explicit
+        malformed-input envelope increments the stable tool+failure-class count;
+        with hard stops enabled, the second malformed call is blocked before
+        handler execution even when a different field is missing.
+        """
+        with self._state_lock:
+            signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+            identity = _malformed_failure_identity(validation_result)
+            if identity is None:
+                self._malformed_failure_counts = {
+                    key: count
+                    for key, count in self._malformed_failure_counts.items()
+                    if key[0] != tool_name
+                }
+                return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+
+            failure_class, _failure_code = identity
+            key = (tool_name, failure_class)
+            count = self._malformed_failure_counts.get(key, 0) + 1
+            self._malformed_failure_counts[key] = count
+            if self.config.hard_stop_enabled and count >= 2:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="structurally_equivalent_malformed_input_block",
+                    message=(
+                        f"Blocked {tool_name}: malformed input in failure class "
+                        f"{failure_class!r} already failed this turn. Correct the "
+                        "tool contract before retrying."
+                    ),
+                    tool_name=tool_name,
+                    count=count,
+                    signature=signature,
+                    failure_class=failure_class,
+                )
+                self._halt_decision = decision
+                return decision
+            return ToolGuardrailDecision(
+                tool_name=tool_name,
+                count=count,
+                signature=signature,
+                failure_class=failure_class,
+            )
+
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         with self._state_lock:
             return self._before_call_unlocked(tool_name, args)
@@ -419,31 +456,6 @@ class ToolCallGuardrailController:
     def _before_call_unlocked(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         coerced_args = _coerce_args(args)
         signature = ToolCallSignature.from_call(tool_name, coerced_args)
-
-        if self.config.hard_stop_enabled:
-            shape_hash = _structural_args_hash(coerced_args)
-            matches = [
-                (key, count)
-                for key, count in self._malformed_failure_counts.items()
-                if key[0] == tool_name and key[3] == shape_hash
-            ]
-            if matches:
-                key, count = max(matches, key=lambda item: item[1])
-                decision = ToolGuardrailDecision(
-                    action="block",
-                    code="structurally_equivalent_malformed_input_block",
-                    message=(
-                        f"Blocked {tool_name}: a structurally equivalent malformed "
-                        "tool call already failed this turn. Correct the argument "
-                        "contract before retrying."
-                    ),
-                    tool_name=tool_name,
-                    count=count,
-                    signature=signature,
-                    failure_class=key[1],
-                )
-                self._halt_decision = decision
-                return decision
 
         # ── Per-turn runaway-loop caps ──────────────────────────────────
         # These are hard ceilings on how many times a runaway-prone tool may
@@ -522,25 +534,6 @@ class ToolCallGuardrailController:
         signature = ToolCallSignature.from_call(tool_name, args)
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
-
-        malformed_identity = _malformed_failure_identity(result) if failed else None
-        if malformed_identity is not None:
-            failure_class, failure_code = malformed_identity
-            malformed_key = (
-                tool_name,
-                failure_class,
-                failure_code,
-                _structural_args_hash(args),
-            )
-            self._malformed_failure_counts[malformed_key] = (
-                self._malformed_failure_counts.get(malformed_key, 0) + 1
-            )
-        elif not failed:
-            self._malformed_failure_counts = {
-                key: count
-                for key, count in self._malformed_failure_counts.items()
-                if key[0] != tool_name
-            }
 
         if failed:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -270,7 +270,7 @@ class ToolGuardrailDecision:
 
     @property
     def should_halt(self) -> bool:
-        return self.action in {"block", "halt"}
+        return self.action == "halt"
 
     def to_metadata(self) -> dict[str, Any]:
         data: dict[str, Any] = {
@@ -440,7 +440,6 @@ class ToolCallGuardrailController:
                     signature=signature,
                     failure_class=failure_class,
                 )
-                self._halt_decision = decision
                 return decision
             return ToolGuardrailDecision(
                 tool_name=tool_name,
@@ -484,7 +483,6 @@ class ToolCallGuardrailController:
                 count=exact_count,
                 signature=signature,
             )
-            self._halt_decision = decision
             return decision
 
         if self._is_idempotent(tool_name):
@@ -504,7 +502,6 @@ class ToolCallGuardrailController:
                         count=repeat_count,
                         signature=signature,
                     )
-                    self._halt_decision = decision
                     return decision
 
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
@@ -782,7 +779,6 @@ class ToolCallGuardrailController:
                     count=self._turn_web_search_count,
                     signature=signature,
                 )
-                self._halt_decision = decision
                 return decision
             self._turn_web_search_count += 1
             return None
@@ -811,7 +807,6 @@ class ToolCallGuardrailController:
                     count=self._turn_subagent_count,
                     signature=signature,
                 )
-                self._halt_decision = decision
                 return decision
             self._turn_subagent_count += spawn_count
             return None

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import threading
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
@@ -261,6 +262,7 @@ class ToolGuardrailDecision:
     tool_name: str = ""
     count: int = 0
     signature: ToolCallSignature | None = None
+    failure_class: str = ""
 
     @property
     def allows_execution(self) -> bool:
@@ -280,6 +282,8 @@ class ToolGuardrailDecision:
         }
         if self.signature is not None:
             data["signature"] = self.signature.to_metadata()
+        if self.failure_class:
+            data["failure_class"] = self.failure_class
         return data
 
 
@@ -294,6 +298,35 @@ def canonical_tool_args(args: Mapping[str, Any]) -> str:
         separators=(",", ":"),
         default=str,
     )
+
+
+def _structural_args_hash(args: Mapping[str, Any]) -> str:
+    """Hash argument keys/container shapes and scalar types, never values."""
+    def shape(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {str(key): shape(child) for key, child in sorted(value.items(), key=lambda item: str(item[0]))}
+        if isinstance(value, list):
+            return [shape(child) for child in value]
+        if value is None:
+            return "null"
+        return type(value).__name__
+
+    return _sha256(json.dumps(shape(args), sort_keys=True, separators=(",", ":")))
+
+
+def _malformed_failure_identity(result: str | None) -> tuple[str, str] | None:
+    """Read an explicit deterministic malformed-input class from a tool result."""
+    data = safe_json_loads(result or "")
+    if not isinstance(data, dict):
+        return None
+    failure = data.get("failure")
+    if not isinstance(failure, dict) or failure.get("kind") != "malformed_input":
+        return None
+    failure_class = failure.get("class")
+    code = failure.get("code")
+    if not isinstance(failure_class, str) or not failure_class:
+        return None
+    return failure_class, code if isinstance(code, str) else ""
 
 
 def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]:
@@ -336,13 +369,19 @@ class ToolCallGuardrailController:
 
     def __init__(self, config: ToolCallGuardrailConfig | None = None):
         self.config = config or ToolCallGuardrailConfig()
+        self._state_lock = threading.RLock()
         self.reset_for_turn()
 
     def reset_for_turn(self) -> None:
+        with self._state_lock:
+            self._reset_for_turn_unlocked()
+
+    def _reset_for_turn_unlocked(self) -> None:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
+        self._malformed_failure_counts: dict[tuple[str, str, str, str], int] = {}
         # Identical-call loop-breaker state (agent.stall_guards): tracks the
         # CONSECUTIVE streak of identical (tool, canonical args) calls whose
         # results were also identical. Any different call — or a different
@@ -374,7 +413,37 @@ class ToolCallGuardrailController:
         return self._halt_decision
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
-        signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+        with self._state_lock:
+            return self._before_call_unlocked(tool_name, args)
+
+    def _before_call_unlocked(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
+        coerced_args = _coerce_args(args)
+        signature = ToolCallSignature.from_call(tool_name, coerced_args)
+
+        if self.config.hard_stop_enabled:
+            shape_hash = _structural_args_hash(coerced_args)
+            matches = [
+                (key, count)
+                for key, count in self._malformed_failure_counts.items()
+                if key[0] == tool_name and key[3] == shape_hash
+            ]
+            if matches:
+                key, count = max(matches, key=lambda item: item[1])
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="structurally_equivalent_malformed_input_block",
+                    message=(
+                        f"Blocked {tool_name}: a structurally equivalent malformed "
+                        "tool call already failed this turn. Correct the argument "
+                        "contract before retrying."
+                    ),
+                    tool_name=tool_name,
+                    count=count,
+                    signature=signature,
+                    failure_class=key[1],
+                )
+                self._halt_decision = decision
+                return decision
 
         # ── Per-turn runaway-loop caps ──────────────────────────────────
         # These are hard ceilings on how many times a runaway-prone tool may
@@ -436,10 +505,42 @@ class ToolCallGuardrailController:
         *,
         failed: bool | None = None,
     ) -> ToolGuardrailDecision:
+        with self._state_lock:
+            return self._after_call_unlocked(
+                tool_name, args, result, failed=failed
+            )
+
+    def _after_call_unlocked(
+        self,
+        tool_name: str,
+        args: Mapping[str, Any] | None,
+        result: str | None,
+        *,
+        failed: bool | None = None,
+    ) -> ToolGuardrailDecision:
         args = _coerce_args(args)
         signature = ToolCallSignature.from_call(tool_name, args)
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
+
+        malformed_identity = _malformed_failure_identity(result) if failed else None
+        if malformed_identity is not None:
+            failure_class, failure_code = malformed_identity
+            malformed_key = (
+                tool_name,
+                failure_class,
+                failure_code,
+                _structural_args_hash(args),
+            )
+            self._malformed_failure_counts[malformed_key] = (
+                self._malformed_failure_counts.get(malformed_key, 0) + 1
+            )
+        elif not failed:
+            self._malformed_failure_counts = {
+                key: count
+                for key, count in self._malformed_failure_counts.items()
+                if key[0] != tool_name
+            }
 
         if failed:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -472,7 +472,7 @@ class ToolCallGuardrailController:
         exact_count = self._exact_failure_counts.get(signature, 0)
         if exact_count >= self.config.exact_failure_block_after:
             decision = ToolGuardrailDecision(
-                action="block",
+                action="halt",
                 code="repeated_exact_failure_block",
                 message=(
                     f"Blocked {tool_name}: the same tool call failed {exact_count} "
@@ -491,7 +491,7 @@ class ToolCallGuardrailController:
                 _result_hash, repeat_count = record
                 if repeat_count >= self.config.no_progress_block_after:
                     decision = ToolGuardrailDecision(
-                        action="block",
+                        action="halt",
                         code="idempotent_no_progress_block",
                         message=(
                             f"Blocked {tool_name}: this read-only call returned the same "
@@ -767,7 +767,7 @@ class ToolCallGuardrailController:
             cap = caps.max_web_searches
             if cap and self._turn_web_search_count >= cap:
                 decision = ToolGuardrailDecision(
-                    action="block",
+                    action="halt",
                     code="loop_web_search_cap",
                     message=(
                         f"Blocked web_search: this turn has already made {cap} "
@@ -795,7 +795,7 @@ class ToolCallGuardrailController:
                 return None
             if self._turn_subagent_count >= cap:
                 decision = ToolGuardrailDecision(
-                    action="block",
+                    action="halt",
                     code="loop_subagent_cap",
                     message=(
                         f"Blocked delegate_task: this turn has already spawned "

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -6056,15 +6056,15 @@ def _get_pre_tool_call_directive_details(
         middleware_trace=list(middleware_trace or []),
     )
 
-    block_msg: Optional[str] = None
+    directive: Optional[_PreToolCallDirective] = None
     modified_args: Optional[Dict[str, Any]] = None
 
     for result in hook_results:
         if not isinstance(result, dict):
             continue
         # "modify" action — transform tool_input before dispatch.
-        # Processed before the block/approve gate so modify directives
-        # are visible even when a later hook blocks. Hooks accumulate:
+        # All mutations are collected before the first block/approve directive
+        # is resolved. Hooks accumulate:
         # each modify directive shallow-merges its keys into one
         # accumulated dict built from the original args on first hit.
         if result.get("action") == "modify":
@@ -6077,6 +6077,8 @@ def _get_pre_tool_call_directive_details(
         action = result.get("action")
         if action not in ("block", "approve"):
             continue
+        if directive is not None:
+            continue
         message = result.get("message")
         message = message if isinstance(message, str) and message else None
         # A block directive requires a message (it becomes the tool result);
@@ -6087,12 +6089,18 @@ def _get_pre_tool_call_directive_details(
         rule_key = rule_key.strip() if isinstance(rule_key, str) else None
         if not rule_key:
             rule_key = None
-        return _PreToolCallDirective(
+        directive = _PreToolCallDirective(
             action=action, message=message, rule_key=rule_key,
-            modified_args=modified_args,
         )
 
-    return _PreToolCallDirective(modified_args=modified_args)
+    if directive is None:
+        return _PreToolCallDirective(modified_args=modified_args)
+    return _PreToolCallDirective(
+        action=directive.action,
+        message=directive.message,
+        rule_key=directive.rule_key,
+        modified_args=modified_args,
+    )
 
 
 def get_pre_tool_call_directive(
@@ -6249,6 +6257,7 @@ def _dispatch_pre_tool_call_hooks(
     turn_id: str = "",
     api_request_id: str = "",
     middleware_trace: Optional[List[Dict[str, Any]]] = None,
+    final_args_validator: Optional[Callable[[Dict[str, Any]], Optional[str]]] = None,
 ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
     """Invoke ``pre_tool_call`` hooks once and process all response types.
 
@@ -6260,6 +6269,9 @@ def _dispatch_pre_tool_call_hooks(
       context set around the human-approval gate.
     - ``modified_args`` — merged args from ``modify`` directives
       (or ``None`` when no hook requested modification).
+
+    When provided, ``final_args_validator`` receives the fully mutated args.
+    A validation result preempts directive resolution, including approval.
 
     This is the single invocation point for ``pre_tool_call`` hooks.
     Callers that only need block detection should keep using
@@ -6273,6 +6285,17 @@ def _dispatch_pre_tool_call_hooks(
         tool_call_id=tool_call_id, turn_id=turn_id,
         api_request_id=api_request_id, middleware_trace=middleware_trace,
     )
+    final_args = details.modified_args
+    if final_args is None:
+        final_args = dict(args) if isinstance(args, dict) else {}
+    validation_result = (
+        final_args_validator(final_args)
+        if final_args_validator is not None
+        else None
+    )
+    if validation_result is not None:
+        return (validation_result, details.modified_args)
+
     block_msg = _resolve_block_from_details(
         details, tool_name,
         turn_id=turn_id, tool_call_id=tool_call_id, session_id=session_id,

--- a/model_tools.py
+++ b/model_tools.py
@@ -1383,6 +1383,16 @@ def handle_function_call(
         # fired it — do nothing here.
         if not skip_pre_tool_call_hook:
             block_message: Optional[str] = None
+            contract_result: Optional[str] = None
+
+            def _validate_final_args(args: Dict[str, Any]) -> Optional[str]:
+                nonlocal contract_result
+                if function_name == "patch":
+                    from tools.file_tools import _validate_patch_contract
+
+                    contract_result = _validate_patch_contract(args)
+                return contract_result
+
             try:
                 from hermes_cli.plugins import _dispatch_pre_tool_call_hooks
                 block_message, modified_args = _dispatch_pre_tool_call_hooks(
@@ -1394,6 +1404,7 @@ def handle_function_call(
                     turn_id=turn_id or "",
                     api_request_id=api_request_id or "",
                     middleware_trace=list(_tool_middleware_trace),
+                    final_args_validator=_validate_final_args,
                 )
                 if modified_args is not None:
                     function_args = modified_args
@@ -1401,7 +1412,11 @@ def handle_function_call(
                 logger.debug("pre_tool_call hook error: %s", _hook_err)
 
             if block_message is not None:
-                result = tool_error(block_message)
+                result = (
+                    contract_result
+                    if contract_result is not None
+                    else tool_error(block_message)
+                )
                 _emit_post_tool_call_hook(
                     function_name=function_name,
                     function_args=function_args,
@@ -1412,7 +1427,11 @@ def handle_function_call(
                     turn_id=turn_id,
                     api_request_id=api_request_id,
                     status="blocked",
-                    error_type="plugin_block",
+                    error_type=(
+                        "malformed_input"
+                        if contract_result is not None
+                        else "plugin_block"
+                    ),
                     error_message=block_message,
                     middleware_trace=list(_tool_middleware_trace),
                 )

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -197,9 +197,9 @@ def test_guardrail_state_updates_are_concurrency_safe():
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
         decisions = list(pool.map(record, range(32)))
 
-    decision = decisions[-1]
-    assert decision.action == "block"
-    assert decision.count == 32
+    assert {decision.count for decision in decisions} == set(range(1, 33))
+    assert max(decision.count for decision in decisions) == 32
+    assert {decision.action for decision in decisions} == {"allow", "block"}
 
 
 def test_new_controller_resets_malformed_streak_for_next_turn():
@@ -261,8 +261,14 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     decision = controller.before_call("web_search", {"query": "q4"})
     assert decision.action == "block"
     assert decision.code == "loop_web_search_cap"
-    assert decision.should_halt is True
+    assert decision.should_halt is False
 
+
+def test_only_explicit_halt_decisions_terminate_the_turn():
+    from agent.tool_guardrails import ToolGuardrailDecision
+
+    assert ToolGuardrailDecision(action="block").should_halt is False
+    assert ToolGuardrailDecision(action="halt").should_halt is True
 
 
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -119,6 +119,90 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
+def test_second_structurally_equivalent_malformed_failure_blocks_before_execution():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    first_args = {"mode": "replace", "old_string": "private-a", "new_string": "x"}
+    second_args = {"mode": "replace", "old_string": "private-b", "new_string": "y"}
+    malformed = json.dumps(
+        {
+            "error": "path is required",
+            "success": False,
+            "failure": {
+                "kind": "malformed_input",
+                "class": "patch_contract",
+                "code": "patch.replace.path.invalid",
+                "tool": "patch",
+            },
+        }
+    )
+
+    assert controller.before_call("patch", first_args).action == "allow"
+    controller.after_call("patch", first_args, malformed, failed=True)
+
+    blocked = controller.before_call("patch", second_args)
+    assert blocked.action == "block"
+    assert blocked.code == "structurally_equivalent_malformed_input_block"
+    metadata = blocked.to_metadata()
+    assert "private-a" not in json.dumps(metadata)
+    assert "private-b" not in json.dumps(metadata)
+
+
+def test_corrected_success_clears_tool_malformed_streak():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    bad = {"mode": "replace", "old_string": "a", "new_string": "b"}
+    good = {"mode": "replace", "path": "x.py", "old_string": "a", "new_string": "b"}
+    malformed = json.dumps(
+        {"error": "bad", "failure": {"kind": "malformed_input", "class": "patch_contract", "code": "patch.replace.path.invalid"}}
+    )
+
+    controller.after_call("patch", bad, malformed, failed=True)
+    controller.after_call("patch", good, '{"success":true}', failed=False)
+
+    assert controller.before_call("patch", {**bad, "old_string": "other"}).action == "allow"
+
+
+def test_external_transient_failures_are_not_malformed():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    args1 = {"url": "https://one.invalid"}
+    args2 = {"url": "https://two.invalid"}
+    controller.after_call(
+        "web_extract", args1, '{"error":"upstream timeout"}', failed=True
+    )
+
+    assert controller.before_call("web_extract", args2).action == "allow"
+
+
+def test_guardrail_state_updates_are_concurrency_safe():
+    import concurrent.futures
+
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    malformed = json.dumps(
+        {"error": "bad", "failure": {"kind": "malformed_input", "class": "patch_contract", "code": "patch.replace.path.invalid"}}
+    )
+
+    def record(i):
+        controller.after_call(
+            "patch", {"mode": "replace", "old_string": str(i), "new_string": "x"}, malformed, failed=True
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(record, range(32)))
+
+    decision = controller.before_call(
+        "patch", {"mode": "replace", "old_string": "next", "new_string": "x"}
+    )
+    assert decision.action == "block"
+    assert decision.count == 32
+
+
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(no_progress_warn_after=2, no_progress_block_after=2)

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -119,11 +119,11 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
 
 
 
-def test_second_structurally_equivalent_malformed_failure_blocks_before_execution():
+def test_second_same_class_malformed_validation_blocks_before_execution():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(hard_stop_enabled=True)
     )
-    first_args = {"mode": "replace", "old_string": "private-a", "new_string": "x"}
+    first_args = {"mode": "replace", "path": "x.py"}
     second_args = {"mode": "replace", "old_string": "private-b", "new_string": "y"}
     malformed = json.dumps(
         {
@@ -138,10 +138,9 @@ def test_second_structurally_equivalent_malformed_failure_blocks_before_executio
         }
     )
 
-    assert controller.before_call("patch", first_args).action == "allow"
-    controller.after_call("patch", first_args, malformed, failed=True)
+    assert controller.before_validated_call("patch", first_args, malformed).action == "allow"
 
-    blocked = controller.before_call("patch", second_args)
+    blocked = controller.before_validated_call("patch", second_args, malformed)
     assert blocked.action == "block"
     assert blocked.code == "structurally_equivalent_malformed_input_block"
     metadata = blocked.to_metadata()
@@ -159,10 +158,12 @@ def test_corrected_success_clears_tool_malformed_streak():
         {"error": "bad", "failure": {"kind": "malformed_input", "class": "patch_contract", "code": "patch.replace.path.invalid"}}
     )
 
-    controller.after_call("patch", bad, malformed, failed=True)
-    controller.after_call("patch", good, '{"success":true}', failed=False)
+    controller.before_validated_call("patch", bad, malformed)
+    controller.before_validated_call("patch", good, None)
 
-    assert controller.before_call("patch", {**bad, "old_string": "other"}).action == "allow"
+    assert controller.before_validated_call(
+        "patch", {**bad, "old_string": "other"}, malformed
+    ).action == "allow"
 
 
 def test_external_transient_failures_are_not_malformed():
@@ -189,18 +190,28 @@ def test_guardrail_state_updates_are_concurrency_safe():
     )
 
     def record(i):
-        controller.after_call(
-            "patch", {"mode": "replace", "old_string": str(i), "new_string": "x"}, malformed, failed=True
+        return controller.before_validated_call(
+            "patch", {"mode": "replace", "old_string": str(i), "new_string": "x"}, malformed
         )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
-        list(pool.map(record, range(32)))
+        decisions = list(pool.map(record, range(32)))
 
-    decision = controller.before_call(
-        "patch", {"mode": "replace", "old_string": "next", "new_string": "x"}
-    )
+    decision = decisions[-1]
     assert decision.action == "block"
     assert decision.count == 32
+
+
+def test_new_controller_resets_malformed_streak_for_next_turn():
+    malformed = json.dumps(
+        {"error": "bad", "failure": {"kind": "malformed_input", "class": "patch_contract", "code": "patch.replace.path.invalid"}}
+    )
+    first_turn = ToolCallGuardrailController(ToolCallGuardrailConfig(hard_stop_enabled=True))
+    first_turn.before_validated_call("patch", {"mode": "replace"}, malformed)
+    assert first_turn.before_validated_call("patch", {"mode": "replace"}, malformed).action == "block"
+
+    next_turn = ToolCallGuardrailController(ToolCallGuardrailConfig(hard_stop_enabled=True))
+    assert next_turn.before_validated_call("patch", {"mode": "replace"}, malformed).action == "allow"
 
 
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -102,9 +102,10 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
     assert second.code == "repeated_exact_failure_warning"
 
     blocked = controller.before_call("web_search", args)
-    assert blocked.action == "block"
+    assert blocked.action == "halt"
     assert blocked.code == "repeated_exact_failure_block"
     assert blocked.count == 2
+    assert blocked.should_halt is True
 
 
 
@@ -259,9 +260,9 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     for i in range(3):
         assert controller.before_call("web_search", {"query": f"q{i}"}).action == "allow"
     decision = controller.before_call("web_search", {"query": "q4"})
-    assert decision.action == "block"
+    assert decision.action == "halt"
     assert decision.code == "loop_web_search_cap"
-    assert decision.should_halt is False
+    assert decision.should_halt is True
 
 
 def test_only_explicit_halt_decisions_terminate_the_turn():

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1222,8 +1222,8 @@ class TestPreToolCallModify:
         assert block_msg == "still blocked"
         assert modified == {"path": "/safe"}
 
-    def test_modify_after_block_is_invisible(self, monkeypatch):
-        """A modify after a block is never reached — first block wins."""
+    def test_modify_after_block_is_included_before_resolution(self, monkeypatch):
+        """Later mutations are included before the first directive resolves."""
         monkeypatch.setattr(
             "hermes_cli.plugins.invoke_hook",
             lambda hook_name, **kwargs: [
@@ -1235,7 +1235,78 @@ class TestPreToolCallModify:
             "write_file", {"path": "/original"}
         )
         assert block_msg == "stopped"
+        assert modified == {"path": "/invisible"}
+
+    def test_final_args_validator_preempts_approval_for_originally_invalid_args(
+        self, monkeypatch
+    ):
+        approvals = []
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "approve", "message": "approve patch"}
+            ],
+        )
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval",
+            lambda *args, **kwargs: approvals.append((args, kwargs))
+            or {"approved": True},
+        )
+
+        block_msg, modified = _dispatch_pre_tool_call_hooks(
+            "patch",
+            {"mode": "replace", "path": "x.py"},
+            final_args_validator=lambda args: "PATCH_CONTRACT_ERROR",
+        )
+
+        assert block_msg == "PATCH_CONTRACT_ERROR"
         assert modified is None
+        assert approvals == []
+
+    def test_final_args_validator_sees_all_mutations_before_approval(
+        self, monkeypatch
+    ):
+        approvals = []
+        validated = []
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {"action": "approve", "message": "approve patch"},
+                {"action": "modify", "args": {"path": None}},
+            ],
+        )
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval",
+            lambda *args, **kwargs: approvals.append((args, kwargs))
+            or {"approved": True},
+        )
+
+        def validate(args):
+            validated.append(dict(args))
+            return "PATCH_CONTRACT_ERROR"
+
+        block_msg, modified = _dispatch_pre_tool_call_hooks(
+            "patch",
+            {
+                "mode": "replace",
+                "path": "x.py",
+                "old_string": "old",
+                "new_string": "new",
+            },
+            final_args_validator=validate,
+        )
+
+        assert block_msg == "PATCH_CONTRACT_ERROR"
+        assert validated == [
+            {
+                "mode": "replace",
+                "path": None,
+                "old_string": "old",
+                "new_string": "new",
+            }
+        ]
+        assert modified == validated[0]
+        assert approvals == []
 
     def test_modify_with_none_args(self, monkeypatch):
         """Modify should handle None args gracefully."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2398,9 +2398,15 @@ class TestConcurrentToolExecution:
             "hermes_cli.middleware.run_tool_execution_middleware",
             lambda _name, args, callback, **_kwargs: callback(args),
         )
+
+        def dispatch_hooks(_name, args, *, final_args_validator=None, **_kwargs):
+            return (
+                final_args_validator(args) if final_args_validator is not None else None,
+                None,
+            )
+
         monkeypatch.setattr(
-            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
-            lambda *_args, **_kwargs: (None, None),
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks", dispatch_hooks
         )
         monkeypatch.setattr(tool_executor, "_begin_tool_execution", lambda *_a, **_k: None)
         monkeypatch.setattr(
@@ -2451,6 +2457,76 @@ class TestConcurrentToolExecution:
             }
         ]
         assert corrected.result == '{"ok":true}'
+
+    @pytest.mark.parametrize(
+        "original_args,hook_results",
+        [
+            (
+                {"mode": "replace", "path": "x.py"},
+                [{"action": "approve", "message": "approve patch"}],
+            ),
+            (
+                {
+                    "mode": "replace",
+                    "path": "x.py",
+                    "old_string": "old",
+                    "new_string": "new",
+                },
+                [
+                    {"action": "approve", "message": "approve patch"},
+                    {"action": "modify", "args": {"path": None}},
+                ],
+            ),
+        ],
+    )
+    def test_patch_final_contract_validation_preempts_plugin_approval_and_dispatch(
+        self, agent, monkeypatch, original_args, hook_results
+    ):
+        from agent import relay_tools, tool_executor
+        from agent.tool_guardrails import ToolCallGuardrailConfig, ToolCallGuardrailController
+
+        approvals = []
+        dispatched = []
+        agent._tool_guardrails = ToolCallGuardrailController(
+            ToolCallGuardrailConfig(hard_stop_enabled=True)
+        )
+        monkeypatch.setattr(
+            "hermes_cli.middleware.apply_tool_request_middleware",
+            lambda _name, args, **_kwargs: SimpleNamespace(payload=args, trace=[]),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.middleware.run_tool_execution_middleware",
+            lambda _name, args, callback, **_kwargs: callback(args),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_results,
+        )
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval",
+            lambda *args, **kwargs: approvals.append((args, kwargs))
+            or {"approved": True},
+        )
+        monkeypatch.setattr(tool_executor, "_begin_tool_execution", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            relay_tools,
+            "execute",
+            lambda _name, args, callback, **_kwargs: (callback(args), args),
+        )
+
+        outcome = tool_executor._run_agent_tool_execution_middleware(
+            agent,
+            function_name="patch",
+            function_args=original_args,
+            effective_task_id="task-1",
+            tool_call_id="call-invalid",
+            execute=lambda final_args: dispatched.append(final_args) or '{"ok":true}',
+        )
+
+        payload = json.loads(outcome.result)
+        assert payload["failure"]["class"] == "patch_contract"
+        assert approvals == []
+        assert dispatched == []
 
     def test_managed_tool_pipeline_allows_one_concurrent_dispatch(
         self,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2380,6 +2380,78 @@ class TestConcurrentToolExecution:
         ]
         assert outcome.blocked is False
 
+    def test_patch_contract_validation_and_retry_guard_precede_dispatch(
+        self, agent, monkeypatch
+    ):
+        from agent import relay_tools, tool_executor
+        from agent.tool_guardrails import ToolCallGuardrailConfig, ToolCallGuardrailController
+
+        dispatched = []
+        agent._tool_guardrails = ToolCallGuardrailController(
+            ToolCallGuardrailConfig(hard_stop_enabled=True)
+        )
+        monkeypatch.setattr(
+            "hermes_cli.middleware.apply_tool_request_middleware",
+            lambda _name, args, **_kwargs: SimpleNamespace(payload=args, trace=[]),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.middleware.run_tool_execution_middleware",
+            lambda _name, args, callback, **_kwargs: callback(args),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda *_args, **_kwargs: (None, None),
+        )
+        monkeypatch.setattr(tool_executor, "_begin_tool_execution", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            relay_tools,
+            "execute",
+            lambda _name, args, callback, **_kwargs: (callback(args), args),
+        )
+
+        def invoke(args, call_id):
+            return tool_executor._run_agent_tool_execution_middleware(
+                agent,
+                function_name="patch",
+                function_args=args,
+                effective_task_id="task-1",
+                tool_call_id=call_id,
+                execute=lambda final_args: dispatched.append(final_args) or '{"ok":true}',
+            )
+
+        first = invoke({"mode": "replace", "path": "x.py"}, "call-1")
+        second = invoke(
+            {"mode": "replace", "old_string": "private", "new_string": "value"},
+            "call-2",
+        )
+        corrected = invoke(
+            {
+                "mode": "replace",
+                "path": "x.py",
+                "old_string": "old",
+                "new_string": "new",
+            },
+            "call-3",
+        )
+
+        first_payload = json.loads(first.result)
+        second_payload = json.loads(second.result)
+        assert first_payload["failure"]["class"] == "patch_contract"
+        assert (
+            second_payload["guardrail"]["code"]
+            == "structurally_equivalent_malformed_input_block"
+        )
+        assert "private" not in json.dumps(second_payload)
+        assert dispatched == [
+            {
+                "mode": "replace",
+                "path": "x.py",
+                "old_string": "old",
+                "new_string": "new",
+            }
+        ]
+        assert corrected.result == '{"ok":true}'
+
     def test_managed_tool_pipeline_allows_one_concurrent_dispatch(
         self,
         agent,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2390,6 +2390,24 @@ class TestConcurrentToolExecution:
         agent._tool_guardrails = ToolCallGuardrailController(
             ToolCallGuardrailConfig(hard_stop_enabled=True)
         )
+        policy_calls = {"validated": 0, "dispatch": 0}
+        original_before_validated = agent._tool_guardrails.before_validated_call
+        original_before_call = agent._tool_guardrails.before_call
+
+        def count_before_validated(*args, **kwargs):
+            policy_calls["validated"] += 1
+            return original_before_validated(*args, **kwargs)
+
+        def count_before_call(*args, **kwargs):
+            policy_calls["dispatch"] += 1
+            return original_before_call(*args, **kwargs)
+
+        monkeypatch.setattr(
+            agent._tool_guardrails,
+            "before_validated_call",
+            count_before_validated,
+        )
+        monkeypatch.setattr(agent._tool_guardrails, "before_call", count_before_call)
         monkeypatch.setattr(
             "hermes_cli.middleware.apply_tool_request_middleware",
             lambda _name, args, **_kwargs: SimpleNamespace(payload=args, trace=[]),
@@ -2457,6 +2475,9 @@ class TestConcurrentToolExecution:
             }
         ]
         assert corrected.result == '{"ok":true}'
+        # The managed executor owns guardrail transitions. The nested runtime
+        # and model-tools paths are skipped, so each call crosses one pipeline.
+        assert policy_calls == {"validated": 3, "dispatch": 1}
 
     @pytest.mark.parametrize(
         "original_args,hook_results",

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -1,6 +1,7 @@
 """Runtime tests for tool-call loop guardrails."""
 
 import json
+import threading
 import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -220,6 +221,116 @@ def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_
     assert completed_events[0][1] == "web_search"
 
 
+def _patch_args(*, path="x.py", old_string="old", new_string="new"):
+    args = {"mode": "replace", "old_string": old_string, "new_string": new_string}
+    if path is not None:
+        args["path"] = path
+    return args
+
+
+def _run_reordered_patch_batch(agent, calls):
+    from agent import relay_tools
+
+    second_ready = threading.Event()
+    first_done = threading.Event()
+    dispatched = []
+    messages = []
+
+    def relay_execute(name, args, callback, **kwargs):
+        del name, kwargs
+        marker = args.get("old_string")
+        if marker == "first":
+            assert second_ready.wait(2)
+            result = callback(args)
+            first_done.set()
+        elif marker == "second":
+            second_ready.set()
+            result = callback(args)
+        else:
+            assert first_done.wait(2)
+            result = callback(args)
+        return result, args
+
+    def dispatch(name, args, task_id, **kwargs):
+        del task_id, kwargs
+        dispatched.append((name, dict(args)))
+        return json.dumps({"ok": args["old_string"]})
+
+    msg = SimpleNamespace(content="", tool_calls=calls)
+    with (
+        patch("agent.relay_tools.execute", side_effect=relay_execute),
+        patch("run_agent.handle_function_call", side_effect=dispatch),
+    ):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+    return messages, dispatched
+
+
+def test_concurrent_patch_contract_streak_follows_model_order_and_corrected_call_clears_it():
+    agent = _make_agent("patch", config=_hard_stop_config())
+    calls = [
+        _mock_tool_call("patch", json.dumps(_patch_args(path=None, old_string="first")), "c1"),
+        _mock_tool_call("patch", json.dumps(_patch_args(old_string="second")), "c2"),
+        _mock_tool_call("patch", json.dumps(_patch_args(path=None, old_string="third")), "c3"),
+    ]
+
+    messages, dispatched = _run_reordered_patch_batch(agent, calls)
+    payloads = [json.loads(message["content"]) for message in messages]
+
+    assert payloads[0]["failure"]["class"] == "patch_contract"
+    assert payloads[1] == {"ok": "second"}
+    assert payloads[2]["failure"]["class"] == "patch_contract"
+    assert "guardrail" not in payloads[2]
+    assert dispatched == [("patch", _patch_args(old_string="second"))]
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_concurrent_patch_contract_streak_blocks_second_malformed_shape_in_model_order():
+    agent = _make_agent("patch", config=_hard_stop_config())
+    first = {"mode": "replace", "path": "x.py", "old_string": "first"}
+    second = _patch_args(path=None, old_string="second")
+    calls = [
+        _mock_tool_call("patch", json.dumps(first), "c1"),
+        _mock_tool_call("patch", json.dumps(second), "c2"),
+    ]
+
+    messages, dispatched = _run_reordered_patch_batch(agent, calls)
+    payloads = [json.loads(message["content"]) for message in messages]
+
+    assert payloads[0]["failure"]["class"] == "patch_contract"
+    assert payloads[1]["guardrail"]["code"] == "structurally_equivalent_malformed_input_block"
+    assert dispatched == []
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_sequential_patch_contract_streak_matches_ordered_concurrent_semantics():
+    agent = _make_agent("patch", config=_hard_stop_config())
+    calls = [
+        _mock_tool_call("patch", json.dumps(_patch_args(path=None, old_string="first")), "s1"),
+        _mock_tool_call("patch", json.dumps(_patch_args(old_string="second")), "s2"),
+        _mock_tool_call("patch", json.dumps(_patch_args(path=None, old_string="third")), "s3"),
+    ]
+    messages = []
+    dispatched = []
+
+    def dispatch(name, args, task_id, **kwargs):
+        del task_id, kwargs
+        dispatched.append((name, dict(args)))
+        return json.dumps({"ok": args["old_string"]})
+
+    with patch("run_agent.handle_function_call", side_effect=dispatch):
+        agent._execute_tool_calls_sequential(
+            SimpleNamespace(content="", tool_calls=calls), messages, "task-1"
+        )
+
+    payloads = [json.loads(message["content"]) for message in messages]
+    assert payloads[0]["failure"]["class"] == "patch_contract"
+    assert payloads[1] == {"ok": "second"}
+    assert payloads[2]["failure"]["class"] == "patch_contract"
+    assert "guardrail" not in payloads[2]
+    assert dispatched == [("patch", _patch_args(old_string="second"))]
+    assert agent._tool_guardrail_halt_decision is None
+
+
 def test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispatch():
     agent = _make_agent("write_file")
     original_args = {"path": "/original/path", "content": "old"}
@@ -247,9 +358,9 @@ def test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispat
         return callback(dict(final_args)), dict(final_args)
 
     def observe_plugin(name, args, **kwargs):
-        del kwargs
         observed["plugin"].append((name, dict(args)))
-        return (None, None)
+        validator = kwargs.get("final_args_validator")
+        return (validator(args) if validator is not None else None, None)
 
     def observe_approval(name, args):
         observed["approval"].append((name, dict(args)))
@@ -384,6 +495,8 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     queue and emits a finish chunk with zero content (indistinguishable
     from a crash for Open WebUI and similar clients).
     """
+    from agent.tool_guardrails import ToolGuardrailDecision
+
     agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
     same_args = {"query": "same"}
     responses = [
@@ -392,7 +505,7 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
             finish_reason="tool_calls",
             tool_calls=[_mock_tool_call("web_search", json.dumps(same_args), f"c{i}")],
         )
-        for i in range(1, 10)
+        for i in range(1, 2)
     ]
     agent.client.chat.completions.create.side_effect = responses
 
@@ -405,6 +518,16 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     agent._disable_streaming = True
 
     with (
+        patch.object(
+            agent._tool_guardrails,
+            "before_call",
+            return_value=ToolGuardrailDecision(
+                action="halt",
+                code="explicit_test_halt",
+                message="Stopped retrying by explicit halt action.",
+                tool_name="web_search",
+            ),
+        ),
         patch("run_agent.handle_function_call", return_value=json.dumps({"error": "boom"})),
         patch.object(agent, "_persist_session"),
         patch.object(agent, "_save_trajectory"),

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -41,6 +41,46 @@ class TestReadFileHandler:
         assert "error" in result
         assert "terminal not available" in result["error"]
 
+    def test_handler_missing_path_key_returns_error(self):
+        """_handle_read_file must reject calls where 'path' is absent,
+        the same way _handle_write_file already does for its required
+        fields (see TestWriteFileHandler below)."""
+        from tools.file_tools import _handle_read_file
+
+        result = json.loads(_handle_read_file({}))
+        assert "error" in result
+        assert "path" in result["error"]
+
+    def test_handler_empty_string_path_returns_error(self):
+        from tools.file_tools import _handle_read_file
+
+        result = json.loads(_handle_read_file({"path": ""}))
+        assert "error" in result
+        assert "path" in result["error"]
+
+    def test_handler_non_string_path_returns_error(self):
+        """A model that emits {"path": 123} instead of a string must be
+        rejected the same way as a missing/empty path."""
+        from tools.file_tools import _handle_read_file
+
+        result = json.loads(_handle_read_file({"path": 123}))
+        assert "error" in result
+        assert "path" in result["error"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_handler_valid_path_still_executes(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "line1"
+        result_obj.to_dict.return_value = {"content": "line1", "total_lines": 1}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import _handle_read_file
+        result = json.loads(_handle_read_file({"path": "/tmp/test.txt"}))
+        assert result["content"] == "line1"
+        mock_ops.read_file.assert_called_once_with("/tmp/test.txt", 1, 500)
+
 
 class TestWriteFileHandler:
     @patch("tools.file_tools._get_file_ops")
@@ -166,6 +206,79 @@ class TestPatchHandler:
     def test_unknown_mode_errors(self, mock_get):
         from tools.file_tools import patch_tool
         result = json.loads(patch_tool(mode="invalid_mode"))
+        assert "error" in result
+        assert "Unknown mode" in result["error"]
+
+    # -- _handle_patch (dict-args handler, one layer above patch_tool) ------
+    # The tests above call patch_tool() directly and already prove it
+    # validates its required fields (patch_tool() itself is unchanged by
+    # this addition). These next tests cover _handle_patch specifically:
+    # the dict-based tool-call entry point gets the same missing-toolset
+    # names + "don't retry" guidance that _handle_write_file already gives
+    # (see TestWriteFileHandler.test_missing_path_key_returns_error etc.).
+
+    def test_handler_replace_mode_missing_all_required_fields_errors(self):
+        from tools.file_tools import _handle_patch
+
+        result = json.loads(_handle_patch({}))  # mode defaults to "replace"
+        assert "error" in result
+        assert "path" in result["error"]
+        assert "old_string" in result["error"]
+        assert "new_string" in result["error"]
+
+    def test_handler_replace_mode_missing_new_string_only_errors(self):
+        from tools.file_tools import _handle_patch
+
+        result = json.loads(_handle_patch({"mode": "replace", "path": "x.py", "old_string": "a"}))
+        assert "error" in result
+        assert "new_string" in result["error"]
+
+    def test_handler_replace_mode_empty_old_string_errors(self):
+        """Deliberate asymmetry with new_string: an empty old_string has no
+        sensible "find and replace" meaning, unlike an empty new_string
+        which legitimately means "delete the matched text" (see
+        test_handler_replace_mode_empty_new_string_is_allowed below)."""
+        from tools.file_tools import _handle_patch
+
+        result = json.loads(
+            _handle_patch({"mode": "replace", "path": "x.py", "old_string": "", "new_string": "y"})
+        )
+        assert "error" in result
+        assert "old_string" in result["error"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_handler_replace_mode_empty_new_string_is_allowed(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "replacements": 1}
+        mock_ops.patch_replace.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import _handle_patch
+        result = json.loads(
+            _handle_patch({"mode": "replace", "path": "/tmp/f.py", "old_string": "a", "new_string": ""})
+        )
+        assert result["status"] == "ok"
+        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "a", "", False)
+
+    def test_handler_patch_mode_missing_patch_field_errors(self):
+        from tools.file_tools import _handle_patch
+
+        result = json.loads(_handle_patch({"mode": "patch"}))
+        assert "error" in result
+        assert "patch" in result["error"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_handler_unknown_mode_defers_to_patch_tool(self, mock_get):
+        """mode values other than 'replace'/'patch' are intentionally NOT
+        handled by this guard -- they fall through unchanged to
+        patch_tool()'s own pre-existing validation, covered above by
+        test_unknown_mode_errors. This test just confirms the handler
+        doesn't intercept or duplicate that path."""
+        mock_get.return_value = MagicMock()
+
+        from tools.file_tools import _handle_patch
+        result = json.loads(_handle_patch({"mode": "invalid_mode"}))
         assert "error" in result
         assert "Unknown mode" in result["error"]
 
@@ -303,6 +416,43 @@ class TestSearchHandler:
         from tools.file_tools import search_tool
         result = json.loads(search_tool(pattern="x"))
         assert "error" in result
+
+    def test_handler_missing_pattern_key_returns_error(self):
+        """_handle_search_files must reject calls where 'pattern' is
+        absent -- previously this silently defaulted to "" and ran a
+        real (meaningless) search instead of being rejected."""
+        from tools.file_tools import _handle_search_files
+
+        result = json.loads(_handle_search_files({}))
+        assert "error" in result
+        assert "pattern" in result["error"]
+
+    def test_handler_empty_string_pattern_returns_error(self):
+        from tools.file_tools import _handle_search_files
+
+        result = json.loads(_handle_search_files({"pattern": ""}))
+        assert "error" in result
+        assert "pattern" in result["error"]
+
+    def test_handler_non_string_pattern_returns_error(self):
+        from tools.file_tools import _handle_search_files
+
+        result = json.loads(_handle_search_files({"pattern": ["not", "a", "string"]}))
+        assert "error" in result
+        assert "pattern" in result["error"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_handler_valid_pattern_still_executes(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"matches": []}
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import _handle_search_files
+        result = json.loads(_handle_search_files({"pattern": "*.md", "target": "files"}))
+        assert "matches" in result
+        mock_ops.search.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -94,7 +95,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            os.path.realpath("/tmp/out.txt"), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -185,7 +188,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "foo", "bar", False
+        )
 
 
     @patch("tools.file_tools._get_file_ops")
@@ -207,7 +212,7 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         result = json.loads(patch_tool(mode="invalid_mode"))
         assert "error" in result
-        assert "Unknown mode" in result["error"]
+        assert "must be either 'replace' or 'patch'" in result["error"]
 
     # -- _handle_patch (dict-args handler, one layer above patch_tool) ------
     # The tests above call patch_tool() directly and already prove it
@@ -259,7 +264,9 @@ class TestPatchHandler:
             _handle_patch({"mode": "replace", "path": "/tmp/f.py", "old_string": "a", "new_string": ""})
         )
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "a", "", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            os.path.realpath("/tmp/f.py"), "a", "", False
+        )
 
     def test_handler_patch_mode_missing_patch_field_errors(self):
         from tools.file_tools import _handle_patch
@@ -270,17 +277,13 @@ class TestPatchHandler:
 
     @patch("tools.file_tools._get_file_ops")
     def test_handler_unknown_mode_defers_to_patch_tool(self, mock_get):
-        """mode values other than 'replace'/'patch' are intentionally NOT
-        handled by this guard -- they fall through unchanged to
-        patch_tool()'s own pre-existing validation, covered above by
-        test_unknown_mode_errors. This test just confirms the handler
-        doesn't intercept or duplicate that path."""
+        """Unknown modes are rejected by the shared contract validator."""
         mock_get.return_value = MagicMock()
 
         from tools.file_tools import _handle_patch
         result = json.loads(_handle_patch({"mode": "invalid_mode"}))
         assert "error" in result
-        assert "Unknown mode" in result["error"]
+        assert "must be either 'replace' or 'patch'" in result["error"]
 
     @patch("tools.file_tools._get_file_ops")
     def test_patch_v4a_rejects_traversal_in_update_header(self, mock_get):

--- a/tests/tools/test_patch_already_applied.py
+++ b/tests/tools/test_patch_already_applied.py
@@ -56,15 +56,16 @@ def _patch_tool(**kwargs):
 
 
 class TestPatchReplaceAlreadyApplied:
-    def test_identical_old_new_present_is_success_noop(self, workdir):
+    def test_identical_old_new_is_rejected_as_malformed_noop(self, workdir):
         f = workdir / "a.py"
-        f.write_text("value = compute_total(items)\n")
+        original = "value = compute_total(items)\n"
+        f.write_text(original)
         r = _patch_tool(path=str(f), old_string="value = compute_total(items)",
                         new_string="value = compute_total(items)", task_id="t-applied")
-        assert r["success"] is True
-        assert r.get("no_change") is True
-        assert "already" in r["note"]
-        assert f.read_text() == "value = compute_total(items)\n"
+        assert r["success"] is False
+        assert r["failure"]["kind"] == "malformed_input"
+        assert r["failure"]["code"] == "patch.replace.no_change"
+        assert f.read_text() == original
 
     def test_replay_of_landed_edit_is_success_noop(self, workdir):
         # old_string is entirely gone (no approximate remnant for the fuzzy

--- a/tests/tools/test_patch_already_applied.py
+++ b/tests/tools/test_patch_already_applied.py
@@ -56,15 +56,14 @@ def _patch_tool(**kwargs):
 
 
 class TestPatchReplaceAlreadyApplied:
-    def test_identical_old_new_is_rejected_as_malformed_noop(self, workdir):
+    def test_identical_old_new_present_is_success_noop(self, workdir):
         f = workdir / "a.py"
         original = "value = compute_total(items)\n"
         f.write_text(original)
         r = _patch_tool(path=str(f), old_string="value = compute_total(items)",
                         new_string="value = compute_total(items)", task_id="t-applied")
-        assert r["success"] is False
-        assert r["failure"]["kind"] == "malformed_input"
-        assert r["failure"]["code"] == "patch.replace.no_change"
+        assert r["success"] is True
+        assert r.get("no_change") is True
         assert f.read_text() == original
 
     def test_replay_of_landed_edit_is_success_noop(self, workdir):

--- a/tests/tools/test_patch_contract_validation.py
+++ b/tests/tools/test_patch_contract_validation.py
@@ -1,0 +1,101 @@
+"""Behavior contract for patch tool argument validation."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tools.file_tools import _handle_patch
+
+
+def _failure(args):
+    with patch("tools.file_tools.patch_tool") as handler:
+        result = json.loads(_handle_patch(args))
+    handler.assert_not_called()
+    assert result["success"] is False
+    assert result["failure"]["kind"] == "malformed_input"
+    assert result["failure"]["class"] == "patch_contract"
+    assert result["failure"]["tool"] == "patch"
+    assert "args" not in result["failure"]
+    return result
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("path", None),
+        ("path", 7),
+        ("old_string", None),
+        ("old_string", ["x"]),
+        ("new_string", None),
+        ("new_string", {"x": 1}),
+    ],
+)
+def test_replace_rejects_missing_or_wrong_type_required_fields(field, value):
+    args = {"mode": "replace", "path": "x.py", "old_string": "old", "new_string": "new"}
+    if value is None:
+        args.pop(field)
+    else:
+        args[field] = value
+
+    result = _failure(args)
+
+    assert result["failure"]["code"] == f"patch.replace.{field}.invalid"
+    assert field in result["error"]
+
+
+def test_replace_allows_empty_new_string_deletion():
+    args = {"mode": "replace", "path": "x.py", "old_string": "old", "new_string": ""}
+    with patch("tools.file_tools.patch_tool", return_value='{"ok":true}') as handler:
+        assert json.loads(_handle_patch(args)) == {"ok": True}
+    handler.assert_called_once()
+
+
+def test_replace_rejects_identical_old_and_new_strings():
+    result = _failure(
+        {"mode": "replace", "path": "x.py", "old_string": "same", "new_string": "same"}
+    )
+    assert result["failure"]["code"] == "patch.replace.no_change"
+
+
+@pytest.mark.parametrize("patch_payload", ["diff", ""])
+def test_replace_rejects_incompatible_patch_payload(patch_payload):
+    result = _failure(
+        {
+            "mode": "replace",
+            "path": "x.py",
+            "old_string": "old",
+            "new_string": "new",
+            "patch": patch_payload,
+        }
+    )
+    assert result["failure"]["code"] == "patch.replace.incompatible_fields"
+
+
+@pytest.mark.parametrize("patch_text", [None, "", "   ", 42])
+def test_patch_mode_requires_nonempty_patch_text(patch_text):
+    args = {"mode": "patch"}
+    if patch_text is not None:
+        args["patch"] = patch_text
+    result = _failure(args)
+    assert result["failure"]["code"] == "patch.patch.patch.invalid"
+
+
+@pytest.mark.parametrize("field,value", [("path", "x.py"), ("old_string", "old"), ("new_string", "new"), ("replace_all", True)])
+def test_patch_mode_rejects_ambiguous_replace_fields(field, value):
+    result = _failure({"mode": "patch", "patch": "*** Begin Patch\n*** End Patch", field: value})
+    assert result["failure"]["code"] == "patch.patch.incompatible_fields"
+
+
+def test_validation_precedes_path_resolution_approval_and_mutation():
+    args = {"mode": "replace", "path": 7, "old_string": "old", "new_string": "new"}
+    with (
+        patch("tools.file_tools._resolve_path_for_task") as resolve,
+        patch("tools.file_tools._check_approval_required_write") as approval,
+        patch("tools.file_tools._get_file_ops") as mutation,
+    ):
+        result = json.loads(_handle_patch(args))
+    assert result["failure"]["kind"] == "malformed_input"
+    resolve.assert_not_called()
+    approval.assert_not_called()
+    mutation.assert_not_called()

--- a/tests/tools/test_patch_contract_validation.py
+++ b/tests/tools/test_patch_contract_validation.py
@@ -87,6 +87,13 @@ def test_patch_mode_rejects_ambiguous_replace_fields(field, value):
     assert result["failure"]["code"] == "patch.patch.incompatible_fields"
 
 
+@pytest.mark.parametrize("mode", ["", "merge", 7])
+def test_unknown_or_invalid_mode_is_rejected(mode):
+    args = {"mode": mode}
+    result = _failure(args)
+    assert result["failure"]["code"] == "patch.mode.invalid"
+
+
 def test_validation_precedes_path_resolution_approval_and_mutation():
     args = {"mode": "replace", "path": 7, "old_string": "old", "new_string": "new"}
     with (

--- a/tests/tools/test_patch_contract_validation.py
+++ b/tests/tools/test_patch_contract_validation.py
@@ -51,11 +51,22 @@ def test_replace_allows_empty_new_string_deletion():
     handler.assert_called_once()
 
 
-def test_replace_rejects_identical_old_and_new_strings():
-    result = _failure(
-        {"mode": "replace", "path": "x.py", "old_string": "same", "new_string": "same"}
-    )
-    assert result["failure"]["code"] == "patch.replace.no_change"
+def test_replace_routes_identical_old_and_new_to_idempotency_handler():
+    args = {
+        "mode": "replace",
+        "path": "x.py",
+        "old_string": "same",
+        "new_string": "same",
+    }
+    with patch(
+        "tools.file_tools.patch_tool",
+        return_value='{"success":true,"no_change":true}',
+    ) as handler:
+        assert json.loads(_handle_patch(args)) == {
+            "success": True,
+            "no_change": True,
+        }
+    handler.assert_called_once()
 
 
 @pytest.mark.parametrize("patch_payload", ["diff", ""])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2371,6 +2371,11 @@ def _validate_patch_contract(args: dict) -> str | None:
                 + ", ".join(incompatible),
                 "patch.patch.incompatible_fields",
             )
+    else:
+        return _patch_contract_error(
+            "patch: 'mode' must be either 'replace' or 'patch'.",
+            "patch.mode.invalid",
+        )
     return None
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2311,6 +2311,69 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         return tool_error(str(e))
 
 
+def _patch_contract_error(message: str, code: str) -> str:
+    """Return a stable malformed-input envelope without echoing arguments."""
+    return json.dumps(
+        {
+            "error": message,
+            "success": False,
+            "failure": {
+                "kind": "malformed_input",
+                "class": "patch_contract",
+                "code": code,
+                "tool": "patch",
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+def _validate_patch_contract(args: dict) -> str | None:
+    """Validate the mode-dependent patch contract before any file-side work."""
+    mode = args.get("mode", "replace")
+    if mode == "replace":
+        invalid_fields = []
+        for field in ("path", "old_string", "new_string"):
+            value = args.get(field)
+            if not isinstance(value, str) or (field != "new_string" and not value):
+                invalid_fields.append(field)
+        if invalid_fields:
+            return _patch_contract_error(
+                "patch mode='replace': required string field(s) invalid: "
+                + ", ".join(invalid_fields),
+                f"patch.replace.{invalid_fields[0]}.invalid",
+            )
+        if args["old_string"] == args["new_string"]:
+            return _patch_contract_error(
+                "patch mode='replace': old_string and new_string must differ.",
+                "patch.replace.no_change",
+            )
+        if "patch" in args:
+            return _patch_contract_error(
+                "patch mode='replace' cannot include the patch payload.",
+                "patch.replace.incompatible_fields",
+            )
+    elif mode == "patch":
+        payload = args.get("patch")
+        if not isinstance(payload, str) or not payload.strip():
+            return _patch_contract_error(
+                "patch mode='patch': 'patch' is required and must be nonempty text.",
+                "patch.patch.patch.invalid",
+            )
+        incompatible = [
+            field for field in ("path", "old_string", "new_string") if field in args
+        ]
+        if args.get("replace_all") is True:
+            incompatible.append("replace_all")
+        if incompatible:
+            return _patch_contract_error(
+                "patch mode='patch' cannot include replace-mode fields: "
+                + ", ".join(incompatible),
+                "patch.patch.incompatible_fields",
+            )
+    return None
+
+
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default", cross_profile: bool = False,
@@ -2321,6 +2384,19 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
     targets under another profile's skills/plugins/cron/memories
     directory. Same shape as ``write_file``'s flag.
     """
+    contract_args = {"mode": mode, "replace_all": replace_all}
+    for key, value in (
+        ("path", path),
+        ("old_string", old_string),
+        ("new_string", new_string),
+        ("patch", patch),
+    ):
+        if value is not None:
+            contract_args[key] = value
+    contract_error = _validate_patch_contract(contract_args)
+    if contract_error:
+        return contract_error
+
     # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
     _paths_to_check = []
     # Paths whose CONTENT will be text-written (Update/Add + explicit path).
@@ -2798,31 +2874,11 @@ def _handle_write_file(args, **kw):
 
 
 def _handle_patch(args, **kw):
+    contract_error = _validate_patch_contract(args)
+    if contract_error:
+        return contract_error
     tid = kw.get("task_id") or "default"
     mode = args.get("mode", "replace")
-    if mode == "replace":
-        missing = []
-        if not args.get("path"):
-            missing.append("path")
-        if not args.get("old_string"):
-            missing.append("old_string")
-        if "new_string" not in args or args.get("new_string") is None:
-            missing.append("new_string")
-        if missing:
-            return tool_error(
-                "patch: mode='replace' is missing required field(s): "
-                f"{', '.join(missing)}. This tool call was not executed. Do not "
-                "re-emit the same incomplete call — set all three fields together. "
-                f"Available tools in this toolset: {_FILE_TOOLSET_TOOL_NAMES}."
-            )
-    elif mode == "patch":
-        if not args.get("patch"):
-            return tool_error(
-                "patch: mode='patch' is missing required field 'patch'. This tool "
-                "call was not executed. Do not re-emit the same empty call — set "
-                "'patch' to real V4A patch content. Available tools in this "
-                f"toolset: {_FILE_TOOLSET_TOOL_NAMES}."
-            )
     return patch_tool(
         mode=mode, path=args.get("path"),
         old_string=args.get("old_string"), new_string=args.get("new_string"),

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2752,9 +2752,22 @@ SEARCH_FILES_SCHEMA = {
 }
 
 
+# Tool names in this toolset, kept next to the registry.register() calls below
+# so it can't silently drift if a tool is added/removed. Mirrors the format
+# conversation_loop.py's _invalid_tool_name_error_content() already uses
+# (sorted, comma-separated) so the two error paths read consistently.
+_FILE_TOOLSET_TOOL_NAMES = "patch, read_file, search_files, write_file"
+
+
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    if not args.get("path") or not isinstance(args.get("path"), str):
+        return tool_error(
+            "read_file: missing required field 'path'. This tool call was not "
+            "executed. Do not re-emit the same empty call — set 'path' to a real "
+            f"file path. Available tools in this toolset: {_FILE_TOOLSET_TOOL_NAMES}."
+        )
+    return read_file_tool(path=args["path"], offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
 
 
 def _handle_write_file(args, **kw):
@@ -2786,8 +2799,32 @@ def _handle_write_file(args, **kw):
 
 def _handle_patch(args, **kw):
     tid = kw.get("task_id") or "default"
+    mode = args.get("mode", "replace")
+    if mode == "replace":
+        missing = []
+        if not args.get("path"):
+            missing.append("path")
+        if not args.get("old_string"):
+            missing.append("old_string")
+        if "new_string" not in args or args.get("new_string") is None:
+            missing.append("new_string")
+        if missing:
+            return tool_error(
+                "patch: mode='replace' is missing required field(s): "
+                f"{', '.join(missing)}. This tool call was not executed. Do not "
+                "re-emit the same incomplete call — set all three fields together. "
+                f"Available tools in this toolset: {_FILE_TOOLSET_TOOL_NAMES}."
+            )
+    elif mode == "patch":
+        if not args.get("patch"):
+            return tool_error(
+                "patch: mode='patch' is missing required field 'patch'. This tool "
+                "call was not executed. Do not re-emit the same empty call — set "
+                "'patch' to real V4A patch content. Available tools in this "
+                f"toolset: {_FILE_TOOLSET_TOOL_NAMES}."
+            )
     return patch_tool(
-        mode=args.get("mode", "replace"), path=args.get("path"),
+        mode=mode, path=args.get("path"),
         old_string=args.get("old_string"), new_string=args.get("new_string"),
         replace_all=args.get("replace_all", False), patch=args.get("patch"), task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
@@ -2797,11 +2834,18 @@ def _handle_patch(args, **kw):
 
 def _handle_search_files(args, **kw):
     tid = kw.get("task_id") or "default"
+    if not args.get("pattern") or not isinstance(args.get("pattern"), str):
+        return tool_error(
+            "search_files: missing required field 'pattern'. This tool call was not "
+            "executed. Do not re-emit the same empty call — set 'pattern' to a real "
+            "search pattern or glob. Available tools in this toolset: "
+            f"{_FILE_TOOLSET_TOOL_NAMES}."
+        )
     target_map = {"grep": "content", "find": "files"}
     raw_target = args.get("target", "content")
     target = target_map.get(raw_target, raw_target)
     return search_tool(
-        pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
+        pattern=args["pattern"], target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
         output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2343,11 +2343,11 @@ def _validate_patch_contract(args: dict) -> str | None:
                 + ", ".join(invalid_fields),
                 f"patch.replace.{invalid_fields[0]}.invalid",
             )
-        if args["old_string"] == args["new_string"]:
-            return _patch_contract_error(
-                "patch mode='replace': old_string and new_string must differ.",
-                "patch.replace.no_change",
-            )
+        # Identical old/new strings are not a malformed contract. The handler
+        # deliberately reads the target and returns a replay-safe no-op success
+        # when that text is already present (or the normal not-found error when
+        # it is absent). Keep that idempotency path out of malformed-retry
+        # streaks.
         if "patch" in args:
             return _patch_contract_error(
                 "patch mode='replace' cannot include the patch payload.",


### PR DESCRIPTION
## Problem

Malformed mode-dependent `patch` calls can reach approval/path/handler work, and repeated malformed retries with different missing fields are not recognized as the same failure class.

## Approach

- Preserve and build on Jonas's required-argument guard commit from #70897; original authorship remains intact as commit `3d7051d42b`.
- Validate final post-middleware/post-hook patch arguments before approval persistence, path resolution, checkpoints, or handler execution.
- Return stable content-free `malformed_input` metadata.
- Track retry equivalence by tool + deterministic failure class, not raw arguments.
- Serialize validation/guardrail state in model tool-call order for concurrent batches.
- Let corrected valid calls clear the malformed streak; `block` does not become a turn halt.
- Cover shared runtime dispatch paths, including model tools and agent runtime helpers.

## Tests

- Canonical focused suite: 452 passed, 2 platform skips
- Additional model-tool suite: 28 passed
- Final independent review suite: 189 passed, 2 skipped
- `test_run_agent.py`: 278 passed
- Concurrency stress: 100 model-order iterations / 200 cases passed
- Ruff, compile, diff, and added-line security scans passed

## Compatibility

- No prompt or tool-schema changes
- Hard-stop behavior remains config-gated
- Transient/external failures are excluded
- Existing plugin hook API remains backward-compatible

## Related work

This PR supersedes and extends #70897 while preserving Jonas's original commit and authorship. It also covers the broader malformed-retry class and approval/concurrency ordering that required integration at the shared dispatch boundary.
