### PR TITLE
fix(tips): remove stale smart model routing tip

### DIFF
--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -255,7 +255,6 @@ TIPS = [
     # --- Miscellaneous ---
     "Prompt caching (Anthropic) reduces costs by reusing cached system prompt prefixes.",
     "The agent auto-generates session titles in a background thread — zero latency impact.",
-    "Smart model routing can auto-route simple queries to a cheaper model.",
     "Slash commands support prefix matching: /h resolves to /help, /mod to /model.",
     "Dragging a file path into the terminal auto-attaches images or sends as context.",
     ".worktreeinclude in your repo root lists gitignored files to copy into worktrees.",


### PR DESCRIPTION
One-line removal. The random startup tip still advertises smart model routing, which was removed in #12732.

Fixes #92572