### PR TITLE
fix(desktop): scope Providers settings key saves to the active profile (#92662)

### DIFF
--- a/apps/desktop/src/app/settings/providers-settings-profile-scope.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings-profile-scope.test.tsx
@@ -1,0 +1,103 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile } from '@/store/profile'
+import { $settingsScopeOverride } from '@/store/settings-scope'
+
+import type * as EnvCredentialsModule from './env-credentials'
+
+// Regression for #92662: the Providers settings page saved API keys to the BASE
+// profile even when a non-default profile was active, because it called
+// `useEnvCredentials()` with no argument. The hook defaults `profile` to `null`,
+// which capabilityScoped/profileScoped route to base (only `undefined` follows
+// the active profile). The page must scope its credential reads/writes to the
+// active (or "Applies to"-selected) profile — the concrete key resolved by
+// `$settingsScopeProfile` — the same target the rest of profile-scoped settings use.
+//
+// This guards the call site: it asserts the profile the page hands to
+// `useEnvCredentials` follows the active profile, so a future revert back to a
+// bare `useEnvCredentials()` fails here.
+
+const useEnvCredentials = vi.fn()
+const listOAuthProviders = vi.fn()
+
+vi.mock('./env-credentials', async importOriginal => ({
+  ...(await importOriginal<typeof EnvCredentialsModule>()),
+  useEnvCredentials: (profile?: null | string) => useEnvCredentials(profile)
+}))
+
+vi.mock('@/hermes', () => ({
+  disconnectOAuthProvider: vi.fn(),
+  listOAuthProviders: () => listOAuthProviders(),
+  setApiRequestProfile: vi.fn()
+}))
+
+vi.mock('@/store/onboarding', () => ({
+  $desktopOnboarding: atom({ manual: false }),
+  startManualLocalEndpoint: vi.fn(),
+  startManualProviderOAuth: vi.fn()
+}))
+
+beforeEach(() => {
+  listOAuthProviders.mockResolvedValue({ providers: [] })
+  useEnvCredentials.mockReturnValue({
+    rowProps: {
+      edits: {},
+      onClear: vi.fn(),
+      onReveal: vi.fn(),
+      onSave: vi.fn(),
+      revealed: {},
+      saving: null,
+      setEdits: vi.fn()
+    },
+    saveValue: vi.fn(),
+    vars: {}
+  })
+  $settingsScopeOverride.set(null)
+})
+
+afterEach(() => {
+  cleanup()
+  $activeGatewayProfile.set('default')
+  $settingsScopeOverride.set(null)
+  vi.clearAllMocks()
+})
+
+async function renderProvidersSettings() {
+  const { ProvidersSettings } = await import('./providers-settings')
+  await act(async () => {
+    render(<ProvidersSettings onClose={vi.fn()} onViewChange={vi.fn()} view="keys" />)
+  })
+}
+
+describe('ProvidersSettings profile scoping (#92662)', () => {
+  it('scopes credentials to the active profile when one is selected', async () => {
+    $activeGatewayProfile.set('foo')
+
+    await renderProvidersSettings()
+
+    // Must NOT be a bare/null call (that routed to base) — it must carry the
+    // active profile so the key lands in that profile's .env.
+    expect(useEnvCredentials).toHaveBeenCalledWith('foo')
+  })
+
+  it('honours the shared "Applies to" override over the active profile', async () => {
+    $activeGatewayProfile.set('foo')
+    $settingsScopeOverride.set('bar')
+
+    await renderProvidersSettings()
+
+    expect(useEnvCredentials).toHaveBeenCalledWith('bar')
+  })
+
+  it('resolves to a concrete key for single-profile users (base, no leak)', async () => {
+    $activeGatewayProfile.set('default')
+
+    await renderProvidersSettings()
+
+    // 'default' resolves to the base home on the backend, so single-profile
+    // users are unaffected while the call is never a bare null.
+    expect(useEnvCredentials).toHaveBeenCalledWith('default')
+  })
+})

--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -16,7 +16,10 @@ const onboarding = atom({ manual: false })
 vi.mock('@/hermes', () => ({
   disconnectOAuthProvider: (providerId: string) => disconnectOAuthProvider(providerId),
   getEnvVars: () => getEnvVars(),
-  listOAuthProviders: () => listOAuthProviders()
+  listOAuthProviders: () => listOAuthProviders(),
+  // The page now scopes credentials via $settingsScopeProfile, which pulls in
+  // @/store/profile; its subscriber calls setApiRequestProfile at import time.
+  setApiRequestProfile: () => undefined
 }))
 
 vi.mock('@/store/onboarding', () => ({

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -23,6 +23,7 @@ import { cn } from '@/lib/utils'
 import { confirm } from '@/store/confirm'
 import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding, startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
+import { $settingsScopeProfile } from '@/store/settings-scope'
 import type { EnvVarInfo, OAuthProvider } from '@/types/hermes'
 
 import { isKeyVar, ProviderKeyRows } from './credential-key-ui'
@@ -340,7 +341,14 @@ export function ProvidersSettings({
   view
 }: ProvidersSettingsProps) {
   const { t } = useI18n()
-  const { rowProps, vars } = useEnvCredentials()
+  // Scope provider-key reads/writes to the active (or "Applies to"-selected)
+  // profile, mirroring the Keys page — otherwise a bare useEnvCredentials()
+  // forwards null, which capabilityScoped/profileScoped route to the base
+  // profile's .env instead of the active one (#92662). $settingsScopeProfile
+  // resolves to a concrete key (override ?? active), so a non-default profile's
+  // keys land in that profile and single-profile users still target base.
+  const scopeProfile = useStore($settingsScopeProfile)
+  const { rowProps, vars } = useEnvCredentials(scopeProfile)
   const [oauthProviders, setOauthProviders] = useState<OAuthProvider[]>([])
   const [openProvider, setOpenProvider] = useState<null | string>(null)
   const [disconnecting, setDisconnecting] = useState<null | string>(null)


### PR DESCRIPTION
## What does this PR do?

The desktop **Settings → Providers** page saved API keys (e.g. `LM_API_KEY`) to the base `~/.hermes/.env` even when a non-default profile was active, so a profile running an api-key provider never saw the key and its chat ran with no credential.

Root cause is a `null` vs `undefined` mismatch in the request-scoping helpers. `profileScoped`/`capabilityScoped` fall back to the active profile (`_apiProfile`) only when the scope is `undefined`; a literal `null` yields `{}` — no `?profile=` on the request. The Providers page called `useEnvCredentials()` with no argument, and the hook's `profile` parameter defaults to `null`, so every `PUT /api/env` from that page dropped the profile and the backend wrote under `_profile_scope(None)` → the dashboard's own (base) home.

This scopes the page's credential reads/writes to the active/selected profile via `$settingsScopeProfile` (the concrete `override ?? active` key), mirroring the shared "Applies to" settings scope the Keys page already uses. Single-profile users resolve to `default`, which the backend maps to the base home, so their behaviour is unchanged.

## Related Issue

Fixes #92662

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/settings/providers-settings.tsx` — call `useEnvCredentials(useStore($settingsScopeProfile))` instead of a bare `useEnvCredentials()`, so provider-key saves target the active profile's `.env`.
- `apps/desktop/src/app/settings/providers-settings-profile-scope.test.tsx` (new) — regression test: the page scopes to the active profile, honours the shared "Applies to" override, and resolves to a concrete key for single-profile users (never a bare `null`).
- `apps/desktop/src/app/settings/providers-settings.test.tsx` — add a `setApiRequestProfile` stub to the `@/hermes` mock, since the page now transitively imports `@/store/profile` whose subscriber calls it at import time.

## How to Test

1. Create/select a non-default profile whose provider is a local api-key provider, e.g. LM Studio: `hermes -p foo`, or the app's profile switcher.
2. Open **Settings → Providers**, enter `LM_API_KEY`, and save.
3. Before this change the key lands in `~/.hermes/.env` (base); after it lands in `~/.hermes/profiles/foo/.env`, and a chat under `foo` picks it up.
4. Automated: `cd apps/desktop && npx vitest run --project ui src/app/settings/providers-settings-profile-scope.test.tsx` — 3 pass; reverting the one-line call-site change makes all 3 fail.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
