### PR TITLE
feat: per-model execution budgets (config-driven)

### DIFF
--- a/agent/model_execution_budget.py
+++ b/agent/model_execution_budget.py
@@ -1,0 +1,272 @@
+"""Config-driven per-model execution budgets.
+
+The execution middleware calls :func:`decide_tool_call` immediately before a
+tool is dispatched. Budgets are opt-in through
+``agent.model_execution_budgets`` in ``config.yaml``; an absent or invalid
+configuration leaves execution unchanged. The state is kept on the active
+agent and scoped to its current turn, so this module does not change prompts,
+tool schemas, or conversation messages.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# These are the public delegation entry points.  Delegation is a handoff rather
+# than execution by the current model, so it never consumes this budget.
+DELEGATION_TOOL_NAMES = frozenset({"delegate", "delegate_task"})
+
+_STATE_INIT_LOCK = threading.Lock()
+_FALLBACK_LOCK = threading.RLock()
+_FALLBACK_STATE = None
+
+
+@dataclass
+class _BudgetState:
+    """Mutable budget window stored on an agent instance."""
+
+    window_key: str = ""
+    limit: int | None = None
+    used: int = 0
+
+
+def _normalise_model(value: Any) -> str:
+    return str(value or "").strip().casefold()
+
+
+def _model_candidates(model: Any) -> tuple[str, ...]:
+    """Return normalized full and provider-free model names."""
+    normalized = _normalise_model(model)
+    if not normalized:
+        return ("",)
+    candidates = [normalized]
+    if "/" in normalized:
+        provider_free = normalized.rsplit("/", 1)[-1]
+        if provider_free and provider_free != normalized:
+            candidates.append(provider_free)
+    return tuple(candidates)
+
+
+def _coerce_limit(value: Any) -> int | None:
+    """Return a non-negative integer limit, or ``None`` for invalid values."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, str):
+        try:
+            value = int(value.strip())
+        except (TypeError, ValueError):
+            return None
+        return value if value >= 0 else None
+    return None
+
+
+def _pattern_specificity(pattern: str, position: int) -> tuple[int, int, int]:
+    """Rank a matching pattern; ties retain config insertion order."""
+    wildcard_count = sum(pattern.count(char) for char in "*?[")
+    literal_count = len(pattern) - wildcard_count
+    return literal_count, -wildcard_count, -position
+
+
+def _pattern_matches(pattern: str, model: Any) -> bool:
+    return any(
+        fnmatch.fnmatchcase(candidate, pattern)
+        for candidate in _model_candidates(model)
+    )
+
+
+def execution_budget_for_model(
+    model: Any,
+    config: Mapping[str, Any] | None = None,
+) -> int | None:
+    """Resolve the configured budget for *model*.
+
+    Patterns use shell-style wildcards (``*``, ``?`` and character classes)
+    and are matched case-insensitively against both the full model identifier
+    and the portion after its final ``/``.  When patterns overlap, the most
+    specific match wins; ties use the order from ``config.yaml``.
+
+    ``None`` means that no budget is configured.  Malformed configuration is
+    deliberately treated as disabled so a typo cannot change the default
+    execution behavior or prevent an agent from starting.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly()
+        except Exception:
+            logger.debug("Unable to load execution budget configuration", exc_info=True)
+            return None
+
+    if not isinstance(config, Mapping):
+        return None
+    agent_config = config.get("agent")
+    if not isinstance(agent_config, Mapping):
+        return None
+    raw_budgets = agent_config.get("model_execution_budgets")
+    if not isinstance(raw_budgets, Mapping) or not raw_budgets:
+        return None
+
+    normalized_model = _normalise_model(model)
+    best: tuple[tuple[int, int, int], int] | None = None
+    for position, (raw_pattern, raw_limit) in enumerate(raw_budgets.items()):
+        if not isinstance(raw_pattern, str):
+            continue
+        pattern = raw_pattern.strip().casefold()
+        if not pattern or not _pattern_matches(pattern, normalized_model):
+            continue
+        limit = _coerce_limit(raw_limit)
+        if limit is None:
+            # Ignore only this malformed entry; a valid fallback pattern may
+            # still apply to the same model.
+            continue
+        score = _pattern_specificity(pattern, position)
+        if best is None or score > best[0]:
+            best = (score, limit)
+    return best[1] if best is not None else None
+
+
+# Short alias for callers that prefer the noun-first spelling.
+budget_for_model = execution_budget_for_model
+
+
+def _turn_key(agent: Any) -> str:
+    turn_id = str(getattr(agent, "_current_turn_id", "") or "").strip()
+    if turn_id:
+        return turn_id
+    task_id = str(getattr(agent, "_current_task_id", "") or "").strip()
+    if task_id:
+        return task_id
+    # Agent instances own their state, so this sentinel scopes an agent that
+    # does not expose turn metadata without introducing process-global state.
+    return "__agent_lifetime__"
+
+
+def _agent_lock(agent: Any) -> threading.RLock:
+    lock = getattr(agent, "_model_execution_budget_lock", None)
+    if lock is not None:
+        return lock
+    with _STATE_INIT_LOCK:
+        lock = getattr(agent, "_model_execution_budget_lock", None)
+        if lock is None:
+            lock = threading.RLock()
+            try:
+                setattr(agent, "_model_execution_budget_lock", lock)
+            except Exception:
+                return _FALLBACK_LOCK
+    return lock
+
+
+def _agent_state(agent: Any) -> _BudgetState:
+    state = getattr(agent, "_model_execution_budget_state", None)
+    if state is not None:
+        return state
+    with _STATE_INIT_LOCK:
+        state = getattr(agent, "_model_execution_budget_state", None)
+        if state is None:
+            state = _BudgetState()
+            try:
+                setattr(agent, "_model_execution_budget_state", state)
+            except Exception:
+                # AIAgent is mutable.  This fallback only protects unusual
+                # agent-like objects used by integrations and tests.
+                global _FALLBACK_STATE
+                if _FALLBACK_STATE is None:
+                    _FALLBACK_STATE = state
+                return _FALLBACK_STATE
+    return state
+
+
+def _refresh_window(agent: Any, state: _BudgetState) -> None:
+    key = _turn_key(agent)
+    if key == state.window_key:
+        return
+    state.window_key = key
+    state.used = 0
+    state.limit = execution_budget_for_model(getattr(agent, "model", ""))
+
+
+def is_delegation_tool(function_name: Any) -> bool:
+    return str(function_name or "").strip().casefold() in DELEGATION_TOOL_NAMES
+
+
+def decide_tool_call(
+    agent: Any,
+    *,
+    function_name: str,
+    final_args: Mapping[str, Any] | None = None,
+    tool_call_id: str = "",
+) -> dict[str, Any]:
+    """Return an allow/block decision for one imminent tool dispatch.
+
+    ``final_args`` and ``tool_call_id`` are accepted to keep the API aligned
+    with the execution middleware.  Budget decisions use only the tool name;
+    arguments are never persisted or inspected.
+    """
+    del final_args, tool_call_id
+    lock = _agent_lock(agent)
+    with lock:
+        state = _agent_state(agent)
+        _refresh_window(agent, state)
+
+        if state.limit is None:
+            return {
+                "action": "allow",
+                "reason": "disabled",
+                "count": 0,
+                "limit": None,
+            }
+
+        if is_delegation_tool(function_name):
+            return {
+                "action": "allow",
+                "reason": "delegation",
+                "count": state.used,
+                "limit": state.limit,
+            }
+
+        if state.used >= state.limit:
+            return {
+                "action": "block",
+                "reason": "execution_budget_exceeded",
+                "count": state.used,
+                "limit": state.limit,
+            }
+
+        state.used += 1
+        return {
+            "action": "allow",
+            "reason": "within_budget",
+            "count": state.used,
+            "limit": state.limit,
+        }
+
+
+def execution_call_count(agent: Any) -> int:
+    """Return the number of allowed non-delegation calls in the current window."""
+    with _agent_lock(agent):
+        state = _agent_state(agent)
+        _refresh_window(agent, state)
+        return state.used
+
+
+# Compatibility-friendly name for tests and integrations.
+worker_call_count = execution_call_count
+
+
+def reset_budget(agent: Any) -> None:
+    """Reset the current agent's budget window."""
+    with _agent_lock(agent):
+        state = _agent_state(agent)
+        state.window_key = ""
+        state.limit = None
+        state.used = 0

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -658,6 +658,32 @@ def _run_agent_tool_execution_middleware(
             if guardrail_decision.allows_execution:
                 guardrail_decision = None
 
+        # ── Config-driven execution budget boundary ─────────────────────
+        # Keep this check immediately before dispatch so it covers every
+        # sequential, concurrent, and segmented execution path without
+        # changing the model-facing prompt, tools, or message history.
+        if block_message is None and guardrail_decision is None:
+            try:
+                from agent.model_execution_budget import decide_tool_call
+
+                budget_decision = decide_tool_call(
+                    agent,
+                    function_name=function_name,
+                    final_args=final_args,
+                    tool_call_id=tool_call_id,
+                )
+                if budget_decision.get("action") == "block":
+                    block_message = (
+                        "Tool execution budget exhausted for this model in "
+                        "the current turn. Delegate bounded work or continue "
+                        "in a new turn."
+                    )
+                    block_error_type = "model_execution_budget"
+            except Exception:
+                # A budget check must never prevent the normal tool pipeline
+                # from handling an otherwise valid call.
+                logger.debug("Execution budget check failed", exc_info=True)
+
         if block_message is not None or guardrail_decision is not None:
             _advance_start_order()
             state["blocked"] = True

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -43,6 +43,10 @@ DEFAULT_CONFIG = {
         "terminal_continue": True,
     },
     "agent": {
+        # Optional per-model cap on non-delegation tool executions per turn.
+        # An empty map keeps the feature fully disabled by default. Keys use
+        # shell-style model-name patterns; values are non-negative integers.
+        "model_execution_budgets": {},
         # Unlimited by default. The agent turn cap caused more problems than
         # it solved (silent mid-task truncation). null = unlimited; set a
         # positive integer to cap, or use "none"/"unlimited"/"inf"/0/-1 —

--- a/tests/agent/test_model_execution_budget.py
+++ b/tests/agent/test_model_execution_budget.py
@@ -1,0 +1,342 @@
+"""Behavior contracts for the config-driven execution budget gate."""
+
+from __future__ import annotations
+
+import copy
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+import agent.model_execution_budget as budget
+
+
+@pytest.fixture(autouse=True)
+def isolated_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _agent(
+    model="provider/model",
+    *,
+    turn="turn-1",
+    task="task-1",
+    session="session-1",
+):
+    return SimpleNamespace(
+        model=model,
+        provider="test-provider",
+        session_id=session,
+        _current_turn_id=turn,
+        _current_task_id=task,
+        _current_api_request_id="request-1",
+    )
+
+
+def _write_config(home, model_budgets):
+    (home / "config.yaml").write_text(
+        json.dumps({"agent": {"model_execution_budgets": model_budgets}}),
+        encoding="utf-8",
+    )
+
+
+def test_default_config_declares_an_empty_budget_map():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["agent"]["model_execution_budgets"] == {}
+
+
+def test_unset_budget_has_zero_default_footprint(isolated_hermes_home):
+    agent = _agent()
+
+    decisions = [
+        budget.decide_tool_call(agent, function_name="write_file")
+        for _ in range(20)
+    ]
+
+    assert all(decision["action"] == "allow" for decision in decisions)
+    assert all(decision["reason"] == "disabled" for decision in decisions)
+    assert budget.execution_call_count(agent) == 0
+    assert not (isolated_hermes_home / "config.yaml").exists()
+
+
+def test_matching_model_budget_blocks_after_limit(isolated_hermes_home):
+    _write_config(isolated_hermes_home, {"provider/model": 2})
+    agent = _agent()
+
+    assert budget.decide_tool_call(agent, function_name="terminal")["action"] == "allow"
+    assert budget.decide_tool_call(agent, function_name="write_file")["action"] == "allow"
+    blocked = budget.decide_tool_call(agent, function_name="patch")
+
+    assert blocked == {
+        "action": "block",
+        "reason": "execution_budget_exceeded",
+        "count": 2,
+        "limit": 2,
+    }
+    assert budget.execution_call_count(agent) == 2
+
+
+def test_patterns_match_case_insensitively_and_provider_free_names(isolated_hermes_home):
+    _write_config(isolated_hermes_home, {"*worker*": 1})
+    agent = _agent(model="Provider/Worker-Model")
+
+    assert budget.decide_tool_call(agent, function_name="terminal")["action"] == "allow"
+    assert budget.decide_tool_call(agent, function_name="terminal")["action"] == "block"
+
+
+def test_most_specific_matching_pattern_wins(isolated_hermes_home):
+    _write_config(
+        isolated_hermes_home,
+        {"*": 1, "provider/model": 3},
+    )
+    agent = _agent()
+
+    decisions = [
+        budget.decide_tool_call(agent, function_name="terminal")
+        for _ in range(4)
+    ]
+
+    assert [decision["action"] for decision in decisions] == [
+        "allow",
+        "allow",
+        "allow",
+        "block",
+    ]
+    assert decisions[-1]["limit"] == 3
+
+
+def test_unmatched_model_is_disabled(isolated_hermes_home):
+    _write_config(isolated_hermes_home, {"other/*": 1})
+    agent = _agent()
+
+    decisions = [
+        budget.decide_tool_call(agent, function_name="terminal")
+        for _ in range(10)
+    ]
+
+    assert all(decision["action"] == "allow" for decision in decisions)
+    assert all(decision["reason"] == "disabled" for decision in decisions)
+    assert budget.execution_call_count(agent) == 0
+
+
+def test_zero_is_a_valid_budget_and_delegation_remains_exempt(isolated_hermes_home):
+    _write_config(isolated_hermes_home, {"provider/model": 0})
+    agent = _agent()
+
+    blocked = budget.decide_tool_call(agent, function_name="terminal")
+    delegated = budget.decide_tool_call(agent, function_name="delegate_task")
+    delegated_alias = budget.decide_tool_call(agent, function_name="delegate")
+
+    assert blocked["action"] == "block"
+    assert delegated["action"] == "allow"
+    assert delegated["reason"] == "delegation"
+    assert delegated_alias["action"] == "allow"
+    assert budget.execution_call_count(agent) == 0
+
+
+def test_delegation_does_not_reset_or_consume_the_same_turn(isolated_hermes_home):
+    _write_config(isolated_hermes_home, {"provider/model": 1})
+    agent = _agent()
+
+    assert budget.decide_tool_call(agent, function_name="terminal")["action"] == "allow"
+    assert budget.decide_tool_call(agent, function_name="delegate_task")["action"] == "allow"
+    assert budget.decide_tool_call(agent, function_name="terminal")["action"] == "block"
+
+
+def test_new_turn_gets_a_fresh_budget_window(isolated_hermes_home):
+    _write_config(isolated_hermes_home, {"provider/model": 2})
+    agent = _agent(turn="turn-a")
+
+    for _ in range(2):
+        assert budget.decide_tool_call(agent, function_name="terminal")["action"] == "allow"
+    assert budget.decide_tool_call(agent, function_name="terminal")["action"] == "block"
+
+    agent._current_turn_id = "turn-b"
+    assert budget.decide_tool_call(agent, function_name="terminal")["count"] == 1
+    assert budget.decide_tool_call(agent, function_name="terminal")["count"] == 2
+    assert budget.decide_tool_call(agent, function_name="terminal")["action"] == "block"
+
+
+def test_budget_windows_are_isolated_between_agents(isolated_hermes_home):
+    _write_config(isolated_hermes_home, {"provider/model": 1})
+    first = _agent()
+    second = _agent(session="session-2")
+
+    assert budget.decide_tool_call(first, function_name="terminal")["action"] == "allow"
+    assert budget.decide_tool_call(first, function_name="terminal")["action"] == "block"
+    assert budget.decide_tool_call(second, function_name="terminal")["action"] == "allow"
+    assert budget.execution_call_count(second) == 1
+
+
+@pytest.mark.parametrize(
+    "model_budgets",
+    [
+        {"provider/model": -1},
+        {"provider/model": True},
+        {"provider/model": {"limit": 1}},
+        ["not-a-map"],
+        "not-a-map",
+    ],
+)
+def test_invalid_budget_entries_fail_open(isolated_hermes_home, model_budgets):
+    _write_config(isolated_hermes_home, model_budgets)
+    agent = _agent()
+
+    decisions = [
+        budget.decide_tool_call(agent, function_name="terminal")
+        for _ in range(8)
+    ]
+
+    assert all(decision["action"] == "allow" for decision in decisions)
+    assert all(decision["reason"] == "disabled" for decision in decisions)
+
+
+def test_malformed_config_fails_open(isolated_hermes_home):
+    (isolated_hermes_home / "config.yaml").write_text(
+        "agent: [this is not a mapping",
+        encoding="utf-8",
+    )
+
+    agent = _agent()
+    decisions = [
+        budget.decide_tool_call(agent, function_name="terminal")
+        for _ in range(8)
+    ]
+
+    assert all(decision["action"] == "allow" for decision in decisions)
+    assert budget.execution_call_count(agent) == 0
+
+
+def test_concurrent_calls_share_one_thread_safe_budget(isolated_hermes_home):
+    _write_config(isolated_hermes_home, {"provider/model": 5})
+    agent = _agent()
+    barrier = threading.Barrier(7)
+    decisions = []
+    errors = []
+    results_lock = threading.Lock()
+
+    def call_once():
+        try:
+            barrier.wait(timeout=5)
+            decision = budget.decide_tool_call(agent, function_name="terminal")
+            with results_lock:
+                decisions.append(decision["action"])
+        except Exception as exc:  # pragma: no cover - diagnostic assertion
+            with results_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=call_once) for _ in range(6)]
+    for thread in threads:
+        thread.start()
+    barrier.wait(timeout=5)
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not errors
+    assert decisions.count("allow") == 5
+    assert decisions.count("block") == 1
+    assert budget.execution_call_count(agent) == 5
+
+
+def _middleware_agent(model="provider/model"):
+    guardrails = SimpleNamespace(
+        before_call=lambda name, args: SimpleNamespace(allows_execution=True),
+    )
+    return SimpleNamespace(
+        model=model,
+        session_id="session-1",
+        _delegate_depth=0,
+        _subagent_id="",
+        _current_turn_id="turn-1",
+        _current_task_id="task-1",
+        _current_api_request_id="request-1",
+        _tool_guardrails=guardrails,
+        _touch_activity=lambda description: None,
+    )
+
+
+def test_execution_middleware_blocks_before_terminal_dispatch(
+    isolated_hermes_home, monkeypatch
+):
+    _write_config(isolated_hermes_home, {"provider/model": 1})
+    import agent.tool_executor as tool_executor
+
+    # Consume the one allowed call so the next call exercises the actual seam.
+    agent = _middleware_agent()
+    assert budget.decide_tool_call(agent, function_name="terminal")["action"] == "allow"
+    execute = Mock(return_value="should-not-run")
+    monkeypatch.setattr(
+        tool_executor,
+        "_emit_terminal_post_tool_call",
+        lambda *args, **kwargs: None,
+    )
+
+    outcome = tool_executor._run_agent_tool_execution_middleware(
+        agent,
+        function_name="terminal",
+        function_args={"command": "true"},
+        effective_task_id="task-1",
+        tool_call_id="call-2",
+        execute=execute,
+    )
+
+    assert outcome.blocked is True
+    assert execute.call_count == 0
+    assert "execution budget" in outcome.result.lower()
+
+
+def test_execution_middleware_preserves_allowed_dispatch(
+    isolated_hermes_home, monkeypatch
+):
+    _write_config(isolated_hermes_home, {"provider/model": 1})
+    import agent.tool_executor as tool_executor
+
+    agent = _middleware_agent()
+    execute = Mock(return_value="ok")
+    monkeypatch.setattr(tool_executor, "_begin_tool_execution", lambda *a, **k: None)
+    monkeypatch.setattr(
+        tool_executor,
+        "_emit_terminal_post_tool_call",
+        lambda *args, **kwargs: None,
+    )
+
+    outcome = tool_executor._run_agent_tool_execution_middleware(
+        agent,
+        function_name="terminal",
+        function_args={"command": "true"},
+        effective_task_id="task-1",
+        tool_call_id="call-1",
+        execute=execute,
+    )
+
+    assert outcome.blocked is False
+    assert outcome.result == "ok"
+    execute.assert_called_once_with({"command": "true"})
+
+
+def test_budget_decision_does_not_mutate_prompt_or_tool_arguments(
+    isolated_hermes_home,
+):
+    _write_config(isolated_hermes_home, {"provider/model": 1})
+    agent = _agent()
+    prompt = [{"role": "system", "content": "stable"}]
+    args = {"command": "printf secret", "nested": {"value": 1}}
+    prompt_before = copy.deepcopy(prompt)
+    args_before = copy.deepcopy(args)
+
+    decision = budget.decide_tool_call(
+        agent,
+        function_name="terminal",
+        final_args=args,
+        tool_call_id="call-1",
+    )
+
+    assert decision["action"] == "allow"
+    assert prompt == prompt_before
+    assert args == args_before

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1015,6 +1015,19 @@ Plugin engines are **never auto-activated** — you must explicitly set `context
 
 See [Memory Providers](/user-guide/features/memory-providers) for the analogous single-select system for memory plugins.
 
+## Per-model Execution Budgets
+
+Execution budgets are optional. When configured, they cap non-delegation tool executions for a matching model during one agent turn; `delegate_task` remains available and does not consume the budget. An unset or empty map has no runtime effect.
+
+```yaml
+agent:
+  model_execution_budgets:
+    "provider/model-pattern": 20
+    "*worker*": 50
+```
+
+Keys use case-insensitive shell-style wildcards and match the full model identifier or its provider-free name. If patterns overlap, the most specific match wins. A value of `0` blocks every non-delegation execution for that model. The gate runs at the execution boundary and does not alter prompts, tool schemas, or cached conversation messages.
+
 ## Iteration Budget
 
 When the agent is working on a complex task with many tool calls, it can burn through its iteration budget (default: 500 turns). Hermes does **not** inject mid-task pressure warnings — earlier builds warned the model at 70%/90% budget, which caused models to abandon complex tasks prematurely and was removed in April 2026.


### PR DESCRIPTION
## Summary

Adds an opt-in, config-driven cap on non-delegation tool executions per turn, keyed by model-name pattern:

```yaml
agent:
  model_execution_budgets:
    "provider/expensive-model": 20
    "*worker*": 50
```

**Motivating use case:** running a stronger 'brain' model as the main agent with cheaper hands models doing bounded worker loops. Without a budget, the main model can silently absorb long execution loops; with this key, operators can cap exactly that. The same mechanism doubles as a generic cost/runaway guardrail for any model.

## Design notes

- **Opt-in and zero-footprint by default**: empty/absent/malformed `model_execution_budgets` disables the gate entirely — no behavior change for existing configs.
- **Fail-open**: any error in budget resolution or state tracking logs at debug and lets the call proceed; a typo can never block execution.
- **Execution-boundary seam**: the check sits in `tool_executor.py` immediately before dispatch, covering sequential, concurrent, and segmented paths. It never mutates prompts, tool schemas, or conversation history (prompt-cache safe).
- **Delegation exempt**: `delegate`/`delegate_task` hand work to other agents rather than executing it in-turn, so they don't consume budget.
- **Per-turn windows scoped per agent**: state lives on the agent instance behind a per-agent lock; turn/task IDs reset the window; a thread-safety test covers concurrent dispatch.
- **Pattern semantics**: case-insensitive shell-style wildcards matched against both full and provider-free model names; most-specific pattern wins.

## Testing

- New suite `tests/agent/test_model_execution_budget.py`: 16 behavior contracts against real temp `HERMES_HOME`, including middleware-level E2E (block happens before terminal dispatch) and concurrency isolation.
- `pytest tests/agent -k budget -q`: **102 passed, 4 skipped**
- Executor regression + new suite: 21 passed
- `git diff --check` clean

## Docs

Short section added to `website/docs/user-guide/configuration.md` alongside the iteration-budget docs.