### PR TITLE
fix(whatsapp): accept both cache layouts in bridge path validator

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -318,6 +318,7 @@ def _is_allowed_bridge_path(url: str) -> bool:
     # constants) so this validator follows the active profile override; under a
     # profile override the inbound bridge writes media into that profile's
     # cache, which the frozen constants would not match.
+    from hermes_constants import get_hermes_home
     from gateway.platforms.base import (
         get_audio_cache_dir,
         get_document_cache_dir,
@@ -325,14 +326,36 @@ def _is_allowed_bridge_path(url: str) -> bool:
         get_video_cache_dir,
     )
 
-    for root in (
-        get_image_cache_dir(),
-        get_audio_cache_dir(),
-        get_video_cache_dir(),
-        get_document_cache_dir(),
+    roots = {
+        Path(root).resolve()
+        for root in (
+            get_image_cache_dir(),
+            get_audio_cache_dir(),
+            get_video_cache_dir(),
+            get_document_cache_dir(),
+        )
+    }
+    # A long-lived bridge process may predate a mid-session layout flip:
+    # get_hermes_dir() resolves ONE layout per kind (legacy ``<kind>_cache``
+    # once it has content, else consolidated ``cache/<kind>``), but the bridge
+    # was launched with env vars pointing at whichever layout was active at
+    # startup and keeps writing there (#92685). Accept both layouts under the
+    # same Hermes home — they are all Hermes-owned media cache directories.
+    home = Path(get_hermes_home()).resolve()
+    for kind_new, kind_old in (
+        ("cache/images", "image_cache"),
+        ("cache/audio", "audio_cache"),
+        ("cache/videos", "video_cache"),
+        ("cache/documents", "document_cache"),
     ):
+        for sub in (kind_new, kind_old):
+            candidate = home / sub
+            if candidate not in roots:
+                roots.add(candidate.resolve())
+
+    for root in roots:
         try:
-            if resolved.is_relative_to(Path(root).resolve()):
+            if resolved.is_relative_to(root):
                 return True
         except (OSError, ValueError):
             continue

--- a/tests/gateway/test_whatsapp_media_path_dual_layout.py
+++ b/tests/gateway/test_whatsapp_media_path_dual_layout.py
@@ -1,0 +1,65 @@
+"""Regression: the WhatsApp inbound-media path validator accepts BOTH cache
+layouts when both exist (#92685).
+
+get_hermes_dir() picks ONE layout per kind — legacy ``audio_cache`` when it
+has content, otherwise the consolidated ``cache/audio``. But a long-lived
+bridge process may have been started while the OTHER layout was active (e.g.
+the legacy dir gained its first file mid-session, flipping the resolution).
+The bridge then writes media into a directory that is real and Hermes-owned
+but is not today's resolved root, and _is_allowed_bridge_path() rejects it,
+so voice notes are never transcribed.
+
+The validator should accept paths under either layout's root, as its
+docstring already promises ("covers both the canonical cache/<kind> layout
+and the legacy <kind>_cache layout").
+"""
+from pathlib import Path
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def test_validator_accepts_both_layouts(tmp_path, monkeypatch):
+    """A path under the non-resolved sibling layout still validates."""
+    import plugins.platforms.whatsapp.adapter as adapter
+
+    home = tmp_path / "home"
+    new_layout = home / "cache" / "audio"
+    legacy = home / "audio_cache"
+    new_layout.mkdir(parents=True)
+    legacy.mkdir(parents=True)
+
+    # Legacy has content -> get_audio_cache_dir() resolves to LEGACY...
+    (legacy / "existing.ogg").write_bytes(b"OggS")
+    # ...but bridge wrote into the NEW layout before the flip.
+    bridged = new_layout / "aud_stale_bridge.ogg"
+    bridged.write_bytes(b"OggS")
+
+    token = set_hermes_home_override(str(home))
+    monkeypatch.delenv("HERMES_AUDIO_CACHE_DIR", raising=False)
+    try:
+        from gateway.platforms.base import get_audio_cache_dir
+
+        assert Path(get_audio_cache_dir()).resolve() == legacy.resolve(), (
+            "precondition: legacy layout must be the resolved root"
+        )
+        # The stale-bridge path under the NEW layout must be accepted.
+        assert adapter._is_allowed_bridge_path(str(bridged)) is True
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_validator_still_rejects_outside_paths(tmp_path, monkeypatch):
+    """Paths outside any Hermes cache layout remain rejected."""
+    import plugins.platforms.whatsapp.adapter as adapter
+
+    home = tmp_path / "home"
+    (home / "cache" / "audio").mkdir(parents=True)
+    evil = tmp_path / "elsewhere" / "secret.txt"
+    evil.parent.mkdir(parents=True)
+    evil.write_text("nope")
+
+    token = set_hermes_home_override(str(home))
+    try:
+        assert adapter._is_allowed_bridge_path(str(evil)) is False
+    finally:
+        reset_hermes_home_override(token)


### PR DESCRIPTION
## Problem

On Windows, inbound WhatsApp voice notes were rejected by the gateway with:

```
[Whatsapp] Rejected bridge audio path outside cache dir: ...\cache\audio\aud_xxx.ogg
```

and never transcribed. Full report: #92685.

## Root cause

`get_hermes_dir()` resolves ONE layout per media kind: legacy `<kind>_cache` once it has content, otherwise consolidated `cache/<kind>`. A long-lived bridge process launched before a mid-session layout flip keeps writing media into the *other* layout — which `_is_allowed_bridge_path()` (correctly resolving per-call) no longer considers a valid cache root. The docstring already promised "covers both the canonical `cache/<kind>` layout and the legacy `<kind>_cache` layout", but the code only checked the single currently-resolved root per kind.

## Fix

The validator now accepts paths under **either** layout of the same Hermes home (`cache/<kind>` and `<kind>_cache` for images/audio/videos/documents), in addition to the resolved roots. Security posture unchanged: every accepted root is still Hermes-owned under `get_hermes_home()`, and arbitrary outside paths remain rejected (covered by test).

## Testing

- New regression test `test_whatsapp_media_path_dual_layout.py`:
  - fails on `main` (verified RED), passes with the fix (GREEN)
  - asserts the stale-bridge path under the non-resolved layout validates
  - asserts outside paths are still rejected
- Existing `test_whatsapp_media_path_profile.py` (profile-override behavior) still passes
- Related bridge tests (`test_whatsapp_stale_bridge.py`, `test_whatsapp_bridge_dir_resolution.py`) pass

Closes #92685