### PR TITLE
fix(models): new Claude models no longer missing from the picker for pool-stored API keys (#71366, salvage #71513)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4519,6 +4519,36 @@ def clear_provider_models_cache(provider: Optional[str] = None) -> None:
         pass
 
 
+def _resolve_anthropic_pool_catalog_credentials() -> tuple[str, str]:
+    """Return a read-only API-key pool credential for model discovery.
+
+    ``resolve_anthropic_token()`` intentionally ignores ``api_key`` pool
+    entries because its runtime contract is OAuth-oriented. The model catalog
+    supports regular ``x-api-key`` auth, so it needs a narrow fallback that
+    preserves the credential's configured endpoint instead of sending a
+    proxy-scoped key to Anthropic's public host.
+    """
+    try:
+        from agent.credential_pool import AUTH_TYPE_API_KEY
+        from hermes_cli.auth import read_credential_pool
+
+        for entry in read_credential_pool("anthropic"):
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("auth_type") != AUTH_TYPE_API_KEY:
+                continue
+            token = str(entry.get("access_token") or "").strip()
+            if not token:
+                continue
+            endpoint = str(
+                entry.get("base_url") or entry.get("inference_base_url") or ""
+            ).strip()
+            return token, endpoint
+    except Exception:
+        pass
+    return "", ""
+
+
 def _fetch_anthropic_models(
     timeout: float = 5.0,
     *,
@@ -4527,8 +4557,9 @@ def _fetch_anthropic_models(
 ) -> Optional[list[str]]:
     """Fetch available models from the Anthropic /v1/models endpoint.
 
-    Uses resolve_anthropic_token() to find credentials (env vars or
-    Claude Code auto-discovery) unless api_key is provided explicitly.
+    Uses resolve_anthropic_token() to find credentials (env vars, OAuth,
+    or Claude Code auto-discovery) unless api_key is provided explicitly. If
+    those sources are empty, a read-only API-key credential_pool entry is used.
     Returns sorted model IDs or None.
     """
     try:
@@ -4536,7 +4567,12 @@ def _fetch_anthropic_models(
     except ImportError:
         return None
 
+    resolved_base_url = base_url
     token = (api_key or "").strip() or resolve_anthropic_token()
+    if not token:
+        token, pool_base_url = _resolve_anthropic_pool_catalog_credentials()
+        if not resolved_base_url and pool_base_url:
+            resolved_base_url = pool_base_url
     if not token:
         return None
 
@@ -4551,7 +4587,7 @@ def _fetch_anthropic_models(
 
     def _do_request(h: dict[str, str]):
         req = urllib.request.Request(
-            _anthropic_models_url(base_url),
+            _anthropic_models_url(resolved_base_url),
             headers=h,
         )
         with _urlopen_model_catalog_request(req, timeout=timeout) as resp:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4570,9 +4570,9 @@ def _fetch_anthropic_models(
     resolved_base_url = base_url
     token = (api_key or "").strip() or resolve_anthropic_token()
     if not token:
-        token, pool_base_url = _resolve_anthropic_pool_catalog_credentials()
-        if not resolved_base_url and pool_base_url:
-            resolved_base_url = pool_base_url
+        # A pool credential and its endpoint are one security boundary. Never
+        # pair the selected pool key with a caller-provided model endpoint.
+        token, resolved_base_url = _resolve_anthropic_pool_catalog_credentials()
     if not token:
         return None
 

--- a/tests/hermes_cli/test_anthropic_pool_model_discovery.py
+++ b/tests/hermes_cli/test_anthropic_pool_model_discovery.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+
+from hermes_cli import models
+
+
+class _Response:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode()
+
+
+def test_anthropic_picker_discovers_models_with_pool_api_key(monkeypatch):
+    """A direct API key stored only in auth.json must reach /v1/models."""
+    monkeypatch.setattr(models, "_get_model_config_dict", lambda: {"provider": "nous"})
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.read_credential_pool",
+        lambda provider: [
+            {
+                "auth_type": "api_key",
+                "access_token": "sk-ant-api03-pool-key",
+                "base_url": "https://api.anthropic.com",
+            }
+        ] if provider == "anthropic" else [],
+    )
+
+    captured = {}
+
+    def _open(request, *, timeout):
+        captured["url"] = request.full_url
+        captured["headers"] = {key.lower(): value for key, value in request.header_items()}
+        captured["timeout"] = timeout
+        return _Response({"data": [{"id": "claude-opus-5"}]})
+
+    monkeypatch.setattr(models, "_urlopen_model_catalog_request", _open)
+
+    result = models.provider_model_ids("anthropic")
+
+    assert "claude-opus-5" in result
+    assert captured["url"] == "https://api.anthropic.com/v1/models"
+    assert captured["headers"]["x-api-key"] == "sk-ant-api03-pool-key"
+    assert "authorization" not in captured["headers"]
+
+
+def test_anthropic_pool_api_key_uses_its_configured_endpoint(monkeypatch):
+    """Never send a proxy-scoped pool credential to Anthropic's public host."""
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.read_credential_pool",
+        lambda _provider: [
+            {
+                "auth_type": "api_key",
+                "access_token": "proxy-key",
+                "base_url": "https://proxy.example/anthropic/v1",
+            }
+        ],
+    )
+
+    captured = {}
+
+    def _open(request, *, timeout):
+        captured["url"] = request.full_url
+        captured["headers"] = {key.lower(): value for key, value in request.header_items()}
+        return _Response({"data": [{"id": "claude-proxy-model"}]})
+
+    monkeypatch.setattr(models, "_urlopen_model_catalog_request", _open)
+
+    assert models._fetch_anthropic_models() == ["claude-proxy-model"]
+    assert captured["url"] == "https://proxy.example/anthropic/v1/models"
+    assert captured["headers"]["x-api-key"] == "proxy-key"

--- a/tests/hermes_cli/test_anthropic_pool_model_discovery.py
+++ b/tests/hermes_cli/test_anthropic_pool_model_discovery.py
@@ -28,20 +28,26 @@ def test_anthropic_picker_discovers_models_with_pool_api_key(monkeypatch):
     )
     monkeypatch.setattr(
         "hermes_cli.auth.read_credential_pool",
-        lambda provider: [
-            {
-                "auth_type": "api_key",
-                "access_token": "sk-ant-api03-pool-key",
-                "base_url": "https://api.anthropic.com",
-            }
-        ] if provider == "anthropic" else [],
+        lambda provider: (
+            [
+                {
+                    "auth_type": "api_key",
+                    "access_token": "sk-ant-api03-pool-key",
+                    "base_url": "https://api.anthropic.com",
+                }
+            ]
+            if provider == "anthropic"
+            else []
+        ),
     )
 
     captured = {}
 
     def _open(request, *, timeout):
         captured["url"] = request.full_url
-        captured["headers"] = {key.lower(): value for key, value in request.header_items()}
+        captured["headers"] = {
+            key.lower(): value for key, value in request.header_items()
+        }
         captured["timeout"] = timeout
         return _Response({"data": [{"id": "claude-opus-5"}]})
 
@@ -55,32 +61,53 @@ def test_anthropic_picker_discovers_models_with_pool_api_key(monkeypatch):
     assert "authorization" not in captured["headers"]
 
 
-def test_anthropic_pool_api_key_uses_its_configured_endpoint(monkeypatch):
-    """Never send a proxy-scoped pool credential to Anthropic's public host."""
+def test_anthropic_pool_api_key_overrides_conflicting_active_endpoint(monkeypatch):
+    """A pool-scoped key must never reach the active model's other endpoint."""
+    active_endpoint = "https://active.example/anthropic/v1"
+    pool_endpoint = "https://pool.example/anthropic/v1"
+    monkeypatch.setattr(
+        models,
+        "_get_model_config_dict",
+        lambda: {"provider": "anthropic", "base_url": active_endpoint},
+    )
     monkeypatch.setattr(
         "agent.anthropic_adapter.resolve_anthropic_token",
         lambda: None,
     )
     monkeypatch.setattr(
         "hermes_cli.auth.read_credential_pool",
-        lambda _provider: [
-            {
-                "auth_type": "api_key",
-                "access_token": "proxy-key",
-                "base_url": "https://proxy.example/anthropic/v1",
-            }
-        ],
+        lambda provider: (
+            [
+                {
+                    "auth_type": "api_key",
+                    "access_token": "proxy-key",
+                    "base_url": pool_endpoint,
+                }
+            ]
+            if provider == "anthropic"
+            else []
+        ),
     )
 
-    captured = {}
+    requests = []
 
     def _open(request, *, timeout):
-        captured["url"] = request.full_url
-        captured["headers"] = {key.lower(): value for key, value in request.header_items()}
+        requests.append((
+            request.full_url,
+            {key.lower(): value for key, value in request.header_items()},
+        ))
         return _Response({"data": [{"id": "claude-proxy-model"}]})
 
     monkeypatch.setattr(models, "_urlopen_model_catalog_request", _open)
 
-    assert models._fetch_anthropic_models() == ["claude-proxy-model"]
-    assert captured["url"] == "https://proxy.example/anthropic/v1/models"
-    assert captured["headers"]["x-api-key"] == "proxy-key"
+    assert models.provider_model_ids("anthropic") == ["claude-proxy-model"]
+    assert requests == [
+        (
+            f"{pool_endpoint}/models",
+            {
+                "anthropic-version": "2023-06-01",
+                "x-api-key": "proxy-key",
+            },
+        )
+    ]
+    assert all(not url.startswith(active_endpoint) for url, _headers in requests)


### PR DESCRIPTION
## Summary

Anthropic live model discovery now works for direct API keys stored only in the credential pool — new Claude models (e.g. `claude-opus-5`) appear in the CLI and Desktop pickers instead of the picker silently falling back to the static catalog. Fixes #71366.

Root cause: `_fetch_anthropic_models()` resolved credentials via `resolve_anthropic_token()`, which intentionally filters pool entries to `auth_type == oauth` (its runtime contract). A valid `auth_type: api_key` pool entry meant no token was resolvable, the `/v1/models` fetch was skipped, and the picker showed only the curated list.

Salvage of #71513 by @yinkev (2 commits, authorship preserved).

## Changes

- `hermes_cli/models.py`: `_resolve_anthropic_pool_catalog_credentials()` — narrow, read-only fallback used only by the catalog fetch when every existing source is empty. Selects the first api_key pool entry and binds the key to that entry's own endpoint (a pool credential and its endpoint are one security boundary — the key is never sent to a caller-provided active endpoint). `x-api-key` header for direct keys; `resolve_anthropic_token()`'s OAuth-only contract untouched.
- `tests/hermes_cli/test_anthropic_pool_model_discovery.py`: pool-key discovery + conflicting-endpoint authority regressions.

## Validation

| | Before | After |
|---|---|---|
| api_key-only pool entry, active provider ≠ anthropic | static catalog only | live `/v1/models`, claude-opus-5 shown |
| Endpoint used with pool key | n/a (no fetch) | pool entry's own base_url, never the active model's |
| Header for direct key | n/a | `x-api-key`, no Authorization |

Targeted tests: 2/2. E2E against a real local HTTP `/v1/models` server with a temp `HERMES_HOME` + real auth.json (issue's exact scenario — provider=nous, api_key pool entry): model discovered, correct path, correct header, key never sent elsewhere.

Companion to #92702 (OAuth visibility in the Desktop filter) — this is the api_key discovery half.

## Infographic

![Pool API keys join model discovery](https://v3b.fal.media/files/b/0aa77340/eYdQ7oXIOkDHutgqZVl8K_fSJlnjQ0.png)
