### PR TITLE
fix(cli): print deferred update notice through a patch_stdout-safe printer

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -503,8 +503,18 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
     _deferred_update_notice_started = True
 
     def _wait_and_print() -> None:
-        if _update_check_done.wait(timeout=max_wait) and _update_result:
-            console.print(_format_update_notice(_update_result))
+        if not _update_check_done.wait(timeout=max_wait):
+            return
+        behind = _update_result
+        if behind is None or behind == 0:
+            return
+        # Once patch_stdout() is active, a Rich Console can leak/sanitize ANSI
+        # through prompt_toolkit's StdoutProxy. Deferred notices stay plain;
+        # the synchronous banner path remains colorized.
+        from rich.text import Text
+
+        print(Text.from_markup(_format_update_notice(behind)).plain)
+
     _daemon("update-notice", _wait_and_print)  # never break the session over an update notice
 
 

--- a/tests/tools/test_startup_latency_regressions.py
+++ b/tests/tools/test_startup_latency_regressions.py
@@ -11,7 +11,7 @@ These pin the CLI cold-start contract established in the sub-400ms pass:
 import sys
 import threading
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -174,16 +174,14 @@ class TestBannerUpdateCheckNonBlocking:
         import hermes_cli.banner as banner
 
         printed = []
-
-        class _Console:
-            def print(self, msg, *a, **k):
-                printed.append(msg)
+        console = MagicMock()
 
         done = threading.Event()
         with patch.object(banner, "_update_check_done", done), \
              patch.object(banner, "_update_result", None), \
-             patch.object(banner, "_deferred_update_notice_started", False):
-            banner._defer_update_notice(_Console(), max_wait=5.0)
+             patch.object(banner, "_deferred_update_notice_started", False), \
+             patch("builtins.print", side_effect=printed.append):
+            banner._defer_update_notice(console, max_wait=5.0)
             banner._update_result = 3
             done.set()
             deadline = time.time() + 5
@@ -191,6 +189,38 @@ class TestBannerUpdateCheckNonBlocking:
                 time.sleep(0.02)
         assert printed, "deferred update notice never printed"
         assert "3 commits behind" in printed[0]
+
+    def test_deferred_notice_uses_prompt_toolkit_safe_printer(self):
+        """Late Rich output must not write ANSI into patch_stdout's proxy."""
+        import hermes_cli.banner as banner
+
+        printed = []
+
+        unsafe_console = MagicMock()
+        unsafe_console.print.side_effect = AssertionError(
+            "raw Rich console must not handle late notice"
+        )
+
+        done = threading.Event()
+        with patch.object(banner, "_update_check_done", done), \
+             patch.object(banner, "_update_result", None), \
+             patch.object(banner, "_deferred_update_notice_started", False), \
+             patch("builtins.print", side_effect=printed.append):
+            banner._defer_update_notice(
+                unsafe_console,
+                max_wait=5.0,
+            )
+            banner._update_result = 922
+            done.set()
+            deadline = time.time() + 5
+            while not printed and time.time() < deadline:
+                time.sleep(0.02)
+
+        assert printed, "safe deferred printer was never called"
+        assert "922 commits behind" in printed[0]
+        assert "?[" not in printed[0]
+        assert "\x1b[" not in printed[0]
+        assert "[bold" not in printed[0]
 
     def test_deferred_notice_silent_when_up_to_date(self):
         import hermes_cli.banner as banner


### PR DESCRIPTION
## Summary

The deferred update notice (`_defer_update_notice`, printed up to 30s after startup when the prefetch finishes late) goes through a normal Rich Console writing rendered ANSI bytes to `sys.stdout`. Inside an interactive CLI session that stream is prompt_toolkit's `StdoutProxy(raw=False)` (patch_stdout), which sanitizes ESC into a literal `?` and renders color codes as text like `?[1;33m` — the notice appears mid-session as garbage.

Fix: print it deliberately plain via `Text.from_markup(...).plain` + builtin `print`. The early path (notice ready before the banner renders) keeps Rich coloring.

Also lands the startup-latency regression coverage additions for this contract (safe-printer used, no ANSI/markup leakage, silence when up to date).

Closes #92362. Closes #92363.

## Verification

- tests/tools/test_startup_latency_regressions.py: 17 passed
