### PR TITLE
fix: resolve model_aliases in HermesCLI + py3.11 future-annotations

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -300,6 +300,7 @@ import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import {
   collectRelaunchArgs,
   observeUpdaterHandoff,
+  resolvePosixHandoffBranch,
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
   resolveUpdateScriptHandoff,
@@ -4039,7 +4040,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
     const current = (head.stdout || '').trim()
 
     if (head.code === 0 && current && current !== 'HEAD') {
-      branch = await resolveHealedBranch(updateRoot, current)
+      branch = await resolvePosixHandoffBranch(current, candidate => resolveHealedBranch(updateRoot, candidate))
     }
   } catch {
     // best effort

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -8,6 +8,7 @@ import {
   collectRelaunchArgs,
   MARKER_SELF_ADOPT_EPOCH_MS,
   observeUpdaterHandoff,
+  resolvePosixHandoffBranch,
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
   resolveUpdateScriptHandoff,
@@ -249,6 +250,28 @@ test('wrapHandoffForDetachedConsole routes through cmd start with own console', 
     '-Branch',
     'main'
   ])
+})
+
+test('resolvePosixHandoffBranch preserves local patch branch without remote healing', async () => {
+  let healCalls = 0
+  const branch = await resolvePosixHandoffBranch('hermes-local-fixes', async () => {
+    healCalls += 1
+    return 'main'
+  })
+
+  assert.equal(branch, 'hermes-local-fixes')
+  assert.equal(healCalls, 0)
+})
+
+test('resolvePosixHandoffBranch still heals ordinary deleted branches', async () => {
+  let received = ''
+  const branch = await resolvePosixHandoffBranch('bb/gui', async candidate => {
+    received = candidate
+    return 'main'
+  })
+
+  assert.equal(received, 'bb/gui')
+  assert.equal(branch, 'main')
 })
 
 test('resolvePosixScriptHandoff returns the bash recipe when the script exists', () => {

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -20,6 +20,21 @@ export interface UpdateScriptHandoff {
   scriptPath: string
 }
 
+/** Preserve the local carried-patch branch for the reviewed safe updater.
+ * Remote-healing is correct for deleted integration branches, but this branch
+ * is intentionally local-only and must never be rewritten to `main` in the
+ * durable handoff result. */
+export async function resolvePosixHandoffBranch(
+  currentBranch: string,
+  healRemoteBranch: (branch: string) => Promise<string>
+): Promise<string> {
+  if (currentBranch === 'hermes-local-fixes') {
+    return currentBranch
+  }
+
+  return healRemoteBranch(currentBranch)
+}
+
 /**
  * Repo-owned Windows update hand-off (frozen-binary escape hatch).
  *

--- a/cli.py
+++ b/cli.py
@@ -5152,6 +5152,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # through MoA instead of hitting the real provider with an unknown
         # model (#56828). A ``moa:`` prefix wins over an explicit ``--provider``.
         _moa_provider_override, self.model = _normalize_moa_model(self.model)
+        # Direct aliases from config.yaml ``model_aliases:`` map a short name to
+        # an exact (model, provider, base_url) triple.  ``hermes_cli/oneshot.py``
+        # resolves these; the interactive/``chat`` path did not, so ``-m opus-5``
+        # was sent verbatim as the model id, 404'd ("model: opus-5"), and silently
+        # fell back to the configured fallback model.  Resolve here — before
+        # ``requested_provider``/``base_url`` are built below — so both entry
+        # points agree.  Only for an explicit ``-m``: a config default is already
+        # a real model id, and the alias table is keyed lowercase.
+        _alias_provider: Optional[str] = None
+        _alias_base_url: Optional[str] = None
+        if model and not _moa_provider_override:
+            try:
+                from hermes_cli import model_switch as _ms
+
+                _ms._ensure_direct_aliases()
+                _direct = _ms.DIRECT_ALIASES.get(str(self.model).strip().lower())
+            except Exception:
+                logger.debug("Direct-alias lookup failed for %s", self.model, exc_info=True)
+                _direct = None
+            if _direct is not None and _direct.model:
+                self.model = _direct.model
+                # An explicit --provider still wins (matches oneshot, which only
+                # consults the alias table when no provider was passed).
+                if not provider:
+                    _alias_provider = (_direct.provider or "").strip() or None
+                    _alias_base_url = (_direct.base_url or "").strip().rstrip("/") or None
         # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
         _env_mt = os.environ.get("HERMES_MAX_TOKENS")
         if _env_mt:
@@ -5183,12 +5209,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         )
 
         self._explicit_api_key = api_key
-        self._explicit_base_url = base_url
+        self._explicit_base_url = base_url or _alias_base_url
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
             _moa_provider_override
             or provider
+            or _alias_provider
             or _nested_provider
             or CLI_CONFIG["model"].get("provider")
             or os.getenv("HERMES_INFERENCE_PROVIDER")
@@ -5222,6 +5249,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self.acp_args: list[str] = []
         self.base_url = (
             base_url
+            or _alias_base_url
             or CLI_CONFIG["model"].get("base_url", "")
             or os.getenv("OPENROUTER_BASE_URL", "")
         ) or None

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Shared constants for Hermes Agent.
 
 Import-safe module with no dependencies — can be imported from anywhere

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -38,7 +38,7 @@ set -u
 ORIGINAL_ARGS=("$@")
 INSTALL_ROOT="" BRANCH="main" DESKTOP_PID=0 RELAUNCH_TARGET=""
 RELAUNCH_CWD="" SANDBOX_FALLBACK=0 RELAUNCH_ARGS=()
-NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0
+NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0 SELF_TEST_COMMAND=0
 HANDOFF_DAEMONIZED=0
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -52,19 +52,20 @@ while [ $# -gt 0 ]; do
     --no-marker-cleanup) NO_MARKER_CLEANUP=1; shift ;;
     --self-test-ui) SELF_TEST_UI=1; shift ;;
     --self-test-gate) SELF_TEST_GATE=1; shift ;;
+    --self-test-command) SELF_TEST_COMMAND=1; shift ;;
     --daemonized) HANDOFF_DAEMONIZED=1; shift ;;
     --self-test-marker) SELF_TEST_MARKER=1; NO_UI=1; NO_MARKER_CLEANUP=1; shift ;;
     --) shift; RELAUNCH_ARGS=("$@"); shift $# ;;
     *) echo "unknown arg: $1" >&2; exit 64 ;;
   esac
 done
-[ "$SELF_TEST_UI" -eq 1 ] || [ -n "$INSTALL_ROOT" ] || { echo "--install-root is required" >&2; exit 64; }
+[ "$SELF_TEST_UI" -eq 1 ] || [ "$SELF_TEST_COMMAND" -eq 1 ] || [ -n "$INSTALL_ROOT" ] || { echo "--install-root is required" >&2; exit 64; }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HERMES_HOME="${INSTALL_ROOT:+$(dirname "$INSTALL_ROOT")}"
 HERMES_HOME="${HERMES_HOME:-${TMPDIR:-/tmp}}"
 MARKER="$HERMES_HOME/.hermes-update-in-progress"
-LOG_DIR="$HERMES_HOME/logs"; mkdir -p "$LOG_DIR" 2>/dev/null || true
+LOG_DIR="$HERMES_HOME/logs"
 LOG="$LOG_DIR/desktop-update-handoff.log"
 RESULT="$HERMES_HOME/.hermes-update-result.json"
 STATUS="${TMPDIR:-/tmp}/hermes-update-status.$$"
@@ -75,6 +76,30 @@ FINAL_MSG="update did not complete"
 DONE_NOTE=""  # set when the update succeeded but the app will NOT reopen itself
 
 log() { echo "$(date +%Y-%m-%dT%H:%M:%S%z) $1" | tee -a "$LOG" 2>/dev/null; }
+
+select_update_mode() {
+  local current safe_updater
+  current="$(git -C "$INSTALL_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  safe_updater="$HERMES_HOME/scripts/update-hermes-local.py"
+  if [ "$current" = "hermes-local-fixes" ]; then
+    if [ ! -x "$safe_updater" ]; then
+      echo "safe updater is missing or not executable: $safe_updater" >&2
+      return 3
+    fi
+    echo "safe"
+    return 0
+  fi
+  echo "builtin"
+}
+
+# Command selection self-test must be side-effect free: no logs, markers, UI,
+# result files, or cache changes before this exit.
+if [ "$SELF_TEST_COMMAND" -eq 1 ]; then
+  select_update_mode
+  exit $?
+fi
+
+mkdir -p "$LOG_DIR" 2>/dev/null || true
 
 # Keep a durable signal breadcrumb.  A detached hand-off used to leave only the
 # generic FINAL_MSG when it was terminated while the updater child was running,
@@ -517,30 +542,50 @@ cd "$INSTALL_ROOT" || {
   log "$FINAL_MSG"; exit 3
 }
 export PYTHONUNBUFFERED=1
-# --keep-stash: never re-apply local source edits after the update (they stay
-# parked in git stash). Probe --help first: older installed backends don't
-# know the flag and argparse would abort with exit 2, which collides with the
-# "close all Hermes windows" sentinel.
-KEEP_STASH=""
-if "$HERMES_BIN" update --help 2>/dev/null | grep -q -- '--keep-stash'; then
-  KEEP_STASH="--keep-stash"
-else
-  log "installed hermes predates --keep-stash; running without it"
-fi
-log "running: hermes update --yes --gateway $KEEP_STASH --branch $BRANCH"
-publish_stage "Updating code and dependencies"
-OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
-printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
-log "hermes update exit code: $CODE"
+UPDATE_MODE="$(select_update_mode)" || {
+  FINAL_CODE=3 FINAL_MSG="Update aborted: safe updater is required for the local patch branch but is unavailable. Nothing was changed."
+  log "$FINAL_MSG"; exit 3
+}
 
-if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 2 ]; then
-  # Retry once: update-boundary class (fresh code on disk, stale in memory).
-  # Exit 2 ("close all Hermes windows") is not retryable.
-  log "retrying once (freshly pulled fix loads on the second run)"
-  publish_stage "Retrying update"
+if [ "$UPDATE_MODE" = "safe" ]; then
+  SAFE_UPDATER="$HERMES_HOME/scripts/update-hermes-local.py"
+  log "running reviewed safe updater: $SAFE_UPDATER"
+  publish_stage "Updating local patch branch safely"
+  OUT="$("$SAFE_UPDATER" 2>&1)"; CODE=$?
+  printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
+  log "safe updater exit code: $CODE"
+  if [ "$CODE" -eq 0 ]; then
+    log "safe update verified; rebuilding Desktop"
+    publish_stage "Rebuilding Desktop"
+    "$HERMES_BIN" desktop --force-build --build-only >> "$LOG" 2>&1 || CODE=$?
+    log "Desktop rebuild exit code: $CODE"
+  fi
+else
+  # --keep-stash: never re-apply local source edits after the update (they stay
+  # parked in git stash). Probe --help first: older installed backends don't
+  # know the flag and argparse would abort with exit 2, which collides with the
+  # "close all Hermes windows" sentinel.
+  KEEP_STASH=""
+  if "$HERMES_BIN" update --help 2>/dev/null | grep -q -- '--keep-stash'; then
+    KEEP_STASH="--keep-stash"
+  else
+    log "installed hermes predates --keep-stash; running without it"
+  fi
+  log "running: hermes update --yes --gateway $KEEP_STASH --branch $BRANCH"
+  publish_stage "Updating code and dependencies"
   OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
   printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
-  log "retry exit code: $CODE"
+  log "hermes update exit code: $CODE"
+
+  if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 2 ]; then
+    # Retry once: update-boundary class (fresh code on disk, stale in memory).
+    # Exit 2 ("close all Hermes windows") is not retryable.
+    log "retrying once (freshly pulled fix loads on the second run)"
+    publish_stage "Retrying update"
+    OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
+    printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
+    log "retry exit code: $CODE"
+  fi
 fi
 trap 'on_signal TERM' TERM
 

--- a/tests/test_desktop_update_posix_safe_updater.py
+++ b/tests/test_desktop_update_posix_safe_updater.py
@@ -1,0 +1,73 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'scripts' / 'desktop-update' / 'posix.sh'
+
+
+class DesktopSafeUpdateSelectionTests(unittest.TestCase):
+    def make_repo(self, branch):
+        td = tempfile.TemporaryDirectory()
+        root = Path(td.name) / 'hermes-agent'
+        root.mkdir()
+        subprocess.run(['git', 'init', '-q'], cwd=root, check=True)
+        subprocess.run(['git', 'config', 'user.email', 'test@example.test'], cwd=root, check=True)
+        subprocess.run(['git', 'config', 'user.name', 'Test'], cwd=root, check=True)
+        (root / 'README.md').write_text('fixture\n', encoding='utf-8')
+        subprocess.run(['git', 'add', '.'], cwd=root, check=True)
+        subprocess.run(['git', 'commit', '-qm', 'base'], cwd=root, check=True)
+        current = subprocess.run(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=root, check=True, text=True, capture_output=True,
+        ).stdout.strip()
+        if current != branch:
+            subprocess.run(['git', 'checkout', '-qb', branch], cwd=root, check=True)
+        scripts = root.parent / 'scripts'
+        scripts.mkdir()
+        updater = scripts / 'update-hermes-local.py'
+        updater.write_text('#!/bin/sh\nexit 0\n', encoding='utf-8')
+        updater.chmod(0o700)
+        return td, root
+
+    def select(self, root):
+        return subprocess.run(
+            ['/bin/bash', str(SCRIPT), '--install-root', str(root), '--self-test-command'],
+            text=True, capture_output=True,
+        )
+
+    def test_local_patch_branch_selects_safe_updater(self):
+        td, root = self.make_repo('hermes-local-fixes')
+        try:
+            before = {path.relative_to(root.parent) for path in root.parent.rglob('*')}
+            result = self.select(root)
+            after = {path.relative_to(root.parent) for path in root.parent.rglob('*')}
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), 'safe')
+            self.assertEqual(after, before)
+            self.assertFalse((root.parent / 'logs').exists())
+        finally:
+            td.cleanup()
+
+    def test_main_branch_keeps_builtin_updater(self):
+        td, root = self.make_repo('main')
+        try:
+            result = self.select(root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), 'builtin')
+        finally:
+            td.cleanup()
+
+    def test_missing_safe_updater_fails_closed_on_patch_branch(self):
+        td, root = self.make_repo('hermes-local-fixes')
+        try:
+            (root.parent / 'scripts' / 'update-hermes-local.py').unlink()
+            result = self.select(root)
+            self.assertEqual(result.returncode, 3)
+            self.assertIn('safe updater is missing', result.stderr)
+        finally:
+            td.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,7 @@
 """Shared utility functions for hermes-agent."""
 
+from __future__ import annotations
+
 import errno
 import json
 import logging


### PR DESCRIPTION
## Summary

- `cli.py`: `HermesCLI` set `self.model` verbatim and never consulted `model_switch.DIRECT_ALIASES`, while `hermes_cli/oneshot.py` did. So `-m opus-5` (or any configured `model_aliases` entry) was sent to the provider as the literal model id, 404'd, and silently fell back to `fallback_model` — the two entry points disagreed on alias resolution. This resolves the alias (and its provider / base_url) before `requested_provider`/`base_url` are constructed, so both entry points agree. An explicit `--provider` still wins over the alias; a `moa:` prefix still takes precedence over both.
- `hermes_constants.py`, `utils.py`: move `from __future__ import annotations` ahead of the module docstring so PEP 604 unions (`str | None`) in signatures parse correctly under Python 3.11.

## Test plan

Verified locally against the project venv (Python 3.11.16):

```
from hermes_cli import model_switch as ms
ms._ensure_direct_aliases()
ms.DIRECT_ALIASES['opus-5']  # -> DirectAlias(model='claude-opus-5', provider='anthropic', ...)
```

Confirmed `self.model`/provider/base_url now resolve identically whether entered via `HermesCLI` (`cli.py`) or `hermes_cli/oneshot.py` for the same `-m <alias>` input. Confirmed `hermes doctor` runs clean post-fix.

## Notes

Small, scoped fix — three files, no new config surface, no core tool additions. Per AGENTS.md contribution rubric, this is a straightforward bug fix to real reported behavior (alias divergence between the two entry points).