### PR TITLE
fix(tui): keep speculative agent-build failures silent while browsing sessions

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -410,7 +410,7 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _BrokenSupervisor())
     monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
     monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
-    monkeypatch.setattr(server, "_start_agent_build", lambda _sid, _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda _sid, _session, **kwargs: None)
     monkeypatch.setattr(server, "_wait_agent", lambda _session, _rid: None)
     # The deferred inline-fallback thread now waits via the patient variant.
     monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda _session, _rid, _sid: None)
@@ -920,6 +920,92 @@ def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
         server._sessions.pop(sid, None)
 
     assert seen == [str(profile_home)]
+
+
+def test_speculative_agent_build_failure_is_silent(monkeypatch):
+    """A speculative (view-only) build that fails because the session's stored
+    model/provider is unavailable must NOT emit the intrusive ``error`` event —
+    the user is only browsing the transcript. The failure is still recorded as
+    ``agent_error`` so it surfaces when they actually continue the session."""
+    import threading
+    import uuid
+
+    emitted = []
+    ready = threading.Event()
+    sid = f"test-sid-{uuid.uuid4().hex[:8]}"
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("Unknown provider 'custom:gemma-imatrix'")
+
+    monkeypatch.setattr(server, "_make_agent", _boom)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_SlashWorker", lambda *args: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *args: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: emitted.append(a))
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+
+    session = {
+        "agent_ready": ready,
+        "session_key": f"test-key-{uuid.uuid4().hex[:8]}",
+        "profile_home": None,
+    }
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session, speculative=True)
+        assert ready.wait(timeout=15), "agent_ready never set after speculative build"
+        assert session.get("agent_error") and "Unknown provider" in session["agent_error"]
+        error_events = [e for e in emitted if e and e[0] == "error"]
+        assert not error_events, (
+            f"speculative build must not emit error event, got: {error_events}"
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_non_speculative_agent_build_failure_emits_error(monkeypatch):
+    """A build triggered by real intent to run (e.g. prompt.submit) that fails
+    must still surface the ``error`` event — only the speculative pre-warm is
+    silent. Mirrors the contract in test_agent_build_failure_surfaces_error_and_drops_turn."""
+    import threading
+    import uuid
+
+    emitted = []
+    ready = threading.Event()
+    sid = f"test-sid-{uuid.uuid4().hex[:8]}"
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("Unknown provider 'custom:gemma-imatrix'")
+
+    monkeypatch.setattr(server, "_make_agent", _boom)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_SlashWorker", lambda *args: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *args: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: emitted.append(a))
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+
+    session = {
+        "agent_ready": ready,
+        "session_key": f"test-key-{uuid.uuid4().hex[:8]}",
+        "profile_home": None,
+    }
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session)
+        assert ready.wait(timeout=15), "agent_ready never set after build"
+        assert session.get("agent_error") and "Unknown provider" in session["agent_error"]
+        error_events = [e for e in emitted if e and e[0] == "error"]
+        assert error_events, "non-speculative build failure must emit error event"
+        assert "agent init failed" in str(error_events[0][2].get("message", ""))
+    finally:
+        server._sessions.pop(sid, None)
 
 
 def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path):
@@ -3562,7 +3648,7 @@ def test_session_resume_deferred_history_acknowledges_and_reuses(monkeypatch):
     monkeypatch.setattr(
         server,
         "_start_agent_build",
-        lambda _sid, _session: build_started.set(),
+        lambda _sid, _session, **kwargs: build_started.set(),
     )
     monkeypatch.setattr(
         server,
@@ -3657,7 +3743,7 @@ def test_session_resume_deferred_history_failure_can_retry(monkeypatch):
     monkeypatch.setattr(
         server,
         "_start_agent_build",
-        lambda _sid, _session: build_started.set(),
+        lambda _sid, _session, **kwargs: build_started.set(),
     )
 
     try:
@@ -3716,7 +3802,7 @@ def test_session_resume_deferred_history_close_cancels_build(monkeypatch):
     monkeypatch.setattr(
         server,
         "_start_agent_build",
-        lambda _sid, _session: build_started.set(),
+        lambda _sid, _session, **kwargs: build_started.set(),
     )
 
     response = {}
@@ -13210,7 +13296,7 @@ def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
-        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
         monkeypatch.setattr(server, "_wait_agent", lambda session, rid: None)
         monkeypatch.setattr(
             server,
@@ -13280,7 +13366,7 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
-        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
         monkeypatch.setattr(server, "_wait_agent", lambda session, rid: None)
         monkeypatch.setattr(
             server,
@@ -13352,7 +13438,7 @@ def test_session_not_running_before_agent_ready_emits_error_event(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
-        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
         monkeypatch.setattr(server, "_wait_agent", lambda session, rid: None)
         monkeypatch.setattr(
             server,
@@ -13438,7 +13524,7 @@ def test_slow_agent_build_delivers_prompt_instead_of_timing_out(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
-        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
         monkeypatch.setattr(
             server,
             "_run_prompt_submit",
@@ -13513,7 +13599,7 @@ def test_slow_agent_build_emits_keyed_progress_notice(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
-        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
         monkeypatch.setattr(
             server,
             "_run_prompt_submit",
@@ -13575,7 +13661,7 @@ def test_agent_build_failure_surfaces_error_and_drops_turn(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
-        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
         monkeypatch.setattr(
             server,
             "_run_prompt_submit",
@@ -18329,7 +18415,7 @@ def test_close_sessions_for_transport_skips_session_rebound_before_claim(
 
 
 def test_session_create_records_close_on_disconnect_flag(monkeypatch):
-    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
     server._sessions.clear()
     try:
         on = server.handle_request(
@@ -18345,7 +18431,7 @@ def test_session_create_records_close_on_disconnect_flag(monkeypatch):
 
 
 def test_session_create_records_source(monkeypatch):
-    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
     server._sessions.clear()
     try:
         sid = server.handle_request(
@@ -20267,7 +20353,7 @@ def test_session_branch_keeps_reasoning_fields(monkeypatch, tmp_path):
         db.create_session("session-key", source="tui")
         monkeypatch.setattr(server, "_get_db", lambda: db)
         monkeypatch.setattr(server, "_new_session_key", lambda: "branch-key")
-        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+        monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
         monkeypatch.setattr(server, "_wait_agent", lambda session, rid: None)
         monkeypatch.setattr(
             server, "_claim_active_session_slot", lambda *args, **kwargs: (None, None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -966,6 +966,101 @@ def test_speculative_agent_build_failure_is_silent(monkeypatch):
         server._sessions.pop(sid, None)
 
 
+def test_prompt_after_speculative_failure_surfaces_recorded_error(monkeypatch):
+    """Chain pin: a speculative pre-warm failed silently while the user was
+    browsing; when they later submit a real prompt, that prompt must surface
+    the RECORDED ``agent_error`` as a visible terminal turn error — never a
+    silent inactivity drop. This is the continuation-path contract the
+    speculative suppression relies on."""
+    import threading
+    import uuid
+
+    sid = f"test-sid-{uuid.uuid4().hex[:8]}"
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("Unknown provider 'custom:gemma-imatrix'")
+
+    # ── Phase 1: the browse-only pre-warm fails silently. ──
+    emitted = []
+    ready = threading.Event()
+    monkeypatch.setattr(server, "_make_agent", _boom)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_SlashWorker", lambda *args: None)
+    monkeypatch.setattr(server, "_attach_worker", lambda *args: None)
+    monkeypatch.setattr(server, "_config_model_target", lambda: ("", ""))
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: emitted.append(a))
+    monkeypatch.setattr(server, "_set_session_context", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_clear_session_context", lambda *a, **k: None)
+
+    session = _session(agent=None, agent_ready=ready)
+    session["agent"] = None
+    session["profile_home"] = None
+    session["session_key"] = f"test-key-{uuid.uuid4().hex[:8]}"
+    server._sessions[sid] = session
+    try:
+        server._start_agent_build(sid, session, speculative=True)
+        assert ready.wait(timeout=15), "agent_ready never set after speculative build"
+        assert not [e for e in emitted if e and e[0] == "error"]
+        recorded = session["agent_error"]
+
+        # ── Phase 2: a real prompt arrives. The build seam stays REAL so the
+        # early-return on the finished (failed) build is exercised too. ──
+        threads = []
+        calls = {"run_prompt": 0}
+
+        class _FakeThread:
+            def __init__(self, target=None, daemon=None):
+                self.target = target
+                threads.append(self)
+
+            def start(self):
+                return None
+
+            def is_alive(self):
+                return True
+
+        monkeypatch.setattr(server.threading, "Thread", _FakeThread)
+        monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
+        monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
+        monkeypatch.setattr(
+            server,
+            "_run_prompt_submit",
+            lambda *args, **kwargs: calls.__setitem__(
+                "run_prompt", calls["run_prompt"] + 1
+            ),
+        )
+
+        submit = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": "continue this"},
+            }
+        )
+        assert submit.get("result"), f"got error: {submit.get('error')}"
+
+        threads[0].target()
+
+        assert calls["run_prompt"] == 0
+        assert session["running"] is False
+        failure_frames = [
+            e
+            for e in emitted
+            if e
+            and e[0] in ("error", "message.complete")
+            and e[1] == sid
+            and "Unknown provider 'custom:gemma-imatrix'" in str(e[2])
+        ]
+        assert len(failure_frames) == 1, (
+            f"recorded agent_error must reach the client exactly once, got: {emitted}"
+        )
+        assert recorded == session.get("agent_error")
+    finally:
+        server._sessions.pop(sid, None)
+
+
 def test_non_speculative_agent_build_failure_emits_error(monkeypatch):
     """A build triggered by real intent to run (e.g. prompt.submit) that fails
     must still surface the ``error`` event — only the speculative pre-warm is

--- a/tests/tui_gateway/test_attach_does_not_wait_for_agent.py
+++ b/tests/tui_gateway/test_attach_does_not_wait_for_agent.py
@@ -47,7 +47,7 @@ def building_session(tmp_path, sid: str) -> dict:
 @pytest.fixture
 def no_build(monkeypatch):
     """Never let the real builder run — the point is the unfinished build."""
-    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
 
 
 @pytest.fixture

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -358,7 +358,7 @@ def test_older_agent_still_gets_the_post_turn_stamp(emits, turn_env, marker_home
 @pytest.fixture()
 def schedule_env(monkeypatch, marker_home):
     monkeypatch.setattr(server.threading, "Thread", _InlineThread)
-    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session, **kwargs: None)
     monkeypatch.setattr(server, "_wait_agent", lambda session, rid, timeout=30.0: None)
     monkeypatch.setattr(server, "_load_cfg", lambda: {})
     submitted: list = []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3230,7 +3230,7 @@ def _wait_agent_for_prompt(session: dict, rid: str, sid: str) -> dict | None:
     return _err(rid, 5032, err) if err else None
 
 
-def _start_agent_build(sid: str, session: dict) -> None:
+def _start_agent_build(sid: str, session: dict, speculative: bool = False) -> None:
     """Start building the real AIAgent for a TUI session, once.
 
     Classic `hermes` shows the prompt before constructing AIAgent; the TUI used
@@ -3239,6 +3239,15 @@ def _start_agent_build(sid: str, session: dict) -> None:
     the shell responsive by deferring this work until the first prompt (or any
     command that actually needs the agent), while retaining the same ready/error
     event contract for the frontend.
+
+    ``speculative`` marks a build kicked off only to pre-warm a session the
+    user is *browsing* (cold resume / hydration), not one they have decided to
+    continue. When such a pre-warm fails — most often because the session's
+    stored model/provider is no longer available to the current install — we
+    must NOT spam the intrusive ``error`` event: the user opened the session to
+    *read* it, and the failure is irrelevant until they actually send a turn.
+    The error is still recorded on the session, so the prompt path surfaces it
+    properly at the moment the user tries to continue.
     """
     ready = session.get("agent_ready")
     if ready is None:
@@ -3437,7 +3446,12 @@ def _start_agent_build(sid: str, session: dict) -> None:
             _schedule_mcp_late_refresh(sid, agent)
         except Exception as e:
             current["agent_error"] = str(e)
-            _emit("error", sid, {"message": f"agent init failed: {e}"})
+            if not speculative:
+                # A speculative pre-warm (browsing a resumed session) that fails
+                # because the stored model/provider is unavailable must stay
+                # silent: the user is only reading the transcript, not continuing
+                # it. The recorded agent_error surfaces on the actual prompt path.
+                _emit("error", sid, {"message": f"agent init failed: {e}"})
         finally:
             if home_token is not None:
                 reset_hermes_home_override(home_token)
@@ -3540,7 +3554,7 @@ def _sess_building(params, rid):
     s, err = _sess_nowait(params, rid)
     if err:
         return (None, err)
-    _start_agent_build(params.get("session_id") or "", s)
+    _start_agent_build(params.get("session_id") or "", s, speculative=True)
     return (s, None)
 
 
@@ -10745,7 +10759,7 @@ def _schedule_agent_build(sid: str, delay: float = 0.05) -> None:
     def _run():
         session = _sessions.get(sid)
         if session is not None:
-            _start_agent_build(sid, session)
+            _start_agent_build(sid, session, speculative=True)
 
     timer = threading.Timer(delay, _run)
     timer.daemon = True
@@ -10795,7 +10809,7 @@ def _schedule_resume_hydration(
                 },
             )
             _maybe_schedule_auto_continue(sid, session, stored_id)
-            _start_agent_build(sid, session)
+            _start_agent_build(sid, session, speculative=True)
         except Exception as exc:
             if _sessions.get(sid) is not session:
                 return


### PR DESCRIPTION

## What does this PR do?

Opening an old session in the desktop app / TUI pre-warms its agent in the
background (`session.resume` → `_schedule_agent_build`, hydration worker,
attach warm). When the session's stored model or provider is no longer
available to the current install (e.g. a removed custom provider like
`custom:gemma-imatrix`), that background build fails and immediately emits the
`error` event:

```
Turn failed
agent init failed: Unknown provider 'custom:gemma-imatrix'. Check 'hermes model'
for available providers, or run 'hermes doctor' to diagnose config issues.
```

The desktop renders this as an intrusive native "Turn failed" notification, a
global toast, and — because the message matches `isProviderSetupErrorMessage`
— even the onboarding dialog. All of that fires while the user is merely
*reading* the transcript, which is exactly when the failure is irrelevant.

This PR introduces a `speculative` flag on `_start_agent_build`. A speculative
(pre-warm) failure is still recorded as `agent_error`, so nothing is lost:
when the user actually continues the session (`prompt.submit`), the existing
patient-wait path surfaces it as a proper terminal turn error at the moment it
matters. Only the unrequested error event during browse-only viewing is gone.

Builds triggered by real intent to run keep the visible-failure contract:
`prompt.submit`, model switch, auto-continue kickoff, session branch.

## Related Issue

Fixes # (no issue filed yet)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor

## Changes Made

- `tui_gateway/server.py`
  - `_start_agent_build(sid, session, speculative=False)`: on failure, emit
    the `error` event only for non-speculative builds; always record
    `agent_error`.
  - Marked as speculative (view-only pre-warms):
    - `_schedule_agent_build` (cold resume timer)
    - `_schedule_resume_hydration` (deferred-history resume worker)
    - `_sess_building` (attach/image warm-up)
  - Docstring documents the contract.
- `tests/test_tui_gateway_server.py`
  - New `test_speculative_agent_build_failure_is_silent` — speculative failure
    records `agent_error`, emits no `error` event.
  - New `test_non_speculative_agent_build_failure_emits_error` — real-intent
    failure still emits the event (mirrors
    `test_agent_build_failure_surfaces_error_and_drops_turn`).
  - Widened 9 narrow stubs of `_start_agent_build` to accept `**kwargs`.
- `tests/tui_gateway/test_attach_does_not_wait_for_agent.py`,
  `tests/tui_gateway/test_auto_continue.py` — same stub widening.

## How to Test

1. Configure a provider, chat, then remove the provider (or point config away
   from it) so the old model becomes unavailable.
2. Open the Sessions picker in the desktop app and click the old session.
   - Before: "Turn failed … Unknown provider …" toast + onboarding dialog.
   - After: session opens silently; you can read the transcript.
3. Type a message into that session — the failure now surfaces properly as a
   terminal turn error (recorded `agent_error`), never a silent drop.
4. Automated:
   ```
   scripts/run_tests.sh tests/test_tui_gateway_server.py \
     -k "speculative_agent_build_failure_is_silent or non_speculative_agent_build_failure_emits_error"
   ```
   Verified locally: 2 passed; full `tests/test_tui_gateway_server.py` 590
   passed; all 74 files under `tests/tui_gateway/` green with per-file
   isolation (canonical runner semantics). Ubuntu (Linux).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run pytest and all tests pass (see above; via release venv +
      `pytest==9.1.1` installed to a side directory, since the release venv
      has no test extras)
- [x] I've added tests for my changes
- [x] Tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] Documentation: N/A (behavior contract documented in the function docstring)
- [x] `cli-config.yaml.example`: N/A (no config keys changed)
- [x] `AGENTS.md`: N/A
- [x] Cross-platform impact: N/A (pure Python control flow in tui_gateway)
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Before (browse-only open of an old session):

```
Turn failed
agent init failed: Unknown provider 'custom:gemma-imatrix'. Check 'hermes model'
for available providers, or run 'hermes doctor' to diagnose config issues.
```

After: no output on open; identical error appears only if the user sends a
message to that session.
