### PR TITLE
fix: stamp _db_persisted at row load time so resumed transcripts never re-append (#92231)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -104,6 +104,27 @@ COMPACTION_STATUS = (
 COMPACTION_DONE_STATUS = "✓ Context compaction complete — continuing turn..."
 
 
+def _strip_marker_for_comparison(msgs: Any) -> Any:
+    """Copy ``msgs`` with the ``_db_persisted`` persistence marker removed.
+
+    Used by the no-op progress check: live and loaded dicts carry the marker
+    (loaded rows are stamped at materialization time, #92231) while
+    ``compress()`` output is marker-swept, so a raw ``==`` would misclassify a
+    semantically-identical no-op copy as progress. Non-list inputs and
+    non-dict entries pass through unchanged.
+    """
+    from agent.context_compressor import _DB_PERSISTED_MARKER
+
+    if not isinstance(msgs, list):
+        return msgs
+    return [
+        {k: v for k, v in m.items() if k != _DB_PERSISTED_MARKER}
+        if isinstance(m, dict)
+        else m
+        for m in msgs
+    ]
+
+
 def _emit_compaction_done(agent: Any) -> None:
     """Emit the structured terminal edge for a started compaction."""
     status_callback = getattr(agent, "status_callback", None)
@@ -3163,8 +3184,15 @@ def compress_context(
         # Compare against the pre-dispatch semantic state, not object identity:
         # legacy/plugin engines may return an equal copy for a no-op, or mutate
         # the live list while returning an unchanged snapshot. Neither case may
-        # rotate or rewrite the session.
-        if compressed == messages_before_compression:
+        # rotate or rewrite the session. The raw ``==`` leg runs FIRST so a
+        # list subclass returned by an engine keeps its ``__eq__`` semantics
+        # (tests seam on this); the marker-insensitive leg (#92231) then covers
+        # the cold-resume shape where the stamped snapshot differs from the
+        # marker-swept compress() output only by ``_db_persisted``.
+        if compressed == messages_before_compression or (
+            _strip_marker_for_comparison(compressed)
+            == _strip_marker_for_comparison(messages_before_compression)
+        ):
             if messages != messages_before_compression:
                 messages[:] = copy.deepcopy(messages_before_compression)
             logger.info(

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -26,6 +26,7 @@ import logging
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.context_compressor import _DB_PERSISTED_MARKER
 from agent.message_content import flatten_message_text
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import _sanitize_surrogates
@@ -377,7 +378,7 @@ def finalize_turn(
                 # re-writes the filled content to the durable store —
                 # otherwise ``/resume`` reloads ``content=""`` and the bug
                 # resurfaces cross-session.
-                _tail.pop("_db_persisted", None)
+                _tail.pop(_DB_PERSISTED_MARKER, None)
                 # The bounded flush-scan cursor (run_agent.py) skips the
                 # identity-matched prefix of its previous snapshot on the
                 # assumption that no live dict loses the marker in place —

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -776,6 +776,14 @@ def _strip_background_review_harness(
 # Matches a bare protocol/tool-name marker such as "[memory]" or "[skill_manage]".
 _STALE_TOOL_CALL_MARKER_RE = re.compile(r"^\[[A-Za-z_][A-Za-z0-9_.-]*\]$")
 
+# Intrinsic persistence marker stamped on message dicts that are known-durable.
+# MUST stay in sync with run_agent._DB_PERSISTED_MARKER and
+# agent.context_compressor._DB_PERSISTED_MARKER (same literal; defined locally
+# because hermes_state must not import run_agent — circular import — and
+# importing the agent layer for one constant inverts the state/agent layering).
+# Drift is guarded by test_marker_constant_in_sync (#92231).
+_DB_PERSISTED_MARKER_KEY = "_db_persisted"
+
 
 def _is_stale_tool_call_marker_message(msg: Dict[str, Any]) -> bool:
     """True when ``msg`` is a persisted assistant turn whose content is a bare
@@ -11090,6 +11098,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}
+            # Born durable (#92231): this dict is materialized FROM a durable
+            # row, so stamp the persistence marker at the source instead of
+            # relying on every restore caller to thread the loaded list back
+            # through a flush as ``conversation_history=`` — any
+            # identity-losing handoff (compression's durable-snapshot
+            # adoption, incremental persists with no history arg) would
+            # otherwise re-append the ENTIRE transcript on flush.
+            # Underscore-prefixed like ``_row_id``: every transport strips it
+            # before the wire, and compression's assembly copies deliberately
+            # strip it so rotated child handoffs still flush (see
+            # _fresh_compaction_message_copy).
+            msg[_DB_PERSISTED_MARKER_KEY] = True
             # Durable per-message identity for surfaces that need to address a
             # specific row later (desktop reactions). OPT-IN: only the gateway
             # asks for it — every other consumer (ACP restore, export,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -37,6 +37,15 @@ from pathlib import Path
 from agent.memory_manager import sanitize_context
 from agent.session_activity import ActivityProvenance
 from agent.message_sanitization import _sanitize_surrogates
+# Intrinsic persistence marker stamped on message dicts that are known-durable
+# (#92231). One shared constant with agent.context_compressor (this module
+# already imports agent.* at module level, and context_compressor is a
+# transitive dependency via hermes_state_common). run_agent keeps its own
+# predating copy — hermes_state cannot import run_agent (circular) — guarded
+# by test_marker_constant_in_sync.
+from agent.context_compressor import (
+    _DB_PERSISTED_MARKER as _DB_PERSISTED_MARKER_KEY,
+)
 from agent.skill_commands import (
     SKILL_EXCERPT_JOINT,
     SKILL_SCAFFOLD_SQL_LIKE,
@@ -775,14 +784,6 @@ def _strip_background_review_harness(
 
 # Matches a bare protocol/tool-name marker such as "[memory]" or "[skill_manage]".
 _STALE_TOOL_CALL_MARKER_RE = re.compile(r"^\[[A-Za-z_][A-Za-z0-9_.-]*\]$")
-
-# Intrinsic persistence marker stamped on message dicts that are known-durable.
-# MUST stay in sync with run_agent._DB_PERSISTED_MARKER and
-# agent.context_compressor._DB_PERSISTED_MARKER (same literal; defined locally
-# because hermes_state must not import run_agent — circular import — and
-# importing the agent layer for one constant inverts the state/agent layering).
-# Drift is guarded by test_marker_constant_in_sync (#92231).
-_DB_PERSISTED_MARKER_KEY = "_db_persisted"
 
 
 def _is_stale_tool_call_marker_message(msg: Dict[str, Any]) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -276,6 +276,15 @@ _MAX_TOOL_WORKERS = 8
 # (agent/transports/chat_completions.py, agent/chat_completion_helpers.py) strip
 # every top-level ``_``-prefixed key before the request leaves the process, so
 # this never reaches a strict OpenAI-compatible gateway.
+#
+# CONTRACT (#92231): the marker asserts "this dict's CONTENT is durable as
+# written". Loaded rows are stamped at materialization time
+# (hermes_state._rows_to_conversation), so any code that mutates a loaded or
+# flushed dict's content in place and needs the change persisted MUST pop the
+# marker (and invalidate _db_flush_scan_prefix if the dict may sit inside the
+# bounded-scan prefix) — see agent/turn_finalizer.py (fill-empty-tail) and
+# agent/context_compressor.py (micro-compaction defrag) for the two canonical
+# pop sites. Mutating without popping leaves the DB silently stale.
 _DB_PERSISTED_MARKER = "_db_persisted"
 
 

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -326,6 +326,9 @@ class TestPersistence:
         assert restored is not None
         msg = restored.history[0]
         assert isinstance(msg.pop("timestamp", None), (int, float))
+        # Load-time durability stamp (#92231): rows materialized from the DB
+        # are marked persisted so a later flush can't re-append them.
+        assert msg.pop("_db_persisted", None) is True
         assert restored.history == [{
             "role": "assistant",
             "content": "hello",

--- a/tests/agent/test_load_time_durability_stamp_92231.py
+++ b/tests/agent/test_load_time_durability_stamp_92231.py
@@ -58,12 +58,25 @@ def _seed_session(db: SessionDB, sid: str, turns: int = 3) -> None:
 
 
 def test_marker_constant_in_sync() -> None:
-    """hermes_state cannot import run_agent (circular) — literals must match."""
+    """One shared literal across every module that touches the marker.
+
+    ``hermes_state`` and ``agent.turn_finalizer`` import the constant from
+    ``agent.context_compressor`` (single source), so the only genuine drift
+    surface left is ``run_agent``'s predating copy — hermes_state cannot
+    import run_agent (circular), and run_agent's own literal predates the
+    consolidation.
+    """
     import agent.context_compressor as cc
+    import agent.turn_finalizer as tf
     import run_agent
 
     assert _DB_PERSISTED_MARKER_KEY == run_agent._DB_PERSISTED_MARKER
     assert _DB_PERSISTED_MARKER_KEY == cc._DB_PERSISTED_MARKER
+    assert _DB_PERSISTED_MARKER_KEY == tf._DB_PERSISTED_MARKER
+    # The import aliases must be the SAME object as the canonical constant,
+    # not re-defined literals.
+    assert _DB_PERSISTED_MARKER_KEY is cc._DB_PERSISTED_MARKER
+    assert tf._DB_PERSISTED_MARKER is cc._DB_PERSISTED_MARKER
 
 
 def test_loaded_rows_are_stamped_durable(tmp_path: Path) -> None:
@@ -145,3 +158,40 @@ def test_compaction_copy_strips_stamp_so_child_flush_writes(tmp_path: Path) -> N
     # Idempotent thereafter: the flush stamped the copies on write.
     agent._flush_messages_to_session_db(compacted)
     assert len(db.get_messages("CHILD")) == len(loaded)
+
+
+def test_noop_progress_check_is_marker_insensitive(tmp_path: Path) -> None:
+    """A marker-swept no-op copy must still compare equal to stamped input.
+
+    The commit layer's "no progress" check compares compress() output against
+    a pre-dispatch deepcopy of the live messages. Load-stamping (#92231) puts
+    ``_db_persisted`` on cold-resumed dicts while compress() output is
+    marker-swept — a raw ``==`` would misclassify the semantically-identical
+    no-op as progress and rotate the session for nothing.
+    """
+    from agent.conversation_compression import _strip_marker_for_comparison
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_session(db, "NOOP", turns=2)
+
+    stamped = db.get_messages_as_conversation("NOOP")
+    assert all(m.get(_DB_PERSISTED_MARKER_KEY) is True for m in stamped)
+    # What a no-op engine hands back after the terminal marker sweep.
+    swept = [
+        {k: v for k, v in m.items() if k != _DB_PERSISTED_MARKER_KEY}
+        for m in stamped
+    ]
+    assert swept != stamped  # raw equality is asymmetric — the bug shape
+    assert _strip_marker_for_comparison(swept) == _strip_marker_for_comparison(
+        stamped
+    )
+
+    # Genuine progress must still register as inequality.
+    compacted = swept[:-1]
+    assert _strip_marker_for_comparison(compacted) != _strip_marker_for_comparison(
+        stamped
+    )
+
+    # Defensive passthrough shapes.
+    assert _strip_marker_for_comparison(None) is None
+    assert _strip_marker_for_comparison(["not-a-dict"]) == ["not-a-dict"]

--- a/tests/agent/test_load_time_durability_stamp_92231.py
+++ b/tests/agent/test_load_time_durability_stamp_92231.py
@@ -1,0 +1,147 @@
+"""Regression (#92231): resumed transcripts must not re-append to state.db.
+
+Root cause: ``get_messages_as_conversation`` / ``get_resume_conversations``
+returned plain dicts WITHOUT ``_DB_PERSISTED_MARKER``. Any flush that received
+that loaded history without a matching ``conversation_history=`` identity
+boundary (compression durable-snapshot adoption, incremental tool-call
+persists, rotation preflight on cold resume) treated every loaded row as new
+and re-appended the ENTIRE transcript. Compression cycles then doubled the
+copies: the incident session grew 998 → 1995 → 3990 → 7981 rows across three
+aborted rotations (15,962 active rows / 472 distinct contents).
+
+Fix: rows are stamped durable at materialization time in
+``SessionDB._rows_to_conversation`` — a dict built FROM a durable row is
+persisted by construction, no matter which caller loads it or how it is later
+handed to a flush.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_state import SessionDB, _DB_PERSISTED_MARKER_KEY
+from run_agent import AIAgent
+
+
+def _make_flush_agent(db: SessionDB, session_id: str):
+    """Minimal agent shell that owns the real flush implementation."""
+    agent = SimpleNamespace(
+        _session_db=db,
+        _session_db_created=True,
+        _persist_disabled=False,
+        session_id=session_id,
+        _session_persist_lock=None,
+        _flushed_db_message_ids=set(),
+        _flushed_db_message_session_id=None,
+        _last_flushed_db_idx=0,
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _pending_cli_user_message=None,
+    )
+    agent._ensure_db_session = lambda: None
+    agent._flush_messages_to_session_db = (
+        AIAgent._flush_messages_to_session_db.__get__(agent, AIAgent)
+    )
+    agent._flush_messages_to_session_db_unlocked = (
+        AIAgent._flush_messages_to_session_db_unlocked.__get__(agent, AIAgent)
+    )
+    return agent
+
+
+def _seed_session(db: SessionDB, sid: str, turns: int = 3) -> None:
+    db.create_session(sid, source="cli")
+    for i in range(turns):
+        db.append_message(sid, "user", f"question {i}")
+        db.append_message(sid, "assistant", f"answer {i}")
+
+
+def test_marker_constant_in_sync() -> None:
+    """hermes_state cannot import run_agent (circular) — literals must match."""
+    import agent.context_compressor as cc
+    import run_agent
+
+    assert _DB_PERSISTED_MARKER_KEY == run_agent._DB_PERSISTED_MARKER
+    assert _DB_PERSISTED_MARKER_KEY == cc._DB_PERSISTED_MARKER
+
+
+def test_loaded_rows_are_stamped_durable(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_session(db, "S1")
+
+    loaded = db.get_messages_as_conversation("S1")
+    assert loaded
+    assert all(m.get(_DB_PERSISTED_MARKER_KEY) is True for m in loaded)
+
+    model_history, display_history = db.get_resume_conversations("S1")
+    assert model_history and display_history
+    assert all(m.get(_DB_PERSISTED_MARKER_KEY) is True for m in model_history)
+    assert all(m.get(_DB_PERSISTED_MARKER_KEY) is True for m in display_history)
+
+
+def test_repeated_identityless_flushes_do_not_amplify(tmp_path: Path) -> None:
+    """The #92231 shape: reload + flush cycles must keep the row count flat.
+
+    Each cycle simulates what compression's durable-snapshot adoption (or any
+    identity-losing handoff) used to do: load the transcript fresh from the DB
+    and flush it with NO ``conversation_history`` boundary. Pre-fix each cycle
+    doubled the row count (998 → 1995 → 3990 → 7981 in the incident session).
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_session(db, "S2", turns=4)
+    baseline = len(db.get_messages("S2"))
+
+    for _ in range(3):
+        loaded = db.get_messages_as_conversation("S2")
+        agent = _make_flush_agent(db, "S2")  # fresh agent: no identity state
+        agent._flush_messages_to_session_db(loaded)
+
+    assert len(db.get_messages("S2")) == baseline
+
+
+def test_new_tail_after_loaded_history_still_flushes(tmp_path: Path) -> None:
+    """Guard against over-skipping: only loaded rows are exempt, new turns write."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_session(db, "S3", turns=1)
+
+    loaded = db.get_messages_as_conversation("S3")
+    live = [
+        *loaded,
+        {"role": "user", "content": "new question"},
+        {"role": "assistant", "content": "new answer"},
+    ]
+    agent = _make_flush_agent(db, "S3")
+    agent._flush_messages_to_session_db(live)
+
+    contents = [m.get("content") for m in db.get_messages("S3")]
+    assert contents == ["question 0", "answer 0", "new question", "new answer"]
+
+
+def test_compaction_copy_strips_stamp_so_child_flush_writes(tmp_path: Path) -> None:
+    """Rotation handoff: compression copies must stay flushable to the child.
+
+    ``_fresh_compaction_message_copy`` / ``_strip_persistence_markers`` remove
+    the marker from assembled compaction output so the rotation flush WRITES
+    the compacted transcript to the child session (#57491). Load-stamping must
+    not defeat that: a loaded row that goes through the compaction copy is
+    written to the child exactly once.
+    """
+    from agent.context_compressor import _fresh_compaction_message_copy
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    _seed_session(db, "PARENT", turns=2)
+    db.create_session("CHILD", source="cli", parent_session_id="PARENT")
+
+    loaded = db.get_messages_as_conversation("PARENT")
+    compacted = [_fresh_compaction_message_copy(m) for m in loaded]
+    assert all(_DB_PERSISTED_MARKER_KEY not in m for m in compacted)
+
+    agent = _make_flush_agent(db, "CHILD")
+    agent._flush_messages_to_session_db(compacted)
+    child_rows = db.get_messages("CHILD")
+    assert len(child_rows) == len(loaded)
+
+    # Idempotent thereafter: the flush stamped the copies on write.
+    agent._flush_messages_to_session_db(compacted)
+    assert len(db.get_messages("CHILD")) == len(loaded)

--- a/tests/agent/test_load_time_durability_stamp_92231.py
+++ b/tests/agent/test_load_time_durability_stamp_92231.py
@@ -73,10 +73,6 @@ def test_marker_constant_in_sync() -> None:
     assert _DB_PERSISTED_MARKER_KEY == run_agent._DB_PERSISTED_MARKER
     assert _DB_PERSISTED_MARKER_KEY == cc._DB_PERSISTED_MARKER
     assert _DB_PERSISTED_MARKER_KEY == tf._DB_PERSISTED_MARKER
-    # The import aliases must be the SAME object as the canonical constant,
-    # not re-defined literals.
-    assert _DB_PERSISTED_MARKER_KEY is cc._DB_PERSISTED_MARKER
-    assert tf._DB_PERSISTED_MARKER is cc._DB_PERSISTED_MARKER
 
 
 def test_loaded_rows_are_stamped_durable(tmp_path: Path) -> None:
@@ -181,7 +177,7 @@ def test_noop_progress_check_is_marker_insensitive(tmp_path: Path) -> None:
         {k: v for k, v in m.items() if k != _DB_PERSISTED_MARKER_KEY}
         for m in stamped
     ]
-    assert swept != stamped  # raw equality is asymmetric — the bug shape
+    assert swept != stamped  # raw == is marker-sensitive — the bug shape
     assert _strip_marker_for_comparison(swept) == _strip_marker_for_comparison(
         stamped
     )

--- a/tests/agent/test_session_rotation_flush_cold_resume_68454.py
+++ b/tests/agent/test_session_rotation_flush_cold_resume_68454.py
@@ -50,8 +50,15 @@ def _contents(rows):
     return [r.get("content") for r in rows]
 
 
-def test_rotation_flush_without_history_boundary_duplicates(tmp_path: Path) -> None:
-    """Control: bare flush of unstamped cold-resume rows double-writes (#68454)."""
+def test_rotation_flush_without_history_boundary_is_safe(tmp_path: Path) -> None:
+    """Bare flush of cold-resumed rows must NOT double-write (#68454 → #92231).
+
+    Historically this was a control test asserting the double-write: loaded
+    rows carried no ``_DB_PERSISTED_MARKER``, so a flush without
+    ``conversation_history=`` re-appended the whole transcript. Since #92231
+    the loaders stamp the marker at row-materialization time, so even the
+    "wrong" call shape (no history boundary) is idempotent.
+    """
     db = SessionDB(db_path=tmp_path / "state.db")
     sid = "COLD_ROTATE_DUP"
     db.create_session(sid, source="cli")
@@ -63,7 +70,7 @@ def test_rotation_flush_without_history_boundary_duplicates(tmp_path: Path) -> N
     agent._flush_messages_to_session_db(loaded)  # missing conversation_history=
 
     rows = db.get_messages_as_conversation(sid, include_inactive=True)
-    assert _contents(rows).count("persisted question") == 2
+    assert _contents(rows) == ["persisted question", "persisted answer"]
 
 
 def test_rotation_flush_with_history_boundary_is_noop(tmp_path: Path) -> None:

--- a/tests/test_message_reactions.py
+++ b/tests/test_message_reactions.py
@@ -164,12 +164,20 @@ def test_row_id_is_opt_in_and_never_reaches_the_provider(session, db):
     """Only include_row_ids=True consumers see _row_id — and it's underscore-
     prefixed so transports strip it before the wire even for them. Default
     consumers (ACP restore, export) get the transcript in its historical shape.
+
+    ``_db_persisted`` is the other sanctioned underscore key: stamped on every
+    loaded row (#92231) so a flush can never re-append a resumed transcript.
+    Like ``_row_id`` it is stripped before the wire by every transport.
     """
     key, _rows = session
 
     for message in db.get_messages_as_conversation(key):
         assert "_row_id" not in message
+        assert message.get("_db_persisted") is True
 
     for message in db.get_messages_as_conversation(key, include_row_ids=True):
         assert "_row_id" in message
-        assert all(not k.startswith("_") or k == "_row_id" for k in message)
+        assert all(
+            not k.startswith("_") or k in {"_row_id", "_db_persisted"}
+            for k in message
+        )


### PR DESCRIPTION
## Summary

Resumed sessions no longer re-append their entire loaded transcript to state.db — message dicts are stamped `_db_persisted` at row load time, closing the row-amplification bug class behind #92231 (one incident session reached 15,962 active rows with only 472 distinct contents, doubling per compression cycle: 998 → 1,995 → 3,990 → 7,981).

**Root cause:** `SessionDB.get_messages_as_conversation` / `get_resume_conversations` returned plain dicts WITHOUT `_DB_PERSISTED_MARKER`. The flush dedup in `_flush_messages_to_session_db` only knew loaded rows were durable when the caller threaded the exact same list object through as `conversation_history=` (identity match). Every identity-losing handoff — compression's durable-snapshot adoption (which re-loads a fresh list), incremental tool-call persists that pass no history, rotation preflight on a cold resume — treated the whole loaded transcript as new and re-inserted it. Aborted rotations then compounded the copies.

**Fix (architectural, one chokepoint):** stamp the marker in `SessionDB._rows_to_conversation`, the shared row→dict conversion behind both loaders. A dict materialized FROM a durable row is durable by construction — no caller needs to know about identity boundaries anymore. This is the same pattern as the existing `_row_id` stamp in the same function.

## Changes

- `hermes_state.py`: define `_DB_PERSISTED_MARKER_KEY` (local literal — importing `run_agent` would be circular) and stamp it per row in `_rows_to_conversation`.
- `tests/agent/test_load_time_durability_stamp_92231.py` (new): marker-literal sync guard across the three defining modules, load-stamp assertions for both loaders, 3-cycle identity-lost flush amplification repro, new-tail-still-writes guard, compaction-copy child-handoff guard.
- `tests/agent/test_session_rotation_flush_cold_resume_68454.py`: the control test asserting the old double-write is now asserting idempotence (the "wrong" call shape is now safe).
- `tests/acp/test_session.py`: restore-shape test pops the new marker like it already pops `timestamp`.
- `tests/test_message_reactions.py`: the underscore-key allow-list test now sanctions `_db_persisted` alongside `_row_id` (same transport-strip contract).

## Why this is safe

- **Wire safety:** every transport strips underscore-prefixed keys before the API request (`chat_completion_helpers.py` `_clean_message_for_api`, `anthropic_adapter.py` key filter) — same contract `_row_id` relies on today.
- **Rotation handoffs still write:** compression's assembly copies strip the marker (`_fresh_compaction_message_copy` + the terminal `_strip_persistence_markers` sweep in `compress()`), so compacted transcripts still flush to the child session — the #57491 invariant is preserved and covered by a new test.
- **Branch/seed copies unaffected:** `/branch` and the TUI `_persist_branch_seed` build fresh field-projected dicts and write via `append_messages_batch` directly — they never pass loaded dicts through the marker-gated flush.
- **turn_finalizer's marker pop** (fill-empty-tail rewrite) still works: it operates on the live dict and invalidates the flush scan cursor, unchanged.
- **Staged CLI input:** `_pending_cli_user_message` is always a freshly constructed dict, never a loaded one — its `_db_persisted` gates keep their semantics.

## Validation

| Check | Result |
|---|---|
| New regression suite (5 tests) | pass |
| 3-agent Phase 2c review (reuse/quality/invariants) | 1 must-fix found+fixed (reactions allow-list test); wire-strip verified on all 3 transports; repair-merge interaction verified pre-existing-safe |
| tests/agent/ + tests/test_hermes_state.py (5,379 tests) | failure set byte-identical to origin/main baseline (189 pre-existing env failures, 0 new) |
| Targeted: rotation-boundary #68196, concurrent fork, ACP, reactions, hermes_state (320 tests) | pass |
| E2E (real AIAgent + real SQLite, temp HERMES_HOME): 3 identity-lost reload+flush cycles | rows stayed 12 → [12, 12, 12]; genuine new tail still writes (→14); re-flush idempotent (14) |
| ruff on changed files | clean |

Fixes #92231


## Review-pass follow-up (commit 2)

Full `/hermes-pr-review` Phase 2 (2a/2b/2c) + `/simplify-code` ran on the final diff; three verified findings folded as a follow-up commit:

- **Literal consolidation:** `hermes_state.py` now imports `_DB_PERSISTED_MARKER` from `agent.context_compressor` (the "can't import agent layer" premise was wrong — hermes_state already imports `agent.*` at module level; only `run_agent` is circular). `agent/turn_finalizer.py`'s raw `"_db_persisted"` string (previously outside the drift guard) now uses the shared constant. `test_marker_constant_in_sync` extended with identity assertions + the turn_finalizer surface.
- **Marker-insensitive no-op check:** with load-stamping, a cold-resumed stamped snapshot vs a marker-swept `compress()` no-op copy would compare unequal under raw `==` and misclassify "no progress" as progress. The commit-layer check now falls back to `_strip_marker_for_comparison` on both sides; raw `==` still runs first so engine-returned list subclasses keep their `__eq__` semantics. New regression test, mutation-checked.

Follow-up validation: 334 targeted tests green (PR suites + hermes_state + turn_finalizer + micro-compaction); compression/compaction/finalizer sweep 269/269; both mutation checks fail-on-mutation/green-on-restore; ruff clean.


## Second review round (commits 3-4)

Distinct 3-parallel-reviewer /simplify-code pass on the full final diff + reviewer-comment triage:

- `docs:` the mutate-then-persist contract (in-place content mutation of a stamped dict ⇒ pop marker + invalidate flush-scan prefix) is now stated on `_DB_PERSISTED_MARKER` itself, addressing the review comment's silent-staleness concern. Both existing mutators already comply.
- `test:` dropped two vacuous `is` identity assertions from the sync guard (CPython interns identifier-like literals, so `is` cannot detect a copy-pasted literal — verified empirically); the `==` assertions are the full honest guard.
- Efficiency reviewer verified the two-leg no-op comparison is immaterial (runs once per compression attempt, adjacent to a multi-second summarization LLM call); reuse reviewer: no material findings; function-local `_DB_PERSISTED_MARKER` import verified cycle-required (context_compressor transitively loads conversation_compression).

Competing PRs #92269 and #92272 closed with credit — both scoped narrower than the chokepoint stamp (live-replay-only marking; per-call-site baseline threading).


## Infographic

![92231-load-time-durability-stamp](https://v3b.fal.media/files/b/0aa77763/M1ECobtTKip_O3Y50BR_4_sB7TMNvd.png)
