### PR TITLE
feat(proxy): forward xAI image endpoints through the OAuth proxy

### DIFF
--- a/hermes_cli/proxy/adapters/xai.py
+++ b/hermes_cli/proxy/adapters/xai.py
@@ -17,6 +17,12 @@ _POOL_PROVIDER = "xai-oauth"
 # xAI's public API is OpenAI-compatible for the endpoints Hermes commonly
 # uses. The Responses endpoint is included because Hermes' native xAI runtime
 # uses codex_responses mode.
+#
+# The image endpoints are included so an external app (e.g. a Django newsroom
+# that must not hold a raw bearer) can generate images through the proxy on the
+# operator's OAuth subscription. They are the same OpenAI-compatible shape as
+# the text endpoints and need the same 401-refresh / 429-rotation handling the
+# adapter already provides.
 _ALLOWED_PATHS: FrozenSet[str] = frozenset(
     {
         "/responses",
@@ -24,6 +30,9 @@ _ALLOWED_PATHS: FrozenSet[str] = frozenset(
         "/completions",
         "/embeddings",
         "/models",
+        "/images/generations",
+        "/images/edits",
+        "/image-generation-models",
     }
 )
 

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -152,6 +152,28 @@ def test_xai_adapter_not_authenticated_when_no_pool_entry(tmp_path, monkeypatch)
     assert not XAIGrokAdapter().is_authenticated()
 
 
+def test_xai_adapter_forwards_the_image_endpoints():
+    """Image generation must be reachable through the proxy.
+
+    xAI OAuth subscription bearers expire every 6 hours and their refresh lives
+    in the Hermes process, so an external app (e.g. a Django service) cannot
+    hold one. Routing its image calls through the proxy is the only way to use
+    the subscription instead of a separately-metered console API key — which
+    requires these OpenAI-compatible image paths to be forwarded, not 404'd.
+    """
+    allowed = XAIGrokAdapter().allowed_paths
+    assert "/images/generations" in allowed
+    assert "/images/edits" in allowed
+    assert "/image-generation-models" in allowed
+
+
+def test_xai_adapter_does_not_forward_unknown_paths():
+    """The allowlist stays an allowlist — no blanket passthrough."""
+    allowed = XAIGrokAdapter().allowed_paths
+    assert "/api-key" not in allowed
+    assert "/" not in allowed
+
+
 def test_xai_adapter_retry_rotates_pool_entry_on_429(tmp_path, monkeypatch):
     """429 from xAI must rotate to the next pool entry, not attempt refresh.
 


### PR DESCRIPTION
## Problem

`XAIGrokAdapter.allowed_paths` allowlists only text endpoints, so a request to `/v1/images/generations` through `hermes proxy --provider xai` is rejected with `path_not_allowed`.

That blocks the workflow the proxy exists for. xAI OAuth subscription bearers expire every 6 hours and their refresh logic lives inside the Hermes process, so an external app cannot hold one. In my case that app is a Django newsroom that generates article featured images. Its only options were:

- embed a short-lived OAuth bearer that starts returning 401 a few hours later, or
- buy a separately-metered `console.x.ai` API key — even though the operator already pays for a SuperGrok subscription (the two are separate billing tracks).

Forwarding the image paths lets the app point at the proxy and spend the subscription it already has, while holding no credential of its own.

## Change

Adds three paths to the existing allowlist:

- `/images/generations`
- `/images/edits`
- `/image-generation-models`

These are the same OpenAI-compatible shape as the text endpoints and need exactly the 401-refresh / 429-rotation handling `get_retry_credential` already implements, so there are no new code paths — it is an allowlist addition. The allowlist stays an allowlist; nothing becomes a blanket passthrough.

## Verification

Live, end-to-end against the real API through a running proxy (placeholder client bearer, real credential attached by the proxy):

```
POST http://127.0.0.1:8645/v1/images/generations
Authorization: Bearer anything

HTTP=200  time=97s
decoded bytes: 7617213
geometry: (2496, 1664)
usage: {'cost_in_usd_ticks': 800000000}
```

Also verified from inside a Docker container against a bridge-bound proxy, where the calling app had no xAI credential at all.

## Tests

Two additions to `tests/hermes_cli/test_proxy.py`: one pins the image paths as forwarded (with the reasoning in the docstring), one pins that the allowlist does not become a blanket passthrough. `tests/hermes_cli/test_proxy.py`: 6 passed.
