### PR TITLE
fix(desktop): Anthropic OAuth logins no longer vanish from the Desktop model picker (salvage #92391)

### DIFF
--- a/contributors/emails/victoronwuanaku@gmail.com
+++ b/contributors/emails/victoronwuanaku@gmail.com
@@ -1,0 +1,1 @@
+victoronwuanaku

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -661,6 +661,33 @@ def _append_unconfigured_rows(
     return extras
 
 
+def _anthropic_oauth_credentials_present() -> bool:
+    """True when the user explicitly authenticated Anthropic via OAuth.
+
+    Two deliberate flows leave no trace in active_provider /
+    model.provider / API-key env vars: Hermes' own Anthropic device flow
+    (token in auth.json) and a Claude Code login (~/.claude/.credentials.json).
+    ``list_authenticated_providers`` already accepts both readers as real
+    credentials when discovering rows; this mirrors that acceptance so the
+    desktop explicit-only filter does not silently drop a provider the user
+    deliberately signed into. Unlike ambient CLI tokens (gh -> copilot),
+    an OAuth access token only exists after an interactive login.
+    """
+    try:
+        from agent.anthropic_adapter import (
+            read_claude_code_credentials,
+            read_hermes_oauth_credentials,
+        )
+
+        hermes_creds = read_hermes_oauth_credentials() or {}
+        if hermes_creds.get("accessToken"):
+            return True
+        cc_creds = read_claude_code_credentials() or {}
+        return bool(cc_creds.get("accessToken"))
+    except Exception:
+        return False
+
+
 def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list[dict]:
     """Keep only rows backed by explicit user configuration.
 
@@ -695,6 +722,14 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
             # Keyless providers (opencode-free) require no configuration at
             # all — there is nothing to "explicitly configure", and hiding
             # them would defeat their purpose (zero-setup discoverability).
+            kept.append(row)
+            continue
+        if slug == "anthropic" and _anthropic_oauth_credentials_present():
+            # Anthropic OAuth logins (Hermes device flow / Claude Code) are
+            # deliberate sign-ins that leave no trace in active_provider,
+            # model.provider, or API-key env vars. The strict gate below
+            # would drop the row even though list_authenticated_providers
+            # just accepted those same credentials when building it.
             kept.append(row)
             continue
         if is_provider_explicitly_configured(slug):

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -683,9 +683,29 @@ def _anthropic_oauth_credentials_present() -> bool:
         if hermes_creds.get("accessToken"):
             return True
         cc_creds = read_claude_code_credentials() or {}
-        return bool(cc_creds.get("accessToken"))
+        if cc_creds.get("accessToken"):
+            return True
     except Exception:
         return False
+    # Pool-only OAuth entries (auth.json credential_pool.anthropic) are the
+    # canonical location for wired tokens and equally deliberate — the
+    # discovery side accepts them via pool.has_credentials(), so the filter
+    # must too or those rows are built and then silently dropped. Read-only
+    # dict access (no load_pool) so a picker open never mutates auth.json.
+    try:
+        from agent.credential_pool import AUTH_TYPE_OAUTH
+        from hermes_cli.auth import read_credential_pool
+
+        for entry in read_credential_pool("anthropic"):
+            if (
+                isinstance(entry, dict)
+                and entry.get("auth_type") == AUTH_TYPE_OAUTH
+                and str(entry.get("access_token") or "").strip()
+            ):
+                return True
+    except Exception:
+        pass
+    return False
 
 
 def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list[dict]:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -274,6 +274,54 @@ def test_explicit_only_drops_anthropic_row_without_oauth_credentials():
     assert "anthropic" not in [row["slug"] for row in payload["providers"]]
 
 
+def test_anthropic_oauth_presence_accepts_pool_only_oauth_entry():
+    """A pool-only OAuth entry (auth.json credential_pool.anthropic) counts.
+
+    Wired/device-flow tokens land in the credential pool, not in
+    .anthropic_oauth.json or ~/.claude/.credentials.json. The presence
+    check must accept them or the row is built and then silently dropped.
+    """
+    from hermes_cli.inventory import _anthropic_oauth_credentials_present
+
+    with (
+        patch(
+            "agent.anthropic_adapter.read_hermes_oauth_credentials",
+            return_value=None,
+        ),
+        patch(
+            "agent.anthropic_adapter.read_claude_code_credentials",
+            return_value=None,
+        ),
+        patch(
+            "hermes_cli.auth.read_credential_pool",
+            return_value=[
+                {"auth_type": "oauth", "access_token": "sk-ant-oat01-pool"}
+            ],
+        ),
+    ):
+        assert _anthropic_oauth_credentials_present() is True
+
+    # api_key pool entries are NOT OAuth logins — presence must stay False
+    # (they are handled by the explicit-config gate / env var paths).
+    with (
+        patch(
+            "agent.anthropic_adapter.read_hermes_oauth_credentials",
+            return_value=None,
+        ),
+        patch(
+            "agent.anthropic_adapter.read_claude_code_credentials",
+            return_value=None,
+        ),
+        patch(
+            "hermes_cli.auth.read_credential_pool",
+            return_value=[
+                {"auth_type": "api_key", "access_token": "sk-ant-api03-key"}
+            ],
+        ),
+    ):
+        assert _anthropic_oauth_credentials_present() is False
+
+
 
 # ─── picker_hints ──────────────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -208,6 +208,72 @@ def test_explicit_only_filters_ambient_credentials_but_keeps_current_and_custom_
     ]
 
 
+def test_explicit_only_keeps_anthropic_row_with_oauth_credentials():
+    """Anthropic OAuth logins are deliberate sign-ins, not ambient credentials.
+
+    Claude Code (~/.claude/.credentials.json) and Hermes' own device flow
+    leave no trace in active_provider / model.provider / API-key env vars,
+    so is_provider_explicitly_configured() returns False even though
+    list_authenticated_providers just accepted those same credentials when
+    building the row. The desktop explicit-only filter must keep it.
+    """
+    rows = [
+        {"slug": "anthropic", "name": "Anthropic", "models": ["claude-sonnet-5"],
+         "total_models": 1, "is_current": False, "is_user_defined": False,
+         "source": "hermes"},
+        {"slug": "copilot", "name": "Copilot", "models": ["gpt-5.4"],
+         "total_models": 1, "is_current": False, "is_user_defined": False,
+         "source": "hermes"},
+    ]
+    ctx = _empty_ctx(provider="opencode-go", model="glm-5.3")
+    with (
+        _list_auth_returning(rows),
+        patch("hermes_cli.config.read_raw_config", return_value={}),
+        patch(
+            "hermes_cli.auth.is_provider_explicitly_configured",
+            return_value=False,
+        ),
+        patch(
+            "hermes_cli.inventory._anthropic_oauth_credentials_present",
+            return_value=True,
+        ),
+    ):
+        payload = build_models_payload(ctx, explicit_only=True)
+
+    slugs = [row["slug"] for row in payload["providers"]]
+    assert "anthropic" in slugs, (
+        "Anthropic OAuth login must survive the explicit-only filter"
+    )
+    assert "copilot" not in slugs, (
+        "ambient credential discovery must stay filtered"
+    )
+
+
+def test_explicit_only_drops_anthropic_row_without_oauth_credentials():
+    """No OAuth token and no explicit config -> Anthropic stays hidden."""
+    rows = [
+        {"slug": "anthropic", "name": "Anthropic", "models": ["claude-sonnet-5"],
+         "total_models": 1, "is_current": False, "is_user_defined": False,
+         "source": "hermes"},
+    ]
+    ctx = _empty_ctx(provider="opencode-go", model="glm-5.3")
+    with (
+        _list_auth_returning(rows),
+        patch("hermes_cli.config.read_raw_config", return_value={}),
+        patch(
+            "hermes_cli.auth.is_provider_explicitly_configured",
+            return_value=False,
+        ),
+        patch(
+            "hermes_cli.inventory._anthropic_oauth_credentials_present",
+            return_value=False,
+        ),
+    ):
+        payload = build_models_payload(ctx, explicit_only=True)
+
+    assert "anthropic" not in [row["slug"] for row in payload["providers"]]
+
+
 
 # ─── picker_hints ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Anthropic OAuth logins now show up in the Desktop model picker. The explicit-only filter (`_filter_explicit_provider_rows`) dropped the Anthropic row for users who authenticated via OAuth — Hermes device flow, Claude Code login, or a wired pool token — because none of those leave a trace in `active_provider`, `model.provider`, or API-key env vars. Discovery built the row; the desktop filter silently deleted it. Result: Anthropic visible on CLI/Telegram, invisible in Desktop (live report from Discord, matches #63835's shape).

Salvage of #92391 by @victoronwuanaku, plus a follow-up widening.

## Changes

- `hermes_cli/inventory.py`: `_anthropic_oauth_credentials_present()` — keep the `anthropic` row when an OAuth credential exists in any of the three deliberate-login locations: `.anthropic_oauth.json` (PKCE), `~/.claude/.credentials.json` (Claude Code), or `auth.json` `credential_pool.anthropic` oauth entries (follow-up: the pool is the canonical wired-token location the original PR missed). Read-only access; `is_provider_explicitly_configured()` (the PR #4210 consent guard) is untouched.
- `tests/hermes_cli/test_inventory.py`: 3 tests — OAuth row survives, no-creds row stays hidden, pool-only oauth accepted while pool api_key entries stay excluded.

## Validation

| Case | Before | After |
|---|---|---|
| No Anthropic creds | hidden | hidden |
| PKCE file token | **hidden** | shown |
| Claude Code creds | **hidden** | shown |
| Pool-only oauth entry | **hidden** | shown |
| Pool api_key entry | hidden | hidden (by design — separate path, #71366/#71513) |

`tests/hermes_cli/test_inventory.py`: 18/18. E2E with real temp `HERMES_HOME` + real auth.json/PKCE files: 4/4 cases.

Fixes the Desktop half of the "Anthropic missing from Desktop picker" report. Sibling: #92229 (same class, different provider).

## Infographic

![Anthropic returns to the picker](https://v3b.fal.media/files/b/0aa7728f/qBdjC8eoZN_pPT9hff9AQ_GRbXyiqs.png)
