### PR TITLE
fix(desktop): always stamp last_read_at when a session is opened

### DIFF
--- a/apps/desktop/src/store/session-unread-remote.test.ts
+++ b/apps/desktop/src/store/session-unread-remote.test.ts
@@ -60,12 +60,18 @@ describe('markSessionUnread', () => {
 })
 
 describe('clearUnreadOnOpen', () => {
-  it('no-ops for a session that is already read', async () => {
-    $sessions.set([row('a', { unread: false })])
+  // Always stamps `last_read_at` on open, even when the backend already
+  // believes the session is read: `SessionDB.session_unread()` returns
+  // False for rows whose `last_read_at` is NULL, so without an unconditional
+  // write the watermark is never seeded and the renderer-side gap keeps
+  // painting green dots after every cold start.
+  it('PATCHes read for an already-read session to seed the backend watermark', async () => {
+    $sessions.set([row('a', { profile: 'p1', unread: false })])
 
     await clearUnreadOnOpen('a')
 
-    expect(patch).not.toHaveBeenCalled()
+    expect(patch).toHaveBeenCalledWith('a', false, 'p1')
+    expect($sessions.get().find(s => s.id === 'a')?.unread).toBe(false)
   })
 
   it('PATCHes read for an unread session, using its owning profile', async () => {

--- a/apps/desktop/src/store/session-unread-remote.test.ts
+++ b/apps/desktop/src/store/session-unread-remote.test.ts
@@ -83,6 +83,17 @@ describe('clearUnreadOnOpen', () => {
     expect($sessions.get().find(s => s.id === 'a')?.unread).toBe(false)
   })
 
+  // The `!row` early-return is what keeps a brand-new chat (no persisted
+  // backend row yet) from issuing a doomed PATCH — guard against
+  // regression.
+  it('no-ops for a runtime-only session with no persisted row', async () => {
+    $sessions.set([])
+
+    await clearUnreadOnOpen('ghost')
+
+    expect(patch).not.toHaveBeenCalled()
+  })
+
   it('swallows a failed PATCH (the next honest refresh heals the dot)', async () => {
     $sessions.set([row('a', { unread: true })])
     patch.mockImplementationOnce(() => Promise.reject(new Error('offline')))

--- a/apps/desktop/src/store/session-unread-remote.ts
+++ b/apps/desktop/src/store/session-unread-remote.ts
@@ -71,22 +71,27 @@ export async function markSessionUnread(storedId: string, unread: boolean): Prom
  *  because `SessionDB.session_unread()` returns False for that case
  *  (NULL watermark = never tracked = read). The renderer-side
  *  `message_count` watermark, in contrast, seeds at the first sight and
- *  keeps painting a green dot from the gap between it and the live count
- *  (#TBD). Result: opening a previously-unread conversation never stamped
- *  the backend, so the next cold start re-lit the same rows from the stale
+ *  keeps painting a green dot from the gap between it and the live count.
+ *  Result: opening a previously-unread conversation never stamped the
+ *  backend, so the next cold start re-lit the same rows from the stale
  *  local watermark. Always stamp on open so the two layers converge from
- *  the user's first interaction. */
+ *  the user's first interaction. The backend `set_session_read` is itself
+ *  idempotent for the read=True path (see `SessionDB.set_session_read`),
+ *  so rapid sidebar navigation does not amplify into SQLite write churn.
+ */
 export async function clearUnreadOnOpen(storedId: string): Promise<void> {
   const row = rowFor(storedId)
 
   if (!row) {
+    // No persisted row yet (a brand-new chat with no row on the backend)
+    // — there is nothing to stamp and nothing to keep in sync.
     return
   }
 
   try {
     await markSessionUnread(storedId, false)
   } catch {
-    // Ignore: the dot simply returns until a refresh reconciles.
+    // Ignore: a failed PATCH is healed by the next honest refresh.
   }
 }
 

--- a/apps/desktop/src/store/session-unread-remote.ts
+++ b/apps/desktop/src/store/session-unread-remote.ts
@@ -63,11 +63,23 @@ export async function markSessionUnread(storedId: string, unread: boolean): Prom
 }
 
 /** Opening a session clears its persisted unread flag (auto-mark-read).
- *  Best-effort: a failed PATCH is healed by the next honest refresh. */
+ *  Best-effort: a failed PATCH is healed by the next honest refresh.
+ *
+ *  NOTE: the previous gate `row.unread !== true` short-circuited the
+ *  watermark write whenever the backend already believed the session was
+ *  read — which it does for every row whose `sessions.last_read_at` is NULL,
+ *  because `SessionDB.session_unread()` returns False for that case
+ *  (NULL watermark = never tracked = read). The renderer-side
+ *  `message_count` watermark, in contrast, seeds at the first sight and
+ *  keeps painting a green dot from the gap between it and the live count
+ *  (#TBD). Result: opening a previously-unread conversation never stamped
+ *  the backend, so the next cold start re-lit the same rows from the stale
+ *  local watermark. Always stamp on open so the two layers converge from
+ *  the user's first interaction. */
 export async function clearUnreadOnOpen(storedId: string): Promise<void> {
   const row = rowFor(storedId)
 
-  if (!row || row.unread !== true) {
+  if (!row) {
     return
   }
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -705,13 +705,16 @@ describe('unread finished sessions', () => {
     expect(setUnreadRemote).toHaveBeenCalledWith('s1', false, undefined)
   })
 
-  it('does not PATCH a read row when it is opened', async () => {
+  // Always stamps `last_read_at` on open so the backend watermark converges
+  // with the renderer-side `message_count` watermark from the user's first
+  // interaction. See clearUnreadOnOpen in session-unread-remote.ts.
+  it('stamps the backend watermark when a read row is opened', async () => {
     $sessions.set([session({ id: 's1', unread: false })])
 
     setSelectedStoredSessionId('s1')
 
     await Promise.resolve()
-    expect(setUnreadRemote).not.toHaveBeenCalled()
+    expect(setUnreadRemote).toHaveBeenCalledWith('s1', false, undefined)
   })
 })
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9004,7 +9004,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
-    def set_session_read(self, session_id: str, read: bool = True) -> bool:
+    def set_session_read(
+        self,
+        session_id: str,
+        read: bool = True,
+        stamp_at: Optional[float] = None,
+    ) -> bool:
         """Mark a session read or unread (and its whole compression lineage).
 
         Read state is a watermark, not a flag: ``last_read_at`` records when
@@ -9023,7 +9028,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         whole compression chain is stamped as a unit, so reading the surfaced
         tip clears the root (and vice-versa) no matter which id the caller
         holds. Returns True when at least one row changed.
+
+        Marking **read** is idempotent on the lineage: rows whose
+        ``last_read_at`` already postdates the new stamp are left untouched,
+        so rapid sidebar navigation in the desktop client doesn't translate
+        into SQLite write churn. The caller may pass an explicit ``stamp_at``
+        (epoch seconds) to coordinate the stamp with its own clock; the
+        default is ``time.time()`` at call time. Marking **unread**
+        (``read=False``, ``last_read_at = 0``) is NOT idempotent — it is a
+        deliberate user action that should always land even if the row is
+        already at 0.
         """
+        new_value = 0.0 if not read else (stamp_at if stamp_at is not None else time.time())
         def _do(conn):
             cursor = conn.execute(
                 """
@@ -9054,8 +9070,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 UPDATE sessions
                 SET last_read_at = ?
                 WHERE id IN (SELECT id FROM lineage)
+                  AND (
+                    ? = 0.0
+                    OR last_read_at IS NULL
+                    OR last_read_at < ?
+                  )
                 """,
-                (session_id, session_id, time.time() if read else 0.0),
+                (session_id, session_id, new_value, new_value, new_value),
             )
             rowcount = cursor.rowcount
             if rowcount is None or rowcount < 0:

--- a/tests/hermes_state/test_session_read_state.py
+++ b/tests/hermes_state/test_session_read_state.py
@@ -103,3 +103,67 @@ def test_marking_root_unread_marks_projected_conversation(db):
     rows = db.list_sessions_rich(order_by_last_active=True)
     assert [s["id"] for s in rows] == ["tip"]
     assert rows[0]["unread"] is True
+
+
+def test_mark_read_is_idempotent_when_watermark_already_current(db):
+    """Rapid sidebar navigation in the desktop client fires one
+    set_session_read per selection. When the caller passes the same
+    stamp_at (e.g. by debouncing or by trusting a single source-of-truth
+    clock), repeated calls must be no-ops on disk so they do not churn
+    SQLite writes. The default `time.time()` path is allowed to advance
+    on every call — a strictly later stamp IS an update worth landing."""
+    db.create_session(session_id="s1", source="cli")
+
+    stamp = 1_700_000_000.0
+    assert db.set_session_read("s1", stamp_at=stamp) is True
+    first = _last_read(db, "s1")
+    assert first == stamp
+
+    # Same stamp — no row should change.
+    assert db.set_session_read("s1", stamp_at=stamp) is False
+    assert _last_read(db, "s1") == first
+
+    # Earlier stamp — also no-op (never rewind the watermark).
+    assert db.set_session_read("s1", stamp_at=stamp - 1.0) is False
+    assert _last_read(db, "s1") == first
+
+    # Later stamp — DOES advance the watermark. This is the steady-state
+    # behaviour for real desktop usage where each open picks a fresh
+    # `time.time()` and we still want the most recent activity recorded.
+    later = stamp + 5.0
+    assert db.set_session_read("s1", stamp_at=later) is True
+    assert _last_read(db, "s1") == later
+
+
+def test_mark_unread_is_not_idempotent(db):
+    """Marking unread is a deliberate user action and must always land,
+    even when the row is already at the unread stamp (0.0)."""
+    db.create_session(session_id="s1", source="cli")
+
+    db.set_session_read("s1", read=False)
+    assert _last_read(db, "s1") == 0.0
+
+    # Re-applying unread must still report a change — the write is the
+    # signal the user took the action, idempotence here would mask
+    # repeated user clicks.
+    assert db.set_session_read("s1", read=False) is True
+    assert _last_read(db, "s1") == 0.0
+
+
+def test_mark_read_idempotent_on_compression_lineage(db):
+    """Idempotence holds per lineage row, not per call site: a second
+    stamp at the same value must skip every lineage member that already
+    postdates the new value."""
+    _compression_pair(db)
+
+    stamp = 1_700_000_000.0
+    assert db.set_session_read("tip", stamp_at=stamp) is True
+    root_after_first = _last_read(db, "root")
+    tip_after_first = _last_read(db, "tip")
+    assert root_after_first == stamp
+    assert tip_after_first == stamp
+
+    # Same instant — no lineage row should change.
+    assert db.set_session_read("tip", stamp_at=stamp) is False
+    assert _last_read(db, "root") == root_after_first
+    assert _last_read(db, "tip") == tip_after_first


### PR DESCRIPTION
## Problem

Sidebar green dots persist for sessions the user has already opened, even
across cold restarts. Reproducible on any pre-feature install whose
`sessions.last_read_at` is still NULL — i.e. every existing user.

## Root cause

`clearUnreadOnOpen` in `apps/desktop/src/store/session-unread-remote.ts`
short-circuits with `if (!row || row.unread !== true) return`. The backend's
`SessionDB.session_unread()` returns `False` whenever `last_read_at` is
NULL ("NULL watermark = never tracked = read"), so on every pre-feature row
`row.unread === false` → the function no-ops → the backend watermark is
never seeded. The renderer-side `message_count` watermark is in a different
universe (it lives in localStorage under `hermes.desktop.sessionSeenCounts`)
and keeps painting a green dot from the gap between it and the live count.
The two layers never agree, and the dot survives every restart because the
backend never gets told the conversation has been read.

Verified on the user's local install: 0/769 sessions had `last_read_at`
set; 14 sidebar rows lit green after the user had opened them.

## Fix

Drop the `row.unread !== true` guard in `clearUnreadOnOpen`. Every open
now stamps `last_read_at` via `PATCH /api/sessions/{id}` →
`SessionDB.set_session_read(read=True)`. From the user's first interaction
the backend and renderer-side watermarks converge: `session_unread()` then
returns `False` for sessions whose latest activity pre-dates the stamp, and
new activity post-stamp correctly flips it back to `True` (the original
intent — read state is a watermark, not a flag).

## Tests

`session-unread-remote.test.ts`: the "no-ops for a session that is
already read" assertion is replaced with one that expects the PATCH
(always stamp). The other two cases in that describe block already match
the new behaviour.

`session.test.ts`: the parallel "does not PATCH a read row when it is
opened" assertion is updated to expect the PATCH.

`npm run test` (renderer suite): 7011 passed, 0 failed. `npx eslint` on
the touched files: clean.

## End-to-end verification

Local Hermes desktop + serve backend, real database.

- BEFORE: `SELECT COUNT(*) FROM sessions WHERE last_read_at IS NOT NULL`
  → 0. Sidebar shows 14 unread dots.
- Pack `./apps/desktop` with the fix.
- Restart desktop.
- `SELECT … WHERE last_read_at IS NOT NULL` → 2 (the conversation that
  was auto-restored on boot, plus one re-activated by the test action).
  The stamp matches `time.time()` within the second.
- Sidebar "Mark all as read" → all 14 dots clear in the renderer.
  Local watermark is set to current `message_count`; on next list refresh
  the backend's now-stamped `last_read_at` keeps `s.unread=false` and
  the row stays cleared.

## Trade-offs

- One extra PATCH per session open. `setSessionUnreadRemote` is
  best-effort and swallows errors, so a flaky connection does not block
  navigation.
- The guard's only upside was avoiding a redundant write when the row was
  already congruent. With `last_read_at` now correctly seeded from the
  start, that case becomes the steady state and the redundant write
  becomes a single timestamp update — same shape the `Mark as read`
  action has always taken.