### PR TITLE
fix(guardrails): track read-shaped calls of mutating tools for no-progress detection

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -38,6 +38,41 @@ IDEMPOTENT_TOOL_NAMES = frozenset(
     }
 )
 
+# Read-shaped calls of mutating tools (#92475). A mutating tool is classified
+# by its worst-case call, but some also expose a pure-read call shape that
+# has no side effect, cannot fail, and returns identical bytes when nothing
+# changed — exactly the profile ``idempotent_no_progress`` exists to catch.
+# Without this table such reads inherit the MUTATING exclusion and get
+# neither the failure detectors (nothing fails) nor the no-progress detector
+# (excluded by classification), so an agent can repeat them indefinitely
+# while producing no signal.
+#
+# Each entry maps a tool name to the argument whose absence or explicit
+# null marks the read path. The value must mirror the tool's OWN branch:
+# e.g. todo_tool runs ``store.write(...)`` whenever ``todos is not None``
+# (an EMPTY list is a write that clears the list), so only absent/null
+# payloads qualify as reads. Deliberately NOT listed here: ``process`` — its
+# repetition is legitimate polling, already exempted via
+# STALL_GUARD_REPEATABLE_TOOLS; putting it in no-progress tracking would
+# fight the intended pattern.
+MUTATING_TOOL_READ_SHAPED_CALLS: dict[str, str] = {
+    "todo": "todos",
+}
+
+
+def is_read_shaped_call(tool_name: str, args: Mapping[str, Any] | None) -> bool:
+    """Whether this specific call of a mutating tool is a pure read.
+
+    True only for tools listed in ``MUTATING_TOOL_READ_SHAPED_CALLS`` whose
+    payload argument is either absent or explicitly None — mirroring each
+    tool's own read/write branch. Any present (even empty) payload counts as
+    the mutating shape and stays outside no-progress tracking.
+    """
+    if not isinstance(args, Mapping):
+        args = {}
+    payload_arg = MUTATING_TOOL_READ_SHAPED_CALLS.get(tool_name)
+    return payload_arg is not None and args.get(payload_arg) is None
+
 MUTATING_TOOL_NAMES = frozenset(
     {
         "terminal",
@@ -406,7 +441,7 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
-        if self._is_idempotent(tool_name):
+        if self._is_idempotent(tool_name, args):
             record = self._no_progress.get(signature)
             if record is not None:
                 _result_hash, repeat_count = record
@@ -493,7 +528,7 @@ class ToolCallGuardrailController:
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
-        if not self._is_idempotent(tool_name):
+        if not self._is_idempotent(tool_name, args):
             self._no_progress.pop(signature, None)
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -520,9 +555,16 @@ class ToolCallGuardrailController:
 
         return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
 
-    def _is_idempotent(self, tool_name: str) -> bool:
+    def _is_idempotent(self, tool_name: str, args: Mapping[str, Any] | None = None) -> bool:
+        """Whether this call should get no-progress loop detection.
+
+        Name-set behaviour for every listed tool; additionally, a mutating
+        tool whose SPECIFIC call is a pure read (#92475) counts as idempotent
+        here so the read shape is tracked like any other read-only call.
+        The ``args`` default keeps the historical single-argument call valid.
+        """
         if tool_name in self.config.mutating_tools:
-            return False
+            return is_read_shaped_call(tool_name, args)
         return tool_name in self.config.idempotent_tools
 
     def observe_identical_call(

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -169,6 +169,94 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.should_halt is True
 
 
+# ── Read-shaped calls of mutating tools (#92475) ─────────────────────────────
+
+from agent.tool_guardrails import is_read_shaped_call  # noqa: E402
+
+
+def test_todo_no_arg_read_gets_no_progress_warn_and_block():
+    # `todo` is classified MUTATING (worst-case call), but the no-todos call
+    # is a pure read (tools/todo_tool.py: `store.read()` whenever todos is
+    # None). It cannot fail and returns identical bytes, so neither the
+    # failure counters nor — before the fix — the no-progress detector ever
+    # saw it. With hard_stop_enabled=True the read must warn at 2 identical
+    # results and block the NEXT execution at 5, like any idempotent read.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    args = {"merge": False}
+
+    actions = []
+    for _ in range(5):
+        assert controller.before_call("todo", args).action == "allow"
+        actions.append(controller.after_call("todo", args, '{"todos":[]}').action)
+
+    assert actions == ["allow", "warn", "warn", "warn", "warn"]
+
+    blocked = controller.before_call("todo", args)
+    assert blocked.action == "block"
+    assert blocked.code == "idempotent_no_progress_block"
+
+
+def test_todo_explicit_null_todos_follows_the_tools_real_read_branch():
+    # todo_tool branches on `todos is not None`, so an EXPLICIT null is also
+    # a pure read and must be detected identically to the absent-argument form.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+
+    for i in range(2):
+        assert controller.before_call("todo", {"todos": None}).action == "allow"
+        controller.after_call("todo", {"todos": None}, '{"todos":[]}')
+
+    assert controller.before_call("todo", {"todos": None}).action == "allow"
+    third = controller.after_call("todo", {"todos": None}, '{"todos":[]}')
+    assert third.action == "warn"
+    assert third.code == "idempotent_no_progress_warning"
+
+
+def test_todo_write_shaped_calls_keep_today_behaviour_exactly():
+    # Any call that carries a todos payload goes through store.write() —
+    # including an EMPTY list, which clears the list. Those calls must remain
+    # outside no-progress tracking (and must reset any read streak recorded
+    # under their own signature, which they always did by classification).
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    args = {"todos": [], "merge": False}
+
+    for _ in range(7):
+        assert controller.before_call("todo", args).action == "allow"
+        assert controller.after_call("todo", args, '{"ok":true}').action == "allow"
+
+
+def test_process_polling_stays_exempt_from_no_progress_detection():
+    # Guard rail against over-generalizing: `process` repeats deliberately
+    # (polling) and is already notice-exempt via STALL_GUARD_REPEATABLE_TOOLS.
+    # It must never enter the no-progress tracker.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    args = {"action": "poll", "session_id": "s1"}
+
+    for _ in range(7):
+        assert controller.before_call("process", args).action == "allow"
+        assert controller.after_call("process", args, '{"status":"running"}').action == "allow"
+
+
+def test_read_shaped_call_table_matches_todo_branch_semantics():
+    # The helper mirrors todo_tool's own branch (`todos is not None` means
+    # write): only absent or explicitly-null payloads count as reads.
+    assert is_read_shaped_call("todo", {}) is True
+    assert is_read_shaped_call("todo", {"merge": False}) is True
+    assert is_read_shaped_call("todo", {"todos": None}) is True
+    assert is_read_shaped_call("todo", {"todos": []}) is False
+    assert is_read_shaped_call("todo", {"todos": [{"id": "x"}]}) is False
+    # Unlisted tools have no read shape — name-set behaviour is untouched.
+    assert is_read_shaped_call("write_file", {}) is False
+    assert is_read_shaped_call("web_search", {}) is False
+
+
 
 
 


### PR DESCRIPTION
## Problem

Closes #92475.

`todo` sits in `MUTATING_TOOL_NAMES`, which makes `_is_idempotent()` return False and `after_call()` take its early exit — so the `idempotent_no_progress` warn/block paths are structurally unreachable for it, even with `hard_stop_enabled: true`. But `todo`'s no-argument call is a pure read (`tools/todo_tool.py`: `store.read()` whenever `todos is None`). It has no side effect, cannot fail, and returns the same bytes every time — a cheap, always-succeeding tool present in nearly every toolset that an agent can repeat indefinitely while producing no signal.

## Approach

Classification stays worst-case **per tool**; detection becomes per **call**.

- New declarative table in `agent/tool_guardrails.py`:

  ```python
  MUTATING_TOOL_READ_SHAPED_CALLS = {"todo": "todos"}
  ```

  Each entry maps a mutating tool to the argument whose absence or explicit null marks its pure-read shape.
- `_is_idempotent(tool_name)` → `_is_idempotent(tool_name, args=None)`: mutating tools now fall through to `is_read_shaped_call(tool_name, args)` before returning False; everything else is unchanged name-set behavior.
- The table mirrors each tool's OWN branch: `todo_tool` writes whenever `todos is not None`, so an EMPTY list (a write that clears the list) is deliberately NOT treated as a read.

This is the issue's "narrower alternative," generalized one notch — a one-line entry for the next dual-mode tool instead of a new special case, without going all the way to a per-tool predicate interface.

**Deliberately out of scope:**
- `process` — its repetition is legitimate polling, already exempted via `STALL_GUARD_REPEATABLE_TOOLS`; it must never enter no-progress tracking (pinned by test).
- `skill_manage(view)` / `cronjob(list)` / `delegate_task(list)` — genuinely read-shaped, but enumerating action vocabularies risks silently dropping write-side protection on a mistake; better as follow-up entries once this mechanism lands.

## Coordination

- #85352 (open) improves the no-progress **counter** (signature-keyed, cross-turn window) for tools already tracked; this PR fixes **classification** so read-shaped calls enter tracking at all. The two compose without conflict — happy to rebase if that lands first.
- #67889 tracks broader terminal-specific progress detection; this change is orthogonal and doesn't touch terminal classification.

## Tests

In `tests/agent/test_tool_guardrails.py`, all invariant-style (no snapshots):

1. Repeated identical no-arg reads warn from call 2 and block the next execution at 5 under `hard_stop_enabled=True`.
2. Explicit `todos: null` follows the tool's real branch and is detected identically to absent.
3. Write-shaped calls (payload present, including empty-list clear) keep today's exact allow-always behavior.
4. `process(action=poll)` stays exempt from no-progress detection.
5. Table semantics pinned against `todo_tool`'s actual branch condition.

Sabotage-verified: restoring pre-fix `_is_idempotent` behavior fails exactly tests 1–2 while preservation tests keep passing.

```
scripts/run_tests.sh tests/agent/test_tool_guardrails.py   # 12 ✓
scripts/run_tests.sh tests/agent/test_stall_guards.py      # 35 ✓
scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py  # 10 ✓
ruff check agent/tool_guardrails.py tests/agent/test_tool_guardrails.py   # clean
```

## Risk

Minimal and contained: production callers (`agent/tool_executor.py` `before_call`, `run_agent.py` `_append_guardrail_observation`) already pass full args into the controller, so no wiring changes are needed. The only behavior change is that repeated identical `todo` reads now produce loop warnings/blocks under existing config thresholds — which is the point of the fix. Rollback is reverting one table + one method signature.
