### PR TITLE
fix(approvals): honor allowlist in single-query deny mode

### DIFF
--- a/tests/tools/test_single_query_allowlist_92405.py
+++ b/tests/tools/test_single_query_allowlist_92405.py
@@ -1,0 +1,53 @@
+from tools import approval
+from tools import tirith_security
+
+
+def _configure_single_query(monkeypatch, *, approved: bool) -> None:
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(approval, "_should_skip_container_guards", lambda *args, **kwargs: False)
+    monkeypatch.setattr(approval, "detect_hardline_command", lambda _cmd: (False, None))
+    monkeypatch.setattr(approval, "_check_sudo_stdin_guard", lambda _cmd: (False, None))
+    monkeypatch.setattr(approval, "_match_user_deny_rule", lambda _cmd: None)
+    monkeypatch.setattr(approval, "_get_approval_mode", lambda: "smart")
+    monkeypatch.setattr(approval, "is_current_session_yolo_enabled", lambda: False)
+    monkeypatch.setattr(approval, "_command_matches_permanent_allowlist", lambda _cmd: False)
+    monkeypatch.setattr(approval, "_resolve_cli_approval_callback", lambda callback: callback)
+    monkeypatch.setattr(approval, "_is_interactive_cli", lambda: False)
+    monkeypatch.setattr(approval, "_is_gateway_approval_context", lambda: False)
+    monkeypatch.setattr(approval, "_is_single_query_approval_context", lambda: True)
+    monkeypatch.setattr(approval, "_get_single_query_approval_mode", lambda: "deny")
+    monkeypatch.setattr(approval, "_is_cron_approval_context", lambda: False)
+    monkeypatch.setattr(approval, "get_current_session_key", lambda: "sq-session")
+    monkeypatch.setattr(
+        approval,
+        "detect_dangerous_command",
+        lambda _cmd: (True, "script execution via heredoc", "script execution via heredoc"),
+    )
+    monkeypatch.setattr(
+        approval,
+        "is_approved",
+        lambda session_key, pattern_key: (
+            approved
+            and session_key == "sq-session"
+            and pattern_key == "script execution via heredoc"
+        ),
+    )
+    monkeypatch.setattr(tirith_security, "check_command_security", lambda _cmd: {"action": "allow"})
+
+
+def test_single_query_deny_honors_pattern_allowlist(monkeypatch):
+    _configure_single_query(monkeypatch, approved=True)
+
+    result = approval.check_all_command_guards("python3 <<EOF\nprint(1)\nEOF", "local")
+
+    assert result == {"approved": True, "message": None}
+
+
+def test_single_query_deny_still_blocks_unapproved_pattern(monkeypatch):
+    _configure_single_query(monkeypatch, approved=False)
+
+    result = approval.check_all_command_guards("python3 <<EOF\nprint(1)\nEOF", "local")
+
+    assert result["approved"] is False
+    assert result["pattern_key"] == "script execution via heredoc"
+    assert "single-query mode" in result["message"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4419,7 +4419,7 @@ def check_all_command_guards(command: str, env_type: str,
         if _is_single_query_approval_context():
             if _get_single_query_approval_mode() == "deny":
                 is_dangerous, _pk, description = detect_dangerous_command(command)
-                if is_dangerous:
+                if is_dangerous and not is_approved(get_current_session_key(), _pk):
                     return {
                         "approved": False,
                         "message": (


### PR DESCRIPTION
Fixes #92405

## What changed
- Make the single-query (`-q`) deny path consult the existing pattern-key allowlist before blocking a dangerous command.
- Preserve the existing fail-closed behavior for dangerous patterns that have not been approved.
- Add focused regression coverage for both the approved and unapproved cases.

## Why
`check_all_command_guards` checked the literal-command permanent allowlist, but its single-query deny branch returned immediately for `detect_dangerous_command(...)` matches without consulting `is_approved(session_key, pattern_key)`. That meant an operator's existing pattern-class approval was ignored only on the `-q` path.

## Verification
- Focused validation ran successfully on the fork after installing the repository's locked dev dependencies.
- Refreshed cleanly onto current upstream `main` (`bdf1047`) with the same two-file diff: the source fix plus focused regression coverage.
- Final duplicate search found no open PR for #92405 or this fix. PR #92437 touches the broader approval system for a separate `approvals.ask` feature but does not address this pattern-allowlist inconsistency.