### PR TITLE
fix(kanban): reject unanchored worktree tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3419,6 +3419,9 @@ def create_task(
     # task would point cleanup at the user's source tree (#28818). The
     # containment guard in ``_cleanup_workspace`` is the safety rail, but
     # we also stop the bad state from being created in the first place.
+    workspace_inherited_from_board = False
+    board_slug: Optional[str] = None
+    board_default: Optional[str] = None
     if (
         workspace_path is None
         and project_repo is None
@@ -3429,16 +3432,14 @@ def create_task(
         board_default = board_meta.get("default_workdir")
         if board_default:
             workspace_path = str(board_default)
+            workspace_inherited_from_board = True
 
     # A worktree task without an explicit path or a resolved Project depends
     # entirely on the board default. Validate that anchor now instead of
     # persisting a task that is guaranteed to fail (and be archived) when the
     # dispatcher eventually tries to materialize its worktree.
     if workspace_kind == "worktree" and project_repo is None:
-        board_slug = board if board else get_current_board()
-        board_default = (
-            read_board_metadata(board_slug).get("default_workdir") or ""
-        ).strip()
+        board_slug = board_slug or (board if board else get_current_board())
         if workspace_path is None:
             raise ValueError(
                 "workspace_kind=worktree has no workspace_path, no resolved "
@@ -3447,7 +3448,8 @@ def create_task(
                 "<slug>, or create the task with "
                 "--workspace worktree:<absolute-repo-path>."
             )
-        if board_default and workspace_path == board_default:
+        if workspace_inherited_from_board and board_default:
+            board_default = str(board_default).strip()
             anchor = Path(board_default).expanduser()
             if not anchor.is_absolute():
                 raise ValueError(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3430,6 +3430,37 @@ def create_task(
         if board_default:
             workspace_path = str(board_default)
 
+    # A worktree task without an explicit path or a resolved Project depends
+    # entirely on the board default. Validate that anchor now instead of
+    # persisting a task that is guaranteed to fail (and be archived) when the
+    # dispatcher eventually tries to materialize its worktree.
+    if workspace_kind == "worktree" and project_repo is None:
+        board_slug = board if board else get_current_board()
+        board_default = (
+            read_board_metadata(board_slug).get("default_workdir") or ""
+        ).strip()
+        if workspace_path is None:
+            raise ValueError(
+                "workspace_kind=worktree has no workspace_path, no resolved "
+                f"project, and board {board_slug!r} has no default_workdir set. "
+                "Set a board default workdir (a git repo), pass --project "
+                "<slug>, or create the task with "
+                "--workspace worktree:<absolute-repo-path>."
+            )
+        if board_default and workspace_path == board_default:
+            anchor = Path(board_default).expanduser()
+            if not anchor.is_absolute():
+                raise ValueError(
+                    f"board {board_slug!r} default_workdir {board_default!r} is not "
+                    "absolute; use an absolute path to a git repo"
+                )
+            if _git_toplevel(anchor) is None:
+                raise ValueError(
+                    f"workspace_kind=worktree has no workspace_path outside the "
+                    f"board default, and board {board_slug!r} default_workdir "
+                    f"{board_default!r} is not inside a git repo"
+                )
+
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
         task_id = _new_task_id()
@@ -7370,7 +7401,7 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, workspace_kind, workspace_path, project_id "
             "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
@@ -7385,6 +7416,46 @@ def decompose_triage_task(
         # override with its own 'workspace_kind' / 'workspace_path'.
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
+        root_project_id = root_row["project_id"]
+
+        # Refuse an unanchored worktree fan-out atomically. Without a root
+        # path, Project, or valid board default, every child would be inserted
+        # successfully only to fail at dispatch.
+        if (
+            root_ws_kind == "worktree"
+            and not root_ws_path
+            and not root_project_id
+        ):
+            board_slug = get_current_board()
+            board_default = (
+                read_board_metadata(board_slug).get("default_workdir") or ""
+            ).strip()
+            if not board_default:
+                raise ValueError(
+                    f"task {task_id} has workspace_kind=worktree but no "
+                    "workspace_path, no project_id, and board "
+                    f"{board_slug!r} has no default_workdir set"
+                )
+            anchor = Path(board_default).expanduser()
+            if not anchor.is_absolute():
+                raise ValueError(
+                    f"board {board_slug!r} default_workdir {board_default!r} is not "
+                    "absolute; use an absolute path to a git repo"
+                )
+            if _git_toplevel(anchor) is None:
+                raise ValueError(
+                    f"task {task_id} has workspace_kind=worktree but board "
+                    f"{board_slug!r} default_workdir {board_default!r} is not "
+                    "inside a git repo"
+                )
+
+        root_project_repo: Optional[Path] = None
+        if root_project_id and root_ws_path:
+            root_path = Path(root_ws_path).expanduser()
+            if root_path.parent.name == ".worktrees":
+                root_project_repo = root_path.parent.parent
+            else:
+                root_project_repo = _git_toplevel(root_path)
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -7411,16 +7482,21 @@ def decompose_triage_task(
                 # concurrently. Leave the path unset so dispatch
                 # materializes a fresh <repo>/.worktrees/<child-id> per
                 # child from the board anchor.
-                child_ws_path = None
+                child_ws_path = (
+                    str(root_project_repo / ".worktrees" / new_id)
+                    if root_project_repo is not None
+                    else None
+                )
             elif child_ws_kind == root_ws_kind:
                 child_ws_path = root_ws_path
             else:
                 child_ws_path = None
+            child_project_id = child.get("project_id") or root_project_id
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, project_id, tenant, created_at, created_by) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -7428,6 +7504,7 @@ def decompose_triage_task(
                     assignee,
                     child_ws_kind,
                     child_ws_path,
+                    child_project_id,
                     tenant,
                     now,
                     (author or "decomposer"),

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -16,6 +16,7 @@ import pytest
 
 import hermes_state
 from hermes_cli import kanban_db as kb
+from hermes_cli import projects_db as pdb
 
 
 @pytest.fixture
@@ -1296,6 +1297,79 @@ def test_worktree_create_rejects_invalid_board_default(
         count = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
         assert count == 0
 
+
+
+
+def test_worktree_create_with_project_anchor_materializes_derived_path(
+    kanban_home, tmp_path
+):
+    # A resolved Project is a create-time anchor just like an explicit
+    # workspace_path or a board default_workdir: the unanchored-worktree
+    # guard must NOT reject it, and the workspace_path is derived from the
+    # project's primary repo instead of being required from the caller.
+    repo = tmp_path / "app"
+    _init_git_repo(repo)
+    with pdb.connect_closing() as pc:
+        pid = pdb.create_project(pc, name="App", folders=[str(repo)])
+        proj = pdb.get_project(pc, pid)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="anchored by project", project_id=proj.slug)
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    assert task.project_id == proj.id
+    assert task.workspace_kind == "worktree"
+    assert task.workspace_path == str(repo / ".worktrees" / tid)
+
+
+def test_worktree_unanchored_state_never_representable(kanban_home):
+    # C1 invariant: on an anchorless board (no board default_workdir, no
+    # resolved project), neither the create nor the decompose path may leave
+    # a task in the (worktree, workspace_path NULL, project_id NULL) state —
+    # the query an operator runs to hunt orphaned unanchored worktree rows
+    # must stay 0 after both flows are refused (and refused atomically).
+    invariant = (
+        "SELECT COUNT(*) FROM tasks WHERE workspace_kind='worktree' "
+        "AND workspace_path IS NULL AND project_id IS NULL"
+    )
+    with kb.connect() as conn:
+        # A-class: an unanchored create is refused before any INSERT.
+        with pytest.raises(ValueError):
+            kb.create_task(
+                conn,
+                title="unanchored",
+                workspace_kind="worktree",
+            )
+        assert conn.execute(invariant).fetchone()[0] == 0
+
+        # B-class: an unanchored root decomposition is refused and the
+        # children are rolled back. The root here is deliberately corrupted
+        # by direct SQL to simulate a LEGACY orphan row (the fix does not
+        # repair historical rows — out of scope), so the invariant must be
+        # checked on the operational rows create/decompose can produce.
+        root = kb.create_task(conn, title="root", triage=True)
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='worktree', workspace_path=NULL, "
+            "project_id=NULL WHERE id = ?",
+            (root,),
+        )
+        conn.commit()
+        with pytest.raises(ValueError):
+            kb.decompose_triage_task(
+                conn,
+                root,
+                root_assignee="orchestrator",
+                children=[{"title": "doomed", "assignee": "alice"}],
+                author="decomposer",
+            )
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE id != ?", (root,)
+        ).fetchall()
+        assert rows == []
+        conn.execute("DELETE FROM tasks WHERE id = ?", (root,))
+        conn.commit()
+        assert conn.execute(invariant).fetchone()[0] == 0
 
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1239,6 +1239,64 @@ def _make_task(**overrides) -> "kb.Task":
 # ---------------------------------------------------------------------------
 
 
+def test_worktree_create_without_anchor_is_rejected_before_insert(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(
+            ValueError, match="no workspace_path.*no default_workdir set"
+        ):
+            kb.create_task(
+                conn,
+                title="unanchored",
+                workspace_kind="worktree",
+            )
+
+        count = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+        assert count == 0
+
+
+def test_worktree_create_inherits_valid_board_default(kanban_home, tmp_path):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.write_board_metadata("default", default_workdir=str(repo))
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="anchored by board",
+            workspace_kind="worktree",
+        )
+        task = kb.get_task(conn, tid)
+
+    assert task is not None
+    assert task.workspace_path == str(repo)
+
+
+@pytest.mark.parametrize(
+    ("default_workdir", "message"),
+    [
+        ("relative/repo", "is not absolute"),
+        ("{non_repo}", "is not inside a git repo"),
+    ],
+)
+def test_worktree_create_rejects_invalid_board_default(
+    kanban_home, tmp_path, default_workdir, message
+):
+    non_repo = tmp_path / "not-a-repo"
+    non_repo.mkdir()
+    value = default_workdir.format(non_repo=non_repo)
+    kb.write_board_metadata("default", default_workdir=value)
+
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match=message):
+            kb.create_task(
+                conn,
+                title="bad board anchor",
+                workspace_kind="worktree",
+            )
+        count = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+        assert count == 0
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_worktree_isolation.py
+++ b/tests/hermes_cli/test_kanban_worktree_isolation.py
@@ -99,6 +99,76 @@ def test_decompose_worktree_children_get_own_workspace(kanban_home):
             assert row["workspace_path"] is None
 
 
+def test_decompose_project_worktree_propagates_project_and_unique_paths(
+    kanban_home, tmp_path
+):
+    repo = _make_repo(tmp_path)
+    root_path = repo / ".worktrees" / "root"
+
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="project root", triage=True)
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='worktree', workspace_path=?, "
+            "project_id='p_project' WHERE id = ?",
+            (str(root_path), root),
+        )
+        conn.commit()
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "first", "assignee": "alice", "parents": []},
+                {"title": "second", "assignee": "bob", "parents": []},
+            ],
+            author="decomposer",
+        )
+
+        assert child_ids is not None and len(child_ids) == 2
+        tasks = [kb.get_task(conn, child_id) for child_id in child_ids]
+
+    assert all(task is not None for task in tasks)
+    assert {task.project_id for task in tasks} == {"p_project"}
+    expected = {
+        str(repo / ".worktrees" / child_id) for child_id in child_ids
+    }
+    assert {task.workspace_path for task in tasks} == expected
+    assert len(expected) == 2
+
+    for task in tasks:
+        workspace, _branch = kb._resolve_worktree_workspace(task)
+        assert workspace == Path(task.workspace_path).resolve()
+        assert workspace.exists()
+
+
+def test_decompose_unanchored_worktree_refuses_atomically(kanban_home):
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="unanchored root", triage=True)
+        conn.execute(
+            "UPDATE tasks SET workspace_kind='worktree', workspace_path=NULL, "
+            "project_id=NULL WHERE id = ?",
+            (root,),
+        )
+        conn.commit()
+
+        with pytest.raises(
+            ValueError, match="no workspace_path.*no project_id.*no default_workdir set"
+        ):
+            kb.decompose_triage_task(
+                conn,
+                root,
+                root_assignee="orchestrator",
+                children=[{"title": "doomed", "assignee": "alice"}],
+                author="decomposer",
+            )
+
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE id != ?", (root,)
+        ).fetchall()
+        assert rows == []
+
+
 
 
 def test_resolve_worktree_falls_back_when_path_occupied(kanban_home, tmp_path):
@@ -124,7 +194,6 @@ def test_resolve_worktree_falls_back_when_path_occupied(kanban_home, tmp_path):
         capture_output=True, text=True, check=True,
     ).stdout.strip()
     assert head == "wt/sibling"
-
 
 
 


### PR DESCRIPTION
## Summary
- reject unanchored worktree cards before INSERT
- validate inherited board defaults are absolute git repositories
- preserve and propagate Project anchors during decomposition
- keep each child on a unique worktree path

## Evidence
- independent review: P0=0, P1=0
- targeted suite: 48 passed, 1 skipped
- CLI UX: unanchored exit 1 with actionable stderr; explicit path and Project-linked cases exit 0
- performance: explicit create -1.10%; Project decompose +0.52%; peak allocations unchanged/+0.03%

Reviewed Spark SHA: `c293bec24`
PR SHA: `862cc7c6b`
Patch SHA-256 identity: `7390c39aefe0d843f994d203f2ca5051f09ca1a7b147d169b2b8d64bb36833f6`