### PR TITLE
fix(desktop): stop the remote OAuth not-signed-in boot loop

### DIFF
--- a/apps/desktop/electron/backend-health.test.ts
+++ b/apps/desktop/electron/backend-health.test.ts
@@ -11,6 +11,7 @@ import {
   isReauthRequiredError,
   isServerSideHttpError,
   makeNousCloudBackendDownError,
+  makeUnsignedOauthError,
   waitForHermesReady
 } from './backend-health'
 
@@ -217,6 +218,20 @@ test('a credentialed 401 fails fast for reauth instead of reporting a dead sessi
 
   // Fail fast: never reached the public /api/status leg.
   assert.deepEqual(calls, [['probe', 'https://gateway.example/api/health']])
+})
+
+test('unsigned OAuth is a terminal reauth failure; needsOauthLogin alone is not', () => {
+  // The unsigned-in throw must set isReauthRequired so startHermes latches.
+  // needsOauthLogin alone (ticket 401/403) stays a Sign-in hint, not a latch —
+  // a lapsed AT cookie can still rotate from a live RT on the next mint.
+  const unsigned = makeUnsignedOauthError() as any
+
+  assert.equal(unsigned.needsOauthLogin, true)
+  assert.equal(unsigned.isReauthRequired, true)
+  assert.equal(isReauthRequiredError(unsigned), true)
+  assert.match(unsigned.message, /not signed in/i)
+  assert.equal(isReauthRequiredError({ needsOauthLogin: true }), false)
+  assert.equal(isReauthRequiredError(new Error('Could not reach the remote Hermes gateway')), false)
 })
 
 test('a credentialed 403 is also a terminal reauth failure', async () => {

--- a/apps/desktop/electron/backend-health.ts
+++ b/apps/desktop/electron/backend-health.ts
@@ -38,6 +38,10 @@ export interface HermesReadyOptions {
 export const REMOTE_SESSION_EXPIRED_MESSAGE =
   'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.'
 
+export const REMOTE_UNSIGNED_OAUTH_MESSAGE =
+  'Remote Hermes gateway uses OAuth, but you are not signed in. ' +
+  'Open Settings → Gateway and click "Sign in", or switch back to Local.'
+
 /**
  * True for HTTP 502/503/504 from the backend — a server-side fault, not a
  * connectivity or auth issue. These keep polling in the readiness loop but,
@@ -196,6 +200,19 @@ export function makeReauthRequiredError(detail?: string): Error {
   if (detail) {
     error.detail = detail
   }
+
+  return error
+}
+
+/**
+ * No native token and no live cookie: boot cannot self-heal. Must carry
+ * `isReauthRequired` so startHermes latches; `needsOauthLogin` alone only
+ * drives Sign in copy and would retry after #88070, hiding the overlay.
+ */
+export function makeUnsignedOauthError(): Error {
+  const error = new Error(REMOTE_UNSIGNED_OAUTH_MESSAGE) as any
+  error.needsOauthLogin = true
+  error.isReauthRequired = true
 
   return error
 }

--- a/apps/desktop/electron/backend-start-failure.test.ts
+++ b/apps/desktop/electron/backend-start-failure.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
+import { isReauthRequiredError, makeUnsignedOauthError } from './backend-health'
 import {
   isHostKeyChangedBootFailure,
   isRetryableRemoteBootFailure,
@@ -67,6 +68,19 @@ test('FIX #82679: a transient remote failure is retryable so a dropped SSH/HTTP 
 
 test('a CONFIRMED reauth rejection is never auto-retried (missing capability, not transient failure)', () => {
   assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: true, isReauth: true }), false)
+})
+
+test('unsigned OAuth latches and is never auto-retried; needsOauthLogin alone still retries', () => {
+  // Production composition in startHermes: isReauth = isReauthRequiredError(error).
+  const unsigned = isReauthRequiredError(makeUnsignedOauthError())
+  const ticketHint = isReauthRequiredError({ needsOauthLogin: true })
+
+  assert.equal(unsigned, true)
+  assert.equal(shouldLatchRemoteReauthFailure({ attemptedRemote: true, isReauth: unsigned }), true)
+  assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: true, isReauth: unsigned }), false)
+  assert.equal(ticketHint, false)
+  assert.equal(shouldLatchRemoteReauthFailure({ attemptedRemote: true, isReauth: ticketHint }), false)
+  assert.equal(isRetryableRemoteBootFailure({ attemptedRemote: true, isReauth: ticketHint }), true)
 })
 
 test('local failures are never auto-retried by the remote self-heal loop', () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -35,7 +35,12 @@ import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } f
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
-import { isReauthRequiredError, makeNousCloudBackendDownError, waitForHermesReady } from './backend-health'
+import {
+  isReauthRequiredError,
+  makeNousCloudBackendDownError,
+  makeUnsignedOauthError,
+  waitForHermesReady
+} from './backend-health'
 import { backendCommandMatches, createBackendOwnership, createBackendShutdownCoordinator } from './backend-ownership'
 import {
   canImportHermesCli,
@@ -8967,13 +8972,7 @@ async function buildRemoteConnection(
       !oauthSessionIsLive(hasNativeSession(baseUrl), await hasLiveOauthSession(baseUrl)) &&
       oauthGuardMayHardFail(await gatewayAuthProviders(baseUrl, remoteHeaders))
     ) {
-      const err = new Error(
-        'Remote Hermes gateway uses OAuth, but you are not signed in. ' +
-          'Open Settings → Gateway and click "Sign in", or switch back to Local.'
-      ) as any
-
-      err.needsOauthLogin = true
-      throw err
+      throw makeUnsignedOauthError()
     }
 
     let ticket


### PR DESCRIPTION
## Summary
- Desktop treats a confirmed "not signed in" remote OAuth boot as a transient failure, so it keeps retrying, hides the recovery overlay, and Sign in never stays clickable.
- That throw only set `needsOauthLogin`. Boot latch/retry keys on `isReauthRequired`. This tags the unsigned-in throw (no token, no cookie) so boot latches and Sign in stays put.
- Ticket-mint 401/403 still use `needsOauthLogin` only, so a lapsed access token can still rotate from a live refresh token on the next connect.

## Test plan
- [x] Electron tests: `backend-health`, `backend-start-failure`, `connection-config`
- [ ] On Desktop pointed at an OAuth remote with no session: boot should show the Sign in overlay once and stop retrying
- [ ] Click **Sign out & sign in**, finish Nous in the browser, confirm the app reconnects
- [ ] A dropped SSH/HTTP remote (non-auth) still retries as before
- [ ] Sleep/wake with a live refresh token still self-heals without forcing Sign in
