### PR TITLE
fix(gateway): persist is_bot on SessionSource so restarts keep bot sessions authorized

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -285,6 +285,13 @@ class SessionSource:
             d["auto_thread_initial_name"] = self.auto_thread_initial_name
         if self.prospective_thread_id:
             d["prospective_thread_id"] = self.prospective_thread_id
+        # `is_bot` gates the {PLATFORM}_ALLOW_BOTS bypass in
+        # GatewayAuthorizationMixin._is_user_authorized. Omitting it here made the
+        # flag live only in memory, so a rehydrated session (gateway restart,
+        # auto-resume) fell through to the human allowlist and revoked every
+        # bot-authored session that ALLOW_BOTS had admitted.
+        if self.is_bot:
+            d["is_bot"] = True
         return d
 
     @classmethod
@@ -309,6 +316,7 @@ class SessionSource:
             auto_thread_created=bool(data.get("auto_thread_created", False)),
             auto_thread_initial_name=data.get("auto_thread_initial_name"),
             prospective_thread_id=data.get("prospective_thread_id"),
+            is_bot=bool(data.get("is_bot", False)),
         )
     
 

--- a/tests/gateway/test_discord_bot_auth_bypass.py
+++ b/tests/gateway/test_discord_bot_auth_bypass.py
@@ -13,6 +13,7 @@ These tests assert both gates now pass a bot message through when
 DISCORD_ALLOW_BOTS permits it AND no user allowlist entry exists.
 """
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -162,3 +163,76 @@ def test_discord_role_config_does_not_leak_to_other_platforms(monkeypatch):
         user_id="999888777",
     )
     assert runner._is_user_authorized(telegram_user) is False
+
+
+# -----------------------------------------------------------------------------
+# `is_bot` must survive persistence, or the ALLOW_BOTS bypass silently expires
+#
+# The bypass above reads `source.is_bot`, but SessionSource.to_dict() did not
+# emit the flag, so it only ever lived in memory.  Sessions are persisted as
+# `origin_json` and rehydrated via from_dict() on gateway restart / auto-resume,
+# where is_bot came back False -> the bypass no longer fired -> the session fell
+# through to the human allowlist and was dropped with "session owner is no
+# longer authorized under the current allowlist".  Every bot-authored thread was
+# therefore revoked by any restart, including scheduled ones.
+# -----------------------------------------------------------------------------
+
+
+def _roundtrip(source: SessionSource) -> SessionSource:
+    """Persist and rehydrate through the same path gateway sessions use."""
+    return SessionSource.from_dict(json.loads(json.dumps(source.to_dict())))
+
+
+@pytest.mark.parametrize(
+    "platform",
+    [Platform.DISCORD, Platform.TELEGRAM, Platform.SLACK, Platform.FEISHU],
+)
+def test_is_bot_survives_source_roundtrip(platform):
+    """Every adapter that sets is_bot (discord/telegram/slack/feishu) must get
+    it back after persistence — the flag is session state, not per-message state.
+    """
+    source = SessionSource(
+        platform=platform,
+        chat_id="123",
+        chat_type="channel",
+        user_id="999888777",
+        user_name="SomeBot",
+        is_bot=True,
+    )
+    assert _roundtrip(source).is_bot is True
+
+
+def test_human_source_does_not_become_a_bot_on_roundtrip():
+    """Negative control: the flag must round-trip its actual value, not default
+    to True.  A human must never gain the ALLOW_BOTS bypass by being persisted.
+    """
+    assert _roundtrip(_make_discord_human_source()).is_bot is False
+
+
+def test_bot_stays_authorized_after_session_is_rehydrated(monkeypatch):
+    """The regression itself: a bot admitted by DISCORD_ALLOW_BOTS must remain
+    authorized after its session is persisted and reloaded, so a gateway restart
+    does not revoke in-flight bot threads.
+    """
+    runner = _make_bare_runner()
+
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")  # human-only allowlist
+
+    source = _make_discord_bot_source(bot_id="999888777")
+    assert runner._is_user_authorized(source) is True, "precondition: live bot is authorized"
+    assert runner._is_user_authorized(_roundtrip(source)) is True
+
+
+def test_rehydrated_bot_still_denied_when_allow_bots_is_off(monkeypatch):
+    """Negative control for the test above: persistence must not become an
+    authorization path of its own.  With ALLOW_BOTS unset, the rehydrated bot is
+    still denied — proving the assertion above tracks the policy, not the
+    round-trip.
+    """
+    runner = _make_bare_runner()
+
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")
+    # DISCORD_ALLOW_BOTS deliberately not set (fixture cleared it).
+
+    assert runner._is_user_authorized(_roundtrip(_make_discord_bot_source())) is False


### PR DESCRIPTION
## What does this PR do?

`SessionSource.to_dict()` never emitted the `is_bot` field, so the flag only ever lived in memory. Sessions persist as `origin_json` and rehydrate through `from_dict()`, where `is_bot` came back as its default `False`.

That flag gates the `{PLATFORM}_ALLOW_BOTS` bypass in `GatewayAuthorizationMixin._is_user_authorized` (`gateway/authz_mixin.py:507`), so a bot session that `ALLOW_BOTS` legitimately admitted while live fell through to the *human* allowlist after a restart, and auto-resume dropped it (`gateway/run.py:11977`):

```
WARNING gateway.run: Skipping auto-resume for agent:main:discord:thread:<id>:<id>:
session owner is no longer authorized under the current allowlist
```

Net effect: every gateway restart silently revoked all in-flight bot-authored sessions. The only symptom is a `WARNING` in `gateway.log`, so the thread just goes quiet — with scheduled restarts it's a recurring, invisible loss. I hit this with three Discord CI-alert threads (48, 69 and 181 messages) dropped mid-conversation.

`is_bot` is session state, not per-message state, so it must survive persistence like every other field on the source. The fix emits it only when `True` (matching the existing optional-field style in `to_dict`) and reads it back in `from_dict`.

Fixing it at `SessionSource` rather than in the Discord adapter covers the whole bug class: four adapters set the flag (discord, telegram, slack, feishu) and all persistence flows through this pair of methods — `SessionEntry.to_dict()` delegates to it.

## Related Issue

Fixes #92496

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py` — `SessionSource.to_dict()` now emits `is_bot` when set; `SessionSource.from_dict()` reads it back.
- `tests/gateway/test_discord_bot_auth_bypass.py` — 5 regression tests plus 2 negative controls, appended to the file that already covers the `ALLOW_BOTS` bypass (#4466).

Backward compatible: existing `origin_json` rows have no `is_bot` key and `from_dict` defaults to `False`, which is exactly the current behavior. Sessions re-persist with the flag on their next write.

## How to Test

Reproduce on `main` (no gateway needed — this is the same path used for `origin_json`):

```python
from gateway.session import SessionSource, Platform

s = SessionSource(platform=Platform.DISCORD, chat_id="123", chat_type="thread",
                  user_id="999888777", user_name="SomeBot", is_bot=True)
print("is_bot" in s.to_dict())                     # False on main, True with this PR
print(SessionSource.from_dict(s.to_dict()).is_bot)  # False on main, True with this PR
```

Then the tests:

```bash
pytest tests/gateway/test_discord_bot_auth_bypass.py -q     # 11 passed
```

**Verified by mutation, not just by green:** reverting only the `to_dict` hunk while keeping the tests makes exactly the 5 new assertions fail (`5 failed, 6 passed`), so they can actually detect the bug. The 2 negative controls keep passing under that mutation by design — they assert the fix does *not* over-reach:

- a human source must not come back as a bot after a round-trip;
- a rehydrated bot with `ALLOW_BOTS` unset must still be denied, proving the main assertion tracks the policy rather than the round-trip itself.

Full gateway suite, same machine, `main` vs this branch:

| | passed | failed |
|---|---|---|
| `main` @ `13f4cfebf` | 6092 | 10 |
| this branch | 6099 | 10 |

The 10 failures are identical in both runs (`comm` diff is empty) — pre-existing and unrelated (whatsapp bridge, systemd notify, scale-to-zero, discord attachments). No new failures introduced.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (Apple Silicon), Python 3.11.16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure serialization, no OS-specific behavior)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Production symptom that led to this, from `gateway.log` on restart — three separate bot-authored threads dropped at once:

```
2026-08-22 14:30:31 WARNING gateway.run: Skipping auto-resume for agent:main:discord:thread:1540791556007788715:...: session owner is no longer authorized under the current allowlist
2026-08-22 14:30:31 WARNING gateway.run: Skipping auto-resume for agent:main:discord:thread:1540796033770983556:...: session owner is no longer authorized under the current allowlist
2026-08-22 14:30:31 WARNING gateway.run: Skipping auto-resume for agent:main:discord:thread:1540796076951609354:...: session owner is no longer authorized under the current allowlist
```

The persisted `origin_json` for those sessions has 14 keys and no `is_bot`, while the author is a bot (`user_name: "Alerts Inmo"`) admitted by `DISCORD_ALLOW_BOTS=mentions`.
