### PR TITLE
fix(desktop): keep newest messages when older backends ignore latest order

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -364,18 +364,26 @@ export function getLatestSessionMessages(id: string, profile?: string | null): P
     limit: LATEST_SESSION_MESSAGES_LIMIT,
     order: 'latest',
     includeCompacted: true
-  }).then(page => {
+  }).then(async page => {
+    // Backends predating `order` still return pagination metadata but silently
+    // serve the oldest page. The missing echo is the only reliable indication
+    // that latest-relative offsets are unsafe, so load their transcript through
+    // the bounded oldest-first compatibility path instead.
+    const transcript = page.pagination && page.pagination.order !== 'latest'
+      ? await getAllSessionMessages(id, profile)
+      : page
+
     // Record whether the tail was truncated (page came back full) and where
     // the next older page starts, so "Show earlier" can backfill over REST
     // (app/chat/transcript-backfill). Keyed under both the requested id and
     // the resolved id — callers hold either.
-    recordTranscriptTail(id, page, profile)
+    recordTranscriptTail(id, transcript, profile)
 
-    if (page.session_id && page.session_id !== id) {
-      recordTranscriptTail(page.session_id, page, profile)
+    if (transcript.session_id && transcript.session_id !== id) {
+      recordTranscriptTail(transcript.session_id, transcript, profile)
     }
 
-    return page
+    return transcript
   })
 }
 

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -410,6 +410,33 @@ describe('Hermes REST helpers', () => {
     })
   })
 
+  it('falls back to the complete transcript when a legacy backend ignores latest ordering', async () => {
+    $transcriptTailBySessionId.set({})
+    api
+      .mockResolvedValueOnce({
+        messages: Array.from({ length: 120 }, (_, index) => ({ content: `oldest-${index}`, id: index })),
+        pagination: { limit: 120, offset: 0, returned: 120 },
+        session_id: 'session-1'
+      })
+      .mockResolvedValueOnce({
+        messages: [{ content: 'oldest', id: 1 }, { content: 'newest', id: 870 }],
+        pagination: { limit: 500, offset: 0, returned: 2 },
+        session_id: 'session-1'
+      })
+
+    const result = await getLatestSessionMessages('session-1', 'xiaoxuxu')
+
+    expect(result).toEqual({
+      messages: [{ content: 'oldest', id: 1 }, { content: 'newest', id: 870 }],
+      session_id: 'session-1'
+    })
+    expect(api).toHaveBeenNthCalledWith(2, {
+      path: '/api/sessions/session-1/messages?profile=xiaoxuxu&limit=500&offset=0&order=oldest&include_compacted=true',
+      profile: 'xiaoxuxu'
+    })
+    expect(transcriptTailState('session-1')).toMatchObject({ possiblyTruncated: false })
+  })
+
   it('records tail truncation state under the requested and resolved session ids', async () => {
     $transcriptTailBySessionId.set({})
     api.mockResolvedValue({

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -609,7 +609,8 @@ export interface SessionMessagesResponse {
   pagination?: {
     limit: number
     offset: number
-    order: 'latest' | 'oldest'
+    /** Absent on backends that predate ordered transcript paging. */
+    order?: 'latest' | 'oldest'
     returned: number
   }
   session_id: string


### PR DESCRIPTION
## What does this PR do?

Desktop sessions opened against a backend that predates ordered transcript paging no longer replace the transcript with the oldest page. When a paginated response does not confirm `order=latest`, Desktop uses the bounded oldest-first compatibility loader to recover the complete chronological history instead of silently dropping newer messages.

### Symptom

After reconnecting to or reopening a long session through an older backend, Desktop shows only the oldest persisted messages. New live messages can appear temporarily and then disappear on the next resume.

### Impact

Users connecting a current Desktop client to an older backend can lose the newest part of a long conversation from the rendered transcript even though the rows remain present in `state.db`.

### Bug Cause

**Trigger:** `apps/desktop/src/api/sessions.ts` / `getLatestSessionMessages()` receives pagination metadata without an `order` echo.

**Causal chain:**
1. Desktop requests the newest 120 persisted rows with `order=latest`.
2. A backend predating ordered paging silently ignores that query parameter and returns the oldest 120 rows with pagination metadata.
3. Desktop treats that page as the authoritative latest tail, replaces the rendered transcript, and enables latest-relative backfill with invalid offsets.

**Why it is wrong:** Pagination metadata alone does not prove that the backend honored latest-relative ordering.

**Working sibling / contrast:** Current backends echo `pagination.order=latest`; older non-paginated backends return the complete transcript and already retire backfill.

**Ruled out:** Renderer cache corruption is not the cause because the REST response is already the oldest bounded slice before conversion or reconciliation.

### Fix

Treat paginated responses that do not echo `order=latest` as a legacy semantic mismatch. Reload the transcript through the existing bounded oldest-first compatibility path, model the legacy `order` field as optional, and record the resulting full transcript as complete so "Show earlier" cannot issue incorrect latest-relative requests.

## Related Issue

Closes #92508

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/api/sessions.ts` - detect ignored latest ordering and fall back to bounded complete loading.
- `apps/desktop/src/types/hermes.ts` - represent the legacy response shape where pagination omits `order`.
- `apps/desktop/src/hermes.test.ts` - reproduce the old-backend response and verify complete transcript recovery.

## How to Test

1. Run the focused REST helper test suite.
2. Confirm the legacy response test performs an oldest-first compatibility request and returns the newest persisted row.
3. Run the Desktop TypeScript checks.

```bash
cd apps/desktop
npx vitest run src/hermes.test.ts
npm run typecheck
npx eslint src/api/sessions.ts src/hermes.test.ts src/types/hermes.ts
```

Result: 31 tests passed; TypeScript and ESLint checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop test suite and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant inline documentation was updated; user documentation is not affected
- [x] No config keys were added or changed
- [x] No architecture or workflow documentation changes are required
- [x] Cross-platform impact was considered; the fix is renderer-side TypeScript with no host-specific behavior
- [x] No tool descriptions or schemas were changed

## Screenshots / Logs

N/A - this regression is covered by the REST helper behavior test.
