### PR TITLE
fix(windows): scope managed launcher cleanup to its owner

### DIFF
--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -444,7 +444,9 @@ def remove_portable_tooling_windows(hermes_home: Path) -> list[Path]:
     return removed
 
 
-def remove_windows_bin_launchers(*, windows: bool | None = None) -> list[Path]:
+def remove_windows_bin_launchers(
+    project_root: Path, *, windows: bool | None = None
+) -> list[Path]:
     """Delete the ``hermes`` launchers install.ps1 staged in the managed
     binary dir (the default Hermes root's ``bin``, next to the managed uv).
 
@@ -459,8 +461,10 @@ def remove_windows_bin_launchers(*, windows: bool | None = None) -> list[Path]:
     ``_install_repair._quarantine_running_hermes_exe`` relies on), so
     deletion falls back to renaming it aside with a non-executable suffix.
 
-    *windows* is an injectable platform verdict for tests (same pattern as
-    ``_install_repair.ensure_windows_bin_launchers``).
+    Only the managed checkout owns launchers in the default root's binary
+    directory. Source/custom checkouts must not remove that other install's
+    launchers when they uninstall. *windows* is an injectable platform verdict
+    for tests (same pattern as ``_install_repair.ensure_windows_bin_launchers``).
     """
     if windows is None:
         windows = _is_windows()
@@ -469,10 +473,18 @@ def remove_windows_bin_launchers(*, windows: bool | None = None) -> list[Path]:
     try:
         # Lockstep launcher-name list — the same names install.ps1 and the
         # startup heal stage into this dir.
-        from hermes_cli._install_repair import _WINDOWS_BIN_LAUNCHERS
+        from hermes_cli._install_repair import (
+            _WINDOWS_BIN_LAUNCHERS,
+            _normalize_windows_path,
+        )
         from hermes_constants import get_default_hermes_root
 
-        bin_dir = get_default_hermes_root() / "bin"
+        home = Path(get_default_hermes_root())
+        if _normalize_windows_path(Path(project_root).parent) != _normalize_windows_path(
+            home
+        ):
+            return []
+        bin_dir = home / "bin"
     except Exception as e:
         log_warn(f"Could not locate the managed binary dir: {e}")
         return []
@@ -897,7 +909,7 @@ def _perform_uninstall(
     #     error on its missing venv target, worse than command-not-found.
     if _is_windows():
         log_info("Removing Windows hermes launchers...")
-        removed_launchers = remove_windows_bin_launchers()
+        removed_launchers = remove_windows_bin_launchers(project_root)
         if removed_launchers:
             for launcher in removed_launchers:
                 log_success(f"Removed {launcher}")

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -483,6 +483,10 @@ def remove_windows_bin_launchers(
         if _normalize_windows_path(Path(project_root).parent) != _normalize_windows_path(
             home
         ):
+            log_info(
+                "Skipping Windows launcher cleanup: this checkout does not own "
+                "the managed binary directory"
+            )
             return []
         bin_dir = home / "bin"
     except Exception as e:
@@ -914,7 +918,7 @@ def _perform_uninstall(
             for launcher in removed_launchers:
                 log_success(f"Removed {launcher}")
         else:
-            log_info("No Windows hermes launchers found")
+            log_info("No owned Windows hermes launchers removed")
 
     # 3b. Remove node/npm/npx symlinks the installer left in ~/.local/bin
     #     (only when they still point into this Hermes home's node dir, so we

--- a/tests/hermes_cli/test_uninstall_windows_bin_launchers.py
+++ b/tests/hermes_cli/test_uninstall_windows_bin_launchers.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from hermes_cli import uninstall
+from hermes_cli import gui_uninstall, uninstall
 from hermes_cli._install_repair import _WINDOWS_BIN_LAUNCHERS
 
 
@@ -34,7 +34,9 @@ def managed_bin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def test_removes_both_launcher_forms_and_keeps_managed_uv(managed_bin: Path):
-    removed = uninstall.remove_windows_bin_launchers(windows=True)
+    removed = uninstall.remove_windows_bin_launchers(
+        managed_bin.parent / "hermes-agent", windows=True
+    )
 
     assert sorted(p.name for p in removed) == ["hermes-acp.cmd", "hermes.exe"]
     assert not (managed_bin / "hermes.exe").exists()
@@ -52,14 +54,21 @@ def test_anchors_on_default_root_not_profile_home(
     home = managed_bin.parent
     monkeypatch.setenv("HERMES_HOME", str(home / "profiles" / "work"))
 
-    removed = uninstall.remove_windows_bin_launchers(windows=True)
+    removed = uninstall.remove_windows_bin_launchers(
+        home / "hermes-agent", windows=True
+    )
 
     assert sorted(p.name for p in removed) == ["hermes-acp.cmd", "hermes.exe"]
     assert not (managed_bin / "hermes.exe").exists()
 
 
 def test_noop_on_posix(managed_bin: Path):
-    assert uninstall.remove_windows_bin_launchers(windows=False) == []
+    assert (
+        uninstall.remove_windows_bin_launchers(
+            managed_bin.parent / "hermes-agent", windows=False
+        )
+        == []
+    )
     assert (managed_bin / "hermes.exe").exists()
 
 
@@ -68,7 +77,105 @@ def test_noop_when_no_launchers_staged(tmp_path: Path, monkeypatch: pytest.Monke
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    assert uninstall.remove_windows_bin_launchers(windows=True) == []
+    assert (
+        uninstall.remove_windows_bin_launchers(home / "hermes-agent", windows=True)
+        == []
+    )
+
+
+def test_unrelated_project_cannot_remove_managed_launchers(managed_bin: Path):
+    unrelated_root = managed_bin.parent.parent / "source-checkout"
+
+    assert uninstall.remove_windows_bin_launchers(unrelated_root, windows=True) == []
+    assert (managed_bin / "hermes.exe").exists()
+    assert (managed_bin / "hermes-acp.cmd").exists()
+    assert (managed_bin / "uv.exe").exists()
+
+
+@pytest.fixture
+def isolated_windows_uninstall(monkeypatch: pytest.MonkeyPatch):
+    """Keep _perform_uninstall focused on launcher/PATH ownership."""
+    path_calls: list[bool] = []
+
+    monkeypatch.setattr(uninstall, "_is_windows", lambda: True)
+    monkeypatch.setattr(uninstall, "uninstall_gateway_service", lambda: False)
+    monkeypatch.setattr(uninstall, "remove_path_from_shell_configs", lambda: [])
+    monkeypatch.setattr(
+        uninstall,
+        "remove_path_from_windows_registry",
+        lambda _home, *, include_managed_bin=False: (
+            path_calls.append(include_managed_bin) or []
+        ),
+    )
+    monkeypatch.setattr(uninstall, "remove_hermes_env_vars_windows", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_wrapper_script", lambda: [])
+    monkeypatch.setattr(uninstall, "remove_node_symlinks", lambda _home: [])
+    monkeypatch.setattr(uninstall, "remove_portable_tooling_windows", lambda _home: [])
+    monkeypatch.setattr(gui_uninstall, "uninstall_gui", lambda _home: [])
+    return path_calls
+
+
+def test_unrelated_keep_data_uninstall_preserves_managed_bin(
+    managed_bin: Path,
+    tmp_path: Path,
+    isolated_windows_uninstall: list[bool],
+):
+    unrelated_root = tmp_path / "source-checkout" / "hermes-agent"
+    unrelated_root.mkdir(parents=True)
+
+    uninstall._perform_uninstall(
+        project_root=unrelated_root,
+        hermes_home=managed_bin.parent,
+        full_uninstall=False,
+        remove_profiles=False,
+        named_profiles=[],
+    )
+
+    assert not unrelated_root.exists()
+    assert (managed_bin / "hermes.exe").exists()
+    assert (managed_bin / "hermes-acp.cmd").exists()
+    assert (managed_bin / "uv.exe").exists()
+    assert isolated_windows_uninstall == [False]
+
+
+def test_managed_keep_data_uninstall_removes_only_owned_launchers(
+    managed_bin: Path,
+    isolated_windows_uninstall: list[bool],
+):
+    project_root = managed_bin.parent / "hermes-agent"
+    project_root.mkdir()
+
+    uninstall._perform_uninstall(
+        project_root=project_root,
+        hermes_home=managed_bin.parent,
+        full_uninstall=False,
+        remove_profiles=False,
+        named_profiles=[],
+    )
+
+    assert not (managed_bin / "hermes.exe").exists()
+    assert not (managed_bin / "hermes-acp.cmd").exists()
+    assert (managed_bin / "uv.exe").exists()
+    assert isolated_windows_uninstall == [False]
+
+
+def test_managed_full_uninstall_sweeps_bin_path_and_home(
+    managed_bin: Path,
+    isolated_windows_uninstall: list[bool],
+):
+    project_root = managed_bin.parent / "hermes-agent"
+    project_root.mkdir()
+
+    uninstall._perform_uninstall(
+        project_root=project_root,
+        hermes_home=managed_bin.parent,
+        full_uninstall=True,
+        remove_profiles=False,
+        named_profiles=[],
+    )
+
+    assert not managed_bin.parent.exists()
+    assert isolated_windows_uninstall == [True]
 
 
 def test_launcher_names_stay_in_lockstep_with_install_ps1():


### PR DESCRIPTION
## What does this PR do?

Follow-up to #92636. That PR correctly moved the Windows `hermes` and `hermes-acp` launchers into the stable managed binary directory, but its uninstall path removed those launchers without checking which checkout was being uninstalled.

A source or custom checkout could therefore run `hermes uninstall` and delete the canonical launchers owned by a separate managed installation under `%LOCALAPPDATA%\hermes`.

This change binds launcher deletion to the uninstall target. `remove_windows_bin_launchers()` now receives `project_root` and reuses the same normalized managed-root ownership predicate used when the launchers are created and migrated. Unrelated checkouts fail closed and leave the managed launcher namespace untouched.

## Related Issue

Follow-up to #92636 and the cross-install teardown finding in its review discussion.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Pass the uninstalling `project_root` into Windows managed-launcher cleanup.
- Delete launchers only when that project is owned by the default managed Hermes root.
- Add a regression proving an unrelated checkout can uninstall without deleting the managed launchers, managed `uv.exe`, or stable-bin PATH ownership.
- Preserve managed keep-data behavior: remove the owned Hermes launchers while retaining managed `uv.exe` and the stable-bin PATH entry.
- Preserve managed full-uninstall behavior: remove the managed home and sweep its stable-bin PATH entry.

## How to Test

1. Create managed launchers under a default Hermes root and a separate source/custom project root.
2. Run `_perform_uninstall()` against the unrelated project root and verify the unrelated checkout is removed while the managed launchers, `uv.exe`, and stable-bin PATH ownership survive.
3. Verify managed keep-data and full-uninstall behavior remains unchanged.

Focused verification performed on Windows 11:

`bash scripts/run_tests.sh tests/hermes_cli/test_uninstall_windows_bin_launchers.py -j 4 -q`

Result: 11 passed.

`ruff check hermes_cli/uninstall.py tests/hermes_cli/test_uninstall_windows_bin_launchers.py`

Result: passed.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this is not a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I ran the complete local Python suite. The repository's focused-test policy was followed; full-suite coverage is left to GitHub CI.
- [x] I added behavioral regression coverage.
- [x] I tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation changes are N/A; this restores the ownership boundary documented by #92636.
- [x] Config-example changes are N/A.
- [x] Contributor/agent-instruction changes are N/A.
- [x] I considered cross-platform impact. The cleanup remains a Windows-only path and the injected POSIX no-op test is preserved.
- [x] Tool description/schema changes are N/A.

## Screenshots / Logs

Not applicable. The focused test output reports 11 passed, 0 failed.