### PR TITLE
fix(update): rebuild Desktop after update even when the release tree was lost

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5406,6 +5406,34 @@ def _desktop_app_present(desktop_dir: Path) -> bool:
     )
 
 
+def _desktop_rebuild_warranted(desktop_dir: Path) -> bool:
+    """True when this machine has (or very recently had) a Desktop build.
+
+    Extends ``_desktop_app_present`` with the persistent build stamp in
+    ``$HERMES_HOME``. The on-disk check alone loses its answer across
+    update attempts: a failed git-path update can fall back to the ZIP
+    path, whose two-phase replace swaps the ``apps/desktop`` tree —
+    including the git-ignored ``release/`` artifact and ``dist/`` — while
+    the failed run never reaches the rebuild step. On the retry (a fresh
+    process) ``_desktop_app_present`` then reports False and the rebuild
+    is silently skipped, leaving a previously working Desktop unbuilt.
+
+    The stamp survives that swap (it lives outside the install tree,
+    under $HERMES_HOME) and is written only by a successful desktop
+    build; ``gui uninstall`` removes it, so it tracks "this machine had
+    a Desktop" rather than "some machine once built one". A stale stamp
+    after an intentional manual removal of ``release/`` costs one
+    redundant Electron build at most.
+    """
+    if _desktop_app_present(desktop_dir):
+        return True
+    try:
+        return _m()._desktop_stamp_path().exists()
+    except Exception:
+        # Stamp introspection must never block the update path.
+        return False
+
+
 def _rebuild_desktop_after_update(
     desktop_dir: Path, *, had_desktop_app_before_update: bool
 ) -> bool:
@@ -5420,7 +5448,9 @@ def _rebuild_desktop_after_update(
     # The release tree is ignored by git and can disappear during an update.
     # Its pre-update presence is enough to restore it; do not make people who
     # have never used Desktop pay for an Electron build.
-    has_desktop_app = had_desktop_app_before_update or _desktop_app_present(desktop_dir)
+    has_desktop_app = had_desktop_app_before_update or _desktop_rebuild_warranted(
+        desktop_dir
+    )
     if not (
         (desktop_dir / "package.json").exists()
         and _m()._resolve_node_runtime_npm()
@@ -5735,7 +5765,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # Capture this after every fail-closed venv guard, but before either
     # update path can remove the ignored release tree.
     desktop_dir = _m().PROJECT_ROOT / "apps" / "desktop"
-    had_desktop_app_before_update = _desktop_app_present(desktop_dir)
+    had_desktop_app_before_update = _desktop_rebuild_warranted(desktop_dir)
 
     # Try git-based update first, fall back to ZIP download on Windows
     # when git file I/O is broken (antivirus, NTFS filter drivers, etc.)

--- a/tests/hermes_cli/test_update_desktop_stamp_survives_zip_swap.py
+++ b/tests/hermes_cli/test_update_desktop_stamp_survives_zip_swap.py
@@ -1,0 +1,148 @@
+"""A lost release tree must not strand an installed Desktop unbuilt.
+
+Reproduction (2026-08-20 incident, Windows): run 1 of ``hermes update``
+failed on the git path (stash conflict) and fell back to the ZIP path,
+whose two-phase replace swapped the ``apps/desktop`` tree — deleting the
+git-ignored ``release/win-unpacked`` artifact — and then died before the
+desktop rebuild step. Run 2 (a fresh process) snapshotted
+``_desktop_app_present() == False``, so the rebuild was silently skipped
+and a previously working Desktop stayed unbuilt.
+
+The persistent build stamp under $HERMES_HOME survives the swap: it is
+written only by successful desktop builds and removed by ``gui
+uninstall``. ``_desktop_rebuild_warranted`` consults it so the retry
+rebuilds instead of skipping.
+"""
+
+import pytest
+
+from hermes_cli.update_cmd import (
+    _desktop_app_present,
+    _desktop_rebuild_warranted,
+    _rebuild_desktop_after_update,
+)
+
+
+class _Result:
+    def __init__(self, returncode: int, stdout: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+@pytest.fixture()
+def stamp_env(tmp_path, monkeypatch):
+    """Desktop dir without any built artifact + a faked CLI main module.
+
+    Mirrors the post-failure state of the incident: package.json exists
+    (the source tree is intact), but ``release/`` and ``dist/`` are gone.
+    """
+    desktop_dir = tmp_path / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+
+    class _FakeMain:
+        PROJECT_ROOT = tmp_path
+
+        @staticmethod
+        def _desktop_packaged_executable(_desktop_dir):
+            return None
+
+        @staticmethod
+        def _desktop_dist_exists(_desktop_dir):
+            return False
+
+        @staticmethod
+        def _desktop_stamp_path():
+            return tmp_path / "hermes-home" / "desktop-build-stamp.json"
+
+        @staticmethod
+        def _resolve_node_runtime_npm():
+            return "/fake/npm"
+
+        @staticmethod
+        def _desktop_build_needed(*_a, **_kw):
+            return True
+
+        @staticmethod
+        def _run_logged_subprocess(cmd, cwd=None, env=None):
+            return _Result(0)
+
+    monkeypatch.setattr(update_cmd_module(), "_m", lambda: _FakeMain)
+    return desktop_dir, tmp_path / "hermes-home"
+
+
+def update_cmd_module():
+    from hermes_cli import update_cmd
+
+    return update_cmd
+
+
+def test_stamp_alone_warrants_rebuild(stamp_env):
+    """The incident: no artifact on disk, but the stamp proves Desktop existed."""
+    desktop_dir, hermes_home = stamp_env
+    assert _desktop_app_present(desktop_dir) is False
+
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "desktop-build-stamp.json").write_text("{}", encoding="utf-8")
+
+    assert _desktop_rebuild_warranted(desktop_dir) is True
+
+
+def test_no_stamp_and_no_artifact_skips_rebuild(stamp_env):
+    """Users who never used Desktop pay nothing for an Electron build."""
+    desktop_dir, hermes_home = stamp_env
+    assert not hermes_home.exists()
+    assert _desktop_rebuild_warranted(desktop_dir) is False
+
+
+def test_artifact_on_disk_warrants_rebuild_without_stamp(stamp_env):
+    """Pre-existing behavior preserved when the artifact is present."""
+    desktop_dir, _hermes_home = stamp_env
+    import unittest.mock as mock
+
+    from hermes_cli import update_cmd
+
+    main_cls = update_cmd._m()
+    # Simulate a dist build existing.
+    with mock.patch.object(
+        main_cls, "_desktop_dist_exists", staticmethod(lambda _d: True)
+    ):
+        assert _desktop_rebuild_warranted(desktop_dir) is True
+
+
+def test_stamp_exception_falls_back_to_false(stamp_env):
+    """Stamp introspection must never break the update path."""
+    desktop_dir, _hermes_home = stamp_env
+    import unittest.mock as mock
+
+    from hermes_cli import update_cmd
+
+    def boom():
+        raise RuntimeError("fs gone")
+
+    with mock.patch.object(update_cmd._m(), "_desktop_stamp_path", staticmethod(boom)):
+        assert _desktop_rebuild_warranted(desktop_dir) is False
+
+
+def test_retry_after_lost_release_tree_runs_the_build(stamp_env, capsys, monkeypatch):
+    """End-to-end shape of run 2: rebuild proceeds despite no artifacts."""
+    desktop_dir, hermes_home = stamp_env
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "desktop-build-stamp.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        "hermes_constants.with_hermes_node_path", lambda: {}, raising=False
+    )
+    monkeypatch.setattr(
+        "hermes_constants.display_hermes_home",
+        lambda: str(hermes_home),
+        raising=False,
+    )
+
+    assert (
+        _rebuild_desktop_after_update(
+            desktop_dir, had_desktop_app_before_update=False
+        )
+        is True
+    )
+    out = capsys.readouterr().out
+    assert "Checking if desktop app needs rebuilding" in out


### PR DESCRIPTION
## Summary

`hermes update` can silently leave an installed Desktop app unbuilt when the update falls back to the ZIP path and then fails before the rebuild step.

### Reproduction (real incident, Windows, 2026-08-20)

1. **Run 1:** the git-path update hit a stash-restore conflict, then `uv pip install -e .` failed → fell back to `_update_via_zip`. The ZIP two-phase replace swapped the `apps/desktop` tree — deleting the git-ignored `release/win-unpacked/` artifact and `dist/` — but the run died before reaching `_rebuild_desktop_after_update`.
2. **Run 2** (the retry every failure message tells the user to do): a *fresh process* snapshots `had_desktop_app_before_update = _desktop_app_present(...)`. With `release/` gone, that is `False`, so per the intentional "don't make people who never used Desktop pay for an Electron build" rule the rebuild is skipped (`desktop skipped`, empty workspace `node_modules`). A previously working Desktop stays unbuilt; launching it fails until a manual `hermes desktop --build-only`.

The root problem: the fact "this machine had a Desktop" does not survive the process restart that a failed update almost always requires.

## Fix

Add `_desktop_rebuild_warranted()` which extends the on-disk check with the persistent build stamp at `$HERMES_HOME/desktop-build-stamp.json`:

- The stamp already exists for exactly this purpose (build freshness), lives **outside** the install tree so the ZIP swap cannot touch it, and its lifecycle is already managed correctly: written only by successful desktop builds, removed by `hermes gui uninstall`.
- So it cleanly encodes "this machine had a working Desktop" with no new state to maintain.
- Machines that never used Desktop still pay nothing (no stamp → no change).
- Worst case of a stale stamp (user manually deleted `release/` without uninstalling): one redundant Electron build on the next update.
- Stamp introspection is wrapped in a broad `try/except` returning `False` — it must never block the update path.

Both call sites switch to the new predicate: the pre-update snapshot (covers both git and ZIP paths within one run) and `_rebuild_desktop_after_update`.

## Test plan

- [x] New tests in `tests/hermes_cli/test_update_desktop_stamp_survives_zip_swap.py`: stamp alone warrants a rebuild after the artifact loss; no stamp + no artifact skips (never-installed users unaffected); artifact-on-disk behavior unchanged; stamp-read exceptions degrade to skip; end-to-end shape of the retry running the build.
- [x] Existing desktop-rebuild test suite passes unchanged (48 passed across `test_cmd_update.py`, `test_update_desktop_stale_warning.py`, and the new file).
- [x] `ruff check` clean on touched files.

Verified against the incident machine's state: after this fix the 2026-08-20 retry would have rebuilt instead of skipping.