### PR TITLE
fix(gateway): scope status fallback to routed profile

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -692,7 +692,13 @@ class GatewaySlashCommandsMixin:
         user_config: dict[str, Any] = {}
         if not model_name or not provider_name or not context_total:
             try:
-                user_config = _load_gateway_config()
+                if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+                    profile_home = self._resolve_profile_home_for_source(source)
+                    user_config = _load_gateway_config(
+                        config_path=profile_home / "config.yaml"
+                    )
+                else:
+                    user_config = _load_gateway_config()
             except Exception:
                 user_config = {}
         if not model_name:

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -142,6 +142,47 @@ async def test_status_command_includes_live_agent_model_and_context():
 
 
 @pytest.mark.asyncio
+async def test_status_command_fallback_uses_routed_profile_config(tmp_path, monkeypatch):
+    """A fresh multiplexed session must not report the process default model."""
+    import gateway.run as gateway_run
+
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="u1",
+        chat_id="group-1",
+        user_name="tester",
+        chat_type="group",
+        profile="wa-omniroute",
+    )
+    session_entry = SessionEntry(
+        session_key="agent:wa-omniroute:whatsapp:group:group-1:u1",
+        session_id="sess-routed",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.WHATSAPP,
+        chat_type="group",
+    )
+    runner = _make_runner(session_entry, platform=Platform.WHATSAPP)
+    runner.config.multiplex_profiles = True
+    profile_home = tmp_path / "profiles" / "wa-omniroute"
+    profile_home.mkdir(parents=True)
+    runner._resolve_profile_home_for_source = lambda _source: profile_home
+
+    def _scoped_config(config_path=None):
+        if config_path == profile_home / "config.yaml":
+            return {"model": {"default": "glm-4.7-flash", "provider": "zai"}}
+        return {"model": {"default": "gpt-5.6-sol", "provider": "openai-codex"}}
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", _scoped_config)
+    event = MessageEvent(text="/status", source=source, message_id="m1")
+
+    result = await runner._handle_status_command(event)
+
+    assert "**Model:** `glm-4.7-flash` (zai)" in result
+    assert "gpt-5.6-sol" not in result
+
+
+@pytest.mark.asyncio
 async def test_status_command_uses_dominant_persisted_model_route(tmp_path):
     """Persisted status must not combine a model and provider from different calls."""
     session_entry = SessionEntry(


### PR DESCRIPTION
## What does this PR do?

Fixes `/status` model/provider reporting for fresh sessions routed to a named profile by a multiplex gateway.

When no live agent or persisted model route exists yet (for example immediately after `/new`), `/status` falls back to gateway configuration. That fallback currently reads the default gateway profile, so a chat routed to a secondary profile can report the default profile's model even though the session namespace and subsequent agent turn use the routed profile.

## Root cause

`_handle_status_command()` called `_load_gateway_config()` without the routed profile's config path. Slash commands return before the normal agent execution path enters the routed profile runtime scope.

## Fix

When multiplexing is enabled, resolve the source profile home and pass its `config.yaml` explicitly to `_load_gateway_config()`. Non-multiplex behavior and the existing live-agent/persisted-route precedence remain unchanged.

This follows the established routed-profile read pattern used by `/model`.

## Regression coverage

Adds a test with:

- default profile: `gpt-5.6-sol` / `openai-codex`
- routed profile: `glm-4.7-flash` / `zai`
- fresh WhatsApp group session with no live or persisted model metadata

The test fails against the previous unconditional config load and verifies that `/status` reports the routed profile model/provider.

## Verification

```text
scripts/run_tests.sh tests/gateway/test_status_command.py -q
12 passed, 0 failed

ruff check gateway/slash_commands.py tests/gateway/test_status_command.py
All checks passed

git diff --check
passed
```

## Risk

Low. The change affects only the final config fallback used when `/status` cannot resolve model/provider/context from a live agent or persisted session metadata. Non-multiplex gateways retain the original code path.

Related to #86946 and #87939.
