### PR TITLE
fix(kanban): reject unresolvable dir/worktree cards at create, not at spawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3419,6 +3419,14 @@ def create_task(
     # task would point cleanup at the user's source tree (#28818). The
     # containment guard in ``_cleanup_workspace`` is the safety rail, but
     # we also stop the bad state from being created in the first place.
+    #
+    # Resolving HERE rather than at each spawn is also the more correct
+    # behaviour: a task's stored ``workspace_path`` is what gets injected
+    # into every claimant's worker_context, and it is never refreshed by a
+    # later board edit. And when neither source yields a path we reject the
+    # create outright — an unresolvable ``dir``/``worktree`` task otherwise
+    # looks healthy on the board and only fails minutes later inside the
+    # dispatcher, as a spawn failure on a card nobody is watching.
     if (
         workspace_path is None
         and project_repo is None
@@ -3429,6 +3437,20 @@ def create_task(
         board_default = board_meta.get("default_workdir")
         if board_default:
             workspace_path = str(board_default)
+        else:
+            # No explicit path, no board default, and no project repo to
+            # anchor on (``project_repo is None`` above): there is nothing
+            # left to resolve at spawn time either, so fail loudly now and
+            # name both remedies.
+            raise ValueError(
+                f"workspace_kind={workspace_kind!r} requires a workspace_path, "
+                f"and board {board_slug!r} has no default_workdir to inherit "
+                "from. Either create the task with an explicit absolute "
+                f"workspace path (CLI: --workspace {workspace_kind}:"
+                "<absolute-repo-path>), or set a board default with "
+                f"`hermes kanban boards set-default-workdir {board_slug} "
+                "<absolute-repo-path>`."
+            )
 
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -528,6 +528,86 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 
 
 
+def test_create_rejects_worktree_without_path_or_board_default(kanban_home):
+    """An unresolvable worktree card must fail at CREATE, not at spawn.
+
+    Regression for the routing gap where ``create_task`` happily returned a
+    card with ``workspace_path=None``; the defect only surfaced minutes later
+    inside the dispatcher as a repeated spawn failure on a card that looked
+    healthy on the board.
+    """
+    with kb.connect() as conn:
+        with pytest.raises(ValueError) as exc:
+            kb.create_task(conn, title="ship", workspace_kind="worktree")
+    msg = str(exc.value)
+    # Both remedies must be named, or the operator has to go read the source.
+    assert "workspace_path" in msg
+    assert "set-default-workdir" in msg
+
+
+def test_create_rejects_dir_without_path_or_board_default(kanban_home):
+    """``dir`` has the same unresolvable-at-spawn shape as ``worktree``."""
+    with kb.connect() as conn:
+        with pytest.raises(ValueError) as exc:
+            kb.create_task(conn, title="ship", workspace_kind="dir")
+    assert "set-default-workdir" in str(exc.value)
+
+
+def test_create_resolves_worktree_path_from_board_default_workdir(kanban_home, tmp_path):
+    """With a board default configured, the path is stored ON THE CARD.
+
+    Resolving at create time (rather than at each spawn) matters because the
+    stored ``workspace_path`` is what gets injected into every future
+    claimant's worker_context and is never refreshed later.
+    """
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.write_board_metadata(kb.get_current_board(), default_workdir=str(repo))
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ship", workspace_kind="worktree")
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.workspace_path == str(repo)
+
+
+def test_create_scratch_without_path_is_unaffected_by_the_guard(kanban_home):
+    """No regression for scratch: it resolves its own per-board root later."""
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ship", workspace_kind="scratch")
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.workspace_kind == "scratch"
+    assert task.workspace_path is None
+
+
+def test_create_scratch_does_not_inherit_board_default_workdir(kanban_home, tmp_path):
+    """Scratch must never inherit the board default (#28818 cleanup safety)."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.write_board_metadata(kb.get_current_board(), default_workdir=str(repo))
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ship", workspace_kind="scratch")
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.workspace_path is None
+
+
+def test_create_worktree_with_explicit_path_ignores_missing_board_default(kanban_home, tmp_path):
+    """An explicit path is always sufficient; no board default needed."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="ship",
+            workspace_kind="worktree",
+            workspace_path=str(repo / ".worktrees" / "explicit"),
+        )
+        task = kb.get_task(conn, task_id)
+    assert task is not None
+    assert task.workspace_path == str(repo / ".worktrees" / "explicit")
+
+
 def test_worktree_workspace_explicit_target_materializes_linked_worktree(kanban_home, tmp_path):
     repo = tmp_path / "repo"
     _init_git_repo(repo)


### PR DESCRIPTION
## The bug

`create_task` accepted `workspace_kind=worktree` (or `dir`) with `workspace_path=None` and no board `default_workdir`, returning `{"ok": true, ..., "workspace_path": null}`. The card looked healthy on the board.

The defect only surfaced minutes later, inside the dispatcher, as a spawn failure:

```
workspace: task <id> has workspace_kind=worktree but no workspace_path,
and board 'personal-infra' has no default_workdir set.
```

Observed live on two cards: each burned several failed spawns, one additionally crashed with pid gone, and only a later retry completed the work. Nothing was lost in those two cases, but a card with worse luck strands, and the failure is reported in the worst possible place — asynchronously, on a card nobody is watching, minutes after the create returned success.

## The fix

Validate at creation instead. When `workspace_kind` is `dir` or `worktree` and no `workspace_path` was given:

- resolve the board's `default_workdir` and store it on the card (this branch already existed), otherwise
- **reject the create** with a message naming both remedies: an explicit absolute workspace path, or `hermes kanban boards set-default-workdir <board> <abs-path>`.

Create-time resolution is also the more correct behaviour independent of the error: a card's stored `workspace_path` is what gets injected into every future claimant's `worker_context`, and it is never refreshed by a later board edit. Resolving once at create beats re-deriving it at each spawn.

Every create surface (`kanban_create` tool, `hermes kanban create`, swarm, decompose) funnels through `create_task`, so the single guard covers them all — no per-surface duplication.

`project_repo is not None` (project-linked worktrees) still short-circuits above the guard and is unaffected.

## Tests

Six tests in `tests/hermes_cli/test_kanban_db.py`:

| Test | Asserts |
|---|---|
| `test_create_rejects_worktree_without_path_or_board_default` | raises, and the message names both remedies |
| `test_create_rejects_dir_without_path_or_board_default` | same shape for `dir` |
| `test_create_resolves_worktree_path_from_board_default_workdir` | path is stored **on the card** |
| `test_create_worktree_with_explicit_path_ignores_missing_board_default` | explicit path always sufficient |
| `test_create_scratch_without_path_is_unaffected_by_the_guard` | no scratch regression |
| `test_create_scratch_does_not_inherit_board_default_workdir` | scratch never inherits the default (#28818 cleanup safety) |

Both rejection tests are proven to fail without the fix:

```
$ git stash push hermes_cli/kanban_db.py
$ pytest tests/hermes_cli/test_kanban_db.py -k "create_rejects or create_resolves or create_scratch or create_worktree"
E   Failed: DID NOT RAISE ValueError
FAILED test_create_rejects_worktree_without_path_or_board_default
FAILED test_create_rejects_dir_without_path_or_board_default
2 failed, 4 passed
```

With the fix:

```
$ pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_project_link.py tests/hermes_cli/test_kanban_worktree_isolation.py
41 passed, 1 skipped in 4.08s
```

Whole kanban selection (`-k kanban` across `tests/hermes_cli/`, `tests/tools/test_kanban_tools.py`, both kanban plugin suites): 374 passed with the fix vs 368 on the untouched base, with an **identical** set of 15 failures on both sides. Those 15 are pre-existing cross-test pollution in the combined run (each passes in isolation on base and on this branch), not introduced here.

## Risk

A create that previously succeeded and then failed at spawn now fails at create. That is the intent: the same card was never dispatchable. Callers relying on the silent `workspace_path=null` result get an actionable error instead of an asynchronous spawn failure.
