### PR TITLE
fix(cli): exit code 2 on failed oneshot run regardless of response text

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -327,7 +327,7 @@ def run_oneshot(
             real_stdout.write("\n")
         real_stdout.flush()
 
-    if (result.get("failed") or result.get("partial")) and not (response or "").strip():
+    if result.get("failed") or result.get("partial"):
         return 2
 
     if not (response or "").strip():

--- a/tests/hermes_cli/test_oneshot_failure_exit_code.py
+++ b/tests/hermes_cli/test_oneshot_failure_exit_code.py
@@ -1,0 +1,107 @@
+"""Tests for hermes -z / run_oneshot failure exit codes (#92502, #74659).
+
+Unattended callers (scripts, CI, fleet runners) rely on exit code 0 indicating
+success. When run_conversation returns failed=True (e.g. content policy refusal,
+rate limit exhaustion, agent failure) or partial=True, run_oneshot must return
+exit code 2 even when final_response contains a non-empty refusal/error message.
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import patch
+
+import hermes_cli.oneshot as oneshot
+
+
+def test_oneshot_returns_2_on_failed_result_with_non_empty_response():
+    """When the turn fails (e.g. content policy refusal), exit code must be 2 even with output."""
+    refusal_text = "I cannot fulfill this request due to content policy."
+    fake_result = {
+        "final_response": refusal_text,
+        "completed": False,
+        "failed": True,
+        "error": "content_policy_blocked: refusal",
+    }
+
+    stdout_buf = io.StringIO()
+    with patch("hermes_cli.oneshot._run_agent", return_value=(refusal_text, fake_result)), \
+         patch("sys.stdout", stdout_buf):
+        rc = oneshot.run_oneshot("test prompt")
+
+    assert rc == 2
+    assert refusal_text in stdout_buf.getvalue()
+
+
+def test_oneshot_returns_2_on_failed_result_with_empty_response():
+    """When the turn fails with empty response, exit code must be 2."""
+    fake_result = {
+        "final_response": "",
+        "completed": False,
+        "failed": True,
+        "error": "api_error: HTTP 500",
+    }
+
+    stdout_buf = io.StringIO()
+    with patch("hermes_cli.oneshot._run_agent", return_value=("", fake_result)), \
+         patch("sys.stdout", stdout_buf):
+        rc = oneshot.run_oneshot("test prompt")
+
+    assert rc == 2
+
+
+def test_oneshot_returns_2_on_partial_result_with_non_empty_response():
+    """When the turn is partial (e.g. tool loop interrupted), exit code must be 2."""
+    partial_text = "Task was interrupted before completion."
+    fake_result = {
+        "final_response": partial_text,
+        "completed": False,
+        "partial": True,
+    }
+
+    stdout_buf = io.StringIO()
+    with patch("hermes_cli.oneshot._run_agent", return_value=(partial_text, fake_result)), \
+         patch("sys.stdout", stdout_buf):
+        rc = oneshot.run_oneshot("test prompt")
+
+    assert rc == 2
+    assert partial_text in stdout_buf.getvalue()
+
+
+def test_oneshot_returns_0_on_success_with_response():
+    """Successful turn with non-empty response returns 0."""
+    success_text = "Everything succeeded."
+    fake_result = {
+        "final_response": success_text,
+        "completed": True,
+        "failed": False,
+        "partial": False,
+    }
+
+    stdout_buf = io.StringIO()
+    with patch("hermes_cli.oneshot._run_agent", return_value=(success_text, fake_result)), \
+         patch("sys.stdout", stdout_buf):
+        rc = oneshot.run_oneshot("test prompt")
+
+    assert rc == 0
+    assert success_text in stdout_buf.getvalue()
+
+
+def test_oneshot_returns_1_on_empty_response_when_not_failed():
+    """When no response is produced without explicit failure dict, return 1."""
+    fake_result = {
+        "final_response": "",
+        "completed": True,
+        "failed": False,
+        "partial": False,
+    }
+
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+    with patch("hermes_cli.oneshot._run_agent", return_value=("", fake_result)), \
+         patch("sys.stdout", stdout_buf), \
+         patch("sys.stderr", stderr_buf):
+        rc = oneshot.run_oneshot("test prompt")
+
+    assert rc == 1
+    assert "no final response was produced" in stderr_buf.getvalue()


### PR DESCRIPTION
## What does this PR do?

In oneshot mode (`hermes -z`), when a turn fails (e.g. content policy block, rate limit exhaustion, model refusal, or agent failure) or is partial, `run_conversation` returns `failed=True` while `final_response` carries the human-readable refusal or error message.

Previously, `run_oneshot` only returned exit code 2 if `response` was empty (`and not (response or "").strip()`). When a refusal or error message was produced, execution fell through to return exit code 0, causing unattended callers, scripts, and queue dispatchers to treat a failed run as a successful execution.

This change removes the empty-response guard so `run_oneshot` returns exit code 2 whenever `result.get("failed")` or `result.get("partial")` is True, while still printing the diagnostic refusal message to `stdout`.

## Related Issue

Fixes #92502

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `hermes_cli/oneshot.py`: Return exit code 2 unconditionally when `result.get("failed")` or `result.get("partial")` is True.
- `tests/hermes_cli/test_oneshot_failure_exit_code.py`: Add unit and regression tests covering failed, partial, success, and empty response exit codes.

## How to Test

Run regression test suite:

```bash
pytest tests/hermes_cli/test_oneshot_failure_exit_code.py -v
pytest tests/hermes_cli/test_oneshot_failure_exit_code.py tests/hermes_cli/test_oneshot_skills.py tests/hermes_cli/test_oneshot_usage_file.py tests/agent/test_oneshot.py tests/cli/test_oneshot_resumed_session_persist.py
```

Pass counts: 28 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
