### PR TITLE
fix(gateway): scope a routed primary message to the profile it routes to

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15847,10 +15847,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return _handler
 
     def _make_default_profile_message_handler(self):
-        """Scope a multiplexed default-profile message from ingress onward."""
-        profile_home = Path(get_hermes_home())
+        """Scope a multiplexed primary-adapter message from ingress onward.
+
+        A primary adapter under multiplex is not only the default profile
+        serving itself: ``gateway.profile_routes`` multiplexes ONE shared bot
+        across profiles, and ``build_source`` stamps ``source.profile`` before
+        this handler runs. Capturing a single home when the adapter is wired
+        therefore scoped every ROUTED message to the multiplexer's own home, so
+        everything ``_handle_message`` does ahead of the narrower agent-turn
+        scope — slash commands, write-approval queues, prompt rendering —
+        read and wrote the default profile while the turn itself ran in the
+        routed one. ``_make_default_profile_platform_event_handler`` already
+        resolves per event; this is the same resolution on the message path.
+
+        Deliberately narrow: the captured home stays the answer unless the
+        source carries an explicit ``profile``. ``_resolve_profile_home_for_source``
+        answers an unstamped source with ``get_profile_dir(active_profile)``,
+        which is not necessarily the ``get_hermes_home()`` this path has always
+        used, so re-resolving unconditionally would change the default-profile
+        case as well — a bigger claim than the bug supports. A source that
+        routes without being stamped keeps the old behaviour.
+
+        A rejected route falls back to the captured home for the SCOPE only.
+        Whether to reject the message is decided downstream, on the path that
+        already owns that decision.
+        """
+        default_home = Path(get_hermes_home())
 
         async def _handler(event):
+            from gateway.profile_routing import ProfileRouteRejected
+
+            profile_home = default_home
+            source = getattr(event, "source", None)
+            if source is not None and (getattr(source, "profile", None) or "").strip():
+                try:
+                    profile_home = self._resolve_profile_home_for_source(source)
+                except ProfileRouteRejected:
+                    profile_home = default_home
+
             with _profile_runtime_scope(profile_home):
                 return await self._handle_message(event)
 

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -213,6 +213,149 @@ class TestPrimaryMessageRuntimeScope:
         with pytest.raises(secret_scope.UnscopedSecretError):
             secret_scope.get_secret("DISCORD_BOT_TOKEN")
 
+    @pytest.mark.asyncio
+    async def test_routed_message_is_scoped_to_the_routed_profile_home(
+        self, tmp_path, monkeypatch
+    ):
+        """A primary adapter routing to a profile must scope to THAT profile.
+
+        ``_make_default_profile_message_handler`` is what every primary adapter
+        gets under multiplex, including the shared bot that ``profile_routes``
+        multiplexes across profiles. The sibling above only covers
+        ``profile=None`` (the default profile serving itself), where binding the
+        handler to ``get_hermes_home()`` is trivially right. It is the routed
+        case that this pins: the home is resolved per message, from the source,
+        the same way ``_make_default_profile_platform_event_handler`` already
+        resolves it.
+
+        Everything ``_handle_message`` does before the agent-turn scope reads
+        this home -- slash commands, write-approval queues, prompt rendering --
+        so a handler bound to the default home serves those from the wrong
+        profile for the whole turn.
+        """
+        from gateway import run as run_mod
+        from gateway.run import GatewayRunner
+        from hermes_constants import get_hermes_home
+
+        default_home = tmp_path / "home"
+        default_home.mkdir()
+        routed_home = tmp_path / "profiles" / "operator"
+        routed_home.mkdir(parents=True)
+
+        monkeypatch.setattr(run_mod, "get_hermes_home", lambda: default_home)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._resolve_profile_home_for_source = (  # type: ignore[method-assign]
+            lambda source: routed_home
+            if getattr(source, "profile", None) == "operator"
+            else default_home
+        )
+
+        seen: dict[str, str] = {}
+
+        async def _handle_message(_event):
+            # Resolved at call time, which is the whole point: the override
+            # _profile_runtime_scope installs is a contextvar, so this reports
+            # whichever home the handler actually scoped the message to.
+            seen["home"] = str(get_hermes_home())
+            return None
+
+        runner._handle_message = _handle_message  # type: ignore[method-assign]
+        handler = runner._primary_message_handler()
+
+        await handler(SimpleNamespace(source=SimpleNamespace(profile="operator")))
+
+        assert seen["home"] == str(routed_home)
+
+    @pytest.mark.asyncio
+    async def test_unstamped_source_keeps_the_captured_default_home(
+        self, tmp_path, monkeypatch
+    ):
+        """An unstamped source must NOT be re-resolved.
+
+        This pins the deliberate narrowness of the fix rather than agreeing
+        with it. ``_resolve_profile_home_for_source`` answers a source with no
+        ``profile`` using ``get_profile_dir(active_profile)``, which is not
+        necessarily the ``get_hermes_home()`` this path has always scoped to,
+        so the resolver is wired here to a DIFFERENT home and the assertion is
+        that the handler ignores it. Re-resolving unconditionally would move
+        the default-profile case too, which is a change the bug does not
+        justify -- and which the #64674 sibling above fails on.
+        """
+        from gateway import run as run_mod
+        from gateway.run import GatewayRunner
+        from hermes_constants import get_hermes_home
+
+        default_home = tmp_path / "home"
+        default_home.mkdir()
+        resolver_home = tmp_path / "profiles" / "active"
+        resolver_home.mkdir(parents=True)
+
+        monkeypatch.setattr(run_mod, "get_hermes_home", lambda: default_home)
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._resolve_profile_home_for_source = (  # type: ignore[method-assign]
+            lambda source: resolver_home
+        )
+
+        seen: dict[str, str] = {}
+
+        async def _handle_message(_event):
+            seen["home"] = str(get_hermes_home())
+            return None
+
+        runner._handle_message = _handle_message  # type: ignore[method-assign]
+        handler = runner._primary_message_handler()
+
+        await handler(SimpleNamespace(source=SimpleNamespace(profile=None)))
+
+        assert seen["home"] == str(default_home)
+
+    @pytest.mark.asyncio
+    async def test_rejected_route_scopes_to_the_captured_home(
+        self, tmp_path, monkeypatch
+    ):
+        """A rejected route must not turn ingress into a raise.
+
+        Routing rejection is decided downstream. Resolving the home earlier
+        must not also move where that rejection surfaces, so the scope falls
+        back and ``_handle_message`` still runs and still owns the outcome.
+        """
+        from gateway import run as run_mod
+        from gateway.run import GatewayRunner
+        from gateway.profile_routing import ProfileRouteRejected
+        from hermes_constants import get_hermes_home
+
+        default_home = tmp_path / "home"
+        default_home.mkdir()
+
+        monkeypatch.setattr(run_mod, "get_hermes_home", lambda: default_home)
+
+        def _reject(_source):
+            raise ProfileRouteRejected("no route")
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        runner._resolve_profile_home_for_source = _reject  # type: ignore[method-assign]
+
+        seen: dict[str, str] = {}
+
+        async def _handle_message(_event):
+            seen["home"] = str(get_hermes_home())
+            return "handled downstream"
+
+        runner._handle_message = _handle_message  # type: ignore[method-assign]
+        handler = runner._primary_message_handler()
+
+        result = await handler(
+            SimpleNamespace(source=SimpleNamespace(profile="operator"))
+        )
+
+        assert result == "handled downstream"
+        assert seen["home"] == str(default_home)
+
 
 class TestReconnectDropsEmptyToken:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Under `gateway.profile_routes`, one shared primary bot serves several profiles. The ingress runtime scope was bound to the multiplexer's own home rather than the routed one:

```python
def _make_default_profile_message_handler(self):
    profile_home = Path(get_hermes_home())      # captured once, when the adapter is wired

    async def _handler(event):
        with _profile_runtime_scope(profile_home):
            return await self._handle_message(event)
```

`_primary_message_handler()` hands this to **every** primary adapter when multiplexing is on, and `build_source` has already stamped `source.profile` by the time it runs. The handler ignores it, so everything `_handle_message` does ahead of the narrower agent-turn scope — slash commands, write-approval queues, prompt rendering — ran in the default profile while the turn itself ran in the routed one.

The sibling on the platform-event path, forty lines below in the same file, already resolves per event:

```python
async def _handler(event, source):
    with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
```

This is that resolution, on the message path.

### The symptom it was reported as

@joebrans-elixus reported on #92279 that `/memory pending` answers "No pending memory writes" while `~/.hermes/profiles/operator/pending/memory/*.json` holds a staged entry, and offered to file it separately. The mechanism checks out: `tools/write_approval.py::_pending_dir` is `get_hermes_home() / "pending" / subsystem`, resolved per call, so it followed the ingress scope straight to the wrong profile. `load_on_disk_store()` resolves the same way, so an `/memory approve` would have been applied against the default profile's MEMORY store.

The history half of #92279 is a different mechanism and is covered by #89346 / #89379. #78440 is also adjacent but complementary: it fixes contextvar loss across an executor hop for `/insights` and `/debug`, and *assumes* the scope installed at ingress is the right one. On a routed primary adapter it was not.

## Related Issue

Fixes #92525

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`gateway/run.py`, `_make_default_profile_message_handler` only.

- **The home is resolved per message, from the source**, instead of captured when the adapter is wired.
- **Deliberately narrow: the captured home stays the answer unless the source carries an explicit `profile`.** This is the part I would most like reviewed. `_resolve_profile_home_for_source` answers an *unstamped* source with `get_profile_dir(active_profile)`, which is not necessarily the `get_hermes_home()` this path has always used — so re-resolving unconditionally changes the default-profile case too. I tried that first and the pre-existing `#64674` test (`test_default_profile_prompt_gate_sees_its_scoped_token`) failed on it, correctly. The cost is that a source which routes *without* being stamped keeps the old behaviour; I have not found a path that does this, since `build_source` stamps before dispatch, but I would rather say so than imply the fix is total.
- **A rejected route falls back to the captured home for the scope only.** Resolving the home earlier must not also move *where* a routing rejection surfaces. `ProfileRouteRejected` is caught here and `_handle_message` still runs and still owns the outcome, exactly as today.

## How to Test

```bash
python -m pytest tests/gateway/test_64674_multiplex_primary_token_scope.py -q
# 9 passed
```

Three tests added to `TestPrimaryMessageRuntimeScope`, which previously exercised this handler with `source.profile = None` only — the one case where binding to `get_hermes_home()` is trivially right, and the reason this held for so long.

1. `test_routed_message_is_scoped_to_the_routed_profile_home` — the bug. `_handle_message` reports `get_hermes_home()` at call time, so it observes whichever home the handler actually scoped to.
2. `test_unstamped_source_keeps_the_captured_default_home` — pins the narrowing rather than agreeing with it: the resolver is wired to a **different** home and the assertion is that an unstamped source ignores it.
3. `test_rejected_route_scopes_to_the_captured_home` — `ProfileRouteRejected` does not become an ingress raise.

**Sabotage proof.** Keeping the tests and reverting `gateway/run.py` alone:

```
FAILED tests/gateway/test_64674_multiplex_primary_token_scope.py::TestPrimaryMessageRuntimeScope::test_routed_message_is_scoped_to_the_routed_profile_home
1 failed, 8 passed
```

Exactly the routed test, and nothing else — including the two guards, which is the point of them.

**Wider run.** Every multiplex / profile-scope / profile-routing test in `tests/gateway/`: **175 passed, 1 skipped**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (26200), Python 3.12

<sub>The full-suite box is left unticked rather than ticked dishonestly: `pytest tests/ -q` does not collect on Windows at all — `tests/hermes_cli/test_doctor_journal_modes.py` raises `AttributeError: module 'os' has no attribute 'geteuid'` at import and aborts collection. The relevant suites are the ones run above. Linux CI on this PR is the authority.</sub>

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): the handler's docstring now states what it scopes, why it is per-message, and why the narrowing is deliberate
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A, no config surface
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS): none. Contextvar scoping and path resolution are platform independent; the report is from Ubuntu and the verification is on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

## Notes for a reviewer

**One thing this does not fix, stated so a scope fix is not mistaken for a complete one.** `gateway/slash_commands.py` does `from gateway.run import _hermes_home`, and `_hermes_home = get_hermes_home()` is evaluated **once at module import**. `_profile_runtime_scope` overrides `get_hermes_home()` *calls* via a contextvar, so a module-level value captured before any scope existed can never follow it. Every `config_path = _hermes_home / "config.yaml"` — `/memory`'s approval-gate write-back, `/skills`, `/verbose`, `/footer`, and the `_save_config_key` helper behind `/reasoning` and `/fast` — still targets the root config regardless of routing.

`/model` already works around it, in one handler out of six:

```python
config_path = (_command_profile_home or _hermes_home) / "config.yaml"
```

That is a different defect with a different fix (a stale module-level constant, not a mis-scoped context), so I have written it up in #92525 rather than widening this diff. Happy to take it as a follow-up if you want it.

**A question I could not answer from the code.** `_resolve_profile_home_for_source` has a defensive second step (`_profile_name_for_source`) for "sources that bypass `build_source`". If such a path exists on the primary message route, the narrowing above means it keeps the old, wrong home. I could not find one, but you would know better than I would whether that fallback is load-bearing — if it is, dropping the `source.profile` precondition is the change, and the `#64674` test would need its expectation revisited rather than preserved.
