### PR TITLE
feat(heartbeat): allow dedicated model/provider for heartbeat turns

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4967,6 +4967,22 @@ class _VoiceInputMessage:
         return self.text
 
 
+class _HeartbeatInputMessage:
+    """Sentinel wrapper for heartbeat prompts in ``_pending_input``.
+
+    Distinguishes heartbeat turns from user-typed messages so the CLI can
+    apply heartbeat model/provider overrides for that turn only (#92579).
+    """
+
+    __slots__ = ("text",)
+
+    def __init__(self, text: str):
+        self.text = text
+
+    def __str__(self) -> str:
+        return self.text
+
+
 class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     """
     Interactive CLI for the Hermes Agent.
@@ -12611,7 +12627,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             continue
                         prompt = mgr.due_prompt()
                         if prompt:
-                            self._pending_input.put(prompt)
+                            self._pending_input.put(_HeartbeatInputMessage(prompt))
                     except Exception as exc:
                         logging.debug("heartbeat watchdog tick failed: %s", exc)
             finally:
@@ -16101,6 +16117,66 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return None
 
         turn_route = self._resolve_turn_agent_config(message)
+
+        # Heartbeat model override: when the turn is a heartbeat and
+        # heartbeat.{model,provider} is configured, switch the route for
+        # this turn only. The next interactive turn returns to the session
+        # route automatically because _active_agent_route_signature will
+        # differ, forcing agent re-initialization.
+        if getattr(self, "_is_heartbeat_turn", False):
+            from hermes_cli.heartbeat import _get_heartbeat_route, has_heartbeat_route_config
+            if has_heartbeat_route_config():
+                hb_route = _get_heartbeat_route()
+                _orig_model = turn_route["model"]
+                _orig_runtime = dict(turn_route["runtime"])
+                if hb_route["provider"]:
+                    try:
+                        from gateway.run import _resolve_runtime_agent_kwargs_for_provider
+                        _hb_kwargs = _resolve_runtime_agent_kwargs_for_provider(
+                            hb_route["provider"]
+                        )
+                        turn_route["runtime"]["provider"] = hb_route["provider"]
+                        turn_route["runtime"]["api_key"] = _hb_kwargs.get("api_key")
+                        turn_route["runtime"]["base_url"] = _hb_kwargs.get("base_url")
+                        turn_route["runtime"]["api_mode"] = _hb_kwargs.get("api_mode")
+                        turn_route["runtime"]["credential_pool"] = _hb_kwargs.get("credential_pool")
+                        if hb_route["model"]:
+                            turn_route["model"] = hb_route["model"]
+                        else:
+                            turn_route["model"] = _hb_kwargs.get("model", _orig_model)
+                    except Exception as exc:
+                        logging.warning(
+                            "heartbeat provider '%s' resolution failed: %s; "
+                            "falling back to session route",
+                            hb_route["provider"], exc,
+                        )
+                elif hb_route["model"]:
+                    turn_route["model"] = hb_route["model"]
+                # Rebuild signature so agent re-initializes with heartbeat route.
+                # Include reasoning_effort so a reasoning-only override also
+                # triggers agent re-initialization.
+                turn_route["signature"] = (
+                    turn_route["model"],
+                    turn_route["runtime"].get("provider"),
+                    turn_route["runtime"].get("requested_provider"),
+                    turn_route["runtime"].get("base_url"),
+                    turn_route["runtime"].get("api_mode"),
+                    turn_route["runtime"].get("command"),
+                    tuple(turn_route["runtime"].get("args") or []),
+                    hb_route.get("reasoning_effort", ""),
+                )
+                if (turn_route["model"] != _orig_model or
+                        turn_route["runtime"].get("provider") != _orig_runtime.get("provider")):
+                    logging.info(
+                        "heartbeat turn: model %s->%s, provider %s->%s",
+                        _orig_model, turn_route["model"],
+                        _orig_runtime.get("provider"), turn_route["runtime"].get("provider"),
+                    )
+                # Apply heartbeat reasoning effort if configured
+                if hb_route["reasoning_effort"]:
+                    turn_route["request_overrides"] = turn_route.get("request_overrides") or {}
+                    turn_route["request_overrides"]["reasoning_effort"] = hb_route["reasoning_effort"]
+
         if turn_route["signature"] != self._active_agent_route_signature:
             self.agent = None
 
@@ -20174,6 +20250,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     if is_voice_input:
                         user_input = user_input.text
 
+                    # Heartbeat prompts arrive wrapped in a sentinel so the
+                    # CLI can apply heartbeat model/provider overrides for
+                    # that turn only (#92579).
+                    is_heartbeat_input = isinstance(user_input, _HeartbeatInputMessage)
+                    if is_heartbeat_input:
+                        user_input = user_input.text
+
                     if not user_input:
                         continue
 
@@ -20288,9 +20371,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     app.invalidate()  # Refresh status line
 
                     try:
+                        self._is_heartbeat_turn = is_heartbeat_input
                         self.chat(user_input, images=submit_images or None, voice_input=is_voice_input)
                     finally:
                         self._agent_running = False
+                        self._is_heartbeat_turn = False
                         self._spinner_text = ""
                         self._tool_start_time = 0.0
                         self._pending_tool_info.clear()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5414,12 +5414,56 @@ class TurnRunner:
                 "tools": [],
             }
 
+        # Heartbeat model override: when the turn is a heartbeat and
+        # heartbeat.{model,provider} is configured, temporarily switch
+        # the route for this turn only. The next interactive user turn
+        # returns to the session's primary route automatically because
+        # the override is applied here (not persisted to session state).
+        _hb_route = None
+        if ctx.is_heartbeat:
+            from hermes_cli.heartbeat import _get_heartbeat_route, has_heartbeat_route_config
+            if has_heartbeat_route_config():
+                _hb_route = _get_heartbeat_route()
+                _orig_model = model
+                _orig_provider = runtime_kwargs.get("provider")
+                if _hb_route["provider"]:
+                    # Resolve the heartbeat provider's credentials
+                    try:
+                        _hb_kwargs = _resolve_runtime_agent_kwargs_for_provider(
+                            _hb_route["provider"]
+                        )
+                        runtime_kwargs.update(_hb_kwargs)
+                        # Use heartbeat model if set, else provider's default
+                        if _hb_route["model"]:
+                            model = _hb_route["model"]
+                        else:
+                            model = runtime_kwargs.pop("model", model)
+                    except Exception as exc:
+                        logger.warning(
+                            "heartbeat provider '%s' resolution failed: %s; "
+                            "falling back to session route",
+                            _hb_route["provider"], exc,
+                        )
+                elif _hb_route["model"]:
+                    # Only model override, keep session provider
+                    model = _hb_route["model"]
+                logger.info(
+                    "heartbeat turn: model %s->%s, provider %s->%s",
+                    _orig_model, model,
+                    _orig_provider, runtime_kwargs.get("provider"),
+                )
+
         pr = self._runner._provider_routing
         reasoning_config = self._runner._resolve_session_reasoning_config(
             source=ctx.source,
             session_key=ctx.session_key,
             model=model,
         )
+        # Heartbeat reasoning_effort override: apply to turn-scoped config
+        # without mutating the shared runner state.
+        if _hb_route and _hb_route.get("reasoning_effort"):
+            reasoning_config = dict(reasoning_config or {})
+            reasoning_config["reasoning_effort"] = _hb_route["reasoning_effort"]
         self._runner._reasoning_config = reasoning_config
         self._runner._service_tier = self._runner._resolve_session_service_tier(
             source=ctx.source, session_key=ctx.session_key
@@ -20381,6 +20425,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=event.message_type,
+                is_heartbeat=bool((event.metadata or {}).get("is_heartbeat")),
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
 
@@ -21596,6 +21641,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             source=source,
                             message_id=None,
                             channel_prompt=None,
+                            metadata={"is_heartbeat": True},
                         )
                         self._enqueue_fifo(quick_key, hb_event, adapter)
                     except Exception as exc:
@@ -28094,6 +28140,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        is_heartbeat: bool = False,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -28114,6 +28161,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
+                is_heartbeat=is_heartbeat,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -28127,6 +28175,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
                 message_type=message_type,
+                is_heartbeat=is_heartbeat,
             )
 
     def _profile_name_for_source(self, source: SessionSource) -> Optional[str]:
@@ -28270,6 +28319,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
         message_type: Optional[str] = None,
+        is_heartbeat: bool = False,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -28576,6 +28626,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _interrupt_depth=_interrupt_depth,
             event_message_id=event_message_id,
             moa_config=moa_config,
+            is_heartbeat=is_heartbeat,
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,
             persist_user_display_kind=persist_user_display_kind,

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -89,6 +89,7 @@ class TurnContext:
     _interrupt_depth: int = 0
     event_message_id: Optional[str] = None
     moa_config: Optional[dict] = None
+    is_heartbeat: bool = False
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None
     # display_kind stamped on the persisted user row at turn start when this

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1963,6 +1963,17 @@ DEFAULT_CONFIG = {
         "subagent_auto_approve": False,
     },
 
+    # Heartbeat — optional model/provider override for /heartbeat turns.
+    # When set, heartbeat turns use a different (typically cheaper/faster)
+    # model than the session's primary interactive model. The next
+    # interactive user turn returns to the session route automatically.
+    # Empty values inherit from the session's current model/provider.
+    "heartbeat": {
+        "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit session model)
+        "provider": "",    # e.g. "openrouter" (empty = inherit session provider)
+        "reasoning_effort": "",  # e.g. "low" (empty = inherit session reasoning)
+    },
+
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.
     # Never saved to sessions, logs, or trajectories.

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -199,6 +199,46 @@ def save_heartbeat(session_id: str, state: HeartbeatState) -> None:
 # ──────────────────────────────────────────────────────────────────────
 
 
+def _get_heartbeat_route() -> Dict[str, str]:
+    """Read the heartbeat model/provider/reasoning_effort from config.
+
+    Returns a dict with keys ``model``, ``provider``, ``reasoning_effort``
+    (each may be empty string if not configured).
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly() or {}
+        hb = cfg.get("heartbeat", {}) or {}
+        return {
+            "model": str(hb.get("model", "") or ""),
+            "provider": str(hb.get("provider", "") or ""),
+            "reasoning_effort": str(hb.get("reasoning_effort", "") or ""),
+        }
+    except Exception:
+        return {"model": "", "provider": "", "reasoning_effort": ""}
+
+
+def has_heartbeat_route_config() -> bool:
+    """True when at least one heartbeat route field is configured."""
+    route = _get_heartbeat_route()
+    return bool(route["model"] or route["provider"] or route["reasoning_effort"])
+
+
+def format_heartbeat_route() -> str:
+    """Human-readable heartbeat route for /heartbeat status display."""
+    route = _get_heartbeat_route()
+    parts = []
+    if route["provider"]:
+        parts.append(f"provider={route['provider']}")
+    if route["model"]:
+        parts.append(f"model={route['model']}")
+    if route["reasoning_effort"]:
+        parts.append(f"reasoning={route['reasoning_effort']}")
+    if not parts:
+        return "inherited from session"
+    return ", ".join(parts)
+
+
 class HeartbeatManager:
     """Per-session heartbeat state + due-tick decisions.
 
@@ -228,13 +268,15 @@ class HeartbeatManager:
             return "No heartbeat. Set one with /heartbeat every <interval> <prompt>."
         every = format_interval(s.interval_seconds)
         fired = f", fired {s.fire_count}×" if s.fire_count else ""
+        route_str = format_heartbeat_route()
+        route_hint = f", route: {route_str}" if has_heartbeat_route_config() else ""
         if s.status == "active":
             anchor = s.last_fired_at or s.created_at
             next_in = max(0, int(anchor + s.interval_seconds - time.time()))
-            return f"♥ Heartbeat (every {every}, next in ~{next_in}s{fired}): {s.prompt}"
+            return f"♥ Heartbeat (every {every}, next in ~{next_in}s{fired}{route_hint}): {s.prompt}"
         if s.status == "paused":
-            return f"⏸ Heartbeat (paused, every {every}{fired}): {s.prompt}"
-        return f"Heartbeat ({s.status}, every {every}{fired}): {s.prompt}"
+            return f"⏸ Heartbeat (paused, every {every}{fired}{route_hint}): {s.prompt}"
+        return f"Heartbeat ({s.status}, every {every}{fired}{route_hint}): {s.prompt}"
 
     # --- mutation -----------------------------------------------------
 
@@ -329,6 +371,9 @@ __all__ = [
     "load_heartbeat",
     "save_heartbeat",
     "migrate_heartbeat_to_session",
+    "has_heartbeat_route_config",
+    "format_heartbeat_route",
+    "_get_heartbeat_route",
     "HEARTBEAT_PROMPT_TEMPLATE",
     "MIN_INTERVAL_SECONDS",
     "POLL_SECONDS",

--- a/tests/hermes_cli/test_heartbeat.py
+++ b/tests/hermes_cli/test_heartbeat.py
@@ -185,3 +185,100 @@ def test_migrate_heartbeat_to_session():
 def test_migrate_noop_without_source():
     assert migrate_heartbeat_to_session("hb-none-a", "hb-none-b") is False
     assert migrate_heartbeat_to_session("same", "same") is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# heartbeat model routing (#92579)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_get_heartbeat_route_defaults():
+    """With no heartbeat config, all fields are empty."""
+    from hermes_cli.heartbeat import _get_heartbeat_route
+    route = _get_heartbeat_route()
+    assert route["model"] == ""
+    assert route["provider"] == ""
+    assert route["reasoning_effort"] == ""
+
+
+def test_get_heartbeat_route_from_config(monkeypatch):
+    """heartbeat.{model,provider,reasoning_effort} are read from config."""
+    from hermes_cli import config as cfg_mod
+
+    monkeypatch.setattr(
+        cfg_mod, "load_config_readonly",
+        lambda: {"heartbeat": {
+            "model": "google/gemini-3-flash-preview",
+            "provider": "openrouter",
+            "reasoning_effort": "low",
+        }},
+    )
+    from hermes_cli.heartbeat import _get_heartbeat_route
+    route = _get_heartbeat_route()
+    assert route["model"] == "google/gemini-3-flash-preview"
+    assert route["provider"] == "openrouter"
+    assert route["reasoning_effort"] == "low"
+
+
+def test_has_heartbeat_route_config_false_by_default():
+    from hermes_cli.heartbeat import has_heartbeat_route_config
+    # Default config has empty heartbeat section
+    assert has_heartbeat_route_config() is False
+
+
+def test_has_heartbeat_route_config_true_when_set(monkeypatch):
+    from hermes_cli import config as cfg_mod
+
+    monkeypatch.setattr(
+        cfg_mod, "load_config_readonly",
+        lambda: {"heartbeat": {"model": "gpt-4o-mini"}},
+    )
+    from hermes_cli.heartbeat import has_heartbeat_route_config
+    assert has_heartbeat_route_config() is True
+
+
+def test_format_heartbeat_route_inherited():
+    from hermes_cli.heartbeat import format_heartbeat_route
+    assert format_heartbeat_route() == "inherited from session"
+
+
+def test_format_heartbeat_route_configured(monkeypatch):
+    from hermes_cli import config as cfg_mod
+
+    monkeypatch.setattr(
+        cfg_mod, "load_config_readonly",
+        lambda: {"heartbeat": {
+            "provider": "openrouter",
+            "model": "google/gemini-3-flash-preview",
+            "reasoning_effort": "low",
+        }},
+    )
+    from hermes_cli.heartbeat import format_heartbeat_route
+    result = format_heartbeat_route()
+    assert "provider=openrouter" in result
+    assert "model=google/gemini-3-flash-preview" in result
+    assert "reasoning=low" in result
+
+
+def test_status_line_shows_route_when_configured(monkeypatch):
+    """status_line() includes route hint when heartbeat config is set."""
+    from hermes_cli import config as cfg_mod
+
+    monkeypatch.setattr(
+        cfg_mod, "load_config_readonly",
+        lambda: {"heartbeat": {"model": "gpt-4o-mini"}},
+    )
+    from hermes_cli.heartbeat import HeartbeatManager
+    mgr = HeartbeatManager(session_id="hb-route-sid")
+    mgr.set("check CI", 600)
+    status = mgr.status_line()
+    assert "route:" in status
+    assert "model=gpt-4o-mini" in status
+
+
+def test_status_line_no_route_when_unconfigured():
+    """status_line() omits route hint when no heartbeat config is set."""
+    mgr = HeartbeatManager(session_id="hb-no-route-sid")
+    mgr.set("check CI", 600)
+    status = mgr.status_line()
+    assert "route:" not in status


### PR DESCRIPTION
## Summary

Adds optional `heartbeat.{model,provider,reasoning_effort}` config to route heartbeat turns through a different (typically cheaper/faster) model than the session's primary interactive model. When absent, behavior is unchanged.

## Motivation

`/heartbeat` re-enters the same session as a normal user turn, preserving conversation history. Currently every heartbeat inherits the session's primary model/provider. Frequent lightweight checks therefore use the same potentially expensive model selected for interactive work.

This PR adds an opt-in config section so heartbeat turns can route to a cheaper model while keeping the interactive session on a high-capability model.

## Configuration

```yaml
heartbeat:
  provider: openai-codex        # optional
  model: gpt-5.6-luna           # optional
  reasoning_effort: low          # optional
```

**Precedence**: `heartbeat.{provider,model}` → session `/model` → channel override → global config

- Only `heartbeat.model` set → retains session provider
- Only `heartbeat.provider` set → uses that provider's default model
- No `heartbeat.*` config → current behavior unchanged

## Changes

| File | Change |
|------|--------|
| `hermes_cli/config_defaults.py` | New `heartbeat` config section |
| `hermes_cli/heartbeat.py` | Route helpers (`_get_heartbeat_route`, `has_heartbeat_route_config`, `format_heartbeat_route`); `status_line()` shows effective route |
| `gateway/turn_context.py` | `is_heartbeat: bool` field |
| `gateway/run.py` | Tag heartbeat `MessageEvent` with `metadata={"is_heartbeat": True}`; apply model override in `run_sync` (turn-scoped, not persisted) |
| `cli.py` | `_HeartbeatInputMessage` sentinel; watchdog wraps prompts; `chat()` applies override via route signature |
| `tests/hermes_cli/test_heartbeat.py` | 8 new tests for route config, format, and status display |

## Invariants preserved

- Heartbeat uses same session ID and ordered transcript
- User/assistant exchange appended to transcript
- Same system prompt and toolset
- Idle-only, missed-tick coalescing unchanged
- Next interactive turn returns to session route automatically
- Invalid provider/model fails visibly with warning, falls back to session route
- `/heartbeat status` displays effective route

## Notes

**Open question:** The cross-vendor review (Gemini 3.7 Flash + GPT-OSS 120B) flagged that integration tests for the actual CLI/Gateway routing logic (not just the helper functions) would strengthen coverage. These require full agent setup and are deferred to a follow-up.

Closes #92579
