### PR TITLE
fix(gateway): keep Kanban notifications out of conversations

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -541,8 +541,14 @@ class GatewaySlashCommandsMixin:
                     if platform_str and chat_id:
                         def _sub():
                             from hermes_cli import kanban_db as _kb
+                            from gateway.run import _load_gateway_config
+
                             conn = _kb.connect(board=requested_board)
                             try:
+                                delivery_mode = _kb.auto_subscribe_delivery_mode(
+                                    _load_gateway_config(),
+                                    platform=platform_str,
+                                )
                                 _kb.add_notify_sub(
                                     conn, task_id=task_id,
                                     platform=platform_str, chat_id=chat_id,
@@ -551,9 +557,7 @@ class GatewaySlashCommandsMixin:
                                     user_id=user_id,
                                     user_id_alt=user_id_alt,
                                     notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
-                                    # Subscribing from chat: deliver the passive
-                                    # message and wake the destination agent.
-                                    delivery_mode="notify+wake",
+                                    delivery_mode=delivery_mode,
                                     delivery_metadata=delivery_metadata,
                                 )
                             finally:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2605,6 +2605,11 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # Automatic gateway subscriptions deliver passive operational updates
+        # by default, keeping them out of the conversational transcript. Set to
+        # "notify+wake" (or "wake") only when terminal task events should
+        # explicitly trigger an agent synthesis turn.
+        "auto_subscribe_delivery_mode": "notify",
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11382,6 +11382,36 @@ def _decode_notify_delivery_metadata(raw: Any) -> dict[str, Any]:
     }
 
 
+def auto_subscribe_delivery_mode(
+    config: Mapping[str, Any] | None,
+    *,
+    platform: str,
+) -> Optional[str]:
+    """Resolve the policy for automatically-created notification edges.
+
+    Push-capable gateway subscriptions are passive by default: operational
+    events are delivered to the chat without becoming synthetic agent turns.
+    Operators that want the previous synthesis behavior can explicitly set
+    ``kanban.auto_subscribe_delivery_mode: notify+wake`` (or ``wake``).
+
+    ``None`` preserves the transport-specific database default for TUI and
+    api_server. The latter has no passive push channel, so its existing default
+    remains an active wake rather than creating an undeliverable subscription.
+    """
+    normalized_platform = str(platform or "").strip().lower()
+    if normalized_platform in {"tui", "api_server"}:
+        return None
+    kanban = config.get("kanban") if isinstance(config, Mapping) else None
+    configured = (
+        kanban.get("auto_subscribe_delivery_mode")
+        if isinstance(kanban, Mapping)
+        else None
+    )
+    if configured in _NOTIFY_DELIVERY_MODES:
+        return str(configured)
+    return "notify"
+
+
 def add_notify_sub(
     conn: sqlite3.Connection,
     *,

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -81,6 +81,21 @@ def _unseen_terminal_events(tid):
         conn.close()
 
 
+def test_passive_notification_does_not_start_agent_turn(tmp_path, monkeypatch):
+    """The default notify edge sends text without injecting a user turn."""
+    db_path = tmp_path / "passive-notification.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _create_completed_subscription()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert adapter.handled == []
+
+
 def test_kanban_notifier_replays_telegram_dm_topic_delivery_metadata(tmp_path, monkeypatch):
     db_path = tmp_path / "dm-topic-metadata.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -690,6 +690,7 @@ async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
     assert len(subs) == 1
     assert subs[0]["chat_id"] == "chat1"
     assert subs[0]["thread_id"] == "20197"
+    assert subs[0]["delivery_mode"] == "notify"
     assert subs[0]["delivery_metadata"] == {
         "chat_type": "dm",
         "direct_messages_topic_id": "20197",
@@ -703,6 +704,41 @@ async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
         assert kb.list_notify_subs(conn) == []
     finally:
         conn.close()
+
+
+@pytest.mark.asyncio
+async def test_gateway_create_can_explicitly_opt_in_to_wake(kanban_home):
+    """Gateway slash creates honor the explicit active-wake policy."""
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    (kanban_home / "config.yaml").write_text(
+        "kanban:\n  auto_subscribe_delivery_mode: notify+wake\n"
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._owns_kanban_dispatcher_lock = lambda: True
+    event = SimpleNamespace(
+        text='/kanban create "wake me" --assignee alice',
+        source=SimpleNamespace(
+            platform=Platform.TELEGRAM,
+            chat_id="chat1",
+            chat_type="dm",
+            thread_id=None,
+            user_id="u1",
+        ),
+    )
+
+    with patch("gateway.run._hermes_home", kanban_home):
+        out = await GatewayRunner._handle_kanban_command(runner, event)
+    assert "subscribed" in out.lower()
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["delivery_mode"] == "notify+wake"
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -868,7 +868,32 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     assert s["user_id"] == "user-9"
     assert s["user_id_alt"] == "alt-user-9"
     assert s["chat_type"] == "forum"
-    assert s["delivery_mode"] == "notify+wake"
+    assert s["delivery_mode"] == "notify"
+
+
+def test_create_gateway_session_can_opt_in_to_wake(monkeypatch, worker_env, tmp_path):
+    """Gateway auto-subscriptions wake only when policy explicitly opts in."""
+    from tools import kanban_tools as kt
+
+    home = tmp_path / "wake-home" / ".hermes"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "kanban:\n  auto_subscribe_delivery_mode: notify+wake\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
+
+    out = kt._handle_create({
+        "title": "explicit wake policy",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+
+    subs = _sub_index(_list_subs_for_task(d["task_id"]))
+    assert len(subs) == 1
+    assert subs[0]["delivery_mode"] == "notify+wake"
 
 
 def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1532,6 +1532,8 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     chat_id = ""
     try:
         from gateway.session_context import get_session_env
+        from hermes_cli import kanban_db as _kb
+
         platform = get_session_env("HERMES_SESSION_PLATFORM", "")
         chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
         if not platform or not chat_id:
@@ -1556,9 +1558,8 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
                 return False  # CLI / cron / test — no persistent channel
             platform = "tui"
             chat_id = session_key
-        is_gateway_session = platform != "tui"
         chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE", "") or None
-        delivery_mode = "notify+wake" if is_gateway_session else None
+        delivery_mode = _kb.auto_subscribe_delivery_mode(cfg, platform=platform)
         thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "") or None
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
         user_id_alt = get_session_env("HERMES_SESSION_USER_ID_ALT", "") or None
@@ -1589,8 +1590,6 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             if message_id:
                 delivery_metadata["telegram_reply_to_message_id"] = str(message_id)
 
-        # Lazy-import to keep the module-level dependency light
-        from hermes_cli import kanban_db as _kb
         _kb.add_notify_sub(
             conn, task_id=task_id,
             platform=platform, chat_id=chat_id,

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -597,7 +597,7 @@ The kanban board has two ways to handle a task you drop into the Triage column:
 
 **Manual** — `kanban.auto_decompose: false`. Triage tasks stay in triage until you act. Click the **⚗ Decompose** button on a card, run `hermes kanban decompose <id>` (or `--all`), or use `/kanban decompose <id>` from a chat. This matches the pre-decomposer behavior of the board, useful when you want full control over what runs when.
 
-**Important boundary:** Manual mode disables only the built-in Triage decomposer. It does not prevent a profile from calling `kanban_create`, and it does not disable creator-session wake-ups. With `kanban.auto_subscribe_on_create: true`, a task's terminal event resumes the originating agent with a synthetic status turn so it can inspect the handoff and decide whether genuinely new follow-up work is needed. Set `auto_subscribe_on_create: false` when task completion should remain passive. For provenance, built-in decomposer children use `created_by=auto-decomposer`; tasks created by a resumed profile carry that profile name instead.
+**Important boundary:** Manual mode disables only the built-in Triage decomposer. It does not prevent a profile from calling `kanban_create`. With `kanban.auto_subscribe_on_create: true`, the originating gateway receives passive terminal-event notifications by default, without adding synthetic turns to its conversation. Set `kanban.auto_subscribe_delivery_mode: notify+wake` when terminal events should explicitly resume the originating agent to inspect the handoff, or set `auto_subscribe_on_create: false` to disable automatic subscriptions entirely. For provenance, built-in decomposer children use `created_by=auto-decomposer`; tasks created by a resumed profile carry that profile name instead.
 
 Flip between the two modes from the **Orchestration: Auto/Manual** pill at the top of the kanban page (emerald = Auto, muted gray = Manual), or by editing `config.yaml` directly. Both modes coexist with `hermes kanban specify` — that's still available as a single-task spec rewrite when you don't want fan-out.
 
@@ -613,7 +613,8 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
-| `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, terminal events resume that originating agent with a synthetic status turn. Set to `false` for passive completion or to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |
+| `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, subscribe the originating surface to terminal events. Set to `false` to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |
+| `auto_subscribe_delivery_mode` | `"notify"` | Gateway auto-subscriptions are passive by default and do not consume agent turns. Set to `"notify+wake"` to send the update and resume the agent, or `"wake"` for a wake-only edge. TUI and stateless API delivery retain their transport-specific behavior. |
 | `done_sub_retention_days` | `30` | Notify subscriptions survive `done` (reopen-safe) and are removed on `archived`. The notifier GC purges subscriptions whose task has been `done` with no new events for this many days, bounding sub-table growth on boards that never archive. `0` disables the sweep. |
 
 And the two auxiliary LLM slots:
@@ -889,7 +890,7 @@ bot> ✓ t_9fc1a3 completed by transcriber
 
 Subscriptions survive a task reaching `done` — completion is reversible (a reviewer or controller can reopen a done task), so the origin session keeps getting notified through reopen cycles. They auto-remove on `archived` (the irreversible end state). On boards that never archive, a GC sweep purges subscriptions for tasks that have sat in `done` with no new activity for `kanban.done_sub_retention_days` days (default 30; set 0 to disable), so stale rows don't accumulate forever. If you script a create with `--json` (machine output) the auto-subscribe is skipped — the assumption is that scripted callers want to manage subscriptions explicitly via `/kanban notify-subscribe`.
 
-A chat-originated auto-subscribe is created in `notify+wake` mode: on a terminal event the destination agent both receives the passive message **and** takes a real turn, so it can read the board context and reply in its own voice. See [Delivery modes](#delivery-modes) below.
+A chat-originated auto-subscribe is created in `notify` mode by default: terminal events are delivered as passive operational updates and do not take an agent turn or enter the conversational transcript. Set `kanban.auto_subscribe_delivery_mode: notify+wake` when the destination agent should also take a real turn, read the board context, and reply in its own voice. See [Delivery modes](#delivery-modes) below.
 
 ### Output truncation in messaging
 


### PR DESCRIPTION
## Summary

- make gateway Kanban auto-subscriptions passive by default so operational updates do not start agent turns or enter conversational history
- add `kanban.auto_subscribe_delivery_mode` for explicit `notify+wake` or `wake` policies while preserving TUI and stateless API transport behavior
- apply the policy to both `/kanban create` and model-tool `kanban_create` paths, with documentation and behavioral regression coverage

## Root cause

Gateway-created notification subscriptions were hard-coded to `notify+wake`. The notifier therefore sent the passive platform update and then injected a synthetic `MessageEvent` through the normal message handler, which consumed an agent turn and persisted the notification in the role-aware session transcript.

## Testing

- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_notify.py tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_config.py -k 'kanban or notify or auto_subscribe'`
- 71 tests passed

## Related Issue

N/A
