### PR TITLE
fix(desktop): clarify tool — buttons render when args carry choices without a gateway request

### DIFF
--- a/apps/desktop/e2e/chat.spec.ts
+++ b/apps/desktop/e2e/chat.spec.ts
@@ -101,6 +101,19 @@ test.describe('chat interaction with mock backend', () => {
     await page.keyboard.press('Enter')
     await page.getByText(BLOCKING_CLARIFY_QUESTION).waitFor({ state: 'visible', timeout: 30_000 })
 
+    // Regression: the BLOCKING_CLARIFY_TURN streams a tool.start with
+    // `choices: ['Yes', 'No']` but the mock gateway never sends a separate
+    // `clarify.request`. Before the renderer fix, that mismatch made
+    // matchingRequest drop to null and the card fell through to a
+    // textarea-only fallback. The buttons must still render from the
+    // tool args, with the keyboard-cursor focus on the first option.
+    await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'No' })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Yes|No/ }).first()).toHaveAttribute(
+      'aria-current',
+      'true'
+    )
+
     await expect(primary).toHaveAttribute('aria-label', 'Stop')
     await expect(primary.locator('span')).toHaveClass(/bg-current/)
 

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -449,6 +449,118 @@ describe('ClarifyTool pending marker', () => {
   })
 })
 
+describe('ClarifyTool hydration-race fallback', () => {
+  // Regression: when the gateway's clarify request carries a question that
+  // disagrees with the tool arg question on whitespace or casing (or simply
+  // hasn't arrived yet), matchingRequest dropped to null and fromArgs.choices
+  // was ignored, so the card rendered a textarea-only fallback instead of the
+  // choice buttons.
+
+  it('still renders choice buttons when args.choices has values even if no matching gateway request is wired', () => {
+    // No setClarifyRequest() — simulates the moment between tool.start and
+    // clarify.request when matchingRequest would have been null AND fromArgs
+    // already carries choices.
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
+
+    const args = { choices: ['staging', 'production'], question: 'Which target?' }
+    renderClarify(
+      <ClarifyTool
+        addResult={vi.fn()}
+        args={args}
+        argsText={JSON.stringify(args)}
+        isError={false}
+        respondToApproval={vi.fn()}
+        result={undefined}
+        resume={vi.fn()}
+        status={{ type: 'running' }}
+        toolCallId="clarify-args-only"
+        toolName="clarify"
+        type="tool-call"
+      />
+    )
+
+    // Both choice buttons are on screen — not a textarea-only fallback.
+    expect(screen.getByRole('button', { name: /staging/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /production/ })).toBeTruthy()
+    // The textarea-only fallback would have shown a single bare textarea.
+    // The choices layout shows the same textarea as the "Other" row, so just
+    // assert the choices marker is present.
+    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+  })
+
+  it('treats a gateway question that only differs on casing as the same question', () => {
+    // Gateway request carries a lowercased version of the question. Before
+    // the fix, the strict `fromArgs.question !== request.question` compare
+    // dropped matchingRequest to null and the card lost its recommended
+    // labels from the gateway. Now we compare via normalize() so they match.
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
+    setClarifyRequest({
+      choices: ['staging (Recommended)', 'production'],
+      multiSelect: false,
+      question: 'which deployment target?  ',
+      requestId: 'request-casing',
+      sessionId: 'session-1'
+    })
+
+    const args = { question: 'Which deployment target?' }
+    renderClarify(
+      <ClarifyTool
+        addResult={vi.fn()}
+        args={args}
+        argsText={JSON.stringify(args)}
+        isError={false}
+        respondToApproval={vi.fn()}
+        result={undefined}
+        resume={vi.fn()}
+        status={{ type: 'running' }}
+        toolCallId="clarify-casing"
+        toolName="clarify"
+        type="tool-call"
+      />
+    )
+
+    // matchingRequest matched, so the gateway's recommended choices won.
+    expect(screen.getByRole('button', { name: /staging/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /production/ })).toBeTruthy()
+  })
+
+  it('still rejects a gateway question that genuinely differs (not just casing/whitespace)', () => {
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
+    setClarifyRequest({
+      choices: ['apple', 'banana'],
+      multiSelect: false,
+      question: 'A fruit?',
+      requestId: 'request-mismatch',
+      sessionId: 'session-1'
+    })
+
+    const args = { choices: ['staging', 'production'], question: 'Which target?' }
+    renderClarify(
+      <ClarifyTool
+        addResult={vi.fn()}
+        args={args}
+        argsText={JSON.stringify(args)}
+        isError={false}
+        respondToApproval={vi.fn()}
+        result={undefined}
+        resume={vi.fn()}
+        status={{ type: 'running' }}
+        toolCallId="clarify-mismatch"
+        toolName="clarify"
+        type="tool-call"
+      />
+    )
+
+    // matchingRequest dropped out, so we fall through to fromArgs.choices
+    // — the buttons still render, but with the args' wording.
+    expect(screen.getByRole('button', { name: /staging/ })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /apple/ })).toBeNull()
+  })
+})
+
 // ─── Batch (multi-question) clarify ─────────────────────────────────────────
 
 function batchArgs(): { questions: { question: string; choices?: string[] }[] } {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -24,6 +24,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
+import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import {
   bareChoice,
@@ -404,7 +405,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
       return null
     }
 
-    if (fromArgs.question && request.question && fromArgs.question !== request.question) {
+    if (fromArgs.question && request.question && normalize(fromArgs.question) !== normalize(request.question)) {
       return null
     }
 
@@ -414,11 +415,15 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
   const question = fromArgs.question || matchingRequest?.question || ''
 
   const choices = useMemo(
-    // Prefer the gateway request's choices over the raw tool args: the backend
-    // labels the recommended option there (`mark_recommended`), and the card
-    // only renders once `matchingRequest` exists, so the args are a fallback
-    // for a hydration race, not the normal path.
-    () => matchingRequest?.choices ?? fromArgs.choices ?? [],
+    // Prefer the raw tool args' choices: they arrive with the tool.start event,
+    // so the card can render before the gateway request_id is wired and avoid
+    // the spinner-then-textarea flash. Fall back to the gateway request's
+    // choices — those carry the `mark_recommended` label from the backend —
+    // when args don't have them.
+    () => {
+      if (fromArgs.choices && fromArgs.choices.length > 0) return fromArgs.choices
+      return matchingRequest?.choices ?? []
+    },
     [fromArgs.choices, matchingRequest?.choices]
   )
 
@@ -436,9 +441,12 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
 
   // Race: tool.start fires a tick before clarify.request, so request_id
   // arrives slightly after the tool block mounts. Hold the whole panel on a
-  // spinner until the gateway request is wired — showing disabled choices or
-  // a "loading question" stub is worse than a brief wait.
-  const ready = Boolean(matchingRequest?.requestId)
+  // spinner until the gateway request is wired — BUT if the tool args
+  // already carry choices, the buttons can mount immediately and the user
+  // isn't held hostage to a gateway request that may never arrive for
+  // single-question blocks. Showing an endlessly-spinning question to a user
+  // who can already see the answer buttons is worse than flashing them on.
+  const ready = Boolean(matchingRequest?.requestId) || hasChoices
   const loading = !ready && !submitting
 
   const respond = useCallback(


### PR DESCRIPTION
The desktop GUI's `ClarifyTool` derives `choices` from two sources: `fromArgs.choices` (the model-emitted tool args) and `matchingRequest?.choices` (a later `clarify.request` event). When `matchingRequest` was null — for example, when the model wrote `choices: ['Yes', 'No']` directly in the tool.start args and the mock harness never sent a separate `clarify.request` — the renderer fell through to a textarea-only fallback because `fromArgs.choices` was empty after a strict-string-compare question-mismatch check on the hydration-race guard.

This PR fixes that by:

1. Normalizing the question-text compare (trim/lowercase) so trivial differences don't kill choice rendering.
2. Preferring `fromArgs.choices` over `matchingRequest?.choices` so the args path is honored when the request is missing.
3. Loosening the loading gate to allow form mount when `fromArgs.choices` is non-empty even without a request.

Plus a regression test in e2e/chat.spec.ts that asserts the buttons are visible in BLOCKING_CLARIFY (where the mock harness only sends tool.start, never a separate clarify.request).

🤖 Generated with [Hermes Agent](https://nousresearch.com)