### PR TITLE
fix(gateway): stop profile rosters hanging on timestamp metadata

### DIFF
--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -229,6 +229,43 @@ def test_ws_transport_replies_with_error_for_unserializable_response(caplog):
         loop.close()
 
 
+def test_ws_transport_write_async_recovers_from_unserializable_response(caplog):
+    async def scenario():
+        sent = []
+
+        class FakeWS:
+            async def send_text(self, line):
+                sent.append(json.loads(line))
+
+        transport = ws_mod.WSTransport(
+            FakeWS(), asyncio.get_running_loop(), peer="async-serialization-test"
+        )
+
+        assert await transport.write_async(
+            {
+                "jsonrpc": "2.0",
+                "id": "profiles-async",
+                "result": {"created": datetime.datetime(2026, 8, 22)},
+            }
+        ) is True
+        assert await transport.write_async(
+            {"jsonrpc": "2.0", "id": "next-async", "result": {}}
+        ) is True
+
+        assert sent == [
+            {
+                "jsonrpc": "2.0",
+                "error": {"code": -32603, "message": "response serialization error"},
+                "id": "profiles-async",
+            },
+            {"jsonrpc": "2.0", "id": "next-async", "result": {}},
+        ]
+        assert transport._closed is False
+
+    asyncio.run(scenario())
+    assert "ws frame serialization failed" in caplog.text
+
+
 def test_ws_transport_preserves_cross_batch_order():
     async def scenario():
         entered = []

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import datetime
 import json
 import threading
 import time
@@ -183,6 +184,44 @@ def test_ws_transport_serializes_concurrent_sends():
 
         assert len(sent) == 2
         assert max_active_sends == 1
+        assert transport._closed is False
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=2)
+        loop.close()
+
+
+def test_ws_transport_replies_with_error_for_unserializable_response(caplog):
+    sent = []
+
+    class FakeWS:
+        async def send_text(self, line):
+            sent.append(json.loads(line))
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+    try:
+        transport = ws_mod.WSTransport(FakeWS(), loop, peer="serialization-test")
+
+        assert transport.write(
+            {
+                "jsonrpc": "2.0",
+                "id": "profiles",
+                "result": {"created": datetime.datetime(2026, 8, 22)},
+            }
+        ) is True
+        assert transport.write({"jsonrpc": "2.0", "id": "next", "result": {}}) is True
+
+        assert sent == [
+            {
+                "jsonrpc": "2.0",
+                "error": {"code": -32603, "message": "response serialization error"},
+                "id": "profiles",
+            },
+            {"jsonrpc": "2.0", "id": "next", "result": {}},
+        ]
+        assert "ws frame serialization failed" in caplog.text
         assert transport._closed is False
     finally:
         loop.call_soon_threadsafe(loop.stop)

--- a/tests/tui_gateway/test_profiles_ui_meta_cas.py
+++ b/tests/tui_gateway/test_profiles_ui_meta_cas.py
@@ -8,6 +8,7 @@ stale writer retry instead of silently replacing somebody else's state.
 
 from __future__ import annotations
 
+import json
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -79,6 +80,18 @@ def test_ui_meta_revision_survives_key_deletion(home):
     )
     assert stale_recreate["ui_meta"] is False
     assert stale_recreate["ui_meta_conflicts"]["shared-room"]["actual"] == 2
+
+
+def test_profiles_list_normalizes_yaml_timestamps_in_ui_meta(home):
+    (home / "profile.yaml").write_text(
+        "ui_meta:\n  hermes-bots:\n    created: 2026-08-22T00:00:00Z\n",
+        encoding="utf-8",
+    )
+
+    row = _default_profile()
+
+    assert row["ui_meta"]["hermes-bots"]["created"] == "2026-08-22T00:00:00+00:00"
+    json.dumps(row)
 
 
 def test_two_concurrent_writers_cannot_both_replace_the_same_revision(home):

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -237,6 +237,7 @@ def _(rid, params: dict) -> dict:
             # order, …) — stored server-side in profile.yaml so every
             # machine connecting to this gateway paints the same roster.
             try:
+                import json as _json
                 import yaml as _yaml
                 from pathlib import Path as _Path
 
@@ -249,7 +250,16 @@ def _(rid, params: dict) -> dict:
                         raw_meta = _yaml.safe_load(f) or {}
                     ui_meta = raw_meta.get("ui_meta")
                     if isinstance(ui_meta, dict) and ui_meta:
-                        row["ui_meta"] = ui_meta
+                        # YAML promotes unquoted timestamps to datetime/date,
+                        # but this handler's contract is JSON. Normalize those
+                        # (and any other YAML-only scalar) at the boundary.
+                        def _json_default(value):
+                            isoformat = getattr(value, "isoformat", None)
+                            return isoformat() if callable(isoformat) else str(value)
+
+                        row["ui_meta"] = _json.loads(
+                            _json.dumps(ui_meta, default=_json_default)
+                        )
                     revisions = raw_meta.get("_ui_meta_revisions")
                     if isinstance(revisions, dict) and revisions:
                         row["ui_meta_revisions"] = {

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -206,6 +206,8 @@ def _(rid, params: dict) -> dict:
             return None, None
 
     try:
+        import json as _json
+
         from hermes_cli.profiles import list_profiles
 
         include_sessions = is_truthy_value(params.get("include_sessions", True))
@@ -237,7 +239,6 @@ def _(rid, params: dict) -> dict:
             # order, …) — stored server-side in profile.yaml so every
             # machine connecting to this gateway paints the same roster.
             try:
-                import json as _json
                 import yaml as _yaml
                 from pathlib import Path as _Path
 

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -124,11 +124,36 @@ class WSTransport:
             return False
         return params.get("type") in _STREAMING_EVENT_TYPES
 
+    def _serialize_frame(self, obj: dict) -> tuple[str, bool]:
+        """Serialize one frame, replacing invalid responses with an RPC error."""
+        try:
+            return json.dumps(obj, ensure_ascii=False), False
+        except Exception as exc:
+            # Pool workers own their futures, so letting serialization escape
+            # here silently abandons the request. Keep the connection usable
+            # and give the caller a terminal response with the original id.
+            rid = obj.get("id") if isinstance(obj, dict) else None
+            if not isinstance(rid, (str, int, float)) or isinstance(rid, bool):
+                rid = None
+            _log.error(
+                "ws frame serialization failed peer=%s id=%s error_type=%s error=%s",
+                self._peer,
+                rid,
+                type(exc).__name__,
+                exc,
+            )
+            fallback = {
+                "jsonrpc": "2.0",
+                "error": {"code": -32603, "message": "response serialization error"},
+                "id": rid,
+            }
+            return json.dumps(fallback, ensure_ascii=False), True
+
     def write(self, obj: dict) -> bool:
         if self._closed:
             return False
 
-        line = json.dumps(obj, ensure_ascii=False)
+        line, serialization_failed = self._serialize_frame(obj)
 
         try:
             on_loop = asyncio.get_running_loop() is self._loop
@@ -140,7 +165,7 @@ class WSTransport:
         # non-blocking — the worker returns immediately. Ordering is preserved
         # because every non-streaming frame (below) drains the buffer ahead of
         # itself.
-        if self._is_streaming_frame(obj):
+        if not serialization_failed and self._is_streaming_frame(obj):
             with self._token_lock:
                 self._pending_tokens.append(line)
                 if not self._token_flush_armed:
@@ -230,7 +255,8 @@ class WSTransport:
         with self._token_lock:
             batch = self._pending_tokens
             self._pending_tokens = []
-            batch.append(json.dumps(obj, ensure_ascii=False))
+            line, _serialization_failed = self._serialize_frame(obj)
+            batch.append(line)
         await self._safe_send_many(batch)
         return not self._closed
 


### PR DESCRIPTION
## What does this PR do?

Profile rosters no longer hang forever when `profile.yaml` contains an unquoted timestamp in `ui_meta`. The profile RPC now normalizes YAML-only scalars at its JSON boundary, and the WebSocket transport converts any remaining serialization failure into a logged JSON-RPC internal-error response instead of silently abandoning the request.

### Symptom

A `profiles.list` WebSocket request never returns when one profile has an unquoted ISO-8601 timestamp under `ui_meta`. Clients continue waiting and repeated roster polls consume more pool workers.

### Impact

Profile roster and bot panels cannot finish loading for affected installations. The same silent response loss can affect any pooled JSON-RPC handler that returns a value `json.dumps` cannot encode.

### Bug Cause

**Trigger:** `tui_gateway/methods_profiles.py` reads `profile.yaml` with `yaml.safe_load`, which promotes an unquoted timestamp to `datetime`, then embeds it in the `profiles.list` result.

**Causal chain:**
1. A profile stores an unquoted ISO-8601 timestamp inside `ui_meta`.
2. `profiles.list` returns the resulting `datetime`, and `WSTransport.write` calls `json.dumps` before any exception guard.
3. Serialization raises `TypeError` in the pool worker; its unobserved future ends without a response, so the client waits indefinitely.

**Why it is wrong:** Transport serialization errors escaped before the existing send-failure handling and the pool future was not observed.

**Working sibling / contrast:** Socket-send exceptions already keep diagnostics inside `_safe_send_many`; the serialization step had no equivalent guard. Both worker-thread `write` and event-loop `write_async` now use the same guarded serializer.

**Ruled out:** The RPC handler itself completes and produces a response dict. Direct `json.dumps` of that response reproduces the failure, so session lookup and WebSocket receive routing are not the cause.

### Fix

- Normalize YAML timestamp/date values and other YAML-only scalars before exposing `ui_meta` through `profiles.list`.
- Serialize every WebSocket frame through a shared guard that logs the failure, preserves a valid request id, and sends JSON-RPC error `-32603` while keeping the transport usable.
- Cover the timestamp trigger and verify that an invalid response is followed by a valid response on the same connection.

## Related Issue

Closes #92506

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_profiles.py` - normalize profile UI metadata to JSON-compatible values.
- `tui_gateway/ws.py` - return and log a JSON-RPC error when frame serialization fails.
- `tests/tui_gateway/test_profiles_ui_meta_cas.py` - cover unquoted YAML timestamp metadata.
- `tests/test_tui_gateway_ws.py` - cover serialization fallback and connection reuse.

## How to Test

1. Store `created: 2026-08-22T00:00:00Z` without quotes under a profile's `ui_meta`.
2. Call `profiles.list` and confirm `created` is returned as an ISO-8601 string.
3. Return an unserializable value through `WSTransport` and confirm the request receives error `-32603`, a diagnostic is logged, and the next valid response still succeeds.

```bash
scripts/run_tests.sh tests/test_tui_gateway_ws.py tests/tui_gateway/test_profiles_ui_meta_cas.py -q
```

Result: 12 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not applicable
- [x] Config example update is not applicable
- [x] Architecture or workflow documentation update is not applicable
- [x] I've considered cross-platform impact; the change uses standard Python JSON and datetime behavior
- [x] Tool description or schema updates are not applicable
