### PR TITLE
feat(nvidia): family-gated reasoning envelopes for NIM thinking models

### DIFF
--- a/agent/nim_reasoning.py
+++ b/agent/nim_reasoning.py
@@ -1,0 +1,48 @@
+"""Shared NVIDIA NIM reasoning-family and effort policy."""
+
+import re
+
+_GLM5_MODEL_RE = re.compile(r"(^|/)glm[-_]?5", re.IGNORECASE)
+_NEMOTRON_3_ULTRA_MODEL_RE = re.compile(
+    r"(^|/)nemotron[-_]?3[-_]?ultra(?:[-_/]|$)", re.IGNORECASE
+)
+_STANDARD_THINKING_FAMILY_MARKERS = (
+    "deepseek",
+    "kimi",
+    "moonshot",
+    "qwen3",
+    "qwen-3",
+    "qwen_3",
+)
+_HERMES_TO_NIM_EFFORT = {
+    "minimal": "low",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "xhigh": "high",
+    "max": "high",
+    "ultra": "high",
+}
+
+
+def is_glm5_nim_model(model: str | None) -> bool:
+    return bool(model and _GLM5_MODEL_RE.search(model))
+
+
+def is_nemotron_3_ultra_nim_model(model: str | None) -> bool:
+    return bool(model and _NEMOTRON_3_ULTRA_MODEL_RE.search(model))
+
+
+def is_nim_thinking_model(model: str | None) -> bool:
+    normalized = (model or "").lower()
+    return (
+        is_glm5_nim_model(model)
+        or is_nemotron_3_ultra_nim_model(model)
+        or any(marker in normalized for marker in _STANDARD_THINKING_FAMILY_MARKERS)
+    )
+
+
+def normalize_nim_reasoning_effort(effort: object) -> tuple[str, str]:
+    """Return ``(raw_effort, low|medium|high)`` for a Hermes effort."""
+    raw = str(effort or "medium").strip().lower()
+    return raw, _HERMES_TO_NIM_EFFORT.get(raw, "high")

--- a/agent/reasoning_params.py
+++ b/agent/reasoning_params.py
@@ -128,23 +128,59 @@ class ReasoningParamsMixin:
     _build_assistant_message = _forward("agent.chat_completion_helpers", "build_assistant_message")
 
     def _needs_thinking_reasoning_pad(self) -> bool:
-        """True when the provider enforces ``reasoning_content`` echo-back on tool-call replays (DeepSeek, Kimi,
-        MiMo thinking all 400 without it). Cached per (provider, model, base_url), invalidated by
-        ``switch_model()`` / ``_try_activate_fallback()`` — called ~16× per turn.
-
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays of assistant tool-call
-        messages that omit ``reasoning_content`` (refs 15250, #17400). Xiaomi MiMo thinking mode has the
-        same requirement.
-        """
-        key = (self.provider, self.model, getattr(self, "_base_url_lower", self.base_url))
+        """Whether the active provider requires reasoning-content echo on tool replays."""
+        reasoning_config = getattr(self, "reasoning_config", None)
+        if not isinstance(reasoning_config, dict):
+            reasoning_config = {}
+        provider = getattr(self, "provider", None)
+        model = getattr(self, "model", None)
+        base_url = getattr(self, "base_url", None)
+        key = (
+            provider,
+            model,
+            getattr(self, "_base_url_lower", base_url),
+            reasoning_config.get("enabled", True),
+            str(reasoning_config.get("effort") or "").strip().lower(),
+        )
         cached = getattr(self, "_thinking_pad_cache", None)
         if cached is not None and cached[0] == key:
             return cached[1]
-        result = (self._needs_deepseek_tool_reasoning() or self._needs_kimi_tool_reasoning()
-                  or self._needs_mimo_tool_reasoning() or self._reasoning_echo_opt_in())
+        is_nim_endpoint = (
+            (provider or "").lower() == "nvidia"
+            or base_url_host_matches(base_url or "", "integrate.api.nvidia.com")
+        )
+        result = (
+            self._needs_nim_tool_reasoning()
+            if is_nim_endpoint
+            else (
+                self._needs_deepseek_tool_reasoning()
+                or self._needs_kimi_tool_reasoning()
+                or self._needs_mimo_tool_reasoning()
+                or self._reasoning_echo_opt_in()
+            )
+        )
         self._thinking_pad_cache = (key, result)
         return result
 
+    def _needs_nim_tool_reasoning(self) -> bool:
+        """True for enabled thinking families on NVIDIA NIM."""
+        from agent.nim_reasoning import is_nim_thinking_model
+
+        provider = getattr(self, "provider", None)
+        base_url = getattr(self, "base_url", None)
+        if not (
+            (provider or "").lower() == "nvidia"
+            or base_url_host_matches(base_url or "", "integrate.api.nvidia.com")
+        ):
+            return False
+        reasoning_config = getattr(self, "reasoning_config", None)
+        if not isinstance(reasoning_config, dict):
+            return False
+        if reasoning_config.get("enabled", True) is False:
+            return False
+        if str(reasoning_config.get("effort") or "").strip().lower() == "none":
+            return False
+        return is_nim_thinking_model(getattr(self, "model", None))
     def _reasoning_echo_opt_in(self) -> bool:
         """``model.reasoning_echo`` opt-in for the *current* provider (covers gateways the host rules miss);
         fallback activation swaps the flag and ``restore_primary_runtime()`` restores it."""

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -125,6 +125,17 @@ def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> di
     return {**reasoning_config, "effort": clamped} if clamped != effort else reasoning_config
 
 
+def _deep_merge_dict(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Merge nested provider request bodies without erasing sibling keys."""
+    merged = dict(base)
+    for key, value in overlay.items():
+        current = merged.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_dict(current, value)
+        else:
+            merged[key] = value
+    return merged
+
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
     """Translate Hermes/OpenRouter-style reasoning config to Gemini thinkingConfig."""
     if not isinstance(reasoning_config, dict):
@@ -449,7 +460,7 @@ class ChatCompletionsTransport(ProviderTransport):
             reasoning_config=reasoning_config, supports_reasoning=params.get("supports_reasoning", False),
             qwen_session_metadata=params.get("qwen_session_metadata"), model=model,
             base_url=params.get("base_url"), ollama_num_ctx=params.get("ollama_num_ctx"),
-            session_id=params.get("session_id"),
+            session_id=params.get("session_id"), request_overrides=params.get("request_overrides"),
         )
         api_kwargs.update(top_level_from_profile)
 
@@ -461,10 +472,10 @@ class ChatCompletionsTransport(ProviderTransport):
         )
         for part in (profile_body, extra_body_from_profile, params.get("extra_body_additions")):
             if part:
-                extra_body.update(part)
+                extra_body = _deep_merge_dict(extra_body, part)
         for k, v in (params.get("request_overrides") or {}).items():
             if k == "extra_body" and isinstance(v, dict):
-                extra_body.update(v)
+                extra_body = _deep_merge_dict(extra_body, v)
             else:
                 api_kwargs[k] = v
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -36,6 +36,18 @@ class CustomProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
         if ollama_num_ctx:
             extra_body["options"] = {"num_ctx": ollama_num_ctx}
+        # A configured provider-specific chat-template envelope is authoritative.
+        # Do not mix it with generic OpenAI/Ollama reasoning controls.
+        request_overrides = ctx.get("request_overrides")
+        override_body = (
+            request_overrides.get("extra_body", {})
+            if isinstance(request_overrides, dict)
+            else {}
+        )
+        if isinstance(override_body, dict) and isinstance(
+            override_body.get("chat_template_kwargs"), dict
+        ):
+            return extra_body, top_level
         # disabled -> top-level reasoning_effort="none" (Ollama's /v1 ignores
         # extra_body.think) plus think=False only on Ollama URLs; enabled+effort ->
         # top-level reasoning_effort clamped to the OpenAI-compat wire (GLM/ARK,

--- a/plugins/model-providers/nvidia/__init__.py
+++ b/plugins/model-providers/nvidia/__init__.py
@@ -1,14 +1,67 @@
 """NVIDIA NIM provider profile."""
 
+import logging
 from typing import Any
 
+from agent.nim_reasoning import (
+    is_glm5_nim_model,
+    is_nemotron_3_ultra_nim_model,
+    is_nim_thinking_model,
+    normalize_nim_reasoning_effort,
+)
 from providers import register_provider
 from providers.base import ProviderProfile
+
+
+logger = logging.getLogger(__name__)
 
 
 class NvidiaProviderProfile(ProviderProfile):
     """NVIDIA NIM accepts a stricter ToolMessage schema than most OpenAI-compatible APIs."""
 
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        model: str | None = None,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if not isinstance(reasoning_config, dict) or not is_nim_thinking_model(model):
+            return {}, {}
+
+        enabled = reasoning_config.get("enabled", True)
+        raw_effort, nim_effort = normalize_nim_reasoning_effort(reasoning_config.get("effort"))
+        if enabled is False or raw_effort == "none":
+            if is_glm5_nim_model(model):
+                template = {"enable_thinking": False, "clear_thinking": False}
+            elif is_nemotron_3_ultra_nim_model(model):
+                template = {"enable_thinking": False}
+            else:
+                template = {"thinking": False}
+            return {"chat_template_kwargs": template}, {}
+
+        if is_nemotron_3_ultra_nim_model(model):
+            template = {"enable_thinking": True}
+            if nim_effort in {"low", "medium"}:
+                template["medium_effort"] = True
+            return {"chat_template_kwargs": template}, {}
+
+        if raw_effort not in {"low", "medium", "high"}:
+            logger.info(
+                "NIM reasoning_effort: clamping %s → %s (NIM supports low/medium/high)",
+                raw_effort,
+                nim_effort,
+            )
+
+        if is_glm5_nim_model(model):
+            template = {
+                "enable_thinking": True,
+                "clear_thinking": False,
+                "reasoning_effort": nim_effort,
+            }
+        else:
+            template = {"thinking": True, "reasoning_effort": nim_effort}
+        return {"chat_template_kwargs": template}, {}
     @staticmethod
     def _needs_strip(msg: Any) -> bool:
         return isinstance(msg, dict) and msg.get("role") == "tool" and ("name" in msg or "tool_name" in msg)

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -170,6 +170,39 @@ class TestCustomReasoningWireShape:
         assert eb.get("think") is not True
 
 
+class TestCustomReasoningWithProviderEnvelope:
+    """Configured provider envelopes own reasoning wire-shape end to end."""
+
+    @pytest.mark.parametrize(
+        "reasoning_config",
+        [
+            {"enabled": True, "effort": "xhigh"},
+            {"enabled": False},
+        ],
+    )
+    def test_chat_template_kwargs_suppress_generic_reasoning(
+        self, custom_profile, reasoning_config
+    ):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="MiniMax-M3",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            provider_profile=custom_profile,
+            reasoning_config=reasoning_config,
+            request_overrides={
+                "extra_body": {"chat_template_kwargs": {"thinking": True}}
+            },
+        )
+
+        assert kwargs["extra_body"] == {
+            "chat_template_kwargs": {"thinking": True}
+        }
+        assert "reasoning_effort" not in kwargs
+        assert "think" not in kwargs["extra_body"]
+
+
 class TestCustomReasoningWithNumCtx:
     """Ollama num_ctx and reasoning are independent and compose."""
 

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -42,6 +42,147 @@ class TestNvidiaParity:
         )
         assert kw["max_completion_tokens"] == 4096  # user overrides default
 
+    @pytest.mark.parametrize(
+        ("model", "effort", "expected"),
+        [
+            (
+                "z-ai/glm5.1",
+                "ultra",
+                {
+                    "chat_template_kwargs": {
+                        "enable_thinking": True,
+                        "clear_thinking": False,
+                        "reasoning_effort": "high",
+                    },
+                },
+            ),
+            (
+                "deepseek-ai/deepseek-v4",
+                "xhigh",
+                {
+                    "chat_template_kwargs": {
+                        "thinking": True,
+                        "reasoning_effort": "high",
+                    },
+                },
+            ),
+            (
+                "moonshotai/kimi-k2.5",
+                "medium",
+                {
+                    "chat_template_kwargs": {
+                        "thinking": True,
+                        "reasoning_effort": "medium",
+                    },
+                },
+            ),
+            (
+                "qwen/qwen3.5-397b-a17b",
+                "minimal",
+                {
+                    "chat_template_kwargs": {
+                        "thinking": True,
+                        "reasoning_effort": "low",
+                    },
+                },
+            ),
+            (
+                "nvidia/nemotron-3-ultra-550b-a55b",
+                "high",
+                {
+                    "chat_template_kwargs": {"enable_thinking": True},
+                },
+            ),
+            (
+                "nvidia/nemotron-3-ultra-550b-a55b",
+                "medium",
+                {
+                    "chat_template_kwargs": {
+                        "enable_thinking": True,
+                        "medium_effort": True,
+                    },
+                },
+            ),
+            (
+                "nvidia/nemotron-3-ultra-550b-a55b",
+                "low",
+                {
+                    "chat_template_kwargs": {
+                        "enable_thinking": True,
+                        "medium_effort": True,
+                    },
+                },
+            ),
+        ],
+    )
+    def test_reasoning_uses_family_specific_nim_envelope(
+        self, transport, model, effort, expected
+    ):
+        kw = transport.build_kwargs(
+            model=model,
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("nvidia"),
+            reasoning_config={"enabled": True, "effort": effort},
+        )
+
+        assert kw["extra_body"] == expected
+        assert "reasoning_effort" not in kw
+
+    def test_nemotron_3_ultra_reasoning_disabled_uses_family_specific_toggle(
+        self, transport
+    ):
+        kw = transport.build_kwargs(
+            model="nvidia/nemotron-3-ultra-550b-a55b",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("nvidia"),
+            reasoning_config={"enabled": False, "effort": "none"},
+        )
+
+        assert kw["extra_body"] == {
+            "chat_template_kwargs": {"enable_thinking": False}
+        }
+        assert "reasoning_budget" not in kw["extra_body"]
+
+    def test_nemotron_3_ultra_does_not_enable_reasoning_without_policy(
+        self, transport
+    ):
+        kw = transport.build_kwargs(
+            model="nvidia/nemotron-3-ultra-550b-a55b",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("nvidia"),
+            reasoning_config=None,
+        )
+
+        assert "extra_body" not in kw
+
+    def test_nim_chat_template_overrides_merge_without_erasing_profile_fields(
+        self, transport
+    ):
+        kw = transport.build_kwargs(
+            model="deepseek-ai/deepseek-v4",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("nvidia"),
+            reasoning_config={"enabled": True, "effort": "high"},
+            request_overrides={
+                "extra_body": {
+                    "chat_template_kwargs": {
+                        "custom_flag": "keep",
+                        "reasoning_effort": "low",
+                    }
+                }
+            },
+        )
+
+        assert kw["extra_body"]["chat_template_kwargs"] == {
+            "thinking": True,
+            "reasoning_effort": "low",
+            "custom_flag": "keep",
+        }
+
 
 class TestKimiParity:
     """Kimi: OMIT temperature, max_tokens=32000, thinking + reasoning_effort."""
@@ -105,7 +246,7 @@ class TestOpenRouterParity:
 
 
 class TestNousParity:
-    """Nous: product tags, reasoning passthrough (disable included)."""
+    """Nous: product tags, reasoning, omit when disabled."""
 
     def test_tags(self, transport):
         from agent.portal_tags import nous_portal_tags

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -84,6 +84,46 @@ class TestNeedsDeepSeekToolReasoning:
 
 
 
+class TestNeedsNimToolReasoning:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "z-ai/glm5.1",
+            "deepseek-ai/deepseek-v4",
+            "moonshotai/kimi-k2.5",
+            "qwen/qwen3.5-397b-a17b",
+            "nvidia/nemotron-3-ultra-550b-a55b",
+        ],
+    )
+    def test_nim_thinking_families_require_reasoning_echo(self, model) -> None:
+        agent = _make_agent(
+            provider="nvidia",
+            model=model,
+            base_url="https://integrate.api.nvidia.com/v1",
+        )
+        setattr(agent, "reasoning_config", {"enabled": True, "effort": "high"})
+
+        assert agent._needs_thinking_reasoning_pad() is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "z-ai/glm5.1",
+            "deepseek-ai/deepseek-v4",
+            "nvidia/nemotron-3-ultra-550b-a55b",
+        ],
+    )
+    def test_disabled_nim_reasoning_is_not_padded(self, model) -> None:
+        agent = _make_agent(
+            provider="nvidia",
+            model=model,
+            base_url="https://integrate.api.nvidia.com/v1",
+        )
+        setattr(agent, "reasoning_config", {"enabled": False, "effort": "high"})
+
+        assert agent._needs_thinking_reasoning_pad() is False
+
+
 class TestCopyReasoningContentForApi:
     """_copy_reasoning_content_for_api pads reasoning_content for DeepSeek tool-calls."""
 


### PR DESCRIPTION
## Summary

NVIDIA NIM thinking models need family-specific request shaping that the current bare provider profile does not provide:

- `agent/nim_reasoning.py` (new): model-family detection (GLM-5, Nemotron-3-Ultra, generic thinking) + effort normalization.
- nvidia profile: family-specific `chat_template_kwargs` envelopes; the disable path emits explicit per-family thinking-off toggles (`enable_thinking: false` / `{enable_thinking: false, clear_thinking: false}` / `thinking: false`) instead of a one-size flag; Nemotron-3-Ultra maps Hermes low/medium to its trained efficient mode rather than inferring a `reasoning_budget`.
- custom profile: when a user configures a provider-specific chat-template envelope it is authoritative — generic reasoning controls are not mixed into the same body (strict gateways such as api.iamhc.cn reject or reinterpret the hybrid shape).
- `transports/chat_completions`: nested `extra_body` is now deep-merged so envelope keys don't erase sibling keys set elsewhere; `request_overrides` are passed through to the profile hook.
- `run_agent`: NIM thinking families join the existing `_needs_*_tool_reasoning` gate (reasoning echo required); the hot-path cache key includes reasoning enabled/effort so config flips invalidate correctly.

Closes #92359.

## Verification

- tests/plugins/model_providers/test_custom_profile.py: 13 passed
- tests/providers/test_transport_parity.py: 20 passed (incl. merge-does-not-erase-siblings)
- tests/run_agent/test_deepseek_reasoning_content_echo.py: 40+ passed
