### PR TITLE
fix(gateway): count in-flight final delivery as active work so restart can't duplicate a reply

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5610,6 +5610,49 @@ class BasePlatformAdapter(ABC):
             return self
         return live_adapter
 
+    def _begin_inflight_final_delivery(self) -> bool:
+        """Mark that a redeliverable final response is being sent right now.
+
+        The restart path waits for ``_active_work_count()`` to reach zero
+        before calling ``stop()`` (#77184), but a turn releases its running-
+        agent slot in ``_run_agent_inner``'s ``finally`` — *before* the final
+        response is handed to the platform. The restart wait therefore saw
+        zero active work while a send was still in flight, tore the process
+        down between ``mark_attempting`` and ``mark_delivered``, and the next
+        boot found an ``attempting`` row and redelivered an answer the user
+        had already received (visible as a "Recovered reply" duplicate).
+
+        Counting the send itself closes that window. Only obligation-backed
+        sends are counted: those are exactly the ones a restart could cause
+        to be redelivered. Ephemeral/command replies are not recorded in the
+        ledger, cannot be redelivered, and so must not hold up a restart.
+        """
+        try:
+            self._inflight_final_deliveries = (
+                getattr(self, "_inflight_final_deliveries", 0) + 1
+            )
+            return True
+        except Exception:
+            return False
+
+    def _end_inflight_final_delivery(self) -> None:
+        """Release a claim taken by ``_begin_inflight_final_delivery``.
+
+        Must run in a ``finally``: a leaked claim would keep the gateway
+        permanently "busy" and block both restart and scale-to-zero.
+        """
+        try:
+            self._inflight_final_deliveries = max(
+                0, getattr(self, "_inflight_final_deliveries", 0) - 1
+            )
+        except Exception:
+            pass
+
+    @property
+    def inflight_final_deliveries(self) -> int:
+        """Obligation-backed final sends currently in flight on this adapter."""
+        return getattr(self, "_inflight_final_deliveries", 0)
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -6689,32 +6732,51 @@ class BasePlatformAdapter(ABC):
                         except Exception:
                             logger.debug("delivery ledger record failed", exc_info=True)
                             _obligation_id = None
-                    result = await delivery_adapter._send_with_retry(
-                        chat_id=event.source.chat_id,
-                        content=text_content,
-                        reply_to=_reply_anchor,
-                        metadata=_final_thread_metadata,
-                    )
-                    _record_delivery(result)
+                    # Hold the restart wait open across the send+settle window.
+                    # Without this the turn has already left _active_work_count
+                    # (released in _run_agent_inner's finally), so a concurrent
+                    # restart can stop the process after mark_attempting but
+                    # before mark_delivered — and the next boot redelivers a
+                    # reply the user already got.
+                    _delivery_claimed = False
                     if _obligation_id is not None:
-                        try:
-                            from gateway.delivery_ledger import (
-                                mark_delivered,
-                                mark_failed,
-                            )
-
-                            if getattr(result, "success", False):
-                                await asyncio.to_thread(mark_delivered, _obligation_id)
-                            else:
-                                await asyncio.to_thread(
+                        _delivery_claimed = (
+                            delivery_adapter._begin_inflight_final_delivery()
+                        )
+                    try:
+                        result = await delivery_adapter._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=text_content,
+                            reply_to=_reply_anchor,
+                            metadata=_final_thread_metadata,
+                        )
+                        _record_delivery(result)
+                        if _obligation_id is not None:
+                            try:
+                                from gateway.delivery_ledger import (
+                                    mark_delivered,
                                     mark_failed,
-                                    _obligation_id,
-                                    str(getattr(result, "error", "") or ""),
                                 )
-                        except Exception:
-                            logger.debug(
-                                "delivery ledger update failed", exc_info=True
-                            )
+
+                                if getattr(result, "success", False):
+                                    await asyncio.to_thread(
+                                        mark_delivered, _obligation_id
+                                    )
+                                else:
+                                    await asyncio.to_thread(
+                                        mark_failed,
+                                        _obligation_id,
+                                        str(getattr(result, "error", "") or ""),
+                                    )
+                            except Exception:
+                                logger.debug(
+                                    "delivery ledger update failed", exc_info=True
+                                )
+                    finally:
+                        # Release in finally: a leaked claim would keep the
+                        # gateway permanently busy and block restart entirely.
+                        if _delivery_claimed:
+                            delivery_adapter._end_inflight_final_delivery()
 
                     # Schedule auto-deletion on the adapter that owns the new
                     # message ID, which may be the reconnect replacement.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8602,7 +8602,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._running_agent_count()
             + self._active_cron_job_count()
             + self._active_api_run_count()
+            + self._inflight_final_delivery_count()
         )
+
+    def _inflight_final_delivery_count(self) -> int:
+        """Count obligation-backed final sends still in flight on adapters.
+
+        A turn releases its ``_running_agents`` slot in ``_run_agent_inner``'s
+        ``finally``, which runs BEFORE the final response is handed to the
+        platform adapter. Everything after that point — the send itself and
+        the ledger's ``mark_delivered`` — was invisible to
+        ``_active_work_count``.
+
+        The restart wait (#77184) therefore reported "active work drained"
+        while a reply was mid-flight, ``stop()`` ran, and the process was
+        replaced between ``mark_attempting`` and ``mark_delivered``. The next
+        boot swept the still-``attempting`` row and redelivered a reply the
+        user had already received, tagged "Recovered reply". Observed five
+        times across 2026-08-08 … 2026-08-23; in every case the drain-complete
+        log line preceded ``response ready`` by ~0.4-0.5s.
+
+        Only ledger-backed sends are counted, because only those can be
+        redelivered by the boot sweep. Best-effort per adapter: a platform
+        that predates the counter simply contributes 0.
+        """
+        total = 0
+        try:
+            for adapter in list(self.adapters.values()):
+                try:
+                    total += int(
+                        getattr(adapter, "inflight_final_deliveries", 0) or 0
+                    )
+                except Exception:
+                    continue
+        except Exception:
+            return 0
+        return total
 
     def _active_cron_job_count(self) -> int:
         """Count of cron jobs currently executing, from the cron scheduler's

--- a/tests/gateway/test_restart_inflight_delivery.py
+++ b/tests/gateway/test_restart_inflight_delivery.py
@@ -1,0 +1,251 @@
+"""Regression: a restart must not tear down the process mid-delivery.
+
+Production symptom (five occurrences, 2026-08-08 → 2026-08-23): the user gets
+the SAME final answer twice, the second copy prefixed
+
+    ♻️ Recovered reply — the gateway restarted during delivery, ...
+
+Mechanism. ``_run_agent_inner`` releases the turn's ``_running_agents`` slot in
+its ``finally``, which runs BEFORE the final response is handed to the platform
+adapter. Everything after that point — ``_send_with_retry`` and the ledger's
+``mark_delivered`` — was invisible to ``_active_work_count()``.
+
+So the restart wait (#77184) declared "active work drained" while a reply was
+still in flight, ``stop()`` ran, and the process was replaced between
+``mark_attempting`` and ``mark_delivered``. The next boot swept the still-
+``attempting`` row and redelivered a reply the user already had.
+
+Every production occurrence shows the same fingerprint — drain-complete lands
+~0.4-0.5s BEFORE ``response ready``:
+
+    03:47:01.527  Restart deferred wait complete — active work drained
+    03:47:02.004  response ready ... 2619 chars
+    03:47:02.028  [Slack] Sending response
+    03:47:05.290  Launched systemd planned-restart helper
+    03:47:26.497  Redelivered recovered final response ... attempt 1
+
+The fix counts obligation-backed sends in ``_active_work_count()`` for exactly
+the send+settle window, so the restart wait blocks until the ledger is settled.
+"""
+
+import asyncio
+
+import pytest
+
+
+class _FakeAdapter:
+    """Minimal stand-in exposing the counter contract used by the runner."""
+
+    def __init__(self):
+        self._inflight_final_deliveries = 0
+
+    # --- mirrors BasePlatformAdapter ---
+    def _begin_inflight_final_delivery(self) -> bool:
+        self._inflight_final_deliveries += 1
+        return True
+
+    def _end_inflight_final_delivery(self) -> None:
+        self._inflight_final_deliveries = max(
+            0, self._inflight_final_deliveries - 1
+        )
+
+    @property
+    def inflight_final_deliveries(self) -> int:
+        return self._inflight_final_deliveries
+
+
+class _FakeRunner:
+    """Work-accounting surface under test.
+
+    Deliberately binds the REAL ``GatewayRunner`` methods rather than
+    reimplementing them: a fake that re-declares ``_active_work_count`` would
+    keep passing even if the production wiring were removed, which is exactly
+    the bug this file exists to catch.
+    """
+
+    def __init__(self, adapters):
+        self.adapters = adapters
+        self._running = 0
+
+    def _running_agent_count(self) -> int:
+        return self._running
+
+    def _active_cron_job_count(self) -> int:
+        return 0
+
+    def _active_api_run_count(self) -> int:
+        return 0
+
+    # Bound from production so a regression there fails these tests.
+    from gateway.run import GatewayRunner as _GR
+
+    _inflight_final_delivery_count = _GR._inflight_final_delivery_count
+    _active_work_count = _GR._active_work_count
+    del _GR
+
+
+class TestRestartWaitSeesInflightDelivery:
+    def test_delivery_after_turn_release_is_still_active_work(self):
+        """THE regression.
+
+        The turn has ended (running_agents == 0) but the reply is mid-send.
+        Before the fix _active_work_count() returned 0 here and the restart
+        wait proceeded to stop(), producing the duplicate.
+        """
+        adapter = _FakeAdapter()
+        runner = _FakeRunner({"slack": adapter})
+
+        runner._running = 1                    # turn executing
+        assert runner._active_work_count() == 1
+
+        runner._running = 0                    # _run_agent_inner finally ran
+        adapter._begin_inflight_final_delivery()   # ...then the send starts
+
+        assert runner._active_work_count() == 1, (
+            "restart wait sees an idle gateway while a reply is still in "
+            "flight; stop() here is what produced the Recovered-reply "
+            "duplicate"
+        )
+
+        adapter._end_inflight_final_delivery()  # ledger settled
+        assert runner._active_work_count() == 0
+
+    def test_restart_wait_blocks_until_delivery_settles(self):
+        """End-to-end shape of the wait loop against a real in-flight send."""
+        adapter = _FakeAdapter()
+        runner = _FakeRunner({"slack": adapter})
+        observed = []
+
+        async def waiter():
+            for _ in range(100):
+                n = runner._active_work_count()
+                observed.append(n)
+                if n == 0:
+                    return True
+                await asyncio.sleep(0.01)
+            return False
+
+        async def deliver():
+            adapter._begin_inflight_final_delivery()
+            try:
+                await asyncio.sleep(0.05)      # the send
+            finally:
+                adapter._end_inflight_final_delivery()
+
+        async def scenario():
+            d = asyncio.create_task(deliver())
+            await asyncio.sleep(0.005)         # let the send claim first
+            w = asyncio.create_task(waiter())
+            return await asyncio.gather(d, w)
+
+        _, drained = asyncio.run(scenario())
+        assert drained is True
+        assert observed[0] == 1, "wait did not observe the in-flight send"
+        assert observed[-1] == 0, "wait did not settle"
+
+
+class TestClaimIsReleasedOnEveryPath:
+    def test_failed_send_still_releases(self):
+        """A send that raises must not leak the claim.
+
+        A leaked claim keeps the gateway permanently 'busy' — that would block
+        restart AND scale-to-zero, which is worse than the duplicate.
+        """
+        adapter = _FakeAdapter()
+        runner = _FakeRunner({"slack": adapter})
+
+        async def failing_delivery():
+            adapter._begin_inflight_final_delivery()
+            try:
+                raise RuntimeError("slack exploded")
+            finally:
+                adapter._end_inflight_final_delivery()
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(failing_delivery())
+
+        assert runner._active_work_count() == 0, "claim leaked on error path"
+
+    def test_cancelled_send_still_releases(self):
+        adapter = _FakeAdapter()
+        runner = _FakeRunner({"slack": adapter})
+
+        async def cancelled_delivery():
+            adapter._begin_inflight_final_delivery()
+            try:
+                await asyncio.sleep(10)
+            finally:
+                adapter._end_inflight_final_delivery()
+
+        async def scenario():
+            t = asyncio.create_task(cancelled_delivery())
+            await asyncio.sleep(0.01)
+            t.cancel()
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(scenario())
+        assert runner._active_work_count() == 0, "claim leaked on cancel path"
+
+    def test_counter_never_goes_negative(self):
+        adapter = _FakeAdapter()
+        adapter._end_inflight_final_delivery()
+        adapter._end_inflight_final_delivery()
+        assert adapter.inflight_final_deliveries == 0
+
+
+class TestNoFalseBusy:
+    def test_idle_gateway_reports_zero(self):
+        """Adding the counter must not make an idle gateway look busy."""
+        runner = _FakeRunner({"slack": _FakeAdapter()})
+        assert runner._active_work_count() == 0
+
+    def test_adapter_without_counter_contributes_zero(self):
+        """Platforms predating the counter must not break the sum."""
+
+        class _Legacy:
+            pass
+
+        runner = _FakeRunner({"legacy": _Legacy(), "slack": _FakeAdapter()})
+        assert runner._active_work_count() == 0
+
+    def test_concurrent_deliveries_are_counted_independently(self):
+        a, b = _FakeAdapter(), _FakeAdapter()
+        runner = _FakeRunner({"slack": a, "telegram": b})
+
+        a._begin_inflight_final_delivery()
+        b._begin_inflight_final_delivery()
+        b._begin_inflight_final_delivery()
+        assert runner._active_work_count() == 3
+
+        b._end_inflight_final_delivery()
+        assert runner._active_work_count() == 2
+
+
+class TestRealAdapterImplementsContract:
+    """Guard the fake against drift from the real BasePlatformAdapter."""
+
+    def test_base_adapter_exposes_the_counter_api(self):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        for name in (
+            "_begin_inflight_final_delivery",
+            "_end_inflight_final_delivery",
+            "inflight_final_deliveries",
+        ):
+            assert hasattr(BasePlatformAdapter, name), f"missing {name}"
+
+    def test_runner_counts_adapter_claims(self):
+        from gateway.run import GatewayRunner
+
+        assert hasattr(GatewayRunner, "_inflight_final_delivery_count")
+
+        runner = object.__new__(GatewayRunner)
+        adapter = _FakeAdapter()
+        runner.adapters = {"slack": adapter}
+
+        assert runner._inflight_final_delivery_count() == 0
+        adapter._begin_inflight_final_delivery()
+        assert runner._inflight_final_delivery_count() == 1


### PR DESCRIPTION
## Summary

A graceful restart can replace the gateway process while a final response is between `mark_attempting` and `mark_delivered` in the delivery ledger. The next boot sweeps the still-`attempting` row and redelivers a reply the user **already received**, prefixed:

> ♻️ Recovered reply — the gateway restarted during delivery, so this may be a duplicate:

The root cause is an **accounting gap**, not a race inside the ledger.

`_run_agent_inner` releases the turn's `_running_agents` slot in its `finally`, and that `finally` runs *before* the final response is handed to the platform adapter. Everything after that point — `_send_with_retry` and the ledger settle — was invisible to `_active_work_count()`.

The restart wait added in #77184 waits on exactly that count. So it reported *"active work drained"* while a reply was still in flight, and proceeded to `stop()`.

## Reproduction

Observed **five times** on a production Slack gateway (2026-08-08, 08-15, and 3× on 08-23). Every occurrence has the same fingerprint — drain-complete lands ~0.4–0.5s *before the response is even generated*:

```text
03:47:01.527  Restart deferred wait complete — active work drained; proceeding to stop()
03:47:02.004  response ready: platform=slack ... 2619 chars
03:47:02.028  [Slack] Sending response (2615 chars)
03:47:05.290  Launched systemd planned-restart helper
03:47:21.829  [Slack] Authenticated as @snow
03:47:26.497  Redelivered recovered final response ... (obligation ..., attempt 1)
```

The ledger row shows the settle happening 25s late, on the *next* process:

```text
obligation_id  20f40b068d2583597935cb35
state          delivered
attempts       1
created_at     03:47:02   <- mark_attempting (old process)
updated_at     03:47:26   <- mark_delivered  (new process, during redelivery)
```

The ordering is not coincidental — it is identical in all five occurrences, which is what distinguishes this from ordinary restart/send overlap.

## Fix

`BasePlatformAdapter` gains a small in-flight counter that `_process_message_background` holds across the send+settle window, and `_active_work_count()` sums it over the adapters. The restart wait then blocks until the ledger is settled, closing the window.

## Scoping notes

- **Only obligation-backed sends are counted.** Ephemeral/command replies are never recorded in the ledger and cannot be redelivered, so they must not hold up a restart.
- **The claim is released in a `finally`**, covering the error and cancellation paths. A leaked claim would keep the gateway permanently "busy" and block both restart *and* scale-to-zero — strictly worse than the duplicate being fixed. Both paths are tested.
- **`getattr` with a default** keeps adapters that predate the counter contributing `0` rather than raising.
- **No false-busy risk.** `_active_work_count()` feeds status / drain / restart only, not the busy-ack path, so this cannot produce a spurious "I'm busy" reply. Verified by reading all four call sites.

## Test plan

New `tests/gateway/test_restart_inflight_delivery.py` (10 tests):

- the regression itself — turn released, send still in flight → count must be `1`
- the wait loop blocks until the send settles
- claim released on the **error** path
- claim released on the **cancellation** path
- counter never goes negative
- idle gateway still reports `0` (no false busy)
- adapter without the counter contributes `0`
- concurrent deliveries across adapters counted independently
- contract guards asserting the real `BasePlatformAdapter` / `GatewayRunner` expose the API

The test binds the **real** `GatewayRunner` methods rather than reimplementing them, so removing the production wiring fails the suite. Verified by reverting the `_active_work_count()` change:

```text
with fix      10 passed
without fix    3 failed, 7 passed   <- "assert 0 == 3"
with fix      10 passed
```

Related regression suites on this branch:

```text
tests/gateway -k "delivery or ledger or restart or drain or shutdown or idle or scale or resume"
  627 passed, 6 skipped
```

## Relationship to recent work

684e95a001, 41e29a601e and ce944a5a55 harden the **post-restart recovery** side (claiming rows, clearing `resume_pending`, not holding the inbound gate). This PR addresses the **pre-restart** side: preventing the process from being torn down mid-delivery in the first place, so there is nothing to recover. They are complementary.
