### PR TITLE
fix(gateway): stamp active profile credit-notices policy on reused agents

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5856,6 +5856,26 @@ class TurnRunner:
         # rides the same show path (it's emitted as a success notice, not a
         # clear). The clear callback is a no-op: a sent platform message
         # can't be cleanly retracted, and the band already fired once.
+        #
+        # Per-turn policy stamp. The agent may be a CACHED instance shared
+        # across the profiles a multiplexed gateway serves. Its
+        # ``_credits_notices_enabled_cache`` is only computed once, on first
+        # use, so a session that first ran under a profile with
+        # ``display.credits_notices=true`` would keep that stale value after
+        # routing to a profile where it is false (and the reverse). Re-resolve
+        # the ACTIVE profile's policy from this turn's already profile-scoped
+        # ``user_config`` and stamp it here, before the provider runs, so a
+        # reused agent cannot leak another profile's setting. Fail-open True
+        # on any config error, matching ``AIAgent._credits_notices_enabled``.
+        _credits_notices_enabled = True
+        try:
+            _credits_display = (ctx.user_config or {}).get("display")
+            if isinstance(_credits_display, dict) and "credits_notices" in _credits_display:
+                _credits_notices_enabled = bool(_credits_display.get("credits_notices"))
+        except Exception:
+            _credits_notices_enabled = True
+        agent._credits_notices_enabled_cache = _credits_notices_enabled
+
         def _notice_callback_sync(notice) -> None:
             if not ctx._status_adapter or not ctx._run_still_current():
                 return
@@ -5873,7 +5893,10 @@ class TurnRunner:
                 log_message="notice_callback delivery scheduling error",
             )
 
-        agent.notice_callback = _notice_callback_sync
+        # Only wire the notice rail when the active profile wants notices; a
+        # profile that disabled ``display.credits_notices`` must not deliver
+        # them even via a reused agent's callback.
+        agent.notice_callback = _notice_callback_sync if _credits_notices_enabled else None
         agent.notice_clear_callback = None
         agent.event_callback = ctx._event_callback_sync
         agent.reasoning_config = reasoning_config

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5889,7 +5889,16 @@ class TurnRunner:
                 _credits_notices_enabled = bool(_credits_display.get("credits_notices"))
         except Exception:
             _credits_notices_enabled = True
-        agent.stamp_credits_notices_policy(_credits_notices_enabled)
+        # Prefer the public AIAgent method (the gateway-facing encapsulation
+        # boundary for the cache write).  Fall back to the direct field for
+        # duck-typed agent stand-ins (gateway test fakes / plugin agents that
+        # don't subclass AIAgent) — same getattr pattern as the
+        # _agent_cache_lock reads below.
+        _stamp_policy = getattr(agent, "stamp_credits_notices_policy", None)
+        if callable(_stamp_policy):
+            _stamp_policy(_credits_notices_enabled)
+        else:
+            agent._credits_notices_enabled_cache = _credits_notices_enabled
 
         def _notice_callback_sync(notice) -> None:
             if not ctx._status_adapter or not ctx._run_still_current():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5867,6 +5867,21 @@ class TurnRunner:
         # ``user_config`` and stamp it here, before the provider runs, so a
         # reused agent cannot leak another profile's setting. Fail-open True
         # on any config error, matching ``AIAgent._credits_notices_enabled``.
+        #
+        # Concurrency: this stamp needs no ``_agent_cache_lock`` because
+        # per-session turn serialization guarantees the cached agent is never
+        # mid-``run_conversation`` here. ``_handle_message`` claims the
+        # session slot (``turn.agent`` sentinel) synchronously before any
+        # await, and only releases it after ``run_sync`` — which runs this
+        # stamp, binds the callbacks below, and then calls
+        # ``run_conversation`` — completes; a second message for the same
+        # session is queued in the adapter's ``_pending_messages`` (Level 1)
+        # or rejected by the turn-lease (``TurnLeaseTimeoutError``, #64934),
+        # never started in parallel. The cached agent is keyed by
+        # ``session_key``, so this stamp + callback bind + provider run form
+        # one critical section per session_key. A lock here would guard only
+        # the assignment, not the provider run — dead weight and a false
+        # safety signal. See ``AIAgent.stamp_credits_notices_policy``.
         _credits_notices_enabled = True
         try:
             _credits_display = (ctx.user_config or {}).get("display")
@@ -5874,7 +5889,7 @@ class TurnRunner:
                 _credits_notices_enabled = bool(_credits_display.get("credits_notices"))
         except Exception:
             _credits_notices_enabled = True
-        agent._credits_notices_enabled_cache = _credits_notices_enabled
+        agent.stamp_credits_notices_policy(_credits_notices_enabled)
 
         def _notice_callback_sync(notice) -> None:
             if not ctx._status_adapter or not ctx._run_still_current():

--- a/run_agent.py
+++ b/run_agent.py
@@ -4294,10 +4294,14 @@ class AIAgent:
         The messaging gateway re-stamps the ACTIVE profile's policy onto a
         possibly CACHED (reused) agent at the start of every turn, before the
         provider runs, so a multiplexed gateway cannot leak one profile's
-        setting into another profile's session.  This method is the sole owner
-        of the ``_credits_notices_enabled_cache`` write — gateway code must
-        never touch that field directly, keeping the cache private and giving
-        one place to evolve the policy logic.  Fail-open semantics (absent or
+        setting into another profile's session.  This method is the
+        gateway-facing encapsulation boundary for the
+        ``_credits_notices_enabled_cache`` write — gateway code must never
+        touch that field directly, keeping the cache private and giving one
+        place to evolve the policy logic.  (The internal
+        ``_credits_notices_enabled()`` read path also lazily initializes the
+        same cache; this method's ownership is scoped to gateway-facing
+        mutations.)  Fail-open semantics (absent or
         error-shaped config = enabled) are resolved by the caller from the
         turn's already profile-scoped ``user_config``; this method only
         records the resolved value.

--- a/run_agent.py
+++ b/run_agent.py
@@ -4288,6 +4288,33 @@ class AIAgent:
         self._credits_notices_enabled_cache = enabled
         return enabled
 
+    def stamp_credits_notices_policy(self, enabled: bool) -> None:
+        """Stamp the per-turn ``display.credits_notices`` policy onto this agent.
+
+        The messaging gateway re-stamps the ACTIVE profile's policy onto a
+        possibly CACHED (reused) agent at the start of every turn, before the
+        provider runs, so a multiplexed gateway cannot leak one profile's
+        setting into another profile's session.  This method is the sole owner
+        of the ``_credits_notices_enabled_cache`` write — gateway code must
+        never touch that field directly, keeping the cache private and giving
+        one place to evolve the policy logic.  Fail-open semantics (absent or
+        error-shaped config = enabled) are resolved by the caller from the
+        turn's already profile-scoped ``user_config``; this method only
+        records the resolved value.
+
+        Concurrency contract: the gateway guarantees per-session turn
+        serialization (the ``turn.agent`` sentinel claim plus the turn-lease
+        rejection in ``gateway/run.py`` — #64934), so at most one
+        ``run_conversation`` executes per session_key at a time and a reused
+        agent (the cache is keyed by session_key) is never mid-run when this
+        is called.  The stamp, the ``notice_callback`` bind, and the provider
+        run that consumes the value therefore form a single critical section
+        per session_key: the value read mid-run is the value stamped at the
+        start of that same turn.  A lock here would guard only this
+        assignment, not the provider run, and is deliberately not used.
+        """
+        self._credits_notices_enabled_cache = bool(enabled)
+
     def get_credits_state(self):
         """Return the last captured CreditsState, or None."""
         return self._credits_state

--- a/tests/gateway/test_multiplex_credit_notices_profile_scope.py
+++ b/tests/gateway/test_multiplex_credit_notices_profile_scope.py
@@ -1,0 +1,222 @@
+"""Multiplex profile-scope regression for the per-turn credit-notice policy.
+
+Under ``gateway.multiplex_profiles`` a single gateway process serves every
+profile, and the agent cache (keyed by session) is shared across them.  A
+cached ``AIAgent`` computes ``display.credits_notices`` once and caches it in
+``_credits_notices_enabled_cache``; the gateway then re-binds
+``notice_callback`` unconditionally on every turn.  If a session first runs
+under a profile with ``display.credits_notices=true`` and is later routed to a
+profile where it is ``false``, the reused agent keeps the stale ``True`` and
+keeps emitting credit notices into the routed chat (and the reverse: a
+disabled-first agent would never emit for an enabled profile).  Each routed
+turn must re-stamp the ACTIVE profile's policy onto the reused agent before
+any provider response.
+
+These tests drive the real ``TurnRunner.run_sync`` callback-binding seam under
+alternating ``_profile_runtime_scope`` entries against real profile-scoped
+config, reusing one shared cached agent across turns.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+from gateway.turn_context import TurnContext
+from run_agent import AIAgent
+
+
+# Real profile-scoped configs (fail-open default is true, so an explicit
+# false must be honored and an explicit true kept).
+_ROOT_CONFIG = {"display": {"credits_notices": True}}
+_SECONDARY_CONFIG = {"display": {"credits_notices": False}}
+
+
+class _StubAgent(AIAgent):
+    """Minimal AIAgent stand-in: real ``_emit_credits_notices`` /
+    ``_credits_notices_enabled`` (so the policy cache is genuinely consulted),
+    plus the handful of attributes ``run_sync`` reads after a turn."""
+
+    def __init__(self, **kwargs):
+        self.model = kwargs.get("model", "")
+        self.base_url = kwargs.get("base_url", "")
+        self.session_id = kwargs.get("session_id", None)
+        self.tools = []
+        self.context_compressor = SimpleNamespace(
+            last_prompt_tokens=0,
+            context_length=200_000,
+        )
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self._credits_state = None
+        self._credits_latch = None
+        self._credits_notices_enabled_cache = None
+        self.notice_callback = None
+        self.notice_clear_callback = None
+
+    def run_conversation(
+        self,
+        user_message: Any,
+        system_message: str = None,
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
+        task_id: str = None,
+        stream_callback: Optional[callable] = None,
+        persist_user_message: Optional[Any] = None,
+        persist_user_timestamp: Optional[float] = None,
+        persist_user_display_kind: Optional[str] = None,
+        persist_user_display_metadata: Optional[Dict[str, Any]] = None,
+        moa_config: Optional[dict] = None,
+        **_kwargs,
+    ):
+        # Simulate the post-provider-response path: the credits policy runs
+        # after each API response and is where the cached setting is read.
+        self._emit_credits_notices()
+        return {"final_response": "ok", "failed": False, "interrupted": False,
+                "completed": True, "messages": []}
+
+
+def _make_gateway_runner():
+    """A runner whose per-turn agent cache is REAL and shared across turns."""
+    runner = MagicMock()
+    runner.config = SimpleNamespace(streaming=None)
+    runner._provider_routing = {}
+    runner._agent_cache_lock = __import__("threading").Lock()
+    runner._agent_cache = {}
+    runner._session_db = None
+    runner._prefill_messages = None
+    runner._pending_model_notes = {}
+    runner._pending_skills_reload_notes = {}
+    runner.session_store._entries = {}
+    runner._get_system_prompt_for_channel.return_value = None
+    runner._resolve_session_agent_runtime.return_value = ("test-model", {})
+    runner._resolve_session_reasoning_config.return_value = None
+    runner._resolve_session_service_tier.return_value = None
+    runner._resolve_turn_agent_config.return_value = {
+        "model": "test-model",
+        "runtime": {},
+    }
+    runner._agent_config_signature.return_value = ("test-signature",)
+    runner._extract_cache_busting_config.return_value = {}
+    runner._refresh_fallback_model.return_value = None
+    runner._consume_pending_native_image_paths.return_value = []
+    runner._consume_pending_turn_sidecar_notes.return_value = []
+    runner._is_telegram_topic_lane.return_value = False
+    runner._is_discord_auto_thread_lane.return_value = False
+    runner._is_relay_discord_channel_lane.return_value = False
+    return runner
+
+
+def _run_turn(runner, profile_home, session_key, user_config, source):
+    """Drive one real ``TurnRunner.run_sync`` turn under a profile scope.
+
+    Returns the (possibly reused) agent instance the turn ran on.
+    """
+    from gateway.run import TurnRunner, _profile_runtime_scope
+
+    ctx = TurnContext(
+        source=source,
+        message="continue",
+        history=[],
+        session_id="test-session",
+        session_key=session_key,
+        run_generation=1,
+        user_config=user_config,
+        AIAgent=_StubAgent,
+        resolve_display_setting=lambda *_args: False,
+        _run_still_current=lambda: True,
+        _hooks_ref=SimpleNamespace(loaded_hooks=False),
+        _loop_for_step=None,
+    )
+    with _profile_runtime_scope(Path(profile_home)):
+        TurnRunner(runner, ctx).run_sync()
+    return ctx.agent_holder[0]
+
+
+def _write_profile_config(profile_home, enabled: bool):
+    profile_home.mkdir(parents=True, exist_ok=True)
+    (profile_home / "config.yaml").write_text(
+        "display:\n  credits_notices: %s\n" % ("true" if enabled else "false"),
+        encoding="utf-8",
+    )
+
+
+class TestMultiplexCreditNoticesProfileScope:
+    def test_reused_agent_re_stamps_policy_per_routed_turn(self, tmp_path, monkeypatch):
+        """The active profile's display.credits_notices must be stamped onto a
+        shared cached agent before every provider response.
+
+        root=true -> secondary=false -> root=true, alternating scopes, with one
+        cached agent reused across all three turns. Without the per-turn stamp
+        the agent keeps the root value (True) and the callback stays bound, so
+        the secondary turn would emit credit notices the profile disabled.
+        """
+        root_home = tmp_path / "root"
+        secondary_home = tmp_path / "profiles" / "secondary"
+        _write_profile_config(root_home, enabled=True)
+        _write_profile_config(secondary_home, enabled=False)
+        monkeypatch.setenv("HERMES_HOME", str(root_home))
+
+        runner = _make_gateway_runner()
+        session_key = "agent:test:local:chat"
+        source = SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="chat",
+            user_id="user",
+        )
+
+        # Turn 1 — root profile: enabled. The agent is created here.
+        agent = _run_turn(
+            runner, root_home, session_key, _ROOT_CONFIG, source
+        )
+        assert agent is not None
+        assert agent._credits_notices_enabled_cache is True
+        assert agent.notice_callback is not None
+
+        # Turn 2 — routed to the secondary profile: disabled. The SAME cached
+        # agent instance must be re-stamped to the active profile's policy.
+        agent2 = _run_turn(
+            runner, secondary_home, session_key, _SECONDARY_CONFIG, source
+        )
+        assert agent2 is agent, "the cached agent must be reused across turns"
+        assert agent._credits_notices_enabled_cache is False
+        assert agent.notice_callback is None
+
+        # Turn 3 — back to root: enabled again, callback restored.
+        agent3 = _run_turn(
+            runner, root_home, session_key, _ROOT_CONFIG, source
+        )
+        assert agent3 is agent
+        assert agent._credits_notices_enabled_cache is True
+        assert agent.notice_callback is not None
+
+        # No contamination: the policy exactly follows the alternating scope.
+        assert agent._credits_notices_enabled_cache is True
+
+    def test_fail_open_when_config_has_no_policy(self, tmp_path, monkeypatch):
+        """An absent/error-shaped policy stays enabled (fail-open True).
+
+        ``ctx.user_config`` is the loader's fail-open ``{}`` on any config
+        error, and ``display.credits_notices`` defaults to true.  The per-turn
+        stamp must keep emitting (callback bound) rather than silently
+        suppressing notices when the active profile's config is unreadable.
+        """
+        root_home = tmp_path / "root"
+        _write_profile_config(root_home, enabled=True)
+        monkeypatch.setenv("HERMES_HOME", str(root_home))
+
+        runner = _make_gateway_runner()
+        session_key = "agent:test:local:chat"
+        source = SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="chat",
+            user_id="user",
+        )
+
+        agent = _run_turn(runner, root_home, session_key, {}, source)
+        assert agent is not None
+        assert agent._credits_notices_enabled_cache is True
+        assert agent.notice_callback is not None

--- a/tests/gateway/test_multiplex_credit_notices_profile_scope.py
+++ b/tests/gateway/test_multiplex_credit_notices_profile_scope.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from agent.credits_tracker import CreditsState
 from gateway.config import Platform
 from gateway.session import SessionSource
 from gateway.turn_context import TurnContext
@@ -39,7 +40,13 @@ _SECONDARY_CONFIG = {"display": {"credits_notices": False}}
 class _StubAgent(AIAgent):
     """Minimal AIAgent stand-in: real ``_emit_credits_notices`` /
     ``_credits_notices_enabled`` (so the policy cache is genuinely consulted),
-    plus the handful of attributes ``run_sync`` reads after a turn."""
+    plus the handful of attributes ``run_sync`` reads after a turn.
+
+    ``run_conversation`` seeds a depleted-shaped ``CreditsState`` (as a real
+    response header capture would) before running the credits policy, and
+    ``_emit_notice`` records every policy emission — so the tests assert the
+    per-turn stamp actually GATES the notice rail, not just the cached flag.
+    """
 
     def __init__(self, **kwargs):
         self.model = kwargs.get("model", "")
@@ -57,6 +64,16 @@ class _StubAgent(AIAgent):
         self._credits_notices_enabled_cache = None
         self.notice_callback = None
         self.notice_clear_callback = None
+        self._emitted: List[Any] = []
+        # The test may inject a per-turn CreditsState to exercise a specific
+        # notice transition (e.g. depleted -> restored) on the reused agent.
+        self._next_credits_state: Optional[CreditsState] = None
+
+    def _emit_notice(self, notice) -> None:
+        # Record policy emissions, then delegate to the real emitter (which
+        # truthiness-gates on the bound notice_callback).
+        self._emitted.append(notice)
+        super()._emit_notice(notice)
 
     def run_conversation(
         self,
@@ -72,8 +89,16 @@ class _StubAgent(AIAgent):
         moa_config: Optional[dict] = None,
         **_kwargs,
     ):
-        # Simulate the post-provider-response path: the credits policy runs
-        # after each API response and is where the cached setting is read.
+        # Simulate the post-provider-response path: a credits state arrives
+        # from response headers, then the policy runs where the cached
+        # per-turn stamp is read.  Reset the emission ledger so each turn's
+        # assertions observe only that turn's policy run.
+        state = self._next_credits_state
+        if state is None:
+            # Default: a depleted-shaped capture that would normally emit.
+            state = CreditsState(paid_access=False)
+        self._credits_state = state
+        self._emitted.clear()
         self._emit_credits_notices()
         return {"final_response": "ok", "failed": False, "interrupted": False,
                 "completed": True, "messages": []}
@@ -175,6 +200,11 @@ class TestMultiplexCreditNoticesProfileScope:
         assert agent is not None
         assert agent._credits_notices_enabled_cache is True
         assert agent.notice_callback is not None
+        # The real credits policy ran this turn with a depleted-shaped state
+        # and the stamp was True, so the depleted notice reached the rail.
+        assert any(
+            getattr(n, "key", None) == "credits.depleted" for n in agent._emitted
+        ), "enabled profile must emit the depleted notice"
 
         # Turn 2 — routed to the secondary profile: disabled. The SAME cached
         # agent instance must be re-stamped to the active profile's policy.
@@ -184,14 +214,28 @@ class TestMultiplexCreditNoticesProfileScope:
         assert agent2 is agent, "the cached agent must be reused across turns"
         assert agent._credits_notices_enabled_cache is False
         assert agent.notice_callback is None
+        # Same depleted state was seeded, but the disabled stamp must gate the
+        # rail entirely — no emission, even though the agent was enabled a
+        # moment ago.
+        assert agent._emitted == [], (
+            "disabled profile must not emit credit notices on a reused agent"
+        )
 
-        # Turn 3 — back to root: enabled again, callback restored.
+        # Turn 3 — back to root: enabled again, callback restored. The
+        # depleted notice already latched in turn 1 (fired-once, no per-turn
+        # re-nag), so prove the rail is genuinely live again by flipping the
+        # next capture to paid_access=True: the latched depleted state must
+        # now emit the "✓ Credit access restored" notice on this reused agent.
+        agent._next_credits_state = CreditsState(paid_access=True)
         agent3 = _run_turn(
             runner, root_home, session_key, _ROOT_CONFIG, source
         )
         assert agent3 is agent
         assert agent._credits_notices_enabled_cache is True
         assert agent.notice_callback is not None
+        assert any(
+            getattr(n, "key", None) == "credits.restored" for n in agent._emitted
+        ), "re-enabled profile must drive a fresh notice transition on the reused agent"
 
         # No contamination: the policy exactly follows the alternating scope.
         assert agent._credits_notices_enabled_cache is True
@@ -220,3 +264,8 @@ class TestMultiplexCreditNoticesProfileScope:
         assert agent is not None
         assert agent._credits_notices_enabled_cache is True
         assert agent.notice_callback is not None
+        # Fail-open: with a depleted state seeded, the notice still reaches
+        # the rail rather than being silently suppressed on config error.
+        assert any(
+            getattr(n, "key", None) == "credits.depleted" for n in agent._emitted
+        ), "fail-open path must keep emitting on unreadable config"

--- a/tests/run_agent/test_credits_notices_toggle.py
+++ b/tests/run_agent/test_credits_notices_toggle.py
@@ -62,3 +62,38 @@ class TestCreditsNoticesToggle:
         with patch("hermes_cli.config.load_config", return_value=_cfg(False)):
             agent._emit_credits_notices()
         assert agent.get_credits_state() is not None
+
+
+class TestStampCreditsNoticesPolicy:
+    """The per-turn policy stamp owns the cached flag the gateway re-stamps
+    onto reused agents before each provider run."""
+
+    def test_stamp_overrides_cached_policy(self):
+        agent = _agent_with_state()
+        agent.stamp_credits_notices_policy(False)
+        assert agent._credits_notices_enabled_cache is False
+        assert agent._credits_notices_enabled() is False
+        agent.stamp_credits_notices_policy(True)
+        assert agent._credits_notices_enabled_cache is True
+        assert agent._credits_notices_enabled() is True
+
+    def test_stamp_true_still_emits_depleted(self):
+        agent = _agent_with_state()
+        received = []
+        agent.notice_callback = received.append
+        agent.stamp_credits_notices_policy(True)
+        with patch("hermes_cli.config.load_config", side_effect=AssertionError("must not load")):
+            agent._emit_credits_notices()
+        assert any(getattr(n, "key", None) == "credits.depleted" for n in received)
+
+    def test_stamp_false_gates_emission_without_consulting_config(self):
+        """A stamped False must be authoritative: the agent's own config is
+        never re-read, so a reused agent cannot resurrect a stale enabled
+        policy from disk mid-turn."""
+        agent = _agent_with_state()
+        agent.notice_callback = lambda n: None
+        agent.stamp_credits_notices_policy(False)
+        with patch("hermes_cli.config.load_config", side_effect=AssertionError("must not load")) as mock_load:
+            agent._emit_credits_notices()
+        assert mock_load.call_count == 0
+        assert agent._credits_notices_enabled_cache is False


### PR DESCRIPTION
## Summary

Fixes #92722.

Multiplexed gateways can reuse one cached agent across routed profiles. `AIAgent._credits_notices_enabled()` caches its first resolved value, while the gateway previously rebound `notice_callback` unconditionally on every turn. That allowed one profile’s `display.credits_notices` policy to contaminate later turns routed to another profile.

This change stamps the active turn’s already profile-scoped policy onto the reused agent before the provider runs and only binds the platform notice callback when that policy is enabled. Missing or malformed policy remains fail-open (`true`), matching existing behavior.

## Regression coverage

The new `TurnRunner.run_sync` regression reuses one cached agent while alternating:

- root profile: notices enabled;
- routed secondary profile: notices disabled;
- root profile again: notices restored.

It asserts both the cached policy and actual callback binding on every turn. The test fails on unmodified `main` and passes with this patch.

## Verification

```text
23 passed
python -m py_compile: passed
ruff check: passed
git diff --check: passed
```

Focused tests include multiplex primary-token scope, profile-scoped session DB behavior, gateway notice rendering, core credit-notice toggle behavior, and the new regression.