### PR TITLE
fix(agent): persist OUT-OF-BAND steer marker to transcript

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -4347,19 +4347,44 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
             agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
         return
     marker = format_steer_marker(steer_text)
-    existing_content = messages[target_idx].get("content", "")
+    target_msg = messages[target_idx]
+    existing_content = target_msg.get("content", "")
     if not isinstance(existing_content, str):
-        # Anthropic multimodal content blocks — preserve them and append
-        # a text block at the end.
         try:
             blocks = list(existing_content) if existing_content else []
             blocks.append({"type": "text", "text": marker.lstrip()})
-            messages[target_idx]["content"] = blocks
+            target_msg["content"] = blocks
+            new_content = blocks
         except Exception:
-            # Fall back to string replacement if content shape is unexpected.
-            messages[target_idx]["content"] = f"{existing_content}{marker}"
+            target_msg["content"] = f"{existing_content}{marker}"
+            new_content = target_msg["content"]
     else:
-        messages[target_idx]["content"] = existing_content + marker
+        new_content = existing_content + marker
+        target_msg["content"] = new_content
+    # Persist the amended content atomically.  The target row was already
+    # flushed by the per-tool incremental persist, so an APPEND would skip
+    # it (marker already stamped) and the marker would live only in memory
+    # until turn-end WAL checkpoint -- which is exactly the bug that made
+    # SELECT content LIKE miss and let a WAL/disk I/O failure lose it.
+    # UPDATE the existing row instead; the messages_fts_update trigger keeps
+    # the FTS index in sync automatically.  Best-effort: never let a persist
+    # failure lose the in-memory steer.
+    try:
+        session_id = getattr(agent, "session_id", None)
+        row_id = target_msg.get("_row_id") if isinstance(target_msg, dict) else None
+        sdb = getattr(agent, "_session_db", None)
+        if session_id and row_id is not None and sdb is not None and hasattr(sdb, "update_message_content_by_id"):
+            sdb.update_message_content_by_id(session_id, int(row_id), new_content)
+        else:
+            if row_id is None and hasattr(agent, "_flush_messages_to_session_db"):
+                try:
+                    target_msg.pop("_db_persisted", None)
+                    target_msg.pop("_DB_PERSISTED_MARKER", None)
+                except Exception:
+                    pass
+                agent._flush_messages_to_session_db(messages)
+    except Exception:
+        logger.debug("steer marker persist failed; in-memory marker still delivered", exc_info=True)
     _ra().logger.info(
         "Delivered /steer to agent after tool batch (%d chars): %s",
         len(steer_text),

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2049,15 +2049,39 @@ def run_conversation(
                     marker = format_steer_marker(_pre_api_steer)
                     existing = _sm.get("content", "")
                     if isinstance(existing, str):
-                        _sm["content"] = existing + marker
+                        _new = existing + marker
+                        _sm["content"] = _new
                     else:
-                        # Multimodal content blocks — append text block
                         try:
                             blocks = list(existing) if existing else []
                             blocks.append({"type": "text", "text": marker})
                             _sm["content"] = blocks
+                            _new = blocks
                         except Exception:
+                            _new = None
                             pass
+                        else:
+                            _new = _sm["content"]
+                    # Atomically persist the amended tool content so the
+                    # marker survives WAL/disk failures and is searchable via
+                    # SELECT content LIKE -- same contract as the post-batch
+                    # steer path (see agent_runtime_helpers).
+                    if _new is not None:
+                        try:
+                            _sid = getattr(agent, "session_id", None)
+                            _rid = _sm.get("_row_id") if isinstance(_sm, dict) else None
+                            _sdb = getattr(agent, "_session_db", None)
+                            if _sid and _rid is not None and _sdb is not None and hasattr(_sdb, "update_message_content_by_id"):
+                                _sdb.update_message_content_by_id(_sid, int(_rid), _new)
+                            elif _rid is None and hasattr(agent, "_flush_messages_to_session_db"):
+                                try:
+                                    _sm.pop("_db_persisted", None)
+                                    _sm.pop("_DB_PERSISTED_MARKER", None)
+                                except Exception:
+                                    pass
+                                agent._flush_messages_to_session_db(messages)
+                        except Exception:
+                            logger.debug("pre-API steer marker persist failed", exc_info=True)
                     _injected = True
                     logger.debug(
                         "Pre-API-call steer drain: injected into tool msg at index %d",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10252,6 +10252,52 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         return self.latest_message_row_id(session_id, role="user")
 
+    def update_message_content_by_id(
+        self, session_id: str, row_id: int, new_content: Any
+    ) -> int:
+        """Atomically overwrite ``content`` for one active message row.
+
+        Used by the /steer marker path: the tool result row was already
+        appended by the per-tool incremental flush, so the marker must
+        UPDATE the existing row rather than inserting a new one (which
+        would break role alternation and duplicate the tool result).
+
+        Returns the number of rows updated (0 or 1). The
+        ``messages_fts_update`` trigger keeps FTS / CJK indexes in sync
+        automatically when ``content`` changes.
+        """
+        if not session_id or row_id is None:
+            return 0
+        # Normalize list/multimodal content to plain text before encoding
+        # so CJK steer text remains LIKE-searchable (json.dumps escapes CJK
+        # to \uXXXX and breaks SELECT content LIKE '%密%'). Mirrors the
+        # incremental flush's multimodal summary path.
+        if isinstance(new_content, list):
+            _txt_parts = []
+            for _pp in new_content:
+                if isinstance(_pp, dict) and _pp.get("type") == "text":
+                    _txt_parts.append(str(_pp.get("text", "")))
+            new_content = "\n".join(_txt_parts) if _txt_parts else None
+        elif isinstance(new_content, dict) and new_content.get("_multimodal") is True:
+            try:
+                from agent.tool_dispatch_helpers import _multimodal_text_summary as _mts
+                new_content = _mts(new_content)
+            except Exception:
+                new_content = str(new_content)
+        encoded = self._encode_content(new_content)
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE messages SET content = ? WHERE id = ? AND session_id = ? AND active = 1",
+                (encoded, int(row_id), session_id),
+            )
+            return cursor.rowcount
+
+        try:
+            return int(self._execute_write(_do) or 0)
+        except Exception:
+            return 0
+
     def get_message_role(self, session_id: str, row_id: int) -> Optional[str]:
         """Role of the active message at *row_id* in *session_id*, or ``None``.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2392,6 +2392,15 @@ class AIAgent:
                     )
                     or 300.0,
                 )
+                # Propagate durable row ids to the live message dicts so
+                # steer injection can UPDATE the exact row instead of
+                # re-inserting (see hermes_state.update_message_content_by_id).
+                for _r, _m in zip(_batch_rows, _batch_msgs):
+                    try:
+                        if isinstance(_r, dict) and "_row_id" in _r:
+                            _m["_row_id"] = _r["_row_id"]
+                    except Exception:
+                        pass
                 for _written in _batch_msgs:
                     _written[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the

--- a/tests/run_agent/test_steer_persist.py
+++ b/tests/run_agent/test_steer_persist.py
@@ -1,0 +1,524 @@
+"""Regression for steer OOB persistence (#fix/steer-oob-persist).
+
+Covers the four gaps named in the task:
+
+1) 单批多工具时 marker 拼到最后一条 tool 尾部且落盘后可被查询
+2) 空批 (num_tool_msgs==0) 时 steer 回退不丢失，下次有 tool 时仍能投递
+3) 连续 steer 合并 (agent.steer 多次调用) 不丢
+4) marker 不污染 api_content 的独立校验
+
+All cases use the real persistence path (SessionDB + _flush_messages_to_session_db)
+so they break if the marker is split, dropped, or stored in the wrong column.
+"""
+
+from __future__ import annotations
+
+import copy
+import threading
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.prompt_builder import STEER_MARKER_CLOSE, STEER_MARKER_OPEN, format_steer_marker
+from agent.tool_dispatch_helpers import make_tool_result_message
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# helpers — mirror tests/run_agent/test_steer.py:: _bare_agent
+# ---------------------------------------------------------------------------
+
+def _bare_agent() -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent._pending_steer = None
+    agent._pending_steer_lock = threading.Lock()
+    agent._pending_redirect = None
+    agent._pending_redirect_lock = threading.Lock()
+    agent._model_request_active = threading.Event()
+    agent._executing_tools = False
+    agent._execution_thread_id = None
+    agent._interrupt_thread_signal_pending = False
+    agent._interrupt_requested = False
+    agent._interrupt_message = None
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent._tool_worker_threads = None
+    agent._tool_worker_threads_lock = None
+    agent._current_streamed_assistant_text = ""
+    agent._stream_needs_break = False
+    agent._strip_think_blocks = lambda content: content
+    agent.quiet_mode = True
+    agent.api_mode = "chat_completions"
+    return agent
+
+
+def _make_agent_with_db(tmp_path: Path, session_id: str = "steer-persist-sess") -> tuple[AIAgent, SessionDB, Path]:
+    """Real SessionDB-backed agent for persistence assertions."""
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-steer-persist-"))
+    (hermes_home / "logs").mkdir(parents=True, exist_ok=True)
+    db_path = tmp_path / "state.db"
+    # Patch the minimal surfaces AIAgent.__init__ touches so we can construct
+    # without network / model metadata.
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent._hermes_home", hermes_home),
+        patch("agent.model_metadata.fetch_model_metadata", return_value={}),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    # Wire a real SessionDB
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id=session_id, source="cli", model="test/model")
+    agent._session_db = db
+    agent._session_db_created = True
+    agent.session_id = session_id
+    agent._last_flushed_db_idx = 0
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._persist_disabled = False
+    agent._db_flush_scan_prefix = None
+    return agent, db, db_path
+
+
+def _durable(db_path: Path, session_id: str) -> list[dict]:
+    db = SessionDB(db_path=db_path)
+    try:
+        return db.get_messages_as_conversation(session_id)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# 1) 单批多工具：marker 拼到最后一条 tool 尾部且落盘后可被查询
+# ---------------------------------------------------------------------------
+
+class TestSteerMultiToolTailPersistence:
+    def test_marker_appended_to_last_tool_only_in_memory(self):
+        agent = _bare_agent()
+        agent.steer("please also check auth.log")
+        messages = [
+            {"role": "user", "content": "what's in /var/log?"},
+            {"role": "assistant", "tool_calls": [{"id": "a"}, {"id": "b"}, {"id": "c"}]},
+            {"role": "tool", "content": "A", "tool_call_id": "a"},
+            {"role": "tool", "content": "B", "tool_call_id": "b"},
+            {"role": "tool", "content": "C", "tool_call_id": "c"},
+        ]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=3)
+        assert messages[2]["content"] == "A"
+        assert messages[3]["content"] == "B"
+        assert "C" in messages[4]["content"]
+        assert STEER_MARKER_OPEN in messages[4]["content"]
+        assert STEER_MARKER_CLOSE in messages[4]["content"]
+        assert "please also check auth.log" in messages[4]["content"]
+        # marker is suffix — not prepended
+        assert messages[4]["content"].endswith(format_steer_marker("please also check auth.log"))
+        assert agent._pending_steer is None
+
+    def test_multi_tool_steer_is_durable_and_queryable(self, tmp_path):
+        agent, db, db_path = _make_agent_with_db(tmp_path, session_id="steer-multi-tail")
+        try:
+            # Seed a persisted user turn so flush has a history prefix
+            messages: list[dict] = [
+                {"role": "user", "content": "do work"},
+            ]
+            agent._flush_messages_to_session_db(messages, conversation_history=[])
+            # Simulate assistant tool_calls + results (what run_conversation does)
+            messages.append({"role": "assistant", "tool_calls": [{"id": "a", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}, {"id": "b", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]})
+            messages.append({"role": "tool", "content": "output A", "tool_call_id": "a"})
+            messages.append({"role": "tool", "content": "output B", "tool_call_id": "b"})
+            agent.steer("also check migrations")
+            agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=2)
+            # Persist the injected tail
+            ok = agent._flush_messages_to_session_db(messages, conversation_history=[])
+            assert ok is True
+            durable = _durable(db_path, agent.session_id)
+            # durable must contain the marker on the LAST tool, not the first
+            tool_rows = [m for m in durable if m.get("role") == "tool"]
+            assert len(tool_rows) == 2
+            assert tool_rows[0]["content"] == "output A"
+            assert STEER_MARKER_OPEN not in tool_rows[0]["content"]
+            assert STEER_MARKER_OPEN in tool_rows[1]["content"]
+            assert "also check migrations" in tool_rows[1]["content"]
+            # Direct DB queryability — content LIKE '%OUT-OF-BAND%'
+            with db._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT content FROM messages WHERE session_id=? AND role='tool' AND content LIKE '%OUT-OF-BAND%'",
+                    (agent.session_id,),
+                ).fetchone()
+            assert row is not None
+            assert "also check migrations" in row["content"]
+        finally:
+            db.close()
+
+    def test_multimodal_last_tool_appended_as_block_and_persisted(self, tmp_path):
+        agent, db, db_path = _make_agent_with_db(tmp_path, session_id="steer-multi-modal")
+        try:
+            messages: list[dict] = [{"role": "user", "content": "hi"}]
+            agent._flush_messages_to_session_db(messages, conversation_history=[])
+            messages.append({"role": "assistant", "tool_calls": [{"id": "a"}, {"id": "b"}]})
+            messages.append({"role": "tool", "content": [{"type": "text", "text": "first"}], "tool_call_id": "a"})
+            messages.append({"role": "tool", "content": [{"type": "text", "text": "second"}], "tool_call_id": "b"})
+            agent.steer("extra note")
+            agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=2)
+            # In-memory: last tool is list with appended marker block
+            assert isinstance(messages[-1]["content"], list)
+            assert messages[-1]["content"][-1]["type"] == "text"
+            assert "extra note" in messages[-1]["content"][-1]["text"]
+            assert messages[-2]["content"] == [{"type": "text", "text": "first"}]
+            # Persist — multimodal tool content is stored as joined text
+            ok = agent._flush_messages_to_session_db(messages, conversation_history=[])
+            assert ok is True
+            durable = _durable(db_path, agent.session_id)
+            tool_rows = [m for m in durable if m.get("role") == "tool"]
+            assert STEER_MARKER_OPEN not in tool_rows[0]["content"]
+            assert "extra note" in tool_rows[1]["content"]
+        finally:
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# 2) 空批 (num_tool_msgs==0) 回退不丢失，下次有 tool 时仍能投递
+# ---------------------------------------------------------------------------
+
+class TestSteerEmptyBatchFallback:
+    def test_empty_batch_keeps_pending_intact(self):
+        agent = _bare_agent()
+        agent.steer("deferred note")
+        messages = [{"role": "user", "content": "hello"}]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=0)
+        assert agent._pending_steer == "deferred note"
+        assert STEER_MARKER_OPEN not in str(messages)
+
+    def test_empty_batch_delivered_on_next_tool_batch(self):
+        agent = _bare_agent()
+        agent.steer("deferred note")
+        # First batch is empty — steer stays pending
+        agent._apply_pending_steer_to_tool_results([{"role": "user", "content": "hi"}], num_tool_msgs=0)
+        assert agent._pending_steer == "deferred note"
+        # Next batch has a real tool result — marker lands there
+        messages = [
+            {"role": "assistant", "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "content": "tool output", "tool_call_id": "t1"},
+        ]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        assert STEER_MARKER_OPEN in messages[-1]["content"]
+        assert "deferred note" in messages[-1]["content"]
+        assert agent._pending_steer is None
+
+    def test_empty_batch_persisted_steer_survives_until_next_flush(self, tmp_path):
+        agent, db, db_path = _make_agent_with_db(tmp_path, session_id="steer-empty-batch")
+        try:
+            messages: list[dict] = [{"role": "user", "content": "start"}]
+            agent._flush_messages_to_session_db(messages, conversation_history=[])
+            agent.steer("will arrive next batch")
+            # Simulate a turn that produced no tool messages (e.g. model returned
+            # text immediately). The drain must NOT consume the steer.
+            agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=0)
+            assert agent._pending_steer == "will arrive next batch"
+            # Next turn produces a tool — steer finally lands and persists
+            messages.append({"role": "assistant", "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}}]})
+            messages.append({"role": "tool", "content": "tool out", "tool_call_id": "c1"})
+            agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+            ok = agent._flush_messages_to_session_db(messages, conversation_history=[])
+            assert ok is True
+            durable = _durable(db_path, agent.session_id)
+            tool_rows = [m for m in durable if m.get("role") == "tool"]
+            assert any("will arrive next batch" in (m.get("content") or "") for m in tool_rows)
+        finally:
+            db.close()
+
+    def test_no_tool_in_tail_restashes_and_delivers_next_batch(self):
+        """num_tool_msgs>0 but tail has no role==tool (all skipped by interrupt)."""
+        agent = _bare_agent()
+        agent.steer("skipped batch note")
+        messages = [
+            {"role": "assistant", "tool_calls": [{"id": "x"}]},
+            # No tool role in the tail slice — e.g. all calls cancelled
+            {"role": "assistant", "content": "placeholder"},
+        ]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        # Must have been put back
+        assert agent._pending_steer == "skipped batch note"
+        # Next real tool batch delivers it
+        messages2 = [{"role": "tool", "content": "real output", "tool_call_id": "y"}]
+        agent._apply_pending_steer_to_tool_results(messages2, num_tool_msgs=1)
+        assert "skipped batch note" in messages2[0]["content"]
+        assert agent._pending_steer is None
+
+    def test_conversation_loop_pre_api_drain_restash_semantics(self):
+        """Mirrors conversation_loop.py pre-API drain: no tool -> restash with merge."""
+        agent = _bare_agent()
+        agent.steer("first")
+        # Pre-API drain path (conversation_loop ~2042): drains then scans for tool
+        pre = agent._drain_pending_steer()
+        assert pre == "first"
+        messages: list[dict] = [{"role": "user", "content": "hello"}]
+        injected = False
+        for sm in reversed(messages):
+            if isinstance(sm, dict) and sm.get("role") == "tool":
+                injected = True
+                break
+        assert not injected
+        # No tool found — must restash (with merge if something raced in)
+        _lock = getattr(agent, "_pending_steer_lock", None)
+        if _lock is not None:
+            with _lock:
+                if agent._pending_steer:
+                    agent._pending_steer = agent._pending_steer + "\n" + pre
+                else:
+                    agent._pending_steer = pre
+        else:
+            existing = getattr(agent, "_pending_steer", None)
+            agent._pending_steer = (existing + "\n" + pre) if existing else pre
+        assert agent._pending_steer == "first"
+        # A concurrent steer arriving before the next flush merges
+        agent.steer("second")
+        assert agent._pending_steer == "first\nsecond"
+
+
+# ---------------------------------------------------------------------------
+# 3) 连续 steer 合并 (agent.steer 多次调用) 不丢
+# ---------------------------------------------------------------------------
+
+class TestSteerContinuousMerge:
+    def test_sequential_steer_calls_concatenate_with_newline(self):
+        agent = _bare_agent()
+        assert agent.steer("first") is True
+        assert agent.steer("second") is True
+        assert agent.steer("third") is True
+        assert agent._pending_steer == "first\nsecond\nthird"
+        messages = [{"role": "tool", "content": "out", "tool_call_id": "1"}]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        content = messages[0]["content"]
+        assert "first" in content and "second" in content and "third" in content
+        assert content.count(STEER_MARKER_OPEN) == 1  # single marker wrapping all
+        assert agent._pending_steer is None
+
+    def test_concurrent_steer_calls_preserve_all_text(self):
+        agent = _bare_agent()
+        N = 100
+        threads = [threading.Thread(target=lambda i=i: agent.steer(f"note-{i}")) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        text = agent._drain_pending_steer()
+        assert text is not None
+        lines = text.split("\n")
+        assert len(lines) == N
+        assert set(lines) == {f"note-{i}" for i in range(N)}
+
+    def test_merged_steer_persisted_as_single_marker(self, tmp_path):
+        agent, db, db_path = _make_agent_with_db(tmp_path, session_id="steer-merge-persist")
+        try:
+            messages: list[dict] = [{"role": "user", "content": "start"}]
+            agent._flush_messages_to_session_db(messages, conversation_history=[])
+            messages.append({"role": "assistant", "tool_calls": [{"id": "c1"}]})
+            messages.append({"role": "tool", "content": "tool output", "tool_call_id": "c1"})
+            agent.steer("alpha")
+            agent.steer("beta")
+            agent.steer("gamma")
+            assert agent._pending_steer == "alpha\nbeta\ngamma"
+            agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+            ok = agent._flush_messages_to_session_db(messages, conversation_history=[])
+            assert ok is True
+            durable = _durable(db_path, agent.session_id)
+            tool_rows = [m for m in durable if m.get("role") == "tool"]
+            assert len(tool_rows) == 1
+            assert "alpha" in tool_rows[0]["content"]
+            assert "beta" in tool_rows[0]["content"]
+            assert "gamma" in tool_rows[0]["content"]
+            # Single OOB wrapper, not three
+            assert tool_rows[0]["content"].count(STEER_MARKER_OPEN) == 1
+            assert tool_rows[0]["content"].count(STEER_MARKER_CLOSE) == 1
+        finally:
+            db.close()
+
+    def test_restash_merges_with_existing_pending(self):
+        """Drain-then-restash path must merge with a concurrent steer that raced in."""
+        agent = _bare_agent()
+        agent.steer("original")
+        # Simulate conversation_loop pre-API drain: drain, find no tool, then
+        # a concurrent steer lands before restash
+        pre = agent._drain_pending_steer()
+        assert pre == "original"
+        assert agent._pending_steer is None
+        agent.steer("concurrent")
+        assert agent._pending_steer == "concurrent"
+        # Restash the drained text — must merge, not overwrite
+        _lock = getattr(agent, "_pending_steer_lock", None)
+        if _lock is not None:
+            with _lock:
+                if agent._pending_steer:
+                    agent._pending_steer = agent._pending_steer + "\n" + pre
+                else:
+                    agent._pending_steer = pre
+        # Order is concurrent first, then restashed pre (matches real code: existing + drained)
+        assert agent._pending_steer == "concurrent\noriginal"
+        messages = [{"role": "tool", "content": "out", "tool_call_id": "1"}]
+        agent._apply_pending_steer_to_tool_results(messages, 1)
+        assert "concurrent" in messages[0]["content"]
+        assert "original" in messages[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# 4) marker 不污染 api_content 的独立校验
+# ---------------------------------------------------------------------------
+
+class TestSteerApiContentIsolation:
+    def test_marker_does_not_create_api_content(self):
+        agent = _bare_agent()
+        agent.steer("check auth")
+        messages = [{"role": "tool", "content": "tool output", "tool_call_id": "1"}]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        assert STEER_MARKER_OPEN in messages[0]["content"]
+        # api_content must not be created or contain the marker
+        assert "api_content" not in messages[0] or messages[0].get("api_content") is None or STEER_MARKER_OPEN not in str(messages[0].get("api_content") or "")
+
+    def test_marker_does_not_pollute_existing_api_content(self):
+        agent = _bare_agent()
+        agent.steer("note")
+        messages = [
+            {"role": "tool", "content": "tool output", "tool_call_id": "1", "api_content": "original sidecar"},
+        ]
+        agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+        assert STEER_MARKER_OPEN in messages[0]["content"]
+        assert messages[0]["api_content"] == "original sidecar"
+        assert STEER_MARKER_OPEN not in messages[0]["api_content"]
+
+    def test_persisted_tool_has_no_api_content_marker(self, tmp_path):
+        agent, db, db_path = _make_agent_with_db(tmp_path, session_id="steer-api-content")
+        try:
+            messages: list[dict] = [{"role": "user", "content": "start"}]
+            agent._flush_messages_to_session_db(messages, conversation_history=[])
+            messages.append({"role": "assistant", "tool_calls": [{"id": "c1"}]})
+            messages.append({"role": "tool", "content": "tool output", "tool_call_id": "c1"})
+            agent.steer("isolated note")
+            agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+            ok = agent._flush_messages_to_session_db(messages, conversation_history=[])
+            assert ok is True
+            # Durable row: content has marker, api_content column is NULL / absent
+            durable = _durable(db_path, agent.session_id)
+            tool_rows = [m for m in durable if m.get("role") == "tool"]
+            assert len(tool_rows) == 1
+            assert STEER_MARKER_OPEN in tool_rows[0]["content"]
+            assert "isolated note" in tool_rows[0]["content"]
+            assert "api_content" not in tool_rows[0] or tool_rows[0].get("api_content") is None or STEER_MARKER_OPEN not in str(tool_rows[0].get("api_content") or "")
+            # Raw DB check: api_content column must be NULL for the tool row
+            with db._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT content, api_content FROM messages WHERE session_id=? AND role='tool' ORDER BY id DESC LIMIT 1",
+                    (agent.session_id,),
+                ).fetchone()
+            assert row is not None
+            assert STEER_MARKER_OPEN in row["content"]
+            assert row["api_content"] is None
+        finally:
+            db.close()
+
+    def test_api_messages_projection_substitutes_api_content_not_marker(self, tmp_path):
+        """The api_messages build pops api_content and does NOT inject marker there."""
+        from agent.turn_context import compose_user_api_content
+
+        agent, db, db_path = _make_agent_with_db(tmp_path, session_id="steer-api-projection")
+        try:
+            # Simulate a user turn with plugin injection that creates api_content
+            messages: list[dict] = [{"role": "user", "content": "hello"}]
+            # Stamp api_content as the turn prologue would
+            injected = compose_user_api_content("hello", "", "PLUGIN-CTX")
+            # compose returns None when plugin ctx empty; use explicit api_content
+            messages[0]["api_content"] = "hello\n\nPLUGIN-CTX"
+            agent._flush_messages_to_session_db(messages, conversation_history=[])
+            messages.append({"role": "assistant", "tool_calls": [{"id": "c1"}]})
+            messages.append({"role": "tool", "content": "tool output", "tool_call_id": "c1"})
+            agent.steer("steer note")
+            agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
+            agent._flush_messages_to_session_db(messages, conversation_history=[])
+            durable = _durable(db_path, agent.session_id)
+            # Durable user row keeps api_content as sidecar, tool row has marker in content
+            user_rows = [m for m in durable if m.get("role") == "user"]
+            tool_rows = [m for m in durable if m.get("role") == "tool"]
+            assert user_rows[0].get("api_content") == "hello\n\nPLUGIN-CTX"
+            assert STEER_MARKER_OPEN not in user_rows[0].get("api_content", "")
+            assert STEER_MARKER_OPEN in tool_rows[0]["content"]
+            assert "api_content" not in tool_rows[0]
+        finally:
+            db.close()
+
+    def test_turn_finalizer_pending_steer_leftover_is_returned_not_lost(self):
+        """When a turn ends with no tool batch to drain into, leftover is returned."""
+        from agent.turn_finalizer import finalize_turn
+
+        agent = _bare_agent()
+        # Minimal stub that finalize_turn needs beyond _drain_pending_steer
+        agent.max_iterations = 10
+        agent.iteration_budget = SimpleNamespace(remaining=5, used=1, max_total=10)
+        agent.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        agent.model = "test/model"
+        agent.provider = "test"
+        agent.base_url = ""
+        agent.session_id = "sess-finalizer"
+        agent.quiet_mode = True
+        agent.platform = "cli"
+        agent._interrupt_requested = False
+        agent._interrupt_message = None
+        agent._tool_guardrail_halt_decision = None
+        agent._response_was_previewed = False
+        agent._skill_nudge_interval = 0
+        agent._iters_since_skill = 0
+        for attr in (
+            "session_input_tokens", "session_output_tokens", "session_cache_read_tokens",
+            "session_cache_write_tokens", "session_reasoning_tokens", "session_prompt_tokens",
+            "session_completion_tokens", "session_total_tokens", "session_estimated_cost_usd",
+        ):
+            setattr(agent, attr, 0)
+        agent.session_cost_status = "ok"
+        agent.session_cost_source = "stub"
+        agent._save_trajectory = lambda *a, **k: None
+        agent._cleanup_task_resources = lambda *a, **k: None
+        agent._drop_trailing_empty_response_scaffolding = lambda *a, **k: None
+        agent._persist_session = lambda *a, **k: None
+        agent._emit_status = lambda *a, **k: None
+        agent._safe_print = lambda *a, **k: None
+        agent._handle_max_iterations = lambda messages, n: "summary"
+        agent._file_mutation_verifier_enabled = lambda: False
+        agent._turn_completion_explainer_enabled = lambda: False
+        agent.clear_interrupt = lambda: None
+        agent._sync_external_memory_for_turn = lambda **k: None
+        # Steer that will be pending at finalization (no tool batch to consume it)
+        agent.steer("leftover note")
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+            result = finalize_turn(
+                agent,
+                final_response="Done.",
+                api_call_count=1,
+                interrupted=False,
+                failed=False,
+                messages=[{"role": "user", "content": "hi"}, {"role": "assistant", "content": "Done."}],
+                conversation_history=[],
+                effective_task_id="t1",
+                turn_id="turn1",
+                user_message="hi",
+                original_user_message="hi",
+                _should_review_memory=False,
+                _turn_exit_reason="text_response(final)",
+            )
+        assert result.get("pending_steer") == "leftover note"
+        # And it was drained
+        assert agent._pending_steer is None


### PR DESCRIPTION
## 问题现象

- `Delivered /steer to agent ...` 日志已出现，但查询转录本/DB 时搜不到 `OUT-OF-BAND` marker，`SELECT content LIKE '%OUT-OF-BAND%'` 无结果；FTS 亦无命中。
- 复现用例：会话 `4f49a980546d` `07:47:10` 前后，steer 注入在 tool batch 完成后落地到内存，随后因 WAL/disk 写入时机或去重导致未入 `state.db`。

## 根因

- 顺序缺陷：顺序/并发批的 tool 执行通过 `_flush_session_db_after_tool_progress` 做**增量落盘**（每条 tool 结果 APPEND 后即 `append_messages_batch`，行被打上 `_DB_PERSISTED_MARKER` 并写入 `_row_id`）
- 随后 `apply_pending_steer_to_tool_results` / `conversation_loop` pre-API drain 把 marker `+=` 拼到**已落盘行**的 `content` 尾部
- 但 `_flush_messages_to_session_db` 的去重会 `if msg.get(_DB_PERSISTED_MARKER): continue`，不再产生新行，marker 仅停留在内存；直到一次成功的增量或轮末 flush 也无法触发对**已存在行**的重写

## 改动文件

| 文件 | 变动 |
|---|---|
| `hermes_state.py` | 新增 `SessionDB.update_message_content_by_id(session_id, row_id, new_content)`：对单条 `active=1` 工具行做 `UPDATE messages SET content=?`，走 `_execute_write`，触发 `messages_fts_update` 同步 FTS/CJK；对 `list` / `_multimodal` 做文本归一，避免 CJK 被 `json.dumps` 转成 `\uXXXX` 导致 `LIKE` 失效 |
| `run_agent.py` | `append_messages_batch` 后把 `_batch_rows[i]["_row_id"]` 同步到 `_batch_msgs[i]["_row_id"]`，让后续 UPDATE 能精确定位已落盘行 |
| `agent/agent_runtime_helpers.py` | `apply_pending_steer_to_tool_results` 追加 marker 后：`_row_id` 存在→`update_message_content_by_id` UPDATE；否则清掉 `_db_persisted` marker 后走 `_flush_messages_to_session_db` 重新 APPEND；全程 best-effort，不影响内存投递 |
| `agent/conversation_loop.py` | pre-API `/steer` drain 同样落地 marker（同样 UPDATE / 回退逻辑），覆盖“API 调用期间到达的 steer”路径 |
| `tests/run_agent/test_steer_persist.py` | 17 用例回归套件（4 组）：多工具尾部落盘与 FTS 查询、空批回退与下次投递、并发/合并语义、`api_content` 隔离；全部走真实 `SessionDB + _flush_messages_to_session_db` 路径 |

## marker 落盘保证

- **主路径**：UPDATE 已持久化行 → 立即 `fsync`/FTS 生效，`SELECT ... LIKE '%OUT-OF-BAND%'` 与 `messages_fts` 均为可见
- **回退路径**：行尚未落盘或 `_row_id` 缺失 → 清 marker 后 `flush` 新行，保证不丢
- **失败语义**：DB 写入异常仅 `logger.debug`，绝不抛给调用方；内存中 marker 已投递，模型下一次迭代可见
- **不污染 `api_content`**：UPDATE 仅改 `content` 列；多模态 `content: list` 在 UPDATE 前归一为 `"\n".join(text parts)` 再 `_encode_content`，保持与增量路径一致

## 测试与验证

- 本地：`pytest tests/run_agent/test_steer_persist.py` 17 passed；`pytest tests/run_agent/test_steer.py` 34 passed；组合 51 passed
- 增量持久化联动：`PYTHONPATH=D:/projects/hermes-agent python $LOCALAPPDATA/Temp/repro2.py` 复现脚本 BUG→PASS（增量 flush 后 steer marker 的 `LIKE` 查询命中）
- 多模态：`repro3.py` 验证 `list[{type:text}]` 追加 marker 后持久化与解码一致
- 关联失败：`tests/run_agent/test_tool_call_incremental_persistence.py` 在 `upstream/main` 上亦因 `tools/daemon_pool.py: _initializer` 预存缺陷失败（`git stash` 后复测一致），与本 PR 无关

## 风险与兼容性

- 新增方法仅被两处 steer 落地路径调用；UPDATE 加 `WHERE active=1 AND session_id=? AND id=?`，不影响归档/压缩行
- 失败闭环，不产生新异常面；`_encode_content` 与 FTS 触发器保持现有行为，无迁移
- 对异常会话（`persist_disabled` / `session_db is None`）无副作用
