### PR TITLE
fix(agent): stop repeating the Codex wait notice every 30s

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -676,6 +676,39 @@ def _estimate_chunk_bytes(chunk: Any) -> int:
     return size
 
 
+def _codex_wait_notice_deadline(
+    *,
+    stale_timeout: float,
+    ttfb_enabled: bool,
+    ttfb_timeout: float,
+    last_event_ts: Optional[float],
+    call_start: float,
+    idle_enabled: bool,
+    idle_timeout: float,
+    elapsed: float,
+) -> "tuple[str, float] | None":
+    """Identify the earliest enabled Codex watchdog on the call timeline.
+
+    Returns ``(label, deadline_seconds_since_call_start)`` for whichever
+    watchdog fires soonest, or ``None`` if none is enabled/finite or its
+    deadline has already passed.
+    """
+    deadlines: list[tuple[str, float]] = []
+    if math.isfinite(stale_timeout):
+        deadlines.append(("wall-clock stale", stale_timeout))
+    if last_event_ts is None:
+        if ttfb_enabled and math.isfinite(ttfb_timeout):
+            deadlines.append(("TTFB", ttfb_timeout))
+    elif idle_enabled and math.isfinite(idle_timeout):
+        deadlines.append(("stream idle", max(0.0, last_event_ts - call_start) + idle_timeout))
+    if not deadlines:
+        return None
+    label, deadline = min(deadlines, key=lambda d: d[1])
+    if deadline <= elapsed:
+        return None
+    return label, deadline
+
+
 def _codex_wait_notice_recovery(
     *,
     stale_timeout: float,
@@ -688,17 +721,19 @@ def _codex_wait_notice_recovery(
     elapsed: float,
 ) -> str:
     """Describe the earliest enabled Codex watchdog on the call timeline."""
-    deadlines: list[float] = []
-    if math.isfinite(stale_timeout):
-        deadlines.append(stale_timeout)
-    if last_event_ts is None:
-        if ttfb_enabled and math.isfinite(ttfb_timeout):
-            deadlines.append(ttfb_timeout)
-    elif idle_enabled and math.isfinite(idle_timeout):
-        deadlines.append(max(0.0, last_event_ts - call_start) + idle_timeout)
-    if not deadlines or min(deadlines) <= elapsed:
+    found = _codex_wait_notice_deadline(
+        stale_timeout=stale_timeout,
+        ttfb_enabled=ttfb_enabled,
+        ttfb_timeout=ttfb_timeout,
+        last_event_ts=last_event_ts,
+        call_start=call_start,
+        idle_enabled=idle_enabled,
+        idle_timeout=idle_timeout,
+        elapsed=elapsed,
+    )
+    if found is None:
         return ""
-    return f"; auto-reconnect at {int(min(deadlines))}s"
+    return f"; auto-reconnect at {int(found[1])}s"
 
 
 # ── Cross-turn stale-call circuit breaker (#58962) ─────────────────────
@@ -1603,35 +1638,54 @@ def interruptible_api_call(agent, api_kwargs: dict):
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
     t.start()
     _poll_count = 0
+    _wait_notice_last_phase: Optional[str] = None
     while t.is_alive():
         t.join(timeout=0.3)
         _poll_count += 1
 
-        # Every ~30s: touch activity for the gateway inactivity monitor AND
-        # rewrite the live spinner/status line so CLI/TUI/Desktop users see
-        # what the agent is waiting on instead of an unexplained generic
-        # spinner (the "infinite thinking" complaint — the wait itself is
-        # usually a slow/overloaded provider, but the UI never said so).
+        # Every ~30s: touch activity for the gateway inactivity monitor.
+        # The visible spinner/status line is only rewritten the first time,
+        # when the wait moves from "no first byte yet" to "first byte seen,
+        # still idle" (a real state change), or once a watchdog deadline is
+        # imminent — repeating the same warning-like wording every 30s
+        # during an otherwise healthy request reads as sustained provider
+        # trouble when there is none (#92550).
         if _poll_count % 100 == 0:  # 100 × 0.3s = 30s
             _elapsed = time.time() - _call_start
             try:
-                _recovery = _codex_wait_notice_recovery(
+                _last_event_ts = getattr(agent, "_codex_stream_last_event_ts", None)
+                _phase = "ttfb" if _last_event_ts is None else "idle"
+                _deadline = _codex_wait_notice_deadline(
                     stale_timeout=_stale_timeout,
                     ttfb_enabled=_ttfb_enabled,
                     ttfb_timeout=_ttfb_timeout,
-                    last_event_ts=getattr(
-                        agent, "_codex_stream_last_event_ts", None
-                    ),
+                    last_event_ts=_last_event_ts,
                     call_start=_call_start,
                     idle_enabled=_codex_idle_enabled,
                     idle_timeout=_codex_idle_timeout,
                     elapsed=_elapsed,
                 )
-                agent._emit_wait_notice(
-                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                    f"{int(_elapsed)}s with no response yet (provider may be slow "
-                    f"or overloaded{_recovery})"
-                )
+                _imminent = _deadline is not None and (_deadline[1] - _elapsed) <= 15.0
+                if _wait_notice_last_phase is None or _wait_notice_last_phase != _phase or _imminent:
+                    if _deadline is not None:
+                        _recovery = f"; {_deadline[0]} reconnect at {int(_deadline[1])}s"
+                    else:
+                        _recovery = ""
+                    _status = (
+                        "provider may be slow or overloaded"
+                        if _imminent
+                        else "no response yet"
+                    )
+                    agent._emit_wait_notice(
+                        f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
+                        f"{int(_elapsed)}s, {_status}{_recovery}"
+                    )
+                else:
+                    agent._touch_activity(
+                        f"waiting on {api_kwargs.get('model', 'the provider')} "
+                        f"({int(_elapsed)}s, no response yet)"
+                    )
+                _wait_notice_last_phase = _phase
             except Exception:
                 logger.debug("wait-notice construction failed", exc_info=True)
 

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -234,6 +234,61 @@ def test_moa_heartbeat_survives_infinite_stale_timeout(monkeypatch):
     assert "auto-reconnect" not in notices[0]
 
 
+def test_wait_notice_does_not_repeat_during_healthy_wait(monkeypatch):
+    """#92550: a second 30s tick with no watchdog state change and no
+    imminent deadline must not repeat the visible warning-like notice —
+    only the quiet activity touch fires, so a long-but-healthy request
+    doesn't read as sustained provider trouble."""
+    from agent import chat_completion_helpers as h
+
+    notices: list[str] = []
+    touches: list[str] = []
+    response = SimpleNamespace(ok=True)
+    agent = SimpleNamespace(
+        platform="desktop",
+        api_mode="chat_completions",
+        provider="moa",
+        _consecutive_stale_streams=0,
+        _interrupt_requested=False,
+        _compute_non_stream_stale_timeout=lambda _kwargs: float("inf"),
+        _touch_activity=touches.append,
+        _emit_wait_notice=notices.append,
+    )
+
+    class HeartbeatThread:
+        """Keep the synthetic worker alive through two heartbeats."""
+
+        def __init__(self, *, target, daemon):
+            self._polls = 0
+            self._target = target
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+        def is_alive(self):
+            self._polls += 1
+            if self._polls == 201:
+                self._target()
+                return False
+            return True
+
+    monkeypatch.setattr(h.threading, "Thread", HeartbeatThread)
+    monkeypatch.setattr(
+        h,
+        "_dispatch_nonstreaming_api_request",
+        lambda *_args, **_kwargs: response,
+    )
+
+    result = h.interruptible_api_call(agent, {"model": "openai-xai-wide"})
+
+    assert result is response
+    assert len(notices) == 1
+    assert any("no response yet" in t for t in touches)
+
+
 def test_wait_notice_formatting_error_does_not_abort_request(monkeypatch):
     """Status construction is fail-open even if its formatter breaks."""
     from agent import chat_completion_helpers as h
@@ -276,7 +331,7 @@ def test_wait_notice_formatting_error_does_not_abort_request(monkeypatch):
     )
     monkeypatch.setattr(
         h,
-        "_codex_wait_notice_recovery",
+        "_codex_wait_notice_deadline",
         lambda **_kwargs: (_ for _ in ()).throw(ValueError("bad display state")),
     )
 


### PR DESCRIPTION
## What

`interruptible_api_call`'s periodic wait notice (the non-streaming path used by, among others, the Codex Responses provider) rewrote the live spinner/status line with the same warning-like text every ~30 seconds for as long as the call stayed alive:

```
⏳ waiting on gpt-5.6-sol — 30s with no response yet (provider may be slow
or overloaded; auto-reconnect at <N>s)
```

Per #92550, that repeats for the entire duration of a normal, healthy call — the issue's own log aggregate shows successful calls with p90 latency 35.5s and p95 53.1s, so most of these repeats fire during requests that finish fine. The message also never said *which* watchdog the "auto-reconnect at Ns" applied to, so it always read as generic provider impairment.

## Why

Three problems, per the issue's "Expected behavior" list:

1. The same "may be slow or overloaded" wording repeated every 30s regardless of whether anything was actually wrong.
2. It didn't distinguish "no first byte yet" (TTFB wait) from "got a byte, now idle" (post-event idle wait) — two different states with two different watchdogs.
3. The reconnect deadline never named the watchdog producing it (TTFB vs. stream-idle vs. wall-clock stale).

## Fix

In the periodic (~30s) tick inside `interruptible_api_call`:

- The visible notice is only rewritten on the **first** tick, on a **state change** (TTFB wait → post-event idle wait), or once the earliest enabled watchdog deadline is **imminent** (within 15s). Every other tick just quietly touches the activity tracker (still keeps the gateway inactivity monitor and CLI "⏳ Working — N min" heartbeat alive) without touching the visible spinner/status line.
- The "may be slow or overloaded" wording is now only used when a deadline is actually imminent; otherwise the notice just says "no response yet".
- `_codex_wait_notice_recovery` (the helper that built the `"; auto-reconnect at Ns"` suffix) is refactored to build on a new `_codex_wait_notice_deadline()` that also returns *which* watchdog produced the deadline (`"TTFB"`, `"stream idle"`, or `"wall-clock stale"`), so the suffix now reads `"; TTFB reconnect at Ns"` etc. The old function's signature and empty-string behavior are unchanged, so its existing test still passes.

No watchdog thresholds or retry/reconnect behavior changed — this is presentation-only, as scoped by the issue.

## Testing

Added `test_wait_notice_does_not_repeat_during_healthy_wait` in `tests/agent/test_codex_ttfb_watchdog.py`, which drives two 30s ticks through a synthetic heartbeat thread with no state change and no imminent deadline, and asserts the visible notice fires only once.

Confirmed it fails without the fix (`git checkout HEAD -- agent/chat_completion_helpers.py`, keeping the new test):

```
assert len(notices) == 1
E   AssertionError: assert 2 == 1
E    +  where 2 = len(['⏳ waiting on openai-xai-wide — 0s with no response yet (provider may be slow or overloaded)', '⏳ waiting on openai-xai-wide — 0s with no response yet (provider may be slow or overloaded)'])
```

With the fix restored:

```
$ python3 -m pytest tests/agent/test_codex_ttfb_watchdog.py -q
.........
9 passed in 14.01s
```

Also updated the existing `test_wait_notice_formatting_error_does_not_abort_request` to monkeypatch the function actually called from the loop now (`_codex_wait_notice_deadline` instead of the now-wrapper `_codex_wait_notice_recovery`), so its fail-open coverage stays meaningful.

Broader regression run (all Codex/watchdog/wait-notice/stale-timeout/cron-API related test files, 174 tests):

```
=== Summary: 17 files, 174 tests passed, 0 failed (100% complete) in 38.8s (8 workers) ===
```

`ruff check .` — all checks passed (pre-existing unrelated `noqa` warnings in two other files, untouched by this change).

`python3 scripts/check-windows-footguns.py agent/chat_completion_helpers.py tests/agent/test_codex_ttfb_watchdog.py` — no footguns found.

## AI assistance disclosure

This change was prepared with AI assistance (Claude).

Closes #92550
