### PR TITLE
fix(whatsapp): timestamp and count allowlist rejections in bridge.log

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -33,6 +33,7 @@ import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { createRejectionLog } from './rejection_log.js';
 import {
   buildPollPayload,
   createReconnectScheduler,
@@ -281,6 +282,11 @@ const MAX_QUEUE_SIZE = 100;
 const recentlySentIds = createOutboundIdTracker(512);
 const recentlyProcessedPollUpdates = createOutboundIdTracker(512);
 const messageStore = createBoundedMessageStore(512);
+
+// Timestamps and counts every 'ignored' admission-decision event (allowlist
+// misses, self-chat mismatches, ...) so operators can tell "rejecting
+// everything" from "rejecting nothing" without tailing bridge.log (#92677).
+const rejectionLog = createRejectionLog();
 
 function normalizePollUpdateOptions(aggregation, pollUpdateMessage, meId) {
   const selected = [];
@@ -591,12 +597,7 @@ async function startSocket() {
           if (decision.action === 'drop_disabled') continue;
           if (decision.action === 'drop_allowlist') {
             try {
-              console.log(JSON.stringify({
-                event: 'ignored',
-                reason: 'allowlist_mismatch_owner_chat',
-                chatId,
-                senderId,
-              }));
+              console.log(JSON.stringify(rejectionLog.record('allowlist_mismatch_owner_chat', { chatId, senderId })));
             } catch {}
             continue;
           }
@@ -637,23 +638,13 @@ async function startSocket() {
       if (!msg.key.fromMe) {
         if (WHATSAPP_MODE === 'self-chat') {
           try {
-            console.log(JSON.stringify({
-              event: 'ignored',
-              reason: 'self_chat_mode_rejects_non_self',
-              chatId,
-              senderId,
-            }));
+            console.log(JSON.stringify(rejectionLog.record('self_chat_mode_rejects_non_self', { chatId, senderId })));
           } catch {}
           continue;
         }
         if (WHATSAPP_DM_POLICY !== 'pairing' && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
           try {
-            console.log(JSON.stringify({
-              event: 'ignored',
-              reason: 'allowlist_mismatch',
-              chatId,
-              senderId,
-            }));
+            console.log(JSON.stringify(rejectionLog.record('allowlist_mismatch', { chatId, senderId })));
           } catch {}
           continue;
         }
@@ -1111,6 +1102,7 @@ app.get('/health', (req, res) => {
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
+    rejectionCounts: rejectionLog.snapshot(),
   });
 });
 

--- a/scripts/whatsapp-bridge/rejection_log.js
+++ b/scripts/whatsapp-bridge/rejection_log.js
@@ -1,0 +1,30 @@
+/**
+ * Timestamped, counted wrapper around the bridge's `ignored` admission
+ * events (allowlist misses, self-chat mismatches, etc).
+ *
+ * Before this, the `ignored` JSON lines written to bridge.log carried no
+ * `ts` field, so an operator staring at thousands of identical rejections
+ * could not correlate them with "the message I sent at 3pm" or with a
+ * config change. Nothing counted them either, so a deployment rejecting
+ * every single inbound message looked the same as one rejecting none.
+ *
+ * `record()` still returns a plain object for `console.log(JSON.stringify(...))`
+ * at the call site — the event shape on stdout is unchanged except for the
+ * added `ts`. `snapshot()` feeds the bridge's `/health` endpoint so the
+ * Python adapter can surface rejection volume without tailing bridge.log.
+ */
+
+export function createRejectionLog() {
+  const counts = Object.create(null);
+
+  function record(reason, fields = {}) {
+    counts[reason] = (counts[reason] || 0) + 1;
+    return { event: 'ignored', reason, ts: Date.now(), ...fields };
+  }
+
+  function snapshot() {
+    return { ...counts };
+  }
+
+  return { record, snapshot };
+}

--- a/scripts/whatsapp-bridge/rejection_log.test.mjs
+++ b/scripts/whatsapp-bridge/rejection_log.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createRejectionLog } from './rejection_log.js';
+
+test('record() stamps every ignored event with a numeric ts', () => {
+  const log = createRejectionLog();
+  const before = Date.now();
+  const event = log.record('allowlist_mismatch', { chatId: 'a@s.whatsapp.net', senderId: 'b@s.whatsapp.net' });
+  const after = Date.now();
+
+  assert.equal(event.event, 'ignored');
+  assert.equal(event.reason, 'allowlist_mismatch');
+  assert.equal(event.chatId, 'a@s.whatsapp.net');
+  assert.equal(event.senderId, 'b@s.whatsapp.net');
+  assert.equal(typeof event.ts, 'number');
+  assert.ok(event.ts >= before && event.ts <= after);
+});
+
+test('snapshot() aggregates counts per reason across many rejections', () => {
+  const log = createRejectionLog();
+  for (let i = 0; i < 4177; i++) log.record('allowlist_mismatch', { chatId: 'x', senderId: 'y' });
+  for (let i = 0; i < 3; i++) log.record('self_chat_mode_rejects_non_self', { chatId: 'x', senderId: 'y' });
+
+  assert.deepEqual(log.snapshot(), {
+    allowlist_mismatch: 4177,
+    self_chat_mode_rejects_non_self: 3,
+  });
+});
+
+test('snapshot() starts empty and is independent per log instance', () => {
+  const a = createRejectionLog();
+  const b = createRejectionLog();
+  a.record('allowlist_mismatch', {});
+
+  assert.deepEqual(b.snapshot(), {});
+  assert.deepEqual(a.snapshot(), { allowlist_mismatch: 1 });
+});

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -251,7 +251,7 @@ Set `text_batch_delay_seconds: 0` to dispatch each message immediately (disables
 | **Bridge crashes or reconnect loops** | Restart the gateway, update Hermes, and re-pair if the session was invalidated by a WhatsApp protocol change. |
 | **Bot stops working after WhatsApp update** | Update Hermes to get the latest bridge version, then re-pair. |
 | **macOS: "Node.js not installed" but node works in terminal** | launchd services don't inherit your shell PATH. Run `hermes gateway install` to re-snapshot your current PATH into the plist, then `hermes gateway start`. See the [Gateway Service docs](./index.md#macos-launchd) for details. |
-| **Messages not being received** | Verify `WHATSAPP_ALLOWED_USERS` includes the sender's number (with country code, no `+` or spaces), or set it to `*` to allow everyone. Set `WHATSAPP_DEBUG=true` in `.env` and restart the gateway to see raw message events in `bridge.log`. |
+| **Messages not being received** | Verify `WHATSAPP_ALLOWED_USERS` includes the sender's number (with country code, no `+` or spaces), or set it to `*` to allow everyone. Set `WHATSAPP_DEBUG=true` in `.env` and restart the gateway to see raw message events in `bridge.log`. Allowlist rejections (`{"event":"ignored","reason":"allowlist_mismatch",...}`) are always logged there, with no debug flag required. |
 | **Bot replies to strangers with a pairing code** | Set `whatsapp.unauthorized_dm_behavior: ignore` in `~/.hermes/config.yaml` if you want unauthorized DMs to be silently ignored instead. |
 
 ---


### PR DESCRIPTION
## What does this PR do?

Since `3ade65599` the bot-mode WhatsApp bridge prints one JSON line per
rejected message on stdout (captured verbatim into `bridge.log` by the
Python adapter):

```json
{"event":"ignored","reason":"allowlist_mismatch","chatId":"...","senderId":"..."}
```

These lines carried no timestamp and nothing counted them, so a
deployment that silently rejects every single inbound message looks
identical, in the log, to one rejecting none — the reporter's
deployment accumulated 4,177 such lines over two weeks before the cause
was found, because even a deliberate log review had no way to notice
the volume or correlate a rejection with a specific message.

This implements two of the issue's three minimal requests (either one
was stated as sufficient on its own):

1. **Timestamp every `ignored` emission.** `allowlist_mismatch`,
   `allowlist_mismatch_owner_chat`, and `self_chat_mode_rejects_non_self`
   now carry `ts` (epoch ms), matching the `ts` convention already used
   by `emitPairEvent`.
2. **Count rejections by reason and expose them.** The existing
   `GET /health` endpoint now reports a `rejectionCounts` object (e.g.
   `{"allowlist_mismatch": 4177}`), so an operator (or the adapter) can
   see rejection volume without tailing `bridge.log`.
3. **One documentation line** in the WhatsApp troubleshooting table
   clarifying that these rejection lines land in `bridge.log`
   unconditionally, not gated behind `WHATSAPP_DEBUG` (the existing row
   only mentioned debug-gated raw message events).

No behavior change to message admission — every accept/reject decision
is byte-identical; this is diagnosis-only.

## Related Issue

Fixes #92677

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/rejection_log.js` (new) — `createRejectionLog()`:
  `record(reason, fields)` stamps + tallies an `ignored` event;
  `snapshot()` returns the per-reason counts. Extracted into its own pure
  module (same pattern as `owner_message_gate.js` / `outbound_ids.js`)
  because `bridge.js` starts an HTTP server and Baileys socket at import
  time and can't be imported directly in tests.
- `scripts/whatsapp-bridge/bridge.js` — instantiate one `rejectionLog` for
  the process; the three `ignored` emission call sites now build their
  payload via `rejectionLog.record(...)` instead of a bare object
  literal; `/health` gained `rejectionCounts: rejectionLog.snapshot()`.
- `scripts/whatsapp-bridge/rejection_log.test.mjs` (new) — 3 tests.
- `website/docs/user-guide/messaging/whatsapp.md` — one line added to the
  troubleshooting table.

## How to Test

1. `node --test scripts/whatsapp-bridge/rejection_log.test.mjs`
2. Prove the test fails without the fix (module didn't exist before this
   PR): moving `rejection_log.js` out of the way and re-running the same
   test file fails with `ERR_MODULE_NOT_FOUND` / test failure; moving it
   back, all 3 pass again.

Real output (this session, Node v22.23.2):

```
$ node --test scripts/whatsapp-bridge/rejection_log.test.mjs
TAP version 13
# Subtest: record() stamps every ignored event with a numeric ts
ok 1 - record() stamps every ignored event with a numeric ts
# Subtest: snapshot() aggregates counts per reason across many rejections
ok 2 - snapshot() aggregates counts per reason across many rejections
# Subtest: snapshot() starts empty and is independent per log instance
ok 3 - snapshot() starts empty and is independent per log instance
1..3
# tests 3
# pass 3
# fail 0
```

Also ran the full existing `scripts/whatsapp-bridge/*.test.mjs` suite:
5/5, 1/1, 1/1, 6/6, 8/8, 3/3 pass across the other files.
`bridge.native.test.mjs` fails in this checkout with
`ERR_MODULE_NOT_FOUND: @whiskeysockets/baileys` — confirmed pre-existing
on unmodified `main` (no `node_modules` installed in this environment,
unrelated to this change).

`node --check` passes on both `bridge.js` and `rejection_log.js`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not hardware-dependent; verified via
  `node --test` only (no live WhatsApp session in this environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (troubleshooting table)
- [ ] N/A — no `config.yaml` keys added
- [ ] N/A — no architecture/workflow change to `CONTRIBUTING.md`/`AGENTS.md`
- [x] Cross-platform impact considered — pure JS timestamp/counter logic,
  no OS-specific behavior
- [ ] N/A — no tool schema changed

## AI assistance disclosure

Investigated, implemented, and tested with AI (Claude) assistance.
