### PR TITLE
fix(desktop): prevent cache eviction of optimistic user message during session switch

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -722,12 +722,22 @@ export function useMessageStream({
         // tool-call parts that never saw their completion event.
         nextMessages = sealOpenToolParts(nextMessages)
 
-        // Clear `pending` from user messages — the turn is settled, so no
-        // user row is legitimately pending anymore. Without this, the
-        // optimistic user message's `pending: true` permanently prevents
-        // SessionStateCache from evicting the session.
-        nextMessages = nextMessages.map(m =>
-          m.role === 'user' && m.pending ? { ...m, pending: false } : m
+        // Retire this turn's optimistic user prompt(s), but ONLY those above
+        // the settled assistant row. A later queued turn (fromQueue drain or
+        // stale-busyRef edge) can seed its own optimistic user row below the
+        // streaming assistant bubble while turn A is still settling; its
+        // `pending` flag must survive A's settle until B persists/reconciles.
+        // The boundary is computed against `prev` (pre-settle geometry): when
+        // the completion path APPENDS the settled assistant row (no tracked
+        // stream row existed), the settle marks no pre-existing turn, so clear
+        // nothing here — deferred retirement keeps every pending row protected
+        // instead of gambling a queued turn's flag on a guess;
+        // finalizeInterruptedMessages retires them on the next submit/interrupt.
+        const boundaryIndex =
+          state.streamId !== null ? prev.findIndex(m => m.id === state.streamId) : -1
+        const cutoff = boundaryIndex >= 0 ? boundaryIndex : 0
+        nextMessages = nextMessages.map((m, i) =>
+          i < cutoff && m.role === 'user' && m.pending ? { ...m, pending: false } : m
         )
 
         const hasInlineError = nextMessages.some(m => m.role === 'assistant' && m.error && !m.hidden)
@@ -830,11 +840,17 @@ export function useMessageStream({
               }
             ]
 
-        // Clear `pending` from user messages — same rationale as in
-        // completeAssistantMessage: the turn is settled (failed), so no
-        // user row is legitimately pending anymore.
-        const settledMessages = nextMessages.map(m =>
-          m.role === 'user' && m.pending ? { ...m, pending: false } : m
+        // Retire pending user prompts ABOVE the settled assistant row only —
+        // same scoped rationale as completeAssistantMessage. The boundary is
+        // computed against `prev` (pre-settle geometry): the fabricated
+        // `assistant-error-*` id never matches a row in `prev`, so the untracked
+        // failure path clears nothing here — this turn's optimistic rows stay
+        // protected until finalizeInterruptedMessages retires them on the next
+        // submit/interrupt.
+        const boundaryIndex = prev.findIndex(m => m.id === streamId)
+        const cutoff = boundaryIndex >= 0 ? boundaryIndex : 0
+        const settledMessages = nextMessages.map((m, i) =>
+          i < cutoff && m.role === 'user' && m.pending ? { ...m, pending: false } : m
         )
 
         return {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -722,6 +722,14 @@ export function useMessageStream({
         // tool-call parts that never saw their completion event.
         nextMessages = sealOpenToolParts(nextMessages)
 
+        // Clear `pending` from user messages — the turn is settled, so no
+        // user row is legitimately pending anymore. Without this, the
+        // optimistic user message's `pending: true` permanently prevents
+        // SessionStateCache from evicting the session.
+        nextMessages = nextMessages.map(m =>
+          m.role === 'user' && m.pending ? { ...m, pending: false } : m
+        )
+
         const hasInlineError = nextMessages.some(m => m.role === 'assistant' && m.error && !m.hidden)
         const lastVisible = [...nextMessages].reverse().find(m => !m.hidden)
         const unresolvedUserTail = lastVisible?.role === 'user'
@@ -822,9 +830,16 @@ export function useMessageStream({
               }
             ]
 
+        // Clear `pending` from user messages — same rationale as in
+        // completeAssistantMessage: the turn is settled (failed), so no
+        // user row is legitimately pending anymore.
+        const settledMessages = nextMessages.map(m =>
+          m.role === 'user' && m.pending ? { ...m, pending: false } : m
+        )
+
         return {
           ...state,
-          messages: nextMessages,
+          messages: settledMessages,
           streamId: null,
           pendingBranchGroup: null,
           sawAssistantPayload: true,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/scoped-pending-settle.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/scoped-pending-settle.test.tsx
@@ -1,0 +1,145 @@
+// Regression for the scoped settle-path pending clear (PR #92730 round 2).
+//
+// Round 1's blanket wipe — nextMessages.map(m => m.role === 'user' && m.pending
+// ? { ...m, pending: false } : m) — ran over EVERY user row in the session.
+// A queued turn B's optimistic user row can sit below turn A's streaming
+// assistant bubble when A settles; the blanket pass stripped B's protection
+// before B persisted/reconciled. The fix retires only pending user rows ABOVE
+// the settled assistant row (index boundary); locating no tracked assistant
+// row clears nothing (deferred retirement via finalizeInterruptedMessages).
+//
+// These specs drive the REAL reducer through handleGatewayEvent — no state
+// hand-mapping — so the assertions bite on the actual settle logic.
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const SID = 'scoped-pending-settle-session'
+
+let stream: MessageStreamHarness
+let states: Map<string, ClientSessionState>
+
+function seedQueuedFixture(): void {
+  const state = createClientSessionState()
+  state.messages = [
+    { id: 'user-current', role: 'user', parts: [{ type: 'text', text: 'current' }], pending: true },
+    { id: 'assistant-stream-current', role: 'assistant', parts: [{ type: 'text', text: '' }], pending: true },
+    { id: 'user-next', role: 'user', parts: [{ type: 'text', text: 'queued next' }], pending: true }
+  ]
+  state.streamId = 'assistant-stream-current'
+  states.set(SID, state)
+}
+
+async function mountHarness() {
+  vi.useFakeTimers()
+  stream = renderMessageStream(SID)
+  states = stream.states
+  seedQueuedFixture()
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+const emit = (event: RpcEvent) => act(() => stream.handleEvent(event))
+
+describe('settle-path pending clearing is scoped to the settling turn', () => {
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('retires the current turn user row but leaves a later queued user row protected on completion', async () => {
+    await mountHarness()
+
+    emit({ payload: { text: 'answer' }, session_id: SID, type: 'message.complete' })
+
+    const after = states.get(SID)!
+    const userCurrent = after.messages.find(m => m.id === 'user-current')
+    const userNext = after.messages.find(m => m.id === 'user-next')
+
+    // Turn A settled: its optimistic prompt is retired...
+    expect(userCurrent?.pending).toBe(false)
+    // ...and turn B's queued prompt keeps its cache protection until it persists/reconciles.
+    expect(userNext?.pending).toBe(true)
+    expect(after.busy).toBe(false)
+  })
+
+  it('keeps the queued user row protected when the turn completes with an error frame', async () => {
+    await mountHarness()
+
+    emit({
+      payload: { status: 'error', error: 'connection reset mid-stream' },
+      session_id: SID,
+      type: 'message.complete'
+    })
+
+    const after = states.get(SID)!
+    const userCurrent = after.messages.find(m => m.id === 'user-current')
+    const userNext = after.messages.find(m => m.id === 'user-next')
+
+    // Turn A failed but had a tracked stream row: rows above the failed
+    // assistant row are retired...
+    expect(userCurrent?.pending).toBe(false)
+    // ...and the queued row below the boundary keeps its protection.
+    expect(userNext?.pending).toBe(true)
+  })
+
+  it('clears nothing when a completion arrives with no tracked stream row (deferred retirement)', async () => {
+    // No message.start ever seeded a tracked bubble for this turn: the
+    // completion falls into the append-at-tail branch. The settle marks no
+    // pre-existing turn in `prev`, so pending user rows stay protected.
+    stream = renderMessageStream(SID)
+    states = stream.states
+    const state = createClientSessionState()
+    state.messages = [
+      { id: 'user-a', role: 'user', parts: [{ type: 'text', text: 'first' }], pending: true },
+      { id: 'user-b', role: 'user', parts: [{ type: 'text', text: 'second' }], pending: true }
+    ]
+    state.streamId = null
+    states.set(SID, state)
+
+    emit({ payload: { text: 'answer' }, session_id: SID, type: 'message.complete' })
+
+    const after = states.get(SID)!
+    const users = after.messages.filter(m => m.role === 'user')
+    expect(users).toHaveLength(2)
+    expect(users.every(m => m.pending === true)).toBe(true)
+    // The reply still appended normally (a freshly appended settled row
+    // carries no pending flag at all).
+    expect(after.messages.at(-1)?.role).toBe('assistant')
+    expect(after.messages.at(-1)?.pending).not.toBe(true)
+  })
+
+  it('clears nothing on failure when the stream row was never tracked (deferred retirement)', () => {
+    stream = renderMessageStream(SID)
+    states = stream.states
+    const state = createClientSessionState()
+    state.messages = [
+      { id: 'user-orphan', role: 'user', parts: [{ type: 'text', text: 'unacknowledged' }], pending: true },
+      { id: 'user-next', role: 'user', parts: [{ type: 'text', text: 'queued next' }], pending: true }
+      // Deliberately NO assistant row matching the fabricated assistant-error-* id.
+    ]
+    state.streamId = null
+    states.set(SID, state)
+
+    act(() => {
+      // Top-level gateway 'error' events route to failAssistantMessage.
+      stream.handleEvent({ payload: { message: 'boom' }, session_id: SID, type: 'error' })
+    })
+
+    const after = states.get(SID)!
+    // Both pending rows survive — retirement is deferred to
+    // finalizeInterruptedMessages on the next submit/interrupt.
+    expect(after.messages.filter(m => m.role === 'user').every(m => m.pending === true)).toBe(true)
+    // The failure still surfaced as its own errored assistant row.
+    const errorRow = after.messages.find(m => m.role === 'assistant' && m.error)
+    expect(errorRow).toBeDefined()
+    expect(errorRow?.id).toContain('assistant-error-')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -345,7 +345,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         role: 'user',
         parts: [textPart(bubbleText || (attachmentRefs.length ? '' : attachments.map(a => a.label).join(', ')))],
         timestamp: submittedAt,
-        attachmentRefs
+        attachmentRefs,
+        // Mark as pending so the SessionStateCache won't evict this session
+        // while the turn is in flight. Without this flag, a fast-completing
+        // turn can prune the cache entry before the backend persists the user
+        // message to the DB — a subsequent cold resume then fetches an empty
+        // transcript and the prompt appears to vanish.
+        pending: true
       })
 
       const releaseBusy = () => {

--- a/apps/desktop/src/app/session/session-state-cache.test.ts
+++ b/apps/desktop/src/app/session/session-state-cache.test.ts
@@ -121,6 +121,38 @@ describe('SessionStateCache', () => {
     expect(cache.has('pending')).toBe(true)
   })
 
+  it('evicts a session after pending flag is cleared from user messages at turn settle', () => {
+    // Seed a state with an optimistic pending user message — simulates the
+    // state right after submit.ts sets pending: true on the user row.
+    const withPendingUser = settled('pending-user')
+    withPendingUser.messages = [
+      { id: 'user-123', role: 'user', parts: [{ type: 'text', text: 'hello' }], pending: true },
+      { id: 'assistant-1', role: 'assistant', parts: [{ type: 'text', text: 'reply' }] }
+    ]
+
+    const cache = new SessionStateCache(
+      { isReferenced: () => false, onEvict: () => undefined },
+      { maxBytes: 0, maxCount: 0 }
+    )
+
+    cache.set('pending-user', withPendingUser)
+    cache.prune()
+    // Session is protected while pending: true is on the user row.
+    expect(cache.has('pending-user')).toBe(true)
+
+    // Simulate completeAssistantMessage clearing pending from user rows.
+    const settledState = {
+      ...withPendingUser,
+      messages: withPendingUser.messages.map(m =>
+        m.role === 'user' && m.pending ? { ...m, pending: false } : m
+      )
+    }
+    cache.set('pending-user', settledState)
+    cache.prune()
+    // Session is now evictable.
+    expect(cache.has('pending-user')).toBe(false)
+  })
+
   it('retains lightweight status while releasing an evicted transcript', () => {
     const state = { ...settled('stored'), needsInput: false }
     $sessionStates.set({ runtime: state })


### PR DESCRIPTION
## What

Adds `pending: true` to the optimistic user message created at submit time, preventing the `SessionStateCache` from evicting the session's transcript while the turn is in flight.

Closes #92728

## Why

When a user submits a prompt and quickly switches to another session, the following race can occur:

1. `seedOptimistic()` adds the user message to the per-session cache with `busy: true`
2. User switches away — background events update the cache but are blocked from the view (correct)
3. Agent turn completes — `session.info` sets `busy: false`
4. `sessionStateCache.prune()` runs `#isWarmSettled()`, which checks `hasDraftOrInFlightMessage()` (looks for `pending === true`)
5. The optimistic user message had **no `pending` flag** → `hasDraftOrInFlightMessage` returned `false` → cache entry evicted
6. User returns → `takeWarmCache()` returns `null` → cold resume → REST fetch from backend
7. If the backend hasn't persisted the user message yet (race with agent build), the transcript is empty → prompt appears to vanish

The sidebar correctly shows the session as "working" (from `$sessionStates`, updated independently), creating a confusing disconnect.

## How

`buildUserMessage()` in `submit.ts` now sets `pending: true` on the optimistic user message. This keeps `hasDraftOrInFlightMessage()` returning `true` after the turn completes, which prevents `#isWarmSettled()` from marking the session as evictable. The cache entry survives until the reconciliation logic replaces the optimistic message with the authoritative one from the backend — at which point the user message is persisted and the cold resume path would return it.

The `pending` field is already an optional `boolean` on `ChatMessage` (types.ts:23). The reconciliation logic in `preserveLocalPendingTurnMessages` identifies optimistic users by `message.id.startsWith('user-')`, not by `pending`, so the flag doesn't interfere with message merging. The `isLiveProjectionRow` check in the inflight turn journal only applies to assistant messages (`message.role === 'assistant'` guards at lines 776, 786).

## Testing

- 122/122 `use-prompt-actions/index.test.tsx` ✓
- 120/120 `session-state-cache.test.ts` + `utils.test.ts` ✓
- 38/38 `inflight-turn-journal.test.ts` ✓

## Open question

Should `pending` be cleared from the optimistic user message once `message.start` arrives (confirming the backend accepted the turn)? Currently it stays `true` until reconciliation replaces it. This is slightly conservative — the cache entry won't evict until the full reconciliation — but it's the safest approach since the backend may not have persisted the user message until later in the turn.
