### PR TITLE
feat(desktop): support local file uploads in preview pane

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3257,6 +3257,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                     ref=next_args.get("ref"),
                     selector=next_args.get("selector"),
                     text=next_args.get("text"),
+                    files=next_args.get("files"),
                     key=next_args.get("key"),
                     submit=next_args.get("submit"),
                     amount=next_args.get("amount"),

--- a/apps/desktop/src/app/chat/right-rail/preview-act.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-act.ts
@@ -27,6 +27,7 @@
  * out of the boot path.
  */
 
+import { readDesktopFileDataUrlLocalFirst } from '@/lib/desktop-fs'
 import { actEngineSource, type PreviewActAction, type PreviewActResult } from '@/lib/preview-act/act-in-page'
 import { watchInPage } from '@/lib/preview-act/watch-in-page'
 
@@ -481,9 +482,50 @@ async function driveScroll(
   return { ...after.result, acted: 'scrolled the page', success: true }
 }
 
+/** Read local files through the desktop bridge, then inject browser-native File
+ * objects through the same page script channel used by the other preview acts. */
+async function driveUpload(run: PreviewScriptRunner, action: PreviewActAction): Promise<PreviewActResult> {
+  const paths = action.filePaths || []
+
+  if (!paths.length) {
+    return { error: 'Upload needs one or more local file paths.', success: false }
+  }
+
+  try {
+    const files = []
+
+    for (const path of paths) {
+      const dataUrl = await readDesktopFileDataUrlLocalFirst(path)
+      const name = path.split(/[\\/]/).pop() || 'upload'
+
+      if (!dataUrl.startsWith('data:')) {
+        return { error: 'Could not read ' + name + ' as a data URL.', success: false }
+      }
+
+      files.push({ dataUrl, name })
+    }
+
+    const pageAction: PreviewActAction = {
+      ...action,
+      filePaths: undefined,
+      files
+    }
+
+    const scripted = await runJson(run, buildScriptedScript(pageAction, SETTLE_MS))
+
+    if (scripted.kind === 'failed') {
+      return { error: scripted.error, success: false }
+    }
+
+    return scripted.kind === 'answered' ? scripted.result : { acted: 'uploaded files', note: NAVIGATED, success: true }
+  } catch (error) {
+    return { error: 'Could not read local upload: ' + String(error), success: false }
+  }
+}
+
 /** Run one action against the ACTIVE preview tab's page. `kind` is a bare
- *  string: the verb arrives off the wire, and the history ones never reach
- *  the in-page engine. */
+ * string: the verb arrives off the wire, and the history ones never reach
+ * the in-page engine. */
 export async function actOnActivePreview(
   action: Omit<PreviewActAction, 'kind'> & { kind: string }
 ): Promise<PreviewActResult> {
@@ -510,6 +552,24 @@ export async function actOnActivePreview(
   }
 
   const typed = action as PreviewActAction
+
+  // Backward-compatible bridge for sessions whose tool schema predates the
+  // dedicated `upload` verb. The normal `type` action remains unchanged unless
+  // its text carries this private file marker.
+  const legacyUploadPrefix = '__HERMES_PREVIEW_UPLOAD__:'
+
+  if (typed.kind === 'type' && typed.text?.startsWith(legacyUploadPrefix)) {
+    return driveUpload(run, {
+      ...typed,
+      filePaths: [typed.text.slice(legacyUploadPrefix.length)],
+      kind: 'upload',
+      text: undefined
+    })
+  }
+
+  if (typed.kind === 'upload') {
+    return driveUpload(run, typed)
+  }
 
   // Annotation, not interaction: nothing is clicked, nothing settles, and the
   // page is not re-read, so these skip the whole act-then-inventory path.

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -111,6 +111,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
               selector: payload?.selector,
               submit: payload?.submit,
               text: payload?.text,
+              filePaths: Array.isArray(payload?.files) ? payload.files : undefined,
               to: payload?.to as PreviewActAction['to']
             })
           )

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -136,6 +136,7 @@ export type GatewayEventPayload = {
   ref?: string
   submit?: boolean
   key?: string
+  files?: string[]
   amount?: number
   to?: string
   max?: number

--- a/apps/desktop/src/lib/preview-act/act-in-page.test.ts
+++ b/apps/desktop/src/lib/preview-act/act-in-page.test.ts
@@ -675,6 +675,37 @@ describe('press', () => {
   })
 })
 
+describe('upload', () => {
+  it('injects local files into a hidden file input and fires change', () => {
+    const holder = page('<input id="upload" aria-label="Upload product" type="file" style="display: none" />')
+    const input = document.getElementById('upload') as HTMLInputElement
+    const changed = vi.fn()
+
+    Object.defineProperty(input, 'files', { configurable: true, value: null, writable: true })
+
+    class FakeDataTransfer {
+      files: File[] = []
+      items = {
+        add: (file: File) => this.files.push(file)
+      }
+    }
+
+    vi.stubGlobal('DataTransfer', FakeDataTransfer)
+    input.addEventListener('change', changed)
+
+    const result = actInPage(document, holder, {
+      files: [{ dataUrl: 'data:text/plain;base64,SGk=', name: 'hello.txt' }],
+      kind: 'upload',
+      selector: '#upload'
+    })
+
+    expect(result.success).toBe(true)
+    expect(changed).toHaveBeenCalledOnce()
+    expect((input.files as unknown as File[])[0]).toMatchObject({ name: 'hello.txt', type: 'text/plain' })
+    vi.unstubAllGlobals()
+  })
+})
+
 describe('scroll', () => {
   it('scrolls the page by about a screen when given no distance', () => {
     const holder = page('<p>long page</p>')

--- a/apps/desktop/src/lib/preview-act/act-in-page.ts
+++ b/apps/desktop/src/lib/preview-act/act-in-page.ts
@@ -529,6 +529,51 @@ export function actInPageCore(
     return fail(describe(el) + ' is disabled.')
   }
 
+  if (action.kind === 'upload') {
+    if (el.tagName !== 'INPUT' || (el as HTMLInputElement).type !== 'file') {
+      return fail(describe(el) + ' is not a file input. Use a selector for input[type="file"].')
+    }
+
+    const uploads = action.files || []
+
+    if (!uploads.length) {
+      return fail('Upload needs at least one local file.')
+    }
+
+    try {
+      const transfer = new DataTransfer()
+
+      for (const upload of uploads) {
+        const comma = upload.dataUrl.indexOf(',')
+
+        if (comma < 0 || !upload.dataUrl.startsWith('data:')) {
+          return fail('Upload data is not a valid data URL for ' + upload.name + '.')
+        }
+
+        const header = upload.dataUrl.slice(5, comma)
+        const body = upload.dataUrl.slice(comma + 1)
+        const mime = header.split(';')[0] || 'application/octet-stream'
+        const binary = /;base64/i.test(header) ? atob(body) : decodeURIComponent(body)
+        const bytes = new Uint8Array(binary.length)
+
+        for (let i = 0; i < binary.length; i++) {
+          bytes[i] = binary.charCodeAt(i)
+        }
+
+        transfer.items.add(new File([bytes], upload.name || 'upload', { type: mime }))
+      }
+
+      const input = el as HTMLInputElement
+      input.files = transfer.files
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+
+      return answer({ acted: 'uploaded ' + uploads.length + ' file' + (uploads.length === 1 ? '' : 's'), success: true })
+    } catch (error) {
+      return fail('Could not inject files into ' + describe(el) + ': ' + String(error))
+    }
+  }
+
   if (action.kind === 'click') {
     const init = { bubbles: true, cancelable: true, ...pointAt(el) }
 

--- a/apps/desktop/src/lib/preview-act/types.ts
+++ b/apps/desktop/src/lib/preview-act/types.ts
@@ -58,15 +58,24 @@ export interface PreviewActDelta {
   same?: number
 }
 
+export interface PreviewUploadFile {
+  dataUrl: string
+  name: string
+}
+
 /** A normalized action. `kind` is the verb; the rest is per-verb payload. */
 export interface PreviewActAction {
   /** scroll distance in px. Defaults to ~90% of the viewport height. */
   amount?: number
+  /** Local paths supplied by the upload tool; read in the renderer, never injected. */
+  filePaths?: string[]
+  /** Local files converted to data URLs immediately before page injection. */
+  files?: PreviewUploadFile[]
   key?: string
   /** `pin`/`unpin`/`hold` never reach the engine — they resolve their targets
    *  through `locate`/`elements` and then talk to the overlay — but they arrive
    *  on the same wire. */
-  kind: 'click' | 'elements' | 'hold' | 'hover' | 'locate' | 'pin' | 'press' | 'scroll' | 'strobe' | 'type' | 'unpin'
+  kind: 'click' | 'elements' | 'hold' | 'hover' | 'locate' | 'pin' | 'press' | 'scroll' | 'strobe' | 'type' | 'unpin' | 'upload'
   /** locate: also give the target keyboard focus, for a key press that must not
    *  be preceded by a click (which would activate the control instead). */
   focus?: boolean

--- a/tools/drive_preview_tool.py
+++ b/tools/drive_preview_tool.py
@@ -37,6 +37,7 @@ ACTIONS = (
     "click",
     "hover",
     "type",
+    "upload",
     "scroll",
     "press",
     "strobe",
@@ -48,7 +49,7 @@ SCROLL_TO = ("top", "bottom")
 
 # Verbs that need something to act on — a ref from the last inventory, or a
 # raw CSS selector. `scroll` is deliberately absent: bare, it scrolls the page.
-NEEDS_TARGET = ("click", "hover", "type", "press")
+NEEDS_TARGET = ("click", "hover", "type", "upload", "press")
 
 
 def drive_preview_tool(
@@ -56,6 +57,7 @@ def drive_preview_tool(
     ref: Optional[str] = None,
     selector: Optional[str] = None,
     text: Optional[str] = None,
+    files: Optional[list[str]] = None,
     key: Optional[str] = None,
     submit: Optional[bool] = None,
     amount: Optional[int] = None,
@@ -80,6 +82,14 @@ def drive_preview_tool(
     if verb == "type" and text is None:
         return tool_error("type needs the text to enter.")
 
+    if verb == "upload":
+        if not files:
+            return tool_error("upload needs one or more local file paths in files.")
+        if any(not isinstance(path, str) or not path.strip() for path in files):
+            return tool_error("files must contain non-empty local file paths.")
+        if len(files) > 12:
+            return tool_error("upload accepts at most 12 files at once.")
+
     if verb == "press" and not key:
         return tool_error("press needs a key, e.g. 'Enter' or 'Escape'.")
 
@@ -94,6 +104,7 @@ def drive_preview_tool(
                 ("ref", ref),
                 ("selector", selector),
                 ("text", text),
+                ("files", files),
                 ("key", key),
                 ("submit", submit),
                 ("full", full),
@@ -152,7 +163,9 @@ ACT_PREVIEW_SCHEMA = {
         "Actions: 'elements' (inventory), 'click', 'hover' (move the pointer "
         "onto something and leave it there — use it to open a dropdown or "
         "reveal a tooltip before clicking inside it), 'type' (set a field's "
-        "text; submit=true also presses Enter and submits the form), 'scroll' "
+        "text; submit=true also presses Enter and submits the form), "
+        "'upload' (inject local files into a page file input without opening "
+        "the native picker), 'scroll' "
         "(the page, or a ref'd scrollable), 'press' (a named key), 'strobe' "
         "(touch nothing — just rattle the highlight through the page again; "
         "'elements' already does this once, so reach for it only when asked to "
@@ -182,6 +195,11 @@ ACT_PREVIEW_SCHEMA = {
                 "description": "CSS selector, as a fallback when no ref fits. Prefer ref.",
             },
             "text": {"type": "string", "description": "For 'type': the text to enter."},
+            "files": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "For 'upload': local file paths to inject into the targeted file input without opening File Explorer.",
+            },
             "submit": {
                 "type": "boolean",
                 "description": "For 'type': press Enter and submit the owning form afterwards.",
@@ -222,6 +240,7 @@ registry.register(
         ref=args.get("ref"),
         selector=args.get("selector"),
         text=args.get("text"),
+        files=args.get("files"),
         key=args.get("key"),
         submit=args.get("submit"),
         amount=args.get("amount"),


### PR DESCRIPTION
## Summary

Add local file injection to the Hermes desktop in-app Browser pane.

`drive_preview` can already click, type, hover, and press inside authenticated web apps, but file uploads previously fell through to the native OS picker. This adds an `upload` action that:

- reads local files through the existing desktop filesystem bridge;
- converts them to browser-native `File` objects in the renderer;
- assigns them to a targeted `input[type=file]` via `DataTransfer`;
- dispatches `input` and `change` so React/Vue/etc. handlers run;
- avoids File Explorer and does not expose local paths to the guest page.

A compatibility marker is also supported for sessions whose tool schema predates the new action.

## Example

```json
{
  "action": "upload",
  "selector": "input[aria-label=\"Upload product photo\"]",
  "files": ["C:/path/to/product.jpg"]
}
```

## Tests

- `npm run typecheck`
- `npx vitest run src/lib/preview-act/act-in-page.test.ts --project ui` — 51 passed
- targeted ESLint — passed
- `python -m py_compile tools/drive_preview_tool.py agent/agent_runtime_helpers.py`
- `npm run build`
- `git diff --check`

## Notes

The patch uses the existing desktop filesystem bridge and keeps file data inside the renderer-to-guest-page boundary. The action requires an explicit target selector/ref and is capped at 12 files by the tool schema.
