### PR TITLE
fix(desktop): confirm guarded model switches instead of snapping back

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient } from '@tanstack/react-query'
-import { cleanup, render, renderHook } from '@testing-library/react'
+import { act, cleanup, render, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelInfo } from '@/hermes'
@@ -21,6 +21,7 @@ import { deferred } from '../../../test/deferred'
 import { useModelControls } from './use-model-controls'
 
 const setGlobalModel = vi.fn()
+const notify = vi.fn()
 const notifyError = vi.fn()
 
 vi.mock('@/hermes', () => ({
@@ -41,6 +42,9 @@ vi.mock('@/store/session-states', async importOriginal => {
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
+      common: {
+        confirm: 'Confirm'
+      },
       desktop: {
         modelSwitchFailed: 'Model switch failed'
       }
@@ -49,6 +53,7 @@ vi.mock('@/i18n', () => ({
 }))
 
 vi.mock('@/store/notifications', () => ({
+  notify: (...args: Parameters<typeof notify>) => notify(...args),
   notifyError: (...args: Parameters<typeof notifyError>) => notifyError(...args)
 }))
 
@@ -299,6 +304,56 @@ describe('useModelControls', () => {
     await controls.selectModel({ model: 'grok-4.5', provider: 'xai' })
 
     expect(invalidate).toHaveBeenCalled()
+  })
+
+  it('confirms a guarded model switch before retrying it', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('gpt-5.6-sol')
+    setCurrentProvider('openai-codex')
+
+    const requestGateway = vi
+      .fn()
+      .mockResolvedValueOnce({
+        confirm_message: 'This contributor model trains on your data.',
+        confirm_required: true,
+        key: 'model',
+        value: 'muse-spark-1.2-contributor'
+      })
+      .mockResolvedValueOnce({ key: 'model', scope: 'global', value: 'muse-spark-1.2-contributor' })
+
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(
+      controls.selectModel({ model: 'muse-spark-1.2-contributor', provider: 'opencode-go' })
+    ).resolves.toBe(false)
+
+    expect($currentModel.get()).toBe('gpt-5.6-sol')
+    expect($currentProvider.get()).toBe('openai-codex')
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: expect.objectContaining({ label: 'Confirm' }),
+        kind: 'warning',
+        message: 'This contributor model trains on your data.'
+      })
+    )
+
+    const action = notify.mock.calls.at(-1)?.[0]?.action
+
+    await act(async () => {
+      await action?.onClick()
+    })
+
+    await waitFor(() => expect(requestGateway).toHaveBeenCalledTimes(2))
+    expect(requestGateway).toHaveBeenLastCalledWith('config.set', {
+      confirm_expensive_model: true,
+      key: 'model',
+      session_id: 'session-1',
+      value: 'muse-spark-1.2-contributor --provider opencode-go --global'
+    })
+    expect($currentModel.get()).toBe('muse-spark-1.2-contributor')
+    expect($currentProvider.get()).toBe('opencode-go')
   })
 
   it('keeps the pick when an OLDER gateway refuses a mid-turn switch', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -23,6 +23,7 @@ import { useModelControls } from './use-model-controls'
 const setGlobalModel = vi.fn()
 const notify = vi.fn()
 const notifyError = vi.fn()
+const dismissNotification = vi.fn()
 
 vi.mock('@/hermes', () => ({
   getGlobalModelInfo: vi.fn(),
@@ -53,6 +54,7 @@ vi.mock('@/i18n', () => ({
 }))
 
 vi.mock('@/store/notifications', () => ({
+  dismissNotification: (...args: Parameters<typeof dismissNotification>) => dismissNotification(...args),
   notify: (...args: Parameters<typeof notify>) => notify(...args),
   notifyError: (...args: Parameters<typeof notifyError>) => notifyError(...args)
 }))

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -6,7 +6,7 @@ import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
 import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
-import { notify, notifyError } from '@/store/notifications'
+import { dismissNotification, notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
@@ -170,12 +170,18 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
     [queryClient]
   )
 
-  // Returns whether the switch succeeded so callers can await it before applying
-  // follow-up changes. The composer model is plain UI state: with no live
-  // session it's just stored (and shipped on the next session.create); with one
-  // it's scoped to that session via config.set. It NEVER writes the profile
-  // default — that lives in Settings → Model — so picking a model here can't
-  // silently mutate global config.
+  // Returns whether the switch was applied so callers can await it before
+  // applying follow-up changes. `true` means applied (or deferred/busy-queued
+  // for the next turn). `false` means NOT applied — either pending
+  // confirmation (warning with Confirm action already shown, pill rolled back)
+  // or a real failure (error toast). Callers must NOT treat `false` as a
+  // generic failure: for `pending` the gateway intentionally returned
+  // `confirm_required` and no error should be surfaced.
+  // The composer model is plain UI state: with no live session it's just
+  // stored (and shipped on the next session.create); with one it's scoped to
+  // that session via config.set. It NEVER writes the profile default — that
+  // lives in Settings → Model — so picking a model here can't silently mutate
+  // global config.
   //
   // `selection.sessionId` targets a specific surface (tile). When omitted, the
   // primary `$activeSessionId` is used (overlay / legacy callers). A tile
@@ -276,7 +282,28 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         }
       }
 
+      let confirmNotificationId: string | null = null
+
       const applyConfirmedSwitch = async () => {
+        // Staleness guard — the warning can linger while the user picks a
+        // different model or switches sessions. Clicking Confirm must not
+        // clobber the newer choice: bail and dismiss if the live state no
+        // longer matches the snapshot this notification was created for.
+        const isStale = touchesPrimary
+          ? $activeSessionId.get() !== liveSessionId ||
+            $currentModel.get() !== prevModel ||
+            $currentProvider.get() !== prevProvider
+          : !liveSessionId ||
+            $sessionStates.get()[liveSessionId]?.model !== prevModel ||
+            $sessionStates.get()[liveSessionId]?.provider !== prevProvider
+
+        if (isStale) {
+          if (confirmNotificationId) dismissNotification(confirmNotificationId)
+          return
+        }
+
+        if (confirmNotificationId) dismissNotification(confirmNotificationId)
+
         paintSelection()
         cacheSelection(selection.provider, selection.model)
 
@@ -299,13 +326,13 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
 
         if (result?.confirm_required) {
           rollbackSelection()
-          notify({
+          confirmNotificationId = notify({
             action: {
               label: t.common.confirm,
               onClick: applyConfirmedSwitch
             },
             kind: 'warning',
-            message: result.confirm_message?.trim() || copy.modelSwitchFailed,
+            message: result.confirm_message?.trim() || 'Confirm this model switch?',
             title: t.common.confirm
           })
 

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -6,7 +6,7 @@ import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
 import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
-import { notifyError } from '@/store/notifications'
+import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
   $activeSessionId,
@@ -25,6 +25,12 @@ import type { ModelOptionsResponse } from '@/types/hermes'
 interface ModelControlsOptions {
   queryClient: QueryClient
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+}
+
+interface ModelSwitchResponse {
+  confirm_message?: string
+  confirm_required?: boolean
+  deferred?: boolean
 }
 
 export function useModelControls({ queryClient, requestGateway }: ModelControlsOptions) {
@@ -190,77 +196,26 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
       const prevSource = getCurrentModelSource()
       const liveGatewayProfile = $activeGatewayProfile.get()
 
-      if (touchesPrimary) {
-        setCurrentModel(selection.model)
-        setCurrentProvider(selection.provider)
-        markComposerSelectionManual()
-      } else if (liveSessionId) {
-        // Optimistic tile paint — session.info will confirm; rollback on error.
-        sessionTileDelegate()?.updateSession(liveSessionId, state => ({
-          ...state,
-          model: selection.model,
-          provider: selection.provider
-        }))
+      const paintSelection = () => {
+        if (touchesPrimary) {
+          setCurrentModel(selection.model)
+          setCurrentProvider(selection.provider)
+          markComposerSelectionManual()
+        } else if (liveSessionId) {
+          // Optimistic tile paint — session.info will confirm; rollback on error.
+          sessionTileDelegate()?.updateSession(liveSessionId, state => ({
+            ...state,
+            model: selection.model,
+            provider: selection.provider
+          }))
+        }
       }
 
-      updateModelOptionsCache(
-        liveSessionId,
-        selection.provider,
-        selection.model,
-        touchesPrimary && !liveSessionId,
-        liveGatewayProfile
-      )
-
-      // No live session yet: the pick is pure UI state. session.create reads
-      // $currentModel/$currentProvider and applies it as that session's override.
-      if (!liveSessionId) {
-        return true
+      const cacheSelection = (provider: string, model: string) => {
+        updateModelOptionsCache(liveSessionId, provider, model, touchesPrimary && !liveSessionId, liveGatewayProfile)
       }
 
-      try {
-        // The PRIMARY profile's main agent is the profile's default — its
-        // model/provider choice IS the default, so persist it to config.yaml
-        // (model.default + model.provider) via --global. This is what makes
-        // the selection "stick": a set model.provider outranks a leftover
-        // OPENAI_API_KEY env var in resolve_provider(), so the main agent
-        // keeps the chosen (e.g. subscription) provider across restarts
-        // instead of silently falling back to an env key.
-        //
-        // Two things stay --session, deliberately:
-        //  - a SECONDARY chat tile: picking a model there must not rewrite the
-        //    profile default (the cross-session-contamination guard).
-        //  - MoA (mixture-of-agents) presets: a transient orchestration choice
-        //    that must never become the persisted global gateway default.
-        const isSessionOnlyPreset = (selection.provider || '').toLowerCase() === 'moa'
-        const persistsAsDefault = touchesPrimary && !isSessionOnlyPreset
-        const scope = persistsAsDefault ? '--global' : '--session'
-
-        const result = await requestGateway<{ deferred?: boolean }>('config.set', {
-          session_id: liveSessionId,
-          key: 'model',
-          value: `${selection.model} --provider ${selection.provider} ${scope}`
-        })
-
-        // A pick made DURING a turn is queued by the gateway and applied at the
-        // next turn start (`deferred`). Re-fetching now would answer with the
-        // model still running and repaint the old name over the user's choice —
-        // the switch publishes session.info when it lands, and that is what
-        // re-syncs every surface.
-        if (!result?.deferred) {
-          void queryClient.invalidateQueries({ queryKey: modelOptionsQueryKey(liveGatewayProfile, liveSessionId) })
-        }
-
-        return true
-      } catch (err) {
-        // An OLDER gateway refuses a mid-turn switch outright (4009) instead of
-        // deferring it. Don't punish the user for a backend they haven't
-        // updated: keep the pick painted as the composer's selection, which is
-        // what the NEXT turn runs anyway. Current gateways never take this
-        // path — they answer `deferred`.
-        if (isBusySessionModelSwitch(err)) {
-          return true
-        }
-
+      const rollbackSelection = () => {
         if (touchesPrimary) {
           setCurrentModel(prevModel)
           setCurrentProvider(prevProvider)
@@ -273,19 +228,110 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
           }))
         }
 
-        updateModelOptionsCache(
-          liveSessionId,
-          prevProvider,
-          prevModel,
-          touchesPrimary && !liveSessionId,
-          liveGatewayProfile
-        )
+        cacheSelection(prevProvider, prevModel)
+      }
+
+      paintSelection()
+      cacheSelection(selection.provider, selection.model)
+
+      // No live session yet: the pick is pure UI state. session.create reads
+      // $currentModel/$currentProvider and applies it as that session's override.
+      if (!liveSessionId) {
+        return true
+      }
+
+      // The PRIMARY profile's main agent is the profile's default — its
+      // model/provider choice IS the default, so persist it to config.yaml
+      // (model.default + model.provider) via --global. This is what makes
+      // the selection "stick": a set model.provider outranks a leftover
+      // OPENAI_API_KEY env var in resolve_provider(), so the main agent
+      // keeps the chosen (e.g. subscription) provider across restarts
+      // instead of silently falling back to an env key.
+      //
+      // Two things stay --session, deliberately:
+      //  - a SECONDARY chat tile: picking a model there must not rewrite the
+      //    profile default (the cross-session-contamination guard).
+      //  - MoA (mixture-of-agents) presets: a transient orchestration choice
+      //    that must never become the persisted global gateway default.
+      const isSessionOnlyPreset = (selection.provider || '').toLowerCase() === 'moa'
+      const persistsAsDefault = touchesPrimary && !isSessionOnlyPreset
+      const scope = persistsAsDefault ? '--global' : '--session'
+
+      const requestSwitch = (confirmExpensiveModel = false) =>
+        requestGateway<ModelSwitchResponse>('config.set', {
+          session_id: liveSessionId,
+          key: 'model',
+          value: `${selection.model} --provider ${selection.provider} ${scope}`,
+          ...(confirmExpensiveModel ? { confirm_expensive_model: true } : {})
+        })
+
+      const finishSwitch = (result: ModelSwitchResponse | undefined) => {
+        // A pick made DURING a turn is queued by the gateway and applied at the
+        // next turn start (`deferred`). Re-fetching now would answer with the
+        // model still running and repaint the old name over the user's choice —
+        // the switch publishes session.info when it lands, and that is what
+        // re-syncs every surface.
+        if (!result?.deferred) {
+          void queryClient.invalidateQueries({ queryKey: modelOptionsQueryKey(liveGatewayProfile, liveSessionId) })
+        }
+      }
+
+      const applyConfirmedSwitch = async () => {
+        paintSelection()
+        cacheSelection(selection.provider, selection.model)
+
+        try {
+          const result = await requestSwitch(true)
+
+          if (result?.confirm_required) {
+            throw new Error(result.confirm_message?.trim() || copy.modelSwitchFailed)
+          }
+
+          finishSwitch(result)
+        } catch (err) {
+          rollbackSelection()
+          notifyError(err, copy.modelSwitchFailed)
+        }
+      }
+
+      try {
+        const result = await requestSwitch()
+
+        if (result?.confirm_required) {
+          rollbackSelection()
+          notify({
+            action: {
+              label: t.common.confirm,
+              onClick: applyConfirmedSwitch
+            },
+            kind: 'warning',
+            message: result.confirm_message?.trim() || copy.modelSwitchFailed,
+            title: t.common.confirm
+          })
+
+          return false
+        }
+
+        finishSwitch(result)
+
+        return true
+      } catch (err) {
+        // An OLDER gateway refuses a mid-turn switch outright (4009) instead of
+        // deferring it. Don't punish the user for a backend they haven't
+        // updated: keep the pick painted as the composer's selection, which is
+        // what the NEXT turn runs anyway. Current gateways never take this
+        // path — they answer `deferred`.
+        if (isBusySessionModelSwitch(err)) {
+          return true
+        }
+
+        rollbackSelection()
         notifyError(err, copy.modelSwitchFailed)
 
         return false
       }
     },
-    [copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
+    [copy.modelSwitchFailed, queryClient, requestGateway, t.common.confirm, updateModelOptionsCache]
   )
 
   return { applySavedMainModel, refreshCurrentModel, selectModel }

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -298,11 +298,16 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
             $sessionStates.get()[liveSessionId]?.provider !== prevProvider
 
         if (isStale) {
-          if (confirmNotificationId) dismissNotification(confirmNotificationId)
+          if (confirmNotificationId) {
+            dismissNotification(confirmNotificationId)
+          }
+
           return
         }
 
-        if (confirmNotificationId) dismissNotification(confirmNotificationId)
+        if (confirmNotificationId) {
+          dismissNotification(confirmNotificationId)
+        }
 
         paintSelection()
         cacheSelection(selection.provider, selection.model)


### PR DESCRIPTION
### Problem

Desktop composer ignored the gateway's confirmation protocol for guarded models (contributor / expensive tiers).

When selecting `muse-spark-1.2-contributor` via `opencode-go` from `gpt-5.6-sol` / `openai-codex`, the gateway correctly returns `confirm_required:true` with the contributor warning instead of applying the model. Desktop previously typed the response as `{deferred?: boolean}` and ignored `confirm_required` / `confirm_message`. It then invalidated `model-options` and refetched the still-active session, so the pill optimistically painted Muse and then instantly snapped back to GPT with no explanation.

Direct CLI `hermes -m muse-spark-1.2-contributor --provider opencode-go` worked because `security.allow_data_training_tiers_noninteractive` was already true - the bug was desktop-only.

### Fix

Handle the confirmation protocol in `useModelControls.selectModel`:

* on `confirm_required` rollback the optimistic paint/cache, surface the backend's `confirm_message` as a persistent `warning` notification with a **Confirm** action
* on Confirm retry `config.set` with `confirm_expensive_model:true` (same scope), preserving data-training consent
* keeps existing deferred/busy-session and MoA session-scoping behavior unchanged

### Verification

* New regression test: `confirms a guarded model switch before retrying it` - asserts the two-request flow (first returns `confirm_required`, rollback + notification, Confirm click retries with `confirm_expensive_model:true` and lands on `muse-spark-1.2-contributor / opencode-go`)
* `npx vitest run --project ui src/app/session/hooks/use-model-controls.test.tsx` -> 21/21 PASS
* `npm run typecheck` -> PASS
* `npm run build` + `electron-builder --dir` -> PASS, packed `app.asar` contains `confirm_expensive_model`

Related gateway logic: `tui_gateway/server.py::_apply_model_switch` / `combined_selection_warning`.
Related desktop logic: `apps/desktop/src/app/session/hooks/use-model-controls.ts`.

### Scope

Desktop-only, no gateway or CLI changes. No new dependencies.