### PR TITLE
fix(desktop): make preview tools opt-in

### DIFF
--- a/apps/desktop/src/lib/desktop-toolsets.test.ts
+++ b/apps/desktop/src/lib/desktop-toolsets.test.ts
@@ -10,7 +10,7 @@ describe('isDesktopToolsetVisible', () => {
   })
 
   it('keeps ordinary user-facing toolsets', () => {
-    for (const name of ['web', 'browser', 'terminal', 'file', 'memory', 'vision', 'image_gen']) {
+    for (const name of ['web', 'browser', 'terminal', 'file', 'memory', 'vision', 'image_gen', 'desktop_ui']) {
       expect(isDesktopToolsetVisible(name)).toBe(true)
     }
   })

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -121,6 +121,7 @@ CONFIGURABLE_TOOLSETS = [
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
     ("computer_use",     "🖱️  Computer Use (macOS/Windows/Linux)", "background desktop control via cua-driver"),
+    ("desktop_ui",       "🖥️  Desktop Preview Pane",    "open/read/drive the desktop preview pane"),
 ]
 
 
@@ -153,7 +154,7 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a"}
+_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a", "desktop_ui"}
 
 
 # Config-only capabilities: they appear in `hermes tools` for provider/API-key

--- a/tests/tui_gateway/test_gui_surface_toolsets.py
+++ b/tests/tui_gateway/test_gui_surface_toolsets.py
@@ -61,9 +61,9 @@ class TestDesktopUiToolset:
 
 
 class TestSurfaceResolution:
-    def test_desktop_session_gets_them_with_no_desktop_env(self, no_desktop_env):
-        """THE regression: a desktop client on a remote/cloud backend."""
-        assert "desktop_ui" in server._gui_surface_toolsets("desktop")
+    def test_desktop_preview_tools_are_not_granted_by_surface(self, no_desktop_env):
+        """Preview tools are user opt-in, not automatic desktop affordances."""
+        assert "desktop_ui" not in server._gui_surface_toolsets("desktop")
 
     def test_tui_session_does_not(self, no_desktop_env):
         assert "desktop_ui" not in server._gui_surface_toolsets("tui")
@@ -89,11 +89,7 @@ class TestResolverPlumbing:
 
         no_desktop_env.setattr(cc, "coding_selection", lambda **_: ["coding"])
 
-        assert server._load_enabled_toolsets("desktop") == [
-            "coding",
-            "desktop_ui",
-            "project",
-        ]
+        assert server._load_enabled_toolsets("desktop") == ["coding", "project"]
         assert server._load_enabled_toolsets("tui") == ["coding", "project"]
 
     def test_config_path_folds_in_the_session_surface(self, no_desktop_env):
@@ -109,8 +105,24 @@ class TestResolverPlumbing:
         tui = server._load_enabled_toolsets("tui")
 
         assert desktop is not None and tui is not None
-        assert "desktop_ui" in desktop
+        assert "desktop_ui" not in desktop
         assert "desktop_ui" not in tui
+
+    def test_explicit_desktop_ui_opt_in_enables_preview_tools(self, no_desktop_env):
+        import agent.coding_context as cc
+        import hermes_cli.config as config_mod
+
+        no_desktop_env.setattr(cc, "coding_selection", lambda **_: None)
+        no_desktop_env.setattr(
+            config_mod,
+            "load_config",
+            lambda: {"platform_toolsets": {"cli": ["memory", "desktop_ui"]}},
+        )
+
+        desktop = server._load_enabled_toolsets("desktop")
+
+        assert desktop is not None
+        assert "desktop_ui" in desktop
 
     def test_explicit_env_pin_still_wins(self, no_desktop_env):
         """HERMES_TUI_TOOLSETS is an operator override; surface can't re-add."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4654,18 +4654,12 @@ def _gui_surface_toolsets(platform: str) -> set[str]:
     platform would carry their schema for nothing — so this resolver is the one
     gate that exposes them.
 
-    ``platform`` is the SESSION's source (``session.create``'s ``source``
-    field), never a process env var. The desktop app is a client: it can be
-    driving a local, SSH, URL, or cloud backend, and only the local/SSH spawn
-    paths run with ``HERMES_DESKTOP=1``. Keying GUI capability off that env var
-    silently stripped every pane/browser tool from URL and cloud gateways while
-    the same backend told the model it was "chatting inside the Hermes desktop
-    app". See the surface-capability rule in AGENTS.md.
+    ``desktop_ui`` is intentionally NOT added here: preview-pane tools are a
+    user-facing capability, so they are exposed as a configurable default-off
+    toolset instead of being silently granted to every desktop session. ``project``
+    remains a surface primitive because the GUI owns project navigation itself.
     """
-    surfaces = {"project"}
-    if platform == "desktop":
-        surfaces.add("desktop_ui")
-    return surfaces
+    return {"project"}
 
 
 def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
@@ -4690,10 +4684,9 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
 
             selection = coding_selection(platform=session_platform)
             if selection is not None:
-                # Fold in the client-surface toolsets here too: the focus-mode
-                # coding posture returns before the fallback path that normally
-                # adds them — without this the desktop loses its pane/project
-                # tools exactly when sitting in a repo (see below).
+                # Fold in non-configurable GUI primitives here too: the
+                # focus-mode coding posture returns before the fallback path
+                # that normally adds them.
                 return sorted({*selection, *_gui_surface_toolsets(session_platform)})
         except Exception:
             pass
@@ -4805,12 +4798,10 @@ def _load_enabled_toolsets(platform: str | None = None) -> list[str] | None:
             print(fallback_notice, file=sys.stderr, flush=True)
         if not enabled:
             return None
-        # The client-surface toolsets are off _HERMES_CORE_TOOLS (every other
-        # platform would carry their schema for nothing), so the platform
+        # Non-configurable GUI primitives are off _HERMES_CORE_TOOLS (every
+        # other platform would carry their schema for nothing), so the platform
         # recovery above — which keys off hermes-cli's tool universe — can't
-        # surface them. This resolver runs ONLY in the desktop/TUI gateway, so
-        # folding them in here is the gate that exposes them on exactly the
-        # surface that can answer them.
+        # surface them.
         return sorted(enabled | _gui_surface_toolsets(session_platform))
     except Exception:
         if fallback_notice is not None:


### PR DESCRIPTION
Summary
Desktop preview-pane tools were automatically added to every desktop gateway session, so the model could use open/read/drive preview affordances even when the user had not enabled them in Tools & Keys. This makes desktop_ui a normal configurable default-off toolset and leaves only non-user-facing project primitives auto-added by the GUI gateway.

Changes
hermes_cli/tools_config.py: exposes desktop_ui in configurable toolsets and marks it default-off so explicit opt-in survives while implicit defaults omit it.
tui_gateway/server.py: stops injecting desktop_ui solely because the session source is desktop; keeps project as the GUI-owned surface primitive.
tests/tui_gateway/test_gui_surface_toolsets.py: updates gateway regression coverage for default-off behavior and explicit opt-in.
apps/desktop/src/lib/desktop-toolsets.test.ts: keeps desktop_ui visible in Desktop Tools & Keys so users can enable it.

How to Test
python -m pytest tests/tui_gateway/test_gui_surface_toolsets.py tests/test_toolsets.py -q
# ✅ 36/36 passed
CHOKIDAR_USEPOLLING=1 npm --workspace apps/desktop run test:ui -- src/lib/desktop-toolsets.test.ts
# ✅ 2/2 passed
ruff check tui_gateway/server.py hermes_cli/tools_config.py tests/tui_gateway/test_gui_surface_toolsets.py
# ✅ passed
git diff --check
# ✅ passed
python scripts/check-windows-footguns.py --diff upstream/main
# ✅ passed
scripts/run_tests.sh
# ⚠️ environment failure on Termux runner: 3183 PermissionError/permission-denied patterns in the full-suite log

Checklist
- [x] Targeted tests pass — 38/38
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

Risk & Impact
Low. This only changes whether preview-pane tools are granted implicitly; users can still enable desktop_ui explicitly from Tools & Keys.
Type: Bug fix
Closes: #92509
