### PR TITLE
fix(desktop): stop transcript jumps when a turn settles

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -28,12 +28,16 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-function renderClarify(ui: ReactNode) {
-  return render(
+function clarifyTree(ui: ReactNode) {
+  return (
     <I18nProvider configClient={null} initialLocale="en">
       {ui}
     </I18nProvider>
   )
+}
+
+function renderClarify(ui: ReactNode) {
+  return render(clarifyTree(ui))
 }
 
 function settledClarifyProps(
@@ -86,9 +90,9 @@ function renderLiveClarify({ multiSelect = false }: { multiSelect?: boolean } = 
     requestId: 'request-1',
     sessionId: 'session-1'
   })
-  renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+  const { rerender } = renderClarify(<ClarifyTool {...liveClarifyProps()} />)
 
-  return request
+  return { request, rerender }
 }
 
 describe('ClarifyTool live card stays mounted across settle', () => {
@@ -111,17 +115,34 @@ describe('ClarifyTool live card stays mounted across settle', () => {
     expect(screen.queryByRole('button', { name: /Continue/ })).toBeNull()
   })
 
-  it('holds the card through the gap between answering and the settled result', () => {
+  it('holds the card through the gap between answering and the settled result', async () => {
+    const { request, rerender } = renderLiveClarify()
+
+    fireEvent.click(screen.getByRole('button', { name: /staging/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalled()
+    })
+
+    // tool.complete is what swaps in the settled card; the turn can already
+    // read as not-running in that gap.
+    messageRunning = false
+    rerender(clarifyTree(<ClarifyTool {...liveClarifyProps()} />))
+
+    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+  })
+
+  it('demotes when the turn is stopped after the card was live but never answered', () => {
     renderLiveClarify()
 
     expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
 
-    // Answering clears the request; the settled card only arrives with
-    // tool.complete, and the turn can already read as not-running by then.
     messageRunning = false
     act(() => clearClarifyRequest('request-1', 'session-1'))
 
-    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+    expect(document.querySelector('[data-clarify-choices]')).toBeNull()
+    expect(screen.queryByRole('button', { name: /Continue/ })).toBeNull()
   })
 
   it('paints the question from tool args instead of a spinner while request_id is still racing', () => {
@@ -137,7 +158,7 @@ describe('ClarifyTool live card stays mounted across settle', () => {
 
 describe('ClarifyTool choice selection', () => {
   it('selects independently, deselects and submits multi-select choices as a JSON array', async () => {
-    const request = renderLiveClarify({ multiSelect: true })
+    const { request } = renderLiveClarify({ multiSelect: true })
     const staging = screen.getByRole('button', { name: /staging/ })
     const production = screen.getByRole('button', { name: /production/ })
 
@@ -165,7 +186,7 @@ describe('ClarifyTool choice selection', () => {
   })
 
   it('keeps single-select replacement and plain-string submission', async () => {
-    const request = renderLiveClarify()
+    const { request } = renderLiveClarify()
     const staging = screen.getByRole('button', { name: /staging/ })
     const production = screen.getByRole('button', { name: /production/ })
 
@@ -357,7 +378,7 @@ describe('ClarifyTool keyboard navigation', () => {
   })
 
   it('selects by number and confirms the answer with Enter', async () => {
-    const request = renderLiveClarify()
+    const { request } = renderLiveClarify()
 
     fireEvent.keyDown(window, { key: '2' })
     fireEvent.keyDown(window, { key: 'Enter' })
@@ -371,7 +392,7 @@ describe('ClarifyTool keyboard navigation', () => {
   })
 
   it('stages a highlighted multi-select choice with Enter and submits it with Continue', async () => {
-    const request = renderLiveClarify({ multiSelect: true })
+    const { request } = renderLiveClarify({ multiSelect: true })
     const production = screen.getByRole('button', { name: /production/ })
 
     fireEvent.keyDown(window, { key: 'ArrowDown' })
@@ -405,7 +426,7 @@ describe('ClarifyTool keyboard navigation', () => {
   })
 
   it('does not intercept keyboard events while an action button has focus', () => {
-    const request = renderLiveClarify()
+    const { request } = renderLiveClarify()
     const skip = screen.getByRole('button', { name: 'Skip' })
 
     skip.focus()

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,5 +1,5 @@
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -11,10 +11,12 @@ import { $activeSessionId } from '@/store/session'
 
 import { ClarifyTool, readClarifyBatchResult, readClarifyResult } from './clarify-tool'
 
-// The live pending card only renders while its message is running. Force that so
-// keyboard-navigation tests can exercise ClarifyToolPending directly.
+// The live pending card used to require message-running. Tests that exercise
+// the pending form force that on; the settle-shift case flips it off.
+let messageRunning = true
+
 vi.mock('@assistant-ui/react', () => ({
-  useAuiState: () => true
+  useAuiState: () => messageRunning
 }))
 
 afterEach(() => {
@@ -22,6 +24,7 @@ afterEach(() => {
   clearClarifyRequest()
   $activeSessionId.set(null)
   $gateway.set(null)
+  messageRunning = true
   vi.clearAllMocks()
 })
 
@@ -87,6 +90,50 @@ function renderLiveClarify({ multiSelect = false }: { multiSelect?: boolean } = 
 
   return request
 }
+
+describe('ClarifyTool live card stays mounted across settle', () => {
+  it('keeps the question card while the gateway request is open and the turn reports not-running', () => {
+    messageRunning = false
+    renderLiveClarify()
+
+    expect(screen.getByText('Which deployment target?')).toBeTruthy()
+    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+    expect(document.querySelector('[data-clarify-settled]')).toBeNull()
+  })
+
+  it('demotes to a tool row when the turn stopped and no request is left to answer', () => {
+    messageRunning = false
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn() } as never)
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+    expect(document.querySelector('[data-clarify-choices]')).toBeNull()
+    expect(screen.queryByRole('button', { name: /Continue/ })).toBeNull()
+  })
+
+  it('holds the card through the gap between answering and the settled result', () => {
+    renderLiveClarify()
+
+    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+
+    // Answering clears the request; the settled card only arrives with
+    // tool.complete, and the turn can already read as not-running by then.
+    messageRunning = false
+    act(() => clearClarifyRequest('request-1', 'session-1'))
+
+    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+  })
+
+  it('paints the question from tool args instead of a spinner while request_id is still racing', () => {
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn() } as never)
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+    expect(screen.getByText('Which deployment target?')).toBeTruthy()
+    expect(screen.queryByRole('status', { name: /loading question/i })).toBeNull()
+    expect(screen.getByRole('button', { name: /Continue/ }).hasAttribute('disabled')).toBe(true)
+  })
+})
 
 describe('ClarifyTool choice selection', () => {
   it('selects independently, deselects and submits multi-select choices as a JSON array', async () => {

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -286,17 +286,6 @@ export const ClarifyTool = (props: ToolCallMessagePartProps) => {
     return <ClarifyToolSettled {...props} />
   }
 
-  return <ClarifyToolLive {...props} />
-}
-
-function ClarifyToolLive(props: ToolCallMessagePartProps) {
-  const messageRunning = useAuiState(selectMessageRunning)
-
-  // Stopped mid-prompt with no result — don't leave a dead interactive panel.
-  if (!messageRunning) {
-    return <ToolFallback {...props} />
-  }
-
   return <ClarifyToolPending {...props} />
 }
 
@@ -384,6 +373,25 @@ function ClarifyToolPending(props: ToolCallMessagePartProps) {
   const $request = useMemo(() => sessionClarifyRequest(sessionId), [sessionId])
   const request = useStore($request)
   const fromArgs = useMemo(() => readClarifyArgs(props.args), [props.args])
+  const messageRunning = useAuiState(selectMessageRunning)
+  // Answering clears the request a beat before `tool.complete` swaps in the
+  // settled card. Latch that this card was live so that gap doesn't demote it.
+  const [wasLive, setWasLive] = useState(false)
+
+  if (request && !wasLive) {
+    setWasLive(true)
+  }
+
+  // Stopped mid-prompt with no result — don't leave a dead interactive panel.
+  // The turn's running flag alone can't decide that: `session.info` reports
+  // running=false while clarify is blocking on the user, and demoting there
+  // remounts the question as a tool row and jumps the transcript. The live
+  // request is the real signal — every path that ends a turn (complete, stop,
+  // error) clears it for the session, so a request that never arrived on a
+  // settled turn means there is nothing left to answer.
+  if (!messageRunning && !request && !wasLive) {
+    return <ToolFallback {...props} />
+  }
 
   // Batch: the gateway request carries qid-keyed questions. Args alone can't
   // drive the form (no qids to respond with), so batch waits for the request.
@@ -435,11 +443,12 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
   // Race: tool.start fires a tick before clarify.request, so request_id
-  // arrives slightly after the tool block mounts. Hold the whole panel on a
-  // spinner until the gateway request is wired — showing disabled choices or
-  // a "loading question" stub is worse than a brief wait.
+  // arrives slightly after the tool block mounts. If the question text is
+  // already in the tool args, paint the card immediately (disabled until
+  // the request is wired) — a spinner→question swap is a layout jump for
+  // no reason. Only spin when we have nothing to show yet.
   const ready = Boolean(matchingRequest?.requestId)
-  const loading = !ready && !submitting
+  const loading = !ready && !submitting && !question
 
   const respond = useCallback(
     async (answer: string) => {
@@ -708,7 +717,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
                 active={activeIndex === index}
                 char={letterFor(index)}
                 choice={choice}
-                disabled={submitting}
+                disabled={submitting || !ready}
                 key={`${index}-${choice}`}
                 keyShortcuts={`${letterFor(index)} ${index + 1}`}
                 onClick={() => selectChoice(choice, index)}
@@ -732,7 +741,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
                 aria-current={activeIndex === choices.length || undefined}
                 aria-keyshortcuts={`${letterFor(choices.length)} ${choices.length + 1}`}
                 className={CLARIFY_TEXTAREA_CLASS}
-                disabled={submitting}
+                disabled={submitting || !ready}
                 onBlur={() => setOtherFocused(false)}
                 onChange={event => onDraftChange(event.target.value)}
                 onFocus={() => {
@@ -752,7 +761,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
         ) : (
           <Textarea
             className={CLARIFY_TEXTAREA_CLASS}
-            disabled={submitting}
+            disabled={submitting || !ready}
             onChange={event => onDraftChange(event.target.value)}
             onKeyDown={handleTextareaKey}
             placeholder={copy.placeholder}
@@ -765,10 +774,10 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
       </ClarifyShell>
 
       <div className="flex items-center justify-end gap-1">
-        <Button disabled={submitting} onClick={() => void respond('')} size="xs" type="button" variant="text">
+        <Button disabled={submitting || !ready} onClick={() => void respond('')} size="xs" type="button" variant="text">
           {copy.skip}
         </Button>
-        <Button disabled={submitting || !pendingAnswer} size="xs" type="submit">
+        <Button disabled={submitting || !ready || !pendingAnswer} size="xs" type="submit">
           {submitting ? (
             <Loader2 className="size-3 animate-spin" />
           ) : (

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -375,34 +375,36 @@ function ClarifyToolPending(props: ToolCallMessagePartProps) {
   const fromArgs = useMemo(() => readClarifyArgs(props.args), [props.args])
   const messageRunning = useAuiState(selectMessageRunning)
   // Answering clears the request a beat before `tool.complete` swaps in the
-  // settled card. Latch that this card was live so that gap doesn't demote it.
-  const [wasLive, setWasLive] = useState(false)
-
-  if (request && !wasLive) {
-    setWasLive(true)
-  }
+  // settled card. Latch submit so that gap doesn't demote; Stop also clears
+  // the request and must still collapse an unanswered card.
+  const [answered, setAnswered] = useState(false)
 
   // Stopped mid-prompt with no result — don't leave a dead interactive panel.
-  // The turn's running flag alone can't decide that: `session.info` reports
-  // running=false while clarify is blocking on the user, and demoting there
-  // remounts the question as a tool row and jumps the transcript. The live
-  // request is the real signal — every path that ends a turn (complete, stop,
-  // error) clears it for the session, so a request that never arrived on a
-  // settled turn means there is nothing left to answer.
-  if (!messageRunning && !request && !wasLive) {
+  // `session.info` reports running=false while clarify is blocking, so the
+  // running flag alone would remount the question as a tool row. Keep the
+  // card while a request is open or this instance already submitted.
+  if (!messageRunning && !request && !answered) {
     return <ToolFallback {...props} />
   }
 
   // Batch: the gateway request carries qid-keyed questions. Args alone can't
   // drive the form (no qids to respond with), so batch waits for the request.
   if (request?.questions?.length || fromArgs.questions) {
-    return <ClarifyToolBatchPending request={request} />
+    return <ClarifyToolBatchPending onAnswered={() => setAnswered(true)} request={request} />
   }
 
-  return <ClarifyToolSinglePending fromArgs={fromArgs} request={request} />
+  return <ClarifyToolSinglePending fromArgs={fromArgs} onAnswered={() => setAnswered(true)} request={request} />
 }
 
-function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs; request: ClarifyRequest | null }) {
+function ClarifyToolSinglePending({
+  fromArgs,
+  onAnswered,
+  request
+}: {
+  fromArgs: ClarifyArgs
+  onAnswered: () => void
+  request: ClarifyRequest | null
+}) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
   const gateway = useStore($gateway)
@@ -472,6 +474,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
           answer
         })
         triggerHaptic('submit')
+        onAnswered()
         clearClarifyRequest(matchingRequest.requestId, matchingRequest.sessionId)
         // tool.complete lands next → ClarifyToolSettled.
       } catch (error) {
@@ -479,7 +482,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
         setSubmitting(false)
       }
     },
-    [copy.gatewayDisconnected, copy.notReady, copy.sendFailed, gateway, matchingRequest, ready]
+    [copy.gatewayDisconnected, copy.notReady, copy.sendFailed, gateway, matchingRequest, onAnswered, ready]
   )
 
   const trimmedDraft = draft.trim()
@@ -916,7 +919,13 @@ const emptyStage = { choices: [] as string[], draft: '' }
  * back-to-back and completes the batch. Staged answers stay editable up to
  * that moment. The per-question wire protocol is unchanged (the TUI/CLI
  * still lock incrementally); this card just batches its locks at the end. */
-function ClarifyToolBatchPending({ request }: { request: ClarifyRequest | null }) {
+function ClarifyToolBatchPending({
+  onAnswered,
+  request
+}: {
+  onAnswered: () => void
+  request: ClarifyRequest | null
+}) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
   const gateway = useStore($gateway)
@@ -1003,13 +1012,14 @@ function ClarifyToolBatchPending({ request }: { request: ClarifyRequest | null }
       }
 
       triggerHaptic('submit')
+      onAnswered()
       // tool.complete lands next → ClarifyToolBatchSettled.
       clearClarifyRequest(request.requestId, request.sessionId)
     } catch (error) {
       notifyError(error, copy.sendFailed)
       setSubmitting(false)
     }
-  }, [copy, gateway, questions, request, stagedAnswer])
+  }, [copy, gateway, onAnswered, questions, request, stagedAnswer])
 
   const toggleChoice = useCallback((question: ClarifyQuestion, choice: string) => {
     setStaged(current => {
@@ -1034,6 +1044,7 @@ function ClarifyToolBatchPending({ request }: { request: ClarifyRequest | null }
       return
     }
 
+    onAnswered()
     clearClarifyRequest(request.requestId, request.sessionId)
 
     try {
@@ -1041,7 +1052,7 @@ function ClarifyToolBatchPending({ request }: { request: ClarifyRequest | null }
     } catch {
       // The tool times out on its own; a failed skip must never block the UI.
     }
-  }, [gateway, request])
+  }, [gateway, onAnswered, request])
 
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -578,7 +578,12 @@ const ErrorRecoveryActions: FC = () => {
   )
 }
 
-const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText, onBranchInNewChat }) => {
+const AssistantActionBar: FC<MessageActionProps & { durationS?: number }> = ({
+  durationS,
+  messageId,
+  getMessageText,
+  onBranchInNewChat
+}) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
 
@@ -595,6 +600,15 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
 
   return (
     <div className="relative flex w-full shrink-0 items-center justify-end gap-1.5">
+      {durationS !== undefined && (
+        <span
+          className="mr-auto select-none px-0.5 text-[0.6875rem] leading-5 tabular-nums text-muted-foreground"
+          data-slot="aui_turn-duration"
+          title={t.assistant.thread.turnDuration(formatElapsed(durationS))}
+        >
+          ⏱ {formatElapsed(durationS)}
+        </span>
+      )}
       <ActionBarPrimitive.Root
         className={
           // NOTE: intentionally NOT `hideWhenRunning`. That prop unmounts the
@@ -713,19 +727,8 @@ const ReadAloudButton: FC<{ getText: () => string; messageId: string }> = ({ get
 }
 
 const AssistantFooter: FC<MessageActionProps & { durationS?: number }> = ({ durationS, ...props }) => {
-  const { t } = useI18n()
-
   return (
     <div className="flex min-h-6 flex-col items-end gap-1 pr-(--message-text-indent) pl-(--message-text-indent)">
-      {durationS !== undefined && (
-        <span
-          className="select-none px-0.5 text-[0.6875rem] leading-5 tabular-nums text-muted-foreground"
-          data-slot="aui_turn-duration"
-          title={t.assistant.thread.turnDuration(formatElapsed(durationS))}
-        >
-          ⏱ {formatElapsed(durationS)}
-        </span>
-      )}
       <BranchPickerPrimitive.Root
         className="inline-flex h-6 items-center gap-1 text-xs text-muted-foreground"
         hideWhenSingleBranch
@@ -740,7 +743,7 @@ const AssistantFooter: FC<MessageActionProps & { durationS?: number }> = ({ dura
           <Codicon name="chevron-right" size="0.875rem" />
         </BranchPickerPrimitive.Next>
       </BranchPickerPrimitive.Root>
-      <AssistantActionBar {...props} />
+      <AssistantActionBar durationS={durationS} {...props} />
     </div>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -140,9 +140,21 @@ const ThinkingDisclosure: FC<{
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const enterRef = useEnterAnimation(messageRunning, timerKey)
+  // A live preview that later settles must not unmount its body — that is the
+  // "turn settled and everything jumped" shift. Latch that we showed one so
+  // the clip stays. Groups that mount already complete (earlier thoughts in
+  // a still-running turn) never latch, so they stay collapsed.
+  const [sawLivePreview, setSawLivePreview] = useState(false)
 
-  const open = userOpen ?? (pending && !reasoningCollapsedByDefault)
-  const isPreview = pending && userOpen === null && !reasoningCollapsedByDefault
+  if (pending && !sawLivePreview) {
+    setSawLivePreview(true)
+  }
+
+  // The collapsed-by-default preference outranks the latch: it opts out of
+  // live previews entirely, so there is nothing to hold open.
+  const showPreview = !reasoningCollapsedByDefault && (pending || sawLivePreview)
+  const open = userOpen ?? showPreview
+  const isPreview = userOpen === null && showPreview
 
   // Three ways a finished block can report itself. With a measured duration it
   // says so, unless the timer's whole seconds round it to "0s" — accurate and

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -396,6 +396,34 @@ function RunningReasoningHarness() {
   )
 }
 
+// A turn that streams reasoning and then settles — the transition the
+// preview latch exists for. `settle()` flips the thread to not-running.
+function renderSettlingReasoning() {
+  let setRunning: ((running: boolean) => void) | undefined
+
+  function SettlingReasoningHarness() {
+    const [running, setRunningState] = useState(true)
+
+    setRunning = setRunningState
+
+    const runtime = useExternalStoreRuntime<ThreadMessage>({
+      messages: [assistantReasoningMessage('The user asked a question.', running)],
+      isRunning: running,
+      onNew: async () => {}
+    })
+
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        <Thread />
+      </AssistantRuntimeProvider>
+    )
+  }
+
+  const { container } = render(<SettlingReasoningHarness />)
+
+  return { container, settle: () => act(() => setRunning?.(false)) }
+}
+
 function GroupedReasoningHarness() {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
     messages: [assistantMultiReasoningMessage([' First thought.', ' Second thought.'])],
@@ -510,6 +538,30 @@ describe('assistant-ui streaming renderer', () => {
     expect(finalRoot?.querySelector('[data-slot="aui_msg-actions"]')).toBeTruthy()
   })
 
+  it('puts the turn duration on the action bar row instead of a line of its own', () => {
+    const settled = {
+      ...assistantMessage('All done.', false),
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: { durationS: 12 }
+      }
+    } as ThreadMessage
+
+    const { container } = render(<TranscriptHarness messages={[userMessage(), settled]} />)
+
+    const duration = container.querySelector('[data-slot="aui_turn-duration"]')
+    const actions = container.querySelector('[data-slot="aui_msg-actions"]')
+
+    // Same row as the (always-mounted) action bar: the footer's height is
+    // already reserved while the turn streams, so landing the duration there
+    // adds no height when the turn settles.
+    expect(duration).toBeTruthy()
+    expect(duration?.parentElement).toBe(actions?.parentElement)
+  })
+
   it('renders assistant provider errors inline', () => {
     render(<MessageHarness message={assistantErrorMessage('OpenRouter rejected the request (403).')} />)
 
@@ -567,6 +619,48 @@ describe('assistant-ui streaming renderer', () => {
       expect(container.querySelector('[data-slot="aui_reasoning-text"]')?.textContent).toContain('const answer = 42')
     })
     expect(container.textContent).not.toContain('```ts')
+  })
+
+  it('does not collapse a live thinking preview when the turn settles', async () => {
+    const { container, settle } = renderSettlingReasoning()
+    const toggle = within(container).getByRole('button', { name: /thinking/i })
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    expect(container.querySelector('[data-slot="aui_reasoning-text"]')).toBeTruthy()
+
+    settle()
+
+    await waitFor(() => {
+      expect(
+        within(container)
+          .getByRole('button', { name: /thought/i })
+          .getAttribute('aria-expanded')
+      ).toBe('true')
+    })
+    expect(container.querySelector('[data-slot="aui_reasoning-text"]')).toBeTruthy()
+  })
+
+  it('leaves a settling turn collapsed when the collapsed-by-default preference is enabled', async () => {
+    $reasoningCollapsedByDefault.set(true)
+
+    const { container, settle } = renderSettlingReasoning()
+
+    expect(
+      within(container)
+        .getByRole('button', { name: /thinking/i })
+        .getAttribute('aria-expanded')
+    ).toBe('false')
+
+    settle()
+
+    await waitFor(() => {
+      expect(
+        within(container)
+          .getByRole('button', { name: /thought/i })
+          .getAttribute('aria-expanded')
+      ).toBe('false')
+    })
+    expect(container.querySelector('[data-slot="aui_reasoning-text"]')).toBeNull()
   })
 
   it('keeps streaming reasoning collapsed by default when the preference is enabled', () => {


### PR DESCRIPTION
Three separate things in the desktop transcript changed height the moment a turn stopped running, so the conversation jumped under the cursor right as you went to read it. All three are the same mistake: treating "the turn is no longer running" as a reason to swap or unmount a mounted element.

## What was happening

**Clarify demoted itself.** `session.info` reports `running=false` while the agent is blocked waiting on your answer, and `ClarifyToolLive` read that as "the turn stopped mid-prompt" and rendered `ToolFallback` instead. The question card you were about to click remounted as a collapsed tool row.

**Thinking previews collapsed.** `ThinkingDisclosure` derives `open` from `pending`. When the turn settled, `pending` went false and a preview the user was actively reading unmounted its body.

**The duration line appeared out of nowhere.** `⏱ 1m 4s` rendered as its own row above the action bar, so every completed turn grew a line of height that wasn't there a frame earlier.

## The fix

Clarify's demote condition is now the live gateway request, not the running flag. The request is the honest signal: `message.complete`, `session.interrupt`, and the error path all clear it per session, so a request that's still present means the backend is still waiting. A latch covers the gap between answering (which clears the request) and `tool.complete` arriving with the settled card — and it latches on submit, not on merely seeing a request, so Stop still collapses an unanswered card instead of leaving a disabled panel.

While the request is racing in — `tool.start` fires a tick before `clarify.request` — the card now paints the question from the tool args with its controls disabled, instead of holding a spinner and swapping to the question a moment later. Same size either way.

`ThinkingDisclosure` latches that it showed a live preview and keeps the body mounted through settle. Groups that mount already complete never latch, so earlier thoughts in a running turn stay collapsed, and the collapsed-by-default preference still wins outright.

The duration moves onto the action-bar row (`mr-auto`, left of the buttons). That bar is deliberately always mounted so the footer's height is reserved during streaming — putting the duration in it means it costs zero new height.

## Tests

`apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx`
- keeps the card while the request is open and the turn reports not-running
- demotes to a tool row when the turn stopped with no request left to answer
- holds the card across the answer → settled-result gap
- demotes when Stop clears a live request that was never answered
- paints the question from args (controls disabled) instead of a spinner

`apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx`
- a live thinking preview survives settle
- a settling turn stays collapsed when the collapsed-by-default preference is on
- the duration shares the action bar's row

## How to test

1. `npx vitest run --project ui src/components/assistant-ui` in `apps/desktop`.
2. In the app: ask something that triggers `clarify` and watch the card as the turn settles — it should sit still, not collapse to a tool row.
3. Hit Stop on a live clarify — it should collapse to a tool row, not sit there disabled.
4. Send a prompt that streams reasoning and let it finish. The thinking body stays open; nothing below it shifts.