### PR TITLE
fix(desktop): make a bare useEnvCredentials() call follow the active profile (#92662)

### DIFF
--- a/apps/desktop/src/app/settings/env-credentials.test.ts
+++ b/apps/desktop/src/app/settings/env-credentials.test.ts
@@ -1,0 +1,46 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getEnvVars = vi.fn()
+const setEnvVar = vi.fn()
+
+vi.mock('@/hermes', () => ({
+  deleteEnvVar: vi.fn(),
+  getEnvVars: (profile?: null | string) => getEnvVars(profile),
+  revealEnvVar: vi.fn(),
+  setEnvVar: (key: string, value: string, profile?: null | string) => setEnvVar(key, value, profile)
+}))
+
+beforeEach(() => {
+  getEnvVars.mockResolvedValue({})
+  setEnvVar.mockResolvedValue({ ok: true })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+// Regression for #92662: the Providers page calls useEnvCredentials() with no
+// argument expecting it to follow the app-wide active profile (per this
+// hook's own doc comment), but a bare call must not silently pin every read
+// and write to the base profile the way a literal `null` scope does.
+describe('useEnvCredentials', () => {
+  it('fetches with the active profile (undefined), not the base profile (null), on a bare call', async () => {
+    const { useEnvCredentials } = await import('./env-credentials')
+
+    renderHook(() => useEnvCredentials())
+
+    await waitFor(() => expect(getEnvVars).toHaveBeenCalled())
+    expect(getEnvVars).toHaveBeenCalledWith(undefined)
+  })
+
+  it('saves against the active profile (undefined) on a bare call', async () => {
+    const { useEnvCredentials } = await import('./env-credentials')
+
+    const { result } = renderHook(() => useEnvCredentials())
+
+    await result.current.saveValue('LM_API_KEY', 'sk-test')
+
+    expect(setEnvVar).toHaveBeenCalledWith('LM_API_KEY', 'sk-test', undefined)
+  })
+})

--- a/apps/desktop/src/app/settings/env-credentials.tsx
+++ b/apps/desktop/src/app/settings/env-credentials.tsx
@@ -44,10 +44,16 @@ export function SettingsCategoryHeading({ count, icon: Icon, title }: CategoryHe
 // mutation handlers instead of duplicating the plumbing. An optional `profile`
 // targets another profile's env store (the shared settings "Applies to"
 // scope); undefined/null keeps the app-wide active profile.
-export function useEnvCredentials(profile: null | string = null): UseEnvCredentials {
+export function useEnvCredentials(profile?: null | string): UseEnvCredentials {
   const { t } = useI18n()
   const credentials = t.settings.credentials
   const toolsets = t.settings.toolsets
+  // profileScoped() only falls back to the app-wide active profile for
+  // `undefined` — a literal `null` forces the primary/base store instead
+  // (api/client.ts). Normalize here so a bare call (Providers) and a `null`
+  // "no override" scope (Keys) both follow the active profile as documented
+  // above, instead of always landing on base.
+  const scopedProfile = profile ?? undefined
   const [vars, setVars] = useState<Record<string, EnvVarInfo> | null>(null)
   const [edits, setEdits] = useState<Record<string, string>>({})
   const [revealed, setRevealed] = useState<Record<string, string>>({})
@@ -70,7 +76,7 @@ export function useEnvCredentials(profile: null | string = null): UseEnvCredenti
 
     void (async () => {
       try {
-        const next = await getEnvVars(profile)
+        const next = await getEnvVars(scopedProfile)
 
         if (!cancelled) {
           setVars(next)
@@ -82,7 +88,7 @@ export function useEnvCredentials(profile: null | string = null): UseEnvCredenti
 
     return () => void (cancelled = true)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- reload per target profile; copy is stable
-  }, [profile])
+  }, [scopedProfile])
 
   function patchVar(key: string, patch: Partial<Pick<EnvVarInfo, 'is_set' | 'redacted_value'>>) {
     setVars(c => (c ? { ...c, [key]: { ...c[key], ...patch } } : c))
@@ -103,7 +109,7 @@ export function useEnvCredentials(profile: null | string = null): UseEnvCredenti
     setSaving(key)
 
     try {
-      await setEnvVar(key, value, profile)
+      await setEnvVar(key, value, scopedProfile)
       patchVar(key, { is_set: true, redacted_value: redactedValue(value) })
       clearLocalState(key)
       notify({ kind: 'success', title: toolsets.savedTitle, message: toolsets.savedMessage(key) })
@@ -127,7 +133,7 @@ export function useEnvCredentials(profile: null | string = null): UseEnvCredenti
     setSaving(key)
 
     try {
-      await setEnvVar(key, trimmed, profile)
+      await setEnvVar(key, trimmed, scopedProfile)
       patchVar(key, { is_set: true, redacted_value: redactedValue(trimmed) })
       clearLocalState(key)
       notify({ kind: 'success', message: toolsets.savedMessage(key), title: toolsets.savedTitle })
@@ -150,7 +156,7 @@ export function useEnvCredentials(profile: null | string = null): UseEnvCredenti
     setSaving(key)
 
     try {
-      await deleteEnvVar(key, profile)
+      await deleteEnvVar(key, scopedProfile)
       patchVar(key, { is_set: false, redacted_value: null })
       clearLocalState(key)
       notify({ kind: 'success', title: toolsets.removedTitle, message: toolsets.removedMessage(key) })
@@ -169,7 +175,7 @@ export function useEnvCredentials(profile: null | string = null): UseEnvCredenti
     }
 
     try {
-      const result = await revealEnvVar(key, profile)
+      const result = await revealEnvVar(key, scopedProfile)
       setRevealed(c => ({ ...c, [key]: result.value }))
     } catch (err) {
       notifyError(err, toolsets.failedReveal(key))


### PR DESCRIPTION
## What does this PR do?

Fixes the Providers settings page always writing API keys to the **base**
profile's `.env`, even when a non-default profile is active — the chat then
runs under that profile with no key.

## Root cause

`useEnvCredentials(profile: null | string = null)` in
`apps/desktop/src/app/settings/env-credentials.tsx` gives a bare call an
explicit `null`, not `undefined`. `profileScoped()` in
`apps/desktop/src/api/client.ts` only falls back to the app-wide active
profile (`_apiProfile`) when the argument is `undefined` — a literal `null`
is treated as "force the primary/base store" and returns `{}` (no `?profile=`
on the request):

```ts
export function profileScoped(profile?: null | string): { profile?: string } {
  const selected = profile === undefined ? _apiProfile : profile
  return selected ? { profile: selected } : {}
}
```

The Providers page calls the hook with no argument
(`providers-settings.tsx:343`), so every save/reveal/delete silently landed
on base regardless of which profile was selected — contradicting the hook's
own doc comment ("undefined/null keeps the app-wide active profile").

## Changes Made

- `apps/desktop/src/app/settings/env-credentials.tsx`: normalize the
  hook's `profile` parameter to `undefined` once (`profile ?? undefined`)
  before it reaches `getEnvVars` / `setEnvVar` / `deleteEnvVar` /
  `revealEnvVar`, and drop the `= null` default so an omitted argument
  stays `undefined` all the way through. This makes the code match the
  hook's existing doc comment, and fixes both a bare call (Providers) and
  a `null` "no override" scope (Keys' `$settingsScopeOverride` default).
- `apps/desktop/src/app/settings/env-credentials.test.ts` (new): asserts a
  bare `useEnvCredentials()` call fetches/saves with `undefined`, not
  `null`.

No dependency, lockfile, or CI changes.

## Related Issue

Fixes #92662

## How to Test

1. `renderHook(() => useEnvCredentials())` with `getEnvVars`/`setEnvVar`
   mocked — assert they're called with `undefined`, not `null`.
2. Manually: switch to a non-default profile, open Settings → Providers,
   save an API key, confirm it lands in that profile's `.env` instead of
   `~/.hermes/.env`.

### Test output

New test, confirmed it fails without the fix:

```
$ git stash push -- apps/desktop/src/app/settings/env-credentials.tsx
$ npx vitest run --project ui src/app/settings/env-credentials.test.ts
 FAIL  useEnvCredentials > fetches with the active profile (undefined) ...
   - undefined
   + null
 FAIL  useEnvCredentials > saves against the active profile (undefined) ...
   - undefined
   + null
 Test Files  1 failed (1)
      Tests  2 failed (2)
$ git stash pop
```

With the fix restored:

```
$ npx vitest run --project ui src/app/settings/env-credentials.test.ts \
    src/app/settings/keys-settings.test.tsx src/app/settings/providers-settings.test.tsx
 Test Files  3 passed (3)
      Tests  12 passed (12)
```

Full settings suite, typecheck, and lint:

```
$ npx vitest run --project ui src/app/settings
 Test Files  32 passed (32)
      Tests  299 passed (299)

$ npx tsc -p . --noEmit
(clean)

$ npx eslint src/app/settings/env-credentials.tsx src/app/settings/env-credentials.test.ts
(clean)

$ npm run lint
✖ 116 problems (0 errors, 116 warnings)   # all pre-existing, none in touched files
```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes, and confirmed they fail without the fix
- [x] Cross-platform: no OS branching in the touched code

## Disclosure

This PR was prepared with AI assistance (Claude Code), with the root cause,
fix, and tests verified by running the actual test suite, typecheck, and
lint locally as shown above.
