### PR TITLE
fix(serve): register shell hooks in the dashboard/serve startup path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11580,6 +11580,21 @@ def cmd_dashboard(args):
             exc_info=True,
         )
 
+    # Declarative shell hooks: the dashboard/serve process builds agents
+    # in-process via tui_gateway.server._make_agent (desktop chat, in-browser
+    # Chat tab), so hooks must be registered here too —
+    # _prepare_agent_startup skips non-_AGENT_COMMANDS (serve is not one),
+    # and the separate `gateway run` process (which does register) never
+    # runs these sessions. Mirrors gateway/run.py's registration.
+    # Failures are logged but must never block startup.
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.warning("shell-hook registration failed at dashboard startup", exc_info=True)
+
     from hermes_cli.web_server import start_server
 
     # Interactive auth setup: if this bind will engage the auth gate but no


### PR DESCRIPTION
## Summary

Declarative shell hooks (`hooks:` in config.yaml) never fire on **desktop sessions** (and any other `hermes serve` / headless-dashboard session): `_prepare_agent_startup` registers them only for `_AGENT_COMMANDS` (`serve` is not one), and the separate `gateway run` process — which *does* register — never runs these in-process sessions (`tui_gateway.server._make_agent`).

Root cause chain, verified against the running processes:
- Desktop chat runs `hermes serve` (headless `dashboard`, shared `cmd_dashboard` handler)
- `cmd_dashboard` never calls `register_from_config`
- Sessions built via `tui_gateway.server._make_agent` therefore have zero shell hooks

## Fix

Register shell hooks in `cmd_dashboard` right before `start_server`, mirroring the existing `gateway/run.py` registration:

```python
try:
    from hermes_cli.config import load_config
    from agent.shell_hooks import register_from_config
    register_from_config(load_config(), accept_hooks=False)
except Exception:
    logger.warning("shell-hook registration failed at dashboard startup", exc_info=True)
```

Semantics preserved: `accept_hooks=False` → consent still resolves through the allowlist (`~/.hermes/shell-hooks-allowlist.json`), `HERMES_ACCEPT_HOOKS`, or `hooks_auto_accept`. Failures log and never block startup (same fail-open posture as gateway).

## Verification

- `python -m py_compile hermes_cli/main.py` — clean
- Live on macOS desktop: after restart, `agent.log` shows the 3 configured hooks registered from the serve/dashboard process (`agent.shell_hooks: shell hook registered: ...` at serve startup), and the hooks fire per turn — `on_session_start` creates the prime context file, `pre_llm_call` injects recall context into the user message, `post_llm_call` queues the writeback nudge. Confirmed end-to-end with the mnemon memory integration.
- Existing `tests/test_tui_gateway_server.py` unaffected (one pre-existing unrelated failure on `desktop_ui` toolset constant drift, reproduced with and without this change).