### PR TITLE
fix(update): Windows update no longer spawns a rogue gateway beside Desktop (#76129, salvage #76745)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4893,6 +4893,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_dependency_sync_would_rewrite",
         "_detect_self_loaded_native_modules",
         "_detect_venv_python_processes",
+        "_desktop_owns_gateway_lifecycle",
         "_defer_update_for_self_lock",
         "_discard_lockfile_churn",
         "_discard_stashed_changes",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4680,9 +4680,16 @@ def _looks_like_desktop_control_plane(cmdline: str) -> bool:
     That is the Desktop control plane, not the messaging gateway. Serve and
     dashboard do not host platform adapters (#92091); do not feed this into
     ``looks_like_gateway_command_line``.
+
+    Token-based via the parser-derived subcommand classifier — never
+    substring (#90778/#91869: ``kanban --preserve-cache`` contains "serve",
+    ``-m dashboard chat`` contains " dashboard"; both are NOT control
+    planes). A cmdline whose subcommand cannot be determined is NOT a
+    control plane — callers must not guess ownership.
     """
-    low = (cmdline or "").lower()
-    return "hermes_cli.main" in low and (" serve" in low or " dashboard" in low)
+    if "hermes_cli.main" not in (cmdline or "").lower():
+        return False
+    return _hermes_holder_subcommand(cmdline) in ("serve", "dashboard")
 
 
 def _desktop_owns_gateway_lifecycle() -> bool:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4674,6 +4674,71 @@ def _stop_process_trees(pids: list[int]) -> None:
             logger.debug("Could not stop process tree %s: %s", pid, exc)
 
 
+def _looks_like_desktop_control_plane(cmdline: str) -> bool:
+    """True for this-install ``hermes serve`` / ``hermes dashboard`` argv.
+
+    That is the Desktop control plane, not the messaging gateway. Serve and
+    dashboard do not host platform adapters (#92091); do not feed this into
+    ``looks_like_gateway_command_line``.
+    """
+    low = (cmdline or "").lower()
+    return "hermes_cli.main" in low and (" serve" in low or " dashboard" in low)
+
+
+def _desktop_owns_gateway_lifecycle() -> bool:
+    """True when Desktop currently supervises this install's control plane.
+
+    The updater must not steal gateway start in that case: Desktop owns
+    start/stop via ``/api/gateway/*``. This is *not* proof messaging is
+    already served — a live serve process is the control plane, and the
+    gateway is a detached sibling (#76129 / #92091).
+
+    Prefer the spawn ledger (owned identity). Fall back to the install-scoped
+    venv-holder scan already used by the lock guard; an orphaned control-plane
+    process (supervisor gone) does not count.
+    """
+    try:
+        from hermes_cli.process_identity import ledger_entries, spawner_is_dead
+
+        for entry in ledger_entries():
+            if entry.get("purpose") not in ("serve", "dashboard"):
+                continue
+            if spawner_is_dead(entry) is False:
+                return True
+    except Exception as exc:
+        logger.debug("Desktop-lifecycle ledger probe failed: %s", exc)
+
+    try:
+        import psutil
+    except Exception:
+        psutil = None
+
+    try:
+        holders = _m()._detect_venv_python_processes()
+    except Exception as exc:
+        logger.debug("Desktop-lifecycle holder scan failed: %s", exc)
+        return False
+
+    for pid, _name, cmdline in holders:
+        if not _looks_like_desktop_control_plane(cmdline):
+            continue
+        if psutil is None:
+            # Cannot prove orphanhood; a live this-install control plane is
+            # enough to refuse stealing gateway start.
+            return True
+        try:
+            proc = psutil.Process(int(pid))
+            parent = proc.parent()
+            if parent is None or not parent.is_running():
+                continue
+            if parent.create_time() > proc.create_time():
+                continue
+            return True
+        except Exception:
+            continue
+    return False
+
+
 def _pause_windows_gateways_for_update() -> dict | None:
     """Stop running Windows gateways before mutating the checkout or venv.
 
@@ -4712,6 +4777,24 @@ def _pause_windows_gateways_for_update() -> dict | None:
         # gateways that were running when the update began. Cold-start one after
         # the update so an installed gateway is actually up post-update. Users
         # who run gateway-less (no autostart entry) get nothing forced on them.
+        #
+        # Exception: Desktop currently owns this install's gateway lifecycle
+        # (live supervised serve/dashboard). A vestigial Startup/Scheduled
+        # Task is not the owner — spawning ``gateway run`` beside Desktop
+        # races ports/state (#76129). Serve is the control plane, not proof
+        # messaging is served; the skip is ownership, not liveness (#92091).
+        try:
+            if _desktop_owns_gateway_lifecycle():
+                logger.debug(
+                    "Skipping Windows gateway cold-start plan: "
+                    "Desktop owns gateway lifecycle"
+                )
+                return None
+        except Exception as exc:
+            logger.debug(
+                "Could not check Desktop gateway-lifecycle ownership before update: %s",
+                exc,
+            )
         try:
             from hermes_cli import gateway_windows
 
@@ -4863,6 +4946,18 @@ def _cold_start_windows_gateway_after_update() -> None:
     except Exception as exc:
         logger.debug("Could not re-check gateway liveness before cold-start: %s", exc)
         return
+
+    try:
+        if _desktop_owns_gateway_lifecycle():
+            logger.debug(
+                "Skipping Windows gateway cold-start: Desktop owns gateway lifecycle"
+            )
+            return
+    except Exception as exc:
+        logger.debug(
+            "Could not re-check Desktop gateway-lifecycle ownership before cold-start: %s",
+            exc,
+        )
 
     try:
         pid = gateway_windows._spawn_detached()

--- a/tests/hermes_cli/test_desktop_lifecycle_windows_live.py
+++ b/tests/hermes_cli/test_desktop_lifecycle_windows_live.py
@@ -1,0 +1,144 @@
+"""LIVE Windows E2E for the Desktop-lifecycle cold-start skip (#76129/#76745).
+
+Runs ONLY on a real Windows host (the on-demand ``windows-venv-e2e.yml``
+lane). Exercises the REAL ownership predicate against REAL processes:
+
+ 1. A real child process self-registers in the REAL spawn ledger as a
+    ``serve`` purpose with THIS process as its live spawner — ownership
+    must hold, and ``_pause_windows_gateways_for_update`` must return None
+    (no cold-start plan) even with an autostart artifact present.
+ 2. Kill the child (dead serve) — ownership drops, the pause plan carries
+    ``cold_start_if_installed`` again.
+ 3. Venv-holder fallback rung: a real venv-python process with true
+    ``serve`` argv is detected by the scan and, having a live parent,
+    confers ownership; the token classifier rejects a ``kanban
+    --preserve-cache`` lookalike (the #90778 class the salvage fixed).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="live Windows lifecycle E2E"
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture()
+def sleeper():
+    procs: list[subprocess.Popen] = []
+
+    def _spawn(*tail: str) -> subprocess.Popen:
+        p = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(120)", *tail],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        procs.append(p)
+        time.sleep(0.5)
+        assert p.poll() is None
+        return p
+
+    yield _spawn
+    for p in procs:
+        if p.poll() is None:
+            p.kill()
+            p.wait()
+
+
+def _write_ledger(entries: list[dict]) -> None:
+    from hermes_cli import process_identity as pid_mod
+
+    path = pid_mod._ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+
+def _entry(proc: subprocess.Popen, purpose: str = "serve") -> dict:
+    import psutil
+
+    from hermes_cli import process_identity as pid_mod
+
+    return {
+        "install": pid_mod.install_id(None),
+        "pid": proc.pid,
+        "create_time": psutil.Process(proc.pid).create_time(),
+        "purpose": purpose,
+        "spawner_pid": os.getpid(),
+        "spawner_create": psutil.Process(os.getpid()).create_time(),
+    }
+
+
+def test_live_supervised_serve_suppresses_cold_start(sleeper, monkeypatch, tmp_path):
+    from hermes_cli import gateway as hermes_gateway
+    from hermes_cli import gateway_windows
+    from hermes_cli import update_cmd
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir()
+
+    serve = sleeper()
+    _write_ledger([_entry(serve)])
+
+    assert update_cmd._desktop_owns_gateway_lifecycle() is True
+
+    # Autostart artifact present + no gateway running: WITHOUT ownership the
+    # pause phase would plan a cold start; WITH it, no plan.
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **_k: [])
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    assert update_cmd._pause_windows_gateways_for_update() is None
+
+    # Dead serve → ownership drops → plan returns.
+    serve.kill()
+    serve.wait()
+    time.sleep(0.5)
+    assert update_cmd._desktop_owns_gateway_lifecycle() is False
+    token = update_cmd._pause_windows_gateways_for_update()
+    assert token is not None and token.get("cold_start_if_installed") is True
+
+
+def test_holder_scan_fallback_respects_token_classifier(sleeper, monkeypatch, tmp_path):
+    from hermes_cli import update_cmd
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir()
+    _write_ledger([])  # force the fallback rung
+
+    # Real process whose argv carries genuine serve shape, visible to psutil.
+    serve_like = sleeper("-m", "hermes_cli.main", "serve")
+    # Lookalike from the #90778 class — must NOT confer ownership.
+    kanban_like = sleeper("-m", "hermes_cli.main", "kanban", "--preserve-cache")
+
+    def fake_holders():
+        import psutil
+
+        out = []
+        for p in (serve_like, kanban_like):
+            proc = psutil.Process(p.pid)
+            out.append((p.pid, proc.name(), " ".join(proc.cmdline())))
+        return out
+
+    monkeypatch.setattr(
+        "hermes_cli.main._detect_venv_python_processes", fake_holders
+    )
+
+    # serve-shaped holder with a live parent (us) → owns
+    assert update_cmd._desktop_owns_gateway_lifecycle() is True
+
+    # Only the kanban lookalike left → classifier rejects → does not own
+    serve_like.kill()
+    serve_like.wait()
+    monkeypatch.setattr(
+        "hermes_cli.main._detect_venv_python_processes",
+        lambda: [fake_holders()[1]],
+    )
+    assert update_cmd._desktop_owns_gateway_lifecycle() is False

--- a/tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py
+++ b/tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py
@@ -41,6 +41,29 @@ def test_control_plane_argv_is_not_a_gateway():
     assert looks_like_gateway_command_line(run) is True
 
 
+def test_control_plane_classifier_is_token_based_not_substring():
+    """#90778/#91869 class: flag values and lookalike tokens must not read
+    as a control plane. The salvage swapped the original substring check
+    for the parser-derived subcommand classifier."""
+    py = "C:\\Hermes\\.venv\\Scripts\\python.exe -m hermes_cli.main"
+    # "dashboard" as a FLAG VALUE, real subcommand is chat
+    assert update_cmd._looks_like_desktop_control_plane(f"{py} -m dashboard chat") is False
+    # "--preserve-cache" contains "serve"; real subcommand is kanban
+    assert (
+        update_cmd._looks_like_desktop_control_plane(f"{py} kanban --preserve-cache")
+        is False
+    )
+    # profile selector before the real subcommand still classifies correctly
+    assert (
+        update_cmd._looks_like_desktop_control_plane(f"{py} --profile serve dashboard")
+        is True
+    )
+    # dashboard as the real subcommand
+    assert update_cmd._looks_like_desktop_control_plane(f"{py} dashboard") is True
+    # undeterminable subcommand → NOT a control plane (never guess ownership)
+    assert update_cmd._looks_like_desktop_control_plane("python.exe -c import time") is False
+
+
 def test_ledger_live_serve_with_live_spawner_owns_lifecycle(monkeypatch):
     monkeypatch.setattr(
         process_identity, "ledger_entries", lambda **_k: [_live_serve_ledger_entry()]

--- a/tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py
+++ b/tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py
@@ -1,0 +1,101 @@
+"""#76129: post-update Windows cold-start must not steal Desktop-owned lifecycle.
+
+A vestigial Startup/Scheduled-Task autostart is not proof the user wants a
+standalone ``gateway run``. When Desktop currently supervises this install's
+control plane, the updater must not spawn a competing messaging daemon.
+
+Serve/dashboard are the control plane, not the messaging gateway (#92091).
+``looks_like_gateway_command_line`` stays strict; ownership is a separate
+predicate.
+"""
+
+from __future__ import annotations
+
+from hermes_cli import gateway as hermes_gateway
+from hermes_cli import gateway_windows
+from hermes_cli import main as cli_main
+from hermes_cli import process_identity
+from hermes_cli import update_cmd
+
+
+def _live_serve_ledger_entry() -> dict:
+    return {
+        "pid": 111,
+        "create_time": 1.0,
+        "purpose": "serve",
+        "install": "abc",
+        "spawner_pid": 99,
+        "spawner_create": 0.5,
+    }
+
+
+def test_control_plane_argv_is_not_a_gateway():
+    from gateway.status import looks_like_gateway_command_line
+
+    serve = "C:\\Hermes\\.venv\\Scripts\\python.exe -m hermes_cli.main serve --host 127.0.0.1"
+    run = "C:\\Hermes\\.venv\\Scripts\\python.exe -m hermes_cli.main gateway run"
+
+    assert update_cmd._looks_like_desktop_control_plane(serve) is True
+    assert looks_like_gateway_command_line(serve) is False
+    assert update_cmd._looks_like_desktop_control_plane(run) is False
+    assert looks_like_gateway_command_line(run) is True
+
+
+def test_ledger_live_serve_with_live_spawner_owns_lifecycle(monkeypatch):
+    monkeypatch.setattr(
+        process_identity, "ledger_entries", lambda **_k: [_live_serve_ledger_entry()]
+    )
+    monkeypatch.setattr(process_identity, "spawner_is_dead", lambda _e: False)
+    monkeypatch.setattr(cli_main, "_detect_venv_python_processes", lambda: [])
+
+    assert update_cmd._desktop_owns_gateway_lifecycle() is True
+
+
+def test_orphaned_control_plane_does_not_own_lifecycle(monkeypatch):
+    monkeypatch.setattr(
+        process_identity, "ledger_entries", lambda **_k: [_live_serve_ledger_entry()]
+    )
+    monkeypatch.setattr(process_identity, "spawner_is_dead", lambda _e: True)
+    monkeypatch.setattr(cli_main, "_detect_venv_python_processes", lambda: [])
+
+    assert update_cmd._desktop_owns_gateway_lifecycle() is False
+
+
+def test_pause_skips_cold_start_plan_when_desktop_owns_lifecycle(monkeypatch):
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **_k: [])
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(update_cmd, "_desktop_owns_gateway_lifecycle", lambda: True)
+
+    assert update_cmd._pause_windows_gateways_for_update() is None
+
+
+def test_pause_still_cold_starts_when_autostart_and_no_desktop_owner(monkeypatch):
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **_k: [])
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(update_cmd, "_desktop_owns_gateway_lifecycle", lambda: False)
+
+    token = update_cmd._pause_windows_gateways_for_update()
+
+    assert token == {
+        "resume_needed": True,
+        "profiles": {},
+        "unmapped_pids": [],
+        "unmapped": [],
+        "cold_start_if_installed": True,
+    }
+
+
+def test_cold_start_aborts_when_desktop_owns_lifecycle(monkeypatch):
+    spawned = []
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **_k: [])
+    monkeypatch.setattr(update_cmd, "_desktop_owns_gateway_lifecycle", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows, "_spawn_detached", lambda: spawned.append(1) or 4242
+    )
+
+    update_cmd._cold_start_windows_gateway_after_update()
+
+    assert spawned == []


### PR DESCRIPTION
## Summary

`hermes update` on Windows no longer spawns a competing gateway beside the Desktop app when a vestigial Startup/Scheduled-Task entry exists (#76129) — salvage of #76745 by @686f6c61, premise-corrected per the #92091 clarification and hardened with the token-based classifier.

Root cause: the post-update cold-start keyed on "autostart artifact exists + no gateway PID found" — blind to Desktop owning the gateway lifecycle via `/api/gateway/*`. The contributor's original fix skipped when a `serve` process existed, which was the wrong premise (serve is the control plane, not proof messaging is served); this replay keys on **ownership**.

## Changes

- `hermes_cli/update_cmd.py` (@686f6c61): `_desktop_owns_gateway_lifecycle()` — spawn-ledger rung first (identity-verified live serve/dashboard whose spawner is alive), venv-holder scan fallback that ignores orphaned control planes. Guards both the pause-phase cold-start plan and the immediately-before-spawn recheck. Gateway-less installs and orphaned control planes keep the cold-start.
- Follow-up (ours): `_looks_like_desktop_control_plane` swapped from substring matching to the parser-derived `_hermes_holder_subcommand` — the #90778/#91869 class (`-m dashboard chat`, `kanban --preserve-cache` no longer read as control planes). Regression test added, sabotage-verified.
- Live E2E tests: Linux (real spawn ledger + real processes) and a Windows live suite for the wine2e lane.

## Validation

| Check | Result |
|---|---|
| Contributor tests + cold-start liveness suite + new classifier regression | 9/9 |
| Sabotage run (classifier reverted to substrings) | regression test FAILS — proves the fix |
| **Live Linux** (real ledger writes, real spawner/serve processes): supervised serve owns → skip; killed spawner (orphan) → no skip; dead serve excluded; empty ledger → no skip | 4/4 |
| **Live windows-latest** (wine2e run 32617626101): real self-registered ledger entry suppresses the ACTUAL `_pause_windows_gateways_for_update` plan; dead serve restores `cold_start_if_installed`; holder-fallback rung with real serve-shaped vs kanban-lookalike argv | 10/10 |

Converges at the control socket (#92091): once `identify` is the primary answer to "is messaging served here," this ownership check becomes the scan-layer fallback.

## Infographic

![No more rogue gateways](https://v3b.fal.media/files/b/0aa7722d/XxDqYmY6UXr0CKodydl_n_fOODZvLV.png)
