### PR TITLE
fix(desktop): preserve custom skin names at startup

### DIFF
--- a/apps/desktop/src/contrib/plugins-store.ts
+++ b/apps/desktop/src/contrib/plugins-store.ts
@@ -75,6 +75,11 @@ function saveDecisions(next: Record<string, boolean>) {
 
 export const $pluginRecords = atom<Record<string, PluginRecord>>({})
 
+/** True after the initial disk-plugin scan has registered its contributions. */
+export const $pluginDiscoveryReady = atom(false)
+
+export const markPluginDiscoveryReady = (): void => $pluginDiscoveryReady.set(true)
+
 /** Loader-owned lifecycle controls for a plugin (activate/deactivate). */
 interface PluginHandle {
   activate: () => Promise<void> | void

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HermesReadDirResult } from '@/global'
 import type * as HermesModule from '@/hermes'
 
-import { $pluginRecords, publishPlugin, setPluginEnabled } from './plugins-store'
+import {
+  $pluginDiscoveryReady,
+  $pluginRecords,
+  publishPlugin,
+  setPluginEnabled
+} from './plugins-store'
 import { discoverRuntimePlugins, loadRuntimePlugin, watchRuntimePlugins } from './runtime-loader'
 
 // getStatus would supply the connected backend's hermes_home — a REMOTE path in
@@ -32,6 +37,7 @@ beforeEach(() => {
   watchPreviewFile.mockReset()
   onPreviewFileChanged.mockReset()
   getStatus.mockClear()
+  $pluginDiscoveryReady.set(false)
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
     agentPluginsRoot,
     desktopPluginsRoot,
@@ -48,6 +54,18 @@ afterEach(() => {
 })
 
 describe('scanDiskPlugins (#66899)', () => {
+  it('marks initial plugin discovery ready after the scan completes', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
+    readDir.mockResolvedValue({ entries: [] })
+
+    expect($pluginDiscoveryReady.get()).toBe(false)
+
+    await discoverRuntimePlugins()
+
+    expect($pluginDiscoveryReady.get()).toBe(true)
+  })
+
   it('scans the Electron-resolved local roots, never the backend hermes_home', async () => {
     desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
     agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -32,7 +32,14 @@ import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
 
 import { createPluginContext, type HermesPlugin } from './plugin'
-import { $pluginRecords, dropPlugin, pluginActive, type PluginKind, publishPlugin } from './plugins-store'
+import {
+  $pluginRecords,
+  dropPlugin,
+  markPluginDiscoveryReady,
+  pluginActive,
+  type PluginKind,
+  publishPlugin
+} from './plugins-store'
 
 interface LoadOptions {
   /** Root-level default-enable CAP: `false` ships the plugin opt-in (inventory
@@ -334,7 +341,13 @@ async function scanDiskPlugins(): Promise<void> {
 
   // Re-entrancy guard: the 5s poll must not overlap a slow in-flight scan
   // (reads/loads can exceed the interval).
-  if (!desktop || scanning) {
+  if (!desktop) {
+    markPluginDiscoveryReady()
+
+    return
+  }
+
+  if (scanning) {
     return
   }
 
@@ -415,6 +428,7 @@ async function scanDiskPlugins(): Promise<void> {
     // No plugin roots (or no gateway yet) — nothing to reconcile.
   } finally {
     scanning = false
+    markPluginDiscoveryReady()
   }
 }
 

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -26,6 +26,9 @@ import type { DesktopTheme } from './types'
 /** Skins pushed by the backend, keyed by name. Merged by `listAllThemes`. */
 export const $backendThemes = atom<Record<string, DesktopTheme>>({})
 
+/** True after the backend has supplied a valid resolved skin at least once. */
+export const $backendSkinReady = atom(false)
+
 /** One-shot skin name the ThemeProvider should switch to (it clears this). */
 export const $pendingSkinApply = atom<string | null>(null)
 
@@ -41,6 +44,7 @@ let lastSynced: { applied: boolean; name: string } | null = null
 export function __resetBackendSkinSync(): void {
   lastSynced = null
   $backendThemes.set({})
+  $backendSkinReady.set(false)
   $pendingSkinApply.set(null)
 }
 
@@ -76,6 +80,10 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
       $backendThemes.set({ ...current, [name]: theme })
     }
   }
+
+  // Registration above is synchronous. Once this flips, the merged registry
+  // can safely distinguish a delayed custom skin from a genuinely stale name.
+  $backendSkinReady.set(true)
 
   if (!apply) {
     // Connect-time seed: record without painting. A reconnect re-seed keeps an

--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -1,9 +1,13 @@
 import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { $pluginDiscoveryReady, markPluginDiscoveryReady } from '@/contrib/plugins-store'
+import { registry } from '@/contrib/registry'
+
 import { __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
 import { skinPref, ThemeProvider, useTheme } from './context'
-import { everforestTheme } from './presets'
+import { DEFAULT_SKIN_NAME, everforestTheme } from './presets'
+import { THEMES_AREA } from './user-themes'
 
 // The live-authoring loop: Hermes writes/edits one skin file and every surface
 // repaints. An in-place edit keeps the NAME — only the palette moves.
@@ -14,10 +18,27 @@ const bloomberg = (foreground: string) => ({
 
 const cssVar = (name: string) => window.document.documentElement.style.getPropertyValue(name)
 
+let observedThemeName = ''
+
+function ThemeNameProbe() {
+  observedThemeName = useTheme().themeName
+
+  return null
+}
+
+const renderThemeNameProbe = () =>
+  render(
+    <ThemeProvider>
+      <ThemeNameProbe />
+    </ThemeProvider>
+  )
+
 describe('ThemeProvider ← backend skin sync', () => {
   beforeEach(() => {
     window.localStorage.clear()
     __resetBackendSkinSync()
+    $pluginDiscoveryReady.set(false)
+    observedThemeName = ''
   })
 
   afterEach(cleanup)
@@ -68,12 +89,71 @@ describe('ThemeProvider ← backend skin sync', () => {
     )
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
   })
+
+  it('repairs an unresolved stored skin after the backend registry is ready', () => {
+    skinPref.assign('default', 'typo-skin')
+    renderThemeNameProbe()
+
+    // Boot preserves the unresolved name while backend themes are still absent.
+    expect(observedThemeName).toBe('typo-skin')
+
+    act(() => ingestBackendSkin({ name: 'default', colors: {} }, { apply: false }))
+
+    // The backend alone is not enough: a persisted theme may still arrive from
+    // the initial disk-plugin scan.
+    expect(observedThemeName).toBe('typo-skin')
+
+    act(() => markPluginDiscoveryReady())
+
+    expect(observedThemeName).toBe(DEFAULT_SKIN_NAME)
+    expect(skinPref.resolve('default')).toBe(DEFAULT_SKIN_NAME)
+  })
+
+  it('keeps a stored custom skin when the backend registers it', () => {
+    skinPref.assign('default', 'bloomberg')
+    renderThemeNameProbe()
+
+    act(() => {
+      ingestBackendSkin(bloomberg('#ff9f0a'), { apply: false })
+      markPluginDiscoveryReady()
+    })
+
+    expect(observedThemeName).toBe('bloomberg')
+    expect(skinPref.resolve('default')).toBe('bloomberg')
+  })
+
+  it('waits for the initial plugin scan before repairing an unresolved skin', () => {
+    skinPref.assign('default', 'plugin-theme')
+    const view = renderThemeNameProbe()
+
+    act(() => ingestBackendSkin({ name: 'default', colors: {} }, { apply: false }))
+    expect(observedThemeName).toBe('plugin-theme')
+
+    let dispose = () => {}
+
+    act(() => {
+      dispose = registry.register({
+        area: THEMES_AREA,
+        data: { ...everforestTheme, label: 'Plugin theme', name: 'plugin-theme' },
+        id: 'plugin-theme'
+      })
+      markPluginDiscoveryReady()
+    })
+
+    expect(observedThemeName).toBe('plugin-theme')
+    expect(skinPref.resolve('default')).toBe('plugin-theme')
+
+    view.unmount()
+    dispose()
+  })
 })
 
 describe('ThemeProvider highlight preview', () => {
   beforeEach(() => {
     window.localStorage.clear()
     __resetBackendSkinSync()
+    $pluginDiscoveryReady.set(false)
+    observedThemeName = ''
   })
 
   afterEach(cleanup)

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -12,6 +12,7 @@
 import { useStore } from '@nanostores/react'
 import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 
+import { $pluginDiscoveryReady } from '@/contrib/plugins-store'
 import { $registryVersion } from '@/contrib/registry'
 import { matchesQuery, useMediaQuery } from '@/hooks/use-media-query'
 import { persistString, persistStringRecord, storedString, storedStringRecord } from '@/lib/storage'
@@ -19,7 +20,7 @@ import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { setAppearance } from '@/store/translucency'
 
 import { $accentOverride } from './accent-override'
-import { $backendThemes, $pendingSkinApply } from './backend-sync'
+import { $backendSkinReady, $backendThemes, $pendingSkinApply } from './backend-sync'
 import { harmonize, hexToRgb, mix, readableOn } from './color'
 import { BUILTIN_THEME_LIST, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAPHY, nousTheme } from './presets'
 import { retintTheme } from './retint'
@@ -38,8 +39,8 @@ const PROFILE_MODES_KEY = 'hermes-desktop-profile-modes-v1'
 // Last active profile, recorded so the boot-time paint can pick that profile's
 // theme before the gateway reports which profile actually launched.
 const LAST_PROFILE_KEY = 'hermes-desktop-active-profile-v1'
-// Skins that no longer exist. A profile still pointing at one falls back to
-// DEFAULT_SKIN_NAME rather than painting a name nothing resolves.
+// Skins that no longer exist. Preserve every other stored name because custom
+// backend skins register after the renderer performs its boot-time paint.
 const RETIRED_SKINS = new Set(['nous-light', 'default', 'gold'])
 
 export type ThemeMode = 'light' | 'dark' | 'system'
@@ -50,7 +51,7 @@ const resolveMode = (mode: ThemeMode, systemDark = matchesQuery('(prefers-color-
   mode === 'system' ? (systemDark ? 'dark' : 'light') : mode
 
 const normalizeSkin = (name: string | null): string =>
-  name && resolveTheme(name) && !RETIRED_SKINS.has(name) ? name : DEFAULT_SKIN_NAME
+  name && !RETIRED_SKINS.has(name) ? name : DEFAULT_SKIN_NAME
 
 /**
  * A stored mode, or `system` when there isn't one.
@@ -357,7 +358,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // grid, and `/skin` without a reload.
   const userThemes = useStore($userThemes)
   const backendThemes = useStore($backendThemes)
+  const backendSkinReady = useStore($backendSkinReady)
   const registryVersion = useStore($registryVersion)
+  const pluginDiscoveryReady = useStore($pluginDiscoveryReady)
 
   const availableThemes = useMemo(
     () =>
@@ -386,6 +389,33 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     setThemeNameState(skinPref.resolve(profileKey))
     setModeState(modePref.resolve(profileKey))
   }, [profileKey])
+
+  // Boot must accept unresolved names because backend and disk-plugin themes
+  // register asynchronously. Once both initial registries are ready, the merged
+  // registry is authoritative: preserve names that now resolve and repair
+  // stale/typo values to the Desktop default.
+  useEffect(() => {
+    if (!backendSkinReady || !pluginDiscoveryReady) {
+      return
+    }
+
+    const stored = skinPref.resolve(profileKey)
+
+    if (resolveTheme(stored)) {
+      return
+    }
+
+    skinPref.assign(profileKey, DEFAULT_SKIN_NAME)
+    setThemeNameState(DEFAULT_SKIN_NAME)
+  }, [
+    backendSkinReady,
+    backendThemes,
+    profileKey,
+    registryVersion,
+    pluginDiscoveryReady,
+    themeName,
+    userThemes
+  ])
 
   // Appearance is per-profile localStorage, and every desktop window is another
   // renderer on the same origin — so a switch made in the HUD (or any peer

--- a/apps/desktop/src/themes/profile-theme.test.ts
+++ b/apps/desktop/src/themes/profile-theme.test.ts
@@ -15,13 +15,12 @@ const cases = [
     pref: skinPref as unknown as Pref,
     fallback: DEFAULT_SKIN_NAME,
     a: 'ember',
-    b: 'catppuccin',
-    junk: 'nope'
+    b: 'catppuccin'
   },
-  { name: 'mode', pref: modePref as unknown as Pref, fallback: 'system', a: 'dark', b: 'light', junk: 'dusk' }
+  { name: 'mode', pref: modePref as unknown as Pref, fallback: 'system', a: 'dark', b: 'light' }
 ]
 
-describe.each(cases)('per-profile $name', ({ pref, fallback, a, b, junk }) => {
+describe.each(cases)('per-profile $name', ({ pref, fallback, a, b }) => {
   beforeEach(() => window.localStorage.clear())
 
   it('falls back to the default when unassigned', () => {
@@ -40,10 +39,23 @@ describe.each(cases)('per-profile $name', ({ pref, fallback, a, b, junk }) => {
     pref.assign('default', a)
     expect(pref.resolve('never-themed')).toBe(a)
   })
+})
 
-  it('normalizes an unknown stored value back to the default', () => {
-    pref.assign('work', junk)
-    expect(pref.resolve('work')).toBe(fallback)
+describe('mode validation', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('normalizes an unknown stored mode back to system', () => {
+    modePref.assign('work', 'dusk' as never)
+    expect(modePref.resolve('work')).toBe('system')
+  })
+})
+
+describe('custom backend skin persistence', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('preserves a stored skin name that may be registered by the backend after startup', () => {
+    skinPref.assign('work', 'custom-backend-skin')
+    expect(skinPref.resolve('work')).toBe('custom-backend-skin')
   })
 })
 


### PR DESCRIPTION
## Summary
- preserve stored custom skin names during boot while asynchronous theme sources register
- wait for both the backend skin baseline and the initial disk-plugin scan before validating
- repair unresolved stale or typo skin names to the Desktop default after registry hydration
- continue rejecting explicitly retired skin names
- keep mode validation separate from skin-name persistence

## Root cause
Desktop validated the persisted skin during module-level boot paint. Custom backend and plugin themes had not necessarily registered yet, so `resolveTheme(name)` returned undefined and the preference fell back to the built-in default.

## Follow-up behavior
Boot now preserves an unresolved name only while theme registration is incomplete. Once the backend baseline and initial disk-plugin scan are ready, Desktop validates against the merged registry. Valid delayed themes survive; stale or typo names self-heal to the default.

## Test plan
- `node ../../node_modules/vitest/vitest.mjs run --project ui src/themes/context.test.tsx src/themes/profile-theme.test.ts src/themes/backend-sync.test.ts src/contrib/runtime-loader.test.ts` (39 passed)
- `node ../../node_modules/typescript/bin/tsc -p . --noEmit`
- `node ../../node_modules/eslint/bin/eslint.js src/contrib/plugins-store.ts src/contrib/runtime-loader.ts src/contrib/runtime-loader.test.ts src/themes/backend-sync.ts src/themes/context.tsx src/themes/context.test.tsx src/themes/profile-theme.test.ts`