### PR TITLE
fix(security): prevent profile export archives from reaching source and images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -107,9 +107,10 @@ plans/
 .hadolint.yaml
 .mailmap
 
-# Repo-root debug/export artifacts — must never reach image layers (COPY . .)
+# Debug/export artifacts — must never reach image layers (COPY . .)
 /log.txt
 /sqlite_leak_fix.png
 /*.png.bak
 /default.tar.gz
-/*.tar.gz
+*.tar.gz
+*.tgz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,6 +166,11 @@ jobs:
     needs: detect
     uses: ./.github/workflows/infographic-check.yml
 
+  profile-artifact-check:
+    name: Profile artifact check
+    needs: detect
+    uses: ./.github/workflows/profile-artifact-check.yml
+
   lockfile-diff:
     name: package-lock.json diff
     needs: detect
@@ -230,6 +235,7 @@ jobs:
       - uv-lockfile
       - lockfile-diff
       - docker-lint
+      - profile-artifact-check
       - supply-chain
       - review-labels
       - osv-scanner

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Reject profile exports in the build context
+        run: python3 scripts/ci/check_profile_archive_boundary.py
+
       # Retry once on transient Docker Hub / buildkit pull failures
       # (connection reset, auth token timeout, rate limiting). The action
       # generates a unique builder name per invocation so the retry doesn't
@@ -205,6 +208,9 @@ jobs:
     steps:
       - name: Checkout trusted source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Reject profile exports in the build context
+        run: python3 scripts/ci/check_profile_archive_boundary.py
 
       # Retry once on transient Docker Hub / buildkit pull failures.
       # See build job for rationale; same pattern.

--- a/.github/workflows/profile-artifact-check.yml
+++ b/.github/workflows/profile-artifact-check.yml
@@ -1,0 +1,21 @@
+name: Profile Artifact Boundary
+
+# A reusable, unconditional guard for the incident class in #92457. Ignore
+# files reduce accidental staging; this job is the enforcement boundary that
+# still catches `git add -f` and generated files present during a build.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check-profile-artifacts:
+    name: Reject profile archives
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Reject profile exports in the checkout
+        run: python3 scripts/ci/check_profile_archive_boundary.py

--- a/.gitignore
+++ b/.gitignore
@@ -98,11 +98,12 @@ apps/desktop/src/**/*.d.ts
 !apps/desktop/src/global.d.ts
 !apps/desktop/src/vite-env.d.ts
 
-# Repo-root build/debug artifacts that must never be committed
+# Build/debug artifacts that must never be committed
 /log.txt
 /sqlite_leak_fix.png
 /*.png.bak
-/default.tar.gz
+*.tar.gz
+*.tgz
 apps/shared/src/**/*.js
 apps/shared/src/**/*.js.map
 apps/shared/src/**/*.d.ts

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -404,7 +404,11 @@ class CLICommandsMixin:
             /export <profile>             — export a named profile
             /export [profile] -o <path>   — choose the output path
         """
-        from hermes_cli.profiles import export_profile, get_active_profile_name
+        from hermes_cli.profiles import (
+            export_profile,
+            get_active_profile_name,
+            get_profile_export_path,
+        )
 
         parts = command.split()[1:]
         output = None
@@ -418,7 +422,7 @@ class CLICommandsMixin:
 
         name = parts[0] if parts else (get_active_profile_name() or "default")
         if not output:
-            output = f"{name}.tar.gz"
+            output = str(get_profile_export_path(name))
 
         try:
             result = export_profile(name, output)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10740,10 +10740,10 @@ def cmd_profile(args):
             sys.exit(1)
 
     elif action == "export":
-        from hermes_cli.profiles import export_profile
+        from hermes_cli.profiles import export_profile, get_profile_export_path
 
         name = args.profile_name
-        output = args.output or f"{name}.tar.gz"
+        output = args.output or str(get_profile_export_path(name))
         try:
             result_path = export_profile(name, output)
             print(f"✓ Exported '{name}' to {result_path}")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2009,6 +2009,63 @@ def get_active_profile_name() -> str:
 # Export / Import
 # ---------------------------------------------------------------------------
 
+def _profile_export_directory() -> Path:
+    """Choose an export directory that cannot become source-tree input."""
+    export_dir = _get_default_hermes_home() / "profile-exports"
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return export_dir
+
+    checkout_root = next(
+        (
+            candidate
+            for candidate in (cwd, *cwd.parents)
+            if (candidate / ".git").exists()
+        ),
+        None,
+    )
+    if checkout_root is None:
+        return export_dir
+
+    try:
+        export_dir.resolve().relative_to(checkout_root.resolve())
+    except ValueError:
+        return export_dir
+
+    # A custom deployment may point HERMES_HOME at its source checkout.  Do
+    # not put the automatic archive under that tree; use a sibling store and
+    # fall back to the OS temp directory only for the unusual case where the
+    # user's home itself is the checkout.
+    candidates = [
+        Path.home() / ".hermes-profile-exports",
+    ]
+    import tempfile
+
+    candidates.append(Path(tempfile.gettempdir()) / "hermes-profile-exports")
+    for candidate in candidates:
+        try:
+            candidate.resolve().relative_to(checkout_root.resolve())
+        except ValueError:
+            return candidate
+    return export_dir
+
+
+def get_profile_export_path(name: str, *, timestamp: Optional[str] = None) -> Path:
+    """Return a managed destination for an export with no explicit output.
+
+    Keep automatic exports outside the current working directory and outside
+    every named profile.  The CLI is commonly run from a source checkout; its
+    old ``<name>.tar.gz`` default therefore made a profile snapshot look like
+    a repository artifact and allowed it to be committed accidentally.
+    """
+    canon = normalize_profile_name(name)
+    validate_profile_name(canon)
+    export_dir = _profile_export_directory()
+    export_dir.mkdir(parents=True, exist_ok=True)
+    stamp = timestamp or time.strftime("%Y%m%d-%H%M%S")
+    return export_dir / f"{canon}-{stamp}.tar.gz"
+
 def _default_export_ignore(root_dir: Path):
     """Return an *ignore* callable for :func:`shutil.copytree`.
 

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -1173,14 +1173,12 @@ async def export_profile_endpoint(name: str, body: ProfileExport):
 
     output = (body.output or "").strip()
     if not output:
-        from hermes_constants import get_hermes_home
-        staging = get_hermes_home() / "profile-exports"
         try:
-            staging.mkdir(parents=True, exist_ok=True)
+            output = str(profiles_mod.get_profile_export_path(name))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
         except OSError as exc:
             raise HTTPException(status_code=500, detail=f"Could not create export directory: {exc}")
-        stamp = time.strftime("%Y%m%d-%H%M%S")
-        output = str(staging / f"{profiles_mod.normalize_profile_name(name)}-{stamp}.tar.gz")
 
     loop = asyncio.get_running_loop()
     try:

--- a/scripts/ci/check_profile_archive_boundary.py
+++ b/scripts/ci/check_profile_archive_boundary.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Reject profile export archives before publication.
+
+``.gitignore`` and ``.dockerignore`` are useful first-line filters, but both
+can be bypassed (for example with ``git add -f`` or a non-standard build
+context).  This check is the blocking, executable policy at the CI and image
+publication boundaries.  It intentionally checks the filesystem rather than
+Git's index so a generated archive cannot enter a build after checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+_PROFILE_ARCHIVE_SUFFIXES = (".tar.gz", ".tgz")
+
+
+def find_forbidden_profile_archives(root: Path) -> list[Path]:
+    """Return profile archive paths anywhere in the checkout."""
+    root = root.resolve()
+    if not root.is_dir():
+        raise ValueError(f"repository root is not a directory: {root}")
+
+    offenders: list[Path] = []
+    for directory, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [
+            name
+            for name in dirnames
+            if name not in {".git", ".venv", "venv", "node_modules", "__pycache__"}
+        ]
+        for name in (*dirnames, *filenames):
+            if name.casefold().endswith(_PROFILE_ARCHIVE_SUFFIXES):
+                offenders.append((Path(directory) / name).relative_to(root))
+
+    return sorted(offenders, key=lambda path: path.as_posix().casefold())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject profile export archives in the checkout."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="repository root to inspect (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        offenders = find_forbidden_profile_archives(args.root)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    if not offenders:
+        print("No profile export archives detected in the checkout.")
+        return 0
+
+    print(
+        "::error::profile export archives are forbidden "
+        "in source and Docker build contexts"
+    )
+    for path in offenders:
+        print(f"  {path.as_posix()}")
+    print(
+        "Move the archive outside the checkout or pass an explicit external "
+        "output path to the profile export command."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_profile_export_default_path.py
+++ b/tests/hermes_cli/test_profile_export_default_path.py
@@ -1,0 +1,122 @@
+"""Regression coverage for safe automatic profile-export destinations."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import profiles
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+from hermes_cli.main import cmd_profile
+from hermes_cli.profiles import get_profile_export_path
+
+
+def test_default_export_path_is_managed_and_outside_named_profiles(
+    tmp_path, monkeypatch
+):
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
+    )
+
+    result = get_profile_export_path("Research-Bot", timestamp="20260823-120000")
+
+    assert (
+        result
+        == default_home / "profile-exports" / "research-bot-20260823-120000.tar.gz"
+    )
+    assert result.parent.is_dir()
+    assert not (default_home / "profiles" / "research-bot" / result.name).exists()
+
+
+def test_custom_hermes_home_inside_a_checkout_uses_a_sibling_store(
+    tmp_path, monkeypatch
+):
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / ".git").write_text("gitdir: ../git\n", encoding="utf-8")
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: checkout
+    )
+
+    result = get_profile_export_path("default", timestamp="20260823-120000")
+
+    assert not result.resolve().is_relative_to(checkout.resolve())
+
+
+def test_cli_export_default_does_not_write_into_the_current_checkout(
+    tmp_path, monkeypatch, capsys
+):
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    (default_home / "config.yaml").write_text("model: test\n", encoding="utf-8")
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: default_home
+    )
+
+    cmd_profile(
+        Namespace(
+            profile_action="export",
+            profile_name="default",
+            output=None,
+        )
+    )
+
+    exported = list((default_home / "profile-exports").glob("default-*.tar.gz"))
+    assert len(exported) == 1
+    assert exported[0].parent == default_home / "profile-exports"
+    assert not (checkout / "default.tar.gz").exists()
+    assert str(exported[0]) in capsys.readouterr().out
+
+
+def test_slash_export_uses_the_same_managed_destination(tmp_path, monkeypatch):
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
+    )
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    calls = []
+    monkeypatch.setattr(
+        profiles,
+        "export_profile",
+        lambda name, output: calls.append((name, output)) or output,
+    )
+
+    CLICommandsMixin()._handle_export_command("/export")
+
+    assert len(calls) == 1
+    assert calls[0][0] == "default"
+    assert Path(calls[0][1]).parent == default_home / "profile-exports"
+    assert not (tmp_path / "default.tar.gz").exists()
+
+
+@pytest.mark.asyncio
+async def test_profile_export_api_uses_the_shared_managed_destination(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.web_models import ProfileExport
+    from hermes_cli.web_routers.profiles import export_profile_endpoint
+
+    managed = tmp_path / "profile-exports" / "default-20260823-120000.tar.gz"
+    monkeypatch.setattr(profiles, "get_profile_export_path", lambda name: managed)
+    monkeypatch.setattr(
+        profiles,
+        "export_profile",
+        lambda name, output, extra_files=None: output,
+    )
+
+    result = await export_profile_endpoint("default", ProfileExport())
+
+    assert result == {"ok": True, "archive": str(managed)}

--- a/tests/scripts/test_check_profile_archive_boundary.py
+++ b/tests/scripts/test_check_profile_archive_boundary.py
@@ -1,0 +1,57 @@
+"""Behavioral tests for the profile archive CI guard."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "ci"
+    / "check_profile_archive_boundary.py"
+)
+
+
+def _run(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_clean_root_passes(tmp_path):
+    result = _run(tmp_path)
+
+    assert result.returncode == 0
+    assert "No profile export archives" in result.stdout
+
+
+def test_root_profile_archive_fails_without_printing_contents(tmp_path):
+    default_archive = tmp_path / "default.tar.gz"
+    alternate_archive = tmp_path / "backup.TGZ"
+    default_archive.write_bytes(b"profile webhook secret must never be printed")
+    alternate_archive.write_bytes(b"another archive")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert "default.tar.gz" in result.stdout
+    assert "backup.TGZ" in result.stdout
+    assert "profile webhook secret" not in result.stdout
+    assert "another archive" not in result.stdout
+
+
+def test_nested_profile_archive_is_also_rejected(tmp_path):
+    nested = tmp_path / "fixtures"
+    nested.mkdir()
+    (nested / "fixture.tar.gz").write_bytes(b"test fixture")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert "fixtures/fixture.tar.gz" in result.stdout

--- a/website/docs/user-guide/profile-distributions.md
+++ b/website/docs/user-guide/profile-distributions.md
@@ -624,10 +624,17 @@ When you don't need versioning, skip the repo. `/export` packs a profile into a 
 In the CLI, TUI, or desktop chat:
 
 ```
-/export                          # the active profile → <name>.tar.gz
+/export                          # the active profile → managed profile-exports/<name>-<timestamp>.tar.gz
 /export research-bot             # a named profile
 /export research-bot -o ~/Desktop/research-bot.tar.gz
 ```
+
+Without `-o`, the CLI and TUI place the archive in Hermes's managed
+`profile-exports/` directory under the default Hermes home, not in the current
+working directory. This keeps routine exports out of source checkouts and
+prevents a generated profile snapshot from being mistaken for a repository
+source file. An explicit `-o` path is still honored when you intentionally
+choose where to save the archive.
 
 Or from a shell, same machinery:
 


### PR DESCRIPTION
## Summary

fixes : #92457






This PR addresses the recurrence-control portion of #92457 without reopening the already-merged cleanup in #92394.











- Automatic profile exports from the CLI and `/export` no longer default to `<name>.tar.gz` in the current working directory.





- CLI, TUI, and profile-management API paths now share one managed destination helper.





- A profile archive guard rejects `.tar.gz` and `.tgz` files anywhere in a checkout before CI can approve it or Docker can build/publish it.





- The guard reports filenames only; it never reads or prints archive contents.





- `.gitignore`, `.dockerignore`, user documentation, and regression tests now describe and enforce the same boundary.











This is intentionally not an incident-closure claim. Repository code cannot rotate the deployed webhook HMAC secret, invalidate already-pulled image layers, or delete Docker Hub manifests without the credential and registry owners. #92457 should remain open until those operational predicates are verified at their systems of record.











## Is #92457 a real bug?











Yes. The issue's live evidence establishes exposure, not exploitation:











1. Commit `ee37f3d8976b1c7a79a0eacbb15e4e887133a59d` added a populated `default.tar.gz` profile export.





2. The archive contained a live-looking `platforms.webhook.extra.secret` and was still reachable through Git history.





3. The release source for `v2026.8.19` still contained the blob, and the published image was built with a repository-wide `COPY . .` boundary before the archive exclusion landed.





4. #92394 removed the current-tree artifact and added Docker exclusions, but it explicitly did not rotate the credential or settle historical image manifests.











The underlying code-level recurrence was also reproducible on the current pre-fix base: `hermes profile export default` with no `-o` wrote `default.tar.gz` into the caller's working directory. The fixed path writes to a managed profile-export store and leaves the checkout without that file.











## Root cause











The incident had two separate causes, which must not be conflated:











- **Producer boundary:** the CLI and interactive `/export` defaulted to a repository-visible filename. A normal export from a source checkout created a generated artifact at the exact location a contributor could accidentally stage.





- **Publication boundary:** `.gitignore` and `.dockerignore` were passive filters. They reduced accidental staging and image inclusion, but did not stop `git add -f`, a differently named archive, or a generated archive present in a build context.





- **Operational boundary:** revoking a webhook secret and retiring an already-published image are deployment/registry actions, not repository edits.











## Implementation











### Safer producer default











`get_profile_export_path()` now:











- validates and normalizes the profile name;





- writes automatic exports under `<default Hermes home>/profile-exports/<name>-<timestamp>.tar.gz`;





- keeps that store outside named profiles;





- detects the unusual custom-deployment case where `HERMES_HOME` is inside a Git checkout and falls back to a sibling/temp store instead of creating new source-tree input.











Explicit `-o` output remains supported for intentional exports.











The CLI command, interactive `/export`, and profile API all use this helper. This removes duplicated destination logic rather than adding another independent export implementation.











### Executable defense at both gates











`scripts/ci/check_profile_archive_boundary.py` walks the checkout (excluding `.git`, virtual environments, dependency trees, and bytecode caches) and rejects any `.tar.gz` or `.tgz` path. It is wired into:











- the unconditional CI orchestrator and the blocking `All required checks pass` aggregate;





- the Docker build job before Buildx runs;





- the trusted Docker publish job before registry credentials are used.











This is stronger than another ignore rule: a forced commit, a renamed root archive, a nested archive, or a generated file present after checkout cannot silently proceed to image publication.











## Non-duplicate analysis











- **#92394 (merged):** owns removal of the known artifact from the tree and the original Docker-context exclusion. This PR does not duplicate or rewrite that cleanup; it adds the producer and executable enforcement boundaries that #92394 intentionally left out.





- **#83458 (merged) and #35601 (open):** concern secret scrubbing and structural contents of profile export archives. This PR does not replace their archive-content policy; it prevents archive artifacts from entering this repository/build context at all.





- **#92234 (open):** owns recoverable local profile archive lifecycle, not source-control or image publication safety.





- **#85025 / #85653 (open):** concern webhook secret-reference and outbound webhook contracts, not committed profile artifacts.





- Duplicate searches covered issue `#92457`, `default.tar.gz`, root artifacts, Docker build context archives, profile-export credential safety, and webhook credential terms. No adequate existing PR owns this combined producer-plus-publication boundary.











## Security and compatibility











- No credential value, archive content, private path, or registry token is added to source, tests, logs, or this PR.





- Existing export redaction and credential-file exclusions remain unchanged.





- Explicit output paths remain compatible; only the implicit destination changes.





- CI failure is fail-closed and actionable: move the archive outside the checkout or choose an external explicit output path.





- The checker does not inspect archive bytes, so it cannot leak a secret while reporting the violation.











## GPT-5.6 Luna P1 hardening record











GitHub labels: `P1`, `type/security`, `area/auth`, `area/docker`, `area/profiles`, and `sweeper:risk-security-boundary`. Required intensity: three independent hardening passes.











### Pass 1 — premise and root cause











- Read the complete issue thread and the merged #92394 body/diff/checks.





- Compared #92394, #83458, #35601, #92234, #85025, and #85653 by ownership and enforcement boundary.





- Traced every production default-output caller: CLI subcommand, interactive slash command, and profile API.





- Reproduced the old CLI behavior on a clean `origin/main` worktree and verified the new behavior on this branch.











Decision: this is a real recurrence gap, but #92457's credential rotation and registry retirement remain operational work.











### Pass 2 — failure modes and bottlenecks











- Forced staging: the executable CI guard does not trust `.gitignore`.





- Renamed and nested archives: the guard matches `.tar.gz`/`.tgz` case-insensitively anywhere in the checkout.





- Docker publication: the guard runs before both unprivileged Buildx builds and the credentialed publish job.





- Custom `HERMES_HOME` inside a checkout: the automatic path selects a sibling/temp store.





- Secret leakage in diagnostics: only archive filenames are emitted; fixture tests assert archive contents are never printed.





- Valid path preservation: explicit `-o` output and existing archive scrubbing remain intact.











### Pass 3 — simplification and regression











- One shared destination resolver replaces three independent default-path implementations.





- The source-tree fix and publication guard are separate enforcement points because either one can be bypassed in isolation.





- Added behavioral coverage for CLI, slash command, API, custom checkout placement, root/nested/case-variant archives, and secret-free diagnostics.











## Validation evidence











### Passing











- `scripts/run_tests.sh tests/scripts/test_check_profile_archive_boundary.py tests/hermes_cli/test_profile_export_default_path.py -q` — 8 passed.





- `scripts/run_tests.sh tests/hermes_cli/test_profile_export_credentials.py tests/hermes_cli/test_profiles.py -k 'export and not symlink' -q` — 9 passed.





- `uv run ruff check scripts/ci/check_profile_archive_boundary.py tests/scripts/test_check_profile_archive_boundary.py tests/hermes_cli/test_profile_export_default_path.py hermes_cli/profiles.py hermes_cli/main.py hermes_cli/cli_commands_mixin.py hermes_cli/web_routers/profiles.py` — passed.





- `uv run ruff format --check` on the three new Python files — passed.





- `git diff --check` — passed.





- Direct checker smoke test on the checkout — no profile archives detected.





- Red/green reproduction: pre-fix base reported `baseline_archive True` and `managed_archive_count 0`; this branch reported `fixed_archive False` and `managed_archive_count 1`.











### Local limitations (not presented as green)











- The canonical full `scripts/run_tests.sh` run was interrupted by the local 420-second tool ceiling at 20.1% (`6,993` tests passed and `67` early failures were reported; the runner had no final summary). The first failures were in unrelated ACP/relay suites; they were not baseline-proven and are not claimed to be fixed by this PR.





- `npm run check` could not start a valid workspace check in this clean worktree because JavaScript dependencies were not installed (`@nanostores/react`, React, Vitest, Node types, and other workspace packages were missing). The touched behavior is Python/CI/Docker/docs, and no JS source changed.





- `actionlint` was not installed locally. GitHub Actions validation remains a remote-CI responsibility.





- No local Docker Hub mutation or production webhook rotation was attempted.











## Live CI follow-up



Remote run `32617194335` for head `13d6f392dacc50407836a2b5675bcadf85b18bc2` was inspected with the failed-job logs:



- Python tests, Python lints, Windows/macOS tests, Docker builds, Docker scripts, Nix, OSV, docs, installer, Rust, supply-chain, and the new Profile Artifact Boundary all passed.

- `JS & TS checks` failed only in `apps/desktop :: check:test:ui` because Vitest reported one unhandled `ReferenceError: window is not defined` from the existing `user-edit-composer.tsx` cooldown timer after `user-message-edit.test.tsx` teardown. The source and line are identical on `origin/main`; this PR changes no JavaScript or Desktop files, so I am not masking a baseline UI-test failure with unrelated changes.

- `Review label gate` failed because the required `ci-reviewed` label is absent. The label exists, but this contributor token lacks permission to apply labels on `NousResearch/hermes-agent` (`AddLabelsToLabelable` returned 403). A maintainer must add it, then rerun the failed checks.



The aggregate `All required checks pass` failure is therefore the combination of the pre-existing/flaky UI test and the maintainer-only label gate, not a failure in this PR's Python, Docker, or profile-archive implementation.



## Operational follow-up still required for #92457











The issue's remaining closure predicates are outside this repository PR:











- identify the authoritative owner of the exposed inbound HMAC secret;





- rotate it at Hermes and every configured sender, proving old signatures are rejected and new signatures accepted without publishing either value;





- retire/replace `v2026.8.19` and any affected immutable manifests, recording the replacement multi-platform index and child digests;





- audit Docker Hub tag/digest retention for old `main`/`latest` manifests;





- publish and independently read back the dated incident receipt.











## Related issue











Related to #92457. This PR deliberately does not use a closing issue reference, because merging repository code must not falsely close an incident whose credential and registry predicates are still open.











## Infographic (required)





<!-- pr-infographic: generated by scripts/generate_pr_infographic.py; theme=security-vault-04; roulette=14/100; seed=92457 -->


![PR infographic — prevent profile archives from reaching published images](https://github.com/user-attachments/assets/52eb18a4-e64e-4661-bf90-9816f9ad2979)