### PR TITLE
fix(discord): partition the provider-select page past Discord's 25-option cap

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -9196,7 +9196,17 @@ def _define_discord_view_classes() -> None:
             )
 
         def _build_provider_select(self):
-            """Build the provider dropdown menu."""
+            """Build the provider dropdown menu(s).
+
+            Discord caps each ``discord.ui.Select`` at 25 options and a View
+            at 5 action rows. Unlike the model-select page, the provider page
+            has no Back button (it's the top level), so only 1 row is needed
+            for Cancel — partition the provider list across up to 4 select
+            menus (100 slots) instead of truncating at 25, mirroring
+            ``_build_model_select``'s fix for the same Discord limit. A user
+            with many authenticated/custom providers configured previously
+            had everything past the 25th silently dropped from the picker.
+            """
             self.clear_items()
             options = []
             for p in self.providers:
@@ -9216,13 +9226,26 @@ def _define_discord_view_classes() -> None:
             if not options:
                 return
 
-            select = discord.ui.Select(
-                placeholder="Choose a provider...",
-                options=options[:_DISCORD_SELECT_MAX_OPTIONS],
-                custom_id="model_provider_select",
-            )
-            select.callback = self._on_provider_selected
-            self.add_item(select)
+            # Slice the provider list into <= 25-option chunks across (up to)
+            # 4 select rows: 4 selects + Cancel = 5 rows, Discord's View cap.
+            chunks = [
+                options[i : i + _DISCORD_SELECT_MAX_OPTIONS]
+                for i in range(0, len(options), _DISCORD_SELECT_MAX_OPTIONS)
+            ][
+                : _DISCORD_SELECT_MAX_ROWS - 1
+            ]  # keep 1 row for Cancel
+
+            for idx, chunk in enumerate(chunks):
+                suffix = f" ({idx + 1}/{len(chunks)})" if len(chunks) > 1 else ""
+                select = discord.ui.Select(
+                    placeholder=f"Choose a provider...{suffix}",
+                    options=chunk,
+                    custom_id=f"model_provider_select_{idx}",
+                )
+                # All provider selects resolve through the same handler — the
+                # selected value is the provider slug, identical across rows.
+                select.callback = self._on_provider_selected
+                self.add_item(select)
 
             cancel_btn = discord.ui.Button(
                 label="Cancel", style=discord.ButtonStyle.red, custom_id="model_cancel"

--- a/tests/gateway/test_discord_model_picker_partition.py
+++ b/tests/gateway/test_discord_model_picker_partition.py
@@ -7,6 +7,10 @@ picker keeps 2 rows for Back/Cancel, so it must partition the model list
 across up to 3 select menus. This is what makes free-tier ``:free`` Portal
 picks (appended after the curated list) appear on Discord — they previously
 fell off the 25-option cliff.
+
+The provider-select page (the picker's top level, one step before the model
+list) has the same 25-option Discord cap but needs only 1 row for Cancel (no
+Back button), so it must partition across up to 4 select menus instead.
 """
 
 from types import SimpleNamespace
@@ -155,3 +159,122 @@ def test_small_provider_single_select_unchanged():
     ]
     assert len(select_rows) == 1
     assert len(select_rows[0].options) == 10
+
+
+def _provider_select_rows(view: "ModelPickerView"):
+    return [
+        c for c in view.children
+        if isinstance(getattr(c, "custom_id", ""), str)
+        and c.custom_id.startswith("model_provider_select")
+    ]
+
+
+def test_many_providers_render_across_partitioned_provider_selects():
+    """A user with >25 configured providers must see ALL of them, not just
+    the first 25 — the provider-select page previously hard-truncated with
+    ``options[:25]`` while its sibling ``_build_model_select`` was fixed to
+    partition across multiple selects for the exact same Discord limit.
+    """
+    providers = [
+        {
+            "slug": f"provider-{i}",
+            "name": f"Provider {i}",
+            "models": [f"provider-{i}/model-a"],
+            "total_models": 1,
+            "is_current": i == 0,
+        }
+        for i in range(40)
+    ]
+
+    view = ModelPickerView(
+        providers=providers,
+        current_model="provider-0/model-a",
+        current_provider="provider-0",
+        session_key="session-1",
+        on_model_selected=lambda *a, **k: None,
+        allowed_user_ids={"123"},
+    )
+
+    select_rows = _provider_select_rows(view)
+    rendered_values = [
+        opt.value for sel in select_rows for opt in getattr(sel, "options", [])
+    ]
+
+    # No truncation, no dupes — every provider slug must appear exactly once.
+    assert sorted(rendered_values) == sorted(p["slug"] for p in providers)
+    assert len(rendered_values) == 40
+
+    # 40 providers => 2 select rows of 25 + 15, plus Cancel = 3 action rows.
+    assert len(select_rows) == 2
+    assert len(select_rows[0].options) == 25
+    assert len(select_rows[1].options) == 15
+
+    # No single select exceeds Discord's 25-option hard cap.
+    for sel in select_rows:
+        assert len(sel.options) <= 25
+
+    # Cancel button still present.
+    cancel_btns = [
+        c for c in view.children
+        if getattr(c, "custom_id", "") == "model_cancel"
+    ]
+    assert len(cancel_btns) == 1
+
+
+def test_small_provider_list_single_select_unchanged():
+    """A <25-provider list still renders as a single select menu."""
+    providers = [
+        {
+            "slug": f"provider-{i}",
+            "name": f"Provider {i}",
+            "models": [f"provider-{i}/model-a"],
+            "total_models": 1,
+            "is_current": i == 0,
+        }
+        for i in range(10)
+    ]
+
+    view = ModelPickerView(
+        providers=providers,
+        current_model="provider-0/model-a",
+        current_provider="provider-0",
+        session_key="session-1",
+        on_model_selected=lambda *a, **k: None,
+        allowed_user_ids={"123"},
+    )
+
+    select_rows = _provider_select_rows(view)
+    assert len(select_rows) == 1
+    assert len(select_rows[0].options) == 10
+
+
+def test_all_provider_select_rows_share_the_same_callback():
+    """Every partitioned provider select must route through
+    ``_on_provider_selected`` — the model-select handler reads
+    ``interaction.data["values"][0]`` without caring which row fired, and the
+    provider selects must follow the same contract.
+    """
+    providers = [
+        {
+            "slug": f"provider-{i}",
+            "name": f"Provider {i}",
+            "models": [f"provider-{i}/model-a"],
+            "total_models": 1,
+            "is_current": False,
+        }
+        for i in range(30)
+    ]
+
+    view = ModelPickerView(
+        providers=providers,
+        current_model="",
+        current_provider="",
+        session_key="session-1",
+        on_model_selected=lambda *a, **k: None,
+        allowed_user_ids={"123"},
+    )
+
+    select_rows = _provider_select_rows(view)
+    assert len(select_rows) == 2
+    for sel in select_rows:
+        assert sel.callback == view._on_provider_selected


### PR DESCRIPTION
## What

Discord's `/model` picker (`ModelPickerView`) has a two-step drill-down: a provider-select page, then a model-select page. `_build_model_select()` was fixed earlier today to partition a provider's model list across up to 3 select menus instead of hard-truncating at Discord's 25-option cap (`options[:25]`), so tail entries (e.g. Nous's `:free` Portal recommendation picks) survive on Discord instead of silently vanishing.

Its sibling — `_build_provider_select()`, the picker's top-level *provider* dropdown, one step before the model list — kept the identical truncation. The earlier fix only renamed the literal `25` to the named `_DISCORD_SELECT_MAX_OPTIONS` constant; the truncation itself is unchanged:

```python
select = discord.ui.Select(
    placeholder="Choose a provider...",
    options=options[:_DISCORD_SELECT_MAX_OPTIONS],   # still hard-capped at 25
    custom_id="model_provider_select",
)
```

A user with more than 25 authenticated + custom providers configured (this repo ships 37 built-in provider plugins plus an unbounded `custom_providers` list) has everything past the 25th silently dropped from the picker's *first* page — no "N more" indicator, no second page.

## Fix

Partition `_build_provider_select()`'s options across multiple select menus, mirroring `_build_model_select()`'s fix for the identical Discord limit. The provider page has no Back button (it's the top level of the drill-down), so only 1 row is needed for Cancel — that leaves room for up to 4 select rows (100 provider slots) instead of 3.

Each partitioned select shares the same `_on_provider_selected` callback (it reads `interaction.data["values"][0]`, so it doesn't care which row fired — the same pattern `_build_model_select`'s partitioned selects already use for `_on_model_selected`).

## Tests

Added to `tests/gateway/test_discord_model_picker_partition.py` (which already covers the model-select partitioning):
- `test_many_providers_render_across_partitioned_provider_selects` — 40 providers render across 2 select rows (25 + 15), every slug appears exactly once, no single select exceeds 25 options.
- `test_small_provider_list_single_select_unchanged` — a <25-provider list still renders as one select (no regression for the common case).
- `test_all_provider_select_rows_share_the_same_callback` — every partitioned row routes through `_on_provider_selected`.

**Mutation-verify:** stashed the production fix and re-ran the new tests — `test_many_providers_render_across_partitioned_provider_selects` and `test_all_provider_select_rows_share_the_same_callback` both failed against the pre-fix code (1 select of 25, tail dropped), confirming they exercise the real bug. Restored the fix, all 5 tests in the file pass.

**Broader run:** `tests/gateway/test_discord_*.py` — 252 passed, 3 pre-existing failures in `test_discord_send.py` (unrelated `discord.File` attribute/test-order issue) reproduced identically on a stash of this change, so unrelated to this fix. `ruff check` clean on both changed files.

## Competing PRs

- #92150 (merged earlier today) is the PR that fixed `_build_model_select()` — this PR is the sibling gap it left behind on `_build_provider_select()`.
- #92337 (opened today, "paginated button grid" rewrite) touches the same file and the same test file, replacing `_build_model_select()` with a button-grid pager — but its diff does not touch `_build_provider_select()` or its `options[:_DISCORD_SELECT_MAX_OPTIONS]` truncation line at all (confirmed via `gh pr diff`). No semantic overlap; some textual proximity in the shared test file (my additions are new functions appended at the end, not touching the model-select tests it rewrites), so a mechanical rebase may be needed if it lands first.