### PR TITLE
feat(release): plain-English release notes for updates

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -249,6 +249,7 @@ import {
 } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { parseReleaseNotes } from './release-notes'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   RemoteLivenessTracker,
@@ -2817,6 +2818,7 @@ async function checkUpdates() {
       currentSha,
       targetSha,
       commits: [],
+      releaseNotes: null,
       dirty: dirtyStr.length > 0,
       hermesRoot: updateRoot,
       fetchedAt: Date.now()
@@ -2886,6 +2888,7 @@ async function checkUpdates() {
   // the shallow log to the fetched tip so the range walk can't enumerate the
   // contaminated ancestry — so "See what's new" stays useful and honest.
   const commits = behind !== 0 ? await readCommitLog(updateRoot, branch, isShallow) : []
+  const releaseNotes = behind !== 0 ? await readReleaseNotes(updateRoot, branch) : null
 
   return {
     supported: true,
@@ -2896,6 +2899,7 @@ async function checkUpdates() {
     currentSha,
     targetSha,
     commits,
+    releaseNotes,
     dirty: dirtyStr.length > 0,
     hermesRoot: updateRoot,
     fetchedAt: Date.now()
@@ -2975,6 +2979,34 @@ async function readCommitLog(cwd, branch, isShallow) {
 
       return { sha, summary, author, at: Number.parseInt(at, 10) * 1000 }
     })
+}
+
+// Read the plain-English release notes committed at release time. Missing on
+// old branches and pre-release checkouts; callers fall back to parsing raw
+// commit subjects when this returns null. The update check runs on every new
+// commit while the notes file only changes at releases, so the file is only
+// read when the remote blob differs from the user's current one; otherwise
+// the overlay would re-show notes for the release the user is already on.
+async function readReleaseNotes(cwd: string, branch: string) {
+  const [localNotes, remoteNotes] = await Promise.all([
+    runGit(['rev-parse', 'HEAD:RELEASE_NOTES.md'], { cwd }),
+    runGit(['rev-parse', `origin/${branch}:RELEASE_NOTES.md`], { cwd })
+  ])
+
+  const localSha = localNotes.code === 0 ? localNotes.stdout.trim() : null
+  const remoteSha = remoteNotes.code === 0 ? remoteNotes.stdout.trim() : null
+
+  if (!notesChangedForUpdate(localSha, remoteSha)) {
+    return null
+  }
+
+  const { stdout, code } = await runGit(['show', `origin/${branch}:RELEASE_NOTES.md`], { cwd })
+
+  if (code !== 0) {
+    return null
+  }
+
+  return parseReleaseNotes(stdout)
 }
 
 let updateInFlight = false

--- a/apps/desktop/electron/release-notes.test.ts
+++ b/apps/desktop/electron/release-notes.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { notesChangedForUpdate, parseReleaseNotes } from './release-notes'
+
+const SAMPLE = `# Hermes v0.21.0 (2026.8.22)
+
+## What's new
+- Messages queued while Hermes was busy no longer get lost
+- A new setup page checks for missing prerequisites
+
+## Fixed
+- Sidebar no longer jitters while dragging
+
+## Improved
+- Clearer wording on update prompts
+`
+
+describe('parseReleaseNotes', () => {
+  it('parses headings and bullets into sections with mapped group ids', () => {
+    const sections = parseReleaseNotes(SAMPLE)
+
+    expect(sections).toEqual([
+      {
+        id: 'new',
+        label: "What's new",
+        items: ['Messages queued while Hermes was busy no longer get lost', 'A new setup page checks for missing prerequisites']
+      },
+      { id: 'fixed', label: 'Fixed', items: ['Sidebar no longer jitters while dragging'] },
+      { id: 'improved', label: 'Improved', items: ['Clearer wording on update prompts'] }
+    ])
+  })
+
+  it('treats unknown section headings as the other group', () => {
+    const sections = parseReleaseNotes('# v1\n\n## Experiments\n- Weird stuff\n')
+
+    expect(sections).toEqual([{ id: 'other', label: 'Experiments', items: ['Weird stuff'] }])
+  })
+
+  it('drops sections that have no items', () => {
+    const sections = parseReleaseNotes('# v1\n\n## Fixed\n\n## Faster\n- Snappier startup\n')
+
+    expect(sections).toEqual([{ id: 'faster', label: 'Faster', items: ['Snappier startup'] }])
+  })
+
+  it('ignores bullets outside any section', () => {
+    const sections = parseReleaseNotes('- orphan bullet\n\n## Fixed\n- Real item\n')
+
+    expect(sections).toEqual([{ id: 'fixed', label: 'Fixed', items: ['Real item'] }])
+  })
+
+  it('returns null when the file has no usable items', () => {
+    expect(parseReleaseNotes('')).toBeNull()
+    expect(parseReleaseNotes('# v1\n\n## Fixed\n\n')).toBeNull()
+    expect(parseReleaseNotes('just prose, no sections')).toBeNull()
+  })
+
+  it('tolerates CRLF line endings and trailing spaces', () => {
+    const sections = parseReleaseNotes('# v1\r\n\r\n## Fixed  \r\n- Item one  \r\n- Item two\r\n')
+
+    expect(sections).toEqual([{ id: 'fixed', label: 'Fixed', items: ['Item one', 'Item two'] }])
+  })
+})
+
+describe('notesChangedForUpdate', () => {
+  it('is true when the remote notes blob differs from the local one', () => {
+    expect(notesChangedForUpdate('aaa', 'bbb')).toBe(true)
+  })
+
+  it('is true when the local checkout predates the notes file entirely', () => {
+    expect(notesChangedForUpdate(null, 'bbb')).toBe(true)
+  })
+
+  it('is false when the remote has the same notes the user already saw', () => {
+    expect(notesChangedForUpdate('aaa', 'aaa')).toBe(false)
+  })
+
+  it('is false when the remote branch carries no notes file', () => {
+    expect(notesChangedForUpdate('aaa', null)).toBe(false)
+    expect(notesChangedForUpdate(null, null)).toBe(false)
+  })
+})

--- a/apps/desktop/electron/release-notes.ts
+++ b/apps/desktop/electron/release-notes.ts
@@ -1,0 +1,78 @@
+/**
+ * Parse the committed RELEASE_NOTES.md into structured sections for the
+ * update overlay. The file is written at release time (scripts/release.py)
+ * as plain-English notes; parsing it beats showing raw commit subjects.
+ *
+ * Pure and dependency-free so it can be unit-tested without Electron.
+ */
+
+export interface ReleaseNotesSection {
+  id: string
+  label: string
+  items: string[]
+}
+
+/** Section heading → renderer group id. Unknown headings become 'other'. */
+const LABEL_TO_ID: Record<string, string> = {
+  "What's new": 'new',
+  Fixed: 'fixed',
+  Faster: 'faster',
+  Improved: 'improved',
+  'Other improvements': 'other'
+}
+
+/**
+ * Parse RELEASE_NOTES.md markdown:
+ *   # Hermes v1.2.3 (2026.8.19)      ← ignored (title line)
+ *   ## What's new                    ← section heading
+ *   - item one                       ← bullet, attached to current section
+ *   - item two
+ *
+ * Returns null when the file has no usable sections or items, so callers
+ * fall back to parsing raw commit subjects.
+ */
+export function parseReleaseNotes(markdown: string): ReleaseNotesSection[] | null {
+  const sections: ReleaseNotesSection[] = []
+  let current: ReleaseNotesSection | null = null
+
+  for (const rawLine of markdown.split(/\r?\n/)) {
+    const line = rawLine.trimEnd()
+
+    if (line.startsWith('## ')) {
+      const label = line.slice(3).trim()
+
+      if (!label) {
+        continue
+      }
+
+      current = { id: LABEL_TO_ID[label] ?? 'other', label, items: [] }
+      sections.push(current)
+
+      continue
+    }
+
+    if (line.startsWith('- ')) {
+      const item = line.slice(2).trim()
+
+      if (current && item) {
+        current.items.push(item)
+      }
+    }
+  }
+
+  const nonEmpty = sections.filter(section => section.items.length > 0)
+
+  return nonEmpty.length > 0 ? nonEmpty : null
+}
+
+/**
+ * The overlay updates on every new commit, but RELEASE_NOTES.md only changes
+ * when a release lands. Showing notes the user already saw for the release
+ * they are on would bury the commits they are actually about to get, so the
+ * notes are only worth rendering when the remote blob differs from the local
+ * one. Both args are blob shas from `git rev-parse <rev>:RELEASE_NOTES.md`;
+ * either may be null when the file does not exist at that rev.
+ */
+export function notesChangedForUpdate(localNotesSha: string | null, remoteNotesSha: string | null): boolean {
+  return remoteNotesSha != null && remoteNotesSha !== localNotesSha
+}

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -14,9 +14,15 @@ import {
 import { ErrorIcon, ErrorState } from '@/components/ui/error-state'
 import { Loader } from '@/components/ui/loader'
 import { Progress } from '@/components/ui/progress'
-import type { DesktopUpdateBlocker, DesktopUpdateCommit, DesktopUpdateStage, DesktopUpdateStatus } from '@/global'
+import type {
+  DesktopUpdateBlocker,
+  DesktopUpdateCommit,
+  DesktopUpdateReleaseNotes,
+  DesktopUpdateStage,
+  DesktopUpdateStatus
+} from '@/global'
 import { useI18n } from '@/i18n'
-import { buildCommitChangelog, type CommitGroup } from '@/lib/commit-changelog'
+import { buildCommitChangelog, type CommitGroup, groupsFromReleaseNotes } from '@/lib/commit-changelog'
 import { AlertCircle, Check, Copy, Terminal } from '@/lib/icons'
 import { resolveUpdateCopy, type UpdateTarget } from '@/lib/update-copy'
 import { cn } from '@/lib/utils'
@@ -139,6 +145,7 @@ export function UpdatesOverlay() {
             onInstall={handleInstall}
             onLater={() => handleClose(false)}
             onRetryCheck={() => void check()}
+            releaseNotes={status?.releaseNotes ?? null}
             status={status}
             target={target}
             updateAvailable={updateAvailable}
@@ -156,6 +163,7 @@ function IdleView({
   onInstall,
   onLater,
   onRetryCheck,
+  releaseNotes,
   status,
   target,
   updateAvailable
@@ -166,6 +174,7 @@ function IdleView({
   onInstall: () => void
   onLater: () => void
   onRetryCheck: () => void
+  releaseNotes: DesktopUpdateReleaseNotes | null
   status: DesktopUpdateStatus | null
   target: UpdateTarget
   updateAvailable: boolean
@@ -231,7 +240,11 @@ function IdleView({
     )
   }
 
-  const groups = buildCommitChangelog(commits)
+  // Plain-English release notes (from origin/<branch>:RELEASE_NOTES.md) are
+  // preferred when the branch ships them. Otherwise fall back to parsing raw
+  // commit subjects, which is what pre-release checkouts and old branches see.
+  const noteGroups = groupsFromReleaseNotes(releaseNotes?.sections)
+  const groups = noteGroups.length > 0 ? noteGroups : buildCommitChangelog(commits)
   const shownItems = totalItems(groups)
   const remaining = Math.max(0, behind - shownItems)
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -545,6 +545,17 @@ export interface DesktopUpdateCommit {
   at: number
 }
 
+/** One group of the committed RELEASE_NOTES.md, already human-readable. */
+export interface DesktopUpdateReleaseNotesSection {
+  id: string
+  label: string
+  items: string[]
+}
+
+export interface DesktopUpdateReleaseNotes {
+  sections: DesktopUpdateReleaseNotesSection[]
+}
+
 export interface DesktopUpdateStatus {
   supported: boolean
   updateAvailable?: boolean
@@ -562,6 +573,9 @@ export interface DesktopUpdateStatus {
   currentVersion?: string
   targetSha?: string
   commits?: DesktopUpdateCommit[]
+  /** Plain-English notes from origin/<branch>:RELEASE_NOTES.md when present.
+   *  Shown instead of parsing commit subjects; null/undefined falls back. */
+  releaseNotes?: DesktopUpdateReleaseNotes | null
   dirty?: boolean
   fetchedAt?: number
 }

--- a/apps/desktop/src/lib/commit-changelog.test.ts
+++ b/apps/desktop/src/lib/commit-changelog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildCommitChangelog, parseCommitHeader } from './commit-changelog'
+import { buildCommitChangelog, groupsFromReleaseNotes, parseCommitHeader } from './commit-changelog'
 
 describe('parseCommitHeader', () => {
   it('extracts type, scope, and subject from a conventional header', () => {
@@ -110,5 +110,31 @@ describe('buildCommitChangelog', () => {
 
     const totalItems = groups.reduce((sum, g) => sum + g.items.length, 0)
     expect(totalItems).toBe(3)
+  })
+})
+
+describe('groupsFromReleaseNotes', () => {
+  it('maps known section ids through and passes labels and items verbatim', () => {
+    const groups = groupsFromReleaseNotes([
+      { id: 'new', label: "What's new", items: ['A'] },
+      { id: 'fixed', label: 'Fixed', items: ['B', 'C'] }
+    ])
+
+    expect(groups).toEqual([
+      { id: 'new', label: "What's new", items: ['A'] },
+      { id: 'fixed', label: 'Fixed', items: ['B', 'C'] }
+    ])
+  })
+
+  it('coerces unknown section ids to the other group', () => {
+    const groups = groupsFromReleaseNotes([{ id: 'wrangling', label: 'Wrangling', items: ['A'] }])
+
+    expect(groups).toEqual([{ id: 'other', label: 'Wrangling', items: ['A'] }])
+  })
+
+  it('drops empty sections and returns [] for null or undefined input', () => {
+    expect(groupsFromReleaseNotes(null)).toEqual([])
+    expect(groupsFromReleaseNotes(undefined)).toEqual([])
+    expect(groupsFromReleaseNotes([{ id: 'fixed', label: 'Fixed', items: [] }])).toEqual([])
   })
 })

--- a/apps/desktop/src/lib/commit-changelog.ts
+++ b/apps/desktop/src/lib/commit-changelog.ts
@@ -177,3 +177,30 @@ export function buildCommitChangelog(
 
   return result
 }
+
+/** One section of the committed RELEASE_NOTES.md, structurally compatible
+ *  with the desktop's DesktopUpdateReleaseNotesSection. */
+export interface ReleaseNotesSectionInput {
+  id: string
+  label: string
+  items: string[]
+}
+
+const VALID_GROUP_IDS: ReadonlySet<string> = new Set(['new', 'fixed', 'faster', 'improved', 'other'])
+
+/**
+ * Convert parsed RELEASE_NOTES.md sections into render-ready groups. Kept
+ * here so the update overlay's "notes over raw subjects" preference is a pure
+ * function the same test file covers.
+ */
+export function groupsFromReleaseNotes(
+  sections: readonly ReleaseNotesSectionInput[] | null | undefined
+): CommitGroup[] {
+  return (sections ?? [])
+    .filter(section => section.items.length > 0)
+    .map(section => ({
+      id: (VALID_GROUP_IDS.has(section.id) ? section.id : 'other') as CommitGroupId,
+      label: section.label,
+      items: section.items
+    }))
+}

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -18,14 +18,27 @@ Usage:
 
     # Override CalVer date (e.g. for a belated release)
     python scripts/release.py --bump minor --publish --date 2026.3.15
+
+Environment (optional):
+    RELEASE_NOTES_API_KEY   API key for the OpenAI-compatible endpoint. Must be
+                            set by whoever publishes the release (their Nous
+                            inference API key); it is read from the environment
+                            only and never committed or printed. Without it,
+                            the raw changelog ships unchanged.
+    RELEASE_NOTES_API_BASE  Endpoint base URL (default:
+                            https://inference-api.nousresearch.com/v1).
+                            Forks can point this at their own endpoint.
+    RELEASE_NOTES_MODEL     Model name (default z-ai/glm-5.3 on the Nous gateway).
 """
 
 import argparse
 import json
+import os
 import re
 import shutil
 import subprocess
 import sys
+import urllib.request
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
@@ -33,6 +46,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 VERSION_FILE = REPO_ROOT / "hermes_cli" / "__init__.py"
 PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
+
+# Plain-English release notes committed to the repo. The desktop app reads this
+# file off the branch it updates to and shows it in the update overlay instead
+# of raw commit subjects. Regenerated (and overwritten) on every release.
+RELEASE_NOTES_FILE = REPO_ROOT / "RELEASE_NOTES.md"
 
 # ──────────────────────────────────────────────────────────────────────
 # Git email → GitHub username mapping
@@ -2278,9 +2296,18 @@ def categorize_commit(subject: str) -> str:
 
 
 def clean_subject(subject: str) -> str:
-    """Clean up a commit subject for display."""
-    # Remove conventional commit prefix
-    cleaned = re.sub(r"^(feat|fix|docs|chore|refactor|test|perf|ci|build|improve|add|update|cleanup|hotfix|breaking|enhance|optimize|bugfix|bug|feature|tests|deps|bump)[\s:(!]+\s*", "", subject, flags=re.IGNORECASE)
+    """Clean up a commit subject for display.
+
+    Strips a Conventional Commits header including any scope, so
+    "fix(ledger): claim rows" becomes "Claim rows" rather than the dangling
+    "Ledger): claim rows" the old prefix-only regex produced.
+    """
+    cleaned = re.sub(
+        r"^(?:feat|fix|docs|chore|refactor|test|perf|ci|build|improve|add|update|cleanup|hotfix|breaking|enhance|optimize|bugfix|bug|feature|tests|deps|bump)\s*(?:\([^)]*\))?\s*!?\s*:\s*",
+        "",
+        subject,
+        flags=re.IGNORECASE,
+    )
     # Remove trailing issue refs that are redundant with PR links
     cleaned = cleaned.strip()
     # Capitalize first letter
@@ -2475,6 +2502,232 @@ def generate_changelog(commits, tag_name, semver, repo_url="https://github.com/N
     return "\n".join(lines)
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Plain-English release notes (LLM translation pass)
+# ──────────────────────────────────────────────────────────────────────
+#
+# Commit subjects are written for maintainers, not users. Before publishing a
+# release, translate the categorized entries into plain language with one LLM
+# call and commit the result as RELEASE_NOTES.md; the desktop app renders that
+# file in its update overlay instead of raw subjects. Everything is optional:
+# without RELEASE_NOTES_API_KEY the release ships exactly as it did before.
+
+PLAIN_GROUPS = [
+    ("new", "What's new"),
+    ("fixed", "Fixed"),
+    ("faster", "Faster"),
+    ("improved", "Improved"),
+    ("other", "Other improvements"),
+]
+
+PLAIN_GROUP_LABELS = {label: gid for gid, label in PLAIN_GROUPS}
+
+# Commit types that never say anything useful to an end user. Mirrors the
+# desktop app's HIDDEN_TYPES so both surfaces agree on what is noise.
+_HIDDEN_TYPES = {
+    "build", "chore", "ci", "dep", "deps", "doc", "docs",
+    "lint", "release", "style", "test", "tests", "wip",
+}
+
+# Entry ordering: breaking and features first, "other" last. Within a bucket,
+# newest commits first (git log order). Cap so the translation call stays
+# small; the raw categorized changelog below the highlights still lists
+# everything.
+_CATEGORY_PRIORITY = ["breaking", "features", "fixes", "improvements", "other"]
+
+_PLAIN_MAX_ITEMS = 60
+
+_PLAIN_SYSTEM_PROMPT = (
+    "You turn developer commit messages into release notes that a non-technical "
+    "user can actually understand. Rewrite every item you are given. Rules:\n"
+    "- One short plain-English sentence per item, 14 words max.\n"
+    "- Say what changed for the user, not what changed in the code.\n"
+    "- No jargon, no internal subsystem or code names, no file paths, no commit "
+    "hashes, no parentheses, no ALL-CAPS identifiers.\n"
+    "- Never repeat the input wording unless it is already plain.\n"
+    "- Assign each item a group from exactly this set: new, fixed, faster, "
+    "improved, other.\n"
+    "- new = a feature or capability the user gains. fixed = a bug fix. faster = "
+    "a performance win. improved = a tweak or polish. other = anything else.\n"
+    "- Reply with ONLY a JSON object in this exact shape: "
+    '{"items":[{"index":0,"group":"fixed","text":"..."}]}.\n'
+    "- One entry per input item, using the same index numbers, in the same order.\n"
+    "- No prose, no markdown fences, nothing outside the JSON object."
+)
+
+
+def _env_flag(name: str) -> str:
+    return (os.environ.get(name) or "").strip()
+
+
+def _plain_note_candidates(commits: list[dict]) -> list[dict]:
+    """Filter noise, order by usefulness, cap for the translation call."""
+    ordered: list[dict] = []
+    for priority in _CATEGORY_PRIORITY:
+        for commit in commits:
+            if commit["category"] == priority:
+                ordered.append(commit)
+
+    return ordered[:_PLAIN_MAX_ITEMS]
+
+
+def _extract_json_object(text: str) -> dict | None:
+    """Parse a model reply that should be a lone JSON object.
+
+    Tolerates markdown fences and stray prose by extracting the outermost
+    brace pair, which keeps the contract with the model lenient.
+    """
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^```[a-zA-Z]*\s*|\s*```$", "", stripped).strip()
+    try:
+        parsed = json.loads(stripped)
+        return parsed if isinstance(parsed, dict) else None
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    start = stripped.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    for i in range(start, len(stripped)):
+        if stripped[i] == "{":
+            depth += 1
+        elif stripped[i] == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    parsed = json.loads(stripped[start:i + 1])
+                    return parsed if isinstance(parsed, dict) else None
+                except (json.JSONDecodeError, ValueError):
+                    return None
+    return None
+
+
+def translate_entries_to_plain_english(entries: list[dict]) -> list[dict] | None:
+    """One LLM call that rewrites commit entries into plain-English items.
+
+    Returns a list of {"index", "group", "text"} aligned with the input, or
+    None when the translation is unavailable or failed, in which case the
+    caller ships the raw changelog unchanged.
+
+    The API key is read from RELEASE_NOTES_API_KEY only; it is never
+    hardcoded, committed, or printed. The base and model default to the Nous
+    inference gateway (https://inference-api.nousresearch.com/v1,
+    z-ai/glm-5.3); forks or alternate deployments can point RELEASE_NOTES_*
+    at their own endpoint.
+    """
+    api_key = _env_flag("RELEASE_NOTES_API_KEY")
+    if not api_key:
+        print("  · Plain release notes skipped: RELEASE_NOTES_API_KEY not set.")
+        return None
+
+    api_base = _env_flag("RELEASE_NOTES_API_BASE") or "https://inference-api.nousresearch.com/v1"
+    model = _env_flag("RELEASE_NOTES_MODEL") or "z-ai/glm-5.3"
+
+    payload_entries = [
+        {"index": i, "subject": clean_subject(e["subject"]), "category": e["category"]}
+        for i, e in enumerate(entries)
+    ]
+    user_prompt = json.dumps({"entries": payload_entries}, ensure_ascii=False)
+
+    body = json.dumps(
+        {
+            "model": model,
+            "temperature": 0.2,
+            "messages": [
+                {"role": "system", "content": _PLAIN_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+        },
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+    url = f"{api_base.rstrip('/')}/chat/completions"
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    last_error = "unknown error"
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(request, timeout=180) as response:
+                reply = json.loads(response.read().decode("utf-8"))
+            content = reply["choices"][0]["message"]["content"]
+            parsed = _extract_json_object(content)
+            if not parsed or not isinstance(parsed.get("items"), list):
+                last_error = "reply was not the expected JSON object"
+                continue
+            items = parsed["items"]
+            if len(items) != len(entries):
+                last_error = f"reply carried {len(items)} items, expected {len(entries)}"
+                continue
+            by_index = {}
+            valid_groups = {gid for gid, _ in PLAIN_GROUPS}
+            for item in items:
+                idx = item.get("index")
+                group = str(item.get("group") or "").lower()
+                text = str(item.get("text") or "").strip()
+                if not isinstance(idx, int) or group not in valid_groups or not text:
+                    last_error = "reply contained a malformed item"
+                    break
+                by_index[idx] = {"index": idx, "group": group, "text": text}
+            else:
+                if len(by_index) != len(entries):
+                    last_error = "reply item indexes do not cover the input"
+                else:
+                    return [by_index[i] for i in range(len(entries))]
+        except Exception as exc:  # noqa: BLE001 - release tooling, best effort
+            last_error = str(exc)
+
+    print(f"  · Plain release notes skipped: translation failed ({last_error}).")
+    return None
+
+
+def build_plain_release_notes(items: list[dict], semver: str, calver: str) -> str:
+    """Render translated items into the RELEASE_NOTES.md markdown."""
+    groups: dict[str, list[str]] = {gid: [] for gid, _ in PLAIN_GROUPS}
+    for item in items:
+        groups[item["group"]].append(item["text"])
+
+    lines = [f"# Hermes v{semver} ({calver})", ""]
+    for gid, label in PLAIN_GROUPS:
+        entries = groups[gid]
+        if not entries:
+            continue
+        lines.append(f"## {label}")
+        lines.append("")
+        for text in entries:
+            lines.append(f"- {text}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_highlights_markdown(items: list[dict]) -> str:
+    """Render translated items as the Highlights section of the GitHub body."""
+    groups: dict[str, list[str]] = {gid: [] for gid, _ in PLAIN_GROUPS}
+    for item in items:
+        groups[item["group"]].append(item["text"])
+
+    lines = ["## ✨ Highlights", ""]
+    for gid, label in PLAIN_GROUPS:
+        entries = groups[gid]
+        if not entries:
+            continue
+        lines.append(f"### {label}")
+        lines.append("")
+        for text in entries:
+            lines.append(f"- {text}")
+        lines.append("")
+    return "\n".join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Hermes Agent Release Tool")
     parser.add_argument("--bump", choices=["major", "minor", "patch"],
@@ -2535,12 +2788,32 @@ def main():
     print(f"{'='*60}")
     print()
 
-    # Generate changelog
-    changelog = generate_changelog(
+    # Generate the raw categorized changelog, then optionally translate the
+    # entries into plain English for end users. Translation is best effort:
+    # without a key, or on failure, the release ships the raw changelog exactly
+    # as it did before this feature existed.
+    raw_changelog = generate_changelog(
         commits, tag_name, new_version,
         prev_tag=prev_tag,
         first_release=args.first_release,
     )
+
+    plain_notes_md = ""
+    translated_items = None
+    candidates = _plain_note_candidates(commits)
+    if candidates:
+        translated_items = translate_entries_to_plain_english(candidates)
+    if translated_items:
+        plain_notes_md = build_plain_release_notes(translated_items, new_version, calver_date)
+
+    changelog = raw_changelog
+    if translated_items:
+        highlights = build_highlights_markdown(translated_items)
+        first_section = raw_changelog.find("## ")
+        if first_section != -1:
+            changelog = raw_changelog[:first_section] + highlights + raw_changelog[first_section:]
+        else:
+            changelog = raw_changelog + "\n" + highlights
 
     if args.output:
         Path(args.output).write_text(changelog, encoding="utf-8")
@@ -2548,30 +2821,44 @@ def main():
     else:
         print(changelog)
 
+    if plain_notes_md and not args.publish:
+        print(f"\n{'='*60}")
+        print(f"  Plain release notes preview (committed on --publish)")
+        print(f"{'='*60}")
+        print(plain_notes_md)
+
     if args.publish:
         print(f"\n{'='*60}")
         print("  Publishing release...")
         print(f"{'='*60}")
 
-        # Update version files
+        # Update version files and stage everything the release must ship:
+        # the version files on a bump, plus RELEASE_NOTES.md when the plain
+        # translation pass produced one.
+        files_to_stage = []
         if args.bump:
             update_version_files(new_version, calver_date)
             print(f"  ✓ Updated version files to v{new_version} ({calver_date})")
+            files_to_stage.extend([str(VERSION_FILE), str(PYPROJECT_FILE)])
 
-            # Commit version bump
-            add_files = [str(VERSION_FILE), str(PYPROJECT_FILE)]
-            add_result = git_result("add", *add_files)
+        if plain_notes_md:
+            RELEASE_NOTES_FILE.write_text(plain_notes_md, encoding="utf-8")
+            print(f"  ✓ Plain release notes written to {RELEASE_NOTES_FILE.name}")
+            files_to_stage.append(str(RELEASE_NOTES_FILE))
+
+        if files_to_stage:
+            add_result = git_result("add", *files_to_stage)
             if add_result.returncode != 0:
-                print(f"  ✗ Failed to stage version files: {add_result.stderr.strip()}")
+                print(f"  ✗ Failed to stage release files: {add_result.stderr.strip()}")
                 return
 
             commit_result = git_result(
-                "commit", "-m", f"chore: bump version to v{new_version} ({calver_date})"
+                "commit", "-m", f"chore: release v{new_version} ({calver_date})"
             )
             if commit_result.returncode != 0:
-                print(f"  ✗ Failed to commit version bump: {commit_result.stderr.strip()}")
+                print(f"  ✗ Failed to commit release files: {commit_result.stderr.strip()}")
                 return
-            print("  ✓ Committed version bump")
+            print("  ✓ Committed release files")
 
         # Create annotated tag
         tag_result = git_result(

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,0 +1,199 @@
+"""Unit tests for the plain-release-notes translation pass in scripts/release.py.
+
+The script is loaded via importlib (scripts/ is not a package) and only its
+pure helpers plus the urllib-based translation call are exercised. Network is
+never touched: urlopen is monkeypatched with an in-memory fake.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "release.py"
+
+
+def _load_release_module():
+    spec = importlib.util.spec_from_file_location("hermes_release_script", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def release():
+    return _load_release_module()
+
+
+def _commit(subject, category):
+    return {"subject": subject, "category": category}
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _completion(content: str) -> bytes:
+    payload = {"choices": [{"message": {"content": content}}]}
+    return json.dumps(payload).encode("utf-8")
+
+
+# ── _extract_json_object ────────────────────────────────────────────────
+
+
+class TestExtractJsonObject:
+    def test_plain_object(self, release):
+        assert release._extract_json_object('{"a": 1}') == {"a": 1}
+
+    def test_fenced_object(self, release):
+        raw = '```json\n{"items": []}\n```'
+        assert release._extract_json_object(raw) == {"items": []}
+
+    def test_prose_wrapped_object(self, release):
+        raw = 'Sure! Here you go:\n\n{"items": [{"index": 0}]}\n\nHope that helps.'
+        assert release._extract_json_object(raw) == {"items": [{"index": 0}]}
+
+    def test_garbage_returns_none(self, release):
+        assert release._extract_json_object("no json here") is None
+        assert release._extract_json_object("") is None
+        assert release._extract_json_object("[1, 2, 3]") is None
+
+
+# ── _plain_note_candidates ──────────────────────────────────────────────
+
+
+class TestPlainNoteCandidates:
+    def test_orders_by_priority(self, release):
+        commits = [
+            _commit("misc thing", "other"),
+            _commit("fix thing", "fixes"),
+            _commit("new feature", "features"),
+            _commit("breaking change", "breaking"),
+            _commit("docs tweak", "docs"),
+            _commit("speed up", "improvements"),
+        ]
+        ordered = release._plain_note_candidates(commits)
+        assert [c["category"] for c in ordered] == [
+            "breaking", "features", "fixes", "improvements", "other",
+        ]
+
+    def test_caps_at_sixty_items(self, release):
+        commits = [_commit(f"misc {i}", "other") for i in range(70)]
+        assert len(release._plain_note_candidates(commits)) == 60
+
+
+# ── build_plain_release_notes / build_highlights_markdown ───────────────
+
+
+class TestPlainMarkdownBuilders:
+    def test_build_plain_release_notes_groups_and_skips_empty(self, release):
+        items = [
+            {"index": 0, "group": "fixed", "text": "Messages are no longer lost"},
+            {"index": 1, "group": "new", "text": "A new setup page"},
+            {"index": 2, "group": "new", "text": "Faster first message"},
+        ]
+        markdown = release.build_plain_release_notes(items, "0.21.0", "2026.8.22")
+
+        assert markdown.startswith("# Hermes v0.21.0 (2026.8.22)\n")
+        assert "## What's new" in markdown
+        assert markdown.index("## What's new") < markdown.index("## Fixed")
+        assert "- A new setup page" in markdown
+        assert "## Faster" not in markdown  # empty group omitted
+
+    def test_build_highlights_markdown(self, release):
+        items = [
+            {"index": 0, "group": "fixed", "text": "Messages are no longer lost"},
+        ]
+        markdown = release.build_highlights_markdown(items)
+
+        assert markdown.startswith("## ✨ Highlights\n")
+        assert "### Fixed" in markdown
+        assert "- Messages are no longer lost" in markdown
+
+
+# ── translate_entries_to_plain_english ──────────────────────────────────
+
+
+class TestTranslateEntries:
+    def test_skips_without_api_key(self, release, monkeypatch):
+        monkeypatch.delenv("RELEASE_NOTES_API_KEY", raising=False)
+        result = release.translate_entries_to_plain_english([_commit("fix thing", "fixes")])
+        assert result is None
+
+    def test_translates_and_aligns_by_index(self, release, monkeypatch):
+        monkeypatch.setenv("RELEASE_NOTES_API_KEY", "test-key")
+        entries = [
+            _commit("fix(ledger): claim ledger rows before abandonable boot-send task", "fixes"),
+            _commit("feat(desktop): NSIS prereq detection page", "features"),
+        ]
+        reply = {
+            "items": [
+                {"index": 0, "group": "fixed", "text": "Queued messages no longer get lost or sent twice"},
+                {"index": 1, "group": "new", "text": "Setup now checks for missing prerequisites"},
+            ]
+        }
+
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["body"] = json.loads(request.data.decode("utf-8"))
+            captured["url"] = request.full_url
+            return _FakeResponse(_completion(json.dumps(reply)))
+
+        monkeypatch.setattr(release.urllib.request, "urlopen", fake_urlopen)
+
+        result = release.translate_entries_to_plain_english(entries)
+
+        assert result == [
+            {"index": 0, "group": "fixed", "text": "Queued messages no longer get lost or sent twice"},
+            {"index": 1, "group": "new", "text": "Setup now checks for missing prerequisites"},
+        ]
+        # The prompt must carry cleaned subjects, not the conventional prefix.
+        prompt = captured["body"]["messages"][1]["content"]
+        assert "claim ledger rows" not in prompt  # cleaned subject form
+        assert "Claim ledger rows" in prompt
+        # Defaults point at the Nous inference gateway and its GLM model.
+        assert captured["url"].startswith("https://inference-api.nousresearch.com/v1/chat/completions")
+        assert captured["body"]["model"] == "z-ai/glm-5.3"
+
+    def test_returns_none_on_item_count_mismatch(self, release, monkeypatch):
+        monkeypatch.setenv("RELEASE_NOTES_API_KEY", "test-key")
+        entries = [_commit("fix thing", "fixes"), _commit("feat thing", "features")]
+        reply = {"items": [{"index": 0, "group": "fixed", "text": "Only one"}]}
+
+        monkeypatch.setattr(
+            release.urllib.request, "urlopen", lambda request, timeout=None: _FakeResponse(_completion(json.dumps(reply)))
+        )
+        assert release.translate_entries_to_plain_english(entries) is None
+
+    def test_returns_none_on_malformed_item(self, release, monkeypatch):
+        monkeypatch.setenv("RELEASE_NOTES_API_KEY", "test-key")
+        entries = [_commit("fix thing", "fixes")]
+        reply = {"items": [{"index": 0, "group": "not-a-group", "text": "x"}]}
+
+        monkeypatch.setattr(
+            release.urllib.request, "urlopen", lambda request, timeout=None: _FakeResponse(_completion(json.dumps(reply)))
+        )
+        assert release.translate_entries_to_plain_english(entries) is None
+
+    def test_returns_none_when_network_raises(self, release, monkeypatch):
+        monkeypatch.setenv("RELEASE_NOTES_API_KEY", "test-key")
+
+        def boom(request, timeout=None):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(release.urllib.request, "urlopen", boom)
+        assert release.translate_entries_to_plain_english([_commit("fix thing", "fixes")]) is None


### PR DESCRIPTION
The desktop update overlay and the GitHub release notes show raw commit subjects. The Conventional Commits prefix gets stripped, then users read maintainer jargon: "Claim ledger rows before abandonable boot-send task". A public report from MastLob called this out (https://x.com/MastLob/status/2091135717028028429) and asked for entries to be translated into actionable copy before users see them.

## What changed

Release side (scripts/release.py)

- An optional LLM pass rewrites the categorized changelog entries into plain English. It uses RELEASE_NOTES_API_KEY, RELEASE_NOTES_API_BASE, and RELEASE_NOTES_MODEL, runs over stdlib urllib, and adds no dependencies. The base and model default to the Nous inference gateway with `z-ai/glm-5.3`; the API key is read from the maintainer's environment, never committed or printed. Without a key, the release ships the same raw changelog as today.
- The translated notes commit as RELEASE_NOTES.md on publish, and the GitHub release body gets a highlights section with them above the raw categorized list.
- clean_subject now strips the full Conventional Commits scope. "fix(ledger): claim rows" used to render as "Ledger): claim rows" in the raw sections.

Desktop

- The update check reads origin/<branch>:RELEASE_NOTES.md after git fetch and parses it into sections (apps/desktop/electron/release-notes.ts).
- The overlay renders those notes only when the file changed relative to the user's checkout (blob compare), so a user never re-reads notes for the release they already have. Between releases, when the file is unchanged, the overlay keeps showing commit-derived entries so "what's new" stays useful for the daily update flow. Once packaged builds notify only at release boundaries, this file becomes the modal's sole source.

## Why release time, not per user

Translating on each user's machine would bill their tokens on every update check, and the local check runs inside Electron where no model is configured. One call per weekly release is paid once, is identical for every user, and can be reviewed before the release goes out. The pass is best effort: a missing key or a malformed reply leaves the raw changelog in place and the release still publishes.

## Testing

- tests/test_release_script.py, 13 tests: JSON reply parsing, index alignment, count mismatch, malformed groups, network failure, and a mocked urlopen path that checks the prompt carries cleaned subjects.
- apps/desktop/electron/release-notes.test.ts and new groupsFromReleaseNotes cases in commit-changelog.test.ts.
- Desktop gates on this branch: tsc --noEmit clean, eslint clean, full vitest --project ui suite green (570 files). The electron project has two pre-existing failures (git-review-ops, git-worktree-ops) from a git hook in my local environment that blocks commits in temporary repos; the same files fail on clean main and this change does not touch them.
- End-to-end dry run against real git history since v2026.8.19 with a mock chat-completions endpoint: the highlights section and the RELEASE_NOTES.md preview render as expected.

## Not covered

Remote-mode update checks still show commit-derived notes in the overlay, and between releases the overlay keeps the commit fallback, so some raw subjects remain visible there until each release translates them into RELEASE_NOTES.md. Closing that gap would need merge-time translation, which is a bigger pipeline decision than this PR takes on.