### PR TITLE
fix(desktop): stop calling setBackgroundMaterial on the Windows HUD path (#91459)

### DIFF
--- a/apps/desktop/electron/hud-ipc.test.ts
+++ b/apps/desktop/electron/hud-ipc.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Contract guard for the HUD frost path.
+ *
+ * The HUD window is created `transparent: true`, and on Windows Electron's
+ * `setBackgroundMaterial` is a one-way door: issuing 'none' flips the backing
+ * to an opaque state with no way back, so any material hand-off leaves the HUD
+ * as a persistent opaque slab over the whole window (issue #91459). The HUD
+ * therefore NEVER calls setBackgroundMaterial, on any platform and in any
+ * translucency/band state — it is CSS-only, exactly as it was before glass
+ * landed for the chat windows.
+ *
+ * This is a behavior contract, not a snapshot: it drives the real
+ * `registerHudIpc` and asserts the material method is never invoked, in any
+ * state. A future change that reintroduces the call fails here immediately.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GlassMaterial, TranslucencyState } from '../../shared/src/translucency'
+
+import { registerHudIpc } from './hud-ipc'
+
+const electronMock = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: any[]) => unknown>()
+  const listeners = new Map<string, (...args: any[]) => void>()
+
+  return {
+    BrowserWindow: class {},
+    ipcMain: {
+      handle: (channel: string, fn: (...args: any[]) => unknown) => {
+        handlers.set(channel, fn)
+      },
+      on: (channel: string, fn: (...args: any[]) => void) => {
+        listeners.set(channel, fn)
+      },
+      handlers,
+      listeners
+    }
+  }
+})
+
+vi.mock('electron', () => ({
+  BrowserWindow: electronMock.BrowserWindow,
+  ipcMain: electronMock.ipcMain
+}))
+
+// The native material methods the frost path could reach. setBackgroundMaterial
+// is deliberately present so the contract assertion is meaningful — a
+// reintroduced call would land on a real spy and fail the "never called" check.
+function makeFakeHudWindow() {
+  return {
+    isDestroyed: () => false,
+    setVibrancy: vi.fn(),
+    setBackgroundMaterial: vi.fn(),
+    setIgnoreMouseEvents: vi.fn(),
+    getPosition: () => [0, 0],
+    setBounds: vi.fn(),
+    getSize: () => [400, 200],
+    isResizable: () => false,
+    setResizable: vi.fn(),
+    webContents: { on: vi.fn(), send: vi.fn() }
+  }
+}
+
+function glassState(intensity: number, material: GlassMaterial): TranslucencyState {
+  return { intensity, fade: 0, mode: 'glass', material, scope: 'window' }
+}
+
+function clearState(intensity: number): TranslucencyState {
+  return { intensity, fade: 0, mode: 'clear', material: 'under-window', scope: 'window' }
+}
+
+beforeEach(() => {
+  electronMock.ipcMain.handlers.clear()
+  electronMock.ipcMain.listeners.clear()
+})
+
+describe('HUD frost (issue #91459)', () => {
+  it('never calls setBackgroundMaterial on the HUD window in any state', () => {
+    const hudWindow = makeFakeHudWindow()
+
+    const states: TranslucencyState[] = [
+      clearState(0),
+      clearState(60),
+      clearState(100),
+      glassState(0, 'header'),
+      glassState(60, 'header'),
+      glassState(60, 'under-window'),
+      glassState(100, 'titlebar')
+    ]
+
+    let stateIndex = 0
+
+    const { applyHudFrost } = registerHudIpc({
+      isMac: true,
+      getTranslucencyState: () => states[stateIndex],
+      getHudWindow: () => hudWindow as never,
+      openHudWindow: vi.fn(),
+      closeHudWindow: vi.fn(),
+      setHudSessionId: vi.fn()
+    })
+
+    // Drive both halves of the frost decision through the real IPC surface:
+    // the band report (latches `bandShowing`) and the frost re-apply.
+    const frostHandler = electronMock.ipcMain.handlers.get('hermes:hud:frost')!
+
+    for (const bandShowing of [false, true]) {
+      frostHandler({} as never, bandShowing)
+
+      for (let i = 0; i < states.length; i += 1) {
+        stateIndex = i
+        applyHudFrost()
+      }
+    }
+
+    // The Windows material door must never open for the transparent HUD.
+    expect(hudWindow.setBackgroundMaterial).not.toHaveBeenCalled()
+  })
+
+  it('still frosts via vibrancy on macOS while the band is showing', () => {
+    const hudWindow = makeFakeHudWindow()
+
+    const { applyHudFrost } = registerHudIpc({
+      isMac: true,
+      getTranslucencyState: () => glassState(60, 'header'),
+      getHudWindow: () => hudWindow as never,
+      openHudWindow: vi.fn(),
+      closeHudWindow: vi.fn(),
+      setHudSessionId: vi.fn()
+    })
+
+    // Latch the band as showing (the renderer's report), then re-apply frost.
+    electronMock.ipcMain.handlers.get('hermes:hud:frost')!({} as never, true)
+    applyHudFrost()
+
+    expect(hudWindow.setVibrancy).toHaveBeenCalledWith('header')
+    expect(hudWindow.setBackgroundMaterial).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/electron/hud-ipc.ts
+++ b/apps/desktop/electron/hud-ipc.ts
@@ -8,8 +8,6 @@ import { hudFrostFor, type TranslucencyState } from './translucency'
 
 export interface HudIpcDeps {
   isMac: boolean
-  isWindows: boolean
-  glassSupported: boolean
   /** Main's authoritative translucency state (Settings → Appearance). */
   getTranslucencyState: () => TranslucencyState
   getHudWindow: () => BrowserWindow | null
@@ -20,8 +18,6 @@ export interface HudIpcDeps {
 
 export function registerHudIpc({
   isMac,
-  isWindows,
-  glassSupported,
   getTranslucencyState,
   getHudWindow,
   openHudWindow,
@@ -76,10 +72,14 @@ export function registerHudIpc({
     if (isMac && typeof hudWindow.setVibrancy === 'function') {
       hudWindow.setVibrancy(frost.vibrancy)
     }
-
-    if (isWindows && glassSupported && typeof hudWindow.setBackgroundMaterial === 'function') {
-      hudWindow.setBackgroundMaterial(frost.backgroundMaterial)
-    }
+    // Windows HUD deliberately never calls setBackgroundMaterial. On a
+    // `transparent: true` window Electron's setBackgroundMaterial is a
+    // one-way door: issuing 'none' flips the backing to an opaque state and
+    // there is no way back to transparency, so any frost hand-off leaves the
+    // HUD as a persistent opaque slab over the whole window (see
+    // electron/electron#49443 and electron/electron#48421, plus the DWM
+    // full-rectangle material behaviour). The HUD therefore stays CSS-only on
+    // Windows, exactly as it was before glass landed for the chat windows.
   }
 
   ipcMain.handle('hermes:hud:open', async (_event, request) => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12453,8 +12453,6 @@ registerPetOverlayIpc({
 // --- HUD mode (chrome-free floating chat) — see hud-ipc.ts. ---------------
 const hudIpc = registerHudIpc({
   isMac: IS_MAC,
-  isWindows: IS_WINDOWS,
-  glassSupported: GLASS_SUPPORTED,
   getTranslucencyState: () => translucencyState,
   getHudWindow: () => hudWindow,
   openHudWindow,

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2736,19 +2736,6 @@ button[data-slot='aui_msg-reactions'] svg {
   background: color-mix(in srgb, var(--ui-bg-chrome) var(--translucency-glass-keep, 100%), transparent);
 }
 
-/* The band spans the window edge to edge under glass. The 8px side inset keeps
-   the sheet clear of the bar's corner controls when it is an opaque panel —
-   but the frost is the WINDOW, so an inset sheet leaves a hairline of bare
-   untinted material down both sides. Nothing to hold off the material's edge:
-   the window's own rounded corners are where the band ends. */
-:root[data-hermes-glass-on] [data-hud-shell] {
-  --hud-band-inset: 0px;
-}
-
-:root[data-hermes-glass-on] [data-hud-shell] [data-hud-glass] {
-  border-radius: 0.75rem 0.75rem 0 0;
-}
-
 /* Engaged, the field steps up the same way the docked thread's does — but
    never below the resting tint, so a high lever cannot make focusing the
    composer paint MORE transparent than glancing at it. */


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows HUD-mode bug where a persistent opaque backdrop covered
the whole HUD window, independent of the Glass setting, theme, or window
size (#91459).

**Root cause.** The HUD window is created `transparent: true`, and
`applyHudFrost` called `setBackgroundMaterial()` on it. On Windows,
Electron's `setBackgroundMaterial` is a one-way door — issuing `'none'`
flips the backing to an opaque state with no way back
(electron/electron#49443, electron/electron#48421), and the DWM backdrop is clipped to the
window's full bounds (`DWMWA_SYSTEMBACKDROP_TYPE` takes only an HWND +
enum, no region/mask). There is no way to frost just the HUD band, so the
material always covers the whole rectangle and leaves the window looking
like a solid slab.

This PR stops calling `setBackgroundMaterial` on the Windows HUD path
entirely, returning to the pre-regression (`7f9e79b2e1`) CSS-only behavior.
The HUD stays CSS-only on Windows: native frost is not viable for a
transparent, non-rectangular window on this platform.

## Related Issue

Fixes #91459

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/hud-ipc.ts`: drop the `isWindows`/`glassSupported`
  deps; never call `setBackgroundMaterial` on the HUD window (WHY comment
  references electron/electron#49443, electron/electron#48421).
- `apps/desktop/electron/main.ts`: remove the two now-unused deps from the
  `registerHudIpc` call site.
- `apps/desktop/src/styles.css`: delete the two glass-on HUD rules. The
  `border-radius` rule was a no-op duplicating the base value; removing the
  `--hud-band-inset: 0px` override returns the HUD to the original 8px side
  inset — keeping the sheet off the bar's corner controls on Windows (where
  the HUD is now pure CSS), and restoring the pre-glass macOS look with
  native vibrancy.
- `apps/desktop/electron/hud-ipc.test.ts` (new): contract test asserting
  `setBackgroundMaterial` is never called on the HUD window across glass /
  band states; the macOS `setVibrancy` path is still verified.

## How to Test

1. On Windows 11, open HUD mode. Verify the window shows the CSS-only band
   and NOT an opaque backdrop, regardless of the Glass setting.
2. `npx tsc -p tsconfig.electron.json --noEmit`
3. `npx eslint electron/hud-ipc.ts electron/hud-ipc.test.ts`
4. `npx vitest run --project electron` (113 files / 1592 tests pass)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional commit; only fix-related changes
- [x] Searched for existing PRs / issue duplication
- [x] Tests added (required for bug fix)
- [x] Tested on Windows 11 (build 26200.9168) — HUD shows correct CSS-only
  backdrop; macOS path unchanged

### Notes

- The surviving `setBackgroundMaterial` in `main.ts` is the chat-window
  (opaque) path — intentionally untouched; this fix is scoped to the
  transparent HUD window only.
- The removed CSS rules applied to macOS too; HUD there now keeps the band
  inset consistently — part of the intended "HUD is CSS-only" behavior.

