### PR TITLE
fix(desktop): hydrate transcript after reconnect attach

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2514,6 +2514,93 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect($clarifyRequests.get()['rt-A']).toMatchObject({ requestId: 'req-newer' })
   })
 
+  it('reads the terminal transcript after warm reconnect transport reattachment', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [
+      {
+        id: 'cached-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'long running prompt' }]
+      },
+      {
+        id: 'cached-assistant',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'partial before disconnect' }],
+        pending: true
+      }
+    ]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    let transportAttached = false
+    let attachedWhenTranscriptRead: boolean | null = null
+
+    vi.mocked(getLatestSessionMessages).mockReset()
+    vi.mocked(getLatestSessionMessages).mockImplementation(async () => {
+      attachedWhenTranscriptRead = transportAttached
+
+      return {
+        messages: [
+          { content: 'long running prompt', role: 'user', timestamp: 1 },
+          {
+            content: transportAttached ? 'complete answer persisted during disconnect' : 'partial before disconnect',
+            role: 'assistant',
+            timestamp: 2
+          }
+        ],
+        session_id: 'stored-A'
+      } as never
+    })
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        // The backend rebinds the session transport before returning this
+        // terminal snapshot. A transcript read issued earlier can miss the
+        // final persisted row and no live event will arrive to repair it.
+        transportAttached = true
+
+        return {
+          session_id: 'rt-A',
+          session_key: 'stored-A',
+          resumed: 'stored-A',
+          message_count: 2,
+          messages: [],
+          messages_omitted: true,
+          running: false,
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resumedState: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_sessionId, next) => (resumedState = next)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-A', true)
+
+    expect(attachedWhenTranscriptRead).toBe(true)
+    expect(getLatestSessionMessages).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(resumedState?.messages)).toContain('complete answer persisted during disconnect')
+    expect(JSON.stringify(resumedState?.messages)).not.toContain('partial before disconnect')
+  })
+
   it('preserves cached image attachments through an idle persisted transcript refresh', async () => {
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
       current: new Map([['stored-A', 'rt-A']])

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2004,21 +2004,43 @@ describe('resumeSession warm-cache mapping integrity', () => {
     }
 
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
-      current: new Map([['stored-warm', 'runtime-warm']])
+      current: new Map([
+        ['stored-warm', 'runtime-warm'],
+        ['stored-legacy', 'runtime-legacy']
+      ])
     }
 
     const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
-      current: new Map([['runtime-warm', clientState('stored-warm')]])
+      current: new Map([
+        ['runtime-warm', clientState('stored-warm')],
+        ['runtime-legacy', clientState('stored-legacy')]
+      ])
     }
 
     // Same-name rows without a source tag are not authoritative for an
     // explicit owner. Metadata must be re-read from the captured connection.
-    setSessions([storedSession({ id: 'stored-warm', profile: 'default' })])
+    setSessions([
+      storedSession({ id: 'stored-warm', profile: 'default' }),
+      storedSession({ id: 'stored-legacy', profile: 'default' })
+    ])
     vi.mocked(getSession).mockImplementation(async id => storedSession({ id, profile: 'default' }))
     vi.mocked(getLatestSessionMessages).mockImplementation(async id => ({ messages: [], session_id: id }) as never)
     vi.mocked(requestGatewayForAgent).mockImplementation(async (_connectionId, _profile, method, params) => {
       if (method === 'session.activate') {
-        throw new Error('Method not found')
+        if (params?.session_id === 'runtime-legacy') {
+          throw new Error('Method not found')
+        }
+
+        return {
+          info: {},
+          message_count: 0,
+          messages: [],
+          messages_omitted: true,
+          resumed: 'stored-warm',
+          running: false,
+          session_id: 'runtime-warm',
+          session_key: 'stored-warm'
+        } as never
       }
 
       if (method === 'session.usage') {
@@ -2054,6 +2076,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
     await waitFor(() => expect(resume).not.toBeNull())
 
     await resume!('stored-warm', true, ownerRoute)
+    await resume!('stored-legacy', true, ownerRoute)
     await resume!('stored-cold', true, ownerRoute)
     await resume!('stored-cold', true, {
       connectionId: 'source-b',
@@ -2082,7 +2105,7 @@ describe('resumeSession warm-cache mapping integrity', () => {
       expect.objectContaining({ session_id: 'runtime-warm' })
     )
     expect(requestGatewayForAgent).toHaveBeenCalledWith('source-a', 'default', 'session.usage', {
-      session_id: 'runtime-warm'
+      session_id: 'runtime-legacy'
     })
     expect(requestGatewayForAgent).toHaveBeenCalledWith(
       'source-a',
@@ -2599,6 +2622,130 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect(getLatestSessionMessages).toHaveBeenCalledTimes(1)
     expect(JSON.stringify(resumedState?.messages)).toContain('complete answer persisted during disconnect')
     expect(JSON.stringify(resumedState?.messages)).not.toContain('partial before disconnect')
+  })
+
+  it('keeps a terminal live state when a running reconnect finishes during transcript hydration', async () => {
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.busy = true
+    state.awaitingResponse = true
+    state.turnLive = true
+    state.turnStartedAt = 1_700_000_123_000
+    state.messages = [
+      {
+        id: 'cached-user',
+        role: 'user',
+        parts: [{ type: 'text', text: 'long running prompt' }]
+      },
+      {
+        id: 'assistant-stream-rt-A',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'partial before terminal event' }],
+        pending: true
+      }
+    ]
+    state.streamId = 'assistant-stream-rt-A'
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const persisted = deferred<Awaited<ReturnType<typeof getLatestSessionMessages>>>()
+
+    vi.mocked(getLatestSessionMessages).mockReturnValue(persisted.promise)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          session_id: 'rt-A',
+          session_key: 'stored-A',
+          resumed: 'stored-A',
+          message_count: 2,
+          messages: [],
+          messages_omitted: true,
+          running: true,
+          turn_started_at: 1_700_000_123,
+          inflight: {
+            user: 'long running prompt',
+            assistant: 'partial before terminal event',
+            streaming: true
+          },
+          info: {}
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let resumedState: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onStateUpdate={(_sessionId, next) => (resumedState = next)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    const resumePromise = resume!('stored-A', true)
+
+    await waitFor(() => expect(getLatestSessionMessages).toHaveBeenCalledTimes(1))
+    expect(sessionStateByRuntimeIdRef.current.get('rt-A')).toMatchObject({
+      awaitingResponse: true,
+      busy: true,
+      turnLive: true
+    })
+
+    // The rebound transport delivers the terminal state while REST is still
+    // pending. Settle the same stream row the real terminal event owns; the
+    // later durable hydration may reconcile messages but cannot revive it.
+    const liveTerminalState = sessionStateByRuntimeIdRef.current.get('rt-A')!
+    sessionStateByRuntimeIdRef.current.set('rt-A', {
+      ...liveTerminalState,
+      adoptedRunningTurn: false,
+      awaitingResponse: false,
+      busy: false,
+      messages: liveTerminalState.messages.map(message =>
+        message.id === 'assistant-stream-rt-A'
+          ? {
+              ...message,
+              parts: [{ type: 'text' as const, text: 'complete durable answer' }],
+              pending: false
+            }
+          : message
+      ),
+      streamId: null,
+      turnLive: false,
+      turnStartedAt: null
+    })
+
+    await act(async () => {
+      persisted.resolve({
+        messages: [
+          { content: 'long running prompt', role: 'user', timestamp: 1 },
+          { content: 'complete durable answer', role: 'assistant', timestamp: 2 }
+        ],
+        session_id: 'stored-A'
+      } as never)
+      await resumePromise
+    })
+
+    expect(JSON.stringify(resumedState?.messages)).toContain('complete durable answer')
+    expect(JSON.stringify(resumedState?.messages)).not.toContain('partial before terminal event')
+    expect(resumedState).toMatchObject({
+      adoptedRunningTurn: false,
+      awaitingResponse: false,
+      busy: false,
+      turnLive: false,
+      turnStartedAt: null
+    })
   })
 
   it('preserves cached image attachments through an idle persisted transcript refresh', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -955,16 +955,6 @@ export function useSessionActions({
               sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
               dropSessionState(cachedRuntimeId)
             } else {
-              // session.activate is the ordering barrier for reconnect recovery:
-              // it atomically rebinds a running turn before returning. If the
-              // turn is already terminal, this post-barrier REST read sees its
-              // durable final row; if it is still running, later deltas/finish
-              // events arrive on the newly attached transport and the
-              // concurrent-overlay step below preserves them.
-              const persistedTranscriptPromise = shouldRefreshPersistedTranscript
-                ? getLatestSessionMessages(storedSessionId, sessionRestScope).catch(() => null)
-                : null
-
               const pendingApproval = restorePendingApproval(activated, cachedRuntimeId)
 
               const pendingClarifyState = restorePendingClarifyFromSnapshot(
@@ -1021,6 +1011,49 @@ export function useSessionActions({
                 typeof activated.turn_started_at === 'number' && activated.turn_started_at > 0
                   ? activated.turn_started_at * 1000
                   : null
+
+              // Settle the activation snapshot before transcript hydration.
+              // Once the attached transport reports a later terminal event,
+              // that live state is authoritative and must not be overwritten
+              // by the older `running` value after the REST request resolves.
+              const activatedLivenessState = updateSessionState(
+                cachedRuntimeId,
+                state => ({
+                  ...state,
+                  ...(runtimeInfo ?? {}),
+                  busy: running,
+                  awaitingResponse: running && !pendingClarify,
+                  // Resumed onto an already-running turn — that IS backend
+                  // proof the turn is live (no message.start will replay).
+                  turnLive: state.turnLive || running,
+                  needsInput:
+                    pendingApproval ||
+                    Boolean(pendingClarify) ||
+                    (clarifyAuthoritativelyAbsent ? false : state.needsInput),
+                  // Adopting someone else's turn: we'll stream its reply
+                  // without ever having received its prompt, so the settle
+                  // path must not take the "I saw it all" shortcut.
+                  adoptedRunningTurn: state.adoptedRunningTurn || running,
+                  turnStartedAt: running ? (activatedTurnStartedAt ?? state.turnStartedAt ?? Date.now()) : null
+                }),
+                storedSessionId
+              )
+
+              busyRef.current = running
+              setBusy(running)
+              setAwaitingResponse(running && !pendingClarify)
+              syncSessionStateToView(cachedRuntimeId, activatedLivenessState)
+
+              // session.activate is the ordering barrier for reconnect recovery:
+              // it atomically rebinds a running turn before returning. If the
+              // turn is already terminal, this post-barrier REST read sees its
+              // durable final row; if it is still running, later deltas/finish
+              // events arrive on the newly attached transport. Hydration below
+              // reconciles only messages, so those events also retain liveness
+              // authority while the request is pending.
+              const persistedTranscriptPromise = shouldRefreshPersistedTranscript
+                ? getLatestSessionMessages(storedSessionId, sessionRestScope).catch(() => null)
+                : null
 
               // The persisted REST transcript is the display authority: a live
               // runtime may carry only the agent's compressed context projection,
@@ -1106,22 +1139,7 @@ export function useSessionActions({
                 cachedRuntimeId,
                 state => ({
                   ...state,
-                  ...(runtimeInfo ?? {}),
                   messages: visibleActivatedMessages,
-                  busy: running,
-                  awaitingResponse: running,
-                  // Resumed onto an already-running turn — that IS backend
-                  // proof the turn is live (no message.start will replay).
-                  turnLive: state.turnLive || running,
-                  needsInput:
-                    pendingApproval ||
-                    Boolean(pendingClarify) ||
-                    (clarifyAuthoritativelyAbsent ? false : state.needsInput),
-                  // Adopting someone else's turn: we'll stream its reply
-                  // without ever having received its prompt, so the settle
-                  // path must not take the "I saw it all" shortcut.
-                  adoptedRunningTurn: state.adoptedRunningTurn || running,
-                  turnStartedAt: running ? (activatedTurnStartedAt ?? state.turnStartedAt ?? Date.now()) : null,
                   ...(pendingClarifyProjection
                     ? {
                         awaitingResponse: false,
@@ -1131,16 +1149,13 @@ export function useSessionActions({
                     : {}),
                   ...(clearedClarifyProjection
                     ? {
-                        streamId: running ? (clearedClarifyProjection.streamId ?? state.streamId) : null
+                        streamId: state.busy ? (clearedClarifyProjection.streamId ?? state.streamId) : null
                       }
                     : {})
                 }),
                 storedSessionId
               )
 
-              busyRef.current = running
-              setBusy(running)
-              setAwaitingResponse(running && !pendingClarify)
               syncSessionStateToView(cachedRuntimeId, activatedState)
               // Cache backend transcript truth only. The pending/running bit and
               // any synthetic clarify row are a live resume projection and must

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -887,16 +887,14 @@ export function useSessionActions({
           sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
           dropSessionState(cachedRuntimeId)
         } else {
-          // Paint the warm cache immediately, but also refresh the persisted
-          // transcript in parallel. A resumed runtime carries the agent's
-          // compression projection, which can have the same row count as the
-          // stored conversation while containing different rows. Trusting that
-          // projection alone made completed prompts disappear after an app
-          // restart whenever this warm path short-circuited the cold REST
-          // prefetch. Watch mirrors stay live-only by design.
-          const persistedTranscriptPromise = isWatchWindow()
-            ? null
-            : getLatestSessionMessages(storedSessionId, sessionRestScope).catch(() => null)
+          // Paint the warm cache immediately. The persisted transcript still
+          // needs a refresh because a resumed runtime may carry only the
+          // agent's compressed projection, but that read must start after
+          // session.activate reattaches the live transport. Otherwise a turn
+          // can finish between the early REST snapshot and the reattach: its
+          // terminal events go to the detached socket while the stale snapshot
+          // leaves Desktop showing only the pre-disconnect partial answer.
+          const shouldRefreshPersistedTranscript = !isWatchWindow()
 
           setFreshDraftReady(false)
           clearNotifications()
@@ -957,6 +955,16 @@ export function useSessionActions({
               sessionStateByRuntimeIdRef.current.delete(cachedRuntimeId)
               dropSessionState(cachedRuntimeId)
             } else {
+              // session.activate is the ordering barrier for reconnect recovery:
+              // it atomically rebinds a running turn before returning. If the
+              // turn is already terminal, this post-barrier REST read sees its
+              // durable final row; if it is still running, later deltas/finish
+              // events arrive on the newly attached transport and the
+              // concurrent-overlay step below preserves them.
+              const persistedTranscriptPromise = shouldRefreshPersistedTranscript
+                ? getLatestSessionMessages(storedSessionId, sessionRestScope).catch(() => null)
+                : null
+
               const pendingApproval = restorePendingApproval(activated, cachedRuntimeId)
 
               const pendingClarifyState = restorePendingClarifyFromSnapshot(


### PR DESCRIPTION
## What does this PR do?

Makes Desktop reconnect recovery converge on both the durable transcript and the newest live turn state.

Desktop already detects a closed-to-open transition, resumes the selected route, and calls `session.activate` for an already-active warm runtime. Two ordering races remained inside that recovery:

1. Desktop started `getLatestSessionMessages()` while the session was still detached. If the turn finished before `session.activate` rebound the transport, the REST snapshot and the detached socket could both miss the durable final answer.
2. After moving REST behind activation, a `running: true` activation snapshot could still be committed after the request completed. If a terminal event arrived while REST was pending, that stale snapshot resurrected `busy`, `awaitingResponse`, `turnLive`, and the turn clock after the live cache had already settled.

The fix keeps warm-cache paint immediate, then uses `session.activate` as the transport barrier. It settles activation liveness before starting the owner-scoped REST read. The later hydration commit reconciles messages and clarify projections only, so deltas and terminal state received on the rebound transport remain authoritative.

## Related Issue

Addresses #92710. This PR fixes the current Desktop recovery failure without automatically closing the issue's broader protocol-level replay proposal.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts`
  - Move warm-cache transcript hydration behind the `session.activate` reattachment barrier.
  - Settle activation liveness before awaiting REST, then make hydration message-only.
  - Preserve current main's owner-scoped `sessionRestScope`, clarify recovery, watch-window behavior, and concurrent message overlay.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`
  - Assert the terminal transcript is read only after transport reattachment.
  - Add a deterministic `running: true` regression where terminal state lands while REST is deferred.
  - Assert the durable complete answer is retained with `busy: false` and `awaitingResponse: false`.

## How to Test

1. Start a long Desktop turn and disconnect the renderer WebSocket.
2. Reconnect while the backend turn is either finishing or still running.
3. Confirm the transcript converges to the complete persisted answer and a consumed terminal event cannot be overwritten back to busy.

Automated verification on the rebased head:

```text
npm test -- src/app/session/hooks/use-session-actions.test.tsx
69 passed

npm test -- src/app/session/hooks/use-route-resume.test.tsx src/app/session/hooks/use-session-actions/utils.test.ts
126 passed

scripts/run_tests.sh tests/test_tui_gateway_server.py -k session_activate
5 passed

npm run typecheck
passed

npm run lint
0 errors (repository-existing warnings only; changed files lint clean)
```

## Checklist

### Code

- [x] I've read the Contribution Guide and repository `AGENTS.md`.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open PRs before publishing; no competing #92710 repair was open.
- [x] The PR contains only reconnect recovery changes and behavior-level regressions.
- [ ] Full repository test suite (focused affected suites are green above).
- [x] Tested on macOS.

### Documentation & Housekeeping

- [x] Documentation: N/A; this restores the existing reconnect contract.
- [x] Config example: N/A; no config keys changed.
- [x] Architecture docs: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: pure renderer state/request ordering with no OS-specific APIs.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Not applicable. The regression tests model both socket timing windows deterministically.
