### PR TITLE
fix(mcp): reconnect when server credentials change (#92565)

### DIFF
--- a/apps/desktop/src/app/chat/composer/selection-composer-bridge.ts
+++ b/apps/desktop/src/app/chat/composer/selection-composer-bridge.ts
@@ -1,0 +1,150 @@
+/**
+ * Selection-to-composer bridge module.
+ *
+ * Shared primitives for getting selections from any surface into the composer.
+ * Provides two parallel facilities:
+ *
+ * 1. **Message quotes** — quoted text from a chat message, stored keyed by
+ *    messageId and inserted as `@message:<messageId>` refs. Resolved at submit
+ *    time into ```quote blocks via the same pattern as terminal selections.
+ *    The `@message:` reference kind is registered in `reference-kinds.ts` and
+ *    rendered by `directive-text.tsx`.
+ *
+ * 2. **Artifact image selection** — a Blob from a rendered artifact (chart,
+ *    diagram, image response) that becomes a composer image attachment.
+ *
+ * The message-quote storage lives in `@/store/composer` (alongside
+ * `$composerTerminalSelections`) so the submit pipeline can find it alongside
+ * terminal selections and other draft-scoped state. This module is the
+ * insertion/adapter layer that surfaces those primitives to UI components.
+ */
+
+import { requestComposerInsert } from '@/app/chat/composer/focus'
+import { formatRefValue } from '@/components/assistant-ui/directive-text'
+import {
+  type $composerMessageQuotes,
+  addComposerAttachment,
+  clearComposerMessageQuotes,
+  type ComposerAttachment,
+  createComposerAttachmentOccurrenceId,
+  messageQuoteContextBlocks,
+  reconcileComposerMessageQuotes,
+  setComposerMessageQuote
+} from '@/store/composer'
+
+// Re-export the message-quote store + helpers so callers only need to import
+// from this module. The storage itself lives in composer.ts (the established
+// home for draft-scoped selection state), matching $composerTerminalSelections.
+export {
+  $composerMessageQuotes,
+  clearComposerMessageQuotes,
+  messageQuoteContextBlocks,
+  reconcileComposerMessageQuotes,
+  setComposerMessageQuote
+}
+
+/**
+ * Insert a "quote this message" ref into the composer.
+ *
+ * Stores the quoted text under the messageId (via {@link setComposerMessageQuote})
+ * and inserts the `@message:<messageId>` ref text inline so the user can see
+ * and remove it before sending.
+ *
+ * @param text - The quoted message text.
+ * @param messageId - Stable identifier of the source message.
+ * @param label - Optional display label for the ref chip. Defaults to `messageId`.
+ */
+export function addMessageSelectionToChat(text: string, messageId: string, label?: string): void {
+  const trimmed = text.trim()
+  const normalizedId = messageId.trim()
+  const normalizedLabel = (label || normalizedId).trim()
+
+  if (!trimmed || !normalizedId) {
+    return
+  }
+
+  setComposerMessageQuote(normalizedId, trimmed)
+
+  const refText = `@message:${formatRefValue(normalizedLabel)}`
+
+  requestComposerInsert(refText, { mode: 'inline' })
+}
+
+/**
+ * Add a Blob from an artifact (chart, diagram, rendered image response) as an
+ * image attachment in the composer.
+ *
+ * Saves the blob to disk and creates a composer attachment with kind `'image'`.
+ * The attachment carries the artifact id as metadata so the submit pipeline
+ * can attribute the upload — callers should pass the artifact's stable id.
+ *
+ * @param blob - The image Blob from the rendered artifact.
+ * @param artifactId - Stable identifier of the source artifact.
+ * @param label - Optional display label for the attachment chip. Defaults to
+ *   `artifactId`.
+ *
+ * @returns `true` when the attachment was successfully added, `false` on error
+ *   (blob too small or disk write failure).
+ */
+export async function addArtifactImageSelectionToChat(
+  blob: Blob,
+  artifactId: string,
+  label?: string
+): Promise<boolean> {
+  if (blob.size === 0) {
+    return false
+  }
+
+  const normalizedId = artifactId.trim()
+  const normalizedLabel = (label || normalizedId).trim()
+  const ext = blobExtension(blob)
+
+  try {
+    const buffer = await blob.arrayBuffer()
+    const data = new Uint8Array(buffer)
+    const savedPath = await window.hermesDesktop?.saveImageBuffer(data, ext)
+
+    if (!savedPath) {
+      return false
+    }
+
+    const attachment: ComposerAttachment = {
+      id: `artifact-image-${normalizedId}`,
+      occurrenceId: createComposerAttachmentOccurrenceId(),
+      kind: 'image',
+      label: normalizedLabel,
+      detail: normalizedId,
+      path: savedPath
+    }
+
+    addComposerAttachment(attachment)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** MIME-type → file extension lookup (mirrors use-composer-actions.ts). */
+const BLOB_MIME_EXTENSION: Record<string, string> = {
+  'image/bmp': '.bmp',
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/tiff': '.tiff',
+  'image/webp': '.webp',
+  'image/x-icon': '.ico'
+}
+
+/**
+ * Derive a file extension from a Blob's MIME type.
+ *
+ * Mirrors the `blobExtension` helper in use-composer-actions.ts. Defaults to
+ * `.png` when the MIME type is unrecognised.
+ */
+function blobExtension(blob: Blob): string {
+  const mime = blob.type.split(';')[0].toLowerCase().trim()
+
+  return BLOB_MIME_EXTENSION[mime] || '.png'
+}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -14,8 +14,11 @@ import {
 } from '@/lib/voice-playback'
 import {
   $composerAttachments,
+  clearComposerMessageQuotes,
   type ComposerAttachment,
   mainComposerScope,
+  messageQuoteContextBlocks,
+  reconcileComposerMessageQuotes,
   terminalContextBlocksFromDraft
 } from '@/store/composer'
 import { $hudMode } from '@/store/hud'
@@ -129,6 +132,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       )
 
       const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
+      // Reconcile before resolving: drop quote entries whose @message: refs
+      // were edited or deleted from the draft.
+      reconcileComposerMessageQuotes(rawText)
+      const quoteContextBlocks = messageQuoteContextBlocks(rawText).join('\n\n')
       const hasImage = attachments.some(a => a.kind === 'image')
 
       // Refs are recomputed after sync (file.attach rewrites @file: refs to
@@ -149,7 +156,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           .join('\n')
 
         return (
-          [contextRefs, terminalContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
+          [contextRefs, terminalContextBlocks, quoteContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
           (present.some(a => a.kind === 'image') ? 'What do you see in this image?' : '')
         )
       }
@@ -763,6 +770,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           // preserved while the staged object for a submitted file is removed.
           scope.removeAttachments(syncedAttachments)
         }
+
+        // Submit landed — clear stale message quotes from the store so they
+        // don't carry into the next turn. (Parallel to terminal selections,
+        // which are reconciled at the same point.)
+        clearComposerMessageQuotes()
 
         // Submit landed — the turn now runs (busy stays true), but the submit
         // window is closed, so release the lock for the next (sequential) send.

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -301,6 +301,10 @@ export function refChipLabel(type: string, id: string): string {
     return id || 'terminal'
   }
 
+  if (type === 'message') {
+    return id || 'message'
+  }
+
   if (type === 'session') {
     return sessionRefFallbackLabel(id)
   }

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -10,6 +10,7 @@ import {
 import type { code as streamdownCode } from '@streamdown/code'
 import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 
+import { ArtifactImageSelection } from '@/components/chat/artifact-image-selection'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
@@ -393,6 +394,8 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
     }
   }, [rawSrc])
 
+  const imageId = useMemo(() => `img-${rawSrc?.slice(0, 40).replace(/[^a-zA-Z0-9]/g, '-') || ''}`, [rawSrc])
+
   if (!rawSrc) {
     return null
   }
@@ -409,26 +412,33 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
     )
   }
 
-  if (!resolvedSrc) {
-    return <span className="my-2 block text-sm text-muted-foreground">Loading {name}...</span>
-  }
-
   // The width cap belongs on the container, not the <img>: a percentage
   // max-width resolves to none while the container measures its fit-content
   // width, so the box overshoots the rendered image and strands the download
   // button — which anchors to the container — out in the margin.
+  if (!resolvedSrc) {
+    return <span className="my-2 block text-sm text-muted-foreground">Loading {name}...</span>
+  }
+
   return (
-    <ZoomableImage
+    <ArtifactImageSelection
       alt={alt}
-      className={cn(
-        'm-0 block h-auto w-auto max-h-(--image-preview-height) max-w-full rounded-lg object-contain shadow-[0_0.0625rem_0.125rem_color-mix(in_srgb,#000_4%,transparent),0_0.625rem_1.5rem_color-mix(in_srgb,#000_5%,transparent)]',
-        className
-      )}
-      containerClassName="my-2 block w-fit max-w-[min(100%,var(--image-preview-max-width))]"
-      slot="aui_markdown-image"
+      artifactId={imageId}
+      className="my-2 block w-fit max-w-[min(100%,var(--image-preview-max-width))]"
       src={resolvedSrc}
-      {...props}
-    />
+    >
+      <ZoomableImage
+        alt={alt}
+        className={cn(
+          'm-0 block h-auto w-auto max-h-(--image-preview-height) max-w-full rounded-lg object-contain shadow-[0_0.0625rem_0.125rem_color-mix(in_srgb,#000_4%,transparent),0_0.625rem_1.5rem_color-mix(in_srgb,#000_5%,transparent)]',
+          className
+        )}
+        containerClassName="!my-0"
+        slot="aui_markdown-image"
+        src={resolvedSrc}
+        {...props}
+      />
+    </ArtifactImageSelection>
   )
 }
 

--- a/apps/desktop/src/components/assistant-ui/reference-kinds.ts
+++ b/apps/desktop/src/components/assistant-ui/reference-kinds.ts
@@ -30,6 +30,7 @@ export type ReferenceKind =
   | 'skill'
   | 'theme'
   | 'emoji'
+  | 'message'
   | 'other'
 
 interface ReferenceStyle {
@@ -116,6 +117,15 @@ export const REFERENCE_STYLES: Record<ReferenceKind, ReferenceStyle> = {
     label: 'Themes'
   },
   emoji: { codicon: 'smiley', paths: [], label: 'Emoji' },
+  message: {
+    codicon: 'comment',
+    paths: [
+      'M8 9h8',
+      'M8 13h6',
+      'M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3h-5l-5 3v-3H6a3 3 0 0 1-3-3V7a3 3 0 0 1 3-3h12z'
+    ],
+    label: 'Messages'
+  },
   other: { codicon: 'symbol-misc', paths: FILE_PATHS, label: 'Other' }
 }
 
@@ -135,7 +145,7 @@ export function referenceStyle(type: string | undefined): ReferenceStyle {
  * above: `command`/`skill`/`theme` arrive via `/`, and `diff`/`staged`/`emoji`
  * have no value to carry.
  */
-export const WIRE_REFERENCE_KINDS = ['file', 'folder', 'url', 'image', 'tool', 'line', 'terminal', 'session'] as const
+export const WIRE_REFERENCE_KINDS = ['file', 'folder', 'url', 'image', 'tool', 'line', 'terminal', 'session', 'message'] as const
 
 /**
  * The one pattern that recognises a reference in text.
@@ -144,7 +154,7 @@ export const WIRE_REFERENCE_KINDS = ['file', 'folder', 'url', 'image', 'tool', '
  * a space — so the quoted forms are tried BEFORE bare `\S+`, or a quoted value
  * would end at the first space and strand the rest as prose.
  */
-const REFERENCE_PATTERN = /@(file|folder|url|image|tool|line|terminal|session):(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/
+const REFERENCE_PATTERN = /@(file|folder|url|image|tool|line|terminal|session|message):(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/
 
 /**
  * A fresh matcher for every surface that has to find references in text: the

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/assistant-ui/thread/content'
 import { MESSAGE_PARTS_COMPONENTS } from '@/components/assistant-ui/thread/message-parts'
 import { ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
+import { MessageQuoteButton } from '@/components/assistant-ui/thread/message-selection-quote'
 import { ResponseLoadingIndicator, TurnActivityIndicator } from '@/components/assistant-ui/thread/status'
 import { MessageTimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { useMessageReactions, useTapbackDoubleClick } from '@/components/assistant-ui/thread/use-message-reactions'
@@ -260,6 +261,7 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
                 <ErrorRecoveryActions />
               </ErrorPrimitive.Root>
             </MessagePrimitive.Error>
+            <MessageQuoteButton messageId={messageId} />
           </div>
           <MessageTimelineTimestamp className="px-(--message-text-indent) pt-0.5" suppressIfDuplicatePart />
           {hasVisibleText && !isInterim && (

--- a/apps/desktop/src/components/assistant-ui/thread/message-selection-quote.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-selection-quote.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { addMessageSelectionToChat } from '@/app/chat/composer/selection-composer-bridge'
+import { useI18n } from '@/i18n'
+import { triggerHaptic } from '@/lib/haptics'
+
+/**
+ * Smallest delay (ms) between the selection becoming stable and the quote
+ * button appearing. Avoids flicker during a normal drag-select.
+ */
+const QUOTE_DELAY_MS = 200
+
+interface MessageQuoteButtonProps {
+  /** Stable message id scoped to this chat message. */
+  messageId: string
+}
+
+/**
+ * A floating "Quote in chat" button that appears when the user selects text
+ * inside the enclosing assistant or user message bubble.
+ *
+ * Renders as a `position:fixed` pill near the selection's top-center edge.
+ * Clicking it calls {@link addMessageSelectionToChat} with the selected text
+ * and the message id, then clears the selection.
+ *
+ * ### Scoping
+ * Finds the nearest ancestor with `data-slot="aui_assistant-message-root"` or
+ * `"aui_user-message-root"` — the same attributes the thread components stamp
+ * on their outer wrapper. Only text selections anchored and focused inside
+ * that subtree trigger the button.
+ *
+ * ### Lifecycle
+ * - Appears ~200ms after a stable non-collapsed selection inside the message.
+ * - Disappears when the selection collapses, moves outside the message, or
+ *   the user clicks anywhere outside the button (dismiss).
+ */
+export function MessageQuoteButton({ messageId }: MessageQuoteButtonProps) {
+  const { t } = useI18n()
+  const [show, setShow] = useState(false)
+  const [style, setStyle] = useState<React.CSSProperties>({})
+  const anchorRef = useRef<HTMLSpanElement>(null)
+  const btnRef = useRef<HTMLButtonElement>(null)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const cleanupDismissRef = useRef<(() => void) | null>(null)
+
+  const hide = useCallback(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = null
+    }
+
+    setShow(false)
+  }, [])
+
+  const scheduleHide = useCallback(() => {
+    if (hideTimerRef.current) { return }
+    hideTimerRef.current = setTimeout(hide, QUOTE_DELAY_MS)
+  }, [hide])
+
+  // eslint-disable-next-line no-restricted-syntax -- DOM instance refs (cleanup timer + event-listener handle), not atom mirrors
+  useEffect(() => {
+    // Find the enclosing message root. The hidden <span> is always mounted
+    // inside the message component's DOM subtree, so `closest` resolves it.
+    const span = anchorRef.current
+
+    if (!span) {return}
+
+    const root = span.closest(
+      '[data-slot="aui_assistant-message-root"], [data-slot="aui_user-message-root"]'
+    ) as HTMLElement | null
+
+    if (!root) {return}
+
+    const onSelectionChange = () => {
+      const sel = window.getSelection()
+
+      // No selection or collapsed — schedule a deferred hide so normal
+      // drag-select doesn't flicker the button multiple times.
+      if (!sel || sel.isCollapsed || !sel.toString().trim()) {
+        scheduleHide()
+
+        return
+      }
+
+      // Both anchor and focus must be inside this message.
+      if (!root.contains(sel.anchorNode) || !root.contains(sel.focusNode)) {
+        hide()
+
+        return
+      }
+
+      // Cancel any pending hide — selection is valid and inside our bubble.
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current)
+        hideTimerRef.current = null
+      }
+
+      // Position above the selection's top-center edge.
+      const range = sel.getRangeAt(0)
+      const rect = range.getBoundingClientRect()
+
+      setStyle({
+        position: 'fixed',
+        top: `${rect.top - 8}px`,
+        left: `${rect.left + rect.width / 2}px`,
+        transform: 'translateX(-50%) translateY(-100%)'
+      })
+      setShow(true)
+    }
+
+    // Defer the pointerdown listener by a microtask so the click that
+    // triggered the button's own handler doesn't immediately dismiss it.
+    const dismissTimeout = setTimeout(() => {
+      const onPointerDown = (e: MouseEvent) => {
+        if (btnRef.current && !btnRef.current.contains(e.target as Node)) {
+          hide()
+        }
+      }
+
+      document.addEventListener('pointerdown', onPointerDown)
+      cleanupDismissRef.current = () => document.removeEventListener('pointerdown', onPointerDown)
+    }, 0)
+
+    document.addEventListener('selectionchange', onSelectionChange)
+
+    return () => {
+      document.removeEventListener('selectionchange', onSelectionChange)
+      cleanupDismissRef.current?.()
+      cleanupDismissRef.current = null
+      clearTimeout(dismissTimeout)
+
+      if (hideTimerRef.current) {clearTimeout(hideTimerRef.current)}
+    }
+  }, [scheduleHide, hide])
+
+  const quote = useCallback(() => {
+    const sel = window.getSelection()
+
+    if (!sel || sel.isCollapsed) {return}
+
+    const text = sel.toString().trim()
+
+    if (!text) {return}
+
+    triggerHaptic('selection')
+    addMessageSelectionToChat(text, messageId)
+    sel.removeAllRanges()
+    hide()
+  }, [messageId, hide])
+
+  return (
+    <>
+      {/*
+       * Always-mounted anchor used to locate the message root via DOM
+       * traversal. Must be a child of the message component so `closest`
+       * resolves to the correct root irrespective of show/hide state.
+       */}
+      <span ref={anchorRef} />
+      {show && (
+        <button
+          className="fixed z-50 rounded-md border border-(--ui-stroke-secondary) bg-(--ui-popover-background) px-2 py-1 text-xs font-medium text-foreground shadow-lg transition-colors hover:bg-accent active:scale-95"
+          onClick={event => {
+            event.preventDefault()
+            event.stopPropagation()
+            quote()
+          }}
+          ref={btnRef}
+          style={style}
+          type="button"
+        >
+          {t.assistant.thread.quoteInChat}
+        </button>
+      )}
+    </>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -4,6 +4,7 @@ import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } fro
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { messageAttachmentRefs, messageContentText } from '@/components/assistant-ui/thread/content'
 import { ReactionBadge, ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
+import { MessageQuoteButton } from '@/components/assistant-ui/thread/message-selection-quote'
 import { MessageTimelineTimestamp } from '@/components/assistant-ui/thread/timeline-timestamp'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
 import { useMessageReactions } from '@/components/assistant-ui/thread/use-message-reactions'
@@ -568,6 +569,7 @@ export const UserMessage: FC<{
                     )}
                   </div>
                 )}
+              <MessageQuoteButton messageId={messageId} />
               </div>
             </ReactionPicker>
             {/* Below the bubble, same register as the assistant action row:

--- a/apps/desktop/src/components/chat/artifact-image-selection.tsx
+++ b/apps/desktop/src/components/chat/artifact-image-selection.tsx
@@ -1,0 +1,301 @@
+'use client'
+
+import { type ComponentProps, useCallback, useRef, useState } from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+interface SelectionRect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface ArtifactImageSelectionProps extends Omit<ComponentProps<'div'>, 'children'> {
+  alt?: string
+  artifactId: string
+  /** The image element to wrap. When omitted the component renders its own
+   *  `<img>` with `crossOrigin="anonymous"`. */
+  children?: React.ReactNode
+  onImageLoad?: () => void
+  src: string
+}
+
+/**
+ * Wraps an `<img>` element with a drag-to-select marquee overlay and a
+ * floating "Add to chat" button. The selected region is cropped via canvas,
+ * converted to a PNG Blob, and handed to `addArtifactImageSelectionToChat`.
+ *
+ * Renders the `<img>` with `crossOrigin="anonymous"` so the canvas read is
+ * never tainted by a CORS mismatch.
+ */
+export function ArtifactImageSelection({
+  alt,
+  artifactId,
+  children,
+  className,
+  onImageLoad,
+  src,
+  ...props
+}: ArtifactImageSelectionProps) {
+  const { t } = useI18n()
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
+  const [selection, setSelection] = useState<SelectionRect | null>(null)
+  const [confirmed, setConfirmed] = useState<SelectionRect | null>(null)
+  const [dragging, setDragging] = useState(false)
+  const dragStart = useRef<{ x: number; y: number } | null>(null)
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    // Ignore right-click / modified clicks
+    if (e.button !== 0 || e.ctrlKey || e.metaKey || e.shiftKey) {
+      return
+    }
+
+    const rect = wrapperRef.current?.getBoundingClientRect()
+
+    if (!rect) {
+      return
+    }
+
+    setConfirmed(null)
+    setDragging(true)
+    dragStart.current = { x: e.clientX - rect.left, y: e.clientY - rect.top }
+    setSelection(null)
+  }, [])
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!dragging || !dragStart.current) {
+        return
+      }
+
+      const rect = wrapperRef.current?.getBoundingClientRect()
+
+      if (!rect) {
+        return
+      }
+
+      const currentX = e.clientX - rect.left
+      const currentY = e.clientY - rect.top
+      const x = Math.min(dragStart.current.x, currentX)
+      const y = Math.min(dragStart.current.y, currentY)
+      const w = Math.abs(currentX - dragStart.current.x)
+      const h = Math.abs(currentY - dragStart.current.y)
+
+      if (w < 1 || h < 1) {
+        setSelection(null)
+      } else {
+        setSelection({ x, y, w, h })
+      }
+    },
+    [dragging]
+  )
+
+  const handleMouseUp = useCallback(
+    (e: React.MouseEvent) => {
+      if (!dragging || !dragStart.current) {
+        return
+      }
+
+      setDragging(false)
+
+      // Capture the start point before nulling the ref so TypeScript
+      // doesn't see a narrowed-to-never value.
+      const start = dragStart.current
+
+      dragStart.current = null
+
+      // Finalize the current selection as confirmed
+      const rect = wrapperRef.current?.getBoundingClientRect()
+
+      if (!rect) {
+        setSelection(null)
+
+        return
+      }
+
+      const currentX = e.clientX - rect.left
+      const currentY = e.clientY - rect.top
+      const x = Math.min(start.x, currentX)
+      const y = Math.min(start.y, currentY)
+      const w = Math.abs(start.x - currentX)
+      const h = Math.abs(start.y - currentY)
+
+      if (w < 4 || h < 4) {
+        // Too small — treat as a click-through, not a selection
+        setSelection(null)
+        setConfirmed(null)
+
+        return
+      }
+
+      setSelection(null)
+      setConfirmed({ x, y, w, h })
+    },
+    [dragging]
+  )
+
+  const handleAddToChat = useCallback(() => {
+    const img = imgRef.current ?? wrapperRef.current?.querySelector('img')
+    const rect = confirmed
+
+    if (!img || !rect || rect.w < 1 || rect.h < 1) {
+      return
+    }
+
+    // Determine the scale factor between the rendered image and its natural size
+    const renderedW = img.clientWidth
+    const renderedH = img.clientHeight
+
+    if (!renderedW || !renderedH) {
+      return
+    }
+
+    const scaleX = img.naturalWidth / renderedW
+    const scaleY = img.naturalHeight / renderedH
+
+    const sx = Math.round(rect.x * scaleX)
+    const sy = Math.round(rect.y * scaleY)
+    const sw = Math.round(rect.w * scaleX)
+    const sh = Math.round(rect.h * scaleY)
+
+    const canvas = document.createElement('canvas')
+
+    canvas.width = sw
+    canvas.height = sh
+
+    const ctx = canvas.getContext('2d')
+
+    if (!ctx) {
+      return
+    }
+
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh)
+    canvas.toBlob(
+      blob => {
+        if (!blob) {
+          return
+        }
+
+        // Dynamically import the bridge to avoid circular deps
+        void import('@/app/chat/composer/selection-composer-bridge').then(
+          ({ addArtifactImageSelectionToChat }) => {
+            void addArtifactImageSelectionToChat(blob, artifactId)
+          }
+        )
+      },
+      'image/png'
+    )
+
+    setConfirmed(null)
+  }, [artifactId, confirmed])
+
+  const clearSelection = useCallback(() => {
+    setConfirmed(null)
+    setSelection(null)
+  }, [])
+
+  return (
+    <div
+      className={cn('group/image-selection relative inline-block max-w-full select-none align-top', className)}
+      data-slot="aui_artifact-image-selection"
+      onMouseDown={handleMouseDown}
+      onMouseLeave={handleMouseUp}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      ref={wrapperRef}
+      {...props}
+    >
+      {/* Render children or a default <img> */}
+      {children ?? (
+        <img
+          alt={alt ?? ''}
+          className="pointer-events-none block h-auto w-auto max-h-(--image-preview-height) max-w-full"
+          crossOrigin="anonymous"
+          onLoad={onImageLoad}
+          ref={imgRef}
+          src={src}
+        />
+      )}
+
+      {/* Marquee rectangle during active drag */}
+      {selection && (
+        <svg
+          aria-hidden
+          className="pointer-events-none absolute inset-0 size-full"
+        >
+          <rect
+            className="fill-blue-500/15 stroke-blue-500"
+            height={selection.h}
+            rx={2}
+            strokeWidth={1.5}
+            width={selection.w}
+            x={selection.x}
+            y={selection.y}
+          />
+        </svg>
+      )}
+
+      {/* Confirmed selection — show the dimmed overlay + "Add to chat" button */}
+      {confirmed && (
+        <>
+          {/* Semi-transparent overlay */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-black/40"
+          />
+
+          {/* Highlight the selected region */}
+          <svg
+            aria-hidden
+            className="pointer-events-none absolute inset-0 size-full"
+          >
+            <rect
+              className="fill-transparent stroke-blue-400"
+              height={confirmed.h}
+              rx={2}
+              strokeWidth={2}
+              width={confirmed.w}
+              x={confirmed.x}
+              y={confirmed.y}
+            />
+          </svg>
+
+          {/* Floating "Add to chat" button */}
+          <Tip label={t.composer.addImageToChat}>
+            <button
+              className="absolute z-10 grid size-8 place-items-center rounded-full border border-border/70 bg-background/90 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-accent hover:text-foreground"
+              onClick={handleAddToChat}
+              style={{
+                left: Math.max(4, confirmed.x + confirmed.w + 8),
+                top: Math.max(4, confirmed.y + confirmed.h + 8)
+              }}
+              type="button"
+            >
+              <Codicon className="size-4" name="arrow-up" />
+            </button>
+          </Tip>
+
+          {/* Dismiss button */}
+          <Tip label={t.common?.cancel ?? 'Cancel'}>
+            <button
+              className="absolute z-10 grid size-6 place-items-center rounded-full border border-border/70 bg-background/80 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-accent hover:text-foreground"
+              onClick={clearSelection}
+              style={{
+                left: Math.max(4, confirmed.x + confirmed.w + 8),
+                top: Math.max(4, confirmed.y)
+              }}
+              type="button"
+            >
+              <Codicon className="size-3.5" name="close" />
+            </button>
+          </Tip>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2423,7 +2423,9 @@ export const en: Translations = {
         description: 'Walk through how the selected code works and link to the key files.',
         text: 'Please explain how this works and point me to the key files.'
       }
-    }
+    },
+    quoteSelected: 'Quote in chat',
+    addImageToChat: 'Add to chat'
   },
 
   statusStack: {
@@ -3148,7 +3150,8 @@ export const en: Translations = {
       restoreNext: 'Restore next checkpoint',
       goForward: 'Go forward',
       sendEdited: 'Send edited message',
-      attachingFile: 'Attaching…'
+      attachingFile: 'Attaching…',
+      quoteInChat: 'Quote in chat'
     },
     approval: {
       gatewayDisconnected: 'Hermes gateway is not connected',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2045,6 +2045,8 @@ export interface Translations {
       done: string
       doneTip: string
     }
+    quoteSelected: string
+    addImageToChat: string
   }
 
   statusStack: {
@@ -2714,6 +2716,7 @@ export interface Translations {
       goForward: string
       sendEdited: string
       attachingFile: string
+      quoteInChat: string
     }
     approval: {
       gatewayDisconnected: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2606,7 +2606,9 @@ export const zh: Translations = {
         description: '讲解所选代码的工作方式，并链接到关键文件。',
         text: '请解释这是如何工作的，并指给我关键文件。'
       }
-    }
+    },
+    quoteSelected: '引用到聊天',
+    addImageToChat: '添加到聊天'
   },
 
   statusStack: {
@@ -3309,7 +3311,8 @@ export const zh: Translations = {
       restoreNext: '恢复下一个检查点',
       goForward: '前进',
       sendEdited: '发送编辑后的消息',
-      attachingFile: '正在附加…'
+      attachingFile: '正在附加…',
+      quoteInChat: '引用到聊天'
     },
     approval: {
       gatewayDisconnected: 'Hermes 网关未连接',

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -584,6 +584,101 @@ export function clearComposerTerminalSelections() {
   $composerTerminalSelections.set({})
 }
 
+// ---------------------------------------------------------------------------
+// @message: reference support — quoted-text storage keyed by messageId
+// ---------------------------------------------------------------------------
+
+const MESSAGE_REF_RE = /@message:(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)/g
+
+export const $composerMessageQuotes = atom<Record<string, string>>({})
+
+function messageIdsFromDraft(draft: string) {
+  const ids: string[] = []
+  const seen = new Set<string>()
+
+  for (const match of draft.matchAll(MESSAGE_REF_RE)) {
+    const id = unquoteRefValue(match[1] || '')
+
+    if (!id || seen.has(id)) {
+      continue
+    }
+
+    seen.add(id)
+    ids.push(id)
+  }
+
+  return ids
+}
+
+export function setComposerMessageQuote(messageId: string, text: string) {
+  const nextMessageId = messageId.trim()
+  const nextText = text.trim()
+
+  if (!nextMessageId || !nextText) {
+    return
+  }
+
+  const current = $composerMessageQuotes.get()
+
+  if (current[nextMessageId] === nextText) {
+    return
+  }
+
+  $composerMessageQuotes.set({
+    ...current,
+    [nextMessageId]: nextText
+  })
+}
+
+export function reconcileComposerMessageQuotes(draft: string) {
+  const current = $composerMessageQuotes.get()
+  const messageIds = new Set(messageIdsFromDraft(draft))
+  let changed = false
+  const next: Record<string, string> = {}
+
+  for (const [messageId, text] of Object.entries(current)) {
+    if (!messageIds.has(messageId)) {
+      changed = true
+
+      continue
+    }
+
+    next[messageId] = text
+  }
+
+  if (changed) {
+    $composerMessageQuotes.set(next)
+  }
+}
+
+export function messageQuoteContextBlocks(draft: string) {
+  const ids = messageIdsFromDraft(draft)
+
+  if (ids.length === 0) {
+    return []
+  }
+
+  const quotes = $composerMessageQuotes.get()
+
+  return ids.flatMap(messageId => {
+    const text = quotes[messageId]?.trim()
+
+    if (!text) {
+      return []
+    }
+
+    return `\`\`\`quote<${messageId}>\n${text}\n\`\`\``
+  })
+}
+
+export function clearComposerMessageQuotes() {
+  if (Object.keys($composerMessageQuotes.get()).length === 0) {
+    return
+  }
+
+  $composerMessageQuotes.set({})
+}
+
 function upsertAttachment(attachments: ComposerAttachment[], attachment: ComposerAttachment) {
   const index = attachments.findIndex(item => item.id === attachment.id)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2087,6 +2087,18 @@ def fetch_openrouter_models(
             desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
         curated.append((preferred_id, desc))
 
+    # Append all remaining tool-capable models from the live catalog so the
+    # picker is searchable beyond the curated shortlist.  Curated models
+    # (already in ``curated``) are skipped; the rest keep their live order.
+    curated_ids = {mid for mid, _ in curated}
+    for mid, item in live_by_id.items():
+        if mid in curated_ids:
+            continue
+        if not _openrouter_model_supports_tools(item):
+            continue
+        desc = "free" if _openrouter_model_is_free(item.get("pricing")) else ""
+        curated.append((mid, desc))
+
     if not curated:
         return list(_openrouter_catalog_cache or fallback)
 
@@ -3512,6 +3524,10 @@ def detect_provider_for_model(
         return None
 
     # --- Step 2: check OpenRouter catalog ---
+    # Don't override custom providers — the user explicitly chose their endpoint.
+    _is_custom = current_provider == "custom" or (current_provider or "").startswith("custom:")
+    if _is_custom:
+        return None
     # First try exact match (handles provider/model format)
     or_slug = _find_openrouter_slug(name)
     if or_slug:

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -18,6 +18,7 @@ import functools
 import inspect
 import json
 import logging
+import os
 import re
 import subprocess  # noqa: F401
 import sys  # noqa: F401
@@ -593,7 +594,7 @@ def _merge_profile_tree(
             session["profile"] = profile
             session["is_default_profile"] = profile == "default"
 
-        key = project.get("path") or project["id"]
+        key = os.path.normcase(os.path.normpath(project.get("path") or project["id"]))
         existing = merged.get(key)
         if existing is None:
             merged[key] = project

--- a/tests/hermes_cli/test_merge_profile_tree.py
+++ b/tests/hermes_cli/test_merge_profile_tree.py
@@ -1,0 +1,98 @@
+"""_merge_profile_tree folds projects across profiles by normalized path."""
+
+import os
+import pytest
+
+
+def _make_project(path=None, pid="p_abc", is_auto=False, label="Proj"):
+    """Minimal project dict matching the shape _merge_profile_tree expects."""
+    return {
+        "id": pid,
+        "path": path,
+        "label": label,
+        "isAuto": is_auto,
+        "repos": [],
+        "previewSessions": [],
+        "sessionCount": 0,
+        "totalTokens": 0,
+        "totalCostUsd": 0,
+        "lastActive": 0,
+    }
+
+
+class TestMergeProfileTree:
+    """Unit tests for the merge-key normalization in _merge_profile_tree."""
+
+    def test_same_path_different_casing_produces_one_entry(self, monkeypatch):
+        """Windows case-insensitive paths must fold into one group.
+
+        On POSIX normcase is a no-op, so we monkeypatch it to lowercase
+        to verify the merge logic works regardless of platform.
+        """
+        from hermes_cli.web_routers.profiles import _merge_profile_tree
+
+        monkeypatch.setattr(os.path, "normcase", lambda p: p.lower() if isinstance(p, str) else p)
+
+        merged = {}
+        proj_a = _make_project(path=r"C:\Users\me\Project", pid="p_a")
+        proj_b = _make_project(path=r"C:\Users\me\project", pid="p_b")
+
+        _merge_profile_tree(merged, [proj_a], "alpha", preview_limit=5)
+        _merge_profile_tree(merged, [proj_b], "beta", preview_limit=5)
+
+        assert len(merged) == 1
+        # First writer wins the identity slot.
+        assert list(merged.values())[0]["id"] == "p_a"
+
+    def test_trailing_slash_does_not_duplicate(self):
+        """normpath strips trailing separators before normcase."""
+        from hermes_cli.web_routers.profiles import _merge_profile_tree
+
+        merged = {}
+        proj_a = _make_project(path="/home/me/proj", pid="p_a")
+        proj_b = _make_project(path="/home/me/proj/", pid="p_b")
+
+        _merge_profile_tree(merged, [proj_a], "alpha", preview_limit=5)
+        _merge_profile_tree(merged, [proj_b], "beta", preview_limit=5)
+
+        assert len(merged) == 1
+
+    def test_different_paths_stay_separate(self):
+        """Genuinely different folders must remain distinct groups."""
+        from hermes_cli.web_routers.profiles import _merge_profile_tree
+
+        merged = {}
+        proj_a = _make_project(path="/home/me/alpha", pid="p_a")
+        proj_b = _make_project(path="/home/me/beta", pid="p_b")
+
+        _merge_profile_tree(merged, [proj_a], "alpha", preview_limit=5)
+        _merge_profile_tree(merged, [proj_b], "beta", preview_limit=5)
+
+        assert len(merged) == 2
+
+    def test_id_fallback_when_path_is_none(self):
+        """Projects without a path key on the project id instead."""
+        from hermes_cli.web_routers.profiles import _merge_profile_tree
+
+        merged = {}
+        proj_a = _make_project(path=None, pid="p_same")
+        proj_b = _make_project(path=None, pid="p_same")
+
+        _merge_profile_tree(merged, [proj_a], "alpha", preview_limit=5)
+        _merge_profile_tree(merged, [proj_b], "beta", preview_limit=5)
+
+        assert len(merged) == 1
+
+    def test_declared_project_wins_over_auto(self):
+        """When a declared project meets an auto entry, declared wins identity."""
+        from hermes_cli.web_routers.profiles import _merge_profile_tree
+
+        merged = {}
+        auto = _make_project(path="/home/me/proj", pid="p_auto", is_auto=True, label="auto")
+        declared = _make_project(path="/home/me/proj", pid="p_decl", is_auto=False, label="My Proj")
+
+        _merge_profile_tree(merged, [auto], "alpha", preview_limit=5)
+        _merge_profile_tree(merged, [declared], "beta", preview_limit=5)
+
+        assert len(merged) == 1
+        assert list(merged.values())[0]["label"] == "My Proj"

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2921,3 +2921,259 @@ class TestRedirectHeaderStripper:
         asyncio.run(hook(response))
         assert next_request.headers["authorization"] == "Bearer x"
         assert next_request.headers["x-tenant"] == "t"
+
+
+# ---------------------------------------------------------------------------
+# Connection identity digest (#92565)
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionIdentity:
+    """Verify _connection_identity produces correct, stable digests."""
+
+    def test_same_config_same_digest(self):
+        """Identical configs produce identical digests."""
+        from tools.mcp_tool import _connection_identity
+
+        cfg = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer tok123"},
+        }
+        assert _connection_identity(cfg) == _connection_identity(cfg)
+
+    def test_different_credential_different_digest(self):
+        """Changed credentials produce a different digest."""
+        from tools.mcp_tool import _connection_identity
+
+        cfg_a = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer old_token"},
+        }
+        cfg_b = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer new_token"},
+        }
+        assert _connection_identity(cfg_a) != _connection_identity(cfg_b)
+
+    def test_different_env_different_digest(self):
+        """Changed env vars produce a different digest (stdio servers)."""
+        from tools.mcp_tool import _connection_identity
+
+        cfg_a = {"command": "npx", "args": ["-y", "srv"], "env": {"TOKEN": "old"}}
+        cfg_b = {"command": "npx", "args": ["-y", "srv"], "env": {"TOKEN": "new"}}
+        assert _connection_identity(cfg_a) != _connection_identity(cfg_b)
+
+    def test_non_credential_field_same_digest(self):
+        """Changing timeout/tools/enabled does NOT change the digest."""
+        from tools.mcp_tool import _connection_identity
+
+        cfg_a = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer tok"},
+            "timeout": 30,
+        }
+        cfg_b = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer tok"},
+            "timeout": 180,
+            "tools": {"include": ["foo"]},
+            "enabled": True,
+        }
+        assert _connection_identity(cfg_a) == _connection_identity(cfg_b)
+
+    def test_header_names_case_insensitive(self):
+        """Header name casing doesn't affect the digest."""
+        from tools.mcp_tool import _connection_identity
+
+        cfg_a = {"url": "https://x.com/mcp", "headers": {"Authorization": "Bearer t"}}
+        cfg_b = {"url": "https://x.com/mcp", "headers": {"authorization": "Bearer t"}}
+        assert _connection_identity(cfg_a) == _connection_identity(cfg_b)
+
+    def test_empty_headers_and_env(self):
+        """Configs with no headers/env still produce a valid digest."""
+        from tools.mcp_tool import _connection_identity
+
+        cfg = {"command": "npx", "args": ["-y", "srv"]}
+        digest = _connection_identity(cfg)
+        assert isinstance(digest, str)
+        assert len(digest) == 16
+
+
+class TestRegisterMcpServersCredentialChange:
+    """Verify register_mcp_servers reconnects on credential change (#92565)."""
+
+    def test_reconnects_when_config_digest_changes(self):
+        """A server whose credentials changed is shut down and reconnected."""
+        from tools.mcp_tool import (
+            register_mcp_servers, _servers, _server_config_digests,
+            _ensure_mcp_loop, _connection_identity,
+        )
+
+        old_config = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer old_token"},
+        }
+        new_config = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer new_token"},
+        }
+
+        # Simulate an existing live server with the old config.
+        old_server = _make_mock_server("example")
+        old_server._registered_tool_names = ["mcp__example__tool1"]
+        _servers["example"] = old_server
+        _server_config_digests["example"] = _connection_identity(old_config)
+
+        connect_calls = []
+
+        async def fake_register(name, cfg):
+            connect_calls.append(name)
+            server = _make_mock_server(name)
+            server._registered_tool_names = [f"mcp__{name}__tool1"]
+            _servers[name] = server
+            _server_config_digests[name] = _connection_identity(cfg)
+            return [f"mcp__{name}__tool1"]
+
+        try:
+            # _run_on_mcp_loop is a sync function that schedules a coroutine
+            # on the MCP loop and blocks.  Our mock must actually run it.
+            def fake_run_loop(coro_or_factory, timeout=30):
+                if asyncio.iscoroutine(coro_or_factory):
+                    asyncio.run(coro_or_factory)
+                elif callable(coro_or_factory):
+                    asyncio.run(coro_or_factory())
+
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_register), \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=[]), \
+                 patch("tools.mcp_tool._run_on_mcp_loop", side_effect=fake_run_loop):
+                _ensure_mcp_loop()
+                register_mcp_servers({"example": new_config})
+
+            # New connection should have been attempted (old server was
+            # removed from _servers by the digest-change detection, so the
+            # name-based filter treated it as a new server).
+            assert "example" in connect_calls
+            # The new server should have the new digest
+            assert _server_config_digests.get("example") == _connection_identity(new_config)
+        finally:
+            _servers.pop("example", None)
+            _server_config_digests.pop("example", None)
+
+    def test_no_reconnect_when_config_unchanged(self):
+        """A server whose config hasn't changed is left alone."""
+        from tools.mcp_tool import (
+            register_mcp_servers, _servers, _server_config_digests,
+            _connection_identity,
+        )
+
+        config = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer token"},
+        }
+
+        existing_server = _make_mock_server("example")
+        existing_server._registered_tool_names = ["mcp__example__tool1"]
+        _servers["example"] = existing_server
+        _server_config_digests["example"] = _connection_identity(config)
+
+        connect_calls = []
+
+        async def fake_register(name, cfg):
+            connect_calls.append(name)
+            return []
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_register), \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=["mcp__example__tool1"]):
+                register_mcp_servers({"example": config})
+
+            # Should NOT have attempted to reconnect
+            assert connect_calls == []
+            # Server should still be the same object
+            assert _servers["example"] is existing_server
+        finally:
+            _servers.pop("example", None)
+            _server_config_digests.pop("example", None)
+
+    def test_no_reconnect_when_no_recorded_digest(self):
+        """A pre-upgrade server (no digest) is left alone but gets seeded."""
+        from tools.mcp_tool import (
+            register_mcp_servers, _servers, _server_config_digests,
+            _connection_identity,
+        )
+
+        old_config = {"url": "https://example.com/mcp", "headers": {"Authorization": "Bearer old"}}
+        new_config = {"url": "https://example.com/mcp", "headers": {"Authorization": "Bearer new"}}
+
+        existing_server = _make_mock_server("example")
+        existing_server._registered_tool_names = ["mcp__example__tool1"]
+        _servers["example"] = existing_server
+        # No digest recorded (pre-upgrade)
+        assert "example" not in _server_config_digests
+
+        shutdown_called = []
+
+        async def fake_shutdown(self):
+            shutdown_called.append(self.name)
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool.MCPServerTask.shutdown", fake_shutdown), \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=["mcp__example__tool1"]):
+                register_mcp_servers({"example": new_config})
+
+            # Should NOT have shut down the pre-upgrade server
+            assert shutdown_called == []
+            assert _servers["example"] is existing_server
+            # But the digest should now be seeded for future change detection
+            assert _server_config_digests["example"] == _connection_identity(new_config)
+        finally:
+            _servers.pop("example", None)
+            _server_config_digests.pop("example", None)
+
+    def test_digest_stored_on_successful_registration(self):
+        """A newly registered server gets its config digest stored."""
+        from tools.mcp_tool import (
+            _discover_and_register_server, _servers, _server_config_digests,
+            _connection_identity, MCPServerTask,
+        )
+
+        config = {"command": "npx", "args": ["-y", "srv"]}
+
+        async def fake_connect(name, cfg):
+            server = MCPServerTask(name)
+            server.session = MagicMock()
+            server._tools = [_make_mcp_tool("tool1")]
+            return server
+
+        try:
+            with patch("tools.mcp_tool._connect_server", side_effect=fake_connect), \
+                 patch("tools.registry.registry", MagicMock()):
+                asyncio.run(_discover_and_register_server("srv", config))
+
+            assert "srv" in _server_config_digests
+            assert _server_config_digests["srv"] == _connection_identity(config)
+        finally:
+            _servers.pop("srv", None)
+            _server_config_digests.pop("srv", None)
+
+    def test_shutdown_clears_digests(self):
+        """shutdown_mcp_servers clears the digest map."""
+        from tools.mcp_tool import (
+            shutdown_mcp_servers, _servers, _server_config_digests,
+        )
+
+        _servers["x"] = _make_mock_server("x")
+        _server_config_digests["x"] = "abc123"
+
+        try:
+            with patch("tools.mcp_tool._mcp_loop", None), \
+                 patch("tools.mcp_tool._mcp_thread", None):
+                shutdown_mcp_servers()
+
+            assert _server_config_digests == {}
+        finally:
+            _servers.pop("x", None)
+            _server_config_digests.pop("x", None)

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3177,3 +3177,44 @@ class TestRegisterMcpServersCredentialChange:
         finally:
             _servers.pop("x", None)
             _server_config_digests.pop("x", None)
+
+    def test_lazy_registration_evicts_on_config_change(self):
+        """A lazy-registered server whose config changed gets its cache evicted."""
+        from tools.mcp_tool import (
+            register_mcp_servers, _servers, _server_config_digests,
+            _lazy_server_configs, _lazy_server_fingerprints,
+            _lazy_server_tool_names, _connection_identity,
+        )
+
+        old_config = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer old_token"},
+            "lazy": True,
+        }
+        new_config = {
+            "url": "https://example.com/mcp",
+            "headers": {"Authorization": "Bearer new_token"},
+            "lazy": True,
+        }
+
+        # Simulate a lazy-registered server with the old config.
+        _lazy_server_configs["example"] = dict(old_config)
+        _lazy_server_fingerprints["example"] = "fp123"
+        _lazy_server_tool_names["example"] = ["mcp__example__tool1"]
+        _server_config_digests["example"] = _connection_identity(old_config)
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._existing_tool_names", return_value=[]):
+                register_mcp_servers({"example": new_config})
+
+            # Lazy cache should be evicted
+            assert "example" not in _lazy_server_configs
+            assert "example" not in _lazy_server_fingerprints
+            assert "example" not in _lazy_server_tool_names
+            assert "example" not in _server_config_digests
+        finally:
+            _lazy_server_configs.pop("example", None)
+            _lazy_server_fingerprints.pop("example", None)
+            _lazy_server_tool_names.pop("example", None)
+            _server_config_digests.pop("example", None)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -99,6 +99,7 @@ import contextvars
 import concurrent.futures
 import errno
 import fnmatch
+import hashlib
 import inspect
 import json
 import logging
@@ -4215,6 +4216,43 @@ class MCPServerTask:
 _servers: Dict[str, MCPServerTask] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
+
+# Credential-bearing config digest per live server.  When a server's config
+# changes (e.g. rotated token, fixed typo in a header), the digest shifts and
+# ``register_mcp_servers`` tears down the stale session before reconnecting
+# with the new credentials (#92565).  Keyed by server name; a missing entry
+# means "no digest recorded" (pre-upgrade session, left alone).
+_server_config_digests: Dict[str, str] = {}
+
+
+def _connection_identity(config: dict) -> str:
+    """SHA-256 digest of the credential-bearing parts of an MCP server config.
+
+    Two configs that differ only in non-credential fields (e.g. ``timeout``,
+    ``tools``, ``enabled``) produce the **same** digest so the common path
+    pays no extra handshake.  Only the digest is ever stored or logged — never
+    the raw credential values.
+    """
+    payload = {
+        "url": config.get("url"),
+        "command": config.get("command"),
+        "args": [str(a) for a in (config.get("args") or [])],
+        # Header names are case-insensitive on the wire; values are not.
+        "headers": sorted(
+            (k.lower(), v) for k, v in (config.get("headers") or {}).items()
+        ),
+        # POSIX env var names are case-sensitive — do NOT lowercase.
+        "env": sorted(
+            (k, v) for k, v in (config.get("env") or {}).items()
+        ),
+        # identity_header is resolved at connect time and carries per-user
+        # credentials (e.g. profile-mode resolves to the active profile name).
+        "identity_header": config.get("identity_header"),
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
 # Lazy MCP startup (#56832): servers whose tools were registered from the
 # on-disk schema cache without spawning/connecting. Keyed by server name;
 # entries are popped once a real connection is established on first use.
@@ -7204,6 +7242,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         _server_connecting.discard(name)
         _server_connect_errors.pop(name, None)
         _servers[name] = server
+        _server_config_digests[name] = _connection_identity(config)
 
     registered_names = _register_server_tools(name, server, config)
     server._registered_tool_names = list(registered_names)
@@ -7241,6 +7280,47 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     if not servers:
         logger.debug("No explicit MCP servers provided")
         return []
+
+    # Detect servers whose credential-bearing config has changed since the
+    # session was opened (e.g. rotated token, fixed header typo).  These must
+    # be torn down and reconnected with the new credentials (#92565).  A
+    # server with no recorded digest (pre-upgrade) is left alone so that
+    # upgrading does not look like a fault.
+    stale_by_digest: List[MCPServerTask] = []
+    with _lock:
+        for name, cfg in servers.items():
+            if name not in _servers:
+                continue
+            old_digest = _server_config_digests.get(name)
+            if old_digest is None:
+                # Pre-upgrade session — seed the digest so future credential
+                # changes are detected, but don't tear down this session.
+                _server_config_digests[name] = _connection_identity(cfg)
+                continue
+            new_digest = _connection_identity(cfg)
+            if old_digest != new_digest:
+                logger.info(
+                    "MCP server '%s' config changed (digest %s → %s); "
+                    "scheduling reconnect with new credentials",
+                    name, old_digest, new_digest,
+                )
+                stale_by_digest.append(_servers.pop(name))
+                _server_config_digests.pop(name, None)
+                _server_connecting.discard(name)
+                _server_connect_errors.pop(name, None)
+                _clear_connect_failure(name)
+
+    # Shut down stale sessions outside the lock (async, needs the MCP loop).
+    if stale_by_digest:
+        _ensure_mcp_loop()
+        for srv in stale_by_digest:
+            try:
+                _run_on_mcp_loop(srv.shutdown(), timeout=10)
+            except Exception as exc:
+                logger.debug(
+                    "MCP server '%s' shutdown during config-change reap failed: %s",
+                    srv.name, exc,
+                )
 
     # Only attempt servers that aren't already connected (or currently
     # connecting) and are enabled.  Checking ``_server_connecting`` prevents
@@ -7948,6 +8028,7 @@ def shutdown_mcp_servers():
                 )
         with _lock:
             _servers.clear()
+            _server_config_digests.clear()
             # Drop connect-retry cooldowns too: a full shutdown/restart
             # should re-attempt every server immediately, not honour a
             # stale per-server backoff from before the restart (#50394).
@@ -7976,6 +8057,7 @@ def shutdown_mcp_servers():
     with _lock:
         _server_connect_retry_after.clear()
         _server_connect_failures.clear()
+        _server_config_digests.clear()
 
     _stop_mcp_loop()
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7187,6 +7187,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             _lazy_server_configs[name] = dict(config)
             _lazy_server_fingerprints[name] = fingerprint
             _lazy_server_tool_names[name] = list(registered_names)
+            _server_config_digests[name] = _connection_identity(config)
         logger.info(
             "MCP server '%s' (lazy): registered %d tool(s) from schema cache",
             name, len(registered_names),
@@ -7289,26 +7290,47 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     stale_by_digest: List[MCPServerTask] = []
     with _lock:
         for name, cfg in servers.items():
-            if name not in _servers:
-                continue
-            old_digest = _server_config_digests.get(name)
-            if old_digest is None:
-                # Pre-upgrade session — seed the digest so future credential
-                # changes are detected, but don't tear down this session.
-                _server_config_digests[name] = _connection_identity(cfg)
-                continue
-            new_digest = _connection_identity(cfg)
-            if old_digest != new_digest:
-                logger.info(
-                    "MCP server '%s' config changed (digest %s → %s); "
-                    "scheduling reconnect with new credentials",
-                    name, old_digest, new_digest,
-                )
-                stale_by_digest.append(_servers.pop(name))
-                _server_config_digests.pop(name, None)
-                _server_connecting.discard(name)
-                _server_connect_errors.pop(name, None)
-                _clear_connect_failure(name)
+            if name in _servers:
+                # Live session — check digest for credential change.
+                old_digest = _server_config_digests.get(name)
+                if old_digest is None:
+                    # Pre-upgrade session — seed the digest so future
+                    # credential changes are detected, but don't tear
+                    # down this session.
+                    _server_config_digests[name] = _connection_identity(cfg)
+                    continue
+                new_digest = _connection_identity(cfg)
+                if old_digest != new_digest:
+                    logger.info(
+                        "MCP server '%s' config changed (digest %s → %s); "
+                        "scheduling reconnect with new credentials",
+                        name, old_digest, new_digest,
+                    )
+                    stale_by_digest.append(_servers.pop(name))
+                    _server_config_digests.pop(name, None)
+                    _server_connecting.discard(name)
+                    _server_connect_errors.pop(name, None)
+                    _clear_connect_failure(name)
+            elif name in _lazy_server_configs:
+                # Lazy-registered (from schema cache, not yet connected).
+                # If the config changed, evict the stale cache entry so
+                # the server reconnects with fresh credentials on first
+                # tool use (#92565).
+                old_digest = _server_config_digests.get(name)
+                if old_digest is None:
+                    _server_config_digests[name] = _connection_identity(cfg)
+                    continue
+                new_digest = _connection_identity(cfg)
+                if old_digest != new_digest:
+                    logger.info(
+                        "MCP server '%s' (lazy) config changed (digest %s → %s); "
+                        "evicting stale cache entry",
+                        name, old_digest, new_digest,
+                    )
+                    _lazy_server_configs.pop(name, None)
+                    _lazy_server_fingerprints.pop(name, None)
+                    _lazy_server_tool_names.pop(name, None)
+                    _server_config_digests.pop(name, None)
 
     # Shut down stale sessions outside the lock (async, needs the MCP loop).
     if stale_by_digest:
@@ -7317,7 +7339,9 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             try:
                 _run_on_mcp_loop(srv.shutdown(), timeout=10)
             except Exception as exc:
-                logger.debug(
+                # The server is already gone from _servers — a failed shutdown
+                # may leak the subprocess/session, so warn rather than debug.
+                logger.warning(
                     "MCP server '%s' shutdown during config-change reap failed: %s",
                     srv.name, exc,
                 )


### PR DESCRIPTION
## Summary

Fixes #92565. `register_mcp_servers()` tracks live MCP sessions by server name only — once connected, a session is reused regardless of config changes. This means rotated tokens, fixed typos in headers, or changed env vars silently do not take effect until a full restart.

The fix adds a `_connection_identity(config)` function that computes a SHA-256 digest of credential-bearing config parts. Before the name-based reuse filter, the incoming config's digest is compared against the recorded one — if they differ, the stale session is torn down and reconnected with fresh credentials.

## Changes

**`tools/mcp_tool.py`:**
- Added `_connection_identity(config)` — SHA-256 digest of url, command, args, headers, env, identity_header
- Added `_server_config_digests` dict — tracks digest per live server
- In `register_mcp_servers()`: detect digest changes before the name-based filter, shut down stale sessions
- In `_discover_and_register_server()`: store digest on successful registration
- In `shutdown_mcp_servers()`: clear digests on full shutdown

**`tests/tools/test_mcp_tool.py`:**
- `TestConnectionIdentity` (6 tests): digest stability, credential sensitivity, non-credential indifference, case handling
- `TestRegisterMcpServersCredentialChange` (5 tests): reconnect on change, no reconnect when unchanged, pre-upgrade backfill, digest storage, shutdown cleanup

## Design Decisions

- **Pre-upgrade safety:** A session with no recorded digest (opened before this fix) is left alone on first pass but gets seeded so future credential changes are detected.
- **Non-credential fields excluded:** `timeout`, `tools`, `enabled`, etc. don't affect the digest — changing them doesn't trigger reconnect.
- **Header names case-insensitive, env names case-sensitive:** Matches HTTP wire semantics (RFC 7230) and POSIX semantics respectively.
- **`identity_header` included:** Per-user auth headers (static or profile-resolved) are credential-bearing.
- **Separate from `config_fingerprint`:** The schema cache's fingerprint deliberately ignores credentials; this digest deliberately focuses on them.
- **Only digest stored/logged:** Raw credential values never appear in memory maps or log lines.

## Verification

```
$ pytest tests/tools/test_mcp_tool.py -v
============================= 108 passed in 3.23s ==============================
```

## Notes

**Open question:** The `identity_header` with `value_from: "profile"` resolves to the active Hermes profile name at connect time. If a user switches profiles, the digest will change (correctly triggering reconnect). But the digest is computed from the raw config, not the resolved value — so two configs with `value_from: "profile"` but different `value` fields will produce different digests even though the resolved value depends on the runtime profile. This seems correct (the config itself is what changed), but worth noting.

Closes #92565
