### PR TITLE
fix(desktop): let backend-pinned messaging sessions be unpinned

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/hermes', () => ({
 
 import { $pinnedSessionIds } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $sessions } from '@/store/session'
+import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
 
 import { $unconfirmedPinWrites, resetSessionPinMirror, watchSessionPins } from './session-pin-sync'
 
@@ -33,6 +33,8 @@ beforeAll(() => {
 
 beforeEach(() => {
   $sessions.set([])
+  $cronSessions.set([])
+  $messagingSessions.set([])
   $pinnedSessionIds.set([])
   // The mirror/pending/unconfirmed maps are module-global, so one test's
   // bookkeeping would otherwise suppress the next test's PATCH (or fence out
@@ -43,6 +45,8 @@ beforeEach(() => {
 
 afterEach(() => {
   $sessions.set([])
+  $cronSessions.set([])
+  $messagingSessions.set([])
   $pinnedSessionIds.set([])
 })
 
@@ -103,6 +107,32 @@ describe('watchSessionPins', () => {
 })
 
 describe('watchSessionPins remote pull', () => {
+  it('adopts and durably unpins a backend-only messaging pin', async () => {
+    $messagingSessions.set([row('photon-pin', { pinned: true, profile: 'messages', source: 'photon' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['photon-pin'])
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('photon-pin', false, 'messages')
+  })
+
+  it('adopts and durably unpins a backend-only cron pin', async () => {
+    $cronSessions.set([row('cron-pin', { pinned: true, profile: 'jobs', source: 'cron' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['cron-pin'])
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('cron-pin', false, 'jobs')
+  })
+
   it('adopts a pin another app made', async () => {
     $sessions.set([row('remote', { pinned: true })])
     await flush()

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -27,7 +27,13 @@ import { setSessionPinnedRemote } from '@/hermes'
 import { onConnectionScopeChange } from '@/lib/connection-scoped'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
+import {
+  $cronSessions,
+  $messagingSessions,
+  $sessions,
+  sessionMatchesStoredId,
+  sessionPinId
+} from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 // pin ids we've successfully PATCHed pinned=true this session.
@@ -71,7 +77,11 @@ function publishUnconfirmed(): void {
 }
 
 function profileFor(pinId: string): null | string | undefined {
-  return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
+  return loadedSessionRows().find(row => sessionMatchesStoredId(row, pinId))?.profile
+}
+
+function loadedSessionRows(): SessionInfo[] {
+  return [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()]
 }
 
 /**
@@ -140,7 +150,7 @@ function writePin(id: string, pinned: boolean, profile?: null | string): Promise
 function pullRemotePins(): void {
   const local = new Set($pinnedSessionIds.get())
 
-  for (const row of rowsByPinId($sessions.get()).values()) {
+  for (const row of rowsByPinId(loadedSessionRows()).values()) {
     // A backend without the flag has no opinion; never act on `undefined`.
     if (typeof row.pinned !== 'boolean') {
       continue
@@ -190,8 +200,8 @@ function pullRemotePins(): void {
   }
 }
 
-// Re-entrancy guard: reconcile() is subscribed to BOTH $sessions and
-// $pinnedSessionIds, and pullRemotePins() mutates $pinnedSessionIds (via
+// Re-entrancy guard: reconcile() is subscribed to every loaded-session slice
+// and $pinnedSessionIds, and pullRemotePins() mutates $pinnedSessionIds (via
 // pinSession/unpinSession), which fires reconcile() again synchronously.
 // Without this guard, a session whose pin state oscillates — two rows with the
 // same durable id but conflicting `pinned` flags, possible when profile
@@ -247,9 +257,9 @@ function reconcileInner(): void {
   }
 
   // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
-  // retry on the next $sessions change.
+  // retry on the next loaded-session slice change.
   for (const id of [...pending]) {
-    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
+    const row = loadedSessionRows().find(entry => sessionMatchesStoredId(entry, id))
 
     if (!row) {
       continue
@@ -276,6 +286,8 @@ export function watchSessionPins(): void {
   reconcile()
   $pinnedSessionIds.listen(reconcile)
   $sessions.listen(reconcile)
+  $cronSessions.listen(reconcile)
+  $messagingSessions.listen(reconcile)
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop can now unpin backend-only messaging and cron sessions instead of leaving them permanently in the Pinned section. Pin reconciliation now uses every loaded session slice, so it adopts backend pins locally, resolves the owning profile, and persists a later unpin through the existing backend API.

### Symptom

A Photon/iMessage conversation with `pinned=true` on the backend appears under Pinned, but clicking Unpin does not remove it or update the backend when its durable ID is absent from Desktop local storage.

### Impact

Users cannot remove affected backend-pinned messaging conversations from Desktop. The same state split also affects cron sessions loaded outside the ordinary recents slice.

### Bug Cause

**Trigger:** `apps/desktop/src/store/session-pin-sync.ts` / `watchSessionPins()` and `reconcileInner()` when a pinned row exists only in `$messagingSessions` or `$cronSessions`.

**Causal chain:**
1. The sidebar displays a backend-pinned messaging or cron row even when its ID is absent from `$pinnedSessionIds`.
2. Pin reconciliation reads and subscribes only to `$sessions`, so it never adopts that backend pin into the local set.
3. Unpin filters an ID that is not present locally, emits no change, and never calls the backend pin PATCH.

**Why it is wrong:** The display path combines ordinary, messaging, and cron rows, but the synchronization path observes only one of those authoritative session slices.

**Working sibling / contrast:** Ordinary sessions work because they are present in `$sessions`, which the synchronizer already reads and observes.

**Ruled out:** This is not the stale-page write race covered by the existing unconfirmed-write fence. In the failing state no local pin transition occurs, so no backend write or fence is created.

### Fix

Use a single combined loaded-row view for pin adoption, profile resolution, and pending-pin flushing. Subscribe reconciliation to ordinary, messaging, and cron session stores. Add regression coverage for backend-only Photon and cron pins, including durable unpin writes to the owning profile.

## Related Issue

Closes #92593

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session-pin-sync.ts` - reconcile pins across ordinary, messaging, and cron session rows.
- `apps/desktop/src/store/session-pin-sync.test.ts` - cover adoption and durable unpinning for backend-only Photon and cron pins.

## How to Test

1. Run the focused pin synchronization suite.
2. Run Desktop renderer type checking and lint the changed files.

```bash
cd apps/desktop
npx vitest run --project ui src/store/session-pin-sync.test.ts --maxWorkers=1
npx tsc -p . --noEmit
npx eslint src/store/session-pin-sync.ts src/store/session-pin-sync.test.ts
```

Focused test result: 24 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is covered by tests and code comments
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - state reconciliation is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - regression is covered by the focused store test suite.
