### PR TITLE
fix(desktop): write backend READY sentinel to fd 1 so stdout-swap can't reroute it

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19161,7 +19161,24 @@ def start_server(
             # plain backend, not a dashboard, so it announces a neutral token;
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            # Direct fd-1 write: the desktop's port-discovery watcher parses
+            # STDOUT only, and tui_gateway/server.py legitimately swaps
+            # sys.stdout -> sys.stderr at import for its JSON-RPC protocol.
+            # A plain print() would be rerouted to stderr, leaving the watcher
+            # empty -> 86% boot timeout while the line shows in desktop.log
+            # (which mirrors both streams). See debugging-hermes-desktop skill.
+            def _write_stdout_line(line: str) -> None:
+                payload = (line + "\n").encode("utf-8", "replace")
+                try:
+                    os.write(1, payload)          # bypasses sys.stdout reassignment
+                except OSError:
+                    try:
+                        sys.stdout.write(line + "\n")
+                        sys.stdout.flush()
+                    except Exception:
+                        pass
+
+            _write_stdout_line(f"{ready_token} port={actual_port}")
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.
@@ -19169,7 +19186,7 @@ def start_server(
                 # block-buffered and can surface MINUTES after the flushed
                 # READY sentinel above, which reads as a slow boot in
                 # support bundles when the backend was actually up.
-                print(f"  Hermes backend listening on {host}:{actual_port}", flush=True)
+                _write_stdout_line(f"  Hermes backend listening on {host}:{actual_port}")
             else:
                 print(f"  Hermes Web UI → http://{host}:{actual_port}")
             _maybe_open_browser(host, actual_port, open_browser, initial_profile)


### PR DESCRIPTION
## Summary

Fixes the Hermes Desktop app hanging at 86% ("Timed out waiting for Hermes backend port announcement") on boot, where the backend is demonstrably healthy and `HERMES_BACKEND_READY port=...` even appears in `desktop.log` — yet Electron never sees it.

## Root cause

`tui_gateway/server.py` performs a module-level `sys.stdout = sys.stderr` swap (legitimate JSON-RPC-over-stdout protocol protection). The desktop's backend spawn (`hermes serve`) announces its bound port with:

```python
print(f"{ready_token} port={actual_port}", flush=True)
```

in `hermes_cli/web_server.py` (`start_server`). When `tui_gateway` has been imported by the time the sentinel prints (the dashboard route setup imports `tui_gateway.ws` before `start_server` reaches the announce), that `print()` is rerouted to **stderr**. Electron's `waitForDashboardPort` parses the **stdout pipe only** — so the watcher never fires, 90s passes, and the healthy backend is killed. `desktop.log` misleadingly shows the line because the parent mirrors both child streams for logging (log visibility ≠ stream correctness).

## Fix

Write the port-discovery sentinel (and the headless "listening" line) directly to **fd 1** via `os.write(1, ...)`, which is immune to Python-object `sys.stdout` reassignment:

```python
def _write_stdout_line(line: str) -> None:
    payload = (line + "\n").encode("utf-8", "replace")
    try:
        os.write(1, payload)
    except OSError:
        try:
            sys.stdout.write(line + "\n")
            sys.stdout.flush()
        except Exception:
            pass
```

The swap module stays untouched (it's right to protect its protocol).

## Verification

- Split-stream repro of the desktop spawn (`HERMES_DESKTOP=1 python -m hermes_cli.main serve --isolated --host 127.0.0.1 --port 0 >out.log 2>err.log`): before the fix the sentinel lands in `err.log` and stdout is empty; after, the sentinel is on **stdout**.
- Full desktop boot progresses 86 → 90 → 94 ("Hermes backend is ready. Finalizing desktop startup"), announced port LISTENING, process tree stable.
