### PR TITLE
feat(kanban): add compute-class model routing

### DIFF
--- a/hermes_cli/compute_routing.py
+++ b/hermes_cli/compute_routing.py
@@ -1,0 +1,345 @@
+"""Pure compute-class routing, downstream of the existing role router."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+from hermes_constants import VALID_REASONING_EFFORTS
+
+COMPUTE_CLASSES = ("quick", "standard", "deep", "architect", "specialist")
+REASONING_EFFORTS = ("none", *VALID_REASONING_EFFORTS)
+ROLE_BOUNDARY_FIELDS = (
+    "role",
+    "assignee",
+    "write_scope",
+    "workspace",
+    "approval",
+    "toolsets",
+    "master_forbidden",
+)
+WORK_FAILURES = {"test_failed", "contract_failed", "invalid_output"}
+
+
+def _decision_id(
+    task_context, role_decision, capability_snapshot, policy, compute_class
+):
+    identity = {
+        "task_id": task_context.get("task_id"),
+        "role_ref": role_decision.get("role_ref"),
+        "snapshot_id": capability_snapshot.get("snapshot_id"),
+        "policy_version": policy.get("policy_version"),
+        "compute_class": compute_class,
+    }
+    digest = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:20]
+    return f"route-{digest}"
+
+
+def _task_contract(role_decision: Mapping[str, Any]) -> dict[str, Any]:
+    return {field: deepcopy(role_decision.get(field)) for field in ROLE_BOUNDARY_FIELDS}
+
+
+def _boundary_changed(proposed: object, baseline: Mapping[str, Any]) -> bool:
+    if not isinstance(proposed, Mapping):
+        return False
+    return any(
+        field in proposed and proposed[field] != baseline.get(field)
+        for field in ROLE_BOUNDARY_FIELDS
+    )
+
+
+def _classify(task_context: Mapping[str, Any], policy: Mapping[str, Any]) -> str | None:
+    signals = {str(item).strip().lower() for item in task_context.get("signals", ())}
+    precedence = policy.get("precedence") or (
+        "specialist",
+        "architect",
+        "deep",
+        "standard",
+        "quick",
+    )
+    return next(
+        (
+            str(item).lower()
+            for item in precedence
+            if str(item).lower() in signals and str(item).lower() in COMPUTE_CLASSES
+        ),
+        None,
+    )
+
+
+def _actual_route(execution: Mapping[str, Any]) -> dict[str, Any] | None:
+    actual = execution.get("actual")
+    keys = ("provider", "model", "reasoning_effort")
+    if not isinstance(actual, Mapping) or not all(actual.get(key) for key in keys):
+        return None
+    return {key: actual[key] for key in keys}
+
+
+def route_task(
+    task_context: Mapping[str, Any],
+    role_decision: Mapping[str, Any],
+    capability_snapshot: Mapping[str, Any],
+    role_constraints: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    execution: Mapping[str, Any],
+    unattended: bool,
+) -> dict[str, Any]:
+    """Resolve a route without mutating inputs or dispatching work."""
+    task_contract = _task_contract(role_decision)
+
+    def result(status: str, **fields: Any) -> dict[str, Any]:
+        return {"status": status, "task_contract": task_contract, **fields}
+
+    if _boundary_changed(task_context.get("proposed_boundary"), role_decision):
+        return result("rejected", spawn=False, reason_code="role_boundary_mutation")
+
+    requested = task_context.get("requested_route")
+    if requested is not None and not isinstance(requested, Mapping):
+        return result("rejected", spawn=False, reason_code="invalid_route")
+    requested = requested or {}
+    if _boundary_changed(requested, role_decision) or _boundary_changed(
+        requested, role_constraints
+    ):
+        return result("rejected", spawn=False, reason_code="safety_boundary_mutation")
+    if requested.get("provider") and not requested.get("model"):
+        return result("rejected", spawn=False, reason_code="provider_requires_model")
+
+    requested_effort = requested.get("reasoning_effort")
+    if requested_effort is not None:
+        requested_effort = str(requested_effort).strip().lower()
+        if requested_effort not in REASONING_EFFORTS:
+            return result(
+                "rejected", spawn=False, reason_code="invalid_reasoning_effort"
+            )
+
+    compute_class = _classify(task_context, policy)
+    if compute_class is None:
+        return result("rejected", spawn=False, reason_code="compute_class_ambiguous")
+    policy_classes = policy.get("classes")
+    class_policy = (
+        policy_classes.get(compute_class)
+        if isinstance(policy_classes, Mapping)
+        else None
+    )
+    if not isinstance(class_policy, Mapping):
+        return result("rejected", spawn=False, reason_code="route_policy_incomplete")
+
+    persisted_input = task_context.get("persisted_route")
+    if persisted_input is not None:
+        required = ("compute_class", "route_decision_id", "policy_version")
+        if not isinstance(persisted_input, Mapping) or not all(
+            persisted_input.get(key) for key in required
+        ):
+            fields: dict[str, Any] = {
+                "spawn": False,
+                "reason_code": "compute_class_not_persisted",
+            }
+            actual = _actual_route(execution)
+            if actual is not None:
+                fields["actual_route"] = actual
+            if execution.get("reported_done"):
+                fields["outcome"] = "reported_done"
+            return result("rejected", **fields)
+
+    route = {
+        "provider": requested.get("provider", class_policy.get("provider")),
+        "model": requested.get("model", class_policy.get("model")),
+        "reasoning_effort": requested_effort or class_policy.get("reasoning_effort"),
+        "max_fallbacks": min(max(int(class_policy.get("max_fallbacks", 0)), 0), 1),
+    }
+    if route["provider"] and not route["model"]:
+        return result("rejected", spawn=False, reason_code="provider_requires_model")
+    if route["reasoning_effort"] not in REASONING_EFFORTS:
+        return result("rejected", spawn=False, reason_code="invalid_reasoning_effort")
+
+    allowed_providers = role_constraints.get("allowed_providers")
+    allowed_models = role_constraints.get("allowed_models")
+    if (
+        allowed_providers is not None and route["provider"] not in allowed_providers
+    ) or (allowed_models is not None and route["model"] not in allowed_models):
+        return result("rejected", spawn=False, reason_code="no_eligible_candidate")
+
+    route_decision_id = _decision_id(
+        task_context, role_decision, capability_snapshot, policy, compute_class
+    )
+    persisted_route = {
+        "compute_class": compute_class,
+        "route_decision_id": route_decision_id,
+        "policy_version": policy.get("policy_version"),
+    }
+    common: dict[str, Any] = {
+        "compute_class": compute_class,
+        "route": route,
+        "persisted_route": persisted_route,
+        "route_decision_id": route_decision_id,
+        "policy_version": policy.get("policy_version"),
+        "verification_required": True,
+    }
+
+    if not (
+        capability_snapshot.get("catalog_observed")
+        and capability_snapshot.get("auth_observed")
+        and capability_snapshot.get("runtime_observed")
+    ):
+        return result(
+            "prepared_not_observed",
+            **common,
+            spawn=False,
+            reason_code="capability_unverified",
+        )
+
+    candidates = capability_snapshot.get("candidates") or ()
+    candidate = next(
+        (
+            item
+            for item in candidates
+            if isinstance(item, Mapping)
+            and item.get("provider") == route["provider"]
+            and item.get("model") == route["model"]
+        ),
+        None,
+    )
+    if candidate is None or route["reasoning_effort"] not in candidate.get(
+        "reasoning_efforts", ()
+    ):
+        return result(
+            "prepared_not_observed",
+            **common,
+            spawn=False,
+            reason_code="no_eligible_candidate",
+        )
+
+    if unattended and class_policy.get("automation") == "attended":
+        return result(
+            "approval_required",
+            **common,
+            spawn=False,
+            reason_code="attended_routing_required",
+        )
+
+    fallback_index = min(max(int(execution.get("fallback_index", 0)), 0), 1)
+    error = execution.get("error")
+    eligible_errors = set(policy.get("eligible_fallback_reasons") or ())
+    ineligible_errors = set(policy.get("ineligible_fallback_reasons") or ())
+
+    if error in WORK_FAILURES:
+        return result(
+            "rework_required",
+            **common,
+            spawn=False,
+            outcome="work_failed",
+            event_kind="verification_failed",
+            fallback_index=fallback_index,
+            retry_policy="same_owner",
+        )
+    if error in eligible_errors:
+        if fallback_index < route["max_fallbacks"]:
+            return result(
+                "fallback_pending",
+                **common,
+                spawn=True,
+                outcome="routing_unavailable",
+                event_kind="fallback_started",
+                fallback_index=fallback_index + 1,
+            )
+        return result(
+            "blocked",
+            **common,
+            spawn=False,
+            outcome="routing_unavailable",
+            event_kind="fallback_exhausted",
+            fallback_index=fallback_index,
+        )
+    if error in ineligible_errors:
+        return result(
+            "blocked",
+            **common,
+            spawn=False,
+            outcome="blocked",
+            event_kind="route_blocked",
+            fallback_index=fallback_index,
+            retry_policy="none",
+        )
+    if error:
+        return result(
+            "blocked",
+            **common,
+            spawn=False,
+            outcome="work_failed",
+            event_kind="route_blocked",
+            fallback_index=fallback_index,
+            reason_code="unclassified_execution_error",
+        )
+
+    actual = _actual_route(execution)
+    if execution.get("reported_done"):
+        if actual is None:
+            return result(
+                "observation_incomplete",
+                **common,
+                spawn=False,
+                outcome="reported_done",
+                reason_code="actual_route_missing",
+            )
+        if any(actual[key] != route[key] for key in actual):
+            return result(
+                "observation_mismatch",
+                **common,
+                actual_route=actual,
+                spawn=False,
+                outcome="reported_done",
+                reason_code="actual_route_mismatch",
+            )
+        verification = execution.get("verification") or {}
+        if not (verification.get("performed") and verification.get("passed")):
+            return result(
+                "verification_required",
+                **common,
+                actual_route=actual,
+                spawn=False,
+                outcome="reported_done",
+            )
+        return result(
+            "verified",
+            **common,
+            actual_route=actual,
+            spawn=False,
+            outcome="verified",
+            event_kind="verification_passed",
+        )
+
+    if execution.get("attempted"):
+        fields = {**common, "spawn": False, "fallback_index": fallback_index}
+        if actual is not None:
+            fields["actual_route"] = actual
+        return result("running", **fields)
+
+    if str(policy.get("mode", "shadow")).strip().lower() == "shadow":
+        return result(
+            "shadow_recorded",
+            **common,
+            spawn=True,
+            apply_route_override=False,
+            dispatch_overrides={},
+            event_kind="route_resolved",
+        )
+    return result(
+        "dispatchable",
+        **common,
+        spawn=True,
+        apply_route_override=True,
+        dispatch_overrides={
+            "model_override": route["model"],
+            "provider_override": route["provider"],
+            "reasoning_effort": route["reasoning_effort"],
+        },
+        event_kind="route_resolved",
+    )
+
+
+__all__ = ["COMPUTE_CLASSES", "route_task"]

--- a/hermes_cli/compute_routing.py
+++ b/hermes_cli/compute_routing.py
@@ -80,6 +80,35 @@ def _actual_route(execution: Mapping[str, Any]) -> dict[str, Any] | None:
     return {key: actual[key] for key in keys}
 
 
+def _has_distinct_candidate(
+    candidates: object,
+    route: Mapping[str, Any],
+    role_constraints: Mapping[str, Any],
+) -> bool:
+    if not isinstance(candidates, (list, tuple)):
+        return False
+    current = (route["provider"], route["model"], route["reasoning_effort"])
+    allowed_providers = role_constraints.get("allowed_providers")
+    allowed_models = role_constraints.get("allowed_models")
+    for item in candidates:
+        if not isinstance(item, Mapping):
+            continue
+        provider = item.get("provider")
+        model = item.get("model")
+        if (
+            not provider
+            or not model
+            or (allowed_providers is not None and provider not in allowed_providers)
+            or (allowed_models is not None and model not in allowed_models)
+        ):
+            continue
+        for effort in item.get("reasoning_efforts") or ():
+            candidate = (provider, model, effort)
+            if effort in REASONING_EFFORTS and candidate != current:
+                return True
+    return False
+
+
 def route_task(
     task_context: Mapping[str, Any],
     role_decision: Mapping[str, Any],
@@ -167,10 +196,26 @@ def route_task(
     route_decision_id = _decision_id(
         task_context, role_decision, capability_snapshot, policy, compute_class
     )
-    persisted_route = {
+    route_identity = {
         "compute_class": compute_class,
-        "route_decision_id": route_decision_id,
         "policy_version": policy.get("policy_version"),
+        "provider": route["provider"],
+        "model": route["model"],
+        "reasoning_effort": route["reasoning_effort"],
+    }
+    if execution.get("attempted") and isinstance(persisted_input, Mapping):
+        if any(
+            persisted_input.get(field) != value
+            for field, value in route_identity.items()
+        ):
+            return result(
+                "rejected",
+                spawn=False,
+                reason_code="route_persistence_mismatch",
+            )
+    persisted_route = {
+        **route_identity,
+        "route_decision_id": route_decision_id,
     }
     common: dict[str, Any] = {
         "compute_class": compute_class,
@@ -238,7 +283,10 @@ def route_task(
             retry_policy="same_owner",
         )
     if error in eligible_errors:
-        if fallback_index < route["max_fallbacks"]:
+        if (
+            fallback_index < route["max_fallbacks"]
+            and _has_distinct_candidate(candidates, route, role_constraints)
+        ):
             return result(
                 "fallback_pending",
                 **common,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3552,6 +3552,7 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "reasoning_effort": reasoning_effort,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)

--- a/tests/fixtures/compute_routing_contract_v1.json
+++ b/tests/fixtures/compute_routing_contract_v1.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "compute_routing_contract/v1",
+  "public_interface": {
+    "module": "hermes_cli.compute_routing",
+    "callable": "route_task",
+    "arguments": ["task_context", "role_decision", "capability_snapshot", "role_constraints", "policy", "execution", "unattended"]
+  },
+  "common_input": {
+    "task_context": {"task_id": "t_route_contract", "signals": ["standard"], "requested_route": null, "persisted_route": null, "proposed_boundary": null},
+    "role_decision": {"role_ref": "role-v7:t_route_contract", "role": "coding", "assignee": "bmk", "write_scope": ["tests/**"], "workspace": "G:/worktrees/t_route_contract", "approval": "review_required", "toolsets": ["terminal", "file", "kanban"], "master_forbidden": true},
+    "capability_snapshot": {
+      "snapshot_id": "cap-20260823-1", "catalog_observed": true, "auth_observed": true, "runtime_observed": true,
+      "candidates": [
+        {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_efforts": ["low"]},
+        {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_efforts": ["medium", "high", "xhigh"]},
+        {"provider": "vision-adapter", "model": "vision-specialist-v1", "reasoning_efforts": ["medium"]}
+      ]
+    },
+    "role_constraints": {"allowed_providers": ["openai-codex", "vision-adapter"], "allowed_models": ["gpt-5.6-luna", "gpt-5.6-sol", "vision-specialist-v1"], "write_scope": ["tests/**"], "workspace": "G:/worktrees/t_route_contract", "approval": "review_required", "toolsets": ["terminal", "file", "kanban"], "master_forbidden": true},
+    "policy": {
+      "schema_version": "compute_routing_policy/v1", "policy_version": "2026-08-contract-1", "mode": "opt_in",
+      "precedence": ["specialist", "architect", "deep", "standard", "quick"],
+      "eligible_fallback_reasons": ["model_unavailable", "provider_rejected", "transient_network", "quota_exhausted"],
+      "ineligible_fallback_reasons": ["auth_missing", "permission_denied", "write_scope_violation", "test_failed", "contract_failed", "invalid_output", "human_denied", "security_block"],
+      "classes": {
+        "quick": {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_effort": "low", "max_fallbacks": 1, "automation": "opt_in"},
+        "standard": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "medium", "max_fallbacks": 1, "automation": "opt_in"},
+        "deep": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "high", "max_fallbacks": 1, "automation": "attended"},
+        "architect": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "xhigh", "max_fallbacks": 0, "automation": "attended"},
+        "specialist": {"provider": "vision-adapter", "model": "vision-specialist-v1", "reasoning_effort": "medium", "max_fallbacks": 0, "automation": "attended"}
+      }
+    },
+    "execution": {"attempted": false, "fallback_index": 0, "error": null, "reported_done": false, "verification": {"performed": false, "passed": false}, "actual": {"provider": null, "model": null, "reasoning_effort": null}},
+    "unattended": false
+  },
+  "normal_cases": [
+    {"id": "N01-specialist-precedence", "input_patch": {"task_context": {"signals": ["specialist", "architect", "deep", "standard", "quick"]}}, "expected": {"status": "dispatchable", "compute_class": "specialist", "route": {"provider": "vision-adapter", "model": "vision-specialist-v1", "reasoning_effort": "medium", "max_fallbacks": 0}}},
+    {"id": "N02-architect-precedence", "input_patch": {"task_context": {"signals": ["architect", "deep", "standard", "quick"]}}, "expected": {"status": "dispatchable", "compute_class": "architect", "route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "xhigh", "max_fallbacks": 0}}},
+    {"id": "N03-deep-precedence", "input_patch": {"task_context": {"signals": ["deep", "standard", "quick"]}}, "expected": {"status": "dispatchable", "compute_class": "deep", "route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "high", "max_fallbacks": 1}}},
+    {"id": "N04-standard-precedence", "input_patch": {"task_context": {"signals": ["standard", "quick"]}}, "expected": {"status": "dispatchable", "compute_class": "standard", "route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "medium", "max_fallbacks": 1}}},
+    {"id": "N05-quick-precedence", "input_patch": {"task_context": {"signals": ["quick"]}}, "expected": {"status": "dispatchable", "compute_class": "quick", "route": {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_effort": "low", "max_fallbacks": 1}, "verification_required": true}}
+  ],
+  "mutants": [
+    {"id": "I01-role-boundary-mutation", "invariant": "I1", "input_patch": {"task_context": {"proposed_boundary": {"role": "review", "assignee": "b", "write_scope": ["**"], "workspace": "G:/other", "approval": "none"}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "role_boundary_mutation"}},
+    {"id": "I02-posthoc-class-inference", "invariant": "I2", "input_patch": {"task_context": {"requested_route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "high"}, "persisted_route": {"compute_class": null, "route_decision_id": null, "policy_version": null}}, "execution": {"attempted": true, "reported_done": true, "verification": {"performed": true, "passed": true}, "actual": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "high"}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "compute_class_not_persisted", "outcome": "reported_done"}},
+    {"id": "I03-provider-without-model", "invariant": "I3", "input_patch": {"task_context": {"requested_route": {"provider": "openai-codex", "model": null, "reasoning_effort": "medium"}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "provider_requires_model"}},
+    {"id": "I04-invalid-reasoning-default-fallback", "invariant": "I4", "input_patch": {"task_context": {"requested_route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "hihg"}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "invalid_reasoning_effort"}},
+    {"id": "I05-catalog-only-capability", "invariant": "I5", "input_patch": {"capability_snapshot": {"auth_observed": false, "runtime_observed": false}}, "expected": {"status": "prepared_not_observed", "spawn": false, "reason_code": "capability_unverified"}},
+    {"id": "I06-work-failure-model-fallback", "invariant": "I6", "input_patch": {"execution": {"attempted": true, "fallback_index": 0, "error": "test_failed"}}, "expected": {"status": "rework_required", "spawn": false, "outcome": "work_failed", "event_kind": "verification_failed", "fallback_index": 0, "retry_policy": "same_owner"}},
+    {"id": "I07-third-spawn-chain", "invariant": "I7", "input_patch": {"execution": {"attempted": true, "fallback_index": 1, "error": "model_unavailable"}}, "expected": {"status": "blocked", "spawn": false, "outcome": "routing_unavailable", "event_kind": "fallback_exhausted", "fallback_index": 1}},
+    {"id": "I08-fallback-widens-safety-boundary", "invariant": "I8", "input_patch": {"task_context": {"requested_route": {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_effort": "low", "fallback_index": 1, "write_scope": ["**"], "toolsets": ["terminal", "file", "kanban", "unsafe"], "approval": "none", "master_forbidden": false}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "safety_boundary_mutation"}},
+    {"id": "I09-verified-without-actual-model", "invariant": "I9", "input_patch": {"execution": {"attempted": true, "reported_done": true, "verification": {"performed": true, "passed": true}, "actual": {"provider": null, "model": null, "reasoning_effort": null}}}, "expected": {"status": "observation_incomplete", "spawn": false, "outcome": "reported_done", "reason_code": "actual_route_missing"}},
+    {"id": "I10-quick-skips-verification", "invariant": "I10", "input_patch": {"task_context": {"signals": ["quick"]}, "execution": {"attempted": true, "reported_done": true, "verification": {"performed": false, "passed": false}, "actual": {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_effort": "low"}}}, "expected": {"status": "verification_required", "spawn": false, "compute_class": "quick", "outcome": "reported_done", "verification_required": true}},
+    {"id": "I11-unattended-architect-spawn", "invariant": "I11", "input_patch": {"task_context": {"signals": ["architect"]}, "unattended": true}, "expected": {"status": "approval_required", "spawn": false, "compute_class": "architect", "reason_code": "attended_routing_required"}},
+    {"id": "I12-quota-work-failure-conflation", "invariant": "I12", "variants": [
+      {"name": "quota", "input_patch": {"execution": {"attempted": true, "fallback_index": 0, "error": "quota_exhausted"}}, "expected": {"status": "fallback_pending", "spawn": true, "outcome": "routing_unavailable", "event_kind": "fallback_started", "fallback_index": 1}},
+      {"name": "work", "input_patch": {"execution": {"attempted": true, "fallback_index": 0, "error": "test_failed"}}, "expected": {"status": "rework_required", "spawn": false, "outcome": "work_failed", "event_kind": "verification_failed", "fallback_index": 0}}
+    ]}
+  ]
+}

--- a/tests/fixtures/quiz_result.md
+++ b/tests/fixtures/quiz_result.md
@@ -1,0 +1,107 @@
+# result — compute_class router oracle (quiz)
+
+## 1. Summary
+
+compute_class 구현 전 고정 RED 오라클을 작성했다. production 코드는 수정하지 않았고 tests/** 아래에만 정상 5종 precedence fixture, I01~I12 known-bad fixture, 단일 route_task 공개 계약 테스트, kanban_create reasoning_effort E2E parity 테스트를 추가했다.
+
+현재 기준 결과는 의도대로 RED다. fixture 자체 검증 2건은 GREEN이고, 미구현 production 계약은 21 failed / 2 passed다. 실패는 hermes_cli.compute_routing.route_task 부재 18건과 kanban_create reasoning_effort schema/handler 부재 3건으로 분리된다.
+
+## 2. Files
+
+- tests/fixtures/compute_routing_contract_v1.json
+  - 정상 class 5종 specialist > architect > deep > standard > quick precedence
+  - 구조적으로 유효한 I01~I12 mutant
+  - capability snapshot, role boundary, fallback 자격표/상한, execution observation fixture
+- tests/test_compute_routing_contract.py
+  - 모든 정상/mutant를 동일 hermes_cli.compute_routing.route_task 키워드 인터페이스로 실행
+  - role/assignee/write_scope/workspace/approval/toolsets/master_forbidden 불변
+  - class/decision id/policy version 실행 전 명시 저장
+  - actual route 없는 verified 금지, quick 검증 필수, unattended architect 차단
+- tests/tools/test_kanban_compute_routing_contract.py
+  - kanban_create reasoning_effort 닫힌 enum
+  - HIGH 입력 → DB/event/show high → spawn --reasoning high parity
+  - hihg 입력 거부 및 DB 변화 0
+
+## 3. Commands + actual output
+
+Command:
+
+    G:labuntimehermes-bappenvScriptspython.exe -m pytest --basetemp <workspace>/tests/.pytest_compute_routing tests/test_compute_routing_contract.py::test_fixture_is_closed_complete_and_structurally_valid tests/test_compute_routing_contract.py::test_i12_expected_contracts_are_not_aliases -q
+
+Output:
+
+    ..                                                                       [100%]
+    2 passed in 2.48s
+
+Command:
+
+    G:labuntimehermes-bappenvScriptspython.exe -m pytest --basetemp <workspace>/tests/.pytest_compute_routing_result tests/test_compute_routing_contract.py tests/tools/test_kanban_compute_routing_contract.py -q --tb=no
+
+Output:
+
+    .FFFFFFFFFFFFFFFFFF.FFF                                                  [100%]
+    =========================== short test summary info ===========================
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N01-specialist-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N02-architect-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N03-deep-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N04-standard-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N05-quick-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I01-role-boundary-mutation]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I02-posthoc-class-inference]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I03-provider-without-model]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I04-invalid-reasoning-default-fallback]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I05-catalog-only-capability]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I06-work-failure-model-fallback]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I07-third-spawn-chain]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I08-fallback-widens-safety-boundary]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I09-verified-without-actual-model]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I10-quick-skips-verification]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I11-unattended-architect-spawn]
+    FAILED tests/test_compute_routing_contract.py::test_quota_and_work_failures_remain_distinct[I12-quota]
+    FAILED tests/test_compute_routing_contract.py::test_quota_and_work_failures_remain_distinct[I12-work]
+    FAILED tests/tools/test_kanban_compute_routing_contract.py::test_kanban_create_schema_exposes_closed_reasoning_effort_enum
+    FAILED tests/tools/test_kanban_compute_routing_contract.py::test_kanban_create_reasoning_effort_parity_to_db_event_show_and_spawn
+    FAILED tests/tools/test_kanban_compute_routing_contract.py::test_kanban_create_rejects_reasoning_typo_without_db_mutation
+    21 failed, 2 passed in 2.72s
+
+Command:
+
+    G:labuntimehermes-bappenvScriptspython.exe -m py_compile tests/test_compute_routing_contract.py tests/tools/test_kanban_compute_routing_contract.py
+
+Output:
+
+    PYCOMPILE_RC=0
+
+Command:
+
+    git diff --check
+
+Output:
+
+    DIFF_CHECK_RC=0
+
+## 4. Verification (known-bad)
+
+- I01 role/assignee/scope/workspace/approval mutation → rejected, spawn false.
+- I02 class/decision/policy 미저장 + actual model 사후 역추정 → rejected, verified 금지.
+- I03 provider-only route → provider_requires_model.
+- I04 hihg → invalid_reasoning_effort; 조용한 profile fallback 금지.
+- I05 catalog-only + auth/runtime 미관측 → prepared_not_observed.
+- I06 test_failed → work_failed + same_owner rework; model fallback 금지.
+- I07 fallback_index=1 이후 추가 spawn → fallback_exhausted.
+- I08 fallback의 write_scope/toolset/approval/master 확대 → rejected.
+- I09 actual provider/model/effort 없음 → observation_incomplete, verified 금지.
+- I10 quick도 verification_required.
+- I11 unattended architect → approval_required, spawn false.
+- I12 quota는 routing_unavailable/fallback_started, test failure는 work_failed/verification_failed.
+
+정상 fixture 5종과 mutant 12종을 모두 같은 route_task 인터페이스에 넣는다. I12는 quota/work 두 variant다. fixture 완전성 테스트가 precedence, I1~I12 연속성, 중복 없는 12개 ID, 공통 인자 구조를 별도로 검증한다.
+
+## 5. Issues / Caveats
+
+- RED는 의도된 구현 전 기준선이다.
+- 기존 DB/spawn builder에는 reasoning_effort 저장/argv 배선이 있으나 kanban_create schema/handler가 값을 받지 않는다. HIGH가 NULL로 저장되고 hihg도 task 생성에 성공한다. created event/show 표면도 parity가 없다.
+- 공유 venv에는 ruff 모듈이 없어 ruff는 실행하지 못했다. JSON parse, Python py_compile, git diff --check는 통과했다.
+- pytest 임시 디렉터리는 제거했다.
+- AGENTS.md가 참조한 RTK.md는 worktree와 인접 worktree에서 발견되지 않았다.
+- 지정 결과 경로 G:/lab/workspace/mas/tasks/compute-class-routing-arena/workers/quiz/result.md는 샌드박스에서 쓰기 거부되어 이 대체본을 tests/fixtures/quiz_result.md에 보존했다. 원래 경로로 복사가 필요하다.

--- a/tests/fixtures/sol_remediation_result.md
+++ b/tests/fixtures/sol_remediation_result.md
@@ -1,0 +1,112 @@
+# SOL remediation result
+
+## 1. Outcome
+
+PASS. Both independent audit findings are repaired without modifying the sealed QUIZ artifacts. The requested external result path (`G:/lab/workspace/mas/tasks/compute-class-routing-arena/workers/sol-remediation/result.md`) is outside the worktree write scope, so this five-section report is preserved at the requested fallback path.
+
+No delegation, re-delegation, commit, push, or merge was performed.
+
+## 2. Changed files
+
+- `tests/test_compute_routing_safety_regressions.py` (new): six executable regression cases covering candidate exhaustion and all five persisted route identity fields.
+- `hermes_cli/compute_routing.py`: minimal production repair.
+  - Availability fallback now requires a distinct, role-allowed `provider/model/reasoning_effort` candidate in the capability snapshot.
+  - Persisted route output now records `compute_class`, `policy_version`, `provider`, `model`, `reasoning_effort`, and `route_decision_id`.
+  - Attempted execution rejects any mismatch across the five route identity fields with `spawn=false` and `reason_code=route_persistence_mismatch`.
+
+Sealed files remain byte-identical to `bfc933073b`:
+
+- `tests/test_compute_routing_contract.py`
+- `tests/tools/test_kanban_compute_routing_contract.py`
+- `tests/fixtures/compute_routing_contract_v1.json`
+- `tests/fixtures/quiz_result.md`
+
+## 3. RED evidence before implementation
+
+The regression file was added before the production repair. A dependency-complete local pytest environment was not initially discoverable, so the two behaviors were first executed directly through the same public `route_task` interface with the repository fixture.
+
+Command (availability fallback mutant):
+
+```powershell
+.\.venv\Scripts\python.exe -c "import copy,json; from pathlib import Path; from hermes_cli.compute_routing import route_task; x=copy.deepcopy(json.loads(Path('tests/fixtures/compute_routing_contract_v1.json').read_text(encoding='utf-8'))['common_input']); x['capability_snapshot']['candidates']=[{'provider':'openai-codex','model':'gpt-5.6-sol','reasoning_efforts':['medium']}]; x['execution'].update(attempted=True,error='model_unavailable',fallback_index=0); r=route_task(**x); print(r); assert r['status']=='blocked' and r['spawn'] is False and r['event_kind']=='fallback_exhausted'"
+```
+
+Observed RED output:
+
+```text
+{'status': 'fallback_pending', 'task_contract': {'role': 'coding', 'assignee': 'bmk', 'write_scope': ['tests/**'], 'workspace': 'G:/worktrees/t_route_contract', 'approval': 'review_required', 'toolsets': ['terminal', 'file', 'kanban'], 'master_forbidden': True}, 'compute_class': 'standard', 'route': {'provider': 'openai-codex', 'model': 'gpt-5.6-sol', 'reasoning_effort': 'medium', 'max_fallbacks': 1}, 'persisted_route': {'compute_class': 'standard', 'route_decision_id': 'route-b70264f16f141e2290f1', 'policy_version': '2026-08-contract-1'}, 'route_decision_id': 'route-b70264f16f141e2290f1', 'policy_version': '2026-08-contract-1', 'verification_required': True, 'spawn': True, 'outcome': 'routing_unavailable', 'event_kind': 'fallback_started', 'fallback_index': 1}
+AssertionError
+RED1_EXIT=1
+```
+
+Command (persisted route identity mutant):
+
+```powershell
+.\.venv\Scripts\python.exe -c "import copy,json; from pathlib import Path; from hermes_cli.compute_routing import route_task; x=copy.deepcopy(json.loads(Path('tests/fixtures/compute_routing_contract_v1.json').read_text(encoding='utf-8'))['common_input']); initial=route_task(**x); print(initial['persisted_route']); required={'compute_class','policy_version','provider','model','reasoning_effort'}; assert required <= set(initial['persisted_route'])"
+```
+
+Observed RED output:
+
+```text
+{'compute_class': 'standard', 'route_decision_id': 'route-b70264f16f141e2290f1', 'policy_version': '2026-08-contract-1'}
+AssertionError
+RED2_EXIT=1
+```
+
+## 4. Repair behavior
+
+For an eligible availability error, the existing fallback ceiling remains necessary but is no longer sufficient. The router expands snapshot entries into `provider/model/effort` identities, filters them through the role provider/model allowlists and the closed effort enum, and only emits `fallback_pending` when at least one identity differs from the current resolved route. With no such identity it emits `blocked`, `spawn=false`, `routing_unavailable`, and `fallback_exhausted`. The sealed I12 quota case still has distinct snapshot candidates and remains unchanged.
+
+For attempted execution, the route is resolved normally and compared to the route identity persisted before dispatch. A missing or different `compute_class`, `policy_version`, `provider`, `model`, or `reasoning_effort` is rejected before fallback, running, or verification states can proceed. `route_decision_id` remains required for persistence presence but is not added to the requested equality set.
+
+## 5. Verification commands and raw results
+
+New regression gate:
+
+```powershell
+$env:HERMES_PYTHON='/g/lab/runtime/hermes-b/app/venv/Scripts/python.exe'; & 'C:\Program Files\Git\usr\bin\bash.exe' -lc './scripts/run_tests.sh tests/test_compute_routing_safety_regressions.py -v --tb=short'
+```
+
+```text
+Discovered 1 test files (~2 tests) under ['tests\\test_compute_routing_safety_regressions.py']; running with -j 24
+[100.0% |     2/~2 | ✓6 | ✗0] ✓ tests\\test_compute_routing_safety_regressions.py (6✓, 2.1s)
+=== Summary: 1 files, 6 tests passed, 0 failed (100% complete) in 2.1s (24 workers) ===
+```
+
+Locked gate:
+
+```powershell
+$env:HERMES_PYTHON='/g/lab/runtime/hermes-b/app/venv/Scripts/python.exe'; & 'C:\Program Files\Git\usr\bin\bash.exe' -lc './scripts/run_tests.sh tests/test_compute_routing_contract.py tests/tools/test_kanban_compute_routing_contract.py -v --tb=short'
+```
+
+```text
+[ 62.5% |     5/~8 | ✓20 | ✗ 0] ✓ tests\\test_compute_routing_contract.py (20✓, 2.2s)
+[100.0% |     8/~8 | ✓23 | ✗ 0] ✓ tests\\tools\\test_kanban_compute_routing_contract.py (3✓, 5.4s)
+=== Summary: 2 files, 23 tests passed, 0 failed (100% complete) in 5.5s (24 workers) ===
+```
+
+Kanban regression gate:
+
+```powershell
+$env:HERMES_PYTHON='/g/lab/runtime/hermes-b/app/venv/Scripts/python.exe'; & 'C:\Program Files\Git\usr\bin\bash.exe' -lc './scripts/run_tests.sh tests/tools/test_kanban_tools.py -v --tb=short'
+```
+
+```text
+[100.0% |    32/~32 | ✓32 | ✗ 0] ✓ tests\\tools\\test_kanban_tools.py (32✓, 18.4s)
+=== Summary: 1 files, 32 tests passed, 0 failed (100% complete) in 18.4s (24 workers) ===
+```
+
+Static and sealed checks:
+
+```powershell
+& 'G:\lab\runtime\hermes-b\app\venv\Scripts\python.exe' -m py_compile hermes_cli/compute_routing.py tests/test_compute_routing_safety_regressions.py
+git diff --check
+git diff --exit-code bfc933073b -- tests/test_compute_routing_contract.py tests/tools/test_kanban_compute_routing_contract.py tests/fixtures/compute_routing_contract_v1.json tests/fixtures/quiz_result.md
+```
+
+```text
+PY_COMPILE_AND_DIFF_CHECK=PASS
+SEALED_QUIZ_AND_DIFF_CHECK=PASS
+```
+
+A Ruff invocation was attempted after the required test gates, but the shared verification venv does not contain Ruff (`No module named ruff`). This did not affect the required gates; `py_compile`, line-length inspection, and `git diff --check` passed.

--- a/tests/fixtures/sol_result.md
+++ b/tests/fixtures/sol_result.md
@@ -1,0 +1,113 @@
+# SOL implementation result
+
+## Outcome
+
+PASS. The sealed QUIZ contract at commit `bfc933073b` is implemented without
+changing any sealed test or fixture. The requested external result path is
+outside this worktree write scope, so this report is preserved at the specified
+fallback path.
+
+## Implementation
+
+- Added pure `hermes_cli.compute_routing.route_task` with deterministic
+  precedence for all five compute classes.
+- Preserved role, assignee, write scope, workspace, approval, toolsets, and
+  master prohibition byte-for-byte in the returned task contract.
+- Added explicit route metadata persistence output, capability gating,
+  availability-only fallback with a Core ceiling of one, attended routing,
+  verification requirements, and separate actual-route observations.
+- Added shadow behavior that records the recommendation while returning empty
+  dispatch overrides.
+- Connected `reasoning_effort` through the existing `kanban_create` schema and
+  handler to DB normalization, created event, show output, and worker argv.
+- Added no dependency and performed no delegation, commit, merge, or push.
+
+## Sealed artifact integrity
+
+Working-tree hashes equal the hashes in `bfc933073b`:
+
+```text
+tests/test_compute_routing_contract.py
+0a3d37e764f35357a2dd616ca24a342f10d94d00 == 0a3d37e764f35357a2dd616ca24a342f10d94d00
+tests/tools/test_kanban_compute_routing_contract.py
+e67470e2df2e95f03048f709376a8058c91621f4 == e67470e2df2e95f03048f709376a8058c91621f4
+tests/fixtures/compute_routing_contract_v1.json
+2ca4fdfb7bac121627ad34a358deb6e93e9c7cb0 == 2ca4fdfb7bac121627ad34a358deb6e93e9c7cb0
+tests/fixtures/quiz_result.md
+b0d05b3ec16d0f4c5af9379b89e114c09a22ba18 == b0d05b3ec16d0f4c5af9379b89e114c09a22ba18
+```
+
+## Normal and mutant raw result
+
+Command: `pytest -vv --tb=short tests/test_compute_routing_contract.py`
+
+```text
+collected 20 items
+test_fixture_is_closed_complete_and_structurally_valid PASSED
+N01-specialist-precedence PASSED
+N02-architect-precedence PASSED
+N03-deep-precedence PASSED
+N04-standard-precedence PASSED
+N05-quick-precedence PASSED
+I01-role-boundary-mutation PASSED
+I02-posthoc-class-inference PASSED
+I03-provider-without-model PASSED
+I04-invalid-reasoning-default-fallback PASSED
+I05-catalog-only-capability PASSED
+I06-work-failure-model-fallback PASSED
+I07-third-spawn-chain PASSED
+I08-fallback-widens-safety-boundary PASSED
+I09-verified-without-actual-model PASSED
+I10-quick-skips-verification PASSED
+I11-unattended-architect-spawn PASSED
+I12-quota PASSED
+I12-work PASSED
+test_i12_expected_contracts_are_not_aliases PASSED
+20 passed in 1.07s
+```
+
+The normal routes are 5/5 PASS and the known-bad invariant set is 12/12 DROP.
+I12 has two variants to prove quota and work failures remain distinct.
+
+## Verification
+
+```text
+Locked combined gate:
+23 passed in 3.35s
+
+Existing Kanban model/spawn regression:
+25 passed in 16.10s
+
+Direct shadow and positive actual-observation assertions:
+shadow_and_actual_observation: PASS
+
+Ruff:
+All checks passed!
+
+git diff --check:
+PASS
+```
+
+Regression files:
+
+- `tests/plugins/test_kanban_model_override.py`
+- `tests/hermes_cli/test_kanban_worker_spawn_toolsets.py`
+- `tests/hermes_cli/test_kanban_dispatch_tick_hook.py`
+
+## Production diff/stat
+
+```text
+hermes_cli/compute_routing.py | 345 insertions (new)
+hermes_cli/kanban_db.py       |   1 insertion
+tools/kanban_tools.py         |  14 insertions
+3 production files changed, 360 insertions
+```
+
+Changed files including this required report: 4.
+
+```text
+M  hermes_cli/kanban_db.py
+M  tools/kanban_tools.py
+?? hermes_cli/compute_routing.py
+?? tests/fixtures/sol_result.md
+```

--- a/tests/test_compute_routing_contract.py
+++ b/tests/test_compute_routing_contract.py
@@ -1,0 +1,197 @@
+"""Fixed RED oracle for compute-class model routing.
+
+Every normal and known-bad fixture enters the same pure public route_task
+interface. Missing production API is a failure, never a skip.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "compute_routing_contract_v1.json"
+BOUNDARY_FIELDS = (
+    "role",
+    "assignee",
+    "write_scope",
+    "workspace",
+    "approval",
+    "toolsets",
+    "master_forbidden",
+)
+REQUIRED_ROUTE_METADATA = (
+    "compute_class",
+    "route_decision_id",
+    "policy_version",
+)
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _deep_merge(base: dict, patch: Mapping) -> dict:
+    merged = copy.deepcopy(base)
+    for key, value in patch.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _materialize(case: Mapping, *, variant: Mapping | None = None) -> dict:
+    materialized = _deep_merge(_fixture()["common_input"], case.get("input_patch", {}))
+    if variant is not None:
+        materialized = _deep_merge(materialized, variant.get("input_patch", {}))
+    return materialized
+
+
+def _route_task(case_input: dict):
+    contract = _fixture()["public_interface"]
+    try:
+        module = importlib.import_module(contract["module"])
+    except ModuleNotFoundError:
+        pytest.fail(
+            f"required public routing module {contract['module']!r} is missing",
+            pytrace=False,
+        )
+    route_task = getattr(module, contract["callable"], None)
+    if not callable(route_task):
+        pytest.fail(
+            f"{contract['module']}.{contract['callable']} must be callable",
+            pytrace=False,
+        )
+    return route_task(**{name: case_input[name] for name in contract["arguments"]})
+
+
+def _assert_subset(actual: Mapping, expected: Mapping, path: str = "result") -> None:
+    assert isinstance(actual, Mapping), (
+        f"{path} must be a mapping, got {type(actual).__name__}"
+    )
+    for key, expected_value in expected.items():
+        assert key in actual, f"{path}.{key} is missing"
+        actual_value = actual[key]
+        if isinstance(expected_value, Mapping):
+            _assert_subset(actual_value, expected_value, f"{path}.{key}")
+        else:
+            assert actual_value == expected_value, (
+                f"{path}.{key}: expected {expected_value!r}, got {actual_value!r}"
+            )
+
+
+def _assert_boundary_unchanged(case_input: Mapping, result: Mapping) -> None:
+    contract = result.get("task_contract")
+    assert isinstance(contract, Mapping), (
+        "result.task_contract must expose role-owned fields"
+    )
+    original = case_input["role_decision"]
+    for field in BOUNDARY_FIELDS:
+        assert contract.get(field) == original[field], (
+            f"compute routing changed role boundary {field}"
+        )
+
+
+def test_fixture_is_closed_complete_and_structurally_valid():
+    data = _fixture()
+    assert data["schema_version"] == "compute_routing_contract/v1"
+    assert data["common_input"]["policy"]["precedence"] == [
+        "specialist",
+        "architect",
+        "deep",
+        "standard",
+        "quick",
+    ]
+    assert [
+        case["expected"]["compute_class"] for case in data["normal_cases"]
+    ] == ["specialist", "architect", "deep", "standard", "quick"]
+    assert [case["invariant"] for case in data["mutants"]] == [
+        f"I{i}" for i in range(1, 13)
+    ]
+    assert len({case["id"] for case in data["mutants"]}) == 12
+
+    required = set(data["public_interface"]["arguments"])
+    materialized_cases = [_materialize(case) for case in data["normal_cases"]]
+    materialized_cases.extend(
+        _materialize(case, variant=variant)
+        for case in data["mutants"]
+        for variant in (case.get("variants") or [None])
+    )
+    for case_input in materialized_cases:
+        assert set(case_input) == required
+        assert set(case_input["role_decision"]) >= set(BOUNDARY_FIELDS)
+        assert (
+            case_input["policy"]["schema_version"]
+            == "compute_routing_policy/v1"
+        )
+
+
+@pytest.mark.parametrize(
+    "case",
+    _fixture()["normal_cases"],
+    ids=lambda case: case["id"],
+)
+def test_normal_routes_use_precedence_and_preserve_role_boundary(case):
+    case_input = _materialize(case)
+    result = _route_task(case_input)
+
+    _assert_subset(result, case["expected"])
+    _assert_boundary_unchanged(case_input, result)
+    persisted = result.get("persisted_route")
+    assert isinstance(persisted, Mapping), (
+        "result.persisted_route must be explicit before dispatch"
+    )
+    assert persisted.get("compute_class") == case["expected"]["compute_class"]
+    assert (
+        persisted.get("policy_version")
+        == case_input["policy"]["policy_version"]
+    )
+    assert persisted.get("route_decision_id")
+    for key in REQUIRED_ROUTE_METADATA:
+        assert key in persisted
+
+
+@pytest.mark.parametrize(
+    "case",
+    [case for case in _fixture()["mutants"] if "variants" not in case],
+    ids=lambda case: case["id"],
+)
+def test_known_bad_mutant_is_dropped_through_route_task(case):
+    case_input = _materialize(case)
+    result = _route_task(case_input)
+
+    _assert_subset(result, case["expected"])
+    _assert_boundary_unchanged(case_input, result)
+    assert result.get("outcome") != "verified" or result.get("actual_route"), (
+        "verified requires actual provider/model/reasoning read-back"
+    )
+
+
+@pytest.mark.parametrize(
+    "variant",
+    _fixture()["mutants"][-1]["variants"],
+    ids=lambda variant: f"I12-{variant['name']}",
+)
+def test_quota_and_work_failures_remain_distinct(variant):
+    case = _fixture()["mutants"][-1]
+    case_input = _materialize(case, variant=variant)
+    result = _route_task(case_input)
+
+    _assert_subset(result, variant["expected"])
+    _assert_boundary_unchanged(case_input, result)
+
+
+def test_i12_expected_contracts_are_not_aliases():
+    variants = _fixture()["mutants"][-1]["variants"]
+    quota, work = (variant["expected"] for variant in variants)
+    assert quota["outcome"] == "routing_unavailable"
+    assert work["outcome"] == "work_failed"
+    assert quota["event_kind"] != work["event_kind"]
+    assert quota["spawn"] is True
+    assert work["spawn"] is False

--- a/tests/test_compute_routing_safety_regressions.py
+++ b/tests/test_compute_routing_safety_regressions.py
@@ -1,0 +1,90 @@
+"""Safety regressions for compute-class fallback and route persistence."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.compute_routing import route_task
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "compute_routing_contract_v1.json"
+ROUTE_IDENTITY_FIELDS = (
+    "compute_class",
+    "policy_version",
+    "provider",
+    "model",
+    "reasoning_effort",
+)
+
+
+def _common_input() -> dict:
+    return copy.deepcopy(
+        json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))["common_input"]
+    )
+
+
+def _route(case_input: dict) -> dict:
+    return route_task(
+        task_context=case_input["task_context"],
+        role_decision=case_input["role_decision"],
+        capability_snapshot=case_input["capability_snapshot"],
+        role_constraints=case_input["role_constraints"],
+        policy=case_input["policy"],
+        execution=case_input["execution"],
+        unattended=case_input["unattended"],
+    )
+
+
+def test_availability_error_without_distinct_candidate_exhausts_fallback():
+    case_input = _common_input()
+    case_input["capability_snapshot"]["candidates"] = [
+        {
+            "provider": "openai-codex",
+            "model": "gpt-5.6-sol",
+            "reasoning_efforts": ["medium"],
+        }
+    ]
+    case_input["execution"].update(
+        attempted=True,
+        error="model_unavailable",
+        fallback_index=0,
+    )
+
+    result = _route(case_input)
+
+    assert result["status"] == "blocked"
+    assert result["spawn"] is False
+    assert result["outcome"] == "routing_unavailable"
+    assert result["event_kind"] == "fallback_exhausted"
+    assert result["fallback_index"] == 0
+
+
+@pytest.mark.parametrize(
+    ("field", "mismatch"),
+    [
+        ("compute_class", "deep"),
+        ("policy_version", "stale-policy"),
+        ("provider", "other-provider"),
+        ("model", "other-model"),
+        ("reasoning_effort", "high"),
+    ],
+)
+def test_attempted_execution_rejects_persisted_route_mismatch(field, mismatch):
+    case_input = _common_input()
+    initial = _route(case_input)
+    persisted_route = copy.deepcopy(initial["persisted_route"])
+    assert set(ROUTE_IDENTITY_FIELDS) <= set(persisted_route)
+
+    persisted_route[field] = mismatch
+    case_input["task_context"]["persisted_route"] = persisted_route
+    case_input["execution"]["attempted"] = True
+
+    result = _route(case_input)
+
+    assert result["status"] == "rejected"
+    assert result["spawn"] is False
+    assert result["reason_code"] == "route_persistence_mismatch"

--- a/tests/tools/test_kanban_compute_routing_contract.py
+++ b/tests/tools/test_kanban_compute_routing_contract.py
@@ -1,0 +1,113 @@
+"""Kanban public-surface contracts required by compute-class routing."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def _isolated_home(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "router-orchestrator")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return kb
+
+
+def test_kanban_create_schema_exposes_closed_reasoning_effort_enum():
+    from hermes_constants import VALID_REASONING_EFFORTS
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    prop = KANBAN_CREATE_SCHEMA["parameters"]["properties"]["reasoning_effort"]
+    assert prop["type"] == "string"
+    assert prop["enum"] == ["none", *VALID_REASONING_EFFORTS]
+
+
+def test_kanban_create_reasoning_effort_parity_to_db_event_show_and_spawn(
+    monkeypatch, tmp_path
+):
+    kb = _isolated_home(monkeypatch, tmp_path)
+    from tools import kanban_tools as kt
+
+    workspace = tmp_path / "worker"
+    workspace.mkdir()
+    created = json.loads(
+        kt._handle_create(
+            {
+                "title": "routed worker",
+                "assignee": "bmk",
+                "workspace_kind": "dir",
+                "workspace_path": str(workspace),
+                "model": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "reasoning_effort": "HIGH",
+            }
+        )
+    )
+    assert created.get("ok") is True, created
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, created["task_id"])
+        events = kb.list_events(conn, created["task_id"])
+    assert task.reasoning_effort == "high"
+    created_event = next(event for event in events if event.kind == "created")
+    assert created_event.payload["reasoning_effort"] == "high"
+    assert created_event.payload["model_override"] == "gpt-5.6-sol"
+    assert created_event.payload["provider_override"] == "openai-codex"
+
+    shown = json.loads(kt._handle_show({"task_id": created["task_id"]}))
+    assert shown["task"]["reasoning_effort"] == "high"
+    assert shown["task"]["model_override"] == "gpt-5.6-sol"
+    assert shown["task"]["provider_override"] == "openai-codex"
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    kb._default_spawn(task, str(workspace))
+
+    argv = captured["cmd"]
+    assert argv[argv.index("--reasoning") + 1] == "high"
+    assert argv[argv.index("-m") + 1] == "gpt-5.6-sol"
+    assert argv[argv.index("--provider") + 1] == "openai-codex"
+
+
+def test_kanban_create_rejects_reasoning_typo_without_db_mutation(
+    monkeypatch, tmp_path
+):
+    kb = _isolated_home(monkeypatch, tmp_path)
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+    result = json.loads(
+        kt._handle_create(
+            {
+                "title": "typo must not inherit",
+                "assignee": "bmk",
+                "reasoning_effort": "hihg",
+            }
+        )
+    )
+    assert "error" in result
+    assert "reasoning_effort" in result["error"]
+
+    with kb.connect() as conn:
+        after = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+    assert after == before

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -34,6 +34,7 @@ import os
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
+from hermes_constants import VALID_REASONING_EFFORTS
 from hermes_cli.goals import judge_goal
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get, load_config
@@ -487,6 +488,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
     parents = kb.parent_ids(conn, task.id)
     children = kb.child_ids(conn, task.id)
     return {
+        "reasoning_effort": task.reasoning_effort,
         "id": task.id,
         "title": task.title,
         "assignee": task.assignee,
@@ -537,6 +539,7 @@ def _handle_show(args: dict, **kw) -> str:
 
             def _task_dict(t):
                 return {
+                    "reasoning_effort": t.reasoning_effort,
                     "id": t.id, "title": t.title, "body": t.body,
                     "assignee": t.assignee, "status": t.status,
                     "tenant": t.tenant, "priority": t.priority,
@@ -1411,6 +1414,7 @@ def _handle_create(args: dict, **kw) -> str:
     goal_max_turns = args.get("goal_max_turns")
     model_override = args.get("model")
     provider_override = args.get("provider")
+    reasoning_effort = args.get("reasoning_effort")
     if provider_override and not model_override:
         return tool_error("'provider' requires 'model' to be set as well")
     if isinstance(parents, str):
@@ -1454,6 +1458,7 @@ def _handle_create(args: dict, **kw) -> str:
                 skills=skills,
                 model_override=model_override,
                 provider_override=provider_override,
+                reasoning_effort=reasoning_effort,
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -2301,6 +2306,15 @@ KANBAN_CREATE_SCHEMA = {
                     "provider — a model name alone is resolved against "
                     "the profile's provider and will fail if it belongs "
                     "to a different one. Requires 'model'."
+                ),
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": ["none", *VALID_REASONING_EFFORTS],
+                "description": (
+                    "Pin the dispatched worker reasoning depth for this task. "
+                    "Values are case-insensitive in the handler; omit to "
+                    "inherit the assignee profile."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
## Summary

- add a pure `compute_class` router downstream of the existing role/assignee/worktree boundary
- expose per-task `reasoning_effort` through `kanban_create`, created events, show/list output, and worker spawn
- separate planned route, persisted route identity, actual route observation, verification, and fallback states
- bound availability fallback to one attempt and require a distinct observed candidate
- reject role/scope/approval mutations, persisted route drift, actual route mismatch, unverified capabilities, and unattended deep/specialist work

## Why

This keeps role ownership and permissions independent from model cost/reasoning selection. The implementation was selected from isolated SOL/TERRA/LUNA ORCA worktrees using a locked RED oracle, then hardened with independent targeted mutants.

## Verification

Fresh checkout on top of current `origin/main`:

```text
61 passed in 25.19s
```

Suites:

- `tests/test_compute_routing_contract.py`
- `tests/tools/test_kanban_compute_routing_contract.py`
- `tests/test_compute_routing_safety_regressions.py`
- `tests/tools/test_kanban_tools.py`

Additional independent targeted audit:

```text
8/8 PASS
```

Covers:

- role/provider/model allowlist preservation
- no phantom fallback without a distinct candidate
- auth and unknown error blocking
- actual route mismatch
- unattended specialist blocking
- persisted route mismatch
- failed verification blocking

Fresh checkout files matched commit blobs for all production changes and the new safety regression.

## Boundaries

- no production auto-routing or policy deployment is enabled by this PR
- no new dependencies
- no master merge performed by the automation/orchestrator
- rollout remains shadow/opt-in work for a follow-up
