### PR TITLE
fix(cli): keep venv symlink in desktop entry Exec, don't dereference

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -57,6 +57,19 @@ def icon_path(project_root: Path) -> Path:
     return project_root / "apps" / "desktop" / "assets" / "icon.png"
 
 
+def _running_interpreter() -> Path:
+    """Absolute ``sys.executable`` WITHOUT dereferencing symlinks.
+
+    ``sys.executable`` in a venv is often a symlink into the base
+    interpreter install (uv, pyenv, conda). ``Path.resolve()`` follows it
+    out of the venv, and the base interpreter has no venv
+    ``site-packages`` — the #90292 silent crash again, one level up. The
+    symlink path itself is what activates the venv (``pyvenv.cfg`` sits
+    next to it), so keep it.
+    """
+    return Path(os.path.abspath(sys.executable))
+
+
 def resolve_exec_command() -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
@@ -77,12 +90,14 @@ def resolve_exec_command() -> str:
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # venv one), so prefix it explicitly. Keep it as-is: resolving
+            # would dereference a venv symlink to the base interpreter,
+            # which lacks the venv's site-packages.
+            argv = [str(_running_interpreter()), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(_running_interpreter()), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 
@@ -98,15 +113,21 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # Native binary (uv tool shim, PyInstaller, distro package) — its own
         # loader is self-sufficient.
         return False
-    shebang = head.decode("utf-8", errors="replace").strip().lower()
-    if "python" not in shebang:
+    shebang = head.decode("utf-8", errors="replace").strip()
+    if "python" not in shebang.lower():
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
+    # a system path) would escape the venv when spawned by the DE. Use the
+    # interpreter path AS RUNNING (a venv python is often a symlink into
+    # the base install): the dereferenced base dir is a DIFFERENT
+    # environment with no venv site-packages, so a shebang pointing there
+    # must still be prefixed. Paths are compared case-SENSITIVELY as the
+    # OS resolves them (lowercasing the shebang only for the ``python``
+    # keyword check).
+    exe_dir = str(_running_interpreter().parent)
     return exe_dir not in shebang
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -107,7 +109,7 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(lde._running_interpreter())
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -130,12 +132,10 @@ def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypat
 
 
 def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch):
-    import sys
-
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(lde._running_interpreter())
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
@@ -147,6 +147,77 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
     assert exec_line == f"{hermes_bin} desktop"
+
+
+# uv/pyenv-style venv: sys.executable is a SYMLINK into the base interpreter
+# install. Path.resolve() dereferences it out of the venv, and the base
+# interpreter has no venv site-packages — the #90292 silent crash again.
+def _fake_symlinked_venv(tmp_path: Path) -> "tuple[Path, Path]":
+    base = tmp_path / "base" / "bin" / "python3.11"
+    base.parent.mkdir(parents=True)
+    base.write_text("#!/bin/sh\n", encoding="utf-8")
+    base.chmod(0o755)
+    venv_dir = tmp_path / "venv"
+    (venv_dir / "bin").mkdir(parents=True)
+    (venv_dir / "pyvenv.cfg").write_text("home = " + str(base.parent) + "\n")
+    venv_python = venv_dir / "bin" / "python"
+    venv_python.symlink_to(base)
+    return venv_python, base
+
+
+def test_running_interpreter_keeps_venv_symlink_unresolved(tmp_path, monkeypatch):
+    venv_python, base = _fake_symlinked_venv(tmp_path)
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+
+    assert str(lde._running_interpreter()) == str(venv_python)
+    assert str(lde._running_interpreter()) != str(base)
+
+
+def test_exec_prefixes_venv_symlink_not_dereferenced_base(
+    tmp_path, xdg_home, monkeypatch
+):
+    venv_python, base = _fake_symlinked_venv(tmp_path)
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+
+    root = _make_project(tmp_path)
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    assert entry is not None
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # The prefix must be the venv python (symlink path kept), never the
+    # dereferenced base interpreter — it lacks the venv's site-packages.
+    assert exec_line.split(" ")[0].strip('"') == str(venv_python)
+    assert str(base) not in exec_line
+
+
+def test_needs_interpreter_flags_shebang_pointing_at_base_install(
+    tmp_path, monkeypatch
+):
+    venv_python, base = _fake_symlinked_venv(tmp_path)
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+
+    # A launcher shebanged with the BASE interpreter path: under the old
+    # code the exe_dir was the dereferenced base dir, this shebang matched
+    # it, and the entry launched the base python — no venv site-packages.
+    script = tmp_path / "bin" / "hermes"
+    script.parent.mkdir()
+    script.write_text(f"#!{base}\nimport hermes_cli\n", encoding="utf-8")
+    script.chmod(0o755)
+
+    assert lde._needs_interpreter(script) is True
+
+    # A launcher shebanged with the venv symlink itself stays unprefixed.
+    venv_shebang = tmp_path / "bin" / "hermes-venv"
+    venv_shebang.write_text(f"#!{venv_python}\nimport hermes_cli\n", encoding="utf-8")
+    venv_shebang.chmod(0o755)
+    assert lde._needs_interpreter(venv_shebang) is False
 
 
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Summary

`hermes desktop` writes a XDG launcher (`hermes.desktop`) whose `Exec=` line could point at the **base** interpreter instead of the venv one, making the app-grid icon silently fail to boot while `hermes desktop` from a terminal worked fine.

**Root cause:** in a uv/pyenv-style venv, `sys.executable` is a symlink into the base interpreter install. `resolve_exec_command()` called `Path(sys.executable).resolve()`, which dereferences that symlink out of the venv. The base interpreter has no venv `site-packages`, so the DE-spawned process died on `import yaml` before Electron ever started — invisible because `Terminal=false`. Same failure class as #90292, one level up.

**Fix:**
- `_running_interpreter()`: keep `sys.executable` absolute but **unresolved** — the symlink path is what activates the venv (`pyvenv.cfg` sits next to it). Used for both the interpreter-prefix and the `-m hermes_cli.main` fallback `Exec` forms.
- `_needs_interpreter()`: the containment check now compares against the unresolved interpreter dir, so a shebang pointing at the **base** install is correctly flagged as escaping the venv (previously it matched and was wrongly left alone). Also fixed case-sensitivity: the shebang used to be lowercased wholesale, breaking the containment match for any path containing uppercase letters.
- Regression tests: interpreter kept unresolved, `Exec` prefixes the venv symlink (never the dereferenced base), base-shebang scripts still flagged.

## Reproduction (before fix)

```
$ grep Exec ~/.local/share/applications/hermes.desktop
Exec=/home/USER/.local/share/uv/python/cpython-3.11.16-linux-aarch64-gnu/bin/python3.11 /home/USER/.hermes/hermes-agent/hermes desktop

# Launching that exact command:
ModuleNotFoundError: No module named 'yaml'
```

After the fix the entry becomes:

```
Exec=/home/USER/.hermes/hermes-agent/venv/bin/python /home/USER/.hermes/hermes-agent/hermes desktop
```

Verified end-to-end on Linux (aarch64, uv-managed venv): the regenerated entry launches the packaged Electron app (zygote processes spawn, window comes up).

## Test Plan

- [x] `pytest tests/hermes_cli/test_linux_desktop_entry.py` — 18 passed, 2 skipped (platform-only)
- [x] Live verification: ran the exact `Exec=` command; Electron app started
- [x] Regenerated local entry confirms venv python in `Exec=`
