### PR TITLE
fix(compression): keep Desktop and TUI previews from mutating sessions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -770,7 +770,7 @@ describe('usePromptActions /compress', () => {
     )
   })
 
-  it('passes a focus topic through as focus_topic', async () => {
+  it('passes the raw compression arguments through the canonical args field', async () => {
     const requestGateway = vi.fn(
       async (_method: string, _params?: Record<string, unknown>, _timeoutMs?: number) => ({ removed: 0 }) as never
     )
@@ -784,8 +784,53 @@ describe('usePromptActions /compress', () => {
 
     expect(requestGateway).toHaveBeenCalledWith(
       'session.compress',
-      expect.objectContaining({ focus_topic: 'the auth refactor' }),
+      expect.objectContaining({ args: 'the auth refactor' }),
       120_000
+    )
+  })
+
+  it('passes preview flags as raw args and renders the read-only report', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        return {
+          status: 'preview',
+          removed: 0,
+          summary: {
+            headline: 'Preview — no changes made.',
+            noop: true,
+            preview: true,
+            token_line: 'Would compress 4 of 6 messages.'
+          }
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/compress --dry-run here 2')
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.compress',
+      expect.objectContaining({ args: '--dry-run here 2' }),
+      120_000
+    )
+    expect(renderedSeedTexts(seeds).some(text => text.includes('Preview — no changes made.'))).toBe(true)
+    expect($notifications.get()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'success', message: expect.stringContaining('Preview — no changes made.') })
+      ])
     )
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -514,7 +514,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
           const { render: renderSlashOutput, sessionId: initialSessionId, storedSessionId } = resolved
           let sessionId = initialSessionId
-          const focusTopic = ctx.arg.trim()
+          const compressArgs = ctx.arg.trim()
+          const preview = /(?:^|\s)--(?:preview|dry-run|dryrun)(?:\s|$)/i.test(compressArgs)
           const noticeId = `session-compress:${sessionId}`
 
           // Coalesce concurrent compress requests for the same session so a
@@ -528,7 +529,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             durationMs: 0,
             id: noticeId,
             kind: 'info',
-            message: focusTopic ? `compressing context for: ${focusTopic}` : 'compressing context...'
+            message: preview
+              ? 'previewing compression...'
+              : compressArgs
+                ? `compressing context for: ${compressArgs}`
+                : 'compressing context...'
           })
 
           try {
@@ -545,7 +550,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
                   'session.compress',
                   {
                     session_id: liveId,
-                    ...(focusTopic ? { focus_topic: focusTopic } : {})
+                    ...(compressArgs ? { args: compressArgs } : {})
                   },
                   SESSION_COMPRESS_TIMEOUT_MS
                 ),

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -73,6 +73,7 @@ export interface SessionCompressResponse {
     headline?: string
     noop?: boolean
     note?: null | string
+    preview?: boolean
     token_line?: string
   }
   usage?: Partial<UsageStats>

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9122,6 +9122,69 @@ def test_session_compress_normalizes_messages_for_desktop_transcript(monkeypatch
     assert "very sensitive tool output" not in str(response["result"]["messages"])
 
 
+@pytest.mark.parametrize("flag", ["--preview", "--dry-run"])
+def test_session_compress_preview_is_side_effect_free(monkeypatch, flag):
+    history = list(_PARTIAL_FAKE_HISTORY)
+    agent = _partial_compress_agent([])
+    session = _session(agent=agent, history=list(history))
+    session["history_version"] = 7
+    session["session_key"] = "original-key"
+    server._sessions["sid"] = session
+    monkeypatch.setattr(
+        server,
+        "_compress_session_history",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("preview must not invoke compression")
+        ),
+    )
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.compress",
+                "params": {"session_id": "sid", "args": f"{flag} here 1"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert response["result"]["status"] == "preview"
+    assert response["result"]["summary"]["noop"] is True
+    assert "no changes made" in response["result"]["summary"]["headline"].lower()
+    assert session["history"] == history
+    assert session["history_version"] == 7
+    assert session["session_key"] == "original-key"
+
+
+def test_session_compress_preview_accepts_legacy_focus_topic_param(monkeypatch):
+    history = list(_PARTIAL_FAKE_HISTORY)
+    session = _session(agent=_partial_compress_agent([]), history=list(history))
+    server._sessions["sid"] = session
+    monkeypatch.setattr(
+        server,
+        "_compress_session_history",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("legacy preview must not invoke compression")
+        ),
+    )
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.compress",
+                "params": {"session_id": "sid", "focus_topic": "--preview auth"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert response["result"]["status"] == "preview"
+    assert 'Focus topic: "auth"' in response["result"]["summary"]["note"]
+    assert session["history"] == history
+
+
 def test_session_compress_returns_compute_host_history(monkeypatch):
     session = _session(agent=None, _compute_host_active=True)
     server._sessions["sid"] = session
@@ -9149,6 +9212,48 @@ def test_session_compress_returns_compute_host_history(monkeypatch):
         "messages": [{"role": "user", "text": "compressed context"}],
         "usage": {"total": 42},
     }
+
+
+def test_session_compress_preview_round_trips_through_compute_host(monkeypatch):
+    session = _session(agent=None, _compute_host_active=True)
+    server._sessions["sid"] = session
+    calls = []
+
+    def send_control(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "type": "control.ack",
+            "session_key": "must-not-replace",
+            "history_version": 99,
+            "message_count": 1,
+            "session_info": {"model": "must-not-mirror"},
+            "result": {
+                "status": "preview",
+                "removed": 0,
+                "summary": {"headline": "Preview — no changes made.", "noop": True},
+            },
+        }
+
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)
+    monkeypatch.setattr(server, "_send_compute_host_control", send_control)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.compress",
+                "params": {"session_id": "sid", "args": "--dry-run here 2"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert response["result"]["status"] == "preview"
+    assert response["result"]["turn_isolation"] is True
+    assert calls[0][1]["command"] == "/compress --dry-run here 2"
+    assert session["session_key"] != "must-not-replace"
+    assert session["history_version"] != 99
+    assert "_metadata_mirror" not in session
 
 
 def test_session_compress_forwards_120_second_budget_to_compute_host(monkeypatch):
@@ -12577,6 +12682,28 @@ def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):
     assert "Compressed:" in warning
     assert "6 → 1 messages" in warning
     assert "tokens" in warning
+
+
+def test_mirror_slash_compress_preview_is_side_effect_free(monkeypatch):
+    history = list(_PARTIAL_FAKE_HISTORY)
+    session = _session(agent=_partial_compress_agent([]), history=list(history))
+    session["history_version"] = 11
+    monkeypatch.setattr(
+        server,
+        "_compress_session_history",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("preview must not invoke compression")
+        ),
+    )
+
+    output = server._mirror_slash_side_effects(
+        "sid", session, "/compress --preview here 1"
+    )
+
+    assert "no changes made" in output.lower()
+    assert "last 1 exchange" in output
+    assert session["history"] == history
+    assert session["history_version"] == 11
 
 
 _PARTIAL_FAKE_HISTORY = [

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -152,6 +152,49 @@ def _record_finalize(monkeypatch, events: list[str], *sids: str) -> None:
     )
 
 
+def test_compute_host_forwards_raw_compress_args(monkeypatch):
+    out = io.StringIO()
+    host = ComputeHost(stdout=out, heartbeat_secs=0)
+    seen = []
+    session = {
+        "agent": object(),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 3,
+        "running": False,
+        "session_key": "key",
+    }
+    monkeypatch.setitem(server._sessions, "sid", session)
+    monkeypatch.setitem(
+        server._methods,
+        "session.compress",
+        lambda request_id, params: (
+            seen.append((request_id, params))
+            or {
+                "result": {
+                    "status": "preview",
+                    "summary": {"headline": "Preview — no changes made.", "noop": True},
+                }
+            }
+        ),
+    )
+    monkeypatch.setattr(server, "_session_info", lambda *_args, **_kwargs: {})
+
+    host._handle_control(
+        {
+            "type": "control",
+            "sid": "sid",
+            "request_id": "req",
+            "route_name": "session.compress",
+            "command": "/compress --dry-run here 2",
+        }
+    )
+
+    assert seen == [("req", {"session_id": "sid", "args": "--dry-run here 2"})]
+    ack = _json_lines(out)[-1]
+    assert ack["result"]["status"] == "preview"
+
+
 def _register_turn(host: ComputeHost, fn, sid: str = "s1") -> None:
     """Submit a turn exactly the way ``_handle_turn_start`` does."""
     host._track_turn_future(host._executor.submit(fn), sid)

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -703,12 +703,12 @@ class ComputeHost:
                 return
             if route_name == "session.compress":
                 command = str(frame.get("command") or "")
-                focus_topic = command.removeprefix("/compress").strip()
+                compress_args = command.removeprefix("/compress").strip()
                 response = server._methods["session.compress"](
                     request_id,
                     {
                         "session_id": sid,
-                        **({"focus_topic": focus_topic} if focus_topic else {}),
+                        **({"args": compress_args} if compress_args else {}),
                     },
                 )
                 if "error" in response:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2703,10 +2703,15 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     assert session is not None
+    # ``args`` is the canonical raw string after /compress.  Keep accepting
+    # ``focus_topic`` from older Desktop/TUI clients, but parse flags before the
+    # value can reach the compression model as a literal focus topic.
+    raw_args = str(
+        params.get("args", params.get("focus_topic", "")) or ""
+    ).strip()
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
-        focus_topic = str(params.get("focus_topic", "") or "").strip()
-        command = "/compress" + (f" {focus_topic}" if focus_topic else "")
+        command = "/compress" + (f" {raw_args}" if raw_args else "")
         try:
             ack = _send_compute_host_control(
                 sid,
@@ -2719,15 +2724,20 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5019, f"compute-host compress failed: {exc}")
         if ack.get("type") in {"control.error", "error"}:
             return _err(rid, 4009, str(ack.get("message") or "compute-host compress failed"))
-        _apply_compute_host_metadata_mirror(session, ack)
         host_result = ack.get("result")
         if isinstance(host_result, dict):
+            # A preview is a strict read-only operation. Even refreshing the
+            # serving process's metadata mirror would write session state, so
+            # only non-preview acknowledgements reconcile it.
+            if host_result.get("status") != "preview":
+                _apply_compute_host_metadata_mirror(session, ack)
             # The host owns the isolated session's agent/history, so preserve
             # its structured compression result verbatim. In particular this
             # carries `status: aborted` and `summary.aborted`; flattening the
             # old text-only acknowledgement made Desktop show aborted work as a
             # success toast.
             return _ok(rid, {**host_result, "turn_isolation": True})
+        _apply_compute_host_metadata_mirror(session, ack)
         host_info = ack.get("session_info") if isinstance(ack.get("session_info"), dict) else {}
         host_messages = _history_to_messages(ack.get("messages")) if isinstance(ack.get("messages"), list) else []
         # `messages` is returned at top level for the desktop transcript
@@ -2752,12 +2762,15 @@ def _(rid, params: dict) -> dict:
         return _err(
             rid, 4009, "session busy — /interrupt the current turn before /compress"
         )
+    compress_args, immediate = _prepare_session_compress(session, raw_args)
+    if immediate is not None:
+        return _ok(rid, immediate)
     from agent.conversation_compression import (
         finalize_context_engine_compression_notification,
     )
 
     sid = params.get("session_id", "")
-    focus_topic = str(params.get("focus_topic", "") or "").strip()
+    focus_topic = compress_args
     try:
         from agent.manual_compression_feedback import summarize_manual_compression
         from agent.model_metadata import estimate_request_tokens_rough

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5284,6 +5284,80 @@ class CompressionLockHeld(Exception):
         super().__init__(f"Compression lock held: {holder or 'unknown'}")
 
 
+def _prepare_session_compress(
+    session: dict,
+    raw_args: str | None,
+) -> tuple[str, dict | None]:
+    """Normalize raw ``/compress`` args and short-circuit read-only modes.
+
+    ``session.compress`` clients send the complete argument string here.  The
+    returned string contains only the positional compression mode/focus and is
+    safe to pass to :func:`_compress_session_history`.  Preview and unsupported
+    aggressive requests return an immediate result without calling the model or
+    mutating session state.
+    """
+    from agent.model_metadata import estimate_request_tokens_rough
+    from hermes_cli.partial_compress import (
+        extract_compress_flags,
+        parse_partial_compress_args,
+        summarize_compress_preview,
+    )
+
+    args, preview, aggressive = extract_compress_flags(raw_args or "")
+    if aggressive and not preview:
+        return args, {
+            "status": "aborted",
+            "removed": 0,
+            "summary": {
+                "aborted": True,
+                "headline": "Compression not started.",
+                "noop": True,
+                "note": (
+                    "--aggressive is not supported; use '/compress here [N]' "
+                    "to keep only recent exchanges, or /undo to drop turns."
+                ),
+            },
+        }
+    if not preview:
+        return args, None
+
+    partial, keep_last, focus_topic = parse_partial_compress_args(args)
+    with session["history_lock"]:
+        history = list(session.get("history", []))
+    agent = session.get("agent")
+    system_prompt = getattr(agent, "_cached_system_prompt", "") or ""
+    tools = getattr(agent, "tools", None) or None
+    approx_tokens = estimate_request_tokens_rough(
+        history,
+        system_prompt=system_prompt,
+        tools=tools,
+    )
+    report = summarize_compress_preview(
+        history,
+        partial,
+        keep_last,
+        focus_topic,
+        approx_tokens,
+    )
+    lines = list(report["lines"])
+    if aggressive:
+        lines.append(
+            "--aggressive is not supported; preview uses the regular "
+            "compression boundary."
+        )
+    return args, {
+        "status": "preview",
+        "removed": 0,
+        "summary": {
+            "headline": lines[0],
+            "token_line": lines[1] if len(lines) > 1 else None,
+            "note": "\n".join(lines[2:]) or None,
+            "noop": True,
+            "preview": True,
+        },
+    }
+
+
 def _compress_session_history(
     session: dict,
     focus_topic: str | None = None,
@@ -14230,6 +14304,19 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             from agent.conversation_compression import (
                 finalize_context_engine_compression_notification,
             )
+
+            arg, _immediate = _prepare_session_compress(session, arg)
+            if _immediate is not None:
+                _summary = _immediate.get("summary") or {}
+                return "\n".join(
+                    str(line)
+                    for line in (
+                        _summary.get("headline"),
+                        _summary.get("token_line"),
+                        _summary.get("note"),
+                    )
+                    if line
+                )
 
             with session["history_lock"]:
                 _before_messages = list(session.get("history", []))

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -222,7 +222,7 @@ export const sessionCommands: SlashCommand[] = [
       ctx.gateway
         .rpc<SessionCompressResponse>('session.compress', {
           session_id: ctx.sid,
-          ...(arg ? { focus_topic: arg } : {})
+          ...(arg ? { args: arg } : {})
         })
         .then(
           ctx.guarded<SessionCompressResponse>(r => {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -301,10 +301,12 @@ export interface SessionCompressResponse {
   info?: SessionInfo
   messages?: GatewayTranscriptMessage[]
   removed?: number
+  status?: string
   summary?: {
     headline?: string
     noop?: boolean
     note?: null | string
+    preview?: boolean
     token_line?: string
   }
   usage?: Usage


### PR DESCRIPTION
## What does this PR do?

Desktop and TUI users can now run `/compress --preview` or `/compress --dry-run` without invoking the compression model or changing the live transcript, session identity, history version, or compute-host metadata mirror. The dedicated RPC now accepts a canonical raw `args` field, preserves the legacy `focus_topic` field for older clients, and applies the same flag parser already used by the CLI and messaging gateway.

### Symptom

In Desktop or TUI, `/compress --preview` and `/compress --dry-run` were forwarded through `session.compress` as a focus topic. The backend then performed and committed a real compression instead of returning a read-only report.

### Impact

A user asking to inspect a proposed compression could unexpectedly replace hundreds of live context messages and rotate session state. The affected paths were the Desktop action, the TUI action, the live slash mirror, and turn-isolated compute-host forwarding.

### Bug Cause

**Trigger:** `tui_gateway/methods_session.py` in the `session.compress` handler and `tui_gateway/server.py` in `_mirror_slash_side_effects`.

**Causal chain:**
1. Desktop or TUI sent the complete text after `/compress` through the field named `focus_topic`.
2. The session RPC and live slash mirror passed that text directly to `_compress_session_history` without calling `extract_compress_flags`.
3. `--preview` and `--dry-run` became literal focus text, so the normal model-backed compression path committed a new history.

**Why it is wrong:** Preview flags are control arguments with a strict no-write contract, not focus content.

**Working sibling / contrast:** The classic CLI and messaging gateway already strip these flags and build a preview report before constructing or calling a compression agent.

**Ruled out:** The partial compression parser and compressor itself were not at fault. They correctly handle `here`, `--keep`, and ordinary focus topics after control flags have been removed.

### Fix

- Added one gateway helper that normalizes raw compression arguments and returns preview or unsupported-aggressive results before any model call or session write.
- Routed the local RPC, live slash mirror, Desktop, TUI, and compute-host boundary through canonical raw `args` while retaining legacy client compatibility.
- Prevented preview acknowledgements from refreshing the serving process metadata mirror.
- Added regression coverage for both preview spellings, legacy clients, local state invariants, compute-host forwarding, and Desktop rendering.

## Related Issue

Closes #92570

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` - parse raw compression flags and build read-only preview responses at the shared live-session boundary.
- `tui_gateway/methods_session.py` - accept canonical raw arguments, preserve legacy compatibility, and keep preview acknowledgements write-free.
- `tui_gateway/compute_host.py` - forward raw compression arguments without reclassifying them as a focus topic.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/` - send raw arguments and render preview status without replacing transcript state.
- `ui-tui/src/app/slash/commands/session.ts` - send the same canonical RPC payload as Desktop.
- `tests/` - cover local, legacy, slash-mirror, compute-host, and Desktop preview behavior.

## How to Test

1. Open a Desktop or TUI session with at least four messages.
2. Run `/compress --preview here 1` and `/compress --dry-run` and confirm a preview report appears while transcript and session state remain unchanged.
3. Run the automated checks:

```bash
scripts/run_tests.sh tests/test_tui_gateway_server.py tests/tui_gateway/test_compress_lock_skip.py tests/cli/test_compress_flags.py tests/gateway/test_compress_preview.py -q
scripts/run_tests.sh tests/tui_gateway/test_compute_host_phase1.py -k test_compute_host_forwards_raw_compress_args -q
cd apps/desktop && npx vitest run src/app/session/hooks/use-prompt-actions/index.test.tsx && npm run typecheck
cd ui-tui && npm run typecheck
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant repository test entries and all targeted checks pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A; the RPC compatibility behavior is documented in code and types
- [x] Config example updates are N/A; no config keys changed
- [x] Contributor or agent guide updates are N/A; no workflow changed
- [x] I've considered cross-platform impact; the change uses platform-neutral parsing and state handling
- [x] Tool description or schema updates are N/A; no model tool changed

## Screenshots / Logs

N/A. Automated tests assert the read-only state invariants and rendered preview response.
