### PR TITLE
fix(gateway): keep delegate completions on parent session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -108,6 +108,13 @@ _USER_BOUNDARY_END_REASONS = (
     "session_switch",
     "new_session",
 )
+# Upper bound on the ``model_config._delegate_from`` chain walked by
+# _resolve_async_delegation_session when canonicalizing a delegate child to its
+# human-facing gateway parent (#92611). Real nesting is bounded far lower by
+# delegation.max_spawn_depth (default 2); this only stops a corrupt chain from
+# turning one completion event into an unbounded run of sequential session
+# reads. Exceeding it is fail-closed, like every other unresolved provenance.
+_MAX_DELEGATE_PROVENANCE_HOPS = 16
 # Round-2 #2: upper bound on a single stall-notify adapter.send so a wedged
 # transport cannot block the session-stall watcher pass (notify-only path;
 # on timeout the latch stays clear and the next tick retries).
@@ -16218,6 +16225,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         never let a late completion override an unrelated /new or restored
         route.  Unknown ownership remains fail-closed; the result is still
         available in the delegation records.
+
+        A pinned *delegate* row is likewise canonicalized to its human-facing
+        parent through ``model_config._delegate_from`` before any route check
+        or mutation (#92611).  Unresolvable provenance — a cycle, a missing
+        parent, a malformed config, or a chain longer than
+        ``_MAX_DELEGATE_PROVENANCE_HOPS`` — drops the injection rather than
+        falling back to the current route entry.  That is deliberate: routing
+        an internal child's output into a session whose ownership was never
+        verified is the same class of defect this canonicalization fixes, and
+        the completion remains readable in the delegation records either way.
         """
         session_db = cast(Any, self._session_db)
         if session_db is None:
@@ -16251,8 +16268,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Follow that durable provenance before any route verification or
         # mutation; otherwise switch_session() can end the real parent and
         # rebind the platform chat to an internal child (#92611).
+        #
+        # Real nesting is bounded by delegation.max_spawn_depth (default 2), so
+        # the hop cap only guards a corrupt/hand-edited chain: without it a
+        # single completion event could fan out into hundreds of sequential
+        # get_session() reads before terminating.
         delegate_chain: set[str] = set()
-        while True:
+        for _ in range(_MAX_DELEGATE_PROVENANCE_HOPS + 1):
             if pinned_session_id in delegate_chain:
                 logger.warning(
                     "Async-delegation completion has cyclic delegate provenance "
@@ -16298,6 +16320,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return None
             pinned_session_id = delegate_parent_id
             pinned_row = delegate_parent_row
+        else:
+            logger.warning(
+                "Async-delegation completion exceeded %d delegate provenance "
+                "hops (last session %s); dropping injection (#92611).",
+                _MAX_DELEGATE_PROVENANCE_HOPS,
+                pinned_session_id,
+            )
+            return None
 
         target_session_id = pinned_session_id
         follows_compression = False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16245,6 +16245,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return None
 
+        # Delegate rows are execution transcripts, not gateway route owners.
+        # A process completion can be stamped with the child session id even
+        # though the human-facing conversation belongs to `_delegate_from`.
+        # Follow that durable provenance before any route verification or
+        # mutation; otherwise switch_session() can end the real parent and
+        # rebind the platform chat to an internal child (#92611).
+        delegate_chain: set[str] = set()
+        while True:
+            if pinned_session_id in delegate_chain:
+                logger.warning(
+                    "Async-delegation completion has cyclic delegate provenance "
+                    "at session %s; dropping injection (#92611).",
+                    pinned_session_id,
+                )
+                return None
+            delegate_chain.add(pinned_session_id)
+            model_config = pinned_row.get("model_config")
+            if isinstance(model_config, str):
+                try:
+                    model_config = json.loads(model_config)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "Async-delegation completion has malformed model_config "
+                        "for session %s; dropping injection (#92611).",
+                        pinned_session_id,
+                    )
+                    return None
+            if model_config is not None and not isinstance(model_config, dict):
+                logger.warning(
+                    "Async-delegation completion has non-object model_config "
+                    "for session %s; dropping injection (#92611).",
+                    pinned_session_id,
+                )
+                return None
+            if not isinstance(model_config, dict):
+                model_config = {}
+            delegate_parent_id = str(model_config.get("_delegate_from") or "").strip()
+            if not delegate_parent_id:
+                break
+            try:
+                delegate_parent_row = await session_db.get_session(delegate_parent_id)
+            except Exception:
+                delegate_parent_row = None
+            if delegate_parent_row is None:
+                logger.warning(
+                    "Async-delegation completion has missing delegate parent %s "
+                    "for child %s; dropping injection (#92611).",
+                    delegate_parent_id,
+                    pinned_session_id,
+                )
+                return None
+            pinned_session_id = delegate_parent_id
+            pinned_row = delegate_parent_row
+
         target_session_id = pinned_session_id
         follows_compression = False
         if pinned_row.get("ended_at"):

--- a/tests/gateway/test_async_delegation_session_binding.py
+++ b/tests/gateway/test_async_delegation_session_binding.py
@@ -118,6 +118,108 @@ class TestGatewayPinningFailsClosed:
         )
 
     @pytest.mark.asyncio
+    async def test_live_delegate_child_resolves_to_parent_without_rebinding_route(self):
+        current = self._entry("sess_parent")
+        runner = self._make_runner(
+            {
+                "sess_parent": {"id": "sess_parent", "ended_at": None},
+                "sess_child": {
+                    "id": "sess_child",
+                    "ended_at": None,
+                    "model_config": {"_delegate_from": "sess_parent"},
+                },
+            },
+        )
+
+        resolved = await runner._resolve_async_delegation_session(current, "sess_child")
+
+        assert resolved is current
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_nested_delegate_child_resolves_to_gateway_parent(self):
+        current = self._entry("sess_parent")
+        runner = self._make_runner(
+            {
+                "sess_parent": {"id": "sess_parent", "ended_at": None},
+                "sess_child": {
+                    "id": "sess_child",
+                    "ended_at": None,
+                    "model_config": {"_delegate_from": "sess_parent"},
+                },
+                "sess_grandchild": {
+                    "id": "sess_grandchild",
+                    "ended_at": None,
+                    "model_config": {"_delegate_from": "sess_child"},
+                },
+            },
+        )
+
+        resolved = await runner._resolve_async_delegation_session(current, "sess_grandchild")
+
+        assert resolved is current
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_delegate_provenance_cycle_fails_closed_without_route_change(self):
+        current = self._entry("sess_current")
+        runner = self._make_runner(
+            {
+                "sess_a": {
+                    "id": "sess_a",
+                    "ended_at": None,
+                    "model_config": {"_delegate_from": "sess_b"},
+                },
+                "sess_b": {
+                    "id": "sess_b",
+                    "ended_at": None,
+                    "model_config": {"_delegate_from": "sess_a"},
+                },
+            },
+        )
+
+        resolved = await runner._resolve_async_delegation_session(current, "sess_a")
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_delegate_with_missing_parent_fails_closed_without_route_change(self):
+        current = self._entry("sess_current")
+        runner = self._make_runner(
+            {
+                "sess_child": {
+                    "id": "sess_child",
+                    "ended_at": None,
+                    "model_config": {"_delegate_from": "sess_missing"},
+                },
+            },
+        )
+
+        resolved = await runner._resolve_async_delegation_session(current, "sess_child")
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_malformed_delegate_config_fails_closed_without_route_change(self):
+        current = self._entry("sess_current")
+        runner = self._make_runner(
+            {
+                "sess_child": {
+                    "id": "sess_child",
+                    "ended_at": None,
+                    "model_config": "{not-json}",
+                },
+            },
+        )
+
+        resolved = await runner._resolve_async_delegation_session(current, "sess_child")
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
     async def test_non_compression_ended_parent_drops(self):
         current = self._entry("sess_old")
         runner = self._make_runner(

--- a/tests/gateway/test_async_delegation_session_binding.py
+++ b/tests/gateway/test_async_delegation_session_binding.py
@@ -184,6 +184,71 @@ class TestGatewayPinningFailsClosed:
         self._assert_no_route_change(runner)
 
     @pytest.mark.asyncio
+    async def test_self_referential_delegate_provenance_fails_closed(self):
+        current = self._entry("sess_current")
+        runner = self._make_runner(
+            {
+                "sess_self": {
+                    "id": "sess_self",
+                    "ended_at": None,
+                    "model_config": {"_delegate_from": "sess_self"},
+                },
+            },
+        )
+
+        resolved = await runner._resolve_async_delegation_session(current, "sess_self")
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_overlong_delegate_chain_fails_closed_without_route_change(self):
+        from gateway.run import _MAX_DELEGATE_PROVENANCE_HOPS
+
+        # One acyclic hop past the cap: the cycle guard cannot catch this, so
+        # only the hop bound stops the walk (#92620 review).
+        depth = _MAX_DELEGATE_PROVENANCE_HOPS + 2
+        rows = {
+            f"sess_{i}": {
+                "id": f"sess_{i}",
+                "ended_at": None,
+                "model_config": {"_delegate_from": f"sess_{i + 1}"},
+            }
+            for i in range(depth)
+        }
+        rows[f"sess_{depth}"] = {"id": f"sess_{depth}", "ended_at": None}
+        current = self._entry("sess_current")
+        runner = self._make_runner(rows)
+
+        resolved = await runner._resolve_async_delegation_session(current, "sess_0")
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
+    async def test_delegate_chain_at_the_hop_limit_still_resolves(self):
+        from gateway.run import _MAX_DELEGATE_PROVENANCE_HOPS
+
+        # Exactly at the bound: the cap must not reject a resolvable chain.
+        depth = _MAX_DELEGATE_PROVENANCE_HOPS
+        rows = {
+            f"sess_{i}": {
+                "id": f"sess_{i}",
+                "ended_at": None,
+                "model_config": {"_delegate_from": f"sess_{i + 1}"},
+            }
+            for i in range(depth)
+        }
+        rows[f"sess_{depth}"] = {"id": f"sess_{depth}", "ended_at": None}
+        current = self._entry(f"sess_{depth}")
+        runner = self._make_runner(rows)
+
+        resolved = await runner._resolve_async_delegation_session(current, "sess_0")
+
+        assert resolved is current
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
     async def test_delegate_with_missing_parent_fails_closed_without_route_change(self):
         current = self._entry("sess_current")
         runner = self._make_runner(


### PR DESCRIPTION
## What does this PR do?

Keeps async delegation completions on the human-facing gateway parent when an internal delegate child or nested delegate child stamped its own session ID onto a process-completion event.

## Related Issue

Fixes #92611

## Root Cause

`_resolve_async_delegation_session()` treated every live `pinned_session_id` as a gateway route owner. Delegate sessions are internal execution transcripts, but their process-completion events can carry the child session ID as `parent_session_id`.

The resolver then called `switch_session()` to the live child. That could end the real human-facing parent with `session_switch`, rebind the platform route to the child transcript, and cause the later real delegation result targeting the parent to be dropped.

The durable ownership marker already exists in `model_config._delegate_from` and is written when a delegate child is created.

## Changes Made

- Follow `_delegate_from` provenance before any route verification or mutation.
- Resolve nested delegate chains back to the gateway parent.
- Fail closed on cyclic provenance, missing parents, malformed JSON config, or non-object config.
- Preserve existing compression-continuation routing for real gateway session rows.
- Add regression coverage for live children, nested children, cycles, missing parents, and malformed config.

## Testing

Canonical repository test entrypoint:

```text
HERMES_PYTHON=C:/Users/wdjes/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe \
scripts/run_tests.sh tests/gateway/test_async_delegation_session_binding.py -q
```

Observed:

```text
11 tests passed, 0 failed
```

Additional verification:

- Sabotage run with the provenance fix removed: 5 new tests failed as expected.
- `python -m py_compile gateway/run.py` passed.
- `git diff --check` passed.
- The PR contains only `gateway/run.py` and its focused regression test.

## Safety

A normal live gateway session without delegate provenance keeps the existing behavior. Compression parents still use the existing verified compression-tip path. Unknown or ambiguous delegate ownership is fail-closed and never mutates the current route.
