### PR TITLE
fix(session-state): lineage walks survive cleared end_reason on reopened links

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -51,6 +51,8 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
     _COMPRESSION_CHILD_SQL,
+    _COMPRESSION_MARKER_CHILD_EDGE_SQL,
+    _COMPRESSION_MARKER_PARENT_EDGE_SQL,
     _FTS_CJK_TRIGGERS,
     _FTS_TRIGGERS,
     _LISTABLE_CHILD_SQL,
@@ -7513,16 +7515,64 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Uses COALESCE so that passing model=None leaves the stored model
         column unchanged.  Routes through _execute_write for the standard
         BEGIN IMMEDIATE + jitter-retry + lock guarantee.
+
+        Reserved lineage markers: keys beginning with ``_`` in the stored
+        config (``_reset_from``, ``_branched_from``, ``_compression_from``,
+        ``_delegate_from``) survive this wholesale replacement — callers
+        pass a complete user-facing metadata dict (cwd, provider, ...) and
+        must not be required to know about internal markers. A future
+        dedicated column would retire this shim.
         """
         # Barrier against queued token deltas — see update_session_model.
         self.flush_token_counts()
 
         def _do(conn):
+            merged = self._preserve_reserved_model_config_keys(
+                conn, session_id, model_config_json
+            )
             conn.execute(
                 "UPDATE sessions SET model_config = ?, model = COALESCE(?, model) WHERE id = ?",
-                (model_config_json, model, session_id),
+                (merged, model, session_id),
             )
         self._execute_write(_do)
+
+    @staticmethod
+    def _preserve_reserved_model_config_keys(
+        conn, session_id: str, incoming_json: str
+    ) -> Optional[str]:
+        """Merge ``_``-prefixed keys from the stored config into *incoming_json*.
+
+        ``update_session_meta`` replaces the whole ``model_config`` document;
+        without this guard a replacement silently drops the immutable
+        compression-lineage stamp (and its ``_reset_from`` / ``_branched_from``
+        predecessors), reintroducing the cleared-end_reason lineage break.
+        """
+        try:
+            incoming = json.loads(incoming_json) if incoming_json else {}
+            if not isinstance(incoming, dict):
+                incoming = {}
+        except (json.JSONDecodeError, TypeError):
+            incoming = {}
+        row = conn.execute(
+            "SELECT model_config FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        reserved: Dict[str, Any] = {}
+        if row is not None:
+            raw = row["model_config"] if isinstance(row, sqlite3.Row) else row[0]
+            if isinstance(raw, str) and raw.strip():
+                try:
+                    stored = json.loads(raw)
+                    if isinstance(stored, dict):
+                        reserved = {
+                            k: v for k, v in stored.items() if k.startswith("_")
+                        }
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            elif isinstance(raw, dict):
+                reserved = {k: v for k, v in raw.items() if k.startswith("_")}
+        merged = {**incoming, **reserved}
+        return json.dumps(merged) if merged else None
 
     def update_system_prompt(
         self, session_id: str, system_prompt: Optional[str]
@@ -8908,7 +8958,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         def _do(conn):
             cursor = conn.execute(
-                """
+                f"""
                 WITH RECURSIVE
                   ancestors(id) AS (
                     SELECT ?
@@ -8917,9 +8967,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM ancestors a
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
-                    WHERE parent.end_reason = 'compression'
-                       OR json_extract(COALESCE(child.model_config, '{}'),
-                                       '$._compression_from') = parent.id
+                    WHERE {_COMPRESSION_CHILD_SQL.format(a="child")}
+                       OR {_COMPRESSION_MARKER_PARENT_EDGE_SQL.format(a="child")}
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -8929,8 +8978,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
-                       OR json_extract(COALESCE(child.model_config, '{}'),
-                                       '$._compression_from') = d.id
+                       OR {_COMPRESSION_MARKER_CHILD_EDGE_SQL.format(a="parent")}
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors
@@ -8964,7 +9012,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         def _do(conn):
             cursor = conn.execute(
-                """
+                f"""
                 WITH RECURSIVE
                   ancestors(id) AS (
                     SELECT ?
@@ -8973,9 +9021,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM ancestors a
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
-                    WHERE parent.end_reason = 'compression'
-                       OR json_extract(COALESCE(child.model_config, '{}'),
-                                       '$._compression_from') = parent.id
+                    WHERE {_COMPRESSION_CHILD_SQL.format(a="child")}
+                       OR {_COMPRESSION_MARKER_PARENT_EDGE_SQL.format(a="child")}
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -8985,8 +9032,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
-                       OR json_extract(COALESCE(child.model_config, '{}'),
-                                       '$._compression_from') = d.id
+                       OR {_COMPRESSION_MARKER_CHILD_EDGE_SQL.format(a="parent")}
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors
@@ -9022,7 +9068,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         def _do(conn):
             cursor = conn.execute(
-                """
+                f"""
                 WITH RECURSIVE
                   ancestors(id) AS (
                     SELECT ?
@@ -9031,9 +9077,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM ancestors a
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
-                    WHERE parent.end_reason = 'compression'
-                       OR json_extract(COALESCE(child.model_config, '{}'),
-                                       '$._compression_from') = parent.id
+                    WHERE {_COMPRESSION_CHILD_SQL.format(a="child")}
+                       OR {_COMPRESSION_MARKER_PARENT_EDGE_SQL.format(a="child")}
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -9043,8 +9088,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
-                       OR json_extract(COALESCE(child.model_config, '{}'),
-                                       '$._compression_from') = d.id
+                       OR {_COMPRESSION_MARKER_CHILD_EDGE_SQL.format(a="parent")}
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors
@@ -9086,7 +9130,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         def _do(conn):
             cursor = conn.execute(
-                """
+                f"""
                 WITH RECURSIVE
                   ancestors(id) AS (
                     SELECT ?
@@ -9095,9 +9139,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM ancestors a
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
-                    WHERE parent.end_reason = 'compression'
-                       OR json_extract(COALESCE(child.model_config, '{}'),
-                                       '$._compression_from') = parent.id
+                    WHERE {_COMPRESSION_CHILD_SQL.format(a="child")}
+                       OR {_COMPRESSION_MARKER_PARENT_EDGE_SQL.format(a="child")}
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -9107,8 +9150,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
-                       OR json_extract(COALESCE(child.model_config, '{}'),
-                                       '$._compression_from') = d.id
+                       OR {_COMPRESSION_MARKER_CHILD_EDGE_SQL.format(a="parent")}
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5319,6 +5319,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                        )""",
                     (session_id,),
                 )
+                # Durable compression-lineage marker (mirrors the ``_reset_from``
+                # pattern used by reopen_session): the parent's mutable
+                # ``end_reason`` is cleared when a row is later reopened after a
+                # mistaken reaper close (``ws_orphan_reap``) or stale-route
+                # recovery, which would silently break every lineage walk that
+                # keys on ``end_reason = 'compression'``. Stamp the child at
+                # creation time so archive/pin/tip walks can still follow the
+                # raw parent edge afterwards.
+                conn.execute(
+                    """UPDATE sessions
+                       SET model_config = json_set(
+                               COALESCE(sessions.model_config, '{}'),
+                               '$._compression_from',
+                               sessions.parent_session_id)
+                     WHERE id = ? AND parent_session_id IS NOT NULL
+                       AND json_extract(COALESCE(sessions.model_config, '{}'),
+                                        '$._compression_from') IS NULL
+                       AND EXISTS (
+                           SELECT 1 FROM sessions p
+                           WHERE p.id = sessions.parent_session_id
+                             AND p.end_reason = 'compression'
+                             AND p.ended_at IS NOT NULL
+                       )""",
+                    (session_id,),
+                )
         # Session-row creation is transcript-critical: if it fails, the
         # first flush of a new session fails and the turn is aborted as
         # session_persistence_failed. Ride out long sibling holds.
@@ -6405,6 +6430,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 raise RuntimeError(
                     f"Compression parent changed during publication: {parent_session_id}"
                 )
+
+            # Belt-and-suspenders marker stamping (mirrors the ``_reset_from``
+            # pattern in reopen_session): the parent's mutable ``end_reason``
+            # is cleared when a row is later reopened after a mistaken reaper
+            # close (``ws_orphan_reap``) or stale-route recovery, which would
+            # silently break every lineage walk keyed on
+            # ``end_reason = 'compression'``. Stamp the continuation child at
+            # rotation time — including the race where the child row was
+            # inserted before the parent's ``ended_at`` landed, which is why
+            # this backfill exists alongside the creation-time stamp in
+            # _insert_session_row.
+            conn.execute(
+                """UPDATE sessions
+                   SET model_config = json_set(
+                           COALESCE(sessions.model_config, '{}'),
+                           '$._compression_from',
+                           parent_session_id)
+                 WHERE id = ?
+                   AND parent_session_id IS NOT NULL
+                   AND json_extract(COALESCE(sessions.model_config, '{}'),
+                                    '$._compression_from') IS NULL""",
+                (child_session_id,),
+            )
 
         self._execute_write(_do)
 
@@ -8870,6 +8918,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
                     WHERE parent.end_reason = 'compression'
+                       OR json_extract(COALESCE(child.model_config, '{}'),
+                                       '$._compression_from') = parent.id
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -8879,6 +8929,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
+                       OR json_extract(COALESCE(child.model_config, '{}'),
+                                       '$._compression_from') = d.id
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors
@@ -8922,6 +8974,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
                     WHERE parent.end_reason = 'compression'
+                       OR json_extract(COALESCE(child.model_config, '{}'),
+                                       '$._compression_from') = parent.id
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -8931,6 +8985,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
+                       OR json_extract(COALESCE(child.model_config, '{}'),
+                                       '$._compression_from') = d.id
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors
@@ -8976,6 +9032,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
                     WHERE parent.end_reason = 'compression'
+                       OR json_extract(COALESCE(child.model_config, '{}'),
+                                       '$._compression_from') = parent.id
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -8985,6 +9043,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
+                       OR json_extract(COALESCE(child.model_config, '{}'),
+                                       '$._compression_from') = d.id
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors
@@ -9036,6 +9096,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions child ON child.id = a.id
                     JOIN sessions parent ON parent.id = child.parent_session_id
                     WHERE parent.end_reason = 'compression'
+                       OR json_extract(COALESCE(child.model_config, '{}'),
+                                       '$._compression_from') = parent.id
                   ),
                   descendants(id) AS (
                     SELECT ?
@@ -9045,6 +9107,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     JOIN sessions parent ON parent.id = d.id
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.end_reason = 'compression'
+                       OR json_extract(COALESCE(child.model_config, '{}'),
+                                       '$._compression_from') = d.id
                   ),
                   lineage(id) AS (
                     SELECT id FROM ancestors

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -183,6 +183,27 @@ _COMPRESSION_CHILD_SQL = (
     "        AND p.end_reason = 'compression')"
 )
 
+# Compression-lineage marker edges: every lineage CTE pairs the legacy
+# ``_COMPRESSION_CHILD_SQL`` heuristic with the immutable
+# ``$._compression_from`` stamp written by ``publish_compression_child`` and
+# ``_insert_session_row``, so walks survive a reopened parent whose mutable
+# ``end_reason`` was cleared (see ``reopen_session`` / ``ws_orphan_reap``).
+# Kept beside ``_COMPRESSION_CHILD_SQL`` so the next lineage walk cannot take
+# one half of the edge without the other.
+_COMPRESSION_MARKER_PARENT_EDGE_SQL = (
+    "EXISTS (SELECT 1 FROM sessions p"
+    "        WHERE p.id = {a}.parent_session_id"
+    "        AND json_extract(COALESCE({a}.model_config, '{{}}'),"
+    "                        '$._compression_from') = p.id)"
+)
+
+_COMPRESSION_MARKER_CHILD_EDGE_SQL = (
+    "EXISTS (SELECT 1 FROM sessions c"
+    "        WHERE c.parent_session_id = {a}.id"
+    "        AND json_extract(COALESCE(c.model_config, '{{}}'),"
+    "                        '$._compression_from') = {a}.id)"
+)
+
 
 _RESET_END_REASONS = (
     "session_reset",

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -1,4 +1,6 @@
+import json
 import time
+from pathlib import Path
 
 import pytest
 
@@ -159,3 +161,69 @@ def test_creation_time_marker_covers_children_of_already_ended_parent(db):
     db.reopen_session("root")
     assert db.set_session_archived("late", True) is True
     assert db.get_session("root")["archived"] == 1
+
+
+def _stamp_compression_marker(db: SessionDB, parent: str, child: str):
+    """Drive the real rotation path so ``$._compression_from`` lands on *child*."""
+    db.create_session(parent, source="cli")
+    db.publish_compression_child(
+        parent_session_id=parent,
+        child_session_id=child,
+        source="cli",
+        messages=[{"role": "user", "content": "hello"}],
+        require_compression_lease=False,
+    )
+
+
+class TestReservedModelConfigKeysSurviveMetaOverwrite:
+    """Review of #92533 point 1: update_session_meta wholesale replacement must
+    preserve ``_``-prefixed lineage markers."""
+
+    def test_compression_marker_survives_acp_style_meta_overwrite(self, db):
+        _stamp_compression_marker(db, "root", "tip")
+
+        # acp_adapter/session.py replaces model_config wholesale on every persist.
+        db.update_session_meta("tip", '{"cwd": "/y", "provider": "openrouter"}')
+
+        stored = json.loads(db.get_session("tip")["model_config"])
+        assert stored["cwd"] == "/y"
+        assert stored["_compression_from"] == "root"
+
+    def test_reset_from_marker_also_survives(self, db):
+        db.create_session("s1", source="cli", model_config={"cwd": "/a"})
+        db._conn.execute(
+            "UPDATE sessions SET model_config = ? WHERE id = 's1'",
+            (json.dumps({"cwd": "/a", "_reset_from": "old-root"}),),
+        )
+        db._conn.commit()
+
+        db.update_session_meta("s1", '{"cwd": "/c"}')
+
+        stored = json.loads(db.get_session("s1")["model_config"])
+        assert stored["_reset_from"] == "old-root"
+        assert stored["cwd"] == "/c"
+
+
+class TestSharedMarkerEdgeConstants:
+    """Review of #92533 point 2: walker SQL interpolates shared constants."""
+
+    def test_no_pasted_marker_arms_in_hermes_state(self):
+        src = (
+            Path(__file__).resolve().parents[2] / "hermes_state.py"
+        ).read_text(encoding="utf-8")
+        assert (
+            "OR json_extract(COALESCE(child.model_config" not in src
+        ), "pasted OR-arm still present in walker SQL"
+
+    def test_marker_edge_constants_render_valid_sql(self):
+        from hermes_state_common import (
+            _COMPRESSION_MARKER_CHILD_EDGE_SQL,
+            _COMPRESSION_MARKER_PARENT_EDGE_SQL,
+        )
+
+        parent_edge = _COMPRESSION_MARKER_PARENT_EDGE_SQL.format(a="child")
+        child_edge = _COMPRESSION_MARKER_CHILD_EDGE_SQL.format(a="parent")
+        assert "child.parent_session_id" in parent_edge
+        assert "'$._compression_from'" in parent_edge
+        assert "parent.id" in child_edge
+        assert "'$._compression_from'" in child_edge

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -49,3 +49,113 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+# --- reopened-link regression -------------------------------------------------
+#
+# A mistaken TUI reaper close (``end_reason = 'ws_orphan_reap'``) followed by
+# stale-route recovery (``reopen_session``) clears the parent's mutable
+# ``end_reason``. Before the ``$._compression_from`` marker existed, every
+# lineage walk keyed on ``end_reason = 'compression'`` silently lost the link:
+# archiving only covered the segment below the break and the unarchived,
+# re-active root resurrected the conversation in the sidebar.
+
+
+def _published_pair(db: SessionDB):
+    """Build root->tip through the real rotation path, then reap + reopen."""
+    import json as _json
+
+    db.create_session("root", source="cli")
+    db.publish_compression_child(
+        parent_session_id="root",
+        child_session_id="tip",
+        source="cli",
+        messages=[{"role": "user", "content": "hello"}],
+        require_compression_lease=False,
+    )
+    # The rotation must have stamped the durable lineage marker.
+    row = db._conn.execute(
+        "SELECT model_config FROM sessions WHERE id = 'tip'"
+    ).fetchone()
+    assert _json.loads(row["model_config"])["_compression_from"] == "root"
+
+    # Simulate the production reap/reopen cycle that erases the link.
+    db._conn.execute(
+        "UPDATE sessions SET end_reason = 'ws_orphan_reap' WHERE id = 'root'"
+    )
+    db._conn.commit()
+    db.reopen_session("root")
+    assert db.get_session("root")["end_reason"] is None
+
+
+def test_publish_compression_child_stamps_durable_marker(db):
+    import json as _json
+
+    db.create_session("root", source="cli")
+    db.publish_compression_child(
+        parent_session_id="root",
+        child_session_id="tip",
+        source="cli",
+        messages=[{"role": "user", "content": "hello"}],
+        require_compression_lease=False,
+    )
+    row = db._conn.execute(
+        "SELECT model_config FROM sessions WHERE id = 'tip'"
+    ).fetchone()
+    assert _json.loads(row["model_config"])["_compression_from"] == "root"
+
+
+def test_archiving_after_reopened_link_still_covers_whole_lineage(db):
+    _published_pair(db)
+
+    assert db.set_session_archived("tip", True) is True
+
+    assert db.get_session("root")["archived"] == 1
+    assert db.get_session("tip")["archived"] == 1
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == []
+
+
+def test_unarchiving_after_reopened_link_restores_whole_lineage(db):
+    _published_pair(db)
+    db.set_session_archived("tip", True)
+
+    assert db.set_session_archived("tip", False) is True
+
+    assert db.get_session("root")["archived"] == 0
+    assert db.get_session("tip")["archived"] == 0
+    # The reopened root is live again (ended_at cleared by reopen_session),
+    # so the sidebar surfaces the root row itself.
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["root"]
+
+
+def test_pinning_after_reopened_link_covers_whole_lineage(db):
+    _published_pair(db)
+
+    assert db.set_session_pinned("tip", True) is True
+
+    assert db.get_session("root")["pinned"] == 1
+    assert db.get_session("tip")["pinned"] == 1
+
+
+def test_creation_time_marker_covers_children_of_already_ended_parent(db):
+    """Children created under an ended compression parent keep the link even
+    if the parent is reopened before any rotation backfill runs."""
+    import json as _json
+
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, "
+        "end_reason = 'compression' WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db.create_session("late", source="cli", parent_session_id="root")
+
+    row = db._conn.execute(
+        "SELECT model_config FROM sessions WHERE id = 'late'"
+    ).fetchone()
+    assert _json.loads(row["model_config"])["_compression_from"] == "root"
+
+    db.reopen_session("root")
+    assert db.set_session_archived("late", True) is True
+    assert db.get_session("root")["archived"] == 1


### PR DESCRIPTION
# PR: fix(session-state): lineage walks survive cleared end_reason on reopened links

Open with:
https://github.com/NousResearch/hermes-agent/compare/main...sebmarion:hermes-agent:fix/archive-lineage-reopened-links?expand=1

## Problem

Archiving a conversation only archived part of it, and the chat kept resurfacing in the sidebar. Reproduced in production.

Root cause chain:

1. The TUI websocket reaper closes stale sessions with `end_reason = 'ws_orphan_reap'`.
2. Stale-route recovery later calls `reopen_session`, which clears `ended_at`/`end_reason` (by design — that is how resume works).
3. Every lineage walk (`set_session_archived`, `set_session_pinned`, `set_session_hidden`, `set_session_read`) traverses only `parent.end_reason = 'compression'` edges.
4. Result: the compression link through a reopened row is invisible. Archive covers only the segment *below* the break; the unarchived, re-active root keeps the conversation alive in the sidebar, and new continuation rows are born unarchived.

The codebase already acknowledges this fragility: `reopen_session` stamps children with `$._reset_from` *before* clearing the parent's mutable `end_reason`, precisely because other logic depends on it. Compression chains had no equivalent durable marker.

## Fix

Follows the existing `_reset_from` pattern:

1. **Stamp at rotation:** `publish_compression_child` writes `$._compression_from = <parent id>` into the continuation child's `model_config` (idempotent, NULL-guarded).
2. **Stamp at creation:** `_insert_session_row` stamps children created under an already-ended compression parent — covers the documented race where a child row is inserted before the parent's `ended_at` lands.
3. **Walk with fallback:** each of the four lineage-flipping CTEs gains one OR-arm that follows the raw parent edge when either side carries the marker.

`get_compression_tip` is intentionally untouched: once archive/pin cover the whole lineage, the archived filter hides the root regardless of tip projection; resume-ordering semantics are unchanged. Diff stays minimal (64 lines in `hermes_state.py`, all additive).

## Testing

- New regression tests in `tests/hermes_state/test_session_archiving.py`: real-rotation stamping, reap→reopen→archive reaching the whole lineage, unarchive restoring it, pin coverage, and creation-time stamping under an already-ended parent.
- `tests/hermes_state/` — 156 passed
- `tests/agent/test_compression_rotation_state.py tests/agent/test_compression_concurrent_fork.py tests/run_agent/test_compression_boundary_hook.py` — 70 passed
