### PR TITLE
fix(desktop): preserve bot metadata across gateway connections

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -253,6 +253,24 @@ test('roster: unique profiles keep bare handles; duplicates get @name-device', (
   assert.equal(roster.length, 4)
 })
 
+test('roster: source profile metadata follows the connection-qualified row', () => {
+  const local = { id: 'local', kind: 'local' as const, label: 'This device' }
+  const vps = { id: 'vps', kind: 'remote' as const, label: 'VPS', url: 'http://vps:8642' }
+  const vpsMeta = {
+    display_name: 'Emma',
+    ui_meta: { 'hermes-bots': { title: 'Emma', shape: 'blobatar::sun', color: '#8b5cf6' } },
+    has_avatar: true
+  }
+
+  const roster = buildAgentRoster([
+    { connection: local, profiles: ['default'] },
+    { connection: vps, profiles: ['default'], profileMetadata: { default: vpsMeta } }
+  ])
+
+  assert.deepEqual(roster.find(agent => agent.connectionId === 'vps')?.profileMetadata, vpsMeta)
+  assert.equal(roster.find(agent => agent.connectionId === 'local')?.profileMetadata, undefined)
+})
+
 test('rememberSshEnumeration: live list wins, cache then seed default', () => {
   assert.deepEqual(rememberSshEnumeration({ profiles: ['bob', 'kai'] }, ['stale'], 'ssh'), {
     profiles: ['bob', 'kai']

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -318,6 +318,9 @@ export interface ConnectionAgents {
   /** Profile names enumerated from the connection, or null when unreachable /
    * connect-on-demand (ssh not yet dialed). */
   profiles: null | string[]
+  /** Credential-free profile metadata from the same connection. Kept separate
+   * from `profiles` so old enumerators can continue returning names only. */
+  profileMetadata?: Record<string, RosterProfileMetadata>
   /** Present when profiles is null: why enumeration was skipped. */
   error?: string
   /** Stable backend identity from the connection's /api/status (`install_id`).
@@ -336,6 +339,15 @@ export interface RosterAgent {
   /** Bare profile name, or `<profile>-<label-slug>` when the profile name
    * exists on more than one registered source (the @name-device rule). */
   handle: string
+  /** Rich metadata for this exact connection + profile, when enumerated. */
+  profileMetadata?: RosterProfileMetadata
+}
+
+export interface RosterProfileMetadata {
+  display_name?: string
+  title?: string
+  ui_meta?: Record<string, unknown>
+  has_avatar?: boolean
 }
 
 /**
@@ -432,18 +444,30 @@ export function buildAgentRoster(
   // counting names for @name-device disambiguation.
   const identities = new Map<
     string,
-    { connection: RegistryConnection; installId?: string; order: number; profile: string }
+    {
+      connection: RegistryConnection
+      installId?: string
+      order: number
+      profile: string
+      profileMetadata?: RosterProfileMetadata
+    }
   >()
 
   let order = 0
 
-  for (const { connection, installId, profiles } of enumerations) {
+  for (const { connection, installId, profiles, profileMetadata } of enumerations) {
     for (const profile of profiles || []) {
       const name = String(profile || '').trim() || 'default'
       const key = `${connection.id}\0${name}`
 
       if (!identities.has(key)) {
-        identities.set(key, { connection, installId, order, profile: name })
+        identities.set(key, {
+          connection,
+          installId,
+          order,
+          profile: name,
+          ...(profileMetadata?.[name] ? { profileMetadata: profileMetadata[name] } : {})
+        })
       }
     }
 
@@ -454,16 +478,19 @@ export function buildAgentRoster(
   // are the SAME physical install registered under two addresses, so their
   // (install, profile) rows are one bot, not two. Connections without an id
   // (older backends, undialed ssh) keep a per-connection key — no collapse.
-  const backends = new Map<string, { connection: RegistryConnection; order: number; profile: string }[]>()
+  const backends = new Map<
+    string,
+    { connection: RegistryConnection; order: number; profile: string; profileMetadata?: RosterProfileMetadata }[]
+  >()
 
-  for (const { connection, installId, order: rank, profile } of identities.values()) {
+  for (const { connection, installId, order: rank, profile, profileMetadata } of identities.values()) {
     const key = installId ? `id:${installId}\0${profile}` : `conn:${connection.id}\0${profile}`
     const group = backends.get(key)
 
     if (group) {
-      group.push({ connection, order: rank, profile })
+      group.push({ connection, order: rank, profile, profileMetadata })
     } else {
-      backends.set(key, [{ connection, order: rank, profile }])
+      backends.set(key, [{ connection, order: rank, profile, profileMetadata }])
     }
   }
 
@@ -480,13 +507,14 @@ export function buildAgentRoster(
 
   const roster: RosterAgent[] = []
 
-  for (const { connection, profile } of rows) {
+  for (const { connection, profile, profileMetadata } of rows) {
     roster.push({
       connectionId: connection.id,
       connectionKind: connection.kind,
       connectionLabel: connection.label,
       profile,
-      handle: agentHandle(profile, connection.label, (counts.get(profile) || 0) > 1)
+      handle: agentHandle(profile, connection.label, (counts.get(profile) || 0) > 1),
+      ...(profileMetadata ? { profileMetadata } : {})
     })
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -117,6 +117,7 @@ import {
   updateEligibility,
   upsertConnection
 } from './connection-registry'
+import type { RosterProfileMetadata } from './connection-registry'
 import { describeCrashReason, installCrashForensics } from './crash-forensics'
 import { adoptServedDashboardToken } from './dashboard-token'
 import { loadOrCreateInstallationId, sshOwnershipId } from './desktop-installation'
@@ -12929,7 +12930,13 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
 
   return Promise.all(
     registry.connections.map(async connection => {
-      let raw: { connection: typeof connection; error?: string; installId?: string; profiles: null | string[] }
+      let raw: {
+        connection: typeof connection
+        error?: string
+        installId?: string
+        profiles: null | string[]
+        profileMetadata?: Record<string, RosterProfileMetadata>
+      }
 
       try {
         // SSH roster listing must never spawn a dashboard. A stale
@@ -12974,13 +12981,52 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
             ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)
             : []
 
+          const profileMetadata = Array.isArray(body?.profiles)
+            ? Object.fromEntries(
+                body.profiles
+                  .map(profile => {
+                    const name = String(profile?.name || '').trim()
+
+                    if (!name) {
+                      return null
+                    }
+
+                    const metadata: RosterProfileMetadata = {}
+
+                    if (typeof profile?.display_name === 'string' && profile.display_name.trim()) {
+                      metadata.display_name = profile.display_name.trim()
+                    }
+
+                    if (typeof profile?.title === 'string' && profile.title.trim()) {
+                      metadata.title = profile.title.trim()
+                    }
+
+                    if (profile?.ui_meta && typeof profile.ui_meta === 'object') {
+                      metadata.ui_meta = profile.ui_meta
+                    }
+
+                    if (typeof profile?.has_avatar === 'boolean') {
+                      metadata.has_avatar = profile.has_avatar
+                    }
+
+                    return [name, metadata] as const
+                  })
+                  .filter((entry): entry is readonly [string, RosterProfileMetadata] => Boolean(entry))
+              )
+            : undefined
+
           // The root HERMES_HOME is an agent too; enumerations that omit it
           // (older backends list only named profiles) still get a default row.
           if (!profiles.includes('default')) {
             profiles.unshift('default')
           }
 
-          raw = { connection, profiles, ...(installId ? { installId } : {}) }
+          raw = {
+            connection,
+            profiles,
+            ...(installId ? { installId } : {}),
+            ...(profileMetadata ? { profileMetadata } : {})
+          }
         }
       } catch (error: any) {
         raw = { connection, profiles: null, error: String(error?.message || error) }
@@ -12992,7 +13038,12 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
 
       const remembered = rememberSshEnumeration(raw, sshRosterCache.get(connection.id), connection.kind)
 
-      return { connection, ...remembered, ...(raw.installId ? { installId: raw.installId } : {}) }
+      return {
+        connection,
+        ...remembered,
+        ...(raw.installId ? { installId: raw.installId } : {}),
+        ...(raw.profileMetadata ? { profileMetadata: raw.profileMetadata } : {})
+      }
     })
   )
 }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1136,7 +1136,8 @@ function handleSessionsGatewayTransition() {
 }
 
 /** Per-bot appearance + display meta, persisted via ctx.storage:
- *  { [botName]: { shape, color, title } } */
+ *  { [botName]: { shape, color, title } } for the active gateway. Remote
+ *  rows receive the equivalent source-qualified metadata from the roster. */
 const $botMeta = atom({})
 
 /** Freshness fence for the server-meta overlay: the last moment each bot's
@@ -3759,7 +3760,8 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
       connectionKind: agent.connectionKind,
       connectionLabel: agent.connectionLabel,
       remoteSource: true,
-      sourceScoped: true
+      sourceScoped: true,
+      ...(agent.profileMetadata ? { profileMetadata: agent.profileMetadata } : {})
     })
   }
 
@@ -4008,12 +4010,20 @@ function groupMemberKey(member) {
   return member?.remoteSource ? botRosterKey(member) : member?.name
 }
 
-// Bot metadata is scoped to the active gateway until the server exposes a
-// union of rich profile rows. Never paint that metadata onto a thin row from
-// another source: two `default` agents must not borrow each other's title,
-// pin, avatar, group, unread state, or canonical-chat pointer.
+// Bot metadata is scoped to the connection + profile. Remote rows carry a
+// credential-free metadata snapshot from their own source; never fall back to
+// the active source's name-keyed metadata for them, because two `default`
+// agents must not borrow each other's title, pin, avatar, group, unread state,
+// or canonical-chat pointer.
 function botRosterMeta(bot, metaByName) {
-  return bot?.remoteSource ? null : metaByName?.[bot?.name]
+  if (bot?.remoteSource) {
+    const source = bot.profileMetadata
+    const uiMeta = source?.ui_meta?.['hermes-bots']
+
+    return uiMeta && typeof uiMeta === 'object' ? uiMeta : null
+  }
+
+  return metaByName?.[bot?.name]
 }
 
 function showsHandle(name, meta, bot) {
@@ -4260,17 +4270,19 @@ async function prepareBotSource(bot) {
 }
 
 function displayName(bot, meta) {
-  // Only THIN rows from another source trade the friendly name for their
-  // connection label — the active gateway's own default must keep reading
-  // "Hermes". Annotated active rows carry sourceScoped too, and keying this
-  // off sourceScoped renamed the user's main agent to an IP-derived label
-  // (community report, Aug 17 2026).
-  if (bot?.remoteSource && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel) {
-    return bot.connectionLabel
-  }
-
   if (meta?.title?.trim()) {
     return meta.title.trim()
+  }
+
+  // Remote rows use their source's profile display name when available. The
+  // connection label is only a disambiguating fallback for older gateways
+  // that do not return profile metadata.
+  if (typeof bot?.profileMetadata?.display_name === 'string' && bot.profileMetadata.display_name.trim()) {
+    return bot.profileMetadata.display_name.trim()
+  }
+
+  if (bot?.remoteSource && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel) {
+    return bot.connectionLabel
   }
 
   // Core-profile display name (profile.yaml, set via `hermes profile rename

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -65,7 +65,10 @@ test('merge: local rows are annotated, remote rows appended with source tags', (
         connectionKind: 'remote',
         connectionLabel: 'Homelab',
         profile: 'research',
-        handle: 'research-homelab'
+        handle: 'research-homelab',
+        profileMetadata: {
+          ui_meta: { 'hermes-bots': { title: 'Remote Research', shape: 'blobatar::sun' } }
+        }
       },
       {
         connectionId: 'homelab',
@@ -91,6 +94,7 @@ test('merge: local rows are annotated, remote rows appended with source tags', (
   assert.equal(remoteRow.handle, 'research-homelab')
   assert.equal(remoteRow.connectionId, 'homelab')
   assert.equal(remoteRow.connectionLabel, 'Homelab')
+  assert.equal(remoteRow.profileMetadata.ui_meta['hermes-bots'].title, 'Remote Research')
 
   const coder = out.profiles.find(p => p.name === 'coder')
   assert.equal(coder.remoteSource, true)
@@ -226,20 +230,30 @@ test('merge: repeated refreshes stay idempotent and do not mutate gateway rows',
   assert.equal(rich.connectionId, undefined)
 })
 
-test('default rows use source identity without borrowing another source title', () => {
+test('default rows use source identity and retain source-qualified metadata', () => {
   const { __botRosterKey: key, __botRosterMeta: metaFor, __displayName: name } = runtime()
   const remote = {
     name: 'default',
     connectionId: 'personal',
     connectionLabel: 'Personal',
     remoteSource: true,
-    sourceScoped: true
+    sourceScoped: true,
+    profileMetadata: {
+      display_name: 'Remote default',
+      ui_meta: {
+        'hermes-bots': { title: 'Remote workspace', shape: 'blobatar::sun', color: '#8b5cf6' }
+      }
+    }
   }
-  const active = { ...remote, remoteSource: undefined }
+  const active = { ...remote, remoteSource: undefined, profileMetadata: undefined }
   const metadata = { default: { title: 'Active workspace' } }
 
-  assert.equal(metaFor(remote, metadata), null)
-  assert.equal(name(remote, metaFor(remote, metadata)), 'Personal')
+  assert.deepEqual(metaFor(remote, metadata), {
+    title: 'Remote workspace',
+    shape: 'blobatar::sun',
+    color: '#8b5cf6'
+  })
+  assert.equal(name(remote, metaFor(remote, metadata)), 'Remote workspace')
   assert.equal(key(remote), 'personal::default')
 
   // The ACTIVE gateway's own default is the user's main agent — annotation


### PR DESCRIPTION
## Summary

Preserve Bot Mode display metadata per `(connection, profile)` when the desktop builds its multi-source roster.

When switching between local and remote gateways, the active source returned rich profile rows but rows from other registered sources were reduced to thin `{ name, handle, connection }` entries. The plugin then intentionally returned `null` metadata for those rows, so their saved title, blobatar shape, and color were replaced by connection/default fallbacks.

## What changed

- Carry credential-free profile metadata (`display_name`, Bot Mode `ui_meta`, and `has_avatar`) through Electron's connection roster.
- Keep the metadata attached to the same connection-qualified roster identity through duplicate/install-id collapse.
- Preserve that metadata on remote Bot Mode rows.
- Render a remote row's own saved title and appearance before falling back to a connection label for older gateways.
- Keep source-qualified routing and duplicate protections unchanged.

This addresses the desktop portion of #91365 without borrowing the active gateway's metadata across two same-named `default` profiles.

## Verification

- `node --test src/plugins/hermes-bots/tests/multi-source-roster.test.mjs`
- `npx vitest run --project electron electron/connection-registry.test.ts`
- `npm run check:test:plugins` (364 passed)
- `npm run typecheck`
- `npx eslint electron/main.ts electron/connection-registry.ts`
- `git diff --check`

Related: #91365
