### PR TITLE
fix(kanban): stamp session_id and auto-subscribe on CLI create

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -343,6 +343,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "worktree under the project's primary repo with a "
                                "deterministic branch. See `hermes project list`.")
     p_create.add_argument("--tenant", default=None, help="Tenant namespace")
+    p_create.add_argument("--session", default=None,
+                          help="Originating chat/agent session id to stamp on the "
+                               "task, so `kanban list --session` can find it. "
+                               "Defaults to $HERMES_SESSION_ID or $HERMES_SESSION_KEY "
+                               "when unset.")
     p_create.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
     p_create.add_argument("--triage", action="store_true",
                           help="Park in triage — a specifier will flesh out the spec and promote to todo")
@@ -1562,6 +1567,12 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    session_id = (
+        getattr(args, "session", None)
+        or os.environ.get("HERMES_SESSION_ID")
+        or os.environ.get("HERMES_SESSION_KEY")
+        or None
+    )
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,
@@ -1586,7 +1597,14 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            session_id=session_id,
         )
+        # Parity with the kanban_create tool (#92583): a persistent TUI/
+        # desktop session env is enough to auto-subscribe, so the completion
+        # notification reaches the pane that asked for this card. No-op for
+        # plain CLI/cron callers with no such env — see _maybe_auto_subscribe.
+        from tools.kanban_tools import _maybe_auto_subscribe
+        _maybe_auto_subscribe(conn, task_id)
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,53 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_kanban_create_stamps_session_id_from_flag(kanban_home):
+    """`create --session` stamps session_id on the new task (#92583), the
+    same field `create --session` did nothing with before this — only
+    `list --session` could filter on it."""
+    raw = kc.run_slash("create --session chat-99 --json my-task")
+    payload = json.loads(raw)
+    assert payload["session_id"] == "chat-99"
+
+
+def test_kanban_create_subscribes_tui_session_via_session_key(kanban_home, monkeypatch):
+    """CLI create running inside a TUI/desktop session (HERMES_SESSION_KEY
+    set, no gateway platform/chat_id) auto-subscribes the same way the
+    kanban_create tool already does (#92583), so the TUI notification
+    poller can wake the originating pane."""
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_KEY", "tui-cli-abc")
+
+    raw = kc.run_slash("create --json tui-created-task")
+    payload = json.loads(raw)
+    task_id = payload["id"]
+
+    with kb.connect() as conn:
+        subs = list(kb.list_notify_subs(conn, task_id))
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "tui"
+    assert subs[0]["chat_id"] == "tui-cli-abc"
+
+
+def test_kanban_create_does_not_subscribe_plain_cli_session(kanban_home, monkeypatch):
+    """A bare CLI invocation with no session env has no persistent delivery
+    channel, so no subscription row is written."""
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+
+    raw = kc.run_slash("create --json plain-cli-task")
+    payload = json.loads(raw)
+    task_id = payload["id"]
+
+    with kb.connect() as conn:
+        subs = list(kb.list_notify_subs(conn, task_id))
+    assert subs == []
+
+
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     with kb.connect_closing() as conn:
         parent_id = kb.create_task(conn, title="parent task")

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -87,6 +87,37 @@ def test_kanban_create_subscribes_tui_session_via_session_key(kanban_home, monke
     assert subs[0]["chat_id"] == "tui-cli-abc"
 
 
+def test_kanban_create_session_flag_wins_over_env(kanban_home, monkeypatch):
+    """`--session` takes precedence over `$HERMES_SESSION_ID` (#92583):
+    an explicit flag is a deliberate override and must not be shadowed by
+    whatever the calling session happens to export."""
+    monkeypatch.setenv("HERMES_SESSION_ID", "env-session")
+
+    raw = kc.run_slash("create --session flag-session --json my-task")
+    payload = json.loads(raw)
+    assert payload["session_id"] == "flag-session"
+
+
+def test_kanban_create_subscribes_gateway_session(kanban_home, monkeypatch):
+    """CLI create running inside a gateway (telegram/discord/etc) session
+    (`HERMES_SESSION_PLATFORM`/`HERMES_SESSION_CHAT_ID` set) subscribes
+    against that real chat, not the TUI fallback path (#92583)."""
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+
+    raw = kc.run_slash("create --json gateway-created-task")
+    payload = json.loads(raw)
+    task_id = payload["id"]
+
+    with kb.connect() as conn:
+        subs = list(kb.list_notify_subs(conn, task_id))
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "chat-42"
+
+
 def test_kanban_create_does_not_subscribe_plain_cli_session(kanban_home, monkeypatch):
     """A bare CLI invocation with no session env has no persistent delivery
     channel, so no subscription row is written."""


### PR DESCRIPTION
## What does this PR do?

Closes the CLI-create gap described in #92583: `hermes kanban create` never
stamped `session_id` on the new task and never called `_maybe_auto_subscribe`,
even though the `kanban_create` **tool** already does both. Concretely, on
current `main`:

- `create`'s argparse parser has no `--session` flag (only `list` has one).
- `_cmd_create` never passes `session_id=` into `kb.create_task()`, so
  `tasks.session_id` stays `NULL` for every CLI-created card.
- `_cmd_create` never calls `_maybe_auto_subscribe`, so no
  `kanban_notify_subs` row is written — a TUI/desktop session that creates a
  card via the CLI (as opposed to the `kanban_create` tool) gets no
  completion notification.

This PR gives `create` parity with the tool for both of those, reusing the
tool's existing, already-tested `_maybe_auto_subscribe` gate rather than
duplicating its logic.

Note: the issue's description also discusses a hypothetical WebUI session
identity (`HERMES_SESSION_PLATFORM=webui`). I could not find that platform
value anywhere in `gateway/config.py`'s `Platform` enum or in any code path
that sets `HERMES_SESSION_PLATFORM`/`HERMES_SESSION_CHAT_ID` to `"webui"` on
current `main` — it isn't wired up in this repo. This PR sticks to the
concrete, verifiable gap (CLI vs. tool parity for the *existing* TUI/desktop
session-key path); the WebUI-specific env stamping would need to land
first, in a separate change, before `_maybe_auto_subscribe` has anything to
special-case for it.

## Related Issue

Fixes #92583 (the CLI-create session/subscription parity portion of it).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py`: add `--session` to `kanban create`; stamp
  `session_id` (from `--session`, else `$HERMES_SESSION_ID`, else
  `$HERMES_SESSION_KEY`) on `kb.create_task()`; call the existing
  `tools.kanban_tools._maybe_auto_subscribe` after create, gated the same
  way the tool already is (`kanban.auto_subscribe_on_create`, TUI/desktop
  `HERMES_SESSION_KEY` fallback, no-op for plain CLI/cron).
- `tests/hermes_cli/test_kanban_cli.py`: three new tests — `--session`
  stamps `session_id`; a TUI-session env (`HERMES_SESSION_KEY` set, no
  gateway platform/chat_id) gets a `platform="tui"` subscription row; a
  plain CLI invocation with no session env gets no subscription row.

## How to Test

```
hermes kanban create --session chat-99 --json "my task"
# -> JSON output now has "session_id": "chat-99"

hermes kanban list --session chat-99
# -> now finds the card (previously impossible: session_id was NULL)
```

Automated, via the repo's own runner:

```
$ HERMES_PYTHON=<venv>/bin/python scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_core_functionality.py -q
Discovered 3 test files (~62 tests) ...
[100.0% |    62/~62 | ✓63 | ✗ 0] ✓ tests/tools/test_kanban_tools.py (32✓, 6.7s)
=== Summary: 3 files, 63 tests passed, 0 failed (100% complete) in 6.7s (8 workers) ===
```

Confirmed the two new behavioral tests fail without the fix
(`git checkout HEAD~1 -- hermes_cli/kanban.py` then re-run):

```
FAILED test_kanban_create_stamps_session_id_from_flag - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
  (argparse rejects --session as unrecognized without the new flag)
FAILED test_kanban_create_subscribes_tui_session_via_session_key - assert 0 == 1
  (no kanban_notify_subs row written)
```

`ruff check hermes_cli/kanban.py tests/hermes_cli/test_kanban_cli.py` — all
checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (2 files, +65/-0)
- [x] I've run the test suite for the touched area and it passes
- [x] I've added tests for my changes
- [ ] I've tested on my platform — CI-only checkout (Linux), not tested on macOS/Windows

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

## AI assistance disclosure

This change (investigation, implementation, and tests) was written by an AI
coding agent (Claude/Anthropic), supervised and reviewed before submission.
