### PR TITLE
fix(api-server): include bounded media tool results

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -285,7 +285,14 @@ def _parse_tool_result_json(value: Any) -> Any:
 
 
 def _has_media_artifact_payload(value: Any, *, _depth: int = 0) -> bool:
-    """Return True when a result appears to contain renderable media metadata."""
+    """Return True when a result appears to contain renderable media metadata.
+
+    Heuristic by design: it only decides whether an unknown tool's result is
+    worth the bounded allowlist pass in ``_bounded_media_tool_result``.  The
+    string-marker branch scans raw text, so results that merely mention those
+    paths (e.g. a shell command echoing a workloads URL) can be false positives;
+    the allowlist projection still strips anything outside the media contract.
+    """
     if _depth > 6:
         return False
     value = _parse_tool_result_json(value)
@@ -406,16 +413,36 @@ def _bounded_media_tool_result(function_name: str, function_result: Any) -> Opti
     encoded = json.dumps(bounded, ensure_ascii=False, separators=(",", ":"))
     if len(encoded.encode("utf-8")) <= _MEDIA_TOOL_RESULT_MAX_BYTES:
         return bounded
-    compact = {
+
+    # Over budget: build the compact fallback and re-measure it.  The fallback
+    # itself can exceed the cap on large artifact lists (up to 20 items x
+    # ~2KB truncated strings), so shrink artifacts until it fits; if a single
+    # artifact still does not fit, drop it entirely rather than forward an
+    # unbounded payload.
+    def _encoded_size(value: Any) -> int:
+        return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+
+    artifacts = (
+        bounded.get("media_artifacts")
+        or (bounded.get("status") or {}).get("media_artifacts")
+        or (((bounded.get("status") or {}).get("job") or {}).get("artifacts"))
+    )
+    compact: dict[str, Any] = {
         "success": bounded.get("success"),
-        "media_artifacts": (
-            bounded.get("media_artifacts")
-            or (bounded.get("status") or {}).get("media_artifacts")
-            or (((bounded.get("status") or {}).get("job") or {}).get("artifacts"))
-        ),
-        "media_artifact_contract": bounded.get("media_artifact_contract") or (bounded.get("status") or {}).get("media_artifact_contract"),
         "truncated": True,
     }
+    if artifacts is not None:
+        compact["media_artifacts"] = list(artifacts)
+    contract = bounded.get("media_artifact_contract") or (bounded.get("status") or {}).get("media_artifact_contract")
+    if contract is not None:
+        compact["media_artifact_contract"] = contract
+
+    while _encoded_size(compact) > _MEDIA_TOOL_RESULT_MAX_BYTES and len(compact.get("media_artifacts", [])) > 0:
+        compact["media_artifacts"].pop()
+    if _encoded_size(compact) > _MEDIA_TOOL_RESULT_MAX_BYTES:
+        compact.pop("media_artifacts", None)
+    if _encoded_size(compact) > _MEDIA_TOOL_RESULT_MAX_BYTES:
+        compact = {"truncated": True}
     return {key: value for key, value in compact.items() if value is not None}
 
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -266,6 +266,157 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+_MEDIA_TOOL_RESULT_NAMES = {"media_generate", "media_artifact_get"}
+_MEDIA_TOOL_RESULT_MAX_BYTES = 16_384
+_MEDIA_TOOL_RESULT_STRING_MAX = 2_048
+
+
+def _parse_tool_result_json(value: Any) -> Any:
+    """Best-effort JSON decode for tool results returned as strings."""
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text or text[0] not in "[{":
+        return value
+    try:
+        return json.loads(text)
+    except Exception:
+        return value
+
+
+def _has_media_artifact_payload(value: Any, *, _depth: int = 0) -> bool:
+    """Return True when a result appears to contain renderable media metadata."""
+    if _depth > 6:
+        return False
+    value = _parse_tool_result_json(value)
+    if isinstance(value, str):
+        return any(
+            marker in value
+            for marker in (
+                "/workloads/artifact/",
+                "\"media_artifacts\"",
+                "\"inline_markdown\"",
+                "\"download_url\"",
+            )
+        )
+    if isinstance(value, list):
+        return any(_has_media_artifact_payload(item, _depth=_depth + 1) for item in value[:25])
+    if not isinstance(value, dict):
+        return False
+    if isinstance(value.get("media_artifacts"), list):
+        return True
+    if value.get("media_artifact_contract"):
+        return True
+    if value.get("inline_markdown") and (value.get("download_url") or value.get("url")):
+        return True
+    job = value.get("job")
+    if isinstance(job, dict) and isinstance(job.get("artifacts"), list):
+        return True
+    return any(_has_media_artifact_payload(child, _depth=_depth + 1) for child in value.values())
+
+
+def _bounded_media_tool_result(function_name: str, function_result: Any) -> Optional[dict[str, Any]]:
+    """Return a compact, OWUI-safe media result for streaming tool-complete SSE.
+
+    Hermes tool results can be arbitrarily large and may contain terminal output,
+    prompts, or other details that do not belong on the progress channel.  The
+    early media renderer only needs the artifact manifest, URLs, and minimal job
+    state, so expose that bounded allowlist only for media tools or results that
+    clearly contain media artifact metadata.
+    """
+    parsed = _parse_tool_result_json(function_result)
+    is_media_tool = function_name in _MEDIA_TOOL_RESULT_NAMES
+    if not is_media_tool and not _has_media_artifact_payload(parsed):
+        return None
+
+    allowed_keys = {
+        "success",
+        "result",
+        "error",
+        "status",
+        "submission",
+        "last_status",
+        "prompt_id",
+        "job",
+        "media_artifacts",
+        "media_artifact_contract",
+        "owui_media",
+        "artifact_count",
+        "state",
+        "display",
+        "primary_field",
+        "fallback_field",
+        "message",
+        "status_url",
+    }
+    artifact_keys = {
+        "artifact_id",
+        "kind",
+        "mime_type",
+        "filename",
+        "url",
+        "preview_url",
+        "download_url",
+        "inline_markdown",
+        "created_at",
+        "state",
+        "width",
+        "height",
+        "source",
+    }
+    job_keys = {
+        "prompt_id",
+        "status",
+        "workload",
+        "artifacts",
+        "owui_media",
+        "status_url",
+        "updated_at",
+        "submitted_at",
+    }
+
+    def clean(value: Any, *, context: str = "root", depth: int = 0) -> Any:
+        value = _parse_tool_result_json(value)
+        if depth > 8:
+            return None
+        if isinstance(value, dict):
+            keys = artifact_keys if context == "artifact" else job_keys if context == "job" else allowed_keys
+            out: dict[str, Any] = {}
+            for key, child in value.items():
+                if key not in keys:
+                    continue
+                child_context = "artifact" if key in {"media_artifacts", "artifacts"} else "job" if key == "job" else key
+                cleaned = clean(child, context=child_context, depth=depth + 1)
+                if cleaned is not None:
+                    out[key] = cleaned
+            return out or None
+        if isinstance(value, list):
+            child_context = "artifact" if context in {"media_artifacts", "artifacts"} else context
+            items = [clean(item, context=child_context, depth=depth + 1) for item in value[:20]]
+            return [item for item in items if item is not None]
+        if isinstance(value, str):
+            return value if len(value) <= _MEDIA_TOOL_RESULT_STRING_MAX else value[:_MEDIA_TOOL_RESULT_STRING_MAX] + "…"
+        if isinstance(value, (bool, int, float)) or value is None:
+            return value
+        return str(value)[:_MEDIA_TOOL_RESULT_STRING_MAX]
+
+    bounded = clean(parsed)
+    if not isinstance(bounded, dict):
+        return None
+    encoded = json.dumps(bounded, ensure_ascii=False, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) <= _MEDIA_TOOL_RESULT_MAX_BYTES:
+        return bounded
+    compact = {
+        "success": bounded.get("success"),
+        "media_artifacts": (
+            bounded.get("media_artifacts")
+            or (bounded.get("status") or {}).get("media_artifacts")
+            or (((bounded.get("status") or {}).get("job") or {}).get("artifacts"))
+        ),
+        "media_artifact_contract": bounded.get("media_artifact_contract") or (bounded.get("status") or {}).get("media_artifact_contract"),
+        "truncated": True,
+    }
+    return {key: value for key, value in compact.items() if value is not None}
 
 
 class ThreadSafeAsyncQueue(asyncio.Queue):
@@ -5245,11 +5396,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 if not tool_call_id or tool_call_id not in _started_tool_call_ids:
                     return
                 _started_tool_call_ids.discard(tool_call_id)
-                _stream_q.put_threadsafe(("__tool_progress__", {
+                payload = {
                     "tool": function_name,
                     "toolCallId": tool_call_id,
                     "status": "completed",
-                }))
+                }
+                bounded_result = _bounded_media_tool_result(function_name, function_result)
+                if bounded_result is not None:
+                    payload["result"] = bounded_result
+                _stream_q.put_threadsafe(("__tool_progress__", payload))
 
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -31,6 +31,7 @@ from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _IdempotencyCache,
+    _bounded_media_tool_result,
     _derive_chat_session_id,
     _hermes_version,
     _redact_api_error_text,
@@ -76,6 +77,97 @@ class TestRedactApiErrorText:
 
     def test_limit_truncates_after_redaction(self):
         assert len(_redact_api_error_text("x" * 500, limit=50)) == 50
+
+
+class TestBoundedMediaToolResult:
+    def test_omits_non_media_tool_result(self):
+        assert _bounded_media_tool_result("read_file", '{"content":"hello"}') is None
+
+    def test_includes_media_artifact_manifest(self):
+        result = _bounded_media_tool_result(
+            "media_generate",
+            json.dumps({
+                "success": True,
+                "prompt": "do not forward full prompt text",
+                "status": {
+                    "job": {
+                        "prompt_id": "abc123",
+                        "status": "completed",
+                        "workload": "gpu0-media-image",
+                        "artifacts": [{
+                            "artifact_id": "abc123:0",
+                            "filename": "image.png",
+                            "mime_type": "image/png",
+                            "url": "https://example.test/workloads/artifact/abc123/0?sig=signed",
+                            "download_url": "https://example.test/workloads/artifact/abc123/0?download=1&sig=signed",
+                            "inline_markdown": "![image.png](https://example.test/workloads/artifact/abc123/0?sig=signed)",
+                            "raw_path": "/tmp/secret.png",
+                        }],
+                    },
+                    "media_artifacts": [{
+                        "artifact_id": "abc123:0",
+                        "filename": "image.png",
+                        "mime_type": "image/png",
+                        "url": "https://example.test/workloads/artifact/abc123/0?sig=signed",
+                        "download_url": "https://example.test/workloads/artifact/abc123/0?download=1&sig=signed",
+                        "inline_markdown": "![image.png](https://example.test/workloads/artifact/abc123/0?sig=signed)",
+                    }],
+                    "media_artifact_contract": {"version": 1, "primary_field": "inline_markdown"},
+                },
+            }),
+        )
+
+        assert result is not None
+        assert result["success"] is True
+        assert result["status"]["job"]["artifacts"][0]["inline_markdown"].startswith("![image.png]")
+        assert result["status"]["media_artifacts"][0]["download_url"].startswith("https://example.test/")
+        assert "prompt" not in result
+        assert "raw_path" not in json.dumps(result)
+
+    def test_detects_artifacts_from_non_media_tool_but_bounds_payload(self):
+        result = _bounded_media_tool_result(
+            "handoff_profile",
+            {
+                "result": {
+                    "media_artifacts": [{
+                        "artifact_id": "abc123:0",
+                        "filename": "image.png",
+                        "url": "https://example.test/workloads/artifact/abc123/0?sig=signed",
+                        "download_url": "https://example.test/workloads/artifact/abc123/0?download=1&sig=signed",
+                        "inline_markdown": "![image.png](https://example.test/workloads/artifact/abc123/0?sig=signed)",
+                    }],
+                    "giant": "x" * 100_000,
+                }
+            },
+        )
+
+        assert result is not None
+        encoded = json.dumps(result)
+        assert "/workloads/artifact/abc123/0" in encoded
+        assert "giant" not in encoded
+        assert len(encoded.encode("utf-8")) < 16_384
+
+    def test_preserves_async_media_submission_status_url(self):
+        result = _bounded_media_tool_result(
+            "media_generate",
+            json.dumps({
+                "success": True,
+                "submission": {
+                    "prompt_id": "prompt-123",
+                    "status_url": "https://example.test/workloads/status/prompt-123?exp=999&sig=signed",
+                    "job": {
+                        "prompt_id": "prompt-123",
+                        "status": "submitted",
+                        "status_url": "https://example.test/workloads/status/prompt-123?exp=999&sig=signed",
+                    },
+                },
+            }),
+        )
+
+        assert result is not None
+        assert result["submission"]["prompt_id"] == "prompt-123"
+        assert result["submission"]["status_url"].startswith("https://example.test/workloads/status/prompt-123")
+        assert result["submission"]["job"]["status_url"].startswith("https://example.test/workloads/status/prompt-123")
 
 
 # ---------------------------------------------------------------------------
@@ -1241,6 +1333,74 @@ class TestChatCompletionsEndpoint:
             assert len(pairs) == 2, f"expected 2 events (running+completed), got {pairs}"
             assert pairs[0] == ("running", "call_terminal_1"), pairs
             assert pairs[1] == ("completed", "call_terminal_1"), pairs
+
+    @pytest.mark.asyncio
+    async def test_stream_tool_complete_includes_bounded_media_result(self, adapter):
+        """Media tool completions carry the artifact manifest for early renderers."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                result = _json.dumps({
+                    "success": True,
+                    "status": {
+                        "media_artifacts": [{
+                            "artifact_id": "abc123:0",
+                            "filename": "image.png",
+                            "url": "https://example.test/workloads/artifact/abc123/0?sig=signed",
+                            "download_url": "https://example.test/workloads/artifact/abc123/0?download=1&sig=signed",
+                            "inline_markdown": "![image.png](https://example.test/workloads/artifact/abc123/0?sig=signed)",
+                        }],
+                        "media_artifact_contract": {"version": 1, "primary_field": "inline_markdown"},
+                    },
+                    "prompt": "must not be forwarded on progress channel",
+                })
+                if ts_cb:
+                    ts_cb("call_media_1", "media_generate", {"workflow_id": "gpu0-media-image"})
+                if tc_cb:
+                    tc_cb("call_media_1", "media_generate", {"workflow_id": "gpu0-media-image"}, result)
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "make image"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        completed = None
+        lines = body.splitlines()
+        for i, line in enumerate(lines):
+            if line.strip() != "event: hermes.tool.progress":
+                continue
+            for follow in lines[i + 1: i + 4]:
+                if follow.startswith("data: "):
+                    payload = _json.loads(follow[len("data: "):])
+                    if payload.get("status") == "completed":
+                        completed = payload
+                    break
+
+        assert completed is not None
+        assert completed["tool"] == "media_generate"
+        assert completed["toolCallId"] == "call_media_1"
+        assert completed["result"]["status"]["media_artifacts"][0]["inline_markdown"].startswith("![image.png]")
+        assert "prompt" not in completed["result"]
 
     @pytest.mark.asyncio
     async def test_stream_tool_lifecycle_skips_internal_and_orphan_completes(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -169,6 +169,80 @@ class TestBoundedMediaToolResult:
         assert result["submission"]["status_url"].startswith("https://example.test/workloads/status/prompt-123")
         assert result["submission"]["job"]["status_url"].startswith("https://example.test/workloads/status/prompt-123")
 
+    def test_compact_fallback_is_remeasured_and_never_exceeds_cap(self):
+        # 20 artifacts x ~2KB truncated strings each: the full allowlist
+        # projection is over budget, and the compact fallback (all 20
+        # artifacts) is also over budget.  The re-measure loop must shrink
+        # the artifact list until the payload fits the cap.
+        big_inline = "![image.png](https://example.test/workloads/artifact/abc123/0?sig=signed)" + ("x" * 2_048)
+        artifacts = [
+            {
+                "artifact_id": f"abc123:{i}",
+                "filename": f"image-{i}.png",
+                "mime_type": "image/png",
+                "url": f"https://example.test/workloads/artifact/abc123/{i}?sig=signed",
+                "download_url": f"https://example.test/workloads/artifact/abc123/{i}?download=1&sig=signed",
+                "inline_markdown": big_inline,
+            }
+            for i in range(20)
+        ]
+        result = _bounded_media_tool_result(
+            "media_generate",
+            json.dumps({
+                "success": True,
+                "status": {
+                    "media_artifacts": artifacts,
+                    "media_artifact_contract": {"version": 1, "primary_field": "inline_markdown"},
+                },
+            }),
+        )
+
+        assert result is not None
+        encoded = json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+        assert len(encoded.encode("utf-8")) <= 16_384
+        assert result["truncated"] is True
+        assert len(result.get("media_artifacts", [])) < 20
+        # First artifacts are kept; the tail was dropped.
+        assert result["media_artifacts"][0]["artifact_id"] == "abc123:0"
+
+    def test_compact_fallback_drops_artifacts_when_single_one_still_exceeds_cap(self):
+        # A single artifact whose truncated strings still push the compact
+        # fallback over the cap must be dropped entirely, leaving a bounded
+        # marker payload.  clean() truncates each string to ~2KB, so an
+        # artifact with all 13 allowlisted fields long is ~26KB after
+        # truncation — over the cap even as a single-item compact fallback.
+        art = {
+            "artifact_id": "a" * 5_000,
+            "kind": "k" * 5_000,
+            "mime_type": "m" * 5_000,
+            "filename": "f" * 5_000,
+            "url": "u" * 5_000,
+            "preview_url": "p" * 5_000,
+            "download_url": "d" * 5_000,
+            "inline_markdown": "i" * 5_000,
+            "created_at": "c" * 5_000,
+            "state": "s" * 5_000,
+            "width": "w" * 5_000,
+            "height": "h" * 5_000,
+            "source": "src" * 5_000,
+        }
+        result = _bounded_media_tool_result(
+            "media_generate",
+            json.dumps({
+                "success": True,
+                "status": {
+                    "media_artifacts": [art],
+                },
+            }),
+        )
+
+        assert result is not None
+        encoded = json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+        assert len(encoded.encode("utf-8")) <= 16_384
+        assert result["truncated"] is True
+        # The oversized artifact was dropped from the manifest.
+        assert not result.get("media_artifacts")
+
 
 # ---------------------------------------------------------------------------
 # ResponseStore


### PR DESCRIPTION
## Summary
- include compact media tool results on API Server streaming tool-complete events
- preserve signed media status URLs for async media submissions
- bound forwarded media payloads so prompts and oversized tool output stay off the progress channel

## Test plan
- `python3 -m pytest tests/gateway/test_api_server.py::TestBoundedMediaToolResult tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_stream_tool_complete_includes_bounded_media_result -q`
- `python3 -m py_compile gateway/platforms/api_server.py`
- `git diff --check -- gateway/platforms/api_server.py tests/gateway/test_api_server.py`
