### PR TITLE
fix(search): files_only silently dropped paths containing spaces

### DIFF
--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -130,3 +130,73 @@ class TestSplitToolDiagnostics:
         assert diagnostics == ""
         assert "--" in payload
         assert "a.py-6-after" in payload
+
+
+class TestSplitToolDiagnosticsFilesOnly:
+    """Unit coverage for mode-aware splitting of files_only output (#91698).
+
+    ``rg -l`` / ``grep -l`` emit bare paths, and paths may contain whitespace.
+    The whitespace-forbidding shape regex misfiled every spaced path as a
+    diagnostic, silently dropping it from the results.
+    """
+
+    def test_spaced_path_is_payload(self):
+        diagnostics, payload = _split_tool_diagnostics(
+            "/tmp/v/Obsidian Vault/note.md\n", output_mode="files_only")
+        assert diagnostics == ""
+        assert "note.md" in payload
+
+    def test_error_block_still_split_from_paths(self):
+        out = ("rg: regex parse error:\n"
+               "    \\\n"
+               "     ^\n"
+               "error: unclosed character class\n"
+               "/tmp/v/Obsidian Vault/note.md\n")
+        diagnostics, payload = _split_tool_diagnostics(out, output_mode="files_only")
+        assert payload.strip() == "/tmp/v/Obsidian Vault/note.md"
+        assert "regex parse error" in diagnostics
+        assert "error: unclosed character class" in diagnostics
+
+    def test_pure_failure_has_empty_payload(self):
+        out = "rg: regex parse error:\n    \\\n     ^\nerror: bad pattern\n"
+        diagnostics, payload = _split_tool_diagnostics(out, output_mode="files_only")
+        assert payload.strip() == ""
+        assert "bad pattern" in diagnostics
+
+    def test_content_mode_shape_rules_unchanged(self):
+        # Match/count lines tolerate spaces after the first char; the
+        # default classification is untouched by the files_only branch.
+        diagnostics, payload = _split_tool_diagnostics("/tmp/my dir/f.py:12:hit\n")
+        assert diagnostics == ""
+        assert "hit" in payload
+
+
+@pytest.mark.parametrize("method", _METHODS)
+class TestFilesOnlySpacePathsEndToEnd:
+    """#91698 end-to-end: files_only must return spaced paths, both backends."""
+
+    @pytest.fixture
+    def spaced_tree(self, tmp_path):
+        (tmp_path / "file with space.md").write_text("needle\n")
+        (tmp_path / "plain.txt").write_text("needle\n")
+        vault = tmp_path / "Obsidian Vault"
+        vault.mkdir()
+        (vault / "note.md").write_text("needle\n")
+        return tmp_path
+
+    def test_files_only_returns_spaced_paths(self, method, spaced_tree):
+        res = _search(_ops(spaced_tree), method, "needle", spaced_tree,
+                      output_mode="files_only")
+        assert res.error is None
+        assert {os.path.basename(p) for p in res.files} == {
+            "file with space.md", "plain.txt", "note.md",
+        }
+        assert res.total_count == 3
+
+    def test_files_only_hard_error_still_surfaced(self, method, match_tree):
+        # The exit-2 guard must keep working in files_only mode: an invalid
+        # regex yields only diagnostic-shaped lines and MUST be surfaced.
+        res = _search(_ops(match_tree), method, "[", match_tree,
+                      output_mode="files_only")
+        assert res.error is not None, "search error was silently swallowed"
+        assert not res.files

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -364,7 +364,7 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     return result.stdout, None
 
 
-def _split_tool_diagnostics(output: str) -> tuple[str, str]:
+def _split_tool_diagnostics(output: str, output_mode: str = "") -> tuple[str, str]:
     """Separate rg/grep diagnostic lines from real match output.
 
     ``_exec`` runs commands with ``stderr=subprocess.STDOUT``, so error and
@@ -377,6 +377,18 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
     a files-only path, a count line, or a context line/separator. Everything
     else (tool-prefixed errors, rg's multi-line ``regex parse error`` block
     with its indented carets, blank lines) is folded into ``diagnostics``.
+
+    In ``output_mode="files_only"`` every payload line IS a path, and paths
+    legitimately contain whitespace (``Obsidian Vault/notes.md``). The shape
+    regex below forbids whitespace, so classifying bare ``-l`` lines by shape
+    misfiled every spaced path as a diagnostic and silently dropped it from
+    the results (#91698). Files-only lines are therefore classified by tool
+    markers only: the ``rg: ``/``grep: `` prefixes above, an indented
+    caret/pipe row from rg's multi-line regex-parse-error block, or that
+    block's unprefixed trailing ``error: ...`` line. A file actually named
+    with leading whitespace or a ``error: `` prefix would be misfiled —
+    impossible on Windows and vanishingly rare elsewhere, against which
+    every spaced path on every machine is dropped today.
 
     Classifying by *shape* rather than by error prefix is what lets the
     exit-2 guard distinguish a pure failure (no usable payload → surface the
@@ -399,12 +411,20 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
         if stripped.startswith("rg: ") or stripped.startswith("grep: "):
             diagnostics.append(line)
             continue
+        if output_mode == "files_only":
+            # Bare-path mode: see the docstring. Only marker-carrying lines
+            # (indented caret rows, unprefixed "error: ..." tails) are noise.
+            if line[:1] in (" ", "\t") or stripped.startswith("error: "):
+                diagnostics.append(line)
+            else:
+                payload.append(line)
+            continue
         # Otherwise classify by output shape. rg's regex-parse-error block
         # also emits an indented caret line and a trailing "error: ..." line
         # with no tool prefix; neither matches a search-output shape, so they
         # fall through to diagnostics.
         #   match / count : "<path>:<...>"   (has a colon; rg -c uses path:count)
-        #   files_only    : "<path>"         (no whitespace, no leading colon)
+        #   files_only    : handled above (shape cannot know a path's spaces)
         #   context line  : "<path>-<line>-" or the "--" group separator
         if line == "--" or _SEARCH_OUTPUT_RE.match(line):
             payload.append(line)
@@ -418,6 +438,8 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
 # diagnostics ("rg: ...", "grep: ...", "error: ...", indented carets) never
 # match because the path token forbids whitespace and a leading tool prefix
 # like "rg" is followed by ": " (space) which the negated class rejects.
+# NOTE(#91698): the bare-path alternative forbids whitespace, so it must NOT
+# be used for ``files_only`` output — see _split_tool_diagnostics.
 _SEARCH_OUTPUT_RE = re.compile(r'^([A-Za-z]:)?[^\s:][^\n]*?[:\-]\d|^[^\s:][^\s]*$')
 
 
@@ -3182,7 +3204,7 @@ class ShellFileOperations(FileOperations):
         # diagnostic lines ("rg: <file>: <error>", "rg: regex parse error:")
         # are interleaved with match output. Split them out: diagnostics must
         # not be parsed as matches, and on a hard error they ARE the message.
-        diagnostics, payload = _split_tool_diagnostics(stdout)
+        diagnostics, payload = _split_tool_diagnostics(stdout, output_mode)
 
         # rg exit codes: 0=matches found, 1=no matches, 2=error. rg returns 2
         # even on partial errors (e.g. one unreadable file in a tree that
@@ -3330,7 +3352,7 @@ class ShellFileOperations(FileOperations):
         # ("grep: <file>: <error>") are interleaved with matches. Split them
         # out so they're never parsed as matches and so a hard error has a
         # clean message.
-        diagnostics, payload = _split_tool_diagnostics(stdout)
+        diagnostics, payload = _split_tool_diagnostics(stdout, output_mode)
 
         # grep exit codes: 0=matches found, 1=no matches, 2=error. grep
         # returns 2 on partial errors (e.g. an unreadable file) even when


### PR DESCRIPTION
Fixes #91698

## The bug

`search_files` with `output_mode="files_only"` silently dropped every path containing whitespace. `_split_tool_diagnostics()` classifies each line of the merged stdout stream by shape, and its bare-path alternative (`^[^\s:][^\s]*$`) forbids whitespace — so `rg -l` / `grep -l` paths like `Obsidian Vault/note.md` or `file with space.md` were misfiled as diagnostics and discarded. A vault search returned `total_count: 0` with no error, exactly like a no-match search.

`content` and `count` modes were unaffected (their `<path>:<line>` shape tolerates spaces after the first character), which is why only `files_only` broke.

## The fix

Thread `output_mode` into `_split_tool_diagnostics()` and classify `-l` lines by tool markers instead of shape:

- **diagnostic**: the existing `rg: `/`grep: ` prefixes, plus indented caret/pipe rows from rg's multi-line regex-parse-error block, plus that block's unprefixed trailing `error: ...` line
- **payload**: every other non-blank line (a path, spaces welcome)

Exit-2 guard semantics are unchanged: a pure failure still yields an empty payload and gets surfaced; a partial failure keeps its matches. `content`/`count` classification is untouched.

## Tests

- unit (`TestSplitToolDiagnosticsFilesOnly`): spaced path lands in payload; rg error block still splits away from paths; pure failure → empty payload; content-mode shape rules unchanged
- end-to-end through both backends (`_search_with_grep`, `_search_with_rg` when installed), mirroring the existing guard-test harness: a spaced *file* and a spaced *directory* both come back in `files` with correct `total_count`; an invalid regex still surfaces as an error in files_only mode

```
scripts/run_tests.sh tests/tools/test_search_error_guard.py \
  tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py
→ 100 passed, 0 failed, 2 skipped
```
