### PR TITLE
feat(cli): opt-in live timestamp prefix on CLI user messages

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -42,6 +42,7 @@ from agent.message_metadata import append_message
 from agent.turn_context import (
     _compression_warrants_another_preflight_pass,
     build_turn_context,
+    cli_live_message_timestamp,
     compose_user_api_content,
     reanchor_current_turn_user_idx,
 )
@@ -2231,6 +2232,9 @@ def run_conversation(
                         api_msg.get("content", ""),
                         _ext_prefetch_cache,
                         _plugin_user_context,
+                        live_timestamp=cli_live_message_timestamp(
+                            agent, msg.get("timestamp")
+                        ),
                     )
                     if _composed is not None:
                         api_msg["content"] = _composed

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -55,12 +55,16 @@ def compose_user_api_content(
     content: Any,
     ext_prefetch_cache: str,
     plugin_user_context: str,
+    *,
+    live_timestamp: Optional[str] = None,
 ) -> Optional[str]:
     """Compose the API-bound content of the current turn's user message.
 
     Sources: memory-manager prefetch + ``pre_llm_call`` plugin context with
-    target="user_message" (the default). Both are appended to the *API copy*
-    of the user message only — the stored content stays clean.
+    target="user_message" (the default), plus an optional pre-rendered
+    ``live_timestamp`` prefix (see ``cli_live_message_timestamp``). All are
+    applied to the *API copy* of the user message only — the stored content
+    stays clean.
 
     This is the single source of that composition. The prologue stamps the
     result onto the live message as ``api_content`` (persisted alongside the
@@ -70,7 +74,7 @@ def compose_user_api_content(
     what turn N sends must be what turn N+1 replays.
 
     Returns ``None`` when nothing is injected (multimodal/non-string content,
-    or no ephemeral context), meaning the message is sent as-is.
+    or no ephemeral context/timestamp), meaning the message is sent as-is.
     """
     if not isinstance(content, str):
         return None
@@ -81,9 +85,41 @@ def compose_user_api_content(
             injections.append(fenced)
     if plugin_user_context:
         injections.append(plugin_user_context)
-    if not injections:
+    if not injections and not live_timestamp:
         return None
-    return content + "\n\n" + "\n\n".join(injections)
+    body = content + "\n\n" + "\n\n".join(injections) if injections else content
+    return f"{live_timestamp} {body}" if live_timestamp else body
+
+
+def cli_live_message_timestamp(agent: Any, msg_timestamp: Optional[float]) -> Optional[str]:
+    """Render a live ``[Tue 2026-08-23 09:31:10 CST]`` prefix for CLI turns.
+
+    Off by default — opt in via ``agent.message_timestamps.enabled`` in
+    config.yaml. Scoped to ``platform == "cli"`` only: gateway platforms have
+    their own separate opt-in (``gateway.message_timestamps``), rebuilt from
+    stored per-message metadata every time a session's history is replayed
+    from disk. A CLI session instead keeps its whole transcript as one
+    growing in-memory list, so this reuses the ``api_content`` sidecar
+    (composed once per turn via ``compose_user_api_content`` and replayed
+    byte-for-byte on every later turn) rather than gateway's rebuild-on-load
+    approach — either mechanism firing for the same turn would double the
+    prefix, so this never fires outside "cli".
+    """
+    if getattr(agent, "platform", None) != "cli":
+        return None
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
+    except Exception:
+        return None
+    agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else None
+    mt = agent_cfg.get("message_timestamps") if isinstance(agent_cfg, dict) else None
+    enabled = mt.get("enabled", False) if isinstance(mt, dict) else bool(mt)
+    if not enabled:
+        return None
+    from gateway.message_timestamps import format_message_timestamp
+    from hermes_time import get_timezone
+    return format_message_timestamp(msg_timestamp, tz=get_timezone()) or None
 
 
 def substitute_api_content(api_msg: Dict[str, Any]) -> Optional[str]:
@@ -1394,7 +1430,12 @@ def build_turn_context(
     ):
         _turn_user_msg = messages[current_turn_user_idx]
         _api_content = compose_user_api_content(
-            _turn_user_msg.get("content", ""), ext_prefetch_cache, plugin_user_context
+            _turn_user_msg.get("content", ""),
+            ext_prefetch_cache,
+            plugin_user_context,
+            live_timestamp=cli_live_message_timestamp(
+                agent, _turn_user_msg.get("timestamp")
+            ),
         )
         if _api_content is not None and _api_content != _turn_user_msg.get("content"):
             _turn_user_msg["api_content"] = _api_content

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -43,6 +43,17 @@ DEFAULT_CONFIG = {
         "terminal_continue": True,
     },
     "agent": {
+        # Inject a human-readable timestamp prefix (e.g.
+        # "[Tue 2026-04-28 13:40:53 CEST]") onto each CLI user message IN THE
+        # MODEL'S CONTEXT, so a long-running session has live temporal
+        # awareness instead of only the date frozen in the system prompt at
+        # session start (agent/system_prompt.py). Off by default — when off,
+        # the model sees clean message text; persisted transcripts always
+        # stay clean either way. Gateway platforms have their own separate
+        # toggle for the same feature: ``gateway.message_timestamps``.
+        "message_timestamps": {
+            "enabled": False,
+        },
         # Unlimited by default. The agent turn cap caused more problems than
         # it solved (silent mid-task truncation). null = unlimited; set a
         # positive integer to cap, or use "none"/"unlimited"/"inf"/0/-1 —

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -30,7 +30,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.memory_manager import build_memory_context_block
-from agent.turn_context import build_turn_context, compose_user_api_content
+from agent.turn_context import (
+    build_turn_context,
+    cli_live_message_timestamp,
+    compose_user_api_content,
+)
 from hermes_state import SessionDB
 
 
@@ -47,6 +51,46 @@ class TestComposeUserApiContent:
         out = compose_user_api_content("hello", "likes tea", "PLUGIN-CTX")
         fenced = build_memory_context_block("likes tea")
         assert out == "hello" + "\n\n" + fenced + "\n\n" + "PLUGIN-CTX"
+
+    def test_prepends_live_timestamp(self):
+        out = compose_user_api_content(
+            "hello", "", "", live_timestamp="[Tue 2026-04-28 13:40:53 CEST]"
+        )
+        assert out == "[Tue 2026-04-28 13:40:53 CEST] hello"
+
+    def test_live_timestamp_combines_with_other_injections(self):
+        out = compose_user_api_content(
+            "hello", "likes tea", "", live_timestamp="[Tue 2026-04-28 13:40:53 CEST]"
+        )
+        fenced = build_memory_context_block("likes tea")
+        assert out == "[Tue 2026-04-28 13:40:53 CEST] " + "hello" + "\n\n" + fenced
+
+
+# ---------------------------------------------------------------------------
+# cli_live_message_timestamp — CLI-only, config-gated, off by default
+# ---------------------------------------------------------------------------
+
+class TestCliLiveMessageTimestamp:
+    def test_none_for_non_cli_platform(self):
+        agent = types.SimpleNamespace(platform="telegram")
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            return_value={"agent": {"message_timestamps": {"enabled": True}}},
+        ):
+            assert cli_live_message_timestamp(agent, 1745836853.0) is None
+
+    def test_none_when_disabled_by_default(self):
+        agent = types.SimpleNamespace(platform="cli")
+        with patch("hermes_cli.config.load_config_readonly", return_value={}):
+            assert cli_live_message_timestamp(agent, 1745836853.0) is None
+
+    def test_renders_bracketed_prefix_when_enabled(self):
+        agent = types.SimpleNamespace(platform="cli")
+        cfg = {"agent": {"message_timestamps": {"enabled": True}}}
+        with patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            out = cli_live_message_timestamp(agent, 1745836853.0)
+        assert out is not None
+        assert out.startswith("[") and out.endswith("]")
 
 
 
@@ -268,6 +312,40 @@ class TestPrologueStamping:
             ctx = _build(agent)
         assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
         assert agent.api_content_at_persist is None
+
+    def test_stamps_live_timestamp_when_cli_toggle_enabled(self):
+        """agent.message_timestamps.enabled=true stamps a live-clock sidecar
+        onto the CLI user message even with no other injections — the
+        stored/displayed content stays clean, only the wire copy carries it
+        (agent/system_prompt.py:878's "Conversation started" date otherwise
+        never updates for the life of the session)."""
+        agent = _FakeAgent()
+        assert agent.platform == "cli"
+        cfg = {"agent": {"message_timestamps": {"enabled": True}}}
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]), patch(
+            "hermes_cli.config.load_config_readonly", return_value=cfg
+        ):
+            ctx = _build(agent)
+        msg = ctx.messages[ctx.current_turn_user_idx]
+        assert msg["content"] == "hello"  # clean content untouched
+        assert msg["api_content"] != "hello"
+        assert msg["api_content"].endswith(" hello")
+        assert msg["api_content"].startswith("[")
+        assert agent.api_content_at_persist == msg["api_content"]
+
+    def test_no_live_timestamp_stamp_for_non_cli_platform(self):
+        """Same toggle must not fire for gateway platforms — they have their
+        own separate opt-in (gateway.message_timestamps) that rebuilds from
+        stored per-message metadata on every history replay; firing both
+        would double the prefix."""
+        agent = _FakeAgent()
+        agent.platform = "telegram"
+        cfg = {"agent": {"message_timestamps": {"enabled": True}}}
+        with patch("hermes_cli.plugins.invoke_hook", return_value=[]), patch(
+            "hermes_cli.config.load_config_readonly", return_value=cfg
+        ):
+            ctx = _build(agent)
+        assert "api_content" not in ctx.messages[ctx.current_turn_user_idx]
 
     def test_no_stamp_for_codex_app_server(self):
         """codex_app_server turns bypass the api_messages build, so the


### PR DESCRIPTION
Fixes #92658

## Problem

In long-lived sessions, the system prompt carries only a `Conversation
started: <date>` line, frozen once at session build time
(`agent/system_prompt.py:878`). When a conversation spans hours or days,
the model has no live clock and confidently reasons from the stale start
date, as described in the issue.

## What already existed

The gateway surface already solved exactly this: `gateway.message_timestamps`
(off by default) renders a `[Tue 2026-04-28 13:40:53 CEST]` prefix onto
user messages for the model, while keeping persisted transcript content
clean (`gateway/message_timestamps.py`, wired in `gateway/run.py`). It
works by rebuilding that prefix from stored per-message metadata every
time a gateway session's history is reconstructed from disk.

CLI had no equivalent — this PR adds one.

## Fix

CLI keeps a session's whole transcript as one growing in-memory list
rather than reconstructing it from disk each turn, so the gateway's
rebuild-on-load approach doesn't fit its data flow. Instead this reuses
the `api_content` sidecar mechanism that already exists in
`agent/turn_context.py` for exactly this class of problem ("bytes sent to
the API differ from the bytes persisted, and must replay identically on
every later turn to keep the provider prompt-cache prefix byte-stable").

- `compose_user_api_content` (`agent/turn_context.py`) gains an optional
  `live_timestamp` prefix, composed once per turn and frozen into the
  `api_content` sidecar — replayed byte-for-byte on every subsequent turn,
  so the cache prefix never drifts.
- `cli_live_message_timestamp` renders that prefix, gated on:
  - `agent.message_timestamps.enabled` in `config.yaml` (new, **default
    off** — zero behavior change unless a user opts in).
  - `agent.platform == "cli"` **only**. Gateway platforms keep using their
    own separate, already-shipped mechanism; this never fires for them, so
    the two mechanisms can never both fire on the same turn and double the
    prefix.
- Both call sites that build the sidecar (the turn prologue in
  `agent/turn_context.py` and the fallback "compose live" path in
  `agent/conversation_loop.py`) are updated, so this covers every CLI
  entry point that funnels through `AIAgent.run_conversation()` (the
  interactive chat loop and the single-query/batch paths) without touching
  `cli.py` at all.

TUI and desktop go through a separate backend (`tui_gateway/`) with its
own `run_conversation()` call sites; extending this there is a natural,
low-risk follow-up (same `cli_live_message_timestamp`-style helper, gated
on that platform string) but is out of scope for this PR to keep the diff
reviewable.

## Why not just extend the CLI toggle to gateway's config key

I deliberately used a new `agent.message_timestamps.enabled` key rather
than repurposing `gateway.message_timestamps.enabled`, and gated
strictly on `platform == "cli"`, so an existing gateway deployment that
already has its toggle on sees **zero change** — there's no scenario in
which enabling one now silently double-injects because of the other.

## Tests

Added to `tests/agent/test_api_content_sidecar.py`:
- `compose_user_api_content` prepends the timestamp alone and combined
  with other injections.
- `cli_live_message_timestamp` returns `None` for non-`cli` platforms,
  `None` when the config toggle is off (default), and a bracketed prefix
  when both are satisfied.
- End-to-end through the real turn prologue (`build_turn_context`): with
  the toggle enabled, a CLI turn's `api_content` sidecar carries the
  timestamp while the persisted `content` stays clean; the same turn on a
  gateway platform (`telegram`) produces no sidecar at all.

Confirmed the new tests fail without the fix:

```
$ git checkout HEAD~1 -- agent/turn_context.py agent/conversation_loop.py hermes_cli/config_defaults.py
$ python -m pytest tests/agent/test_api_content_sidecar.py -q
ImportError: cannot import name 'cli_live_message_timestamp' from 'agent.turn_context'
1 error in 0.42s
$ git checkout HEAD -- agent/turn_context.py agent/conversation_loop.py hermes_cli/config_defaults.py
```

Full run with the fix in place:

```
$ python -m pytest tests/agent/test_api_content_sidecar.py -q
34 passed in 10.93s

$ python -m pytest tests/agent/test_turn_context.py tests/agent/test_gateway_turn_sidecar.py \
    tests/run_agent/test_run_agent.py tests/agent/test_api_content_sidecar.py -q
336 passed, 1 warning in 71.73s
```

(the one warning is a pre-existing, unrelated background-thread assertion
in `test_run_agent.py`, reproducible on unmodified `main`)

```
$ ruff check agent/turn_context.py agent/conversation_loop.py hermes_cli/config_defaults.py \
    tests/agent/test_api_content_sidecar.py
All checks passed!

$ python -m py_compile agent/turn_context.py agent/conversation_loop.py \
    hermes_cli/config_defaults.py tests/agent/test_api_content_sidecar.py
$ git diff --check
(clean)
```

## AI assistance disclosure

This change was written with AI assistance (Claude).
