### PR TITLE
feat(stash): add disk persistence for prompt stash

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5533,10 +5533,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._attached_images: list[Path] = []
         self._image_counter = 0
         # Ctrl+S prompt stash — park a half-written draft, send something
-        # else, bring the draft back.  Session-scoped and in-memory only:
-        # drafts routinely contain secrets, so nothing is written to disk.
+        # else, bring the draft back.  Persisted to disk (0o600 permissions)
+        # so drafts survive crashes and are restored on `hermes -c` / `/resume`.
         from hermes_cli.prompt_stash import PromptStash as _PromptStash
-        self._prompt_stash = _PromptStash()
+        from hermes_cli.prompt_stash import load_stash as _load_stash
+        self._prompt_stash = _load_stash()
         self.preloaded_skills: list[str] = []
         self._startup_skills_line_shown = False
         # Background --skills preload (started by cmd_chat; joined by
@@ -7255,6 +7256,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return frags
         except Exception:
             return [("class:status-bar", f" {self._build_status_bar_text()} ")]
+
+    def _save_stash_to_disk(self) -> None:
+        """Persist the prompt stash to disk after a mutation.
+
+        Called after every Ctrl+S action that changes stash contents (push,
+        pop, delete).  Errors are swallowed — a failed save must never break
+        the interactive TUI.
+        """
+        try:
+            from hermes_cli.prompt_stash import save_stash as _save_stash
+            _save_stash(self._prompt_stash)
+        except Exception:
+            pass
 
     @staticmethod
     def _fmt_stash_age(stashed_at: float) -> str:
@@ -18077,8 +18091,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # the undo stack are cleared along with the text.
                 buf.reset()
                 cli_ref._attached_images.clear()
+                cli_ref._save_stash_to_disk()
             elif action == ACTION_RESTORED:
                 _restore_stash_payload(event, payload)
+                cli_ref._save_stash_to_disk()
             elif action == ACTION_OPEN_PANEL:
                 pass  # resolve_ctrl_s already flipped panel_open
 
@@ -18099,6 +18115,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             """Enter in the browse panel restores the highlighted draft."""
             payload = cli_ref._prompt_stash.restore_at_cursor()
             _restore_stash_payload(event, payload)
+            cli_ref._save_stash_to_disk()
             event.app.invalidate()
 
         @kb.add('d', filter=_stash_panel_filter, eager=True)
@@ -18106,6 +18123,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         def handle_stash_panel_delete(event):
             """D in the browse panel discards the highlighted draft."""
             cli_ref._prompt_stash.delete_at_cursor()
+            cli_ref._save_stash_to_disk()
             event.app.invalidate()
 
         @kb.add('escape', filter=_stash_panel_filter, eager=True)

--- a/hermes_cli/prompt_stash.py
+++ b/hermes_cli/prompt_stash.py
@@ -15,16 +15,22 @@ Gesture
 Newest-first ordering: index 0 is always the most recently stashed draft, so
 the common "undo my last Ctrl+S" case is a single keystroke.
 
-Nothing is written to disk. Drafts frequently contain credentials, prompts
-under NDA, or pasted secrets, and a session-scoped stash keeps that material
-in memory only. Callers that later want cross-restart persistence must route
-through ``get_hermes_home()`` rather than hardcoding ``~/.hermes``.
+Disk persistence (optional)
+----------------------------
+The stash can be saved to and loaded from disk via ``save_stash()`` /
+``load_stash()``.  The serialized format uses wall-clock timestamps so
+entries are meaningful across restarts.  Files are written atomically
+(tmp + rename) and locked to owner-only permissions (``0o600``) because
+drafts frequently contain credentials, prompts under NDA, or pasted secrets.
 """
 
 from __future__ import annotations
 
+import json
+import logging
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, List, Optional, Sequence, Tuple
 
 # Single-line preview length for the browse panel.
@@ -171,6 +177,69 @@ class PromptStash:
         self.panel_open = False
         self.panel_cursor = 0
 
+    # ---------------------------------------------------------- serialization
+
+    def to_dict(self) -> dict:
+        """Serialize stash items to a JSON-safe dict with wall-clock timestamps.
+
+        Returns ``{"items": [{text, images, stashed_at_wall, preview}, ...]}``.
+        Each entry's ``stashed_at_wall`` is derived from the in-memory monotonic
+        clock so the value is meaningful across restarts.
+        """
+        mono_now = self._clock()
+        wall_now = time.time()
+        items = []
+        for entry in self._items:
+            wall_time = wall_now - (mono_now - entry.stashed_at)
+            items.append({
+                "text": entry.text,
+                "images": list(entry.images),
+                "stashed_at_wall": wall_time,
+                "preview": entry.preview,
+            })
+        return {"items": items}
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict,
+        *,
+        max_items: int = MAX_STASH_ITEMS,
+        clock=None,
+    ) -> PromptStash:
+        """Deserialize stash items from a dict produced by :meth:`to_dict`.
+
+        Wall-clock timestamps are converted back to monotonic offsets so the
+        age display stays accurate for the current session.  Entries with
+        missing or invalid fields are silently skipped.
+        """
+        stash = cls(max_items=max_items, clock=clock)
+        raw_items = data.get("items", []) if isinstance(data, dict) else []
+        entries: list[StashEntry] = []
+        for item in raw_items:
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text")
+            images = item.get("images")
+            wall_time = item.get("stashed_at_wall")
+            preview = item.get("preview")
+            if text is None or images is None or wall_time is None:
+                continue
+            if not isinstance(wall_time, (int, float)):
+                continue
+            # Convert wall clock → session monotonic offset.
+            monotonic_at = time.monotonic() - time.time() + wall_time
+            entries.append(StashEntry(
+                text=text,
+                images=list(images),
+                stashed_at=monotonic_at,
+                preview=preview or "",
+            ))
+        # Restore newest-first ordering (matching in-memory convention).
+        entries.sort(key=lambda e: e.stashed_at, reverse=True)
+        stash._items = entries[: stash._max_items]
+        return stash
+
     # ------------------------------------------------------------ panel state
 
     def _clamp_cursor(self, value: int) -> int:
@@ -258,3 +327,54 @@ def resolve_ctrl_s(
         return ACTION_RESTORED, stash.pop(0)
     stash.open_panel()
     return ACTION_OPEN_PANEL, None
+
+
+# ------------------------------------------------------------------ persistence
+
+_log = logging.getLogger(__name__)
+
+
+def save_stash(stash: PromptStash, path: Path | None = None) -> None:
+    """Persist *stash* to a JSON file.
+
+    The file is written atomically (to a ``.tmp`` sibling, then renamed) and
+    locked to owner-only permissions (``0o600``).  Nothing is written when the
+    stash is empty.
+
+    *path* defaults to ``get_hermes_home() / "stash.json"``.
+    """
+    if not stash:
+        return  # no-op — don't create a file for an empty stash.
+    if path is None:
+        from hermes_constants import get_hermes_home
+
+        path = Path(get_hermes_home()) / "stash.json"
+
+    try:
+        data = stash.to_dict()
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+        tmp.chmod(0o600)
+        tmp.rename(path)
+    except Exception:
+        _log.exception("Failed to save prompt stash to %s", path)
+
+
+def load_stash(path: Path | None = None) -> PromptStash:
+    """Load a previously saved stash from disk.
+
+    Returns an empty :class:`PromptStash` on any error (missing file, corrupt
+    JSON, invalid data).
+
+    *path* defaults to ``get_hermes_home() / "stash.json"``.
+    """
+    if path is None:
+        from hermes_constants import get_hermes_home
+
+        path = Path(get_hermes_home()) / "stash.json"
+
+    try:
+        data = json.loads(path.read_text())
+        return PromptStash.from_dict(data)
+    except Exception:
+        return PromptStash()

--- a/hermes_cli/prompt_stash.py
+++ b/hermes_cli/prompt_stash.py
@@ -228,7 +228,8 @@ class PromptStash:
             if not isinstance(wall_time, (int, float)):
                 continue
             # Convert wall clock → session monotonic offset.
-            monotonic_at = time.monotonic() - time.time() + wall_time
+            _clock = stash._clock
+            monotonic_at = _clock() - time.time() + wall_time
             entries.append(StashEntry(
                 text=text,
                 images=list(images),
@@ -351,11 +352,13 @@ def save_stash(stash: PromptStash, path: Path | None = None) -> None:
         path = Path(get_hermes_home()) / "stash.json"
 
     try:
+        import os as _os
+
         data = stash.to_dict()
         tmp = path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
         tmp.chmod(0o600)
-        tmp.rename(path)
+        _os.replace(tmp, path)  # os.replace, not Path.rename — atomic on Windows
     except Exception:
         _log.exception("Failed to save prompt stash to %s", path)
 
@@ -374,7 +377,10 @@ def load_stash(path: Path | None = None) -> PromptStash:
         path = Path(get_hermes_home()) / "stash.json"
 
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         return PromptStash.from_dict(data)
+    except FileNotFoundError:
+        return PromptStash()
     except Exception:
+        _log.warning("Corrupt or unreadable stash file %s — starting fresh", path)
         return PromptStash()

--- a/tests/cli/test_prompt_stash.py
+++ b/tests/cli/test_prompt_stash.py
@@ -422,6 +422,172 @@ class TestResolveCtrlS:
             assert len(stash) == 0
 
 
+# ---------------------------------------------------------------- serialization
+
+
+class TestSerialization:
+    """to_dict / from_dict for disk persistence."""
+
+    def test_to_dict_empty_stash(self):
+        s = PromptStash()
+        data = s.to_dict()
+        assert data == {"items": []}
+
+    def test_to_dict_with_entries(self, stash):
+        stash.stash("hello world")
+        stash.stash("nested\ntext")
+        data = stash.to_dict()
+        assert len(data["items"]) == 2
+        # Newest-first order
+        assert data["items"][0]["text"] == "nested\ntext"
+        assert data["items"][1]["text"] == "hello world"
+        for item in data["items"]:
+            assert "text" in item
+            assert "images" in item
+            assert "stashed_at_wall" in item
+            assert "preview" in item
+            # stashed_at_wall should be a reasonable wall-clock time
+            assert isinstance(item["stashed_at_wall"], (int, float))
+            assert item["stashed_at_wall"] > 1_600_000_000  # well past year 2020
+
+    def test_to_dict_includes_images(self, stash):
+        stash.stash("with images", ["/tmp/a.png", "/tmp/b.png"])
+        data = stash.to_dict()
+        assert data["items"][0]["images"] == ["/tmp/a.png", "/tmp/b.png"]
+
+    def test_from_dict_round_trip(self):
+        """Manually build a dict and verify from_dict reconstructs entries."""
+        data = {
+            "items": [
+                {
+                    "text": "first draft",
+                    "images": [],
+                    "stashed_at_wall": 1_700_000_000.0,
+                    "preview": "first draft",
+                },
+                {
+                    "text": "second\ndraft",
+                    "images": ["/tmp/pic.png"],
+                    "stashed_at_wall": 1_700_000_100.0,
+                    "preview": "second ⏎ draft",
+                },
+            ]
+        }
+        restored = PromptStash.from_dict(data)
+        assert len(restored) == 2
+        assert restored._items[0].text == "second\ndraft"
+        assert restored._items[1].text == "first draft"
+        assert restored._items[0].images == ["/tmp/pic.png"]
+        # stashed_at should be adjusted to monotonic — just verify it's a number
+        assert isinstance(restored._items[0].stashed_at, float)
+        assert restored._items[1].preview == "first draft"
+
+    def test_from_dict_missing_fields_skipped(self):
+        """Entries with missing/invalid fields are skipped."""
+        data = {
+            "items": [
+                {"text": "good", "images": [], "stashed_at_wall": 1_700_000_000.0, "preview": "good"},
+                {"text": "bad", "images": [], "stashed_at_wall": None, "preview": "bad"},
+                {},
+                {"text": "no timestamp", "images": []},
+            ]
+        }
+        restored = PromptStash.from_dict(data)
+        assert len(restored) == 1
+        assert restored._items[0].text == "good"
+
+    def test_from_dict_empty_items(self):
+        restored = PromptStash.from_dict({"items": []})
+        assert len(restored) == 0
+
+
+# ---------------------------------------------------------------- persistence
+
+
+class TestDiskPersistence:
+    """save_stash / load_stash — atomic writes, permissions, graceful errors."""
+
+    def test_save_creates_file_with_600_permissions(self, tmp_path):
+        from hermes_cli.prompt_stash import save_stash
+
+        stash = PromptStash()
+        stash.stash("draft one")
+        stash.stash("draft two")
+
+        path = tmp_path / "stash.json"
+        save_stash(stash, path)
+        assert path.exists()
+        stat = path.stat()
+        # Unix permissions: 0o600 = owner read+write only
+        assert stat.st_mode & 0o777 == 0o600
+
+    def test_save_load_round_trip(self, tmp_path):
+        from hermes_cli.prompt_stash import save_stash, load_stash
+
+        stash = PromptStash()
+        stash.stash("hello")
+        stash.stash("line one\nline two", ["/tmp/img.png"])
+
+        path = tmp_path / "stash.json"
+        save_stash(stash, path)
+
+        loaded = load_stash(path)
+        assert len(loaded) == 2
+        entries = loaded.items
+        assert entries[0].text == "line one\nline two"
+        assert entries[0].images == ["/tmp/img.png"]
+        assert entries[1].text == "hello"
+        # Round-trip preserves previews
+        assert entries[0].preview == "line one ⏎ line two"
+
+    def test_load_after_crash(self, tmp_path):
+        """Partial/corrupt JSON still returns an empty stash."""
+        path = tmp_path / "stash.json"
+        path.write_text('{"items": [{"text": "incomplete"')
+        from hermes_cli.prompt_stash import load_stash
+
+        loaded = load_stash(path)
+        assert len(loaded) == 0
+
+    def test_from_dict_missing_file_returns_empty(self, tmp_path):
+        from hermes_cli.prompt_stash import load_stash
+
+        loaded = load_stash(tmp_path / "nonexistent.json")
+        assert len(loaded) == 0
+        assert isinstance(loaded, PromptStash)
+
+    def test_from_dict_corrupt_json_returns_empty(self, tmp_path):
+        """Non-JSON file returns empty stash."""
+        path = tmp_path / "stash.json"
+        path.write_text("this is not json")
+        from hermes_cli.prompt_stash import load_stash
+
+        loaded = load_stash(path)
+        assert len(loaded) == 0
+
+    def test_save_stash_noop_on_empty(self, tmp_path):
+        """Don't create a file when the stash is empty."""
+        from hermes_cli.prompt_stash import save_stash
+
+        stash = PromptStash()
+        path = tmp_path / "stash.json"
+        save_stash(stash, path)
+        assert not path.exists()
+
+    def test_save_stash_empty_with_images(self, tmp_path):
+        """An images-only draft is not empty — should write."""
+        from hermes_cli.prompt_stash import save_stash, load_stash
+
+        stash = PromptStash()
+        stash.stash("", ["/tmp/img.png"])
+        path = tmp_path / "stash.json"
+        save_stash(stash, path)
+        assert path.exists()
+        loaded = load_stash(path)
+        assert len(loaded) == 1
+        assert loaded.peek().preview == "(images only)"
+
+
 # --------------------------------------------------------------------- ages
 
 


### PR DESCRIPTION
## feat(stash): add disk persistence for prompt stash

Adds disk persistence to the existing multi-item prompt stash (Ctrl+S), so drafts survive crashes and are restored on `hermes -c` or `/resume`.

### What's already on main

The multi-item stash state machine (`PromptStash`), browsable panel renderer, and Ctrl+S keybindings were merged previously. The stash supports push/pop/browse with newest-first ordering, a visual panel (↑↓/Enter/D/Esc), status-bar indicator (📌), and image attachments.

### What this PR adds

**`hermes_cli/prompt_stash.py`** — serialization + persistence:
- `to_dict()` — serializes items to JSON-safe dict with wall-clock timestamps (converted from monotonic clock)
- `from_dict()` — deserializes, converts wall-clock back to monotonic offsets for accurate age display
- `save_stash()` — atomic write (tmp + rename), `0o600` permissions, no-op on empty stash
- `load_stash()` — graceful on corrupt/missing files → returns empty stash

**`cli.py`** — wiring:
- Init: `load_stash()` restores drafts on startup
- `_save_stash_to_disk()` helper called after every mutation (stash/restore/delete)
- Errors are swallowed — a failed save never breaks the TUI

**`tests/cli/test_prompt_stash.py`** — 13 new tests:
- `TestSerialization` (6): to_dict/from_dict round-trips, images, missing fields
- `TestDiskPersistence` (7): 0o600 permissions, save/load round-trip, corrupt JSON recovery, empty stash no-op

### Design decisions

- **Wall-clock timestamps in serialized format only** — in-memory operation still uses `time.monotonic` (existing behavior unchanged)
- **Atomic write** (tmp + rename) prevents corrupt files on crash
- **`0o600` permissions** — drafts frequently contain credentials/secrets
- **Graceful degradation** — corrupt/missing file → empty stash, never crashes
- **No-op on empty** — don't create a file when there's nothing to persist

Closes #5512
