### PR TITLE
fix(desktop): force Windows accessibility tree so UI Automation sees the composer

### DIFF
--- a/apps/desktop/electron/accessibility-support.test.ts
+++ b/apps/desktop/electron/accessibility-support.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldForceAccessibilitySupport } from './accessibility-support'
+
+describe('shouldForceAccessibilitySupport', () => {
+  it('forces accessibility support on Windows, where UI Automation dictation tools need it (#92607)', () => {
+    expect(shouldForceAccessibilitySupport('win32')).toBe(true)
+  })
+
+  it('leaves it off on macOS and Linux, where the reported gap does not apply', () => {
+    expect(shouldForceAccessibilitySupport('darwin')).toBe(false)
+    expect(shouldForceAccessibilitySupport('linux')).toBe(false)
+  })
+})

--- a/apps/desktop/electron/accessibility-support.ts
+++ b/apps/desktop/electron/accessibility-support.ts
@@ -1,0 +1,25 @@
+/**
+ * Whether to force Chromium's renderer accessibility tree on at launch.
+ *
+ * Why this exists
+ * ───────────────
+ * Chromium only builds its accessibility tree once it detects an assistive
+ * technology talking to it, and on Windows that detection is keyed off the
+ * *screen reader* client contract (it watches for the COM calls a screen
+ * reader like Narrator/NVDA makes). Dictation tools such as Wispr Flow speak
+ * plain Windows UI Automation to find the focused editable control, but
+ * never make those calls, so Chromium never turns the tree on. UI Automation
+ * inspection then only sees the native window chrome (`Minimize`/`Maximize`/
+ * `Close`) — the composer is never exposed as an editable control at all
+ * (#92607).
+ *
+ * `app.setAccessibilitySupportEnabled(true)` forces the tree on
+ * unconditionally, which is exactly the escape hatch Electron ships for
+ * this: OS-level assistive tooling that doesn't identify itself as a
+ * screen reader. Scoped to Windows because that's the platform where the
+ * detection gap exists and was reported; forcing it elsewhere would pay the
+ * tree-construction cost for no known benefit.
+ */
+export function shouldForceAccessibilitySupport(platform: NodeJS.Platform): boolean {
+  return platform === 'win32'
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -30,6 +30,7 @@ import {
   systemPreferences
 } from 'electron'
 
+import { shouldForceAccessibilitySupport } from './accessibility-support'
 import { classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
@@ -15041,6 +15042,12 @@ app.on('open-url', (event, url) => {
 })
 
 app.whenReady().then(() => {
+  // Force Chromium's accessibility tree on for Windows UI Automation clients
+  // (dictation tools like Wispr Flow) that don't identify themselves as a
+  // screen reader, so Chromium never auto-detects them and the composer is
+  // otherwise exposed as nothing but the native window chrome (#92607).
+  app.setAccessibilitySupportEnabled(shouldForceAccessibilitySupport(process.platform))
+
   // Warm the login-shell PATH resolution immediately so it usually completes
   // before the backend start path awaits the same single-flight promise.
   void ensureLoginShellPath()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15046,7 +15046,13 @@ app.whenReady().then(() => {
   // (dictation tools like Wispr Flow) that don't identify themselves as a
   // screen reader, so Chromium never auto-detects them and the composer is
   // otherwise exposed as nothing but the native window chrome (#92607).
-  app.setAccessibilitySupportEnabled(shouldForceAccessibilitySupport(process.platform))
+  // Only call the API when forcing is actually wanted: an explicit call
+  // takes manual control of accessibility support, which would override
+  // Chromium's native assistive-tech auto-detection on other platforms
+  // (e.g. VoiceOver on macOS, Orca on Linux).
+  if (shouldForceAccessibilitySupport(process.platform)) {
+    app.setAccessibilitySupportEnabled(true)
+  }
 
   // Warm the login-shell PATH resolution immediately so it usually completes
   // before the backend start path awaits the same single-flight promise.


### PR DESCRIPTION
Fixes #92607.

## Problem

Wispr Flow (and, by the same mechanism, any other Windows dictation tool
that drives apps via UI Automation rather than acting as a registered
screen reader) cannot insert dictated text into the Hermes Desktop
composer. The issue's own UI Automation inspection of the running window
found only `Minimize` / `Maximize` / `Close` — no editable control at all,
even though the composer already renders with `role="textbox"` and an
`aria-label` (`apps/desktop/src/app/chat/composer/index.tsx`).

## Root cause

Chromium (and therefore Electron) does not build its accessibility tree by
default — it stays off until Chromium detects an assistive-technology
client. On Windows, that auto-detection is keyed off the screen-reader COM
contract (the calls a tool like Narrator/NVDA makes). Wispr Flow talks
plain Windows UI Automation to locate the focused editable control, but
never makes those calls, so Chromium never turns the tree on. With the
tree off, UI Automation only ever sees the native window chrome the OS
itself exposes, never the renderer's contents — which matches the report
exactly.

`app.setAccessibilitySupportEnabled(true)` is Electron's documented escape
hatch for assistive tooling that doesn't self-identify as a screen reader.

## Fix

Force it on at startup, scoped to Windows (`apps/desktop/electron/main.ts`,
in the `app.whenReady()` handler), since that's the platform where the
detection gap was reported and where forcing it on has a known payoff:

```ts
app.setAccessibilitySupportEnabled(shouldForceAccessibilitySupport(process.platform))
```

`shouldForceAccessibilitySupport` is a small pure decision function in the
new `apps/desktop/electron/accessibility-support.ts`, following this
codebase's existing pattern of keeping Electron-API wiring in `main.ts`
thin and putting the actual decision in a unit-testable module (see
`bootstrap-repair-guard.ts` for the same shape).

## Testing

Added `apps/desktop/electron/accessibility-support.test.ts`, asserting the
decision is Windows-only:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Confirmed it fails without the fix (the new source file didn't exist yet,
so the test file can't even import it):

```
FAIL  |electron| electron/accessibility-support.test.ts [ electron/accessibility-support.test.ts ]
Error: Cannot find module './accessibility-support' imported from .../accessibility-support.test.ts
```

Full electron-side suite still green after the change:

```
 Test Files  113 passed | 1 skipped (114)
      Tests  1592 passed | 3 skipped (1595)
```

Also ran clean:
- `tsc -p tsconfig.electron.json --noEmit`
- `eslint electron/accessibility-support.ts electron/accessibility-support.test.ts electron/main.ts`

## AI assistance disclosure

This change was written by an AI coding agent (Claude, via Claude Code)
investigating and fixing this issue autonomously, with the diff reviewed
before push.
