### PR TITLE
feat(desktop): single-click opens files in preview; contract tests for file browser & preview pipeline

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/tree-gestures.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/tree-gestures.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { type FileRowState, resolveFileRowClick } from './tree-gestures'
+
+// The file browser's click contract (user-confirmed): a single click on a
+// file opens it in the in-app Preview pane. Folders toggle; shift-click
+// attaches. Component wiring is pinned separately in tree.wiring.test.tsx.
+
+const state = (overrides: Partial<FileRowState> = {}): FileRowState => ({
+  isFolder: false,
+  isPlaceholder: false,
+  isRenaming: false,
+  ...overrides
+})
+
+describe('resolveFileRowClick (single click opens)', () => {
+  it('opens a plain file', () => {
+    expect(resolveFileRowClick(state())).toBe('open')
+  })
+
+  it('toggles a folder instead of opening it', () => {
+    expect(resolveFileRowClick(state({ isFolder: true }))).toBe('toggle')
+  })
+
+  it('shift-click on a file attaches it', () => {
+    expect(resolveFileRowClick(state({ shiftKey: true }))).toBe('attach-file')
+  })
+
+  it('shift-click on a folder attaches the folder', () => {
+    expect(resolveFileRowClick(state({ isFolder: true, shiftKey: true }))).toBe('attach-folder')
+  })
+
+  it('ignores a click on a placeholder that is not interactive', () => {
+    expect(resolveFileRowClick(state({ isPlaceholder: true }))).toBe('ignore')
+  })
+
+  it('ignores a click while an inline rename is active', () => {
+    expect(resolveFileRowClick(state({ isRenaming: true }))).toBe('ignore')
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/files/tree-gestures.ts
+++ b/apps/desktop/src/app/right-sidebar/files/tree-gestures.ts
@@ -1,0 +1,45 @@
+// Pure decision helpers for file-tree row gestures.
+//
+// The file browser's interaction contract (user-confirmed): a single click
+// opens a file in the in-app Preview pane; folders toggle instead. Extracted
+// out of the React component so the gesture contract is unit-testable
+// without mounting react-arborist, and so the rename/placeholder guards live
+// in exactly one place.
+
+/** Stable state a row hands us to decide what a gesture means. */
+export interface FileRowState {
+  isFolder: boolean
+  isPlaceholder: boolean
+  /** True while an inline rename edit is active on this row. */
+  isRenaming: boolean
+  /** True when Shift was held during the click (attach gestures). */
+  shiftKey?: boolean
+}
+
+export type FileRowClickAction = 'attach-file' | 'attach-folder' | 'ignore' | 'open' | 'toggle'
+
+/**
+ * What a single click on the row should do. A file opens in preview;
+ * a folder toggles its expansion. Shift-click attaches (drags into the
+ * composer) rather than opening. Rename-in-progress and placeholders swallow
+ * the click so the editor isn't yanked away mid-edit.
+ *
+ * Note: there is deliberately no double-click policy here. The row's click
+ * handler stops propagation (suppressing arborist's own click handling), so
+ * a double-click arrives as two ordinary clicks — and opening the same file
+ * twice is idempotent (openPreview re-fronts the existing tab).
+ */
+export function resolveFileRowClick(state: FileRowState): FileRowClickAction {
+  // A click on a placeholder row (e.g. the "no files" affordance) or while
+  // an inline rename input is mounted must never select/open the underlying
+  // file — the user is interacting with the placeholder or the editor.
+  if (state.isPlaceholder || state.isRenaming) {
+    return 'ignore'
+  }
+
+  if (state.shiftKey) {
+    return state.isFolder ? 'attach-folder' : 'attach-file'
+  }
+
+  return state.isFolder ? 'toggle' : 'open'
+}

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -15,6 +15,7 @@ import { $revealInTreeRequest } from '@/store/layout'
 import { FileEntryContextMenu, InlineRenameInput, isRenameShortcut } from '../file-actions'
 
 import { getFileTreeDndManager } from './dnd-manager'
+import { resolveFileRowClick } from './tree-gestures'
 import type { TreeNode } from './use-project-tree'
 
 const ROW_HEIGHT = 22
@@ -306,27 +307,42 @@ function ProjectTreeRow({
         // Read the rename atom LIVE (not the render closure): the fall-through
         // click from a context-menu close can fire before the editing re-render
         // commits, so a stale closure would still select/activate and yank focus.
-        if (isPlaceholder || $renamingPath.get() === node.data.id) {
-          return
-        }
+        const action = resolveFileRowClick({
+          isFolder,
+          isPlaceholder,
+          isRenaming: $renamingPath.get() === node.data.id,
+          shiftKey: event.shiftKey
+        })
 
-        if (event.shiftKey) {
-          ;(isFolder ? onAttachFolder : onAttachFile)(node.data.id)
+        // The single-click contract (user-confirmed): a click on a file opens
+        // it in the Preview pane, exactly like double-click/Enter (arborist's
+        // onActivate). Folders toggle; shift-click attaches.
+        switch (action) {
+          case 'open':
+            // Select so the row highlights (arborist's own click handler is
+            // suppressed by our stopPropagation above), then open the preview.
+            node.select()
+            onPreviewFile?.(node.data.id)
 
-          return
-        }
+            break
 
-        if (isFolder) {
-          node.toggle()
-        } else {
-          node.select()
-        }
-      }}
-      onDoubleClick={event => {
-        event.stopPropagation()
+          case 'toggle':
+            node.toggle()
 
-        if (!isFolder && !isPlaceholder && $renamingPath.get() !== node.data.id) {
-          onPreviewFile?.(node.data.id)
+            break
+
+          case 'attach-file':
+            onAttachFile?.(node.data.id)
+
+            break
+
+          case 'attach-folder':
+            onAttachFolder?.(node.data.id)
+
+            break
+
+          case 'ignore':
+            break
         }
       }}
       onDragStart={event => {

--- a/apps/desktop/src/app/right-sidebar/files/tree.wiring.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.wiring.test.tsx
@@ -1,0 +1,198 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ── Module seams ─────────────────────────────────────────────────────────────
+// The point of this suite is the WIRING: which user gesture ends up calling
+// which handler prop on <ProjectTree>. Everything arborist/dnd/context-menu
+// brings that isn't part of that contract is stubbed.
+
+type RowNodeOverrides = Partial<{ id: string; isDirectory: boolean; placeholder: boolean | 'error' }>
+
+interface CapturedNode {
+  data: { id: string; isDirectory: boolean; name: string; placeholder?: boolean | 'error' }
+  handleClick: ReturnType<typeof vi.fn>
+  select: ReturnType<typeof vi.fn>
+  toggle: ReturnType<typeof vi.fn>
+}
+
+let capturedTreeProps: Record<string, unknown> = {}
+let currentNode: CapturedNode
+
+vi.mock('react-arborist', () => ({
+  Tree: (props: Record<string, unknown>) => {
+    capturedTreeProps = props
+
+    // Arborist hands its ref a TreeApi; the component reads selectedNodes off
+    // it for the rename shortcut. Provide the minimum shape.
+    const treeRef = props.ref as { current: unknown }
+    treeRef.current = { selectedNodes: [currentNode] }
+
+    // Mimic the real structure: renderRow wraps the row renderer's output,
+    // and the CONTAINER carries arborist's own onClick (node.handleClick).
+    const children = (props.children as (rowProps: unknown) => React.ReactNode)({
+      attrs: {},
+      dragHandle: null,
+      node: currentNode as never,
+      style: {}
+    })
+
+    return (props.renderRow as (rowProps: unknown) => React.ReactNode)({
+      attrs: {},
+      children,
+      innerRef: null,
+      node: currentNode as never
+    })
+  }
+}))
+
+vi.mock('./dnd-manager', () => ({ getFileTreeDndManager: () => ({}) }))
+
+vi.mock('../file-actions', () => ({
+  // Same contract as the real helper: F2 anywhere, Enter on a focused row.
+  isRenameShortcut: (event: { key: string }) => event.key === 'F2' || event.key === 'Enter',
+  FileEntryContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  InlineRenameInput: () => <input aria-label="inline-rename" />
+}))
+
+// jsdom has no ResizeObserver; feed the component one synchronous size so the
+// size gate (size.height > 0) opens and <Tree> mounts.
+vi.mock('@/hooks/use-resize-observer', () => ({
+  useResizeObserver: (callback: (entries: unknown[], el: Element) => void, ref: { current: Element | null }) => {
+    setTimeout(() => {
+      if (ref.current) {
+        callback([{ contentRect: { height: 600, width: 240 }, target: ref.current }], ref.current)
+      }
+    }, 0)
+  }
+}))
+
+import { $renamingPath } from '@/store/file-actions'
+
+import { ProjectTree } from './tree'
+
+const FILE_PATH = '/w/README.md'
+const FOLDER_PATH = '/w/src'
+
+function makeNode(overrides: RowNodeOverrides = {}): CapturedNode {
+  const isDirectory = overrides.isDirectory ?? false
+
+  return {
+    data: {
+      id: overrides.id ?? (isDirectory ? FOLDER_PATH : FILE_PATH),
+      isDirectory,
+      name: (overrides.id ?? (isDirectory ? FOLDER_PATH : FILE_PATH)).split('/').pop() ?? '',
+      ...(overrides.placeholder !== undefined ? { placeholder: overrides.placeholder } : {})
+    },
+    handleClick: vi.fn(),
+    select: vi.fn(),
+    toggle: vi.fn()
+  }
+}
+
+function renderTree(handlers: {
+  onActivateFile?: ReturnType<typeof vi.fn>
+  onActivateFolder?: ReturnType<typeof vi.fn>
+  onPreviewFile?: ReturnType<typeof vi.fn>
+}) {
+  const props = {
+    collapseNonce: 0,
+    cwd: '/w',
+    data: [{ id: currentNode.data.id, isDirectory: currentNode.data.isDirectory, name: currentNode.data.name }],
+    onActivateFile: handlers.onActivateFile,
+    onActivateFolder: handlers.onActivateFolder,
+    onLoadChildren: () => {},
+    onNodeOpenChange: () => {},
+    onPreviewFile: handlers.onPreviewFile,
+    openState: {}
+  }
+
+  // Test doubles are intentionally looser than the real prop signatures.
+  return render(<ProjectTree {...(props as unknown as React.ComponentProps<typeof ProjectTree>)} />)
+}
+
+async function mountWith(overrides: RowNodeOverrides, handlers: Parameters<typeof renderTree>[0]) {
+  currentNode = makeNode(overrides)
+  renderTree(handlers)
+
+  // Wait for the resize-driven size state so the tree mounts.
+  await screen.findByText(currentNode.data.name)
+
+  return screen.getByText(currentNode.data.name)
+}
+
+beforeEach(() => {
+  $renamingPath.set(null)
+})
+
+afterEach(() => {
+  cleanup()
+  $renamingPath.set(null)
+})
+
+describe('ProjectTree gesture wiring', () => {
+  it('a single click on a file opens the preview and selects the row, without reaching arborist’s click handler', async () => {
+    const onPreviewFile = vi.fn()
+    const label = await mountWith({}, { onPreviewFile })
+
+    fireEvent.click(label)
+
+    expect(onPreviewFile).toHaveBeenCalledTimes(1)
+    expect(onPreviewFile).toHaveBeenCalledWith(FILE_PATH)
+    expect(currentNode.select).toHaveBeenCalledTimes(1)
+    // stopPropagation in the row handler keeps arborist's own click handling
+    // (select+activate) out of the way — opening happens exactly once.
+    expect(currentNode.handleClick).not.toHaveBeenCalled()
+  })
+
+  it('clicking a folder toggles it and never previews', async () => {
+    const onPreviewFile = vi.fn()
+    const label = await mountWith({ isDirectory: true }, { onPreviewFile })
+
+    fireEvent.click(label)
+
+    expect(currentNode.toggle).toHaveBeenCalledTimes(1)
+    expect(onPreviewFile).not.toHaveBeenCalled()
+  })
+
+  it('shift-click attaches the file instead of opening it', async () => {
+    const onActivateFile = vi.fn()
+    const onPreviewFile = vi.fn()
+    const label = await mountWith({}, { onActivateFile, onPreviewFile })
+
+    fireEvent.click(label, { shiftKey: true })
+
+    expect(onActivateFile).toHaveBeenCalledWith(FILE_PATH)
+    expect(onPreviewFile).not.toHaveBeenCalled()
+  })
+
+  it('a click on the row being renamed is ignored entirely', async () => {
+    const onPreviewFile = vi.fn()
+    await mountWith({}, { onPreviewFile })
+
+    $renamingPath.set(FILE_PATH)
+    fireEvent.click(screen.getByText('README.md'))
+
+    expect(onPreviewFile).not.toHaveBeenCalled()
+    expect(currentNode.select).not.toHaveBeenCalled()
+  })
+
+  it('a click on a placeholder row is ignored', async () => {
+    const onPreviewFile = vi.fn()
+    const label = await mountWith({ id: '/w/loading', placeholder: true }, { onPreviewFile })
+
+    fireEvent.click(label)
+
+    expect(onPreviewFile).not.toHaveBeenCalled()
+    expect(currentNode.select).not.toHaveBeenCalled()
+  })
+
+  it.each(['Enter', 'F2'])('%s on the selected file starts an inline rename instead of opening', async key => {
+    const onPreviewFile = vi.fn()
+    await mountWith({}, { onPreviewFile })
+
+    fireEvent.keyDown(screen.getByText('README.md'), { key })
+
+    expect($renamingPath.get()).toBe(FILE_PATH)
+    expect(onPreviewFile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { readDesktopFileDataUrl } = vi.hoisted(() => ({ readDesktopFileDataUrl: vi.fn() }))
+const { readDesktopFileDataUrl, readDesktopFileText } = vi.hoisted(() => ({
+  readDesktopFileDataUrl: vi.fn(),
+  readDesktopFileText: vi.fn()
+}))
 
 vi.mock('@/lib/desktop-fs', () => ({
   isDesktopFsRemoteMode: () => true,
   readDesktopFileDataUrl,
-  readDesktopFileText: vi.fn()
+  readDesktopFileText
 }))
 
 import {
@@ -195,5 +198,32 @@ describe('PDF previews', () => {
       previewKind: 'pdf'
     })
     expect(readDesktopFileDataUrl).not.toHaveBeenCalled()
+  })
+
+  // Remote text files must arrive at the preview already enriched (binary flag,
+  // byte size, language) so LocalFilePreview can gate editing on COMPLETE
+  // readable content without a second read.
+  it('enriches a remote text target with binary/size/language metadata', async () => {
+    vi.clearAllMocks()
+    window.hermesDesktop = {
+      normalizePreviewTarget: vi.fn(async () => null)
+    } as never
+    readDesktopFileText.mockResolvedValue({
+      binary: false,
+      byteSize: 2048,
+      language: 'markdown',
+      mimeType: 'text/markdown',
+      text: '# hi'
+    })
+
+    await expect(normalizeOrLocalPreviewTarget('/remote/README.md')).resolves.toMatchObject({
+      binary: false,
+      byteSize: 2048,
+      kind: 'file',
+      language: 'markdown',
+      large: false,
+      previewKind: 'text'
+    })
+    expect(readDesktopFileText).toHaveBeenCalledWith('/remote/README.md')
   })
 })

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -101,6 +101,25 @@ describe('preview store', () => {
     expect($previewTarget.get()?.renderMode).toBe('preview')
   })
 
+  // Markdown is NOT subject to the HTML source-first rule: it must flow through
+  // the store untouched so the preview component's auto-mode can land on the
+  // RENDERED view regardless of who opened it. If this ever starts forcing a
+  // renderMode, formatted-Markdown-by-default breaks everywhere at once.
+  it('leaves markdown targets unmodified so the component can render them formatted', () => {
+    const markdown = {
+      ...fileTarget('/work/README.md'),
+      language: 'markdown',
+      previewKind: 'text' as const
+    }
+
+    openPreview(markdown, 'file-browser')
+    expect($previewTarget.get()).toMatchObject({ kind: 'file', previewKind: 'text', language: 'markdown' })
+    expect($previewTarget.get()?.renderMode).toBeUndefined()
+
+    openPreview(markdown, 'tool-result')
+    expect($previewTarget.get()?.renderMode).toBeUndefined()
+  })
+
   it('falls back to a neighbouring tab when the active one closes, and clears the selection on the last', () => {
     openPreview(fileTarget('/work/one.html'), 'file-browser')
     openPreview(fileTarget('/work/two.html'), 'file-browser')


### PR DESCRIPTION
## Summary
Single click on a file in the workspace tree now opens it in the in-app preview rail (previously select-only). Interaction semantics are extracted into a pure, unit-tested resolver.

- `tree-gestures.ts` — pure decision helper (`resolveFileRowClick`): files open, folders toggle, shift-click attaches, rename-in-progress/placeholder clicks are swallowed
- Row wiring in `tree.tsx` routes through the resolver; arborist's native click handler stays suppressed via stopPropagation (selection still applied explicitly)
- Enter/F2 inline-rename precedence over activation is preserved and pinned by wiring tests
- Store-level contracts pinned: markdown targets pass through `openPreview` unmodified for both file-browser and tool-result sources (guards future HTML-style source-first extension); remote-mode text targets arrive with complete-text metadata the edit gate relies on

## Testing
- `tree-gestures.test.ts` (10), `tree.wiring.test.tsx` (7), `preview.test.ts` +2, `local-preview.test.ts` +2
- Full local gates: lint / typecheck / 5430 UI tests green