### PR TITLE
fix(cron): forward attach_to_session from the cronjob tool handler

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -388,6 +388,77 @@ class TestUnifiedCronjobTool:
         assert stored["deliver"] == "telegram"
 
 
+    def test_create_persists_attach_to_session_through_the_handler(self):
+        """A schema-declared flag must survive the registered handler.
+
+        Every other case in this class calls ``cronjob()`` directly, which is
+        not the path the agent takes: a tool call goes through the registered
+        handler, and only what that handler reads out of ``args`` reaches the
+        function.  This dispatches the way the agent does.
+        """
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {
+                    "action": "create",
+                    "prompt": "Daily briefing",
+                    "schedule": "every 1h",
+                    "name": "Briefing",
+                    "attach_to_session": True,
+                },
+            )
+        )
+        assert created["success"] is True
+        assert get_job(created["job_id"])["attach_to_session"] is True
+
+    def test_update_persists_attach_to_session_through_the_handler(self):
+        """update carrying only the flag must not fall through to a no-op.
+
+        With the flag dropped, ``updates`` stays empty and the tool answers
+        "No updates provided." — a false error on a valid call.
+        """
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {"action": "create", "prompt": "Check", "schedule": "every 1h"},
+            )
+        )
+        job_id = created["job_id"]
+        assert "attach_to_session" not in get_job(job_id)
+
+        updated = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {"action": "update", "job_id": job_id, "attach_to_session": True},
+            )
+        )
+        assert updated["success"] is True
+        assert get_job(job_id)["attach_to_session"] is True
+
+    def test_omitted_attach_to_session_leaves_the_key_absent(self):
+        """Absent flag keeps the key out of the record.
+
+        ``create_job`` only writes it when explicitly set, so an untouched job
+        keeps falling back to the global ``cron.mirror_delivery`` config.
+        """
+        from cron.jobs import get_job
+        from tools.registry import registry
+
+        created = json.loads(
+            registry.dispatch(
+                "cronjob",
+                {"action": "create", "prompt": "Check", "schedule": "every 1h"},
+            )
+        )
+        assert "attach_to_session" not in get_job(created["job_id"])
+
+
 # =========================================================================
 # Agent-facing surface: per-job model pins are user-owned
 # =========================================================================

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1861,6 +1861,7 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
         task_id=kw.get("task_id"),


### PR DESCRIPTION
## Problem

`CRONJOB_SCHEMA` declares `attach_to_session` (`tools/cronjob_tools.py:1802`), but the tool's registry handler lambda never reads `args.get("attach_to_session")` — the flag is **silently dropped** when creating/updating jobs through the agent tool. The direct `cronjob()` function works (programmatic callers keep the parameter); only the tool boundary loses it.

## Root cause

The handler lambda registered via `registry.register(name="cronjob", ...)` passes a fixed whitelist of `args.get(...)` to `cronjob()`. The parameter was added to the function signature and the schema in the original feature commits (`1b181724fa`, `98f3c19282`), but the lambda bridge was never updated. Result: model sends `attach_to_session: true` → `coerce_tool_args` passes it through → lambda drops it → `cronjob(attach_to_session=None)` → `create_job` intentionally skips the key when it's `None`.

## Repro (through the real agent path)

1. `registry.dispatch("cronjob", {"action": "create", ..., "attach_to_session": true})` → job record in `jobs.json` has **no** `attach_to_session` key.
2. `update` with `attach_to_session` as the only field → `updates` dict stays empty → tool returns misleading error `"No updates provided."` (`tools/cronjob_tools.py:1667-1668`).

## What this is NOT

Upstream intentionally removed `model/provider/base_url` from the handler args (spend-safety: an agent must not point unattended spend at a different model). `attach_to_session` is a session-continuation convenience flag with zero spend implications — it only controls mirroring/topic delivery. This change does not reintroduce anything that was deliberately removed.

## Fix

One line in the handler lambda (forwarded before `task_id`/`session_id`):

```diff
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
         monitor_script=args.get("monitor_script"),
```

## Test

Regression test added in `tests/tools/test_cronjob_tools.py`: drives the registered handler via `registry.dispatch` (the actual agent code path, not the bare function) and asserts the flag reaches `create_job` and lands in `jobs.json`. Verified on clean upstream HEAD: 3 assertions fail before the change, 0 after.

## Related open PRs

Other PRs touching this area exist (#84833, #90813, #84829, #57556, #67711). This PR is deliberately minimal: 1 code line + 1 regression test, with the spend-safety distinction called out so reviewers can see it does not conflict with the intentional `model/provider/base_url` removal.