### PR TITLE
fix(computer_use): restore element targeting on cua-driver 0.21.x

### DIFF
--- a/tests/computer_use/test_cua_element_token_gate.py
+++ b/tests/computer_use/test_cua_element_token_gate.py
@@ -1,0 +1,94 @@
+"""Regression tests for the element_token attach gate.
+
+``_maybe_attach_element_token`` decides whether to send the opaque
+``element_token`` alongside ``element_index`` on a cua-driver action.
+
+Getting that gate wrong is not a soft degradation. cua-driver 0.21 REFUSES a
+bare ``element_index``::
+
+    click: bare element_index is not accepted; pass element_token,
+    or snapshot_id together with element_index
+
+so a gate that fails closed breaks every element-targeted click and leaves
+agents with nothing but blind pixel coordinates.
+
+The original gate consulted only the trycua/cua#1961 capability vocabulary.
+cua-driver 0.21 stopped publishing per-tool capability sets — every tool
+reports an empty set — while still accepting ``element_token`` in its input
+schema, so that check alone silently disabled element targeting on 0.21.x.
+The schema (``tools/list``) is the authoritative signal; the capability token
+is kept as a fallback for drivers that shipped the vocabulary.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tools.computer_use.cua_backend import CuaDriverBackend
+
+
+def _backend(*, schema_ok: bool, capability_ok: bool) -> CuaDriverBackend:
+    """A backend whose session advertises support via one channel, both, or neither."""
+    backend = CuaDriverBackend.__new__(CuaDriverBackend)
+    backend._snapshot_tokens = {7: "s00000001:7"}
+    session = MagicMock()
+    session.supports_input_property.return_value = schema_ok
+    session.supports_capability.return_value = capability_ok
+    backend._session = session
+    return backend
+
+
+def test_schema_alone_is_enough() -> None:
+    """0.21.x: schema accepts element_token, capability vocabulary is gone."""
+    backend = _backend(schema_ok=True, capability_ok=False)
+    args = {"element_index": 7}
+    backend._maybe_attach_element_token("click", args)
+    assert args["element_token"] == "s00000001:7"
+
+
+def test_capability_alone_is_enough() -> None:
+    """Older drivers: capability advertised, schema introspection unavailable."""
+    backend = _backend(schema_ok=False, capability_ok=True)
+    args = {"element_index": 7}
+    backend._maybe_attach_element_token("click", args)
+    assert args["element_token"] == "s00000001:7"
+
+
+def test_neither_signal_leaves_args_untouched() -> None:
+    """Pre-#1961 drivers reject unknown properties, so send nothing."""
+    backend = _backend(schema_ok=False, capability_ok=False)
+    args = {"element_index": 7}
+    backend._maybe_attach_element_token("click", args)
+    assert "element_token" not in args
+
+
+def test_unknown_index_is_not_guessed() -> None:
+    """An index with no cached token must not borrow another element's."""
+    backend = _backend(schema_ok=True, capability_ok=True)
+    args = {"element_index": 999}
+    backend._maybe_attach_element_token("click", args)
+    assert "element_token" not in args
+
+
+def test_non_element_calls_are_ignored() -> None:
+    """Coordinate-based actions carry no element_index and must be left alone."""
+    backend = _backend(schema_ok=True, capability_ok=True)
+    args = {"x": 10, "y": 20}
+    backend._maybe_attach_element_token("click", args)
+    assert "element_token" not in args
+
+
+def test_schema_is_consulted_before_capability() -> None:
+    """The schema check must be able to satisfy the gate on its own.
+
+    Guards against a regression to capability-first evaluation, which is what
+    failed closed on 0.21.x.
+    """
+    backend = _backend(schema_ok=True, capability_ok=False)
+    args = {"element_index": 7}
+    backend._maybe_attach_element_token("click", args)
+
+    backend._session.supports_input_property.assert_called_once_with(
+        "click", "element_token"
+    )
+    assert args["element_token"] == "s00000001:7"

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -137,6 +137,35 @@ def _action_result_from(
     # `path` records the rung that ran; this records what we asked for).
     delivery_mode = requested_delivery if isinstance(requested_delivery, str) else None
 
+    # `escalation.reason == "delivery_failed"` on a FOREGROUND action is not
+    # trustworthy on Linux/X11. Verified by observation: text typed with
+    # delivery_mode="foreground" lands correctly in the target widget while
+    # the driver reports delivery_failed for that same call. The driver has
+    # no read-back channel to confirm with — its own AT-SPI elements carry
+    # only role/label/frame/enabled and never a `value` — so "could not
+    # confirm" is being reported as "failed".
+    #
+    # Taken at face value this reads as "typing is broken", which is how an
+    # agent ends up retrying, escalating, and reporting a false blocker to
+    # the user. Annotate rather than suppress: a real failure looks identical
+    # from here, so the only sound move is a visual check.
+    if (
+        escalation
+        and escalation.get("reason") == "delivery_failed"
+        and delivery_mode == "foreground"
+        and sys.platform.startswith("linux")
+    ):
+        message = (
+            f"{message}\n\n" if message else ""
+        ) + (
+            "⚠️ The driver reports escalation.reason='delivery_failed', but on "
+            "Linux/X11 this signal is unreliable for foreground delivery — it "
+            "fires even when the input landed correctly, because the driver has "
+            "no way to read the target back. DO NOT treat this as proof of "
+            "failure and DO NOT retry blindly. Take a capture and look at the "
+            "target widget: if the text/effect is there, the action succeeded."
+        )
+
     return ActionResult(
         ok=ok,
         action=name,

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -3907,8 +3907,24 @@ class CuaDriverBackend(ComputerUseBackend):
         token = self._snapshot_tokens.get(idx)
         if not token:
             return
-        if not self._session.supports_capability(
-            "accessibility.element_tokens", tool=tool
+        # Two ways to establish support, in order of reliability:
+        #
+        #   1. The live input schema accepts `element_token` (tools/list).
+        #   2. The driver advertises the #1961 capability token.
+        #
+        # (1) is authoritative and must be checked first. cua-driver 0.21.0
+        # stopped publishing per-tool capability sets entirely — every tool
+        # reports `[]` — while still accepting `element_token` in its schema.
+        # Gating on (2) alone therefore fails closed on 0.21.x: we send a bare
+        # `element_index`, and the driver refuses the call outright with
+        # `snapshot_id_required`. That breaks EVERY element-targeted click,
+        # forcing agents onto blind pixel coordinates. (2) is retained so
+        # older drivers that shipped the vocabulary keep working.
+        if not (
+            self._session.supports_input_property(tool, "element_token")
+            or self._session.supports_capability(
+                "accessibility.element_tokens", tool=tool
+            )
         ):
             return
         args["element_token"] = token


### PR DESCRIPTION
## Summary

Two independent computer-use faults found while debugging a live agent that could click but not type. Both are Linux/X11-facing; the first is a hard regression against current cua-driver.

Commit 1 is the important one and stands alone — happy to drop commit 2 if you'd rather take it separately.

## 1. Every element-targeted click is refused on cua-driver 0.21.x

cua-driver 0.21 rejects a bare `element_index`:

```
click: bare element_index is not accepted; pass element_token,
or snapshot_id together with element_index
```

`_maybe_attach_element_token()` gated solely on the trycua/cua#1961 capability vocabulary. **0.21 stopped publishing per-tool capability sets entirely** — every tool reports an empty set — while still accepting `element_token` in its input schema. The gate fails closed, we send the bare index, and the driver refuses the call.

The effect is total, not partial: element targeting stops working, and agents silently fall back to blind pixel coordinates. Observed on cua-driver 0.21.0 / X11, where a capture returned **762 elements with 762 tokens cached** and every subsequent click still failed:

```python
capture(mode='som')                     -> 762 elements, 762 element_tokens
supports_capability('accessibility.element_tokens', tool='click')  -> False   # 0.21 publishes nothing
supports_input_property('click', 'element_token')                  -> True    # schema does accept it
click(element=84)  -> refused: snapshot_id_required
```

The fix checks the live input schema first. `supports_input_property()` already exists for exactly this case, and its own docstring says it *"deliberately inspects tools/list rather than guessing from the package version or requiring a capability token the driver never shipped."* The capability check is kept as a fallback so drivers that did ship the vocabulary are unaffected.

After the fix: `click ok=True — Clicked element [84]`.

## 2. `delivery_failed` is a false negative for Linux foreground input

cua-driver reports `escalation.reason="delivery_failed"` on foreground actions **that actually succeeded**. Reproduced repeatedly — text typed with `delivery_mode="foreground"` appears correctly in the target widget while that same call reports failure. The driver has no read-back channel (its AT-SPI elements carry `role`/`label`/`frame`/`enabled`, never a `value`), so "could not confirm" surfaces as "failed".

This is not cosmetic. In the incident that prompted this PR, the agent retried, escalated, and reported a false blocker to its user — while every keystroke had landed.

Annotating rather than suppressing, because a genuine failure is indistinguishable from here: the note tells the model not to treat the signal as proof of failure, not to retry blindly, and to confirm with a capture. Scoped to Linux + foreground, so macOS/Windows and background delivery (where the signal is meaningful) are untouched.

## Testing

New `tests/computer_use/test_cua_element_token_gate.py` — 6 cases covering schema-only (0.21.x), capability-only (older drivers), neither, unknown index, non-element calls, and schema-before-capability ordering.

Verified the tests actually catch the regression: against the unfixed gate, exactly the two schema-path cases fail.

```
$ pytest tests/computer_use/test_cua_element_token_gate.py -q
6 passed

$ git stash && pytest tests/computer_use/test_cua_element_token_gate.py -q   # unfixed
FAILED test_schema_alone_is_enough
FAILED test_schema_is_consulted_before_capability
2 failed, 4 passed

$ pytest tests/computer_use/ -q
50 passed, 1 skipped
```

Also validated end-to-end against a real app (Skool in Chrome): capture → element click → navigate → click composer entry → `type_text` → visually confirmed the text landed → cleared.

## Notes

Related but out of scope: cua-driver leaks its XInput2 MPX virtual master pointer/keyboard pair when it exits abnormally. A leaked master keyboard captures X11 focus and blocks *all* keyboard input to the affected window — for the agent and the human — which is what made this fault so hard to localise. Filed upstream as trycua/cua#3337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
