### PR TITLE
fix(cli): stop labeling shadowed lazy-target dists as venv

### DIFF
--- a/hermes_cli/security_audit.py
+++ b/hermes_cli/security_audit.py
@@ -2,6 +2,10 @@
 
 Vulnerabilities are looked up against OSV.dev (``api.osv.dev/v1/querybatch`` + ``/v1/vulns/{id}``).
 Single-shot, on-demand, never daily — see ``references/security-disclosure-triage.md``.
+
+Durable lazy-install copies (``HERMES_LAZY_INSTALL_TARGET``) are classified
+separately: the importable copy is the effective component; a shadowed lazy
+copy is ``lazy-shadowed`` and does not trip ``--fail-on``.
 """
 
 from __future__ import annotations
@@ -9,13 +13,14 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import json
+import os
 import re
 import sys
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Sequence
 
 from hermes_constants import get_hermes_home
 
@@ -36,7 +41,7 @@ class Component:
     name: str
     version: str
     ecosystem: str  # "PyPI" | "npm" — exactly as OSV expects
-    source: str    # human-readable origin, e.g. "venv", "plugin:foo", "mcp:bar"
+    source: str    # "venv" | "lazy" | "lazy-shadowed" | "plugin:foo" | "mcp:bar"
 
 
 @dataclass
@@ -53,20 +58,180 @@ class Finding:
     vuln: Vulnerability
 
 
-def _discover_venv() -> list[Component]:
-    """Every dist installed in the running Python's import path."""
-    from importlib.metadata import distributions
+# Source labels for installed PyPI dists. ``venv`` is the sealed/core
+# environment (anything not under the durable lazy target). ``lazy`` is a
+# dist that lives in HERMES_LAZY_INSTALL_TARGET *and* would actually be
+# imported (no earlier sys.path collision). ``lazy-shadowed`` is a stale
+# copy in that target that cannot win imports because the target is
+# append-only on sys.path — reported for cleanup, ignored by --fail-on.
+SOURCE_VENV = "venv"
+SOURCE_LAZY = "lazy"
+SOURCE_LAZY_SHADOWED = "lazy-shadowed"
 
-    out: dict[tuple[str, str], Component] = {}
-    for dist in distributions():
+# Matches tools.lazy_deps._LAZY_TARGET_ENV. Read here directly so the
+# audit module does not import the lazy-install machinery.
+_LAZY_TARGET_ENV = "HERMES_LAZY_INSTALL_TARGET"
+
+
+def _lazy_install_target_path() -> Optional[Path]:
+    raw = os.environ.get(_LAZY_TARGET_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        return Path(raw).resolve()
+    except OSError:
+        return Path(raw)
+
+
+def _is_under(path: Path, root: Path) -> bool:
+    """True if ``path`` is ``root`` or a descendant, after resolving."""
+    try:
+        resolved_path = path.resolve()
+        resolved_root = root.resolve()
+    except OSError:
+        resolved_path, resolved_root = path, root
+    if resolved_path == resolved_root:
+        return True
+    try:
+        return resolved_path.is_relative_to(resolved_root)
+    except (ValueError, TypeError):
+        return False
+
+
+def _dist_install_root(dist) -> Optional[Path]:
+    """sys.path entry that owns this distribution (parent of dist-info)."""
+    try:
+        located = dist.locate_file("")
+        if located is not None:
+            return Path(str(located)).resolve()
+    except Exception:
+        pass
+    path_attr = getattr(dist, "_path", None)
+    if path_attr is None:
+        return None
+    try:
+        p = Path(path_attr)
+        name = p.name
+        if name.endswith(".dist-info") or name.endswith(".egg-info"):
+            p = p.parent
+        return p.resolve()
+    except Exception:
+        return None
+
+
+def _path_rank(install_root: Optional[Path], search_path: Sequence[str]) -> int:
+    """Lower rank = earlier on sys.path = wins imports. Missing → last."""
+    if install_root is None:
+        return len(search_path)
+    try:
+        resolved = install_root.resolve()
+    except OSError:
+        resolved = install_root
+    for i, entry in enumerate(search_path):
+        if not entry:
+            continue
+        try:
+            entry_path = Path(entry).resolve()
+        except OSError:
+            continue
+        if resolved == entry_path or _is_under(resolved, entry_path):
+            return i
+    return len(search_path)
+
+
+def _fail_on_applies(source: str) -> bool:
+    """Shadowed durable-target copies cannot be imported; they don't fail the audit."""
+    return source != SOURCE_LAZY_SHADOWED
+
+
+def _classify_installed_distributions(
+    dists: Iterable,
+    *,
+    search_path: Sequence[str],
+    lazy_target: Optional[Path],
+) -> list[Component]:
+    """Turn raw distributions into Components using path + import precedence.
+
+    For each normalized package name the copy whose install root appears
+    earliest on ``search_path`` is the effective/runtime version. A later
+    copy under ``lazy_target`` is kept as ``lazy-shadowed`` (different
+    version only — same-version dupes are dropped). Other non-winning
+    copies are skipped so they cannot be mislabeled as active ``venv``.
+    """
+    candidates: list[tuple[int, str, Component]] = []
+    for dist in dists:
         try:
             name = (dist.metadata["Name"] or "").strip()
         except Exception:
             continue
         version = (dist.version or "").strip()
-        if name and version:
-            out.setdefault((name.lower(), version), Component(name=name, version=version, ecosystem="PyPI", source="venv"))
-    return list(out.values())
+        if not name or not version:
+            continue
+        root = _dist_install_root(dist)
+        if lazy_target is not None and root is not None and _is_under(root, lazy_target):
+            source = SOURCE_LAZY
+        else:
+            source = SOURCE_VENV
+        rank = _path_rank(root, search_path)
+        candidates.append((rank, name.lower(), Component(
+            name=name, version=version, ecosystem="PyPI", source=source,
+        )))
+
+    best_rank: dict[str, int] = {}
+    for rank, nkey, _comp in candidates:
+        prev = best_rank.get(nkey)
+        if prev is None or rank < prev:
+            best_rank[nkey] = rank
+
+    # Process earlier-on-sys.path first so the effective copy of a given
+    # (name, version) is recorded before a shadowed duplicate is considered.
+    candidates.sort(key=lambda item: item[0])
+
+    out: list[Component] = []
+    seen_effective: set[tuple[str, str]] = set()
+    seen_shadowed: set[tuple[str, str]] = set()
+    for rank, nkey, comp in candidates:
+        source = comp.source
+        if source == SOURCE_LAZY and rank > best_rank[nkey]:
+            source = SOURCE_LAZY_SHADOWED
+        elif source == SOURCE_VENV and rank > best_rank[nkey]:
+            # A non-lazy copy that loses import precedence is not the
+            # running package; don't label it ``venv``.
+            continue
+        nv = (nkey, comp.version)
+        if source == SOURCE_LAZY_SHADOWED:
+            if nv in seen_effective or nv in seen_shadowed:
+                continue
+            seen_shadowed.add(nv)
+        else:
+            if nv in seen_effective:
+                continue
+            seen_effective.add(nv)
+        if source != comp.source:
+            comp = Component(
+                name=comp.name,
+                version=comp.version,
+                ecosystem=comp.ecosystem,
+                source=source,
+            )
+        out.append(comp)
+    return out
+
+
+def _discover_venv() -> list[Component]:
+    """Every dist on the running Python's import path, classified by origin.
+
+    The durable lazy-install target is appended at the end of ``sys.path``,
+    so a stale copy there cannot shadow the sealed venv. That copy is
+    reported as ``lazy-shadowed`` rather than ``venv``.
+    """
+    from importlib.metadata import distributions
+
+    return _classify_installed_distributions(
+        distributions(),
+        search_path=sys.path,
+        lazy_target=_lazy_install_target_path(),
+    )
 
 
 # ``name[extras]==version ; marker`` — an exact pin, optionally with extras and an environment marker.
@@ -307,6 +472,13 @@ def cmd_security_audit(args: argparse.Namespace) -> int:
         return 2
 
     print((_render_json if output_json else _render_human)(findings, total))
-    # Exit code: 1 iff any finding meets or exceeds the --fail-on threshold.
+    # Exit code: 1 iff any *importable* finding meets or exceeds --fail-on.
+    # Shadowed lazy-target copies are reported in the output but cannot be
+    # imported (append-only sys.path), so they must not keep the audit red
+    # after the sealed venv is already patched.
     threshold = SEVERITY_ORDER[fail_on]
-    return int(any(SEVERITY_ORDER.get(f.vuln.severity, 0) >= threshold for f in findings))
+    return int(any(
+        _fail_on_applies(f.component.source)
+        and SEVERITY_ORDER.get(f.vuln.severity, 0) >= threshold
+        for f in findings
+    ))

--- a/hermes_cli/subcommands/security.py
+++ b/hermes_cli/subcommands/security.py
@@ -24,7 +24,11 @@ def build_security_parser(subparsers, *, cmd_security: Callable) -> None:
     add_json_flag(audit_parser, "Emit machine-readable JSON instead of human-readable text")
     audit_parser.add_argument(
         "--fail-on", default="critical", choices=["low", "moderate", "high", "critical"],
-        help="Exit non-zero when any finding meets this severity (default: critical)")
+        help=(
+            "Exit non-zero when any finding on an importable component meets "
+            "this severity (default: critical). Shadowed durable lazy-target "
+            "copies are reported but do not trip the threshold."
+        ))
     audit_parser.add_argument(
         "--skip-venv", action="store_true", help="Skip scanning the Hermes Python venv")
     audit_parser.add_argument(

--- a/tests/hermes_cli/test_security_audit.py
+++ b/tests/hermes_cli/test_security_audit.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+from importlib.metadata import PathDistribution
 
 from hermes_cli import security_audit as sa
 
@@ -214,3 +215,275 @@ class TestExitCodes:
         assert data["finding_count"] == 1
         assert data["findings"][0]["severity"] == "HIGH"
         assert data["findings"][0]["fixed_versions"] == ["1.1"]
+
+    def test_fail_on_high_ignores_shadowed_lazy_finding(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """Stale lazy-target aiohttp must not keep --fail-on high red.
+
+        Regression for #92549: the sealed venv is already patched (3.14.3)
+        while HERMES_LAZY_INSTALL_TARGET still holds 3.14.1. The shadowed
+        copy is reported, but the exit code follows the importable version.
+        """
+        monkeypatch.setattr(sa, "get_hermes_home", lambda: str(tmp_path))
+        venv_comp = sa.Component(
+            name="aiohttp", version="3.14.3", ecosystem="PyPI", source=sa.SOURCE_VENV
+        )
+        shadowed = sa.Component(
+            name="aiohttp",
+            version="3.14.1",
+            ecosystem="PyPI",
+            source=sa.SOURCE_LAZY_SHADOWED,
+        )
+        monkeypatch.setattr(sa, "_discover_venv", lambda: [venv_comp, shadowed])
+
+        def fake_batch(comps):
+            out = {}
+            for c in comps:
+                if c.version == "3.14.1":
+                    out[c] = ["GHSA-cq5v-8q36-5273"]
+            return out
+
+        monkeypatch.setattr(sa, "_osv_query_batch", fake_batch)
+        monkeypatch.setattr(
+            sa,
+            "_osv_fetch_details",
+            lambda ids: {
+                "GHSA-cq5v-8q36-5273": sa.Vulnerability(
+                    osv_id="GHSA-cq5v-8q36-5273",
+                    severity="HIGH",
+                    summary="stale lazy copy",
+                    fixed_versions=["3.14.3"],
+                )
+            },
+        )
+        code = sa.cmd_security_audit(
+            self._build_args(skip_venv=False, json=True, fail_on="high")
+        )
+        payload = capsys.readouterr().out
+        lines = payload.splitlines()
+        json_start = next(i for i, l in enumerate(lines) if l.startswith("{"))
+        data = json.loads("\n".join(lines[json_start:]))
+        assert code == 0
+        assert data["finding_count"] == 1
+        assert data["findings"][0]["source"] == sa.SOURCE_LAZY_SHADOWED
+        assert data["findings"][0]["version"] == "3.14.1"
+
+    def test_fail_on_high_still_trips_on_effective_venv(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """A vuln in the imported venv copy must still fail the audit."""
+        monkeypatch.setattr(sa, "get_hermes_home", lambda: str(tmp_path))
+        venv_comp = sa.Component(
+            name="aiohttp", version="3.14.1", ecosystem="PyPI", source=sa.SOURCE_VENV
+        )
+        shadowed = sa.Component(
+            name="aiohttp",
+            version="3.14.3",
+            ecosystem="PyPI",
+            source=sa.SOURCE_LAZY_SHADOWED,
+        )
+        monkeypatch.setattr(sa, "_discover_venv", lambda: [venv_comp, shadowed])
+
+        def fake_batch(comps):
+            out = {}
+            for c in comps:
+                if c.version == "3.14.1":
+                    out[c] = ["GHSA-cq5v-8q36-5273"]
+            return out
+
+        monkeypatch.setattr(sa, "_osv_query_batch", fake_batch)
+        monkeypatch.setattr(
+            sa,
+            "_osv_fetch_details",
+            lambda ids: {
+                "GHSA-cq5v-8q36-5273": sa.Vulnerability(
+                    osv_id="GHSA-cq5v-8q36-5273",
+                    severity="HIGH",
+                    summary="imported copy is vulnerable",
+                    fixed_versions=["3.14.3"],
+                )
+            },
+        )
+        code = sa.cmd_security_audit(
+            self._build_args(skip_venv=False, json=True, fail_on="high")
+        )
+        payload = capsys.readouterr().out
+        lines = payload.splitlines()
+        json_start = next(i for i, l in enumerate(lines) if l.startswith("{"))
+        data = json.loads("\n".join(lines[json_start:]))
+        assert code == 1
+        assert data["findings"][0]["source"] == sa.SOURCE_VENV
+        assert data["findings"][0]["version"] == "3.14.1"
+
+    def test_fail_on_high_trips_on_effective_lazy_only_package(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """A package imported only from the lazy target is still fail-on surface."""
+        monkeypatch.setattr(sa, "get_hermes_home", lambda: str(tmp_path))
+        lazy_comp = sa.Component(
+            name="honcho-ai", version="0.1.0", ecosystem="PyPI", source=sa.SOURCE_LAZY
+        )
+        monkeypatch.setattr(sa, "_discover_venv", lambda: [lazy_comp])
+        monkeypatch.setattr(
+            sa, "_osv_query_batch", lambda comps: {lazy_comp: ["GHSA-lazy-1"]}
+        )
+        monkeypatch.setattr(
+            sa,
+            "_osv_fetch_details",
+            lambda ids: {
+                "GHSA-lazy-1": sa.Vulnerability(
+                    osv_id="GHSA-lazy-1",
+                    severity="HIGH",
+                    summary="imported from lazy target",
+                    fixed_versions=["0.2.0"],
+                )
+            },
+        )
+        code = sa.cmd_security_audit(
+            self._build_args(skip_venv=False, json=True, fail_on="high")
+        )
+        capsys.readouterr()
+        assert code == 1
+
+
+# ─── Venv vs durable lazy-target classification ───────────────────────────────
+
+
+def _write_distinfo(site_dir: Path, name: str, version: str) -> PathDistribution:
+    """Create a minimal dist-info tree and return a real PathDistribution."""
+    info = site_dir / f"{name}-{version}.dist-info"
+    info.mkdir(parents=True)
+    (info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n",
+        encoding="utf-8",
+    )
+    return PathDistribution(info)
+
+
+class TestVenvLazyClassification:
+    def test_shadowed_lazy_aiohttp_is_not_labeled_venv(self, tmp_path: Path):
+        """Sealed venv 3.14.3 wins; stale lazy 3.14.1 is lazy-shadowed.
+
+        Mirrors the Docker durable-target layout from #92549:
+        HERMES_LAZY_INSTALL_TARGET is appended on sys.path, so the venv
+        copy is the one ``import aiohttp`` would load.
+        """
+        venv_site = tmp_path / "venv" / "lib" / "python3.13" / "site-packages"
+        lazy = tmp_path / "lazy-packages"
+        venv_dist = _write_distinfo(venv_site, "aiohttp", "3.14.3")
+        lazy_dist = _write_distinfo(lazy, "aiohttp", "3.14.1")
+        # venv first, lazy last — the durable-target contract.
+        search_path = [str(venv_site), str(lazy)]
+
+        components = sa._classify_installed_distributions(
+            [venv_dist, lazy_dist],
+            search_path=search_path,
+            lazy_target=lazy,
+        )
+        by_source = {(c.source, c.version): c for c in components if c.name.lower() == "aiohttp"}
+        assert (sa.SOURCE_VENV, "3.14.3") in by_source
+        assert (sa.SOURCE_LAZY_SHADOWED, "3.14.1") in by_source
+        assert all(c.source != sa.SOURCE_VENV or c.version != "3.14.1" for c in components)
+
+    def test_lazy_only_package_is_effective_lazy(self, tmp_path: Path):
+        """A package that exists only in the lazy target *is* imported."""
+        venv_site = tmp_path / "venv" / "site-packages"
+        lazy = tmp_path / "lazy-packages"
+        venv_site.mkdir(parents=True)
+        lazy_dist = _write_distinfo(lazy, "honcho-ai", "1.2.0")
+        components = sa._classify_installed_distributions(
+            [lazy_dist],
+            search_path=[str(venv_site), str(lazy)],
+            lazy_target=lazy,
+        )
+        assert len(components) == 1
+        assert components[0].name == "honcho-ai"
+        assert components[0].version == "1.2.0"
+        assert components[0].source == sa.SOURCE_LAZY
+
+    def test_without_lazy_target_env_everything_stays_venv(self, tmp_path: Path):
+        venv_site = tmp_path / "venv" / "site-packages"
+        other = tmp_path / "other"
+        venv_dist = _write_distinfo(venv_site, "aiohttp", "3.14.3")
+        other_dist = _write_distinfo(other, "aiohttp", "3.14.1")
+        components = sa._classify_installed_distributions(
+            [venv_dist, other_dist],
+            search_path=[str(venv_site), str(other)],
+            lazy_target=None,
+        )
+        # Import-path precedence still drops the losing copy so it cannot
+        # be labeled as an extra active venv version.
+        aio = [c for c in components if c.name.lower() == "aiohttp"]
+        assert len(aio) == 1
+        assert aio[0].version == "3.14.3"
+        assert aio[0].source == sa.SOURCE_VENV
+
+    def test_same_version_in_lazy_is_not_duplicated(self, tmp_path: Path):
+        venv_site = tmp_path / "venv" / "site-packages"
+        lazy = tmp_path / "lazy-packages"
+        venv_dist = _write_distinfo(venv_site, "aiohttp", "3.14.3")
+        lazy_dist = _write_distinfo(lazy, "aiohttp", "3.14.3")
+        components = sa._classify_installed_distributions(
+            [venv_dist, lazy_dist],
+            search_path=[str(venv_site), str(lazy)],
+            lazy_target=lazy,
+        )
+        aio = [c for c in components if c.name.lower() == "aiohttp"]
+        assert len(aio) == 1
+        assert aio[0].source == sa.SOURCE_VENV
+        assert aio[0].version == "3.14.3"
+
+    def test_inverted_path_reports_imported_lazy_copy(self, tmp_path: Path):
+        """If lazy precedes venv on sys.path, that copy is the imported one."""
+        venv_site = tmp_path / "venv" / "site-packages"
+        lazy = tmp_path / "lazy-packages"
+        venv_dist = _write_distinfo(venv_site, "aiohttp", "3.14.3")
+        lazy_dist = _write_distinfo(lazy, "aiohttp", "3.14.1")
+        components = sa._classify_installed_distributions(
+            [venv_dist, lazy_dist],
+            search_path=[str(lazy), str(venv_site)],
+            lazy_target=lazy,
+        )
+        aio = [c for c in components if c.name.lower() == "aiohttp"]
+        assert len(aio) == 1
+        assert aio[0].source == sa.SOURCE_LAZY
+        assert aio[0].version == "3.14.1"
+
+    def test_discover_venv_honors_lazy_target_env(self, tmp_path: Path, monkeypatch):
+        """Wire-up: env var + distributions() + classification."""
+        venv_site = tmp_path / "venv" / "site-packages"
+        lazy = tmp_path / "lazy-packages"
+        venv_dist = _write_distinfo(venv_site, "aiohttp", "3.14.3")
+        lazy_dist = _write_distinfo(lazy, "aiohttp", "3.14.1")
+        monkeypatch.setenv("HERMES_LAZY_INSTALL_TARGET", str(lazy))
+        import importlib.metadata as md
+
+        monkeypatch.setattr(md, "distributions", lambda: [venv_dist, lazy_dist])
+        captured: dict = {}
+        real_classify = sa._classify_installed_distributions
+
+        def fake_classify(dists, *, search_path, lazy_target):
+            captured["lazy_target"] = lazy_target
+            captured["n_dists"] = sum(1 for _ in dists)
+            # Hermetic search_path so this test does not mutate process sys.path.
+            return real_classify(
+                [venv_dist, lazy_dist],
+                search_path=[str(venv_site), str(lazy)],
+                lazy_target=lazy_target,
+            )
+
+        monkeypatch.setattr(sa, "_classify_installed_distributions", fake_classify)
+        components = sa._discover_venv()
+        assert captured["lazy_target"] == lazy.resolve()
+        assert captured["n_dists"] == 2
+        sources = {(c.source, c.version) for c in components if c.name.lower() == "aiohttp"}
+        assert (sa.SOURCE_VENV, "3.14.3") in sources
+        assert (sa.SOURCE_LAZY_SHADOWED, "3.14.1") in sources
+
+    def test_fail_on_applies_to_importable_sources_only(self):
+        assert sa._fail_on_applies(sa.SOURCE_VENV)
+        assert sa._fail_on_applies(sa.SOURCE_LAZY)
+        assert sa._fail_on_applies("plugin:foo")
+        assert sa._fail_on_applies("mcp:bar")
+        assert not sa._fail_on_applies(sa.SOURCE_LAZY_SHADOWED)


### PR DESCRIPTION
Fixes #92549

`hermes security audit` was calling the leftover lazy-packages aiohttp a venv dep, so `--fail-on high` stayed red after the sealed venv was already patched.

shadowed copy is `lazy-shadowed` now and doesn't trip fail-on. the one you actually import still does.

thx