### PR TITLE
feat(doctor): windows environment preflight checks

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1031,6 +1031,226 @@ def managed_scope_check() -> None:
         check_info(f"managed dir set via HERMES_MANAGED_DIR={managed_dir}")
 
 
+# ── Windows environment preflight (#91942) ──────────────────────────────
+# Probes are small and dependency-injectable so tests exercise failure
+# modes without faking the host OS; host-dependent assertions live under
+# @pytest.mark.windows_only.
+
+
+def _native_path_to_msys(path_str: str) -> str:
+    """Convert ``C:\\foo\\bar`` to the MSYS spelling ``/c/foo/bar``."""
+    p = str(path_str).replace("\\", "/")
+    if len(p) >= 2 and p[0].isalpha() and p[1] == ":":
+        return f"/{p[0].lower()}{p[2:]}"
+    return p
+
+
+def _windows_symlink_probe(base_dir=None, symlink_to=None):
+    """Create and delete a real file symlink. Returns ``(ok, detail)``.
+
+    ``detail`` is empty on success and carries a plain-language remedy
+    otherwise. ``symlink_to(target, link)`` is injectable so privilege
+    failures are testable on any host.
+    """
+    import tempfile
+
+    created_dir = base_dir is None
+    if created_dir:
+        base_dir = Path(tempfile.mkdtemp(prefix="hermes-doctor-symlink-"))
+    base_dir = Path(base_dir)
+    target = base_dir / "doctor_symlink_target.txt"
+    link = base_dir / "doctor_symlink_link"
+    try:
+        target.write_text("hermes doctor symlink probe", encoding="utf-8")
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        if symlink_to is None:
+            link.symlink_to(target)
+        else:
+            symlink_to(target, link)
+        if not link.is_symlink():
+            return False, "symlink was not created (no error reported)"
+        return True, ""
+    except OSError as exc:
+        if getattr(exc, "winerror", None) == 1314 or "privilege" in str(exc).lower():
+            detail = (
+                "creating symlinks requires privilege "
+                "(enable Developer Mode under Settings > Privacy & security "
+                "> For developers, or run once from an elevated terminal)"
+            )
+        else:
+            detail = f"symlink probe failed: {exc}"
+        return False, detail
+    finally:
+        if created_dir:
+            shutil.rmtree(base_dir, ignore_errors=True)
+        else:
+            for probe_file in (link, target):
+                try:
+                    probe_file.unlink()
+                except OSError:
+                    pass
+
+
+def _classify_git_interactive_risk(env, credential_helper=""):
+    """Classify whether spawned git may block on a credential prompt.
+
+    Pure function taking the environment and the resolved
+    ``credential.helper`` value as data. Returns ``(level, detail)`` where
+    level is ``"ok"`` or ``"warn"``.
+    """
+    if env.get("GIT_TERMINAL_PROMPT") == "0":
+        return "ok", ""
+    helper_first = ""
+    for token in (credential_helper or "").split():
+        helper_first = token
+        break
+    fix_hint = "setx GIT_TERMINAL_PROMPT 0"
+    if not helper_first:
+        return "warn", (
+            "no credential.helper configured and GIT_TERMINAL_PROMPT is unset — "
+            "git spawned by background/gateway contexts falls back to an "
+            f"interactive prompt and hangs. Fix: {fix_hint}"
+        )
+    if helper_first.startswith("manager"):
+        return "warn", (
+            f"credential.helper '{helper_first}' may open an interactive UI "
+            f"that blocks background/gateway git operations. Fix: {fix_hint}"
+        )
+    return "ok", f"non-interactive credential helper ({helper_first})"
+
+
+def _windows_bash_path_roundtrip(bash_path, sample_native, sample_msys,
+                                 extra_env=None, run=subprocess.run):
+    """Echo both path spellings through bash; require byte-identical output.
+
+    With Hermes' MSYS opt-outs applied (``MSYS_NO_PATHCONV=1`` plus
+    ``MSYS2_ARG_CONV_EXCL=*``, see #56700), neither spelling may be
+    rewritten. A rewrite means argv conversion is active despite the
+    opt-outs, so native tools invoked from bash will mangle Windows paths.
+    """
+    env = dict(os.environ)
+    try:
+        from tools.environments.local import _apply_windows_msys_bash_env_defaults
+        _apply_windows_msys_bash_env_defaults(env)
+    except Exception:
+        pass
+    if extra_env:
+        env.update(extra_env)
+    seen = {}
+    for label, sample in (("C:/ form", sample_native), ("/c/ form", sample_msys)):
+        try:
+            proc = run(
+                [bash_path, "-c", 'printf "%s" "$1"', "--", sample],
+                capture_output=True, text=True, timeout=15, env=env,
+            )
+            seen[label] = proc.stdout.strip()
+        except (OSError, subprocess.SubprocessError) as exc:
+            return False, f"{label} probe failed to run: {exc}"
+    problems = []
+    if seen["C:/ form"] != sample_native:
+        problems.append(f"C:/ form was rewritten to '{seen['C:/ form']}'")
+    if seen["/c/ form"] != sample_msys:
+        problems.append(f"/c/ form was rewritten to '{seen['/c/ form']}'")
+    return (not problems), "; ".join(problems)
+
+
+def _read_long_paths_enabled(query=None):
+    """Read LongPathsEnabled from the registry. Returns ``(state, value)``.
+
+    state is ``"enabled"`` | ``"disabled"`` | ``None`` (unreadable).
+    """
+    def _query(key_path, value_name):
+        import winreg
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, key_path) as key:
+            value, _ = winreg.QueryValueEx(key, value_name)
+            return int(value)
+
+    query_fn = query or _query
+    try:
+        value = query_fn(r"SYSTEM\CurrentControlSet\Control\FileSystem",
+                         "LongPathsEnabled")
+    except OSError:
+        return None, None
+    return ("enabled" if value else "disabled"), value
+
+
+def _check_windows_environment(issues, manual_issues):
+    """Windows section checks (#91942). Called only on win32 hosts."""
+
+    # 1. Symlink privilege — predicts EPERM failures when anything stages
+    #    trees containing symlinks (test fixtures, installs).
+    ok, detail = _windows_symlink_probe()
+    if ok:
+        check_ok("Symlink creation allowed")
+    else:
+        check_fail("Symlink creation denied", f"({detail})")
+        issues.append(f"Symlinks cannot be created — {detail}")
+
+    # 2. Non-interactive git safety — spawned git must fail fast instead of
+    #    hanging silently on a credential prompt.
+    git_bin = _safe_which("git")
+    if git_bin:
+        level, detail = "ok", ""
+        try:
+            helper_result = subprocess.run(
+                [git_bin, "config", "--get-all", "credential.helper"],
+                capture_output=True, text=True, timeout=10,
+            )
+            helper_value = "\n".join((helper_result.stdout or "").split())
+            level, detail = _classify_git_interactive_risk(os.environ, helper_value)
+        except Exception:
+            level, detail = "ok", ""
+        if level == "ok":
+            check_ok("Background git safety", (f"({detail})" if detail else ""))
+        else:
+            check_warn("Spawned git may hang on a credential prompt", f"({detail})")
+
+    # 3. Bash/MSYS sanity — the shell the terminal toolchain expects exists
+    #    and passes both path spellings through untouched.
+    try:
+        from tools.environments.local import _find_bash
+    except Exception:
+        _find_bash = None
+    if _find_bash is None:
+        check_info("bash discovery unavailable — skipping shell round-trip check")
+    else:
+        try:
+            bash_path = _find_bash()
+        except RuntimeError as exc:
+            check_fail("Git Bash failed to start", f"({exc})")
+            manual_issues.append(f"Repair Git Bash: {exc}")
+        except Exception as exc:
+            check_info(f"shell round-trip skipped ({exc})")
+        else:
+            sample_native = str(PROJECT_ROOT).replace("\\", "/")
+            ok, detail = _windows_bash_path_roundtrip(bash_path, sample_native,
+                                                      _native_path_to_msys(PROJECT_ROOT))
+            if ok:
+                check_ok("Shell passes native paths through untouched", f"({bash_path})")
+            else:
+                check_warn("Shell rewrites path arguments", f"({detail})")
+                manual_issues.append(
+                    "bash rewrites path arguments despite Hermes' MSYS opt-outs — "
+                    "native tools invoked from bash will fail to resolve paths"
+                )
+
+    # 4. Long paths — deep checkouts (node_modules depth) hit MAX_PATH when
+    #    the policy is off.
+    state, value = _read_long_paths_enabled()
+    if state == "enabled":
+        check_ok("Long paths enabled (LongPathsEnabled=1)")
+    elif state == "disabled":
+        fix_cmd = ('reg add "HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem" '
+                   "/v LongPathsEnabled /t REG_DWORD /d 1 /f")
+        check_fail("Long paths disabled",
+                   "(deep node_modules trees can exceed MAX_PATH)")
+        check_info(f"Fix (elevated): {fix_cmd}")
+        manual_issues.append(f"Enable Win32 long paths (elevated): {fix_cmd}")
+    else:
+        check_info("LongPathsEnabled unreadable — skipping long-path check")
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -2056,6 +2276,10 @@ def run_doctor(args):
                         manual_issues.append(f"Add {_cmd_link_display} to your PATH")
                 else:
                     issues.append(f"Missing {_cmd_link_display}/hermes symlink — run 'hermes doctor --fix'")
+
+    if sys.platform == "win32":
+        _section("Windows Environment")
+        _check_windows_environment(issues, manual_issues)
 
     _section("External Tools")
     # Git

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1038,7 +1038,12 @@ def managed_scope_check() -> None:
 
 
 def _native_path_to_msys(path_str: str) -> str:
-    """Convert ``C:\\foo\\bar`` to the MSYS spelling ``/c/foo/bar``."""
+    """Convert ``C:\\foo\\bar`` to the MSYS spelling ``/c/foo/bar``.
+
+    UNC paths (``\\\\server\\share``) become ``//server/share`` — fine for
+    this module's use generating round-trip samples from PROJECT_ROOT, but
+    not a general-purpose converter.
+    """
     p = str(path_str).replace("\\", "/")
     if len(p) >= 2 and p[0].isalpha() and p[1] == ":":
         return f"/{p[0].lower()}{p[2:]}"
@@ -1115,7 +1120,8 @@ def _classify_git_interactive_risk(env, credential_helper=""):
     if helper_first.startswith("manager"):
         return "warn", (
             f"credential.helper '{helper_first}' may open an interactive UI "
-            f"that blocks background/gateway git operations. Fix: {fix_hint}"
+            f"that blocks background/gateway git operations (custom GUI "
+            f"helpers are not detected). Fix: {fix_hint}"
         )
     return "ok", f"non-interactive credential helper ({helper_first})"
 
@@ -1199,12 +1205,14 @@ def _check_windows_environment(issues, manual_issues):
             )
             helper_value = "\n".join((helper_result.stdout or "").split())
             level, detail = _classify_git_interactive_risk(os.environ, helper_value)
-        except Exception:
-            level, detail = "ok", ""
-        if level == "ok":
-            check_ok("Background git safety", (f"({detail})" if detail else ""))
+        except Exception as exc:
+            # absence of evidence is not evidence of safety — label it
+            check_info(f"could not query git credential.helper ({exc})")
         else:
-            check_warn("Spawned git may hang on a credential prompt", f"({detail})")
+            if level == "ok":
+                check_ok("Background git safety", (f"({detail})" if detail else ""))
+            else:
+                check_warn("Spawned git may hang on a credential prompt", f"({detail})")
 
     # 3. Bash/MSYS sanity — the shell the terminal toolchain expects exists
     #    and passes both path spellings through untouched.

--- a/tests/hermes_cli/test_doctor_windows_env.py
+++ b/tests/hermes_cli/test_doctor_windows_env.py
@@ -1,0 +1,228 @@
+"""Tests for the Windows Environment section of hermes doctor (#91942).
+
+Probe functions are dependency-injectable so privilege/registry failure
+modes are exercised as data on any host. Assertions that depend on the
+real Windows filesystem/registry are marked ``windows_only``.
+"""
+
+import os
+import subprocess
+import sys
+import types
+
+import pytest
+
+import hermes_cli.doctor as doctor_mod
+
+
+# ── pure classification: git interactive risk ────────────────────────────
+
+
+class TestGitInteractiveRisk:
+    def test_explicit_prompt_disabled_is_ok(self):
+        level, detail = doctor_mod._classify_git_interactive_risk(
+            {"GIT_TERMINAL_PROMPT": "0"}, ""
+        )
+        assert level == "ok"
+        assert detail == ""
+
+    def test_no_helper_and_no_opt_out_warns_with_fix_command(self):
+        level, detail = doctor_mod._classify_git_interactive_risk({}, "")
+        assert level == "warn"
+        assert "setx GIT_TERMINAL_PROMPT 0" in detail
+        assert "hangs" in detail or "hang" in detail
+
+    def test_gui_manager_helper_warns_even_when_configured(self):
+        level, detail = doctor_mod._classify_git_interactive_risk(
+            {}, "manager-core"
+        )
+        assert level == "warn"
+        assert "manager-core" in detail
+        assert "setx GIT_TERMINAL_PROMPT 0" in detail
+
+    def test_noninteractive_helpers_are_ok(self):
+        for helper in ("cache", "store"):
+            level, detail = doctor_mod._classify_git_interactive_risk({}, helper)
+            assert level == "ok", helper
+            assert helper in detail
+
+    def test_multiline_helper_uses_first_entry(self):
+        level, _ = doctor_mod._classify_git_interactive_risk(
+            {}, "store\nhttps://example.com/helper"
+        )
+        assert level == "ok"
+
+
+# ── symlink probe (injected failure modes + real host behavior) ─────────
+
+
+def _raise_eperm(target, link):
+    err = OSError(13, "A required privilege is not held by the client.")
+    err.winerror = 1314
+    raise err
+
+
+class TestWindowsSymlinkProbe:
+    def test_injected_privilege_failure_reports_developer_mode_remedy(self, tmp_path):
+        ok, detail = doctor_mod._windows_symlink_probe(
+            base_dir=tmp_path, symlink_to=_raise_eperm
+        )
+        assert ok is False
+        assert "Developer Mode" in detail
+
+    def test_injected_generic_failure_reports_error(self, tmp_path):
+        def boom(target, link):
+            raise OSError(22, "invalid argument")
+
+        ok, detail = doctor_mod._windows_symlink_probe(base_dir=tmp_path, symlink_to=boom)
+        assert ok is False
+        assert "symlink probe failed" in detail
+
+    def test_probe_cleans_up_artifacts(self, tmp_path):
+        doctor_mod._windows_symlink_probe(base_dir=tmp_path, symlink_to=_raise_eperm)
+        names = {p.name for p in tmp_path.iterdir()}
+        assert not ({"doctor_symlink_target.txt", "doctor_symlink_link"} & names)
+
+    @pytest.mark.windows_only
+    def test_real_symlink_succeeds_on_privileged_host(self, tmp_path):
+        ok, detail = doctor_mod._windows_symlink_probe(base_dir=tmp_path)
+        if not ok and "Developer Mode" in detail:
+            pytest.skip("host lacks symlink privilege (Developer Mode off)")
+        assert ok is True, f"symlink probe failed on privileged host: {detail}"
+
+
+# ── bash path round-trip (fake runner = data, not a fake OS) ─────────────
+
+
+def _fake_runner(outputs_by_arg):
+    calls = []
+
+    def run(cmd, capture_output=None, text=None, timeout=None, env=None):
+        sample = cmd[-1]
+        calls.append((sample, env))
+        return types.SimpleNamespace(stdout=outputs_by_arg[sample])
+
+    run.calls = calls
+    return run
+
+
+class TestBashPathRoundtrip:
+    SAMPLE_NATIVE = "C:/Users/dev/project"
+    SAMPLE_MSYS = "/c/Users/dev/project"
+
+    def test_passthrough_both_forms_passes(self):
+        runner = _fake_runner({self.SAMPLE_NATIVE: self.SAMPLE_NATIVE,
+                               self.SAMPLE_MSYS: self.SAMPLE_MSYS})
+        ok, detail = doctor_mod._windows_bash_path_roundtrip(
+            "bash", self.SAMPLE_NATIVE, self.SAMPLE_MSYS, run=runner
+        )
+        assert ok is True
+        assert detail == ""
+
+    def test_rewritten_msys_form_fails_and_names_the_rewrite(self):
+        rewritten = "C:/Program Files/Git/Users/dev/project"
+        runner = _fake_runner({self.SAMPLE_NATIVE: self.SAMPLE_NATIVE,
+                               self.SAMPLE_MSYS: rewritten})
+        ok, detail = doctor_mod._windows_bash_path_roundtrip(
+            "bash", self.SAMPLE_NATIVE, self.SAMPLE_MSYS, run=runner
+        )
+        assert ok is False
+        assert rewritten in detail
+        assert "/c/ form was rewritten" in detail
+
+    def test_runner_receives_msys_opt_out_env(self):
+        runner = _fake_runner({self.SAMPLE_NATIVE: self.SAMPLE_NATIVE,
+                               self.SAMPLE_MSYS: self.SAMPLE_MSYS})
+        doctor_mod._windows_bash_path_roundtrip(
+            "bash", self.SAMPLE_NATIVE, self.SAMPLE_MSYS, run=runner
+        )
+        _, env = runner.calls[0]
+        if sys.platform == "win32":
+            # opt-outs are set by default; user overrides still win
+            assert env.get("MSYS_NO_PATHCONV", "1") == "1"
+            assert env.get("MSYS2_ARG_CONV_EXCL", "*") == "*"
+
+    def test_runner_crash_reports_probe_failed(self):
+        def run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="bash", timeout=15)
+
+        ok, detail = doctor_mod._windows_bash_path_roundtrip(
+            "bash", self.SAMPLE_NATIVE, self.SAMPLE_MSYS, run=run
+        )
+        assert ok is False
+        assert "probe failed to run" in detail
+
+
+# ── long paths (registry read as injected data) ──────────────────────────
+
+
+class TestLongPathsEnabled:
+    def test_value_one_reads_as_enabled(self):
+        state, value = doctor_mod._read_long_paths_enabled(query=lambda k, n: 1)
+        assert (state, value) == ("enabled", 1)
+
+    def test_value_zero_reads_as_disabled(self):
+        state, value = doctor_mod._read_long_paths_enabled(query=lambda k, n: 0)
+        assert (state, value) == ("disabled", 0)
+
+    def test_unreadable_registry_degrades_to_unknown(self):
+        def denied(key_path, value_name):
+            raise PermissionError("access denied")
+
+        state, value = doctor_mod._read_long_paths_enabled(query=denied)
+        assert state is None
+        assert value is None
+
+
+# ── native → msys conversion ──────────────────────────────────────────────
+
+
+class TestNativePathToMsys:
+    def test_windows_path_converts(self):
+        assert doctor_mod._native_path_to_msys("C:\\Users\\dev") == "/c/Users/dev"
+
+    def test_forward_slash_windows_path_converts(self):
+        assert doctor_mod._native_path_to_msys("D:/work/repo") == "/d/work/repo"
+
+    def test_posix_path_unchanged(self):
+        assert doctor_mod._native_path_to_msys("/usr/bin") == "/usr/bin"
+
+
+# ── full section against the real host (E2E, windows lane) ───────────────
+
+
+@pytest.mark.windows_only
+class TestWindowsSectionEndToEnd:
+    def test_section_reports_all_four_checks_with_consistent_summary(self, capsys):
+        issues, manual_issues = [], []
+        doctor_mod._check_windows_environment(issues, manual_issues)
+        out = capsys.readouterr().out
+        # every check reports exactly one of its outcomes, never silence
+        assert "Symlink creation allowed" in out or "Symlink creation denied" in out
+        # check 2 stays silent when git itself is absent (External Tools covers that)
+        if doctor_mod._safe_which("git"):
+            assert "Background git safety" in out or "credential prompt" in out
+        assert ("native paths through untouched" in out
+                or "rewrites path arguments" in out
+                or "round-trip skipped" in out)
+        assert ("Long paths enabled" in out or "Long paths disabled" in out
+                or "skipping long-path check" in out)
+        # contract: hard failures must land in the actionable summary lists
+        if "Symlink creation denied" in out:
+            assert any("Symlinks cannot be created" in i for i in issues)
+            assert any("Developer Mode" in i for i in issues)
+        else:
+            assert not any("Symlinks cannot be created" in i for i in issues)
+        if "Long paths disabled" in out:
+            assert any("reg add" in i for i in manual_issues)
+
+    def test_registry_read_matches_host_policy_domain(self):
+        state, value = doctor_mod._read_long_paths_enabled()
+        assert state in ("enabled", "disabled", None)
+        if state is not None:
+            assert value in (0, 1)
+            assert state == ("enabled" if value else "disabled")
+
+    def test_os_environment_is_a_plain_mapping_for_classifier(self):
+        level, _ = doctor_mod._classify_git_interactive_risk(os.environ, "store")
+        assert level == "ok"


### PR DESCRIPTION
## Summary

Implements the Windows section proposed in #91942: `hermes doctor` now runs four environment preflight checks on Windows hosts (skipped silently on other platforms, mirroring the existing POSIX-only "Command Installation" gate).

1. **Symlink privilege**: creates and deletes a real file symlink under a temp dir. On EPERM/winerror 1314 it prints the actual remedy (Developer Mode under Settings > Privacy & security > For developers, or one elevated run) instead of leaving the contributor to decode a bare winerror. Predicts failures in anything that stages trees containing symlinks.
2. **Non-interactive git safety**: warns when `GIT_TERMINAL_PROMPT` is unset and no non-interactive `credential.helper` is configured (or only a GUI `manager*` helper is), with a copy-pasteable `setx GIT_TERMINAL_PROMPT 0` fix so gateway/background-spawned git fails fast instead of hanging silently.
3. **Bash/MSYS sanity**: discovers bash through the same `_find_bash()` the terminal toolchain uses (so the probe cannot diverge from runtime), then round-trips both `C:/...` and `/c/...` spellings through it byte-identically under Hermes' MSYS opt-outs (`MSYS_NO_PATHCONV=1`, `MSYS2_ARG_CONV_EXCL=*`), matching the `_escape_native_tool_arg` contract in `tools/file_operations.py`. A rewrite means argv conversion is active despite the opt-outs (#56700 class of failure). ASLR-broken installs surface via `_find_bash()`'s own RuntimeError help text.
4. **Long paths**: reads `LongPathsEnabled` from HKLM and prints the elevated `reg add ... /d 1 /f` fix when deep checkouts (`node_modules` depth) risk MAX_PATH.

## Testing

- New `tests/hermes_cli/test_doctor_windows_env.py`: 22 tests. Probes are small dependency-injected functions, so privilege/registry/runner failure modes are exercised as data without faking the host OS (per AGENTS.md); assertions that depend on real filesystem/registry state are marked `windows_only`, and `scripts/ci/list_os_marked_tests.py windows_only` picks up the file for the Windows lane.
- Local run on native Windows 11: 21 passed, 1 skipped (the skip is the unprivileged-host path itself).
- Existing doctor suites (`test_doctor.py`, `test_doctor_command_install.py`, `test_doctor_dedicated_provider_skip.py`): 57 passed, 3 skipped, no regressions.
- The checks were validated against a machine that actually exhibits three of the four problems (symlink privilege off, `manager` helper with `GIT_TERMINAL_PROMPT` unset, long paths disabled); doctor reports each with its fix.

Refs #91942
