### PR TITLE
fix(state): sweep orphaned sidecars left by a hard kill mid-publish

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2234,6 +2234,28 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
                     old.unlink(missing_ok=True)
                 except OSError:  # pragma: no cover - best effort
                     pass
+        # Sweep orphaned sidecars (kill mid-PUBLISH). The publish loop below
+        # writes sidecars to their FINAL name before the main DB — the main
+        # file is the bundle's commit marker (see the publish-order comment
+        # further down) — so a hard kill between two os.replace() calls can
+        # leave a published ``-wal``/``-shm``/``-journal`` sidecar with no
+        # matching main backup on disk. Neither sweep pattern above catches
+        # this: it isn't a staging name (already renamed to its final name)
+        # and isn't the ``.incomplete`` spelling. _existing_malformed_backups()
+        # explicitly excludes sidecar-suffixed names from its count, so such
+        # an orphan is never pruned by _prune_malformed_backups() either — it
+        # would otherwise sit on disk forever, growing unbounded across
+        # repeated interrupted passes.
+        for suffix in _DB_SIDECAR_SUFFIXES:
+            for sidecar in db_path.parent.glob(
+                f"{db_path.name}.malformed-backup-*{suffix}"
+            ):
+                main = sidecar.with_name(sidecar.name[: -len(suffix)])
+                if not main.exists():
+                    try:
+                        sidecar.unlink(missing_ok=True)
+                    except OSError:  # pragma: no cover - best effort
+                        pass
         # Dedupe (#86747): a repair loop used to copy the SAME damaged bytes
         # on every restart — ~900MB a pass, 89GB over 11 days in the
         # reporting install. If the newest existing backup is byte-identical to

--- a/tests/test_state_db_repair_loop_mtime.py
+++ b/tests/test_state_db_repair_loop_mtime.py
@@ -782,3 +782,94 @@ def test_publication_failure_leaves_no_countable_partial_bundle(tmp_path):
     assert reason is None and path is not None
     strays = list(tmp_path.glob("*.backup-staging-*"))
     assert not strays, f"staging debris survived: {strays}"
+
+
+# ---------------------------------------------------------------------------
+# Orphaned sidecars left by a hard kill mid-PUBLISH (not mid-copy).
+#
+# ``test_publication_failure_leaves_no_countable_partial_bundle`` above only
+# exercises a *raising* os.replace() failure, where the except-block rolls
+# back every already-published destination. A hard kill (SIGKILL, OOM,
+# power loss) between two os.replace() calls raises nothing — the process
+# just stops — so the rollback never runs and a published sidecar can be
+# left with no matching main backup. These tests exercise that shape
+# directly: plant the orphan a hard kill would leave, then assert the next
+# pass's sweep removes it.
+# ---------------------------------------------------------------------------
+
+
+def test_orphaned_published_sidecar_is_swept_on_next_pass(tmp_path):
+    """A sidecar promoted to its final name with no matching main backup
+    (a hard kill between the sidecar and main os.replace() calls) must be
+    swept on the next pass — it is never counted by
+    ``_existing_malformed_backups`` (which excludes sidecar suffixes), so
+    without an explicit sweep it survives forever.
+    """
+    db = _damaged_db(tmp_path, size=20_000)
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+
+    # Plant an orphan exactly as a hard kill would leave one: a published
+    # sidecar (final name, no staging/incomplete marker) with no main file.
+    orphan = db.with_name(f"{db.name}.malformed-backup-20260101_000000-wal")
+    orphan.write_bytes(os.urandom(1_000))
+    assert orphan.exists()
+    assert not orphan.with_name(orphan.name[: -len("-wal")]).exists()
+
+    # The orphan must never be countable as a backup (root cause of why it
+    # would otherwise survive every prune pass).
+    assert not _existing_malformed_backups(db)
+
+    with patch("shutil.disk_usage", return_value=roomy):
+        path, reason = _backup_db_file(db)
+
+    assert reason is None and path is not None
+    assert not orphan.exists(), "orphaned published sidecar was not swept"
+
+
+def test_orphaned_sidecar_sweep_does_not_touch_a_healthy_backup(tmp_path):
+    """The sweep must only remove a sidecar whose main file is ABSENT — a
+    sidecar belonging to a genuine, complete forensic backup must survive.
+    """
+    db = _damaged_db(tmp_path, size=20_000)
+    db.with_name(db.name + "-wal").write_bytes(os.urandom(5_000))
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+
+    with patch("shutil.disk_usage", return_value=roomy):
+        first, reason = _backup_db_file(db)
+    assert reason is None and first is not None
+    first_sidecar = first.with_name(first.name + "-wal")
+    assert first_sidecar.exists()
+
+    # A second pass must not disturb the first backup's sidecar — its main
+    # file is present, so the sweep must leave it alone.
+    with patch("shutil.disk_usage", return_value=roomy):
+        second, reason = _backup_db_file(db)
+    assert reason is None and second is not None
+    assert first.exists(), "sweep removed a healthy backup's main file"
+    assert first_sidecar.exists(), "sweep removed a healthy backup's sidecar"
+
+
+def test_orphaned_sidecar_sweep_covers_all_sidecar_suffixes(tmp_path):
+    """The sweep must cover every sidecar suffix, not just ``-wal``."""
+    db = _damaged_db(tmp_path, size=20_000)
+    roomy = type(
+        "Usage", (), {"total": 500_000_000_000, "used": 0, "free": 400_000_000_000}
+    )()
+
+    orphans = [
+        db.with_name(f"{db.name}.malformed-backup-20260101_000000{suffix}")
+        for suffix in ("-wal", "-shm", "-journal")
+    ]
+    for orphan in orphans:
+        orphan.write_bytes(os.urandom(100))
+
+    with patch("shutil.disk_usage", return_value=roomy):
+        path, reason = _backup_db_file(db)
+
+    assert reason is None and path is not None
+    for orphan in orphans:
+        assert not orphan.exists(), f"orphan survived: {orphan.name}"


### PR DESCRIPTION
## What

`_backup_db_file()`'s publish loop writes the forensic backup's sidecars (`-wal`/`-shm`/`-journal`) to their **final** name before the main DB — sidecars first, main last, because the main file is the bundle's commit marker (`_existing_malformed_backups()` counts on `{db}.malformed-backup-*` matches, explicitly excluding sidecar suffixes):

```python
# Publish sidecars first, main DB LAST (the commit marker), so a
# mid-publish failure never leaves a countable-but-incomplete bundle.
publish_order = [(s, d) for _src, s, d in staged_sidecars] + [main_pair]
for src, dst in publish_order:
    os.replace(src, dst)
    published.append(dst)
```

A **raising** `os.replace()` failure between two of these calls is already handled — the `except Exception:` block rolls back every already-published destination.

A **hard kill** (SIGKILL, OOM-killer, host power loss/reboot) landing between the same two `os.replace()` calls raises nothing, so that rollback never runs. The result: a published sidecar (e.g. `state.db.malformed-backup-<stamp>-wal`) sits on disk with no matching main backup file.

Neither of the two existing sweep patterns at the top of the next pass catches this file:
- `{db}.backup-staging-*` — no match, the sidecar was already renamed to its **final** name before the kill.
- `{db}.malformed-backup-*.incomplete*` — no match, that's the pre-merge spelling for a different debris shape.

And `_existing_malformed_backups()` explicitly excludes sidecar-suffixed names from its count (`not p.name.endswith(_DB_SIDECAR_SUFFIXES)`), so this orphan is never counted as a backup either — which means `_prune_malformed_backups()` (which only deletes sidecars belonging to main files it already enumerated) never sees it. It survives on disk **forever**, unbounded across every future interrupted pass. This is the same class of disk-filling risk the surrounding series (#86747 dedupe, #69603 hard-stop, this week's disk-guard/atomic-publish rewrite) exists to bound — just at the publish step instead of the copy step.

## Fix

Add a sweep step, run at the top of every pass (same spot as the existing staging/incomplete sweeps, before the dedupe check): for each sidecar suffix, glob published-name `{db}.malformed-backup-*{suffix}` files and delete any whose corresponding main file (name with the suffix stripped) does not exist.

## Tests

Added to `tests/test_state_db_repair_loop_mtime.py` (which already covers this series' repair-loop/backup guards):
- `test_orphaned_published_sidecar_is_swept_on_next_pass` — plants an orphan exactly as a hard kill would leave one (published-name sidecar, no main file), confirms it's never countable by `_existing_malformed_backups()`, and that the next `_backup_db_file()` pass removes it.
- `test_orphaned_sidecar_sweep_does_not_touch_a_healthy_backup` — a genuine backup's sidecar (main file present) must survive a later pass — the sweep must not be a blunt "delete all sidecars" hammer.
- `test_orphaned_sidecar_sweep_covers_all_sidecar_suffixes` — `-wal`/`-shm`/`-journal` orphans are all swept, not just `-wal`.

**Mutation-verify:** stashed the production fix and re-ran the new tests — `test_orphaned_published_sidecar_is_swept_on_next_pass` and `test_orphaned_sidecar_sweep_covers_all_sidecar_suffixes` both failed against the pre-fix code (orphan survives). Restored the fix, all 31 tests in the file pass.

**Broader run:** every `tests/test_*state*db*.py` + `tests/hermes_cli/test_state_db_guard.py` + `tests/test_hermes_state.py` (328 tests total across these files) — all pass. `ruff check` clean on both changed files.

## Competing PRs

Searched multiple keyword combinations (`malformed-backup`, `_backup_db_file`, `_existing_malformed_backups`, `state.db publish sidecar wal`, `state.db repair forensic backup`). Nothing targets this specific publish-order orphan-sweep gap. Two tangentially related PRs, neither overlapping:
- #71982 ("make malformed-DB backup copies atomic with the live-connection registry") touches `_backup_db_file` but targets an old pre-rewrite version of the function (line 801, `Optional[Path]` return type — the function is now at a different location with a `Tuple[Optional[Path], Optional[str]]` signature after this week's disk-guard/atomic-publish series), so it predates and is unrelated to the shape this PR fixes.
- #72085 ("clear stale SQLite sidecars on snapshot restore") touches a completely different module (`hermes_cli/backup.py`, the `hermes sessions backup`/snapshot CLI command) and code path.