### PR TITLE
fix(desktop): give the gateway save dialog a file type to keep

### DIFF
--- a/apps/desktop/electron/gateway-file-download-transport.test.ts
+++ b/apps/desktop/electron/gateway-file-download-transport.test.ts
@@ -69,3 +69,22 @@ test('data-url fallback reads the capped route and decodes it', () => {
   assert.match(fn, /\/api\/fs\/read-data-url\?path=/)
   assert.match(fn, /parseDataUrlToBuffer\(/)
 })
+
+// #92480: both gateway save dialogs opened with no `filters`, so the Windows
+// dialog offered only "All Files" and had no default extension to append. The
+// name was never the problem, which is why this is a wiring assertion: the
+// helper's own behavior is covered in gateway-file-download.test.ts.
+test('the streaming save dialog carries a file type for the resolved name', () => {
+  const fn = extract('async function finalizeGatewayDownload', '\nfunction readGatewayErrorText')
+
+  assert.match(fn, /filters: saveDialogFilters\(filename\)/)
+})
+
+test('the data-url save dialog carries one too', () => {
+  const fn = extract('async function saveGatewayFileViaDataUrl', '// Mint a single-use WS ticket')
+
+  // The fallback saves the same bytes to the same kind of destination; a fix
+  // that reached only the streaming path would leave the bug alive on any
+  // gateway old enough to 404 the streaming route.
+  assert.match(fn, /filters: saveDialogFilters\(filename\)/)
+})

--- a/apps/desktop/electron/gateway-file-download.test.ts
+++ b/apps/desktop/electron/gateway-file-download.test.ts
@@ -8,7 +8,8 @@ import {
   gatewayFilePath,
   isNotFoundError,
   parseDataUrlToBuffer,
-  pumpStreamToFile
+  pumpStreamToFile,
+  saveDialogFilters
 } from './gateway-file-download'
 
 // A Readable-like response driven manually in tests.
@@ -187,4 +188,63 @@ test('isNotFoundError matches only HTTP 404', () => {
   assert.equal(isNotFoundError(forbidden), false)
   assert.equal(isNotFoundError(new Error('plain')), false)
   assert.equal(isNotFoundError(null), false)
+})
+
+// #92480: a .pptx saved through the gateway dialog arrived as a typeless
+// "File". The name reaching the dialog was correct; the dialog had no file
+// type to keep it with, so Windows had no default extension to append.
+test('saveDialogFilters offers the download own type before All Files', () => {
+  assert.deepEqual(saveDialogFilters('Presentation_2026-08-14.pptx'), [
+    { name: 'PPTX File', extensions: ['pptx'] },
+    { name: 'All Files', extensions: ['*'] }
+  ])
+  assert.deepEqual(saveDialogFilters('report.pdf'), [
+    { name: 'PDF File', extensions: ['pdf'] },
+    { name: 'All Files', extensions: ['*'] }
+  ])
+})
+
+test('saveDialogFilters keeps All Files last so any name stays saveable', () => {
+  // The escape hatch must survive every branch: a filter list without it turns
+  // a save dialog into a rename requirement.
+  for (const name of ['a.pptx', 'a.tar.gz', 'noext', '.gitignore', '', null]) {
+    const filters = saveDialogFilters(name)
+
+    assert.deepEqual(filters[filters.length - 1], { name: 'All Files', extensions: ['*'] })
+  }
+})
+
+test('saveDialogFilters normalizes case and reads only the last extension', () => {
+  assert.deepEqual(saveDialogFilters('SHOUTING.PDF')[0], { name: 'PDF File', extensions: ['pdf'] })
+  // Not 'tar.gz': the shell appends one extension, and gz is the one the name
+  // actually ends with.
+  assert.deepEqual(saveDialogFilters('archive.tar.gz')[0], { name: 'GZ File', extensions: ['gz'] })
+})
+
+test('saveDialogFilters falls back to All Files when there is no usable extension', () => {
+  // A dotfile has no extension in path.extname terms, and inventing one from
+  // the basename would offer to save .gitignore as "GITIGNORE File".
+  assert.deepEqual(saveDialogFilters('.gitignore'), [{ name: 'All Files', extensions: ['*'] }])
+  assert.deepEqual(saveDialogFilters('README'), [{ name: 'All Files', extensions: ['*'] }])
+  assert.deepEqual(saveDialogFilters(''), [{ name: 'All Files', extensions: ['*'] }])
+  assert.deepEqual(saveDialogFilters(undefined), [{ name: 'All Files', extensions: ['*'] }])
+})
+
+test('saveDialogFilters refuses an extension it cannot vouch for', () => {
+  // The name can come from a server-supplied Content-Disposition header, so the
+  // extension is whitelisted rather than merely extracted. Rejection is not a
+  // failure: it saves under All Files, which is today's behavior.
+  assert.deepEqual(saveDialogFilters('x.' + 'a'.repeat(17)), [{ name: 'All Files', extensions: ['*'] }])
+  assert.deepEqual(saveDialogFilters('x.p p t'), [{ name: 'All Files', extensions: ['*'] }])
+  assert.deepEqual(saveDialogFilters('x.pp*t'), [{ name: 'All Files', extensions: ['*'] }])
+  assert.deepEqual(saveDialogFilters('x.p;t'), [{ name: 'All Files', extensions: ['*'] }])
+})
+
+test('saveDialogFilters reads the basename, not a directory component', () => {
+  // filenameFromContentDisposition already reduces to a basename; this makes
+  // the helper safe on its own rather than only in that company.
+  assert.deepEqual(saveDialogFilters('/tmp/a.pdf/report.pptx')[0], {
+    name: 'PPTX File',
+    extensions: ['pptx']
+  })
 })

--- a/apps/desktop/electron/gateway-file-download.ts
+++ b/apps/desktop/electron/gateway-file-download.ts
@@ -141,6 +141,40 @@ export function filenameFromContentDisposition(value: unknown): string {
   }
 }
 
+export interface SaveDialogFilter {
+  name: string
+  extensions: string[]
+}
+
+const ALL_FILES: SaveDialogFilter = { name: 'All Files', extensions: ['*'] }
+
+// Build the Electron save-dialog `filters` for a resolved download name.
+//
+// Not cosmetic. Electron hands `filters` to the platform save dialog as its set
+// of file types, and on Windows the selected type is also what supplies the
+// default extension. Omit it and the dialog has exactly one type, "All Files",
+// with no default extension to append — so a name the shell chose to display
+// without its extension is then SAVED without it, and a .pptx lands as a
+// typeless "File" that Explorer cannot open (#92480). The image-save dialog
+// already carries a filter for the same reason.
+//
+// The extension is whitelisted rather than merely extracted, because the name
+// it comes from can be attacker-influenced: `filenameFromContentDisposition`
+// reads a server-supplied header. A filter is a poor injection target, but an
+// unbounded string from the network has no business reaching a native dialog,
+// and anything failing the test still saves — under "All Files", exactly as
+// it does today.
+export function saveDialogFilters(filename: unknown): SaveDialogFilter[] {
+  const name = path.basename(String(filename || '').trim())
+  const ext = path.extname(name).replace(/^\./, '').toLowerCase()
+
+  if (!/^[a-z0-9]{1,16}$/.test(ext)) {
+    return [ALL_FILES]
+  }
+
+  return [{ name: `${ext.toUpperCase()} File`, extensions: [ext] }, ALL_FILES]
+}
+
 // Normalize a gateway file path that may arrive as a bare path or a file:// URL.
 export function gatewayFilePath(rawPath: unknown): string {
   const value = String(rawPath || '').trim()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -156,7 +156,8 @@ import {
   gatewayFilePath,
   isNotFoundError,
   parseDataUrlToBuffer,
-  pumpStreamToFile
+  pumpStreamToFile,
+  saveDialogFilters
 } from './gateway-file-download'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { registerGitIpc } from './git-ipc'
@@ -7410,6 +7411,7 @@ async function finalizeGatewayDownload(res, statusCode, headers, ctx: any = {}) 
 
   const result = await dialog.showSaveDialog(mainWindow, {
     defaultPath: filename,
+    filters: saveDialogFilters(filename),
     title: 'Save File'
   })
 
@@ -7539,6 +7541,7 @@ async function saveGatewayFileViaDataUrl(connection, profile, filePath, ctx: any
 
   const result = await dialog.showSaveDialog(mainWindow, {
     defaultPath: filename,
+    filters: saveDialogFilters(filename),
     title: 'Save File'
   })
 


### PR DESCRIPTION
## What does this PR do?

Gives the two gateway save dialogs a file type, so a downloaded `.pptx` stops arriving as a typeless "File".

`finalizeGatewayDownload` resolves the name correctly:

```js
const filename = filenameFromContentDisposition(disposition) || ctx.suggested || ctx.fallbackName
```

and then throws the extension away one line later:

```js
const result = await dialog.showSaveDialog(mainWindow, {
  defaultPath: filename,
  title: 'Save File'
})
```

No `filters`. Electron hands `filters` to the platform save dialog as its set of file types, and on Windows the selected type is also what supplies the default extension. With none given, the dialog has exactly one type, "All Files", and nothing to append. Whatever the shell decides to display in the edit box is what gets written. That is precisely what the reporter sees: the Type field offering only "All Files", the name shown without its extension, and a saved file Explorer calls "File" until it is renamed by hand.

The same repository already learned this, at the image-save dialog a few thousand lines up in the same file:

```js
// Keep the name but always guarantee an extension - without
// one Windows saves an unopenable "All Files" blob (#image18 report).
```

That site passes an `Images` filter plus `All Files`. The gateway file path never got the same treatment.

### The part I have not proved

This explains the extension loss. It does not by itself explain why the reporter's `.docx` and `.xlsx` survive while `.pptx` and `.pdf` do not, since all four take this identical code path with no per-type branching anywhere in it. My working theory is the Windows shell's "hide extensions for known file types" setting, which hides the extension in the edit box only for types actually registered on the machine, so the split would follow which handlers are installed rather than anything in this code.

I have asked the reporter to check `assoc` for the four extensions. I am not treating that as a blocker, because the missing `filters` is a defect on its own terms and its fix is the same either way, but I would rather have the asymmetry named than quietly folded into a fix that might only cover part of it.

## Related Issue

Fixes #92480

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`apps/desktop/electron/gateway-file-download.ts`**: new `saveDialogFilters(filename)`. It lives here rather than in `main.ts` because this module exists to hold the parts of the save path that can be unit-tested without Electron, which is exactly what a pure name-to-filters function is.

Three decisions worth stating, since each of them is a place the obvious version would be wrong:

- **`All Files` is last on every branch, including the rejection branch.** A filter list without it does not merely narrow the dialog, it turns "save this file" into "rename this file first" for anything the list did not anticipate. The type is an offer, not a restriction.
- **The extension is whitelisted (`/^[a-z0-9]{1,16}$/`), not merely extracted.** The name can come from a server-supplied `Content-Disposition` header. A filter list is a poor injection target and I am not claiming a vulnerability here, but an unbounded string arriving from the network has no business reaching a native dialog, and the cost of the guard is nil: anything it declines saves under `All Files`, which is today's behaviour. The guard can only fail to improve a save, never break one.
- **`path.extname` semantics are kept rather than second-guessed.** `.gitignore` has no extension and gets `All Files` (inventing one would offer to save it as "GITIGNORE File"), and `archive.tar.gz` gets `gz`, because the shell appends one extension and `gz` is the one the name actually ends with.

**`apps/desktop/electron/main.ts`**: both `showSaveDialog` calls on the gateway path now pass `filters: saveDialogFilters(filename)`, the streaming finalizer and the data-url fallback. Fixing only the streaming one would leave the bug alive on any gateway old enough to 404 that route.

**`apps/desktop/electron/gateway-file-download.test.ts`**: 6 behavioural tests for the helper.

**`apps/desktop/electron/gateway-file-download-transport.test.ts`**: 2 wiring assertions, following the source-shape convention that file already uses for `main.ts` functions that cannot be imported.

Nothing else moves. No new IPC, no renderer changes, no change to what is downloaded or where it is written.

## How to Test

1. ```
   cd apps/desktop
   npx vitest run electron/gateway-file-download.test.ts electron/gateway-file-download-transport.test.ts
   ```
   **23 passed** (16 + 7). `eslint` clean on all four changed files; `tsc --noEmit -p tsconfig.electron.json` clean.

2. Mutation proof for the wiring. Delete the two `filters:` lines from `main.ts` and rerun the transport file: exactly the 2 new tests fail

   - `the streaming save dialog carries a file type for the resolved name`
   - `the data-url save dialog carries one too`

   and the 5 pre-existing ones still pass, so they are pinning the fix rather than restating the file.

3. Manually, on Windows, with the reporter's setup (Desktop against a remote `hermes serve`): have the agent deliver a `.pptx` via `MEDIA:/path/to/file.pptx` and click the download link. The dialog should now propose `Presentation_....pptx` with a **PPTX File** type in the Type dropdown and `All Files` available beneath it, and the saved file should open without renaming.

I do not have the reporter's exact remote-SSH setup, so step 3 is the one I am relying on review or the reporter to confirm rather than claiming myself.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate: the nearest is **#86903**, which hardens this same save path (redirects, atomic finalization, size bound, dialog parenting) and re-parents these two `showSaveDialog` calls to the sender window. It does not touch `filters` and this does not touch anything it changes, so they are complementary; whichever lands second gets a one-line rebase and I am happy for that to be mine. #90669 and #65331 also touch desktop download paths but neither is this bug.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass: N/A, this is a TypeScript-only change in `apps/desktop`. The vitest runs are above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Node 22

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A: the reasoning lives in the helper's own comment, which is where the next person to see a filter-less dialog will look. No user-facing doc describes the save dialog's type list.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: N/A, no config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A: N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): the reported symptom is Windows-specific because the default-extension behaviour is, but the change is not Windows-only code. macOS's `NSSavePanel` and the GTK dialog both take the same filter list from Electron and both benefit from being told the type; neither loses anything, since `All Files` remains available on every branch. There is no platform branching in the helper and nothing in it touches path separators.
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A: N/A.

## Screenshots / Logs

Before, from the report: save dialog shows `Presentation_Myrmikan_2026-08-14`, Type offers only `All Files`, and the saved file appears in Explorer as `File`.

After: the same dialog proposes `Presentation_Myrmikan_2026-08-14.pptx` with

```
PPTX File (*.pptx)
All Files (*.*)
```

in the Type dropdown, and Windows appends `.pptx` if the name in the box has lost it.
