### PR TITLE
fix(desktop): quit remote sessions on first request

### DIFF
--- a/apps/desktop/electron/backend-connection-state.test.ts
+++ b/apps/desktop/electron/backend-connection-state.test.ts
@@ -105,3 +105,19 @@ test('an invalidated attempt cannot attach a late-spawned process', () => {
   assert.equal(state.attachProcess(staleAttempt, { id: 'late' }), null)
   assert.equal(state.getProcess(), null)
 })
+
+test('distinguishes a pending connection attempt from a cached settled descriptor', async () => {
+  const state = createBackendConnectionState<FakeProcess, string>()
+  const connection = deferred<string>()
+  const attempt = state.startAttempt()
+
+  state.setPromise(attempt, connection.promise)
+  assert.equal(state.getPendingPromise(), connection.promise)
+
+  connection.resolve('https://remote.example')
+  await connection.promise
+  await Promise.resolve()
+
+  assert.equal(state.getPromise(), connection.promise)
+  assert.equal(state.getPendingPromise(), null)
+})

--- a/apps/desktop/electron/backend-connection-state.ts
+++ b/apps/desktop/electron/backend-connection-state.ts
@@ -12,6 +12,7 @@ export function createBackendConnectionState<TProcess, TConnection>() {
   let generation = 0
   let process: TProcess | null = null
   let promise: Promise<TConnection> | null = null
+  let pendingPromise: Promise<TConnection> | null = null
 
   return {
     startAttempt(): BackendConnectionAttempt<TConnection> {
@@ -25,6 +26,20 @@ export function createBackendConnectionState<TProcess, TConnection>() {
 
       attempt.promise = nextPromise
       promise = nextPromise
+      pendingPromise = nextPromise
+
+      void nextPromise.then(
+        () => {
+          if (attempt.generation === generation && promise === nextPromise) {
+            pendingPromise = null
+          }
+        },
+        () => {
+          if (attempt.generation === generation && promise === nextPromise) {
+            pendingPromise = null
+          }
+        }
+      )
 
       return true
     },
@@ -53,6 +68,7 @@ export function createBackendConnectionState<TProcess, TConnection>() {
 
       process = null
       promise = null
+      pendingPromise = null
 
       return true
     },
@@ -63,6 +79,7 @@ export function createBackendConnectionState<TProcess, TConnection>() {
       }
 
       promise = null
+      pendingPromise = null
 
       return true
     },
@@ -75,12 +92,17 @@ export function createBackendConnectionState<TProcess, TConnection>() {
       return promise
     },
 
+    getPendingPromise(): Promise<TConnection> | null {
+      return pendingPromise
+    },
+
     invalidate(): TProcess | null {
       const currentProcess = process
 
       generation += 1
       process = null
       promise = null
+      pendingPromise = null
 
       return currentProcess
     }

--- a/apps/desktop/electron/backend-ownership.test.ts
+++ b/apps/desktop/electron/backend-ownership.test.ts
@@ -269,8 +269,8 @@ test('shutdown coordinator returns one promise and awaits teardown exactly once'
 
   assert.equal(first, second)
   assert.equal(coordinator.hasStarted(), true)
-  await Promise.resolve()
   assert.equal(teardown.mock.calls.length, 1)
+  assert.equal(coordinator.isPending(), true)
 
   let finished = false
   first.then(() => {
@@ -282,6 +282,7 @@ test('shutdown coordinator returns one promise and awaits teardown exactly once'
   completion.resolve()
   await second
   assert.equal(finished, true)
+  assert.equal(coordinator.isPending(), false)
   assert.equal(coordinator.run(), first)
 })
 

--- a/apps/desktop/electron/backend-ownership.ts
+++ b/apps/desktop/electron/backend-ownership.ts
@@ -293,17 +293,36 @@ export function backendCommandMatches(command: unknown): boolean {
 /** Coordinates all quit paths so asynchronous backend teardown runs once. */
 export function createBackendShutdownCoordinator(teardown: () => Promise<void> | void) {
   let completion: Promise<void> | undefined
+  let settled = false
 
   return {
     run(): Promise<void> {
       if (!completion) {
-        completion = Promise.resolve().then(teardown)
+        try {
+          // Invoke synchronously so no-wait quit paths still invalidate cached
+          // connection state and stop timers before Electron exits.
+          completion = Promise.resolve(teardown())
+        } catch (error) {
+          completion = Promise.reject(error)
+        }
+
+        void completion.then(
+          () => {
+            settled = true
+          },
+          () => {
+            settled = true
+          }
+        )
       }
 
       return completion
     },
     hasStarted(): boolean {
       return completion !== undefined
+    },
+    isPending(): boolean {
+      return completion !== undefined && !settled
     }
   }
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -249,6 +249,7 @@ import {
 } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { backendQuitNeedsWait, createQuitTeardownCoordinator } from './quit-teardown'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   RemoteLivenessTracker,
@@ -9050,9 +9051,6 @@ const desktopInstallationId = loadOrCreateInstallationId(DESKTOP_INSTALLATION_PA
 
 const sshBootstrapCoordinator = createBootstrapCoordinator()
 
-let sshQuitTeardownDone = false
-let backendQuitTeardownDone = false
-
 function sshScopeKey(profile) {
   return connectionScopeKey(profile) || ''
 }
@@ -10480,6 +10478,7 @@ function stopAllPoolBackends() {
 }
 
 const backendShutdown = createBackendShutdownCoordinator(async () => {
+  const pendingConnection = backendConnectionState.getPendingPromise()
   const primary = backendConnectionState.invalidate()
 
   stopBackendChild(primary)
@@ -10490,8 +10489,28 @@ const backendShutdown = createBackendShutdownCoordinator(async () => {
     poolIdleReaper = null
   }
 
-  await Promise.all([waitForBackendExit(primary), pooledStops])
+  const pendingConnectionSettled = pendingConnection?.then(
+    () => undefined,
+    () => undefined
+  )
+
+  await Promise.all([waitForBackendExit(primary), pooledStops, pendingConnectionSettled])
 })
+
+const quitTeardown = createQuitTeardownCoordinator(() => app.quit())
+
+async function teardownSshForQuit() {
+  sshBootstrapCoordinator.cancelAll()
+  const scopes = [...sshConnections.keys()]
+
+  const pending = Promise.allSettled([
+    ...scopes.map(scope => teardownSshConnection(scope || null)),
+    ...sshBootstrapCoordinator.promises()
+  ])
+
+  await Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))])
+  await sshBootstrapCoordinator.forceCleanupAll()
+}
 
 async function exitAfterBackendShutdown(code) {
   await backendShutdown.run()
@@ -15199,29 +15218,22 @@ app.on('before-quit', event => {
     return
   }
 
-  if (!backendQuitTeardownDone) {
-    event.preventDefault()
-    void backendShutdown.run().finally(() => {
-      backendQuitTeardownDone = true
-      app.quit()
-    })
+  const backendNeedsWait = backendQuitNeedsWait({
+    connectionPending: backendConnectionState.getPendingPromise() !== null,
+    poolPending: poolStopper.hasPending(),
+    processAttached: backendConnectionState.getProcess() !== null,
+    shutdownPending: backendShutdown.isPending()
+  })
+
+  const sshNeedsWait = sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0
+  const teardownTasks = [{ run: () => backendShutdown.run(), waitForCompletion: backendNeedsWait }]
+
+  if (sshNeedsWait) {
+    teardownTasks.push({ run: teardownSshForQuit, waitForCompletion: true })
   }
 
-  if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
+  if (quitTeardown.begin(teardownTasks)) {
     event.preventDefault()
-    sshBootstrapCoordinator.cancelAll()
-    const scopes = [...sshConnections.keys()]
-
-    const pending = Promise.allSettled([
-      ...scopes.map(scope => teardownSshConnection(scope || null)),
-      ...sshBootstrapCoordinator.promises()
-    ])
-
-    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))]).then(async () => {
-      await sshBootstrapCoordinator.forceCleanupAll()
-      sshQuitTeardownDone = true
-      app.quit()
-    })
   }
 
   // Clean quit mid-boot should not trip next-launch --no-sandbox (#38216).
@@ -15278,8 +15290,6 @@ app.on('before-quit', event => {
   // Kill open PTYs before environment teardown to avoid the node-pty#904
   // ThreadSafeFunction SIGABRT race.
   terminalIpc.disposeAllTerminalSessions()
-
-  void backendShutdown.run()
 })
 
 app.on('window-all-closed', () => {

--- a/apps/desktop/electron/pool-stop.test.ts
+++ b/apps/desktop/electron/pool-stop.test.ts
@@ -89,6 +89,14 @@ test('stop of an unknown key resolves without signalling anything', async () => 
   assert.equal(stopper.inFlight('ghost'), undefined)
 })
 
+test('a remote pooled descriptor without a local child does not require quit deferral', () => {
+  const { pool, stopper } = harness()
+
+  pool.set('remote', {})
+
+  assert.equal(stopper.hasPending(), false)
+})
+
 test('stopAll stops every pooled backend and resolves after all exits', async () => {
   const { addChild, exitResolvers, pool, stopper } = harness()
   const a = addChild('a')
@@ -111,6 +119,31 @@ test('stopAll stops every pooled backend and resolves after all exits', async ()
   exitResolvers.get(b)?.()
   await all
   assert.equal(settled, true)
+})
+
+test('stopAll joins a stop whose pool entry was already evicted', async () => {
+  const { addChild, exitResolvers, pool, stopper } = harness()
+  const child = addChild('already-stopping')
+
+  const first = stopper.stop('already-stopping')
+
+  assert.equal(pool.size, 0)
+  assert.equal(stopper.hasPending(), true)
+
+  let settled = false
+
+  const all = stopper.stopAll().then(() => {
+    settled = true
+  })
+
+  await Promise.resolve()
+
+  assert.equal(settled, false)
+
+  exitResolvers.get(child)?.()
+  await Promise.all([first, all])
+  assert.equal(settled, true)
+  assert.equal(stopper.hasPending(), false)
 })
 
 test('a respawn can await the in-flight stop before reusing the key', async () => {

--- a/apps/desktop/electron/pool-stop.ts
+++ b/apps/desktop/electron/pool-stop.ts
@@ -38,9 +38,11 @@ export interface PoolStopperDeps {
 export interface PoolStopper {
   /** The in-flight stop for a key, if any — await before respawning it. */
   inFlight: (key: string) => Promise<void> | undefined
+  /** Whether the pool has a local child or an already-evicted stop in flight. */
+  hasPending: () => boolean
   /** Stop one pooled backend; concurrent calls share the same promise. */
   stop: (key: string) => Promise<void>
-  /** Stop every pooled backend currently in the pool. */
+  /** Stop every pooled backend and join stops already in flight. */
   stopAll: () => Promise<void>
 }
 
@@ -78,9 +80,12 @@ export function createPoolStopper(deps: PoolStopperDeps): PoolStopper {
 
   return {
     inFlight: key => stops.get(key),
+    hasPending: () => stops.size > 0 || [...deps.pool.values()].some(entry => entry.process != null),
     stop,
     stopAll: async () => {
-      await Promise.all([...deps.pool.keys()].map(stop))
+      const currentStops = [...deps.pool.keys()].map(stop)
+
+      await Promise.all(new Set([...stops.values(), ...currentStops]))
     }
   }
 }

--- a/apps/desktop/electron/quit-teardown.test.ts
+++ b/apps/desktop/electron/quit-teardown.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { backendQuitNeedsWait, createQuitTeardownCoordinator } from './quit-teardown'
+
+function deferred() {
+  let resolve!: () => void
+
+  const promise = new Promise<void>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+test('remote-only cleanup does not cancel the original quit', () => {
+  const cleanup = vi.fn()
+  const requestFinalQuit = vi.fn()
+  const coordinator = createQuitTeardownCoordinator(requestFinalQuit)
+
+  const shouldPrevent = coordinator.begin([{ run: cleanup, waitForCompletion: false }])
+
+  assert.equal(shouldPrevent, false)
+  assert.equal(cleanup.mock.calls.length, 1)
+  assert.equal(requestFinalQuit.mock.calls.length, 0)
+})
+
+test('a settled remote descriptor is not backend work that requires a deferred quit', () => {
+  assert.equal(
+    backendQuitNeedsWait({
+      connectionPending: false,
+      poolPending: false,
+      processAttached: false,
+      shutdownPending: false
+    }),
+    false
+  )
+
+  for (const key of ['connectionPending', 'poolPending', 'processAttached', 'shutdownPending'] as const) {
+    assert.equal(
+      backendQuitNeedsWait({
+        connectionPending: false,
+        poolPending: false,
+        processAttached: false,
+        shutdownPending: false,
+        [key]: true
+      }),
+      true,
+      `${key} must defer quit`
+    )
+  }
+})
+
+test('one final quit waits for every required teardown branch', async () => {
+  const backend = deferred()
+  const ssh = deferred()
+  const requestFinalQuit = vi.fn()
+  const backendRun = vi.fn(() => backend.promise)
+  const sshRun = vi.fn(() => ssh.promise)
+  const coordinator = createQuitTeardownCoordinator(requestFinalQuit)
+
+  const tasks = [
+    { run: backendRun, waitForCompletion: true },
+    { run: sshRun, waitForCompletion: true }
+  ]
+
+  assert.equal(coordinator.begin(tasks), true)
+
+  assert.equal(coordinator.begin(tasks), true, 'a re-entrant quit stays deferred while teardown is pending')
+  assert.equal(backendRun.mock.calls.length, 1)
+  assert.equal(sshRun.mock.calls.length, 1)
+
+  backend.resolve()
+  await Promise.resolve()
+  assert.equal(requestFinalQuit.mock.calls.length, 0)
+
+  ssh.resolve()
+  await Promise.all([backend.promise, ssh.promise])
+  await Promise.resolve()
+  assert.equal(requestFinalQuit.mock.calls.length, 1)
+
+  assert.equal(coordinator.begin(tasks), false, 'the coordinator must not cancel its own final quit')
+  assert.equal(backendRun.mock.calls.length, 1)
+  assert.equal(sshRun.mock.calls.length, 1)
+})
+
+test('teardown failure still releases the final quit after all branches settle', async () => {
+  const requestFinalQuit = vi.fn()
+  const coordinator = createQuitTeardownCoordinator(requestFinalQuit)
+
+  assert.equal(
+    coordinator.begin([
+      {
+        run: () => {
+          throw new Error('cleanup failed')
+        },
+        waitForCompletion: true
+      }
+    ]),
+    true
+  )
+
+  await Promise.resolve()
+  await Promise.resolve()
+  assert.equal(requestFinalQuit.mock.calls.length, 1)
+})

--- a/apps/desktop/electron/quit-teardown.ts
+++ b/apps/desktop/electron/quit-teardown.ts
@@ -1,0 +1,75 @@
+export interface QuitTeardownTask {
+  /** Whether Electron must defer this quit until the task settles. */
+  waitForCompletion: boolean
+  /** Starts teardown. This is invoked synchronously from before-quit. */
+  run: () => Promise<unknown> | unknown
+}
+
+export interface QuitTeardownCoordinator {
+  /**
+   * Starts teardown once and reports whether the current quit must be
+   * prevented. Re-entrant quit requests are held until all required teardown
+   * settles; the coordinator then requests exactly one final quit.
+   */
+  begin: (tasks: readonly QuitTeardownTask[]) => boolean
+}
+
+export interface BackendQuitActivity {
+  connectionPending: boolean
+  poolPending: boolean
+  processAttached: boolean
+  shutdownPending: boolean
+}
+
+export function backendQuitNeedsWait(activity: BackendQuitActivity): boolean {
+  return activity.shutdownPending || activity.processAttached || activity.connectionPending || activity.poolPending
+}
+
+function runTask(task: QuitTeardownTask): Promise<unknown> {
+  try {
+    return Promise.resolve(task.run())
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}
+
+/**
+ * Coordinates Electron's before-quit teardown without cancelling a quit that
+ * has no asynchronous work to wait for.
+ */
+export function createQuitTeardownCoordinator(requestFinalQuit: () => void): QuitTeardownCoordinator {
+  let completion: Promise<void> | null = null
+  let finished = false
+
+  return {
+    begin(tasks): boolean {
+      if (finished) {
+        return false
+      }
+
+      if (completion) {
+        return true
+      }
+
+      const executions = tasks.map(task => ({ promise: runTask(task), waitForCompletion: task.waitForCompletion }))
+      const mustWait = executions.some(task => task.waitForCompletion)
+
+      if (!mustWait) {
+        // Even no-wait cleanup may return a promise. Observe all outcomes so a
+        // late rejection cannot become unhandled, but let Electron continue
+        // the original quit synchronously.
+        void Promise.allSettled(executions.map(task => task.promise))
+        finished = true
+
+        return false
+      }
+
+      completion = Promise.allSettled(executions.map(task => task.promise)).then(() => {
+        finished = true
+        requestFinalQuit()
+      })
+
+      return true
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the macOS Desktop path where a remote-only session can require two Quit requests before the app process leaves the Dock.

`before-quit` currently prevents every first Quit so it can await `backendShutdown.run()`, even when the active connection is a settled remote descriptor and Desktop owns no local backend process. This change distinguishes cached connection state from teardown work, starts no-wait cleanup synchronously, and lets Electron continue the original Quit when there is nothing asynchronous to drain.

When real work exists, one re-entrant barrier now waits for all backend and SSH teardown branches before requesting exactly one final Quit. This also closes two sibling lifecycle gaps: pending connection startup is tracked separately from a settled descriptor, and pool-wide shutdown joins already-evicted stops still in flight.

This builds on the single-barrier direction explored by @spfcraze in #76755 and the broader teardown work from @ChanPark03 in #82461, adapted to current `main` and the exact settled-remote/no-local-work path. #82461 currently validates two rapid Quit requests and does not cover allowing the original no-work Quit to proceed.

## Related Issue

No public issue. Related prior work: #76755 and #82461.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a dependency-injected quit-teardown coordinator that only defers Electron Quit when a task has real asynchronous work.
- Track unresolved backend connection attempts separately from cached, settled connection descriptors.
- Start backend shutdown synchronously so no-wait Quit still invalidates connection state and clears timers before exit.
- Coordinate backend and SSH teardown behind one final re-entrant Quit.
- Make pool shutdown join already-evicted stops while ignoring remote descriptors that own no local child process for wait decisions.
- Add behavioral regression coverage for remote-only first Quit, pending teardown, re-entrant Quit, cleanup failure, and pooled-stop joining.

## How to Test

1. Configure Desktop to use a remote dashboard backend and let the connection settle. Ensure there is no local managed backend, pooled local child, pending connection attempt, or SSH tunnel.
2. On macOS, choose **Hermes > Quit Hermes** or press `Cmd+Q` once.
3. Confirm the Hermes process exits and the Dock indicator disappears after that single request.
4. Run the focused Electron regression suite:

   ```bash
   npm --prefix apps/desktop run test:desktop:platforms -- electron/quit-teardown.test.ts electron/backend-connection-state.test.ts electron/backend-ownership.test.ts electron/pool-stop.test.ts
   ```

5. Run Desktop type checking and lint for the changed Electron files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run: this is an Electron/TypeScript-only change; focused Vitest and TypeScript checks passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 focused Electron tests, type checking, and lint; exact packaged macOS runtime smoke test remains pending

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused validation on Windows 11:

```text
Test Files  4 passed (4)
Tests       34 passed (34)
```

- `npm --prefix apps/desktop run typecheck`: passed
- `tsc -p apps/desktop/tsconfig.electron.json --noEmit`: passed
- ESLint on all changed Electron files: passed
- `git diff --check`: passed
