### PR TITLE
feat(config): surface user-set values whose upstream default changed

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2512,6 +2512,28 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         config["_config_version"] = latest_ver
         _persist_migration(config)
 
+    # ── Default-drift notice (#91501) ────────────────────────────────────
+    # "Never overwrite user values" also meant "never tell users their values
+    # went stale." Surface — purely informationally — user-set keys whose
+    # upstream default changed in this upgrade window. Nothing is rewritten.
+    if current_ver < latest_ver and not floor_refused:
+        try:
+            from hermes_cli.config_migrations import collect_default_drift
+
+            for drift in collect_default_drift(read_raw_config(), current_ver):
+                msg = (
+                    f"  ⚠ {drift['key']} = {drift['value']} (user-set)\n"
+                    f"    Upstream default changed: {drift['change']}.\n"
+                    f"    Your value may now behave differently than when you set it."
+                )
+                results["warnings"].append(msg.strip())
+                if not quiet:
+                    print("\n⚠️  Config default changed since your last version:")
+                    print(msg)
+                    print("   Keep it if intentional; see docs for the new default.")
+        except Exception:
+            logger.debug("default-drift check skipped", exc_info=True)
+
     # ── Skill-declared config vars ──────────────────────────────────────
     # Skills can declare config.yaml settings they need via
     # metadata.hermes.config in their SKILL.md frontmatter.

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -874,6 +874,90 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
 )
 
 
+#: History of upstream default changes for keys users may have explicitly set.
+#: Maps dotted config key -> list of (config_version_where_change_landed, old_default).
+#: The last entry is the most recent pre-change default; the CURRENT default lives
+#: in DEFAULT_CONFIG and is never duplicated here. Purely informational — this
+#: registry never rewrites user values (#91501): the invariant "never overwrite
+#: user-set config" stays intact, this only tells users when a value they set may
+#: now behave differently than when they wrote it.
+DEFAULT_HISTORY: Dict[str, Tuple[Tuple[int, Any], ...]] = {
+    # 300s blanket cap introduced (#13770), then removed entirely (#45149):
+    # an explicit user value re-enables the removed wall-clock cap.
+    "delegation.child_timeout_seconds": ((31, None),),
+    # 400 was a plausible value under the old default era; upstream later
+    # standardized on 5000, so a stale 400 force-compresses ~12x earlier.
+    "compression.hygiene_hard_message_limit": ((33, 400),),
+}
+
+
+_MISSING_DEFAULT = object()  # sentinel: key absent from DEFAULT_CONFIG
+
+
+def collect_default_drift(
+    config: Optional[Dict[str, Any]],
+    previous_version: int,
+) -> List[Dict[str, str]]:
+    """Find user-set values whose upstream default changed at/after *previous_version*.
+
+    Non-destructive and purely informational: returns one record per drifted key
+    with the user value, the old default(s) and the current schema default. Only
+    keys the user explicitly set on disk are considered — anything absent from
+    *config* already tracks its default by definition. Called after the version
+    bump in ``migrate_config`` so *previous_version* is the on-disk version the
+    user upgraded FROM.
+    """
+    if not config or not isinstance(config, dict):
+        return []
+
+    try:
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+    except Exception:
+        return []
+
+    def _current_default(dotted: str) -> Any:
+        node: Any = DEFAULT_CONFIG
+        for part in dotted.split("."):
+            if not isinstance(node, dict) or part not in node:
+                return _MISSING_DEFAULT
+            node = node[part]
+        return node
+
+    drifts: List[Dict[str, str]] = []
+    for key, history in DEFAULT_HISTORY.items():
+        # Must be explicitly set by the user.
+        node: Any = config
+        present = True
+        for part in key.split("."):
+            if not isinstance(node, dict) or part not in node:
+                present = False
+                break
+            node = node[part]
+        if not present:
+            continue
+
+        changes = [h for h in history if h[0] > previous_version]
+        if not changes:
+            continue
+
+        current_default = _current_default(key)
+        if current_default is _MISSING_DEFAULT:
+            continue
+        # Unchanged intent: user value equals the current default → nothing to flag.
+        if node == current_default:
+            continue
+
+        old_desc = " → ".join(
+            "removed" if old is None else repr(old) for _, old in changes
+        )
+        drifts.append({
+            "key": key,
+            "value": repr(node),
+            "change": f"{old_desc} → {current_default!r}",
+        })
+    return drifts
+
+
 def run_migrations(current_ver: int, results: Dict[str, Any], quiet: bool) -> None:
     """Apply every registered migration whose target version exceeds *current_ver*.
 

--- a/tests/hermes_cli/test_config_default_drift.py
+++ b/tests/hermes_cli/test_config_default_drift.py
@@ -1,0 +1,56 @@
+"""Tests for default-drift detection (#91501).
+
+User-set config values whose upstream default changed should surface an
+informational notice — without ever rewriting the user's value.
+"""
+
+from hermes_cli.config_migrations import DEFAULT_HISTORY, collect_default_drift
+
+
+class TestCollectDefaultDrift:
+    def test_user_set_changed_key_is_flagged(self):
+        cfg = {
+            "delegation": {"child_timeout_seconds": 600},
+            "_config_version": 30,
+        }
+        drifts = collect_default_drift(cfg, previous_version=30)
+        assert len(drifts) == 1
+        assert drifts[0]["key"] == "delegation.child_timeout_seconds"
+        assert "600" in drifts[0]["value"]
+        assert "removed" in drifts[0]["change"]
+
+    def test_unchanged_intent_not_flagged(self):
+        # User value equals the CURRENT default → nothing to tell them.
+        cfg = {"compression": {"hygiene_hard_message_limit": 5000}}
+        drifts = collect_default_drift(cfg, previous_version=32)
+        assert drifts == []
+
+    def test_key_absent_means_tracking_default(self):
+        cfg = {"delegation": {}, "_config_version": 30}
+        assert collect_default_drift(cfg, previous_version=30) == []
+
+    def test_no_changes_in_window(self):
+        # Change landed at v31; upgrading from 31 → nothing new to report.
+        cfg = {"delegation": {"child_timeout_seconds": 600}}
+        assert collect_default_drift(cfg, previous_version=31) == []
+
+    def test_empty_or_invalid_config(self):
+        assert collect_default_drift(None, previous_version=1) == []
+        assert collect_default_drift("not-a-dict", previous_version=1) == []
+
+    def test_registry_entries_resolve_to_real_defaults(self):
+        """Every registry key must exist in DEFAULT_CONFIG with a non-missing default."""
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        for key in DEFAULT_HISTORY:
+            node = DEFAULT_CONFIG
+            for part in key.split("."):
+                assert isinstance(node, dict) and part in node, f"{key} missing from DEFAULT_CONFIG"
+                node = node[part]
+
+    def test_hygiene_limit_change_reported_with_old_and_new(self):
+        cfg = {"compression": {"hygiene_hard_message_limit": 400}}
+        drifts = collect_default_drift(cfg, previous_version=32)
+        assert len(drifts) == 1
+        assert "400" in drifts[0]["change"]  # old default
+        assert "5000" in drifts[0]["change"]  # current default


### PR DESCRIPTION
## What

Surfaces an informational notice when a user explicitly set a config value whose upstream default changed in the upgrade window — without ever rewriting the user's value.

Closes #91501.

## Why

"Never overwrite user-set config" is the right invariant, but it also meant "never tell users their values went stale." Two real incidents from the issue:

- `delegation.child_timeout_seconds: 600` set under the old 300s default silently re-enabled the blanket wall-clock cap that #45149 deliberately removed.
- A stale `compression.hygiene_hard_message_limit: 400` force-compressed gateway sessions 12.5× more aggressively than any default Hermes ever shipped — until manually noticed.

## How

1. **`DEFAULT_HISTORY` registry** (`config_migrations.py`) — maps dotted config keys to `(config_version, old_default)` tuples, next to the existing migration ladder. Seeded with the two documented real cases; new entries are one line.
2. **`collect_default_drift(config, previous_version)`** — pure function: flags keys that are (a) explicitly set on disk, (b) have a default change landing after `previous_version`, and (c) don't already equal the *current* default (unchanged intent = nothing to say).
3. **Hook in `migrate_config()`** — after the version bump, prints a non-blocking notice per drifted key and collects it into `results["warnings"]`. Guarded so any failure skips silently (never blocks migration).

Example output:

```
⚠️  Config default changed since your last version:
  ⚠ delegation.child_timeout_seconds = 600 (user-set)
    Upstream default changed: removed → None.
    Your value may now behave differently than when you set it.
   Keep it if intentional; see docs for the new default.
```

## Tests

7 new tests in `tests/hermes_cli/test_config_default_drift.py`: flagged / unchanged-intent-not-flagged / absent-key-tracks-default / no-changes-in-window / invalid-config, plus a **registry integrity guard** asserting every `DEFAULT_HISTORY` key resolves to a live `DEFAULT_CONFIG` entry (so a future default removal can't leave a dangling registry entry).

Verified: 7/7 pass; full migrate/config-version test slice passes (55); ruff clean on all touched files.

## Risk

Very low. Purely informational, opt-out by doing nothing (it only prints during a version-changing migration). No user value is read-modified-written; the only new failure mode is a skipped notice.