### PR TITLE
fix(gateway): register secondary profiles' shell hooks and outbound webhooks

### DIFF
--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -98,8 +98,12 @@ _TOOL_SCOPED_EVENTS = {"pre_tool_call", "post_tool_call"}
 # kwargs promoted to top-level payload keys (mirrors shell hooks wire).
 _TOP_LEVEL_PAYLOAD_KEYS = {"tool_name", "args", "session_id", "parent_session_id"}
 
-# (event, url) pairs already wired to the plugin manager in this process.
-_registered: Set[Tuple[str, str]] = set()
+# (home, event, url) triples already wired to the plugin manager in this
+# process. Home is part of the key so a multiplexed gateway's secondary
+# profiles — each with their own plugin manager (see
+# hermes_cli.plugins.get_plugin_manager) — can register identical webhook
+# targets without the first profile's registration shadowing the rest.
+_registered: Set[Tuple[str, str, str]] = set()
 _registered_lock = threading.Lock()
 
 _delivery_queue: "queue.Queue[Optional[Dict[str, Any]]]" = queue.Queue(
@@ -180,15 +184,17 @@ def register_from_config(cfg: Optional[Dict[str, Any]]) -> List[WebhookTarget]:
         return []
 
     from hermes_cli.plugins import get_plugin_manager
+    from hermes_constants import get_hermes_home
 
     manager = get_plugin_manager()
+    home_key = str(get_hermes_home().expanduser().resolve())
 
     registered: List[WebhookTarget] = []
     with _registered_lock:
         for target in targets:
             wired_any = False
             for event in target.events:
-                key = (event, target.url)
+                key = (home_key, event, target.url)
                 if key in _registered:
                     continue
                 manager._hooks.setdefault(event, []).append(

--- a/agent/outbound_webhooks.py
+++ b/agent/outbound_webhooks.py
@@ -237,6 +237,29 @@ def flush(timeout: float = 5.0) -> bool:
         return _delivery_queue.unfinished_tasks == 0
 
 
+def re_register_config_hooks() -> None:
+    """Re-register outbound webhooks from config after a plugin force-reload.
+
+    Mirrors ``agent.shell_hooks.re_register_config_hooks``: config-owned
+    outbound-webhook callbacks live in the same ``_hooks`` dict that
+    ``PluginManager.discover_and_load(force=True)`` clears via ``unload()``,
+    so without this the force-reloaded profile's outbound webhooks go
+    silently inert (#92682 review). Only the current home's idempotence
+    keys are cleared so a force-reload in one profile cannot invalidate
+    another profile's still-live registration.
+    """
+    from hermes_cli.config import load_config
+    from hermes_constants import get_hermes_home
+
+    home_key = str(get_hermes_home().expanduser().resolve())
+    with _registered_lock:
+        _registered.difference_update(
+            {key for key in _registered if key[0] == home_key}
+        )
+
+    register_from_config(load_config())
+
+
 def reset_for_tests() -> None:
     """Clear the idempotence set and drain the queue.  Test-only helper."""
     with _registered_lock:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -182,13 +182,17 @@ _BLOCKING_EVENTS = frozenset({"pre_tool_call"})
 _STDERR_MESSAGE_LIMIT = 400
 
 
-# (event, matcher, command) triples that have been wired to the plugin
+# (home, event, matcher, command) tuples that have been wired to the plugin
 # manager in the current process.  Matcher is part of the key because
 # the same script can legitimately register for different matchers under
-# the same event (e.g. one entry per tool the user wants to gate).
-# Second registration attempts for the exact same triple become no-ops
+# the same event (e.g. one entry per tool the user wants to gate). Home is
+# part of the key so a multiplexed gateway's secondary profiles — each with
+# their own plugin manager (see hermes_cli.plugins.get_plugin_manager) — can
+# register identical hook triples without the first profile's registration
+# silently shadowing the rest.
+# Second registration attempts for the exact same tuple become no-ops
 # so the CLI and gateway can both call register_from_config() safely.
-_registered: Set[Tuple[str, Optional[str], str]] = set()
+_registered: Set[Tuple[str, str, Optional[str], str]] = set()
 _registered_lock = threading.Lock()
 
 # Intra-process lock for allowlist read-modify-write on platforms that
@@ -289,13 +293,14 @@ def register_from_config(
     from hermes_cli.plugins import get_plugin_manager
 
     manager = get_plugin_manager()
+    home_key = str(get_hermes_home().expanduser().resolve())
 
     # Idempotence + allowlist read happen under the lock; the TTY
     # prompt runs outside so other threads aren't parked on a blocking
     # input().  Mutation re-takes the lock with a defensive idempotence
     # re-check in case two callers ever race through the prompt.
     for spec in specs:
-        key = (spec.event, spec.matcher, spec.command)
+        key = (home_key, spec.event, spec.matcher, spec.command)
         with _registered_lock:
             if key in _registered:
                 continue

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -354,11 +354,20 @@ def re_register_config_hooks() -> None:
     are wired again (#60036 / PR #60267; tracking #64178 — salvaged from
     PR #64188).
 
+    Only the idempotence keys for the *current* Hermes home are cleared —
+    ``discover_and_load(force=True)`` only unloads the manager scoped to
+    that one home, so clearing every home's keys would make a force-reload
+    in profile A drop profile B's still-live registration from the ledger
+    and duplicate it on B's next registration call (#92682 review).
+
     Commands already allowlisted stay allowlisted, so this never re-prompts
     at a TTY for hooks the user previously approved.
     """
+    home_key = str(get_hermes_home().expanduser().resolve())
     with _registered_lock:
-        _registered.clear()
+        _registered.difference_update(
+            {key for key in _registered if key[0] == home_key}
+        )
     from hermes_cli.config import load_config
 
     register_from_config(load_config())

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15445,6 +15445,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from hermes_cli.plugins import discover_plugins
 
             discover_plugins()
+
+            # Register this profile's own declarative shell hooks and
+            # outbound webhooks. The startup-time registration in
+            # start() only ever sees the root/default profile's config
+            # (it runs before any profile scope exists), so without this
+            # a secondary profile's `hooks:` block is silently inert —
+            # its turns run under this profile's own plugin manager
+            # (hermes_cli.plugins.get_plugin_manager keys by resolved
+            # home), which never received the callbacks.
+            try:
+                from hermes_cli.config import load_config as _load_profile_config
+                from agent.shell_hooks import (
+                    register_from_config as _register_shell_hooks,
+                )
+                from agent.outbound_webhooks import (
+                    register_from_config as _register_outbound_webhooks,
+                )
+
+                _profile_hooks_cfg = _load_profile_config()
+                _register_shell_hooks(_profile_hooks_cfg, accept_hooks=False)
+                _register_outbound_webhooks(_profile_hooks_cfg)
+            except Exception:
+                logger.warning(
+                    "shell-hook/webhook registration failed for profile '%s'",
+                    profile_name,
+                    exc_info=True,
+                )
+
             profile_cfg = load_gateway_config()
             violation = _own_policy_open_startup_violation(profile_cfg)
         self._snapshot_profile_busy_modes(profile_name, profile_runtime_cfg)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -3802,18 +3802,21 @@ class PluginManager:
                 # first process sees plugin backends (tracking #64177).
                 self._refresh_secret_sources_after_discovery()
                 if force:
-                    # config.yaml shell hooks live in ``_hooks`` but are
-                    # config-owned, not plugin-owned — the ledger-driven
-                    # unload() above wiped them and cannot restore them.
-                    # Re-register so force-reload is symmetric (#60036;
-                    # tracking #64178 — salvaged from PR #64188).
-                    self._re_register_shell_hooks_after_force()
+                    # config.yaml shell hooks and outbound webhooks live in
+                    # ``_hooks`` but are config-owned, not plugin-owned —
+                    # the ledger-driven unload() above wiped them and
+                    # cannot restore them. Re-register so force-reload is
+                    # symmetric (#60036; tracking #64178 — salvaged from
+                    # PR #64188; outbound webhooks added per #92682 review).
+                    self._re_register_config_hooks_after_force()
             except BaseException:
                 self._discovered = False
                 raise
 
-    def _re_register_shell_hooks_after_force(self) -> None:
-        """Restore config.yaml shell hooks wiped by force-clear of ``_hooks``."""
+    def _re_register_config_hooks_after_force(self) -> None:
+        """Restore config.yaml shell hooks/outbound webhooks wiped by
+        force-clear of ``_hooks``. Each re-register call is independently
+        guarded so one failing does not skip the other."""
         try:
             from agent.shell_hooks import re_register_config_hooks
 
@@ -3821,6 +3824,14 @@ class PluginManager:
         except Exception as exc:
             # Import cycle / missing module must not abort force reload.
             logger.debug("force-reload shell-hook re-register skipped: %s", exc)
+        try:
+            from agent.outbound_webhooks import (
+                re_register_config_hooks as re_register_outbound_webhooks,
+            )
+
+            re_register_outbound_webhooks()
+        except Exception as exc:
+            logger.debug("force-reload outbound-webhook re-register skipped: %s", exc)
 
     def _refresh_secret_sources_after_discovery(self) -> None:
         """If any plugin secret source is enabled, reset cache and re-apply.

--- a/tests/agent/test_outbound_webhooks.py
+++ b/tests/agent/test_outbound_webhooks.py
@@ -345,6 +345,46 @@ class TestRegistration:
         assert len(http_server.captured) == 1
 
 
+class TestForceReloadHomeScoping:
+    """Force-reloading one profile's plugin manager must restore that
+    profile's own outbound webhook and leave it firing exactly once —
+    the mirror of the shell-hook force-reload symmetry fix (#92682
+    review: outbound webhooks were the "same symptom class... after a
+    supported lifecycle transition instead of initial startup").
+    """
+
+    def test_force_reload_restores_webhook_and_fires_once(
+        self, monkeypatch, http_server,
+    ):
+        from hermes_cli import plugins
+
+        cfg = _cfg({"url": _url(http_server), "events": ["on_session_end"]})
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+
+        monkeypatch.setenv("HERMES_HOME", "/tmp/profile-b-webhook")
+        mgr_b = plugins.PluginManager()
+        plugins._plugin_manager = mgr_b
+        outbound_webhooks.register_from_config(cfg)
+        assert len(mgr_b._hooks.get("on_session_end", [])) == 1
+
+        # Force-reload: unload() wipes _hooks (config-owned webhook
+        # callbacks included, same as the ledger-driven plugin sweep), so
+        # without the fix the idempotence key alone would survive and a
+        # later register_from_config() call would see it and skip
+        # re-wiring — leaving the webhook silently inert.
+        mgr_b.unload()
+        assert mgr_b._hooks.get("on_session_end", []) == []
+
+        outbound_webhooks.re_register_config_hooks()
+        assert len(mgr_b._hooks.get("on_session_end", [])) == 1
+
+        plugins.get_plugin_manager().invoke_hook(
+            "on_session_end", session_id="s1",
+        )
+        assert outbound_webhooks.flush()
+        assert len(http_server.captured) == 1
+
+
 # ── E2E delivery against a real HTTP server ──────────────────────────────
 
 

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -612,6 +612,53 @@ class TestSecondaryProfileConfigHandling:
         assert runner._profile_adapters["later"][photon] is later
 
 
+class TestSecondaryProfileHookRegistration:
+    """A secondary profile's own `hooks:` block must register on ITS
+    plugin manager, not just the root/default profile's (#92672).
+
+    Startup only calls agent.shell_hooks/outbound_webhooks
+    register_from_config() once, against the root config, before any
+    profile scope exists. Without a matching call inside
+    _start_one_profile_adapters, a secondary profile's config.yaml
+    `hooks:` block (shell hooks and outbound webhooks) never registers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_registers_shell_hooks_and_webhooks_for_secondary_profile(
+        self, monkeypatch
+    ):
+        runner = _secondary_recovery_runner()
+        config = GatewayConfig(multiplex_profiles=True, platforms={})
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+
+        profile_cfg = {
+            "hooks": {
+                "pre_tool_call": [
+                    {"matcher": "write_file", "command": "~/.hermes/deny.sh"}
+                ],
+                "outbound": [
+                    {"url": "http://127.0.0.1:9000/hook", "events": ["on_session_end"]}
+                ],
+            }
+        }
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: profile_cfg)
+
+        seen = []
+        monkeypatch.setattr(
+            "agent.shell_hooks.register_from_config",
+            lambda cfg, **kwargs: seen.append(("shell", cfg)) or [],
+        )
+        monkeypatch.setattr(
+            "agent.outbound_webhooks.register_from_config",
+            lambda cfg: seen.append(("webhook", cfg)) or [],
+        )
+
+        await runner._start_one_profile_adapters("second", "/tmp/second", {})
+
+        assert ("shell", profile_cfg) in seen
+        assert ("webhook", profile_cfg) in seen
+
+
 class TestFeishuPortBindingConditional:
     """Feishu websocket mode does NOT bind a port; only webhook mode does (#52563)."""
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -932,6 +932,13 @@ class TestDeliveryParity:
 class TestForceReloadSymmetry:
     """Force rediscovery restores non-plugin state it wiped (#64178)."""
 
+    @pytest.fixture(autouse=True)
+    def _cleanup_shell_hook_registry(self):
+        yield
+        import agent.shell_hooks as shell_hooks_mod
+
+        shell_hooks_mod.reset_for_tests()
+
     def test_force_reload_re_registers_shell_hooks(self, monkeypatch):
         """config.yaml shell hooks are re-wired after force=True (#60036)."""
         calls = []
@@ -991,6 +998,7 @@ class TestForceReloadSymmetry:
 
     def test_re_register_config_hooks_clears_idempotence_set(self, monkeypatch):
         import agent.shell_hooks as shell_hooks_mod
+        from hermes_constants import get_hermes_home
 
         recorded = {}
         monkeypatch.setattr(
@@ -1001,14 +1009,84 @@ class TestForceReloadSymmetry:
         monkeypatch.setattr(
             "hermes_cli.config.load_config", lambda: {"hooks": {}}
         )
+        home_key = str(get_hermes_home().expanduser().resolve())
         with shell_hooks_mod._registered_lock:
-            shell_hooks_mod._registered.add(("post_llm_call", None, "echo hi"))
+            shell_hooks_mod._registered.add((home_key, "post_llm_call", None, "echo hi"))
 
         shell_hooks_mod.re_register_config_hooks()
 
         with shell_hooks_mod._registered_lock:
             assert not shell_hooks_mod._registered
         assert recorded["cfg"] == {"hooks": {}}
+
+    def test_re_register_config_hooks_is_home_scoped(self, monkeypatch):
+        """Force-reloading home A's idempotence ledger must not drop a
+        still-live home B registration (#92682 review)."""
+        import agent.shell_hooks as shell_hooks_mod
+
+        monkeypatch.setattr(
+            shell_hooks_mod,
+            "register_from_config",
+            lambda cfg: [],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config", lambda: {"hooks": {}}
+        )
+        key_a = ("/home/a", "pre_tool_call", None, "deny.sh")
+        key_b = ("/home/b", "pre_tool_call", None, "deny.sh")
+        with shell_hooks_mod._registered_lock:
+            shell_hooks_mod._registered.update({key_a, key_b})
+
+        monkeypatch.setenv("HERMES_HOME", "/home/a")
+        shell_hooks_mod.re_register_config_hooks()
+
+        with shell_hooks_mod._registered_lock:
+            assert key_a not in shell_hooks_mod._registered
+            assert key_b in shell_hooks_mod._registered
+
+    def test_force_reload_of_one_profile_does_not_orphan_another(self, monkeypatch):
+        """Real two-manager regression: force-reloading profile A's plugin
+        manager must leave profile B's shell hook registered exactly once —
+        not duplicated, not dropped (#92682 review).
+        """
+        import hermes_cli.plugins as plugins_mod
+        import agent.shell_hooks as shell_hooks_mod
+
+        cfg = {"hooks": {"on_session_start": [{"command": "/bin/true"}]}}
+        monkeypatch.setenv("HERMES_ACCEPT_HOOKS", "1")
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+        monkeypatch.setattr(
+            PluginManager, "_discover_and_load_inner", lambda self_inner: None,
+        )
+
+        monkeypatch.setenv("HERMES_HOME", "/tmp/profile-a")
+        mgr_a = PluginManager()
+        plugins_mod._plugin_manager = mgr_a
+        shell_hooks_mod.register_from_config(cfg, accept_hooks=True)
+
+        monkeypatch.setenv("HERMES_HOME", "/tmp/profile-b")
+        mgr_b = PluginManager()
+        plugins_mod._plugin_manager = mgr_b
+        shell_hooks_mod.register_from_config(cfg, accept_hooks=True)
+
+        assert len(mgr_a._hooks.get("on_session_start", [])) == 1
+        assert len(mgr_b._hooks.get("on_session_start", [])) == 1
+
+        # Force-reload A. Its own manager's hook is wiped and restored;
+        # B's manager (and idempotence key) must be untouched.
+        mgr_a.discover_and_load(force=True)
+
+        assert len(mgr_a._hooks.get("on_session_start", [])) == 1
+        assert len(mgr_b._hooks.get("on_session_start", [])) == 1
+
+        # B's later adapter reconnect re-runs register_from_config(); its
+        # idempotence key must still be intact, so this must be a no-op
+        # rather than appending a second callback to B's live manager.
+        monkeypatch.setenv("HERMES_HOME", "/tmp/profile-b")
+        second = shell_hooks_mod.register_from_config(cfg, accept_hooks=True)
+
+        assert second == []
+        assert len(mgr_b._hooks.get("on_session_start", [])) == 1
 
 
 class TestPreToolCallBlocking:


### PR DESCRIPTION
Fixes #92672.

## Root cause

With `gateway.multiplex_profiles: true`, `GatewayRunner.start()` registers declarative shell hooks and outbound webhooks exactly once, at process startup, against the root/default profile's config (`gateway/run.py`, the `register_from_config` call site right before `self.hooks.discover_and_load()`). That call runs before any profile scope exists.

Secondary profiles are started later, in `_start_one_profile_adapters()`, which runs each profile's turns under its own `_profile_runtime_scope` (its own `HERMES_HOME` override) and already calls `discover_plugins()` there so per-profile *plugins* work — but it never called `agent.shell_hooks.register_from_config()` / `agent.outbound_webhooks.register_from_config()` for that profile's own `config.yaml`. Because `hermes_cli.plugins.get_plugin_manager()` caches one `PluginManager` per resolved home, a secondary profile's turns dispatch through its own manager, which never received the root profile's (or its own) hook callbacks. Result: a secondary profile's `hooks.pre_tool_call` / `hooks.outbound` block is silently inert — no error, no webhook fires, and a security gate (e.g. a deny-writes hook) never runs.

Additional wrinkle noted in the issue: `agent/shell_hooks.py`'s `_registered` idempotence set (and the analogous one in `agent/outbound_webhooks.py`) was keyed only by `(event, matcher, command)` / `(event, url)`, with no home/profile scoping. Even after wiring the registration call into the secondary-profile startup path, two profiles configuring an *identical* hook would have the second call see the triple already in `_registered` and skip wiring it onto its own (different) plugin manager.

## Fix

- `gateway/run.py`: inside `_start_one_profile_adapters()`, within the profile's `_profile_runtime_scope`, load that profile's own config and call `agent.shell_hooks.register_from_config()` / `agent.outbound_webhooks.register_from_config()` against it (mirrors the exact call shape used at root startup, including `accept_hooks=False` so `hooks_auto_accept` in the profile's own config is honored). Failures are logged and never block startup, matching the root startup call site's behavior.
- `agent/shell_hooks.py` / `agent/outbound_webhooks.py`: the module-global idempotence sets are now keyed by resolved Hermes home in addition to the existing fields, so identical hook/webhook configuration in two different profiles registers independently on each profile's own plugin manager instead of the second profile's attempt being dropped as a duplicate.

## Test plan

Added `TestSecondaryProfileHookRegistration` to `tests/gateway/test_multiplex_adapter_registry.py`, asserting that `_start_one_profile_adapters()` calls both `agent.shell_hooks.register_from_config` and `agent.outbound_webhooks.register_from_config` with the secondary profile's own config.

Confirmed the new test fails without the fix:

```
$ git stash push -- gateway/run.py agent/shell_hooks.py agent/outbound_webhooks.py
$ python3 -m pytest tests/gateway/test_multiplex_adapter_registry.py -q -k TestSecondaryProfileHookRegistration
FAILED ...::test_registers_shell_hooks_and_webhooks_for_secondary_profile
AssertionError: assert ('shell', {...}) in []
1 failed, 18 deselected in 0.89s
$ git stash pop
```

And passes with it, alongside the full surrounding suites:

```
$ python3 -m pytest tests/gateway/test_multiplex_adapter_registry.py -q
19 passed in 1.89s

$ python3 -m pytest tests/gateway/ -q -k multiplex
159 passed, 2 skipped, 5983 deselected in 12.82s

$ python3 -m pytest tests/agent/test_shell_hooks.py tests/agent/test_shell_hooks_tree_kill.py tests/agent/test_shell_hooks_consent.py tests/agent/test_outbound_webhooks.py tests/hermes_cli/test_plugins.py -q
158 passed in 14.53s

$ python3 -m ruff check gateway/run.py agent/shell_hooks.py agent/outbound_webhooks.py tests/gateway/test_multiplex_adapter_registry.py
All checks passed!
```

## Notes

Authored with AI assistance; the diff, reproduction, and test were verified manually (real test runs, real ruff run, and a stash-based before/after check of the new regression test) before pushing.
