### PR TITLE
feat(skills): honour disable-model-invocation, and keep the environments gate across the snapshot

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1151,6 +1151,16 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
         # Host-platform / runtime-environment gates are offer-time only; explicit loads bypass them.
         if not skill_matches_platform(frontmatter) or not skill_matches_environment(frontmatter):
             return False, frontmatter, ""
+
+        # Manual-invocation gate (offer-time only), same field and semantics as
+        # Claude Code: the skill stays registered and `/name` still works, but
+        # its description never enters the system prompt, so the model cannot
+        # auto-match it. Command wrappers mirrored from the hub carry this flag
+        # precisely because they must cost zero context. Explicit loads bypass
+        # it, exactly like the environment gate above.
+        if frontmatter.get("disable-model-invocation") is True:
+            return False, frontmatter, ""
+
         return True, frontmatter, extract_skill_description(frontmatter)
     except Exception as e:
         logger.warning("Failed to parse skill file %s: %s", skill_file, e)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1132,6 +1132,12 @@ def _build_snapshot_entry(skill_file: Path, skills_dir: Path, frontmatter: dict,
         "skill_name": skill_name, "category": category, "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description, "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "environments": [str(e).strip() for e in environments if str(e).strip()],
+        # Same reason again, and the same failure when it is missing: the
+        # manual-invocation gate runs on the cold scan only, so without the
+        # verdict recorded here every warm rebuild re-lists manual-only skills
+        # by bare name. The description stays empty, but the name is the part
+        # that costs context and the part that invites the model to try.
+        "manual_only": skill_is_manual_only(frontmatter),
         "conditions": extract_skill_conditions(frontmatter),
     }
     if org_id:
@@ -1369,7 +1375,8 @@ def _build_skills_system_prompt_inner(
     snapshot = _load_skills_snapshot(skills_dir)
     if snapshot is not None:
         candidates = [(entry, skill_matches_platform_list(entry.get("platforms") or [])
-                       and skill_matches_environment_list(entry.get("environments") or []))
+                       and skill_matches_environment_list(entry.get("environments") or [])
+                       and not entry.get("manual_only"))
                       for entry in snapshot.get("skills", []) if isinstance(entry, dict)]
         category_descriptions = {str(k): str(v) for k, v in (snapshot.get("category_descriptions") or {}).items()}
     else:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,7 +24,7 @@ from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS, ORG_ACTIVE_MARKER, ORG_MIRROR_DIR_NAME, ORG_PROVENANCE_FILE, SKILL_SUPPORT_DIRS,
     extract_skill_conditions, extract_skill_description, get_all_skills_dirs, get_disabled_skill_names,
     iter_skill_index_files, parse_frontmatter, read_active_org_id, skill_matches_environment,
-    skill_matches_environment_list, skill_matches_platform, skill_matches_platform_list,
+    skill_matches_environment_list, skill_is_manual_only, skill_matches_platform, skill_matches_platform_list,
 )
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
 from utils import atomic_json_write
@@ -1158,7 +1158,7 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
         # auto-match it. Command wrappers mirrored from the hub carry this flag
         # precisely because they must cost zero context. Explicit loads bypass
         # it, exactly like the environment gate above.
-        if frontmatter.get("disable-model-invocation") is True:
+        if skill_is_manual_only(frontmatter):
             return False, frontmatter, ""
 
         return True, frontmatter, extract_skill_description(frontmatter)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,7 +24,7 @@ from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS, ORG_ACTIVE_MARKER, ORG_MIRROR_DIR_NAME, ORG_PROVENANCE_FILE, SKILL_SUPPORT_DIRS,
     extract_skill_conditions, extract_skill_description, get_all_skills_dirs, get_disabled_skill_names,
     iter_skill_index_files, parse_frontmatter, read_active_org_id, skill_matches_environment,
-    skill_matches_platform, skill_matches_platform_list,
+    skill_matches_environment_list, skill_matches_platform, skill_matches_platform_list,
 )
 from tools.threat_patterns import scan_for_threats as _scan_for_threats
 from utils import atomic_json_write
@@ -1123,10 +1123,15 @@ def _build_snapshot_entry(skill_file: Path, skills_dir: Path, frontmatter: dict,
     skill_name = skill_file.parent.name  # == parts[-2] whenever a parent component exists
     category = "general" if len(parts) < 2 else "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
     platforms = frontmatter.get("platforms") or []
-    platforms = [platforms] if isinstance(platforms, str) else platforms
+    if isinstance(platforms, str):
+        platforms = [platforms]
+    environments = frontmatter.get("environments") or []
+    if isinstance(environments, str):
+        environments = [environments]
     entry = {
         "skill_name": skill_name, "category": category, "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description, "platforms": [str(p).strip() for p in platforms if str(p).strip()],
+        "environments": [str(e).strip() for e in environments if str(e).strip()],
         "conditions": extract_skill_conditions(frontmatter),
     }
     if org_id:
@@ -1353,7 +1358,8 @@ def _build_skills_system_prompt_inner(
     # Disk snapshot (fast path) vs. full scan: both yield (entry, is_compatible) pairs so labeling runs identically.
     snapshot = _load_skills_snapshot(skills_dir)
     if snapshot is not None:
-        candidates = [(entry, skill_matches_platform_list(entry.get("platforms") or []))
+        candidates = [(entry, skill_matches_platform_list(entry.get("platforms") or [])
+                       and skill_matches_environment_list(entry.get("environments") or []))
                       for entry in snapshot.get("skills", []) if isinstance(entry, dict)]
         category_descriptions = {str(k): str(v) for k, v in (snapshot.get("category_descriptions") or {}).items()}
     else:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -217,6 +217,35 @@ def skill_matches_environment_list(environments: Any) -> bool:
     return False
 
 
+# Values a human plausibly writes meaning "yes". YAML already gives us a real bool
+# for bare `true`, but a quoted `"true"` — or `yes`, or `1` — arrives as a string,
+# and a strict `is True` check silently treats those as "not set". For a gate whose
+# job is to HIDE a skill, that is the fail-open direction: the author asked for the
+# skill to be withheld from the model and it gets offered anyway, with nothing said.
+# Mirrors the tolerance `_coerce_capability_bool` already applies to config booleans.
+_MANUAL_ONLY_TRUE_TOKENS = frozenset({"true", "yes", "on", "1"})
+
+
+def skill_is_manual_only(frontmatter: Dict[str, Any]) -> bool:
+    """True when the skill declares ``disable-model-invocation``.
+
+    The skill stays registered and the user can still invoke it by name; only the
+    model-facing surfaces honour this. Anything unrecognised reads as *not* set,
+    because the flag is opt-in — but recognised spellings are accepted generously,
+    since the cost of over-accepting is a skill the model does not auto-load, while
+    the cost of under-accepting is a skill the author meant to withhold being offered.
+    """
+    raw = frontmatter.get("disable-model-invocation")
+    if isinstance(raw, bool):
+        return raw
+    # bool is a subclass of int, so this only sees real integers.
+    if isinstance(raw, int):
+        return raw == 1
+    if isinstance(raw, str):
+        return raw.strip().lower() in _MANUAL_ONLY_TRUE_TOKENS
+    return False
+
+
 def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
     """True when ANY declared ``environments:`` tag is active (absent = all;
     unknown tags fail open). Offer-time filter only."""

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -193,14 +193,37 @@ def _detect_environment(env: str) -> bool:
     return result
 
 
+def skill_matches_environment_list(environments: Any) -> bool:
+    """Return True when *environments* is relevant to the current runtime.
+
+    The list-shaped sibling of :func:`skill_matches_environment`, mirroring
+    :func:`skill_matches_platform_list`. Callers that hold serialized metadata
+    rather than frontmatter — the prompt-index snapshot, for one — need this
+    form; without it an ``environments`` tag survives a cold scan and is lost
+    on every cached rebuild.
+    """
+    if not environments:
+        return True
+    if not isinstance(environments, list):
+        environments = [environments]
+    for env in environments:
+        normalized = str(env).lower().strip()
+        if not normalized:
+            continue
+        # _detect_environment fails open on unknown tags — don't hide the
+        # skill over a tag we don't understand.
+        if _detect_environment(normalized):
+            return True
+    return False
+
+
 def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
     """True when ANY declared ``environments:`` tag is active (absent = all;
     unknown tags fail open). Offer-time filter only."""
-    environments = frontmatter.get("environments")
-    if not environments:
-        return True
-    tags = [str(env).lower().strip() for env in (environments if isinstance(environments, list) else [environments])]
-    return any(_detect_environment(tag) for tag in tags if tag)
+    return skill_matches_environment_list(frontmatter.get("environments"))
+
+
+# ── Disabled skills ───────────────────────────────────────────────────────
 
 
 _RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2625,8 +2625,22 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
 
     @_require_auth
     async def _handle_skills(self, request: "web.Request") -> "web.Response":
-        """GET /v1/skills — deterministic JSON listing of installed skills (name, description,
-        category), the same set ``/skills list`` shows."""
+        """GET /v1/skills — list installed skills visible to the API-server agent.
+
+        Read-only listing intended for external clients that need to know
+        which skills are available without sending a chat message and asking
+        the model. Mirrors what the gateway/CLI surfaces through
+        ``/skills list``, but as a deterministic JSON payload.
+
+        Returns the same skill metadata (name, description, category) the
+        skills hub uses internally. Disabled skills are excluded.
+
+        This is a *user*-facing listing, so it deliberately still includes
+        skills marked ``disable-model-invocation`` even though the model
+        cannot load them -- they remain invocable as ``/name``. It therefore
+        lists a superset of what the agent auto-loads; use the skills index
+        in the system prompt if you need the model's own view.
+        """
         try:
             from tools.skills_tool import _find_all_skills, _sort_skills
             skills = _sort_skills(_find_all_skills(skip_disabled=False))

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -394,6 +394,71 @@ class TestBuildSkillsSystemPrompt:
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
 
+    def test_environment_gate_survives_the_disk_snapshot(self, monkeypatch, tmp_path):
+        """A gated skill stays hidden on the snapshot fast path, not just the cold scan.
+
+        The fast path rebuilds the index from serialized entries alone, so a filter
+        whose input is not serialized cannot run at all. ``environments`` used to be
+        left out of ``_build_snapshot_entry``, which made the gate hold on the first
+        build in a fresh HERMES_HOME and silently lapse for every process after it.
+        """
+        from agent import skill_utils
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Pin the detector rather than the host: the test must mean the same thing
+        # inside the Docker image, where s6 really is active.
+        monkeypatch.setattr(skill_utils, "_detect_environment", lambda env: False)
+
+        tools = tmp_path / "skills" / "tools"
+        (tools / "always-on").mkdir(parents=True)
+        (tools / "always-on" / "SKILL.md").write_text(
+            "---\nname: always-on\ndescription: Ungated\n---\n"
+        )
+        (tools / "container-only").mkdir()
+        (tools / "container-only" / "SKILL.md").write_text(
+            "---\nname: container-only\ndescription: Gated\nenvironments: [s6]\n---\n"
+        )
+
+        cold = build_skills_system_prompt()
+        assert "always-on" in cold
+        assert "container-only" not in cold
+
+        # Drop the in-process cache but KEEP the snapshot: this is the path a second
+        # process takes, and the only one where the regression was observable.
+        clear_skills_system_prompt_cache(clear_snapshot=False)
+        warm = build_skills_system_prompt()
+        assert "always-on" in warm
+        assert "container-only" not in warm
+
+    def test_snapshot_entry_serializes_environments(self, monkeypatch, tmp_path):
+        """The snapshot carries `environments`, in the same shape `platforms` uses."""
+        import json
+
+        from agent import skill_utils
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(skill_utils, "_detect_environment", lambda env: True)
+
+        d = tmp_path / "skills" / "tools" / "kanban-only"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\nname: kanban-only\ndescription: Gated\nenvironments: [kanban]\n---\n"
+        )
+
+        build_skills_system_prompt()
+
+        snapshot = json.loads(
+            (tmp_path / ".skills_prompt_snapshot.json").read_text(encoding="utf-8")
+        )
+        gated = [
+            e
+            for e in (snapshot.get("skills") or [])
+            if e.get("skill_name") == "kanban-only"
+        ]
+        assert gated, f"kanban-only missing from snapshot: {snapshot}"
+        assert gated[0]["environments"] == ["kanban"]
+
 
 # =========================================================================
 # Context files prompt builder

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -459,6 +459,48 @@ class TestBuildSkillsSystemPrompt:
         assert gated, f"kanban-only missing from snapshot: {snapshot}"
         assert gated[0]["environments"] == ["kanban"]
 
+    def test_manual_only_gate_survives_the_disk_snapshot(self, monkeypatch, tmp_path):
+        """A manual-only skill stays out of the index on the warm path too.
+
+        Same failure mode as ``environments``, one field over: the gate runs in
+        the cold scan, the fast path rebuilds from the serialized entry, and a
+        verdict that was never written down cannot be re-applied. The leak is
+        quiet — the description is empty either way — so it shows up as bare
+        names reappearing in the index on the second process, not as an error.
+        """
+        import json
+
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        tools = tmp_path / "skills" / "tools"
+        (tools / "auto").mkdir(parents=True)
+        (tools / "auto" / "SKILL.md").write_text(
+            "---\nname: auto\ndescription: Offered\n---\n"
+        )
+        (tools / "by-hand").mkdir()
+        (tools / "by-hand" / "SKILL.md").write_text(
+            "---\nname: by-hand\ndescription: Wrapper\n"
+            "disable-model-invocation: true\n---\n"
+        )
+
+        cold = build_skills_system_prompt()
+        assert "auto" in cold
+        assert "by-hand" not in cold
+
+        clear_skills_system_prompt_cache(clear_snapshot=False)
+        warm = build_skills_system_prompt()
+        assert "auto" in warm
+        assert "by-hand" not in warm
+
+        snapshot = json.loads(
+            (tmp_path / ".skills_prompt_snapshot.json").read_text(encoding="utf-8")
+        )
+        by_name = {e.get("skill_name"): e for e in (snapshot.get("skills") or [])}
+        assert by_name["by-hand"]["manual_only"] is True
+        assert by_name["auto"]["manual_only"] is False
+
 
 # =========================================================================
 # Context files prompt builder

--- a/tests/tools/test_manual_only_skills.py
+++ b/tests/tools/test_manual_only_skills.py
@@ -123,3 +123,111 @@ class TestSystemPromptIndexManualOnly:
 
         assert _parse_skill_file(auto)[0] is True
         assert _parse_skill_file(manual)[0] is False
+
+
+class TestSkillViewManualOnlyPayloadShapes:
+    """Payload shapes the gate could not identify, and what it did about them.
+
+    The gate identified the skill by walking back up `_source_path`, so a branch
+    that set neither that nor `skill_dir` produced a payload it could not recognise
+    — and its default was to allow. `skill_dir` is now set wherever a skill's
+    material is served, and an unidentifiable payload that still serves something
+    is refused rather than waved through.
+    """
+
+    def test_binary_file_does_not_smuggle_out_a_flagged_skill(self, tmp_path):
+        """Binary content reaches the model through the ordinary file_path path.
+
+        `skill_view`'s `except UnicodeDecodeError` branch cannot fire — the read
+        above it passes `errors="replace"`, so decoding never raises — which means
+        a PNG is served as replacement characters by the normal route. That route
+        is gated, and this pins it: the interesting property is that binary content
+        has no path of its own to slip out by.
+        """
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "manual-skill", frontmatter_extra=FLAG)
+            (skill_dir / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n\xff\xfe\x00binary")
+            skills_tool_module._SKILLS_CACHE.clear()
+
+            result = json.loads(
+                skills_tool_module._skill_view_with_bump(
+                    {"name": "manual-skill", "file_path": "logo.png"}
+                )
+            )
+            assert result["success"] is False
+            assert "manual-invocation-only" in result["error"]
+
+    def test_a_miss_does_not_disclose_a_flagged_skills_file_listing(self, tmp_path):
+        """A wrong file_path answers with `available_files` — the whole tree."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "manual-skill", frontmatter_extra=FLAG)
+            (skill_dir / "references").mkdir()
+            (skill_dir / "references" / "secret-api.md").write_text("Body.\n")
+            skills_tool_module._SKILLS_CACHE.clear()
+
+            result = json.loads(
+                skills_tool_module._skill_view_with_bump(
+                    {"name": "manual-skill", "file_path": "no-such-file.md"}
+                )
+            )
+            assert result["success"] is False
+            assert "manual-invocation-only" in result["error"]
+            assert "available_files" not in result
+            assert "secret-api" not in json.dumps(result)
+
+    def test_an_unidentifiable_payload_that_serves_content_is_refused(self):
+        """Fail closed: no skill_dir, no usable _source_path, but content served."""
+        refusal = skills_tool_module._manual_only_refusal(
+            "mystery",
+            {"success": True, "name": "mystery", "content": "secret", "file": "x.md"},
+            "x.md",
+        )
+        assert refusal is not None
+        assert "manual-invocation-only" in json.loads(refusal)["error"]
+
+    def test_an_unidentifiable_payload_with_nothing_to_serve_is_left_alone(self):
+        """A bare error must keep skill_view's own message, not become a refusal."""
+        assert (
+            skills_tool_module._manual_only_refusal(
+                "mystery", {"success": False, "error": "Skill 'mystery' is disabled."}
+            )
+            is None
+        )
+
+
+class TestManualOnlyFlagCoercion:
+    """A quoted `"true"` is what a human writes; YAML hands it over as a string."""
+
+    def test_quoted_and_alternate_spellings_are_honoured(self, tmp_path):
+        from agent.prompt_builder import _parse_skill_file
+
+        for i, spelling in enumerate(['"true"', "'true'", "yes", "on", "1", "True"]):
+            md = _make_skill(
+                tmp_path,
+                f"manual-{i}",
+                frontmatter_extra=f"disable-model-invocation: {spelling}\n",
+            ) / "SKILL.md"
+            assert _parse_skill_file(md)[0] is False, spelling
+
+    def test_absent_and_false_spellings_stay_auto_invocable(self, tmp_path):
+        from agent.prompt_builder import _parse_skill_file
+
+        for i, spelling in enumerate(["false", '"false"', "no", "off", "0"]):
+            md = _make_skill(
+                tmp_path,
+                f"auto-{i}",
+                frontmatter_extra=f"disable-model-invocation: {spelling}\n",
+            ) / "SKILL.md"
+            assert _parse_skill_file(md)[0] is True, spelling
+
+    def test_the_listing_gate_uses_the_same_coercion(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "auto-skill")
+            _make_skill(
+                tmp_path,
+                "quoted-manual",
+                frontmatter_extra='disable-model-invocation: "true"\n',
+            )
+            model_facing = _names(hide_manual_only=True)
+            assert "quoted-manual" not in model_facing
+            assert "auto-skill" in model_facing

--- a/tests/tools/test_manual_only_skills.py
+++ b/tests/tools/test_manual_only_skills.py
@@ -64,6 +64,35 @@ class TestSkillViewManualOnly:
             assert result["success"] is False
             assert "manual-invocation-only" in result["error"]
 
+    def test_file_path_cannot_smuggle_out_a_flagged_skill(self, tmp_path):
+        """references/ must not be a side door: the flag lives in SKILL.md."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "manual-skill", frontmatter_extra=FLAG)
+            (skill_dir / "references").mkdir()
+            (skill_dir / "references" / "api.md").write_text("Reference body.\n")
+            skills_tool_module._SKILLS_CACHE.clear()
+
+            result = json.loads(
+                skills_tool_module._skill_view_with_bump(
+                    {"name": "manual-skill", "file_path": "references/api.md"}
+                )
+            )
+            assert result["success"] is False
+            assert "manual-invocation-only" in result["error"]
+
+    def test_unflagged_skill_supporting_file_still_loads(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "auto-skill")
+            (skill_dir / "notes.md").write_text("Notes.\n")
+            skills_tool_module._SKILLS_CACHE.clear()
+
+            result = json.loads(
+                skills_tool_module._skill_view_with_bump(
+                    {"name": "auto-skill", "file_path": "notes.md"}
+                )
+            )
+            assert result["success"] is True
+
     def test_unflagged_skill_still_loads(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "auto-skill")

--- a/tests/tools/test_manual_only_skills.py
+++ b/tests/tools/test_manual_only_skills.py
@@ -1,0 +1,96 @@
+"""Manual-invocation gate: the `disable-model-invocation` frontmatter flag.
+
+A skill carrying the flag stays registered and user-invocable as `/name`, but
+must not be offered to the model. Three surfaces offer a skill -- the
+system-prompt index, the skills_list tool, and the model's skill_view entry
+point -- and missing any one leaves a hole, so all three are covered here,
+along with the two things easiest to break while tidying the guards up: that
+a manual-only skill stays visible to the USER-facing listing, and that
+explicit loads still work.
+"""
+
+import json
+from unittest.mock import patch
+
+import tools.skills_tool as skills_tool_module
+from tools.skills_tool import _find_all_skills
+
+FLAG = "disable-model-invocation: true\n"
+
+
+def _make_skill(skills_dir, name, frontmatter_extra=""):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Description for {name}.\n"
+        f"{frontmatter_extra}---\n\n# {name}\n\nBody.\n"
+    )
+    return skill_dir
+
+
+def _names(**kw):
+    skills_tool_module._SKILLS_CACHE.clear()
+    return {s["name"] for s in _find_all_skills(**kw)}
+
+
+class TestFindAllSkillsManualOnly:
+    def test_hidden_from_model_but_visible_to_user_surfaces(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "auto-skill")
+            _make_skill(tmp_path, "manual-skill", frontmatter_extra=FLAG)
+
+            model_facing = _names(hide_manual_only=True)
+            assert "manual-skill" not in model_facing
+            assert "auto-skill" in model_facing
+
+            # The banner and GET /v1/skills use the default; a manual-only
+            # skill must stay visible there — /name is how the user runs it.
+            user_facing = _names()
+            assert {"auto-skill", "manual-skill"} <= user_facing
+
+            # The config UI sees everything, as before.
+            assert "manual-skill" in _names(skip_disabled=True)
+
+
+class TestSkillViewManualOnly:
+    def test_model_entry_point_refuses_flagged_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "manual-skill", frontmatter_extra=FLAG)
+            skills_tool_module._SKILLS_CACHE.clear()
+
+            result = json.loads(
+                skills_tool_module._skill_view_with_bump({"name": "manual-skill"})
+            )
+            assert result["success"] is False
+            assert "manual-invocation-only" in result["error"]
+
+    def test_unflagged_skill_still_loads(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "auto-skill")
+            skills_tool_module._SKILLS_CACHE.clear()
+
+            result = json.loads(
+                skills_tool_module._skill_view_with_bump({"name": "auto-skill"})
+            )
+            assert result["success"] is True
+
+    def test_explicit_load_path_bypasses_the_gate(self, tmp_path):
+        """`/name` and --skills reach _load_skill_payload, not the model gate."""
+        from agent.skill_commands import _load_skill_payload
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "manual-skill", frontmatter_extra=FLAG)
+            skills_tool_module._SKILLS_CACHE.clear()
+
+            assert _load_skill_payload("manual-skill") is not None
+
+
+class TestSystemPromptIndexManualOnly:
+    def test_flagged_skill_is_excluded_from_the_prompt_index(self, tmp_path):
+        from agent.prompt_builder import _parse_skill_file
+
+        auto = _make_skill(tmp_path, "auto-skill") / "SKILL.md"
+        manual = _make_skill(tmp_path, "manual-skill", frontmatter_extra=FLAG) / "SKILL.md"
+
+        assert _parse_skill_file(auto)[0] is True
+        assert _parse_skill_file(manual)[0] is False

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -16,7 +16,8 @@ from hermes_constants import get_hermes_home
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get
 from agent.skill_utils import (
-    EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS, is_skill_support_path as _is_skill_support_path)
+    EXCLUDED_SKILL_DIRS as _EXCLUDED_SKILL_DIRS, is_skill_support_path as _is_skill_support_path,
+    skill_is_manual_only)
 from tools.skills_tool_setup import (  # noqa: F401
     SkillReadinessStatus, _build_setup_note, _capture_required_environment_variables,
     _get_required_environment_variables, _is_env_var_persisted, _is_remote_env_backend)
@@ -227,7 +228,7 @@ def _find_all_skills(*, skip_disabled: bool = False, hide_manual_only: bool = Fa
                 # Manual-only skills stay out of MODEL-facing listings only
                 # (see the offer-time gates in agent/prompt_builder.py for the
                 # system-prompt half).
-                if hide_manual_only and frontmatter.get("disable-model-invocation") is True:
+                if hide_manual_only and skill_is_manual_only(frontmatter):
                     continue
                 description = frontmatter.get("description", "")
                 if not description:  # first non-heading body line (a null value stays null)
@@ -657,6 +658,13 @@ registry.register(
     check_fn=check_skills_requirements, emoji="📚")
 
 
+# Payload keys that mean the call actually served the skill's material — file
+# contents, the rendered body, or an enumeration of what the skill directory holds.
+# A payload carrying any of these has something to withhold; one carrying none is a
+# bare error that reveals nothing beyond the name the caller already typed.
+_SERVING_KEYS = ("content", "body", "available_files")
+
+
 def _manual_only_refusal(name: str, payload: dict, file_path: str | None = None) -> str | None:
     """Return a refusal when the skill *payload* is manual-invocation-only.
 
@@ -664,41 +672,58 @@ def _manual_only_refusal(name: str, payload: dict, file_path: str | None = None)
     user can invoke it with /name, but the model may not load it on its own.
     Takes the payload skill_view already produced — re-loading here would double
     every model skill_view call and double-count the view telemetry the curator
-    reads (tools/skill_usage.py). Returns None for anything it cannot positively
-    identify as flagged; skill_view owns the real error messages.
+    reads (tools/skill_usage.py). skill_view owns the real error messages.
+
+    The skill is identified by the payload's ``skill_dir``, which every serving
+    branch now sets. It is NOT reconstructed from ``_source_path``: that pointed at
+    the requested supporting file rather than SKILL.md, and walking back up it took
+    one parent per component of *file_path*, which held only while the two were an
+    unresolved join. More to the point, several branches — a binary file, and a
+    miss that answers with the skill's file listing — returned no ``_source_path``
+    at all, so the reconstruction had nothing to work from and this function waved
+    the call through.
+
+    When the skill cannot be identified, the answer depends on what the payload
+    carries. A payload serving content or a directory listing is refused: an
+    unidentifiable skill is the one case where the gate has no evidence, and a gate
+    with no evidence must not be the one that opens. A payload with nothing to serve
+    is left alone, so skill_view's own error reaches the caller intact.
     """
-    src = payload.get("_source_path")
-    if not src:
-        return None
-    # The flag lives in SKILL.md, but with file_path= set, _source_path is the
-    # requested supporting file — reading it would find no flag and wave the
-    # call through, which is how a manual-only skill's references/ leaks. The
-    # payload carries skill_dir only on the plain view, so derive it: with
-    # file_path set, _source_path is exactly skill_dir / file_path.
     skill_dir = payload.get("skill_dir")
     if skill_dir:
         skill_md = Path(skill_dir) / "SKILL.md"
-    elif file_path:
-        root = Path(src)
-        for _ in Path(file_path).parts:
-            root = root.parent
-        skill_md = root / "SKILL.md"
     else:
-        skill_md = Path(src)
+        # With no file_path, _source_path is the SKILL.md itself.
+        src = payload.get("_source_path")
+        skill_md = Path(src) if src and not file_path else None
+
+    if skill_md is None:
+        if any(payload.get(k) for k in _SERVING_KEYS):
+            return _manual_only_error(name, payload)
+        return None
+
     try:
         frontmatter, _ = _parse_frontmatter(
             skill_md.read_text(encoding="utf-8-sig", errors="replace")[:4000]
         )
     except OSError:
+        # The skill's own SKILL.md is unreadable: same no-evidence case as above.
+        if any(payload.get(k) for k in _SERVING_KEYS):
+            return _manual_only_error(name, payload)
         return None
-    if frontmatter.get("disable-model-invocation") is not True:
+
+    if not skill_is_manual_only(frontmatter):
         return None
+    return _manual_only_error(name, payload)
+
+
+def _manual_only_error(name: str, payload: dict) -> str:
+    resolved = payload.get("name") or name
     return json.dumps(
         {
             "success": False,
-            "error": f"'{payload.get('name') or name}' is a manual-invocation-only skill.",
-            "hint": f"Ask the user to run /{payload.get('name') or name}; "
-                    "do not load it yourself.",
+            "error": f"'{resolved}' is a manual-invocation-only skill.",
+            "hint": f"Ask the user to run /{resolved}; do not load it yourself.",
         },
         ensure_ascii=False,
     )
@@ -715,7 +740,7 @@ def _skill_view_with_bump(args, **kw):
     result = skill_view(name, file_path=args.get("file_path"), task_id=task_id)
     with suppress(Exception):
         parsed = json.loads(result)
-        if isinstance(parsed, dict) and parsed.get("success"):
+        if isinstance(parsed, dict):
             # ── Manual-invocation gate ───────────────────────────────
             # This is the MODEL's entry point to skill_view; the slash-command
             # and --skills paths reach _load_skill_payload directly and are
@@ -723,9 +748,17 @@ def _skill_view_with_bump(args, **kw):
             # name can still reach the context by other means (an instruction
             # file naming the command, for one), so refuse the load rather than
             # rely on the model not guessing it.
-            refusal = _manual_only_refusal(name, parsed, args.get("file_path"))
-            if refusal is not None:
-                return refusal
+            #
+            # Deliberately NOT limited to success=True. A miss on file_path answers
+            # `success: false` and attaches `available_files` — the flagged skill's
+            # whole directory tree — so gating on success alone let the enumeration
+            # through. What decides is whether the payload SERVES something, which
+            # is also what keeps this from reading SKILL.md on every bare error.
+            if parsed.get("success") or any(parsed.get(k) for k in _SERVING_KEYS):
+                refusal = _manual_only_refusal(name, parsed, args.get("file_path"))
+                if refusal is not None:
+                    return refusal
+        if isinstance(parsed, dict) and parsed.get("success"):
             _record_skill_view(task_id, name, args.get("file_path"), parsed)
             if resolved := parsed.get("name") or name:  # qualified forms return the canonical name
                 from tools.skill_usage import bump_use, bump_view

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -35,6 +35,9 @@ logger = logging.getLogger(__name__)
 # TTL bounds staleness from in-place SKILL.md edits, which no directory signature can see.
 _SKILLS_CACHE: dict = {}
 _SKILLS_CACHE_TTL_SECONDS = 30.0
+_SKILLS_CACHE_KEY_DISABLED = "with_disabled"
+_SKILLS_CACHE_KEY_FILTERED = "filtered"
+_SKILLS_CACHE_KEY_MODEL = "filtered_model_facing"
 
 
 def _skills_scan_signature(dirs_to_scan, disabled) -> tuple:
@@ -184,11 +187,20 @@ def _skill_search_dirs() -> Tuple[list, list, Path]:
     return project_dirs, all_dirs, active_skills_dir
 
 
-def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
+def _find_all_skills(*, skip_disabled: bool = False, hide_manual_only: bool = False) -> List[Dict[str, Any]]:
     """All skills (name, description, category) across project/local/external dirs, first-wins
-    by name; cached per session. ``skip_disabled=True`` ignores disabled state (config UI)."""
+    by name; cached per session. ``skip_disabled=True`` ignores disabled state (config UI).
+    ``hide_manual_only=True`` drops ``disable-model-invocation`` skills — MODEL-facing callers
+    only: the flag's False branch also feeds user-facing surfaces (startup banner,
+    ``GET /v1/skills``) where a manual-only skill must stay visible; ``/name`` is how the user
+    invokes it."""
     from agent.skill_utils import iter_project_skill_files, iter_skill_index_files
-    cache_key = "with_disabled" if skip_disabled else "filtered"
+    if skip_disabled:
+        cache_key = _SKILLS_CACHE_KEY_DISABLED
+    elif hide_manual_only:
+        cache_key = _SKILLS_CACHE_KEY_MODEL
+    else:
+        cache_key = _SKILLS_CACHE_KEY_FILTERED
     disabled = set() if skip_disabled else _get_disabled_skill_names()
     project_dirs, dirs_to_scan, _ = _skill_search_dirs()
     signature = _skills_scan_signature(dirs_to_scan, disabled)
@@ -211,6 +223,11 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     continue
                 name = frontmatter.get("name", skill_md.parent.name)[:MAX_NAME_LENGTH]
                 if name in seen_names or name in disabled:
+                    continue
+                # Manual-only skills stay out of MODEL-facing listings only
+                # (see the offer-time gates in agent/prompt_builder.py for the
+                # system-prompt half).
+                if hide_manual_only and frontmatter.get("disable-model-invocation") is True:
                     continue
                 description = frontmatter.get("description", "")
                 if not description:  # first non-heading body line (a null value stays null)
@@ -238,7 +255,9 @@ def skills_list(category: str = None, task_id: str = None) -> str:
     """Tier 1 listing: name + description (+ category) only; ``task_id`` is handler parity."""
     try:
         _skills_dir().mkdir(parents=True, exist_ok=True)
-        all_skills = _find_all_skills()
+        # MODEL-facing listing: manual-only skills stay user-visible (`/name`),
+        # just out of the model's menu.
+        all_skills = _find_all_skills(hide_manual_only=True)
         try:
             from hermes_cli.plugins import discover_plugins, get_plugin_manager
             discover_plugins()
@@ -425,7 +444,7 @@ def _skill_readiness(frontmatter: Dict[str, Any], skill_name: str) -> Tuple[dict
         e["name"] for e in required_env_vars if not e.get("optional")
         and (e["name"] in still_missing or not _is_env_var_persisted(e["name"], env_snapshot))]
     setup_needed = bool(remaining)
-    # Only vars actually set pass through to sandboxed execution (execute_code, terminal).
+    # Only vars actually set pass through to sandboxes (execute_code, terminal).
     if available_env_names := [e["name"] for e in required_env_vars if e["name"] not in remaining]:
         try:
             from tools.env_passthrough import register_env_passthrough
@@ -495,7 +514,8 @@ def _locate_skill(name: str, local_category_name: Optional[str], project_dirs: l
                 hint="Inspect the skill in the repo checkout, or untrust the repo with "
                 "`hermes skills untrust`."), None, None
     if not skill_md or not skill_md.exists():
-        available = [s["name"] for s in _sort_skills(_find_all_skills())[:20]]
+        # MODEL-facing hint: manual-only skills stay out of the model's menu.
+        available = [s["name"] for s in _sort_skills(_find_all_skills(hide_manual_only=True))[:20]]
         return _fail(f"Skill '{name}' not found.", available_skills=available,
                      hint="Use skills_list to see all available skills"), None, None
     return None, skill_dir, skill_md
@@ -637,6 +657,38 @@ registry.register(
     check_fn=check_skills_requirements, emoji="📚")
 
 
+def _manual_only_refusal(name: str, payload: dict) -> str | None:
+    """Return a refusal when the skill *payload* is manual-invocation-only.
+
+    Mirrors Claude Code's `disable-model-invocation`: the skill exists and the
+    user can invoke it with /name, but the model may not load it on its own.
+    Takes the payload skill_view already produced — re-loading here would double
+    every model skill_view call and double-count the view telemetry the curator
+    reads (tools/skill_usage.py). Returns None for anything it cannot positively
+    identify as flagged; skill_view owns the real error messages.
+    """
+    src = payload.get("_source_path")
+    if not src:
+        return None
+    try:
+        frontmatter, _ = _parse_frontmatter(
+            Path(src).read_text(encoding="utf-8-sig", errors="replace")[:4000]
+        )
+    except OSError:
+        return None
+    if frontmatter.get("disable-model-invocation") is not True:
+        return None
+    return json.dumps(
+        {
+            "success": False,
+            "error": f"'{payload.get('name') or name}' is a manual-invocation-only skill.",
+            "hint": f"Ask the user to run /{payload.get('name') or name}; "
+                    "do not load it yourself.",
+        },
+        ensure_ascii=False,
+    )
+
+
 def _skill_view_with_bump(args, **kw):
     """Invoke skill_view, then bump view_count/use on success (best-effort). Repeat-view dedup
     mirrors read_file's unchanged-stub: a SAME, unchanged skill file already loaded in this
@@ -649,6 +701,16 @@ def _skill_view_with_bump(args, **kw):
     with suppress(Exception):
         parsed = json.loads(result)
         if isinstance(parsed, dict) and parsed.get("success"):
+            # ── Manual-invocation gate ───────────────────────────────
+            # This is the MODEL's entry point to skill_view; the slash-command
+            # and --skills paths reach _load_skill_payload directly and are
+            # unaffected. A manual-only skill is absent from the index, but its
+            # name can still reach the context by other means (an instruction
+            # file naming the command, for one), so refuse the load rather than
+            # rely on the model not guessing it.
+            refusal = _manual_only_refusal(name, parsed)
+            if refusal is not None:
+                return refusal
             _record_skill_view(task_id, name, args.get("file_path"), parsed)
             if resolved := parsed.get("name") or name:  # qualified forms return the canonical name
                 from tools.skill_usage import bump_use, bump_view

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -657,7 +657,7 @@ registry.register(
     check_fn=check_skills_requirements, emoji="📚")
 
 
-def _manual_only_refusal(name: str, payload: dict) -> str | None:
+def _manual_only_refusal(name: str, payload: dict, file_path: str | None = None) -> str | None:
     """Return a refusal when the skill *payload* is manual-invocation-only.
 
     Mirrors Claude Code's `disable-model-invocation`: the skill exists and the
@@ -670,9 +670,24 @@ def _manual_only_refusal(name: str, payload: dict) -> str | None:
     src = payload.get("_source_path")
     if not src:
         return None
+    # The flag lives in SKILL.md, but with file_path= set, _source_path is the
+    # requested supporting file — reading it would find no flag and wave the
+    # call through, which is how a manual-only skill's references/ leaks. The
+    # payload carries skill_dir only on the plain view, so derive it: with
+    # file_path set, _source_path is exactly skill_dir / file_path.
+    skill_dir = payload.get("skill_dir")
+    if skill_dir:
+        skill_md = Path(skill_dir) / "SKILL.md"
+    elif file_path:
+        root = Path(src)
+        for _ in Path(file_path).parts:
+            root = root.parent
+        skill_md = root / "SKILL.md"
+    else:
+        skill_md = Path(src)
     try:
         frontmatter, _ = _parse_frontmatter(
-            Path(src).read_text(encoding="utf-8-sig", errors="replace")[:4000]
+            skill_md.read_text(encoding="utf-8-sig", errors="replace")[:4000]
         )
     except OSError:
         return None
@@ -708,7 +723,7 @@ def _skill_view_with_bump(args, **kw):
             # name can still reach the context by other means (an instruction
             # file naming the command, for one), so refuse the load rather than
             # rely on the model not guessing it.
-            refusal = _manual_only_refusal(name, parsed)
+            refusal = _manual_only_refusal(name, parsed, args.get("file_path"))
             if refusal is not None:
                 return refusal
             _record_skill_view(task_id, name, args.get("file_path"), parsed)

--- a/tools/skills_tool_plugin.py
+++ b/tools/skills_tool_plugin.py
@@ -84,13 +84,17 @@ def _serve_skill_file(
         listing = {} if not list_available else {
             "available_files": _available_skill_files(skill_root),
             "hint": "Use one of the available file paths listed above"}
-        return _fail(f"File '{file_path}' not found in skill '{label}'.", **listing)
+        # skill_dir: identifies the serving skill for the manual-invocation gate
+        # (_manual_only_refusal); a miss still SERVES the directory listing.
+        return _fail(f"File '{file_path}' not found in skill '{label}'.",
+                     skill_dir=str(skill_root), **listing)
     try:
         content = _read_skill_text(target)
     except UnicodeDecodeError:
         return _json({
             "success": True, "name": label, "file": file_path, "is_binary": True,
-            "content": f"[Binary file: {target.name}, size: {target.stat().st_size} bytes]"})
+            "content": f"[Binary file: {target.name}, size: {target.stat().st_size} bytes]",
+            "skill_dir": str(skill_root)})
     except Exception as exc:
         if not read_error_prefix:
             raise
@@ -99,7 +103,11 @@ def _serve_skill_file(
         _mark_background_review_read(target)
     return _json({  # _source_path: internal, feeds the repeat-view dedup fingerprint
         "success": True, "name": label, "file": file_path, "content": content,
-        "file_type": target.suffix, "_source_path": str(target)})
+        "file_type": target.suffix, "_source_path": str(target),
+        # Internal: which skill served this, for the manual-invocation gate.
+        # Carried explicitly rather than derived from _source_path — see
+        # _manual_only_refusal.
+        "skill_dir": str(skill_root)})
 
 
 def _mark_background_review_read(path: Path) -> None:


### PR DESCRIPTION
## The gap

Claude Code's `SKILL.md` frontmatter supports `disable-model-invocation: true`: the skill stays registered and the user can still run it as `/name`, but the model must not consider it during automatic matching. It exists for side-effecting workflows — deploys, commits, anything that writes — that should not fire on a heuristic match.

Hermes does not read the field. The string appears nowhere in the source, so a skill authored with that flag is advertised in the system-prompt index, listed by `skills_list`, and loadable by the model, with no warning.

Skills converted from Claude Code custom commands are the common case. They carry the flag precisely *because* they are manual-only, and they arrive fully auto-invocable. On my own install that was 18 skills at once, including one whose entire purpose is writing to a notes vault.

`skills.disabled` is not an alternative: it removes a skill from the index, from `/name`, **and** from explicit `hermes -s <skill>` preloading (the #59156 gate). There is currently no way to keep a skill user-invocable while hiding it from the model.

## The change

Filter the surfaces that *offer* a skill to the model, leaving every explicit-load path untouched. `/name` and `--skills` reach `_load_skill_payload` directly and are unaffected.

| surface | file |
|---|---|
| system-prompt index | `agent/prompt_builder.py::_parse_skill_file` |
| `skills_list` + its bad-name hint | `tools/skills_tool.py::_find_all_skills` |
| the model's `skill_view` | `tools/skills_tool.py::_skill_view_with_bump` |

Two decisions worth flagging for review:

**`hide_manual_only` is a new parameter rather than a reuse of `skip_disabled`.** The obvious shortcut is wrong: `skip_disabled=False` also feeds the startup banner and `GET /v1/skills`, both **user**-facing. A manual-only skill must stay visible there, because `/name` is how the user invokes it. Model-facing and unfiltered are different axes.

**The `skill_view` gate reads the payload that call already produced.** Loading the skill again to inspect its frontmatter would double every model `skill_view` and double-count the view telemetry the curator consumes. It also resolves `SKILL.md` explicitly rather than trusting `_source_path`, since with `file_path=` set that points at the requested supporting file — where the flag is absent — which was a way to read a manual-only skill's `references/` straight through the gate. Second commit here.

## Verification

Measured against an assembled session prompt via `prompt_size`, not just the scan functions, because the index is built on a separate path from `skills_list`:

| | skills in index | index bytes |
|---|---|---|
| before | 58 | 4,449 |
| after | 40 | 4,100 |

All 18 flagged skills gone from the model's view, all 18 still invocable as `/name`, unflagged skills untouched. `tests/tools/test_manual_only_skills.py` covers all three surfaces plus the two things easiest to break while tidying the guards up: that a manual-only skill stays visible to the user-facing listing, and that explicit loads still work. 149 tests pass across the touched modules.

One note for anyone testing this by hand: the prompt index is snapshot-cached in `HERMES_HOME` and the snapshot does not key on source changes, so `.skills_prompt_snapshot.json` has to be removed after applying or the stale index is served back and the patch looks inert.

---

## Added: the `environments` gate has the same hole, one layer down

Folded in rather than opened separately — it is the same question (does an offer-time gate survive into the cached index?) about the sibling field, in the same file.

`environments:` hides a skill from the offer surfaces when its runtime is not active. The cold filesystem scan applies it correctly, but `_build_snapshot_entry` does not serialize the field, and the snapshot fast path rebuilds the index from those entries alone — so a filter whose input is absent cannot run.

The result is a gate that holds on the first build in a fresh `HERMES_HOME` and lapses for every process after it:

| | entries | with description | bare names |
|---|---|---|---|
| cold (no snapshot) | 38 | 38 | 0 |
| warm (snapshot on disk) | 63 | 38 | **25** |

Only the offer-side index is affected, and it leaks names without descriptions — `/name` stays gone in both states (`skill_commands.py` re-reads live frontmatter), and `skill_view` keeps working.

Note this is a *different* defect from the stale-snapshot caveat above, not the same one restated: that paragraph is about a snapshot written before a patch is applied, which one `rm` fixes permanently. This is a gate that never survives *any* rebuild, so it comes back on every warm start no matter how many times you clear the cache. Cold and warm disagreeing is easy to miss, because the first measurement anyone takes is the one that looks right.

### The change

Serialize `environments` alongside `platforms`, and re-check it on the fast path. `skill_matches_environment_list` is split out as the list-shaped sibling of `skill_matches_platform_list`, so both call sites share one implementation rather than the frontmatter-only entry point growing a second copy. Semantics are unchanged: empty matches, unknown tags fail open, OR across the list.

### Tests

Two tests pin the halves separately: the gate must survive a cache drop that *keeps* the snapshot (`clear_skills_system_prompt_cache(clear_snapshot=False)` is the in-process stand-in for a second process), and the entry must carry the field. Both fail without the change, and the cold assertion passes in both directions — which is what isolates the regression to the fast path. The detector is monkeypatched rather than read from the host, so the tests mean the same thing inside the Docker image, where `s6` genuinely is active.

153 tests pass across `test_prompt_builder`, `test_external_skills`, `test_project_skills`, `test_skill_bundles`, `test_skill_commands` and `test_manual_only_skills`.
