### PR TITLE
fix(docker): sanitize task_id when building persistent sandbox path

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -590,6 +590,26 @@ def test_run_command_sanitizes_unsafe_task_id(monkeypatch):
     )
 
 
+def test_persistent_sandbox_dir_sanitizes_unsafe_task_id(monkeypatch, tmp_path):
+    """A task_id containing colons (e.g. a gateway session key like
+    ``session:agent:main:weixin:dm:<id>@im.wechat``) must not reach the
+    persistent sandbox directory path unsanitized: Docker's ``-v`` bind-mount
+    parser treats ``:`` as a field separator, so an unsanitized path makes
+    every ``docker run`` for that session fail with exit 125 "too many
+    colons"."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path))
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(
+        task_id="session:agent:main:weixin:dm:12345@im.wechat",
+        persistent_filesystem=True,
+    )
+
+    assert ":" not in env._home_dir, f"colon leaked into sandbox home dir: {env._home_dir}"
+    assert ":" not in env._workspace_dir, f"colon leaked into sandbox workspace dir: {env._workspace_dir}"
+
+
 def test_labels_attribute_populated_after_init(monkeypatch):
     """``self._labels`` must be set to the same key/value pairs that went onto
     docker run, so subsequent reuse / reaper paths can match without re-running

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -980,7 +980,7 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            sandbox = get_sandbox_dir() / "docker" / _sanitize_label_value(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([


### PR DESCRIPTION
Fixes #92701.

## Summary

With `terminal.backend: docker` and `terminal.container_persistent: true`, every
tool call (`terminal`, `read_file`, `write_file`, `search_files`, `execute_code`)
fails with `docker run` exit 125 whenever the session `task_id` contains a colon
(`:`) — e.g. any gateway session key of the form
`session:agent:main:<platform>:<channel>:<id>` (WeChat, Telegram, Discord, Slack, ...).

In `tools/environments/docker.py`, the persistent sandbox directory was built
from the **raw** `task_id`:

```python
sandbox = get_sandbox_dir() / "docker" / task_id
```

Docker's `-v` bind-mount parser treats `:` as a field separator, so the
generated spec (e.g. `/opt/data/sandboxes/docker/session:agent:main:weixin:dm:<id>@im.wechat/home:/root`)
has "too many colons" and `docker run` exits 125. The container *label*
(`task_label = _sanitize_label_value(task_id)`) already sanitized `task_id` for
exactly this reason — the sandbox path just wasn't using the same helper.

## Fix

Reuse the existing `_sanitize_label_value()` helper for the sandbox path, so it
matches the (already-sanitized) `hermes-task-id` label 1:1:

```python
sandbox = get_sandbox_dir() / "docker" / _sanitize_label_value(task_id)
```

## Testing

Added `test_persistent_sandbox_dir_sanitizes_unsafe_task_id` to
`tests/tools/test_docker_environment.py`, constructing a persistent
`DockerEnvironment` with a colon-bearing task_id
(`session:agent:main:weixin:dm:12345@im.wechat`) and asserting neither
`self._home_dir` nor `self._workspace_dir` contains a colon.

Confirmed the test fails without the fix:

```
$ git stash push -- tools/environments/docker.py
$ python -m pytest tests/tools/test_docker_environment.py -k persistent_sandbox_dir_sanitizes -v
...
AssertionError: colon leaked into sandbox home dir: /tmp/.../docker/session:agent:main:weixin:dm:12345@im.wechat/home
assert ':' not in '...'
1 failed, 51 deselected in 1.28s
$ git stash pop
```

And passes with the fix, alongside the full existing docker environment/session
isolation suites:

```
$ python -m pytest tests/tools/test_docker_environment.py tests/tools/test_docker_session_isolation.py -v
...
79 passed in 3.49s
```

`ruff check tools/environments/docker.py tests/tools/test_docker_environment.py`
— all checks passed.

## AI assistance disclosure

This change was implemented with the help of an AI coding assistant (Claude),
including drafting the fix, test, and this description. All changes were
reviewed and verified by running the real test suite and lint locally before
pushing.
