### PR TITLE
fix(tools): don't pre-check keyless local backends in Tool Gateway checklist

### DIFF
--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -1034,16 +1034,34 @@ _GATEWAY_DIRECT_LABELS = {
 
 _ALL_GATEWAY_KEYS = ("web", "image_gen", "video_gen", "tts", "stt", "browser")
 
+# Config section + selection field for each gateway key, matching the
+# field names ``apply_gateway_defaults`` writes and
+# ``get_nous_subscription_features`` reads (web uses "backend", browser
+# uses "cloud_provider", everything else uses "provider").
+_GATEWAY_SECTION_FIELDS = {
+    "web": ("web", "backend"),
+    "image_gen": ("image_gen", "provider"),
+    "video_gen": ("video_gen", "provider"),
+    "tts": ("tts", "provider"),
+    "stt": ("stt", "provider"),
+    "browser": ("browser", "cloud_provider"),
+}
+
 
 def get_gateway_eligible_tools(
     config: Optional[Dict[str, object]] = None,
     *,
     force_fresh: bool = False,
-) -> tuple[list[str], list[str], list[str]]:
-    """Return (unconfigured, has_direct, already_managed) tool key lists.
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Return (unconfigured, has_direct, explicit_configured, already_managed)
+    tool key lists.
 
-    - unconfigured: tools with no direct credentials (easy switch)
+    - unconfigured: tools with no direct credentials and no explicit
+      non-nous selection (easy switch, safe to pre-check)
     - has_direct: tools where the user has their own API keys
+    - explicit_configured: tools with an explicit non-nous selection stored
+      (e.g. ``web.backend: searxng``), including keyless backends that would
+      otherwise look unconfigured
     - already_managed: tools already routed through the gateway
 
     All lists are empty when the user is not a paid Nous subscriber or
@@ -1084,6 +1102,7 @@ def get_gateway_eligible_tools(
 
     unconfigured: list[str] = []
     has_direct: list[str] = []
+    explicit_configured: list[str] = []
     already_managed: list[str] = []
     for key in _ALL_GATEWAY_KEYS:
         # Only offer tools the user's entitlement actually covers. For a free
@@ -1093,13 +1112,20 @@ def get_gateway_eligible_tools(
             MANAGED_FEATURE_COVERAGE_CATEGORY[key]
         ):
             continue
+        section_key, field = _GATEWAY_SECTION_FIELDS[key]
+        selected = _selected_provider(config.get(section_key), field)
         if opted_in.get(key):
             already_managed.append(key)
+        elif selected is not None and selected != "nous":
+            # An explicit non-nous selection (e.g. a keyless local backend
+            # like SearXNG or Camofox) is configured on purpose, even
+            # though it has no direct credentials to detect.
+            explicit_configured.append(key)
         elif direct.get(key):
             has_direct.append(key)
         else:
             unconfigured.append(key)
-    return unconfigured, has_direct, already_managed
+    return unconfigured, has_direct, explicit_configured, already_managed
 
 
 def apply_gateway_defaults(
@@ -1193,7 +1219,10 @@ def prompt_enable_tool_gateway(
     Returns the set of tools that were enabled, or empty set if the user
     declined or no tools were eligible.
     """
-    unconfigured, has_direct, already_managed = get_gateway_eligible_tools(
+    # explicit_configured tools (e.g. an explicit `web.backend: searxng`) are
+    # configured on purpose and are never offered here — same treatment as
+    # already_managed, just for a non-nous vendor.
+    unconfigured, has_direct, _explicit_configured, already_managed = get_gateway_eligible_tools(
         config,
         force_fresh=force_fresh,
     )

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -1073,9 +1073,9 @@ def get_gateway_eligible_tools(
     try:
         account_info = get_nous_portal_account_info(force_fresh=force_fresh)
     except Exception:
-        return [], [], []
+        return [], [], [], []
     if not (account_info and account_info.logged_in and account_info.tool_gateway_entitled):
-        return [], [], []
+        return [], [], [], []
 
     if config is None:
         config = load_config() or {}
@@ -1083,7 +1083,7 @@ def get_gateway_eligible_tools(
     # Quick provider check without the heavy get_nous_subscription_features call
     model_cfg = config.get("model")
     if not isinstance(model_cfg, dict) or str(model_cfg.get("provider") or "").strip().lower() != "nous":
-        return [], [], []
+        return [], [], [], []
 
     direct = _get_gateway_direct_credentials()
 

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -228,6 +228,29 @@ def test_get_gateway_eligible_tools_treats_explicit_backend_as_configured(monkey
     assert "web" not in already_managed
 
 
+def test_get_gateway_eligible_tools_not_entitled_returns_four_empty_lists(monkeypatch):
+    """A logged-in Nous account with no paid access and no free tool pool
+    must fail closed with a 4-tuple, not a 3-tuple — regression for a crash
+    where the early 'not entitled' return still had the pre-refactor arity
+    while the happy path and every caller had moved to 4 values."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=False))
+
+    config = {"model": {"provider": "nous"}}
+    result = ns.get_gateway_eligible_tools(config)
+
+    assert result == ([], [], [], [])
+
+
+def test_prompt_enable_tool_gateway_not_entitled_does_not_crash(monkeypatch):
+    """The unconditional call site in model_setup_flows (no try/except) must
+    not raise when a Nous account is logged in but not entitled to the Tool
+    Gateway (i.e. an ordinary non-paid, non-pool account)."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=False))
+
+    config = {"model": {"provider": "nous"}}
+    assert ns.prompt_enable_tool_gateway(config) == set()
+
+
 def test_prompt_enable_tool_gateway_never_offers_explicit_backend(monkeypatch):
     """The checklist itself must not list (let alone pre-check) a tool with
     an explicit non-nous selection, so it can never be silently overwritten

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -228,6 +228,30 @@ def test_get_gateway_eligible_tools_treats_explicit_backend_as_configured(monkey
     assert "web" not in already_managed
 
 
+def test_get_gateway_eligible_tools_treats_browser_use_selection_as_explicit(monkeypatch):
+    """An explicit BYOK `browser.cloud_provider: browser-use` selection must
+    land in explicit_configured, not unconfigured/has_direct — the same
+    protection as searxng above. This is distinct from the gateway's own
+    managed selection, which is always stored as `cloud_provider: nous`
+    (see apply_gateway_defaults); "browser-use" only appears here when the
+    user picked it directly, so it must never be treated as up for grabs.
+    """
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=True))
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "browser": True},
+    )
+
+    config = {"model": {"provider": "nous"}, "browser": {"cloud_provider": "browser-use"}}
+    unconfigured, has_direct, explicit_configured, already_managed = ns.get_gateway_eligible_tools(config)
+
+    assert "browser" not in unconfigured
+    assert "browser" not in has_direct
+    assert "browser" in explicit_configured
+    assert "browser" not in already_managed
+
+
 def test_get_gateway_eligible_tools_not_entitled_returns_four_empty_lists(monkeypatch):
     """A logged-in Nous account with no paid access and no free tool pool
     must fail closed with a 4-tuple, not a 3-tuple — regression for a crash

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -206,6 +206,46 @@ def test_prompt_enable_tool_gateway_pool_offers_covered_tools_only(monkeypatch):
     assert "free" in captured["title"].lower() and "pool" in captured["title"].lower()
 
 
+def test_get_gateway_eligible_tools_treats_explicit_backend_as_configured(monkeypatch):
+    """A keyless local backend (e.g. searxng) has no credentials to detect,
+    but an explicit non-nous selection must still keep it out of
+    'unconfigured' — regression for #92647, where it was pre-checked and a
+    single Enter during `hermes model` overwrote it to `web.backend: nous`.
+    """
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=True))
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "browser": False},
+    )
+
+    config = {"model": {"provider": "nous"}, "web": {"backend": "searxng"}}
+    unconfigured, has_direct, explicit_configured, already_managed = ns.get_gateway_eligible_tools(config)
+
+    assert "web" not in unconfigured
+    assert "web" not in has_direct
+    assert "web" in explicit_configured
+    assert "web" not in already_managed
+
+
+def test_prompt_enable_tool_gateway_never_offers_explicit_backend(monkeypatch):
+    """The checklist itself must not list (let alone pre-check) a tool with
+    an explicit non-nous selection, so it can never be silently overwritten
+    by an accidental Enter."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=True))
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "browser": False},
+    )
+    captured = _capture_checklist(monkeypatch, selected_idx=[])
+
+    config = {"model": {"provider": "nous"}, "web": {"backend": "searxng"}}
+    ns.prompt_enable_tool_gateway(config)
+
+    blob = " ".join(captured["items"]).lower()
+    assert "firecrawl" not in blob  # web (searxng-configured) NOT offered
+    assert "image" in blob  # other unconfigured tools still offered
 
 
 def test_apply_nous_managed_defaults_writes_video_gen_config(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`get_gateway_eligible_tools()` (`hermes_cli/nous_subscription.py`) classified a tool as **"unconfigured"** whenever it found no direct API-key credential, ignoring an explicit non-nous selection already stored in config (e.g. `web.backend: searxng`, a keyless self-hosted backend — SearXNG requires no API key). Every "unconfigured" tool is pre-checked in the `hermes model` Tool Gateway checklist (`pre_selected = list(range(len(unconfigured)))`), so a single Enter during Nous model setup silently rewrote `web.backend` (and similarly `browser.cloud_provider`, `tts`/`stt`/`image_gen.provider`) to `"nous"` for users who had deliberately configured a keyless local backend — breaking self-hosted web search/browser automation at runtime with no visible indication at the moment it happened.

## Related Issue

Fixes #92647

## Changes Made

- `get_gateway_eligible_tools()` now resolves each tool's stored selection via the existing `_selected_provider()` helper (already used elsewhere in this module to keep `hermes status` in lockstep with the runtime resolver) and routes an explicit non-nous selection into a new `explicit_configured` bucket instead of `unconfigured`.
- `prompt_enable_tool_gateway()` never offers `explicit_configured` tools in the checklist — same treatment as `already_managed` tools, just for a non-nous vendor — so they can no longer be pre-checked or accidentally overwritten by an unrelated Enter/edit.

This directly fixes the reported root cause (misclassification of explicit non-nous selections). It does not implement the issue's secondary "nice-to-have" suggestions (persisting a decline, printing changed config keys before saving) — those are separate, larger UX decisions the maintainers may want to weigh in on; the misclassification is the actual data-loss bug.

### Follow-up fix: arity crash in the three early-return branches

A review pass caught a second, more severe bug introduced by the first commit: `get_gateway_eligible_tools()`'s happy-path return grew from a 3-tuple to a 4-tuple (adding `explicit_configured`), and every caller was updated to unpack 4 values — but the function's three "fail closed" early returns (account-fetch exception, not entitled, provider isn't `nous`) were left as 3-element tuples. Any logged-in Nous account that isn't a paid subscriber or enrolled in a live free tool pool hits the "not entitled" branch, and `prompt_enable_tool_gateway()` is called unconditionally (no try/except) from `hermes model` right after `save_config(config)` — so picking Nous as provider crashed with `ValueError: not enough values to unpack (expected 4, got 3)` for the common non-entitled case. Fixed all three early returns to `[], [], [], []` and added two regression tests that exercise the previously-uncovered early-exit paths directly.

## How to Test

Regression tests added to `tests/hermes_cli/test_nous_subscription.py`, reproducing the exact repro steps from the issue (a Nous-provider config with `web.backend: searxng` and no direct web credentials), plus two new tests covering the not-entitled early-return path:

```
python -m pytest tests/hermes_cli/test_nous_subscription.py -q
```

Result: `17 passed` (13 pre-existing + 2 from the first commit + 2 for the arity fix).

Confirmed all 4 new tests fail without their respective source change:

```
FAILED tests/hermes_cli/test_nous_subscription.py::test_get_gateway_eligible_tools_treats_explicit_backend_as_configured - ValueError: not enough values to unpack (expected 4, got 3)
FAILED tests/hermes_cli/test_nous_subscription.py::test_prompt_enable_tool_gateway_never_offers_explicit_backend - AssertionError: assert 'firecrawl' not in 'web search ...browser use)'
FAILED tests/hermes_cli/test_nous_subscription.py::test_get_gateway_eligible_tools_not_entitled_returns_four_empty_lists - assert ([], [], []) == ([], [], [], [])
FAILED tests/hermes_cli/test_nous_subscription.py::test_prompt_enable_tool_gateway_not_entitled_does_not_crash - ValueError: not enough values to unpack (expected 4, got 3)
```

Also ran the surrounding suites that exercise this module's callers, all green:

```
python -m pytest tests/hermes_cli/test_nous_subscription.py tests/cli/test_cli_provider_resolution.py tests/hermes_cli/test_auth_nous_provider.py tests/hermes_cli/test_setup_model_provider.py tests/hermes_cli/test_imagegen_managed_gateway.py -q
```
Result: `70 passed`.

`ruff check hermes_cli/nous_subscription.py tests/hermes_cli/test_nous_subscription.py` — all checks passed.

Also manually reproduced the reviewer's exact repro snippet (logged-in, non-entitled Nous account calling `prompt_enable_tool_gateway`) against the fixed code — no longer crashes, returns `set()`.

## Checklist

- [x] I searched for existing PRs/issues; no open PR references #92647 or this function
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added regression tests that fail without the fix and pass with it
- [x] I've run the affected suites and they pass
- [x] Tested on Ubuntu (CI runner), Python 3.12

## AI assistance disclosure

This PR was prepared with AI assistance (Claude, Anthropic) under human supervision — investigation, fix, and tests were reviewed before submission.
