### PR TITLE
fix(dashboard): scope memory-provider config requests to the selected profile

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api, fetchJSON } from "./api";
+import { api, fetchJSON, setManagementProfile } from "./api";
 
 const reloadMocks = vi.hoisted(() => ({
   attemptDashboardTokenReloadOnce: vi.fn(() => false),
@@ -114,6 +114,42 @@ describe("api.getModelOptions", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/model/options?profile=default&refresh=1&include_unconfigured=1",
       expect.objectContaining({ credentials: "include" }),
+    );
+  });
+});
+
+describe("api memory provider config", () => {
+  afterEach(() => {
+    setManagementProfile("");
+  });
+
+  it("scopes reads to the dashboard's selected profile", async () => {
+    vi.stubGlobal("window", {});
+    setManagementProfile("caishenye");
+
+    const fetchMock = jsonFetchMock({ name: "hindsight", fields: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getMemoryProviderConfig("hindsight");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/memory/providers/hindsight/config?profile=caishenye",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("scopes saves to the dashboard's selected profile", async () => {
+    vi.stubGlobal("window", {});
+    setManagementProfile("caishenye");
+
+    const fetchMock = jsonFetchMock({ ok: true, active: "hindsight" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.updateMemoryProviderConfig("hindsight", { bank_id: "god-of-fortune" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/memory/providers/hindsight/config?profile=caishenye",
+      expect.objectContaining({ credentials: "include", method: "PUT" }),
     );
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -76,6 +76,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/config",
   "/api/env",
   "/api/mcp",
+  "/api/memory/providers",
   "/api/messaging/platforms",
   "/api/messaging/telegram/onboarding",
   "/api/messaging/whatsapp/onboarding",


### PR DESCRIPTION
## What does this PR do?

Fixes the Dashboard's Runtime Provider Plugins → Hindsight (and any other
native memory-provider) config form so it actually reads and writes the
profile selected in the Dashboard UI, instead of always targeting the
Dashboard server process's own `HERMES_HOME`.

## Related Issue

Fixes #92520

## Root cause

`hermes_cli/web_server.py`'s `GET/PUT /api/memory/providers/{name}/config`
handlers already wrap their body in `_profile_scope(profile)`, which
correctly redirects `get_hermes_home()` (and therefore
`_save_memory_provider_native_config`/`_read_memory_provider_existing_values`)
to the requested profile's home when a `?profile=` query param is present.

The bug is entirely on the frontend: `web/src/lib/api.ts`'s `fetchJSON`
auto-appends `?profile=<selected>` to any endpoint whose path is listed in
`PROFILE_SCOPED_PREFIXES` (this is how the global Dashboard profile switcher
reaches profile-scoped endpoints like `/api/config`, `/api/env`,
`/api/messaging/platforms`, etc.). `/api/memory/providers` was never added to
that list, so `getMemoryProviderConfig` / `updateMemoryProviderConfig` always
called the backend with no `profile` param — which the backend correctly
falls back to treating as "the Dashboard's own profile". The write therefore
silently landed in the Dashboard process's `HERMES_HOME` no matter which
profile was selected in the UI.

## Changes Made

- `web/src/lib/api.ts`: add `/api/memory/providers` to `PROFILE_SCOPED_PREFIXES`
  so the selected Dashboard profile is forwarded on both the config read
  (`GET`) and save (`PUT`) requests.
- `web/src/lib/api.test.ts`: add regression tests asserting that
  `getMemoryProviderConfig`/`updateMemoryProviderConfig` append
  `?profile=<selected>` when a non-default management profile is active.

## How to Test

1. `cd web && npx vitest run src/lib/api.test.ts`
2. Confirmed the new tests fail without the fix (reverted only
   `web/src/lib/api.ts` via `git checkout HEAD~1 -- web/src/lib/api.ts`) and
   pass with it restored.

### Test output — before the fix (`web/src/lib/api.ts` reverted)

```
 FAIL  src/lib/api.test.ts > api memory provider config > scopes reads to the dashboard's selected profile
AssertionError: expected "vi.fn()" to be called with arguments: [ …(2) ]
Received:
  [
-   "/api/memory/providers/hindsight/config?profile=caishenye",
+   "/api/memory/providers/hindsight/config",
    ...
  ]

 FAIL  src/lib/api.test.ts > api memory provider config > scopes saves to the dashboard's selected profile
AssertionError: expected "vi.fn()" to be called with arguments: [ …(2) ]
Received:
  [
-   "/api/memory/providers/hindsight/config?profile=caishenye",
+   "/api/memory/providers/hindsight/config",
    ...
  ]

 Test Files  1 failed (1)
      Tests  2 failed | 7 passed (9)
```

### Test output — after the fix

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

### Full web suite + typecheck (after the fix)

```
$ npx vitest run
 Test Files  36 passed (36)
      Tests  277 passed (277)

$ npm run typecheck
> tsc -p . --noEmit
(no output, exit 0)
```

### Lint

```
$ npx eslint web/src/lib/api.ts web/src/lib/api.test.ts
(no output, exit 0)
```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (none
      of the open PRs with similar titles touch this path; grepped for
      `_save_memory_provider_native_config` / "hindsight profile" across
      open+closed PRs)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suite and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested in a Linux CI container only, not
      manually against a live multi-profile Dashboard install

## AI assistance disclosure

This change (root-cause analysis, fix, and tests) was authored with the
assistance of an AI coding agent (Claude), reviewed and verified by the
submitter before opening.
