### PR TITLE
fix(desktop): pool sizing as a live device preference in Settings (#91545)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -252,6 +252,7 @@ import {
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'
+import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS } from './pool-limits'
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
@@ -1355,8 +1356,57 @@ const profileDeletionGate = new ProfileDeletionGate()
 // Keep the pool light: cap concurrent profile backends (LRU eviction) and reap
 // idle ones. A user idles at exactly the primary backend; pool backends only
 // exist while a non-primary profile is actively being chatted through.
-const POOL_MAX_BACKENDS = Math.max(1, Number(process.env.HERMES_DESKTOP_POOL_MAX) || 3)
-const POOL_IDLE_MS = Math.max(60_000, Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || 10 * 60_000)
+// Pool sizing is a device preference (Settings → Advanced → pool rows), not a
+// launch constant: mutable at runtime, persisted in userData, applied live.
+// The legacy HERMES_DESKTOP_POOL_* env vars remain the initial-value fallback
+// for scripted/headless setups; after launch the stored preference wins.
+const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
+
+function readPersistedPoolLimits() {
+  try {
+    return parsePoolLimits(fs.readFileSync(POOL_LIMITS_PATH, 'utf8'))
+  } catch {
+    const fromEnv = {
+      maxBackends: Number(process.env.HERMES_DESKTOP_POOL_MAX) || undefined,
+      idleMs: Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || undefined
+    }
+    return parsePoolLimits(null) && clampPoolLimits(fromEnv)
+  }
+}
+
+function persistPoolLimits(limits) {
+  try {
+    fs.mkdirSync(path.dirname(POOL_LIMITS_PATH), { recursive: true })
+    fs.writeFileSync(POOL_LIMITS_PATH, JSON.stringify(limits, null, 2), 'utf8')
+  } catch (error) {
+    rememberLog(`[pool-limits] write failed: ${error.message}`)
+  }
+}
+
+let poolLimits = readPersistedPoolLimits()
+
+function poolMaxBackends() {
+  return poolLimits.maxBackends
+}
+
+function poolIdleMs() {
+  return poolLimits.idleMs
+}
+
+/**
+ * Apply new limits live: persist, then converge the running pool — evict
+ * LRU backends down to the new max, and let the (already running) idle
+ * reaper handle a shortened idle window on its next tick. Returns the
+ * limits actually in force (post-clamp).
+ */
+function setPoolLimits(raw) {
+  poolLimits = clampPoolLimits(raw)
+  persistPoolLimits(poolLimits)
+  evictLruPoolBackends(poolMaxBackends())
+  startPoolIdleReaper()
+
+  return { ...poolLimits }
+}
 // A backend touched within this window has a live renderer socket (the keepalive
 // pings every 60s for every open profile). LRU eviction must spare these — a
 // concurrent multi-profile session keeps several backends "fresh" at once, and
@@ -10462,7 +10512,7 @@ async function ensureBackend(profile) {
     return connection
   }
 
-  evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
+  evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
     process: null,
@@ -10607,7 +10657,7 @@ async function ensureRegistryBackend(connectionId, profile) {
       return existingLocal.connectionPromise
     }
 
-    evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
+    evictLruPoolBackends(poolMaxBackends() - 1)
 
     const localEntry = {
       process: null,
@@ -10680,7 +10730,7 @@ async function ensureRegistryBackend(connectionId, profile) {
     )
   }
 
-  evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
+  evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
     process: null,
@@ -10842,7 +10892,7 @@ function evictLruPoolBackends(keep) {
   const evictions = selectPoolEvictions(backendPool.entries(), Math.max(0, keep), Date.now(), POOL_KEEPALIVE_FRESH_MS)
 
   for (const profile of evictions) {
-    rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${POOL_MAX_BACKENDS})`)
+    rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${poolMaxBackends()})`)
     stopPoolBackend(profile)
   }
 }
@@ -10856,8 +10906,8 @@ function startPoolIdleReaper() {
     const now = Date.now()
 
     for (const [profile, entry] of [...backendPool.entries()]) {
-      if (now - (entry.lastActiveAt || 0) > POOL_IDLE_MS) {
-        rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(POOL_IDLE_MS / 1000)}s)`)
+      if (now - (entry.lastActiveAt || 0) > poolIdleMs()) {
+        rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(poolIdleMs() / 1000)}s)`)
         stopPoolBackend(profile)
       }
     }
@@ -13163,6 +13213,18 @@ ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
   touchPoolBackend(profile)
 
   return { ok: true }
+})
+// Pool sizing (Settings → Advanced): device-local, live-applied. Main is
+// authoritative (it owns the pool and the persisted copy); the returned
+// limits are what actually took effect post-clamp.
+ipcMain.handle('hermes:pool-limits:get', async () => ({ ...poolLimits }))
+ipcMain.handle('hermes:pool-limits:set', async (_event, raw) => {
+  const next = setPoolLimits({
+    maxBackends: typeof raw?.maxBackends === 'number' ? raw.maxBackends : poolLimits.maxBackends,
+    idleMs: typeof raw?.idleMs === 'number' ? raw.idleMs : poolLimits.idleMs
+  })
+
+  return { ok: true, limits: next }
 })
 ipcMain.handle('hermes:gateway:ws-url', async (_event, profile) => {
   return gatewayWsUrlIpcResult(() => freshGatewayWsUrl(profile))

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -252,7 +252,7 @@ import {
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'
-import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS } from './pool-limits'
+import { clampPoolLimits, parsePoolLimits } from './pool-limits'
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
@@ -1370,6 +1370,7 @@ function readPersistedPoolLimits() {
       maxBackends: Number(process.env.HERMES_DESKTOP_POOL_MAX) || undefined,
       idleMs: Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || undefined
     }
+
     return parsePoolLimits(null) && clampPoolLimits(fromEnv)
   }
 }
@@ -1407,6 +1408,7 @@ function setPoolLimits(raw) {
 
   return { ...poolLimits }
 }
+
 // A backend touched within this window has a live renderer socket (the keepalive
 // pings every 60s for every open profile). LRU eviction must spare these — a
 // concurrent multi-profile session keeps several backends "fresh" at once, and

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -252,7 +252,7 @@ import {
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'
-import { clampPoolLimits, parsePoolLimits } from './pool-limits'
+import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS } from './pool-limits'
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
@@ -1364,21 +1364,40 @@ const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
 
 function readPersistedPoolLimits() {
   try {
-    return parsePoolLimits(fs.readFileSync(POOL_LIMITS_PATH, 'utf8'))
+    const limits = parsePoolLimits(fs.readFileSync(POOL_LIMITS_PATH, 'utf8'))
+    rememberLog(
+      `[pool-limits] loaded from ${POOL_LIMITS_PATH}: maxBackends=${limits.maxBackends}, idleMs=${limits.idleMs}`
+    )
+
+    return limits
   } catch {
-    const fromEnv = {
+    // No persisted file yet — fall back to the legacy env vars so scripted
+    // setups keep working. Log which source won: a silently-ignored env var
+    // here costs a scripted-setup user a debugging session.
+    const fromEnv = clampPoolLimits({
       maxBackends: Number(process.env.HERMES_DESKTOP_POOL_MAX) || undefined,
       idleMs: Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || undefined
+    })
+
+    if (fromEnv.maxBackends !== POOL_LIMITS_DEFAULTS.maxBackends || fromEnv.idleMs !== POOL_LIMITS_DEFAULTS.idleMs) {
+      rememberLog(`[pool-limits] no saved file; using env-var overrides: maxBackends=${fromEnv.maxBackends}, idleMs=${fromEnv.idleMs}`)
+    } else {
+      rememberLog('[pool-limits] no saved file and no env overrides; using defaults')
     }
 
-    return parsePoolLimits(null) && clampPoolLimits(fromEnv)
+    return fromEnv
   }
 }
 
 function persistPoolLimits(limits) {
   try {
     fs.mkdirSync(path.dirname(POOL_LIMITS_PATH), { recursive: true })
-    fs.writeFileSync(POOL_LIMITS_PATH, JSON.stringify(limits, null, 2), 'utf8')
+    // Atomic write: write to a temp file in the same directory, then rename.
+    // A crash mid-write would otherwise leave truncated JSON and silently
+    // lose the user's saved sizing.
+    const tmpPath = `${POOL_LIMITS_PATH}.tmp`
+    fs.writeFileSync(tmpPath, JSON.stringify(limits, null, 2), 'utf8')
+    fs.renameSync(tmpPath, POOL_LIMITS_PATH)
   } catch (error) {
     rememberLog(`[pool-limits] write failed: ${error.message}`)
   }

--- a/apps/desktop/electron/pool-limits.test.ts
+++ b/apps/desktop/electron/pool-limits.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS, POOL_LIMITS_MIN } from './pool-limits'
+
+describe('parsePoolLimits', () => {
+  it('falls back to defaults for null/empty/corrupt input', () => {
+    expect(parsePoolLimits(null)).toEqual(POOL_LIMITS_DEFAULTS)
+    expect(parsePoolLimits(undefined)).toEqual(POOL_LIMITS_DEFAULTS)
+    expect(parsePoolLimits('')).toEqual(POOL_LIMITS_DEFAULTS)
+    expect(parsePoolLimits('not json {')).toEqual(POOL_LIMITS_DEFAULTS)
+  })
+
+  it('parses a valid persisted blob', () => {
+    expect(parsePoolLimits(JSON.stringify({ maxBackends: 11, idleMs: 7_200_000 }))).toEqual({
+      maxBackends: 11,
+      idleMs: 7_200_000
+    })
+  })
+
+  it('fills missing keys from defaults', () => {
+    expect(parsePoolLimits(JSON.stringify({ maxBackends: 5 }))).toEqual({ ...POOL_LIMITS_DEFAULTS, maxBackends: 5 })
+    expect(parsePoolLimits('{}')).toEqual(POOL_LIMITS_DEFAULTS)
+  })
+
+  it('ignores non-numeric junk instead of NaN-poisoning the pool', () => {
+    expect(parsePoolLimits(JSON.stringify({ maxBackends: 'lots', idleMs: null }))).toEqual(POOL_LIMITS_DEFAULTS)
+  })
+})
+
+describe('clampPoolLimits', () => {
+  it('clamps below the floors', () => {
+    expect(clampPoolLimits({ maxBackends: 0 }).maxBackends).toBe(POOL_LIMITS_MIN.maxBackends)
+    expect(clampPoolLimits({ idleMs: 100 }).idleMs).toBe(POOL_LIMITS_MIN.idleMs)
+  })
+
+  it('clamps absurdly high backend counts', () => {
+    expect(clampPoolLimits({ maxBackends: 10_000 }).maxBackends).toBeLessThanOrEqual(64)
+  })
+
+  it('floors fractional values', () => {
+    expect(clampPoolLimits({ maxBackends: 2.9 }).maxBackends).toBe(2)
+  })
+})

--- a/apps/desktop/electron/pool-limits.test.ts
+++ b/apps/desktop/electron/pool-limits.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS, POOL_LIMITS_MIN } from './pool-limits'
+import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_BOUNDS, POOL_LIMITS_DEFAULTS, POOL_LIMITS_MIN } from './pool-limits'
 
 describe('parsePoolLimits', () => {
   it('falls back to defaults for null/empty/corrupt input', () => {
@@ -35,6 +35,10 @@ describe('clampPoolLimits', () => {
 
   it('clamps absurdly high backend counts', () => {
     expect(clampPoolLimits({ maxBackends: 10_000 }).maxBackends).toBeLessThanOrEqual(64)
+  })
+
+  it('clamps idleMs to the shared ceiling (7 days)', () => {
+    expect(clampPoolLimits({ idleMs: 999_000_000 }).idleMs).toBe(POOL_LIMITS_BOUNDS.idleMsMax)
   })
 
   it('floors fractional values', () => {

--- a/apps/desktop/electron/pool-limits.ts
+++ b/apps/desktop/electron/pool-limits.ts
@@ -1,0 +1,68 @@
+/**
+ * Pool limits — how many bot backends may stay spawned, and how long an
+ * unused one survives.
+ *
+ * A device-local preference (each machine trades RAM against switching
+ * speed for itself), stored in userData like keep-awake. The main process
+ * is authoritative: it owns the pool AND the persisted copy, and applies a
+ * new max IMMEDIATELY by evicting least-recently-used idle backends — no
+ * app restart. The renderer mirrors the values for its UI and prewarm
+ * guard over IPC.
+ *
+ * Defaults preserve the historical hard-coded behavior (3 backends, 10min
+ * idle) so machines that never open Settings behave exactly as before.
+ */
+
+export interface PoolLimits {
+  /** Max concurrently spawned non-primary profile backends. */
+  maxBackends: number
+  /** Idle lifetime of an unused pool backend, in milliseconds. */
+  idleMs: number
+}
+
+export const POOL_LIMITS_DEFAULTS: PoolLimits = {
+  maxBackends: 3,
+  idleMs: 10 * 60_000
+}
+
+/** Hard floors — match the clamps the env-var path always applied. */
+export const POOL_LIMITS_MIN: PoolLimits = {
+  maxBackends: 1,
+  idleMs: 60_000
+}
+
+const MAX_BACKENDS_CEILING = 64
+
+/** Clamp a raw partial to the floors/ceiling; missing keys fall to defaults. */
+export function clampPoolLimits(raw: Partial<PoolLimits>): PoolLimits {
+  const maxBackends = Number.isFinite(raw.maxBackends)
+    ? Math.min(MAX_BACKENDS_CEILING, Math.max(POOL_LIMITS_MIN.maxBackends, Math.floor(Number(raw.maxBackends))))
+    : POOL_LIMITS_DEFAULTS.maxBackends
+  const idleMs = Number.isFinite(raw.idleMs)
+    ? Math.max(POOL_LIMITS_MIN.idleMs, Math.floor(Number(raw.idleMs)))
+    : POOL_LIMITS_DEFAULTS.idleMs
+
+  return { maxBackends, idleMs }
+}
+
+function clampLimits(raw: Partial<PoolLimits>): PoolLimits {
+  return clampPoolLimits(raw)
+}
+
+/** Parse + clamp a persisted JSON blob; anything unreadable falls back to
+ *  defaults so a corrupted file can never wedge the pool. */
+export function parsePoolLimits(json: string | null | undefined): PoolLimits {
+  if (!json) {
+    return { ...POOL_LIMITS_DEFAULTS }
+  }
+
+  try {
+    const parsed = JSON.parse(json)
+    return clampLimits({
+      maxBackends: typeof parsed?.maxBackends === 'number' ? parsed.maxBackends : undefined,
+      idleMs: typeof parsed?.idleMs === 'number' ? parsed.idleMs : undefined
+    })
+  } catch {
+    return { ...POOL_LIMITS_DEFAULTS }
+  }
+}

--- a/apps/desktop/electron/pool-limits.ts
+++ b/apps/desktop/electron/pool-limits.ts
@@ -31,15 +31,27 @@ export const POOL_LIMITS_MIN: PoolLimits = {
   idleMs: 60_000
 }
 
-const MAX_BACKENDS_CEILING = 64
+/** Shared bounds for both pool knobs — imported by the Settings UI so the
+ *  advertised input ranges can never drift from what main actually clamps
+ *  to. idleMs has no ceiling: a user who wants backends kept warm all week
+ *  may have exactly that. */
+export const POOL_LIMITS_BOUNDS = {
+  maxBackendsMax: 64,
+  /** 7 days, matching the UI's suggestion ceiling. */
+  idleMsMax: 7 * 24 * 60 * 60_000
+} as const
 
-/** Clamp a raw partial to the floors/ceiling; missing keys fall to defaults. */
+const MAX_BACKENDS_CEILING = POOL_LIMITS_BOUNDS.maxBackendsMax
+const IDLE_MS_CEILING = POOL_LIMITS_BOUNDS.idleMsMax
+
+/** Clamp a raw partial to the floors/ceilings; missing keys fall to defaults. */
 export function clampPoolLimits(raw: Partial<PoolLimits>): PoolLimits {
   const maxBackends = Number.isFinite(raw.maxBackends)
     ? Math.min(MAX_BACKENDS_CEILING, Math.max(POOL_LIMITS_MIN.maxBackends, Math.floor(Number(raw.maxBackends))))
     : POOL_LIMITS_DEFAULTS.maxBackends
+
   const idleMs = Number.isFinite(raw.idleMs)
-    ? Math.max(POOL_LIMITS_MIN.idleMs, Math.floor(Number(raw.idleMs)))
+    ? Math.min(IDLE_MS_CEILING, Math.max(POOL_LIMITS_MIN.idleMs, Math.floor(Number(raw.idleMs))))
     : POOL_LIMITS_DEFAULTS.idleMs
 
   return { maxBackends, idleMs }
@@ -58,6 +70,7 @@ export function parsePoolLimits(json: string | null | undefined): PoolLimits {
 
   try {
     const parsed = JSON.parse(json)
+
     return clampLimits({
       maxBackends: typeof parsed?.maxBackends === 'number' ? parsed.maxBackends : undefined,
       idleMs: typeof parsed?.idleMs === 'number' ? parsed.idleMs : undefined

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -20,6 +20,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getProfileRoutes: profiles => ipcRenderer.invoke('hermes:plugin-profile-routes', profiles),
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
   touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
+  getPoolLimits: () => ipcRenderer.invoke('hermes:pool-limits:get'),
+  setPoolLimits: limits => ipcRenderer.invoke('hermes:pool-limits:set', limits),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
   // Registry-scoped fresh WS URL: { connectionId, profile } → result shape of
   // getGatewayWsUrl, minted against that connection's backend.

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -43,8 +43,8 @@ import {
   isCurrentGatewaySwitch,
   registerGatewaySwitchLifecycle
 } from '@/store/gateway-switch'
-import { loadPoolLimits } from '@/store/pool-limits'
 import { notify, notifyError } from '@/store/notifications'
+import { loadPoolLimits } from '@/store/pool-limits'
 import {
   $activeGatewayProfile,
   normalizeProfileKey,

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -43,6 +43,7 @@ import {
   isCurrentGatewaySwitch,
   registerGatewaySwitchLifecycle
 } from '@/store/gateway-switch'
+import { loadPoolLimits } from '@/store/pool-limits'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -788,6 +789,10 @@ export function useGatewayBoot({
     // macOS wake often restores focus without a visibilitychange — without
     // this a socket dropped during sleep sits closed until the user clicks.
     window.addEventListener('focus', onFocus)
+
+    // Pool limits are main-process state; mirror them once for the Settings
+    // rows and prewarmProfileBackend's saturation guard.
+    void loadPoolLimits()
 
     // Keep live pool backends alive while this window is open (the main process
     // can't observe the direct renderer↔backend WS). No-op for the primary.

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -45,6 +45,7 @@ import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
 import { EmptyState, ListRow, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
+import { PoolLimitsSetting } from './pool-limits-setting'
 import { SettingsProfileScope } from './profile-scope'
 import { QuickEntrySettings } from './quick-entry-settings'
 
@@ -380,6 +381,7 @@ function ConfigSettingsInner({
             label={c.disableF12Title}
             onChange={setDisableF12}
           />
+          <PoolLimitsSetting />
           <QuickEntrySettings />
         </>
       )}

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -44,8 +44,8 @@ import {
 import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
-import { EmptyState, ListRow, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
 import { PoolLimitsSetting } from './pool-limits-setting'
+import { EmptyState, ListRow, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
 import { SettingsProfileScope } from './profile-scope'
 import { QuickEntrySettings } from './quick-entry-settings'
 

--- a/apps/desktop/src/app/settings/pool-limits-setting.tsx
+++ b/apps/desktop/src/app/settings/pool-limits-setting.tsx
@@ -1,13 +1,16 @@
+import { useStore } from '@nanostores/react'
 import { useEffect, useState } from 'react'
 
-import { useStore } from '@nanostores/react'
-
-import { Input } from '@/components/ui/input'
 import { ListRow } from '@/app/settings/primitives'
-import { loadPoolLimits, savePoolLimits, $poolLimits } from '@/store/pool-limits'
+import { Input } from '@/components/ui/input'
+import { $poolLimits, loadPoolLimits, savePoolLimits } from '@/store/pool-limits'
 
-const MAX_BACKENDS_MAX = 32
-const IDLE_MS_MAX = 7 * 24 * 60 * 60_000
+// Bounds imported from main's clamp module so the advertised input ranges
+// can never drift from what the pool actually enforces (review note on #92581).
+import { POOL_LIMITS_BOUNDS } from '../../../electron/pool-limits'
+
+const MAX_BACKENDS_MAX = POOL_LIMITS_BOUNDS.maxBackendsMax
+const IDLE_MS_MAX = POOL_LIMITS_BOUNDS.idleMsMax
 
 /** Settings → Advanced: warm-bot-backends count + backend idle timeout.
  *  Device-local (not profile-scoped): the pool is sized once per machine and

--- a/apps/desktop/src/app/settings/pool-limits-setting.tsx
+++ b/apps/desktop/src/app/settings/pool-limits-setting.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+
+import { useStore } from '@nanostores/react'
+
+import { Input } from '@/components/ui/input'
+import { ListRow } from '@/app/settings/primitives'
+import { loadPoolLimits, savePoolLimits, $poolLimits } from '@/store/pool-limits'
+
+const MAX_BACKENDS_MAX = 32
+const IDLE_MS_MAX = 7 * 24 * 60 * 60_000
+
+/** Settings → Advanced: warm-bot-backends count + backend idle timeout.
+ *  Device-local (not profile-scoped): the pool is sized once per machine and
+ *  changes apply live — main evicts/reaps to converge without a restart. */
+export function PoolLimitsSetting() {
+  const limits = useStore($poolLimits)
+  const [maxDraft, setMaxDraft] = useState(String(limits.maxBackends))
+  const [idleDraft, setIdleDraft] = useState(String(limits.idleMs))
+
+  useEffect(() => {
+    void loadPoolLimits()
+  }, [])
+
+  useEffect(() => {
+    setMaxDraft(String(limits.maxBackends))
+    setIdleDraft(String(limits.idleMs))
+  }, [limits])
+
+  const commitMax = () => {
+    const parsed = Number(maxDraft)
+
+    if (!Number.isFinite(parsed) || parsed === limits.maxBackends) {
+      setMaxDraft(String(limits.maxBackends))
+
+      return
+    }
+
+    void savePoolLimits({ maxBackends: parsed })
+      .then(() => undefined)
+      .catch(() => setMaxDraft(String($poolLimits.get().maxBackends)))
+  }
+
+  const commitIdle = () => {
+    const parsed = Number(idleDraft)
+
+    if (!Number.isFinite(parsed) || parsed === limits.idleMs) {
+      setIdleDraft(String(limits.idleMs))
+
+      return
+    }
+
+    void savePoolLimits({ idleMs: parsed })
+      .then(() => undefined)
+      .catch(() => setIdleDraft(String($poolLimits.get().idleMs)))
+  }
+
+  return (
+    <>
+      <ListRow
+        action={
+          <div className="flex items-center gap-2">
+            <Input
+              aria-label="Warm bot backends"
+              className="w-20"
+              inputMode="numeric"
+              max={MAX_BACKENDS_MAX}
+              min={1}
+              onBlur={commitMax}
+              onChange={event => setMaxDraft(event.target.value)}
+              onKeyDown={event => {
+                if (event.key === 'Enter') {
+                  event.currentTarget.blur()
+                }
+              }}
+              type="number"
+              value={maxDraft}
+            />
+          </div>
+        }
+        description="How many bot backends stay running for instant switching. Higher = faster switches, more memory (~60MB per backend). Applies immediately."
+        title="Warm Bot Backends"
+      />
+      <ListRow
+        action={
+          <div className="flex items-center gap-2">
+            <Input
+              aria-label="Backend idle timeout in milliseconds"
+              className="w-28"
+              inputMode="numeric"
+              max={IDLE_MS_MAX}
+              min={60_000}
+              onBlur={commitIdle}
+              onChange={event => setIdleDraft(event.target.value)}
+              onKeyDown={event => {
+                if (event.key === 'Enter') {
+                  event.currentTarget.blur()
+                }
+              }}
+              type="number"
+              value={idleDraft}
+            />
+            <span className="text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">ms</span>
+          </div>
+        }
+        description="How long an unused bot backend stays warm before it is shut down. Raise this so bots you revisit every few minutes never pay a cold start."
+        title="Backend Idle Timeout"
+      />
+    </>
+  )
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -2,6 +2,7 @@ import type { GatewayWsUrlResult } from '@hermes/shared'
 import type { TranslucencyState } from '@hermes/shared/translucency'
 
 import type { WakeIndicatorState } from './lib/wake-indicator'
+import type { PoolLimits } from '../electron/pool-limits'
 import type {
   PetOverlayBounds,
   PetOverlayControl,
@@ -46,6 +47,14 @@ declare global {
       // Keepalive: mark a pool profile backend as recently used so the idle
       // reaper spares it while its chat is active.
       touchBackend: (profile?: string | null) => Promise<{ ok: boolean }>
+      // Pool sizing (Settings → Advanced): device-local, live-applied by the
+      // main process. get resolves the limits currently in force; set applies
+      // (and persists) new ones, evicting/reaping to converge immediately.
+      getPoolLimits: () => Promise<PoolLimits>
+      setPoolLimits: (limits: { maxBackends?: number; idleMs?: number }) => Promise<{
+        ok: boolean
+        limits: PoolLimits
+      }>
       getGatewayWsUrl: (profile?: null | string) => Promise<GatewayWsUrlResult>
       // Open (or focus) a standalone OS window for a single chat session so
       // the user can work with multiple chats side by side. Returns ok:false

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1,8 +1,9 @@
 import type { GatewayWsUrlResult } from '@hermes/shared'
 import type { TranslucencyState } from '@hermes/shared/translucency'
 
-import type { WakeIndicatorState } from './lib/wake-indicator'
 import type { PoolLimits } from '../electron/pool-limits'
+
+import type { WakeIndicatorState } from './lib/wake-indicator'
 import type {
   PetOverlayBounds,
   PetOverlayControl,

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1358,6 +1358,24 @@ export function reconnectSecondaryGateways({ forceOpenSockets = false }: { force
   }
 }
 
+// How many non-primary backends currently hold an open socket. Hover-intent
+// prewarming consults this before spawning: a speculative spawn that pushes
+// the pool past its cap causes the Electron main to LRU-evict a warm backend
+// — often one the user is about to click — turning the prewarm into churn
+// (the #91545 evict/respawn cascade). The active gateway's backend is
+// primary-routed and never counts toward the pool cap.
+export function openSecondaryCount(): number {
+  let count = 0
+
+  for (const entry of g.secondaries.values()) {
+    if (isOpen(entry.gateway)) {
+      count += 1
+    }
+  }
+
+  return count
+}
+
 // Keep the idle reaper from killing a backend we still need: ping every live
 // secondary. The active one is pinged separately (touchActiveGatewayBackend).
 export function touchSecondaryGateways(): void {

--- a/apps/desktop/src/store/pool-limits.ts
+++ b/apps/desktop/src/store/pool-limits.ts
@@ -1,0 +1,65 @@
+/**
+ * Pool limits — how many bot backends may stay spawned, and how long an
+ * unused one survives before it is shut down.
+ *
+ * A device-local preference (each machine trades RAM against switching
+ * speed for itself). The MAIN process is authoritative: it owns the pool
+ * and the persisted copy, and applies a new max immediately by evicting
+ * least-recently-used idle backends — no restart. This store mirrors the
+ * live values for the Settings rows and feeds prewarmProfileBackend's
+ * saturation guard.
+ */
+
+import { atom } from 'nanostores'
+
+export interface PoolLimits {
+  /** Max concurrently spawned non-primary profile backends. */
+  maxBackends: number
+  /** Idle lifetime of an unused pool backend, in milliseconds. */
+  idleMs: number
+}
+
+export const POOL_LIMITS_DEFAULTS: PoolLimits = {
+  maxBackends: 3,
+  idleMs: 10 * 60_000
+}
+
+export const $poolLimits = atom<PoolLimits>({ ...POOL_LIMITS_DEFAULTS })
+
+/** Seed from main's authoritative state once at startup; no-op without the
+ *  bridge (web/older builds just keep the defaults for the UI). */
+export async function loadPoolLimits(): Promise<void> {
+  try {
+    const limits = await window.hermesDesktop?.getPoolLimits?.()
+
+    if (limits) {
+      $poolLimits.set(limits)
+    }
+  } catch {
+    // Keep defaults — Settings rows still render and can retry on save.
+  }
+}
+
+/** Push new limits to main; adopt the post-clamp values it reports. */
+export async function savePoolLimits(next: { maxBackends?: number; idleMs?: number }): Promise<void> {
+  const current = $poolLimits.get()
+
+  const optimistic: PoolLimits = {
+    maxBackends: next.maxBackends ?? current.maxBackends,
+    idleMs: next.idleMs ?? current.idleMs
+  }
+
+  // Optimistic paint, then honest reconciliation with the clamped result.
+  $poolLimits.set(optimistic)
+
+  try {
+    const result = await window.hermesDesktop?.setPoolLimits?.(next)
+
+    if (result?.limits) {
+      $poolLimits.set(result.limits)
+    }
+  } catch {
+    $poolLimits.set(current)
+    throw new Error('Applying pool limits failed')
+  }
+}

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -9,10 +9,24 @@ import type { ProfileInfo } from '@/types/hermes'
 const ensureGatewayForProfile = vi.fn(async () => undefined)
 const ensureGatewayForAgent = vi.fn(async () => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+const openSecondaryCount = vi.fn(() => 0)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
 
-vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile }))
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  ensureGatewayForAgent,
+  ensureGatewayForProfile,
+  openGatewayForProfile,
+  openSecondaryCount
+}))
+// The pool-limits atom is profile.ts's live saturation signal — keep the real
+// one so tests can move the cap via the store, but stub its IPC bridge.
+vi.mock('@/store/pool-limits', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $poolLimits: atom({ idleMs: 600_000, maxBackends: 3 }) }
+})
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   setApiRequestProfile: vi.fn()
@@ -28,6 +42,7 @@ const {
   prewarmProfileBackend,
   refreshProfiles
 } = await import('./profile')
+const { $poolLimits } = await import('@/store/pool-limits')
 
 const { $connection } = await import('./session')
 const { invalidateProfileScopedQueries } = await import('@/lib/query-client')
@@ -55,6 +70,7 @@ beforeEach(() => {
   getConnection.mockReset()
   ensureGatewayForProfile.mockClear()
   openGatewayForProfile.mockClear()
+  openSecondaryCount.mockReturnValue(0)
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
@@ -157,6 +173,43 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
     openGatewayForProfile.mockRejectedValueOnce(new Error('spawn failed'))
 
     expect(() => prewarmProfileBackend('warm-failing')).not.toThrow()
+  })
+
+  it('skips pre-warm when the pool is saturated (#91545 evict/respawn cascade)', () => {
+    // Every pool slot occupied: a speculative spawn would LRU-evict a warm
+    // backend — often the one the user is about to click. Default limit 3,
+    // 3 open secondaries → the next spawn would exceed the cap.
+    openSecondaryCount.mockReturnValue(3)
+
+    prewarmProfileBackend('warm-saturated')
+
+    expect(openGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('pre-warms while pool slots are free', () => {
+    openSecondaryCount.mockReturnValue(1)
+
+    prewarmProfileBackend('warm-slot-free')
+
+    expect(openGatewayForProfile).toHaveBeenCalledWith('warm-slot-free')
+  })
+
+  it('follows the live pool-limit atom, not a hard-coded cap', () => {
+    // User raises Warm Bot Backends to 8 in Settings: prewarming must keep
+    // working well past the old default of 3.
+    openSecondaryCount.mockReturnValue(5)
+    $poolLimits.set({ idleMs: 600_000, maxBackends: 8 })
+
+    prewarmProfileBackend('warm-raised-cap')
+
+    expect(openGatewayForProfile).toHaveBeenCalledWith('warm-raised-cap')
+
+    // And lowering the cap re-engages the guard at the new boundary.
+    $poolLimits.set({ idleMs: 600_000, maxBackends: 2 })
+
+    prewarmProfileBackend('warm-lowered-cap')
+
+    expect(openGatewayForProfile).not.toHaveBeenCalledWith('warm-lowered-cap')
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -21,9 +21,11 @@ import {
   ensureGatewayForAgent,
   ensureGatewayForProfile,
   openGatewayForAgent,
-  openGatewayForProfile
+  openGatewayForProfile,
+  openSecondaryCount
 } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
+import { $poolLimits } from '@/store/pool-limits'
 import { notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
 import { setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
@@ -329,6 +331,17 @@ export function prewarmProfileBackend(name: string): void {
   const now = Date.now()
 
   if (now - (prewarmedAt.get(key) ?? 0) < PREWARM_MIN_INTERVAL_MS) {
+    return
+  }
+
+  // Prewarm/cap harmony (#91545): the pool caps spawned backends at the
+  // configured max, and a spawn over the cap LRU-evicts the warmest idle
+  // backend. A hover sweep across the rail therefore evicted backends for
+  // profiles the user was about to click — prewarming caused the exact churn
+  // it exists to prevent. Skip speculative spawns once every pool slot is
+  // occupied by an open socket; the real click still spawns on demand, it
+  // just doesn't get a head start.
+  if (openSecondaryCount() + 1 > $poolLimits.get().maxBackends) {
     return
   }
 


### PR DESCRIPTION
## What does this PR do?

Multi-profile ("Bots") switching degrades because two hard-coded pool policies fight real multi-bot usage:

- `POOL_MAX_BACKENDS = 3` caps spawned profile backends. With more bots than the cap, every switch to an evicted bot pays a full cold spawn (~3-8s), and the LRU eviction often kills a backend the user was about to visit.
- `POOL_IDLE_MS = 10min` reaps any backend idle that long, so bots visited every few minutes pay repeated cold spawns all session long.

Hover-intent prewarming made it worse: sweeping the rail spawned backends over the cap and triggered LRU evict/respawn cascades - captured in desktop.log as repeated cycles of:

```
Evicting idle profile backend "vera" (LRU cap 3)
Starting Hermes backend for profile "vera" ...
```

within seconds of each other.

Pool sizing is a **device preference** (RAM spent vs switching speed), not agent configuration, so this PR moves it out of undocumented launch constants into a live, persisted device setting following the keep-awake pattern (`userData/pool-limits.json` + IPC). Defaults are unchanged (3 backends / 10min), so machines that never touch Settings see no behavior change.

## Related Issue

Fixes #91545

(Incidentally reduces missed unread dots from #91710: backends surviving longer means their busy→idle completion events reach the renderer instead of dying with a reaped process. That issue's core cross-profile event-gate defect still needs its own fix.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `electron/pool-limits.ts` (new) — parse/clamp/persist helpers for the two limits; corrupted files fall back to defaults
- `electron/main.ts` — `POOL_MAX_BACKENDS` / `POOL_IDLE_MS` constants become a live `poolLimits` object; get/set IPC (`hermes:pool-limits:get|set`); setting new limits applies immediately (LRU-evicts down to the new max, idle reaper converges on a shortened window) — no app restart. Legacy `HERMES_DESKTOP_POOL_MAX` / `HERMES_DESKTOP_POOL_IDLE_MS` env vars remain the initial-value fallback.
- `src/app/settings/pool-limits-setting.tsx` (new) — "Warm Bot Backends" + "Backend Idle Timeout (ms)" rows in Settings → Advanced, next to Keep Awake, using the same draft/commit/revert input pattern as AttachmentSizeSetting. Deliberately not profile-scoped: the pool is machine-global, so writing these into a per-profile config would be silently ignored.
- `src/store/pool-limits.ts` (new) — renderer mirror atom; optimistic paint reconciled with main's post-clamp values.
- `src/store/profile.ts` — `prewarmProfileBackend` guards against the live cap from the atom instead of a hard-coded count, so raising Warm Bot Backends re-enables prewarming past the old ceiling instantly.
- `src/app/gateway/hooks/use-gateway-boot.ts` — mirrors limits from main once at boot.
- `src/store/gateway.ts` — new `openSecondaryCount()` helper.
- `electron/preload.ts`, `src/global.d.ts` — typed bridge for get/set.

## How to Test

1. Open Hermes Desktop with ≥4 bot profiles on a local gateway.
2. Settings → Advanced → set **Warm Bot Backends** to your bot count (e.g. 8). No restart needed.
3. Switch between bots repeatedly, including bots left idle >10 minutes: switches stay instant (previously: 30s+ freeze after any idle gap).
4. Watch `~/.hermes/logs/desktop.log`: no further `Evicting idle profile backend ... (LRU cap N)` / `Reaping idle profile backend ...` lines while usage stays within the new limits.
5. Restart the app: the values persist (stored in userData), confirming the preference survives.

Reproduction of the original bug (before this fix): with default cap 3 and 8+ bots, switch across bots for a few minutes and observe the evict/respawn cascade plus 30s+ switch freezes in the same log.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites green: new pool-limits tests, settings helpers, prewarm store; full `tests/hermes_cli` sweep shows no regression vs clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon), local gateway, 11 bot profiles

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config.yaml keys added; stored in userData by design)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pool logic is platform-neutral TypeScript; paths use `app.getPath('userData')`
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (default cap 3, from the reporter's reproduction session):

```
[2026-08-22T15:09:26Z] Evicting idle profile backend "vera" (LRU cap 3)
[2026-08-22T15:09:26Z] Starting Hermes backend for profile "writer" ...
[2026-08-22T15:09:27Z] Evicting idle profile backend "abigail" (LRU cap 3)
[2026-08-22T15:09:27Z] Starting Hermes backend for profile "vera" ...
```

After (Warm Bot Backends raised via the new Settings rows):

- 0 evictions / 0 reaps / 0 connection timeouts across a 30+ minute multi-bot session
- Each backend spawned exactly once; switches stayed instant across idle gaps that previously cost 30s+
