### PR TITLE
fix(compaction): recognize kanban wake notifications as synthetic user turns

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -192,6 +192,12 @@ MAX_ITERATIONS_SUMMARY_REQUEST = (
     "without calling any more tools."
 )
 _BACKGROUND_PROCESS_NOTIFICATION_PREFIX = "[IMPORTANT: Background process "
+# Kanban wake turns (gateway/kanban_watchers.py, via gateway.wake.deliver_wake)
+# are injected as role="user" rows to resume a session on task completion.
+# The "[kanban] " tag is emitted verbatim by every locale catalog (see
+# locales/*.yaml gateway.kanban.wake.message) so it is a stable marker even
+# though the rest of the message is translated.
+_KANBAN_WAKE_NOTIFICATION_PREFIX = "[kanban] "
 
 
 def _fresh_compaction_message_copy(msg: Dict[str, Any]) -> Dict[str, Any]:
@@ -5239,6 +5245,8 @@ This compaction should PRIORITISE preserving all information related to the focu
             _LENGTH_CONTINUATION_OUTPUT_LIMIT,
         } or text.startswith(
             _BACKGROUND_PROCESS_NOTIFICATION_PREFIX
+        ) or text.startswith(
+            _KANBAN_WAKE_NOTIFICATION_PREFIX
         ) or text.startswith(
             TODO_INJECTION_HEADER + "\n"
         ) or text.startswith(

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -284,6 +284,37 @@ def test_background_process_notifications_do_not_become_compaction_anchors(
     assert compressor._find_last_user_message_idx(messages, head_end=0) == 0
 
 
+def test_kanban_wake_notifications_do_not_become_compaction_anchors(compressor):
+    """#92703: kanban wake turns (``gateway/wake.py::deliver_wake``) are
+    injected as ``role="user"`` rows to resume a session on task completion/
+    blockage/etc. Like the background-process notifications above, they must
+    not hijack the compaction focus topic or the tail anchor."""
+    from agent.i18n import t
+
+    wake_text = t(
+        "gateway.kanban.wake.message",
+        task_id="k7",
+        status="completed",
+        title="Ship release notes",
+        assignee="worker1",
+        board="main",
+    )
+    wake_turn = {"role": "user", "content": wake_text}
+    human = {"role": "user", "content": "Refactor the auth module and add tests."}
+    messages = [
+        human,
+        {"role": "assistant", "content": "Working on it."},
+        wake_turn,
+    ]
+
+    assert ContextCompressor._is_synthetic_compression_user_turn(wake_turn) is True
+    assert ContextCompressor._transcript_has_real_user_turn([wake_turn]) is False
+    assert compressor._derive_auto_focus_topic(messages) == (
+        "Recent user focus:\n- Refactor the auth module and add tests."
+    )
+    assert compressor._find_last_user_message_idx(messages, head_end=0) == 0
+
+
 @pytest.mark.parametrize(
     "content",
     [


### PR DESCRIPTION
## What does this PR do?

Scopes down one concrete, testable piece of #92703: kanban "wake" notifications leaking into compaction's auto-derived focus topic and tail-anchor selection.

When a kanban subscription's `delivery_mode` includes `wake` (the gateway/Telegram default is `notify+wake`), `gateway/kanban_watchers.py` calls `gateway.wake.deliver_wake()` to resume the operator's session on task completion/block/crash/etc. That function injects the notification as a plain `role="user"` message (`gateway/wake.py:80-94, 130-134`) — the same entry point a real inbound message uses, so the agent responds to it as a turn.

`agent/context_compressor.py::_is_synthetic_compression_user_turn()` already exists to recognize exactly this class of injected "not a real human turn" row for two other sibling sites (background-process completion pings, the max-iterations nudge, several codex continuation nudges) so that `_derive_auto_focus_topic()` and `_find_last_user_message_idx()` skip them when deciding what the operator is actually working on. The kanban wake message (`[kanban] Task {id} {status}...`, `locales/*.yaml gateway.kanban.wake.message`) was never added to that recognizer, so if a kanban ping happens to be the newest `user`-role row at compaction time, it can become the auto-focus **FOCUS TOPIC** or displace the operator's real last request as the tail anchor — the same bug class already fixed for background-process notifications, just for a different injection site. This is one of the sibling-site regressions flagged generally in `AGENTS.md`'s "fix the whole bug class... sibling call paths included."

I confirmed the `"[kanban] "` tag is emitted verbatim by every one of the 17 locale catalogs under `locales/` (only the rest of the message is translated), so it's a safe, stable content marker exactly like the existing `"[IMPORTANT: Background process "` prefix.

This does **not** attempt the rest of #92703 (a separate bounded notification ledger, coalescing/digest, selective per-event import into conversation, or a three-way conversation/operational/action-required UI taxonomy) — those need real design decisions and touch several subsystems, so they're out of scope for this PR.

## Related Issue

Related to #92703 (addresses expected-behavior item 4: "Compaction focus and latest-user anchors must ignore notification/event rows" — for the kanban-wake injection path specifically)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py`: add `_KANBAN_WAKE_NOTIFICATION_PREFIX = "[kanban] "` and check it in `_is_synthetic_compression_user_turn()`, alongside the existing background-process-notification prefix.
- `tests/agent/test_context_compressor_zero_user_provenance.py`: add `test_kanban_wake_notifications_do_not_become_compaction_anchors`, mirroring the existing background-process-notification test, using the real `agent.i18n.t()` catalog string so it stays in sync with the production message.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_context_compressor_zero_user_provenance.py -v`
2. Confirm the new test fails on the pre-fix code (`git checkout HEAD~1 -- agent/context_compressor.py`) and passes after restoring the fix.

### Real output

Before the fix (`agent/context_compressor.py` reverted to the parent commit, test added):
```
FAILED tests/agent/test_context_compressor_zero_user_provenance.py::test_kanban_wake_notifications_do_not_become_compaction_anchors
AssertionError: assert False is True
 +  where False = _is_synthetic_compression_user_turn({'role': 'user', 'content': '[kanban] Task k7 completed.\nTitle: Ship release notes\nAssignee: @worker1\nBoard: main\n\nCheck the result or decide the next step.'})
1 failed, 15 deselected in 0.29s
```

After the fix:
```
[100.0% |     9/~9 | ✓16 | ✗ 0] ✓ tests/agent/test_context_compressor_zero_user_provenance.py (16✓, 3.9s)
=== Summary: 1 files, 16 tests passed, 0 failed (100% complete) in 3.9s (8 workers) ===
```

Broader regression check (all compaction/compression tests + all kanban/wake gateway tests):
```
scripts/run_tests.sh tests/agent/ -k "compress or compaction or context_compressor"
=== Summary: 417 files, 512 tests passed, 0 failed, 1 skipped (100% complete) in 99.1s (8 workers) ===

scripts/run_tests.sh tests/gateway/ -k "kanban or wake"
=== Summary: 682 files, 64 tests passed, 0 failed (100% complete) in 188.4s (8 workers) ===
```
(`ruff check agent/context_compressor.py tests/agent/test_context_compressor_zero_user_provenance.py` also passes clean.)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the test suite (`scripts/run_tests.sh`, scoped as above) and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — ran in a Linux CI-parity sandbox only; no macOS/Windows access for this change (the fix is pure Python string matching, not platform-dependent)

### Documentation & Housekeeping

- [x] N/A — no docs/config keys/architecture changed

## AI assistance disclosure

This PR was prepared with AI assistance (an autonomous coding agent), under human oversight of the final diff, tests, and test output shown above.
