### PR TITLE
feat(credentials): persist least_used seats and keep them session-sticky

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1534,6 +1534,14 @@ def init_agent(
     # the failure to its source entry.
     from agent.agent_runtime_helpers import sync_credential_pool_entry_id
     sync_credential_pool_entry_id(agent)
+    try:
+        from agent.credential_pool import apply_session_seat_notice
+
+        _pool = getattr(agent, "_credential_pool", None)
+        _entry = _pool.current() if _pool is not None else None
+        apply_session_seat_notice(agent, _entry, reused=False)
+    except Exception:
+        pass
     
     # Provider fallback chain — ordered list of backup providers tried
     # when the primary is exhausted (rate-limit, overload, connection

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1682,14 +1682,20 @@ def restore_primary_runtime(agent) -> bool:
         # turns the pool may have rotated (token revocation, billing/rate-limit
         # exhaustion, cooldown), leaving the snapshot key stale.  Restoring it
         # blindly re-fails on the first request and burns through the remaining
-        # pool entries before cross-provider fallback even gets a chance.  Ask
-        # the pool for its current best entry and swap the live credential in.
-        # When the pool is absent, empty, or the entry has no usable key, we
-        # keep the snapshot key (the existing behavior).  Fixes #25205.
+        # pool entries before cross-provider fallback even gets a chance.  Reuse
+        # this session's pinned seat when it is still available so a live chat
+        # does not hop SuperGrok accounts (and dump the xAI prefix cache) on
+        # every restore.  Only assign a new seat when the pin is gone/exhausted.
+        pinned_id = getattr(agent, "_credential_pool_entry_id", None)
         agent._credential_pool_entry_id = None
         pool = getattr(agent, "_credential_pool", None)
         if pool is not None and pool.has_available():
-            entry = pool.select()
+            reuse = getattr(pool, "select_or_reuse", None)
+            entry = (
+                reuse(pinned_id if isinstance(pinned_id, str) else None)
+                if callable(reuse)
+                else pool.select()
+            )
             if entry is not None:
                 entry_provider = str(getattr(entry, "provider", "") or "").strip().lower()
                 entry_matches_primary = entry_provider == primary_provider
@@ -1726,6 +1732,17 @@ def restore_primary_runtime(agent) -> bool:
                     # reapplies base-url-scoped headers, and carries the
                     # accumulated base_url / OAuth-detection fixes (#33163).
                     agent._swap_credential(entry)
+                    try:
+                        from agent.credential_pool import apply_session_seat_notice
+
+                        apply_session_seat_notice(
+                            agent,
+                            entry,
+                            reused=isinstance(pinned_id, str)
+                            and pinned_id == getattr(entry, "id", None),
+                        )
+                    except Exception:
+                        pass
                     logger.info(
                         "Restore re-selected pool entry %s (%s)",
                         getattr(entry, "id", "?"),

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -647,6 +647,65 @@ def _write_through_provider_state_to_global_root(
         )
 
 
+def format_pool_seat_notice(
+    entry: Optional[PooledCredential],
+    *,
+    provider: str = "",
+) -> str:
+    """One-line notice naming the subscription/credential a session landed on.
+
+    Labels only — never tokens or emails. Empty when there is no entry.
+    """
+    if entry is None:
+        return ""
+    label = str(getattr(entry, "label", None) or getattr(entry, "id", None) or "").strip()
+    if not label:
+        label = "unnamed"
+    prov = (provider or getattr(entry, "provider", None) or "").strip().lower()
+    if prov in {"xai-oauth", "x-ai-oauth", "grok-oauth", "xai-grok-oauth"}:
+        return f"🎫 SuperGrok seat: {label}"
+    if prov:
+        return f"🎫 Credential seat: {label} ({prov})"
+    return f"🎫 Credential seat: {label}"
+
+
+def apply_session_seat_notice(agent: Any, entry: Optional[PooledCredential], *, reused: bool = False) -> str:
+    """Queue (and optionally emit) a one-shot seat line for this session.
+
+    Reuse of the same seat is silent after the first notice. A hop to a new
+    seat (exhausted pin, rotation) emits again.
+    """
+    notice = format_pool_seat_notice(
+        entry, provider=str(getattr(agent, "provider", None) or "")
+    )
+    if not notice:
+        return ""
+    entry_id = getattr(entry, "id", None)
+    last = getattr(agent, "_emitted_seat_notice", None)
+    if reused and last == entry_id:
+        return ""
+    agent._pending_seat_notice = notice
+    agent._emitted_seat_notice = entry_id
+    emit = getattr(agent, "_emit_status", None)
+    if callable(emit):
+        try:
+            emit(notice)
+        except Exception:
+            pass
+    return notice
+
+
+def consume_pending_seat_notice(agent: Any, response_text: str) -> str:
+    """Append a pending seat notice to the first user-visible final once."""
+    notice = getattr(agent, "_pending_seat_notice", None)
+    if not notice or not response_text:
+        return response_text
+    agent._pending_seat_notice = None
+    if notice in response_text:
+        return response_text
+    return response_text.rstrip() + "\n\n" + notice
+
+
 class CredentialPool:
     def __init__(self, provider: str, entries: List[PooledCredential]):
         self.provider = provider
@@ -1798,6 +1857,34 @@ class CredentialPool:
                 self._unmatched_rotation_streak = 0
         return entry
 
+    def select_or_reuse(self, pinned_id: Optional[str] = None) -> Optional[PooledCredential]:
+        """Reuse *pinned_id* when that seat is still available; else ``select()``.
+
+        New Desktop/CLI sessions assign a seat with ``select()``. A live
+        session must keep that seat across turn-start restore so xAI prompt
+        cache stays warm. Exhausted/dead pins fall through to a new assignment.
+        Reuse does not increment ``request_count``.
+        """
+        pinned = (pinned_id or "").strip()
+        if pinned:
+            available, pending_refresh = self._select_under_lock_available()
+            if pending_refresh:
+                self._refresh_pending_entries(pending_refresh)
+                available, _ = self._select_under_lock_available(refresh=False)
+            match = next((entry for entry in available if entry.id == pinned), None)
+            if match is not None:
+                with self._lock:
+                    self._current_id = match.id
+                self._unmatched_rotation_streak = 0
+                return match
+        return self.select()
+
+    def _select_under_lock_available(
+        self, *, refresh: bool = True
+    ) -> Tuple[List[PooledCredential], List[tuple]]:
+        with self._lock:
+            return self._available_entries(clear_expired=True, refresh=refresh)
+
     def _select_under_lock(self) -> Tuple[Optional[PooledCredential], List[tuple]]:
         """Run selection under the lock, returning entry + pending refreshes."""
         with self._lock:
@@ -2016,9 +2103,12 @@ class CredentialPool:
 
         if self._strategy == STRATEGY_LEAST_USED and len(available) > 1:
             entry = min(available, key=lambda e: e.request_count)
-            # Increment usage counter so subsequent selections distribute load
+            # Increment usage counter so subsequent selections distribute load.
+            # Persist: every Desktop/gateway session calls load_pool() fresh,
+            # so an in-memory-only increment never spreads seats (#session-sticky).
             updated = replace(entry, request_count=entry.request_count + 1)
             self._replace_entry(entry, updated)
+            self._persist()
             self._current_id = entry.id
             return updated, pending_refresh
 

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -608,9 +608,17 @@ def finalize_turn(
                     _pre_transform_response = final_response
                     final_response = _hook_result
                     _response_transformed = True
-                    break  # First non-empty string wins
+                    break
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
+
+    try:
+        from agent.credential_pool import consume_pending_seat_notice
+
+        if final_response:
+            final_response = consume_pending_seat_notice(agent, final_response)
+    except Exception:
+        pass
 
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1700,6 +1700,220 @@ class TestLeastUsedStrategy:
             "least_used should alternate or increment"
         )
 
+    def test_least_used_request_count_survives_reload(self, tmp_path, monkeypatch):
+        """New sessions call load_pool() fresh. Counts must persist or every
+        Desktop chat re-selects p0 and three SuperGrok seats never spread."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr(
+            "agent.credential_pool.get_pool_strategy",
+            lambda _provider: "least_used",
+        )
+        monkeypatch.setattr(
+            "agent.credential_pool._seed_from_singletons",
+            lambda provider, entries: (False, set()),
+        )
+        monkeypatch.setattr(
+            "agent.credential_pool._seed_from_env",
+            lambda provider, entries: (False, set()),
+        )
+        _write_auth_store(
+            tmp_path,
+            {
+                "version": 1,
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "seat-a",
+                            "label": "getlasso",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual:device_code",
+                            "access_token": "tok-a",
+                            "request_count": 0,
+                        },
+                        {
+                            "id": "seat-b",
+                            "label": "clearplan",
+                            "auth_type": "oauth",
+                            "priority": 1,
+                            "source": "manual:device_code",
+                            "access_token": "tok-b",
+                            "request_count": 0,
+                        },
+                    ]
+                },
+            },
+        )
+        from agent.credential_pool import load_pool
+
+        first = load_pool("xai-oauth").select()
+        assert first is not None
+        second = load_pool("xai-oauth").select()
+        assert second is not None
+        assert second.id != first.id
+
+    def test_select_or_reuse_keeps_pinned_seat(self, tmp_path, monkeypatch):
+        """A live session must stay on its assigned seat even if least_used
+        would now prefer another account."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr(
+            "agent.credential_pool.get_pool_strategy",
+            lambda _provider: "least_used",
+        )
+        monkeypatch.setattr(
+            "agent.credential_pool._seed_from_singletons",
+            lambda provider, entries: (False, set()),
+        )
+        monkeypatch.setattr(
+            "agent.credential_pool._seed_from_env",
+            lambda provider, entries: (False, set()),
+        )
+        _write_auth_store(
+            tmp_path,
+            {
+                "version": 1,
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "seat-a",
+                            "label": "getlasso",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual:device_code",
+                            "access_token": "tok-a",
+                            "request_count": 5,
+                        },
+                        {
+                            "id": "seat-b",
+                            "label": "clearplan",
+                            "auth_type": "oauth",
+                            "priority": 1,
+                            "source": "manual:device_code",
+                            "access_token": "tok-b",
+                            "request_count": 0,
+                        },
+                    ]
+                },
+            },
+        )
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("xai-oauth")
+        reused = pool.select_or_reuse("seat-a")
+        assert reused is not None
+        assert reused.id == "seat-a"
+        # Reuse must not increment as a new assignment.
+        reloaded = load_pool("xai-oauth")
+        counts = {e.id: e.request_count for e in reloaded.entries()}
+        assert counts["seat-a"] == 5
+        assert counts["seat-b"] == 0
+
+    def test_select_or_reuse_assigns_when_pin_exhausted(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        monkeypatch.setattr(
+            "agent.credential_pool.get_pool_strategy",
+            lambda _provider: "least_used",
+        )
+        monkeypatch.setattr(
+            "agent.credential_pool._seed_from_singletons",
+            lambda provider, entries: (False, set()),
+        )
+        monkeypatch.setattr(
+            "agent.credential_pool._seed_from_env",
+            lambda provider, entries: (False, set()),
+        )
+        now = time.time()
+        _write_auth_store(
+            tmp_path,
+            {
+                "version": 1,
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "seat-a",
+                            "label": "getlasso",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "source": "manual:device_code",
+                            "access_token": "tok-a",
+                            "last_status": "exhausted",
+                            "last_status_at": now,
+                            "last_error_code": 402,
+                            "last_error_reset_at": now + 3600,
+                            "request_count": 3,
+                        },
+                        {
+                            "id": "seat-b",
+                            "label": "clearplan",
+                            "auth_type": "oauth",
+                            "priority": 1,
+                            "source": "manual:device_code",
+                            "access_token": "tok-b",
+                            "request_count": 0,
+                        },
+                    ]
+                },
+            },
+        )
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("xai-oauth")
+        entry = pool.select_or_reuse("seat-a")
+        assert entry is not None
+        assert entry.id == "seat-b"
+
+
+class TestPoolSeatNotice:
+    def test_format_xai_oauth_uses_label_only(self):
+        from agent.credential_pool import PooledCredential, format_pool_seat_notice
+
+        entry = PooledCredential(
+            provider="xai-oauth",
+            id="13932f",
+            label="premium-plus-getlasso",
+            auth_type="oauth",
+            source="manual:device_code",
+            access_token="tok",
+            priority=0,
+        )
+        notice = format_pool_seat_notice(entry)
+        assert "premium-plus-getlasso" in notice
+        assert "tok" not in notice
+        assert "SuperGrok seat" in notice
+
+    def test_apply_then_consume_appends_once(self):
+        from types import SimpleNamespace
+        from agent.credential_pool import (
+            PooledCredential,
+            apply_session_seat_notice,
+            consume_pending_seat_notice,
+        )
+
+        seen = []
+        agent = SimpleNamespace(
+            provider="xai-oauth",
+            _emit_status=seen.append,
+        )
+        entry = PooledCredential(
+            provider="xai-oauth",
+            id="seat-a",
+            label="premium-plus-gmail",
+            auth_type="oauth",
+            source="manual:device_code",
+            access_token="secret-token",
+            priority=0,
+        )
+        notice = apply_session_seat_notice(agent, entry, reused=False)
+        assert notice
+        assert seen == [notice]
+        first = consume_pending_seat_notice(agent, "Hello")
+        assert first.endswith(notice)
+        assert "secret-token" not in first
+        # Second consume is a no-op.
+        assert consume_pending_seat_notice(agent, first) == first
+        # Same-seat reuse is silent.
+        assert apply_session_seat_notice(agent, entry, reused=True) == ""
+
 
 # ── PR #10160 salvage: Nous OAuth cross-process sync tests ─────────────────
 


### PR DESCRIPTION
## Summary

Desktop/gateway sessions each call `load_pool()` fresh. `least_used` incremented `request_count` only in memory, so every new chat re-selected p0 and three SuperGrok seats never spread. A live session that later restored the primary also re-`select()`ed and could hop accounts, dumping the xAI prefix cache.

## What changed

- Persist `request_count` on `least_used` select so a later `load_pool()` sees the assignment.
- `select_or_reuse(pinned_id)` keeps a live session on its seat; exhausted/dead pins assign a new one.
- `restore_primary_runtime` reuses the pin instead of always `select()`.
- First user-visible final appends `🎫 SuperGrok seat: <label>` once (label only — no tokens/emails). Status line emits the same text at assignment.

Opt-in: `credential_pool_strategies.xai-oauth: least_used` (still defaults to `fill_first`). Do **not** use `round_robin` — it rewrites `priority` on disk every select.

## Test plan

- [x] `scripts/run_tests.sh tests/agent/test_credential_pool.py tests/run_agent/test_primary_runtime_restore.py tests/agent/test_turn_finalizer_final_response_persistence.py` — 92 passed
- [ ] New Desktop chat with `least_used` set shows a seat line on first output
- [ ] Second new chat lands on a different healthy seat
- [ ] Resume of the first chat stays on the same seat (cache stays warm)

## Not this PR

- Does not change default `fill_first`.
- Does not rewrite OAuth priority order.
- Does not drop `fallback_providers` (paid `xai` → Anthropic).
