### PR TITLE
fix(nous): keep explicit non-Nous backends out of the pre-checked gateway offer

### DIFF
--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -1034,6 +1034,42 @@ _GATEWAY_DIRECT_LABELS = {
 
 _ALL_GATEWAY_KEYS = ("web", "image_gen", "video_gen", "tts", "stt", "browser")
 
+# cloud_provider values the Tool Gateway itself writes (apply_gateway_defaults).
+# An explicit cloud_provider equal to one of these is a gateway decision, not
+# the user's own backend selection.
+_GATEWAY_BROWSER_PROVIDER_VALUES = {"browser-use"}
+
+
+def _explicit_non_nous_selections(config: Dict[str, object]) -> set:
+    """Tool keys where the user deliberately selected a non-Nous backend.
+
+    Keyless-by-design backends (self-hosted SearXNG, a local Camofox, …) can
+    never prove themselves through credentials, so ``_uses_gateway`` is False
+    and ``_get_gateway_direct_credentials`` returns False for them — which
+    landed them in ``unconfigured`` and got them pre-checked by the Tool
+    Gateway checklist. Accepting the offer then overwrote the explicit
+    selection (``apply_gateway_defaults`` writes ``web.backend =
+    "firecrawl"`` / ``browser.cloud_provider = "browser-use"``), breaking
+    the user's working local setup (#92647). An explicit stored selection is
+    a deliberate non-gateway decision and must be treated like a direct
+    credential: offered unchecked, never pre-checked.
+    """
+    explicit: set = set()
+
+    web_cfg = config.get("web")
+    if isinstance(web_cfg, dict):
+        web_backend = str(web_cfg.get("backend") or "").strip().lower()
+        if web_backend and web_backend != "nous":
+            explicit.add("web")
+
+    browser_cfg = config.get("browser")
+    if isinstance(browser_cfg, dict) and "cloud_provider" in browser_cfg:
+        provider = str(browser_cfg.get("cloud_provider") or "").strip().lower()
+        if provider and provider not in _GATEWAY_BROWSER_PROVIDER_VALUES:
+            explicit.add("browser")
+
+    return explicit
+
 
 def get_gateway_eligible_tools(
     config: Optional[Dict[str, object]] = None,
@@ -1042,8 +1078,10 @@ def get_gateway_eligible_tools(
 ) -> tuple[list[str], list[str], list[str]]:
     """Return (unconfigured, has_direct, already_managed) tool key lists.
 
-    - unconfigured: tools with no direct credentials (easy switch)
-    - has_direct: tools where the user has their own API keys
+    - unconfigured: tools with no direct credentials and no explicit
+      non-Nous backend selection (easy switch, pre-checked)
+    - has_direct: tools where the user has their own API keys or their own
+      explicit backend selection (offered unchecked)
     - already_managed: tools already routed through the gateway
 
     All lists are empty when the user is not a paid Nous subscriber or
@@ -1085,6 +1123,7 @@ def get_gateway_eligible_tools(
     unconfigured: list[str] = []
     has_direct: list[str] = []
     already_managed: list[str] = []
+    explicit = _explicit_non_nous_selections(config)
     for key in _ALL_GATEWAY_KEYS:
         # Only offer tools the user's entitlement actually covers. For a free
         # tool pool that means image but not video; paid users are covered for
@@ -1095,7 +1134,7 @@ def get_gateway_eligible_tools(
             continue
         if opted_in.get(key):
             already_managed.append(key)
-        elif direct.get(key):
+        elif direct.get(key) or key in explicit:
             has_direct.append(key)
         else:
             unconfigured.append(key)
@@ -1220,14 +1259,21 @@ def prompt_enable_tool_gateway(
     source_label = "free tool pool" if pool_only else "Nous subscription"
 
     # Per-tool checklist: unconfigured tools first (pre-checked for new users),
-    # then tools where the user already has their own key (left unchecked so we
-    # don't override their own setup unless they ask).
+    # then tools where the user already has their own key or their own backend
+    # selection (left unchecked so we don't override their own setup unless
+    # they ask).
+    explicit = _explicit_non_nous_selections(config)
     offer_keys: list[str] = list(unconfigured) + list(has_direct)
     labels: list[str] = [_GATEWAY_TOOL_LABELS[k] for k in unconfigured]
-    labels += [
-        f"{_GATEWAY_TOOL_LABELS[k]} — keep using your {_GATEWAY_DIRECT_LABELS[k]}"
-        for k in has_direct
-    ]
+    for k in has_direct:
+        if k in explicit and not _get_gateway_direct_credentials().get(k):
+            # Keyless local backend — there is no credential label to cite,
+            # only the explicit selection itself.
+            labels.append(f"{_GATEWAY_TOOL_LABELS[k]} — keep your own backend")
+        else:
+            labels.append(
+                f"{_GATEWAY_TOOL_LABELS[k]} — keep using your {_GATEWAY_DIRECT_LABELS[k]}"
+            )
     pre_selected = list(range(len(unconfigured)))
 
     if pool_only:

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -206,6 +206,87 @@ def test_prompt_enable_tool_gateway_pool_offers_covered_tools_only(monkeypatch):
     assert "free" in captured["title"].lower() and "pool" in captured["title"].lower()
 
 
+def test_explicit_local_web_backend_not_prechecked(monkeypatch):
+    """#92647: an explicit keyless backend (web.backend: searxng) must not be
+    classified unconfigured — it used to be pre-checked, and accepting the
+    checklist overwrote the working local setup with the gateway default.
+    It belongs on the has_direct side (offered, unchecked) instead."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _pool_account())
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "browser": False},
+    )
+    captured = _capture_checklist(monkeypatch, selected_idx=[])
+
+    config = {
+        "model": {"provider": "nous"},
+        "web": {"backend": "searxng"},
+    }
+    ns.prompt_enable_tool_gateway(config)
+
+    blob = " ".join(captured["items"]).lower()
+    # Web still offered (the user may want the gateway), but as an explicit
+    # selection — not the credential label, and never pre-checked.
+    assert "firecrawl" in blob
+    web_label = next(i for i in captured["items"] if "Firecrawl" in i)
+    assert "keep your own backend" in web_label
+    web_idx = captured["items"].index(web_label)
+    assert web_idx not in captured["pre_selected"]
+
+
+def test_explicit_local_browser_provider_not_prechecked(monkeypatch):
+    """Same guard for browser.cloud_provider: a stored non-gateway provider
+    (self-hosted Camofox) is a deliberate non-Nous decision — unchecked."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _pool_account())
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "browser": False},
+    )
+    captured = _capture_checklist(monkeypatch, selected_idx=[])
+
+    config = {
+        "model": {"provider": "nous"},
+        "browser": {"cloud_provider": "camofox"},
+    }
+    ns.prompt_enable_tool_gateway(config)
+
+    browser_label = next(
+        i for i in captured["items"] if "Browser automation" in i
+    )
+    assert "keep your own backend" in browser_label
+    browser_idx = captured["items"].index(browser_label)
+    assert browser_idx not in captured["pre_selected"]
+
+
+def test_gateway_browser_provider_value_is_not_an_explicit_selection():
+    """cloud_provider='browser-use' is what apply_gateway_defaults writes —
+    it must NOT count as the user's own backend choice (it IS the gateway)."""
+    config = {"browser": {"cloud_provider": "browser-use"}}
+    assert "browser" not in ns._explicit_non_nous_selections(config)
+    # web.backend='nous' is the gateway-side value for web — same rule.
+    assert "web" not in ns._explicit_non_nous_selections({"web": {"backend": "nous"}})
+
+
+def test_no_selection_still_prechecked(monkeypatch):
+    """A tool with no credentials and no stored selection stays unconfigured
+    (pre-checked) — the new guard must not dampen the fresh-user offer."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _pool_account())
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "browser": False},
+    )
+    captured = _capture_checklist(monkeypatch, selected_idx=[])
+
+    config = {"model": {"provider": "nous"}}
+    ns.prompt_enable_tool_gateway(config)
+
+    # The first (unconfigured web) item remains pre-checked.
+    assert 0 in captured["pre_selected"]
+
+
 
 
 def test_apply_nous_managed_defaults_writes_video_gen_config(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Stops the Tool Gateway checklist from pre-checking (and then overwriting) tools the user has explicitly pointed at a non-Nous backend.

`get_gateway_eligible_tools` classified a tool as `unconfigured` unless it could detect direct cloud credentials or `use_gateway: true`. A keyless-by-design backend — self-hosted SearXNG (`web.backend: searxng`), a local Camofox (`browser.cloud_provider: camofox`), local faster-whisper — can never satisfy either check, so it always landed in `unconfigured`, which the checklist pre-selects. Pressing Enter (fatfingered or to accept one unrelated item) applied `apply_gateway_defaults`, which writes `web.backend = "firecrawl"` and `browser.cloud_provider = "browser-use"` — overwriting the user's working local setup. Strict provider resolution then refuses to fall back, and the tool breaks at runtime ("no registered provider/plugin").

This PR treats a stored explicit non-Nous backend selection the same way a direct API key is treated: the tool moves to the `has_direct` side of the checklist (offered, but unchecked, labeled "keep your own backend"). The gateway value `browser-use` (which `apply_gateway_defaults` itself writes) is excluded, so a gateway decision is never misread as the user's own choice.

## Related Issue

Fixes #92647

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/nous_subscription.py` — new `_explicit_non_nous_selections(config)` helper: returns tool keys with a stored non-Nous backend choice (`web.backend` set and not `nous`; `browser.cloud_provider` set and not a gateway-written value).
- `hermes_cli/nous_subscription.py` — `get_gateway_eligible_tools`: keys in the explicit-selection set are classified `has_direct` instead of `unconfigured`, so they are never pre-checked.
- `hermes_cli/nous_subscription.py` — `prompt_enable_tool_gateway`: checklist label for a keyless explicit selection reads "keep your own backend" instead of citing a cloud credential label that does not exist.
- `tests/hermes_cli/test_nous_subscription.py` — four regression tests: explicit SearXNG backend not pre-checked (fail on unpatched main), explicit Camofox provider not pre-checked (fail on unpatched main), gateway-written `browser-use`/`nous` values not counted as explicit selections, and fresh-user pre-check behavior preserved.

## How to Test

1. `pytest tests/hermes_cli/test_nous_subscription.py tests/hermes_cli/test_auth_nous_provider.py -q` — 47 passed (13 pre-existing + 4 new). Observed result: the two new pre-check tests fail on unpatched `main` and pass with this change.
2. `pytest tests/cli/test_cli_provider_resolution.py -q` — 15 passed, no regressions on the `hermes model` flow that invokes the checklist.

Manual shape (covered by the tests, no live Nous account needed): with `config = {"model": {"provider": "nous"}, "web": {"backend": "searxng"}}`, the checklist lists web as "Web search & extract (Firecrawl) — keep your own backend", unchecked; on unpatched main the same config produced a pre-checked unconfigured entry whose acceptance rewrote `web.backend` to the gateway default.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (relevant suites listed under How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (helper docstring names the contract and the issue)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure config-dict inspection)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — checklist-label assertions in the regression tests cover the visible shape.
