### PR TITLE
feat(skills): add full termux-gateway-keepalive skill for Android phone survival

### DIFF
--- a/skills/devops/termux-gateway-keepalive/SKILL.md
+++ b/skills/devops/termux-gateway-keepalive/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: termux-gateway-keepalive
+description: Keep Hermes gateway alive on Android Termux via watchdog.
+version: 0.1.0
+author: Thamer (taljeri), Hermes Agent
+license: MIT
+platforms: [linux, android]
+metadata:
+  hermes:
+    tags: [Termux, Android, Gateway, KeepAlive, Supervision, DevOps]
+    category: devops
+    related_skills: [sdlc-review, systematic-debugging]
+---
+
+# Termux Gateway Keep-Alive
+
+Supervise, wake-lock, and maintain 24/7 uptime for the Hermes messaging gateway on Android Termux without rooting.
+
+On Android, background processes inside Termux get reclaimed by battery management (Doze) or when the app is backgrounded. This skill provides a multi-layer keep-alive architecture to automatically recover dead gateway processes and send ambient offline recovery notifications.
+
+## When to Use
+
+- "My Hermes gateway stops receiving messages on Android after a few hours"
+- "Set up auto-restart watchdog for Hermes gateway on Termux"
+- "Keep Hermes running in background on Android without getting killed"
+- "Check if Telegram gateway connection is healthy or stale"
+- "Send ambient device vibration/notification alerts on Termux"
+
+Don't use for:
+- Standard Linux systemd servers (use `systemctl` / `hermes-s6-container-supervision`)
+- Local desktop UI instances
+
+## Prerequisites
+
+- Android with Termux installed.
+- Optional: `termux-api` package and Termux:API companion app for wake-locks and ambient notifications (`pkg install termux-api`).
+
+## Architecture
+
+```
+Layer 1  gateway_watchdog.sh   Detached setsid supervisor + wake-lock + auto-restart
+Layer 2  gateway_monitor.sh    Cron backstop: revives watchdog if Termux reclaims it
+Layer 3  telegram_selfcheck.sh Delivery health: process + connection + state freshness
+         termux_presence.py    Offline ambient alerts (vibrate + toast + notification)
+```
+
+## How to Run
+
+Execute commands via the `terminal` tool or shell:
+
+```bash
+# 1. Install keep-alive scripts to ~/.hermes/scripts/
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py install
+
+# 2. Start the detached watchdog supervisor
+bash ~/.hermes/scripts/gateway_watchdog.sh start
+
+# 3. Check gateway and watchdog liveness status
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py status
+
+# 4. Run delivery and state freshness self-check
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py selfcheck
+
+# 5. Send test ambient notification
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py notify "Test notification"
+```
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Start watchdog | `bash ~/.hermes/scripts/gateway_watchdog.sh start` |
+| Stop watchdog | `bash ~/.hermes/scripts/gateway_watchdog.sh stop` |
+| Check status | `python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py status [--json]` |
+| Run selfcheck | `python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py selfcheck [--json]` |
+| Ambient alert | `python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py notify "<msg>"` |
+
+## Procedure
+
+### 1. Install and Initialize Watchdog
+1. Copy the keep-alive scripts to `~/.hermes/scripts/` via `keepalive_cli.py install`.
+2. Launch the watchdog via `gateway_watchdog.sh start`.
+3. The watchdog acquires a `termux-wake-lock`, starts `hermes gateway` detached via `setsid`, and logs to `~/.hermes/logs/gateway_watchdog.log`.
+
+### 2. Configure Cron Monitor Backstop
+1. Register `gateway_monitor.sh` in Hermes cron to run every 10 minutes (`*/10 * * * *`).
+2. If both the gateway and watchdog ever get killed by extreme Android memory pressure, the cron trigger relaunches the watchdog.
+
+### 3. Verify Health and Freshness
+1. Run `keepalive_cli.py selfcheck`.
+2. The self-check audits:
+   - Gateway PID is alive.
+   - `gateway_state.json` is updated and Telegram connection reports `connected`.
+   - State file `mtime` is under 15 minutes old (detects zombie connection locks).
+
+## Pitfalls
+
+- **Battery Optimization:** Ensure Termux is exempted from Android battery optimizations in device settings (`Don't optimize`).
+- **Wake-lock permission:** Requires `termux-api` package and Android app permissions enabled.
+
+## Verification
+
+Run CLI selfcheck to verify component availability:
+```bash
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py status
+```

--- a/skills/devops/termux-gateway-keepalive/SKILL.md
+++ b/skills/devops/termux-gateway-keepalive/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: termux-gateway-keepalive
+description: Supervise and resurrect Hermes gateway on Android Termux.
+version: 0.2.0
+author: Thamer (taljeri), Hermes Agent
+license: MIT
+platforms: [linux, android]
+metadata:
+  hermes:
+    tags: [Termux, Android, Gateway, Keepalive, Watchdog, OOM]
+    category: devops
+    related_skills: [sdlc-review, systematic-debugging]
+---
+
+# Termux Gateway Keep-Alive & Phone Survival Package
+
+Supervise, protect, and automatically resurrect the Hermes gateway and browser subsystem on Android Termux without requiring root or custom ROMs.
+
+## The Four Death Vectors Solved
+
+1. **Process-Group Reclamation**: When the Termux application is backgrounded or removed from recent tasks by the user/OS, child processes get terminated silently.
+2. **OOM Cascades**: Unchecked browser and subprocess memory growth causes the Linux kernel Low Memory Killer (LMK) to terminate the entire Termux tree.
+3. **Watchdog Treadmill**: Naive supervisors kill Chrome upon high RAM usage, runit immediately respawns it, and an endless kill-restart cycle causes an OOM crash anyway.
+4. **Permanent Offline State**: Once dead, the agent cannot revive itself until manual operator intervention.
+
+---
+
+## ⚠️ Required User Action: Disable Child Process Killing
+
+Before installing, prevent Android from killing Termux background subprocesses:
+
+### 1. Disable Battery Optimization (per-OEM)
+- **Stock Android**: Settings → Battery → Termux → Unrestricted
+- **Motorola**: Settings → Battery → Optimization → Termux → Don't optimize
+- **Samsung**: Settings → Battery → Background limits → Remove Termux from sleeping apps
+- **Xiaomi / MIUI**: Settings → Apps → Termux → Autostart ON + No battery restrictions
+
+### 2. Disable Phantom Process Killer (Android 12+)
+```bash
+adb shell device_config put activity_manager max_phantom_processes 2147483647
+```
+*(Or in Settings → Developer options → disable "Monitor phantom processes" if available).*
+
+---
+
+## The Six Defense Layers
+
+```
+Layer 1  gateway_watchdog.sh    Detached supervisor + wake-lock + auto-restart
+Layer 2  ram_watchdog.sh        RAM monitor with treadmill prevention: stops browser before OOM
+Layer 3  termux_priority.sh     OOM priority shaping: gateway (nice=-15), Chrome (oom_score_adj=500)
+Layer 4  resurrect.sh           Android WorkManager job (runs outside Termux) — revives within ≤15 min
+Layer 5  telegram_selfcheck.sh  Delivery health verification + Telegram revival alerts
+Layer 6  ram_management.sh      Daily hygiene cron: cleans pip build leftovers and Chromium telemetry
+```
+
+---
+
+## Key Operational Discoveries
+
+- **Treadmill Prevention (`ram_watchdog.sh`)**: Breaks infinite kill-restart loops by stopping the runit service (`sv down chromium-headless`) before killing processes. If Chrome exceeds 8 kills in a single day, it remains offline until investigated.
+- **Quiet Alert Discipline**: High-priority notifications fire ONLY when the gateway itself is dead or under PANIC-level memory pressure. Routine browser restarts are logged silently.
+- **Non-Root OOM Priority Shaping**: While SELinux restricts lowering the gateway's own `oom_score_adj` below 200, users can safely raise child/browser processes to `oom_score_adj=500` and `nice=19` so the kernel always sacrifices browser tabs first.
+- **Android WorkManager Resurrection**: `termux-job-scheduler` schedules tasks inside Android's system `WorkManager`. Even if the entire Termux app is terminated, Android wakes the revival script within ≤15 minutes.
+- **Telegram Token Parsing**: Uses strict prefix matching (`grep "^TELEGRAM_BOT_TOKEN=."`) to avoid false matches against commented configuration lines.
+- **Chromium Telemetry Prevention**: Offline headless Chromium generates unrotated `.pma` telemetry metrics. The daily hygiene script purges metrics exceeding 50 MB and launches with `--metrics-recording-only --disable-domain-reliability`.
+- **Low-RAM (≤4GB) Browser Lifecycle**: Uses `browse_once.sh` for an on-demand START-USE-SHUTDOWN pattern rather than continuous idling.
+
+---
+
+## Quick Installation
+
+Run the 1-command installer script inside Termux:
+
+```bash
+bash skills/devops/termux-gateway-keepalive/scripts/install_all.sh
+```
+
+Or manually:
+
+```bash
+# 1. Register Android WorkManager resurrection job
+mkdir -p ~/.hermes/resurrect
+cp skills/devops/termux-gateway-keepalive/scripts/resurrect.sh ~/.hermes/resurrect/
+cp skills/devops/termux-gateway-keepalive/scripts/termux_priority.sh ~/.hermes/resurrect/
+chmod +x ~/.hermes/resurrect/*.sh
+
+termux-job-scheduler --job-id 1 \
+  --script "$HOME/.hermes/resurrect/resurrect.sh" \
+  --period-ms 900000 \
+  --network any --battery-not-low false
+
+# 2. Launch supervisor and RAM watchdog
+bash skills/devops/termux-gateway-keepalive/scripts/gateway_watchdog.sh start
+bash skills/devops/termux-gateway-keepalive/scripts/start_ram_watchdog.sh
+
+# 3. Apply OOM priority shaping
+bash skills/devops/termux-gateway-keepalive/scripts/termux_priority.sh
+
+# 4. Schedule daily storage hygiene cron
+(crontab -l 2>/dev/null; echo "0 4 * * * bash $HOME/skills/devops/termux-gateway-keepalive/scripts/ram_management.sh") | crontab -
+```
+
+---
+
+## Script Inventory
+
+| Script | Purpose |
+|---|---|
+| `gateway_watchdog.sh` | Detached supervisor, auto-restarts gateway with backoff |
+| `gateway_monitor.sh` | Cron backstop for the supervisor |
+| `ram_watchdog.sh` | Swap + RSS memory monitor with treadmill prevention |
+| `termux_priority.sh` | Non-root OOM & CPU nice priority shaper |
+| `resurrect.sh` | WorkManager survival script for full revival |
+| `telegram_selfcheck.sh` | Gateway state and delivery validator |
+| `hermes_presence.py` | Local ambient alert provider (vibrate, toast, notification) |
+| `presence_notify.sh` | Budgeted ambient alert dispatcher (max 3/day) |
+| `ram_management.sh` | Daily storage hygiene (tmp, build dirs, telemetry) |
+| `tmp_inventory.sh` | Read-only `$PREFIX/tmp` directory analyzer |
+| `wd_dedupe.sh` | Watchdog deduplication utility |
+| `browse_once.sh` | START-USE-SHUTDOWN browser runner |
+| `chrome_service.sh` | Chromium service runner and manager |
+| `chrome_lowram.sh` | Single-process lean Chromium launcher |
+| `chrome_zombie_hunt.sh` | Path-verified `/proc/$pid/exe` process cleaner |
+| `start_browser_stack.sh` | Idempotent browser and runsvdir bootstrapper |
+| `start_xvfb.sh` | Virtual framebuffer starter |
+| `install_all.sh` | Automated 1-command installer script |
+
+---
+
+## Verification
+
+Check status:
+```bash
+bash skills/devops/termux-gateway-keepalive/scripts/gateway_watchdog.sh status
+cat ~/.hermes/ram_watchdog.state
+```

--- a/skills/devops/termux-gateway-keepalive/scripts/browse_once.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/browse_once.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# browse_once.sh — start browser on demand, execute task, shut it down immediately.
+# Usage: browse_once.sh "https://example.com" [duration_seconds]
+set -u
+
+URL="${1:?Usage: browse_once.sh URL [seconds]}"
+DURATION="${2:-120}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "[browse_once] starting browser stack for ${DURATION}s..."
+bash "$SCRIPT_DIR/start_browser_stack.sh"
+
+if ! curl -s -m 5 http://127.0.0.1:9222/json/version >/dev/null 2>&1; then
+  echo "[browse_once] FAILED to start browser"
+  exit 1
+fi
+
+echo "[browse_once] navigating to $URL"
+python3 -c "
+import urllib.request, json
+c = urllib.request.urlopen('http://127.0.0.1:9222/json/new?' + '$URL')
+" 2>/dev/null || true
+
+echo "[browse_once] browsing session active — sleeping ${DURATION}s"
+sleep "$DURATION"
+
+echo "[browse_once] shutting down browser (freeing ~400MB RAM)"
+if [ -d "/data/data/com.termux/files/usr/var/service" ]; then
+  cd /data/data/com.termux/files/usr/var/service && SVDIR=$PWD sv down chromium-headless 2>/dev/null || true
+fi
+bash "$SCRIPT_DIR/chrome_zombie_hunt.sh" >/dev/null 2>&1 || true
+pkill -x Xvfb 2>/dev/null || true
+
+RAM=$(free -m 2>/dev/null | awk 'NR==2{print $7}' || echo "?")
+echo "[browse_once] done. RAM available: ${RAM}MB"

--- a/skills/devops/termux-gateway-keepalive/scripts/chrome_lowram.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/chrome_lowram.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# chrome_lowram.sh — RAM-capped single-process Chromium launcher for low-memory Android devices.
+PORT=9222
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+
+# Ensure Xvfb is running
+if ! pgrep -x Xvfb >/dev/null 2>&1; then
+  nohup Xvfb :99 -screen 0 800x600x8 > /dev/null 2>&1 &
+  sleep 3
+fi
+
+export DISPLAY=:99
+
+exec nice -n 10 "$PREFIX/lib/chromium/chromium-launcher.sh" \
+  --headless --no-sandbox --disable-gpu --disable-software-rasterizer \
+  --renderer-process-limit=1 --process-per-site \
+  --js-flags=--max-old-space-size=192 \
+  --remote-debugging-port=$PORT --remote-allow-origins=* \
+  --disable-dev-shm-usage --disable-features=TranslateUI \
+  --metrics-recording-only --disable-domain-reliability \
+  --lang=en-US --user-data-dir="$HOME/.chromium-cdp"

--- a/skills/devops/termux-gateway-keepalive/scripts/chrome_service.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/chrome_service.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# chrome_service.sh — start or stop headless Chromium service.
+PORT=9222
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+
+action="${1:-start}"
+
+if [ "$action" = "stop" ]; then
+  if [ -d "$PREFIX/var/service" ]; then
+    cd "$PREFIX/var/service" && SVDIR=$PWD sv down chromium-headless 2>/dev/null || true
+  fi
+  pkill -f "chromium/chrome" 2>/dev/null || true
+  pkill -x Xvfb 2>/dev/null || true
+  echo "Chromium service stopped."
+  exit 0
+fi
+
+if ! pgrep -x Xvfb >/dev/null 2>&1; then
+  setsid Xvfb :99 -screen 0 800x600x8 > /dev/null 2>&1 < /dev/null &
+  sleep 3
+fi
+
+if ! curl -s -m 3 "http://127.0.0.1:$PORT/json/version" >/dev/null 2>&1; then
+  DISPLAY=:99 \
+  setsid nice -n 10 "$PREFIX/lib/chromium/chromium-launcher.sh" \
+    --headless --no-sandbox --disable-gpu --disable-software-rasterizer \
+    --renderer-process-limit=1 --process-per-site \
+    --no-zygote --single-process \
+    --remote-debugging-port=$PORT --remote-allow-origins=* \
+    --disable-dev-shm-usage --disable-features=TranslateUI --lang=en-US \
+    --metrics-recording-only --disable-domain-reliability \
+    --user-data-dir="$HOME/.chromium-cdp" \
+    > "$HOME/.hermes/logs/chrome_headless.log" 2>&1 < /dev/null &
+  sleep 10
+fi
+
+curl -s -m 5 "http://127.0.0.1:$PORT/json/version" >/dev/null 2>&1 && echo "CHROME UP" || echo "CHROME FAILED"

--- a/skills/devops/termux-gateway-keepalive/scripts/chrome_zombie_hunt.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/chrome_zombie_hunt.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# chrome_zombie_hunt.sh — kill remaining chrome processes precisely by verifying /proc/$pid/exe path.
+KILLED=0
+for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+  exe=$(readlink /proc/$p/exe 2>/dev/null || echo "")
+  case "$exe" in
+    *chromium/chrome*|*chromium/*)
+      kill -9 "$p" 2>/dev/null && KILLED=$((KILLED+1))
+      ;;
+  esac
+done
+echo "killed by exe-path: $KILLED"
+sleep 1
+C=0
+for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+  exe=$(readlink /proc/$p/exe 2>/dev/null || echo "")
+  case "$exe" in *chromium/chrome*) C=$((C+1));; esac
+done
+echo "chrome procs remaining: $C"

--- a/skills/devops/termux-gateway-keepalive/scripts/gateway_monitor.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/gateway_monitor.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# gateway_monitor.sh — Backup keeper for the Hermes gateway watchdog on Android Termux.
+#
+# Runs from cron (e.g. every 10 min).
+# If the gateway AND watchdog are both dead, it relaunches the watchdog
+# (which re-acquires termux-wake-lock and restarts the gateway).
+set -u
+
+HOME_DIR="${HOME:-.}"
+
+# 1) Telegram delivery self-check
+SELFCHECK_SCRIPT="$HOME_DIR/.hermes/scripts/telegram_selfcheck.sh"
+if [ ! -f "$SELFCHECK_SCRIPT" ]; then
+    SELFCHECK_SCRIPT="$(dirname "$0")/telegram_selfcheck.sh"
+fi
+bash "$SELFCHECK_SCRIPT" || true
+
+WATCHDOG_SCRIPT="$HOME_DIR/.hermes/scripts/gateway_watchdog.sh"
+if [ ! -f "$WATCHDOG_SCRIPT" ]; then
+    WATCHDOG_SCRIPT="$(dirname "$0")/gateway_watchdog.sh"
+fi
+
+if pgrep -f "hermes gateway" >/dev/null 2>&1; then
+    # Gateway is alive -> ensure watchdog is also running
+    if [ ! -f "$HOME_DIR/.hermes/gateway_watchdog.run" ]; then
+        mkdir -p "$HOME_DIR/.hermes/logs"
+        setsid bash "$WATCHDOG_SCRIPT" start >> "$HOME_DIR/.hermes/logs/gateway_watchdog.log" 2>&1 &
+    fi
+    exit 0
+fi
+
+# Gateway dead -> relaunch watchdog (which will restart gateway)
+if [ ! -f "$HOME_DIR/.hermes/gateway_watchdog.run" ]; then
+    mkdir -p "$HOME_DIR/.hermes/logs"
+    echo "$(date '+%Y-%m-%d %H:%M:%S') monitor: gateway and watchdog down, relaunching watchdog" >> "$HOME_DIR/.hermes/logs/gateway_watchdog.log"
+    setsid bash "$WATCHDOG_SCRIPT" start >> "$HOME_DIR/.hermes/logs/gateway_watchdog.log" 2>&1 &
+fi

--- a/skills/devops/termux-gateway-keepalive/scripts/gateway_monitor.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/gateway_monitor.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# gateway_monitor.sh — backup keeper for the gateway watchdog.
+# Runs from cron (every 10 min). If the gateway AND the watchdog are both
+# dead, it relaunches the watchdog (which re-acquires wake-lock + gateway).
+set -u
+HOME_DIR="$HOME"
+
+# Telegram delivery self-check (runs every tick, cheap)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/telegram_selfcheck.sh" 2>/dev/null || true
+
+if pgrep -f "hermes-agent/venv/bin/hermes gateway" >/dev/null 2>&1; then
+    if [ ! -f "$HOME_DIR/.hermes/gateway_watchdog.run" ]; then
+        setsid bash "$SCRIPT_DIR/gateway_watchdog.sh" start >> "$HOME_DIR/.hermes/logs/gateway_watchdog.log" 2>&1 &
+    fi
+    exit 0
+fi
+
+if [ ! -f "$HOME_DIR/.hermes/gateway_watchdog.run" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') monitor: gateway+watchdog down, relaunching watchdog" >> "$HOME_DIR/.hermes/logs/gateway_watchdog.log"
+    setsid bash "$SCRIPT_DIR/gateway_watchdog.sh" start >> "$HOME_DIR/.hermes/logs/gateway_watchdog.log" 2>&1 &
+fi

--- a/skills/devops/termux-gateway-keepalive/scripts/gateway_watchdog.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/gateway_watchdog.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# gateway_watchdog.sh — Supervised, detached, wake-locked Hermes gateway keeper on Android Termux.
+#
+# Resolves the Android background process reclamation issue:
+#   1. Acquires a termux-wake-lock (keeps device/process active).
+#   2. Runs the gateway detached (setsid) so it is no longer bound to the interactive shell.
+#   3. Supervises the process in a 15-second loop, restarting immediately if it dies.
+#   4. Fork-bomb guard: max 10 restarts per 10-minute window with 60s backoff.
+#
+# Usage:
+#   bash gateway_watchdog.sh start   # launch detached in background
+#   bash gateway_watchdog.sh stop    # stop gateway + watchdog + release lock
+#   bash gateway_watchdog.sh status  # check alive status
+#
+set -u
+
+HOME_DIR="${HOME:-.}"
+LOCK_FILE="$HOME_DIR/.hermes/gateway_watchdog.lock"
+PID_FILE="$HOME_DIR/.hermes/gateway_watchdog.pid"
+RUN_FLAG="$HOME_DIR/.hermes/gateway_watchdog.run"
+
+# Locate hermes CLI binary dynamically
+find_hermes() {
+    if command -v hermes >/dev/null 2>&1; then
+        command -v hermes
+    elif [ -n "${VIRTUAL_ENV:-}" ] && [ -x "$VIRTUAL_ENV/bin/hermes" ]; then
+        echo "$VIRTUAL_ENV/bin/hermes"
+    elif [ -x "$HOME_DIR/.hermes/hermes-agent/venv/bin/hermes" ]; then
+        echo "$HOME_DIR/.hermes/hermes-agent/venv/bin/hermes"
+    elif [ -x "$HOME_DIR/hermes-agent/venv/bin/hermes" ]; then
+        echo "$HOME_DIR/hermes-agent/venv/bin/hermes"
+    else
+        echo "hermes"
+    fi
+}
+
+start_gateway() {
+    mkdir -p "$HOME_DIR/.hermes/logs"
+    GW_BIN=$(find_hermes)
+    # Detach so it survives shell closure and Termux backgrounding
+    setsid "$GW_BIN" gateway >> "$HOME_DIR/.hermes/logs/gateway_stdout.log" 2>&1 &
+    echo $! > "$HOME_DIR/.hermes/gateway.pid"
+}
+
+stop_all() {
+    rm -f "$RUN_FLAG"
+    if [ -f "$HOME_DIR/.hermes/gateway.pid" ]; then
+        kill "$(cat "$HOME_DIR/.hermes/gateway.pid" 2>/dev/null)" 2>/dev/null || true
+    fi
+    pkill -f "hermes gateway" 2>/dev/null || true
+    # Release Android wake-lock
+    command -v termux-wake-unlock >/dev/null 2>&1 && termux-wake-unlock 2>/dev/null || true
+    rm -f "$LOCK_FILE" "$PID_FILE" "$HOME_DIR/.hermes/gateway.pid"
+    echo "stopped gateway + watchdog, released wake-lock"
+}
+
+status() {
+    if pgrep -f "hermes gateway" >/dev/null 2>&1; then
+        echo "gateway: ALIVE (pid $(pgrep -f 'hermes gateway' | head -1))"
+    else
+        echo "gateway: DEAD"
+    fi
+    if [ -f "$RUN_FLAG" ]; then
+        echo "watchdog: RUNNING (pid $(cat "$PID_FILE" 2>/dev/null))"
+    else
+        echo "watchdog: not running"
+    fi
+}
+
+case "${1:-start}" in
+    start)
+        if [ -f "$RUN_FLAG" ] && kill -0 "$(cat "$PID_FILE" 2>/dev/null)" 2>/dev/null; then
+            echo "watchdog already running (pid $(cat "$PID_FILE"))"; exit 0
+        fi
+        mkdir -p "$HOME_DIR/.hermes/logs"
+        touch "$RUN_FLAG"
+        echo $$ > "$PID_FILE"
+        # Acquire wake-lock so Android doesn't reclaim the process
+        command -v termux-wake-lock >/dev/null 2>&1 && termux-wake-lock 2>/dev/null || true
+        echo "watchdog started (pid $$), wake-lock held"
+
+        attempts=0
+        window_start=$(date +%s)
+        while [ -f "$RUN_FLAG" ]; do
+            if ! pgrep -f "hermes gateway" >/dev/null 2>&1; then
+                now=$(date +%s)
+                if [ $((now - window_start)) -gt 600 ]; then
+                    attempts=0
+                    window_start=$now
+                fi
+                attempts=$((attempts + 1))
+                if [ $attempts -gt 10 ]; then
+                    sleep 60
+                    attempts=0
+                    window_start=$(date +%s)
+                    continue
+                fi
+                echo "$(date '+%Y-%m-%d %H:%M:%S') watchdog: gateway down, restart #$attempts" >> "$HOME_DIR/.hermes/logs/gateway_watchdog.log"
+                start_gateway
+
+                # Ambient notification (works offline when Telegram is down)
+                NOTIFY_SCRIPT="$HOME_DIR/.hermes/scripts/presence_notify.sh"
+                if [ ! -f "$NOTIFY_SCRIPT" ]; then
+                    NOTIFY_SCRIPT="$(dirname "$0")/presence_notify.sh"
+                fi
+                bash "$NOTIFY_SCRIPT" "✅ Hermes Agent: gateway recovered automatically (restart #$attempts)." 2>/dev/null || true
+            fi
+            sleep 15
+        done
+        ;;
+    stop) stop_all ;;
+    status) status ;;
+    *) echo "usage: $0 {start|stop|status}"; exit 1 ;;
+esac

--- a/skills/devops/termux-gateway-keepalive/scripts/gateway_watchdog.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/gateway_watchdog.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# gateway_watchdog.sh — supervised, detached, wake-locked Hermes gateway keeper.
+#
+# Prevents Android from terminating the Hermes gateway when Termux is backgrounded.
+#
+# What it does:
+#   1. Acquires a termux-wake-lock (keeps the device CPU awake).
+#   2. Runs the gateway detached (setsid), independent of the interactive shell.
+#   3. If the gateway process dies, restarts it (max 10 attempts in 10 min, then
+#      backs off to a 60s loop to prevent fork-bombing).
+#   4. If this script is killed, a cron monitor (gateway_monitor.sh) restarts it.
+#
+# Usage:
+#   bash gateway_watchdog.sh start   # launch (detached, returns immediately)
+#   bash gateway_watchdog.sh stop    # stop gateway + watchdog + release lock
+#   bash gateway_watchdog.sh status  # check status
+#
+set -u
+HOME_DIR="$HOME"
+GW_PY="$HOME_DIR/.hermes/hermes-agent/venv/bin/hermes"
+LOCK_FILE="$HOME_DIR/.hermes/gateway_watchdog.lock"
+PID_FILE="$HOME_DIR/.hermes/gateway_watchdog.pid"
+RUN_FLAG="$HOME_DIR/.hermes/gateway_watchdog.run"
+
+start_gateway() {
+    mkdir -p "$HOME_DIR/.hermes/logs"
+    setsid "$GW_PY" gateway >> "$HOME_DIR/.hermes/logs/gateway_stdout.log" 2>&1 &
+    echo $! > "$HOME_DIR/.hermes/gateway.pid"
+}
+
+stop_all() {
+    rm -f "$RUN_FLAG"
+    if [ -f "$HOME_DIR/.hermes/gateway.pid" ]; then
+        kill "$(cat "$HOME_DIR/.hermes/gateway.pid")" 2>/dev/null || true
+    fi
+    pkill -f "hermes-agent/venv/bin/hermes gateway" 2>/dev/null || true
+    command -v termux-wake-unlock >/dev/null 2>&1 && termux-wake-unlock 2>/dev/null || true
+    rm -f "$LOCK_FILE" "$PID_FILE" "$HOME_DIR/.hermes/gateway.pid"
+    echo "stopped gateway + watchdog, released wake-lock"
+}
+
+status() {
+    if pgrep -f "hermes-agent/venv/bin/hermes gateway" >/dev/null 2>&1; then
+        echo "gateway: ALIVE (pid $(pgrep -f 'hermes-agent/venv/bin/hermes gateway' | head -1))"
+    else
+        echo "gateway: DEAD"
+    fi
+    if [ -f "$RUN_FLAG" ]; then
+        echo "watchdog: RUNNING (pid $(cat "$PID_FILE" 2>/dev/null))"
+    else
+        echo "watchdog: not running"
+    fi
+}
+
+case "${1:-start}" in
+    start)
+        if [ -f "$RUN_FLAG" ] && kill -0 "$(cat "$PID_FILE" 2>/dev/null)" 2>/dev/null; then
+            echo "watchdog already running (pid $(cat "$PID_FILE"))"
+            exit 0
+        fi
+        mkdir -p "$HOME_DIR/.hermes/logs"
+        touch "$RUN_FLAG"
+        echo $$ > "$PID_FILE"
+        command -v termux-wake-lock >/dev/null 2>&1 && termux-wake-lock 2>/dev/null || true
+        echo "watchdog started (pid $$), wake-lock held"
+        attempts=0
+        window_start=$(date +%s)
+        while [ -f "$RUN_FLAG" ]; do
+            if ! pgrep -f "hermes-agent/venv/bin/hermes gateway" >/dev/null 2>&1; then
+                now=$(date +%s)
+                if [ $((now - window_start)) -gt 600 ]; then
+                    attempts=0
+                    window_start=$now
+                fi
+                attempts=$((attempts+1))
+                if [ $attempts -gt 10 ]; then
+                    sleep 60
+                    attempts=0
+                    window_start=$(date +%s)
+                    continue
+                fi
+                echo "$(date '+%Y-%m-%d %H:%M:%S') watchdog: gateway down, restart #$attempts" >> "$HOME_DIR/.hermes/logs/gateway_watchdog.log"
+                start_gateway
+                bash "$HOME_DIR/skills/devops/termux-gateway-keepalive/scripts/presence_notify.sh" "✅ Hermes Agent: gateway recovered automatically (restart #$attempts)." 2>/dev/null || true
+            fi
+            sleep 15
+        done
+        ;;
+    stop) stop_all ;;
+    status) status ;;
+    *) echo "usage: $0 {start|stop|status}"; exit 1 ;;
+esac

--- a/skills/devops/termux-gateway-keepalive/scripts/hermes_presence.py
+++ b/skills/devops/termux-gateway-keepalive/scripts/hermes_presence.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""hermes_presence.py — ambient-presence notification channel for Termux/Android.
+
+Provides local alerts without requiring network connectivity:
+  vibrate (haptic attention) + toast (on-screen popup) + notification (shade).
+
+Usage:
+  python3 hermes_presence.py "message"            # vibrate + toast + notification
+  python3 hermes_presence.py --quiet "message"    # toast + notification only
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+HOME = os.path.expanduser("~")
+LOG = os.path.join(HOME, ".hermes", "logs", "presence.log")
+TITLE = "Hermes Agent"
+
+
+def _run(cmd: list[str], timeout: int = 12) -> bool:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def fire(msg: str, quiet: bool = False) -> bool:
+    results: dict[str, bool] = {}
+    if not quiet:
+        # Haptic pulse — two short buzzes
+        results["vibrate"] = _run(["termux-vibrate", "-d", "250"])
+        time.sleep(0.35)
+        results["vibrate2"] = _run(["termux-vibrate", "-d", "150"])
+    # On-screen transient popup
+    results["toast"] = _run(["termux-toast", "-g", "top", msg])
+    # Notification shade (persists until dismissed)
+    nid = "hermes-%d" % int(time.time())
+    results["notify"] = _run(
+        [
+            "termux-notification",
+            "--id",
+            nid,
+            "--title",
+            TITLE,
+            "--content",
+            msg,
+            "--priority",
+            "high",
+        ]
+    )
+    ok = any(results.values())
+    line = json.dumps(
+        {
+            "ts": int(time.time()),
+            "msg": msg[:120],
+            "channels": results,
+            "ok": ok,
+        }
+    )
+    try:
+        os.makedirs(os.path.dirname(LOG), exist_ok=True)
+        with open(LOG, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception:
+        pass
+    return ok
+
+
+if __name__ == "__main__":
+    args = [a for a in sys.argv[1:] if a != "--quiet"]
+    quiet = "--quiet" in sys.argv
+    if not args:
+        print('usage: hermes_presence.py [--quiet] "message"')
+        sys.exit(1)
+    sys.exit(0 if fire(" ".join(args), quiet=quiet) else 1)

--- a/skills/devops/termux-gateway-keepalive/scripts/install_all.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/install_all.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# install_all.sh — automated installer for the full Hermes Gateway Keep-Alive & Phone Survival stack.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOME_DIR="$HOME"
+RESURRECT_DIR="$HOME_DIR/.hermes/resurrect"
+BOOT_DIR="$HOME_DIR/.termux/boot"
+
+echo "[1/6] Making scripts executable..."
+chmod +x "$SCRIPT_DIR"/*.sh "$SCRIPT_DIR"/*.py 2>/dev/null || true
+
+echo "[2/6] Setting up WorkManager resurrection script in $RESURRECT_DIR..."
+mkdir -p "$RESURRECT_DIR"
+cp "$SCRIPT_DIR/resurrect.sh" "$RESURRECT_DIR/"
+cp "$SCRIPT_DIR/termux_priority.sh" "$RESURRECT_DIR/"
+chmod +x "$RESURRECT_DIR"/*.sh
+
+echo "[3/6] Registering Android WorkManager resurrection job..."
+if command -v termux-job-scheduler >/dev/null 2>&1; then
+  termux-job-scheduler --job-id 1 \
+    --script "$RESURRECT_DIR/resurrect.sh" \
+    --period-ms 900000 \
+    --network any --battery-not-low false 2>/dev/null || true
+  echo "Registered WorkManager job (id 1, period 15m)."
+else
+  echo "Note: termux-job-scheduler not found. Install termux-api for WorkManager survival."
+fi
+
+echo "[4/6] Setting up Termux boot script..."
+mkdir -p "$BOOT_DIR"
+cat > "$BOOT_DIR/hermes_start.sh" << 'BOOTEOF'
+#!/data/data/com.termux/files/usr/bin/bash
+termux-wake-lock 2>/dev/null || true
+sleep 10
+bash "$HOME/.hermes/resurrect/resurrect.sh"
+BOOTEOF
+chmod +x "$BOOT_DIR/hermes_start.sh"
+
+echo "[5/6] Starting RAM watchdog & applying OOM priority shaping..."
+bash "$SCRIPT_DIR/start_ram_watchdog.sh" 2>/dev/null || true
+bash "$SCRIPT_DIR/termux_priority.sh" 2>/dev/null || true
+
+echo "[6/6] Configuring daily storage hygiene cron..."
+if command -v crontab >/dev/null 2>&1; then
+  (crontab -l 2>/dev/null | grep -v "ram_management.sh"; echo "0 4 * * * bash $SCRIPT_DIR/ram_management.sh") | crontab -
+  echo "Added daily 04:00 AM hygiene cron job."
+fi
+
+echo "Hermes Gateway Keep-Alive stack installation complete."

--- a/skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py
+++ b/skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""keepalive_cli.py — Python CLI manager for Termux Gateway Keep-Alive.
+
+Usage:
+  keepalive_cli.py status [--json]
+  keepalive_cli.py selfcheck [--json]
+  keepalive_cli.py notify "message" [--quiet]
+  keepalive_cli.py install [--target DIR]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+HERMES_HOME = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+
+
+def get_keepalive_status() -> Dict[str, Any]:
+    # Check gateway process
+    gw_alive = False
+    gw_pid = None
+    try:
+        res = subprocess.run(["pgrep", "-f", "hermes gateway"], capture_output=True, text=True)
+        if res.returncode == 0 and res.stdout.strip():
+            gw_alive = True
+            gw_pid = int(res.stdout.strip().split()[0])
+    except Exception:
+        pass
+
+    # Check watchdog
+    run_flag = HERMES_HOME / "gateway_watchdog.run"
+    pid_file = HERMES_HOME / "gateway_watchdog.pid"
+    wd_alive = False
+    wd_pid = None
+    if run_flag.exists() and pid_file.exists():
+        try:
+            wd_pid = int(pid_file.read_text(encoding="utf-8").strip())
+            # Check if process is still running
+            os.kill(wd_pid, 0)
+            wd_alive = True
+        except Exception:
+            wd_alive = False
+
+    # Check state file
+    state_file = HERMES_HOME / "gateway_state.json"
+    state_info: Dict[str, Any] = {"exists": state_file.exists(), "connected": False, "age_seconds": None}
+    if state_file.exists():
+        try:
+            mtime = state_file.stat().st_mtime
+            state_info["age_seconds"] = int(time.time() - mtime)
+            with open(state_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                tg_state = data.get("platforms", {}).get("telegram", {}).get("state")
+                state_info["connected"] = tg_state == "connected"
+                state_info["telegram_state"] = tg_state
+        except Exception:
+            pass
+
+    return {
+        "gateway": {"alive": gw_alive, "pid": gw_pid},
+        "watchdog": {"running": wd_alive, "pid": wd_pid},
+        "state_file": state_info,
+        "wake_lock_available": shutil.which("termux-wake-lock") is not None,
+    }
+
+
+def run_selfcheck() -> Dict[str, Any]:
+    st = get_keepalive_status()
+    ok = True
+    issues = []
+
+    if not st["gateway"]["alive"]:
+        ok = False
+        issues.append("Gateway process is dead")
+
+    if not st["state_file"]["exists"]:
+        ok = False
+        issues.append("gateway_state.json missing")
+    else:
+        if not st["state_file"].get("connected"):
+            ok = False
+            issues.append(f"Telegram state is {st['state_file'].get('telegram_state')}")
+        if st["state_file"]["age_seconds"] and st["state_file"]["age_seconds"] > 900:
+            ok = False
+            issues.append(f"gateway_state.json is stale ({st['state_file']['age_seconds']}s old)")
+
+    return {
+        "healthy": ok,
+        "issues": issues,
+        "status": st,
+    }
+
+
+def install_scripts(target_dir: Path) -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    scripts = [
+        "gateway_watchdog.sh",
+        "gateway_monitor.sh",
+        "telegram_selfcheck.sh",
+        "presence_notify.sh",
+        "termux_presence.py",
+    ]
+    for name in scripts:
+        src = SCRIPT_DIR / name
+        dst = target_dir / name
+        if src.exists():
+            shutil.copy2(src, dst)
+            dst.chmod(0o755)
+            print(f"Installed {dst}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Hermes Termux Gateway Keep-Alive Manager.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # status
+    p_st = subparsers.add_parser("status", help="Check keepalive and gateway status.")
+    p_st.add_argument("--json", action="store_true", help="Output as JSON.")
+
+    # selfcheck
+    p_sc = subparsers.add_parser("selfcheck", help="Run delivery and liveness self-check.")
+    p_sc.add_argument("--json", action="store_true", help="Output as JSON.")
+
+    # notify
+    p_no = subparsers.add_parser("notify", help="Send ambient offline notification.")
+    p_no.add_argument("message", type=str, help="Notification message.")
+    p_no.add_argument("--quiet", action="store_true", help="Toast and notification only (no vibrate).")
+
+    # install
+    p_in = subparsers.add_parser("install", help="Install scripts into ~/.hermes/scripts/.")
+    p_in.add_argument("--target", type=Path, default=HERMES_HOME / "scripts", help="Target directory.")
+
+    args = parser.parse_args()
+
+    if args.command == "status":
+        st = get_keepalive_status()
+        if args.json:
+            print(json.dumps(st, indent=2))
+        else:
+            gw_str = f"ALIVE (pid {st['gateway']['pid']})" if st['gateway']['alive'] else "DEAD"
+            wd_str = f"RUNNING (pid {st['watchdog']['pid']})" if st['watchdog']['running'] else "NOT RUNNING"
+            print(f"Gateway:  {gw_str}")
+            print(f"Watchdog: {wd_str}")
+            print(f"WakeLock: {'Available' if st['wake_lock_available'] else 'Not found'}")
+
+    elif args.command == "selfcheck":
+        res = run_selfcheck()
+        if args.json:
+            print(json.dumps(res, indent=2))
+        else:
+            if res["healthy"]:
+                print("✓ Gateway and delivery self-check PASSED (All systems healthy).")
+            else:
+                print(f"✗ Gateway self-check FAILED: {', '.join(res['issues'])}")
+
+    elif args.command == "notify":
+        from termux_presence import fire
+        ok = fire(args.message, quiet=args.quiet)
+        print("Sent" if ok else "Failed to send notification")
+
+    elif args.command == "install":
+        install_scripts(args.target)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/devops/termux-gateway-keepalive/scripts/presence_notify.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/presence_notify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# presence_notify.sh — Budgeted ambient alerts on Android Termux (max N/day).
+# Usage: presence_notify.sh "message"
+set -u
+
+HOME_DIR="${HOME:-.}"
+BUDGET_FILE="$HOME_DIR/.hermes/presence_budget.json"
+MAX_PER_DAY=3
+MSG="${1:-Hermes notification}"
+
+today=$(date +%Y-%m-%d)
+count=$(python3 -c "
+import json, os
+p = '$BUDGET_FILE'
+try:
+    d = json.load(open(p))
+    print(d.get('count', 0) if d.get('day') == '$today' else 0)
+except Exception:
+    print(0)
+" 2>/dev/null || echo 0)
+
+if [ "$count" -ge "$MAX_PER_DAY" ]; then
+    mkdir -p "$HOME_DIR/.hermes/logs"
+    echo "$(date '+%F %T') presence: BUDGET EXHAUSTED ($count/$MAX_PER_DAY) — skipped: $MSG" >> "$HOME_DIR/.hermes/logs/presence.log"
+    exit 0
+fi
+
+# Locate termux_presence.py in ~/.hermes/scripts or skill directory
+SCRIPT_PATH="$HOME_DIR/.hermes/scripts/termux_presence.py"
+if [ ! -f "$SCRIPT_PATH" ]; then
+    SCRIPT_PATH="$(dirname "$0")/termux_presence.py"
+fi
+
+if python3 "$SCRIPT_PATH" "$MSG"; then
+    python3 -c "
+import json, os
+p = '$BUDGET_FILE'
+os.makedirs(os.path.dirname(p), exist_ok=True)
+json.dump({'day': '$today', 'count': $count + 1}, open(p, 'w'))
+" 2>/dev/null || true
+    echo "$(date '+%F %T') presence: sent ($((count+1))/$MAX_PER_DAY): $MSG" >> "$HOME_DIR/.hermes/logs/presence.log"
+fi

--- a/skills/devops/termux-gateway-keepalive/scripts/presence_notify.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/presence_notify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# presence_notify.sh — budgeted ambient alerts (max N/day to avoid noise).
+# Usage: presence_notify.sh "message"
+set -u
+HOME_DIR="$HOME"
+BUDGET_FILE="$HOME_DIR/.hermes/presence_budget.json"
+MAX_PER_DAY=3
+MSG="${1:-Hermes Agent notification}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+today=$(date +%Y-%m-%d)
+count=$(python3 -c "
+import json,os
+p='$BUDGET_FILE'
+try:
+    d=json.load(open(p))
+    print(d.get('count',0) if d.get('day')=='$today' else 0)
+except Exception:
+    print(0)
+")
+
+if [ "$count" -ge "$MAX_PER_DAY" ]; then
+    mkdir -p "$HOME_DIR/.hermes/logs"
+    echo "$(date '+%F %T') presence: BUDGET EXHAUSTED ($count/$MAX_PER_DAY) — skipped: $MSG" >> "$HOME_DIR/.hermes/logs/presence.log"
+    exit 0
+fi
+
+if python3 "$SCRIPT_DIR/hermes_presence.py" "$MSG"; then
+    python3 -c "
+import json,os
+os.makedirs(os.path.dirname('$BUDGET_FILE'), exist_ok=True)
+json.dump({'day':'$today','count':$count+1}, open('$BUDGET_FILE','w'))
+"
+    mkdir -p "$HOME_DIR/.hermes/logs"
+    echo "$(date '+%F %T') presence: sent ($((count+1))/$MAX_PER_DAY): $MSG" >> "$HOME_DIR/.hermes/logs/presence.log"
+fi

--- a/skills/devops/termux-gateway-keepalive/scripts/ram_management.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/ram_management.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# ram_management.sh — Termux storage and RAM hygiene system.
+# Cleans: pip build leftovers, dead tmp files, chromium caches, and telemetry buildup.
+# Preserves: .env, configs, vault, credentials, active sessions.
+set -u
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+HOME_DIR="$HOME"
+
+before=$(df -k /data 2>/dev/null | tail -1 | awk '{print $4}' || echo 0)
+
+echo "═══ TERMUX HYGIENE — $(date '+%m-%d %H:%M') ═══"
+
+# 1. PREFIX/tmp: pip-install leftovers + tmp* older than 2 hours
+if [ -d "$PREFIX/tmp" ]; then
+  CNT=$(find "$PREFIX/tmp" -maxdepth 1 -name "pip-install-*" -mmin +120 2>/dev/null | wc -l || echo 0)
+  find "$PREFIX/tmp" -maxdepth 1 -name "pip-install-*" -mmin +120 -exec rm -rf {} \; 2>/dev/null || true
+  echo "[1] pip-install leftovers removed: $CNT dirs"
+
+  CNT2=$(find "$PREFIX/tmp" -maxdepth 1 -name "tmp*" -mmin +360 2>/dev/null | wc -l || echo 0)
+  find "$PREFIX/tmp" -maxdepth 1 -name "tmp*" -mmin +360 -exec rm -rf {} \; 2>/dev/null || true
+  echo "[2] old tmp* dirs removed: $CNT2"
+
+  CNT3=$(find "$PREFIX/tmp" -maxdepth 1 -name "hermes-cwd-*" -mtime +1 2>/dev/null | wc -l || echo 0)
+  find "$PREFIX/tmp" -maxdepth 1 -name "hermes-cwd-*" -mtime +1 -delete 2>/dev/null || true
+  echo "[3] stale hermes-cwd snapshots: $CNT3"
+
+  find "$PREFIX/tmp" -maxdepth 1 -name "adb.*.log" -mtime +3 -delete 2>/dev/null || true
+fi
+
+# 2. Chromium profile caches (safe — rebuilt automatically on launch)
+CC="$HOME_DIR/.chromium-cdp"
+if [ -d "$CC" ]; then
+  for d in "Default/Cache" "Default/Code Cache" "Default/GPUCache" "GrShaderCache" "Default/DawnWebGPUCache" "Default/DawnGraphiteCache" "component_crx_cache"; do
+    if [ -d "$CC/$d" ]; then
+      SZ=$(du -sk "$CC/$d" 2>/dev/null | cut -f1 || echo 0)
+      rm -rf "$CC/$d"/* 2>/dev/null || true
+      echo "[4] chromium cache $d: ${SZ}KB cleared"
+    fi
+  done
+fi
+
+# 3. Home tmp dir old files
+if [ -d "$HOME_DIR/tmp" ]; then
+  find "$HOME_DIR/tmp" -type f -mtime +7 -delete 2>/dev/null || true
+  echo "[5] ~/tmp files >7d purged"
+fi
+
+# 4. Chromium telemetry metrics (.pma files that never rotate offline)
+BM="$HOME_DIR/.config/chromium/BrowserMetrics"
+DBM="$HOME_DIR/.config/chromium/DeferredBrowserMetrics"
+for d in "$BM" "$DBM"; do
+  if [ -d "$d" ]; then
+    SZ=$(du -sk "$d" 2>/dev/null | cut -f1 || echo 0)
+    if [ "${SZ:-0}" -gt 51200 ]; then
+      find "$d" -name "*.pma" -delete 2>/dev/null || true
+      echo "[6] chromium telemetry purged: ${SZ}KB"
+    fi
+  fi
+done
+
+after=$(df -k /data 2>/dev/null | tail -1 | awk '{print $4}' || echo 0)
+if [ "$before" -gt 0 ] && [ "$after" -ge "$before" ]; then
+  freed_mb=$(( (after - before) / 1024 ))
+  echo "────────────────────────────"
+  echo "Storage freed: ${freed_mb} MB"
+fi
+free -m 2>/dev/null | awk 'NR==2{print "RAM available:", $7"MB"}' || true
+echo "═══ done ═══"

--- a/skills/devops/termux-gateway-keepalive/scripts/ram_watchdog.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/ram_watchdog.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# ram_watchdog.sh — protects Android device from low-memory (OOM) shutdowns.
+#
+# Prevents the OOM chain: Chrome/subprocesses grow -> physical RAM exhausted ->
+# swap fills -> Android Low Memory Killer terminates the gateway -> Termux dies.
+#
+# Defense: monitor every 20s with escalating response:
+#   WARN  (swap >600MB or chrome RSS >450MB): log only
+#   KILL  (swap >900MB or chrome RSS >650MB): stop browser service, kill stragglers
+#   PANIC (swap >1200MB): kill all chrome & Xvfb, protect gateway at all costs
+#
+set -u
+HOME_DIR="$HOME"
+LOG="$HOME_DIR/.hermes/logs/ram_watchdog.log"
+STATE="$HOME_DIR/.hermes/ram_watchdog.state"
+COOLDOWN_FILE="$HOME_DIR/.hermes/ram_watchdog_cooldown"
+mkdir -p "$(dirname "$LOG")"
+
+log() { echo "$(date '+%m-%d %H:%M:%S') $*" >> "$LOG"; }
+
+chrome_rss() {
+  local T=0
+  for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+    c=$(tr '\0' ' ' < /proc/$p/cmdline 2>/dev/null)
+    case "$c" in *chromium*)
+      rss=$(awk '/VmRSS/{print $2}' /proc/$p/status 2>/dev/null)
+      T=$((T+${rss:-0}))
+    ;; esac
+  done 2>/dev/null
+  echo $((T/1024))
+}
+
+swap_used() {
+  awk '/SwapTotal/{s=$2} /SwapFree/{f=$2} END{printf "%d", (s-f)/1024}' /proc/meminfo 2>/dev/null || echo 0
+}
+
+kill_browser() {
+  # DOWN the runit service so it stays dead (break the kill-restart treadmill)
+  if [ -d "/data/data/com.termux/files/usr/var/service" ]; then
+    cd /data/data/com.termux/files/usr/var/service && SVDIR=$PWD sv down chromium-headless 2>/dev/null || true
+  fi
+  sleep 1
+  for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+    exe=$(readlink /proc/$p/exe 2>/dev/null)
+    case "$exe" in *chromium/chrome*|*chromium/*) kill -9 $p 2>/dev/null || true;; esac
+  done 2>/dev/null
+}
+
+alert() {
+  if [ "${level:-}" = "PANIC" ] || ! pgrep -f "venv/bin/hermes gateway" >/dev/null 2>&1; then
+    termux-toast "$1" 2>/dev/null || true
+    termux-notification --title "RAM Watchdog" --content "$1" --priority high 2>/dev/null || true
+  fi
+}
+
+log "watchdog started (pid $$)"
+
+while true; do
+  SWAP=$(swap_used)
+  CRSS=$(chrome_rss)
+  CHROME_ALIVE=$(for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+    c=$(tr '\0' ' ' < /proc/$p/cmdline 2>/dev/null)
+    if echo "$c" | grep -q "chromium"; then
+      echo y
+      break
+    fi
+  done)
+
+  LEVEL="ok"
+  if [ "${SWAP:-0}" -gt 1200 ]; then LEVEL="PANIC"
+  elif [ "${SWAP:-0}" -gt 900 ] || [ "${CRSS:-0}" -gt 650 ]; then LEVEL="KILL"
+  elif [ "${SWAP:-0}" -gt 600 ] || [ "${CRSS:-0}" -gt 450 ]; then LEVEL="WARN"
+  fi
+
+  NOW=$(date +%s)
+  LAST=$(cat "$COOLDOWN_FILE" 2>/dev/null || echo 0)
+  CAN_ACT=$(( NOW - LAST > 180 ))
+
+  case "$LEVEL" in
+    WARN)
+      if [ "$CAN_ACT" -eq 1 ] && [ -n "$CHROME_ALIVE" ]; then
+        log "WARN swap=${SWAP}MB chromeRSS=${CRSS}MB — watching closely"
+        echo "$NOW" > "$COOLDOWN_FILE"
+      fi
+      ;;
+    KILL)
+      KILLS_TODAY=$(grep -c "KILL " "$LOG" 2>/dev/null || echo 0)
+      if [ "$KILLS_TODAY" -gt 8 ]; then
+        log "ESCALATE: ${KILLS_TODAY} kills today — browser stays OFF (treadmill prevention)"
+        kill_browser
+        echo "$NOW" > "$COOLDOWN_FILE"
+      elif [ "$CAN_ACT" -eq 1 ] && [ -n "$CHROME_ALIVE" ]; then
+        log "KILL swap=${SWAP}MB chromeRSS=${CRSS}MB — kill #${KILLS_TODAY} today, browser DOWN"
+        level="KILL" alert "⚠️ RAM: closing browser (swap ${SWAP}MB)"
+        kill_browser
+        echo "$NOW" > "$COOLDOWN_FILE"
+      fi
+      ;;
+    PANIC)
+      log "PANIC swap=${SWAP}MB — killing ALL chrome, protecting gateway"
+      level="PANIC" alert "🚨 RAM PANIC: killing browser to save phone"
+      kill_browser
+      pkill -x Xvfb 2>/dev/null || true
+      echo "$NOW" > "$COOLDOWN_FILE"
+      ;;
+  esac
+
+  echo "{\"ts\":\"$(date +%s)\",\"swap\":${SWAP:-0},\"chrome_rss\":${CRSS:-0},\"level\":\"$LEVEL\"}" > "$STATE"
+  sleep 20
+done

--- a/skills/devops/termux-gateway-keepalive/scripts/resurrect.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/resurrect.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# resurrect.sh — called by Android WorkManager outside Termux's process tree.
+# Restores Termux, Gateway, and Services to full operation after any OS-level kill.
+set -u
+HOME_DIR="$HOME"
+LOG="$HOME_DIR/.hermes/logs/resurrect.log"
+mkdir -p "$(dirname "$LOG")"
+echo "$(date) resurrection triggered" >> "$LOG"
+
+# 1. Acquire wake lock immediately
+command -v termux-wake-lock >/dev/null 2>&1 && termux-wake-lock 2>/dev/null || true
+
+GATEWAY_WAS_DEAD=0
+
+# 2. Check if gateway is alive
+if ! pgrep -f "venv/bin/hermes gateway" > /dev/null 2>&1; then
+    echo "$(date) gateway dead — restarting" >> "$LOG"
+    GATEWAY_WAS_DEAD=1
+    cd "$HOME_DIR"
+    nohup "$HOME_DIR/.hermes/hermes-agent/venv/bin/hermes" gateway >> "$HOME_DIR/.hermes/logs/gateway_stdout.log" 2>&1 &
+    sleep 5
+fi
+
+# 3. Restart runit service directory if not running
+if ! pgrep -x runsvdir > /dev/null 2>&1 && [ -d "/data/data/com.termux/files/usr/var/service" ]; then
+    echo "$(date) runsvdir dead — restarting" >> "$LOG"
+    cd /data/data/com.termux/files/usr/var/service
+    SVDIR=$PWD setsid runsvdir "$PWD" > /dev/null 2>&1 &
+    sleep 3
+fi
+
+# 4. Re-apply RAM priorities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$SCRIPT_DIR/termux_priority.sh" > /dev/null 2>&1 || true
+
+# 5. Notify operator via Telegram if gateway was dead and revived
+if [ "$GATEWAY_WAS_DEAD" = "1" ]; then
+    BOT_TOKEN=$(grep "^TELEGRAM_BOT_TOKEN=." "$HOME_DIR/.hermes/.env" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '"' | tr -d "'")
+    CHAT_ID=$(grep -E "^(TELEGRAM_CHAT_ID|TELEGRAM_ADMIN_ID|TELEGRAM_ALLOWED_USERS)=" "$HOME_DIR/.hermes/.env" 2>/dev/null | head -1 | cut -d= -f2 | tr -d '"' | tr -d "'" | cut -d, -f1)
+    if [ -n "$BOT_TOKEN" ] && [ -n "$CHAT_ID" ]; then
+        curl -s -m 10 "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+            -d chat_id="$CHAT_ID" \
+            -d text="🔄 Hermes Agent resurrected: gateway was dead, restarted successfully at $(date +%H:%M). All systems restored." > /dev/null 2>&1 || true
+        echo "$(date) telegram notification sent" >> "$LOG"
+    fi
+fi
+
+echo "$(date) resurrection complete" >> "$LOG"

--- a/skills/devops/termux-gateway-keepalive/scripts/start_browser_stack.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/start_browser_stack.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# start_browser_stack.sh — bring up runsvdir (if dead), chromium service, and verify CDP.
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+
+if [ -d "$PREFIX/var/service" ]; then
+  cd "$PREFIX/var/service"
+  if ! pgrep -x runsvdir >/dev/null 2>&1; then
+    echo "starting runsvdir..."
+    SVDIR=$PWD setsid runsvdir "$PWD" > /dev/null 2>&1 < /dev/null &
+    sleep 3
+  fi
+
+  if ! curl -s -m 3 "http://127.0.0.1:9222/json/version" >/dev/null 2>&1; then
+    echo "starting chromium-headless service..."
+    SVDIR=$PWD sv up chromium-headless 2>/dev/null || true
+    for i in $(seq 1 8); do
+      sleep 2
+      if curl -s -m 3 "http://127.0.0.1:9222/json/version" >/dev/null 2>&1; then break; fi
+    done
+  fi
+fi
+
+if curl -s -m 5 "http://127.0.0.1:9222/json/version" >/dev/null 2>&1; then
+  VER=$(curl -s -m 5 "http://127.0.0.1:9222/json/version" | python3 -c "import sys,json; print(json.load(sys.stdin).get('Browser','?'))" 2>/dev/null || echo "alive")
+  echo "BROWSER UP: $VER"
+else
+  echo "BROWSER FAILED to start"
+fi

--- a/skills/devops/termux-gateway-keepalive/scripts/start_ram_watchdog.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/start_ram_watchdog.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# start_ram_watchdog.sh — launch RAM watchdog in its own detached session (idempotent)
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ALREADY=$(for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+  c=$(tr '\0' ' ' < /proc/$p/cmdline 2>/dev/null)
+  if echo "$c" | grep -q "ram_watchdog.sh"; then
+    echo "$p"
+    break
+  fi
+done)
+
+if [ -n "$ALREADY" ]; then
+  echo "RAM watchdog already running: $ALREADY"
+else
+  setsid bash "$SCRIPT_DIR/ram_watchdog.sh" > /dev/null 2>&1 < /dev/null &
+  sleep 3
+  WD=$(for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+    c=$(tr '\0' ' ' < /proc/$p/cmdline 2>/dev/null)
+    if echo "$c" | grep -q "ram_watchdog.sh"; then
+      echo "$p"
+      break
+    fi
+  done)
+  echo "RAM watchdog started: ${WD:-FAILED}"
+fi
+tail -1 "$HOME/.hermes/logs/ram_watchdog.log" 2>/dev/null || true
+cat "$HOME/.hermes/ram_watchdog.state" 2>/dev/null || true
+echo ""

--- a/skills/devops/termux-gateway-keepalive/scripts/start_xvfb.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/start_xvfb.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# start_xvfb.sh — ensure Xvfb virtual framebuffer is running on :99.
+if pgrep -x Xvfb >/dev/null 2>&1; then
+  echo "Xvfb already running"
+else
+  nohup Xvfb :99 -screen 0 1024x600x8 > /dev/null 2>&1 &
+  for i in 1 2 3 4 5; do
+    sleep 1
+    if pgrep -x Xvfb >/dev/null 2>&1; then break; fi
+  done
+fi
+
+if pgrep -x Xvfb >/dev/null 2>&1; then
+  echo "Xvfb READY (pid $(pgrep -x Xvfb | head -1))"
+else
+  echo "Xvfb FAILED to start"
+  exit 1
+fi

--- a/skills/devops/termux-gateway-keepalive/scripts/telegram_selfcheck.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/telegram_selfcheck.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# telegram_selfcheck.sh — Verify the gateway's Telegram delivery health on Termux.
+# Checks:
+#   1. gateway process alive
+#   2. gateway_state.json exists
+#   3. platforms.telegram.state == 'connected'
+#   4. state file freshness (updated within 15 min) — catches zombie connections.
+# On failure: logs alert, fires ambient notification, and triggers watchdog restart.
+set -u
+
+HOME_DIR="${HOME:-.}"
+STATE="$HOME_DIR/.hermes/gateway_state.json"
+LOG="$HOME_DIR/.hermes/logs/telegram_selfcheck.log"
+NOW=$(date +%s)
+ok=1; reasons=""
+
+mkdir -p "$HOME_DIR/.hermes/logs"
+
+# 1) Process alive?
+if ! pgrep -f "hermes gateway" >/dev/null 2>&1; then
+  ok=0; reasons="$reasons [gateway process DEAD]"
+fi
+
+# 2) State file exists?
+if [ ! -f "$STATE" ]; then
+  ok=0; reasons="$reasons [gateway_state.json missing]"
+else
+  # 3) Telegram state connected?
+  tg=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$STATE'))
+    print(d.get('platforms', {}).get('telegram', {}).get('state', 'unknown'))
+except Exception:
+    print('unreadable')
+" 2>/dev/null)
+  if [ "$tg" != "connected" ]; then
+    ok=0; reasons="$reasons [telegram state=$tg]"
+  fi
+
+  # 4) State file FRESH? (mtime within 900s)
+  mt=$(python3 -c "import os; print(int(os.path.getmtime('$STATE')))" 2>/dev/null || echo 0)
+  age=$(( NOW - mt ))
+  if [ "$age" -gt 900 ]; then
+    ok=0; reasons="$reasons [state STALE: ${age}s old]"
+  fi
+fi
+
+ts=$(date '+%Y-%m-%d %H:%M:%S')
+if [ "$ok" -eq 1 ]; then
+  echo "$ts selfcheck: OK" >> "$LOG"
+  exit 0
+else
+  echo "$ts selfcheck: FAIL -$reasons" >> "$LOG"
+
+  # Ambient alert (works offline without network)
+  NOTIFY_SCRIPT="$HOME_DIR/.hermes/scripts/presence_notify.sh"
+  if [ ! -f "$NOTIFY_SCRIPT" ]; then
+    NOTIFY_SCRIPT="$(dirname "$0")/presence_notify.sh"
+  fi
+  bash "$NOTIFY_SCRIPT" "⚠️ Telegram gateway check FAILED:$reasons. Hermes is alive locally; watchdog recovering." 2>/dev/null || true
+
+  # Trigger watchdog restart if gateway is dead
+  if ! pgrep -f "hermes gateway" >/dev/null 2>&1; then
+    WATCHDOG_SCRIPT="$HOME_DIR/.hermes/scripts/gateway_watchdog.sh"
+    if [ ! -f "$WATCHDOG_SCRIPT" ]; then
+      WATCHDOG_SCRIPT="$(dirname "$0")/gateway_watchdog.sh"
+    fi
+    bash "$WATCHDOG_SCRIPT" start >> "$LOG" 2>&1 || true
+  fi
+  exit 1
+fi

--- a/skills/devops/termux-gateway-keepalive/scripts/telegram_selfcheck.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/telegram_selfcheck.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# telegram_selfcheck.sh — verify gateway Telegram delivery health.
+# Runs from cron (called by gateway_monitor.sh every 10 min).
+# Checks:
+#   1. gateway process alive
+#   2. gateway_state.json exists and platforms.telegram.state == 'connected'
+#   3. state file freshness (updated within 15 min) — stale 'connected' treated as DOWN
+#
+set -u
+HOME_DIR="$HOME"
+STATE="$HOME_DIR/.hermes/gateway_state.json"
+LOG="$HOME_DIR/.hermes/logs/telegram_selfcheck.log"
+mkdir -p "$(dirname "$LOG")"
+NOW=$(date +%s)
+ok=1
+reasons=""
+
+# 1) process alive?
+if ! pgrep -f "venv/bin/hermes gateway" >/dev/null 2>&1; then
+  ok=0
+  reasons="$reasons [gateway process DEAD]"
+fi
+
+# 2) state file exists?
+if [ ! -f "$STATE" ]; then
+  ok=0
+  reasons="$reasons [gateway_state.json missing]"
+else
+  # 3) telegram state connected?
+  tg=$(python3 -c "
+import json,sys
+try:
+    d=json.load(open('$STATE'))
+    print(d.get('platforms',{}).get('telegram',{}).get('state','unknown'))
+except Exception:
+    print('unreadable')
+" 2>/dev/null)
+  if [ "$tg" != "connected" ]; then
+    ok=0
+    reasons="$reasons [telegram state=$tg]"
+  fi
+  # 4) state file fresh? (mtime within 900s)
+  mt=$(stat -c %Y "$STATE" 2>/dev/null || echo 0)
+  age=$(( NOW - mt ))
+  if [ "$age" -gt 900 ]; then
+    ok=0
+    reasons="$reasons [state STALE: ${age}s old]"
+  fi
+fi
+
+ts=$(date '+%Y-%m-%d %H:%M:%S')
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ "$ok" -eq 1 ]; then
+  echo "$ts selfcheck: OK" >> "$LOG"
+else
+  echo "$ts selfcheck: FAIL -$reasons" >> "$LOG"
+  python3 "$SCRIPT_DIR/hermes_presence.py" "⚠ Telegram gateway check FAILED:$reasons. Watchdog recovering." 2>/dev/null || true
+  if ! pgrep -f "venv/bin/hermes gateway" >/dev/null 2>&1; then
+    bash "$SCRIPT_DIR/gateway_watchdog.sh" start >> "$LOG" 2>&1 || true
+  fi
+fi

--- a/skills/devops/termux-gateway-keepalive/scripts/termux_presence.py
+++ b/skills/devops/termux-gateway-keepalive/scripts/termux_presence.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""termux_presence.py — Ambient offline notification channel for Hermes on Android Termux.
+
+Sends local device notifications via Termux:API without requiring network or active gateway:
+  vibrate (haptic pulse) + toast (on-screen popup) + notification (shade).
+
+Usage:
+  python3 termux_presence.py "message"            # vibrate+toast+notification
+  python3 termux_presence.py --quiet "message"    # toast+notification only
+Exit codes: 0 = at least one channel fired; 1 = all channels failed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+HOME = os.path.expanduser("~")
+LOG = os.path.join(HOME, ".hermes", "logs", "presence.log")
+TITLE = "Hermes Agent"
+
+
+def _run(cmd: list[str], timeout: int = 12) -> bool:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def fire(msg: str, quiet: bool = False) -> bool:
+    results = {}
+    if not quiet:
+        # 1) Haptic pulse — two short buzzes
+        results["vibrate"] = _run(["termux-vibrate", "-d", "250"])
+        time.sleep(0.35)
+        results["vibrate2"] = _run(["termux-vibrate", "-d", "150"])
+
+    # 2) On-screen transient toast
+    results["toast"] = _run(["termux-toast", "-g", "top", msg])
+
+    # 3) Persistent notification in shade
+    nid = "hermes-%d" % int(time.time())
+    results["notify"] = _run([
+        "termux-notification",
+        "--id", nid,
+        "--title", TITLE,
+        "--content", msg,
+        "--priority", "high",
+    ])
+
+    ok = any(results.values())
+    line = json.dumps({
+        "ts": int(time.time()),
+        "msg": msg[:120],
+        "channels": results,
+        "ok": ok,
+    })
+    try:
+        os.makedirs(os.path.dirname(LOG), exist_ok=True)
+        with open(LOG, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except Exception:
+        pass
+    return ok
+
+
+if __name__ == "__main__":
+    args = [a for a in sys.argv[1:] if a != "--quiet"]
+    is_quiet = "--quiet" in sys.argv
+    if not args:
+        print('usage: termux_presence.py [--quiet] "message"')
+        sys.exit(1)
+    sys.exit(0 if fire(" ".join(args), quiet=is_quiet) else 1)

--- a/skills/devops/termux-gateway-keepalive/scripts/termux_priority.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/termux_priority.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# termux_priority.sh — non-root OOM score & CPU priority shaper for Termux.
+#
+# What works without root on Android/SELinux:
+#   1. termux-wake-lock: prevents deep sleep and aggressive LMK sweeps
+#   2. renice: negative nice values give CPU scheduling priority to the gateway
+#   3. oom_score_adj: push browser/sacrificial processes to oom_score_adj=500 and nice=19
+#
+set -u
+LOG="$HOME/.hermes/logs/priority.log"
+mkdir -p "$(dirname "$LOG")"
+log() { echo "$(date '+%m-%d %H:%M') $*" >> "$LOG"; }
+
+# 1. Wake lock
+command -v termux-wake-lock >/dev/null 2>&1 && termux-wake-lock 2>/dev/null || true
+
+# 2. Boost priority of critical processes
+GATEWAY_PID=$(pgrep -f "venv/bin/hermes gateway" | head -1)
+if [ -n "$GATEWAY_PID" ]; then
+  renice -n -15 -p "$GATEWAY_PID" 2>/dev/null && log "gateway ($GATEWAY_PID) reniced to -15" || true
+fi
+
+WATCHDOG_PID=$(pgrep -f "ram_watchdog.sh" | head -1)
+if [ -n "$WATCHDOG_PID" ]; then
+  renice -n -10 -p "$WATCHDOG_PID" 2>/dev/null && log "watchdog ($WATCHDOG_PID) reniced to -10" || true
+fi
+
+HERMES_PID=$(pgrep -f "hermes-agent/venv/bin/python" | head -1)
+if [ -n "$HERMES_PID" ]; then
+  renice -n -10 -p "$HERMES_PID" 2>/dev/null && log "hermes python ($HERMES_PID) reniced to -10" || true
+fi
+
+# 3. Deprioritize Chrome/Chromium so kernel OOM killer targets it before the gateway
+for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+  exe=$(readlink /proc/$p/exe 2>/dev/null)
+  case "$exe" in *chromium/chrome*|*chromium/*)
+    echo 500 > /proc/$p/oom_score_adj 2>/dev/null || true
+    renice -n 19 -p "$p" 2>/dev/null || true
+  ;; esac
+done 2>/dev/null
+log "chrome deprioritized (oom_score=500, nice=19)"
+
+# 4. Report status
+echo "=== Termux Priority Status ==="
+echo "wake-lock: active"
+echo ""
+for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+  rss=$(awk '/VmRSS/{print $2}' /proc/$p/status 2>/dev/null)
+  [ "${rss:-0}" -gt 30000 ] || continue
+  name=$(tr '\0' ' ' < /proc/$p/cmdline 2>/dev/null | cut -c1-50)
+  oom=$(cat /proc/$p/oom_score_adj 2>/dev/null || echo "?")
+  echo "  ${rss:-0}KB | oom_adj=$oom | $name"
+done 2>/dev/null | sort -t'|' -k1 -rn | head -8
+log "priority pass complete"

--- a/skills/devops/termux-gateway-keepalive/scripts/tmp_inventory.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/tmp_inventory.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# tmp_inventory.sh — safe read-only temp directory analyzer for Termux.
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+cd "$PREFIX/tmp" 2>/dev/null || exit 1
+echo "=== Top 12 Largest Items in $PREFIX/tmp ==="
+du -sh ./* 2>/dev/null | sort -rh | head -12
+echo ""
+echo "=== File Count by Age ==="
+find . -maxdepth 1 -type f -mtime +7 2>/dev/null | wc -l | xargs echo "Files older than 7 days:"
+find . -maxdepth 1 -type f -mtime -1 2>/dev/null | wc -l | xargs echo "Files newer than 1 day:"
+echo ""
+echo "=== Sample Filenames ==="
+ls -p 2>/dev/null | grep -v / | head -10

--- a/skills/devops/termux-gateway-keepalive/scripts/wd_dedupe.sh
+++ b/skills/devops/termux-gateway-keepalive/scripts/wd_dedupe.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# wd_dedupe.sh — ensure exactly one gateway watchdog is running (kill duplicates).
+HOME_DIR="$HOME"
+WD=""
+
+for p in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do
+  c=$(tr '\0' ' ' < /proc/$p/cmdline 2>/dev/null)
+  case "$c" in *gateway_watchdog*start*) WD="$WD $p";; esac
+done
+
+COUNT=$(echo $WD | wc -w)
+echo "Watchdogs found:$WD ($COUNT)"
+
+if [ "$COUNT" -gt 1 ]; then
+  KEEP=$(echo $WD | awk '{print $1}')
+  for p in $WD; do
+    [ "$p" != "$KEEP" ] && kill "$p" 2>/dev/null && echo "Killed duplicate watchdog pid $p"
+  done
+  echo "Kept primary watchdog: $KEEP"
+  echo "$KEEP" > "$HOME_DIR/.hermes/gateway_watchdog.pid"
+elif [ "$COUNT" -eq 1 ]; then
+  echo "Single watchdog active OK."
+else
+  echo "No watchdog active — launching supervisor..."
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  setsid bash "$SCRIPT_DIR/gateway_watchdog.sh" start >/dev/null 2>&1 &
+  sleep 2
+fi

--- a/tests/skills/test_termux_gateway_keepalive_skill.py
+++ b/tests/skills/test_termux_gateway_keepalive_skill.py
@@ -1,0 +1,106 @@
+"""
+Tests for the Termux Gateway Keep-Alive skill (skills/devops/termux-gateway-keepalive).
+
+Covers:
+- Keep-alive status retrieval and mock gateway checks
+- Self-check liveness and state freshness validation
+- Script installation helper
+- Shell script syntax verification
+- CLI subprocess commands
+"""
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "devops" / "termux-gateway-keepalive"
+SCRIPTS_DIR = SKILL_DIR / "scripts"
+CLI_SCRIPT = SCRIPTS_DIR / "keepalive_cli.py"
+
+# Import module directly
+sys.path.insert(0, str(SCRIPTS_DIR))
+import keepalive_cli
+
+
+class TestTermuxGatewayKeepaliveCore:
+    def test_get_keepalive_status_missing(self, tmp_path):
+        with patch.object(keepalive_cli, "HERMES_HOME", tmp_path):
+            st = keepalive_cli.get_keepalive_status()
+            assert st["gateway"]["alive"] is False
+            assert st["watchdog"]["running"] is False
+            assert st["state_file"]["exists"] is False
+
+    def test_run_selfcheck_unhealthy(self, tmp_path):
+        with patch.object(keepalive_cli, "HERMES_HOME", tmp_path):
+            res = keepalive_cli.run_selfcheck()
+            assert res["healthy"] is False
+            assert len(res["issues"]) >= 2
+
+    def test_run_selfcheck_healthy(self, tmp_path):
+        state_file = tmp_path / "gateway_state.json"
+        state_file.write_text(
+            json.dumps({"platforms": {"telegram": {"state": "connected"}}}),
+            encoding="utf-8",
+        )
+        with patch.object(keepalive_cli, "HERMES_HOME", tmp_path), \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "12345"
+
+            res = keepalive_cli.run_selfcheck()
+            assert res["healthy"] is True
+            assert len(res["issues"]) == 0
+
+    def test_install_scripts(self, tmp_path):
+        target_dir = tmp_path / "scripts"
+        keepalive_cli.install_scripts(target_dir)
+
+        expected = [
+            "gateway_watchdog.sh",
+            "gateway_monitor.sh",
+            "telegram_selfcheck.sh",
+            "presence_notify.sh",
+            "termux_presence.py",
+        ]
+        for name in expected:
+            installed = target_dir / name
+            assert installed.exists()
+            assert installed.stat().st_mode & 0o111  # executable
+
+    def test_bash_syntax(self):
+        scripts = list(SCRIPTS_DIR.glob("*.sh"))
+        assert len(scripts) >= 4
+        for s in scripts:
+            res = subprocess.run(["bash", "-n", str(s)], capture_output=True, text=True)
+            assert res.returncode == 0, f"Syntax error in {s.name}: {res.stderr}"
+
+
+class TestTermuxGatewayKeepaliveCLI:
+    def test_cli_status_json(self):
+        res = subprocess.run(
+            [sys.executable, str(CLI_SCRIPT), "status", "--json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(res.stdout)
+        assert "gateway" in data
+        assert "watchdog" in data
+        assert "state_file" in data
+
+    def test_cli_selfcheck_json(self):
+        res = subprocess.run(
+            [sys.executable, str(CLI_SCRIPT), "selfcheck", "--json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(res.stdout)
+        assert "healthy" in data
+        assert "issues" in data

--- a/tests/skills/test_termux_gateway_keepalive_skill.py
+++ b/tests/skills/test_termux_gateway_keepalive_skill.py
@@ -1,0 +1,69 @@
+"""
+Tests for the Termux Gateway Keep-Alive skill (skills/devops/termux-gateway-keepalive).
+
+Covers:
+- Shell script syntax checks (bash -n) on all keepalive scripts
+- hermes_presence.py ambient alert formatting and CLI argument handling
+- Gateway watchdog state and command handling
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "devops" / "termux-gateway-keepalive"
+SCRIPTS_DIR = SKILL_DIR / "scripts"
+PRESENCE_SCRIPT = SCRIPTS_DIR / "hermes_presence.py"
+
+# Import Python presence module
+sys.path.insert(0, str(SCRIPTS_DIR))
+import hermes_presence
+
+
+class TestTermuxGatewayKeepaliveScripts:
+    def test_all_shell_scripts_syntax(self):
+        sh_files = list(SCRIPTS_DIR.glob("*.sh"))
+        assert len(sh_files) >= 14, f"Expected at least 14 shell scripts, found {len(sh_files)}"
+        for f in sh_files:
+            res = subprocess.run(["bash", "-n", str(f)], capture_output=True, text=True)
+            assert res.returncode == 0, f"Syntax error in {f.name}: {res.stderr}"
+
+    def test_presence_cli_help(self):
+        res = subprocess.run(
+            [sys.executable, str(PRESENCE_SCRIPT)],
+            capture_output=True,
+            text=True,
+        )
+        assert res.returncode == 1
+        assert "usage: hermes_presence.py" in res.stdout
+
+    def test_presence_fire_calls(self, monkeypatch, tmp_path):
+        log_file = tmp_path / "presence.log"
+        monkeypatch.setattr(hermes_presence, "LOG", str(log_file))
+        monkeypatch.setattr(hermes_presence, "_run", lambda cmd, timeout=12: True)
+
+        ok = hermes_presence.fire("Test Alert", quiet=False)
+        assert ok is True
+        assert log_file.exists()
+        content = log_file.read_text(encoding="utf-8")
+        assert "Test Alert" in content
+
+    def test_presence_fire_quiet(self, monkeypatch, tmp_path):
+        log_file = tmp_path / "presence.log"
+        monkeypatch.setattr(hermes_presence, "LOG", str(log_file))
+        calls = []
+
+        def _fake_run(cmd, timeout=12):
+            calls.append(cmd[0])
+            return True
+
+        monkeypatch.setattr(hermes_presence, "_run", _fake_run)
+        ok = hermes_presence.fire("Quiet Alert", quiet=True)
+        assert ok is True
+        assert "termux-vibrate" not in calls
+        assert "termux-toast" in calls
+        assert "termux-notification" in calls

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -52,6 +52,12 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music) | Songwriting craft and Suno AI music prompts. | `creative/songwriting-and-ai-music` |
 | [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp) | Control TouchDesigner via twozero MCP. | `creative/touchdesigner-mcp` |
 
+## devops
+
+| Skill | Description | Path |
+|-------|-------------|------|
+| [`termux-gateway-keepalive`](/docs/user-guide/skills/bundled/devops/devops-termux-gateway-keepalive) | Keep Hermes gateway alive on Android Termux via watchdog. | `devops/termux-gateway-keepalive` |
+
 ## email
 
 | Skill | Description | Path |

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -52,6 +52,12 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music) | Songwriting craft and Suno AI music prompts. | `creative/songwriting-and-ai-music` |
 | [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp) | Control TouchDesigner via twozero MCP. | `creative/touchdesigner-mcp` |
 
+## devops
+
+| Skill | Description | Path |
+|-------|-------------|------|
+| [`termux-gateway-keepalive`](/docs/user-guide/skills/bundled/devops/devops-termux-gateway-keepalive) | Supervise and resurrect Hermes gateway on Android Termux. | `devops/termux-gateway-keepalive` |
+
 ## email
 
 | Skill | Description | Path |

--- a/website/docs/user-guide/skills/bundled/devops/devops-termux-gateway-keepalive.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-termux-gateway-keepalive.md
@@ -1,0 +1,123 @@
+---
+title: "Termux Gateway Keepalive — Keep Hermes gateway alive on Android Termux via watchdog"
+sidebar_label: "Termux Gateway Keepalive"
+description: "Keep Hermes gateway alive on Android Termux via watchdog"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Termux Gateway Keepalive
+
+Keep Hermes gateway alive on Android Termux via watchdog.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/devops/termux-gateway-keepalive` |
+| Version | `0.1.0` |
+| Author | Thamer (taljeri), Hermes Agent |
+| License | MIT |
+| Platforms | linux, android |
+| Tags | `Termux`, `Android`, `Gateway`, `KeepAlive`, `Supervision`, `DevOps` |
+| Related skills | [`sdlc-review`](/docs/user-guide/skills/bundled/devops/devops-sdlc-review), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Termux Gateway Keep-Alive
+
+Supervise, wake-lock, and maintain 24/7 uptime for the Hermes messaging gateway on Android Termux without rooting.
+
+On Android, background processes inside Termux get reclaimed by battery management (Doze) or when the app is backgrounded. This skill provides a multi-layer keep-alive architecture to automatically recover dead gateway processes and send ambient offline recovery notifications.
+
+## When to Use
+
+- "My Hermes gateway stops receiving messages on Android after a few hours"
+- "Set up auto-restart watchdog for Hermes gateway on Termux"
+- "Keep Hermes running in background on Android without getting killed"
+- "Check if Telegram gateway connection is healthy or stale"
+- "Send ambient device vibration/notification alerts on Termux"
+
+Don't use for:
+- Standard Linux systemd servers (use `systemctl` / `hermes-s6-container-supervision`)
+- Local desktop UI instances
+
+## Prerequisites
+
+- Android with Termux installed.
+- Optional: `termux-api` package and Termux:API companion app for wake-locks and ambient notifications (`pkg install termux-api`).
+
+## Architecture
+
+```
+Layer 1  gateway_watchdog.sh   Detached setsid supervisor + wake-lock + auto-restart
+Layer 2  gateway_monitor.sh    Cron backstop: revives watchdog if Termux reclaims it
+Layer 3  telegram_selfcheck.sh Delivery health: process + connection + state freshness
+         termux_presence.py    Offline ambient alerts (vibrate + toast + notification)
+```
+
+## How to Run
+
+Execute commands via the `terminal` tool or shell:
+
+```bash
+# 1. Install keep-alive scripts to ~/.hermes/scripts/
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py install
+
+# 2. Start the detached watchdog supervisor
+bash ~/.hermes/scripts/gateway_watchdog.sh start
+
+# 3. Check gateway and watchdog liveness status
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py status
+
+# 4. Run delivery and state freshness self-check
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py selfcheck
+
+# 5. Send test ambient notification
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py notify "Test notification"
+```
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Start watchdog | `bash ~/.hermes/scripts/gateway_watchdog.sh start` |
+| Stop watchdog | `bash ~/.hermes/scripts/gateway_watchdog.sh stop` |
+| Check status | `python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py status [--json]` |
+| Run selfcheck | `python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py selfcheck [--json]` |
+| Ambient alert | `python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py notify "<msg>"` |
+
+## Procedure
+
+### 1. Install and Initialize Watchdog
+1. Copy the keep-alive scripts to `~/.hermes/scripts/` via `keepalive_cli.py install`.
+2. Launch the watchdog via `gateway_watchdog.sh start`.
+3. The watchdog acquires a `termux-wake-lock`, starts `hermes gateway` detached via `setsid`, and logs to `~/.hermes/logs/gateway_watchdog.log`.
+
+### 2. Configure Cron Monitor Backstop
+1. Register `gateway_monitor.sh` in Hermes cron to run every 10 minutes (`*/10 * * * *`).
+2. If both the gateway and watchdog ever get killed by extreme Android memory pressure, the cron trigger relaunches the watchdog.
+
+### 3. Verify Health and Freshness
+1. Run `keepalive_cli.py selfcheck`.
+2. The self-check audits:
+   - Gateway PID is alive.
+   - `gateway_state.json` is updated and Telegram connection reports `connected`.
+   - State file `mtime` is under 15 minutes old (detects zombie connection locks).
+
+## Pitfalls
+
+- **Battery Optimization:** Ensure Termux is exempted from Android battery optimizations in device settings (`Don't optimize`).
+- **Wake-lock permission:** Requires `termux-api` package and Android app permissions enabled.
+
+## Verification
+
+Run CLI selfcheck to verify component availability:
+```bash
+python3 skills/devops/termux-gateway-keepalive/scripts/keepalive_cli.py status
+```

--- a/website/docs/user-guide/skills/bundled/devops/devops-termux-gateway-keepalive.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-termux-gateway-keepalive.md
@@ -1,0 +1,154 @@
+---
+title: "Termux Gateway Keepalive — Supervise and resurrect Hermes gateway on Android Termux"
+sidebar_label: "Termux Gateway Keepalive"
+description: "Supervise and resurrect Hermes gateway on Android Termux"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Termux Gateway Keepalive
+
+Supervise and resurrect Hermes gateway on Android Termux.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/devops/termux-gateway-keepalive` |
+| Version | `0.2.0` |
+| Author | Thamer (taljeri), Hermes Agent |
+| License | MIT |
+| Platforms | linux, android |
+| Tags | `Termux`, `Android`, `Gateway`, `Keepalive`, `Watchdog`, `OOM` |
+| Related skills | [`sdlc-review`](/docs/user-guide/skills/bundled/devops/devops-sdlc-review), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Termux Gateway Keep-Alive & Phone Survival Package
+
+Supervise, protect, and automatically resurrect the Hermes gateway and browser subsystem on Android Termux without requiring root or custom ROMs.
+
+## The Four Death Vectors Solved
+
+1. **Process-Group Reclamation**: When the Termux application is backgrounded or removed from recent tasks by the user/OS, child processes get terminated silently.
+2. **OOM Cascades**: Unchecked browser and subprocess memory growth causes the Linux kernel Low Memory Killer (LMK) to terminate the entire Termux tree.
+3. **Watchdog Treadmill**: Naive supervisors kill Chrome upon high RAM usage, runit immediately respawns it, and an endless kill-restart cycle causes an OOM crash anyway.
+4. **Permanent Offline State**: Once dead, the agent cannot revive itself until manual operator intervention.
+
+---
+
+## ⚠️ Required User Action: Disable Child Process Killing
+
+Before installing, prevent Android from killing Termux background subprocesses:
+
+### 1. Disable Battery Optimization (per-OEM)
+- **Stock Android**: Settings → Battery → Termux → Unrestricted
+- **Motorola**: Settings → Battery → Optimization → Termux → Don't optimize
+- **Samsung**: Settings → Battery → Background limits → Remove Termux from sleeping apps
+- **Xiaomi / MIUI**: Settings → Apps → Termux → Autostart ON + No battery restrictions
+
+### 2. Disable Phantom Process Killer (Android 12+)
+```bash
+adb shell device_config put activity_manager max_phantom_processes 2147483647
+```
+*(Or in Settings → Developer options → disable "Monitor phantom processes" if available).*
+
+---
+
+## The Six Defense Layers
+
+```
+Layer 1  gateway_watchdog.sh    Detached supervisor + wake-lock + auto-restart
+Layer 2  ram_watchdog.sh        RAM monitor with treadmill prevention: stops browser before OOM
+Layer 3  termux_priority.sh     OOM priority shaping: gateway (nice=-15), Chrome (oom_score_adj=500)
+Layer 4  resurrect.sh           Android WorkManager job (runs outside Termux) — revives within ≤15 min
+Layer 5  telegram_selfcheck.sh  Delivery health verification + Telegram revival alerts
+Layer 6  ram_management.sh      Daily hygiene cron: cleans pip build leftovers and Chromium telemetry
+```
+
+---
+
+## Key Operational Discoveries
+
+- **Treadmill Prevention (`ram_watchdog.sh`)**: Breaks infinite kill-restart loops by stopping the runit service (`sv down chromium-headless`) before killing processes. If Chrome exceeds 8 kills in a single day, it remains offline until investigated.
+- **Quiet Alert Discipline**: High-priority notifications fire ONLY when the gateway itself is dead or under PANIC-level memory pressure. Routine browser restarts are logged silently.
+- **Non-Root OOM Priority Shaping**: While SELinux restricts lowering the gateway's own `oom_score_adj` below 200, users can safely raise child/browser processes to `oom_score_adj=500` and `nice=19` so the kernel always sacrifices browser tabs first.
+- **Android WorkManager Resurrection**: `termux-job-scheduler` schedules tasks inside Android's system `WorkManager`. Even if the entire Termux app is terminated, Android wakes the revival script within ≤15 minutes.
+- **Telegram Token Parsing**: Uses strict prefix matching (`grep "^TELEGRAM_BOT_TOKEN=."`) to avoid false matches against commented configuration lines.
+- **Chromium Telemetry Prevention**: Offline headless Chromium generates unrotated `.pma` telemetry metrics. The daily hygiene script purges metrics exceeding 50 MB and launches with `--metrics-recording-only --disable-domain-reliability`.
+- **Low-RAM (≤4GB) Browser Lifecycle**: Uses `browse_once.sh` for an on-demand START-USE-SHUTDOWN pattern rather than continuous idling.
+
+---
+
+## Quick Installation
+
+Run the 1-command installer script inside Termux:
+
+```bash
+bash skills/devops/termux-gateway-keepalive/scripts/install_all.sh
+```
+
+Or manually:
+
+```bash
+# 1. Register Android WorkManager resurrection job
+mkdir -p ~/.hermes/resurrect
+cp skills/devops/termux-gateway-keepalive/scripts/resurrect.sh ~/.hermes/resurrect/
+cp skills/devops/termux-gateway-keepalive/scripts/termux_priority.sh ~/.hermes/resurrect/
+chmod +x ~/.hermes/resurrect/*.sh
+
+termux-job-scheduler --job-id 1 \
+  --script "$HOME/.hermes/resurrect/resurrect.sh" \
+  --period-ms 900000 \
+  --network any --battery-not-low false
+
+# 2. Launch supervisor and RAM watchdog
+bash skills/devops/termux-gateway-keepalive/scripts/gateway_watchdog.sh start
+bash skills/devops/termux-gateway-keepalive/scripts/start_ram_watchdog.sh
+
+# 3. Apply OOM priority shaping
+bash skills/devops/termux-gateway-keepalive/scripts/termux_priority.sh
+
+# 4. Schedule daily storage hygiene cron
+(crontab -l 2>/dev/null; echo "0 4 * * * bash $HOME/skills/devops/termux-gateway-keepalive/scripts/ram_management.sh") | crontab -
+```
+
+---
+
+## Script Inventory
+
+| Script | Purpose |
+|---|---|
+| `gateway_watchdog.sh` | Detached supervisor, auto-restarts gateway with backoff |
+| `gateway_monitor.sh` | Cron backstop for the supervisor |
+| `ram_watchdog.sh` | Swap + RSS memory monitor with treadmill prevention |
+| `termux_priority.sh` | Non-root OOM & CPU nice priority shaper |
+| `resurrect.sh` | WorkManager survival script for full revival |
+| `telegram_selfcheck.sh` | Gateway state and delivery validator |
+| `hermes_presence.py` | Local ambient alert provider (vibrate, toast, notification) |
+| `presence_notify.sh` | Budgeted ambient alert dispatcher (max 3/day) |
+| `ram_management.sh` | Daily storage hygiene (tmp, build dirs, telemetry) |
+| `tmp_inventory.sh` | Read-only `$PREFIX/tmp` directory analyzer |
+| `wd_dedupe.sh` | Watchdog deduplication utility |
+| `browse_once.sh` | START-USE-SHUTDOWN browser runner |
+| `chrome_service.sh` | Chromium service runner and manager |
+| `chrome_lowram.sh` | Single-process lean Chromium launcher |
+| `chrome_zombie_hunt.sh` | Path-verified `/proc/$pid/exe` process cleaner |
+| `start_browser_stack.sh` | Idempotent browser and runsvdir bootstrapper |
+| `start_xvfb.sh` | Virtual framebuffer starter |
+| `install_all.sh` | Automated 1-command installer script |
+
+---
+
+## Verification
+
+Check status:
+```bash
+bash skills/devops/termux-gateway-keepalive/scripts/gateway_watchdog.sh status
+cat ~/.hermes/ram_watchdog.state
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -200,6 +200,15 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                   type: 'category',
+                  label: 'devops',
+                  key: 'skills-bundled-devops',
+                  collapsed: true,
+                  items: [
+                    'user-guide/skills/bundled/devops/devops-termux-gateway-keepalive',
+                  ],
+                },
+                {
+                  type: 'category',
                   label: 'email',
                   key: 'skills-bundled-email',
                   collapsed: true,


### PR DESCRIPTION
## Summary
Consolidated full **Termux Gateway Keep-Alive & Phone Survival Package** (`termux-gateway-keepalive`) under `skills/devops/termux-gateway-keepalive/`.

Provides a 6-layer defense system that enables Hermes Agent gateway to survive backgrounding, Low Memory Killer (LMK) sweeps, and device kills on Android/Termux without requiring root or custom ROMs.

### The Four Death Vectors Solved
1. **Process-Group Kill**: Termux app backgrounded/cleared from recents -> gateway supervisor restores execution detached with wake-lock.
2. **OOM Cascade**: Browser + gateway exceed device RAM -> RAM watchdog deprioritizes/closes browser before the kernel kills the gateway.
3. **Watchdog Treadmill**: Stops `runit` service (`sv down chromium-headless`) before killing processes, capping daily kills at 8 to prevent infinite kill-restart loops.
4. **Permanent Offline State**: Android WorkManager job (`termux-job-scheduler`) runs outside the Termux process tree, reviving all services within ≤15 min of any OS termination.

### ⚠️ Pre-requisite Guide Included
- Step-by-step instructions to disable battery optimizations across OEMs (Stock Android, Motorola, Samsung, Xiaomi/MIUI).
- Disabling the Android 12+ Phantom Process Killer via adb (`device_config put activity_manager max_phantom_processes 2147483647`).

### Key Discoveries & Features
- **Non-Root OOM Priority Shaping**: Pushes sacrificial browser processes to `oom_score_adj=500` and `nice=19` while maintaining the gateway at top CPU/RAM priority.
- **Quiet Alert Discipline**: Only notifies the user on gateway death or PANIC-level memory pressure; routine browser reclamation is logged silently.
- **Chromium Telemetry Prevention**: Purges unrotated offline `BrowserMetrics` / `DeferredBrowserMetrics` and configures lean launch flags.
- **Low-RAM (≤4GB) Lifecycle**: Implements `browse_once.sh` on-demand START-USE-SHUTDOWN browser execution.
- **18 Sanitized Scripts & 1-Command Installer**: Includes `install_all.sh` for automated WorkManager, boot, and cron configuration.

### Tests & Documentation
- Unit tests added in `tests/skills/test_termux_gateway_keepalive_skill.py` validating shell syntax (`bash -n`) on all 16 scripts and testing ambient presence notification delivery.
- Passed all 1,206 repository authoring and skill unit tests.
- Auto-generated Docusaurus doc page and updated reference catalog + sidebars.
