### PR TITLE
fix(tool-search): parallel-execution barrier, listing truncation, source indexing, availability-cache staleness

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -114,6 +114,38 @@ def _is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return False
 
 
+# Read-only bridge lookups: dispatch_tool_search / dispatch_tool_describe are
+# stateless catalog reads (the catalog is rebuilt from the current tool-defs
+# list on every call), so a batch of them can run concurrently.
+_PARALLEL_SAFE_BRIDGE_LOOKUPS = frozenset({"tool_search", "tool_describe"})
+
+
+def _peel_bridge_call(tool_name: str, function_args: dict) -> tuple[str, dict]:
+    """Resolve a ``tool_call`` bridge invocation to its underlying tool.
+
+    The batch planner admits calls to a parallel run by tool NAME, but when
+    tool search is active the model emits the literal name ``tool_call`` for
+    every deferred tool — so a server opted in via
+    ``supports_parallel_tool_calls: true`` silently lost concurrency the
+    moment the bridge activated. Peel the wrapper here so admission is
+    decided on the underlying tool, exactly like the executors' unwrap.
+
+    Returns ``(underlying_name, underlying_args)`` when the wrapper parses
+    cleanly, else ``(tool_name, function_args)`` unchanged — an unparseable
+    bridge call stays a sequential barrier and fails at dispatch as before.
+    """
+    try:
+        from tools.tool_search import TOOL_CALL_NAME, resolve_underlying_call
+        if tool_name != TOOL_CALL_NAME:
+            return tool_name, function_args
+        underlying, underlying_args, err = resolve_underlying_call(function_args)
+        if err is not None or not underlying:
+            return tool_name, function_args
+        return underlying, underlying_args
+    except Exception:
+        return tool_name, function_args
+
+
 def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = None) -> List[tuple]:
     """Split a tool-call batch into ordered ``(kind, calls)`` segments.
 
@@ -193,14 +225,23 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
             _add_sequential(tool_call)
             continue
 
-        if tool_name in _PATH_SCOPED_TOOLS:
+        # Bridge unwrap: admission is decided on the UNDERLYING tool, not on
+        # the literal wrapper name the model emitted. Read-only bridge
+        # lookups (tool_search / tool_describe) are parallel-safe as-is.
+        effective_name, effective_args = _peel_bridge_call(tool_name, function_args)
+
+        if effective_name in _NEVER_PARALLEL_TOOLS:
+            _add_sequential(tool_call)
+            continue
+
+        if effective_name in _PATH_SCOPED_TOOLS:
             scoped_paths = _extract_parallel_scope_paths(
-                tool_name, function_args, execution_cwd=execution_cwd
+                effective_name, effective_args, execution_cwd=execution_cwd
             )
             if not scoped_paths:
                 _add_sequential(tool_call)
                 continue
-            is_writer = tool_name in _PATH_SCOPED_WRITERS
+            is_writer = effective_name in _PATH_SCOPED_WRITERS
             if any(
                 (is_writer or existing_is_writer)
                 and _paths_overlap(scoped_path, existing)
@@ -216,7 +257,11 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
             current.append(tool_call)
             continue
 
-        if tool_name in _PARALLEL_SAFE_TOOLS or _is_mcp_tool_parallel_safe(tool_name):
+        if (
+            effective_name in _PARALLEL_SAFE_TOOLS
+            or effective_name in _PARALLEL_SAFE_BRIDGE_LOOKUPS
+            or _is_mcp_tool_parallel_safe(effective_name)
+        ):
             current.append(tool_call)
             continue
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -375,11 +375,23 @@ def _tool_search_scoped_names(agent) -> frozenset:
 
     enabled = getattr(agent, "enabled_toolsets", None)
     disabled = getattr(agent, "disabled_toolsets", None)
+    try:
+        # Same staleness class as get_tool_definitions' memo: the generation
+        # only moves on registry MUTATIONS, but a check_fn verdict can flip
+        # without one (credential lands, daemon starts). Without the verdict
+        # snapshot in this key, the unwrap kept rejecting a tool the bridge
+        # could already discover — or kept admitting one whose availability
+        # probe had gone false. The snapshot is memoized in the registry, so
+        # the common case stays a dict lookup.
+        verdicts = _registry.check_fn_verdict_snapshot()
+    except Exception:
+        verdicts = ()
     cache_key = (
         _registry.current_scope_key(),
         getattr(_registry, "_generation", 0),
         frozenset(enabled) if enabled is not None else None,
         frozenset(disabled) if disabled is not None else None,
+        verdicts,
     )
     cached = getattr(agent, "_tool_search_scope_cache", None)
     if cached is not None and cached[0] == cache_key:
@@ -395,7 +407,13 @@ def _tool_search_scoped_names(agent) -> frozenset:
     except Exception:
         names = frozenset()
     try:
-        agent._tool_search_scope_cache = (cache_key, names)
+        # TOCTOU guard (same as get_tool_definitions' memo): the verdicts in
+        # cache_key were snapshotted BEFORE the rebuild above. If a verdict
+        # flipped during it, `names` reflects the new state but the key
+        # carries the old — storing would poison the old key. Skip the store;
+        # the next call re-keys coherently.
+        if _registry.check_fn_verdict_snapshot() == verdicts:
+            agent._tool_search_scope_cache = (cache_key, names)
     except Exception:
         pass
     return names

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -362,9 +362,9 @@ def _tool_search_scoped_names(agent) -> frozenset:
     set: the deferrable subset of the session's own enabled/disabled toolset
     scope.
 
-    Result is cached on the agent and refreshed when the tool registry's
-    generation changes (e.g. an MCP server reconnects), so the common case is
-    a dict lookup, not a full tool-defs rebuild on every tool call.
+    Result is cached on the agent and refreshed when the registry generation,
+    availability snapshot, or config fingerprint changes, so the common case
+    is a dict lookup, not a full tool-defs rebuild on every tool call.
     """
     try:
         import model_tools
@@ -375,6 +375,13 @@ def _tool_search_scoped_names(agent) -> frozenset:
 
     enabled = getattr(agent, "enabled_toolsets", None)
     disabled = getattr(agent, "disabled_toolsets", None)
+    try:
+        from hermes_cli.config import get_config_path
+
+        cfg_stat = get_config_path().stat()
+        cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
+    except (FileNotFoundError, OSError, ImportError):
+        cfg_fp = None
     try:
         # Same staleness class as get_tool_definitions' memo: the generation
         # only moves on registry MUTATIONS, but a check_fn verdict can flip
@@ -391,6 +398,7 @@ def _tool_search_scoped_names(agent) -> frozenset:
         getattr(_registry, "_generation", 0),
         frozenset(enabled) if enabled is not None else None,
         frozenset(disabled) if disabled is not None else None,
+        cfg_fp,
         verdicts,
     )
     cached = getattr(agent, "_tool_search_scope_cache", None)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2728,6 +2728,10 @@ DEFAULT_CONFIG = {
             #     model knows which domains are reachable; individual tools
             #     discoverable through tool_search only.
             # "auto"/"on" — activate when at least one deferrable tool exists.
+            #   Today "auto" is an alias of "on"; it stays the default so a
+            #   future budget-gated mode (inline schemas when they fit, defer
+            #   only when they don't) can land on "auto" without changing
+            #   behavior for anyone who pinned "on" or "off" explicitly.
             # "off" — disable entirely. Tools-array assembly is a pass-through.
             "enabled": "auto",
             # Listing budget as a percentage of the active model's context

--- a/model_tools.py
+++ b/model_tools.py
@@ -297,9 +297,11 @@ _LEGACY_TOOLSET_MAP = {
 # because quiet_mode=False has stdout side effects (tool-selection prints).
 #
 # Invalidation happens transparently via the registry's _generation counter,
-# which bumps on register() / deregister() / register_toolset_alias(). The
-# inner check_fn TTL cache in registry.py handles environment drift (Docker
-# daemon start/stop, env var changes, etc.) on a 30 s horizon.
+# which bumps on register() / deregister() / register_toolset_alias(), plus a
+# TTL-cached snapshot of every check_fn verdict in the cache key. The verdict
+# snapshot is what lets environment drift (Docker daemon start/stop, env var
+# changes, credential logins) propagate through THIS cache on the inner TTL's
+# ~30 s horizon — the generation counter alone never re-probes on a hit.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 _tool_defs_cache_lock = threading.Lock()
 
@@ -374,6 +376,14 @@ def get_tool_definitions(
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
                 profile_scope,
+                # check_fn verdicts: the registry generation only captures
+                # registry MUTATIONS. An availability probe can flip without
+                # one (Docker daemon starts, credential lands, OAuth login),
+                # and before this key member a memo hit skipped probing
+                # entirely — the tool list stayed stale for the process
+                # lifetime. TTL-cached, so hits cost dict lookups; a flip
+                # changes the tuple and forces a recompute within ~30 s.
+                registry.check_fn_verdict_snapshot(),
             )
         with _tool_defs_cache_lock:
             cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None

--- a/model_tools.py
+++ b/model_tools.py
@@ -355,6 +355,7 @@ def get_tool_definitions(
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
     cache_key = None
+    verdict_snapshot: tuple = ()
     if quiet_mode:
         try:
             from hermes_cli.config import get_config_path
@@ -365,6 +366,16 @@ def get_tool_definitions(
             cfg_fp = None
         profile_scope = check_fn_cache_scope()
         if profile_scope != CHECK_FN_CACHE_BYPASS:
+            # check_fn verdicts: the registry generation only captures
+            # registry MUTATIONS. An availability probe can flip without
+            # one (Docker daemon starts, credential lands, OAuth login),
+            # and before this key member a memo hit skipped probing
+            # entirely — the tool list stayed stale for the process
+            # lifetime. TTL-cached, so hits cost dict lookups; a flip
+            # changes the tuple and forces a recompute within ~35 s worst case.
+            # Held in a named local (not just a key slot) because the
+            # TOCTOU guard below re-checks it after compute.
+            verdict_snapshot = registry.check_fn_verdict_snapshot()
             cache_key = (
                 registry.current_scope_key(),
                 frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
@@ -376,14 +387,7 @@ def get_tool_definitions(
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
                 profile_scope,
-                # check_fn verdicts: the registry generation only captures
-                # registry MUTATIONS. An availability probe can flip without
-                # one (Docker daemon starts, credential lands, OAuth login),
-                # and before this key member a memo hit skipped probing
-                # entirely — the tool list stayed stale for the process
-                # lifetime. TTL-cached, so hits cost dict lookups; a flip
-                # changes the tuple and forces a recompute within ~30 s.
-                registry.check_fn_verdict_snapshot(),
+                verdict_snapshot,
             )
         with _tool_defs_cache_lock:
             cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
@@ -399,6 +403,16 @@ def get_tool_definitions(
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
                                        skip_tool_search_assembly=skip_tool_search_assembly)
     if quiet_mode and cache_key is not None:
+        # TOCTOU guard: the verdict snapshot in cache_key was taken BEFORE
+        # compute. If a verdict flipped (and the snapshot cache was
+        # invalidated) while compute ran, the result reflects the NEW
+        # verdicts but cache_key carries the OLD ones — caching it would
+        # poison the old key: flip back later and the memo would serve this
+        # mismatched list. Skip caching when the snapshot moved; the next
+        # call re-keys and recomputes coherently. (cache_key is not None
+        # implies verdict_snapshot was bound above.)
+        if verdict_snapshot != registry.check_fn_verdict_snapshot():
+            return list(result)
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
         # schemas to self.tools) don't poison the cache. Without this, a

--- a/model_tools.py
+++ b/model_tools.py
@@ -356,6 +356,7 @@ def get_tool_definitions(
     # invalidate hook on every config-writer.
     cache_key = None
     verdict_snapshot: tuple = ()
+    key_generation: int = -1
     if quiet_mode:
         try:
             from hermes_cli.config import get_config_path
@@ -376,11 +377,20 @@ def get_tool_definitions(
             # Held in a named local (not just a key slot) because the
             # TOCTOU guard below re-checks it after compute.
             verdict_snapshot = registry.check_fn_verdict_snapshot()
+            key_generation = registry._generation
+            if verdict_snapshot != registry.check_fn_verdict_snapshot():
+                # Probes executed by the first snapshot can lazily import
+                # and register tools, bumping the generation — the first
+                # snapshot then describes a registry state older than the
+                # key's. Re-take once so key_generation and the snapshot
+                # agree; the second pass runs no new registrations.
+                key_generation = registry._generation
+                verdict_snapshot = registry.check_fn_verdict_snapshot()
             cache_key = (
                 registry.current_scope_key(),
                 frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
                 frozenset(disabled_toolsets) if disabled_toolsets else None,
-                registry._generation,
+                key_generation,
                 cfg_fp,
                 bool(os.environ.get("HERMES_KANBAN_TASK")),
                 bool(skip_tool_search_assembly),
@@ -405,13 +415,19 @@ def get_tool_definitions(
     if quiet_mode and cache_key is not None:
         # TOCTOU guard: the verdict snapshot in cache_key was taken BEFORE
         # compute. If a verdict flipped (and the snapshot cache was
-        # invalidated) while compute ran, the result reflects the NEW
-        # verdicts but cache_key carries the OLD ones — caching it would
-        # poison the old key: flip back later and the memo would serve this
-        # mismatched list. Skip caching when the snapshot moved; the next
-        # call re-keys and recomputes coherently. (cache_key is not None
+        # invalidated) while compute ran — with NO registry mutation — the
+        # result reflects the NEW verdicts but cache_key carries the OLD
+        # ones; caching would poison the old key (flip back later and the
+        # memo serves this mismatched list). Skip caching in that case.
+        # When the GENERATION moved during compute (first call in a process
+        # triggers lazy tool registration), the old key can never be looked
+        # up again, so caching under it is harmless — and skipping would
+        # leave the first call permanently uncached. (cache_key is not None
         # implies verdict_snapshot was bound above.)
-        if verdict_snapshot != registry.check_fn_verdict_snapshot():
+        if (
+            registry._generation == key_generation
+            and verdict_snapshot != registry.check_fn_verdict_snapshot()
+        ):
             return list(result)
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool

--- a/model_tools.py
+++ b/model_tools.py
@@ -298,10 +298,10 @@ _LEGACY_TOOLSET_MAP = {
 #
 # Invalidation happens transparently via the registry's _generation counter,
 # which bumps on register() / deregister() / register_toolset_alias(), plus a
-# TTL-cached snapshot of every check_fn verdict in the cache key. The verdict
-# snapshot is what lets environment drift (Docker daemon start/stop, env var
-# changes, credential logins) propagate through THIS cache on the inner TTL's
-# ~30 s horizon — the generation counter alone never re-probes on a hit.
+# Short-TTL aggregate snapshot of every cached check_fn verdict in the cache
+# key. The snapshot lets external availability drift propagate through THIS
+# cache on the combined probe/snapshot TTL horizon — the generation counter
+# alone never re-probes on a hit.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 _tool_defs_cache_lock = threading.Lock()
 
@@ -372,7 +372,7 @@ def get_tool_definitions(
             # one (Docker daemon starts, credential lands, OAuth login),
             # and before this key member a memo hit skipped probing
             # entirely — the tool list stayed stale for the process
-            # lifetime. TTL-cached, so hits cost dict lookups; a flip
+            # lifetime. The aggregate is TTL-cached, so hits cost one lookup; a flip
             # changes the tuple and forces a recompute within ~35 s worst case.
             # Held in a named local (not just a key slot) because the
             # TOCTOU guard below re-checks it after compute.

--- a/tests/tools/test_deferral_fixes.py
+++ b/tests/tools/test_deferral_fixes.py
@@ -111,17 +111,19 @@ class TestBridgePeelInPlanner:
         assert _kinds(segments) == ["parallel"]
         assert _flatten_ids(segments) == ["a", "b"]
 
-    def test_bridged_call_to_non_opted_in_tool_stays_sequential(self, mcp_pair, monkeypatch):
+    def test_bridged_call_to_non_opted_in_tool_stays_sequential(self, mcp_pair):
         from tools import mcp_tool
+
         with mcp_tool._lock:
             mcp_tool._parallel_safe_servers.discard("pytestsrv")
-        alpha, beta = mcp_pair
-        calls = [_bridge_tc(alpha, call_id="a"), _bridge_tc(beta, call_id="b")]
-        segments = _plan_tool_batch_segments(calls)
-        assert _kinds(segments) == ["sequential"]
-        # restore for the fixture's teardown symmetry
-        with mcp_tool._lock:
-            mcp_tool._parallel_safe_servers.add("pytestsrv")
+        try:
+            alpha, beta = mcp_pair
+            calls = [_bridge_tc(alpha, call_id="a"), _bridge_tc(beta, call_id="b")]
+            segments = _plan_tool_batch_segments(calls)
+            assert _kinds(segments) == ["sequential"]
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._parallel_safe_servers.add("pytestsrv")
 
     def test_bridge_lookups_are_parallel_safe(self):
         calls = [
@@ -173,22 +175,15 @@ class TestBridgePeelInPlanner:
         assert [(k, [c.id for c in cs]) for k, cs in direct] == \
                [(k, [c.id for c in cs]) for k, cs in bridged]
 
-    def test_bridged_path_tools_get_path_conflict_analysis(self, tmp_path, monkeypatch):
-        """A write_file smuggled through the bridge must not share a parallel
-        segment with a bridged read of the same file — the peel exposes the
-        underlying args to the path-overlap analysis."""
-        monkeypatch.chdir(tmp_path)
+    def test_core_file_tools_cannot_be_smuggled_through_the_bridge(self):
+        """Wrapped core file tools remain sequential because they are not deferrable."""
         calls = [
             _bridge_tc("write_file", {"path": "a.py", "content": "x"}, call_id="w"),
             _bridge_tc("read_file", {"path": "a.py"}, call_id="r"),
         ]
-        # write_file/read_file are core tools, not deferrable, so the peel
-        # refuses them (resolve_underlying_call errors) and both stay
-        # sequential barriers — same net safety as before the fix.
         segments = _plan_tool_batch_segments(calls)
-        for kind, seg_calls in segments:
-            ids = [tc.id for tc in seg_calls]
-            assert not (kind == "parallel" and {"w", "r"} <= set(ids))
+        assert _kinds(segments) == ["sequential"]
+        assert _flatten_ids(segments) == ["w", "r"]
 
 
 class TestShortDescSentenceBoundary:
@@ -283,6 +278,34 @@ class TestSourceNameIndexing:
         finally:
             for n in names:
                 registry.deregister(n)
+
+    def test_source_label_is_indexed_once_for_native_and_plugin_names(self):
+        from tools.registry import registry
+
+        source_label = "catalogsource"
+        names = [
+            self._register(
+                "mcp__catalogsource__native_action",
+                "mcp-catalogsource",
+                "Perform a native action.",
+            ),
+            self._register(
+                "plugin_action",
+                "mcp-catalogsource",
+                "Perform a plugin action.",
+            ),
+        ]
+        try:
+            catalog = build_catalog([
+                _td("mcp__catalogsource__native_action", "Perform a native action."),
+                _td("plugin_action", "Perform a plugin action."),
+            ])
+            tokens_by_name = {entry.name: entry._tokens for entry in catalog}
+            assert tokens_by_name[names[0]].count(source_label) == 1
+            assert tokens_by_name[names[1]].count(source_label) == 1
+        finally:
+            for name in names:
+                registry.deregister(name)
 
     def test_substring_fallback_covers_token_misses(self):
         """"hub" is a substring of github but never a token — the fallback
@@ -394,6 +417,93 @@ class TestCheckFnFlipBustsToolDefsMemo:
         finally:
             registry.deregister("mcp__scopeflip__gated")
             model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+    def test_scope_cache_observes_config_fingerprint(self, monkeypatch, tmp_path):
+        import model_tools
+        from agent.tool_executor import _tool_search_scoped_names
+        from tools.registry import (
+            _NO_CACHE_CHECK_FNS,
+            invalidate_check_fn_cache,
+            no_cache_check_fn,
+            registry,
+        )
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("off", encoding="utf-8")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_path)
+
+        def _config_check():
+            return config_path.read_text(encoding="utf-8") == "enabled"
+
+        no_cache_check_fn(_config_check)
+        tool_name = "mcp__configscope__gated"
+        registry.register(
+            name=tool_name,
+            toolset="mcp-configscope",
+            schema=_td(tool_name, "Config-gated test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=_config_check,
+        )
+        agent = SimpleNamespace(
+            enabled_toolsets=["mcp-configscope"],
+            disabled_toolsets=None,
+        )
+        try:
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+            assert tool_name not in _tool_search_scoped_names(agent)
+
+            config_path.write_text("enabled", encoding="utf-8")
+            assert tool_name in _tool_search_scoped_names(agent)
+        finally:
+            registry.deregister(tool_name)
+            _NO_CACHE_CHECK_FNS.discard(_config_check)
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+    def test_snapshot_coalesces_grace_probe_and_invalidation(self, monkeypatch):
+        import tools.registry as registry_module
+        from tools.registry import ToolRegistry, invalidate_check_fn_cache
+
+        local_registry = ToolRegistry()
+        available = {"value": True}
+        probe_calls = {"n": 0}
+        clock = {"now": 1000.0}
+
+        def _probe():
+            probe_calls["n"] += 1
+            return available["value"]
+
+        monkeypatch.setattr(registry_module.time, "monotonic", lambda: clock["now"])
+        local_registry.register(
+            name="snapshot_gated_tool",
+            toolset="snapshottest",
+            schema=_td("snapshot_gated_tool", "Snapshot test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=_probe,
+        )
+        try:
+            invalidate_check_fn_cache()
+            assert local_registry.check_fn_verdict_snapshot()[0][1] is True
+
+            available["value"] = False
+            clock["now"] += registry_module._CHECK_FN_TTL_SECONDS + 1
+            calls_before_grace = probe_calls["n"]
+            grace_snapshots = [
+                local_registry.check_fn_verdict_snapshot()
+                for _ in range(8)
+            ]
+
+            assert probe_calls["n"] - calls_before_grace == 1
+            assert all(snapshot == grace_snapshots[0] for snapshot in grace_snapshots)
+            assert grace_snapshots[0][0][1] is True
+
+            invalidate_check_fn_cache()
+            refreshed = local_registry.check_fn_verdict_snapshot()
+            assert probe_calls["n"] - calls_before_grace == 2
+            assert refreshed[0][1] is False
+        finally:
             invalidate_check_fn_cache()
 
     def test_memo_still_hits_within_ttl(self, monkeypatch):

--- a/tests/tools/test_deferral_fixes.py
+++ b/tests/tools/test_deferral_fixes.py
@@ -1,0 +1,399 @@
+"""Deferral-layer fixes: behavior regression suite.
+
+Each test class pins one user-visible behavior that was broken while the
+tool_search bridge was active. Tests assert at public seams (planner
+segment shapes, search results, listing lines, get_tool_definitions
+output) — not private implementation details — so refactors that keep
+the behavior keep the tests.
+
+The bugs, as reproduced before the fix:
+
+1. ``_plan_tool_batch_segments`` classified the literal name ``tool_call``
+   as a sequential barrier, so a server opted in via
+   ``supports_parallel_tool_calls: true`` silently lost all concurrency
+   the moment the bridge activated (every deferred call arrives wrapped).
+2. ``_short_desc`` cut at the first ``.`` anywhere, so "e.g.", "v1.2",
+   and "api.github.com" truncated catalog listing lines to garbage.
+3. The BM25 document didn't include the tool's source, so a query naming
+   the service ("linear") missed tools whose own name omits it.
+4. (docstring-only) the substring fallback documented a zero-IDF case
+   that cannot occur with the Lucene IDF variant.
+5. A ``check_fn`` verdict flip (credential appears, daemon starts) never
+   invalidated the ``get_tool_definitions`` memo — the stale tool list
+   survived until an unrelated registry mutation.
+"""
+
+import json
+import time
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from agent.tool_dispatch_helpers import _plan_tool_batch_segments
+from tools.tool_search import _short_desc, build_catalog, search_catalog
+
+
+def _tc(name, arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _bridge_tc(underlying, arguments=None, call_id=None):
+    """A tool_call bridge invocation as the model emits it."""
+    return _tc(
+        "tool_call",
+        json.dumps({"name": underlying, "arguments": arguments or {}}),
+        call_id=call_id,
+    )
+
+
+def _td(name, desc="", params=None, required=None):
+    parameters = {"type": "object", "properties": params or {}}
+    if required:
+        parameters["required"] = required
+    return {
+        "type": "function",
+        "function": {"name": name, "description": desc, "parameters": parameters},
+    }
+
+
+def _kinds(segments):
+    return [kind for kind, _ in segments]
+
+
+def _flatten_ids(segments):
+    return [tc.id for _, calls in segments for tc in calls]
+
+
+@pytest.fixture
+def mcp_pair(monkeypatch):
+    """Two tools on a parallel-opted-in MCP server, registered for real.
+
+    Registers via the actual registry (so ``resolve_underlying_call``'s
+    deferability check passes) and marks the server parallel-safe through
+    the real provenance maps in ``tools.mcp_tool``.
+    """
+    from tools import mcp_tool
+    from tools.registry import registry
+
+    names = ["mcp__pytestsrv__alpha_read", "mcp__pytestsrv__beta_read"]
+    for n in names:
+        registry.register(
+            name=n,
+            toolset="mcp-pytestsrv",
+            schema=_td(n, "Read-only test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+        )
+    with mcp_tool._lock:
+        for n in names:
+            mcp_tool._mcp_tool_server_names[n] = "pytestsrv"
+        mcp_tool._parallel_safe_servers.add("pytestsrv")
+    yield names
+    with mcp_tool._lock:
+        mcp_tool._parallel_safe_servers.discard("pytestsrv")
+        for n in names:
+            mcp_tool._mcp_tool_server_names.pop(n, None)
+    for n in names:
+        registry.deregister(n)
+
+
+class TestBridgePeelInPlanner:
+    """Fix 1: batch admission is decided on the underlying tool."""
+
+    def test_two_bridged_parallel_safe_mcp_calls_run_parallel(self, mcp_pair):
+        alpha, beta = mcp_pair
+        calls = [_bridge_tc(alpha, call_id="a"), _bridge_tc(beta, call_id="b")]
+        segments = _plan_tool_batch_segments(calls)
+        assert _kinds(segments) == ["parallel"]
+        assert _flatten_ids(segments) == ["a", "b"]
+
+    def test_bridged_call_to_non_opted_in_tool_stays_sequential(self, mcp_pair, monkeypatch):
+        from tools import mcp_tool
+        with mcp_tool._lock:
+            mcp_tool._parallel_safe_servers.discard("pytestsrv")
+        alpha, beta = mcp_pair
+        calls = [_bridge_tc(alpha, call_id="a"), _bridge_tc(beta, call_id="b")]
+        segments = _plan_tool_batch_segments(calls)
+        assert _kinds(segments) == ["sequential"]
+        # restore for the fixture's teardown symmetry
+        with mcp_tool._lock:
+            mcp_tool._parallel_safe_servers.add("pytestsrv")
+
+    def test_bridge_lookups_are_parallel_safe(self):
+        calls = [
+            _tc("tool_search", '{"query": "issues"}', call_id="s1"),
+            _tc("tool_search", '{"query": "pages"}', call_id="s2"),
+            _tc("tool_describe", '{"name": "mcp__x__y"}', call_id="d1"),
+        ]
+        segments = _plan_tool_batch_segments(calls)
+        assert _kinds(segments) == ["parallel"]
+        assert _flatten_ids(segments) == ["s1", "s2", "d1"]
+
+    def test_malformed_bridge_call_stays_a_barrier(self):
+        calls = [
+            _tc("tool_call", '{"arguments": {}}', call_id="bad"),  # no name
+            _tc("web_search", '{"query": "x"}', call_id="r1"),
+            _tc("web_search", '{"query": "y"}', call_id="r2"),
+        ]
+        segments = _plan_tool_batch_segments(calls)
+        assert _kinds(segments) == ["sequential", "parallel"]
+        assert [tc.id for tc in segments[0][1]] == ["bad"]
+
+    def test_emission_order_survives_the_peel(self, mcp_pair):
+        alpha, beta = mcp_pair
+        calls = [
+            _bridge_tc(alpha, call_id="a"),
+            _tc("terminal", '{"command": "make"}', call_id="t"),
+            _bridge_tc(beta, call_id="b"),
+        ]
+        segments = _plan_tool_batch_segments(calls)
+        assert _flatten_ids(segments) == ["a", "t", "b"]
+
+    def test_bridged_path_tools_get_path_conflict_analysis(self, tmp_path, monkeypatch):
+        """A write_file smuggled through the bridge must not share a parallel
+        segment with a bridged read of the same file — the peel exposes the
+        underlying args to the path-overlap analysis."""
+        monkeypatch.chdir(tmp_path)
+        calls = [
+            _bridge_tc("write_file", {"path": "a.py", "content": "x"}, call_id="w"),
+            _bridge_tc("read_file", {"path": "a.py"}, call_id="r"),
+        ]
+        # write_file/read_file are core tools, not deferrable, so the peel
+        # refuses them (resolve_underlying_call errors) and both stay
+        # sequential barriers — same net safety as before the fix.
+        segments = _plan_tool_batch_segments(calls)
+        for kind, seg_calls in segments:
+            ids = [tc.id for tc in seg_calls]
+            assert not (kind == "parallel" and {"w", "r"} <= set(ids))
+
+
+class TestShortDescSentenceBoundary:
+    """Fix 2: listing lines survive abbreviations, versions, hostnames."""
+
+    def test_clean_two_sentence_case_still_clips_at_first(self):
+        assert _short_desc("Open an issue. Second sentence dropped.") == "Open an issue."
+
+    def test_abbreviation_does_not_truncate(self):
+        s = _short_desc("Create an issue (e.g. a bug report) in a repository.")
+        assert s.startswith("Create an issue (e.g. a bug report)")
+
+    def test_hostname_does_not_truncate(self):
+        s = _short_desc("Fetch a page from api.github.com and return the JSON body.")
+        assert "api.github.com" in s
+
+    def test_version_string_does_not_truncate(self):
+        s = _short_desc("Upgrade to v1.2 of the schema and migrate all rows.")
+        assert "v1.2" in s
+
+    def test_exclamation_terminator_is_kept(self):
+        assert _short_desc("List repos! Supports pagination.") == "List repos!"
+
+    def test_question_terminator_is_kept(self):
+        s = _short_desc("What does this do? It lists channels.")
+        assert s == "What does this do?"
+
+    def test_long_text_still_clips_with_ellipsis(self):
+        s = _short_desc("word " * 40)
+        assert len(s) <= 61
+        assert s.endswith("…")
+
+    def test_empty_is_empty(self):
+        assert _short_desc("") == ""
+
+
+class TestSourceNameIndexing:
+    """Fix 3: a query naming the service finds that source's tools."""
+
+    @staticmethod
+    def _register(name, toolset, desc):
+        from tools.registry import registry
+
+        registry.register(
+            name=name,
+            toolset=toolset,
+            schema=_td(name, desc)["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+        )
+        return name
+
+    def test_service_query_reaches_tool_without_service_in_name(self):
+        """A plugin tool named ``create_issue`` in toolset ``mcp-linear``
+        must be reachable by the query "linear"."""
+        from tools.registry import registry
+
+        names = [
+            self._register("create_issue", "mcp-linear", "Create a new issue in a team."),
+            self._register("post_message", "mcp-slack", "Post a message to a channel."),
+        ]
+        try:
+            defs = [_td(n, d) for n, d in
+                    [("create_issue", "Create a new issue in a team."),
+                     ("post_message", "Post a message to a channel.")]]
+            catalog = build_catalog(defs)
+            hits = search_catalog(catalog, "linear")
+            assert [h.name for h in hits] == ["create_issue"]
+        finally:
+            for n in names:
+                registry.deregister(n)
+
+    def test_mcp_prefix_is_not_a_matchable_token(self):
+        """The shared ``mcp`` prefix used to sit in every native MCP document
+        as a near-zero-IDF token: a query containing "mcp" matched EVERY
+        tool, drowning the discriminating terms. Now "mcp" contributes
+        nothing to ranking, so the discriminating term decides alone."""
+        from tools.registry import registry
+
+        names = [
+            self._register("mcp__linear__create_issue", "mcp-linear", "Create an issue."),
+            self._register("mcp__slack__post_message", "mcp-slack", "Post a message."),
+        ]
+        try:
+            defs = [_td("mcp__linear__create_issue", "Create an issue."),
+                    _td("mcp__slack__post_message", "Post a message.")]
+            catalog = build_catalog(defs)
+            hits = search_catalog(catalog, "mcp message")
+            # Before the fix "mcp" BM25-matched both docs, so both came
+            # back and the order was decided by document length, not by
+            # the term the model actually meant.
+            assert [h.name for h in hits] == ["mcp__slack__post_message"]
+        finally:
+            for n in names:
+                registry.deregister(n)
+
+    def test_substring_fallback_covers_token_misses(self):
+        """"hub" is a substring of github but never a token — the fallback
+        (not BM25) must return the github tools."""
+        from tools.registry import registry
+
+        names = [
+            self._register("github_create_issue", "mcp-github", "Create an issue."),
+            self._register("github_merge_pr", "mcp-github", "Merge a pull request."),
+        ]
+        try:
+            defs = [_td("github_create_issue", "Create an issue."),
+                    _td("github_merge_pr", "Merge a pull request.")]
+            catalog = build_catalog(defs)
+            hits = search_catalog(catalog, "hub")
+            assert {h.name for h in hits} == {"github_create_issue", "github_merge_pr"}
+            assert search_catalog(catalog, "zzzz") == []
+        finally:
+            for n in names:
+                registry.deregister(n)
+
+
+class TestCheckFnFlipBustsToolDefsMemo:
+    """Fix 5: an availability flip propagates without a registry mutation."""
+
+    def test_verdict_flip_changes_tool_definitions(self, monkeypatch):
+        import model_tools
+        from tools.registry import registry, invalidate_check_fn_cache
+
+        available = {"value": False}
+
+        def _flip_check():
+            return available["value"]
+
+        registry.register(
+            name="flip_gated_tool",
+            toolset="fliptest",
+            schema=_td("flip_gated_tool", "Gated test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=_flip_check,
+        )
+        try:
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+            # skip_tool_search_assembly: assert on the raw exposed list —
+            # deferral would otherwise (correctly) fold a plugin tool into
+            # the bridge and hide the name we're asserting on. The memo
+            # path under test is identical for both shapes.
+            names_before = {
+                t["function"]["name"]
+                for t in model_tools.get_tool_definitions(
+                    enabled_toolsets=["fliptest"], quiet_mode=True,
+                    skip_tool_search_assembly=True,
+                )
+            }
+            assert "flip_gated_tool" not in names_before
+
+            # The flip: credential lands / daemon starts. No registry
+            # mutation. Config untouched. Same toolsets. The TTL cache is
+            # cleared the way `hermes tools enable` / config writers do.
+            available["value"] = True
+            invalidate_check_fn_cache()
+
+            names_after = {
+                t["function"]["name"]
+                for t in model_tools.get_tool_definitions(
+                    enabled_toolsets=["fliptest"], quiet_mode=True,
+                    skip_tool_search_assembly=True,
+                )
+            }
+            assert "flip_gated_tool" in names_after
+        finally:
+            registry.deregister("flip_gated_tool")
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+    def test_memo_still_hits_within_ttl(self, monkeypatch):
+        """The fix must not disable memoization: with stable verdicts, repeat
+        calls must be served from cache (probes may run; compute must not).
+
+        A warmup call settles lazy registration first — the first compute
+        after registry churn registers dynamic tools itself, which bumps the
+        generation and changes the key. That warmup miss predates this fix;
+        what this test pins is that the verdict-snapshot key member does not
+        introduce PERPETUAL misses.
+        """
+        import model_tools
+        from tools.registry import registry, invalidate_check_fn_cache
+
+        probe_calls = {"n": 0}
+
+        def _steady_check():
+            probe_calls["n"] += 1
+            return True
+
+        registry.register(
+            name="steady_gated_tool",
+            toolset="steadytest",
+            schema=_td("steady_gated_tool", "Gated test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=_steady_check,
+        )
+        try:
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+            # Warmup: let lazy registration inside compute settle the
+            # generation, then once more to seed the settled key.
+            for _ in range(2):
+                model_tools.get_tool_definitions(
+                    enabled_toolsets=["steadytest"], quiet_mode=True)
+
+            compute_calls = {"n": 0}
+            real_compute = model_tools._compute_tool_definitions
+
+            def _counting_compute(*args, **kwargs):
+                compute_calls["n"] += 1
+                return real_compute(*args, **kwargs)
+
+            monkeypatch.setattr(model_tools, "_compute_tool_definitions", _counting_compute)
+
+            first = model_tools.get_tool_definitions(
+                enabled_toolsets=["steadytest"], quiet_mode=True)
+            second = model_tools.get_tool_definitions(
+                enabled_toolsets=["steadytest"], quiet_mode=True)
+
+            assert compute_calls["n"] == 0
+            assert [t["function"]["name"] for t in first] == \
+                   [t["function"]["name"] for t in second]
+        finally:
+            registry.deregister("steady_gated_tool")
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()

--- a/tests/tools/test_deferral_fixes.py
+++ b/tests/tools/test_deferral_fixes.py
@@ -452,10 +452,22 @@ class TestCheckFnFlipBustsToolDefsMemo:
         try:
             model_tools._clear_tool_defs_cache()
             invalidate_check_fn_cache()
+            # Warm-up: the first rebuild can lazily register tools, which
+            # flips the verdict snapshot mid-build and makes the TOCTOU
+            # guard skip the store. The second call stores deterministically.
+            _tool_search_scoped_names(agent)
             assert tool_name not in _tool_search_scoped_names(agent)
+            cache_before = agent._tool_search_scope_cache
+            assert cache_before is not None
 
             config_path.write_text("enabled", encoding="utf-8")
             assert tool_name in _tool_search_scoped_names(agent)
+            # The config fingerprint is part of the cache key: a config write
+            # must re-key the scope cache, never serve the pre-write entry.
+            # Asserting the key change keeps this test red on a key that
+            # omits the fingerprint even when an unrelated cache miss makes
+            # the membership assert above pass by recomputation.
+            assert agent._tool_search_scope_cache[0] != cache_before[0]
         finally:
             registry.deregister(tool_name)
             _NO_CACHE_CHECK_FNS.discard(_config_check)

--- a/tests/tools/test_deferral_fixes.py
+++ b/tests/tools/test_deferral_fixes.py
@@ -153,6 +153,26 @@ class TestBridgePeelInPlanner:
         segments = _plan_tool_batch_segments(calls)
         assert _flatten_ids(segments) == ["a", "t", "b"]
 
+    def test_bridged_mcp_admission_matches_direct_admission(self, mcp_pair, tmp_path, monkeypatch):
+        """The peel restores PARITY, not extra permissiveness: a bridged call
+        to an opted-in MCP tool gets exactly the admission the same tool gets
+        when called directly. Opted-in MCP tools have always shared parallel
+        runs with core path-scoped tools (the server opt-in is the owner's
+        declared contract; the planner has never had per-MCP-tool resource
+        scopes) — the bridge must not silently upgrade OR downgrade that."""
+        monkeypatch.chdir(tmp_path)
+        alpha, _ = mcp_pair
+        direct = _plan_tool_batch_segments([
+            _tc(alpha, "{}", call_id="m1"),
+            _tc("write_file", '{"path":"x.py","content":"a"}', call_id="w1"),
+        ])
+        bridged = _plan_tool_batch_segments([
+            _bridge_tc(alpha, {}, call_id="m1"),
+            _tc("write_file", '{"path":"x.py","content":"a"}', call_id="w1"),
+        ])
+        assert [(k, [c.id for c in cs]) for k, cs in direct] == \
+               [(k, [c.id for c in cs]) for k, cs in bridged]
+
     def test_bridged_path_tools_get_path_conflict_analysis(self, tmp_path, monkeypatch):
         """A write_file smuggled through the bridge must not share a parallel
         segment with a bridged read of the same file — the peel exposes the
@@ -337,6 +357,42 @@ class TestCheckFnFlipBustsToolDefsMemo:
             assert "flip_gated_tool" in names_after
         finally:
             registry.deregister("flip_gated_tool")
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+    def test_scope_cache_observes_verdict_flip(self):
+        """Sibling site of the same staleness class: the executor's per-agent
+        deferred-scope cache must also observe an availability flip, or the
+        bridge unwrap keeps rejecting (or admitting) a tool whose probe
+        verdict changed with no registry mutation."""
+        from types import SimpleNamespace as NS
+
+        import model_tools
+        from agent.tool_executor import _tool_search_scoped_names
+        from tools.registry import registry, invalidate_check_fn_cache
+
+        available = {"value": False}
+
+        registry.register(
+            name="mcp__scopeflip__gated",
+            toolset="mcp-scopeflip",
+            schema=_td("mcp__scopeflip__gated", "Gated test tool.")["function"],
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            check_fn=lambda: available["value"],
+        )
+        agent = NS(enabled_toolsets=["mcp-scopeflip"], disabled_toolsets=None)
+        try:
+            model_tools._clear_tool_defs_cache()
+            invalidate_check_fn_cache()
+
+            assert "mcp__scopeflip__gated" not in _tool_search_scoped_names(agent)
+
+            available["value"] = True
+            invalidate_check_fn_cache()
+
+            assert "mcp__scopeflip__gated" in _tool_search_scoped_names(agent)
+        finally:
+            registry.deregister("mcp__scopeflip__gated")
             model_tools._clear_tool_defs_cache()
             invalidate_check_fn_cache()
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -298,6 +298,8 @@ def _prune_check_fn_caches(now: float) -> None:
             _check_fn_last_good.pop(key, None)
     while len(_check_fn_cache) >= _CHECK_FN_CACHE_MAX:
         _check_fn_cache.pop(next(iter(_check_fn_cache)))
+    # Same hard cap as _check_fn_cache: TTL pruning alone leaves last-good
+    # unbounded under high (fn, scope) churn inside one grace window.
     while len(_check_fn_last_good) >= _CHECK_FN_CACHE_MAX:
         _check_fn_last_good.pop(next(iter(_check_fn_last_good)))
 
@@ -522,10 +524,10 @@ class ToolRegistry:
 
         Each distinct probe runs through :func:`_check_fn_cached`, so within
         a TTL window this is dictionary lookups; at most one real probe per
-        function per TTL. When a verdict flips after its TTL expires (or
-        after :func:`invalidate_check_fn_cache`), the returned tuple changes
-        and any memo keyed on it recomputes. Verdicts propagate on the same
-        ~30 s horizon the TTL cache already promises.
+        function per TTL. When a verdict flips, the returned tuple changes
+        and any memo keyed on it recomputes — worst case within the probe
+        TTL plus the snapshot TTL (~35 s); immediately after
+        :func:`invalidate_check_fn_cache`, which clears both layers.
 
         Probes marked :func:`no_cache_check_fn` are skipped: they are local,
         config-backed checks that execute UNCACHED on every call (some with

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -545,7 +545,7 @@ class ToolRegistry:
         """
         registry_scope = scope or self.current_scope_key()
         probe_scope = check_fn_cache_scope()
-        cache_key = (self, registry_scope, probe_scope)
+        cache_key = (self, registry_scope, probe_scope, self._generation)
         now = time.monotonic()
         snapshot_epoch = -1
         if probe_scope != CHECK_FN_CACHE_BYPASS:

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -272,8 +272,11 @@ _CHECK_FN_TTL_SECONDS = 30.0
 # so a genuinely-down backend is reflected within a couple of turns.
 _CHECK_FN_FAILURE_GRACE_SECONDS = 60.0
 _CHECK_FN_CACHE_MAX = 512
+_VERDICT_SNAPSHOT_TTL_SECONDS = 5.0
 _check_fn_cache: Dict[tuple[Callable, Optional[str]], tuple[float, bool]] = {}
 _check_fn_last_good: Dict[tuple[Callable, Optional[str]], float] = {}
+_verdict_snapshot_cache: Dict[tuple, tuple[float, tuple]] = {}
+_verdict_snapshot_epoch = 0
 _check_fn_cache_lock = threading.Lock()
 CHECK_FN_CACHE_BYPASS = ""
 _NO_CACHE_CHECK_FNS: Set[Callable] = set()
@@ -420,11 +423,16 @@ def _check_fn_cached(fn: Callable) -> bool:
 
 
 def invalidate_check_fn_cache() -> None:
-    """Drop all cached ``check_fn`` results. Call after config changes that
-    affect tool availability (e.g. ``hermes tools enable``)."""
+    """Drop cached probes and aggregate verdict snapshots.
+
+    Call after config changes that affect tool availability.
+    """
+    global _verdict_snapshot_epoch
     with _check_fn_cache_lock:
         _check_fn_cache.clear()
         _check_fn_last_good.clear()
+        _verdict_snapshot_cache.clear()
+        _verdict_snapshot_epoch += 1
 
 
 def get_cached_check_fn_result(fn: Callable) -> Optional[bool]:
@@ -522,12 +530,12 @@ class ToolRegistry:
         indefinitely after such a flip, because nothing on the cache-hit
         path ever re-probed.
 
-        Each distinct probe runs through :func:`_check_fn_cached`, so within
-        a TTL window this is dictionary lookups; at most one real probe per
-        function per TTL. When a verdict flips, the returned tuple changes
-        and any memo keyed on it recomputes — worst case within the probe
-        TTL plus the snapshot TTL (~35 s); immediately after
-        :func:`invalidate_check_fn_cache`, which clears both layers.
+        Aggregate snapshots are cached briefly per registry and profile, so a
+        hot-path hit is one dictionary lookup. On a snapshot miss, each
+        distinct probe runs through :func:`_check_fn_cached`. A verdict flip
+        changes the tuple after the probe TTL plus the snapshot TTL (~35 s),
+        or immediately after :func:`invalidate_check_fn_cache`, which clears
+        both layers. Request-bound cache-bypass scopes are never aggregated.
 
         Probes marked :func:`no_cache_check_fn` are skipped: they are local,
         config-backed checks that execute UNCACHED on every call (some with
@@ -535,7 +543,19 @@ class ToolRegistry:
         their verdicts only change when config changes — which the outer
         memo key already captures through the config-file fingerprint.
         """
-        entries, toolset_checks = self._snapshot_state(scope)
+        registry_scope = scope or self.current_scope_key()
+        probe_scope = check_fn_cache_scope()
+        cache_key = (self, registry_scope, probe_scope)
+        now = time.monotonic()
+        snapshot_epoch = -1
+        if probe_scope != CHECK_FN_CACHE_BYPASS:
+            with _check_fn_cache_lock:
+                snapshot_epoch = _verdict_snapshot_epoch
+                cached = _verdict_snapshot_cache.get(cache_key)
+                if cached is not None and now - cached[0] < _VERDICT_SNAPSHOT_TTL_SECONDS:
+                    return cached[1]
+
+        entries, toolset_checks = self._snapshot_state(registry_scope)
         fns: Dict[Callable, str] = {}
         for entry in entries:
             if entry.check_fn is not None and entry.check_fn not in fns:
@@ -551,7 +571,14 @@ class ToolRegistry:
             if fn not in _NO_CACHE_CHECK_FNS
         ]
         verdicts.sort(key=lambda item: (item[0], item[1]))
-        return tuple((label, value) for label, _, value in verdicts)
+        snapshot = tuple((label, value) for label, _, value in verdicts)
+        if probe_scope != CHECK_FN_CACHE_BYPASS:
+            with _check_fn_cache_lock:
+                if snapshot_epoch == _verdict_snapshot_epoch:
+                    while len(_verdict_snapshot_cache) >= _CHECK_FN_CACHE_MAX:
+                        _verdict_snapshot_cache.pop(next(iter(_verdict_snapshot_cache)))
+                    _verdict_snapshot_cache[cache_key] = (time.monotonic(), snapshot)
+        return snapshot
 
     def _toolset_has_exposable_tools(
         self,

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -509,6 +509,48 @@ class ToolRegistry:
         """Return a stable snapshot of registered tool entries."""
         return self._snapshot_state()[0]
 
+    def check_fn_verdict_snapshot(self, scope: Optional[str] = None) -> tuple:
+        """Return a hashable snapshot of every availability probe's verdict.
+
+        Built for outer memo keys (``get_tool_definitions``' cache): the
+        registry generation captures registry *mutations*, but a ``check_fn``
+        verdict can flip without any mutation — a daemon starts, a credential
+        file appears, an OAuth login lands. Before this existed, an outer
+        memo keyed only on the generation served stale tool lists
+        indefinitely after such a flip, because nothing on the cache-hit
+        path ever re-probed.
+
+        Each distinct probe runs through :func:`_check_fn_cached`, so within
+        a TTL window this is dictionary lookups; at most one real probe per
+        function per TTL. When a verdict flips after its TTL expires (or
+        after :func:`invalidate_check_fn_cache`), the returned tuple changes
+        and any memo keyed on it recomputes. Verdicts propagate on the same
+        ~30 s horizon the TTL cache already promises.
+
+        Probes marked :func:`no_cache_check_fn` are skipped: they are local,
+        config-backed checks that execute UNCACHED on every call (some with
+        deliberate side effects, e.g. the memory tool's flag snapshot), and
+        their verdicts only change when config changes — which the outer
+        memo key already captures through the config-file fingerprint.
+        """
+        entries, toolset_checks = self._snapshot_state(scope)
+        fns: Dict[Callable, str] = {}
+        for entry in entries:
+            if entry.check_fn is not None and entry.check_fn not in fns:
+                fns[entry.check_fn] = getattr(
+                    entry.check_fn, "__qualname__", repr(entry.check_fn)
+                )
+        for fn in toolset_checks.values():
+            if fn is not None and fn not in fns:
+                fns[fn] = getattr(fn, "__qualname__", repr(fn))
+        verdicts = [
+            (label, id(fn), _check_fn_cached(fn))
+            for fn, label in fns.items()
+            if fn not in _NO_CACHE_CHECK_FNS
+        ]
+        verdicts.sort(key=lambda item: (item[0], item[1]))
+        return tuple((label, value) for label, _, value in verdicts)
+
     def _toolset_has_exposable_tools(
         self,
         toolset: str,

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -386,7 +386,8 @@ def _entry_search_text(td: Dict[str, Any], source_label: str = "") -> str:
     param_names = " ".join(params.keys())
     # Break snake_case and dotted names into words for BM25.
     name_words = name.replace("_", " ").replace(".", " ").replace("-", " ").replace(":", " ")
-    return f"{name_words} {source_label} {desc} {param_names}"
+    extra = source_label if source_label and source_label not in name_words.split() else ""
+    return f"{name_words} {extra} {desc} {param_names}"
 
 
 def _classify_source(name: str) -> Tuple[str, str]:
@@ -470,10 +471,10 @@ def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> L
     Falls back to a stable name-substring match when every query token
     misses every document — e.g. the query ``"hub"`` against ``github_*``
     tools ("hub" is a substring of the name but never a token, so BM25
-    scores nothing). The Lucene IDF variant used here,
+    scores nothing). The IDF variant used here,
     ``log(1 + (N - df + 0.5) / (df + 0.5))``, is strictly positive even
-    when a term appears in every document, so a tokenizable query always
-    produces positive scores and the fallback stays out of the way.
+    when a term appears in every document, so the fallback only runs when
+    no query token appears in any document.
     """
     if not catalog or limit <= 0:
         return []
@@ -514,65 +515,24 @@ def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> L
 # ---------------------------------------------------------------------------
 
 
-# A sentence ends at ., !, or ? followed by whitespace or end-of-string.
-# A bare ``[.!?]`` search is NOT a sentence detector: "e.g.", "v1.2",
-# "api.github.com", and decimals all contain periods that used to truncate
-# a listing line to fragments like "Create an issue (e." — the period had
-# only to appear, not to end anything. Whitespace is collapsed before
-# matching, so a newline class here would be dead code.
-_SENTENCE_END_RE = re.compile(r"[.!?](?=\s|$)")
-
-# Dotted abbreviations whose trailing period does not end a sentence even
-# when followed by whitespace ("Create an issue (e.g. a bug report) ...").
-_ABBREV_NO_SENTENCE_END_RE = re.compile(
-    r"\b(?:e\.g|i\.e|etc|et al|vs|cf|approx|dr|mr|mrs|ms|st|jr|sr)\.$",
-    re.IGNORECASE,
-)
-
-# Look-behind window for the abbreviation check: longest listed entry plus
-# a leading word-boundary character, derived so adding a longer abbreviation
-# can never silently outgrow the window. ("et al" is 5 chars + "." + 1.)
-_ABBREV_WINDOW_CHARS = max(
-    len(a) for a in (
-        "e.g", "i.e", "etc", "et al", "vs", "cf", "approx",
-        "dr", "mr", "mrs", "ms", "st", "jr", "sr",
-    )
-) + 4
+# A sentence ends at ., !, or ? followed by whitespace or end-of-string, but
+# not at the end of a common dotted abbreviation.
+_SENTENCE_END_RE = re.compile(r"(?<!\be\.g)(?<!\bi\.e)(?<!\betc)[.!?](?=\s|$)")
 
 
 def _short_desc(description: str, max_chars: int = 60) -> str:
     """First sentence of a tool description, clipped to ``max_chars``.
 
-    Mirrors the skills-listing convention: one terse line per capability.
-    Whitespace is collapsed; a hard clip never cuts mid-word unless the
-    first word itself exceeds the budget. Sentence detection requires the
-    terminator to be followed by whitespace or end-of-string and not to
-    close a known abbreviation, so hostnames, version strings, decimals,
-    and "e.g."/"i.e." pass through intact.
-
-    Bounded work on hostile input: the abbreviation check looks at a small
-    fixed window before each candidate terminator (never a growing prefix
-    slice), and scanning stops once a candidate starts past ``max_chars`` —
-    beyond that point the hard clip decides the output regardless, so a
-    description with thousands of dotted abbreviations costs O(max_chars),
-    not O(len**2). MCP descriptions are third-party input.
+    A terminator must be followed by whitespace or end-of-string; ``e.g.``,
+    ``i.e.``, and ``etc.`` do not end a sentence. Whitespace normalization and
+    the unbounded regex search both remain linear-time on hostile input.
     """
     text = " ".join((description or "").split())
     if not text:
         return ""
-    for m in _SENTENCE_END_RE.finditer(text):
-        if m.start() > max_chars:
-            # The first sentence (if any) ends beyond the clip budget; the
-            # hard clip below yields the same output either way.
-            break
-        end = m.end()
-        # Window derived from the abbreviation list, so the end-anchored
-        # regex sees everything it needs without rescanning the prefix.
-        window = text[max(0, end - _ABBREV_WINDOW_CHARS):end]
-        if text[m.start()] == "." and _ABBREV_NO_SENTENCE_END_RE.search(window):
-            continue
-        text = text[:end]
-        break
+    m = _SENTENCE_END_RE.search(text)
+    if m:
+        text = text[:m.end()]
     if len(text) <= max_chars:
         return text
     clipped = text[:max_chars]

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -81,7 +81,7 @@ CHARS_PER_TOKEN = 4.0
 class ToolSearchConfig:
     """Resolved, validated tool-search configuration for a single assembly."""
 
-    enabled: str  # "auto" | "on" | "off"
+    enabled: str  # "auto" | "on" | "off" — "auto" is an alias of "on" today
     # Listing budget as a percentage of the model's context window. Under
     # tiered disclosure this no longer gates *activation* (any deferrable
     # tool activates the bridge) — it bounds how much context the embedded
@@ -295,6 +295,13 @@ def should_activate(
     ``"off"`` skips unconditionally. ``"on"`` and ``"auto"`` activate whenever
     at least one deferrable tool exists (there's no point swapping a no-op).
 
+    ``"auto"`` is an ALIAS of ``"on"`` under tiered disclosure — it is kept
+    as the shipped default so that a future budget-gated mode ("inline the
+    schemas when they fit, defer only when they don't") can change ``auto``'s
+    behavior without breaking users who explicitly pinned ``on`` or ``off``.
+    Do not add behavior that distinguishes them without that design; see the
+    config reference for the user-facing statement of this contract.
+
     Tiered-disclosure semantics (July 2026): the presence of ANY MCP/plugin
     tool activates the bridge — schemas always defer. What the threshold now
     controls is the *listing budget* (see :func:`listing_token_budget`), not
@@ -353,22 +360,33 @@ def _tokenize(text: str) -> List[str]:
     return [t.lower() for t in _TOKEN_RE.findall(text)]
 
 
-def _entry_search_text(td: Dict[str, Any]) -> str:
+def _entry_search_text(td: Dict[str, Any], source_label: str = "") -> str:
     """Build the search-text blob for a deferrable tool.
 
     Includes the tool name (with underscores broken into words so BM25 can
-    match against query terms), the description, and the names of the
-    top-level parameters. Schema bodies are deliberately excluded —
-    indexing them adds noise without improving recall in our measurement.
+    match against query terms), the source label (the MCP server / plugin
+    toolset the tool belongs to, e.g. ``linear`` for toolset ``mcp-linear``),
+    the description, and the names of the top-level parameters. Schema
+    bodies are deliberately excluded — indexing them adds noise without
+    improving recall in our measurement.
+
+    The ``mcp__`` name prefix is stripped before splitting: ``mcp`` appears
+    in every native MCP tool document, so its IDF collapses to near zero —
+    it is dead weight in every document and useless as a query term.
+    Indexing the source label is what makes a service-name query ("linear")
+    reach a tool whose NAME does not carry the service (a plugin tool named
+    ``create_issue``, or any catalog whose naming omits the vendor).
     """
     fn = td.get("function") or {}
     name = fn.get("name", "")
+    if name.startswith("mcp__"):
+        name = name[len("mcp__"):]
     desc = fn.get("description", "") or ""
     params = ((fn.get("parameters") or {}).get("properties") or {})
     param_names = " ".join(params.keys())
     # Break snake_case and dotted names into words for BM25.
     name_words = name.replace("_", " ").replace(".", " ").replace("-", " ").replace(":", " ")
-    return f"{name_words} {desc} {param_names}"
+    return f"{name_words} {source_label} {desc} {param_names}"
 
 
 def _classify_source(name: str) -> Tuple[str, str]:
@@ -399,13 +417,17 @@ def build_catalog(tool_defs: List[Dict[str, Any]]) -> List[CatalogEntry]:
             continue
         desc = fn.get("description", "") or ""
         source, source_name = _classify_source(name)
+        # Index the human-facing group label ("linear", not "mcp-linear") so
+        # a service-name query matches tools from that source even when the
+        # tool's own name omits the service.
+        source_label = _listing_group_label(source_name) if source_name else ""
         entry = CatalogEntry(
             name=name,
             description=desc,
             schema=td,
             source=source,
             source_name=source_name,
-            _tokens=_tokenize(_entry_search_text(td)),
+            _tokens=_tokenize(_entry_search_text(td, source_label)),
         )
         catalog.append(entry)
     return catalog
@@ -445,11 +467,13 @@ def _bm25_score(query_tokens: List[str], doc_tokens: List[str],
 def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> List[CatalogEntry]:
     """Return the top-``limit`` catalog entries for ``query`` by BM25.
 
-    Falls back to a stable name-substring match when BM25 yields no hits
-    above zero. That ensures a query like ``"github"`` against a catalog
-    where every tool is named ``github_*`` still returns results — BM25
-    can underperform when query and document share only one token that
-    appears in every document (zero IDF).
+    Falls back to a stable name-substring match when every query token
+    misses every document — e.g. the query ``"hub"`` against ``github_*``
+    tools ("hub" is a substring of the name but never a token, so BM25
+    scores nothing). The Lucene IDF variant used here,
+    ``log(1 + (N - df + 0.5) / (df + 0.5))``, is strictly positive even
+    when a term appears in every document, so a tokenizable query always
+    produces positive scores and the fallback stays out of the way.
     """
     if not catalog or limit <= 0:
         return []
@@ -490,7 +514,20 @@ def search_catalog(catalog: List[CatalogEntry], query: str, limit: int = 5) -> L
 # ---------------------------------------------------------------------------
 
 
-_SENTENCE_END_RE = re.compile(r"[.!?\n]")
+# A sentence ends at ., !, or ? followed by whitespace or end-of-string.
+# A bare ``[.!?]`` search is NOT a sentence detector: "e.g.", "v1.2",
+# "api.github.com", and decimals all contain periods that used to truncate
+# a listing line to fragments like "Create an issue (e." — the period had
+# only to appear, not to end anything. Whitespace is collapsed before
+# matching, so a newline class here would be dead code.
+_SENTENCE_END_RE = re.compile(r"[.!?](?=\s|$)")
+
+# Dotted abbreviations whose trailing period does not end a sentence even
+# when followed by whitespace ("Create an issue (e.g. a bug report) ...").
+_ABBREV_NO_SENTENCE_END_RE = re.compile(
+    r"\b(?:e\.g|i\.e|etc|et al|vs|cf|approx|dr|mr|mrs|ms|st|jr|sr)\.$",
+    re.IGNORECASE,
+)
 
 
 def _short_desc(description: str, max_chars: int = 60) -> str:
@@ -498,14 +535,20 @@ def _short_desc(description: str, max_chars: int = 60) -> str:
 
     Mirrors the skills-listing convention: one terse line per capability.
     Whitespace is collapsed; a hard clip never cuts mid-word unless the
-    first word itself exceeds the budget.
+    first word itself exceeds the budget. Sentence detection requires the
+    terminator to be followed by whitespace or end-of-string and not to
+    close a known abbreviation, so hostnames, version strings, decimals,
+    and "e.g."/"i.e." pass through intact.
     """
     text = " ".join((description or "").split())
     if not text:
         return ""
-    m = _SENTENCE_END_RE.search(text)
-    if m:
-        text = text[:m.start() + (1 if text[m.start()] == "." else 0)]
+    for m in _SENTENCE_END_RE.finditer(text):
+        end = m.end()
+        if text[m.start()] == "." and _ABBREV_NO_SENTENCE_END_RE.search(text[:end]):
+            continue
+        text = text[:end]
+        break
     if len(text) <= max_chars:
         return text
     clipped = text[:max_chars]

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -529,6 +529,16 @@ _ABBREV_NO_SENTENCE_END_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Look-behind window for the abbreviation check: longest listed entry plus
+# a leading word-boundary character, derived so adding a longer abbreviation
+# can never silently outgrow the window. ("et al" is 5 chars + "." + 1.)
+_ABBREV_WINDOW_CHARS = max(
+    len(a) for a in (
+        "e.g", "i.e", "etc", "et al", "vs", "cf", "approx",
+        "dr", "mr", "mrs", "ms", "st", "jr", "sr",
+    )
+) + 4
+
 
 def _short_desc(description: str, max_chars: int = 60) -> str:
     """First sentence of a tool description, clipped to ``max_chars``.
@@ -539,13 +549,27 @@ def _short_desc(description: str, max_chars: int = 60) -> str:
     terminator to be followed by whitespace or end-of-string and not to
     close a known abbreviation, so hostnames, version strings, decimals,
     and "e.g."/"i.e." pass through intact.
+
+    Bounded work on hostile input: the abbreviation check looks at a small
+    fixed window before each candidate terminator (never a growing prefix
+    slice), and scanning stops once a candidate starts past ``max_chars`` —
+    beyond that point the hard clip decides the output regardless, so a
+    description with thousands of dotted abbreviations costs O(max_chars),
+    not O(len**2). MCP descriptions are third-party input.
     """
     text = " ".join((description or "").split())
     if not text:
         return ""
     for m in _SENTENCE_END_RE.finditer(text):
+        if m.start() > max_chars:
+            # The first sentence (if any) ends beyond the clip budget; the
+            # hard clip below yields the same output either way.
+            break
         end = m.end()
-        if text[m.start()] == "." and _ABBREV_NO_SENTENCE_END_RE.search(text[:end]):
+        # Window derived from the abbreviation list, so the end-anchored
+        # regex sees everything it needs without rescanning the prefix.
+        window = text[max(0, end - _ABBREV_WINDOW_CHARS):end]
+        if text[m.start()] == "." and _ABBREV_NO_SENTENCE_END_RE.search(window):
             continue
         text = text[:end]
         break

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -85,7 +85,7 @@ tools:
 
 | Key | Default | Meaning |
 | --- | --- | --- |
-| `enabled` | `auto` | `auto`/`on` activate whenever at least one deferrable tool exists; `off` disables entirely (everything stays eager). |
+| `enabled` | `auto` | `auto`/`on` activate whenever at least one deferrable tool exists; `off` disables entirely (everything stays eager). `auto` is currently an alias of `on` — it is reserved for a future mode that inlines schemas when they fit the context and defers only when they don't. Pin `on` or `off` if you want today's behavior guaranteed across upgrades. |
 | `threshold_pct` | `5` | Listing budget as a percentage of the active model's context length. Range 0–100. |
 | `search_default_limit` | `5` | Hits returned when the model calls `tool_search` without a `limit`. |
 | `max_search_limit` | `20` | Hard upper bound the model can request via `limit`. Range 1–50. |
@@ -148,11 +148,18 @@ to any progressive-disclosure design, not specific to this implementation:
 
 ## Implementation details
 
-- **Retrieval:** BM25 over tokenized tool name + description + parameter
-  names. Falls back to a literal substring match on the tool name when
-  BM25 returns no positive-score hits, which protects against
-  zero-IDF degenerate cases (e.g. searching `"github"` against a
-  catalog where every tool name contains "github").
+- **Retrieval:** BM25 over tokenized tool name, source name (the MCP
+  server or plugin toolset the tool belongs to, so searching `"linear"`
+  finds that server's tools even when a tool's own name doesn't carry
+  the service), description, and parameter names. Falls back to a
+  literal substring match on the tool name when no query token matches
+  any document (e.g. searching `"hub"` where the token is `github`).
+- **Parallel execution unwraps the bridge.** The batch planner decides
+  concurrency on the *underlying* tool of a `tool_call`, not on the
+  literal bridge name — so an MCP server opted in via
+  `supports_parallel_tool_calls: true` keeps its concurrency when its
+  tools are called through the bridge, and `tool_search` /
+  `tool_describe` lookups batch concurrently like any read-only tool.
 - **Catalog is stateless across turns.** It rebuilds from the current
   tool-defs list every assembly — no session-keyed `Map`. This avoids
   the class of bug where a stored catalog drifts out of sync with the


### PR DESCRIPTION
## Summary

Five bugs in the tool-search deferral layer, one PR. The headline: `supports_parallel_tool_calls` silently stopped working the moment any MCP server was attached, because the batch planner treated the literal name `tool_call` as a sequential barrier. The rest: catalog listing lines truncated at "e.g.", service-name searches missing their own tools, a docstring describing impossible math, and a tool-availability cache that never noticed when a credential appeared.

No new tools, no schema changes, no cache-shape changes beyond a one-time prefix bust on release (same as any tool-description edit).

## Background: how deferred tool dispatch works

With many MCP servers attached, sending every tool's JSON schema to the model on every turn gets expensive. So Hermes defers them: the model sees three bridge tools instead, and loads schemas on demand.

```mermaid
flowchart LR
    subgraph model_sees [what the model sees]
        TS[tool_search]
        TD[tool_describe]
        TC[tool_call]
    end
    subgraph hidden [deferred catalog]
        L1[mcp__linear__get_issue]
        L2[mcp__linear__create_issue]
        G1[mcp__granola__get_meetings]
        DOTS[... 200 more]
    end
    TS -- "BM25 search" --> hidden
    TD -- "load one schema" --> hidden
    TC -- "unwrap + dispatch" --> hidden
```

A deferred call arrives as `tool_call(name="mcp__linear__get_issue", arguments={...})`. The executor unwraps it and dispatches the real tool, so hooks, approvals, and guardrails all see the underlying name. That part worked. The problem was everything *around* dispatch that keyed on the literal string `tool_call` instead of unwrapping first.

## Fix 1: the parallel-execution barrier (the big one)

When the model emits several tool calls in one turn, a planner splits them into segments: runs of read-only/safe calls execute concurrently on a thread pool, everything else runs in order. Admission is by tool name.

The planner never unwrapped the bridge. `tool_call` is not in any safe list, so it always fell through to "sequential barrier" — for *every* deferred tool, regardless of what was inside:

```mermaid
flowchart TD
    subgraph before [before — bridge active]
        A1["tool_call(linear get_issue)"] --> P1{planner sees name tool_call}
        A2["tool_call(granola folders)"] --> P1
        P1 -- "not in safe list" --> S1[sequential: one at a time]
    end
    subgraph after [after — planner peels the wrapper]
        B1["tool_call(linear get_issue)"] --> P2{peel to underlying tool}
        B2["tool_call(granola folders)"] --> P2
        P2 -- "server opted in to parallel" --> R1[parallel: both at once]
        P2 -- "not opted in / unparseable" --> S2[sequential, as before]
    end
```

The practical effect: setting `supports_parallel_tool_calls: true` on an MCP server did nothing once deferral was active — which is always, since any MCP server activates the bridge. The config option and the bridge were mutually exclusive and nothing said so.

The planner now peels the wrapper with the same parser the executor uses (`resolve_underlying_call`) and decides admission on the underlying tool and its real arguments:

- A bridged call gets exactly the admission the same call gets direct — parity, not extra permissiveness.
- A wrapper that fails to parse (bad JSON, missing name, core tool smuggled through, bridge recursion) stays a sequential barrier and fails at dispatch exactly as before.
- Path-conflict analysis sees the underlying arguments, so overlap detection works on what will actually run.
- `tool_search` and `tool_describe` are stateless catalog reads, so a batch of them runs concurrently too.

### Reproduction

Live agent, two MCP servers with `supports_parallel_tool_calls: true`, one prompt asking for both calls in a single batch. Tool start time = completed timestamp minus logged duration:

| | linear call | granola call | batch wall time |
|---|---|---|---|
| before | starts 09:11:24.08, runs 0.54s | starts 09:11:24.63 — **after linear finished** | 1.31s (sum) |
| after | starts 09:12:37.10, runs 0.65s | starts 09:12:37.10 — **same instant** | 1.18s (max) |

Two tools make a small difference; a fan-out of eight I/O-bound calls pays the full serialization tax.

## Fix 2: listing lines truncated at the first period

Tier-1 disclosure embeds a catalog listing: one line per tool, `name: first sentence of description`. The "first sentence" cut searched for the first `.`, `!`, or `?` *anywhere*:

| description | listing line before | after |
|---|---|---|
| `Fetch a page from api.github.com and return the JSON body.` | `Fetch a page from api.` | full sentence |
| `Create an issue (e.g. a bug report) in a repository.` | `Create an issue (e.` | full sentence |
| `Upgrade to v1.2 of the schema and migrate all rows.` | `Upgrade to v1.` | full sentence |
| `List repos! Supports pagination.` | `List repos` (terminator dropped) | `List repos!` |

The listing is the model's only view of a deferred tool until it loads the schema, so garbled lines directly hurt tool selection. The boundary is now one regex: a terminator must be followed by whitespace or end-of-string, and `e.g.`, `i.e.`, `etc.` don't count. Linear-time on hostile input (MCP descriptions are third-party), and byte-identical output on the 211 real MCP descriptions in a live install except the one `e.g.` case this exists to fix.

## Fix 3: searching for a service missed the service's tools

### How the search works, in one paragraph

Each deferred tool becomes a small text document: its name split into words, its description, its parameter names. Queries score against these documents with BM25 — a term that appears in few documents is worth more than one that appears everywhere (IDF), a term matching a short document is worth more than the same match in a long one (length normalization). Top scores win.

### What was wrong

Two things about how the documents were built:

1. **The source wasn't in the document.** A tool named `create_issue` living on the `linear` server had no "linear" anywhere in its indexed text — so the obvious query `"linear"` returned nothing. Native MCP tools dodged this only because their names happen to embed the server (`mcp__linear__create_issue`).
2. **The `mcp` prefix was indexed.** Every native MCP tool document carried the token `mcp`, worth nearly zero information (it's in every document, so IDF collapses) but still able to match every tool at once and drown out the term the model actually meant.

```mermaid
flowchart LR
    subgraph doc_before [indexed text — before]
        D1["mcp linear create issue + description + params"]
    end
    subgraph doc_after [indexed text — after]
        D2["linear create issue + description + params"]
    end
    Q1["query: linear"] -.->|"only matches if name contains it"| D1
    Q1 ==>|"always matches via source label"| D2
```

Now the group label (`linear`, not `mcp-linear`) is indexed with every tool from that source — exactly once, whether or not the tool's own name already carries it, so native and plugin tools get the same term weight — and the dead prefix is stripped before tokenizing.

### What this deliberately does not do

No stemming, no synonyms, no field weights, no multi-query — those are a separate, larger change to the ranking itself. This fix only makes the document contain what it always should have.

## Fix 4: a docstring describing impossible math

The search's substring fallback claimed to protect against "zero IDF" — a term appearing in every document scoring zero. With the IDF variant actually used, `log(1 + (N - df + 0.5)/(df + 0.5))`, that cannot happen: the value is strictly positive for every df ≤ N. The fallback's real (and useful) job is total token misses — `"hub"` never tokenizes out of `github_create_issue`, so nothing scores, and the substring pass catches it. The docstring and the user docs now describe the mechanism that exists.

No behavior change. This matters because the wrong rationale invites a "fix" for a case that can't occur.

## Fix 5: the tool list couldn't notice a credential appearing

`get_tool_definitions` memoizes its result. The cache key captured registry mutations (a counter that bumps on register/deregister) and config-file edits (mtime fingerprint) — but not the *availability probes*. Tools gated on external state (is Docker running? is this credential set?) run a `check_fn`, and those verdicts are TTL-cached for 30 seconds precisely so they can flip when the world changes. Except a flip changed nothing in the memo key:

```mermaid
sequenceDiagram
    participant W as world
    participant M as memo (get_tool_definitions)
    participant P as availability probes
    Note over M: before
    W->>M: request tool list
    M->>P: probe (first call, cache miss)
    P-->>M: unavailable → tool omitted
    W->>W: credential lands / daemon starts
    W->>M: request tool list (any time later)
    M-->>W: cache HIT — stale list, probes never re-run
    Note over M: after
    W->>M: request tool list
    M->>P: TTL-cached verdict snapshot in the key
    P-->>M: verdict flipped → key changed → recompute
    M-->>W: fresh list within ~35s worst case
```

The key now includes an aggregate snapshot of every probe's verdict. The snapshot has its own short-TTL cache (keyed on registry scope, probe scope, and registry generation; cleared by `invalidate_check_fn_cache()`), so a hot-path hit is one dictionary lookup and a flaky probe coalesces to at most one live re-probe per window instead of one per rebuild. A flip propagates within the probe TTL plus the snapshot TTL (~35s worst case), or immediately on explicit invalidation. Probes marked no-cache (local config reads) are excluded — their inputs are covered by the config fingerprint.

The same staleness class existed at a second site: the executor's cache of which tools a session may reach through the bridge. It now keys on the verdict snapshot and the config fingerprint too. Both cache sites re-check the snapshot after computing and skip the store on mismatch, so a verdict flipping mid-compute can't park a fresh result under a stale key.

## Also in this PR

`enabled: auto` and `enabled: on` do the same thing today. That is now stated at all three surfaces (dataclass, shipped config comment, docs) along with why `auto` remains the default: it reserves room for a future mode that inlines schemas when they fit and defers only when they don't, without breaking anyone who pinned `on` or `off`.

## Validation

- `tests/tools/test_deferral_fixes.py` — 24 behavior-level tests at public seams (planner segment shapes, search results, listing lines, `get_tool_definitions` / scope-cache output), not internals. Each fix's tests verified red against the unfixed code; the invariant tests (unparseable wrappers stay barriers, non-opted-in servers stay sequential, direct/bridged parity, fallback on token misses, memo still hits when verdicts are stable) hold on both sides.
- Sibling suites green: `test_tool_search.py`, `test_tool_batch_segmentation.py`, `test_builtin_memory_disabled_surface.py`, `test_get_tool_definitions_cache_isolation.py`, `test_terminal_tool_requirements.py`, `test_mcp_reload_refreshes_cached_agents.py`, `test_discord_tool.py`, `test_kanban_tools.py`, `test_plugins_hub_perf_guard.py`, `test_x_search_tool.py`, `test_delegate_kanban_isolation.py`.
- Live red→green on a real agent with two OAuth MCP servers (table in Fix 1); search results and listing lines re-checked against 211 real MCP descriptions.

## Cache impact

Fixes 1, 3, 4, 5 don't touch the request prefix at all (planner/dispatch/memo internals). Fix 2 changes listing bytes: one-time prefix bust on the release that ships it, identical to any listing edit; lines get slightly longer (real sentences instead of fragments), which can shift a borderline catalog's listing form — the byte-stability suite stayed green.
