### PR TITLE
fix: restore one bundled skill for opted-out profiles

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -593,6 +593,87 @@ class TestResetBundledSkill:
         assert "GW v2" in (dest / "SKILL.md").read_text()
 
 
+    def test_reset_restore_installs_only_requested_skill_when_profile_opted_out(self, tmp_path):
+        """An explicit restore works without undoing the profile-wide opt-out."""
+        bundled = self._setup_bundled(tmp_path)
+        unrelated = bundled / "devops" / "unrelated-skill"
+        unrelated.mkdir(parents=True)
+        (unrelated / "SKILL.md").write_text(
+            "---\nname: unrelated-skill\n---\n# Must stay uninstalled\n"
+        )
+
+        hermes_home = tmp_path / "home"
+        skills_dir = hermes_home / "skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        hermes_home.mkdir()
+        marker = hermes_home / ".no-bundled-skills"
+        marker.write_text("opted out\n")
+
+        with self._patches(bundled, skills_dir, manifest_file), patch(
+            "tools.skills_sync.HERMES_HOME", hermes_home
+        ):
+            result = reset_bundled_skill("google-workspace", restore=True)
+            manifest_after = _read_manifest()
+
+        restored = skills_dir / "productivity" / "google-workspace" / "SKILL.md"
+        assert result["ok"] is True
+        assert result["action"] == "restored"
+        assert restored.exists()
+        assert "upstream" in restored.read_text()
+        assert manifest_after["google-workspace"] == _dir_hash(
+            bundled / "productivity" / "google-workspace"
+        )
+        assert marker.exists()
+        assert not (skills_dir / "devops" / "unrelated-skill").exists()
+
+    def test_opted_out_targeted_restore_preserves_copy_when_backup_move_fails(self, tmp_path):
+        """A failed pre-copy backup must not delete the existing user copy."""
+        bundled = self._setup_bundled(tmp_path)
+        hermes_home = tmp_path / "home"
+        skills_dir = hermes_home / "skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        dest = skills_dir / "productivity" / "google-workspace"
+        dest.mkdir(parents=True)
+        user_copy = dest / "SKILL.md"
+        user_copy.write_text("# user version\n")
+        manifest_file.write_text("google-workspace:STALEHASH\n")
+        marker = hermes_home / ".no-bundled-skills"
+        marker.write_text("opted out\n")
+
+        with self._patches(bundled, skills_dir, manifest_file), patch(
+            "tools.skills_sync.HERMES_HOME", hermes_home
+        ), patch(
+            "tools.skills_sync.shutil.move", side_effect=PermissionError("move denied")
+        ):
+            result = reset_bundled_skill("google-workspace", restore=True)
+
+        assert result["ok"] is False
+        assert result["action"] == "not_reset"
+        assert user_copy.read_text() == "# user version\n"
+        assert manifest_file.read_text() == "google-workspace:STALEHASH\n"
+        assert marker.exists()
+
+    def test_opted_out_restore_reports_removed_bundled_source(self, tmp_path):
+        """Opt-out handling must preserve the normal missing-source error."""
+        bundled = self._setup_bundled(tmp_path)
+        hermes_home = tmp_path / "home"
+        skills_dir = hermes_home / "skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        skills_dir.mkdir(parents=True)
+        manifest_file.write_text("ghost-skill:OLDHASH\n")
+        marker = hermes_home / ".no-bundled-skills"
+        marker.write_text("opted out\n")
+
+        with self._patches(bundled, skills_dir, manifest_file), patch(
+            "tools.skills_sync.HERMES_HOME", hermes_home
+        ):
+            result = reset_bundled_skill("ghost-skill", restore=True)
+
+        assert result["ok"] is False
+        assert result["action"] == "bundled_missing"
+        assert manifest_file.read_text() == "ghost-skill:OLDHASH\n"
+        assert marker.exists()
+
     def test_reset_errors_when_untracked_or_removed_upstream(self, tmp_path):
         """Untracked skills and skills removed upstream both fail clearly."""
         bundled = self._setup_bundled(tmp_path)

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -653,6 +653,59 @@ class TestResetBundledSkill:
         assert manifest_file.read_text() == "google-workspace:STALEHASH\n"
         assert marker.exists()
 
+    def test_opted_out_targeted_restore_rolls_back_when_manifest_write_fails(self, tmp_path):
+        """A failed manifest write must roll back the targeted restore."""
+        bundled = self._setup_bundled(tmp_path)
+        hermes_home = tmp_path / "home"
+        skills_dir = hermes_home / "skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        dest = skills_dir / "productivity" / "google-workspace"
+        dest.mkdir(parents=True)
+        user_copy = dest / "SKILL.md"
+        user_copy.write_text("# user version\n")
+        manifest_file.write_text("google-workspace:STALEHASH\n")
+        marker = hermes_home / ".no-bundled-skills"
+        marker.write_text("opted out\n")
+
+        with self._patches(bundled, skills_dir, manifest_file), patch(
+            "tools.skills_sync.HERMES_HOME", hermes_home
+        ), patch(
+            "tools.skills_sync.atomic_write_text", side_effect=OSError("disk full")
+        ):
+            result = reset_bundled_skill("google-workspace", restore=True)
+
+        assert result["ok"] is False
+        assert result["action"] == "not_reset"
+        assert "manifest" in result["message"]
+        assert user_copy.read_text() == "# user version\n"
+        assert manifest_file.read_text() == "google-workspace:STALEHASH\n"
+        assert not dest.with_suffix(".reset.bak").exists()
+        assert marker.exists()
+
+    def test_opted_out_targeted_restore_remains_absent_when_manifest_write_fails(self, tmp_path):
+        """A failed first manifest write must remove the untracked restored copy."""
+        bundled = self._setup_bundled(tmp_path)
+        hermes_home = tmp_path / "home"
+        skills_dir = hermes_home / "skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        marker = hermes_home / ".no-bundled-skills"
+        hermes_home.mkdir()
+        marker.write_text("opted out\n")
+
+        with self._patches(bundled, skills_dir, manifest_file), patch(
+            "tools.skills_sync.HERMES_HOME", hermes_home
+        ), patch(
+            "tools.skills_sync.atomic_write_text", side_effect=OSError("disk full")
+        ):
+            result = reset_bundled_skill("google-workspace", restore=True)
+
+        dest = skills_dir / "productivity" / "google-workspace"
+        assert result["ok"] is False
+        assert result["action"] == "not_reset"
+        assert not dest.exists()
+        assert not manifest_file.exists()
+        assert marker.exists()
+
     def test_opted_out_restore_reports_removed_bundled_source(self, tmp_path):
         """Opt-out handling must preserve the normal missing-source error."""
         bundled = self._setup_bundled(tmp_path)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -1132,8 +1132,40 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
                 "synced": None,
             }
 
+        previous_manifest = dict(manifest)
         manifest[name] = bundled_hash
         _write_manifest(manifest)
+        if _read_manifest() != manifest:
+            rollback_errors = []
+            if dest.exists():
+                try:
+                    _rmtree_writable(dest)
+                except (OSError, IOError) as e:
+                    rollback_errors.append(f"could not remove restored copy: {e}")
+            if moved_user_copy and backup.exists() and not dest.exists():
+                try:
+                    shutil.move(str(backup), str(dest))
+                except (OSError, IOError) as e:
+                    rollback_errors.append(f"could not restore prior copy: {e}")
+
+            if _read_manifest() != previous_manifest:
+                _write_manifest(previous_manifest)
+                if _read_manifest() != previous_manifest:
+                    rollback_errors.append("could not restore prior manifest")
+
+            rollback_detail = ""
+            if rollback_errors:
+                rollback_detail = f" Rollback incomplete: {'; '.join(rollback_errors)}."
+            return {
+                "ok": False,
+                "action": "not_reset",
+                "message": (
+                    f"Could not restore '{name}' from bundled source because the "
+                    f"bundled manifest was not persisted.{rollback_detail} The profile "
+                    "remains opted out of bundled-skill seeding."
+                ),
+                "synced": None,
+            }
         if backup.exists():
             try:
                 _rmtree_writable(backup)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -1035,9 +1035,10 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
 
     Args:
         name: The skill name (matches the manifest key / skill frontmatter name).
-        restore: If True, also delete the user's copy in the skills dir and let
-                 the next sync re-copy the current bundled version. If False
-                 (default), only clear the manifest entry — the user's
+        restore: If True, also replace the user's copy with the current bundled
+                 version. Opted-out profiles receive only the requested skill;
+                 other profiles delete the copy and let sync_skills() re-copy it.
+                 If False (default), only clear the manifest entry — the user's
                  current copy is preserved but future updates work again.
 
     Returns:
@@ -1046,7 +1047,7 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
           - action: one of "manifest_cleared", "restored", "not_in_manifest",
                     "bundled_missing"
           - message: human-readable description
-          - synced: dict from sync_skills() if a sync was triggered, else None
+          - synced: sync-style details if a sync or targeted restore ran, else None
     """
     manifest = _read_manifest()
     bundled_dir = _get_bundled_dir()
@@ -1067,21 +1068,96 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
             "synced": None,
         }
 
+    if restore and not is_bundled:
+        return {
+            "ok": False,
+            "action": "bundled_missing",
+            "message": (
+                f"'{name}' has no bundled source — manifest entry preserved "
+                f"but cannot restore from bundled (skill was removed upstream)."
+            ),
+            "synced": None,
+        }
+
+    # An opted-out profile deliberately makes sync_skills() a no-op. A manual
+    # ``reset --restore`` is narrower than opting the whole profile back in, so
+    # install only the requested skill and leave the marker untouched. Use a
+    # rollback copy so a failed copy never destroys the user's prior version.
+    opted_out = (_hermes_home() / NO_BUNDLED_SKILLS_MARKER).exists()
+    if restore and opted_out:
+        dest = _compute_relative_dest(bundled_by_name[name], bundled_dir)
+        backup = dest.with_suffix(".reset.bak")
+        bundled_hash = _dir_hash(bundled_by_name[name])
+        moved_user_copy = False
+        copy_started = False
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if backup.exists():
+                if dest.exists():
+                    _rmtree_writable(backup)
+                else:
+                    # Recover a prior interrupted restore before replacing it.
+                    shutil.move(str(backup), str(dest))
+            if dest.exists():
+                shutil.move(str(dest), str(backup))
+                moved_user_copy = True
+            copy_started = True
+            shutil.copytree(bundled_by_name[name], dest)
+            if _dir_hash(dest) != bundled_hash:
+                raise OSError("restored copy did not match bundled source")
+        except (OSError, IOError) as e:
+            if copy_started and dest.exists():
+                try:
+                    _rmtree_writable(dest)
+                except (OSError, IOError):
+                    logger.warning(
+                        "Could not clear partial targeted restore %s", dest,
+                        exc_info=True,
+                    )
+            if moved_user_copy and backup.exists() and not dest.exists():
+                try:
+                    shutil.move(str(backup), str(dest))
+                except (OSError, IOError):
+                    logger.warning(
+                        "Could not roll back targeted restore %s", dest,
+                        exc_info=True,
+                    )
+            return {
+                "ok": False,
+                "action": "not_reset",
+                "message": (
+                    f"Could not restore '{name}' from bundled source: {e}. "
+                    "The profile remains opted out of bundled-skill seeding."
+                ),
+                "synced": None,
+            }
+
+        manifest[name] = bundled_hash
+        _write_manifest(manifest)
+        if backup.exists():
+            try:
+                _rmtree_writable(backup)
+            except (OSError, IOError):
+                logger.debug("Could not remove reset backup %s", backup, exc_info=True)
+        return {
+            "ok": True,
+            "action": "restored",
+            "message": (
+                f"Restored '{name}' from bundled source. The profile remains "
+                "opted out of automatic bundled-skill seeding."
+            ),
+            "synced": {
+                "copied": [name],
+                "updated": [],
+                "targeted_restore": True,
+            },
+        }
+
     # Step 1 (optional): delete the user's copy so next sync re-copies bundled.
     # Must happen BEFORE manifest deletion so that a failed rmtree does not
     # leave the skill in a manifest-less limbo state (see #34972).
     deleted_user_copy = False
     if restore:
-        if not is_bundled:
-            return {
-                "ok": False,
-                "action": "bundled_missing",
-                "message": (
-                    f"'{name}' has no bundled source — manifest entry preserved "
-                    f"but cannot restore from bundled (skill was removed upstream)."
-                ),
-                "synced": None,
-            }
         dest = _compute_relative_dest(bundled_by_name[name], bundled_dir)
         if dest.exists():
             try:


### PR DESCRIPTION
## Summary
- allow an explicit single-skill restore while a profile remains opted out of automatic bundled-skill seeding
- make the targeted restore transactional across copy and manifest-write failures
- add behavior coverage for targeted install, missing source, and rollback paths

## QA purpose
This draft PR is the repository-supported cross-platform CI gate for Kanban task `t_2aae5255`. Do not merge from this QA run. Release/merge remains a separate authorized action.

## Scope
- `tools/skills_sync.py`
- `tests/tools/test_skills_sync.py`

## Existing local evidence
- focused: 102 passed, 0 failed, 2 Windows-only skipped
- broad relevant: 1,957 passed, 0 failed, 2 Windows-only skipped
- isolated opted-out CLI E2E passed
- four rollback paths passed

The required release gate is the current `CI` workflow, especially `OS-specific tests / Windows-only tests`.