### PR TITLE
fix(hooks): stop shell hook approval requests from bypassing confirmation

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -720,21 +720,14 @@ def _evaluate_result(
         )
 
     stdout = (r["stdout"] or "").strip()
-    parsed = _parse_response(spec.event, stdout)
-
-    if parsed is None and fail_closed and stdout:
-        # The hook produced output we could not turn into a directive.
-        # A fail-closed gate must not silently allow the action on
-        # garbage output (e.g. a stack trace on stdout).
-        try:
-            data = json.loads(stdout)
-            valid_json = isinstance(data, dict)
-        except json.JSONDecodeError:
-            valid_json = False
-        if not valid_json:
-            return _fail_closed_block(
-                spec, "unparseable stdout (expected a JSON object)",
-            )
+    parsed, response_error = _parse_response_with_error(spec.event, stdout)
+    if response_error:
+        logger.warning(
+            "shell hook response rejected (event=%s command=%s): %s",
+            spec.event, spec.command, response_error,
+        )
+        if fail_closed:
+            return _fail_closed_block(spec, response_error)
 
     return parsed
 
@@ -786,42 +779,81 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     ``{"action": "modify", "args": {...}}`` so callers can merge the
     returned fields into the tool's ``args`` before dispatch.
 
+    The canonical ``{"action": "approve"}`` shape is passed through with
+    optional ``message`` and ``rule_key`` fields so it reaches the shared
+    human-approval gate.
+
     For ``pre_llm_call``, ``{"context": "..."}`` is passed through
     unchanged to match the existing plugin-hook contract.
 
-    Anything else returns ``None``.
+    Valid no-op objects return ``None``. Unsupported directive values are
+    logged, and callers configured with ``fail_closed`` turn them into blocks.
     """
+    parsed, response_error = _parse_response_with_error(event, stdout)
+    if response_error:
+        logger.warning("shell hook response rejected (event=%s): %s", event, response_error)
+    return parsed
+
+
+def response_validation_error(event: str, stdout: str) -> Optional[str]:
+    """Return why non-empty shell-hook stdout cannot be honored, if any."""
+    _, error = _parse_response_with_error(event, stdout)
+    return error
+
+
+def _parse_response_with_error(
+    event: str, stdout: str,
+) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
     stdout = (stdout or "").strip()
     if not stdout:
-        return None
+        return None, None
 
     try:
         data = json.loads(stdout)
     except json.JSONDecodeError:
-        logger.warning(
-            "shell hook stdout was not valid JSON (event=%s): %s",
-            event, stdout[:200],
-        )
-        return None
+        return None, "unparseable stdout (expected a JSON object)"
 
     if not isinstance(data, dict):
-        return None
+        return None, "unparseable stdout (expected a JSON object)"
 
     if event == "pre_tool_call":
         if data.get("action") == "block":
-            return {"action": "block", "message": _block_message(data.get("message"), data.get("reason"))}
+            return {
+                "action": "block",
+                "message": _block_message(data.get("message"), data.get("reason")),
+            }, None
         if data.get("decision") == "block":
-            return {"action": "block", "message": _block_message(data.get("reason"), data.get("message"))}
+            return {
+                "action": "block",
+                "message": _block_message(data.get("reason"), data.get("message")),
+            }, None
+        if data.get("action") == "approve":
+            directive: Dict[str, Any] = {"action": "approve"}
+            message = data.get("message")
+            if isinstance(message, str) and message:
+                directive["message"] = message
+            rule_key = data.get("rule_key")
+            if isinstance(rule_key, str) and rule_key.strip():
+                directive["rule_key"] = rule_key.strip()
+            return directive, None
         # "modify" action — transform tool_input before dispatch
         if data.get("action") == "modify":
             new_args = data.get("args")
             if isinstance(new_args, dict):
-                return {"action": "modify", "args": new_args}
+                return {"action": "modify", "args": new_args}, None
+            return None, "invalid pre_tool_call action 'modify': args must be an object"
         if data.get("decision") == "modify":
             new_args = data.get("tool_input")
             if isinstance(new_args, dict):
-                return {"action": "modify", "args": new_args}
-        return None
+                return {"action": "modify", "args": new_args}, None
+            return None, (
+                "invalid pre_tool_call decision 'modify': tool_input must be an object"
+            )
+        if "action" in data:
+            return None, f"unsupported pre_tool_call action: {data['action']!r}"
+        if "decision" in data:
+            return None, f"unsupported pre_tool_call decision: {data['decision']!r}"
+        return None, None
 
     if event == "pre_verify":
         # "continue" (Hermes) / "block" (Claude-Code Stop: block the stop) both
@@ -831,14 +863,14 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
         if action in {"continue", "block"}:
             message = data.get("message") or data.get("reason")
             if isinstance(message, str) and message.strip():
-                return {"action": "continue", "message": message.strip()}
-        return None
+                return {"action": "continue", "message": message.strip()}, None
+        return None, None
 
     context = data.get("context")
     if isinstance(context, str) and context.strip():
-        return {"context": context}
+        return {"context": context}, None
 
-    return None
+    return None, None
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -423,14 +423,16 @@ def _doctor_one(spec, shell_hooks) -> int:
             elapsed = result.get("elapsed_seconds", 0)
             stdout = (result.get("stdout") or "").strip()
             if stdout:
-                try:
-                    json.loads(stdout)
+                response_error = shell_hooks.response_validation_error(
+                    spec.event, stdout,
+                )
+                if response_error:
+                    problems += 1
+                    print(f"      ✗ unsupported response (exit={rc}, "
+                          f"{elapsed}s): {response_error}")
+                else:
                     print(f"      ✓ produced valid JSON on synthetic payload "
                           f"(exit={rc}, {elapsed}s)")
-                except json.JSONDecodeError:
-                    problems += 1
-                    print(f"      ✗ stdout was not valid JSON (exit={rc}, "
-                          f"{elapsed}s): {_truncate(stdout, 120)}")
             else:
                 print(f"      ✓ ran clean with empty stdout "
                       f"(exit={rc}, {elapsed}s) — hook is observer-only")

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5983,6 +5983,7 @@ class _PreToolCallDirective:
     action: Optional[str] = None
     message: Optional[str] = None
     rule_key: Optional[str] = None
+    approval_requests: Tuple[Tuple[Optional[str], Optional[str]], ...] = ()
     modified_args: Optional[Dict[str, Any]] = None
 
 
@@ -6031,8 +6032,11 @@ def _get_pre_tool_call_directive_details(
     - ``rule_key`` is optional and only honored for ``approve`` directives. It
       lets plugins choose the allowlist grain for `[a]lways` approvals.
 
-    The first valid directive wins. Invalid or irrelevant hook return values
-    are silently ignored so existing observer-only hooks are unaffected.
+    All hooks run once before control directives are resolved. A valid block
+    dominates every approval regardless of registration order. Otherwise each
+    approval is resolved independently so one rule's grant cannot authorize a
+    different rule. Invalid or irrelevant return values are silently ignored
+    so existing observer-only hooks are unaffected.
     """
     allowed = getattr(_thread_tool_whitelist, "allowed", None)
     if allowed is not None and tool_name not in allowed:
@@ -6057,6 +6061,7 @@ def _get_pre_tool_call_directive_details(
     )
 
     block_msg: Optional[str] = None
+    approval_requests: List[Tuple[Optional[str], Optional[str]]] = []
     modified_args: Optional[Dict[str, Any]] = None
 
     for result in hook_results:
@@ -6087,8 +6092,23 @@ def _get_pre_tool_call_directive_details(
         rule_key = rule_key.strip() if isinstance(rule_key, str) else None
         if not rule_key:
             rule_key = None
+        if action == "block":
+            if block_msg is None:
+                block_msg = message
+        else:
+            approval_requests.append((message, rule_key))
+
+    if block_msg is not None:
         return _PreToolCallDirective(
-            action=action, message=message, rule_key=rule_key,
+            action="block", message=block_msg, modified_args=modified_args,
+        )
+    if approval_requests:
+        message, rule_key = approval_requests[0]
+        return _PreToolCallDirective(
+            action="approve",
+            message=message,
+            rule_key=rule_key,
+            approval_requests=tuple(approval_requests),
             modified_args=modified_args,
         )
 
@@ -6216,12 +6236,21 @@ def _resolve_block_from_details(
                 )
             except Exception:
                 pass
+            requests = details.approval_requests or (
+                (details.message, details.rule_key),
+            )
             try:
-                result = request_tool_approval(
-                    tool_name,
-                    details.message or "",
-                    rule_key=details.rule_key or tool_name,
-                )
+                for message, rule_key in requests:
+                    result = request_tool_approval(
+                        tool_name,
+                        message or "",
+                        rule_key=rule_key or "",
+                    )
+                    if not result.get("approved"):
+                        return str(
+                            result.get("message")
+                            or f"BLOCKED: plugin approval required for {tool_name}"
+                        )
             finally:
                 if approval_tokens is not None:
                     try:
@@ -6232,11 +6261,6 @@ def _resolve_block_from_details(
             # Fail-closed: if the gate itself errors, block rather than
             # silently execute an action a plugin flagged for approval.
             return f"BLOCKED: plugin approval gate failed for {tool_name}"
-        if not result.get("approved"):
-            return str(
-                result.get("message")
-                or f"BLOCKED: plugin approval required for {tool_name}"
-            )
     return None
 
 

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -9,6 +9,7 @@ covered in ``test_shell_hooks_consent.py``.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -48,6 +49,22 @@ class TestParseResponse:
             '{"decision": "block", "reason": "nope"}',
         )
         assert r == {"action": "block", "message": "nope"}
+
+    def test_approve_canonical_preserves_gate_metadata(self):
+        r = shell_hooks._parse_response(
+            "pre_tool_call",
+            json.dumps({
+                "action": "approve",
+                "message": "confirm sensitive write",
+                "rule_key": "write_file:ssh",
+            }),
+        )
+
+        assert r == {
+            "action": "approve",
+            "message": "confirm sensitive write",
+            "rule_key": "write_file:ssh",
+        }
 
 
 
@@ -200,6 +217,64 @@ class TestCallbackSubprocess:
             args={"command": "rm"},
         )
         assert msg == "blocked-by-shell"
+
+    def test_approve_escalates_through_plugin_manager(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins
+
+        script = _write_script(
+            tmp_path, "approve.py",
+            'print(\'{"action": "approve", "message": "confirm write", '
+            '"rule_key": "write_file:ssh"}\')\n',
+        )
+        command = f'"{sys.executable}" "{script}"'
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        plugins._plugin_manager = plugins.PluginManager()
+        shell_hooks.register_from_config({
+            "hooks": {"pre_tool_call": [{"command": command}]},
+        }, accept_hooks=True)
+
+        seen = {}
+
+        def approve(tool_name, reason, **kwargs):
+            seen.update(
+                tool_name=tool_name,
+                reason=reason,
+                rule_key=kwargs.get("rule_key"),
+            )
+            return {"approved": True, "message": None}
+
+        monkeypatch.setattr("tools.approval.request_tool_approval", approve)
+
+        assert plugins.resolve_pre_tool_block("write_file", {"path": "id_rsa"}) is None
+        assert seen == {
+            "tool_name": "write_file",
+            "reason": "confirm write",
+            "rule_key": "write_file:ssh",
+        }
+
+    def test_unknown_directive_fails_closed(self, caplog):
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_tool_call",
+            command="policy-hook",
+            fail_closed=True,
+        )
+        result = shell_hooks._evaluate_result(spec, {
+            "error": None,
+            "timed_out": False,
+            "elapsed_seconds": 0.01,
+            "stderr": "",
+            "stdout": '{"action": "permit"}',
+            "returncode": 0,
+        })
+
+        assert result == {
+            "action": "block",
+            "message": (
+                "hook policy-hook failed closed: unsupported pre_tool_call "
+                "action: 'permit'"
+            ),
+        }
+        assert "unsupported pre_tool_call action" in caplog.text
 
     def test_matcher_regex_filters_callback(self, tmp_path, monkeypatch):
         """A matcher set to 'terminal' must not fire for 'web_search'."""

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import sys
 from contextlib import redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
@@ -203,3 +204,25 @@ class TestHooksDoctor:
         )
         assert "not allowlisted" in out.lower()
         assert "skipped JSON smoke test" in out
+
+    def test_flags_unsupported_pre_tool_call_directive(self, tmp_path):
+        script = _hook_script(
+            tmp_path,
+            'print(\'{"action": "permit"}\')\n',
+            name="hook.py",
+        )
+        command = f'"{sys.executable}" "{script}"'
+        shell_hooks._record_approval("pre_tool_call", command)
+        cfg = {
+            "hooks": {
+                "pre_tool_call": [
+                    {"command": command, "fail_closed": True},
+                ],
+            },
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            out = _run(SimpleNamespace(hooks_action="doctor"))
+
+        assert "unsupported pre_tool_call action: 'permit'" in out
+        assert "1 issue(s) found" in out

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1147,6 +1147,84 @@ class TestResolvePreToolBlock:
             "rule_key": "write_file:ssh",
         }
 
+    def test_later_block_dominates_earlier_approval(self, monkeypatch):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {
+                    "action": "approve",
+                    "message": "confirm sensitive write",
+                    "rule_key": "write_file:ssh",
+                },
+                {"action": "block", "message": "target is forbidden"},
+            ],
+        )
+
+        def _unexpected_approval(*args, **kwargs):
+            raise AssertionError("a hard block must bypass the approval gate")
+
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval", _unexpected_approval,
+        )
+        assert resolve_pre_tool_block("write_file", {}) == "target is forbidden"
+
+    def test_cached_approval_cannot_bypass_later_block(self, monkeypatch):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                {
+                    "action": "approve",
+                    "message": "already approved",
+                    "rule_key": "write_file:cached",
+                },
+                {"action": "block", "message": "independent veto"},
+            ],
+        )
+        approval_calls = []
+        monkeypatch.setattr(
+            "tools.approval.request_tool_approval",
+            lambda *args, **kwargs: approval_calls.append((args, kwargs))
+            or {"approved": True, "message": None},
+        )
+
+        assert resolve_pre_tool_block("write_file", {}) == "independent veto"
+        assert approval_calls == []
+
+    def test_independent_approval_keys_require_independent_decisions(
+        self, monkeypatch,
+    ):
+        from hermes_cli.plugins import resolve_pre_tool_block
+
+        calls = 0
+
+        def _hook_results(hook_name, **kwargs):
+            nonlocal calls
+            calls += 1
+            return [
+                {"action": "approve", "message": "first", "rule_key": "rule:a"},
+                {"action": "approve", "message": "second", "rule_key": "rule:b"},
+            ]
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _hook_results)
+        seen = []
+
+        def _approve(tool_name, reason, **kwargs):
+            seen.append((tool_name, reason, kwargs.get("rule_key")))
+            return {"approved": True, "message": None}
+
+        monkeypatch.setattr("tools.approval.request_tool_approval", _approve)
+
+        assert resolve_pre_tool_block("write_file", {}) is None
+        assert calls == 1
+        assert seen == [
+            ("write_file", "first", "rule:a"),
+            ("write_file", "second", "rule:b"),
+        ]
+
 
     def test_approve_gate_exception_fails_closed(self, monkeypatch):
         from hermes_cli.plugins import resolve_pre_tool_block
@@ -1222,20 +1300,20 @@ class TestPreToolCallModify:
         assert block_msg == "still blocked"
         assert modified == {"path": "/safe"}
 
-    def test_modify_after_block_is_invisible(self, monkeypatch):
-        """A modify after a block is never reached — first block wins."""
+    def test_modify_after_block_is_still_accumulated(self, monkeypatch):
+        """Gathering control directives must preserve later modifications."""
         monkeypatch.setattr(
             "hermes_cli.plugins.invoke_hook",
             lambda hook_name, **kwargs: [
                 {"action": "block", "message": "stopped"},
-                {"action": "modify", "args": {"path": "/invisible"}},
+                {"action": "modify", "args": {"path": "/visible"}},
             ],
         )
         block_msg, modified = _dispatch_pre_tool_call_hooks(
             "write_file", {"path": "/original"}
         )
         assert block_msg == "stopped"
-        assert modified is None
+        assert modified == {"path": "/visible"}
 
     def test_modify_with_none_args(self, monkeypatch):
         """Modify should handle None args gracefully."""

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1645,6 +1645,9 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 {"action": "modify", "args": {"new_string": "fixed content"}}         // Hermes-canonical
 {"decision": "modify", "tool_input": {"new_string": "fixed content"}} // Claude-Code style
 
+// Require human approval before a pre_tool_call proceeds:
+{"action": "approve", "message": "Confirm sensitive write", "rule_key": "write_file:ssh"}
+
 // Inject context for pre_llm_call:
 {"context": "Today is Friday, 2026-04-17"}
 
@@ -1697,6 +1700,7 @@ With `fail_closed: true`, each of these now **blocks** the tool call with `hook 
 | Command not found / not executable | warn, proceed | **block** |
 | Timeout | warn, proceed | **block** |
 | Non-JSON stdout (e.g. a stack trace) | warn, proceed | **block** |
+| Unsupported `action` / `decision` value | warn, proceed | **block** |
 | Clean exit, valid no-op JSON (`{}`) | proceed | proceed |
 
 `fail_closed` only applies to blocking-capable events (`pre_tool_call` today); setting it on any other event logs a warning at config-parse time and is ignored. `hermes hooks test` reflects these semantics — the `parsed` line shows exactly the block shape the dispatcher would receive.


### PR DESCRIPTION
## What does this PR do?

Shell `pre_tool_call` hooks can now require human confirmation with the documented `{"action":"approve"}` response instead of silently allowing the tool call. Unsupported directive values are reported and honor `fail_closed`, and `hermes hooks doctor` now rejects syntactically valid JSON that the runtime cannot honor.

### Symptom

A configured shell hook that returns `{"action":"approve"}` is reported as healthy by `hermes hooks doctor`, but its response is discarded and the tool executes without an approval prompt.

### Impact

Operators relying on shell hooks as approval policy can have protected tool calls proceed without the requested confirmation. The affected population is limited to users with `pre_tool_call` shell hooks that emit approval directives.

### Bug Cause

**Trigger:** `agent/shell_hooks.py` / `_parse_response()` when a `pre_tool_call` hook returns an approval directive.

**Causal chain:**
1. A shell hook emits valid JSON with `action` set to `approve`.
2. `_parse_response()` recognizes only `block` and `modify`, so it returns no directive.
3. The existing plugin approval dispatcher receives nothing and lets the tool call proceed.

**Why it is wrong:** The shell bridge silently drops a documented control directive even though the downstream plugin hook path already supports approval escalation.

**Working sibling / contrast:** Python `pre_tool_call` hooks returning the same canonical approval shape already reach `resolve_pre_tool_block()` and the shared approval gate. Shell `block` and `modify` responses are also normalized correctly.

**Ruled out:** The approval gate itself is not bypassing the request. An end-to-end regression test proves that once the shell response reaches the existing directive dispatcher, `request_tool_approval()` receives the expected tool, reason, and rule key.

### Fix

The shell response parser now preserves canonical approval directives and their optional `message` and `rule_key`. A shared semantic validator reports malformed or unsupported directives, lets valid no-op objects remain no-ops, blocks invalid directives when `fail_closed` is enabled, and powers the doctor smoke test so runtime and diagnostics agree.

## Related Issue

Fixes #92553

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/shell_hooks.py` - parse shell approval directives and centralize semantic response validation.
- `hermes_cli/hooks.py` - make hooks doctor reject unsupported directive JSON.
- `tests/agent/test_shell_hooks.py` - cover parsing, approval escalation, and fail-closed behavior.
- `tests/hermes_cli/test_hooks_cli.py` - cover doctor diagnostics for unsupported directives.
- `website/docs/user-guide/features/hooks.md` - document the shell approval response and unsupported-directive failure semantics.

## How to Test

1. Configure an allowlisted `pre_tool_call` shell hook that prints `{"action":"approve","message":"confirm"}` and verify the normal approval gate is invoked.
2. Configure a hook that prints `{"action":"permit"}` and verify `hermes hooks doctor` reports an unsupported response; with `fail_closed: true`, verify the runtime blocks the call.
3. Run the focused regression suites:

```bash
scripts/run_tests.sh tests/agent/test_shell_hooks.py -k 'ParseResponse or EvaluateResult or approve_escalates_through_plugin_manager' -q
scripts/run_tests.sh tests/hermes_cli/test_hooks_cli.py -k unsupported_pre_tool_call -q
scripts/run_tests.sh tests/hermes_cli/test_plugins.py -k 'PreToolCall or ResolvePreToolBlock' -q
```

All 35 selected tests pass on Windows 11.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation and docstrings
- [x] `cli-config.yaml.example` update is not applicable because no config key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not applicable because no architecture or workflow changed
- [x] I've considered cross-platform impact and used Python subprocess fixtures for the new end-to-end tests
- [x] Tool description/schema updates are not applicable because no model tool contract changed

## Screenshots / Logs

Not applicable. The focused automated regression suites above exercise the shell response bridge, approval escalation, fail-closed behavior, and doctor diagnostic path.
