### PR TITLE
fix(gateway): Nous model swap no longer overwrites local tool backends; checklist declines persist (#92647, salvage #92665)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1999,6 +1999,7 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "platform_toolsets",     # written by the setup wizard (hermes_cli/setup.py)
     "known_plugin_toolsets", # written/read by hermes_cli/tools_config.py toolset-save flow
     "known_builtin_toolsets",  # ditto — which builtin toolsets a platform's checklist has offered
+    "tool_gateway_declined_tools",  # per-tool Tool Gateway offer declines (hermes_cli/nous_subscription.py, #92647)
     "session_reset",         # top-level form read by gateway/config.py + setup
     "group_sessions_per_user",   # top-level form bridged by gateway/config.py
     "thread_sessions_per_user",  # top-level form bridged by gateway/config.py

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -1034,16 +1034,34 @@ _GATEWAY_DIRECT_LABELS = {
 
 _ALL_GATEWAY_KEYS = ("web", "image_gen", "video_gen", "tts", "stt", "browser")
 
+# Config section + selection field for each gateway key, matching the
+# field names ``apply_gateway_defaults`` writes and
+# ``get_nous_subscription_features`` reads (web uses "backend", browser
+# uses "cloud_provider", everything else uses "provider").
+_GATEWAY_SECTION_FIELDS = {
+    "web": ("web", "backend"),
+    "image_gen": ("image_gen", "provider"),
+    "video_gen": ("video_gen", "provider"),
+    "tts": ("tts", "provider"),
+    "stt": ("stt", "provider"),
+    "browser": ("browser", "cloud_provider"),
+}
+
 
 def get_gateway_eligible_tools(
     config: Optional[Dict[str, object]] = None,
     *,
     force_fresh: bool = False,
-) -> tuple[list[str], list[str], list[str]]:
-    """Return (unconfigured, has_direct, already_managed) tool key lists.
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Return (unconfigured, has_direct, explicit_configured, already_managed)
+    tool key lists.
 
-    - unconfigured: tools with no direct credentials (easy switch)
+    - unconfigured: tools with no direct credentials and no explicit
+      non-nous selection (easy switch, safe to pre-check)
     - has_direct: tools where the user has their own API keys
+    - explicit_configured: tools with an explicit non-nous selection stored
+      (e.g. ``web.backend: searxng``), including keyless backends that would
+      otherwise look unconfigured
     - already_managed: tools already routed through the gateway
 
     All lists are empty when the user is not a paid Nous subscriber or
@@ -1084,6 +1102,7 @@ def get_gateway_eligible_tools(
 
     unconfigured: list[str] = []
     has_direct: list[str] = []
+    explicit_configured: list[str] = []
     already_managed: list[str] = []
     for key in _ALL_GATEWAY_KEYS:
         # Only offer tools the user's entitlement actually covers. For a free
@@ -1093,13 +1112,20 @@ def get_gateway_eligible_tools(
             MANAGED_FEATURE_COVERAGE_CATEGORY[key]
         ):
             continue
+        section_key, field = _GATEWAY_SECTION_FIELDS[key]
+        selected = _selected_provider(config.get(section_key), field)
         if opted_in.get(key):
             already_managed.append(key)
+        elif selected is not None and selected != "nous":
+            # An explicit non-nous selection (e.g. a keyless local backend
+            # like SearXNG or Camofox) is configured on purpose, even
+            # though it has no direct credentials to detect.
+            explicit_configured.append(key)
         elif direct.get(key):
             has_direct.append(key)
         else:
             unconfigured.append(key)
-    return unconfigured, has_direct, already_managed
+    return unconfigured, has_direct, explicit_configured, already_managed
 
 
 def apply_gateway_defaults(
@@ -1193,7 +1219,10 @@ def prompt_enable_tool_gateway(
     Returns the set of tools that were enabled, or empty set if the user
     declined or no tools were eligible.
     """
-    unconfigured, has_direct, already_managed = get_gateway_eligible_tools(
+    # explicit_configured tools (e.g. an explicit `web.backend: searxng`) are
+    # configured on purpose and are never offered here — same treatment as
+    # already_managed, just for a non-nous vendor.
+    unconfigured, has_direct, _explicit_configured, already_managed = get_gateway_eligible_tools(
         config,
         force_fresh=force_fresh,
     )

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -1000,6 +1000,11 @@ def _get_gateway_direct_credentials() -> Dict[str, bool]:
             or get_env_value("PARALLEL_API_KEY")
             or get_env_value("TAVILY_API_KEY")
             or get_env_value("EXA_API_KEY")
+            # Env-configured keyless local backend: a reachable self-hosted
+            # SearXNG is a working web setup even with no stored selection
+            # (the autodetect cascade in tools/web_tools.py picks it up), so
+            # it must not be classified "unconfigured" and pre-checked (#92647).
+            or get_env_value("SEARXNG_URL")
         ),
         "image_gen": fal_direct,
         "video_gen": fal_direct,
@@ -1019,17 +1024,22 @@ def _get_gateway_direct_credentials() -> Dict[str, bool]:
         "browser": bool(
             get_env_value("BROWSER_USE_API_KEY")
             or (get_env_value("BROWSERBASE_API_KEY") and get_env_value("BROWSERBASE_PROJECT_ID"))
+            # Env-configured keyless local backend: CAMOFOX_URL activates the
+            # Camofox browser via never-configured autodetect (see
+            # _resolve_browser_state above), so it counts as configured even
+            # with no stored cloud_provider selection (#92647).
+            or get_env_value("CAMOFOX_URL")
         ),
     }
 
 
 _GATEWAY_DIRECT_LABELS = {
-    "web": "Firecrawl/Exa/Parallel/Tavily key",
+    "web": "Firecrawl/Exa/Parallel/Tavily key or SearXNG",
     "image_gen": "FAL key",
     "video_gen": "FAL key",
     "tts": "OpenAI/ElevenLabs key",
     "stt": "OpenAI/Groq/Mistral key",
-    "browser": "Browser Use/Browserbase key",
+    "browser": "Browser Use/Browserbase key or Camofox",
 }
 
 _ALL_GATEWAY_KEYS = ("web", "image_gen", "video_gen", "tts", "stt", "browser")
@@ -1251,13 +1261,26 @@ def prompt_enable_tool_gateway(
     # Per-tool checklist: unconfigured tools first (pre-checked for new users),
     # then tools where the user already has their own key (left unchecked so we
     # don't override their own setup unless they ask).
+    #
+    # Decline persistence (#92647): tools the user has previously seen offered
+    # and left unchecked are recorded in ``tool_gateway_declined_tools`` and
+    # are never pre-checked again — the offer downgrades to opt-in-only.
+    # Acceptance used to be sticky while refusal was not, so the identical
+    # pre-checked checklist re-fired on every Nous model swap.
+    declined_raw = config.get("tool_gateway_declined_tools")
+    declined: set[str] = (
+        {str(k) for k in declined_raw} if isinstance(declined_raw, list) else set()
+    )
+
     offer_keys: list[str] = list(unconfigured) + list(has_direct)
     labels: list[str] = [_GATEWAY_TOOL_LABELS[k] for k in unconfigured]
     labels += [
         f"{_GATEWAY_TOOL_LABELS[k]} — keep using your {_GATEWAY_DIRECT_LABELS[k]}"
         for k in has_direct
     ]
-    pre_selected = list(range(len(unconfigured)))
+    pre_selected = [
+        i for i, k in enumerate(unconfigured) if k not in declined
+    ]
 
     if pool_only:
         title = "Your free Nous tool pool — pick the tools to enable:"
@@ -1273,11 +1296,28 @@ def prompt_enable_tool_gateway(
         return set()
 
     chosen_keys = [offer_keys[i] for i in chosen_idx if 0 <= i < len(offer_keys)]
+
+    # Persist per-tool declines: every unconfigured tool that was offered and
+    # NOT chosen was actively left (or unchecked) by the user — remember that
+    # so the next Nous model swap doesn't pre-check it again. Cancel paths
+    # (Ctrl-C/ESC above) return before this and record nothing. Choosing a
+    # previously-declined tool clears its decline.
+    newly_declined = [k for k in unconfigured if k not in chosen_keys and k not in declined]
+    undeclined = declined & set(chosen_keys)
+    if newly_declined or undeclined:
+        config["tool_gateway_declined_tools"] = sorted(
+            (declined | set(newly_declined)) - set(chosen_keys)
+        )
+
     if not chosen_keys:
+        if newly_declined:
+            from hermes_cli.config import save_config
+
+            save_config(config)
         return set()
 
     changed = apply_gateway_defaults(config, chosen_keys)
-    if changed:
+    if changed or newly_declined:
         from hermes_cli.config import save_config
 
         save_config(config)

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -1073,9 +1073,9 @@ def get_gateway_eligible_tools(
     try:
         account_info = get_nous_portal_account_info(force_fresh=force_fresh)
     except Exception:
-        return [], [], []
+        return [], [], [], []
     if not (account_info and account_info.logged_in and account_info.tool_gateway_entitled):
-        return [], [], []
+        return [], [], [], []
 
     if config is None:
         config = load_config() or {}
@@ -1083,7 +1083,7 @@ def get_gateway_eligible_tools(
     # Quick provider check without the heavy get_nous_subscription_features call
     model_cfg = config.get("model")
     if not isinstance(model_cfg, dict) or str(model_cfg.get("provider") or "").strip().lower() != "nous":
-        return [], [], []
+        return [], [], [], []
 
     direct = _get_gateway_direct_credentials()
 

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -228,6 +228,29 @@ def test_get_gateway_eligible_tools_treats_explicit_backend_as_configured(monkey
     assert "web" not in already_managed
 
 
+def test_get_gateway_eligible_tools_not_entitled_returns_four_empty_lists(monkeypatch):
+    """A logged-in Nous account with no paid access and no free tool pool
+    must fail closed with a 4-tuple, not a 3-tuple — regression for a crash
+    where the early 'not entitled' return still had the pre-refactor arity
+    while the happy path and every caller had moved to 4 values."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=False))
+
+    config = {"model": {"provider": "nous"}}
+    result = ns.get_gateway_eligible_tools(config)
+
+    assert result == ([], [], [], [])
+
+
+def test_prompt_enable_tool_gateway_not_entitled_does_not_crash(monkeypatch):
+    """The unconditional call site in model_setup_flows (no try/except) must
+    not raise when a Nous account is logged in but not entitled to the Tool
+    Gateway (i.e. an ordinary non-paid, non-pool account)."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=False))
+
+    config = {"model": {"provider": "nous"}}
+    assert ns.prompt_enable_tool_gateway(config) == set()
+
+
 def test_prompt_enable_tool_gateway_never_offers_explicit_backend(monkeypatch):
     """The checklist itself must not list (let alone pre-check) a tool with
     an explicit non-nous selection, so it can never be silently overwritten

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -228,6 +228,30 @@ def test_get_gateway_eligible_tools_treats_explicit_backend_as_configured(monkey
     assert "web" not in already_managed
 
 
+def test_get_gateway_eligible_tools_treats_browser_use_selection_as_explicit(monkeypatch):
+    """An explicit BYOK `browser.cloud_provider: browser-use` selection must
+    land in explicit_configured, not unconfigured/has_direct — the same
+    protection as searxng above. This is distinct from the gateway's own
+    managed selection, which is always stored as `cloud_provider: nous`
+    (see apply_gateway_defaults); "browser-use" only appears here when the
+    user picked it directly, so it must never be treated as up for grabs.
+    """
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=True))
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "browser": True},
+    )
+
+    config = {"model": {"provider": "nous"}, "browser": {"cloud_provider": "browser-use"}}
+    unconfigured, has_direct, explicit_configured, already_managed = ns.get_gateway_eligible_tools(config)
+
+    assert "browser" not in unconfigured
+    assert "browser" not in has_direct
+    assert "browser" in explicit_configured
+    assert "browser" not in already_managed
+
+
 def test_get_gateway_eligible_tools_not_entitled_returns_four_empty_lists(monkeypatch):
     """A logged-in Nous account with no paid access and no free tool pool
     must fail closed with a 4-tuple, not a 3-tuple — regression for a crash

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -295,6 +295,86 @@ def test_prompt_enable_tool_gateway_never_offers_explicit_backend(monkeypatch):
     assert "image" in blob  # other unconfigured tools still offered
 
 
+def test_gateway_direct_credentials_honor_env_configured_local_backends(monkeypatch):
+    """SEARXNG_URL / CAMOFOX_URL are env-configured keyless local backends
+    with no stored selection — they must still count as direct credentials
+    so the tool is offered unchecked, never pre-checked (#92647)."""
+    monkeypatch.setattr(
+        ns,
+        "get_env_value",
+        lambda name: "http://localhost:9377" if name in ("SEARXNG_URL", "CAMOFOX_URL") else "",
+    )
+    monkeypatch.setattr(ns, "fal_key_is_configured", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: None)
+
+    direct = ns._get_gateway_direct_credentials()
+
+    assert direct["web"] is True
+    assert direct["browser"] is True
+    assert direct["image_gen"] is False
+
+
+def test_prompt_enable_tool_gateway_persists_decline(monkeypatch):
+    """Submitting the checklist with a tool left unchecked records it in
+    tool_gateway_declined_tools and never pre-checks it again (#92647:
+    acceptance was sticky, refusal was not)."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=True))
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "stt": False, "browser": False},
+    )
+    saved = []
+    captured = _capture_checklist(monkeypatch, selected_idx=[])
+    monkeypatch.setattr(
+        "hermes_cli.config.save_config", lambda cfg: saved.append(dict(cfg)), raising=False
+    )
+
+    config = {"model": {"provider": "nous"}}
+    assert ns.prompt_enable_tool_gateway(config) == set()
+
+    # First offer: everything pre-checked, decline recorded and saved.
+    assert captured["pre_selected"] == list(range(len(captured["items"])))
+    declined = config.get("tool_gateway_declined_tools")
+    assert isinstance(declined, list) and "web" in declined and "browser" in declined
+    assert saved, "decline must be persisted via save_config"
+
+    # Second offer with the recorded declines: nothing is pre-checked.
+    captured2 = _capture_checklist(monkeypatch, selected_idx=[])
+    monkeypatch.setattr(
+        "hermes_cli.config.save_config", lambda cfg: saved.append(dict(cfg)), raising=False
+    )
+    ns.prompt_enable_tool_gateway(config)
+    assert captured2["pre_selected"] == []
+
+
+def test_prompt_enable_tool_gateway_choosing_declined_tool_clears_decline(monkeypatch):
+    """Opting in to a previously-declined tool removes it from the decline
+    list, so state tracks the user's latest explicit choice."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=True))
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "stt": False, "browser": False},
+    )
+    captured = _capture_checklist(monkeypatch, selected_idx=[0])
+
+    config = {
+        "model": {"provider": "nous"},
+        "tool_gateway_declined_tools": ["browser", "web"],
+    }
+    ns.prompt_enable_tool_gateway(config)
+
+    # The first offered key was chosen; it must leave the decline list.
+    chosen_key = None
+    for key, label in ns._GATEWAY_TOOL_LABELS.items():
+        if captured["items"][0].startswith(label):
+            chosen_key = key
+            break
+    assert chosen_key is not None
+    assert chosen_key not in config["tool_gateway_declined_tools"]
+
+
 def test_apply_nous_managed_defaults_writes_video_gen_config(monkeypatch):
     """apply_nous_managed_defaults must store the managed 'nous' selection
     when a Nous subscriber selects video_gen without a direct FAL_KEY."""

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -206,6 +206,46 @@ def test_prompt_enable_tool_gateway_pool_offers_covered_tools_only(monkeypatch):
     assert "free" in captured["title"].lower() and "pool" in captured["title"].lower()
 
 
+def test_get_gateway_eligible_tools_treats_explicit_backend_as_configured(monkeypatch):
+    """A keyless local backend (e.g. searxng) has no credentials to detect,
+    but an explicit non-nous selection must still keep it out of
+    'unconfigured' — regression for #92647, where it was pre-checked and a
+    single Enter during `hermes model` overwrote it to `web.backend: nous`.
+    """
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=True))
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "browser": False},
+    )
+
+    config = {"model": {"provider": "nous"}, "web": {"backend": "searxng"}}
+    unconfigured, has_direct, explicit_configured, already_managed = ns.get_gateway_eligible_tools(config)
+
+    assert "web" not in unconfigured
+    assert "web" not in has_direct
+    assert "web" in explicit_configured
+    assert "web" not in already_managed
+
+
+def test_prompt_enable_tool_gateway_never_offers_explicit_backend(monkeypatch):
+    """The checklist itself must not list (let alone pre-check) a tool with
+    an explicit non-nous selection, so it can never be silently overwritten
+    by an accidental Enter."""
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=True))
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": False, "image_gen": False, "video_gen": False, "tts": False, "browser": False},
+    )
+    captured = _capture_checklist(monkeypatch, selected_idx=[])
+
+    config = {"model": {"provider": "nous"}, "web": {"backend": "searxng"}}
+    ns.prompt_enable_tool_gateway(config)
+
+    blob = " ".join(captured["items"]).lower()
+    assert "firecrawl" not in blob  # web (searxng-configured) NOT offered
+    assert "image" in blob  # other unconfigured tools still offered
 
 
 def test_apply_nous_managed_defaults_writes_video_gen_config(monkeypatch):

--- a/website/docs/user-guide/features/tool-gateway.md
+++ b/website/docs/user-guide/features/tool-gateway.md
@@ -84,6 +84,15 @@ The Tool Gateway is a **paid-subscription** feature. Free-tier Nous accounts can
 
 Some accounts are also entitled to a **free tool pool** — a small managed-tool allowance that covers gateway tool calls without a paid subscription. When a free pool is available, the gateway surfaces it and shows a setup prompt on first use, so you can opt in and start using managed tools right away.
 
+## The enablement checklist
+
+Picking a Nous model (`hermes model`) offers a per-tool checklist of gateway backends. Its behavior respects your existing setup:
+
+- Tools you've explicitly pointed at another backend (e.g. `web.backend: searxng`, `browser.cloud_provider: camofox`) are **never offered** — your selection can't be accidentally overwritten.
+- Tools configured via environment variables alone (e.g. `SEARXNG_URL`, `CAMOFOX_URL`) are offered **unchecked**, labeled to keep your own backend.
+- Only genuinely unconfigured tools come pre-checked.
+- Declines stick: if you submit the checklist with a tool unchecked, it won't be pre-checked on future Nous model swaps (stored in `tool_gateway_declined_tools` in `config.yaml`; checking it later clears the decline).
+
 ## Mix and match
 
 The gateway is per-tool. Turn it on for just what you want:


### PR DESCRIPTION
## Summary

Picking a Nous model no longer overwrites explicitly-configured or env-configured local tool backends, and declining the Tool Gateway checklist now sticks. Fixes #92647 — salvage of #92665 by @chelsealong (authorship preserved) plus two follow-up gap fixes.

Root cause: `get_gateway_eligible_tools()` classified any tool without a detectable API credential as "unconfigured", and unconfigured tools come pre-checked in the `hermes model` Tool Gateway checklist — so keyless local backends (self-hosted SearXNG, Camofox) were one accidental Enter away from `web.backend`/`browser.cloud_provider` being rewritten to `nous`, breaking them at runtime.

## Changes

- **Salvaged from #92665 (@chelsealong):** new `explicit_configured` bucket derived via `_selected_provider()` (the runtime resolver's own selection semantics) — explicit non-Nous selections across all six sections are never offered in the checklist at all; plus a fix for the 3-tuple/4-tuple arity crash in the fail-closed early returns, with regression tests.
- **Follow-up — env-configured backends:** `SEARXNG_URL` / `CAMOFOX_URL` now count as direct web/browser configuration, so env-only local setups are offered unchecked instead of pre-checked.
- **Follow-up — decline persistence:** submitting the checklist with unconfigured tools left unchecked records them in `tool_gateway_declined_tools` (new known root key in config validation); they are never pre-checked again on later Nous model swaps. Opting in later clears the decline. Cancel (Ctrl-C/ESC) records nothing.
- `hermes_cli/nous_subscription.py`, `hermes_cli/config.py`, `tests/hermes_cli/test_nous_subscription.py` (+7 regression tests total), `website/docs/user-guide/features/tool-gateway.md` (new "enablement checklist" section).

## Validation

| | Before | After |
|---|---|---|
| `web.backend: searxng` during Nous model swap | pre-checked, one Enter overwrites to `nous` | never offered |
| `CAMOFOX_URL`-only setup | pre-checked | offered unchecked |
| Decline the checklist | re-offered pre-checked on every swap | decline persisted, opt-in-only afterwards |
| Non-entitled Nous account | `ValueError: not enough values to unpack` (introduced mid-PR, caught + fixed) | returns `set()` |

`tests/hermes_cli/test_nous_subscription.py`: 21 passed. Sabotage run: all new tests fail against pre-fix source. E2E against a temp `HERMES_HOME` with real `save_config`/`load_config`: decline round-trips to disk, second offer pre-checks nothing, explicit searxng never offered.

## Infographic

![Tool Gateway checklist respects your backends](https://v3b.fal.media/files/b/0aa77241/sKRW2UITVLJoHZYt3rPsU_diCYD7F5.png)
