### PR TITLE
config: stop dropping per-provider max_output_tokens

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1393,6 +1393,12 @@ def _normalize_custom_provider_entry(
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
         "ssl_ca_cert", "ssl_verify",
+        # Per-provider output cap. runtime_provider._lift_max_output_tokens
+        # reads these off a custom_providers entry, but they were missing
+        # here, so the normalizer dropped them before the lifter ran: the
+        # setting silently did nothing and every startup logged
+        # "unknown config keys ignored: max_output_tokens".
+        "max_output_tokens", "max_tokens",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -1553,6 +1559,15 @@ def _normalize_custom_provider_entry(
         normalized["ssl_verify"] = ssl_verify
     elif isinstance(ssl_verify, str) and ssl_verify.strip():
         normalized["ssl_verify"] = ssl_verify.strip()
+
+    # Per-provider output cap. runtime_provider._lift_max_output_tokens reads
+    # these off the entry, but normalization rebuilds entries field-by-field
+    # and dropped them, so the setting silently did nothing.
+    for _cap_key in ("max_output_tokens", "max_tokens"):
+        _cap = entry.get(_cap_key)
+        if isinstance(_cap, int) and _cap > 0:
+            normalized["max_output_tokens"] = _cap
+            break
 
     return normalized
 


### PR DESCRIPTION
## Summary

`custom_providers[].max_output_tokens` is silently ignored: `_normalize_custom_provider_entry` rebuilds each entry field-by-field and drops the key, so `runtime_provider._lift_max_output_tokens` never sees it. Two defects compound:

1. `max_output_tokens` / `max_tokens` are missing from `_KNOWN_KEYS`, so every startup also logs `providers.<name>: unknown config keys ignored: max_output_tokens`.
2. The normalizer never copies the value into the normalized entry, so fixing the allowlist alone silences the warning but still leaves the setting dead.

This PR adds both keys to `_KNOWN_KEYS` and copies the cap through normalization (preferring `max_output_tokens`, falling back to `max_tokens`, ints > 0 only).

## Verification

Before (current `main`):

```python
entry = {"name": "t", "base_url": "http://x:11434/v1", "model": "m", "max_output_tokens": 8192}
n = _normalize_custom_provider_entry(dict(entry))   # n["max_output_tokens"] -> None
_lift_max_output_tokens(n, result)                  # result -> {}
```

After:

```python
n["max_output_tokens"]  # 8192
result                  # {"max_output_tokens": 8192}
```

Live consumers that currently get nothing from this setting: `gateway/run.py:2870`, `gateway/platforms/api_server.py:449`, `agent/background_review.py:334` (all read `runtime.get("max_output_tokens")`).

`tests/hermes_cli/test_config.py`, `test_runtime_provider_resolution.py`, `test_custom_provider_extra_headers.py`: 152 passed.

Found in production: a config had carried `max_output_tokens: 8192` for months while the warning fired 346 times; the resolved runtime reported `None` until patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzTbrbNEdaD2BDn1GhNgT8
