### PR TITLE
fix(tools): harden read_extract against XXE/billion-laughs via DTD pre-screen

### DIFF
--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -903,5 +903,37 @@ class TestPdfCoverageNote(unittest.TestCase):
         self.assertEqual(text, "converted\n")
 
 
+class TestXmlHardening(unittest.TestCase):
+    """Documents parsed by the stdlib extractor must not trigger XXE or
+    billion-laughs expansion through DTD/entity declarations (S314)."""
+
+    def test_docx_with_dtd_entity_is_rejected(self):
+        with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as fh:
+            _write_docx(
+                fh.name,
+                '<!DOCTYPE root [<!ENTITY x "B">]><root>&x;</root>',
+            )
+        try:
+            with self.assertRaises(ExtractionError):
+                extract_document_text(fh.name)
+        finally:
+            os.unlink(fh.name)
+
+    def test_docx_comment_with_dtd_substring_still_works(self):
+        """A benign OOXML comment containing the literal DTD substring should
+        not be mistaken for an actual DTD declaration."""
+        valid_xml = (
+            f'<w:document xmlns:w="{_NS_W}">'
+            '<w:body><w:p><!-- <!DOCTYPE root> --><w:r><w:t>safe</w:t></w:r></w:p></w:body>'
+            '</w:document>'
+        )
+        with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as fh:
+            _write_docx(fh.name, valid_xml)
+        try:
+            self.assertEqual(extract_document_text(fh.name), "safe\n")
+        finally:
+            os.unlink(fh.name)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -11,6 +11,7 @@ Run with:  python -m pytest tests/tools/test_read_extract.py -v
 """
 
 import base64
+import codecs
 import json
 import os
 import tempfile
@@ -931,6 +932,48 @@ class TestXmlHardening(unittest.TestCase):
             _write_docx(fh.name, valid_xml)
         try:
             self.assertEqual(extract_document_text(fh.name), "safe\n")
+        finally:
+            os.unlink(fh.name)
+
+    def test_docx_utf16_dtd_is_rejected(self):
+        """A UTF-16 document with a real DTD must be rejected, even though the
+        byte-level pre-screen does not see an ASCII-style ``<!DOCTYPE``."""
+        xml = (
+            '<?xml version="1.0" encoding="UTF-16"?>'
+            '<!DOCTYPE root [<!ENTITY x "B">]><root>&x;</root>'
+        )
+        data = codecs.BOM_UTF16_LE + xml.encode("utf-16-le")
+        with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as fh:
+            _write_docx(fh.name, data)
+        try:
+            with self.assertRaises(ExtractionError):
+                extract_document_text(fh.name)
+        finally:
+            os.unlink(fh.name)
+
+    def test_billion_laughs_payload_is_rejected(self):
+        """Nested internal entities must be rejected before expansion."""
+        dtd = '<?xml version="1.0"?><!DOCTYPE lolz ['
+        for i in range(1, 9):
+            prev = f"&lol{i - 1};" if i > 1 else "lol"
+            dtd += f'<!ENTITY lol{i} "{prev * 10}">'
+        dtd += ']><lolz>&lol8;</lolz>'
+        with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as fh:
+            _write_docx(fh.name, dtd)
+        try:
+            with self.assertRaises(ExtractionError):
+                extract_document_text(fh.name)
+        finally:
+            os.unlink(fh.name)
+
+    def test_undeclared_entity_still_raises(self):
+        """An undeclared entity reference is still a parse error, not a
+        security pass-through."""
+        with tempfile.NamedTemporaryFile(suffix=".docx", delete=False) as fh:
+            _write_docx(fh.name, "<?xml version=\"1.0\"?><root>&x;</root>")
+        try:
+            with self.assertRaises(ExtractionError):
+                extract_document_text(fh.name)
         finally:
             os.unlink(fh.name)
 

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -5,6 +5,7 @@ documents raise :class:`ExtractionError`; callers fall back to text/binary handl
 
 from __future__ import annotations
 
+import codecs
 import contextlib
 import functools
 import importlib
@@ -454,22 +455,70 @@ def _open_zip(path: str, kind: str) -> Iterator[zipfile.ZipFile]:
         raise ExtractionError(f"Not a valid {kind}: {exc}" if bad_zip else str(exc)) from exc
 
 
+# Byte-order marks for XML encodings that Python/Expat need to know about.
+_BOMS = (
+    (codecs.BOM_UTF8, "utf-8"),
+    (codecs.BOM_UTF16_LE, "utf-16-le"),
+    (codecs.BOM_UTF16_BE, "utf-16-be"),
+    (codecs.BOM_UTF32_LE, "utf-32-le"),
+    (codecs.BOM_UTF32_BE, "utf-32-be"),
+)
+
+# XML declaration encoding attribute (UTF-16/UTF-32 files are detected by BOM
+# rather than by scanning the declaration, whose bytes are interleaved with NULs).
+_XML_DECL_RE = re.compile(
+    rb'''<\?xml[^?]*?encoding=([A-Za-z0-9._-]+)''',
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Remove the encoding attribute from the XML declaration after we've decoded
+# with it, so ElementTree gets bytes whose declared encoding matches the data.
+_XML_DECL_ENCODING_RE = re.compile(
+    r'''\s+encoding=(["'])([^"']*?)\1''',
+    re.IGNORECASE,
+)
+
+
+def _normalize_to_utf8(data: bytes) -> bytes:
+    """Return ``data`` decoded and re-encoded as UTF-8.
+
+    Uses the BOM or ``<?xml ... encoding="..."?>`` declaration to decide the
+    source encoding. The encoding attribute is stripped from the declaration
+    so callers see consistent UTF-8 bytes.
+    """
+    encoding = "utf-8"
+    for bom, enc in _BOMS:
+        if data.startswith(bom):
+            encoding = enc
+            data = data[len(bom):]
+            break
+    else:
+        m = _XML_DECL_RE.search(data[:256])
+        if m:
+            encoding = m.group(1).decode("ascii")
+    try:
+        text = data.decode(encoding)
+    except (LookupError, UnicodeError) as exc:
+        raise ET.ParseError(f"Unsupported or malformed XML encoding {encoding!r}: {exc}")
+    text = _XML_DECL_ENCODING_RE.sub("", text, count=1)
+    return text.encode("utf-8")
+
+
 def _parse_xml(data: bytes) -> ET.Element:
     """Parse XML bytes, rejecting documents that declare a DTD or entity.
 
     ``xml.etree.ElementTree`` does not safely handle internal/external
-    entity expansion by default (S314 / billion-laughs / XXE). We pre-screen
-    every payload for ``<!DOCTYPE ...>`` / ``<!ENTITY ...>`` declarations;
-    any match is confirmed by a short Expat pass that distinguishes real
-    declarations from the same substring appearing in escaped text or
-    comments. Documents without declarations use the normal parser.
+    entity expansion by default (S314 / billion-laughs / XXE). We first
+    normalize every payload to UTF-8, then pre-screen it for
+    ``<!DOCTYPE ...>`` / ``<!ENTITY ...>`` declarations. Any match is confirmed
+    by a short Expat pass that distinguishes real declarations from the same
+    substring appearing in escaped text or comments. Documents without
+    declarations are parsed normally.
     """
-    if _DTD_ENTITY_RE.search(data):
-        _confirm_no_dtd_or_entity(data)
-    try:
-        return ET.fromstring(data)
-    except ET.ParseError:
-        raise
+    utf8_data = _normalize_to_utf8(data)
+    if _DTD_ENTITY_RE.search(utf8_data):
+        _confirm_no_dtd_or_entity(utf8_data)
+    return ET.fromstring(utf8_data)
 
 
 def _confirm_no_dtd_or_entity(data: bytes) -> None:

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -18,6 +18,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import xml.parsers.expat
 import zipfile
 from pathlib import Path
 from typing import Any, Callable, Iterator, Optional
@@ -40,6 +41,12 @@ _NS_W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 _NS_S = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 _NS_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 _NS_PKG_REL = "http://schemas.openxmlformats.org/package/2006/relationships"
+
+
+# Precompiled regex that matches DOCTYPE or ENTITY declarations in an XML
+# prolog/Dtd. This is used to reject billion-laughs / XXE payloads before the
+# stdlib parser is invoked, without adding a hard dependency on defusedxml.
+_DTD_ENTITY_RE = re.compile(rb"<!\s*(DOCTYPE|ENTITY)\b", re.IGNORECASE)
 
 
 class ExtractionError(Exception):
@@ -447,10 +454,48 @@ def _open_zip(path: str, kind: str) -> Iterator[zipfile.ZipFile]:
         raise ExtractionError(f"Not a valid {kind}: {exc}" if bad_zip else str(exc)) from exc
 
 
+def _parse_xml(data: bytes) -> ET.Element:
+    """Parse XML bytes, rejecting documents that declare a DTD or entity.
+
+    ``xml.etree.ElementTree`` does not safely handle internal/external
+    entity expansion by default (S314 / billion-laughs / XXE). We pre-screen
+    every payload for ``<!DOCTYPE ...>`` / ``<!ENTITY ...>`` declarations;
+    any match is confirmed by a short Expat pass that distinguishes real
+    declarations from the same substring appearing in escaped text or
+    comments. Documents without declarations use the normal parser.
+    """
+    if _DTD_ENTITY_RE.search(data):
+        _confirm_no_dtd_or_entity(data)
+    try:
+        return ET.fromstring(data)
+    except ET.ParseError:
+        raise
+
+
+def _confirm_no_dtd_or_entity(data: bytes) -> None:
+    """Raise ``ET.ParseError`` if the data declares a DTD or entity."""
+    class _UnsafeXML(Exception):
+        pass
+
+    def _reject(*_args, **_kwargs):
+        raise _UnsafeXML()
+
+    parser = xml.parsers.expat.ParserCreate()
+    parser.StartDoctypeDeclHandler = _reject
+    parser.EntityDeclHandler = _reject
+    try:
+        parser.Parse(data, True)
+    except _UnsafeXML:
+        raise ET.ParseError("XML DTD/entity declarations are not supported")
+    except xml.parsers.expat.ExpatError:
+        # Let ElementTree surface the real parse-error details.
+        return
+
+
 def _zip_xml(zf: zipfile.ZipFile, name: str, optional: bool = False) -> Any:
     """Parse a package part; ``optional`` parts yield an empty element when absent or malformed."""
     try:
-        return ET.fromstring(zf.read(name))
+        return _parse_xml(zf.read(name))
     except (KeyError, ET.ParseError) as exc:
         if optional:
             return ET.Element("missing")
@@ -502,7 +547,7 @@ def _col_index(ref: str) -> int:
 
 
 def _sheet_rows(xml_bytes: bytes, shared: list[str]) -> list[list[str]]:
-    root = ET.fromstring(xml_bytes)
+    root = _parse_xml(xml_bytes)
     s = f"{{{_NS_S}}}"
     rows: list[list[str]] = []
     for row in itertools.islice(root.iter(f"{s}row"), _MAX_XLSX_ROWS_PER_SHEET):


### PR DESCRIPTION
## What does this PR do?

`tools/read_extract.py` extracts `.docx` / `.xlsx` (OOXML) by unzipping XML parts and feeding them to `xml.etree.ElementTree`. The stdlib parser expands internal/external entities and DTDs by default, leaving `read_file` exposed to billion-laughs / XXE (Bandit `S314`).

This change adds a small `_parse_xml` helper that:
1. Pre-screens every XML payload for `<!DOCTYPE` / `<!ENTITY` declarations with a regex.
2. Confirms any match using `xml.parsers.expat.ParserCreate` with `StartDoctypeDeclHandler` and `EntityDeclHandler` callbacks, so comments/CDATA containing the literal substring are not mistaken for real declarations.
3. Raises `ET.ParseError` for any real DTD/entity, preserving the existing `_zip_xml` / `_shared_strings` / `_workbook_rels` / `_sheet_rows` error handling.

It keeps `read_extract.py` stdlib-only, so it does not add a hard dependency on `defusedxml` or churn the lockfile.

## Related Issue

Fixes # (none filed)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/read_extract.py`: add `_parse_xml` / `_confirm_no_dtd_or_entity` helpers, route all `ET.fromstring(...)` calls through them.
- `tests/tools/test_read_extract.py`: add `TestXmlHardening` regression tests for DTD/entity rejection and benign substring handling.

## How to Test

1. `uv tool run ruff check --select PLW1514 tools/read_extract.py tests/tools/test_read_extract.py`
2. `python -m pytest tests/tools/test_read_extract.py -v` (or `python -m unittest tests.tools.test_read_extract.TestXmlHardening`)
3. Manual: create a `.docx` with `word/document.xml` containing `<!DOCTYPE root [<!ENTITY x "B">]><root>&x;</root>` and verify `extract_document_text` raises `ExtractionError`.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) for duplicates
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu (this Devin VM)

### Documentation & Housekeeping
- [ ] I've updated relevant documentation — N/A (docstrings are sufficient)
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (uses stdlib modules only)
- [ ] I've updated tool descriptions/schemas — N/A