### PR TITLE
fix(desktop): global reload tick no longer discards in-progress preview drafts (+E2E suite)

### DIFF
--- a/apps/desktop/e2e/file-preview.spec.ts
+++ b/apps/desktop/e2e/file-preview.spec.ts
@@ -1,0 +1,200 @@
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import {
+  buildAppEnv,
+  createSandbox,
+  launchDesktop,
+  type MockBackendFixture,
+  waitForAppReady,
+  writeEnvFile,
+  writeMockProviderConfig
+} from './fixtures'
+import { startMockServer } from './mock-server'
+import { expect, type Page, test } from './test'
+
+// FILE PREVIEW end-to-end: selecting files in the workspace tree opens them
+// INSIDE the app's preview rail; Markdown renders formatted by default; the
+// spot editor writes through the REAL Electron bridge (disk contents are
+// asserted from this process, not from any renderer state).
+
+let fixture: MockBackendFixture | null = null
+
+function createWorkspace(root: string): string {
+  const repo = path.join(root, 'workspace')
+
+  fs.mkdirSync(repo, { recursive: true })
+  execFileSync('git', ['init', '--initial-branch=main'], { cwd: repo })
+  execFileSync('git', ['config', 'user.email', 'e2e@example.com'], { cwd: repo })
+  execFileSync('git', ['config', 'user.name', 'Hermes E2E'], { cwd: repo })
+
+  fs.writeFileSync(
+    path.join(repo, 'README.md'),
+    ['# E2E Preview', '', '- alpha', '- beta', '', '```sh', 'echo hello', '```'].join('\n'),
+    'utf8'
+  )
+  fs.writeFileSync(path.join(repo, 'notes.txt'), 'plain notes body', 'utf8')
+  fs.mkdirSync(path.join(repo, 'src'), { recursive: true })
+  fs.writeFileSync(path.join(repo, 'src', 'util.ts'), 'export const x = 1\n', 'utf8')
+
+  execFileSync('git', ['add', '.'], { cwd: repo })
+  execFileSync('git', ['commit', '-m', 'initial'], { cwd: repo })
+
+  return repo
+}
+
+test.beforeAll(async () => {
+  const sandbox = createSandbox('file-preview')
+  const repo = createWorkspace(sandbox.root)
+  const mock = await startMockServer()
+
+  writeMockProviderConfig(sandbox.hermesHome, mock.url)
+  fs.appendFileSync(path.join(sandbox.hermesHome, 'config.yaml'), `\nterminal:\n  cwd: ${repo}\n`, 'utf8')
+  writeEnvFile(sandbox.hermesHome)
+
+  const { app, page } = await launchDesktop(buildAppEnv(sandbox))
+  fixture = {
+    app,
+    page,
+    mock,
+    mockUrl: mock.url,
+    sandbox,
+    cleanup: async () => {
+      await app.close().catch(() => undefined)
+      await mock.close()
+      sandbox.cleanup()
+    }
+  }
+
+  await waitForAppReady(fixture, 120_000)
+
+  // The session resolves its cwd on the first turn; the Files pane shows that
+  // cwd's tree. One throwaway turn against the mock model is enough.
+  const composer = fixture.page.locator('[contenteditable="true"]').first()
+  await composer.click()
+  await composer.type('open the workspace', { delay: 2 })
+  await fixture.page.keyboard.press('Enter')
+  await fixture.page.waitForFunction(
+    prompt => (document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent ?? '').includes(prompt),
+    'open the workspace',
+    { timeout: 15_000 }
+  )
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+async function openFilesPane(): Promise<void> {
+  const page = fixture!.page
+  const tree = page.locator('[data-project-tree]')
+
+  if ((await tree.count()) === 0) {
+    // mod+j = Cmd+J on macOS / Ctrl+J elsewhere ('view.toggleRightSidebar').
+    await page.keyboard.press(process.platform === 'darwin' ? 'Meta+J' : 'Control+J')
+    await expect(tree).toBeVisible({ timeout: 10_000 })
+  }
+}
+
+async function clickFile(name: string): Promise<void> {
+  const page = fixture!.page
+
+  await page.locator(`[data-project-tree] [title="${path.join(fixture!.sandbox.root, 'workspace', name)}"]`).click()
+}
+
+test.describe('file preview e2e', () => {
+  // The mode-switcher/edit controls render uppercase labels ('SOURCE', 'EDIT').
+  // Anchored case-insensitive regexes match those exactly while never
+  // substring-matching chrome like "Layout editor" or "Edit message". Every
+  // open preview TAB stays mounted, so multiple EDIT/SAVE/CANCEL controls
+  // exist at once; the just-fronted tab is the most recently appended one
+  // (openPreview appends), so .last() addresses ITS control.
+  const previewButton = (page: Page, name: string) =>
+    page.getByRole('button', { name: new RegExp(`^${name}$`, 'i') }).last()
+
+  test('single-click opens a markdown file formatted inside the app', async () => {
+    const page = fixture!.page
+
+    await openFilesPane()
+    await clickFile('README.md')
+
+    // Formatted, not raw: an H1 exists and the fence became a code block.
+    await expect(page.getByRole('heading', { level: 1, name: 'E2E Preview' })).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('source mode shows raw markdown', async () => {
+    const page = fixture!.page
+
+    await openFilesPane()
+    await clickFile('README.md')
+    await previewButton(page, 'source').click()
+    await expect(page.locator('.preview-source-code')).toContainText('# E2E Preview')
+  })
+
+  test('edit + save persists the draft to real disk', async () => {
+    const page = fixture!.page
+    const readmePath = path.join(fixture!.sandbox.root, 'workspace', 'README.md')
+
+    await openFilesPane()
+    await clickFile('README.md')
+    await previewButton(page, 'edit').click()
+
+    const editor = page.locator('.cm-content')
+    await editor.click()
+    await page.keyboard.press('ControlOrMeta+a')
+    await page.keyboard.type('# Edited by E2E')
+
+    await previewButton(page, 'save').click()
+
+    await expect.poll(() => fs.readFileSync(readmePath, 'utf8'), { timeout: 10_000 }).toContain('# Edited by E2E')
+  })
+
+  test('cancel discards the draft and leaves disk untouched', async () => {
+    const page = fixture!.page
+    const notesPath = path.join(fixture!.sandbox.root, 'workspace', 'notes.txt')
+    const before = fs.readFileSync(notesPath, 'utf8')
+
+    // notes.txt was never written by earlier tests, so no watcher/save churn
+    // can remount the editor under us mid-flow.
+    await openFilesPane()
+    await clickFile('notes.txt')
+    await previewButton(page, 'edit').click()
+
+    // Only the FRONTED tab's editor is interactable; background preview tabs
+    // keep their (hidden) CodeMirror surfaces mounted too.
+    const editor = page.locator('.cm-content').filter({ visible: true })
+    await expect(editor).toHaveCount(1)
+    await expect(editor).toBeVisible()
+    await editor.click()
+    await page.keyboard.press('ControlOrMeta+a')
+    await page.keyboard.type('# SHOULD NOT PERSIST')
+
+    await previewButton(page, 'cancel').click()
+
+    expect(fs.readFileSync(notesPath, 'utf8')).toBe(before)
+  })
+
+  // Preview tabs cache their loaded snapshot: re-selecting a file re-FRONTS
+  // its existing tab rather than re-reading disk (openPreview's documented
+  // identity rule). Pin that switching between two files gives each its own
+  // tab and switching back restores the first view.
+  test('a second file opens as its own tab and switching back re-fronts the first', async () => {
+    const page = fixture!.page
+
+    await openFilesPane()
+
+    await clickFile('notes.txt')
+    await expect(page.locator('body')).toContainText('plain notes body')
+
+    await clickFile('README.md')
+    // Test 3's save self-reloaded THIS tab, so it shows the saved content
+    // ('# Edited by E2E' — a paragraph, hence no H1). Switching back must
+    // restore that view rather than showing notes.txt.
+    await expect(page.locator('body')).toContainText('Edited by E2E')
+
+    await clickFile('notes.txt')
+    await expect(page.locator('body')).toContainText('plain notes body')
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-editing.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-editing.test.tsx
@@ -1,0 +1,207 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// EDITING SAFETY contract for the file preview's spot editor:
+//  - Edit exists ONLY for complete readable text (never binary/truncated);
+//  - Save writes the FULL draft through writeDesktopFileText;
+//  - a disk change since open surfaces Overwrite/Discard instead of clobbering;
+//  - Cancel/Discard never touch disk.
+// Electron/backend stay authoritative for I/O — everything here goes through
+// the mocked @/lib/desktop-fs seam.
+// (The clean-draft no-op guard lives on the real Save button's disabled
+// state; the mocked editor here drives saveEdit directly.)
+
+const { readDesktopFileText, writeDesktopFileText, desktopGitRoot, desktopFileDiff } = vi.hoisted(() => ({
+  readDesktopFileText: vi.fn(),
+  writeDesktopFileText: vi.fn(),
+  desktopGitRoot: vi.fn(),
+  desktopFileDiff: vi.fn()
+}))
+
+vi.mock('@/lib/desktop-fs', () => ({
+  isDesktopFsRemoteMode: () => false,
+  desktopFsCacheKey: () => 'local:',
+  readDesktopFileText,
+  writeDesktopFileText,
+  desktopGitRoot,
+  desktopFileDiff
+}))
+
+vi.mock('@/store/preview-edit', () => ({ setPreviewDirty: vi.fn() }))
+vi.mock('@/store/workspace-events', () => ({ notifyWorkspaceChanged: vi.fn() }))
+
+vi.mock('@/store/session', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $connection: atom(null), $currentCwd: atom('/w') }
+})
+
+// The real CodeEditor drags in CodeMirror; the contract under test only needs
+// "an editable surface that reports its value upward".
+vi.mock('@/components/chat/code-editor', () => ({
+  CodeEditor: ({
+    initialValue,
+    onChange,
+    onSave
+  }: {
+    initialValue: string
+    onChange: (value: string) => void
+    onSave?: () => void
+  }) => (
+    <div>
+      <textarea
+        aria-label="spot-editor"
+        defaultValue={initialValue}
+        onChange={event => onChange(event.currentTarget.value)}
+      />
+      <button onClick={onSave} type="button">
+        editor-save
+      </button>
+    </div>
+  )
+}))
+
+import { I18nProvider } from '@/i18n'
+
+import { LocalFilePreview } from './preview-file'
+
+const PATH = '/w/notes.md'
+
+const TARGET = {
+  kind: 'file' as const,
+  label: 'notes.md',
+  language: 'markdown',
+  path: PATH,
+  previewKind: 'text' as const,
+  source: PATH,
+  url: `file://${PATH}`
+}
+
+const BASE_TEXT = '# notes\n\noriginal body'
+
+function okRead(text = BASE_TEXT) {
+  return { binary: false, byteSize: text.length, language: 'markdown', mimeType: 'text/markdown', text }
+}
+
+function mount(target = TARGET) {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <LocalFilePreview reloadKey={0} target={target} />
+    </I18nProvider>
+  )
+}
+
+async function enterEdit() {
+  fireEvent.click(await screen.findByRole('button', { name: /edit/i }))
+
+  return screen.findByLabelText('spot-editor') as Promise<HTMLTextAreaElement>
+}
+
+beforeEach(() => {
+  readDesktopFileText.mockResolvedValue(okRead())
+  desktopGitRoot.mockResolvedValue(null)
+  desktopFileDiff.mockResolvedValue('')
+  writeDesktopFileText.mockResolvedValue({ path: PATH })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('LocalFilePreview spot editing', () => {
+  it('offers Edit for complete readable text and seeds the editor with disk content', async () => {
+    mount()
+
+    const edit = await screen.findByRole('button', { name: /edit/i })
+    fireEvent.click(edit)
+
+    const editor = (await screen.findByLabelText('spot-editor')) as HTMLTextAreaElement
+    expect(editor.value).toBe(BASE_TEXT)
+  })
+
+  it('does NOT offer Edit for binary content', async () => {
+    readDesktopFileText.mockResolvedValue({ ...okRead(), binary: true })
+
+    mount()
+
+    await waitFor(() => expect(readDesktopFileText).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /edit/i })).toBeNull()
+  })
+
+  it('does NOT offer Edit for truncated reads (saving would drop the tail)', async () => {
+    readDesktopFileText.mockResolvedValue({ ...okRead(), text: `${BASE_TEXT}\n`, truncated: true })
+
+    mount()
+
+    await waitFor(() => expect(readDesktopFileText).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /edit/i })).toBeNull()
+  })
+
+  it('Cancel discards the draft without writing to disk', async () => {
+    mount()
+    fireEvent.click(await screen.findByRole('button', { name: /edit/i }))
+
+    const editor = (await screen.findByLabelText('spot-editor')) as HTMLTextAreaElement
+    fireEvent.change(editor, { target: { value: '# rewritten' } })
+    fireEvent.click(await screen.findByRole('button', { name: /^cancel$/i }))
+
+    expect(writeDesktopFileText).not.toHaveBeenCalled()
+    // Back in read view with the ORIGINAL disk content.
+    expect(screen.getByText(/original body/)).toBeTruthy()
+  })
+
+  it('Save writes the full edited draft through the fs bridge and exits edit mode', async () => {
+    // Read sequence: initial load, then the save-time staleness re-read (both
+    // see the original), then the post-save self-reload sees the new content.
+    readDesktopFileText
+      .mockResolvedValueOnce(okRead())
+      .mockResolvedValueOnce(okRead())
+      .mockResolvedValue(okRead('# notes\n\nedited body'))
+
+    mount()
+    fireEvent.click(await screen.findByRole('button', { name: /edit/i }))
+
+    const editor = (await screen.findByLabelText('spot-editor')) as HTMLTextAreaElement
+    fireEvent.change(editor, { target: { value: '# notes\n\nedited body' } })
+    fireEvent.click(screen.getByRole('button', { name: 'editor-save' }))
+
+    await waitFor(() => expect(writeDesktopFileText).toHaveBeenCalledTimes(1))
+    expect(writeDesktopFileText).toHaveBeenCalledWith(PATH, '# notes\n\nedited body')
+    expect(await screen.findByText(/edited body/)).toBeTruthy()
+  })
+
+  it('surfaces Overwrite/Discard when the file changed on disk mid-edit; Discard never writes', async () => {
+    mount()
+    fireEvent.click(await screen.findByRole('button', { name: /edit/i }))
+
+    // Something else edits the file while the user types.
+    readDesktopFileText.mockResolvedValue(okRead('# clobbered externally'))
+    const editor = (await screen.findByLabelText('spot-editor')) as HTMLTextAreaElement
+    fireEvent.change(editor, { target: { value: '# my draft' } })
+    fireEvent.click(screen.getByRole('button', { name: 'editor-save' }))
+
+    // Conflict banner appears INSTEAD of a silent write.
+    expect(await screen.findByText(/file changed on disk/i)).toBeTruthy()
+    expect(writeDesktopFileText).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /discard & reload/i }))
+    await waitFor(() => expect(screen.getByText(/clobbered externally/)).toBeTruthy())
+    expect(writeDesktopFileText).not.toHaveBeenCalled()
+  })
+
+  it('Overwrite intentionally wins the conflict and persists the draft', async () => {
+    mount()
+    fireEvent.click(await screen.findByRole('button', { name: /edit/i }))
+
+    readDesktopFileText.mockResolvedValue(okRead('# clobbered externally'))
+    const editor = (await screen.findByLabelText('spot-editor')) as HTMLTextAreaElement
+    fireEvent.change(editor, { target: { value: '# my draft' } })
+    fireEvent.click(screen.getByRole('button', { name: 'editor-save' }))
+    await screen.findByText(/file changed on disk/i)
+
+    fireEvent.click(screen.getByRole('button', { name: /overwrite/i }))
+
+    await waitFor(() => expect(writeDesktopFileText).toHaveBeenCalledWith(PATH, '# my draft'))
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -40,6 +40,8 @@ import { setPreviewDirty } from '@/store/preview-edit'
 import { $connection, $currentCwd } from '@/store/session'
 import { notifyWorkspaceChanged } from '@/store/workspace-events'
 
+import { availableViewModes, type PreviewViewMode, resolveViewMode } from './preview-view-mode'
+
 const SHIKI_THEME = { dark: 'github-dark-default', light: 'github-light-default' } as const
 const TEXT_PREVIEW_MAX_BYTES = 512 * 1024
 const SOURCE_CHUNK_LINES = 200
@@ -428,6 +430,7 @@ const MARKDOWN_COMPONENTS = {
   a: MarkdownLink
 }
 
+// Exported for the view-mode renderer test; not part of any other surface.
 export function MarkdownPreview({ text }: { text: string }) {
   const mathText = useMemo(() => normalizeFilePreviewMath(text), [text])
 
@@ -681,7 +684,10 @@ export function SourceView({ filePath, language, text }: { filePath?: string; la
   )
 }
 
-export type PreviewViewMode = 'diff' | 'rendered' | 'source'
+// The type lives in preview-view-mode.ts with the policy that owns it; kept
+// importable from here because the artifact preview and mode switcher have
+// always taken it from this module.
+export type { PreviewViewMode } from './preview-view-mode'
 
 export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; target: PreviewTarget }) {
   const { t } = useI18n()
@@ -1100,21 +1106,8 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
   if (isText && state.text !== undefined) {
     const isMarkdown = (state.language || target.language) === 'markdown'
     const hasDiff = Boolean(state.diff && state.diff.trim())
-    // Order the toggle reads left→right; default lands on the most useful view.
-    const modes: PreviewViewMode[] = []
-
-    if (isMarkdown) {
-      modes.push('rendered')
-    }
-
-    modes.push('source')
-
-    if (hasDiff) {
-      modes.push('diff')
-    }
-
-    const autoMode: PreviewViewMode = hasDiff ? 'diff' : isMarkdown ? 'rendered' : 'source'
-    const mode = userMode && modes.includes(userMode) ? userMode : autoMode
+    const modes = availableViewModes({ hasDiff, isMarkdown })
+    const mode = resolveViewMode({ hasDiff, isMarkdown }, userMode)
 
     return (
       <div

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -732,7 +732,13 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
     setConflict(false)
     draftRef.current = ''
     baselineRef.current = ''
-  }, [filePath, reloadKey])
+    // Keyed on file IDENTITY only. The global reload tick (workspace events,
+    // unrelated saves elsewhere) must NOT reset an in-progress edit: the load
+    // effect below deliberately renders the editor before its own loading
+    // branch so background re-reads can't drop the draft — a reloadKey here
+    // would undo exactly that protection (found via E2E: saving one file
+    // killed a draft being typed in another preview tab).
+  }, [filePath])
 
   // HTML files are rendered as source code, not in a webview - so they take
   // the same path as plain text files. `previewKind === 'binary'` arrives

--- a/apps/desktop/src/app/chat/right-rail/preview-markdown.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-markdown.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// The RENDERER half of the view-mode contract: when LocalFilePreview lands on
+// the 'rendered' mode for a .md file (see preview-view-mode.test.ts), the user
+// must see formatted Markdown. This exercises the REAL Streamdown pipeline
+// through MarkdownPreview's own component map — headings, lists, links,
+// inline/fenced code, tables — plus the safety floor: no script execution.
+import { MarkdownPreview } from './preview-file'
+
+const DOC = [
+  '# Release notes',
+  '',
+  'See the [migration guide](https://example.com/guide) first.',
+  '',
+  '- one',
+  '- two',
+  '',
+  '1. first',
+  '2. second',
+  '',
+  'Use `npm run build` locally.',
+  '',
+  '```ts',
+  'export const answer = 42',
+  '```',
+  '',
+  '| Stage | Status |',
+  '| ----- | ------ |',
+  '| build | green  |'
+].join('\n')
+
+function renderDoc() {
+  return render(<MarkdownPreview text={DOC} />)
+}
+
+describe('MarkdownPreview (rendered file view)', () => {
+  afterEach(cleanup)
+
+  it('renders structure semantically', () => {
+    const { container } = renderDoc()
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Release notes' })).toBeTruthy()
+    expect(screen.getByText('migration guide').closest('a')).toHaveProperty('href')
+    expect(container.querySelector('ul')?.children.length).toBe(2)
+    expect(container.querySelector('ol')?.children.length).toBe(2)
+    expect(container.querySelector('table')).not.toBeNull()
+    // Inline code and fenced code both present.
+    expect(screen.getByText('npm run build')).toBeTruthy()
+    expect(screen.getByText(/answer = 42/)).toBeTruthy()
+  })
+
+  it('never executes or emits scripts from document content', () => {
+    const { container } = render(
+      <MarkdownPreview
+        text={'# Title\n\n<script>window.__pwned = true</script>\n\n<img src=x onerror="window.__pwned = true">'}
+      />
+    )
+
+    expect((window as unknown as Record<string, unknown>).__pwned).toBeUndefined()
+    expect(container.querySelectorAll('script').length).toBe(0)
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-view-mode.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-view-mode.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { availableViewModes, resolveViewMode } from './preview-view-mode'
+
+// The preview rail's view-mode policy, extracted verbatim from
+// LocalFilePreview: which toggles a text file offers and which one it lands
+// on. Markdown renders formatted by default; an uncommitted diff always wins
+// the default because reviewing changes beats reading; a user's explicit
+// pick survives only while it is still offered.
+
+describe('availableViewModes', () => {
+  it('offers rendered + source for clean markdown', () => {
+    expect(availableViewModes({ isMarkdown: true, hasDiff: false })).toEqual(['rendered', 'source'])
+  })
+
+  it('appends diff for changed markdown', () => {
+    expect(availableViewModes({ isMarkdown: true, hasDiff: true })).toEqual(['rendered', 'source', 'diff'])
+  })
+
+  it('offers only source for clean plain text', () => {
+    expect(availableViewModes({ isMarkdown: false, hasDiff: false })).toEqual(['source'])
+  })
+
+  it('offers source + diff for changed plain text', () => {
+    expect(availableViewModes({ isMarkdown: false, hasDiff: true })).toEqual(['source', 'diff'])
+  })
+})
+
+describe('resolveViewMode', () => {
+  it('defaults clean markdown to the rendered view', () => {
+    expect(resolveViewMode({ isMarkdown: true, hasDiff: false }, null)).toBe('rendered')
+  })
+
+  it('defaults changed markdown to the diff view', () => {
+    expect(resolveViewMode({ isMarkdown: true, hasDiff: true }, null)).toBe('diff')
+  })
+
+  it('defaults plain text to source', () => {
+    expect(resolveViewMode({ isMarkdown: false, hasDiff: false }, null)).toBe('source')
+  })
+
+  it('defaults changed plain text to the diff view', () => {
+    expect(resolveViewMode({ isMarkdown: false, hasDiff: true }, null)).toBe('diff')
+  })
+
+  it('honors a user-picked mode that is still available', () => {
+    expect(resolveViewMode({ isMarkdown: true, hasDiff: true }, 'source')).toBe('source')
+    expect(resolveViewMode({ isMarkdown: true, hasDiff: false }, 'rendered')).toBe('rendered')
+  })
+
+  it('falls back to the auto mode when the user pick is no longer offered', () => {
+    // Picked diff, then the diff disappeared (changes committed externally).
+    expect(resolveViewMode({ isMarkdown: true, hasDiff: false }, 'diff')).toBe('rendered')
+    // Picked rendered on a file that was never markdown.
+    expect(resolveViewMode({ isMarkdown: false, hasDiff: false }, 'rendered')).toBe('source')
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-view-mode.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-view-mode.ts
@@ -1,0 +1,52 @@
+// The preview rail's view-mode policy, extracted from LocalFilePreview so the
+// Markdown-defaults-to-rendered contract is unit-testable without mounting the
+// preview component (which pulls Streamdown, Shiki, CodeMirror and the desktop
+// fs bridge).
+//
+// Policy: which toggles a text file offers, and which one it lands on when the
+// user hasn't picked. Markdown renders formatted by default; an uncommitted
+// diff always wins the default because reviewing changes beats reading; a
+// user's explicit pick survives only while it is still offered.
+
+export type PreviewViewMode = 'diff' | 'rendered' | 'source'
+
+export interface ViewModeInputs {
+  /** The file parses as Markdown — the rendered toggle exists. */
+  isMarkdown: boolean
+  /** A non-empty working-tree-vs-HEAD diff exists. */
+  hasDiff: boolean
+}
+
+/**
+ * Toggle order is also display order: rendered first (markdown only), then
+ * source, then diff. The default lands on the most useful view.
+ */
+export function availableViewModes({ hasDiff, isMarkdown }: ViewModeInputs): PreviewViewMode[] {
+  const modes: PreviewViewMode[] = []
+
+  if (isMarkdown) {
+    modes.push('rendered')
+  }
+
+  modes.push('source')
+
+  if (hasDiff) {
+    modes.push('diff')
+  }
+
+  return modes
+}
+
+/**
+ * Which mode the preview shows: the user's explicit pick while it is still
+ * available, else the automatic default (diff beats rendered beats source).
+ */
+export function resolveViewMode(inputs: ViewModeInputs, userPick: null | PreviewViewMode): PreviewViewMode {
+  const modes = availableViewModes(inputs)
+
+  if (userPick && modes.includes(userPick)) {
+    return userPick
+  }
+
+  return inputs.hasDiff ? 'diff' : inputs.isMarkdown ? 'rendered' : 'source'
+}

--- a/apps/desktop/src/app/right-sidebar/files/tree-gestures.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/tree-gestures.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { type FileRowState, resolveFileRowClick } from './tree-gestures'
+
+// The file browser's click contract (user-confirmed): a single click on a
+// file opens it in the in-app Preview pane. Folders toggle; shift-click
+// attaches. Component wiring is pinned separately in tree.wiring.test.tsx.
+
+const state = (overrides: Partial<FileRowState> = {}): FileRowState => ({
+  isFolder: false,
+  isPlaceholder: false,
+  isRenaming: false,
+  ...overrides
+})
+
+describe('resolveFileRowClick (single click opens)', () => {
+  it('opens a plain file', () => {
+    expect(resolveFileRowClick(state())).toBe('open')
+  })
+
+  it('toggles a folder instead of opening it', () => {
+    expect(resolveFileRowClick(state({ isFolder: true }))).toBe('toggle')
+  })
+
+  it('shift-click on a file attaches it', () => {
+    expect(resolveFileRowClick(state({ shiftKey: true }))).toBe('attach-file')
+  })
+
+  it('shift-click on a folder attaches the folder', () => {
+    expect(resolveFileRowClick(state({ isFolder: true, shiftKey: true }))).toBe('attach-folder')
+  })
+
+  it('ignores a click on a placeholder that is not interactive', () => {
+    expect(resolveFileRowClick(state({ isPlaceholder: true }))).toBe('ignore')
+  })
+
+  it('ignores a click while an inline rename is active', () => {
+    expect(resolveFileRowClick(state({ isRenaming: true }))).toBe('ignore')
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/files/tree-gestures.ts
+++ b/apps/desktop/src/app/right-sidebar/files/tree-gestures.ts
@@ -1,0 +1,45 @@
+// Pure decision helpers for file-tree row gestures.
+//
+// The file browser's interaction contract (user-confirmed): a single click
+// opens a file in the in-app Preview pane; folders toggle instead. Extracted
+// out of the React component so the gesture contract is unit-testable
+// without mounting react-arborist, and so the rename/placeholder guards live
+// in exactly one place.
+
+/** Stable state a row hands us to decide what a gesture means. */
+export interface FileRowState {
+  isFolder: boolean
+  isPlaceholder: boolean
+  /** True while an inline rename edit is active on this row. */
+  isRenaming: boolean
+  /** True when Shift was held during the click (attach gestures). */
+  shiftKey?: boolean
+}
+
+export type FileRowClickAction = 'attach-file' | 'attach-folder' | 'ignore' | 'open' | 'toggle'
+
+/**
+ * What a single click on the row should do. A file opens in preview;
+ * a folder toggles its expansion. Shift-click attaches (drags into the
+ * composer) rather than opening. Rename-in-progress and placeholders swallow
+ * the click so the editor isn't yanked away mid-edit.
+ *
+ * Note: there is deliberately no double-click policy here. The row's click
+ * handler stops propagation (suppressing arborist's own click handling), so
+ * a double-click arrives as two ordinary clicks — and opening the same file
+ * twice is idempotent (openPreview re-fronts the existing tab).
+ */
+export function resolveFileRowClick(state: FileRowState): FileRowClickAction {
+  // A click on a placeholder row (e.g. the "no files" affordance) or while
+  // an inline rename input is mounted must never select/open the underlying
+  // file — the user is interacting with the placeholder or the editor.
+  if (state.isPlaceholder || state.isRenaming) {
+    return 'ignore'
+  }
+
+  if (state.shiftKey) {
+    return state.isFolder ? 'attach-folder' : 'attach-file'
+  }
+
+  return state.isFolder ? 'toggle' : 'open'
+}

--- a/apps/desktop/src/app/right-sidebar/files/tree.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.tsx
@@ -15,6 +15,7 @@ import { $revealInTreeRequest } from '@/store/layout'
 import { FileEntryContextMenu, InlineRenameInput, isRenameShortcut } from '../file-actions'
 
 import { getFileTreeDndManager } from './dnd-manager'
+import { resolveFileRowClick } from './tree-gestures'
 import type { TreeNode } from './use-project-tree'
 
 const ROW_HEIGHT = 22
@@ -306,27 +307,42 @@ function ProjectTreeRow({
         // Read the rename atom LIVE (not the render closure): the fall-through
         // click from a context-menu close can fire before the editing re-render
         // commits, so a stale closure would still select/activate and yank focus.
-        if (isPlaceholder || $renamingPath.get() === node.data.id) {
-          return
-        }
+        const action = resolveFileRowClick({
+          isFolder,
+          isPlaceholder,
+          isRenaming: $renamingPath.get() === node.data.id,
+          shiftKey: event.shiftKey
+        })
 
-        if (event.shiftKey) {
-          ;(isFolder ? onAttachFolder : onAttachFile)(node.data.id)
+        // The single-click contract (user-confirmed): a click on a file opens
+        // it in the Preview pane, exactly like double-click/Enter (arborist's
+        // onActivate). Folders toggle; shift-click attaches.
+        switch (action) {
+          case 'open':
+            // Select so the row highlights (arborist's own click handler is
+            // suppressed by our stopPropagation above), then open the preview.
+            node.select()
+            onPreviewFile?.(node.data.id)
 
-          return
-        }
+            break
 
-        if (isFolder) {
-          node.toggle()
-        } else {
-          node.select()
-        }
-      }}
-      onDoubleClick={event => {
-        event.stopPropagation()
+          case 'toggle':
+            node.toggle()
 
-        if (!isFolder && !isPlaceholder && $renamingPath.get() !== node.data.id) {
-          onPreviewFile?.(node.data.id)
+            break
+
+          case 'attach-file':
+            onAttachFile?.(node.data.id)
+
+            break
+
+          case 'attach-folder':
+            onAttachFolder?.(node.data.id)
+
+            break
+
+          case 'ignore':
+            break
         }
       }}
       onDragStart={event => {

--- a/apps/desktop/src/app/right-sidebar/files/tree.wiring.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/tree.wiring.test.tsx
@@ -1,0 +1,198 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ── Module seams ─────────────────────────────────────────────────────────────
+// The point of this suite is the WIRING: which user gesture ends up calling
+// which handler prop on <ProjectTree>. Everything arborist/dnd/context-menu
+// brings that isn't part of that contract is stubbed.
+
+type RowNodeOverrides = Partial<{ id: string; isDirectory: boolean; placeholder: boolean | 'error' }>
+
+interface CapturedNode {
+  data: { id: string; isDirectory: boolean; name: string; placeholder?: boolean | 'error' }
+  handleClick: ReturnType<typeof vi.fn>
+  select: ReturnType<typeof vi.fn>
+  toggle: ReturnType<typeof vi.fn>
+}
+
+let capturedTreeProps: Record<string, unknown> = {}
+let currentNode: CapturedNode
+
+vi.mock('react-arborist', () => ({
+  Tree: (props: Record<string, unknown>) => {
+    capturedTreeProps = props
+
+    // Arborist hands its ref a TreeApi; the component reads selectedNodes off
+    // it for the rename shortcut. Provide the minimum shape.
+    const treeRef = props.ref as { current: unknown }
+    treeRef.current = { selectedNodes: [currentNode] }
+
+    // Mimic the real structure: renderRow wraps the row renderer's output,
+    // and the CONTAINER carries arborist's own onClick (node.handleClick).
+    const children = (props.children as (rowProps: unknown) => React.ReactNode)({
+      attrs: {},
+      dragHandle: null,
+      node: currentNode as never,
+      style: {}
+    })
+
+    return (props.renderRow as (rowProps: unknown) => React.ReactNode)({
+      attrs: {},
+      children,
+      innerRef: null,
+      node: currentNode as never
+    })
+  }
+}))
+
+vi.mock('./dnd-manager', () => ({ getFileTreeDndManager: () => ({}) }))
+
+vi.mock('../file-actions', () => ({
+  // Same contract as the real helper: F2 anywhere, Enter on a focused row.
+  isRenameShortcut: (event: { key: string }) => event.key === 'F2' || event.key === 'Enter',
+  FileEntryContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  InlineRenameInput: () => <input aria-label="inline-rename" />
+}))
+
+// jsdom has no ResizeObserver; feed the component one synchronous size so the
+// size gate (size.height > 0) opens and <Tree> mounts.
+vi.mock('@/hooks/use-resize-observer', () => ({
+  useResizeObserver: (callback: (entries: unknown[], el: Element) => void, ref: { current: Element | null }) => {
+    setTimeout(() => {
+      if (ref.current) {
+        callback([{ contentRect: { height: 600, width: 240 }, target: ref.current }], ref.current)
+      }
+    }, 0)
+  }
+}))
+
+import { $renamingPath } from '@/store/file-actions'
+
+import { ProjectTree } from './tree'
+
+const FILE_PATH = '/w/README.md'
+const FOLDER_PATH = '/w/src'
+
+function makeNode(overrides: RowNodeOverrides = {}): CapturedNode {
+  const isDirectory = overrides.isDirectory ?? false
+
+  return {
+    data: {
+      id: overrides.id ?? (isDirectory ? FOLDER_PATH : FILE_PATH),
+      isDirectory,
+      name: (overrides.id ?? (isDirectory ? FOLDER_PATH : FILE_PATH)).split('/').pop() ?? '',
+      ...(overrides.placeholder !== undefined ? { placeholder: overrides.placeholder } : {})
+    },
+    handleClick: vi.fn(),
+    select: vi.fn(),
+    toggle: vi.fn()
+  }
+}
+
+function renderTree(handlers: {
+  onActivateFile?: ReturnType<typeof vi.fn>
+  onActivateFolder?: ReturnType<typeof vi.fn>
+  onPreviewFile?: ReturnType<typeof vi.fn>
+}) {
+  const props = {
+    collapseNonce: 0,
+    cwd: '/w',
+    data: [{ id: currentNode.data.id, isDirectory: currentNode.data.isDirectory, name: currentNode.data.name }],
+    onActivateFile: handlers.onActivateFile,
+    onActivateFolder: handlers.onActivateFolder,
+    onLoadChildren: () => {},
+    onNodeOpenChange: () => {},
+    onPreviewFile: handlers.onPreviewFile,
+    openState: {}
+  }
+
+  // Test doubles are intentionally looser than the real prop signatures.
+  return render(<ProjectTree {...(props as unknown as React.ComponentProps<typeof ProjectTree>)} />)
+}
+
+async function mountWith(overrides: RowNodeOverrides, handlers: Parameters<typeof renderTree>[0]) {
+  currentNode = makeNode(overrides)
+  renderTree(handlers)
+
+  // Wait for the resize-driven size state so the tree mounts.
+  await screen.findByText(currentNode.data.name)
+
+  return screen.getByText(currentNode.data.name)
+}
+
+beforeEach(() => {
+  $renamingPath.set(null)
+})
+
+afterEach(() => {
+  cleanup()
+  $renamingPath.set(null)
+})
+
+describe('ProjectTree gesture wiring', () => {
+  it('a single click on a file opens the preview and selects the row, without reaching arborist’s click handler', async () => {
+    const onPreviewFile = vi.fn()
+    const label = await mountWith({}, { onPreviewFile })
+
+    fireEvent.click(label)
+
+    expect(onPreviewFile).toHaveBeenCalledTimes(1)
+    expect(onPreviewFile).toHaveBeenCalledWith(FILE_PATH)
+    expect(currentNode.select).toHaveBeenCalledTimes(1)
+    // stopPropagation in the row handler keeps arborist's own click handling
+    // (select+activate) out of the way — opening happens exactly once.
+    expect(currentNode.handleClick).not.toHaveBeenCalled()
+  })
+
+  it('clicking a folder toggles it and never previews', async () => {
+    const onPreviewFile = vi.fn()
+    const label = await mountWith({ isDirectory: true }, { onPreviewFile })
+
+    fireEvent.click(label)
+
+    expect(currentNode.toggle).toHaveBeenCalledTimes(1)
+    expect(onPreviewFile).not.toHaveBeenCalled()
+  })
+
+  it('shift-click attaches the file instead of opening it', async () => {
+    const onActivateFile = vi.fn()
+    const onPreviewFile = vi.fn()
+    const label = await mountWith({}, { onActivateFile, onPreviewFile })
+
+    fireEvent.click(label, { shiftKey: true })
+
+    expect(onActivateFile).toHaveBeenCalledWith(FILE_PATH)
+    expect(onPreviewFile).not.toHaveBeenCalled()
+  })
+
+  it('a click on the row being renamed is ignored entirely', async () => {
+    const onPreviewFile = vi.fn()
+    await mountWith({}, { onPreviewFile })
+
+    $renamingPath.set(FILE_PATH)
+    fireEvent.click(screen.getByText('README.md'))
+
+    expect(onPreviewFile).not.toHaveBeenCalled()
+    expect(currentNode.select).not.toHaveBeenCalled()
+  })
+
+  it('a click on a placeholder row is ignored', async () => {
+    const onPreviewFile = vi.fn()
+    const label = await mountWith({ id: '/w/loading', placeholder: true }, { onPreviewFile })
+
+    fireEvent.click(label)
+
+    expect(onPreviewFile).not.toHaveBeenCalled()
+    expect(currentNode.select).not.toHaveBeenCalled()
+  })
+
+  it.each(['Enter', 'F2'])('%s on the selected file starts an inline rename instead of opening', async key => {
+    const onPreviewFile = vi.fn()
+    await mountWith({}, { onPreviewFile })
+
+    fireEvent.keyDown(screen.getByText('README.md'), { key })
+
+    expect($renamingPath.get()).toBe(FILE_PATH)
+    expect(onPreviewFile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -12,7 +12,8 @@ import {
   readDesktopFileDataUrlLocalFirst,
   readDesktopFileText,
   selectDesktopPaths,
-  setDesktopFsRemotePicker
+  setDesktopFsRemotePicker,
+  writeDesktopFileText
 } from './desktop-fs'
 
 const readDir = vi.fn(async () => ({ entries: [{ name: 'local', path: '/local', isDirectory: true }] }))
@@ -32,6 +33,10 @@ const api = vi.fn(async ({ path }: { path: string }) => {
 
   if (path.startsWith('/api/fs/read-data-url?')) {
     return { dataUrl: 'data:text/plain;base64,cmVtb3Rl' }
+  }
+
+  if (path === '/api/fs/write-text') {
+    return { ok: true }
   }
 
   if (path.startsWith('/api/fs/git-root?')) {
@@ -192,6 +197,41 @@ describe('desktop filesystem facade', () => {
 
     expect(otherOwner).not.toBe(first)
     expect(desktopFsCacheKey()).not.toBe(first)
+  })
+
+  // The preview editor's write path. Local saves go through the hardened
+  // Electron bridge; remote saves POST the same content to the backend with
+  // the ACTIVE PROFILE attached, so a remote edit can never land on the wrong
+  // backend. A bridge without writeTextFile refuses rather than pretending.
+  it('writes text through the Electron bridge in local mode', async () => {
+    $connection.set({ mode: 'local', profile: 'team-local' } as never)
+    const writeTextFile = vi.fn(async () => ({ path: '/local/notes.md' }))
+
+    vi.stubGlobal('window', { hermesDesktop: { ...window.hermesDesktop, writeTextFile } })
+
+    await expect(writeDesktopFileText('/local/notes.md', 'body')).resolves.toEqual({ path: '/local/notes.md' })
+    expect(writeTextFile).toHaveBeenCalledWith('/local/notes.md', 'body')
+    expect(api).not.toHaveBeenCalled()
+  })
+
+  it('POSTs remote writes to /api/fs/write-text with the active profile', async () => {
+    $connection.set({ mode: 'remote', profile: 'srv-2' } as never)
+
+    await expect(writeDesktopFileText('/remote/notes.md', 'body')).resolves.toEqual({ path: '/remote/notes.md' })
+
+    expect(api).toHaveBeenCalledWith({
+      body: { content: 'body', path: '/remote/notes.md' },
+      method: 'POST',
+      path: '/api/fs/write-text',
+      profile: 'srv-2'
+    })
+  })
+
+  it('refuses local writes when the running Electron build lacks writeTextFile', async () => {
+    $connection.set({ mode: 'local' } as never)
+
+    await expect(writeDesktopFileText('/local/notes.md', 'body')).rejects.toThrow('Saving is not available')
+    expect(api).not.toHaveBeenCalled()
   })
 
   it('routes file diffs through backend git in remote mode', async () => {

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { readDesktopFileDataUrl } = vi.hoisted(() => ({ readDesktopFileDataUrl: vi.fn() }))
+const { readDesktopFileDataUrl, readDesktopFileText } = vi.hoisted(() => ({
+  readDesktopFileDataUrl: vi.fn(),
+  readDesktopFileText: vi.fn()
+}))
 
 vi.mock('@/lib/desktop-fs', () => ({
   isDesktopFsRemoteMode: () => true,
   readDesktopFileDataUrl,
-  readDesktopFileText: vi.fn()
+  readDesktopFileText
 }))
 
 import {
@@ -195,5 +198,32 @@ describe('PDF previews', () => {
       previewKind: 'pdf'
     })
     expect(readDesktopFileDataUrl).not.toHaveBeenCalled()
+  })
+
+  // Remote text files must arrive at the preview already enriched (binary flag,
+  // byte size, language) so LocalFilePreview can gate editing on COMPLETE
+  // readable content without a second read.
+  it('enriches a remote text target with binary/size/language metadata', async () => {
+    vi.clearAllMocks()
+    window.hermesDesktop = {
+      normalizePreviewTarget: vi.fn(async () => null)
+    } as never
+    readDesktopFileText.mockResolvedValue({
+      binary: false,
+      byteSize: 2048,
+      language: 'markdown',
+      mimeType: 'text/markdown',
+      text: '# hi'
+    })
+
+    await expect(normalizeOrLocalPreviewTarget('/remote/README.md')).resolves.toMatchObject({
+      binary: false,
+      byteSize: 2048,
+      kind: 'file',
+      language: 'markdown',
+      large: false,
+      previewKind: 'text'
+    })
+    expect(readDesktopFileText).toHaveBeenCalledWith('/remote/README.md')
   })
 })

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -101,6 +101,25 @@ describe('preview store', () => {
     expect($previewTarget.get()?.renderMode).toBe('preview')
   })
 
+  // Markdown is NOT subject to the HTML source-first rule: it must flow through
+  // the store untouched so the preview component's auto-mode can land on the
+  // RENDERED view regardless of who opened it. If this ever starts forcing a
+  // renderMode, formatted-Markdown-by-default breaks everywhere at once.
+  it('leaves markdown targets unmodified so the component can render them formatted', () => {
+    const markdown = {
+      ...fileTarget('/work/README.md'),
+      language: 'markdown',
+      previewKind: 'text' as const
+    }
+
+    openPreview(markdown, 'file-browser')
+    expect($previewTarget.get()).toMatchObject({ kind: 'file', previewKind: 'text', language: 'markdown' })
+    expect($previewTarget.get()?.renderMode).toBeUndefined()
+
+    openPreview(markdown, 'tool-result')
+    expect($previewTarget.get()?.renderMode).toBeUndefined()
+  })
+
   it('falls back to a neighbouring tab when the active one closes, and clears the selection on the last', () => {
     openPreview(fileTarget('/work/one.html'), 'file-browser')
     openPreview(fileTarget('/work/two.html'), 'file-browser')


### PR DESCRIPTION
## Summary
`LocalFilePreview`'s editor-reset effect keyed on the **global** `reloadKey`, so any workspace tick (e.g. saving an unrelated file) killed editing state — and the unsaved draft — in every open preview tab, mid-typing. The component's own comment claimed background re-reads can't drop the draft; this dependency defeated exactly that protection.

**Fix:** reset keys on file identity only (`[filePath]`). Identity changes still reset fully; unrelated ticks no longer touch drafts.

Found by the new E2E suite: the cancel test passed in isolation but failed after a save test ran first — cross-tab interference traced to this effect.

## E2E suite (`e2e/file-preview.spec.ts`)
Real Electron app against a temp workspace (repo's standard sandbox + mock-inference fixture):
1. single-click opens markdown formatted (H1 rendered)
2. source toggle shows raw markdown
3. edit+save persists to real disk
4. cancel leaves disk byte-identical
5. second file gets its own tab; switching back re-fronts the first

Also pinned: preview tabs self-reload their own file at save time; background tabs keep hidden editors mounted.

## Testing
5430 UI tests, 1593 electron-platform tests, 5/5 new E2E, lint/typecheck clean. Manually verified on macOS dev build.

Stacked on #92668 (feature branch) — merge that first or review together.