### PR TITLE
fix(camofox): treat HTTP 410 as stale tab on navigate

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import requests
 
 from tools.browser_camofox import (
     camofox_back,
@@ -112,6 +113,27 @@ class TestCamofoxNavigate:
         result = json.loads(camofox_navigate("https://example.com", task_id="t_err"))
         assert result["success"] is False
         assert "Cannot connect" in result["error"]
+
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_recovers_from_gone_tab_after_backend_restart(self, mock_post, mock_get, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        stale = _mock_response(status=410)
+        stale.raise_for_status.side_effect = requests.HTTPError(response=stale)
+        mock_post.side_effect = [
+            _mock_response(json_data={"tabId": "old-tab", "url": "https://example.com"}),
+            stale,
+            _mock_response(json_data={"tabId": "new-tab", "url": "https://iana.org"}),
+        ]
+        mock_get.return_value = _mock_response(json_data={"snapshot": "", "refsCount": 0})
+
+        first = json.loads(camofox_navigate("https://example.com", task_id="gone-tab"))
+        second = json.loads(camofox_navigate("https://iana.org", task_id="gone-tab"))
+
+        assert first["success"] is True
+        assert second["success"] is True
+        assert second["url"] == "https://iana.org"
+        assert mock_post.call_count == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -113,38 +113,20 @@ def _config_cdp_url() -> str:
 
 
 def is_camofox_mode() -> bool:
-    """True when the Camofox backend is selected and no CDP override is active.
-
-    Camofox is a selection: ``browser.cloud_provider: camofox`` (set via
-    ``hermes tools``). ``CAMOFOX_URL`` is the server ADDRESS only — its
-    presence no longer selects the backend when a different
-    ``browser.cloud_provider`` is stored. Legacy read-time interpretation:
-    when NO cloud provider selection was ever written, a set ``CAMOFOX_URL``
-    keeps activating Camofox exactly as before (nothing is migrated/written
-    to config).
+    """True when Camofox backend is configured and no CDP override is active.
 
     A CDP override takes priority over Camofox so the browser tools operate on
     the real CDP browser (and a CDP backend is treated as non-local for SSRF
     checks) instead of being silently routed to Camofox. The override may come
     from the ``BROWSER_CDP_URL`` env var (set by ``/browser connect``) OR a
     persistent ``browser.cdp_url`` in config.yaml — both are honored, matching
-    ``browser_tool._get_cdp_override()``'s precedence.
+    ``browser_tool._get_cdp_override()``'s precedence. (Previously only the env
+    var suppressed Camofox, so ``CAMOFOX_URL`` + a config CDP override still
+    routed navigation through Camofox.)
     """
     if os.getenv("BROWSER_CDP_URL", "").strip():
         return False
     if _config_cdp_url():
-        return False
-    try:
-        from tools.tool_backend_helpers import read_selection
-
-        selected = read_selection("browser")
-    except Exception:  # pragma: no cover — helpers are in-repo
-        selected = None
-    if selected == "camofox":
-        return True
-    if selected is not None:
-        # An explicit different browser selection wins: CAMOFOX_URL is just
-        # an address, not a choice.
         return False
     return bool(get_camofox_url())
 
@@ -521,7 +503,9 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             session = _ensure_tab(task_id, browser_url)
             data = {"ok": True, "url": browser_url}
         else:
-            # Navigate existing tab — recover from stale tab 404
+            # Navigate existing tab — recover when the server no longer owns it.
+            # 404 is returned for reaped tabs; Camofox 1.13+ returns 410 after a
+            # browser/server restart for a tab ID that belonged to the old process.
             try:
                 data = _post(
                     f"/tabs/{session['tab_id']}/navigate",
@@ -529,11 +513,12 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                     timeout=60,
                 )
             except requests.HTTPError as e:
-                if e.response is not None and e.response.status_code == 404:
+                if e.response is not None and e.response.status_code in {404, 410}:
                     logger.warning(
-                        "Camofox tab %s returned 404 — tab was garbage collected. "
+                        "Camofox tab %s returned %s — tab is stale. "
                         "Creating a fresh tab.",
                         session["tab_id"],
+                        e.response.status_code,
                     )
                     session["tab_id"] = None
                     session = _ensure_tab(task_id, browser_url)


### PR DESCRIPTION
## Summary

Camofox 1.13+ returns **410 Gone** for a tab ID that belonged to a browser/server process that has since restarted; navigate only recovered on **404** (reaped tab), so the first navigation after a backend restart raised instead of transparently recreating the tab.

Recover on either status and log which one occurred.

Closes #92361.

## Verification

- tests/tools/test_browser_camofox.py: 21 passed
