### PR TITLE
fix(tui): recover model switches after failed session resume

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8484,26 +8484,41 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
 
 
 @pytest.mark.parametrize(
-    "provider_flag", [" --provider custom:new-provider", ""]
+    ("provider_flag", "failure_text"),
+    [
+        (" --provider custom:new-provider", "Unknown provider 'removed-provider'"),
+        ("", ""),
+    ],
 )
 def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
-    monkeypatch, tmp_path, provider_flag
+    monkeypatch, tmp_path, provider_flag, failure_text
 ):
-    """Recovery waits for the failed generation and uses the session profile.
+    """Recovery waits for the real failed build and uses its owning profile.
 
-    Exercise the real model-switch and deferred-build boundaries: only their
-    provider/network and agent-construction leaves are replaced.
+    Both the failed and replacement generations cross the real deferred-build
+    boundary. Provider resolution is the only model-switch leaf replaced.
     """
     from agent.secret_scope import current_secret_scope
     from hermes_constants import get_hermes_home
 
+    launch_url = "https://launch.example/v1"
+    profile_url = "https://profile.example/v1"
     launch_home = tmp_path / "launch"
     profile_home = tmp_path / "profiles" / "work"
     launch_home.mkdir()
     profile_home.mkdir(parents=True)
     (launch_home / "config.yaml").write_text(
-        "model:\n  default: launch/model\n  provider: launch-provider\n",
+        "model:\n"
+        "  default: launch/model\n"
+        "  provider: custom:new-provider\n"
+        "providers:\n"
+        "  new-provider:\n"
+        f"    base_url: {launch_url}\n"
+        "    key_env: LAUNCH_API_KEY\n",
         encoding="utf-8",
+    )
+    (launch_home / ".env").write_text(
+        "LAUNCH_API_KEY=launch-secret\n", encoding="utf-8"
     )
     (profile_home / "config.yaml").write_text(
         "model:\n"
@@ -8511,7 +8526,7 @@ def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
         "  provider: custom:new-provider\n"
         "providers:\n"
         "  new-provider:\n"
-        "    base_url: https://profile.example/v1\n"
+        f"    base_url: {profile_url}\n"
         "    key_env: PROFILE_API_KEY\n",
         encoding="utf-8",
     )
@@ -8542,8 +8557,7 @@ def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
     old_override = {"model": "old/model", "provider": "removed-provider"}
     session = _session(
         agent_ready=old_ready,
-        agent_build_started=True,
-        agent_error="Unknown provider 'removed-provider'",
+        agent_error=None,
         model_override=old_override,
         resume_runtime_overrides={
             "model_override": old_override,
@@ -8554,52 +8568,85 @@ def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
     )
     session["agent"] = None
     server._sessions["sid"] = session
+    old_finally_entered = threading.Event()
+    release_old_finally = threading.Event()
     switch_called = threading.Event()
-    seen = {"switch": None, "build": None, "persist": 0}
-
-    result = types.SimpleNamespace(
-        success=True,
-        new_model="new/model",
-        target_provider="custom:new-provider",
-        api_key="profile-secret",
-        base_url="https://profile.example/v1",
-        api_mode="chat_completions",
-        warning_message="",
-        model_info=None,
-        error_message="",
-    )
+    seen = {"switch": None, "build": None, "persisted": []}
+    make_calls = 0
 
     def fake_switch_model(**kwargs):
+        provider = kwargs["user_providers"]["new-provider"]
+        secrets = dict(current_secret_scope() or {})
+        api_key = secrets[provider["key_env"]]
         seen["switch"] = {
             "home": get_hermes_home(),
-            "secrets": dict(current_secret_scope() or {}),
-            "providers": kwargs["user_providers"],
+            "secrets": secrets,
+            "base_url": provider["base_url"],
+            "api_key": api_key,
             "current_provider": kwargs["current_provider"],
             "current_api_key": kwargs["current_api_key"],
         }
         switch_called.set()
-        return result
+        return types.SimpleNamespace(
+            success=True,
+            new_model="new/model",
+            target_provider="custom:new-provider",
+            api_key=api_key,
+            base_url=provider["base_url"],
+            api_mode="chat_completions",
+            warning_message="",
+            model_info=None,
+            error_message="",
+        )
 
     class FakeDb:
-        def __init__(self, **_kwargs):
+        def __init__(self, *_args, **_kwargs):
             pass
+
+        def get_session(self, _key):
+            return {"model_config": {}}
+
+        def update_session_meta(self, key, model_config, model):
+            seen["persisted"].append(
+                {
+                    "key": key,
+                    "model": model,
+                    "config": json.loads(model_config),
+                }
+            )
 
         def close(self):
             pass
 
     def fake_make_agent(_sid, _key, **kwargs):
+        nonlocal make_calls
+        make_calls += 1
+        if make_calls == 1:
+            raise RuntimeError(failure_text)
+        override = kwargs["model_override"]
         seen["build"] = {
             "home": get_hermes_home(),
             "secrets": dict(current_secret_scope() or {}),
             "overrides": kwargs,
         }
         return types.SimpleNamespace(
-            model="new/model",
-            provider="custom:new-provider",
-            base_url="https://profile.example/v1",
-            api_mode="chat_completions",
+            model=override["model"],
+            provider="custom",
+            base_url=override["base_url"],
+            api_key=override["api_key"],
+            api_mode=override["api_mode"],
+            reasoning_config=kwargs.get("reasoning_config_override"),
+            service_tier=None,
             _session_db=kwargs.get("session_db"),
         )
+
+    real_transfer = server._transfer_db_to_agent
+
+    def barrier_transfer(agent, db):
+        if agent is None and not old_finally_entered.is_set():
+            old_finally_entered.set()
+            assert release_old_finally.wait(timeout=10)
+        return real_transfer(agent, db)
 
     monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
     monkeypatch.setattr(
@@ -8608,6 +8655,7 @@ def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
     )
     monkeypatch.setattr("hermes_state.SessionDB", FakeDb)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_transfer_db_to_agent", barrier_transfer)
     monkeypatch.setattr(
         "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
     )
@@ -8618,17 +8666,12 @@ def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
     monkeypatch.setattr(server, "_probe_config_health", lambda *_args: None)
     monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
     monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
-    monkeypatch.setattr(
-        server,
-        "_persist_live_session_runtime",
-        lambda _session: seen.__setitem__("persist", seen["persist"] + 1),
-    )
 
-    response = []
+    response = {}
 
     def run_request():
-        response.append(
-            server.handle_request(
+        try:
+            response["value"] = server.handle_request(
                 {
                     "id": "1",
                     "method": "config.set",
@@ -8639,30 +8682,35 @@ def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
                     },
                 }
             )
-        )
+        except BaseException as exc:
+            response["error"] = exc
 
     request_thread = threading.Thread(target=run_request)
+    old_build_thread = None
     try:
+        server._start_agent_build("sid", session)
+        old_build_thread = session["_agent_build_thread"]
+        assert old_finally_entered.wait(timeout=10)
+        assert session["agent_error"] == failure_text
+        assert not old_ready.is_set()
+
         request_thread.start()
         assert old_ready.wait_entered.wait(timeout=2), (
             "model recovery did not wait for the failed build generation"
         )
         assert not switch_called.is_set()
-        old_ready.set()
+        release_old_finally.set()
         request_thread.join(timeout=10)
 
         assert not request_thread.is_alive()
-        assert response[0]["result"]["value"] == "new/model"
-        assert seen["persist"] == 1
+        assert "error" not in response
+        assert response["value"]["result"]["value"] == "new/model"
+        assert make_calls == 2
         assert seen["switch"] == {
             "home": profile_home,
             "secrets": {"PROFILE_API_KEY": "profile-secret"},
-            "providers": {
-                "new-provider": {
-                    "base_url": "https://profile.example/v1",
-                    "key_env": "PROFILE_API_KEY",
-                }
-            },
+            "base_url": profile_url,
+            "api_key": "profile-secret",
             "current_provider": (
                 "custom:new-provider" if provider_flag else "custom"
             ),
@@ -8678,9 +8726,30 @@ def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
         assert overrides["reasoning_config_override"] == reasoning
         assert session["agent_error"] is None
         assert session["agent"].model == "new/model"
+        assert session["agent"].base_url == profile_url
+        assert session["agent"].api_key == "profile-secret"
+        assert seen["persisted"] == [
+            {
+                "key": "session-key",
+                "model": "new/model",
+                "config": {
+                    "model": "new/model",
+                    "provider": "custom:new-provider",
+                    "base_url": profile_url,
+                    "api_mode": "chat_completions",
+                    "reasoning_config": reasoning,
+                },
+            }
+        ]
     finally:
+        release_old_finally.set()
         old_ready.set()
         request_thread.join(timeout=10)
+        if old_build_thread is not None:
+            old_build_thread.join(timeout=10)
+        new_build_thread = session.get("_agent_build_thread")
+        if new_build_thread is not None:
+            new_build_thread.join(timeout=10)
         server._sessions.pop("sid", None)
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8486,9 +8486,58 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
 @pytest.mark.parametrize(
     "provider_flag", [" --provider custom:new-provider", ""]
 )
-def test_config_set_model_recovers_failed_deferred_resume(monkeypatch, provider_flag):
-    old_ready = threading.Event()
-    old_ready.set()
+def test_config_set_model_recovers_failed_profile_resume_after_build_completes(
+    monkeypatch, tmp_path, provider_flag
+):
+    """Recovery waits for the failed generation and uses the session profile.
+
+    Exercise the real model-switch and deferred-build boundaries: only their
+    provider/network and agent-construction leaves are replaced.
+    """
+    from agent.secret_scope import current_secret_scope
+    from hermes_constants import get_hermes_home
+
+    launch_home = tmp_path / "launch"
+    profile_home = tmp_path / "profiles" / "work"
+    launch_home.mkdir()
+    profile_home.mkdir(parents=True)
+    (launch_home / "config.yaml").write_text(
+        "model:\n  default: launch/model\n  provider: launch-provider\n",
+        encoding="utf-8",
+    )
+    (profile_home / "config.yaml").write_text(
+        "model:\n"
+        "  default: old/model\n"
+        "  provider: custom:new-provider\n"
+        "providers:\n"
+        "  new-provider:\n"
+        "    base_url: https://profile.example/v1\n"
+        "    key_env: PROFILE_API_KEY\n",
+        encoding="utf-8",
+    )
+    (profile_home / ".env").write_text(
+        "PROFILE_API_KEY=profile-secret\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+
+    class ControlledReady:
+        def __init__(self):
+            self._event = threading.Event()
+            self.wait_entered = threading.Event()
+
+        def wait(self, timeout=None):
+            self.wait_entered.set()
+            return self._event.wait(timeout)
+
+        def is_set(self):
+            return self._event.is_set()
+
+        def set(self):
+            self._event.set()
+
+    old_ready = ControlledReady()
     reasoning = {"effort": "high"}
     old_override = {"model": "old/model", "provider": "removed-provider"}
     session = _session(
@@ -8501,62 +8550,137 @@ def test_config_set_model_recovers_failed_deferred_resume(monkeypatch, provider_
             "provider_override": "removed-provider",
             "reasoning_config_override": reasoning,
         },
+        profile_home=str(profile_home),
     )
     session["agent"] = None
     server._sessions["sid"] = session
-    seen = {"build": 0, "persist": 0}
+    switch_called = threading.Event()
+    seen = {"switch": None, "build": None, "persist": 0}
 
-    def fake_apply_model_switch(_sid, current, _value, **_kwargs):
-        current["model_override"] = {
-            "model": "new/model",
-            "provider": "custom:new-provider",
+    result = types.SimpleNamespace(
+        success=True,
+        new_model="new/model",
+        target_provider="custom:new-provider",
+        api_key="profile-secret",
+        base_url="https://profile.example/v1",
+        api_mode="chat_completions",
+        warning_message="",
+        model_info=None,
+        error_message="",
+    )
+
+    def fake_switch_model(**kwargs):
+        seen["switch"] = {
+            "home": get_hermes_home(),
+            "secrets": dict(current_secret_scope() or {}),
+            "providers": kwargs["user_providers"],
+            "current_provider": kwargs["current_provider"],
+            "current_api_key": kwargs["current_api_key"],
         }
-        return {
-            "value": "new/model",
-            "warning": "",
-            "confirm_required": False,
-            "scope": "session",
+        switch_called.set()
+        return result
+
+    class FakeDb:
+        def __init__(self, **_kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    def fake_make_agent(_sid, _key, **kwargs):
+        seen["build"] = {
+            "home": get_hermes_home(),
+            "secrets": dict(current_secret_scope() or {}),
+            "overrides": kwargs,
         }
+        return types.SimpleNamespace(
+            model="new/model",
+            provider="custom:new-provider",
+            base_url="https://profile.example/v1",
+            api_mode="chat_completions",
+            _session_db=kwargs.get("session_db"),
+        )
 
-    def fake_start_agent_build(sid, current):
-        seen["build"] += 1
-        assert sid == "sid"
-        assert current["agent_error"] is None
-        assert current["agent_ready"] is not old_ready
-        assert current.get("agent_build_started") is None
-        overrides = current["resume_runtime_overrides"]
-        assert overrides["model_override"] == current["model_override"]
-        assert overrides["provider_override"] == "custom:new-provider"
-        assert overrides["reasoning_config_override"] == reasoning
-        current["agent"] = types.SimpleNamespace(model="new/model")
-        current["agent_ready"].set()
-
-    monkeypatch.setattr(server, "_apply_model_switch", fake_apply_model_switch)
-    monkeypatch.setattr(server, "_start_agent_build", fake_start_agent_build)
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
+    monkeypatch.setattr(
+        "hermes_cli.model_selection_guards.combined_selection_warning",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr("hermes_state.SessionDB", FakeDb)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(
+        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
+    )
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
+    monkeypatch.setattr(server, "_probe_config_health", lambda *_args: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **k: None)
     monkeypatch.setattr(
         server,
         "_persist_live_session_runtime",
         lambda _session: seen.__setitem__("persist", seen["persist"] + 1),
     )
 
-    try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": f"new/model{provider_flag}",
-                },
-            }
+    response = []
+
+    def run_request():
+        response.append(
+            server.handle_request(
+                {
+                    "id": "1",
+                    "method": "config.set",
+                    "params": {
+                        "session_id": "sid",
+                        "key": "model",
+                        "value": f"new/model{provider_flag}",
+                    },
+                }
+            )
         )
 
-        assert resp["result"]["value"] == "new/model"
-        assert seen == {"build": 1, "persist": 1}
+    request_thread = threading.Thread(target=run_request)
+    try:
+        request_thread.start()
+        assert old_ready.wait_entered.wait(timeout=2), (
+            "model recovery did not wait for the failed build generation"
+        )
+        assert not switch_called.is_set()
+        old_ready.set()
+        request_thread.join(timeout=10)
+
+        assert not request_thread.is_alive()
+        assert response[0]["result"]["value"] == "new/model"
+        assert seen["persist"] == 1
+        assert seen["switch"] == {
+            "home": profile_home,
+            "secrets": {"PROFILE_API_KEY": "profile-secret"},
+            "providers": {
+                "new-provider": {
+                    "base_url": "https://profile.example/v1",
+                    "key_env": "PROFILE_API_KEY",
+                }
+            },
+            "current_provider": (
+                "custom:new-provider" if provider_flag else "custom"
+            ),
+            "current_api_key": "profile-secret" if not provider_flag else "",
+        }
+        assert seen["build"]["home"] == profile_home
+        assert seen["build"]["secrets"] == {
+            "PROFILE_API_KEY": "profile-secret"
+        }
+        overrides = seen["build"]["overrides"]
+        assert overrides["model_override"] == session["model_override"]
+        assert overrides["provider_override"] == "custom:new-provider"
+        assert overrides["reasoning_config_override"] == reasoning
         assert session["agent_error"] is None
         assert session["agent"].model == "new/model"
     finally:
+        old_ready.set()
+        request_thread.join(timeout=10)
         server._sessions.pop("sid", None)
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8483,6 +8483,83 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
         server._sessions.pop("sid", None)
 
 
+@pytest.mark.parametrize(
+    "provider_flag", [" --provider custom:new-provider", ""]
+)
+def test_config_set_model_recovers_failed_deferred_resume(monkeypatch, provider_flag):
+    old_ready = threading.Event()
+    old_ready.set()
+    reasoning = {"effort": "high"}
+    old_override = {"model": "old/model", "provider": "removed-provider"}
+    session = _session(
+        agent_ready=old_ready,
+        agent_build_started=True,
+        agent_error="Unknown provider 'removed-provider'",
+        model_override=old_override,
+        resume_runtime_overrides={
+            "model_override": old_override,
+            "provider_override": "removed-provider",
+            "reasoning_config_override": reasoning,
+        },
+    )
+    session["agent"] = None
+    server._sessions["sid"] = session
+    seen = {"build": 0, "persist": 0}
+
+    def fake_apply_model_switch(_sid, current, _value, **_kwargs):
+        current["model_override"] = {
+            "model": "new/model",
+            "provider": "custom:new-provider",
+        }
+        return {
+            "value": "new/model",
+            "warning": "",
+            "confirm_required": False,
+            "scope": "session",
+        }
+
+    def fake_start_agent_build(sid, current):
+        seen["build"] += 1
+        assert sid == "sid"
+        assert current["agent_error"] is None
+        assert current["agent_ready"] is not old_ready
+        assert current.get("agent_build_started") is None
+        overrides = current["resume_runtime_overrides"]
+        assert overrides["model_override"] == current["model_override"]
+        assert overrides["provider_override"] == "custom:new-provider"
+        assert overrides["reasoning_config_override"] == reasoning
+        current["agent"] = types.SimpleNamespace(model="new/model")
+        current["agent_ready"].set()
+
+    monkeypatch.setattr(server, "_apply_model_switch", fake_apply_model_switch)
+    monkeypatch.setattr(server, "_start_agent_build", fake_start_agent_build)
+    monkeypatch.setattr(
+        server,
+        "_persist_live_session_runtime",
+        lambda _session: seen.__setitem__("persist", seen["persist"] + 1),
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {
+                    "session_id": "sid",
+                    "key": "model",
+                    "value": f"new/model{provider_flag}",
+                },
+            }
+        )
+
+        assert resp["result"]["value"] == "new/model"
+        assert seen == {"build": 1, "persist": 1}
+        assert session["agent_error"] is None
+        assert session["agent"].model == "new/model"
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_config_set_model_explicit_provider_surfaces_selected_provider_errors(monkeypatch):
     seen = {"build": 0, "wait": 0}
     session = _session()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4927,6 +4927,22 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
         )
 
 
+@contextlib.contextmanager
+def _session_profile_runtime_scope(session: dict):
+    """Bind model resolution to the session's profile config and secrets."""
+    profile_home = session.get("profile_home")
+    if not profile_home:
+        yield
+        return
+    home_token = set_hermes_home_override(profile_home)
+    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    try:
+        yield
+    finally:
+        reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)
+
+
 def _apply_model_switch(
     sid: str,
     session: dict,
@@ -12077,6 +12093,19 @@ def _(rid, params: dict) -> dict:
                 failed_agent_init = session.get("agent") is None and bool(
                     session.get("agent_error")
                 )
+                failed_ready = session.get("agent_ready") if failed_agent_init else None
+                if (
+                    failed_agent_init
+                    and failed_ready is not None
+                    and not failed_ready.wait(timeout=30.0)
+                ):
+                    return _err(rid, 5032, "agent initialization timed out")
+                failed_agent_init = (
+                    failed_agent_init
+                    and session.get("agent") is None
+                    and bool(session.get("agent_error"))
+                    and session.get("agent_ready") is failed_ready
+                )
                 if (
                     session.get("agent") is None
                     and not explicit_provider.strip()
@@ -12089,33 +12118,47 @@ def _(rid, params: dict) -> dict:
                         return init_err
                     if session.get("agent") is None:
                         return _err(rid, 5032, "agent initialization failed")
-                result = _apply_model_switch(
-                    params.get("session_id", ""),
-                    session,
-                    value,
-                    confirm_expensive_model=bool(
-                        params.get("confirm_expensive_model", False)
-                    ),
-                    parsed_flags=parsed_flags,
-                )
+                with _session_profile_runtime_scope(session):
+                    result = _apply_model_switch(
+                        params.get("session_id", ""),
+                        session,
+                        value,
+                        confirm_expensive_model=bool(
+                            params.get("confirm_expensive_model", False)
+                        ),
+                        parsed_flags=parsed_flags,
+                    )
                 if failed_agent_init and not result.get("confirm_required"):
-                    model_override = session.get("model_override")
-                    resume_overrides = session.get("resume_runtime_overrides")
-                    if isinstance(model_override, dict) and isinstance(
-                        resume_overrides, dict
-                    ):
-                        resume_overrides = dict(resume_overrides)
-                        resume_overrides["model_override"] = model_override
-                        if provider := model_override.get("provider"):
-                            resume_overrides["provider_override"] = provider
-                        else:
-                            resume_overrides.pop("provider_override", None)
-                        session["resume_runtime_overrides"] = resume_overrides
-                    session["agent_error"] = None
-                    session["agent_ready"] = threading.Event()
-                    session.pop("agent_build_started", None)
-                    session.pop("_agent_build_thread", None)
-                    _start_agent_build(params.get("session_id", ""), session)
+                    restart_build = False
+                    build_lock = session.setdefault(
+                        "agent_build_lock", threading.Lock()
+                    )
+                    with build_lock:
+                        if (
+                            session.get("agent") is None
+                            and session.get("agent_error")
+                            and session.get("agent_ready") is failed_ready
+                            and (failed_ready is None or failed_ready.is_set())
+                        ):
+                            model_override = session.get("model_override")
+                            resume_overrides = session.get("resume_runtime_overrides")
+                            if isinstance(model_override, dict) and isinstance(
+                                resume_overrides, dict
+                            ):
+                                resume_overrides = dict(resume_overrides)
+                                resume_overrides["model_override"] = model_override
+                                if provider := model_override.get("provider"):
+                                    resume_overrides["provider_override"] = provider
+                                else:
+                                    resume_overrides.pop("provider_override", None)
+                                session["resume_runtime_overrides"] = resume_overrides
+                            session["agent_error"] = None
+                            session["agent_ready"] = threading.Event()
+                            session.pop("agent_build_started", None)
+                            session.pop("_agent_build_thread", None)
+                            restart_build = True
+                    if restart_build:
+                        _start_agent_build(params.get("session_id", ""), session)
                     init_err = _wait_agent(session, rid)
                     if init_err:
                         return init_err

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12074,7 +12074,14 @@ def _(rid, params: dict) -> dict:
                     )
                 parsed_flags = parse_model_switch_args(value)
                 explicit_provider = parsed_flags.explicit_provider
-                if session.get("agent") is None and not explicit_provider.strip():
+                failed_agent_init = session.get("agent") is None and bool(
+                    session.get("agent_error")
+                )
+                if (
+                    session.get("agent") is None
+                    and not explicit_provider.strip()
+                    and not failed_agent_init
+                ):
                     session_id = params.get("session_id", "")
                     _start_agent_build(session_id, session)
                     init_err = _wait_agent(session, rid)
@@ -12091,6 +12098,30 @@ def _(rid, params: dict) -> dict:
                     ),
                     parsed_flags=parsed_flags,
                 )
+                if failed_agent_init and not result.get("confirm_required"):
+                    model_override = session.get("model_override")
+                    resume_overrides = session.get("resume_runtime_overrides")
+                    if isinstance(model_override, dict) and isinstance(
+                        resume_overrides, dict
+                    ):
+                        resume_overrides = dict(resume_overrides)
+                        resume_overrides["model_override"] = model_override
+                        if provider := model_override.get("provider"):
+                            resume_overrides["provider_override"] = provider
+                        else:
+                            resume_overrides.pop("provider_override", None)
+                        session["resume_runtime_overrides"] = resume_overrides
+                    session["agent_error"] = None
+                    session["agent_ready"] = threading.Event()
+                    session.pop("agent_build_started", None)
+                    session.pop("_agent_build_thread", None)
+                    _start_agent_build(params.get("session_id", ""), session)
+                    init_err = _wait_agent(session, rid)
+                    if init_err:
+                        return init_err
+                    if session.get("agent") is None:
+                        return _err(rid, 5032, "agent initialization failed")
+                    _persist_live_session_runtime(session)
             else:
                 result = _apply_model_switch(
                     "",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4943,6 +4943,39 @@ def _session_profile_runtime_scope(session: dict):
         reset_hermes_home_override(home_token)
 
 
+def _restart_completed_failed_agent_build(
+    sid: str, session: dict, failed_ready: threading.Event | None
+) -> bool:
+    """Replace one completed failed build generation and start its retry."""
+    if failed_ready is None:
+        return False
+    build_lock = session.setdefault("agent_build_lock", threading.Lock())
+    with build_lock:
+        if (
+            session.get("agent") is not None
+            or session.get("agent_error") is None
+            or session.get("agent_ready") is not failed_ready
+            or not failed_ready.is_set()
+        ):
+            return False
+        model_override = session.get("model_override")
+        resume_overrides = session.get("resume_runtime_overrides")
+        if isinstance(model_override, dict) and isinstance(resume_overrides, dict):
+            resume_overrides = dict(resume_overrides)
+            resume_overrides["model_override"] = model_override
+            if provider := model_override.get("provider"):
+                resume_overrides["provider_override"] = provider
+            else:
+                resume_overrides.pop("provider_override", None)
+            session["resume_runtime_overrides"] = resume_overrides
+        session["agent_error"] = None
+        session["agent_ready"] = threading.Event()
+        session.pop("agent_build_started", None)
+        session.pop("_agent_build_thread", None)
+    _start_agent_build(sid, session)
+    return True
+
+
 def _apply_model_switch(
     sid: str,
     session: dict,
@@ -12090,21 +12123,27 @@ def _(rid, params: dict) -> dict:
                     )
                 parsed_flags = parse_model_switch_args(value)
                 explicit_provider = parsed_flags.explicit_provider
-                failed_agent_init = session.get("agent") is None and bool(
-                    session.get("agent_error")
+                failed_agent_init = (
+                    session.get("agent") is None
+                    and session.get("agent_error") is not None
                 )
                 failed_ready = session.get("agent_ready") if failed_agent_init else None
-                if (
-                    failed_agent_init
-                    and failed_ready is not None
-                    and not failed_ready.wait(timeout=30.0)
-                ):
-                    return _err(rid, 5032, "agent initialization timed out")
+                if failed_agent_init:
+                    if failed_ready is None:
+                        return _err(
+                            rid,
+                            5032,
+                            session.get("agent_error")
+                            or "agent initialization failed",
+                        )
+                    if not failed_ready.wait(timeout=30.0):
+                        return _err(rid, 5032, "agent initialization timed out")
                 failed_agent_init = (
                     failed_agent_init
                     and session.get("agent") is None
-                    and bool(session.get("agent_error"))
+                    and session.get("agent_error") is not None
                     and session.get("agent_ready") is failed_ready
+                    and failed_ready.is_set()
                 )
                 if (
                     session.get("agent") is None
@@ -12129,42 +12168,16 @@ def _(rid, params: dict) -> dict:
                         parsed_flags=parsed_flags,
                     )
                 if failed_agent_init and not result.get("confirm_required"):
-                    restart_build = False
-                    build_lock = session.setdefault(
-                        "agent_build_lock", threading.Lock()
+                    _restart_completed_failed_agent_build(
+                        params.get("session_id", ""), session, failed_ready
                     )
-                    with build_lock:
-                        if (
-                            session.get("agent") is None
-                            and session.get("agent_error")
-                            and session.get("agent_ready") is failed_ready
-                            and (failed_ready is None or failed_ready.is_set())
-                        ):
-                            model_override = session.get("model_override")
-                            resume_overrides = session.get("resume_runtime_overrides")
-                            if isinstance(model_override, dict) and isinstance(
-                                resume_overrides, dict
-                            ):
-                                resume_overrides = dict(resume_overrides)
-                                resume_overrides["model_override"] = model_override
-                                if provider := model_override.get("provider"):
-                                    resume_overrides["provider_override"] = provider
-                                else:
-                                    resume_overrides.pop("provider_override", None)
-                                session["resume_runtime_overrides"] = resume_overrides
-                            session["agent_error"] = None
-                            session["agent_ready"] = threading.Event()
-                            session.pop("agent_build_started", None)
-                            session.pop("_agent_build_thread", None)
-                            restart_build = True
-                    if restart_build:
-                        _start_agent_build(params.get("session_id", ""), session)
                     init_err = _wait_agent(session, rid)
                     if init_err:
                         return init_err
                     if session.get("agent") is None:
                         return _err(rid, 5032, "agent initialization failed")
-                    _persist_live_session_runtime(session)
+                    with _session_profile_runtime_scope(session):
+                        _persist_live_session_runtime(session)
             else:
                 result = _apply_model_switch(
                     "",


### PR DESCRIPTION
## What does this PR do?

A deferred session resume can fail when its persisted provider no longer exists. The failed build leaves `agent_ready` set and `agent_build_started` latched. `config.set model` can resolve and record a replacement model while no agent exists, but it cannot start another build; stale resume overrides also keep winning when the session is reopened.

This change gives an explicit model selection a recovery path. After selection succeeds, it refreshes the resume model and provider while retaining reasoning and tier overrides, resets the failed build state, rebuilds on the selected runtime, and persists that runtime. Fresh lazy sessions keep their existing behavior.

## Related Issue

Related to #58907.

This is complementary to #92498, which suppresses speculative browse-time errors but intentionally retains the failed state. It is distinct from #75385, which reconciles settings changed while a build is still in progress; this handles a build that has already failed and completed.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor
- [ ] ⚡ Performance improvement
- [x] ✅ Tests

## Changes Made

- `tui_gateway/server.py` — allow `config.set model` to reset and retry a completed failed initialization, refresh stale resume overrides, and persist the selected runtime.
- `tests/test_tui_gateway_server.py` — cover recovery with both an explicit provider (Desktop picker) and the configured provider, including preservation of reasoning state.

## How to Test

1. Resume a session whose persisted provider has been removed; initialization reports `Unknown provider`.
2. Select a valid model and provider from the model picker.
3. Confirm the session initializes on the selected model and reopening the session restores that runtime.
4. Run `scripts/run_tests.sh tests/test_tui_gateway_server.py`.
5. Run `ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`.

The affected test module passes with 590 tests. Ruff and `git diff --check` pass. The full canonical suite was also attempted in a restricted macOS environment; unrelated environment-sensitive tests failed on denied socket and process operations, platform assumptions, and unavailable optional SDKs.

## Checklist

### Code Quality

- [x] I have read the [Contributing Guide](../blob/main/CONTRIBUTING.md)
- [x] My commits follow the project conventional commit format
- [x] I have searched for duplicate pull requests
- [x] This PR contains only changes related to the described issue
- [ ] All existing tests pass locally
- [x] I have added tests that prove the fix is effective
- [x] I have tested this change on macOS

### Documentation

- [x] Relevant documentation is not affected
- [x] CLI or configuration documentation is not affected
- [x] Contributor documentation and `AGENTS.md` are not affected
- [x] Cross-platform behavior was considered; the change is in platform-neutral session control code

## Screenshots / Logs

Before:

`agent init failed: Unknown provider removed-provider.`

After selecting a valid model, the session rebuilds and persists the selected runtime for the next resume.