### PR TITLE
fix(gateway): decode forwarded A2A profile output as UTF-8

### DIFF
--- a/plugins/platforms/a2a/DESIGN.md
+++ b/plugins/platforms/a2a/DESIGN.md
@@ -68,6 +68,17 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
   receives a v1.0 `StreamResponse` (`statusUpdate`) payload, HMAC-SHA256
   signed (`X-A2A-Signature`, secret `A2A_PUSH_SECRET` falling back to the
   bearer token), with SSRF-guarded callback URLs.
+- **Forwarded-profile output must be UTF-8.** When a bot agent forwards a task
+  to another profile, the child process is spawned with `PYTHONUTF8=1` and its
+  stdout is decoded as UTF-8 with `errors="replace"`. A child that emits text
+  in a legacy code page (GBK, CP1253, …) will surface U+FFFD replacement
+  characters rather than raising. Decoding with the host ANSI code page instead
+  is what produced empty-but-`COMPLETED` tasks on non-UTF-8 Windows hosts.
+- **Child stderr is never returned to a peer.** A failing forwarded profile
+  yields a generic `[profile exited N; …]` reply; the stderr tail goes to the
+  gateway log. `security.redact_outbound` scrubs credential *shapes* only —
+  filesystem paths, usernames and hostnames are not credential-shaped and
+  would otherwise cross the trust boundary verbatim.
 
 ## v1.0 wire format notes
 - Task states / roles are SCREAMING_SNAKE_CASE (TASK_STATE_*, ROLE_*).

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -877,6 +877,7 @@ class A2AAdapter(BasePlatformAdapter):
             try:
                 proc = subprocess.run(
                     cmd, capture_output=True, text=True, timeout=timeout,
+                    encoding="utf-8", errors="replace",
                     env=env, check=False, stdin=subprocess.DEVNULL,
                 )
             except subprocess.TimeoutExpired:
@@ -891,7 +892,14 @@ class A2AAdapter(BasePlatformAdapter):
                 if session_id:
                     self._profile_sessions[key] = session_id
                     self._title_forward_session(profile, session_id, session_title)
-            return security.redact_outbound((proc.stdout or "").strip()), protocol.STATE_COMPLETED
+            _out = (proc.stdout or "").strip()
+            if not _out:
+                _err = (proc.stderr or "").strip()
+                _detail = f" stderr: {_err[-400:]}" if _err else ""
+                return security.redact_outbound(
+                    f"[profile produced no output (rc={proc.returncode}){_detail}]"
+                ), protocol.STATE_FAILED
+            return security.redact_outbound(_out), protocol.STATE_COMPLETED
 
     def _finalize_task(self, pending: dict, state: str, reply: str) -> tuple[str, str]:
         """Record the outcome of a dispatched task. Returns (state, reply) after

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -886,7 +886,13 @@ class A2AAdapter(BasePlatformAdapter):
                 return security.redact_outbound(f"Profile dispatch failed: {e}"), protocol.STATE_FAILED
             if proc.returncode != 0:
                 msg = (proc.stderr or proc.stdout or f"profile exited {proc.returncode}").strip()
-                return security.redact_outbound(msg[-2000:]), protocol.STATE_FAILED
+                logger.error(
+                    "a2a: profile %r exited %d; stderr tail: %s",
+                    profile, proc.returncode, msg[-2000:],
+                )
+                return security.redact_outbound(
+                    f"[profile exited {proc.returncode}; see gateway logs for details]"
+                ), protocol.STATE_FAILED
             if not session_id:
                 session_id = self._latest_a2a_session(profile, start)
                 if session_id:
@@ -895,9 +901,13 @@ class A2AAdapter(BasePlatformAdapter):
             _out = (proc.stdout or "").strip()
             if not _out:
                 _err = (proc.stderr or "").strip()
-                _detail = f" stderr: {_err[-400:]}" if _err else ""
+                if _err:
+                    logger.error(
+                        "a2a: profile %r produced no stdout (rc=%d); stderr tail: %s",
+                        profile, proc.returncode, _err[-2000:],
+                    )
                 return security.redact_outbound(
-                    f"[profile produced no output (rc={proc.returncode}){_detail}]"
+                    f"[profile produced no output (rc={proc.returncode})]"
                 ), protocol.STATE_FAILED
             return security.redact_outbound(_out), protocol.STATE_COMPLETED
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1430,7 +1430,11 @@ class TestMultiAgentRouting:
         agent = adapter._agents["dev"]
 
         def fake_run(cmd, **kwargs):
-            return SimpleNamespace(returncode=0, stdout="   \n", stderr="boom")
+            return SimpleNamespace(
+                returncode=0,
+                stdout="   \n",
+                stderr=r'File "C:\dev\hermes\venv\lib\app.py" USER=220697 HOST=IGRATHIN2001',
+            )
 
         monkeypatch.setattr(_sp, "run", fake_run)
         monkeypatch.setattr(adapter, "_latest_a2a_session", lambda *a, **k: None)
@@ -1439,7 +1443,41 @@ class TestMultiAgentRouting:
 
         assert state == protocol.STATE_FAILED
         assert "no output" in reply
-        assert "boom" in reply
+        # The peer must learn THAT it failed, never the child's stderr: paths,
+        # usernames and hostnames are not credential-shaped, so redact_outbound
+        # does not remove them. Details go to the gateway log instead.
+        assert "C:\\dev" not in reply
+        assert "220697" not in reply
+        assert "IGRATHIN2001" not in reply
+
+    def test_forward_nonzero_exit_does_not_leak_stderr_to_peer(self, monkeypatch):
+        """A crashing child must not echo its traceback to a remote peer."""
+        import subprocess as _sp
+        from plugins.platforms.a2a.adapter import A2AAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = A2AAdapter(PlatformConfig(enabled=True, extra={
+            "agents": {"dev": {"profile": "dev", "tenant": "dev"}}
+        }))
+        agent = adapter._agents["dev"]
+
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(
+                returncode=2,
+                stdout="",
+                stderr=r'Traceback: File "C:\Users\220697\app.py" on IGRATHIN2001',
+            )
+
+        monkeypatch.setattr(_sp, "run", fake_run)
+        monkeypatch.setattr(adapter, "_latest_a2a_session", lambda *a, **k: None)
+
+        reply, state = adapter._forward_to_profile(agent, "peer-x", "ctx-1", "hi")
+
+        assert state == protocol.STATE_FAILED
+        assert "exited 2" in reply
+        assert "Traceback" not in reply
+        assert "C:\\Users" not in reply
+        assert "IGRATHIN2001" not in reply
 
 
 class TestClientTenantAndDiscovery:

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1382,6 +1382,65 @@ class TestMultiAgentRouting:
         assert protocol.extract_text(terminal["artifacts"][0]) == "dev reply"
         assert adapter.tasks.get(terminal["id"])["state"] == protocol.STATE_COMPLETED
 
+    def test_forward_decodes_child_stdout_as_utf8(self, monkeypatch):
+        """Non-ASCII replies survive regardless of the host's ANSI code page.
+
+        subprocess.run(text=True) without an explicit encoding decodes using the
+        locale code page on Windows, which silently mangles or drops output the
+        page cannot represent (e.g. Greek under cp737). Regression test for the
+        empty-but-COMPLETED task that produced.
+        """
+        import subprocess as _sp
+        from plugins.platforms.a2a.adapter import A2AAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = A2AAdapter(PlatformConfig(enabled=True, extra={
+            "agents": {"dev": {"profile": "dev", "tenant": "dev"}}
+        }))
+        agent = adapter._agents["dev"]
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(returncode=0, stdout="ΔΟΚΙΜΗ café ✓", stderr="")
+
+        monkeypatch.setattr(_sp, "run", fake_run)
+        monkeypatch.setattr(adapter, "_latest_a2a_session", lambda *a, **k: None)
+
+        reply, state = adapter._forward_to_profile(agent, "peer-x", "ctx-1", "hi")
+
+        assert captured.get("encoding") == "utf-8", "child stdout must be decoded as UTF-8"
+        assert state == protocol.STATE_COMPLETED
+        assert reply == "ΔΟΚΙΜΗ café ✓"
+
+    def test_forward_reports_failure_when_child_produces_no_output(self, monkeypatch):
+        """An empty reply is a failure, not a successful empty answer.
+
+        Reporting STATE_COMPLETED with no text makes a dead child look like an
+        agent that chose to say nothing, which callers cannot distinguish from
+        a real answer.
+        """
+        import subprocess as _sp
+        from plugins.platforms.a2a.adapter import A2AAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = A2AAdapter(PlatformConfig(enabled=True, extra={
+            "agents": {"dev": {"profile": "dev", "tenant": "dev"}}
+        }))
+        agent = adapter._agents["dev"]
+
+        def fake_run(cmd, **kwargs):
+            return SimpleNamespace(returncode=0, stdout="   \n", stderr="boom")
+
+        monkeypatch.setattr(_sp, "run", fake_run)
+        monkeypatch.setattr(adapter, "_latest_a2a_session", lambda *a, **k: None)
+
+        reply, state = adapter._forward_to_profile(agent, "peer-x", "ctx-1", "hi")
+
+        assert state == protocol.STATE_FAILED
+        assert "no output" in reply
+        assert "boom" in reply
+
 
 class TestClientTenantAndDiscovery:
     def test_rpc_body_echoes_tenant_from_agent_card(self, monkeypatch):


### PR DESCRIPTION
Fixes #92566.

## What

`_forward_to_profile()` in the A2A adapter ran the forwarded profile with
`subprocess.run(..., text=True)` and no explicit `encoding=`, so the child's stdout was
decoded using the host's locale code page instead of UTF-8.

Two changes:

1. Pass `encoding="utf-8", errors="replace"` so the reply decodes correctly regardless of
   the host's ANSI code page.
2. Return `STATE_FAILED` (including the child's stderr) when the child produces no output,
   instead of reporting `STATE_COMPLETED` with an empty message.

## Why

On a Windows host running code page 737 (Greek OEM), any forwarded reply containing Greek
text came back as `TASK_STATE_COMPLETED` **with no message part at all** — no error, no
traceback, nothing in the gateway log. Latin-1 text that degrades to ASCII was silently
altered instead (`café` → `cafe`).

`PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` do not help: they govern the child's own I/O,
not the parent's decode of the pipe.

The second change is what makes the failure *visible*. With only the encoding fix, any
other cause of an empty child reply would still be reported as a successful task. That
distinction matters in a multi-agent setup: the delegating agent receives what looks like
a successful but empty delegation, and a model handling that loosely may fill the gap from
its own knowledge. In our case a delegated agent was wrongly suspected of fabricating
results when it had in fact fetched correct data that the parent process then discarded —
the profile's own log showed `response_len=281` at the moment the caller got nothing.

This is the same defect class as #47939 (cron/kanban workers) and the `_popen_bash` UTF-8
fix, at a call site neither covered. #66668 anticipated exactly this kind of straggler.

## How to test

Two regression tests are included in `TestMultiAgentRouting`. Both fail on `main` and pass
with the fix:

```bash
pytest tests/plugins/test_a2a_plugin.py -k "forward_decodes or forward_reports_failure"
```

`test_forward_decodes_child_stdout_as_utf8` asserts `encoding="utf-8"` reaches
`subprocess.run` and that `ΔΟΚΙΜΗ café ✓` round-trips.
`test_forward_reports_failure_when_child_produces_no_output` asserts an empty child reply
yields `STATE_FAILED` carrying stderr.

Verified red/green by stashing the adapter change and re-running: both fail, then pass
once restored.

Manually verified end to end on the affected host — an A2A served agent backed by a
profile, asked for Greek text:

| Requested reply | Before | After |
| --- | --- | --- |
| `HELLO` | ✅ | ✅ |
| `café` | ⚠️ `cafe` | ✅ exact |
| `ΔΟΚΙΜΗ` | ❌ empty `COMPLETED` | ✅ exact |
| Greek news headline via delegation | ❌ empty | ✅ full text |

Codepoint-level check on the round-tripped reply confirms `U+00E9` and `U+2713` arrive
intact.

## Platforms tested

- **Windows Server 2016 (10.0.14393), code page 737** — original repro host, fix verified
  live against a running gateway.
- **macOS 15.7 (UTF-8 locale)** — full a2a test suite: 154 passed, 17 deselected.
  No behaviour change (the explicit encoding matches what the locale already provided).
- Not tested on Linux; the change is platform-independent and makes the previously
  implicit UTF-8 decode explicit.

`scripts/check-windows-footguns.py` passes on the changed adapter. It reports two
pre-existing `read_text()` findings in `tests/plugins/test_a2a_plugin.py` (lines 204 and
1673) that are unrelated to this change — identical count before and after — so I've left
them for a separate PR rather than widen this one.

## Note on scope

The `STATE_FAILED` change is arguably a separate concern from the encoding fix. I've kept
them together because the encoding bug is only *silent* because of the unconditional
`STATE_COMPLETED`, and fixing one without the other leaves the failure mode that cost the
most time. Happy to split it into its own PR if you'd prefer.
