### PR TITLE
feat(skills): add termux-chromium-browser skill with CDP automation

### DIFF
--- a/skills/devops/termux-chromium-browser/SKILL.md
+++ b/skills/devops/termux-chromium-browser/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: termux-chromium-browser
+description: Native headless Chromium browser over CDP for Termux.
+version: 0.1.0
+author: Thamer (taljeri), @pjy010218, Hermes Agent
+license: MIT
+platforms: [linux, android]
+metadata:
+  hermes:
+    tags: [Termux, Android, Chromium, Browser, CDP, Automation]
+    category: devops
+    related_skills: [sdlc-review, systematic-debugging]
+---
+
+# Termux Chromium Browser
+
+Run a native headless Chromium browser on Android Termux and automate browsing over the Chrome DevTools Protocol (CDP) without requiring proot, root, or a graphical desktop.
+
+Credits: Special thanks to **@pjy010218** for discovering and implementing the single-process Chromium flag combination that resolves the Android Termux `LD_PRELOAD` child execution conflict.
+
+## When to Use
+
+- "Browse web pages directly inside Android Termux"
+- "Extract rendered text and JavaScript DOM content from a website on Termux"
+- "Take web page screenshots on Android without proot or root"
+- "Run headless Chromium over CDP on Android without Selenium or Playwright"
+- "Interact with web forms, click buttons, or verify video playback on Termux"
+
+Don't use for:
+- Standard desktop/server systems with pre-installed Chrome or Playwright
+- GPU-accelerated 3D WebGL games (single-process mode lacks full GPU acceleration on most mobile chipsets)
+
+## The Android Technical Gotchas & Solution
+
+Running Chromium natively inside Termux typically hits two major obstacles:
+1. **ET_DYN ELF Executable**: The Android Linux kernel cannot exec Chromium directly without Termux's `LD_PRELOAD=libtermux-exec.so`.
+2. **Child Process Breakage**: However, `LD_PRELOAD` breaks Chromium's internal zygote and network service child processes (`ERR_ABORTED`).
+
+**The Solution**: Launch Chromium with `--no-zygote --single-process`. This forces Chromium to run entirely inside a single process tree, eliminating child process spawning and enabling seamless operation under Termux.
+
+## Prerequisites
+
+- Android device with Termux.
+- Packages: `x11-repo`, `tur-repo`, `chromium`, `runit`, `python`.
+- Python package: `websocket-client`.
+
+## Installation
+
+Run the setup commands in Termux:
+
+```bash
+# 1. Install packages
+pkg install -y x11-repo tur-repo
+pkg install -y chromium runit python
+pip install websocket-client
+
+# 2. Run service configuration script
+bash skills/devops/termux-chromium-browser/scripts/setup_service.sh
+
+# 3. Verify CDP liveness (listening on 127.0.0.1:9222)
+python3 skills/devops/termux-chromium-browser/scripts/browser.py version
+```
+
+## How to Run
+
+Execute commands via the `terminal` tool or shell:
+
+```bash
+# Open a new tab and navigate to a URL
+python3 skills/devops/termux-chromium-browser/scripts/browser.py newtab "https://en.wikipedia.org"
+
+# Read rendered visible text from the active page
+python3 skills/devops/termux-chromium-browser/scripts/browser.py read 2000
+
+# Search for specific text on the page
+python3 skills/devops/termux-chromium-browser/scripts/browser.py find "Wikipedia"
+
+# Capture a full-page screenshot
+python3 skills/devops/termux-chromium-browser/scripts/browser.py shot page.png
+
+# Evaluate JavaScript expression
+python3 skills/devops/termux-chromium-browser/scripts/browser.py eval "document.title"
+
+# List all open tabs
+python3 skills/devops/termux-chromium-browser/scripts/browser.py tabs
+```
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Open new tab | `python3 scripts/browser.py newtab <url>` |
+| Navigate tab | `python3 scripts/browser.py navigate <url>` |
+| Read page text | `python3 scripts/browser.py read [n]` |
+| Screenshot | `python3 scripts/browser.py shot [out.png]` |
+| Evaluate JS | `python3 scripts/browser.py eval "<expr>"` |
+| Search text | `python3 scripts/browser.py find "<text>"` |
+| Check version | `python3 scripts/browser.py version` |
+
+## Pitfalls
+
+- **ICU Data Permissions**: If Chromium fails with `Invalid file descriptor to ICU data received`, ensure read permissions on `$PREFIX/lib/chromium/` (`chmod -R 755 $PREFIX/lib/chromium`).
+- **Memory Footprint**: Headless Chromium idles around 300–400 MB RSS. Close unused tabs periodically.
+- **Renderer Idle**: Long-idle tabs in single-process mode may delay screenshot captures. Use `newtab` for fresh automation tasks.
+
+## Verification
+
+Verify CDP connection:
+```bash
+python3 skills/devops/termux-chromium-browser/scripts/browser.py version
+```

--- a/skills/devops/termux-chromium-browser/scripts/browser.py
+++ b/skills/devops/termux-chromium-browser/scripts/browser.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""browser.py — Native Chromium browser driver over CDP for Termux.
+
+Credits: @pjy010218
+
+The browser runs as a persistent headless runit service (port 9222).
+This driver communicates via raw Chrome DevTools Protocol (CDP) over WebSocket
+without requiring Selenium, Playwright, or Node.js.
+
+Usage:
+  python3 browser.py navigate <url>       # Navigate active tab
+  python3 browser.py read [n]             # Read visible page text (first n chars)
+  python3 browser.py eval "<js>"          # Evaluate JavaScript expression
+  python3 browser.py shot [out.png]       # Capture screenshot to file
+  python3 browser.py find "<text>"        # Search for text in page body
+  python3 browser.py tabs                 # List open browser tabs
+  python3 browser.py newtab <url>         # Open a new tab and attach to it
+  python3 browser.py version              # Print browser version / CDP status
+"""
+
+from __future__ import annotations
+
+import base64
+import http.client
+import json
+import os
+import sys
+import time
+from typing import Any, Dict, List, Optional
+
+try:
+    import websocket
+except ImportError:
+    websocket = None
+
+CDP_HOST = "127.0.0.1"
+CDP_PORT = 9222
+
+
+def http_json(path: str, method: str = "GET") -> Any:
+    c = http.client.HTTPConnection(CDP_HOST, CDP_PORT, timeout=15)
+    c.request(method, path)
+    r = c.getresponse()
+    body = r.read().decode("utf-8", errors="replace")
+    c.close()
+    try:
+        return json.loads(body)
+    except Exception:
+        return body
+
+
+class CDPBrowser:
+    """Thin CDP-over-WebSocket driver for headless Chromium on Termux."""
+
+    STATEFILE = os.path.join(os.path.expanduser("~"), ".cdp_last_tab")
+
+    def __init__(self, host: str = CDP_HOST, port: int = CDP_PORT):
+        self.host = host
+        self.port = port
+        self.ws: Any = None
+        self._id = 0
+        self.tab_url: Optional[str] = None
+
+    @staticmethod
+    def alive() -> str:
+        try:
+            v = http_json("/json/version")
+            if isinstance(v, dict):
+                return v.get("Browser", "")
+            return ""
+        except Exception:
+            return ""
+
+    def tabs(self) -> List[Dict[str, Any]]:
+        try:
+            res = http_json("/json")
+            if isinstance(res, list):
+                return [t for t in res if t.get("type") == "page"]
+            return []
+        except Exception:
+            return []
+
+    def attach(self, url_substr: Optional[str] = None) -> Dict[str, Any]:
+        """Attach to the last-used tab, matching url_substr, or latest open page tab."""
+        if websocket is None:
+            raise RuntimeError("websocket-client is required. Run: pip install websocket-client")
+
+        pages = self.tabs()
+        if not pages:
+            raise RuntimeError("No page tabs open in Chromium.")
+
+        t = None
+        if os.path.exists(self.STATEFILE):
+            try:
+                with open(self.STATEFILE, "r", encoding="utf-8") as f:
+                    wanted = f.read().strip()
+                t = next((p for p in pages if p.get("id") == wanted), None)
+            except Exception:
+                pass
+
+        if t is None and url_substr:
+            t = next((p for p in pages if url_substr in p.get("url", "")), None)
+
+        if t is None:
+            t = pages[-1]
+
+        ws_url = t.get("webSocketDebuggerUrl")
+        if not ws_url:
+            raise RuntimeError(f"Tab {t.get('id')} has no webSocketDebuggerUrl.")
+
+        self.ws = websocket.create_connection(ws_url, timeout=45)
+        self.tab_url = t.get("url")
+        return t
+
+    def _cmd(self, method: str, **params: Any) -> Any:
+        if not self.ws:
+            self.attach()
+        self._id += 1
+        payload = json.dumps({"id": self._id, "method": method, "params": params})
+        self.ws.send(payload)
+        while True:
+            msg = json.loads(self.ws.recv())
+            if msg.get("id") == self._id:
+                return msg.get("result", msg)
+
+    def newtab(self, url: str) -> Dict[str, Any]:
+        c = http.client.HTTPConnection(self.host, self.port, timeout=15)
+        c.request("PUT", "/json/new?" + url)
+        res = c.getresponse().read().decode("utf-8", errors="replace")
+        tab = json.loads(res)
+        c.close()
+
+        try:
+            with open(self.STATEFILE, "w", encoding="utf-8") as f:
+                f.write(tab.get("id", ""))
+        except Exception:
+            pass
+
+        self.attach()
+        self.settle()
+        return tab
+
+    def navigate(self, url: str) -> None:
+        if not self.ws:
+            self.attach()
+        self._cmd("Page.navigate", url=url)
+        self.settle()
+
+    def settle(self, seconds: Optional[int] = None) -> None:
+        deadline = time.time() + (seconds if seconds is not None else 15)
+        while time.time() < deadline:
+            try:
+                if (self.text() or "").strip():
+                    return
+            except Exception:
+                pass
+            time.sleep(1)
+        time.sleep(1)
+
+    def js(self, expr: str) -> Any:
+        r = self._cmd("Runtime.evaluate", expression=expr, returnByValue=True)
+        res = r.get("result", {})
+        if res.get("subtype") == "error":
+            raise RuntimeError(res.get("description", "JavaScript evaluation error"))
+        return res.get("value")
+
+    def text(self) -> str:
+        return self.js("document.body ? document.body.innerText : ''") or ""
+
+    def find(self, needle: str) -> bool:
+        return bool(self.js(f"document.body ? document.body.innerText.includes({needle!r}) : false"))
+
+    def shot(self, out_path: str) -> str:
+        r = self._cmd("Page.captureScreenshot", format="png")
+        data = r.get("data")
+        if not data:
+            raise RuntimeError(f"Screenshot failed: {str(r)[:120]}")
+        with open(out_path, "wb") as f:
+            f.write(base64.b64decode(data))
+        return out_path
+
+
+def main() -> None:
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "tabs"
+
+    if cmd == "tabs":
+        for t in CDPBrowser().tabs():
+            print((t.get("title") or "")[:50], "|", t.get("url"))
+        return
+
+    if cmd == "version":
+        ver = CDPBrowser.alive()
+        print(ver if ver else "CDP DOWN")
+        return
+
+    b = CDPBrowser()
+    arg = sys.argv[2] if len(sys.argv) > 2 else None
+
+    if cmd == "newtab":
+        if not arg:
+            print("Error: newtab requires a URL", file=sys.stderr)
+            sys.exit(1)
+        b.newtab(arg)
+        print("opened:", arg)
+    elif cmd == "navigate":
+        if not arg:
+            print("Error: navigate requires a URL", file=sys.stderr)
+            sys.exit(1)
+        b.navigate(arg)
+        print("navigated:", arg)
+    elif cmd == "read":
+        n = int(arg) if arg else 4000
+        print(b.text()[:n])
+    elif cmd == "eval":
+        if not arg:
+            print("Error: eval requires a JS expression", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(b.js(arg), default=str)[:3000])
+    elif cmd == "find":
+        if not arg:
+            print("Error: find requires search text", file=sys.stderr)
+            sys.exit(1)
+        print("FOUND" if b.find(arg) else "NOT FOUND")
+    elif cmd == "shot":
+        out = arg or os.path.join(os.path.expanduser("~"), "page_screenshot.png")
+        print("saved:", b.shot(out))
+    else:
+        print(__doc__)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/devops/termux-chromium-browser/scripts/setup_service.sh
+++ b/skills/devops/termux-chromium-browser/scripts/setup_service.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# setup_service.sh — Configure permissions and install runit service for Termux Chromium.
+# Credits: @pjy010218
+set -u
+
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+SERVICE_DIR="$PREFIX/var/service/chromium-headless"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICE_RUN_SRC="$(cd "$SCRIPT_DIR/../service" && pwd)/run"
+
+echo "[1/4] Checking prerequisites (chromium, runit, python)..."
+if ! command -v chromium-browser >/dev/null 2>&1 && ! command -v chromium >/dev/null 2>&1 && [ ! -f "$PREFIX/lib/chromium/chrome" ]; then
+    echo "Chromium not found. Please install: pkg install -y x11-repo tur-repo && pkg install -y chromium runit python"
+fi
+
+echo "[2/4] Setting proper file permissions on Chromium binaries..."
+if [ -d "$PREFIX/lib/chromium" ]; then
+    chmod -R 755 "$PREFIX/lib/chromium" 2>/dev/null || true
+    find "$PREFIX/lib/chromium" -type f -exec chmod 644 {} + 2>/dev/null || true
+    chmod 755 "$PREFIX/lib/chromium/chrome" "$PREFIX/lib/chromium/chromedriver" \
+              "$PREFIX/lib/chromium/chromium-launcher.sh" 2>/dev/null || true
+fi
+
+echo "[3/4] Provisioning runit service..."
+mkdir -p "$SERVICE_DIR"
+if [ -f "$SERVICE_RUN_SRC" ]; then
+    cp "$SERVICE_RUN_SRC" "$SERVICE_DIR/run"
+    chmod +x "$SERVICE_DIR/run"
+    echo "Installed service script to $SERVICE_DIR/run"
+fi
+
+echo "[4/4] Starting runsvdir if not running..."
+if command -v runsvdir >/dev/null 2>&1; then
+    pgrep -x runsvdir >/dev/null 2>&1 || nohup runsvdir "$PREFIX/var/service" >/dev/null 2>&1 &
+    echo "runsvdir active."
+fi
+
+echo "Chromium service configuration complete."

--- a/skills/devops/termux-chromium-browser/scripts/yt_proof.py
+++ b/skills/devops/termux-chromium-browser/scripts/yt_proof.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""yt_proof.py — End-to-end YouTube video playback and frame capture proof in native Chromium on Termux.
+
+Credits: @pjy010218
+"""
+
+from __future__ import annotations
+
+import base64
+import http.client
+import json
+import os
+import sys
+import time
+
+CDP = ("127.0.0.1", 9222)
+
+
+def newtab(url: str) -> dict:
+    c = http.client.HTTPConnection(*CDP, timeout=10)
+    c.request("PUT", "/json/new?" + url)
+    res = c.getresponse().read().decode("utf-8", errors="replace")
+    c.close()
+    return json.loads(res)
+
+
+def drive(tab: dict):
+    import websocket
+    ws = websocket.create_connection(tab["webSocketDebuggerUrl"], timeout=45)
+    n = [0]
+
+    def cmd(method: str, **params):
+        n[0] += 1
+        ws.send(json.dumps({"id": n[0], "method": method, "params": params}))
+        while True:
+            r = json.loads(ws.recv())
+            if r.get("id") == n[0]:
+                return r
+    return cmd
+
+
+def main() -> None:
+    try:
+        import websocket
+    except ImportError:
+        print("Error: websocket-client required. Run: pip install websocket-client", file=sys.stderr)
+        sys.exit(1)
+
+    print("[1] Opening YouTube watch page...")
+    tab = newtab("https://www.youtube.com/watch?v=jNQXAC9IVRw")
+    cmd = drive(tab)
+    time.sleep(12)
+
+    r = cmd("Runtime.evaluate", expression="""
+    JSON.stringify({
+      title: document.title.slice(0, 80),
+      channel: (document.querySelector('ytd-channel-name a') || {}).innerText || 'n/a',
+      playerAlive: !!document.querySelector('#movie_player'),
+      videoEl: !!document.querySelector('video'),
+      t: (document.querySelector('video') || {}).currentTime || 0,
+      dur: (document.querySelector('video') || {}).duration || 0,
+      paused: (document.querySelector('video') || {paused: '?'})['paused']
+    })
+    """, returnByValue=True)
+    state = json.loads(r.get("result", {}).get("result", {}).get("value", "{}"))
+    for k, v in state.items():
+        print(f"    {k}: {v}")
+
+    print("[2] Capturing decoded frame from the <video> element...")
+    r = cmd("Runtime.evaluate", expression="""
+    (function(){
+      const v = document.querySelector('video');
+      if (!v || !v.videoWidth) return JSON.stringify({err: 'no decodable video'});
+      const cv = document.createElement('canvas');
+      cv.width = 640; cv.height = 360;
+      cv.getContext('2d').drawImage(v, 0, 0, 640, 360);
+      return JSON.stringify({frame: cv.toDataURL('image/jpeg', 0.75).split(',')[1], t: v.currentTime});
+    })()
+    """, returnByValue=True)
+    val = json.loads(r.get("result", {}).get("result", {}).get("value", "{}"))
+    if "frame" not in val:
+        print("    Frame capture failed:", val)
+    else:
+        out_frame = os.path.join(os.path.expanduser("~"), "proof_yt_frame.jpg")
+        with open(out_frame, "wb") as f:
+            f.write(base64.b64decode(val["frame"]))
+        print(f"    Frame captured at t={val.get('t', 0):.1f}s -> {out_frame}")
+
+    print("[3] Full-page screenshot...")
+    r = cmd("Page.captureScreenshot", format="png")
+    data = r.get("result", {}).get("data")
+    if data:
+        out_page = os.path.join(os.path.expanduser("~"), "proof_yt_page.png")
+        with open(out_page, "wb") as f:
+            f.write(base64.b64decode(data))
+        print(f"    Saved screenshot -> {out_page}")
+    else:
+        print("    Page screenshot failed:", str(r)[:150])
+
+    print("Verification completed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/devops/termux-chromium-browser/service/run
+++ b/skills/devops/termux-chromium-browser/service/run
@@ -1,0 +1,18 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Chromium headless CDP service for Termux — runit-managed.
+# Place at: $PREFIX/var/service/chromium-headless/run (chmod +x)
+#
+# Credits: @pjy010218
+# Android Fix: chromium's ELF is ET_DYN and needs Termux's LD_PRELOAD (termux-exec)
+# to exec, but LD_PRELOAD breaks Chromium's child processes.
+# --no-zygote --single-process runs with zero children and operates stably.
+
+termux-wake-lock 2>/dev/null || true
+
+exec "$PREFIX/lib/chromium/chromium-launcher.sh" \
+  --headless --no-sandbox --disable-gpu \
+  --no-zygote --single-process \
+  --remote-debugging-port=9222 --remote-allow-origins=* \
+  --disable-dev-shm-usage --disable-features=TranslateUI \
+  --lang=en-US --user-data-dir="$HOME/.chromium-cdp" \
+  2>&1

--- a/tests/skills/test_termux_chromium_browser_skill.py
+++ b/tests/skills/test_termux_chromium_browser_skill.py
@@ -1,0 +1,84 @@
+"""
+Tests for the Termux Chromium Browser skill (skills/devops/termux-chromium-browser).
+
+Covers:
+- CDPBrowser class instantiation and statefile management
+- JavaScript evaluation payload formulation
+- Shell script syntax checks (service/run and setup_service.sh)
+- CLI argument handling and help display
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "devops" / "termux-chromium-browser"
+SCRIPTS_DIR = SKILL_DIR / "scripts"
+SERVICE_DIR = SKILL_DIR / "service"
+BROWSER_SCRIPT = SCRIPTS_DIR / "browser.py"
+
+# Import module directly
+sys.path.insert(0, str(SCRIPTS_DIR))
+import browser
+
+
+class TestTermuxChromiumBrowserCore:
+    def test_browser_init(self):
+        b = browser.CDPBrowser(host="127.0.0.1", port=9222)
+        assert b.host == "127.0.0.1"
+        assert b.port == 9222
+        assert b.ws is None
+
+    def test_tabs_empty_on_connection_error(self):
+        with patch.object(browser, "http_json", return_value="Connection Refused"):
+            b = browser.CDPBrowser()
+            assert b.tabs() == []
+
+    def test_tabs_parsing_success(self):
+        mock_tabs = [
+            {"id": "tab1", "type": "page", "url": "https://example.com", "title": "Example"},
+            {"id": "tab2", "type": "background_page", "url": "chrome://extension"},
+        ]
+        with patch.object(browser, "http_json", return_value=mock_tabs):
+            b = browser.CDPBrowser()
+            tabs = b.tabs()
+            assert len(tabs) == 1
+            assert tabs[0]["id"] == "tab1"
+
+    def test_statefile_tab_tracking(self, tmp_path):
+        state_file = tmp_path / ".cdp_last_tab"
+        b = browser.CDPBrowser()
+        b.STATEFILE = str(state_file)
+
+        mock_tabs = [{"id": "tab_123", "type": "page", "url": "https://example.com", "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/page/tab_123"}]
+        with patch.object(browser, "http_json", return_value=mock_tabs), \
+             patch("websocket.create_connection") as mock_ws:
+            state_file.write_text("tab_123", encoding="utf-8")
+            tab = b.attach()
+            assert tab["id"] == "tab_123"
+            assert b.tab_url == "https://example.com"
+
+
+class TestTermuxChromiumBrowserScripts:
+    def test_shell_syntax(self):
+        sh_files = [
+            SCRIPTS_DIR / "setup_service.sh",
+            SERVICE_DIR / "run",
+        ]
+        for f in sh_files:
+            assert f.exists(), f"File missing: {f}"
+            res = subprocess.run(["bash", "-n", str(f)], capture_output=True, text=True)
+            assert res.returncode == 0, f"Syntax error in {f.name}: {res.stderr}"
+
+    def test_cli_help(self):
+        res = subprocess.run(
+            [sys.executable, str(BROWSER_SCRIPT), "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert res.returncode == 0
+        assert "browser.py" in res.stdout

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -52,6 +52,12 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music) | Songwriting craft and Suno AI music prompts. | `creative/songwriting-and-ai-music` |
 | [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp) | Control TouchDesigner via twozero MCP. | `creative/touchdesigner-mcp` |
 
+## devops
+
+| Skill | Description | Path |
+|-------|-------------|------|
+| [`termux-chromium-browser`](/docs/user-guide/skills/bundled/devops/devops-termux-chromium-browser) | Native headless Chromium browser over CDP for Termux. | `devops/termux-chromium-browser` |
+
 ## email
 
 | Skill | Description | Path |

--- a/website/docs/user-guide/skills/bundled/devops/devops-termux-chromium-browser.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-termux-chromium-browser.md
@@ -1,0 +1,128 @@
+---
+title: "Termux Chromium Browser — Native headless Chromium browser over CDP for Termux"
+sidebar_label: "Termux Chromium Browser"
+description: "Native headless Chromium browser over CDP for Termux"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Termux Chromium Browser
+
+Native headless Chromium browser over CDP for Termux.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/devops/termux-chromium-browser` |
+| Version | `0.1.0` |
+| Author | Thamer (taljeri), @pjy010218, Hermes Agent |
+| License | MIT |
+| Platforms | linux, android |
+| Tags | `Termux`, `Android`, `Chromium`, `Browser`, `CDP`, `Automation` |
+| Related skills | [`sdlc-review`](/docs/user-guide/skills/bundled/devops/devops-sdlc-review), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Termux Chromium Browser
+
+Run a native headless Chromium browser on Android Termux and automate browsing over the Chrome DevTools Protocol (CDP) without requiring proot, root, or a graphical desktop.
+
+Credits: Special thanks to **@pjy010218** for discovering and implementing the single-process Chromium flag combination that resolves the Android Termux `LD_PRELOAD` child execution conflict.
+
+## When to Use
+
+- "Browse web pages directly inside Android Termux"
+- "Extract rendered text and JavaScript DOM content from a website on Termux"
+- "Take web page screenshots on Android without proot or root"
+- "Run headless Chromium over CDP on Android without Selenium or Playwright"
+- "Interact with web forms, click buttons, or verify video playback on Termux"
+
+Don't use for:
+- Standard desktop/server systems with pre-installed Chrome or Playwright
+- GPU-accelerated 3D WebGL games (single-process mode lacks full GPU acceleration on most mobile chipsets)
+
+## The Android Technical Gotchas & Solution
+
+Running Chromium natively inside Termux typically hits two major obstacles:
+1. **ET_DYN ELF Executable**: The Android Linux kernel cannot exec Chromium directly without Termux's `LD_PRELOAD=libtermux-exec.so`.
+2. **Child Process Breakage**: However, `LD_PRELOAD` breaks Chromium's internal zygote and network service child processes (`ERR_ABORTED`).
+
+**The Solution**: Launch Chromium with `--no-zygote --single-process`. This forces Chromium to run entirely inside a single process tree, eliminating child process spawning and enabling seamless operation under Termux.
+
+## Prerequisites
+
+- Android device with Termux.
+- Packages: `x11-repo`, `tur-repo`, `chromium`, `runit`, `python`.
+- Python package: `websocket-client`.
+
+## Installation
+
+Run the setup commands in Termux:
+
+```bash
+# 1. Install packages
+pkg install -y x11-repo tur-repo
+pkg install -y chromium runit python
+pip install websocket-client
+
+# 2. Run service configuration script
+bash skills/devops/termux-chromium-browser/scripts/setup_service.sh
+
+# 3. Verify CDP liveness (listening on 127.0.0.1:9222)
+python3 skills/devops/termux-chromium-browser/scripts/browser.py version
+```
+
+## How to Run
+
+Execute commands via the `terminal` tool or shell:
+
+```bash
+# Open a new tab and navigate to a URL
+python3 skills/devops/termux-chromium-browser/scripts/browser.py newtab "https://en.wikipedia.org"
+
+# Read rendered visible text from the active page
+python3 skills/devops/termux-chromium-browser/scripts/browser.py read 2000
+
+# Search for specific text on the page
+python3 skills/devops/termux-chromium-browser/scripts/browser.py find "Wikipedia"
+
+# Capture a full-page screenshot
+python3 skills/devops/termux-chromium-browser/scripts/browser.py shot page.png
+
+# Evaluate JavaScript expression
+python3 skills/devops/termux-chromium-browser/scripts/browser.py eval "document.title"
+
+# List all open tabs
+python3 skills/devops/termux-chromium-browser/scripts/browser.py tabs
+```
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Open new tab | `python3 scripts/browser.py newtab <url>` |
+| Navigate tab | `python3 scripts/browser.py navigate <url>` |
+| Read page text | `python3 scripts/browser.py read [n]` |
+| Screenshot | `python3 scripts/browser.py shot [out.png]` |
+| Evaluate JS | `python3 scripts/browser.py eval "<expr>"` |
+| Search text | `python3 scripts/browser.py find "<text>"` |
+| Check version | `python3 scripts/browser.py version` |
+
+## Pitfalls
+
+- **ICU Data Permissions**: If Chromium fails with `Invalid file descriptor to ICU data received`, ensure read permissions on `$PREFIX/lib/chromium/` (`chmod -R 755 $PREFIX/lib/chromium`).
+- **Memory Footprint**: Headless Chromium idles around 300–400 MB RSS. Close unused tabs periodically.
+- **Renderer Idle**: Long-idle tabs in single-process mode may delay screenshot captures. Use `newtab` for fresh automation tasks.
+
+## Verification
+
+Verify CDP connection:
+```bash
+python3 skills/devops/termux-chromium-browser/scripts/browser.py version
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -200,6 +200,15 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                   type: 'category',
+                  label: 'devops',
+                  key: 'skills-bundled-devops',
+                  collapsed: true,
+                  items: [
+                    'user-guide/skills/bundled/devops/devops-termux-chromium-browser',
+                  ],
+                },
+                {
+                  type: 'category',
                   label: 'email',
                   key: 'skills-bundled-email',
                   collapsed: true,


### PR DESCRIPTION
## Summary
Adds the **Termux Chromium Browser Skill** (`termux-chromium-browser`) under `skills/devops/termux-chromium-browser/`.

Enables AI agents to run and automate a native headless Chromium browser on Android Termux over the Chrome DevTools Protocol (CDP) without requiring proot, root, or desktop environments.

### Technical Breakthrough & Credits
- **Attribution**: Special credits to **@pjy010218** for the Termux single-process flag orchestration and CDP browser driver architecture.
- **Android Gotcha Solved**: Termux requires `LD_PRELOAD=libtermux-exec.so` to execute the `ET_DYN` Chromium ELF, but `LD_PRELOAD` causes child process zygote/network failures. Running Chromium with `--no-zygote --single-process` eliminates child process spawning, allowing stable headless browser execution directly on Android.

### Features
- **CDP-over-WebSocket Driver (`browser.py`)**: Zero heavy dependencies (no Selenium, Playwright, or Node). Automates tab management, page navigation, text reading, JS evaluation, element search, and screenshots.
- **Runit Service Integration (`service/run` & `setup_service.sh`)**: Persistent background service on port 9222 with `termux-wake-lock` to prevent OS reclamation.
- **Video & DOM Verification (`yt_proof.py`)**: Validated on-device HTML5 video decode and canvas frame extraction.

### Tests & Documentation
- Unit tests added in `tests/skills/test_termux_chromium_browser_skill.py` covering CDP statefile management, tab parsing, and shell script syntax.
- Compliant with all repository authoring standards (`pytest tests/skills/test_authoring_standards.py`).
- Auto-generated Docusaurus doc page and updated catalog + sidebars.
