### PR TITLE
fix(backup): bound non-advancing SQLite snapshots

### DIFF
--- a/contributors/emails/local-hermes-patch@localhost
+++ b/contributors/emails/local-hermes-patch@localhost
@@ -1,0 +1,1 @@
+keeltrace

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -113,7 +113,7 @@ class _SQLiteSnapshotError(RuntimeError):
 
 
 class _SQLiteBackupTimeout(RuntimeError):
-    """Raised when a SQLite snapshot remains busy past its deadline."""
+    """Raised when a SQLite snapshot stalls or stops converging past its deadline."""
 
 
 @contextmanager
@@ -293,16 +293,30 @@ def _safe_copy_db(src: Path, dst: Path, *, timeout_seconds: float = 10.0) -> boo
         # full locked-source deadline instead of adding the default timeout before each callback.
         conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True, timeout=0.0)
         backup_conn = sqlite3.connect(str(dst))
-        busy_deadline = time.monotonic() + max(0.0, timeout_seconds)
+        stall_timeout = max(0.0, timeout_seconds)
+        last_progress_at = time.monotonic()
+        lowest_remaining: int | None = None
 
-        def _check_backup_progress(status: int, _remaining: int, _total: int) -> None:
-            nonlocal busy_deadline
+        def _check_backup_progress(status: int, remaining: int, total: int) -> None:
+            nonlocal last_progress_at, lowest_remaining
             now = time.monotonic()
-            if status in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
-                if now >= busy_deadline:
-                    raise _SQLiteBackupTimeout(f"database remained locked for {timeout_seconds:g} seconds")
-            else:
-                busy_deadline = now + max(0.0, timeout_seconds)
+
+            if status == sqlite3.SQLITE_DONE:
+                return
+
+            if status == sqlite3.SQLITE_OK and (
+                lowest_remaining is None or remaining < lowest_remaining
+            ):
+                lowest_remaining = remaining
+                last_progress_at = now
+                return
+
+            if now - last_progress_at >= stall_timeout:
+                raise _SQLiteBackupTimeout(
+                    "database backup made no forward progress for "
+                    f"{timeout_seconds:g} seconds "
+                    f"(status={status}, remaining={remaining}, total={total})"
+                )
 
         conn.backup(backup_conn, pages=256, progress=_check_backup_progress, sleep=0.1)
         return True

--- a/tests/hermes_cli/test_backup_progress_timeout.py
+++ b/tests/hermes_cli/test_backup_progress_timeout.py
@@ -1,0 +1,97 @@
+import sqlite3
+
+
+class _FakeBackupConnection:
+    def __init__(self, events):
+        self.events = events
+        self.closed = False
+
+    def backup(self, _destination, **kwargs):
+        progress = kwargs["progress"]
+        for status, remaining, total in self.events:
+            progress(status, remaining, total)
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeDestination:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _run_fake_backup(monkeypatch, tmp_path, events, clock):
+    import hermes_cli.backup as backup_mod
+
+    src = tmp_path / "source.db"
+    dst = tmp_path / "dest.db"
+    src.touch()
+    dst.write_bytes(b"partial")
+
+    source = _FakeBackupConnection(events)
+    destination = _FakeDestination()
+    connections = iter((source, destination))
+
+    monkeypatch.setattr(
+        backup_mod.sqlite3,
+        "connect",
+        lambda *_args, **_kwargs: next(connections),
+    )
+    times = iter(clock)
+    monkeypatch.setattr(backup_mod.time, "monotonic", lambda: next(times))
+
+    result = backup_mod._safe_copy_db(src, dst, timeout_seconds=0.05)
+    return result, dst, source, destination
+
+
+def test_nonadvancing_sqlite_ok_callbacks_timeout(monkeypatch, tmp_path):
+    events = [
+        (sqlite3.SQLITE_OK, 10, 10),
+        (sqlite3.SQLITE_OK, 10, 10),
+        (sqlite3.SQLITE_OK, 10, 10),
+    ]
+    result, dst, source, destination = _run_fake_backup(
+        monkeypatch, tmp_path, events, [0.00, 0.00, 0.03, 0.06]
+    )
+    assert result is False
+    assert not dst.exists()
+    assert source.closed
+    assert destination.closed
+
+
+def test_restart_oscillation_does_not_count_as_forward_progress(monkeypatch, tmp_path):
+    events = [
+        (sqlite3.SQLITE_OK, 10, 20),
+        (sqlite3.SQLITE_OK, 6, 20),
+        (sqlite3.SQLITE_OK, 12, 20),
+        (sqlite3.SQLITE_OK, 11, 20),
+        (sqlite3.SQLITE_OK, 12, 20),
+        (sqlite3.SQLITE_OK, 11, 20),
+    ]
+    result, dst, source, destination = _run_fake_backup(
+        monkeypatch, tmp_path, events, [0.00, 0.00, 0.01, 0.02, 0.03, 0.05, 0.07]
+    )
+    assert result is False
+    assert not dst.exists()
+    assert source.closed
+    assert destination.closed
+
+
+def test_restart_that_reaches_new_low_can_complete(monkeypatch, tmp_path):
+    events = [
+        (sqlite3.SQLITE_OK, 10, 20),
+        (sqlite3.SQLITE_OK, 6, 20),
+        (sqlite3.SQLITE_OK, 12, 20),
+        (sqlite3.SQLITE_OK, 5, 20),
+        (sqlite3.SQLITE_BUSY, 5, 20),
+        (sqlite3.SQLITE_DONE, 0, 20),
+    ]
+    result, _dst, source, destination = _run_fake_backup(
+        monkeypatch, tmp_path, events, [0.00, 0.00, 0.01, 0.02, 0.03, 0.04, 0.05]
+    )
+    assert result is True
+    assert source.closed
+    assert destination.closed


### PR DESCRIPTION
## Summary

I reproduced a real `hermes update` hang on Hermes 0.20.5 during the pre-update SQLite snapshot. The process remained inside `sqlite3.Connection.backup()` until interrupted.

#86680 bounded continuous `SQLITE_BUSY` / `SQLITE_LOCKED` waits. The remaining liveness hole is repeated or oscillating `SQLITE_OK`: the old callback refreshed its deadline on every non-busy callback, so a backup that never made net progress could run indefinitely.

## Fix

Refresh the stall timer only when `remaining` reaches a new global low-water mark.

This bounds unchanged progress and restart oscillation while still allowing a concurrent-write restart to recover if it catches up and reaches a new low. The existing Online Backup API path, WAL-safe snapshot semantics, fail-closed cleanup, and unlimited total duration for genuinely converging backups are preserved.

## Current exact head / base

- head: `b09ac8bcdc43ec114df12a70d2fcae2db02b01aa`
- upstream `main`: `79445a496c86a19332ad786494b8384d2167e2d0`
- changed files: **3**
- diff: **+121 / -9**

The current-main reconciliation is a normal non-force branch update. None of the three PR paths changed upstream between the prior base and current main, so the reviewed backup/test blobs are preserved exactly. The historical `local-hermes-patch@localhost` author is explicitly mapped to `keeltrace` in `contributors/emails/local-hermes-patch@localhost`, satisfying the repository attribution mechanism without rewriting history again.

## Regression coverage

The focused regressions cover:

- unchanged `SQLITE_OK` -> timeout + partial cleanup;
- restart oscillation without a new global low -> timeout;
- restart that catches up to a new low -> success.

Earlier independent review also reproduced the real SQLite restart/oscillation class and found no remaining code-level blocker in the low-water design.

## Overlap

- #86680: merged predecessor for continuous BUSY/LOCKED waits; preserved.
- #68868: competing open implementation on the same seam; it treats broader restart movement as progress and does not close the same oscillation shape.
- #72966 / #88853: closed unmerged prior art for non-advancing `SQLITE_OK`.
- #91793: merged browser-profile / locked-source work; complementary and not duplicated.

## Verification status

Prior focused local receipts include the backup regressions, Ruff, `py_compile`, and `git diff --check`. They are not relabeled as hosted exact-head CI. Fresh GitHub CI/Docker/Nix on this exact head are authoritative; fork-triggered workflows may require maintainer authorization before jobs are created.

No merge is requested by this update.