### PR TITLE
feat(api): support approvals in session chat streams

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -461,12 +461,12 @@ class _ConcurrentToolAuthorizationGate:
         self._session_key = session_key
         if self._session_key is None:
             try:
-                from tools.approval import get_current_session_key
+                from tools.approval import get_current_approval_namespace_key
 
-                # Snapshot the batch's session identity on the SUBMITTING
+                # Snapshot the batch's approval namespace on the SUBMITTING
                 # thread: excluded_seconds() is polled from the batch wait
                 # loop, whose context may differ from the workers'.
-                self._session_key = get_current_session_key()
+                self._session_key = get_current_approval_namespace_key()
             except Exception:
                 logger.debug(
                     "authorization gate could not snapshot the session key; "

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1540,6 +1540,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
+        # Transport-specific event sink for approval lifecycle events. Native
+        # session streams and /v1/runs use different queue shapes, so the
+        # shared approval bridge targets this run-scoped callable instead.
+        self._run_approval_event_sinks: Dict[str, Any] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
         self._session_dbs: Dict[str, Any] = {}
         self._session_db_cache_lock = threading.Lock()
@@ -4711,6 +4715,7 @@ class APIServerAdapter(BasePlatformAdapter):
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
         message_id = f"msg_{uuid.uuid4().hex}"
         run_id = f"run_{uuid.uuid4().hex}"
+        approval_session_key = run_id
         self._set_run_status(
             run_id,
             "queued",
@@ -4742,6 +4747,16 @@ class APIServerAdapter(BasePlatformAdapter):
             except RuntimeError:
                 pass
 
+        def _emit_approval_event(event: Dict[str, Any]) -> None:
+            _enqueue(str(event.get("event") or "approval.request"), event)
+
+        self._run_approval_sessions[run_id] = approval_session_key
+        self._run_approval_event_sinks[run_id] = _emit_approval_event
+        approval_notify = self._make_run_approval_notify(
+            run_id,
+            _emit_approval_event,
+        )
+
         def _delta(delta: str) -> None:
             if delta:
                 _enqueue("assistant.delta", {"message_id": message_id, "delta": delta})
@@ -4770,6 +4785,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     active_run_id=run_id,
+                    approval_notify_callback=approval_notify,
                     gateway_session_key=gateway_session_key,
                     route=route,
                     session_model=session_model,
@@ -4845,6 +4861,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 await queue.put(_event_payload("error", {"message": _redact_api_error_text(exc)}))
             finally:
                 self._active_run_agents.pop(run_id, None)
+                self._run_approval_sessions.pop(run_id, None)
+                self._run_approval_event_sinks.pop(run_id, None)
                 await queue.put(_event_payload("done", {}))
                 await queue.put(None)
 
@@ -7132,6 +7150,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         active_run_id: Optional[str] = None,
+        approval_notify_callback=None,
         gateway_session_key: Optional[str] = None,
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
@@ -7197,7 +7216,22 @@ class APIServerAdapter(BasePlatformAdapter):
                     ),
                 )
                 agent = None
+                approval_token = None
+                approval_session_key = active_run_id or ""
                 try:
+                    if approval_session_key and approval_notify_callback is not None:
+                        from tools.approval import (
+                            register_gateway_notify,
+                            set_current_approval_namespace_key,
+                        )
+
+                        approval_token = set_current_approval_namespace_key(
+                            approval_session_key
+                        )
+                        register_gateway_notify(
+                            approval_session_key,
+                            approval_notify_callback,
+                        )
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,
@@ -7367,6 +7401,19 @@ class APIServerAdapter(BasePlatformAdapter):
                         # shutdown.  pop() is a no-op when _create_agent
                         # succeeded but the turn never reached registration.
                         self._shutdown_interruptible_agents.pop(id(agent), None)
+                    if approval_session_key and approval_notify_callback is not None:
+                        from tools.approval import (
+                            clear_session as clear_approval_session,
+                            reset_current_approval_namespace_key,
+                            unregister_gateway_notify,
+                        )
+
+                        try:
+                            unregister_gateway_notify(approval_session_key)
+                        finally:
+                            clear_approval_session(approval_session_key)
+                            if approval_token is not None:
+                                reset_current_approval_namespace_key(approval_token)
                     clear_session_vars(tokens)
 
         self._activate_admitted_request()
@@ -7491,6 +7538,56 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return _callback
 
+    def _make_run_approval_notify(self, run_id: str, emit_event):
+        """Build the shared, whitelisted approval.request bridge for an API run."""
+
+        def _approval_notify(approval_data: Dict[str, Any]) -> None:
+            source = approval_data if isinstance(approval_data, dict) else {}
+            smart_denied = bool(source.get("smart_denied"))
+            allow_permanent = source.get("allow_permanent") is not False
+            # This is an authenticated API egress boundary, not merely a UI
+            # convenience. Force-redact every free-text field we expose even
+            # when global redaction is disabled, and never forward unknown
+            # payload keys supplied by an approval producer.
+            event = {
+                "request_id": str(source.get("request_id") or ""),
+                "command": redact_sensitive_text(
+                    str(source.get("command") or ""), force=True
+                ),
+                "description": redact_sensitive_text(
+                    str(source.get("description") or ""), force=True
+                ),
+                "pattern_key": redact_sensitive_text(
+                    str(source.get("pattern_key") or ""), force=True
+                ),
+                "pattern_keys": [
+                    redact_sensitive_text(str(value), force=True)
+                    for value in (source.get("pattern_keys") or [])
+                    if isinstance(value, str)
+                ],
+                "smart_denied": smart_denied,
+                "allow_permanent": allow_permanent,
+                "allow_session": source.get("allow_session") is not False,
+                "event": "approval.request",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "choices": _approval_event_choices(
+                    smart_denied=smart_denied,
+                    allow_permanent=allow_permanent,
+                ),
+            }
+            self._set_run_status(
+                run_id,
+                "waiting_for_approval",
+                last_event="approval.request",
+            )
+            try:
+                emit_event(event)
+            except Exception:
+                pass
+
+        return _approval_notify
+
     @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
@@ -7601,6 +7698,25 @@ class APIServerAdapter(BasePlatformAdapter):
             if self._run_streams.get(run_id) is q:
                 q.put_nowait(event)
 
+        def _emit_approval_event(event: Dict[str, Any]) -> None:
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+            try:
+                if running_loop is loop:
+                    _put_event_if_active(event)
+                else:
+                    loop.call_soon_threadsafe(_put_event_if_active, event)
+            except RuntimeError:
+                pass
+
+        self._run_approval_event_sinks[run_id] = _emit_approval_event
+        approval_notify = self._make_run_approval_notify(
+            run_id,
+            _emit_approval_event,
+        )
+
         # Also wire stream_delta_callback so message.delta events flow through.
         def _text_cb(delta: Optional[str]) -> None:
             if delta is None:
@@ -7664,41 +7780,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 self._active_run_agents[run_id] = agent
 
-                def _approval_notify(approval_data: Dict[str, Any]) -> None:
-                    event = dict(approval_data or {})
-                    # Redact credentials from the command before it enters the
-                    # SSE/API event stream — same egress bug as #48456, second
-                    # transport: API/desktop clients would otherwise receive the
-                    # raw command Tirith flagged. Reuse the gateway seam.
-                    if "command" in event:
-                        from gateway.run import _redact_approval_command
-
-                        event["command"] = _redact_approval_command(event.get("command"))
-                    event.update({
-                        "event": "approval.request",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "choices": _approval_event_choices(
-                            smart_denied=bool(event.get("smart_denied")),
-                            allow_permanent=event.get("allow_permanent") is not False,
-                        ),
-                    })
-                    self._set_run_status(
-                        run_id,
-                        "waiting_for_approval",
-                        last_event="approval.request",
-                    )
-                    try:
-                        loop.call_soon_threadsafe(q.put_nowait, event)
-                    except Exception:
-                        pass
-
                 def _run_sync():
                     from gateway.session_context import clear_session_vars
                     from tools.approval import (
                         register_gateway_notify,
-                        reset_current_session_key,
-                        set_current_session_key,
+                        reset_current_approval_namespace_key,
+                        set_current_approval_namespace_key,
                         unregister_gateway_notify,
                     )
 
@@ -7710,7 +7797,9 @@ class APIServerAdapter(BasePlatformAdapter):
                             # Bind approval/session identity for this API run via
                             # contextvars so concurrent runs do not share process
                             # environment state.
-                            approval_token = set_current_session_key(approval_session_key)
+                            approval_token = set_current_approval_namespace_key(
+                                approval_session_key
+                            )
                             session_tokens = self._bind_api_server_session(
                                 # chat_id carries the raw session id (the
                                 # X-Hermes-Session-Id equivalent) exactly like
@@ -7721,7 +7810,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                 # background delegations stay forced-sync
                                 # (no wake target).
                                 chat_id=session_id or "",
-                                session_key=approval_session_key,
+                                session_key=gateway_session_key or session_id or "",
                                 session_id=session_id or "",
                                 browser_control_principal=(
                                     request_browser_control_principal
@@ -7730,7 +7819,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                     request_browser_control_transport_family
                                 ),
                             )
-                            register_gateway_notify(approval_session_key, _approval_notify)
+                            register_gateway_notify(approval_session_key, approval_notify)
                             # /v1/runs runs its own agent lifecycle (no
                             # TurnRunner, no _run_agent) — record turn process
                             # ownership so stop/cancel can reap only the
@@ -7753,7 +7842,9 @@ class APIServerAdapter(BasePlatformAdapter):
                             finally:
                                 if approval_token is not None:
                                     try:
-                                        reset_current_session_key(approval_token)
+                                        reset_current_approval_namespace_key(
+                                            approval_token
+                                        )
                                     except Exception:
                                         pass
                                 if session_tokens:
@@ -7885,9 +7976,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 # waits immediately; the in-thread unregister is harmlessly
                 # idempotent on normal completion.
                 try:
-                    from tools.approval import unregister_gateway_notify
+                    from tools.approval import (
+                        clear_session as clear_approval_session,
+                        unregister_gateway_notify,
+                    )
 
                     unregister_gateway_notify(approval_session_key)
+                    clear_approval_session(approval_session_key)
                 except Exception:
                     pass
                 # Sentinel: signal SSE stream to close
@@ -7898,6 +7993,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
+                self._run_approval_event_sinks.pop(run_id, None)
                 self._stopping_run_ids.discard(run_id)
 
         self._activate_admitted_request()
@@ -8017,6 +8113,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 ),
                 status=400,
             )
+        request_id = body.get("request_id")
+        if not isinstance(request_id, str) or not request_id:
+            return web.json_response(
+                _openai_error(
+                    "A non-empty request_id is required to resolve an approval",
+                    code="invalid_approval_request_id",
+                ),
+                status=400,
+            )
 
         approval_session_key = self._run_approval_sessions.get(run_id)
         if not approval_session_key:
@@ -8028,48 +8133,76 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=409,
             )
 
-        resolve_all = (
-            _coerce_request_bool(body.get("all"), default=False)
-            or _coerce_request_bool(body.get("resolve_all"), default=False)
-        )
-        try:
-            from tools.approval import resolve_gateway_approval
+        def _publish_before_wake(resolution: Dict[str, Any]) -> None:
+            pending = bool(resolution.get("pending"))
+            self._set_run_status(
+                run_id,
+                "waiting_for_approval" if pending else "running",
+                last_event="approval.responded",
+            )
+            responded_event = {
+                "event": "approval.responded",
+                "run_id": run_id,
+                "request_id": request_id,
+                "timestamp": time.time(),
+                "choice": choice,
+                # Exact resolution always resolves one request. Keep this a
+                # bounded positive integer so malformed payloads cannot make a
+                # dashboard clear unrelated pending approvals.
+                "resolved": 1,
+            }
+            event_sink = self._run_approval_event_sinks.get(run_id)
+            if event_sink is not None:
+                try:
+                    event_sink(responded_event)
+                except Exception:
+                    pass
+                return
+            # Compatibility for tests/extensions that seed a /v1/runs queue
+            # directly instead of creating the run through _handle_runs.
+            q = self._run_streams.get(run_id)
+            if q is not None:
+                try:
+                    q.put_nowait(responded_event)
+                except Exception:
+                    pass
 
-            resolved = resolve_gateway_approval(
+        try:
+            from tools.approval import resolve_gateway_approval_exact
+
+            resolution = resolve_gateway_approval_exact(
                 approval_session_key,
+                request_id,
                 choice,
-                resolve_all=resolve_all,
+                before_wake=_publish_before_wake,
             )
         except Exception as exc:
             logger.exception("[api_server] approval resolution failed for run %s", run_id)
-            return web.json_response(_openai_error(str(exc)), status=500)
+            return web.json_response(
+                _openai_error(_redact_api_error_text(exc)), status=500
+            )
 
-        if resolved <= 0:
+        if resolution.get("status") == "not_found":
             return web.json_response(
                 _openai_error(
-                    f"Run has no pending approval: {run_id}",
-                    code="approval_not_pending",
+                    "Approval request is stale or no longer pending",
+                    code="approval_request_stale",
                 ),
                 status=409,
             )
-
-        self._set_run_status(run_id, "running", last_event="approval.responded")
-        q = self._run_streams.get(run_id)
-        if q is not None:
-            try:
-                q.put_nowait({
-                    "event": "approval.responded",
-                    "run_id": run_id,
-                    "timestamp": time.time(),
-                    "choice": choice,
-                    "resolved": resolved,
-                })
-            except Exception:
-                pass
-
+        if resolution.get("status") == "choice_not_allowed":
+            return web.json_response(
+                _openai_error(
+                    "Approval choice is not allowed for this request",
+                    code="approval_choice_not_allowed",
+                ),
+                status=400,
+            )
+        resolved = 1
         return web.json_response({
             "object": "hermes.run.approval_response",
             "run_id": run_id,
+            "request_id": request_id,
             "choice": choice,
             "resolved": resolved,
         })
@@ -8188,17 +8321,22 @@ class APIServerAdapter(BasePlatformAdapter):
             task_done = task is None or task.done()
             if task_done:
                 try:
-                    from tools.approval import unregister_gateway_notify
+                    from tools.approval import (
+                        clear_session as clear_approval_session,
+                        unregister_gateway_notify,
+                    )
 
                     approval_session_key = self._run_approval_sessions.get(run_id)
                     if approval_session_key:
                         unregister_gateway_notify(approval_session_key)
+                        clear_approval_session(approval_session_key)
                 except Exception:
                     pass
             # The transport TTL always bounds buffering. Live control state is
             # independent and survives until the executor-backed task returns.
             self._run_streams.pop(run_id, None)
             self._run_streams_created.pop(run_id, None)
+            self._run_approval_event_sinks.pop(run_id, None)
             if task_done:
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -39,6 +39,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from tools import approval as approval_mod
 
 
 # ---------------------------------------------------------------------------
@@ -314,6 +315,8 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
     app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
@@ -323,6 +326,21 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
         adapter._handle_platform_event_callback,
     )
     return app
+
+
+async def _read_sse_event(response):
+    event_name = ""
+    data_lines = []
+    while True:
+        raw_line = await asyncio.wait_for(response.content.readline(), timeout=3)
+        assert raw_line, "SSE stream closed before the expected event"
+        line = raw_line.decode().rstrip("\r\n")
+        if line.startswith("event: "):
+            event_name = line.removeprefix("event: ")
+        elif line.startswith("data: "):
+            data_lines.append(line.removeprefix("data: "))
+        elif not line and event_name:
+            return event_name, json.loads("\n".join(data_lines))
 
 
 class _FakeGoogleChatAdapter:
@@ -1052,6 +1070,211 @@ class TestChatCompletionsEndpoint:
         assert kwargs["requested_model"] == "MiniMax-M3"
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
+
+    @pytest.mark.asyncio
+    async def test_session_chat_stream_emits_and_resolves_approval(self, adapter):
+        app = _create_app(adapter)
+        agent = MagicMock()
+        agent.session_prompt_tokens = 1
+        agent.session_completion_tokens = 1
+        agent.session_total_tokens = 2
+        observed = {}
+
+        def _run_conversation(**_kwargs):
+            approval_session_key = approval_mod.get_current_approval_namespace_key()
+            observed["stable_session_key"] = approval_mod.get_current_session_key()
+            with approval_mod._lock:
+                notify_cb = approval_mod._gateway_notify_cbs.get(approval_session_key)
+            if notify_cb is None:
+                return {"final_response": "approval bridge missing", "messages": []}
+            observed["approval_session_key"] = approval_session_key
+            observed["decision"] = approval_mod._await_gateway_decision(
+                approval_session_key,
+                notify_cb,
+                {
+                    "command": "OPENAI_API_KEY=sk-test-secret bash -c dangerous",
+                    "description": "synthetic dangerous tool",
+                    "pattern_key": "shell-c",
+                    "pattern_keys": ["shell-c"],
+                    "smart_denied": False,
+                    "allow_permanent": True,
+                },
+            )
+            return {"final_response": "approved and complete", "messages": []}
+
+        agent.run_conversation.side_effect = _run_conversation
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(
+                    adapter,
+                    "_get_existing_session_or_404",
+                    return_value=({"id": "s1"}, None),
+                ),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(adapter, "_create_agent", return_value=agent),
+            ):
+                response = await cli.post(
+                    "/api/sessions/s1/chat/stream",
+                    json={"message": "run a dangerous tool"},
+                )
+                assert response.status == 200
+
+                while True:
+                    event_name, approval_event = await _read_sse_event(response)
+                    if event_name == "approval.request":
+                        break
+
+                run_id = approval_event["run_id"]
+                assert approval_event["request_id"]
+                assert approval_event["description"] == "synthetic dangerous tool"
+                assert approval_event["pattern_keys"] == ["shell-c"]
+                assert approval_event["smart_denied"] is False
+                assert approval_event["allow_permanent"] is True
+                assert approval_event["choices"] == [
+                    "once",
+                    "session",
+                    "always",
+                    "deny",
+                ]
+                assert "sk-test-secret" not in approval_event["command"]
+
+                status_response = await cli.get(f"/v1/runs/{run_id}")
+                assert status_response.status == 200
+                assert (await status_response.json())["status"] == "waiting_for_approval"
+
+                approval_response = await cli.post(
+                    f"/v1/runs/{run_id}/approval",
+                    json={
+                        "request_id": approval_event["request_id"],
+                        "choice": "once",
+                    },
+                )
+                assert approval_response.status == 200
+                assert (await approval_response.json())["object"] == (
+                    "hermes.run.approval_response"
+                )
+
+                remaining_events = []
+                while "run.completed" not in remaining_events:
+                    event_name, _ = await _read_sse_event(response)
+                    remaining_events.append(event_name)
+
+        assert observed["approval_session_key"] == run_id
+        assert observed["stable_session_key"] == "s1"
+        assert observed["decision"]["choice"] == "once"
+        assert remaining_events.index("approval.responded") < remaining_events.index(
+            "run.completed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_chat_stream_approvals_are_isolated_per_run(self, adapter):
+        app = _create_app(adapter)
+
+        def _approval_agent(label):
+            agent = MagicMock()
+            agent.session_prompt_tokens = 0
+            agent.session_completion_tokens = 0
+            agent.session_total_tokens = 0
+
+            def _run_conversation(**_kwargs):
+                approval_session_key = approval_mod.get_current_approval_namespace_key()
+                with approval_mod._lock:
+                    notify_cb = approval_mod._gateway_notify_cbs.get(
+                        approval_session_key
+                    )
+                if notify_cb is None:
+                    return {"final_response": "approval bridge missing", "messages": []}
+                approval_mod._await_gateway_decision(
+                    approval_session_key,
+                    notify_cb,
+                    {
+                        "command": f"bash -c {label}-dangerous",
+                        "description": f"{label} approval",
+                        "pattern_key": "shell-c",
+                        "pattern_keys": ["shell-c"],
+                        "allow_permanent": True,
+                    },
+                )
+                return {"final_response": f"{label} complete", "messages": []}
+
+            agent.run_conversation.side_effect = _run_conversation
+            return agent
+
+        first_agent = _approval_agent("first")
+        second_agent = _approval_agent("second")
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(
+                    adapter,
+                    "_get_existing_session_or_404",
+                    return_value=({"id": "shared-session"}, None),
+                ),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(
+                    adapter,
+                    "_create_agent",
+                    side_effect=[first_agent, second_agent],
+                ),
+            ):
+                first_response, second_response = await asyncio.gather(
+                    cli.post(
+                        "/api/sessions/shared-session/chat/stream",
+                        json={"message": "first"},
+                    ),
+                    cli.post(
+                        "/api/sessions/shared-session/chat/stream",
+                        json={"message": "second"},
+                    ),
+                )
+
+                async def _next_approval(response):
+                    while True:
+                        event_name, event = await _read_sse_event(response)
+                        if event_name == "approval.request":
+                            return event
+
+                first_event, second_event = await asyncio.gather(
+                    _next_approval(first_response),
+                    _next_approval(second_response),
+                )
+                first_run_id = first_event["run_id"]
+                second_run_id = second_event["run_id"]
+                assert first_run_id != second_run_id
+                assert adapter._run_approval_sessions[first_run_id] == first_run_id
+                assert adapter._run_approval_sessions[second_run_id] == second_run_id
+
+                first_approval = await cli.post(
+                    f"/v1/runs/{first_run_id}/approval",
+                    json={
+                        "request_id": first_event["request_id"],
+                        "choice": "once",
+                    },
+                )
+                assert first_approval.status == 200
+
+                while True:
+                    event_name, _ = await _read_sse_event(first_response)
+                    if event_name == "run.completed":
+                        break
+
+                second_status = await cli.get(f"/v1/runs/{second_run_id}")
+                assert (await second_status.json())["status"] == "waiting_for_approval"
+                assert approval_mod.list_gateway_approvals(second_run_id)
+
+                second_approval = await cli.post(
+                    f"/v1/runs/{second_run_id}/approval",
+                    json={
+                        "request_id": second_event["request_id"],
+                        "choice": "deny",
+                    },
+                )
+                assert second_approval.status == 200
+                while True:
+                    event_name, _ = await _read_sse_event(second_response)
+                    if event_name == "run.completed":
+                        break
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -192,6 +192,50 @@ class TestStartRun:
             "runs route must bind chat_id so delegation dispatch sees a wake target"
         )
 
+    @pytest.mark.asyncio
+    async def test_start_preserves_stable_identity_with_run_scoped_approvals(
+        self, auth_adapter
+    ):
+        adapter = auth_adapter
+        app = _create_runs_app(adapter)
+        captured = {}
+
+        def _capture_identity(**kwargs):
+            captured["task_id"] = kwargs["task_id"]
+            captured["stable_session_key"] = approval_mod.get_current_session_key()
+            captured["approval_namespace"] = (
+                approval_mod.get_current_approval_namespace_key()
+            )
+            return {"final_response": "done"}
+
+        agent = MagicMock()
+        agent.run_conversation.side_effect = _capture_identity
+        agent.session_prompt_tokens = 0
+        agent.session_completion_tokens = 0
+        agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=agent):
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "native-history-id"},
+                    headers={
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "persisted-native-key",
+                    },
+                )
+                run_id = (await response.json())["run_id"]
+                for _ in range(40):
+                    if adapter._run_statuses.get(run_id, {}).get("status") == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured == {
+            "task_id": "native-history-id",
+            "stable_session_key": "persisted-native-key",
+            "approval_namespace": run_id,
+        }
+
 
     @pytest.mark.asyncio
     async def test_start_rejects_conflicting_route_and_request_provider(self):
@@ -381,7 +425,10 @@ class TestRunEvents:
 
                 approval_resp = await cli.post(
                     f"/v1/runs/{attacker_run}/approval",
-                    json={"choice": "always", "resolve_all": True},
+                    json={
+                        "request_id": attacker_entry.data["request_id"],
+                        "choice": "always",
+                    },
                     headers={"Authorization": "Bearer sk-secret"},
                 )
                 approval_data = await approval_resp.json()
@@ -403,6 +450,133 @@ class TestRunEvents:
                     approval_mod._gateway_queues.pop(victim_run, None)
                 victim_interrupted.set()
                 attacker_interrupted.set()
+
+
+class TestRunApproval:
+    @staticmethod
+    def _seed(adapter, run_id, entries, markers):
+        adapter._set_run_status(run_id, "waiting_for_approval")
+        adapter._run_approval_sessions[run_id] = run_id
+        adapter._run_approval_event_sinks[run_id] = markers.append
+        with approval_mod._lock:
+            approval_mod._gateway_queues[run_id] = entries
+
+    @pytest.mark.asyncio
+    async def test_response_resolves_exact_request_and_keeps_waiting_for_newer(
+        self, adapter
+    ):
+        app = _create_runs_app(adapter)
+        run_id = "run-exact"
+        markers = []
+        first = approval_mod._ApprovalEntry({
+            "command": "bash -c first",
+            "description": "first",
+            "pattern_keys": ["shell-c"],
+            "allow_session": True,
+            "allow_permanent": True,
+        })
+        second = approval_mod._ApprovalEntry({
+            "command": "bash -c second",
+            "description": "second",
+            "pattern_keys": ["shell-c"],
+            "allow_session": True,
+            "allow_permanent": True,
+        })
+
+        class _RecordingEvent(threading.Event):
+            def __init__(self, label):
+                super().__init__()
+                self.label = label
+
+            def set(self):
+                markers.append(f"wake:{self.label}")
+                super().set()
+
+        first.event = _RecordingEvent("first")
+        second.event = _RecordingEvent("second")
+        self._seed(adapter, run_id, [first, second], markers)
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={"request_id": second.data["request_id"], "choice": "once"},
+            )
+            payload = await response.json()
+
+        assert response.status == 200
+        assert payload["request_id"] == second.data["request_id"]
+        assert first.result is None
+        assert not first.event.is_set()
+        assert second.result == "once"
+        assert second.event.is_set()
+        assert approval_mod.list_gateway_approvals(run_id) == [first.data]
+        assert adapter._run_statuses[run_id]["status"] == "waiting_for_approval"
+        assert markers[0]["event"] == "approval.responded"
+        assert markers[0]["request_id"] == second.data["request_id"]
+        assert markers[1] == "wake:second"
+        approval_mod.clear_session(run_id)
+
+    @pytest.mark.asyncio
+    async def test_stale_request_id_does_not_resolve_another_approval(self, adapter):
+        app = _create_runs_app(adapter)
+        run_id = "run-stale"
+        markers = []
+        current = approval_mod._ApprovalEntry({
+            "command": "bash -c current",
+            "description": "current",
+            "pattern_keys": ["shell-c"],
+            "allow_session": True,
+            "allow_permanent": True,
+        })
+        self._seed(adapter, run_id, [current], markers)
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={"request_id": "expired-request", "choice": "once"},
+            )
+            payload = await response.json()
+
+        assert response.status == 409
+        assert payload["error"]["code"] == "approval_request_stale"
+        assert current.result is None
+        assert not current.event.is_set()
+        assert approval_mod.list_gateway_approvals(run_id) == [current.data]
+        assert markers == []
+        approval_mod.clear_session(run_id)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("choice", ["session", "always"])
+    async def test_disallowed_choice_does_not_wake_approval(
+        self, adapter, choice
+    ):
+        app = _create_runs_app(adapter)
+        run_id = f"run-disallowed-{choice}"
+        markers = []
+        entry = approval_mod._ApprovalEntry({
+            "command": "bash -c guarded",
+            "description": "guardian denied",
+            "pattern_keys": ["shell-c"],
+            "smart_denied": True,
+            "allow_session": False,
+            "allow_permanent": False,
+        })
+        self._seed(adapter, run_id, [entry], markers)
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/v1/runs/{run_id}/approval",
+                json={"request_id": entry.data["request_id"], "choice": choice},
+            )
+            payload = await response.json()
+
+        assert response.status == 400
+        assert payload["error"]["code"] == "approval_choice_not_allowed"
+        assert entry.result is None
+        assert not entry.event.is_set()
+        assert approval_mod.list_gateway_approvals(run_id) == [entry.data]
+        assert markers == []
+        approval_mod.clear_session(run_id)
 
 
 # ---------------------------------------------------------------------------
@@ -622,7 +796,7 @@ class TestRunLifecycleSweep:
 
                 approval_resp = await cli.post(
                     f"/v1/runs/{run_id}/approval",
-                    json={"choice": "once"},
+                    json={"request_id": pending.data["request_id"], "choice": "once"},
                 )
                 assert approval_resp.status == 200
                 assert pending.event.is_set()

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -115,10 +115,35 @@ class TestApprovalCommandWiring:
 
         self._assert_redacts_then_uses(run, "_approval_notify_sync", "send_exec_approval")
 
-    def test_sse_api_path_redacts_before_enqueue(self):
-        from gateway.platforms import api_server
+    def test_sse_api_path_redacts_before_enqueue(self, monkeypatch):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.api_server import APIServerAdapter
 
-        self._assert_redacts_then_uses(api_server, "_approval_notify", "put_nowait")
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        emitted = []
+        notify = adapter._make_run_approval_notify("run-redaction", emitted.append)
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False, raising=False)
+
+        notify({
+            "request_id": "approval-1",
+            "command": "export OPENAI_API_KEY=" + _FAKE_OPENAI + " && python s.py",
+            "description": "credential found: " + _FAKE_GHP,
+            "pattern_key": "shell-c",
+            "pattern_keys": ["shell-c"],
+            "smart_denied": False,
+            "allow_permanent": True,
+            "allow_session": True,
+            "untrusted_extra": "must not cross egress: " + _FAKE_GHP,
+        })
+
+        assert len(emitted) == 1
+        event = emitted[0]
+        assert _FAKE_OPENAI not in event["command"]
+        assert _FAKE_GHP not in event["description"]
+        assert "python s.py" in event["command"]
+        assert "untrusted_extra" not in event
+        assert event["request_id"] == "approval-1"
+        assert event["pattern_keys"] == ["shell-c"]
 
 
 class TestApprovalTextFallbackContract:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -24,6 +24,26 @@ from tools.approval import (
 )
 
 
+class TestApprovalNamespaceContext:
+    def test_run_namespace_preserves_stable_session_identity_and_restores(self):
+        """Per-run approval isolation must not replace tools' native session key."""
+        stable_token = approval_module.set_current_session_key("native-session")
+        try:
+            assert approval_module.get_current_session_key() == "native-session"
+
+            run_token = approval_module.set_current_approval_namespace_key("run-123")
+            try:
+                assert approval_module.get_current_session_key() == "native-session"
+                assert approval_module.get_current_approval_namespace_key() == "run-123"
+            finally:
+                approval_module.reset_current_approval_namespace_key(run_token)
+
+            assert approval_module.get_current_session_key() == "native-session"
+            assert approval_module.get_current_approval_namespace_key() == "native-session"
+        finally:
+            approval_module.reset_current_session_key(stable_token)
+
+
 class TestApprovalModeParsing:
     def test_normalization_table(self):
         # Unquoted YAML `off`/`on` arrive as booleans; unknown/empty fall back

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -44,6 +44,14 @@ _approval_session_key: contextvars.ContextVar[str] = contextvars.ContextVar(
     "approval_session_key",
     default="",
 )
+# Optional authorization namespace, distinct from the persisted session key.
+# API runs use a unique run id here so concurrent turns sharing one native
+# session cannot resolve or inherit each other's approvals. All non-approval
+# tools continue to read the stable identity from get_current_session_key().
+_approval_namespace_key: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "approval_namespace_key",
+    default="",
+)
 _approval_turn_id: contextvars.ContextVar[str] = contextvars.ContextVar(
     "approval_turn_id",
     default="",
@@ -196,6 +204,18 @@ def reset_current_session_key(token: contextvars.Token[str]) -> None:
     _approval_session_key.reset(token)
 
 
+def set_current_approval_namespace_key(
+    namespace_key: str,
+) -> contextvars.Token[str]:
+    """Bind a run-local namespace for approval queues and allowlists only."""
+    return _approval_namespace_key.set(namespace_key or "")
+
+
+def reset_current_approval_namespace_key(token: contextvars.Token[str]) -> None:
+    """Restore the prior run-local approval namespace."""
+    _approval_namespace_key.reset(token)
+
+
 def set_current_observability_context(
     *,
     turn_id: str = "",
@@ -237,6 +257,14 @@ def get_current_session_key(default: str = "default") -> str:
         return session_key
     from gateway.session_context import get_session_env
     return get_session_env("HERMES_SESSION_KEY", default)
+
+
+def get_current_approval_namespace_key(default: str = "default") -> str:
+    """Return the approval namespace, falling back to stable session identity."""
+    namespace_key = _approval_namespace_key.get()
+    if namespace_key:
+        return namespace_key
+    return get_current_session_key(default=default)
 
 
 def _get_session_platform() -> str:
@@ -2307,11 +2335,17 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
         return False
 
     operand = argv[2]
-    temp_dir = os.path.realpath(tempfile.gettempdir())
+    raw_temp_dir = os.path.abspath(tempfile.gettempdir())
+    temp_dir = os.path.realpath(raw_temp_dir)
     basename = os.path.basename(operand)
-    if operand != os.path.join(temp_dir, basename):
+    if not os.path.isabs(operand) or os.path.normpath(operand) != operand:
         return False
-
+    allowed_operand_dirs = {temp_dir}
+    if {raw_temp_dir, temp_dir} == {"/tmp", "/private/tmp"}:
+        # macOS exposes /tmp as a stable system alias for /private/tmp.
+        allowed_operand_dirs.add(raw_temp_dir)
+    if os.path.dirname(operand) not in allowed_operand_dirs:
+        return False
     target = os.path.realpath(operand)
     if os.path.dirname(target) != temp_dir:
         return False
@@ -2446,7 +2480,7 @@ def human_wait_window(session_key: str | None = None):
     Overlapping windows for the same session coalesce (pending counter), so
     two serialized approval prompts don't double-count the same wall clock.
     """
-    key = session_key if session_key is not None else get_current_session_key()
+    key = session_key if session_key is not None else get_current_approval_namespace_key()
     now = time.monotonic()
     with _human_wait_lock:
         state = _human_wait_state(key)
@@ -2488,7 +2522,7 @@ def human_wait_seconds(session_key: str | None = None) -> float:
     window that overstays that bound is itself wedged and must not keep
     extending a batch deadline (belt-and-braces for #79719).
     """
-    key = session_key if session_key is not None else get_current_session_key()
+    key = session_key if session_key is not None else get_current_approval_namespace_key()
     now = time.monotonic()
     # Resolve the clamp outside the lock: it reads the config cache, which
     # must never nest under _human_wait_lock.
@@ -2629,6 +2663,96 @@ def unregister_gateway_notify(session_key: str) -> None:
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
         entry.event.set()
+
+
+def allowed_gateway_approval_choices(approval_data: dict) -> list[str]:
+    """Return the authoritative choices for one queued approval request."""
+    explicit = approval_data.get("choices")
+    if isinstance(explicit, (list, tuple)):
+        allowed_values = {"once", "session", "always", "deny"}
+        choices = [
+            value for value in explicit
+            if isinstance(value, str) and value in allowed_values
+        ]
+        if choices:
+            return list(dict.fromkeys(choices))
+    if approval_data.get("smart_denied"):
+        return ["once", "deny"]
+    choices = ["once"]
+    if approval_data.get("allow_session") is not False:
+        choices.append("session")
+    if approval_data.get("allow_permanent") is not False:
+        choices.append("always")
+    choices.append("deny")
+    return choices
+
+
+def resolve_gateway_approval_exact(
+    session_key: str,
+    request_id: str,
+    choice: str,
+    *,
+    reason: Optional[str] = None,
+    before_wake=None,
+) -> dict:
+    """Atomically validate and resolve exactly one queued approval.
+
+    ``before_wake`` runs under the approval lock after queue mutation and
+    before the waiter is signalled. It must not call back into approval APIs.
+    This ordering lets transports publish ``approval.responded`` and the
+    correct remaining-pending status before the agent can enqueue a successor.
+    """
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return {"status": "not_found", "resolved": 0, "pending": False}
+        entry = next(
+            (
+                candidate
+                for candidate in queue
+                if candidate.data.get("request_id") == request_id
+            ),
+            None,
+        )
+        if entry is None:
+            return {
+                "status": "not_found",
+                "resolved": 0,
+                "pending": bool(queue),
+            }
+        allowed_choices = allowed_gateway_approval_choices(entry.data)
+        if choice not in allowed_choices:
+            return {
+                "status": "choice_not_allowed",
+                "resolved": 0,
+                "pending": bool(queue),
+                "allowed_choices": allowed_choices,
+            }
+
+        queue.remove(entry)
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+        entry.result = choice
+        if reason:
+            entry.reason = reason
+        resolution = {
+            "status": "resolved",
+            "resolved": 1,
+            "pending": bool(queue),
+            "request_id": request_id,
+            "choice": choice,
+            "allowed_choices": allowed_choices,
+        }
+        if before_wake is not None:
+            try:
+                before_wake(dict(resolution))
+            except Exception:
+                logger.exception(
+                    "Approval before_wake callback failed for request %s",
+                    request_id,
+                )
+        entry.event.set()
+        return resolution
 
 
 def resolve_gateway_approval(session_key: str, choice: str,
@@ -2788,7 +2912,7 @@ def is_session_yolo_enabled(session_key: str) -> bool:
 
 def is_current_session_yolo_enabled() -> bool:
     """Return True when the active approval session has YOLO bypass enabled."""
-    return is_session_yolo_enabled(get_current_session_key(default=""))
+    return is_session_yolo_enabled(get_current_approval_namespace_key(default=""))
 
 
 def is_approved(session_key: str, pattern_key: str) -> bool:
@@ -3214,7 +3338,7 @@ def is_approval_bypass_active_for_session(session_key: str) -> bool:
 def is_approval_bypass_active() -> bool:
     """Return whether the current approval context has bypass enabled."""
     return is_approval_bypass_active_for_session(
-        get_current_session_key(default="")
+        get_current_approval_namespace_key(default="")
     )
 
 
@@ -3472,7 +3596,7 @@ def _run_approval_gate(
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
 
-    session_key = get_current_session_key()
+    session_key = get_current_approval_namespace_key()
     if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
@@ -4060,7 +4184,9 @@ def _present_with_selected_transport(
 def _transport_denied_result(
     *, pattern_key: str, description: str, failure: str
 ) -> dict:
-    breaker_addendum = _denial_breaker_addendum(get_current_session_key())
+    breaker_addendum = _denial_breaker_addendum(
+        get_current_approval_namespace_key()
+    )
     return {
         "approved": False,
         "message": (
@@ -4600,7 +4726,7 @@ def check_all_command_guards(command: str, env_type: str,
     # Collect warnings that need approval
     warnings = []  # list of (pattern_key, description, is_tirith)
 
-    session_key = get_current_session_key()
+    session_key = get_current_approval_namespace_key()
 
     # Tirith block/warn → approvable warning with rich findings.
     # Previously, tirith "block" was a hard block with no approval prompt.
@@ -5090,7 +5216,7 @@ def check_execute_code_guard(code: str, env_type: str,
     if not is_gateway and not is_ask:
         return {"approved": True, "message": None}
 
-    session_key = get_current_session_key()
+    session_key = get_current_approval_namespace_key()
     # Built only now (past the early-return gates) so the common non-approval
     # paths don't pay to copy a potentially-large script into this string.
     command = f"execute_code <<'PY'\n{code}\nPY"
@@ -5429,7 +5555,7 @@ def request_elicitation_consent(
     Returns one of ``"accept" | "decline" | "cancel"``.
     """
     try:
-        session_key = get_current_session_key()
+        session_key = get_current_approval_namespace_key()
     except Exception as exc:  # pragma: no cover -- defensive
         logger.warning("Elicitation consent: session lookup failed: %s", exc)
         return "decline"

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -869,7 +869,7 @@ def _request_protected_instruction_approval(
     # Gateway surface: block on the button round-trip when a notify callback
     # is registered for this session (Telegram/Discord/Slack). One-operation
     # only — no session/permanent buttons are offered.
-    session_key = _approval.get_current_session_key()
+    session_key = _approval.get_current_approval_namespace_key()
     notify_cb = None
     try:
         with _approval._lock:

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -544,9 +544,19 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 | `GET` | `/api/sessions/{id}/messages` | Message history for a session |
 | `POST` | `/api/sessions/{id}/fork` | Branch the session via `SessionDB` lineage (matches CLI `/branch` semantics) |
 | `POST` | `/api/sessions/{id}/chat` | Run one synchronous agent turn |
-| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits `assistant.delta`, `tool.started`, `tool.completed`, `run.completed` events |
+| `POST` | `/api/sessions/{id}/chat/stream` | SSE wrapper over a single turn — emits assistant, tool, approval, and run lifecycle events |
 
 `/v1/capabilities` advertises the full surface via `session_*` feature flags and `endpoints.session_*` entries so external UIs can detect support and fall back safely. Inline images are supported in `chat` and `chat/stream` payloads (multimodal-aware path).
+
+When a tool needs confirmation, the session stream pauses with
+`approval.request`. Its payload includes the stream's `run_id`, a `request_id`,
+the redacted command and description, and the allowed `choices`. Resolve it
+with `POST /v1/runs/{run_id}/approval` using that exact `request_id` and one of
+the supplied choices (`once`, `session`, `always`, or `deny`). The server
+atomically rejects stale request IDs and disallowed choices; the same session
+stream then emits `approval.responded` with the matching `request_id` before
+normal completion. Approval state is isolated by `run_id`, including when
+concurrent streams use the same session ID.
 
 ```bash
 # fork a session and run one turn


### PR DESCRIPTION
## Summary
Adds native approval support to the /v1/runs session chat streams so external UIs (e.g. the Hermes dashboard) can surface and resolve tool approvals inline.

## Changes
- `approval.request` SSE event carrying `run_id`, `request_id`, redacted `command`/`description`, and the authoritative allowed `choices`; run status becomes `waiting_for_approval`
- `POST /v1/runs/{run_id}/approval` resolves exactly one request: validates `request_id` and allowed choice atomically, emits `approval.responded` with the matching `request_id`, keeps `waiting_for_approval` when more requests are pending
- Dedicated approval namespace ContextVar in `tools/approval.py`: approval queues/allowlists are isolated per run while tools' stable `get_current_session_key()` identity (terminal cwd, delegation, file/process/computer-use) is preserved
- Run-scoped approval state is cleared on success, error, cancel, stop, and orphan sweep via `clear_session`
- API egress force-redacts command, description, and exposed pattern text and whitelists payload fields
- Docs updated in `website/docs/user-guide/features/api-server.md`

## Test Plan
- 264 tests pass across test_api_server (111), test_api_server_runs (28), test_approval_prompt_redaction (7), test_approve_deny_commands (15), test_approval (103)
- New coverage: dedicated identity continuity + ContextVar restoration, exact/stale/disallowed request binding, sequential approvals, run-scoped cleanup, orphan sweep, behavioral command+description redaction