### PR TITLE
fix(auth): keep Anthropic OAuth sessions valid after token rotation

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1556,6 +1556,24 @@ def _get_hermes_oauth_file() -> Path:
     return get_hermes_home() / ".anthropic_oauth.json"
 
 
+def _write_hermes_oauth_credentials(
+    access_token: str, refresh_token: str, expires_at_ms: int
+) -> None:
+    """Atomically persist the rotating Hermes-managed PKCE grant."""
+    from utils import atomic_json_write
+
+    atomic_json_write(
+        _get_hermes_oauth_file(),
+        {
+            "accessToken": access_token,
+            "refreshToken": refresh_token,
+            "expiresAt": expires_at_ms,
+        },
+        indent=2,
+        mode=0o600,
+    )
+
+
 def _generate_pkce() -> tuple:
     """Generate PKCE code_verifier and code_challenge (S256)."""
     import base64

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -904,6 +904,40 @@ class CredentialPool:
             logger.debug("Failed to sync from credentials file: %s", exc)
         return entry
 
+    def _sync_anthropic_entry_from_pool_store(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
+        """Adopt an Anthropic token pair rotated by another pool instance."""
+        if self.provider != "anthropic":
+            return entry
+        try:
+            persisted = next(
+                (
+                    payload
+                    for payload in read_credential_pool(self.provider)
+                    if isinstance(payload, dict) and payload.get("id") == entry.id
+                ),
+                None,
+            )
+            if not isinstance(persisted, dict):
+                return entry
+            stored = PooledCredential.from_dict(self.provider, persisted)
+            if (
+                stored.access_token != entry.access_token
+                or stored.refresh_token != entry.refresh_token
+            ):
+                logger.debug(
+                    "Pool entry %s: adopting Anthropic OAuth tokens rotated by another process",
+                    entry.id,
+                )
+                self._replace_entry(entry, stored)
+                return stored
+        except Exception as exc:
+            logger.debug(
+                "Failed to sync Anthropic OAuth entry from credential pool: %s", exc
+            )
+        return entry
+
     def _sync_codex_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
         """Sync a Codex device_code pool entry from auth.json if tokens differ.
 
@@ -1310,7 +1344,7 @@ class CredentialPool:
                 self._mark_exhausted(entry, None)
             return None
 
-        # Codex and xAI OAuth refresh tokens are single-use.  The
+        # Codex, xAI, and Anthropic OAuth refresh tokens are single-use. The
         # sync→POST→write-back sequence below must run atomically across Hermes
         # processes: otherwise two processes can both adopt the same on-disk
         # token, both POST it, and the loser gets ``refresh_token_reused``.
@@ -1319,11 +1353,13 @@ class CredentialPool:
         # resolve_codex_runtime_credentials()).  When a waiter finally acquires
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
-        if self.provider in ("openai-codex", "xai-oauth"):
+        if self.provider in ("openai-codex", "xai-oauth", "anthropic"):
             sync_entry = (
                 self._sync_codex_entry_from_auth_store
                 if self.provider == "openai-codex"
                 else self._sync_xai_oauth_entry_from_pool_store
+                if self.provider == "xai-oauth"
+                else self._sync_anthropic_entry_from_pool_store
             )
             with _auth_store_lock(
                 timeout_seconds=self._single_use_refresh_lock_timeout()
@@ -1355,6 +1391,8 @@ class CredentialPool:
             "HERMES_CODEX_REFRESH_TIMEOUT_SECONDS"
             if self.provider == "openai-codex"
             else "HERMES_XAI_REFRESH_TIMEOUT_SECONDS"
+            if self.provider == "xai-oauth"
+            else "HERMES_ANTHROPIC_REFRESH_TIMEOUT_SECONDS"
         )
         refresh_timeout_seconds = auth_mod.env_float(env_var, 20)
         return max(
@@ -1494,6 +1532,23 @@ class CredentialPool:
                     # Credentials file had a valid (non-expired) token — use it directly
                     logger.debug("Credentials file has valid token, using without refresh")
                     return synced
+            elif self.provider == "anthropic":
+                # Re-check canonical state before a terminal response poisons
+                # this process-local copy of a grant another process rotated.
+                synced = self._sync_anthropic_entry_from_pool_store(entry)
+                if synced.refresh_token != entry.refresh_token:
+                    updated = replace(
+                        synced,
+                        last_status=STATUS_OK,
+                        last_status_at=None,
+                        last_error_code=None,
+                        last_error_reason=None,
+                        last_error_message=None,
+                        last_error_reset_at=None,
+                    )
+                    self._replace_entry(synced, updated)
+                    self._persist()
+                    return updated
             # For xai-oauth: same race as nous — another process may have
             # consumed the refresh token between our proactive sync and the
             # HTTP call.  Re-check auth.json and adopt the fresh tokens if
@@ -1841,10 +1896,10 @@ class CredentialPool:
         reset to STATUS_OK and persisted.  When *refresh* is True, entries
         that need a token refresh are refreshed (skipped on failure).
 
-        Single-use-token refreshes (openai-codex, xai-oauth) are returned as
-        *pending_refresh* tuples so the caller can execute them outside the
-        lock, avoiding stalling all pool consumers during cross-process flock
-        acquisition + OAuth network I/O.
+        Single-use-token refreshes (openai-codex, xai-oauth, anthropic) are
+        returned as *pending_refresh* tuples so the caller can execute them
+        outside the lock, avoiding stalling all pool consumers during
+        cross-process flock acquisition + OAuth network I/O.
         """
         now = time.time()
         cleared_any = False
@@ -1969,13 +2024,15 @@ class CredentialPool:
                     entry = cleared
                     cleared_any = True
             if refresh and self._entry_needs_refresh(entry):
-                if self.provider in ("openai-codex", "xai-oauth"):
+                if self.provider in ("openai-codex", "xai-oauth", "anthropic"):
                     # Defer single-use-token refresh to avoid holding the
                     # threading lock during cross-process flock + network I/O.
                     sync_fn = (
                         self._sync_codex_entry_from_auth_store
                         if self.provider == "openai-codex"
                         else self._sync_xai_oauth_entry_from_pool_store
+                        if self.provider == "xai-oauth"
+                        else self._sync_anthropic_entry_from_pool_store
                     )
                     pending_refresh.append((entry, sync_fn))
                     continue

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2352,7 +2352,8 @@ class CredentialPool:
 
     def try_refresh_current(self) -> Optional[PooledCredential]:
         with self._lock:
-            return self._try_refresh_current_unlocked()
+            entry = self._current_unlocked()
+        return self._try_refresh_entry(entry)
 
     def try_refresh_matching(
         self,
@@ -2392,18 +2393,20 @@ class CredentialPool:
                     entry = self._current_unlocked() or self._select_unlocked(
                         refresh=False
                     )[0]
-            if entry is None:
-                return None
-            self._current_id = entry.id
-            return self._try_refresh_current_unlocked()
+            if entry is not None:
+                self._current_id = entry.id
+        return self._try_refresh_entry(entry)
 
-    def _try_refresh_current_unlocked(self) -> Optional[PooledCredential]:
-        entry = self._current_unlocked()
+    def _try_refresh_entry(
+        self, entry: Optional[PooledCredential]
+    ) -> Optional[PooledCredential]:
+        """Force one refresh without holding the pool lock over I/O."""
         if entry is None:
             return None
         refreshed = self._refresh_entry(entry, force=True)
         if refreshed is not None:
-            self._current_id = refreshed.id
+            with self._lock:
+                self._current_id = refreshed.id
         return refreshed
 
     def reset_statuses(self) -> int:
@@ -3297,7 +3300,11 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
-    authority = _auth_store_lock() if provider == "anthropic" else nullcontext()
+    authority = (
+        _auth_store_lock(timeout_seconds=25.0)
+        if provider == "anthropic"
+        else nullcontext()
+    )
     with authority:
         return _load_pool_under_authority(provider)
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1392,6 +1392,19 @@ class CredentialPool:
                         )
                     except Exception as wexc:
                         logger.debug("Failed to write refreshed token to credentials file: %s", wexc)
+                elif entry.source == "hermes_pkce":
+                    try:
+                        from agent.anthropic_adapter import _write_hermes_oauth_credentials
+
+                        _write_hermes_oauth_credentials(
+                            refreshed["access_token"],
+                            refreshed["refresh_token"],
+                            refreshed["expires_at_ms"],
+                        )
+                    except Exception as wexc:
+                        logger.debug(
+                            "Failed to write refreshed Hermes PKCE token: %s", wexc
+                        )
             elif self.provider == "openai-codex":
                 # Adopt fresher tokens from auth.json before spending the
                 # refresh_token — single-use tokens consumed by another Hermes
@@ -2427,13 +2440,39 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
     field_updates = {}
     extra_updates = {}
     _field_names = {f.name for f in fields(existing)}
+    incoming_expires_at_ms = payload.get("expires_at_ms")
+    preserve_fresher_pkce_tokens = False
+    if (
+        provider == "anthropic"
+        and source == "hermes_pkce"
+        and existing.auth_type == AUTH_TYPE_OAUTH
+        and existing.expires_at_ms is not None
+        and incoming_expires_at_ms is not None
+    ):
+        try:
+            preserve_fresher_pkce_tokens = (
+                int(incoming_expires_at_ms) <= int(existing.expires_at_ms)
+                and (
+                    payload.get("access_token") != existing.access_token
+                    or payload.get("refresh_token") != existing.refresh_token
+                )
+            )
+        except (TypeError, ValueError):
+            preserve_fresher_pkce_tokens = False
     token_changed = (
-        "access_token" in payload
+        not preserve_fresher_pkce_tokens
+        and "access_token" in payload
         and payload["access_token"] is not None
         and payload["access_token"] != existing.access_token
     )
     for key, value in payload.items():
         if key in {"id", "priority"} or value is None:
+            continue
+        if preserve_fresher_pkce_tokens and key in {
+            "access_token",
+            "refresh_token",
+            "expires_at_ms",
+        }:
             continue
         if key == "label" and existing.label:
             continue
@@ -2565,10 +2604,15 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                 changed = True
             return changed, active_sources
 
-        from agent.anthropic_adapter import read_claude_code_credentials, read_hermes_oauth_credentials
+        from agent.anthropic_adapter import (
+            _write_hermes_oauth_credentials,
+            read_claude_code_credentials,
+            read_hermes_oauth_credentials,
+        )
 
+        hermes_oauth_creds = read_hermes_oauth_credentials()
         for source_name, creds in (
-            ("hermes_pkce", read_hermes_oauth_credentials()),
+            ("hermes_pkce", hermes_oauth_creds),
             ("claude_code", read_claude_code_credentials()),
         ):
             if creds and creds.get("accessToken"):
@@ -2588,6 +2632,63 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                         "label": label_from_token(creds.get("accessToken", ""), source_name),
                     },
                 )
+
+        # Older dashboard logins mirrored the one file-backed PKCE grant into
+        # a second manual:dashboard_pkce row. Anthropic refresh tokens rotate
+        # on use, so two rows must never retain the same underlying grant.
+        # Collapse that legacy pair while preserving whichever pool row has
+        # the latest expiry; on a tie prefer the dashboard row because the
+        # file-backed row may just have been re-seeded from stale disk state.
+        if hermes_oauth_creds and "hermes_pkce" in active_sources:
+            shared_sources = {"hermes_pkce", "manual:dashboard_pkce"}
+            candidates = [
+                entry for entry in entries if entry.source in shared_sources
+            ]
+            if len(candidates) > 1:
+
+                def _pkce_freshness(item: PooledCredential) -> Tuple[int, int]:
+                    try:
+                        expires = int(item.expires_at_ms or 0)
+                    except (TypeError, ValueError):
+                        expires = 0
+                    return expires, int(item.source == "manual:dashboard_pkce")
+
+                winner = max(candidates, key=_pkce_freshness)
+                canonical = next(
+                    item for item in candidates if item.source == "hermes_pkce"
+                )
+                merged = replace(
+                    winner,
+                    id=canonical.id,
+                    source="hermes_pkce",
+                    priority=canonical.priority,
+                )
+                collapsed = []
+                inserted = False
+                for item in entries:
+                    if item.source not in shared_sources:
+                        collapsed.append(item)
+                    elif not inserted:
+                        collapsed.append(merged)
+                        inserted = True
+                entries[:] = collapsed
+                changed = True
+
+                if (
+                    winner.access_token != hermes_oauth_creds.get("accessToken")
+                    or winner.refresh_token != hermes_oauth_creds.get("refreshToken")
+                    or winner.expires_at_ms != hermes_oauth_creds.get("expiresAt")
+                ):
+                    try:
+                        _write_hermes_oauth_credentials(
+                            winner.access_token,
+                            winner.refresh_token or "",
+                            int(winner.expires_at_ms or 0),
+                        )
+                    except Exception as exc:
+                        logger.debug(
+                            "Failed to repair stale Hermes PKCE singleton: %s", exc
+                        )
 
     elif provider == "nous":
         state = _load_provider_state(auth_store, "nous")

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1397,6 +1397,7 @@ class CredentialPool:
         """Refresh one canonical PKCE generation without lock-order inversion."""
         result: Optional[PooledCredential] = None
         refresh_failed = False
+        removed = False
         with _auth_store_lock(
             timeout_seconds=self._single_use_refresh_lock_timeout()
         ):
@@ -1408,70 +1409,96 @@ class CredentialPool:
                 ),
                 None,
             )
-            stored = (
-                PooledCredential.from_dict("anthropic", persisted)
-                if isinstance(persisted, dict)
-                else entry
-            )
-            if (
-                stored.access_token != entry.access_token
-                or stored.refresh_token != entry.refresh_token
-            ):
-                result = stored
+            if not isinstance(persisted, dict):
+                # Another process explicitly removed this canonical identity.
+                # Never resurrect it from a stale process-local snapshot.
+                removed = True
             else:
-                try:
-                    from agent.anthropic_adapter import (
-                        _write_hermes_oauth_credentials,
-                        refresh_anthropic_oauth_pure,
-                    )
+                stored = PooledCredential.from_dict("anthropic", persisted)
+                if (
+                    stored.access_token != entry.access_token
+                    or stored.refresh_token != entry.refresh_token
+                ):
+                    result = stored
+                else:
+                    try:
+                        from agent.anthropic_adapter import (
+                            _write_hermes_oauth_credentials,
+                            refresh_anthropic_oauth_pure,
+                        )
 
-                    refreshed = refresh_anthropic_oauth_pure(
-                        stored.refresh_token, use_json=True
-                    )
-                    result = replace(
-                        stored,
-                        access_token=refreshed["access_token"],
-                        refresh_token=refreshed["refresh_token"],
-                        expires_at_ms=refreshed["expires_at_ms"],
-                        last_status=STATUS_OK,
-                        last_status_at=None,
-                        last_error_code=None,
-                        last_error_reason=None,
-                        last_error_message=None,
-                        last_error_reset_at=None,
-                    )
-                    _write_hermes_oauth_credentials(
-                        result.access_token,
-                        result.refresh_token or "",
-                        int(result.expires_at_ms or 0),
-                    )
-                    write_credential_pool(
-                        "anthropic",
-                        [result.to_dict()],
-                        authoritative_ids=[result.id],
-                    )
-                except Exception as exc:
-                    logger.debug(
-                        "Credential refresh failed for anthropic/%s: %s",
-                        entry.id,
-                        exc,
-                    )
-                    # Re-check once before treating this generation as dead.
-                    winner = next(
-                        (
-                            payload
-                            for payload in read_credential_pool("anthropic")
-                            if isinstance(payload, dict)
-                            and payload.get("id") == entry.id
-                        ),
-                        None,
-                    )
-                    if isinstance(winner, dict):
-                        candidate = PooledCredential.from_dict("anthropic", winner)
-                        if candidate.refresh_token != entry.refresh_token:
-                            result = candidate
-                    refresh_failed = result is None
+                        refreshed = refresh_anthropic_oauth_pure(
+                            stored.refresh_token, use_json=True
+                        )
+                        result = replace(
+                            stored,
+                            access_token=refreshed["access_token"],
+                            refresh_token=refreshed["refresh_token"],
+                            expires_at_ms=refreshed["expires_at_ms"],
+                            last_status=STATUS_OK,
+                            last_status_at=None,
+                            last_error_code=None,
+                            last_error_reason=None,
+                            last_error_message=None,
+                            last_error_reset_at=None,
+                        )
+                    except Exception as exc:
+                        logger.debug(
+                            "Credential refresh failed for anthropic/%s: %s",
+                            entry.id,
+                            exc,
+                        )
+                        # Re-check once before treating this generation as dead.
+                        winner = next(
+                            (
+                                payload
+                                for payload in read_credential_pool("anthropic")
+                                if isinstance(payload, dict)
+                                and payload.get("id") == entry.id
+                            ),
+                            None,
+                        )
+                        if isinstance(winner, dict):
+                            candidate = PooledCredential.from_dict(
+                                "anthropic", winner
+                            )
+                            if candidate.refresh_token != entry.refresh_token:
+                                result = candidate
+                        refresh_failed = result is None
+                    else:
+                        # Persistence errors must not turn a successful token
+                        # redemption into a false exhausted state. Commit the
+                        # canonical row first, then independently repair the
+                        # singleton; either store can heal the other on load.
+                        try:
+                            write_credential_pool(
+                                "anthropic",
+                                [result.to_dict()],
+                                authoritative_ids=[result.id],
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                "Failed to persist refreshed Anthropic PKCE pool row: %s",
+                                exc,
+                            )
+                        try:
+                            _write_hermes_oauth_credentials(
+                                result.access_token,
+                                result.refresh_token or "",
+                                int(result.expires_at_ms or 0),
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                "Failed to persist refreshed Anthropic PKCE singleton: %s",
+                                exc,
+                            )
 
+        if removed:
+            with self._lock:
+                self._entries = [item for item in self._entries if item.id != entry.id]
+                if self._current_id == entry.id:
+                    self._current_id = None
+            return None
         if result is not None:
             self._replace_entry(entry, result)
             return result

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1351,7 +1351,14 @@ class CredentialPool:
                 self._mark_exhausted(entry, None)
             return None
 
-        # Codex, xAI, and Anthropic OAuth refresh tokens are single-use. The
+        # Hermes-managed PKCE grants need a cross-process refresh authority,
+        # but that authority must never nest the process-local pool lock. The
+        # dedicated path persists the canonical row while authoritative, then
+        # updates this pool only after releasing the file lock.
+        if self.provider == "anthropic" and entry.source == "hermes_pkce":
+            return self._refresh_hermes_pkce_entry(entry)
+
+        # Codex and xAI OAuth refresh tokens are single-use. The
         # sync→POST→write-back sequence below must run atomically across Hermes
         # processes: otherwise two processes can both adopt the same on-disk
         # token, both POST it, and the loser gets ``refresh_token_reused``.
@@ -1360,13 +1367,11 @@ class CredentialPool:
         # resolve_codex_runtime_credentials()).  When a waiter finally acquires
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
-        if self.provider in ("openai-codex", "xai-oauth", "anthropic"):
+        if self.provider in ("openai-codex", "xai-oauth"):
             sync_entry = (
                 self._sync_codex_entry_from_auth_store
                 if self.provider == "openai-codex"
                 else self._sync_xai_oauth_entry_from_pool_store
-                if self.provider == "xai-oauth"
-                else self._sync_anthropic_entry_from_pool_store
             )
             with _auth_store_lock(
                 timeout_seconds=self._single_use_refresh_lock_timeout()
@@ -1385,6 +1390,94 @@ class CredentialPool:
                     return synced
                 return self._refresh_entry_impl(synced, force=force)
         return self._refresh_entry_impl(entry, force=force)
+
+    def _refresh_hermes_pkce_entry(
+        self, entry: PooledCredential
+    ) -> Optional[PooledCredential]:
+        """Refresh one canonical PKCE generation without lock-order inversion."""
+        result: Optional[PooledCredential] = None
+        refresh_failed = False
+        with _auth_store_lock(
+            timeout_seconds=self._single_use_refresh_lock_timeout()
+        ):
+            persisted = next(
+                (
+                    payload
+                    for payload in read_credential_pool("anthropic")
+                    if isinstance(payload, dict) and payload.get("id") == entry.id
+                ),
+                None,
+            )
+            stored = (
+                PooledCredential.from_dict("anthropic", persisted)
+                if isinstance(persisted, dict)
+                else entry
+            )
+            if (
+                stored.access_token != entry.access_token
+                or stored.refresh_token != entry.refresh_token
+            ):
+                result = stored
+            else:
+                try:
+                    from agent.anthropic_adapter import (
+                        _write_hermes_oauth_credentials,
+                        refresh_anthropic_oauth_pure,
+                    )
+
+                    refreshed = refresh_anthropic_oauth_pure(
+                        stored.refresh_token, use_json=True
+                    )
+                    result = replace(
+                        stored,
+                        access_token=refreshed["access_token"],
+                        refresh_token=refreshed["refresh_token"],
+                        expires_at_ms=refreshed["expires_at_ms"],
+                        last_status=STATUS_OK,
+                        last_status_at=None,
+                        last_error_code=None,
+                        last_error_reason=None,
+                        last_error_message=None,
+                        last_error_reset_at=None,
+                    )
+                    _write_hermes_oauth_credentials(
+                        result.access_token,
+                        result.refresh_token or "",
+                        int(result.expires_at_ms or 0),
+                    )
+                    write_credential_pool(
+                        "anthropic",
+                        [result.to_dict()],
+                        authoritative_ids=[result.id],
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "Credential refresh failed for anthropic/%s: %s",
+                        entry.id,
+                        exc,
+                    )
+                    # Re-check once before treating this generation as dead.
+                    winner = next(
+                        (
+                            payload
+                            for payload in read_credential_pool("anthropic")
+                            if isinstance(payload, dict)
+                            and payload.get("id") == entry.id
+                        ),
+                        None,
+                    )
+                    if isinstance(winner, dict):
+                        candidate = PooledCredential.from_dict("anthropic", winner)
+                        if candidate.refresh_token != entry.refresh_token:
+                            result = candidate
+                    refresh_failed = result is None
+
+        if result is not None:
+            self._replace_entry(entry, result)
+            return result
+        if refresh_failed:
+            self._mark_exhausted(entry, None)
+        return None
 
     def _single_use_refresh_lock_timeout(self) -> float:
         """Lock timeout for single-use-refresh-token providers.

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -775,6 +775,25 @@ class CredentialPool:
                     self._entries[idx] = new
                     return
 
+    def _adopt_refresh_result(
+        self, expected: PooledCredential, refreshed: PooledCredential
+    ) -> Optional[PooledCredential]:
+        """Install a refresh result only while its starting generation is current."""
+        with self._lock:
+            for idx, current in enumerate(self._entries):
+                if current.id != expected.id:
+                    continue
+                if (
+                    current.access_token == expected.access_token
+                    and current.refresh_token == expected.refresh_token
+                ):
+                    self._entries[idx] = refreshed
+                    return refreshed
+                # Another actor already advanced this row after the refresh
+                # authority was released. Preserve and adopt that generation.
+                return current
+        return None
+
     def _persist(
         self,
         *,
@@ -1397,6 +1416,7 @@ class CredentialPool:
         """Refresh one canonical PKCE generation without lock-order inversion."""
         result: Optional[PooledCredential] = None
         refresh_failed = False
+        settlement_failed = False
         removed = False
         with _auth_store_lock(
             timeout_seconds=self._single_use_refresh_lock_timeout()
@@ -1463,24 +1483,39 @@ class CredentialPool:
                                 "anthropic", winner
                             )
                             if candidate.refresh_token != entry.refresh_token:
-                                result = candidate
+                                result = replace(
+                                    candidate,
+                                    last_status=STATUS_OK,
+                                    last_status_at=None,
+                                    last_error_code=None,
+                                    last_error_reason=None,
+                                    last_error_message=None,
+                                    last_error_reset_at=None,
+                                )
                         refresh_failed = result is None
                     else:
-                        # Persistence errors must not turn a successful token
-                        # redemption into a false exhausted state. Commit the
-                        # canonical row first, then independently repair the
-                        # singleton; either store can heal the other on load.
-                        try:
-                            write_credential_pool(
-                                "anthropic",
-                                [result.to_dict()],
-                                authoritative_ids=[result.id],
-                            )
-                        except Exception as exc:
-                            logger.warning(
-                                "Failed to persist refreshed Anthropic PKCE pool row: %s",
-                                exc,
-                            )
+                        # A single-use redemption is not settled until its
+                        # successor is durable in the store every waiter reads.
+                        # Retry one transient atomic-write failure while still
+                        # holding the refresh authority; never report a
+                        # memory-only winner as ordinary success.
+                        canonical_committed = False
+                        for attempt in range(2):
+                            try:
+                                write_credential_pool(
+                                    "anthropic",
+                                    [result.to_dict()],
+                                    authoritative_ids=[result.id],
+                                )
+                                canonical_committed = True
+                                break
+                            except Exception as exc:
+                                logger.warning(
+                                    "Failed to persist refreshed Anthropic PKCE pool row"
+                                    " (attempt %s/2): %s",
+                                    attempt + 1,
+                                    exc,
+                                )
                         try:
                             _write_hermes_oauth_credentials(
                                 result.access_token,
@@ -1492,6 +1527,9 @@ class CredentialPool:
                                 "Failed to persist refreshed Anthropic PKCE singleton: %s",
                                 exc,
                             )
+                        if not canonical_committed:
+                            settlement_failed = True
+                            result = None
 
         if removed:
             with self._lock:
@@ -1500,8 +1538,9 @@ class CredentialPool:
                     self._current_id = None
             return None
         if result is not None:
-            self._replace_entry(entry, result)
-            return result
+            return self._adopt_refresh_result(entry, result)
+        if settlement_failed:
+            return None
         if refresh_failed:
             self._mark_exhausted(entry, None)
         return None

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -774,7 +774,12 @@ class CredentialPool:
                     self._entries[idx] = new
                     return
 
-    def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+    def _persist(
+        self,
+        *,
+        removed_ids: Optional[List[str]] = None,
+        authoritative_ids: Optional[List[str]] = None,
+    ) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
@@ -782,6 +787,7 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                authoritative_ids=authoritative_ids,
             )
 
     def _is_terminal_auth_failure(
@@ -1382,19 +1388,20 @@ class CredentialPool:
     def _single_use_refresh_lock_timeout(self) -> float:
         """Lock timeout for single-use-refresh-token providers.
 
-        Covers the configured refresh POST timeout plus a margin so a slow
-        token endpoint cannot make the flock give up before the refresh
-        resolves.  Reads the provider's ``HERMES_*_REFRESH_TIMEOUT_SECONDS``
-        override.
+        Covers the refresh POST timeout plus a margin so a slow token endpoint
+        cannot make the flock give up before the refresh resolves. Codex and
+        xAI retain their existing timeout overrides; Anthropic uses its
+        adapter's 20-second request budget.
         """
-        env_var = (
-            "HERMES_CODEX_REFRESH_TIMEOUT_SECONDS"
-            if self.provider == "openai-codex"
-            else "HERMES_XAI_REFRESH_TIMEOUT_SECONDS"
-            if self.provider == "xai-oauth"
-            else "HERMES_ANTHROPIC_REFRESH_TIMEOUT_SECONDS"
-        )
-        refresh_timeout_seconds = auth_mod.env_float(env_var, 20)
+        if self.provider == "anthropic":
+            refresh_timeout_seconds = 20.0
+        else:
+            env_var = (
+                "HERMES_CODEX_REFRESH_TIMEOUT_SECONDS"
+                if self.provider == "openai-codex"
+                else "HERMES_XAI_REFRESH_TIMEOUT_SECONDS"
+            )
+            refresh_timeout_seconds = auth_mod.env_float(env_var, 20)
         return max(
             float(auth_mod.AUTH_LOCK_TIMEOUT_SECONDS),
             float(refresh_timeout_seconds) + 5.0,
@@ -1783,7 +1790,7 @@ class CredentialPool:
             last_error_reset_at=None,
         )
         self._replace_entry(entry, updated)
-        self._persist()
+        self._persist(authoritative_ids=[updated.id])
         # Sync refreshed tokens back to auth.json providers so that
         # _seed_from_singletons() on the next load_pool() sees fresh state
         # instead of re-seeding stale/consumed tokens.

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -9,6 +9,7 @@ import threading
 import time
 import uuid
 import re
+from contextlib import nullcontext
 from dataclasses import dataclass, fields, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -3296,6 +3297,13 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
+    authority = _auth_store_lock() if provider == "anthropic" else nullcontext()
+    with authority:
+        return _load_pool_under_authority(provider)
+
+
+def _load_pool_under_authority(provider: str) -> CredentialPool:
+    """Load and heal one pool while any required provider authority is held."""
     raw_entries = read_credential_pool(provider)
     disk_ids = {
         entry.get("id")
@@ -3314,7 +3322,8 @@ def load_pool(provider: str) -> CredentialPool:
             provider,
             payload.get("access_token"),
             payload.get("auth_type", AUTH_TYPE_API_KEY),
-        ) != payload.get("auth_type", AUTH_TYPE_API_KEY)
+        )
+        != payload.get("auth_type", AUTH_TYPE_API_KEY)
         for payload in raw_entries
     )
     if raw_needs_auth_normalization:
@@ -3322,16 +3331,39 @@ def load_pool(provider: str) -> CredentialPool:
         # Keep that fallback read-only: only the store that owns these rows may
         # rewrite them. Loading the default/root profile will heal global rows.
         active_pool = _load_auth_store().get("credential_pool")
-        active_entries = active_pool.get(provider) if isinstance(active_pool, dict) else None
+        active_entries = (
+            active_pool.get(provider) if isinstance(active_pool, dict) else None
+        )
         raw_needs_auth_normalization = bool(active_entries)
 
+    authoritative_ids = set()
     if provider.startswith(CUSTOM_POOL_PREFIX):
         # Custom endpoint pool — seed from custom_providers config and model config
         custom_changed, custom_sources = _seed_custom_pool(provider, entries)
-        changed = raw_needs_sanitization or raw_needs_auth_normalization or custom_changed
+        changed = (
+            raw_needs_sanitization
+            or raw_needs_auth_normalization
+            or custom_changed
+        )
         changed |= _prune_stale_seeded_entries(entries, custom_sources)
     else:
+        canonical_before = next(
+            (
+                entry
+                for entry in entries
+                if provider == "anthropic" and entry.source == "hermes_pkce"
+            ),
+            None,
+        )
+        had_legacy_pkce_mirror = canonical_before is not None and any(
+            entry.source == "manual:dashboard_pkce" for entry in entries
+        )
         singleton_changed, singleton_sources = _seed_from_singletons(provider, entries)
+        if had_legacy_pkce_mirror and singleton_changed:
+            # The migration explicitly selected one generation while the same
+            # authority covered singleton repair. Let that winner cross the
+            # disk-boundary stale-writer guard, including on an expiry tie.
+            authoritative_ids.add(canonical_before.id)
         env_changed, env_sources = _seed_from_env(provider, entries)
         changed = (
             raw_needs_sanitization
@@ -3352,9 +3384,15 @@ def load_pool(provider: str) -> CredentialPool:
 
     if changed:
         new_ids = {entry.id for entry in entries}
+        write_kwargs = {"removed_ids": disk_ids - new_ids}
+        if authoritative_ids:
+            write_kwargs["authoritative_ids"] = authoritative_ids
         write_credential_pool(
             provider,
-            [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
-            removed_ids=disk_ids - new_ids,
+            [
+                entry.to_dict()
+                for entry in sorted(entries, key=lambda item: item.priority)
+            ],
+            **write_kwargs,
         )
     return CredentialPool(provider, entries)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1223,7 +1223,12 @@ def _file_lock(
     # On Windows, msvcrt.locking needs the file to have content and the
     # file pointer at position 0. Ensure the lock file has at least 1 byte.
     if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
-        lock_path.write_text(" ", encoding="utf-8")
+        try:
+            lock_path.write_text(" ", encoding="utf-8")
+        except (OSError, PermissionError):
+            # Another process may already hold the byte-range lock. The
+            # acquisition loop below owns contention handling.
+            pass
 
     with lock_path.open("r+" if msvcrt else "a+", encoding="utf-8") as lock_file:
         deadline = time.monotonic() + max(1.0, timeout_seconds)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1670,6 +1670,40 @@ _POOL_STATUS_FIELDS = (
 )
 
 
+def _merge_disk_rotating_token_state(
+    entry: Dict[str, Any],
+    disk_entry: Optional[Dict[str, Any]],
+    provider_id: str,
+) -> Dict[str, Any]:
+    """Keep a newer canonical rotating grant over a stale process snapshot."""
+    if (
+        provider_id != "anthropic"
+        or not isinstance(disk_entry, dict)
+        or entry.get("source") != "hermes_pkce"
+        or disk_entry.get("source") != "hermes_pkce"
+    ):
+        return entry
+    token_fields = ("access_token", "refresh_token", "expires_at_ms")
+    if not any(entry.get(key) != disk_entry.get(key) for key in token_fields):
+        return entry
+    try:
+        incoming_expiry = int(entry.get("expires_at_ms") or 0)
+        disk_expiry = int(disk_entry.get("expires_at_ms") or 0)
+    except (TypeError, ValueError):
+        return entry
+    if disk_expiry < incoming_expiry:
+        return entry
+
+    merged = dict(entry)
+    for field in token_fields:
+        merged[field] = disk_entry.get(field)
+    # A status observed for the consumed generation must not poison the newer
+    # generation that another process already persisted.
+    for field in _POOL_STATUS_FIELDS:
+        merged[field] = disk_entry.get(field)
+    return merged
+
+
 def _merge_disk_cooldown_state(
     entry: Dict[str, Any],
     disk_entry: Optional[Dict[str, Any]],
@@ -1732,6 +1766,7 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    authoritative_ids: Optional[Iterable[str]] = None,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1749,9 +1784,12 @@ def write_credential_pool(
     snapshot cannot erase a cooldown/quarantine another process just wrote.
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
-    merge does not resurrect them from the on-disk copy.
+    merge does not resurrect them from the on-disk copy. ``authoritative_ids``
+    identifies rows whose rotating token material was produced while this same
+    cross-process authority was held, so an equal-expiry rotation can commit.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
+    authoritative = {rid for rid in (authoritative_ids or ()) if rid}
     with _auth_store_lock():
         auth_store = _load_auth_store()
         pool = auth_store.get("credential_pool")
@@ -1775,14 +1813,19 @@ def write_credential_pool(
             for entry in sanitized_entries
             if isinstance(entry, dict) and entry.get("id")
         }
-        merged: List[Dict[str, Any]] = [
-            _merge_disk_cooldown_state(
-                entry, existing_by_id.get(entry.get("id")), provider_id
+        merged: List[Dict[str, Any]] = []
+        for entry in sanitized_entries:
+            if not isinstance(entry, dict):
+                merged.append(entry)
+                continue
+            disk_entry = existing_by_id.get(entry.get("id"))
+            if entry.get("id") not in authoritative:
+                entry = _merge_disk_rotating_token_state(
+                    entry, disk_entry, provider_id
+                )
+            merged.append(
+                _merge_disk_cooldown_state(entry, disk_entry, provider_id)
             )
-            if isinstance(entry, dict)
-            else entry
-            for entry in sanitized_entries
-        ]
         for disk_entry in existing_list:
             if not isinstance(disk_entry, dict):
                 continue

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11005,22 +11005,9 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
     Mirrors what auth_commands.add_command does so the dashboard flow leaves
     the system in the same state as ``hermes auth add anthropic``.
     """
-    from agent.anthropic_adapter import _get_hermes_oauth_file
-    oauth_file = _get_hermes_oauth_file()
-    payload = {
-        "accessToken": access_token,
-        "refreshToken": refresh_token,
-        "expiresAt": expires_at_ms,
-    }
-    # atomic_json_write creates the temp with mode 0o600 (via mkstemp) *before*
-    # any content is written, then fsyncs and atomically replaces the target.
-    # The previous os.replace + post-hoc chmod left a TOCTOU window in which the
-    # OAuth token file was world-readable at the default umask (0o644 on most
-    # hosts) between the rename and the chmod. atomic_json_write also preserves
-    # the existing file's owner and cleans up its temp on failure.
-    from utils import atomic_json_write
+    from agent.anthropic_adapter import _write_hermes_oauth_credentials
 
-    atomic_json_write(oauth_file, payload, indent=2, mode=0o600)
+    _write_hermes_oauth_credentials(access_token, refresh_token, expires_at_ms)
     # Best-effort credential-pool insert. Failure here doesn't invalidate
     # the file write — pool registration only matters for the rotation
     # strategy, not for runtime credential resolution.
@@ -11029,12 +11016,18 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
             PooledCredential,
             load_pool,
             AUTH_TYPE_OAUTH,
-            SOURCE_MANUAL,
         )
         import uuid
         pool = load_pool("anthropic")
-        # Avoid duplicate entries: delete any prior dashboard-issued OAuth entry
-        existing = [e for e in pool.entries() if getattr(e, "source", "").startswith(f"{SOURCE_MANUAL}:dashboard_pkce")]
+        # The dashboard and singleton seeder both represent the one grant in
+        # .anthropic_oauth.json. Replace every legacy mirror with one canonical
+        # source so a rotating refresh token can only be consumed by one row.
+        existing = [
+            e
+            for e in pool.entries()
+            if getattr(e, "source", "")
+            in {"hermes_pkce", "manual:dashboard_pkce"}
+        ]
         for e in existing:
             try:
                 pool.remove_entry(getattr(e, "id", ""))
@@ -11046,7 +11039,7 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
             label="dashboard PKCE",
             auth_type=AUTH_TYPE_OAUTH,
             priority=0,
-            source=f"{SOURCE_MANUAL}:dashboard_pkce",
+            source="hermes_pkce",
             access_token=access_token,
             refresh_token=refresh_token,
             expires_at_ms=expires_at_ms,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11006,47 +11006,52 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
     the system in the same state as ``hermes auth add anthropic``.
     """
     from agent.anthropic_adapter import _write_hermes_oauth_credentials
+    from hermes_cli.auth import _auth_store_lock
 
-    _write_hermes_oauth_credentials(access_token, refresh_token, expires_at_ms)
-    # Best-effort credential-pool insert. Failure here doesn't invalidate
-    # the file write — pool registration only matters for the rotation
-    # strategy, not for runtime credential resolution.
-    try:
-        from agent.credential_pool import (
-            PooledCredential,
-            load_pool,
-            AUTH_TYPE_OAUTH,
-        )
-        import uuid
-        pool = load_pool("anthropic")
-        # The dashboard and singleton seeder both represent the one grant in
-        # .anthropic_oauth.json. Replace every legacy mirror with one canonical
-        # source so a rotating refresh token can only be consumed by one row.
-        existing = [
-            e
-            for e in pool.entries()
-            if getattr(e, "source", "")
-            in {"hermes_pkce", "manual:dashboard_pkce"}
-        ]
-        for e in existing:
-            try:
-                pool.remove_entry(getattr(e, "id", ""))
-            except Exception:
-                pass
-        entry = PooledCredential(
-            provider="anthropic",
-            id=uuid.uuid4().hex[:6],
-            label="dashboard PKCE",
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source="hermes_pkce",
-            access_token=access_token,
-            refresh_token=refresh_token,
-            expires_at_ms=expires_at_ms,
-        )
-        pool.add_entry(entry)
-    except Exception as e:
-        _log.warning("anthropic pool add (dashboard) failed: %s", e)
+    # Refreshes use this same authority. Holding it across both stores prevents
+    # a refresh from interleaving between the singleton and canonical-row write.
+    with _auth_store_lock(timeout_seconds=25.0):
+        _write_hermes_oauth_credentials(access_token, refresh_token, expires_at_ms)
+        # Best-effort credential-pool insert. Failure here doesn't invalidate
+        # the file write — pool registration only matters for the rotation
+        # strategy, not for runtime credential resolution.
+        try:
+            from agent.credential_pool import (
+                AUTH_TYPE_OAUTH,
+                PooledCredential,
+                load_pool,
+            )
+            import uuid
+
+            pool = load_pool("anthropic")
+            # The dashboard and singleton seeder both represent the one grant in
+            # .anthropic_oauth.json. Replace every legacy mirror with one canonical
+            # source so a rotating refresh token can only be consumed by one row.
+            existing = [
+                e
+                for e in pool.entries()
+                if getattr(e, "source", "")
+                in {"hermes_pkce", "manual:dashboard_pkce"}
+            ]
+            for e in existing:
+                try:
+                    pool.remove_entry(getattr(e, "id", ""))
+                except Exception:
+                    pass
+            entry = PooledCredential(
+                provider="anthropic",
+                id=uuid.uuid4().hex[:6],
+                label="dashboard PKCE",
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=0,
+                source="hermes_pkce",
+                access_token=access_token,
+                refresh_token=refresh_token,
+                expires_at_ms=expires_at_ms,
+            )
+            pool.add_entry(entry)
+        except Exception as e:
+            _log.warning("anthropic pool add (dashboard) failed: %s", e)
 
 
 def _start_anthropic_pkce(profile: Optional[str] = None) -> Dict[str, Any]:

--- a/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
+++ b/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
@@ -195,6 +195,42 @@ def test_singleton_seed_collapses_legacy_dashboard_mirror(monkeypatch):
     assert written == [("rotated-access", "rotated-refresh", 3_000)]
 
 
+def test_load_pool_commits_equal_expiry_legacy_migration(tmp_path, monkeypatch):
+    from agent.anthropic_adapter import _write_hermes_oauth_credentials
+    from agent.credential_pool import load_pool, read_credential_pool, write_credential_pool
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    canonical = _pkce_entry(
+        id="canonical",
+        access_token="stale-access",
+        refresh_token="stale-refresh",
+        expires_at_ms=2_000,
+    )
+    legacy = _pkce_entry(
+        id="dashboard",
+        source="manual:dashboard_pkce",
+        access_token="winner-access",
+        refresh_token="winner-refresh",
+        expires_at_ms=2_000,
+    )
+    write_credential_pool(
+        "anthropic", [canonical.to_dict(), legacy.to_dict()]
+    )
+    _write_hermes_oauth_credentials("stale-access", "stale-refresh", 2_000)
+
+    first = load_pool("anthropic").entries()
+    second = load_pool("anthropic").entries()
+
+    assert len(first) == len(second) == 1
+    assert first[0].id == second[0].id == "canonical"
+    assert first[0].refresh_token == second[0].refresh_token == "winner-refresh"
+    persisted = read_credential_pool("anthropic")
+    assert len(persisted) == 1
+    assert persisted[0]["refresh_token"] == "winner-refresh"
+    singleton = json.loads((tmp_path / ".anthropic_oauth.json").read_text("utf-8"))
+    assert singleton["refreshToken"] == "winner-refresh"
+
+
 _CHILD_REFRESH = r"""
 import json
 import os

--- a/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
+++ b/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
@@ -120,6 +120,26 @@ def test_pkce_refresh_persists_rotated_singleton(tmp_path, monkeypatch):
     }
 
 
+def test_forced_refresh_releases_pool_lock_before_authority(monkeypatch):
+    entry = _pkce_entry()
+    pool = CredentialPool("anthropic", [entry])
+    pool._current_id = entry.id
+    observations = []
+
+    def refresh(candidate, *, force):
+        observations.append((candidate.id, force, pool._lock._is_owned()))
+        return candidate
+
+    monkeypatch.setattr(pool, "_refresh_entry", refresh)
+
+    assert pool.try_refresh_current() is entry
+    assert pool.try_refresh_matching(credential_id=entry.id) is entry
+    assert observations == [
+        (entry.id, True, False),
+        (entry.id, True, False),
+    ]
+
+
 def test_terminal_refresh_failure_adopts_newer_canonical_row(monkeypatch):
     stale = _pkce_entry(
         access_token="stale-access",

--- a/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
+++ b/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
@@ -3,6 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 
 from agent.credential_pool import (
     AUTH_TYPE_OAUTH,
@@ -113,6 +120,38 @@ def test_pkce_refresh_persists_rotated_singleton(tmp_path, monkeypatch):
     }
 
 
+def test_terminal_refresh_failure_adopts_newer_canonical_row(monkeypatch):
+    stale = _pkce_entry(
+        access_token="stale-access",
+        refresh_token="stale-refresh",
+        expires_at_ms=1_000,
+    )
+    winner = _pkce_entry(
+        access_token="winner-access",
+        refresh_token="winner-refresh",
+        expires_at_ms=3_000,
+        last_status=STATUS_EXHAUSTED,
+    )
+    pool = CredentialPool("anthropic", [stale])
+
+    def fail_refresh(_refresh_token, *, use_json):
+        raise ValueError("invalid_grant")
+
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.refresh_anthropic_oauth_pure", fail_refresh
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool.read_credential_pool", lambda _provider: [winner.to_dict()]
+    )
+    monkeypatch.setattr(pool, "_persist", lambda **_kwargs: None)
+
+    updated = pool._refresh_entry_impl(stale, force=True)
+
+    assert updated is not None
+    assert updated.refresh_token == "winner-refresh"
+    assert updated.last_status == "ok"
+
+
 def test_singleton_seed_collapses_legacy_dashboard_mirror(monkeypatch):
     from agent.credential_pool import _seed_from_singletons
 
@@ -154,3 +193,141 @@ def test_singleton_seed_collapses_legacy_dashboard_mirror(monkeypatch):
     assert entries[0].access_token == "rotated-access"
     assert entries[0].refresh_token == "rotated-refresh"
     assert written == [("rotated-access", "rotated-refresh", 3_000)]
+
+
+_CHILD_REFRESH = r"""
+import json
+import os
+import time
+import urllib.request
+from pathlib import Path
+
+from agent import anthropic_adapter
+from agent.credential_pool import load_pool
+
+endpoint = os.environ["FAKE_REFRESH_ENDPOINT"]
+ready = Path(os.environ["READY_FILE"])
+barrier = Path(os.environ["BARRIER_FILE"])
+
+
+def fake_refresh(refresh_token, *, use_json):
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps({"refresh_token": refresh_token}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        return json.load(response)
+
+
+anthropic_adapter.refresh_anthropic_oauth_pure = fake_refresh
+pool = load_pool("anthropic")
+entry = next(item for item in pool.entries() if item.source == "hermes_pkce")
+ready.write_text("ready", encoding="utf-8")
+while not barrier.exists():
+    time.sleep(0.01)
+updated = pool._refresh_entry(entry, force=True)
+print(json.dumps({
+    "access_token": updated.access_token if updated else None,
+    "refresh_token": updated.refresh_token if updated else None,
+    "last_status": updated.last_status if updated else None,
+}))
+"""
+
+
+def test_two_processes_share_one_pkce_refresh_authority(tmp_path, monkeypatch):
+    """Only one process redeems a rotating grant; the waiter adopts it."""
+    from agent.anthropic_adapter import _write_hermes_oauth_credentials
+    from agent.credential_pool import read_credential_pool
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    initial = _pkce_entry(
+        access_token="stale-access",
+        refresh_token="stale-refresh",
+        expires_at_ms=0,
+    )
+    CredentialPool("anthropic", [initial])._persist()
+    _write_hermes_oauth_credentials("stale-access", "stale-refresh", 0)
+
+    calls = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length))
+            calls.append(payload["refresh_token"])
+            body = json.dumps(
+                {
+                    "access_token": "rotated-access",
+                    "refresh_token": "rotated-refresh",
+                    "expires_at_ms": 4_000_000_000_000,
+                }
+            ).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    barrier = tmp_path / "release-workers"
+    ready_files = [tmp_path / f"worker-{index}.ready" for index in range(2)]
+    env_base = os.environ.copy()
+    env_base["FAKE_REFRESH_ENDPOINT"] = (
+        f"http://127.0.0.1:{server.server_address[1]}/refresh"
+    )
+    env_base["BARRIER_FILE"] = str(barrier)
+    processes = []
+    try:
+        for ready in ready_files:
+            env = dict(env_base)
+            env["READY_FILE"] = str(ready)
+            processes.append(
+                subprocess.Popen(
+                    [sys.executable, "-c", _CHILD_REFRESH],
+                    cwd=Path(__file__).parents[2],
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+            )
+
+        deadline = time.monotonic() + 10
+        while not all(path.exists() for path in ready_files):
+            assert time.monotonic() < deadline, "workers did not reach refresh barrier"
+            time.sleep(0.02)
+        barrier.write_text("go", encoding="utf-8")
+        outputs = [process.communicate(timeout=15) for process in processes]
+    finally:
+        server.shutdown()
+        server.server_close()
+        for process in processes:
+            if process.poll() is None:
+                process.kill()
+
+    assert [(process.returncode, stderr) for process, (_, stderr) in zip(processes, outputs)] == [
+        (0, ""),
+        (0, ""),
+    ]
+    results = [json.loads(stdout) for stdout, _ in outputs]
+    assert calls == ["stale-refresh"]
+    assert {result["refresh_token"] for result in results} == {"rotated-refresh"}
+    assert {result["last_status"] for result in results} == {"ok"}
+
+    persisted = next(
+        item for item in read_credential_pool("anthropic") if item["id"] == initial.id
+    )
+    singleton = json.loads((tmp_path / ".anthropic_oauth.json").read_text("utf-8"))
+    assert persisted["refresh_token"] == "rotated-refresh"
+    assert singleton == {
+        "accessToken": "rotated-access",
+        "refreshToken": "rotated-refresh",
+        "expiresAt": 4_000_000_000_000,
+    }

--- a/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
+++ b/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
@@ -140,6 +140,60 @@ def test_forced_refresh_releases_pool_lock_before_authority(monkeypatch):
     ]
 
 
+def test_removed_pkce_row_is_not_resurrected(monkeypatch):
+    entry = _pkce_entry()
+    pool = CredentialPool("anthropic", [entry])
+    pool._current_id = entry.id
+    refresh_calls = []
+    monkeypatch.setattr("agent.credential_pool.read_credential_pool", lambda _p: [])
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.refresh_anthropic_oauth_pure",
+        lambda *_args, **_kwargs: refresh_calls.append(True),
+    )
+
+    assert pool._refresh_entry(entry, force=True) is None
+    assert pool.entries() == []
+    assert pool._current_id is None
+    assert refresh_calls == []
+
+
+def test_rotated_pkce_remains_usable_when_both_persistence_writes_fail(monkeypatch):
+    entry = _pkce_entry(access_token="old-access", refresh_token="old-refresh")
+    pool = CredentialPool("anthropic", [entry])
+    attempts = []
+    monkeypatch.setattr(
+        "agent.credential_pool.read_credential_pool", lambda _p: [entry.to_dict()]
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.refresh_anthropic_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": "rotated-access",
+            "refresh_token": "rotated-refresh",
+            "expires_at_ms": 5_000,
+        },
+    )
+
+    def fail_pool(*_args, **_kwargs):
+        attempts.append("pool")
+        raise OSError("pool unavailable")
+
+    def fail_singleton(*_args, **_kwargs):
+        attempts.append("singleton")
+        raise OSError("singleton unavailable")
+
+    monkeypatch.setattr("agent.credential_pool.write_credential_pool", fail_pool)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._write_hermes_oauth_credentials", fail_singleton
+    )
+
+    updated = pool._refresh_entry(entry, force=True)
+
+    assert updated is not None
+    assert updated.refresh_token == "rotated-refresh"
+    assert updated.last_status == "ok"
+    assert attempts == ["pool", "singleton"]
+
+
 def test_terminal_refresh_failure_adopts_newer_canonical_row(monkeypatch):
     stale = _pkce_entry(
         access_token="stale-access",

--- a/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
+++ b/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
@@ -157,7 +157,7 @@ def test_removed_pkce_row_is_not_resurrected(monkeypatch):
     assert refresh_calls == []
 
 
-def test_rotated_pkce_remains_usable_when_both_persistence_writes_fail(monkeypatch):
+def test_rotated_pkce_is_not_successful_without_canonical_persistence(monkeypatch):
     entry = _pkce_entry(access_token="old-access", refresh_token="old-refresh")
     pool = CredentialPool("anthropic", [entry])
     attempts = []
@@ -188,10 +188,60 @@ def test_rotated_pkce_remains_usable_when_both_persistence_writes_fail(monkeypat
 
     updated = pool._refresh_entry(entry, force=True)
 
+    assert updated is None
+    assert pool.entries() == [entry]
+    assert attempts == ["pool", "pool", "singleton"]
+
+
+def test_rotated_pkce_retries_canonical_persistence_before_releasing_authority(
+    monkeypatch,
+):
+    entry = _pkce_entry(access_token="old-access", refresh_token="old-refresh")
+    pool = CredentialPool("anthropic", [entry])
+    persisted = [entry.to_dict()]
+    writes = []
+    monkeypatch.setattr(
+        "agent.credential_pool.read_credential_pool", lambda _p: persisted
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.refresh_anthropic_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": "rotated-access",
+            "refresh_token": "rotated-refresh",
+            "expires_at_ms": 5_000,
+        },
+    )
+
+    def flaky_pool_write(_provider, entries, **_kwargs):
+        writes.append(entries[0]["refresh_token"])
+        if len(writes) == 1:
+            raise PermissionError("transient contention")
+        persisted[:] = entries
+
+    monkeypatch.setattr("agent.credential_pool.write_credential_pool", flaky_pool_write)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._write_hermes_oauth_credentials",
+        lambda *_args: None,
+    )
+
+    updated = pool._refresh_entry(entry, force=True)
+
     assert updated is not None
     assert updated.refresh_token == "rotated-refresh"
-    assert updated.last_status == "ok"
-    assert attempts == ["pool", "singleton"]
+    assert writes == ["rotated-refresh", "rotated-refresh"]
+    assert persisted[0]["refresh_token"] == "rotated-refresh"
+
+
+def test_delayed_refresh_handoff_preserves_newer_local_generation():
+    original = _pkce_entry(access_token="n", refresh_token="n")
+    delayed = _pkce_entry(access_token="n+1", refresh_token="n+1")
+    current = _pkce_entry(access_token="n+2", refresh_token="n+2")
+    pool = CredentialPool("anthropic", [current])
+
+    adopted = pool._adopt_refresh_result(original, delayed)
+
+    assert adopted == current
+    assert pool.entries() == [current]
 
 
 def test_terminal_refresh_failure_adopts_newer_canonical_row(monkeypatch):
@@ -214,12 +264,12 @@ def test_terminal_refresh_failure_adopts_newer_canonical_row(monkeypatch):
     monkeypatch.setattr(
         "agent.anthropic_adapter.refresh_anthropic_oauth_pure", fail_refresh
     )
+    reads = iter([[stale.to_dict()], [winner.to_dict()]])
     monkeypatch.setattr(
-        "agent.credential_pool.read_credential_pool", lambda _provider: [winner.to_dict()]
+        "agent.credential_pool.read_credential_pool", lambda _provider: next(reads)
     )
-    monkeypatch.setattr(pool, "_persist", lambda **_kwargs: None)
 
-    updated = pool._refresh_entry_impl(stale, force=True)
+    updated = pool._refresh_entry(stale, force=True)
 
     assert updated is not None
     assert updated.refresh_token == "winner-refresh"

--- a/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
+++ b/tests/agent/test_credential_pool_anthropic_pkce_rotation.py
@@ -1,0 +1,156 @@
+"""Regression tests for Hermes-managed Anthropic PKCE rotation."""
+
+from __future__ import annotations
+
+import json
+
+from agent.credential_pool import (
+    AUTH_TYPE_OAUTH,
+    STATUS_EXHAUSTED,
+    CredentialPool,
+    PooledCredential,
+    _upsert_entry,
+)
+
+
+def _pkce_entry(**overrides):
+    values = {
+        "provider": "anthropic",
+        "id": "pkce-1",
+        "label": "Hermes PKCE",
+        "auth_type": AUTH_TYPE_OAUTH,
+        "priority": 0,
+        "source": "hermes_pkce",
+        "access_token": "fresh-access",
+        "refresh_token": "fresh-refresh",
+        "expires_at_ms": 2_000,
+    }
+    values.update(overrides)
+    return PooledCredential(**values)
+
+
+def test_singleton_seed_cannot_regress_rotated_pkce_token():
+    entry = _pkce_entry(
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=10.0,
+        last_error_code=401,
+        last_error_reason="token_revoked",
+    )
+    entries = [entry]
+
+    changed = _upsert_entry(
+        entries,
+        "anthropic",
+        "hermes_pkce",
+        {
+            "source": "hermes_pkce",
+            "auth_type": AUTH_TYPE_OAUTH,
+            "access_token": "stale-access",
+            "refresh_token": "stale-refresh",
+            "expires_at_ms": 2_000,
+        },
+    )
+
+    assert changed is False
+    assert entries == [entry]
+
+
+def test_newer_singleton_token_replaces_exhausted_pkce_entry():
+    entries = [
+        _pkce_entry(
+            expires_at_ms=2_000,
+            last_status=STATUS_EXHAUSTED,
+            last_error_code=401,
+        )
+    ]
+
+    changed = _upsert_entry(
+        entries,
+        "anthropic",
+        "hermes_pkce",
+        {
+            "source": "hermes_pkce",
+            "auth_type": AUTH_TYPE_OAUTH,
+            "access_token": "new-login-access",
+            "refresh_token": "new-login-refresh",
+            "expires_at_ms": 4_000,
+        },
+    )
+
+    assert changed is True
+    assert entries[0].refresh_token == "new-login-refresh"
+    assert entries[0].expires_at_ms == 4_000
+    assert entries[0].last_status is None
+    assert entries[0].last_error_code is None
+
+
+def test_pkce_refresh_persists_rotated_singleton(tmp_path, monkeypatch):
+    oauth_file = tmp_path / ".anthropic_oauth.json"
+    entry = _pkce_entry(expires_at_ms=1_000)
+    pool = CredentialPool("anthropic", [entry])
+
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.refresh_anthropic_oauth_pure",
+        lambda refresh_token, *, use_json: {
+            "access_token": "rotated-access",
+            "refresh_token": "rotated-refresh",
+            "expires_at_ms": 3_000,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._get_hermes_oauth_file", lambda: oauth_file
+    )
+    monkeypatch.setattr(pool, "_persist", lambda **_kwargs: None)
+
+    updated = pool._refresh_entry_impl(entry, force=True)
+
+    assert updated is not None
+    assert updated.refresh_token == "rotated-refresh"
+    assert json.loads(oauth_file.read_text(encoding="utf-8")) == {
+        "accessToken": "rotated-access",
+        "refreshToken": "rotated-refresh",
+        "expiresAt": 3_000,
+    }
+
+
+def test_singleton_seed_collapses_legacy_dashboard_mirror(monkeypatch):
+    from agent.credential_pool import _seed_from_singletons
+
+    legacy = _pkce_entry(
+        id="dashboard",
+        source="manual:dashboard_pkce",
+        access_token="rotated-access",
+        refresh_token="rotated-refresh",
+        expires_at_ms=3_000,
+    )
+    entries = [legacy]
+    written = []
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.is_provider_explicitly_configured", lambda _provider: True
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_hermes_oauth_credentials",
+        lambda: {
+            "accessToken": "stale-access",
+            "refreshToken": "stale-refresh",
+            "expiresAt": 2_000,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._write_hermes_oauth_credentials",
+        lambda access, refresh, expires: written.append((access, refresh, expires)),
+    )
+
+    changed, active_sources = _seed_from_singletons("anthropic", entries)
+
+    assert changed is True
+    assert active_sources == {"hermes_pkce"}
+    assert len(entries) == 1
+    assert entries[0].source == "hermes_pkce"
+    assert entries[0].access_token == "rotated-access"
+    assert entries[0].refresh_token == "rotated-refresh"
+    assert written == [("rotated-access", "rotated-refresh", 3_000)]

--- a/tests/hermes_cli/test_auth_store_lock_concurrent.py
+++ b/tests/hermes_cli/test_auth_store_lock_concurrent.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import threading
 
-from hermes_cli.auth import _auth_store_lock
+from agent.credential_pool import AUTH_TYPE_OAUTH, PooledCredential
+from hermes_cli.auth import _auth_store_lock, read_credential_pool, write_credential_pool
 
 
 def test_concurrent_windows_lock_initialization_is_retried(tmp_path, monkeypatch):
@@ -34,3 +35,42 @@ def test_concurrent_windows_lock_initialization_is_retried(tmp_path, monkeypatch
     assert not [thread for thread in threads if thread.is_alive()]
     assert errors == []
     assert entered == concurrency
+
+
+def test_stale_pool_writer_cannot_restore_consumed_pkce_generation(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def entry(access: str, refresh: str, *, status=None):
+        return PooledCredential(
+            provider="anthropic",
+            id="canonical",
+            label="Hermes PKCE",
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source="hermes_pkce",
+            access_token=access,
+            refresh_token=refresh,
+            expires_at_ms=2_000,
+            last_status=status,
+            last_status_at=50.0 if status else None,
+        ).to_dict()
+
+    write_credential_pool("anthropic", [entry("winner-access", "winner-refresh")])
+    write_credential_pool(
+        "anthropic", [entry("consumed-access", "consumed-refresh", status="exhausted")]
+    )
+
+    persisted = read_credential_pool("anthropic")[0]
+    assert persisted["access_token"] == "winner-access"
+    assert persisted["refresh_token"] == "winner-refresh"
+    assert persisted.get("last_status") is None
+
+    write_credential_pool(
+        "anthropic",
+        [entry("next-access", "next-refresh")],
+        authoritative_ids=["canonical"],
+    )
+    persisted = read_credential_pool("anthropic")[0]
+    assert persisted["refresh_token"] == "next-refresh"

--- a/tests/hermes_cli/test_auth_store_lock_concurrent.py
+++ b/tests/hermes_cli/test_auth_store_lock_concurrent.py
@@ -1,0 +1,36 @@
+"""Concurrency regression tests for the shared auth-store lock."""
+
+from __future__ import annotations
+
+import threading
+
+from hermes_cli.auth import _auth_store_lock
+
+
+def test_concurrent_windows_lock_initialization_is_retried(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    concurrency = 40
+    barrier = threading.Barrier(concurrency)
+    errors: list[BaseException] = []
+    entered = 0
+    entered_guard = threading.Lock()
+
+    def acquire() -> None:
+        nonlocal entered
+        try:
+            barrier.wait(timeout=10)
+            with _auth_store_lock(timeout_seconds=10):
+                with entered_guard:
+                    entered += 1
+        except BaseException as exc:  # pragma: no cover - diagnostic capture
+            errors.append(exc)
+
+    threads = [threading.Thread(target=acquire) for _ in range(concurrency)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not [thread for thread in threads if thread.is_alive()]
+    assert errors == []
+    assert entered == concurrency

--- a/tests/hermes_cli/test_auth_store_lock_concurrent.py
+++ b/tests/hermes_cli/test_auth_store_lock_concurrent.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import threading
 
+import pytest
+
 from agent.credential_pool import AUTH_TYPE_OAUTH, PooledCredential
 from hermes_cli.auth import _auth_store_lock, read_credential_pool, write_credential_pool
 
 
+@pytest.mark.windows_only
 def test_concurrent_windows_lock_initialization_is_retried(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     concurrency = 40

--- a/tests/hermes_cli/test_web_server_oauth_write.py
+++ b/tests/hermes_cli/test_web_server_oauth_write.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import contextmanager
 
 import pytest
 
@@ -83,3 +84,53 @@ def test_dashboard_oauth_write_reuses_file_seeded_pool_identity(
     assert len(pool.added) == 1
     assert pool.added[0].source == "hermes_pkce"
     assert pool.added[0].refresh_token == "refresh-token"
+
+
+def test_dashboard_oauth_write_holds_refresh_authority_across_both_stores(
+    oauth_file, monkeypatch
+):
+    authority_held = False
+    observed = []
+
+    @contextmanager
+    def recording_lock(*, timeout_seconds):
+        nonlocal authority_held
+        assert timeout_seconds >= 25
+        authority_held = True
+        try:
+            yield
+        finally:
+            authority_held = False
+
+    class RecordingPool(_DummyPool):
+        def remove_entry(self, entry_id):
+            assert authority_held
+            observed.append(("remove", entry_id))
+
+        def add_entry(self, entry):
+            assert authority_held
+            observed.append(("add", entry.refresh_token))
+
+    real_writer = __import__(
+        "agent.anthropic_adapter", fromlist=["_write_hermes_oauth_credentials"]
+    )._write_hermes_oauth_credentials
+
+    def recording_writer(*args):
+        assert authority_held
+        observed.append(("singleton", args[1]))
+        return real_writer(*args)
+
+    pool = RecordingPool()
+    monkeypatch.setattr("hermes_cli.auth._auth_store_lock", recording_lock)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._write_hermes_oauth_credentials", recording_writer
+    )
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda _provider: pool)
+
+    _save_anthropic_oauth_creds("access-token", "refresh-token", 123456)
+
+    assert observed == [
+        ("singleton", "refresh-token"),
+        ("add", "refresh-token"),
+    ]
+    assert authority_held is False

--- a/tests/hermes_cli/test_web_server_oauth_write.py
+++ b/tests/hermes_cli/test_web_server_oauth_write.py
@@ -6,13 +6,20 @@ from hermes_cli.web_server import _save_anthropic_oauth_creds
 
 
 class _DummyPool:
-    def entries(self):
-        return []
+    def __init__(self, entries=None):
+        self._entries = list(entries or [])
+        self.removed = []
+        self.added = []
 
-    def remove_entry(self, _id):
+    def entries(self):
+        return list(self._entries)
+
+    def remove_entry(self, entry_id):
+        self.removed.append(entry_id)
         return None
 
-    def add_entry(self, _entry):
+    def add_entry(self, entry):
+        self.added.append(entry)
         return None
 
 
@@ -56,3 +63,23 @@ def test_dashboard_oauth_write_uses_atomic_json_write_with_owner_only_mode(oauth
     assert calls.get('mode') == 0o600, \
         'OAuth creds must be written 0o600 atomically (no chmod-after-replace window)'
     assert oauth_file.exists()
+
+
+def test_dashboard_oauth_write_reuses_file_seeded_pool_identity(
+    oauth_file, monkeypatch
+):
+    from types import SimpleNamespace
+
+    canonical = SimpleNamespace(id="canonical", source="hermes_pkce")
+    duplicate = SimpleNamespace(id="duplicate", source="manual:dashboard_pkce")
+    pool = _DummyPool([canonical, duplicate])
+    monkeypatch.setattr(
+        "agent.credential_pool.load_pool", lambda _provider: pool
+    )
+
+    _save_anthropic_oauth_creds("access-token", "refresh-token", 123456)
+
+    assert pool.removed == ["canonical", "duplicate"]
+    assert len(pool.added) == 1
+    assert pool.added[0].source == "hermes_pkce"
+    assert pool.added[0].refresh_token == "refresh-token"


### PR DESCRIPTION
## What does this PR do?

Keeps Hermes-managed Anthropic OAuth sessions usable after a refresh token rotates. The fix persists the rotated PKCE grant, prevents an older singleton snapshot from replacing newer pool credentials, and collapses the dashboard and file-backed aliases into one pool identity so a single-use refresh token cannot be consumed twice.

### Symptom

After an Anthropic PKCE login, a later token rotation can produce `OAuth access token has been revoked`, followed by `No Anthropic credentials found` in new chats until the user logs in again.

### Impact

Users authenticating Anthropic through the Hermes PKCE or dashboard PKCE flows can lose their active credential pool after rotation and must repeatedly re-authenticate.

### Bug Cause

**Trigger:** `agent/credential_pool.py:CredentialPool._refresh_entry_impl` refreshes a file-backed `hermes_pkce` entry.

**Causal chain:**
1. Anthropic rotates the access and single-use refresh token in the credential pool.
2. `.anthropic_oauth.json` retains the consumed token, and a later singleton seed can replace the rotated pool fields while clearing the previous failure state.
3. Dashboard login also mirrored that same file-backed grant into `manual:dashboard_pkce`, leaving two rows able to consume one refresh token and eventually emptying the usable pool.

**Why it is wrong:** the singleton file and its pool representation are one credential identity, but refresh persistence and dashboard registration treated them as independent authorities.

**Working sibling / contrast:** Claude Code sourced credentials already write rotated values back to their credential file; independent `manual:hermes_pkce` entries remain separate because they are not backed by `.anthropic_oauth.json`.

**Ruled out:** the failure is not an Anthropic account entitlement problem; the issue reproduction shows freshly logged-in credentials authenticate and isolates the regression to local credential state transitions.

### Fix

- Add one atomic writer for Hermes-managed Anthropic PKCE credentials and invoke it after file-backed pool refreshes.
- Preserve a newer canonical pool token when singleton seeding presents an equal or older expiration snapshot.
- Migrate legacy dashboard mirrors to one `hermes_pkce` row, retaining the freshest pool state and repairing the singleton file when needed.
- Make new dashboard logins replace both legacy aliases with one canonical row.

## Related Issue

Closes #92606

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` - centralize atomic Hermes PKCE credential persistence.
- `agent/credential_pool.py` - persist rotation, reject stale singleton downgrades, and migrate duplicate PKCE identities.
- `hermes_cli/web_server.py` - register dashboard PKCE grants under the canonical file-backed source.
- `tests/agent/test_credential_pool_anthropic_pkce_rotation.py` - cover persistence, freshness, and legacy migration behavior.
- `tests/hermes_cli/test_web_server_oauth_write.py` - cover canonical dashboard pool registration.

## How to Test

1. Run the focused PKCE, credential-pool, and auth command regression suites.
2. Confirm 89 relevant tests pass on Windows 11.

```bash
scripts/run_tests.sh tests/agent/test_credential_pool_anthropic_pkce_rotation.py tests/agent/test_credential_pool_key_rotation.py tests/agent/test_credential_pool.py tests/agent/test_anthropic_oauth_pkce.py tests/hermes_cli/test_auth_commands.py -q
scripts/run_tests.sh tests/hermes_cli/test_web_server_oauth_write.py -k 'not owner_only_permissions' -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates: N/A - no user-facing workflow changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: persistence continues to use the existing cross-platform atomic JSON writer
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed

## Screenshots / Logs

N/A - automated regression tests exercise the credential state transitions without exposing live tokens.
