### PR TITLE
fix(desktop): reconcile pins across sidebar slices

### DIFF
--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/hermes', () => ({
 
 import { $pinnedSessionIds } from '@/store/layout'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $sessions } from '@/store/session'
+import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
 
 import { $unconfirmedPinWrites, resetSessionPinMirror, watchSessionPins } from './session-pin-sync'
 
@@ -33,6 +33,8 @@ beforeAll(() => {
 
 beforeEach(() => {
   $sessions.set([])
+  $cronSessions.set([])
+  $messagingSessions.set([])
   $pinnedSessionIds.set([])
   // The mirror/pending/unconfirmed maps are module-global, so one test's
   // bookkeeping would otherwise suppress the next test's PATCH (or fence out
@@ -43,6 +45,8 @@ beforeEach(() => {
 
 afterEach(() => {
   $sessions.set([])
+  $cronSessions.set([])
+  $messagingSessions.set([])
   $pinnedSessionIds.set([])
 })
 
@@ -79,6 +83,27 @@ describe('watchSessionPins', () => {
     expect(patch).toHaveBeenCalledWith('c', true, 'p2')
   })
 
+  it('flushes a deferred messaging pin when its row appears', async () => {
+    $pinnedSessionIds.set(['message-pin'])
+    await flush()
+    expect(patch).not.toHaveBeenCalled()
+
+    $messagingSessions.set([row('message-pin', { profile: 'chat', source: 'photon' })])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('message-pin', true, 'chat')
+  })
+
+  it('writes once when multiple slices represent the same durable conversation', async () => {
+    $sessions.set([row('local-tip', { _lineage_root_id: 'shared-pin' })])
+    $messagingSessions.set([row('message-tip', { _lineage_root_id: 'shared-pin', source: 'photon' })])
+    $pinnedSessionIds.set(['shared-pin'])
+    await flush()
+
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(patch).toHaveBeenCalledWith('shared-pin', true, undefined)
+  })
+
   it('matches a pin id against the lineage root', async () => {
     // pin id is the lineage root; the live row carries it as _lineage_root_id.
     $sessions.set([row('tip', { _lineage_root_id: 'root' })])
@@ -103,6 +128,75 @@ describe('watchSessionPins', () => {
 })
 
 describe('watchSessionPins remote pull', () => {
+  it('adopts and can unpin a backend-only messaging pin', async () => {
+    $messagingSessions.set([row('photon', { pinned: true, profile: 'default', source: 'photon' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['photon'])
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('photon', false, 'default')
+  })
+
+  it('keeps the only explicit pin opinion in a split lineage', async () => {
+    $sessions.set([row('shared-root')])
+    $messagingSessions.set([row('shared-tip', { _lineage_root_id: 'shared-root', pinned: true, source: 'photon' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['shared-root'])
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('defers same-profile conflicts until the slices converge', async () => {
+    $messagingSessions.set([row('conflict-root', { pinned: false, source: 'photon' })])
+    $sessions.set([row('conflict-tip', { _lineage_root_id: 'conflict-root', pinned: true })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual([])
+    expect(patch).not.toHaveBeenCalled()
+
+    $messagingSessions.set([row('conflict-root', { pinned: true, source: 'photon' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['conflict-root'])
+    expect(patch).not.toHaveBeenCalled()
+  })
+
+  it('adopts and can unpin a backend-only cron pin', async () => {
+    $cronSessions.set([row('cron-run', { pinned: true, profile: 'default', source: 'cron' })])
+    await flush()
+
+    expect($pinnedSessionIds.get()).toEqual(['cron-run'])
+    patch.mockClear()
+
+    $pinnedSessionIds.set([])
+    await flush()
+
+    expect(patch).toHaveBeenCalledWith('cron-run', false, 'default')
+  })
+
+  it('routes a cross-slice unpin to the active profile', async () => {
+    $activeGatewayProfile.set('work')
+
+    try {
+      $sessions.set([row('shared', { pinned: true, profile: 'default' })])
+      $messagingSessions.set([row('shared', { pinned: true, profile: 'work', source: 'photon' })])
+      await flush()
+      expect($pinnedSessionIds.get()).toEqual(['shared'])
+      patch.mockClear()
+
+      $pinnedSessionIds.set([])
+      await flush()
+
+      expect(patch).toHaveBeenCalledWith('shared', false, 'work')
+    } finally {
+      $activeGatewayProfile.set('default')
+    }
+  })
+
   it('adopts a pin another app made', async () => {
     $sessions.set([row('remote', { pinned: true })])
     await flush()

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -27,7 +27,7 @@ import { setSessionPinnedRemote } from '@/hermes'
 import { onConnectionScopeChange } from '@/lib/connection-scoped'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
+import { $cronSessions, $messagingSessions, $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 // pin ids we've successfully PATCHed pinned=true this session.
@@ -70,41 +70,77 @@ function publishUnconfirmed(): void {
   $unconfirmedPinWrites.set(new Set(unconfirmed.keys()))
 }
 
-function profileFor(pinId: string): null | string | undefined {
-  return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
+function loadedRows(): SessionInfo[] {
+  return [...$sessions.get(), ...$cronSessions.get(), ...$messagingSessions.get()]
 }
 
-/**
- * One authoritative row per durable pin id. Session ids are only unique inside
- * a profile, so the cross-profile list can legitimately hold two rows with the
- * same `sessionPinId` but different `pinned` flags (copied/imported profile
- * databases). Iterating both would pin then unpin the same id in one pass and
- * re-fire `reconcile` forever — the runaway that overflows nanostores'
- * listenerQueue. Collapse to a single row per id, preferring the active
- * gateway's profile (the same tie-break `resolveLoadedRow` uses), so the pull
- * is deterministic and never oscillates.
+/** Resolve a stored id across every sidebar slice, preferring the active
+ * gateway when two profiles legitimately share the same session id. */
+function resolveLoadedRow(storedId: string, rows: readonly SessionInfo[] = loadedRows()): SessionInfo | undefined {
+  const matches = rows.filter(row => sessionMatchesStoredId(row, storedId))
+
+  if (matches.length < 2) {
+    return matches[0]
+  }
+
+  const gateway = normalizeProfileKey($activeGatewayProfile.get())
+
+  return matches.find(row => normalizeProfileKey(row.profile) === gateway) ?? matches[0]
+}
+
+function profileFor(pinId: string, rows: readonly SessionInfo[]): null | string | undefined {
+  return resolveLoadedRow(pinId, rows)?.profile
+}
+
+interface PinSyncConversation {
+  conflicted: boolean
+  pinId: string
+  representative: SessionInfo
+  rows: SessionInfo[]
+}
+
+/** One reconciliation group per durable pin id across every sidebar slice.
+ *
+ * Session ids are only unique inside a profile, so first choose the active
+ * gateway's rows (or the first-seen profile when none are active). Within that
+ * profile an explicit backend pin opinion outranks an older row that omits the
+ * flag. Conflicting explicit opinions are left unresolved until a later slice
+ * refresh converges; choosing either stale page would synthesize authority.
  */
-function rowsByPinId(rows: readonly SessionInfo[]): Map<string, SessionInfo> {
-  const byId = new Map<string, SessionInfo>()
+function pinSyncConversations(rows: readonly SessionInfo[]): PinSyncConversation[] {
+  const grouped = new Map<string, SessionInfo[]>()
   const gateway = normalizeProfileKey($activeGatewayProfile.get())
 
   for (const row of rows) {
     const pinId = sessionPinId(row)
-    const existing = byId.get(pinId)
+    const existing = grouped.get(pinId)
 
-    if (!existing) {
-      byId.set(pinId, row)
-
-      continue
-    }
-
-    // Prefer the active gateway's profile; otherwise keep the first seen.
-    if (normalizeProfileKey(row.profile) === gateway && normalizeProfileKey(existing.profile) !== gateway) {
-      byId.set(pinId, row)
+    if (existing) {
+      existing.push(row)
+    } else {
+      grouped.set(pinId, [row])
     }
   }
 
-  return byId
+  return [...grouped].map(([pinId, members]) => {
+    const active = members.filter(row => normalizeProfileKey(row.profile) === gateway)
+
+    const profile = active.length
+      ? active
+      : members.filter(row => normalizeProfileKey(row.profile) === normalizeProfileKey(members[0]?.profile))
+
+    const explicit = profile.filter(row => typeof row.pinned === 'boolean')
+    const opinions = new Set(explicit.map(row => row.pinned))
+
+    const representative =
+      (opinions.size === 1 ? explicit[0] : undefined) ?? profile.find(row => row.id === pinId) ?? profile[0]
+
+    if (!representative) {
+      throw new Error(`Pin group ${pinId} has no representative`)
+    }
+
+    return { conflicted: opinions.size > 1, pinId, representative, rows: members }
+  })
 }
 
 /** PATCH the flag, guarding reads against pages that predate the write. */
@@ -137,10 +173,14 @@ function writePin(id: string, pinned: boolean, profile?: null | string): Promise
  * (#74570). Remote pins adopted here are marked mirrored before the local set
  * changes, so the re-entrant reconcile doesn't echo them back as a PATCH.
  */
-function pullRemotePins(): void {
+function pullRemotePins(conversations: readonly PinSyncConversation[]): void {
   const local = new Set($pinnedSessionIds.get())
 
-  for (const row of rowsByPinId($sessions.get()).values()) {
+  for (const { conflicted, pinId, representative: row, rows } of conversations) {
+    if (conflicted) {
+      continue
+    }
+
     // A backend without the flag has no opinion; never act on `undefined`.
     if (typeof row.pinned !== 'boolean') {
       continue
@@ -148,15 +188,15 @@ function pullRemotePins(): void {
 
     // Pins are keyed on the durable lineage root so they survive compression
     // tip rotation; the row may surface under either identity.
-    const pinId = sessionPinId(row)
-    const heldLocally = local.has(pinId) || local.has(row.id)
+    const heldId = local.has(pinId) ? pinId : rows.find(entry => local.has(entry.id))?.id
+    const heldLocally = heldId !== undefined
 
     // A write of ours this page may predate. Confirmed (page agrees) → release
     // the guard, the server has caught up. Contradicted but still inside the
     // cooldown → the page was almost certainly issued before our PATCH, so our
     // write is newer: skip the row. Contradicted past the cooldown → no page
     // ever confirmed us, so stop fencing and let the server win.
-    const guardKey = unconfirmed.has(pinId) ? pinId : unconfirmed.has(row.id) ? row.id : null
+    const guardKey = [pinId, ...rows.map(entry => entry.id)].find(id => unconfirmed.has(id)) ?? null
     const guard = guardKey ? unconfirmed.get(guardKey) : undefined
 
     if (guard && guardKey) {
@@ -171,7 +211,7 @@ function pullRemotePins(): void {
 
     // Local intent still waiting on its PATCH (row unresolved when the push
     // pass ran) is also newer than the page — never revert it.
-    if (pending.has(pinId) || pending.has(row.id)) {
+    if (pending.has(pinId) || rows.some(entry => pending.has(entry.id))) {
       continue
     }
 
@@ -180,17 +220,21 @@ function pullRemotePins(): void {
       // and the nested reconcile must not see this as a new pin to PATCH.
       mirrored.add(pinId)
       pinSession(pinId)
-    } else if (!row.pinned && heldLocally) {
+    } else if (!row.pinned && heldId !== undefined) {
       // Same discipline on the way down: forget the mirror before the nested
       // reconcile runs, or it re-PATCHes pinned=false the server already has.
       mirrored.delete(pinId)
-      mirrored.delete(row.id)
-      unpinSession(local.has(pinId) ? pinId : row.id)
+
+      for (const entry of rows) {
+        mirrored.delete(entry.id)
+      }
+
+      unpinSession(heldId)
     }
   }
 }
 
-// Re-entrancy guard: reconcile() is subscribed to BOTH $sessions and
+// Re-entrancy guard: reconcile() is subscribed to the session-list stores and
 // $pinnedSessionIds, and pullRemotePins() mutates $pinnedSessionIds (via
 // pinSession/unpinSession), which fires reconcile() again synchronously.
 // Without this guard, a session whose pin state oscillates — two rows with the
@@ -229,13 +273,15 @@ function reconcileInner(): void {
   // writePin) — only then may the pull read the page, where those fences stop
   // the still-stale row from silently reverting the user's action (#74570).
   const current = new Set($pinnedSessionIds.get())
+  const rows = loadedRows()
+  const conversations = pinSyncConversations(rows)
 
   // Unpinned: anything we were tracking that's no longer in the set.
   for (const id of [...mirrored, ...pending]) {
     if (!current.has(id)) {
       mirrored.delete(id)
       pending.delete(id)
-      void writePin(id, false, profileFor(id)).catch(() => {})
+      void writePin(id, false, profileFor(id, rows)).catch(() => {})
     }
   }
 
@@ -247,9 +293,9 @@ function reconcileInner(): void {
   }
 
   // Flush whatever we can resolve now; unresolved ids (row not loaded yet)
-  // retry on the next $sessions change.
+  // retry on the next loaded-session-list change.
   for (const id of [...pending]) {
-    const row = $sessions.get().find(entry => sessionMatchesStoredId(entry, id))
+    const row = resolveLoadedRow(id, rows)
 
     if (!row) {
       continue
@@ -264,7 +310,7 @@ function reconcileInner(): void {
     })
   }
 
-  pullRemotePins()
+  pullRemotePins(conversations)
 }
 
 // Sync once, then re-sync on pin-set and session-list changes. Call once per app.
@@ -276,6 +322,8 @@ export function watchSessionPins(): void {
   reconcile()
   $pinnedSessionIds.listen(reconcile)
   $sessions.listen(reconcile)
+  $cronSessions.listen(reconcile)
+  $messagingSessions.listen(reconcile)
 }
 
 /**


### PR DESCRIPTION
## Bug Description

A backend-pinned Photon/messaging conversation can appear in Desktop's Pinned section while **Unpin** is a permanent no-op. The sidebar can render the row from the backend `pinned=true` fallback, but the pin reconciler reads and subscribes only to `$sessions`; messaging rows live in `$messagingSessions`, and cron rows have the same gap in `$cronSessions`.

Fixes #92593.

## Attribution and prior work

This PR supersedes the now-conflicted #74550 by @hashtag1974. It selectively salvages that PR's still-relevant identity grouping, explicit-opinion, conflict-deferral, alias, and duplicate-write contracts, ports them onto current `main`, and extends the fix to cron rows. Current `main` has since added active-profile precedence, timestamped stale-page guards and cooldowns, push-before-pull ordering, reentrancy protection, and connection-scope reset; those newer invariants are retained rather than replaced with the older implementation.

#89716 addresses the separate temporary "unpin bounces back into Pinned" symptom after a write has started. #92593 is the server-only messaging case where no local state change or write starts at all.

#92601 by @fangliquanflq is a concurrent, independent implementation of the direct messaging/cron fix and covers the issue's exact reproduction. This PR differs by also consolidating #74550's split-lineage opinions, conflict deferral, alias handling, duplicate-write suppression, and current-main active-profile rules. If maintainers prefer #92601 as the primary vehicle, these additional tests and reconciliation rules can be ported there; there is no intent to erase or compete with that work.

## Root Cause

`resolvePinnedSessions()` builds the visible Pinned section from all three sidebar slices, but `session-pin-sync.ts` previously used only `$sessions` for:

- backend pin adoption;
- profile resolution;
- pending local-pin flushing;
- list-change subscriptions.

A backend-only messaging pin therefore stayed absent from `$pinnedSessionIds`. Clicking Unpin filtered an ID that was not there, produced no atom update, and never issued `PATCH pinned=false`.

Simply concatenating the slices is insufficient. The same durable conversation can appear under multiple live/root aliases, profiles, or temporarily inconsistent slice snapshots. Reconciliation must preserve active-profile authority, prefer an explicit boolean over a missing opinion within that profile, and defer conflicting explicit opinions until the slices converge.

## Fix

- Reconcile one durable pin group across `$sessions`, `$messagingSessions`, and `$cronSessions`.
- Resolve stored IDs and write profiles across the same combined row snapshot, preferring the active gateway profile.
- Prefer the only explicit backend pin opinion over rows that omit `pinned`.
- Defer same-profile conflicting opinions until a later refresh converges.
- Include every grouped alias in held-local, pending-write, stale-write-guard, and mirrored cleanup checks.
- Subscribe reconciliation to all three sidebar stores.

## How to Verify

1. Start with a Photon row present only in `$messagingSessions`, with `pinned=true` and no local pin ID.
2. Confirm the reconciler adopts its durable ID without echoing a PATCH.
3. Remove the local pin and confirm one `PATCH pinned=false` targets the owning profile.
4. Repeat with a cron-only row.
5. Load same-lineage rows with one explicit opinion and confirm it wins; load conflicting same-profile opinions and confirm reconciliation waits until convergence.

## Test Plan

- [x] Added regression coverage for backend-only messaging adoption and Unpin
- [x] Added deferred messaging-pin and cron-slice coverage
- [x] Added active-profile cross-slice routing, split-lineage opinion, conflict-convergence, alias grouping, and duplicate-write coverage
- [x] Proved the tests bite: pristine `HEAD` fails 6 new contracts while 23 existing tests pass
- [x] Focused pin-sync suite: 29/29
- [x] Related pin/sidebar suites: 47/47
- [x] Full Desktop UI suite: 570 files, 5,441 tests
- [x] Desktop typecheck
- [x] Scoped ESLint and Prettier
- [x] `git diff --check`
- [ ] Manual verification of the fixed build (the pre-fix bug was reproduced on current `main`; this branch has not been installed over the user's production Desktop)

## Risk Assessment

**Medium-low.** This touches the hot bidirectional pin reconciler and broadens its inputs, so stale pages, lineage aliases, duplicate IDs, and profile collisions are the relevant risks. The implementation keeps current-main ordering and write guards intact, takes one immutable row snapshot per reconcile pass, defers same-profile conflicts, and has focused plus full-UI regression coverage. No backend API, database schema, session creation, or routing behavior changes.
