### PR TITLE
fix(gateway): restore persisted heartbeat watches

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13232,6 +13232,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # that session) is strictly cheaper and more correct than re-running
         # the whole turn.
         await self._redeliver_pending_obligations()
+        await self._restore_heartbeat_watches()
         self._schedule_resume_pending_sessions()
         await self._finish_startup_restore()
 
@@ -14365,6 +14366,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except Exception:
                             logger.debug(
                                 "resume-pending reschedule after %s reconnect failed",
+                                platform.value,
+                                exc_info=True,
+                            )
+                        try:
+                            await self._restore_heartbeat_watches(platform=platform)
+                        except Exception:
+                            logger.debug(
+                                "heartbeat restoration after %s reconnect failed",
                                 platform.value,
                                 exc_info=True,
                             )
@@ -21325,14 +21334,103 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return None, None
         return HeartbeatManager(session_id=sid), session_entry
 
+    async def _restore_heartbeat_watches(self, platform=None) -> int:
+        """Rebuild active heartbeat watches from durable session routing.
+
+        Heartbeat intent lives in ``state_meta`` while the source needed to
+        route a turn lives in the gateway session index. Join those durable
+        records after adapters connect so a restart cannot leave an active
+        heartbeat without an executable watch.
+
+        ``platform`` limits reconnect-time passes. The registry is a dict, so
+        repeating a pass replaces the same route rather than creating a second
+        tick source. Returns the number of newly registered watches.
+        """
+        try:
+            from hermes_cli.heartbeat import list_heartbeats
+
+            await self._warm_goals_session_db("heartbeat restore")
+            persisted = list_heartbeats()
+            with self.session_store._lock:  # noqa: SLF001 — atomic routing snapshot
+                self.session_store._ensure_loaded_locked()  # noqa: SLF001
+                entries = list(self.session_store._entries.values())  # noqa: SLF001
+        except Exception as exc:
+            logger.warning("Could not enumerate persisted heartbeat routes: %s", exc)
+            return 0
+
+        restored = 0
+        watch = getattr(self, "_heartbeat_watch", None)
+        if watch is None:
+            watch = {}
+            self._heartbeat_watch = watch
+
+        entries_by_session = {
+            str(getattr(entry, "session_id", None) or ""): entry
+            for entry in entries
+            if getattr(entry, "session_id", None)
+        }
+        for session_id, state in persisted.items():
+            if state.status != "active":
+                continue
+            entry = entries_by_session.get(session_id)
+            if entry is None:
+                logger.warning(
+                    "Persisted heartbeat %s is active but unroutable: no durable "
+                    "gateway route exists",
+                    session_id,
+                )
+                continue
+            source = getattr(entry, "origin", None)
+            quick_key = str(getattr(entry, "session_key", None) or "")
+            if not source or not session_id or not quick_key:
+                continue
+            if platform is not None and source.platform != platform:
+                continue
+
+            adapter = self._adapter_for_source(source)
+            if adapter is None:
+                logger.warning(
+                    "Persisted heartbeat %s is active but unroutable: adapter "
+                    "for %s is not connected",
+                    session_id,
+                    getattr(source.platform, "value", source.platform),
+                )
+                continue
+            try:
+                if not self._is_user_authorized(source):
+                    logger.warning(
+                        "Persisted heartbeat %s is active but unroutable: "
+                        "session owner is no longer authorized",
+                        session_id,
+                    )
+                    continue
+            except Exception as exc:
+                logger.warning(
+                    "Persisted heartbeat %s routing authorization failed: %s",
+                    session_id,
+                    exc,
+                )
+                continue
+
+            previous = watch.get(quick_key)
+            current = (source, session_id)
+            if previous == current:
+                continue
+            watch[quick_key] = current
+            restored += 1
+
+        if restored:
+            self._start_heartbeat_poller()
+            logger.info("Restored %d persisted heartbeat watch(es)", restored)
+        return restored
+
     def _register_heartbeat_watch(self, quick_key: str, source: Any, session_id: str) -> None:
         """Track a session with an active heartbeat and start the poller.
 
         The registry maps ``quick_key`` → ``(source, session_id)`` so the
         poller can rebuild a MessageEvent and enqueue via the adapter FIFO.
-        In-memory by design: heartbeat STATE survives restarts in SessionDB,
-        but firing resumes when the user touches /heartbeat again in the new
-        gateway process (documented; durable schedules belong to cron).
+        Startup joins persisted heartbeat state with the durable gateway
+        routing entry to rebuild this process-local execution registry.
         """
         watch = getattr(self, "_heartbeat_watch", None)
         if watch is None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2899,10 +2899,18 @@ class GatewaySlashCommandsMixin:
         quick_key = self._session_key_for_source(event.source) if event.source else None
 
         if not args or lower == "status":
-            return mgr.status_line()
+            line = mgr.status_line()
+            if mgr.is_active() and quick_key:
+                watch = getattr(self, "_heartbeat_watch", None) or {}
+                registered = watch.get(quick_key)
+                if not registered or registered[1] != mgr.session_id:
+                    line += "\n⚠ Runtime: active but not registered; routing is unavailable."
+            return line
 
         if lower == "pause":
             state = mgr.pause()
+            if quick_key:
+                self._unregister_heartbeat_watch(quick_key)
             return f"⏸ Heartbeat paused: {state.prompt}" if state else "No heartbeat set."
 
         if lower == "resume":
@@ -2949,7 +2957,7 @@ class GatewaySlashCommandsMixin:
         return (
             f"♥ Heartbeat set (every {format_interval(state.interval_seconds)}): {state.prompt}\n"
             "Fires as a normal turn whenever this session is idle and the interval has "
-            "elapsed. Lives while the gateway runs — use `hermes cron` for durable schedules."
+            "elapsed. The gateway restores it after restart; use `hermes cron` for isolated schedules."
         )
 
     async def _handle_refine_command(self, event: "MessageEvent") -> str:

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -194,6 +194,36 @@ def save_heartbeat(session_id: str, state: HeartbeatState) -> None:
         logger.debug("HeartbeatManager: set_meta failed: %s", exc)
 
 
+def list_heartbeats() -> Dict[str, HeartbeatState]:
+    """Return all persisted, non-cleared heartbeats keyed by session id."""
+    db = _get_session_db()
+    if db is None:
+        return {}
+    try:
+        rows = db.list_meta_prefix("heartbeat:")
+    except Exception as exc:
+        logger.warning("HeartbeatManager: could not enumerate heartbeats: %s", exc)
+        return {}
+
+    states: Dict[str, HeartbeatState] = {}
+    for key, raw in rows:
+        session_id = key[len("heartbeat:"):]
+        if not session_id:
+            continue
+        try:
+            state = HeartbeatState.from_json(raw)
+        except Exception as exc:
+            logger.warning(
+                "HeartbeatManager: could not parse stored heartbeat for %s: %s",
+                session_id,
+                exc,
+            )
+            continue
+        if state.status != "cleared":
+            states[session_id] = state
+    return states
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Manager — the surface CLI + gateway talk to
 # ──────────────────────────────────────────────────────────────────────
@@ -327,6 +357,7 @@ __all__ = [
     "parse_interval",
     "format_interval",
     "load_heartbeat",
+    "list_heartbeats",
     "save_heartbeat",
     "migrate_heartbeat_to_session",
     "HEARTBEAT_PROMPT_TEMPLATE",

--- a/tests/gateway/test_heartbeat_restore.py
+++ b/tests/gateway/test_heartbeat_restore.py
@@ -1,0 +1,157 @@
+import threading
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionEntry, SessionSource
+from hermes_cli.heartbeat import HeartbeatState
+
+
+def _entry(session_id: str, chat_id: str, thread_id: str) -> SessionEntry:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="group",
+        thread_id=thread_id,
+        user_id="owner",
+    )
+    return SessionEntry(
+        session_key=f"agent:main:telegram:group:{chat_id}:thread:{thread_id}",
+        session_id=session_id,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+
+
+def _runner(*entries: SessionEntry) -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: object()}
+    runner._heartbeat_watch = {}
+    runner._heartbeat_poll_task = None
+    runner._background_tasks = set()
+    runner._start_heartbeat_poller = MagicMock()
+    runner._warm_goals_session_db = AsyncMock()
+    runner._is_user_authorized = MagicMock(return_value=True)
+    runner.session_store = SimpleNamespace(
+        _lock=threading.RLock(),
+        _entries={entry.session_key: entry for entry in entries},
+        _ensure_loaded_locked=lambda: None,
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_restore_heartbeat_watches_preserves_multiple_topic_routes(monkeypatch):
+    first = _entry("sid-1", "chat", "topic-1")
+    second = _entry("sid-2", "chat", "topic-2")
+    states = {
+        "sid-1": HeartbeatState("one", 300, status="active"),
+        "sid-2": HeartbeatState("two", 300, status="active"),
+    }
+
+    monkeypatch.setattr("hermes_cli.heartbeat.list_heartbeats", lambda: states)
+    runner = _runner(first, second)
+
+    restored = await runner._restore_heartbeat_watches()
+
+    assert restored == 2
+    assert runner._heartbeat_watch == {
+        first.session_key: (first.origin, "sid-1"),
+        second.session_key: (second.origin, "sid-2"),
+    }
+    runner._start_heartbeat_poller.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_restore_heartbeat_watches_skips_paused_and_unroutable(monkeypatch, caplog):
+    active = _entry("sid-active", "chat", "topic-active")
+    paused = _entry("sid-paused", "chat", "topic-paused")
+    unroutable = _entry("sid-unroutable", "chat", "topic-unroutable")
+    unroutable.origin.platform = Platform.DISCORD
+    states = {
+        "sid-active": HeartbeatState("active", 300, status="active"),
+        "sid-paused": HeartbeatState("paused", 300, status="paused"),
+        "sid-unroutable": HeartbeatState("missing adapter", 300, status="active"),
+        "sid-orphan": HeartbeatState("missing route", 300, status="active"),
+    }
+
+    monkeypatch.setattr("hermes_cli.heartbeat.list_heartbeats", lambda: states)
+    runner = _runner(active, paused, unroutable)
+
+    restored = await runner._restore_heartbeat_watches()
+
+    assert restored == 1
+    assert set(runner._heartbeat_watch) == {active.session_key}
+    assert "heartbeat sid-unroutable is active but unroutable" in caplog.text
+    assert "heartbeat sid-orphan is active but unroutable" in caplog.text
+    assert "no durable gateway route exists" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_restore_heartbeat_watches_is_idempotent(monkeypatch):
+    entry = _entry("sid", "chat", "topic")
+
+    monkeypatch.setattr(
+        "hermes_cli.heartbeat.list_heartbeats",
+        lambda: {"sid": HeartbeatState("active", 300, status="active")},
+    )
+    runner = _runner(entry)
+
+    assert await runner._restore_heartbeat_watches() == 1
+    assert await runner._restore_heartbeat_watches() == 0
+    assert list(runner._heartbeat_watch) == [entry.session_key]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_status_reports_active_but_unregistered_runtime():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    source = _entry("sid", "chat", "topic").origin
+    manager = MagicMock(session_id="sid")
+    manager.is_active.return_value = True
+    manager.status_line.return_value = "configured active"
+    runner._get_heartbeat_manager_for_event = AsyncMock(
+        return_value=(manager, SimpleNamespace(session_id="sid"))
+    )
+    runner._session_key_for_source = MagicMock(return_value="quick-key")
+    runner._heartbeat_watch = {}
+    event = SimpleNamespace(
+        source=source,
+        get_command_args=lambda: "status",
+    )
+
+    result = await runner._handle_heartbeat_command(event)
+
+    assert result == (
+        "configured active\n"
+        "⚠ Runtime: active but not registered; routing is unavailable."
+    )
+
+
+@pytest.mark.asyncio
+async def test_pause_unregisters_runtime_watch():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    source = _entry("sid", "chat", "topic").origin
+    state = HeartbeatState("pause me", 300, status="paused")
+    manager = MagicMock(session_id="sid")
+    manager.pause.return_value = state
+    runner._get_heartbeat_manager_for_event = AsyncMock(
+        return_value=(manager, SimpleNamespace(session_id="sid"))
+    )
+    runner._session_key_for_source = MagicMock(return_value="quick-key")
+    runner._heartbeat_watch = {"quick-key": (source, "sid")}
+    event = SimpleNamespace(
+        source=source,
+        get_command_args=lambda: "pause",
+    )
+
+    result = await runner._handle_heartbeat_command(event)
+
+    assert result == "⏸ Heartbeat paused: pause me"
+    assert runner._heartbeat_watch == {}

--- a/tests/hermes_cli/test_heartbeat.py
+++ b/tests/hermes_cli/test_heartbeat.py
@@ -9,6 +9,7 @@ from hermes_cli.heartbeat import (
     HeartbeatState,
     MIN_INTERVAL_SECONDS,
     format_interval,
+    list_heartbeats,
     load_heartbeat,
     migrate_heartbeat_to_session,
     parse_interval,
@@ -67,6 +68,21 @@ def test_state_roundtrip():
     assert loaded.prompt == "check CI"
     assert loaded.interval_seconds == 600
     assert loaded.status == "active"
+
+
+def test_list_heartbeats_enumerates_active_and_paused_but_not_cleared():
+    active = HeartbeatState(prompt="active", interval_seconds=600)
+    paused = HeartbeatState(prompt="paused", interval_seconds=600, status="paused")
+    cleared = HeartbeatState(prompt="cleared", interval_seconds=600, status="cleared")
+    save_heartbeat("list-active", active)
+    save_heartbeat("list-paused", paused)
+    save_heartbeat("list-cleared", cleared)
+
+    states = list_heartbeats()
+
+    assert states["list-active"].status == "active"
+    assert states["list-paused"].status == "paused"
+    assert "list-cleared" not in states
 
 
 def test_is_due_anchors_on_created_then_last_fired():


### PR DESCRIPTION
## Summary

- restore active persisted heartbeat watches from durable gateway session routing after startup
- retry platform-scoped restoration after adapter reconnects while preserving chat, thread/topic, and profile identity
- distinguish configured heartbeat state from runtime registration and log unroutable or stale records
- unregister paused heartbeats immediately and keep startup restoration idempotent

## Root cause

Heartbeat configuration survived in `state_meta`, but the gateway's executable `_heartbeat_watch` registry was process-local and was only populated by `/heartbeat set` or `/heartbeat resume`. After restart, the poller therefore had no routing tuple even though `/heartbeat status` still reported an active state.

## Testing

- `scripts/run_tests.sh tests/gateway/test_heartbeat_restore.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_platform_reconnect.py tests/hermes_cli/test_heartbeat.py -q` (87 passed)

## Related Issue

N/A
