### PR TITLE
fix(agent): explain turns stopped by iteration limits

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -704,6 +704,10 @@ def finalize_turn(
         "api_calls": api_call_count,
         "completed": completed,
         "turn_exit_reason": _turn_exit_reason,
+        # Stable machine-readable provenance for callers. Human-readable
+        # turn_exit_reason keeps its diagnostic detail and may evolve without
+        # silently changing gateway completion semantics.
+        "turn_exit_kind": "max_iterations" if iteration_limit_fallback else None,
         "failed": failed,
         "partial": False,  # True only when stopped due to invalid tool calls
         "interrupted": interrupted,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -175,7 +175,13 @@ def finalize_turn(
         _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
         iteration_limit_fallback = True
         preserved_verification_fallback = True
-    elif final_response is None and budget_fallback_eligible:
+    # A no-tool empty response sets ``final_response`` to "" before recovery.
+    # If later tool turns consume the call cap, that stale blank must not make
+    # the turn look answered and suppress this final fallback (#92552).
+    elif (
+        final_response is None
+        or (isinstance(final_response, str) and not final_response.strip())
+    ) and budget_fallback_eligible:
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
         # user message and makes a single toolless request.

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -142,6 +142,7 @@ def test_blank_response_at_iteration_limit_requests_summary(monkeypatch):
     assert agent._handle_max_iterations_called is True
     assert result["final_response"] == "summary from extra call"
     assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
+    assert result["turn_exit_kind"] == "max_iterations"
     assert result["completed"] is False
 
 

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -128,6 +128,23 @@ def _finalize(
 
 
 
+def test_blank_response_at_iteration_limit_requests_summary(monkeypatch):
+    """A prior empty completion must not suppress the limit fallback."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent(budget_remaining=182)
+
+    result = _finalize(
+        agent,
+        final_response="",
+        exit_reason="unknown",
+    )
+
+    assert agent._handle_max_iterations_called is True
+    assert result["final_response"] == "summary from extra call"
+    assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
+    assert result["completed"] is False
+
+
 @pytest.mark.parametrize(
     ("exit_reason", "interrupted", "failed"),
     [

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -205,6 +205,41 @@ def test_iteration_limit_result_is_not_reported_as_complete(emits, turn_env):
     assert snapshot["incomplete_reason"] == "max_iterations"
 
 
+@pytest.mark.parametrize(
+    ("turn_exit_kind", "expected_status"),
+    [
+        (None, "error"),
+        ("text_response", "complete"),
+    ],
+)
+def test_iteration_limit_legacy_reason_only_falls_back_when_kind_is_absent(
+    emits, turn_env, turn_exit_kind, expected_status
+):
+    result = {
+        "final_response": "terminal text",
+        "completed": False,
+        "failed": False,
+        "turn_exit_reason": "max_iterations_reached(240/240)",
+    }
+    if turn_exit_kind is not None:
+        result["turn_exit_kind"] = turn_exit_kind
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=lambda *a, **k: result,
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True)
+    server._start_inflight_turn(session, "do the thing")
+
+    server._run_prompt_submit("rid", "sid", session, "do the thing")
+
+    payload = _events(emits, "message.complete")[0]
+    assert payload["status"] == expected_status
+    assert (payload.get("incomplete_reason") == "max_iterations") is (
+        expected_status == "error"
+    )
+
+
 def test_returned_error_result_carries_error_surface(emits, turn_env):
     """A classified failure_reason rides the terminal frame AND the retained
     snapshot as a structured {layer, code, retryable} descriptor, so the

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -179,7 +179,10 @@ def test_iteration_limit_result_is_not_reported_as_complete(emits, turn_env):
             "final_response": summary,
             "completed": False,
             "failed": False,
-            "turn_exit_reason": "max_iterations_reached(240/240)",
+            # The machine-readable kind remains authoritative even if the
+            # diagnostic reason's presentation changes.
+            "turn_exit_reason": "iteration_budget_exhausted(240/240)",
+            "turn_exit_kind": "max_iterations",
         },
         clear_interrupt=lambda: None,
     )
@@ -193,11 +196,13 @@ def test_iteration_limit_result_is_not_reported_as_complete(emits, turn_env):
     assert payload["status"] == "error"
     assert payload["error"] == summary
     assert payload["recoverable"] is True
+    assert payload["incomplete_reason"] == "max_iterations"
 
     snapshot = server._inflight_snapshot(session)
     assert snapshot is not None
     assert snapshot["status"] == "error"
     assert snapshot["error"] == summary
+    assert snapshot["incomplete_reason"] == "max_iterations"
 
 
 def test_returned_error_result_carries_error_surface(emits, turn_env):

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -171,6 +171,35 @@ def test_returned_error_result_retains_snapshot_and_emits_terminal_frame(
     assert session["running"] is False
 
 
+def test_iteration_limit_result_is_not_reported_as_complete(emits, turn_env):
+    summary = "I reached the iteration limit while still working."
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=lambda *a, **k: {
+            "final_response": summary,
+            "completed": False,
+            "failed": False,
+            "turn_exit_reason": "max_iterations_reached(240/240)",
+        },
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True)
+    server._start_inflight_turn(session, "do the thing")
+
+    server._run_prompt_submit("rid", "sid", session, "do the thing")
+
+    payload = _events(emits, "message.complete")[0]
+    assert payload["text"] == summary
+    assert payload["status"] == "error"
+    assert payload["error"] == summary
+    assert payload["recoverable"] is True
+
+    snapshot = server._inflight_snapshot(session)
+    assert snapshot is not None
+    assert snapshot["status"] == "error"
+    assert snapshot["error"] == summary
+
+
 def test_returned_error_result_carries_error_surface(emits, turn_env):
     """A classified failure_reason rides the terminal frame AND the retained
     snapshot as a structured {layer, code, retryable} descriptor, so the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11242,12 +11242,20 @@ def _run_prompt_submit(
                 # The iteration-summary fallback is useful assistant text, but
                 # it does not mean the requested work completed. Preserve it
                 # while exposing recoverable error semantics to clients.
-                _iteration_limit_incomplete = result.get("completed") is False and (
-                    result.get("turn_exit_kind") == "max_iterations"
-                    # Compatibility with result producers predating the
-                    # structured turn-exit kind.
-                    or str(result.get("turn_exit_reason") or "").startswith(
-                        "max_iterations_reached("
+                _turn_exit_kind = result.get("turn_exit_kind")
+                _iteration_limit_incomplete = (
+                    result.get("completed") is False
+                    and (
+                        _turn_exit_kind == "max_iterations"
+                        # Compatibility with result producers predating the
+                        # structured turn-exit kind. Once present, the kind is
+                        # authoritative over diagnostic text.
+                        or (
+                            _turn_exit_kind is None
+                            and str(result.get("turn_exit_reason") or "").startswith(
+                                "max_iterations_reached("
+                            )
+                        )
                     )
                 )
                 status = (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7915,7 +7915,10 @@ def _clear_inflight_turn(session: dict) -> None:
 
 
 def _fail_inflight_turn(
-    session: dict, error: Any, error_surface: Optional[dict] = None
+    session: dict,
+    error: Any,
+    error_surface: Optional[dict] = None,
+    incomplete_reason: Optional[str] = None,
 ) -> None:
     """Mark the in-flight turn terminal-error but keep it replayable.
 
@@ -7940,6 +7943,10 @@ def _fail_inflight_turn(
     turn["error"] = message or "turn failed"
     turn["status"] = "error"
     turn["recoverable"] = True
+    if incomplete_reason:
+        turn["incomplete_reason"] = incomplete_reason
+    else:
+        turn.pop("incomplete_reason", None)
     if error_surface:
         # Structured {layer, code, retryable} descriptor — replayed to
         # resuming clients via the resume snapshot so a reconnect renders the
@@ -8506,6 +8513,9 @@ def _inflight_snapshot(session: dict) -> dict | None:
         snapshot["error"] = error
         snapshot["status"] = str(turn.get("status") or "error")
         snapshot["recoverable"] = bool(turn.get("recoverable"))
+        incomplete_reason = str(turn.get("incomplete_reason") or "").strip()
+        if incomplete_reason:
+            snapshot["incomplete_reason"] = incomplete_reason
         surface = turn.get("error_surface")
         if isinstance(surface, dict) and surface:
             snapshot["error_surface"] = surface
@@ -11232,9 +11242,11 @@ def _run_prompt_submit(
                 # The iteration-summary fallback is useful assistant text, but
                 # it does not mean the requested work completed. Preserve it
                 # while exposing recoverable error semantics to clients.
-                _iteration_limit_incomplete = (
-                    result.get("completed") is False
-                    and str(result.get("turn_exit_reason") or "").startswith(
+                _iteration_limit_incomplete = result.get("completed") is False and (
+                    result.get("turn_exit_kind") == "max_iterations"
+                    # Compatibility with result producers predating the
+                    # structured turn-exit kind.
+                    or str(result.get("turn_exit_reason") or "").startswith(
                         "max_iterations_reached("
                     )
                 )
@@ -11323,6 +11335,9 @@ def _run_prompt_submit(
                             else raw
                         ),
                         error_surface=_error_surface,
+                        incomplete_reason=(
+                            "max_iterations" if _iteration_limit_incomplete else None
+                        ),
                     )
                     turn_error_retained = True
                 else:
@@ -11332,6 +11347,10 @@ def _run_prompt_submit(
                     (result.get("error") if isinstance(result, dict) else "") or raw
                 )
                 payload["recoverable"] = True
+                if _iteration_limit_incomplete:
+                    # Keep status/error for older clients' recoverable-turn
+                    # contract while giving newer UIs a non-failure semantic.
+                    payload["incomplete_reason"] = "max_iterations"
                 if _error_surface:
                     payload["error_surface"] = _error_surface
             _retire_turn_marker(session, marker_key)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11229,10 +11229,21 @@ def _run_prompt_submit(
                 )
 
                 raw = result.get("final_response", "")
+                # The iteration-summary fallback is useful assistant text, but
+                # it does not mean the requested work completed. Preserve it
+                # while exposing recoverable error semantics to clients.
+                _iteration_limit_incomplete = (
+                    result.get("completed") is False
+                    and str(result.get("turn_exit_reason") or "").startswith(
+                        "max_iterations_reached("
+                    )
+                )
                 status = (
                     "interrupted"
                     if result.get("interrupted")
-                    else "error" if result.get("error") else "complete"
+                    else "error"
+                    if result.get("error") or _iteration_limit_incomplete
+                    else "complete"
                 )
                 # When the backend produced no visible response AND reported a
                 # real error (e.g. invalid model slug → provider 4xx), surface
@@ -11306,7 +11317,11 @@ def _run_prompt_submit(
                     # inflight payload is the only carrier of the failure.
                     _fail_inflight_turn(
                         session,
-                        result.get("error") if isinstance(result, dict) else raw,
+                        (
+                            result.get("error")
+                            if isinstance(result, dict) and result.get("error")
+                            else raw
+                        ),
                         error_surface=_error_surface,
                     )
                     turn_error_retained = True


### PR DESCRIPTION
## What does this PR do?

Turns that reach `agent.max_iterations` after an earlier empty completion now run the existing summary fallback instead of ending with a blank response. TUI and Desktop clients also receive recoverable error semantics for this incomplete turn instead of a misleading `status=complete` frame.

### Symptom

A tool-heavy turn can end at `api_calls=N/N` with `reason=unknown`, `last_msg_role=tool`, and `response_len=0`. The TUI renders a blank completed reply, so the user must guess that they should send `continue`.

### Impact

Users can lose the visible conclusion of long-running work and receive no explanation that the configured iteration limit stopped the turn.

### Bug Cause

**Trigger:** `agent/turn_finalizer.py:finalize_turn` when the API-call cap is reached with a refunded shared budget and a stale blank `final_response`.

**Causal chain:**
1. A no-tool empty completion stores `final_response=""` before recovery continues.
2. Later tool turns reach `max_iterations` while iteration-budget refunds keep `remaining > 0`, so the loop falls through with `turn_exit_reason="unknown"`.
3. The finalizer accepted only `final_response is None` for the max-iteration summary fallback, so the stale blank suppressed both limit classification and summary generation. The TUI then ignored `completed=False` and emitted `status=complete`.

**Why it is wrong:** An empty string is not a usable final answer and must not bypass the same exhaustion handling as `None`.

**Working sibling / contrast:** The existing `None` path already classifies the exit as `max_iterations_reached(...)`, requests a toolless summary, and marks the result incomplete.

**Ruled out:** The shared iteration budget itself was not exhausted in the reported trace (`182/240` remained), which excludes the separate `iteration_budget.consume()` failure branch as the source of the warning.

### Fix

Treat blank string responses as unanswered at the max-iteration finalizer boundary, preserving the existing bounded summary and completion-explainer flow. In the TUI gateway, classify incomplete `max_iterations_reached(...)` results as recoverable errors while retaining the generated summary text.

## Related Issue

Closes #92552

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_finalizer.py` - allow blank responses to enter the existing max-iteration summary fallback.
- `tui_gateway/server.py` - emit recoverable error semantics for incomplete iteration-limit turns.
- `tests/agent/test_turn_finalizer_iteration_limit_exit.py` - reproduce the refunded-budget blank-response state.
- `tests/tui_gateway/test_failed_turn_retention.py` - verify the terminal frame and retained recovery snapshot.

## How to Test

1. Run the focused agent finalizer and conversation-loop tests.
2. Run the focused TUI gateway failure-retention test.
3. Confirm all 44 tests pass:

```bash
scripts/run_tests.sh tests/agent/test_turn_finalizer_iteration_limit_exit.py tests/run_agent/test_turn_completion_explainer.py tests/run_agent/test_dict_tool_call_args.py tests/tui_gateway/test_failed_turn_retention.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

The regression tests encode the captured `api_calls=240/240`, refunded-budget, blank-response state and the TUI terminal-frame behavior.
