### PR TITLE
fix(gateway): apply the follow-up grace window to every platform, not just Telegram

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9700,6 +9700,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return modes.get(profile_name, fallback) if isinstance(modes, dict) else fallback
 
     @staticmethod
+    def _followup_grace_seconds(platform: "Platform") -> float:
+        """Seconds after a run starts during which a text message is a FOLLOW-UP.
+
+        Some transports deliver ONE human message as SEVERAL events. iMessage does
+        this whenever the message carries a URL preview or an attachment: the user
+        types a sentence plus a link, presses send once, and the adapter receives two
+        TEXT events a second or two apart. Telegram behaves the same way.
+
+        Without this window the trailing event lands mid-turn and is treated as the
+        user interrupting themselves — the run is aborted and the user is told they
+        interrupted a message they sent as one piece.
+
+        Resolution order, first match wins:
+
+          HERMES_<PLATFORM>_FOLLOWUP_GRACE_SECONDS   per-platform override
+          HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS      every platform
+          3.0                                        default
+
+        The per-platform form reproduces ``HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS``
+        exactly, so the documented Telegram knob keeps working by construction rather
+        than by special case. Set a value to ``0`` to disable the window.
+        """
+        names = ("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS",)
+        value = getattr(platform, "value", "") or ""
+        if value:
+            names = (f"HERMES_{value.upper()}_FOLLOWUP_GRACE_SECONDS",) + names
+        for name in names:
+            raw = os.getenv(name, "").strip()
+            if not raw:
+                continue
+            try:
+                return float(raw)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Ignoring %s=%r — not a number; falling back.", name, raw
+                )
+        return 3.0
+
+    @staticmethod
     def _load_restart_drain_timeout() -> float:
         """Load graceful gateway restart/stop drain timeout in seconds."""
         raw = os.getenv("HERMES_RESTART_DRAIN_TIMEOUT", "").strip()
@@ -17268,20 +17307,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return None
 
             effective_busy_input_mode = self._effective_busy_input_mode(source)
-            _telegram_followup_grace = float(
-                os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
-            )
+            _followup_grace = self._followup_grace_seconds(source.platform)
             _grace_state = self._peek_session_state(_quick_key)
             _started_at = _grace_state.turn.started_ts if _grace_state else 0
             if (
-                source.platform == Platform.TELEGRAM
-                and event.message_type == MessageType.TEXT
-                and _telegram_followup_grace > 0
+                event.message_type == MessageType.TEXT
+                and _followup_grace > 0
                 and _started_at
-                and (time.time() - _started_at) <= _telegram_followup_grace
+                and (time.time() - _started_at) <= _followup_grace
             ):
                 logger.debug(
-                    "Telegram follow-up arrived %.2fs after run start for %s — queueing without interrupt",
+                    "%s follow-up arrived %.2fs after run start for %s — queueing without interrupt",
+                    source.platform.value,
                     time.time() - _started_at,
                     _quick_key,
                 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31,6 +31,7 @@ import faulthandler
 import inspect
 import json
 import logging
+import math
 import os
 import queue
 import re
@@ -2548,6 +2549,23 @@ if _config_path.exists():
             _trust_recent_seconds = _gateway_cfg.get("trust_recent_files_seconds")
             if _trust_recent_seconds is not None:
                 os.environ["HERMES_MEDIA_TRUST_RECENT_SECONDS"] = str(_trust_recent_seconds)
+            # Bridge gateway.followup_grace_seconds (+ per-platform overrides) to
+            # the internal env vars _followup_grace_seconds() reads. config.yaml
+            # is the user-facing surface; the env names are the mechanism, plus
+            # back-compat for the pre-existing Telegram variable. An explicitly
+            # set env var wins, so the documented escape hatch keeps working.
+            _followup_grace = _gateway_cfg.get("followup_grace_seconds")
+            if (
+                _followup_grace is not None
+                and "HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS" not in os.environ
+            ):
+                os.environ["HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS"] = str(_followup_grace)
+            _followup_by_platform = _gateway_cfg.get("followup_grace_seconds_by_platform")
+            if isinstance(_followup_by_platform, dict):
+                for _plat, _secs in _followup_by_platform.items():
+                    _name = f"HERMES_{str(_plat).upper()}_FOLLOWUP_GRACE_SECONDS"
+                    if _secs is not None and _name not in os.environ:
+                        os.environ[_name] = str(_secs)
             # Bridge gateway.platform_connect_timeout → the internal env var the
             # connect path + Discord adapter ready-wait both read (#19776).
             # Unlike the agent.*/display.* bridges above (config-authoritative),
@@ -9731,11 +9749,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not raw:
                 continue
             try:
-                return float(raw)
+                parsed = float(raw)
             except (TypeError, ValueError):
                 logger.warning(
                     "Ignoring %s=%r — not a number; falling back.", name, raw
                 )
+                continue
+            # float() accepts "nan"/"inf". NaN fails every comparison, silently
+            # disabling the window; inf makes it unbounded. Neither is a value a
+            # user can have meant, and both fail quietly, so reject them here.
+            if not math.isfinite(parsed):
+                logger.warning(
+                    "Ignoring %s=%r — not a finite number; falling back.", name, raw
+                )
+                continue
+            return parsed
         return 3.0
 
     @staticmethod

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3047,6 +3047,24 @@ DEFAULT_CONFIG = {
         # Only consulted when ``strict`` is true.
         "trust_recent_files_seconds": 600,
 
+        # Seconds after a run STARTS during which an incoming text message is
+        # treated as a follow-up to the message that started it — queued into
+        # the same turn instead of interrupting it.
+        #
+        # Some transports deliver ONE human message as SEVERAL events: iMessage
+        # splits on a URL preview or an attachment, Telegram behaves similarly.
+        # Without this window the trailing event lands mid-turn and looks like
+        # the user interrupting themselves.
+        #
+        # Recognized slash commands never reach this path — they are dispatched
+        # by their own busy_policy first — so /stop stays responsive.
+        # Set to 0 to disable. Bridged to HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS.
+        "followup_grace_seconds": 3.0,
+        # Optional per-platform overrides, e.g. {"bluebubbles": 5.0}. Each key
+        # is bridged to HERMES_<PLATFORM>_FOLLOWUP_GRACE_SECONDS and takes
+        # precedence over followup_grace_seconds for that platform.
+        "followup_grace_seconds_by_platform": {},
+
         # OpenAI-compatible API server platform
         # (gateway/platforms/api_server.py).
         "api_server": {

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -149,6 +149,107 @@ class TestBusySessionAck:
         agent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_followup_grace_applies_to_non_telegram_platforms(self, monkeypatch):
+        """A rapid text follow-up must not interrupt on ANY platform, not just Telegram.
+
+        Some transports deliver ONE human message as TWO events. iMessage does this
+        whenever the message carries a URL preview or an attachment: the user types
+        "subscribe to this calendar?" plus a link, presses send once, and the adapter
+        receives two TEXT events a second or two apart.
+
+        Without a follow-up grace window the second event lands mid-turn and is treated
+        as the user interrupting themselves — the run is aborted and the user is told
+        they interrupted a message they sent as one piece.
+
+        The grace window already solves this. It was simply gated to Telegram, so every
+        other adapter re-encounters the same bug.
+        """
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", "3.0")
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner._queued_events = {}
+        adapter = _make_adapter()
+
+        source = SessionSource(
+            platform=Platform.BLUEBUBBLES,
+            chat_id="any;-;+15550001111",
+            chat_type="dm",
+            user_id="+15550001111",
+        )
+        sk = build_session_key(source)
+        runner.adapters[source.platform] = adapter
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {"seconds_since_activity": 0.0}
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+
+        # The two halves of a single iMessage send.
+        halves = [
+            "Can you subscribe to this calendar?",
+            "https://example.com/calendars/team.ics",
+        ]
+        for idx, text in enumerate(halves, start=1):
+            result = await GatewayRunner._handle_message(
+                runner,
+                MessageEvent(
+                    text=text,
+                    message_type=MessageType.TEXT,
+                    source=source,
+                    message_id=f"bb-{idx}",
+                ),
+            )
+            assert result is None
+
+        # The run must survive: the user did not interrupt anything.
+        agent.interrupt.assert_not_called()
+        # And the second half must still be waiting to be handled, not dropped.
+        assert sk in adapter._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_telegram_env_var_still_honoured_after_generalisation(self, monkeypatch):
+        """The platform-specific env var must keep working — it is documented and in use."""
+        from gateway.run import GatewayRunner
+
+        # Only the LEGACY Telegram name is set; the generic one is explicitly off.
+        monkeypatch.setenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
+        monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", "0")
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner._queued_events = {}
+        adapter = _make_adapter()
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+            user_id="user1",
+        )
+        sk = build_session_key(source)
+        runner.adapters[source.platform] = adapter
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {"seconds_since_activity": 0.0}
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+
+        result = await GatewayRunner._handle_message(
+            runner,
+            MessageEvent(
+                text="follow-up",
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id="tg-1",
+            ),
+        )
+        assert result is None
+        agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_sends_ack_when_agent_running(self):
         """First message during busy session should get a status ack."""
         runner, sentinel = _make_runner()

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -210,6 +210,82 @@ class TestBusySessionAck:
         assert sk in adapter._pending_messages
 
     @pytest.mark.asyncio
+    async def test_control_command_is_not_swallowed_by_the_grace_window(self, monkeypatch):
+        """`/stop` inside the grace window must still reach command handling.
+
+        The window exists to absorb the trailing half of a split send. A control
+        command is never that — it is the user deliberately intervening, and it is
+        exactly the moment they most need to be heard. If `/stop` lands in the
+        pending slot instead, the fix trades "user interrupted themselves" for
+        "user cannot stop a runaway run", which is a strictly worse bug.
+        """
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", "3.0")
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        runner._queued_events = {}
+        adapter = _make_adapter()
+
+        source = SessionSource(
+            platform=Platform.BLUEBUBBLES,
+            chat_id="any;-;+15550001111",
+            chat_type="dm",
+            user_id="+15550001111",
+        )
+        sk = build_session_key(source)
+        runner.adapters[source.platform] = adapter
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {"seconds_since_activity": 0.0}
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()   # run started just now
+
+        stop_event = MessageEvent(
+            text="/stop",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="stop-1",
+        )
+        assert stop_event.is_command(), "precondition: /stop must parse as a command"
+
+        await GatewayRunner._handle_message(runner, stop_event)
+
+        # The command must NOT have been parked in the pending slot.
+        parked = adapter._pending_messages.get(sk)
+        assert parked is None or parked.text != "/stop", (
+            "/stop was swallowed by the follow-up grace window"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", ["nan", "inf", "-inf", "banana"])
+    async def test_non_finite_grace_values_fall_back(self, monkeypatch, bad):
+        """`float()` accepts nan/inf; neither is a window a user could have meant.
+
+        NaN fails every comparison and silently disables the feature; inf makes the
+        window unbounded so nothing ever interrupts. Both fail QUIETLY, which is the
+        worst way for a misconfiguration to behave — hence an explicit guard.
+        """
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", bad)
+        monkeypatch.delenv("HERMES_BLUEBUBBLES_FOLLOWUP_GRACE_SECONDS", raising=False)
+
+        assert GatewayRunner._followup_grace_seconds(Platform.BLUEBUBBLES) == 3.0
+
+    @pytest.mark.asyncio
+    async def test_per_platform_override_beats_the_gateway_wide_value(self, monkeypatch):
+        """Per-platform wins; other platforms still read the gateway-wide value."""
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS", "1.0")
+        monkeypatch.setenv("HERMES_BLUEBUBBLES_FOLLOWUP_GRACE_SECONDS", "5.0")
+
+        assert GatewayRunner._followup_grace_seconds(Platform.BLUEBUBBLES) == 5.0
+        assert GatewayRunner._followup_grace_seconds(Platform.MATRIX) == 1.0
+
+    @pytest.mark.asyncio
     async def test_telegram_env_var_still_honoured_after_generalisation(self, monkeypatch):
         """The platform-specific env var must keep working — it is documented and in use."""
         from gateway.run import GatewayRunner

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -741,7 +741,8 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Delay between split chunks when a single Telegram message exceeds the length limit (default: `2.0`). |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into a single MessageEvent — same pattern as Telegram's text batching. |
 | `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Grace window before flushing queued Telegram media (default: `0.6`). |
-| `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` | Delay before sending a follow-up after the agent finishes, to avoid racing the last stream chunk. |
+| `HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS` | Seconds after a run STARTS during which an incoming text is treated as a follow-up to the same message and queued instead of interrupting the run. Applies to every platform. Default `3.0`; `0` disables. |
+| `HERMES_<PLATFORM>_FOLLOWUP_GRACE_SECONDS` | Per-platform override of the above, e.g. `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS`, `HERMES_BLUEBUBBLES_FOLLOWUP_GRACE_SECONDS`. Takes precedence over the gateway-wide value. |
 | `HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT` / `_READ_TIMEOUT` / `_WRITE_TIMEOUT` / `_POOL_TIMEOUT` | Override the underlying `python-telegram-bot` HTTP timeouts (seconds). |
 | `HERMES_TELEGRAM_INIT_TIMEOUT` | Per-attempt cap (seconds) on the Telegram `initialize()` connect chain during gateway startup, so an unreachable fallback-IP chain can't block startup indefinitely (default: `30`). |
 | `HERMES_TELEGRAM_HTTP_POOL_SIZE` | Max concurrent HTTP connections to the Telegram API. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -741,8 +741,8 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Delay between split chunks when a single Telegram message exceeds the length limit (default: `2.0`). |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into a single MessageEvent — same pattern as Telegram's text batching. |
 | `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Grace window before flushing queued Telegram media (default: `0.6`). |
-| `HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS` | Seconds after a run STARTS during which an incoming text is treated as a follow-up to the same message and queued instead of interrupting the run. Applies to every platform. Default `3.0`; `0` disables. |
-| `HERMES_<PLATFORM>_FOLLOWUP_GRACE_SECONDS` | Per-platform override of the above, e.g. `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS`, `HERMES_BLUEBUBBLES_FOLLOWUP_GRACE_SECONDS`. Takes precedence over the gateway-wide value. |
+| `HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS` | Internal bridge for `gateway.followup_grace_seconds` in `config.yaml` — **set it there**. Seconds after a run starts during which an incoming text is treated as a follow-up and queued instead of interrupting. |
+| `HERMES_<PLATFORM>_FOLLOWUP_GRACE_SECONDS` | Internal bridge for `gateway.followup_grace_seconds_by_platform` — **set it there**. Per-platform override, e.g. `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` (pre-existing, still honoured). |
 | `HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT` / `_READ_TIMEOUT` / `_WRITE_TIMEOUT` / `_POOL_TIMEOUT` | Override the underlying `python-telegram-bot` HTTP timeouts (seconds). |
 | `HERMES_TELEGRAM_INIT_TIMEOUT` | Per-attempt cap (seconds) on the Telegram `initialize()` connect chain during gateway startup, so an unreachable fallback-IP chain can't block startup indefinitely (default: `30`). |
 | `HERMES_TELEGRAM_HTTP_POOL_SIZE` | Max concurrent HTTP connections to the Telegram API. |


### PR DESCRIPTION
## Problem

Some transports deliver **one human message as several events**. iMessage does this whenever the message carries a URL preview or an attachment: the user types a sentence, pastes a link, presses send **once**, and the BlueBubbles adapter receives two `TEXT` events a second or two apart.

Without a follow-up grace window the trailing event lands mid-turn and is treated as the user interrupting themselves. The run is aborted, and the user is told they interrupted a message they sent as one piece.

The gateway **already solves this**. `_handle_message` has a grace window that folds a text arriving shortly after a run starts into that run instead of interrupting it — but it is gated to a single platform:

```python
if (
    source.platform == Platform.TELEGRAM     # <-- here
    and event.message_type == MessageType.TEXT
    and _telegram_followup_grace > 0
    and _started_at
    and (time.time() - _started_at) <= _telegram_followup_grace
):
```

Telegram hit this first, and the fix was written at the call site rather than as a transport-level property, so every other adapter re-encounters a solved bug. BlueBubbles is the one I hit; anything that splits sends has the same problem.

## Reproduction

Added to `tests/gateway/test_busy_session_ack.py`. Against `main`, unchanged:

```
AssertionError: Expected 'interrupt' to not have been called. Called 2 times.
Calls: [call('Can you subscribe to this calendar?'),
        call('https://example.com/calendars/team.ics')]
```

Both halves of a single send interrupt the run.

## Fix

Replace the platform check with a resolver, `GatewayRunner._followup_grace_seconds(platform)`:

```
HERMES_<PLATFORM>_FOLLOWUP_GRACE_SECONDS   per-platform override
HERMES_GATEWAY_FOLLOWUP_GRACE_SECONDS      every platform
3.0                                        default (unchanged)
```

**`HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` keeps working by construction, not by special case** — `Platform.TELEGRAM.value.upper()` reproduces that exact name. A test asserts this explicitly, including the case where the legacy name is set while the gateway-wide value is `0`.

The default stays `3.0`, so Telegram behaviour is byte-for-byte what it was; other platforms gain the window. Set any of these to `0` to disable. Happy to flip the generic default to `0` (opt-in) if you would rather not change behaviour for existing installs — it is a one-line change and I have no strong view.

## Docs

`environment-variables.md` described this variable as:

> Delay before sending a follow-up **after the agent finishes**, to avoid racing the last stream chunk.

That is not what the code does — it is a window measured from when the turn **starts**, used to fold an incoming message *into* the running turn. Corrected, and the two new names documented.

## Tests

- `test_followup_grace_applies_to_non_telegram_platforms` — fails on `main`, passes here.
- `test_telegram_env_var_still_honoured_after_generalisation` — pins the backward-compatibility contract.
- Full `tests/gateway` suite: **identical failure set before and after** (all pre-existing and unrelated — `test_wecom_callback`, `test_telegram_polling_health_confirmation`), with the two new tests added to the pass column.

## Note on overlapping PRs

#50227 and #51324 both harden parsing of `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` against bad values, and touch the same line. I have deliberately **not** duplicated that work; the resolver here has a small `try/except` only because it introduces a *second* env name and I did not want to add a new crash surface. Glad to rebase on whichever of those lands first.

---

*Investigated and prepared with AI assistance; the reproduction, the fix, and the full-suite regression comparison were run and reviewed before opening.*
