### PR TITLE
feat(vision): resolve supports_vision_tool_messages per model

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -384,6 +384,105 @@ def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
     return True
 
 
+def supports_vision_tool_messages_override(
+    provider: str,
+    model: str,
+    cfg: Optional[Dict[str, Any]] = None,
+    *,
+    requested_provider: str = "",
+) -> Optional[bool]:
+    """Per-model override for accepting list-type ``role: "tool"`` content.
+
+    ``ProviderProfile.supports_vision_tool_messages`` is keyed on the provider,
+    which cannot express a relay that fronts several vendors: the OpenCode Go
+    catalog serves MiMo alongside Kimi, GLM, MiniMax, DeepSeek and Qwen, and
+    only the MiMo route rejects a content-parts list inside a ``role: "tool"``
+    message.  Setting the flag provider-wide fixes MiMo by downgrading every
+    other family on the same relay (the objection raised on #47026), so allow
+    the incompatibility to be scoped to the affected model:
+
+        providers:
+          <provider>:
+            models:
+              <model>:
+                supports_vision_tool_messages: false
+
+    Resolution deliberately mirrors ``_supports_vision_override`` so the two
+    capability keys behave identically for the same config shapes: the same
+    provider-candidate order (``requested_provider``, the runtime provider, and
+    the config-declared ``model.provider``, plus the bare name behind
+    ``custom:<name>``) and the same legacy list-form ``custom_providers``
+    fallback.  Without that parity the override would silently not resolve for
+    named custom providers, which are rewritten to ``provider="custom"`` at
+    runtime.
+
+    Returns None when unset or unparseable, so callers fall through to the
+    provider profile.  Uses the same strict boolean coercion as
+    ``supports_vision``, so a quoted ``"false"`` cannot read as True.
+    """
+    if cfg is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+            cfg = load_config_readonly()
+        except Exception:
+            return None
+    if not isinstance(cfg, dict):
+        return None
+
+    model_cfg_raw = cfg.get("model")
+    model_cfg: Dict[str, Any] = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
+    config_provider = str(model_cfg.get("provider") or "").strip()
+
+    candidates: List[str] = []
+    for candidate in (requested_provider, provider, config_provider):
+        if not candidate:
+            continue
+        candidates.append(candidate)
+        if candidate.startswith("custom:"):
+            stripped = candidate[len("custom:"):]
+            if stripped:
+                candidates.append(stripped)
+
+    providers_raw = cfg.get("providers")
+    providers_cfg: Dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
+    for name in dict.fromkeys(candidates):
+        entry_raw = providers_cfg.get(name)
+        entry: Dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
+        models_raw = entry.get("models")
+        models_cfg: Dict[str, Any] = models_raw if isinstance(models_raw, dict) else {}
+        per_model_raw = models_cfg.get(model)
+        per_model: Dict[str, Any] = per_model_raw if isinstance(per_model_raw, dict) else {}
+        coerced = _coerce_capability_bool(
+            per_model.get("supports_vision_tool_messages")
+        )
+        if coerced is not None:
+            return coerced
+
+    # Legacy list-style ``custom_providers``, same shape and candidate priority
+    # as ``_supports_vision_override``.
+    custom_providers = cfg.get("custom_providers")
+    if isinstance(custom_providers, list):
+        for candidate in dict.fromkeys(candidates):
+            candidate_name = candidate.strip().lower()
+            for entry_raw in custom_providers:
+                if not isinstance(entry_raw, dict):
+                    continue
+                entry_name = str(entry_raw.get("name") or "").strip().lower()
+                if entry_name != candidate_name:
+                    continue
+                models_raw = entry_raw.get("models")
+                models_cfg = models_raw if isinstance(models_raw, dict) else {}
+                per_model_raw = models_cfg.get(model)
+                per_model = per_model_raw if isinstance(per_model_raw, dict) else {}
+                coerced = _coerce_capability_bool(
+                    per_model.get("supports_vision_tool_messages")
+                )
+                if coerced is not None:
+                    return coerced
+
+    return None
+
+
 def _lookup_supports_vision(
     provider: str,
     model: str,

--- a/run_agent.py
+++ b/run_agent.py
@@ -7210,12 +7210,29 @@ class AIAgent:
             return False
 
     def _provider_supports_vision_tool_messages(self) -> bool:
-        """Return True if the active provider accepts list-type tool content.
+        """Return True if the active provider/model accepts list-type tool content.
 
         Some providers (e.g. Xiaomi MiMo) support multimodal user messages
         but reject list-type tool message content with 400 errors.  This
         checks the provider profile's ``supports_vision_tool_messages`` field.
+
+        The profile field is keyed on the *provider*, which is too coarse for
+        an OpenAI-compatible relay that fronts several vendors: the OpenCode Go
+        catalog serves MiMo alongside Kimi, GLM, MiniMax, DeepSeek and Qwen, so
+        setting the flag provider-wide downgrades multipart tool results for
+        every one of them (the objection raised on #47026).  Consult a
+        per-model override first so the incompatibility can be scoped to the
+        routes that actually have it.
         """
+        try:
+            from agent.image_routing import supports_vision_tool_messages_override
+            provider = (getattr(self, "provider", "") or "").strip()
+            model = (getattr(self, "model", "") or "").strip()
+            override = supports_vision_tool_messages_override(provider, model)
+            if override is not None:
+                return override
+        except Exception:
+            pass
         try:
             from providers import get_provider_profile
             provider = (getattr(self, "provider", "") or "").strip()

--- a/tests/agent/test_per_model_vision_tool_messages.py
+++ b/tests/agent/test_per_model_vision_tool_messages.py
@@ -1,0 +1,254 @@
+"""Per-model override for list-type ``role: "tool"`` content.
+
+``ProviderProfile.supports_vision_tool_messages`` is keyed on the provider,
+which cannot express a relay that fronts several vendors.  The OpenCode Go
+catalog serves MiMo alongside Kimi, GLM, MiniMax, DeepSeek and Qwen
+(``hermes_cli/models.py``), and only the MiMo route rejects multimodal
+tool-result content — so setting the flag provider-wide fixes MiMo by
+downgrading every other family on the same relay.  That is the objection
+raised on #47026, and #89057 is the same failure reported again (HTTP 500 from
+the OpenCode Go proxy, with the rejected image persisting in history so every
+later turn in the thread fails too).
+
+These tests pin the scoped alternative: an explicit per-model
+``supports_vision_tool_messages`` in config.yaml, resolved before the provider
+profile.  Each positive case is paired with a control on a sibling model of the
+*same* provider, so a green run cannot mean "everything is downgraded".
+"""
+
+from __future__ import annotations
+
+import base64
+
+from agent.image_routing import supports_vision_tool_messages_override
+
+
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+_DATA_URL = "data:image/png;base64," + base64.b64encode(_PNG).decode()
+
+
+def _cfg(mimo_value):
+    """OpenCode Go-shaped config: MiMo carries the override, siblings do not."""
+    mimo = {"supports_vision": True}
+    if mimo_value is not None:
+        mimo["supports_vision_tool_messages"] = mimo_value
+    return {
+        "model": {"provider": "opencode-go"},
+        "providers": {
+            "opencode-go": {
+                "models": {
+                    "mimo-v2.5": mimo,
+                    "kimi-k2": {"supports_vision": True},
+                    "glm-4.6": {"supports_vision": True},
+                }
+            }
+        },
+    }
+
+
+class TestScopedOverrideResolution:
+    def test_mimo_route_is_downgraded(self):
+        assert supports_vision_tool_messages_override(
+            "opencode-go", "mimo-v2.5", _cfg(False)
+        ) is False
+
+    def test_non_mimo_siblings_are_untouched(self):
+        """The control case requested on #47026.
+
+        A provider-wide flag would return False here too, silently costing
+        Kimi and GLM their native tool-result images on this relay.
+        """
+        cfg = _cfg(False)
+        assert supports_vision_tool_messages_override(
+            "opencode-go", "kimi-k2", cfg
+        ) is None
+        assert supports_vision_tool_messages_override(
+            "opencode-go", "glm-4.6", cfg
+        ) is None
+
+    def test_absent_key_returns_none_not_false(self):
+        """None means "defer to the provider profile", not "reject"."""
+        assert supports_vision_tool_messages_override(
+            "opencode-go", "mimo-v2.5", _cfg(None)
+        ) is None
+
+    def test_quoted_false_still_means_false(self):
+        """``supports_vision`` already guards this common YAML mistake."""
+        assert supports_vision_tool_messages_override(
+            "opencode-go", "mimo-v2.5", _cfg("false")
+        ) is False
+
+    def test_unparseable_value_defers_instead_of_guessing(self):
+        assert supports_vision_tool_messages_override(
+            "opencode-go", "mimo-v2.5", _cfg("maybe")
+        ) is None
+
+    def test_resolves_via_runtime_provider_when_config_provider_differs(self):
+        """The runtime provider argument must be honored on its own.
+
+        Regression guard: dropping it from the candidate list still passed the
+        config-provider test below, because that one only exercises the
+        fallback half of the lookup.
+        """
+        cfg = _cfg(False)
+        cfg["model"]["provider"] = "some-other-provider"
+        assert supports_vision_tool_messages_override(
+            "opencode-go", "mimo-v2.5", cfg
+        ) is False
+
+    def test_resolves_via_config_provider_when_runtime_is_custom(self):
+        """Named custom providers are rewritten to ``provider="custom"`` at
+        runtime, so the user-declared name survives only under
+        ``model.provider``.  Ignoring it would make the override unreachable on
+        exactly the setups that need it (same order as ``supports_vision``).
+        """
+        assert supports_vision_tool_messages_override(
+            "custom", "mimo-v2.5", _cfg(False)
+        ) is False
+
+    def test_resolves_via_requested_provider_keyword(self):
+        cfg = _cfg(False)
+        cfg["model"]["provider"] = "some-other-provider"
+        assert supports_vision_tool_messages_override(
+            "custom", "mimo-v2.5", cfg, requested_provider="opencode-go"
+        ) is False
+
+    def test_resolves_through_legacy_custom_providers_list(self):
+        """Parity with ``_supports_vision_override``, which reads this shape."""
+        cfg = {
+            "model": {"provider": "custom"},
+            "custom_providers": [
+                {
+                    "name": "my-relay",
+                    "models": {
+                        "mimo-v2.5": {"supports_vision_tool_messages": False},
+                        "kimi-k2": {"supports_vision": True},
+                    },
+                }
+            ],
+        }
+        assert supports_vision_tool_messages_override(
+            "my-relay", "mimo-v2.5", cfg
+        ) is False
+        assert supports_vision_tool_messages_override(
+            "my-relay", "kimi-k2", cfg
+        ) is None
+
+    def test_no_matching_provider_anywhere_returns_none(self):
+        cfg = _cfg(False)
+        cfg["model"]["provider"] = "unrelated-provider"
+        assert supports_vision_tool_messages_override(
+            "another-unrelated", "mimo-v2.5", cfg
+        ) is None
+
+
+def _agent(model, monkeypatch, overrides):
+    from run_agent import AIAgent
+    import agent.image_routing as ir
+
+    agent = object.__new__(AIAgent)
+    agent.provider = "opencode-go"
+    agent.model = model
+    monkeypatch.setattr(
+        ir,
+        "supports_vision_tool_messages_override",
+        lambda provider, model, cfg=None: overrides.get(model),
+    )
+    return agent
+
+
+def _multimodal_result():
+    return {
+        "_multimodal": True,
+        "text_summary": "Screenshot (image)",
+        "content": [
+            {"type": "text", "text": "Screenshot"},
+            {"type": "image_url", "image_url": {"url": _DATA_URL}},
+        ],
+    }
+
+
+def _has_image(sent):
+    return isinstance(sent, list) and any(
+        isinstance(p, dict) and p.get("type") == "image_url" for p in sent
+    )
+
+
+class TestMethodIntegration:
+    """``_provider_supports_vision_tool_messages`` without stubbing the lookup.
+
+    The end-to-end class below monkeypatches the override helper to isolate the
+    branching in ``_tool_result_content_for_active_model``.  These tests patch
+    only the *config source*, so they also pin that the method passes the real
+    provider/model through and that the provider-profile fallback still decides
+    when no override exists.
+    """
+
+    def _agent_for(self, provider, model):
+        from run_agent import AIAgent
+        agent = object.__new__(AIAgent)
+        agent.provider = provider
+        agent.model = model
+        return agent
+
+    def test_per_model_override_beats_provider_profile(self, monkeypatch):
+        import agent.image_routing as ir
+        monkeypatch.setattr(
+            ir, "load_config_readonly", lambda: _cfg(False), raising=False
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", lambda: _cfg(False)
+        )
+        agent = self._agent_for("opencode-go", "mimo-v2.5")
+        assert agent._provider_supports_vision_tool_messages() is False
+
+    def test_sibling_model_is_not_downgraded_by_the_override(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", lambda: _cfg(False)
+        )
+        agent = self._agent_for("opencode-go", "kimi-k2")
+        assert agent._provider_supports_vision_tool_messages() is True
+
+    def test_provider_profile_still_decides_without_an_override(self, monkeypatch):
+        """Negative control for the fallback path.
+
+        With no per-model key, the answer must come from the provider profile,
+        not from a hardcoded constant.  ``xiaomi`` ships
+        ``supports_vision_tool_messages=False``.
+        """
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config_readonly", lambda: _cfg(None)
+        )
+        strict = self._agent_for("xiaomi", "mimo-v2.5")
+        assert strict._provider_supports_vision_tool_messages() is False
+        permissive = self._agent_for("openai", "gpt-5.4")
+        assert permissive._provider_supports_vision_tool_messages() is True
+
+
+class TestEndToEndToolResultShape:
+    """What actually reaches the wire — the property #89057 is about."""
+
+    def test_scoped_model_gets_text_summary(self, monkeypatch):
+        agent = _agent("mimo-v2.5", monkeypatch, {"mimo-v2.5": False})
+        monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
+        sent = agent._tool_result_content_for_active_model(
+            "vision_analyze", _multimodal_result()
+        )
+        assert not _has_image(sent)
+        # Degradation must land on the text summary, not an empty list or None:
+        # a stripped-but-empty result would also satisfy "no image".
+        assert isinstance(sent, str)
+        assert "Screenshot" in sent
+
+    def test_sibling_model_keeps_native_image(self, monkeypatch):
+        """Control: without an override the image must survive untouched."""
+        agent = _agent("kimi-k2", monkeypatch, {})
+        monkeypatch.setattr(agent, "_model_supports_vision", lambda: True)
+        sent = agent._tool_result_content_for_active_model(
+            "vision_analyze", _multimodal_result()
+        )
+        assert _has_image(sent)
+        # And the parts arrive intact, not a re-wrapped or truncated payload.
+        assert sent == _multimodal_result()["content"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1349,6 +1349,28 @@ model:
 
 The same key is honored on per-named-provider models (`providers.<name>.models.<id>.supports_vision`) and accepts standard YAML booleans (`true/false/yes/no/on/off/1/0`).
 
+**Images in tool results (`supports_vision_tool_messages`).** Vision capability and
+*where* a model accepts an image are two different things. Some models read images in
+`user` messages but reject a content-parts list inside a `role: "tool"` message, which
+is how Hermes returns screenshots from `vision_analyze` / `browser_vision` /
+`computer_use`. A provider profile can declare this with
+`supports_vision_tool_messages=False`, but that flag is provider-wide — too coarse for
+an OpenAI-compatible relay serving several vendors, where only some routes are strict.
+Scope it to the affected model instead:
+
+```yaml
+providers:
+  opencode-go:
+    models:
+      mimo-v2.5:
+        supports_vision: true                  # images in user messages: yes
+        supports_vision_tool_messages: false   # images in tool results: no
+```
+
+Models without the key are unaffected and keep resolving through the provider profile,
+so sibling models on the same provider still receive native screenshots. Same boolean
+tokens as `supports_vision`.
+
 Switch between them mid-session with the triple syntax:
 
 ```


### PR DESCRIPTION
## What does this PR do?

Makes `supports_vision_tool_messages` resolvable **per model**, so the
incompatibility can be scoped to the routes that actually have it instead of to a
whole provider.

`ProviderProfile.supports_vision_tool_messages` (`providers/base.py:73`) is keyed on
the provider. That is exact for a single-vendor provider like `xiaomi`, but too coarse
for an OpenAI-compatible relay serving several vendors: the OpenCode Go catalog carries
MiMo alongside Kimi, GLM, MiniMax, DeepSeek and Qwen (`hermes_cli/models.py`), and only
the MiMo route rejects a content-parts list inside a `role: "tool"` message. Setting the
flag provider-wide therefore fixes MiMo by silently downgrading every other family on
the same relay to text summaries.

That trade-off is exactly the objection raised on #47026:

> `supports_vision_tool_messages` is a static provider-wide field. Setting it on
> `opencode-go` would downgrade multipart tool results for every vision-capable
> OpenCode Go model […] Scope the incompatibility to the OpenCode Go `mimo-*` route
> rather than the entire relay profile, and test both the MiMo downgrade and a
> non-MiMo control case.

This PR provides the scoping mechanism and both test cases. It does **not** set the
flag for any provider or model, so on its own it changes no behavior for anyone: it
only makes the narrow fix expressible.

New resolution order in `_provider_supports_vision_tool_messages`:

1. per-model override from `config.yaml` (new),
2. provider profile field (existing),
3. permissive default (existing).

Only an explicit boolean counts. An absent or unparseable value returns `None` and
falls through, so installations that never set the key behave bit-identically to
before.

## Related Issue

Refs #47742
Refs #89057
Refs #47026

(Deliberately `Refs`, not `Fixes`: this adds the mechanism those reports need, but it
does not by itself mark any provider or model as strict, so none of them is fully
resolved by merging this alone.)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/image_routing.py`: new `supports_vision_tool_messages_override(provider,
  model, cfg=None, *, requested_provider="")`. Reads
  `providers.<provider>.models.<model>.supports_vision_tool_messages` and mirrors
  `_supports_vision_override` deliberately: same provider-candidate order
  (`requested_provider`, runtime provider, config-declared `model.provider`, plus the
  bare name behind `custom:<name>`) and the same legacy list-form `custom_providers`
  fallback. Without that parity the override would silently fail to resolve for named
  custom providers, which are rewritten to `provider="custom"` at runtime, so the two
  capability keys would disagree on identical config. Reuses
  `_coerce_capability_bool`, so a quoted `"false"` cannot read as `True`.
- `run_agent.py`: `_provider_supports_vision_tool_messages` consults the override
  before the provider profile, and falls through unchanged when there is none.
- `website/docs/integrations/providers.md`: documents the key next to
  `supports_vision`, with the distinction that vision capability and *where* an image
  is accepted are two different things.
- `tests/agent/test_per_model_vision_tool_messages.py`: 15 assertions across three
  classes (resolution, the method in integration, and the resulting wire shape).

## How to Test

1. `pytest tests/agent/test_per_model_vision_tool_messages.py -q` → 15 passed.
2. Together with the adjacent suites, unchanged: `pytest
   tests/agent/test_per_model_vision_tool_messages.py tests/agent/test_image_routing.py
   tests/run_agent/test_vision_tool_messages.py
   tests/tools/test_vision_native_fast_path.py
   tests/run_agent/test_vision_aware_preprocessing.py
   tests/agent/test_custom_providers_vision.py -q` → 89 passed.
3. `ruff check agent/image_routing.py run_agent.py tests/agent/test_per_model_vision_tool_messages.py` → All checks passed.

**Fail-on-main check.** With only the new helper added to `agent/image_routing.py` and
the `run_agent.py` call site left untouched, `test_scoped_model_gets_text_summary`
fails on an otherwise clean `main` (the image still reaches the tool result) while the
resolution tests pass. So the end-to-end assertion pins the wiring, not merely the
presence of a function.

**Mutation check.** Each of these fails at least one test: making the call site accept
only `override is True`; dropping the runtime provider from the candidate list;
removing the legacy `custom_providers` branch; replacing `_coerce_capability_bool` with
`bool()`; reversing override/profile precedence; and hardcoding the provider-profile
result. The suite grew from 9 to 15 assertions precisely because the first two of those
initially slipped through.

**Control case (the one requested on #47026).**
`test_non_mimo_siblings_are_untouched` asserts that with `mimo-v2.5` marked strict,
`kimi-k2` and `glm-4.6` on the *same* provider still resolve to `None`, i.e. they keep
receiving native screenshots. A provider-wide flag returns `False` for all three and
fails this test.

Manual reproduction of the scoping, in `config.yaml`:

```yaml
providers:
  opencode-go:
    models:
      mimo-v2.5:
        supports_vision: true
        supports_vision_tool_messages: false
```

`vision_analyze` then returns a text summary on `mimo-v2.5` and a native `image_url`
part on `kimi-k2`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 on WSL2, Python 3.12

On the full-suite box: I ran the vision/image-routing suites listed above (74 + 9
passed) rather than the entire `tests/` tree, because this environment has unrelated
pre-existing failures (Docker/PipeWire voice-mode tests and a browser timeout) that
would make a full run's output misleading. Happy to post a complete run if useful.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] N/A for `cli-config.yaml.example` — the sibling key `supports_vision` is not
      documented there either; both live in `website/docs/integrations/providers.md`,
      which this PR updates.
- [x] N/A for `CONTRIBUTING.md` / `AGENTS.md` — no architecture or workflow change.
- [x] I've considered cross-platform impact — pure config resolution, no OS-specific
      paths or process handling.
- [x] N/A for tool descriptions/schemas — no tool behavior or schema change.

## Notes for reviewers

- **Complementary to #89987, not competing.** That PR makes the existing gates in
  `tools/vision_tools.py` respect an explicit `supports_vision_tool_messages=False`;
  this PR is about the *level* at which the flag can be set. They compose: with both,
  a strict route can be declared per model and every gate honors it.
- The provider-candidate list intentionally includes the config-declared
  `model.provider`, matching `_supports_vision_override`. Without it the override would
  be unreachable for named custom providers, which are rewritten to
  `provider="custom"` at runtime. `test_config_declared_provider_is_also_tried` pins
  this, and `test_no_matching_provider_anywhere_returns_none` bounds it.
- Second observed case of the same class, outside the OpenCode Go relay: a
  Foundry-hosted openai-compat endpoint where `kimi-k2-5` accepts an image in a `user`
  message and rejects the identical image in a `tool` message, while the GPT models on
  the same endpoint accept both. Mentioned only as evidence that the granularity
  problem is not specific to one relay; nothing in this PR targets that provider.
