### PR TITLE
fix(agent): catch stop-as-length misreports on opted-in shims

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3485,6 +3485,34 @@ def run_conversation(
                 elif agent.api_mode == "anthropic_messages":
                     _tfr = agent._get_transport()
                     finish_reason = _tfr.map_finish_reason(response.stop_reason)
+                    # Stop→length misreport guard (config opt-in only — the
+                    # built-in Ollama-GLM auto-detect is chat_completions
+                    # only).  Normalize lazily, solely to feed the guard, so
+                    # non-opted-in backends pay nothing; the truncated path
+                    # below re-normalizes anyway.  Partial-stream stubs are
+                    # excluded — they already resolve to finish_reason='length'
+                    # via their own tag and must not be re-judged.
+                    if (
+                        finish_reason == "stop"
+                        and getattr(response, "id", "") != PARTIAL_STREAM_STUB_ID
+                        and agent._backend_opted_into_stop_misreport_guard()
+                    ):
+                        _anth_stop_result = _tfr.normalize_response(
+                            response, strip_tool_prefix=agent._is_anthropic_oauth
+                        )
+                        if agent._should_treat_stop_as_truncated(
+                            finish_reason,
+                            _anth_stop_result,
+                            messages,
+                            response=response,
+                            api_kwargs=api_kwargs,
+                        ):
+                            agent._vprint(
+                                f"{agent.log_prefix}⚠️  Provider reported stop but the response looks "
+                                f"truncated — treating as finish_reason='length'",
+                                force=True,
+                            )
+                            finish_reason = "length"
                 elif agent.api_mode == "bedrock_converse":
                     # Bedrock response already normalized at dispatch — use transport
                     _bt_fr = agent._get_transport()
@@ -3499,9 +3527,12 @@ def run_conversation(
                         finish_reason,
                         assistant_message,
                         messages,
+                        response=response,
+                        api_kwargs=api_kwargs,
                     ):
                         agent._vprint(
-                            f"{agent.log_prefix}⚠️  Treating suspicious Ollama/GLM stop response as truncated",
+                            f"{agent.log_prefix}⚠️  Provider reported stop but the response looks "
+                            f"truncated — treating as finish_reason='length'",
                             force=True,
                         )
                         finish_reason = "length"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -54,6 +54,20 @@ DEFAULT_CONFIG = {
         # implicit provider stale timeouts are capped to the remaining
         # budget. CLI one-shot equivalent: `hermes chat --run-budget N`.
         "run_budget_seconds": None,
+        # Some OpenAI/Anthropic-compatible shims (e.g. the MiniMax /anthropic
+        # endpoint, some local MLX servers) report finish_reason="stop" when
+        # they actually hit their output-token cap, silently truncating the
+        # reply. When this fires, Hermes treats the response as
+        # finish_reason="length" and runs the normal continuation path.
+        #   true        = apply the mid-sentence / near-output-cap heuristics
+        #                 to every backend
+        #   list of str = only backends whose provider id, base URL, or model
+        #                 name contains one of these case-insensitive
+        #                 substrings (e.g. ["minimax", "127.0.0.1:8025"])
+        #   false       = only the built-in Ollama-GLM auto-detection
+        # False positives are bounded by the 4-attempt continuation cap and
+        # cost at most one extra API call when the response ended naturally.
+        "treat_stop_as_length": False,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has
@@ -1934,6 +1948,13 @@ DEFAULT_CONFIG = {
         # instruction). 0 disables the hard ceiling; the dynamic headroom
         # budget still applies.
         "max_summary_chars": 24000,
+        # Floor for the dynamic per-summary budget computed from the parent's
+        # remaining context headroom. The dynamic budget can shrink toward the
+        # built-in 2000-char floor when the parent's context is nearly full or
+        # the batch is large; raise this to keep summaries more complete at the
+        # cost of parent headroom. max_summary_chars still caps from above (if
+        # min_summary_chars > max_summary_chars, the static ceiling wins).
+        "min_summary_chars": 2000,
 
         "child_timeout_seconds": 0,  # optional wall-clock cap per child agent. 0 (default)
                                      # = no timeout: children fail only from real errors

--- a/run_agent.py
+++ b/run_agent.py
@@ -1779,22 +1779,107 @@ class AIAgent:
             return True
         return provider_lower == "ollama"
 
+    def _backend_opted_into_stop_misreport_guard(self) -> bool:
+        """Config opt-in for backends that misreport truncation as 'stop'.
+
+        Reads ``agent.treat_stop_as_length`` from config.yaml:
+        - ``true``  — apply the guard to every backend
+        - list      — only backends whose provider id, base URL, or model
+                      name contains one of the case-insensitive substrings
+                      (e.g. ["minimax", "127.0.0.1:8025"])
+        - ``false`` — only the built-in Ollama-GLM auto-detection (default)
+
+        Read once per agent and cached (mirroring
+        ``_file_mutation_verifier_enabled``) — the guard runs at most once
+        per turn, and a config flip applying on the next session is fine.
+        The provider/URL match runs at call time so mid-session failover to
+        a fallback backend is matched against the now-active backend.
+        """
+        cached = getattr(self, "_stop_misreport_opt_in_cache", None)
+        if cached is None:
+            try:
+                from hermes_cli.config import load_config as _load_config
+                _cfg = _load_config() or {}
+            except Exception:
+                _cfg = {}
+            _agent = _cfg.get("agent") if isinstance(_cfg, dict) else None
+            cached = _agent.get("treat_stop_as_length", False) if isinstance(_agent, dict) else False
+            self._stop_misreport_opt_in_cache = cached
+        if cached is True:
+            return True
+        if isinstance(cached, list):
+            haystack = " ".join([
+                (self.provider or "").lower(),
+                self._base_url_lower or "",
+                (self.model or "").lower(),
+            ])
+            return any(
+                str(needle).lower() in haystack for needle in cached if needle
+            )
+        return False
+
+    def _output_tokens_near_requested_cap(self, response, api_kwargs) -> bool:
+        """True when reported output tokens are >= 90% of the requested cap.
+
+        Hard-evidence signal: a provider that reports 'stop' while having
+        generated (nearly) the entire requested output budget almost
+        certainly hit its own cap and misreported. Returns False whenever
+        usage or the requested cap is unavailable.
+        """
+        try:
+            cap = self._requested_output_cap_from_api_kwargs(api_kwargs)
+            if not cap:
+                return False
+            usage = getattr(response, "usage", None)
+            if usage is None and isinstance(response, dict):
+                usage = response.get("usage")
+            if usage is None:
+                return False
+            if isinstance(usage, dict):
+                out = usage.get("completion_tokens") or usage.get("output_tokens") or 0
+            else:
+                out = (getattr(usage, "completion_tokens", 0)
+                       or getattr(usage, "output_tokens", 0) or 0)
+            return bool(out) and int(out) >= int(cap * 0.9)
+        except Exception:
+            return False
+
     def _should_treat_stop_as_truncated(
         self,
         finish_reason: str,
         assistant_message,
         messages: Optional[list] = None,
+        response: Any = None,
+        api_kwargs: Any = None,
     ) -> bool:
-        """Detect conservative stop->length misreports for Ollama-hosted GLM models."""
-        if finish_reason != "stop" or self.api_mode != "chat_completions":
+        """Detect conservative stop->length misreports.
+
+        Two paths:
+        - Auto-detect: Ollama-hosted GLM models (chat_completions only),
+          which require a tool-turn precondition to avoid the #13971
+          false-positive class.
+        - Config opt-in (``agent.treat_stop_as_length``): known-bad shims
+          such as the MiniMax /anthropic endpoint or local MLX servers that
+          hit their own output cap but report finish_reason='stop'. Works
+          for both chat_completions and anthropic_messages api modes and
+          drops the tool-turn precondition — the observed failure was a
+          plain mid-sentence reply with no tool history.
+        """
+        if finish_reason != "stop":
             return False
-        if not self._is_ollama_glm_backend():
+        if self.api_mode not in ("chat_completions", "anthropic_messages"):
             return False
-        if not any(
-            isinstance(msg, dict) and msg.get("role") == "tool"
-            for msg in (messages or [])
-        ):
-            return False
+        opted_in = self._backend_opted_into_stop_misreport_guard()
+        if not opted_in:
+            if self.api_mode != "chat_completions":
+                return False
+            if not self._is_ollama_glm_backend():
+                return False
+            if not any(
+                isinstance(msg, dict) and msg.get("role") == "tool"
+                for msg in (messages or [])
+            ):
+                return False
         if assistant_message is None or getattr(assistant_message, "tool_calls", None):
             return False
 
@@ -1805,6 +1890,10 @@ class AIAgent:
         visible_text = self._strip_think_blocks(content).strip()
         if not visible_text:
             return False
+
+        if self._output_tokens_near_requested_cap(response, api_kwargs):
+            return True
+
         if len(visible_text) < 20 or not re.search(r"\s", visible_text):
             return False
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4215,6 +4215,114 @@ class TestRunConversation:
         assert third_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in third_call_messages[-1]["content"]
 
+    def test_stop_misreport_guard_opted_in_anthropic_mode_mid_sentence(self, agent):
+        """Config-opted-in backends get the guard in anthropic_messages mode."""
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "minimax"
+        agent._stop_misreport_opt_in_cache = ["minimax"]
+        msg = SimpleNamespace(
+            content="Based on the search results, the best next", tool_calls=None
+        )
+        assert agent._should_treat_stop_as_truncated("stop", msg, []) is True
+
+    def test_stop_misreport_guard_opted_in_natural_ending_passes(self, agent):
+        """A natural sentence ending is not treated as truncated."""
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "minimax"
+        agent._stop_misreport_opt_in_cache = ["minimax"]
+        msg = SimpleNamespace(
+            content="Based on the search results, update the config.", tool_calls=None
+        )
+        assert agent._should_treat_stop_as_truncated("stop", msg, []) is False
+
+    def test_stop_misreport_guard_not_opted_in_anthropic_mode_skipped(self, agent):
+        """Without opt-in, anthropic_messages never fires (no #13971 regression)."""
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "minimax"
+        agent._stop_misreport_opt_in_cache = False
+        msg = SimpleNamespace(
+            content="Based on the search results, the best next", tool_calls=None
+        )
+        assert agent._should_treat_stop_as_truncated("stop", msg, []) is False
+
+    def test_stop_misreport_guard_near_cap_usage_overrides_natural_ending(self, agent):
+        """Output tokens >= 90% of the requested cap is hard evidence of a cap hit."""
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "minimax"
+        agent._stop_misreport_opt_in_cache = ["minimax"]
+        msg = SimpleNamespace(
+            content="Based on the search results, update the config.", tool_calls=None
+        )
+        response = SimpleNamespace(
+            usage=SimpleNamespace(input_tokens=10, output_tokens=950)
+        )
+        assert agent._should_treat_stop_as_truncated(
+            "stop", msg, [], response=response, api_kwargs={"max_tokens": 1000}
+        ) is True
+
+    def test_stop_misreport_guard_opted_in_skips_tool_turn_precondition(self, agent):
+        """Opted-in chat_completions backends fire without tool history."""
+        agent.provider = "minimax"
+        agent._stop_misreport_opt_in_cache = ["minimax"]
+        msg = SimpleNamespace(
+            content="Based on the search results, the best next", tool_calls=None
+        )
+        assert agent._should_treat_stop_as_truncated("stop", msg, []) is True
+
+    def test_stop_misreport_guard_not_opted_in_requires_ollama_glm(self, agent):
+        """Without opt-in, non-Ollama-GLM chat_completions backends never fire."""
+        agent.provider = "minimax"
+        agent._stop_misreport_opt_in_cache = False
+        msg = SimpleNamespace(
+            content="Based on the search results, the best next", tool_calls=None
+        )
+        messages = [{"role": "tool", "content": "search result"}]
+        assert agent._should_treat_stop_as_truncated("stop", msg, messages) is False
+
+    def test_stop_misreport_opt_in_matches_base_url_substring(self, agent):
+        """The opt-in list matches provider id, base URL, or model name."""
+        agent._stop_misreport_opt_in_cache = ["127.0.0.1:8025"]
+        agent.provider = "openrouter"
+        agent._base_url_lower = "http://127.0.0.1:8025/v1"
+        assert agent._backend_opted_into_stop_misreport_guard() is True
+        agent._stop_misreport_opt_in_cache = ["some-other-host"]
+        assert agent._backend_opted_into_stop_misreport_guard() is False
+        agent._stop_misreport_opt_in_cache = True
+        assert agent._backend_opted_into_stop_misreport_guard() is True
+
+    def test_minimax_opted_in_stop_without_tools_requests_continuation(self, agent):
+        """End-to-end: an opted-in shim misreporting stop gets continued."""
+        self._setup_agent(agent)
+        agent.provider = "minimax"
+        agent._stop_misreport_opt_in_cache = ["minimax"]
+
+        misreported_stop = _mock_response(
+            content="Based on the search results, the best next",
+            finish_reason="stop",
+        )
+        continued = _mock_response(
+            content=" step is to update the config.",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            misreported_stop,
+            continued,
+        ]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert (
+            result["final_response"]
+            == "Based on the search results, the best next step is to update the config."
+        )
+
 
 
 

--- a/tests/tools/test_delegate_summary_budget.py
+++ b/tests/tools/test_delegate_summary_budget.py
@@ -76,3 +76,56 @@ def test_empty_results_is_noop():
         [{"task_index": 0, "status": "failed", "summary": None}],
         _FakeParent(131_000, 1_000, 8_000),
     )
+
+
+def test_trim_emits_single_batch_warning_naming_dynamic_binding(monkeypatch, caplog):
+    # Parent nearly full → dynamic budget (floored at 2000) binds below the
+    # static 24000 ceiling.
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        parent = _FakeParent(context_length=131_000, used_tokens=120_000, max_tokens=8_000)
+        big = "HEAD\n" + ("X" * 50_000) + "\nTAIL"
+        results = [{"task_index": i, "summary": big, "status": "completed"} for i in range(5)]
+        with caplog.at_level("WARNING", logger="tools.delegate_tool"):
+            dt._apply_summary_budget(results, parent)
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1  # one line per batch, not per summary
+    msg = warnings[0].getMessage()
+    assert "trimmed 5 subagent summaries" in msg
+    assert "binding constraint: dynamic context-headroom budget" in msg
+
+
+def test_trim_warning_names_static_binding_when_ceiling_is_lower(monkeypatch, caplog):
+    # Huge parent context → dynamic budget far above the static ceiling.
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        parent = _FakeParent(context_length=2_000_000, used_tokens=10_000, max_tokens=8_000)
+        big = "HEAD\n" + ("X" * 50_000) + "\nTAIL"
+        results = [{"task_index": 0, "summary": big, "status": "completed"}]
+        with caplog.at_level("WARNING", logger="tools.delegate_tool"):
+            dt._apply_summary_budget(results, parent)
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "binding constraint: static delegation.max_summary_chars ceiling" in (
+        warnings[0].getMessage()
+    )
+
+
+def test_min_summary_chars_floors_dynamic_budget(monkeypatch):
+    # Without the floor this parent/batch lands on the built-in 2000-char
+    # dynamic floor; min_summary_chars=8000 must raise the cap.
+    monkeypatch.setattr(
+        dt, "_load_config",
+        lambda: {"max_summary_chars": 24000, "min_summary_chars": 8000},
+    )
+    with tempfile.TemporaryDirectory() as td:
+        monkeypatch.setenv("HERMES_HOME", os.path.join(td, ".hermes"))
+        parent = _FakeParent(context_length=131_000, used_tokens=120_000, max_tokens=8_000)
+        big = "HEAD\n" + ("X" * 50_000) + "\nTAIL"
+        results = [{"task_index": i, "summary": big, "status": "completed"} for i in range(5)]
+        dt._apply_summary_budget(results, parent)
+        for r in results:
+            assert r["summary_truncated"] is True
+            # Trimmed to ~8000 (75/25 head/tail + footer), not the 2000 floor.
+            assert len(r["summary"]) > 6000
+            assert len(r["summary"]) < 12000

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2393,8 +2393,14 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
         static_ceiling = int(cfg.get("max_summary_chars", DEFAULT_MAX_SUMMARY_CHARS))
     except (TypeError, ValueError):
         static_ceiling = DEFAULT_MAX_SUMMARY_CHARS
+    try:
+        min_chars = int(cfg.get("min_summary_chars", _MIN_SUMMARY_CHARS))
+    except (TypeError, ValueError):
+        min_chars = _MIN_SUMMARY_CHARS
 
     dynamic_budget = _parent_summary_char_budget(parent_agent, len(summaries))
+    if dynamic_budget is not None and min_chars > 0:
+        dynamic_budget = max(min_chars, dynamic_budget)
 
     # Combine the two caps. Either can be absent/disabled.
     candidates = [c for c in (static_ceiling, dynamic_budget) if c and c > 0]
@@ -2402,6 +2408,7 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
         return  # both disabled / unknown → leave summaries untouched
     cap = min(candidates)
 
+    trimmed_count = 0
     for entry in summaries:
         summary = entry["summary"]
         if len(summary) <= cap:
@@ -2414,12 +2421,35 @@ def _apply_summary_budget(results: List[Dict[str, Any]], parent_agent) -> None:
         entry["summary_truncated"] = True
         if spill_path:
             entry["summary_full_path"] = spill_path
+        trimmed_count += 1
         logger.debug(
             "[subagent-%s] summary trimmed %d → ~%d chars (spill=%s)",
             entry.get("task_index", "?"),
             original_len,
             cap,
             spill_path or "none",
+        )
+
+    if trimmed_count:
+        # One operator-visible line per batch (not per summary) so a wide
+        # fan-out can't spam the log. Names the binding constraint so the
+        # operator knows which knob to turn.
+        binding = (
+            "dynamic context-headroom budget"
+            if dynamic_budget and cap == dynamic_budget and (
+                not static_ceiling or dynamic_budget < static_ceiling
+            )
+            else "static delegation.max_summary_chars ceiling"
+        )
+        logger.warning(
+            "delegate_task: trimmed %d subagent summar%s to ~%d chars each "
+            "(binding constraint: %s). Full texts spilled to disk; in-context "
+            "footers carry read_file offsets. Raise delegation.min_summary_chars "
+            "or delegation.max_summary_chars to loosen this.",
+            trimmed_count,
+            "y" if trimmed_count == 1 else "ies",
+            cap,
+            binding,
         )
 
 


### PR DESCRIPTION
# Catch stop-as-length misreports on opted-in shims (+ delegate summary trim observability)

## Problem

Some OpenAI/Anthropic-compatible shims report `finish_reason="stop"` when they actually hit their output-token cap. Two concrete examples: the MiniMax `/anthropic` endpoint and some local MLX servers. When this happens the reply is **silently truncated mid-sentence** — the conversation loop's loud continuation path (`finish_reason == "length"`) never fires because the provider claimed a normal stop.

The existing misreport guard (`_should_treat_stop_as_truncated`, #13971) only covers Ollama-hosted GLM models over `chat_completions`. Backends running in `anthropic_messages` mode never even evaluate it.

Observed in the wild: a long multi-section synthesis reply from a MiniMax-M3 backend (`api.minimax.io/anthropic`) cut off mid-sentence with no warning, no continuation, no error.

## Fix

**Opt-in generalization of the guard** (deliberately not default-on — the #13971 lesson was that broad auto-detection burns correctly-reporting proxies):

- New config knob `agent.treat_stop_as_length`: `false` (default, current behavior), `true` (all backends), or a list of case-insensitive substrings matched against the active provider id / base URL / model name (e.g. `["minimax", "127.0.0.1:8025"]`). Evaluated at call time, so mid-session failover to a fallback backend matches the now-active backend.
- Opted-in backends are guarded in **both** `chat_completions` and `anthropic_messages` api modes, and skip the legacy tool-turn precondition (the observed failure was a plain mid-sentence reply with no tool history).
- New corroborating signal: reported output tokens ≥ 90% of the requested cap is treated as hard evidence of a cap hit, even when the text ends naturally.
- The legacy Ollama-GLM auto-detect path is byte-for-byte unchanged.
- A flip lands in the existing `length` path, so false positives are bounded by the 4-attempt continuation cap and cost at most one extra API call when the response ended naturally (the natural-ending gate stops re-fires).

In the `anthropic_messages` branch the response is normalized lazily, only when the backend is opted in, so non-opted-in backends pay nothing; partial-stream stubs are excluded (they already resolve to `length` via their own tag).

**Drive-by observability fix in `delegate_task`:** when subagent summaries are trimmed against the parent's context budget, the only record was a `logger.debug` — invisible at default log levels. Now emits one batch-level `logger.warning` naming the binding constraint (dynamic headroom budget vs static `max_summary_chars` ceiling). Also adds `delegation.min_summary_chars` (default 2000, current behavior) as a floor for the dynamic budget — previously `max_summary_chars: 0` disabled the static ceiling but left no config lever against an over-aggressive dynamic clip.

## Tests

- 8 new unit tests for the guard: opt-in matching (provider/URL/model substrings, `true`), anthropic_messages mode, natural-ending pass-through, near-cap usage override, tool-turn precondition dropped for opt-in / preserved for legacy, no-fire without opt-in (#13971 regression guard), plus an end-to-end `run_conversation` test proving an opted-in shim's misreported stop triggers continuation and stitches the full reply.
- 3 new delegate tests: single batch-level warning naming the dynamic binding, warning naming the static binding, `min_summary_chars` floor raising the effective cap.
- `tests/run_agent/test_run_agent.py`: 283 passed. `tests/tools/test_delegate_summary_budget.py`: 6 passed.

Related: #13971, #9126
