### PR TITLE
feat(pricing): user-declared pricing_overrides in config.yaml drive cost tracking for custom providers (salvage #22614)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1161,6 +1161,93 @@ def _normalize_anthropic_model_name(model: str) -> str:
     return name
 
 
+def _load_user_pricing_overrides() -> list:
+    """Read the ``pricing_overrides:`` list from ``~/.hermes/config.yaml``.
+
+    Returns an empty list when the key is absent, the config can't be
+    loaded, or the value isn't a list. Imports ``load_config`` lazily so
+    that ``agent.usage_pricing`` doesn't pull in the CLI config module at
+    import time (which would invert the dependency direction).
+    """
+    try:
+        from hermes_cli.config import load_config
+    except Exception:
+        return []
+    try:
+        cfg = load_config()
+    except Exception:
+        return []
+    raw = cfg.get("pricing_overrides") if isinstance(cfg, dict) else None
+    return raw if isinstance(raw, list) else []
+
+
+def _entry_from_user_override(entry: Dict[str, Any]) -> Optional[PricingEntry]:
+    """Build a ``PricingEntry`` from one ``pricing_overrides`` list item.
+
+    Requires ``input_per_million`` and ``output_per_million``. Other rate
+    fields are optional. Bad / missing required fields produce ``None``.
+    """
+    if not isinstance(entry, dict):
+        return None
+    ipm = _to_decimal(entry.get("input_per_million"))
+    opm = _to_decimal(entry.get("output_per_million"))
+    if ipm is None or opm is None:
+        return None
+    source_url = entry.get("source_url")
+    pricing_version = entry.get("pricing_version")
+    return PricingEntry(
+        input_cost_per_million=ipm,
+        output_cost_per_million=opm,
+        cache_read_cost_per_million=_to_decimal(entry.get("cache_read_per_million")),
+        cache_write_cost_per_million=_to_decimal(entry.get("cache_write_per_million")),
+        request_cost=_to_decimal(entry.get("request_cost")),
+        source="user_override",
+        source_url=str(source_url) if isinstance(source_url, str) else None,
+        pricing_version=str(pricing_version) if isinstance(pricing_version, str) else None,
+    )
+
+
+def _lookup_user_override_pricing(route: BillingRoute) -> Optional[PricingEntry]:
+    """Match the first ``pricing_overrides`` entry whose ``provider`` matches
+    ``route.provider`` and whose ``model`` matches either the full
+    ``route.model`` or its last path segment (basename).
+
+    Provider strings of the form ``custom:<name>`` are preserved by
+    ``resolve_billing_route``; for those, ``route.model`` is the basename
+    (e.g. ``kimi-k2p6``). For ``provider == "custom"`` (no suffix),
+    ``route.model`` is the full id (e.g. ``accounts/fireworks/models/kimi-k2p6``).
+    Matching against both forms means users don't have to think about
+    that distinction.
+    """
+    overrides = _load_user_pricing_overrides()
+    if not overrides:
+        return None
+    target_provider = (route.provider or "").lower()
+    target_model = (route.model or "").lower()
+    target_basename = target_model.rsplit("/", 1)[-1]
+    for raw in overrides:
+        if not isinstance(raw, dict):
+            continue
+        ep = str(raw.get("provider", "")).strip().lower()
+        em = str(raw.get("model", "")).strip().lower()
+        if not ep or not em:
+            continue
+        if ep != target_provider:
+            continue
+        em_basename = em.rsplit("/", 1)[-1]
+        # Match either form on either side: lets users write the full
+        # "accounts/.../kimi-k2p6" or just "kimi-k2p6" without caring
+        # which form their custom_providers setup routes with.
+        if em != target_model and em_basename != target_model and em != target_basename:
+            continue
+        entry = _entry_from_user_override(raw)
+        if entry is not None:
+            return entry
+        # Bad entry (missing required rates) — keep scanning so a single
+        # malformed item doesn't mask a later valid one for the same model.
+    return None
+
+
 def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
     model = route.model.lower()
     # Direct lookup first
@@ -1254,6 +1341,13 @@ def get_pricing_entry(
             source="none",
             pricing_version="included-route",
         )
+    # User-supplied overrides win over all auto-discovery sources. This is
+    # the supported escape hatch for providers without a pricing API
+    # (e.g. Fireworks) and for keeping rates current when the bundled
+    # ``_OFFICIAL_DOCS_PRICING`` snapshot lags behind a vendor change.
+    user_entry = _lookup_user_override_pricing(route)
+    if user_entry is not None:
+        return user_entry
     if route.provider == "openrouter":
         return _openrouter_pricing_entry(route)
     if route.base_url:

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1232,7 +1232,13 @@ def _lookup_user_override_pricing(route: BillingRoute) -> Optional[PricingEntry]
         em = str(raw.get("model", "")).strip().lower()
         if not ep or not em:
             continue
-        if ep != target_provider:
+        # ``resolve_billing_route`` normalizes recognized custom endpoints to
+        # their canonical provider name (e.g. ``custom:fireworks`` routes as
+        # ``fireworks``). Accept the ``custom:<name>`` spelling users see in
+        # their config alongside the normalized name so overrides keep
+        # matching regardless of which form the router produces.
+        ep_normalized = ep.split(":", 1)[1] if ep.startswith("custom:") else ep
+        if target_provider not in (ep, ep_normalized):
             continue
         em_basename = em.rsplit("/", 1)[-1]
         # Match either form on either side: lets users write the full

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -248,6 +248,45 @@ model:
 #                             # (approval prompts, clarify) never count against it.
 
 # =============================================================================
+# Pricing Overrides (cost reporting for any model/provider)
+# =============================================================================
+# Hermes derives per-turn cost from token counts × pricing. For providers
+# that don't expose pricing through their API (e.g. Fireworks AI) and for
+# any model not in the bundled docs snapshot, declare prices here. Entries
+# win over auto-discovery so you can also use this to fix stale defaults.
+#
+# Match keys:
+#   provider:  the provider string Hermes resolves to. For models served
+#              by a custom_providers entry named "fireworks", it's
+#              "custom:fireworks". Run `hermes config show` to confirm.
+#   model:     match against either the full model id
+#              ("accounts/fireworks/models/kimi-k2p6") OR its basename
+#              ("kimi-k2p6"). Either form works.
+#
+# Rate fields (USD per 1M tokens unless noted):
+#   input_per_million        required
+#   output_per_million       required
+#   cache_read_per_million   optional
+#   cache_write_per_million  optional
+#   request_cost             optional — flat USD per request
+#   source_url               optional — free-form, helps audits
+#   pricing_version          optional — free-form label
+#
+# pricing_overrides:
+#   - provider: custom:fireworks
+#     model: kimi-k2p6
+#     input_per_million: 0.95
+#     output_per_million: 4.00
+#     cache_read_per_million: 0.16
+#     source_url: https://docs.fireworks.ai/serverless/pricing
+#     pricing_version: fireworks-2026-05
+#   - provider: custom:fireworks
+#     model: glm-5p1
+#     input_per_million: 1.40
+#     output_per_million: 4.40
+#     cache_read_per_million: 0.26
+
+# =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)
 # =============================================================================
 # Control how requests are routed across providers on OpenRouter.

--- a/contributors/emails/abdul.kaderjailani@trilogy.com
+++ b/contributors/emails/abdul.kaderjailani@trilogy.com
@@ -1,0 +1,1 @@
+abdulkader-ti

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2013,6 +2013,7 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "unauthorized_dm_behavior",  # top-level form read by gateway/config.py
     "signal",            # Signal settings bridged to env vars by gateway/config.py
     "timeouts",          # unified timeout resolution section (agent/deadline.py, #85125)
+    "pricing_overrides", # user-supplied per-model pricing (agent/usage_pricing.py)
 }
 _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -880,3 +880,41 @@ def test_pricing_overrides_skip_entries_missing_required_fields(monkeypatch):
     # The first (incomplete) entry should be skipped; the second wins.
     assert entry is not None
     assert float(entry.input_cost_per_million) == 0.95
+
+
+def test_pricing_overrides_custom_prefix_matches_normalized_route(monkeypatch):
+    """resolve_billing_route normalizes recognized custom endpoints to their
+    canonical provider name (custom:fireworks routes as provider="fireworks").
+    An override written with the config-visible custom:<name> spelling must
+    still match that normalized route."""
+    monkeypatch.setattr(
+        "agent.usage_pricing._load_user_pricing_overrides",
+        lambda: [
+            {
+                "provider": "custom:fireworks",
+                "model": "kimi-k2p6",
+                "input_per_million": 0.5,
+                "output_per_million": 1.5,
+            }
+        ],
+    )
+
+    from agent.usage_pricing import resolve_billing_route
+
+    route = resolve_billing_route(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="custom:fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+    # Precondition: this test only exercises the bug when the router
+    # actually normalizes away the custom: prefix.
+    assert route.provider == "fireworks"
+
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="custom:fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+    assert entry is not None
+    assert entry.source == "user_override"
+    assert float(entry.input_cost_per_million) == 0.5

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -766,3 +766,117 @@ def test_normalize_usage_nested_details_win_over_qwen_flat_top_level():
 
     assert normalized.cache_read_tokens == 900
     assert normalized.input_tokens == 1100
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# pricing_overrides — user-supplied prices win over auto-discovery sources.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_pricing_overrides_resolve_for_custom_provider(monkeypatch):
+    """A user override for a custom_providers-routed model (e.g. Fireworks)
+    should resolve via get_pricing_entry, even though Fireworks has no
+    pricing API and isn't in the bundled docs snapshot."""
+    monkeypatch.setattr(
+        "agent.usage_pricing._load_user_pricing_overrides",
+        lambda: [
+            {
+                "provider": "custom:fireworks",
+                "model": "kimi-k2p6",
+                "input_per_million": 0.95,
+                "output_per_million": 4.00,
+                "cache_read_per_million": 0.16,
+                "source_url": "https://docs.fireworks.ai/serverless/pricing",
+            }
+        ],
+    )
+
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="custom:fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    assert entry is not None
+    assert entry.source == "user_override"
+    assert float(entry.input_cost_per_million) == 0.95
+    assert float(entry.output_cost_per_million) == 4.00
+    assert float(entry.cache_read_cost_per_million) == 0.16
+
+
+def test_pricing_overrides_match_full_model_id_or_basename(monkeypatch):
+    """The matcher should accept either the full slash-prefixed id or the
+    basename, so users don't have to know which form Hermes routes with
+    for their particular custom_providers configuration."""
+    monkeypatch.setattr(
+        "agent.usage_pricing._load_user_pricing_overrides",
+        lambda: [
+            {
+                # Full id form
+                "provider": "custom:fireworks",
+                "model": "accounts/fireworks/models/kimi-k2p6",
+                "input_per_million": 1.0,
+                "output_per_million": 2.0,
+            }
+        ],
+    )
+
+    # Basename form on the route should still hit the full-id override.
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="custom:fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 1.0
+
+
+def test_pricing_overrides_take_precedence_over_docs_snapshot(monkeypatch):
+    """When both a user override and a bundled snapshot entry exist for the
+    same (provider, model), the override wins. This is the supported way
+    to correct stale rates without waiting for a Hermes release."""
+    monkeypatch.setattr(
+        "agent.usage_pricing._load_user_pricing_overrides",
+        lambda: [
+            {
+                "provider": "anthropic",
+                "model": "claude-opus-4-7",
+                "input_per_million": 99.0,  # absurd value to prove override wins
+                "output_per_million": 99.0,
+            }
+        ],
+    )
+
+    entry = get_pricing_entry("claude-opus-4-7", provider="anthropic")
+
+    assert entry is not None
+    assert entry.source == "user_override"
+    assert float(entry.input_cost_per_million) == 99.0
+
+
+def test_pricing_overrides_skip_entries_missing_required_fields(monkeypatch):
+    """Entries without input_per_million OR output_per_million are skipped
+    silently — we don't want a single bad entry to mask later valid ones
+    or crash cost computation."""
+    monkeypatch.setattr(
+        "agent.usage_pricing._load_user_pricing_overrides",
+        lambda: [
+            {"provider": "custom:fireworks", "model": "kimi-k2p6"},  # no rates
+            {
+                "provider": "custom:fireworks",
+                "model": "kimi-k2p6",
+                "input_per_million": 0.95,
+                "output_per_million": 4.00,
+            },
+        ],
+    )
+
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="custom:fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    # The first (incomplete) entry should be skipped; the second wins.
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.95

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1984,6 +1984,25 @@ Signal is listed as a valid platform key because the setting can be saved per pl
 
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
 
+## Pricing Overrides
+
+Hermes derives per-turn dollar costs (the `display.show_cost` status bar, `hermes insights`, the model cost guard) from token counts × per-model pricing. Pricing is auto-discovered from provider APIs and a bundled snapshot, but some providers (e.g. Fireworks AI) don't publish pricing through their API, and the bundled snapshot can lag a vendor price change. The root-level `pricing_overrides:` list lets you declare rates yourself — user entries win over every auto-discovery source:
+
+```yaml
+pricing_overrides:
+  - provider: custom:fireworks   # provider string Hermes resolves to; `custom:<name>` and the bare name both match
+    model: kimi-k2p6             # full model id or its basename — either form matches
+    input_per_million: 0.95      # required, USD per 1M input tokens
+    output_per_million: 4.00     # required, USD per 1M output tokens
+    cache_read_per_million: 0.16 # optional
+    cache_write_per_million: 0   # optional
+    request_cost: 0              # optional — flat USD per request
+    source_url: https://docs.fireworks.ai/serverless/pricing  # optional, free-form
+    pricing_version: fireworks-2026-05                        # optional, free-form
+```
+
+Entries missing either required rate are skipped (a malformed item never masks a later valid one or breaks cost computation). Costs resolved this way are labeled `user_override` in cost surfaces.
+
 ## Privacy
 
 ```yaml


### PR DESCRIPTION
## Summary

Users can now declare per-model USD pricing in a root-level `pricing_overrides:` list in `config.yaml`, and those rates win over every auto-discovery source — closing the gap where custom-provider models (Fireworks etc.) showed correct token counts but no dollar amount, and giving a supported way to correct a stale bundled rate without waiting for a release. Salvage of #22614 by @abdulkader-ti, hardened for current `main`.

Inspired by this week's goose merge (aaif-goose/goose#11220 — config-declared pricing fallback drives cost tracking for custom providers), which validated the same design upstream.

## Changes
- `agent/usage_pricing.py`: `_load_user_pricing_overrides` / `_lookup_user_override_pricing` — consulted first in `get_pricing_entry` (after subscription-included routes); entries missing a required rate are skipped so one bad item never masks a valid one
- Hardening commit (ours): `resolve_billing_route` on current main normalizes `custom:fireworks` → `fireworks`, which would have made `custom:`-spelled overrides never match — matcher now accepts both spellings (regression test verified to fail without the fix via sabotage run)
- `hermes_cli/config.py`: `pricing_overrides` accepted as a known root key
- `cli-config.yaml.example` + `website/docs/user-guide/configuration.md`: documented section with a worked Fireworks example
- `tests/agent/test_usage_pricing.py`: 5 new tests (resolution, full-id/basename matching, precedence over docs snapshot, malformed-entry skip, custom:-prefix normalization)

## Validation
| | Result |
|---|---|
| `pytest tests/agent/test_usage_pricing.py` | 45 passed |
| E2E: real temp `HERMES_HOME` + real `config.yaml` → `get_pricing_entry` | resolves `user_override` at declared rates |
| Sabotage run (fix reverted) | new regression test fails as expected |

Credit: @abdulkader-ti (#22614, cherry-picked with authorship preserved). Related open PRs on the same theme: #57387 (subscription-route overrides — intentionally NOT covered here; overrides still yield $0 on `subscription_included` routes), earlier closed attempts #9421 (@NewTurn2017, first to propose overrides), #40720 (@liuhao1024).

## Infographic

![pricing_overrides in config.yaml](https://v3b.fal.media/files/b/0aa76def/298rjqEhtRoij2DiK7_S__LlN4TH4x.png)
