### PR TITLE
fix(desktop): route sidebar sessions through active backend

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -581,8 +581,37 @@ test('translateSelfProfileQuery rewrites the self-profile filter into the backen
   )
 })
 
+test('translateSelfProfileQuery rewrites sidebar recents_profile aliases for managed SSH', () => {
+  assert.equal(
+    translateSelfProfileQuery(
+      '/api/profiles/sessions/sidebar?recents_profile=research&recents_limit=20&cron_limit=50&messaging_limit=100',
+      'research',
+      'remote-research'
+    ),
+    '/api/profiles/sessions/sidebar?recents_profile=remote-research&recents_limit=20&cron_limit=50&messaging_limit=100'
+  )
+})
+
+test('registry SSH sidebar requests keep their connection pin while translating the profile alias', () => {
+  const request = {
+    connectionId: 'homelab',
+    path: '/api/profiles/sessions/sidebar?recents_profile=research&recents_exclude=cron%2Cdesktop',
+    profile: 'research'
+  }
+
+  assert.equal(apiRequestRegistryConnectionId(request), 'homelab')
+  assert.equal(
+    translateSelfProfileQuery(request.path, request.profile, 'remote-research'),
+    '/api/profiles/sessions/sidebar?recents_profile=remote-research&recents_exclude=cron%2Cdesktop'
+  )
+})
+
 test('translateSelfProfileQuery leaves cross-profile and unfiltered paths untouched', () => {
   assert.equal(translateSelfProfileQuery('/api/cron/jobs?profile=all', 'mara', 'default'), '/api/cron/jobs?profile=all')
+  assert.equal(
+    translateSelfProfileQuery('/api/profiles/sessions/sidebar?recents_profile=all', 'mara', 'default'),
+    '/api/profiles/sessions/sidebar?recents_profile=all'
+  )
   assert.equal(
     translateSelfProfileQuery('/api/cron/jobs?profile=worker', 'mara', 'default'),
     '/api/cron/jobs?profile=worker'

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -701,11 +701,12 @@ function pathWithGlobalRemoteProfile(path, profile, opts: ProfileRouteOptions = 
 /**
  * Translate an explicit self-profile query from a Desktop routing alias to the
  * backend's own profile namespace (a managed SSH `remoteProfile` can map local
- * `mara` to remote `default`). Only a `?profile=` equal to the alias itself is
- * rewritten; cross-profile selectors (`all`, another concrete profile) and
- * unfiltered paths pass through untouched. Used by the v1 profile route above
- * and by the registry SSH branch of the `hermes:api` handler — both routes
- * reach a backend whose namespace is the remote profile, not the alias.
+ * `mara` to remote `default`). Only endpoint-declared profile-valued query
+ * params equal to the alias itself are rewritten; cross-profile selectors
+ * (`all`, another concrete profile) and unfiltered paths pass through
+ * untouched. Used by the v1 profile route above and by the registry SSH branch
+ * of the `hermes:api` handler — both routes reach a backend whose namespace is
+ * the remote profile, not the alias.
  */
 function translateSelfProfileQuery(path, profile, backendProfile) {
   const scopedProfile = connectionScopeKey(profile)
@@ -729,11 +730,26 @@ function translateSelfProfileQuery(path, profile, backendProfile) {
     return path
   }
 
-  if (connectionScopeKey(parsed.searchParams.get('profile')) !== scopedProfile) {
-    return path
+  const profileQueryKeys = ['profile']
+
+  if (parsed.pathname === '/api/profiles/sessions/sidebar') {
+    profileQueryKeys.push('recents_profile')
   }
 
-  parsed.searchParams.set('profile', backend)
+  let changed = false
+
+  for (const key of profileQueryKeys) {
+    if (connectionScopeKey(parsed.searchParams.get(key)) !== scopedProfile) {
+      continue
+    }
+
+    parsed.searchParams.set(key, backend)
+    changed = true
+  }
+
+  if (!changed) {
+    return path
+  }
 
   return `${parsed.pathname}${parsed.search}${parsed.hash}`
 }

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -97,7 +97,7 @@ export function connectionScoped(): { connectionId?: string } {
  *  to whatever remote gateway happened to be active. Those helpers call the
  *  bridge directly and own their routing end to end. */
 export function hermesApi<T>(request: HermesApiRequest): Promise<T> {
-  return window.hermesDesktop.api<T>({ ...connectionScoped(), ...request })
+  return window.hermesDesktop.api<T>({ ...connectionScoped(), ...profileScoped(), ...request })
 }
 
 // ── Capability scope: (connection, profile) routing for the Capabilities

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -137,6 +137,44 @@ describe('Hermes REST helpers', () => {
     expect(api).toHaveBeenCalledWith(expect.objectContaining({ connectionId: 'local', path: '/api/profiles' }))
   })
 
+  it('routes the batched sidebar refresh through the active backend scope', async () => {
+    setApiRequestConnection('cubi')
+    setApiRequestProfile('default')
+    api.mockResolvedValue({ recents: { sessions: [] }, cron: { sessions: [] }, messaging: { sessions: [] } })
+
+    await listSidebarSessions({
+      recentsProfile: 'default',
+      recentsLimit: 20,
+      recentsExclude: ['cron'],
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: ['cron', 'desktop']
+    })
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: 'cubi',
+        profile: 'default',
+        path: expect.stringContaining('/api/profiles/sessions/sidebar?recents_profile=default')
+      })
+    )
+  })
+
+  it('routes legacy profile-session slices through the active backend scope', async () => {
+    setApiRequestConnection('cubi')
+    setApiRequestProfile('default')
+
+    await listAllProfileSessions(20, 1, 'exclude', 'recent', 'default')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: 'cubi',
+        profile: 'default',
+        path: expect.stringContaining('/api/profiles/sessions?')
+      })
+    )
+  })
+
   it('defaults missing sidebar slices to empty session arrays', async () => {
     api.mockResolvedValue({})
 


### PR DESCRIPTION
## Summary
- route batched and legacy Desktop session-list requests through the active profile and registered backend
- translate `recents_profile` for managed SSH profile aliases, matching existing `profile` translation
- add regression coverage at the renderer API and Electron connection-routing seams

This addresses sessions remaining intact in `state.db` while disappearing from the Desktop sidebar after switching profiles or remote connections.

Fixes #87759
Related: #88528

## Verification
- `npm run test:desktop:platforms -- connection-config.test.ts` — 114 passed
- `npm run test:ui -- hermes.test.ts` — 32 passed
- `npm run typecheck` — passed
- `scripts/run_tests.sh tests/hermes_cli/test_profiles_sidebar_scope.py -v --tb=short` — 8 passed
- independent exact-SHA review passed for `71892bfdb2e8ae5a0370646058dc9d95962dbd83`