### PR TITLE
feat(kanban): promote Sol compute-class routing

### DIFF
--- a/hermes_cli/compute_routing.py
+++ b/hermes_cli/compute_routing.py
@@ -1,0 +1,345 @@
+"""Pure compute-class routing, downstream of the existing role router."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+from hermes_constants import VALID_REASONING_EFFORTS
+
+COMPUTE_CLASSES = ("quick", "standard", "deep", "architect", "specialist")
+REASONING_EFFORTS = ("none", *VALID_REASONING_EFFORTS)
+ROLE_BOUNDARY_FIELDS = (
+    "role",
+    "assignee",
+    "write_scope",
+    "workspace",
+    "approval",
+    "toolsets",
+    "master_forbidden",
+)
+WORK_FAILURES = {"test_failed", "contract_failed", "invalid_output"}
+
+
+def _decision_id(
+    task_context, role_decision, capability_snapshot, policy, compute_class
+):
+    identity = {
+        "task_id": task_context.get("task_id"),
+        "role_ref": role_decision.get("role_ref"),
+        "snapshot_id": capability_snapshot.get("snapshot_id"),
+        "policy_version": policy.get("policy_version"),
+        "compute_class": compute_class,
+    }
+    digest = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()[:20]
+    return f"route-{digest}"
+
+
+def _task_contract(role_decision: Mapping[str, Any]) -> dict[str, Any]:
+    return {field: deepcopy(role_decision.get(field)) for field in ROLE_BOUNDARY_FIELDS}
+
+
+def _boundary_changed(proposed: object, baseline: Mapping[str, Any]) -> bool:
+    if not isinstance(proposed, Mapping):
+        return False
+    return any(
+        field in proposed and proposed[field] != baseline.get(field)
+        for field in ROLE_BOUNDARY_FIELDS
+    )
+
+
+def _classify(task_context: Mapping[str, Any], policy: Mapping[str, Any]) -> str | None:
+    signals = {str(item).strip().lower() for item in task_context.get("signals", ())}
+    precedence = policy.get("precedence") or (
+        "specialist",
+        "architect",
+        "deep",
+        "standard",
+        "quick",
+    )
+    return next(
+        (
+            str(item).lower()
+            for item in precedence
+            if str(item).lower() in signals and str(item).lower() in COMPUTE_CLASSES
+        ),
+        None,
+    )
+
+
+def _actual_route(execution: Mapping[str, Any]) -> dict[str, Any] | None:
+    actual = execution.get("actual")
+    keys = ("provider", "model", "reasoning_effort")
+    if not isinstance(actual, Mapping) or not all(actual.get(key) for key in keys):
+        return None
+    return {key: actual[key] for key in keys}
+
+
+def route_task(
+    task_context: Mapping[str, Any],
+    role_decision: Mapping[str, Any],
+    capability_snapshot: Mapping[str, Any],
+    role_constraints: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    execution: Mapping[str, Any],
+    unattended: bool,
+) -> dict[str, Any]:
+    """Resolve a route without mutating inputs or dispatching work."""
+    task_contract = _task_contract(role_decision)
+
+    def result(status: str, **fields: Any) -> dict[str, Any]:
+        return {"status": status, "task_contract": task_contract, **fields}
+
+    if _boundary_changed(task_context.get("proposed_boundary"), role_decision):
+        return result("rejected", spawn=False, reason_code="role_boundary_mutation")
+
+    requested = task_context.get("requested_route")
+    if requested is not None and not isinstance(requested, Mapping):
+        return result("rejected", spawn=False, reason_code="invalid_route")
+    requested = requested or {}
+    if _boundary_changed(requested, role_decision) or _boundary_changed(
+        requested, role_constraints
+    ):
+        return result("rejected", spawn=False, reason_code="safety_boundary_mutation")
+    if requested.get("provider") and not requested.get("model"):
+        return result("rejected", spawn=False, reason_code="provider_requires_model")
+
+    requested_effort = requested.get("reasoning_effort")
+    if requested_effort is not None:
+        requested_effort = str(requested_effort).strip().lower()
+        if requested_effort not in REASONING_EFFORTS:
+            return result(
+                "rejected", spawn=False, reason_code="invalid_reasoning_effort"
+            )
+
+    compute_class = _classify(task_context, policy)
+    if compute_class is None:
+        return result("rejected", spawn=False, reason_code="compute_class_ambiguous")
+    policy_classes = policy.get("classes")
+    class_policy = (
+        policy_classes.get(compute_class)
+        if isinstance(policy_classes, Mapping)
+        else None
+    )
+    if not isinstance(class_policy, Mapping):
+        return result("rejected", spawn=False, reason_code="route_policy_incomplete")
+
+    persisted_input = task_context.get("persisted_route")
+    if persisted_input is not None:
+        required = ("compute_class", "route_decision_id", "policy_version")
+        if not isinstance(persisted_input, Mapping) or not all(
+            persisted_input.get(key) for key in required
+        ):
+            fields: dict[str, Any] = {
+                "spawn": False,
+                "reason_code": "compute_class_not_persisted",
+            }
+            actual = _actual_route(execution)
+            if actual is not None:
+                fields["actual_route"] = actual
+            if execution.get("reported_done"):
+                fields["outcome"] = "reported_done"
+            return result("rejected", **fields)
+
+    route = {
+        "provider": requested.get("provider", class_policy.get("provider")),
+        "model": requested.get("model", class_policy.get("model")),
+        "reasoning_effort": requested_effort or class_policy.get("reasoning_effort"),
+        "max_fallbacks": min(max(int(class_policy.get("max_fallbacks", 0)), 0), 1),
+    }
+    if route["provider"] and not route["model"]:
+        return result("rejected", spawn=False, reason_code="provider_requires_model")
+    if route["reasoning_effort"] not in REASONING_EFFORTS:
+        return result("rejected", spawn=False, reason_code="invalid_reasoning_effort")
+
+    allowed_providers = role_constraints.get("allowed_providers")
+    allowed_models = role_constraints.get("allowed_models")
+    if (
+        allowed_providers is not None and route["provider"] not in allowed_providers
+    ) or (allowed_models is not None and route["model"] not in allowed_models):
+        return result("rejected", spawn=False, reason_code="no_eligible_candidate")
+
+    route_decision_id = _decision_id(
+        task_context, role_decision, capability_snapshot, policy, compute_class
+    )
+    persisted_route = {
+        "compute_class": compute_class,
+        "route_decision_id": route_decision_id,
+        "policy_version": policy.get("policy_version"),
+    }
+    common: dict[str, Any] = {
+        "compute_class": compute_class,
+        "route": route,
+        "persisted_route": persisted_route,
+        "route_decision_id": route_decision_id,
+        "policy_version": policy.get("policy_version"),
+        "verification_required": True,
+    }
+
+    if not (
+        capability_snapshot.get("catalog_observed")
+        and capability_snapshot.get("auth_observed")
+        and capability_snapshot.get("runtime_observed")
+    ):
+        return result(
+            "prepared_not_observed",
+            **common,
+            spawn=False,
+            reason_code="capability_unverified",
+        )
+
+    candidates = capability_snapshot.get("candidates") or ()
+    candidate = next(
+        (
+            item
+            for item in candidates
+            if isinstance(item, Mapping)
+            and item.get("provider") == route["provider"]
+            and item.get("model") == route["model"]
+        ),
+        None,
+    )
+    if candidate is None or route["reasoning_effort"] not in candidate.get(
+        "reasoning_efforts", ()
+    ):
+        return result(
+            "prepared_not_observed",
+            **common,
+            spawn=False,
+            reason_code="no_eligible_candidate",
+        )
+
+    if unattended and class_policy.get("automation") == "attended":
+        return result(
+            "approval_required",
+            **common,
+            spawn=False,
+            reason_code="attended_routing_required",
+        )
+
+    fallback_index = min(max(int(execution.get("fallback_index", 0)), 0), 1)
+    error = execution.get("error")
+    eligible_errors = set(policy.get("eligible_fallback_reasons") or ())
+    ineligible_errors = set(policy.get("ineligible_fallback_reasons") or ())
+
+    if error in WORK_FAILURES:
+        return result(
+            "rework_required",
+            **common,
+            spawn=False,
+            outcome="work_failed",
+            event_kind="verification_failed",
+            fallback_index=fallback_index,
+            retry_policy="same_owner",
+        )
+    if error in eligible_errors:
+        if fallback_index < route["max_fallbacks"]:
+            return result(
+                "fallback_pending",
+                **common,
+                spawn=True,
+                outcome="routing_unavailable",
+                event_kind="fallback_started",
+                fallback_index=fallback_index + 1,
+            )
+        return result(
+            "blocked",
+            **common,
+            spawn=False,
+            outcome="routing_unavailable",
+            event_kind="fallback_exhausted",
+            fallback_index=fallback_index,
+        )
+    if error in ineligible_errors:
+        return result(
+            "blocked",
+            **common,
+            spawn=False,
+            outcome="blocked",
+            event_kind="route_blocked",
+            fallback_index=fallback_index,
+            retry_policy="none",
+        )
+    if error:
+        return result(
+            "blocked",
+            **common,
+            spawn=False,
+            outcome="work_failed",
+            event_kind="route_blocked",
+            fallback_index=fallback_index,
+            reason_code="unclassified_execution_error",
+        )
+
+    actual = _actual_route(execution)
+    if execution.get("reported_done"):
+        if actual is None:
+            return result(
+                "observation_incomplete",
+                **common,
+                spawn=False,
+                outcome="reported_done",
+                reason_code="actual_route_missing",
+            )
+        if any(actual[key] != route[key] for key in actual):
+            return result(
+                "observation_mismatch",
+                **common,
+                actual_route=actual,
+                spawn=False,
+                outcome="reported_done",
+                reason_code="actual_route_mismatch",
+            )
+        verification = execution.get("verification") or {}
+        if not (verification.get("performed") and verification.get("passed")):
+            return result(
+                "verification_required",
+                **common,
+                actual_route=actual,
+                spawn=False,
+                outcome="reported_done",
+            )
+        return result(
+            "verified",
+            **common,
+            actual_route=actual,
+            spawn=False,
+            outcome="verified",
+            event_kind="verification_passed",
+        )
+
+    if execution.get("attempted"):
+        fields = {**common, "spawn": False, "fallback_index": fallback_index}
+        if actual is not None:
+            fields["actual_route"] = actual
+        return result("running", **fields)
+
+    if str(policy.get("mode", "shadow")).strip().lower() == "shadow":
+        return result(
+            "shadow_recorded",
+            **common,
+            spawn=True,
+            apply_route_override=False,
+            dispatch_overrides={},
+            event_kind="route_resolved",
+        )
+    return result(
+        "dispatchable",
+        **common,
+        spawn=True,
+        apply_route_override=True,
+        dispatch_overrides={
+            "model_override": route["model"],
+            "provider_override": route["provider"],
+            "reasoning_effort": route["reasoning_effort"],
+        },
+        event_kind="route_resolved",
+    )
+
+
+__all__ = ["COMPUTE_CLASSES", "route_task"]

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3552,6 +3552,7 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "reasoning_effort": reasoning_effort,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)

--- a/tests/fixtures/compute_routing_contract_v1.json
+++ b/tests/fixtures/compute_routing_contract_v1.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": "compute_routing_contract/v1",
+  "public_interface": {
+    "module": "hermes_cli.compute_routing",
+    "callable": "route_task",
+    "arguments": ["task_context", "role_decision", "capability_snapshot", "role_constraints", "policy", "execution", "unattended"]
+  },
+  "common_input": {
+    "task_context": {"task_id": "t_route_contract", "signals": ["standard"], "requested_route": null, "persisted_route": null, "proposed_boundary": null},
+    "role_decision": {"role_ref": "role-v7:t_route_contract", "role": "coding", "assignee": "bmk", "write_scope": ["tests/**"], "workspace": "G:/worktrees/t_route_contract", "approval": "review_required", "toolsets": ["terminal", "file", "kanban"], "master_forbidden": true},
+    "capability_snapshot": {
+      "snapshot_id": "cap-20260823-1", "catalog_observed": true, "auth_observed": true, "runtime_observed": true,
+      "candidates": [
+        {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_efforts": ["low"]},
+        {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_efforts": ["medium", "high", "xhigh"]},
+        {"provider": "vision-adapter", "model": "vision-specialist-v1", "reasoning_efforts": ["medium"]}
+      ]
+    },
+    "role_constraints": {"allowed_providers": ["openai-codex", "vision-adapter"], "allowed_models": ["gpt-5.6-luna", "gpt-5.6-sol", "vision-specialist-v1"], "write_scope": ["tests/**"], "workspace": "G:/worktrees/t_route_contract", "approval": "review_required", "toolsets": ["terminal", "file", "kanban"], "master_forbidden": true},
+    "policy": {
+      "schema_version": "compute_routing_policy/v1", "policy_version": "2026-08-contract-1", "mode": "opt_in",
+      "precedence": ["specialist", "architect", "deep", "standard", "quick"],
+      "eligible_fallback_reasons": ["model_unavailable", "provider_rejected", "transient_network", "quota_exhausted"],
+      "ineligible_fallback_reasons": ["auth_missing", "permission_denied", "write_scope_violation", "test_failed", "contract_failed", "invalid_output", "human_denied", "security_block"],
+      "classes": {
+        "quick": {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_effort": "low", "max_fallbacks": 1, "automation": "opt_in"},
+        "standard": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "medium", "max_fallbacks": 1, "automation": "opt_in"},
+        "deep": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "high", "max_fallbacks": 1, "automation": "attended"},
+        "architect": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "xhigh", "max_fallbacks": 0, "automation": "attended"},
+        "specialist": {"provider": "vision-adapter", "model": "vision-specialist-v1", "reasoning_effort": "medium", "max_fallbacks": 0, "automation": "attended"}
+      }
+    },
+    "execution": {"attempted": false, "fallback_index": 0, "error": null, "reported_done": false, "verification": {"performed": false, "passed": false}, "actual": {"provider": null, "model": null, "reasoning_effort": null}},
+    "unattended": false
+  },
+  "normal_cases": [
+    {"id": "N01-specialist-precedence", "input_patch": {"task_context": {"signals": ["specialist", "architect", "deep", "standard", "quick"]}}, "expected": {"status": "dispatchable", "compute_class": "specialist", "route": {"provider": "vision-adapter", "model": "vision-specialist-v1", "reasoning_effort": "medium", "max_fallbacks": 0}}},
+    {"id": "N02-architect-precedence", "input_patch": {"task_context": {"signals": ["architect", "deep", "standard", "quick"]}}, "expected": {"status": "dispatchable", "compute_class": "architect", "route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "xhigh", "max_fallbacks": 0}}},
+    {"id": "N03-deep-precedence", "input_patch": {"task_context": {"signals": ["deep", "standard", "quick"]}}, "expected": {"status": "dispatchable", "compute_class": "deep", "route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "high", "max_fallbacks": 1}}},
+    {"id": "N04-standard-precedence", "input_patch": {"task_context": {"signals": ["standard", "quick"]}}, "expected": {"status": "dispatchable", "compute_class": "standard", "route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "medium", "max_fallbacks": 1}}},
+    {"id": "N05-quick-precedence", "input_patch": {"task_context": {"signals": ["quick"]}}, "expected": {"status": "dispatchable", "compute_class": "quick", "route": {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_effort": "low", "max_fallbacks": 1}, "verification_required": true}}
+  ],
+  "mutants": [
+    {"id": "I01-role-boundary-mutation", "invariant": "I1", "input_patch": {"task_context": {"proposed_boundary": {"role": "review", "assignee": "b", "write_scope": ["**"], "workspace": "G:/other", "approval": "none"}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "role_boundary_mutation"}},
+    {"id": "I02-posthoc-class-inference", "invariant": "I2", "input_patch": {"task_context": {"requested_route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "high"}, "persisted_route": {"compute_class": null, "route_decision_id": null, "policy_version": null}}, "execution": {"attempted": true, "reported_done": true, "verification": {"performed": true, "passed": true}, "actual": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "high"}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "compute_class_not_persisted", "outcome": "reported_done"}},
+    {"id": "I03-provider-without-model", "invariant": "I3", "input_patch": {"task_context": {"requested_route": {"provider": "openai-codex", "model": null, "reasoning_effort": "medium"}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "provider_requires_model"}},
+    {"id": "I04-invalid-reasoning-default-fallback", "invariant": "I4", "input_patch": {"task_context": {"requested_route": {"provider": "openai-codex", "model": "gpt-5.6-sol", "reasoning_effort": "hihg"}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "invalid_reasoning_effort"}},
+    {"id": "I05-catalog-only-capability", "invariant": "I5", "input_patch": {"capability_snapshot": {"auth_observed": false, "runtime_observed": false}}, "expected": {"status": "prepared_not_observed", "spawn": false, "reason_code": "capability_unverified"}},
+    {"id": "I06-work-failure-model-fallback", "invariant": "I6", "input_patch": {"execution": {"attempted": true, "fallback_index": 0, "error": "test_failed"}}, "expected": {"status": "rework_required", "spawn": false, "outcome": "work_failed", "event_kind": "verification_failed", "fallback_index": 0, "retry_policy": "same_owner"}},
+    {"id": "I07-third-spawn-chain", "invariant": "I7", "input_patch": {"execution": {"attempted": true, "fallback_index": 1, "error": "model_unavailable"}}, "expected": {"status": "blocked", "spawn": false, "outcome": "routing_unavailable", "event_kind": "fallback_exhausted", "fallback_index": 1}},
+    {"id": "I08-fallback-widens-safety-boundary", "invariant": "I8", "input_patch": {"task_context": {"requested_route": {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_effort": "low", "fallback_index": 1, "write_scope": ["**"], "toolsets": ["terminal", "file", "kanban", "unsafe"], "approval": "none", "master_forbidden": false}}}, "expected": {"status": "rejected", "spawn": false, "reason_code": "safety_boundary_mutation"}},
+    {"id": "I09-verified-without-actual-model", "invariant": "I9", "input_patch": {"execution": {"attempted": true, "reported_done": true, "verification": {"performed": true, "passed": true}, "actual": {"provider": null, "model": null, "reasoning_effort": null}}}, "expected": {"status": "observation_incomplete", "spawn": false, "outcome": "reported_done", "reason_code": "actual_route_missing"}},
+    {"id": "I10-quick-skips-verification", "invariant": "I10", "input_patch": {"task_context": {"signals": ["quick"]}, "execution": {"attempted": true, "reported_done": true, "verification": {"performed": false, "passed": false}, "actual": {"provider": "openai-codex", "model": "gpt-5.6-luna", "reasoning_effort": "low"}}}, "expected": {"status": "verification_required", "spawn": false, "compute_class": "quick", "outcome": "reported_done", "verification_required": true}},
+    {"id": "I11-unattended-architect-spawn", "invariant": "I11", "input_patch": {"task_context": {"signals": ["architect"]}, "unattended": true}, "expected": {"status": "approval_required", "spawn": false, "compute_class": "architect", "reason_code": "attended_routing_required"}},
+    {"id": "I12-quota-work-failure-conflation", "invariant": "I12", "variants": [
+      {"name": "quota", "input_patch": {"execution": {"attempted": true, "fallback_index": 0, "error": "quota_exhausted"}}, "expected": {"status": "fallback_pending", "spawn": true, "outcome": "routing_unavailable", "event_kind": "fallback_started", "fallback_index": 1}},
+      {"name": "work", "input_patch": {"execution": {"attempted": true, "fallback_index": 0, "error": "test_failed"}}, "expected": {"status": "rework_required", "spawn": false, "outcome": "work_failed", "event_kind": "verification_failed", "fallback_index": 0}}
+    ]}
+  ]
+}

--- a/tests/fixtures/quiz_result.md
+++ b/tests/fixtures/quiz_result.md
@@ -1,0 +1,107 @@
+# result — compute_class router oracle (quiz)
+
+## 1. Summary
+
+compute_class 구현 전 고정 RED 오라클을 작성했다. production 코드는 수정하지 않았고 tests/** 아래에만 정상 5종 precedence fixture, I01~I12 known-bad fixture, 단일 route_task 공개 계약 테스트, kanban_create reasoning_effort E2E parity 테스트를 추가했다.
+
+현재 기준 결과는 의도대로 RED다. fixture 자체 검증 2건은 GREEN이고, 미구현 production 계약은 21 failed / 2 passed다. 실패는 hermes_cli.compute_routing.route_task 부재 18건과 kanban_create reasoning_effort schema/handler 부재 3건으로 분리된다.
+
+## 2. Files
+
+- tests/fixtures/compute_routing_contract_v1.json
+  - 정상 class 5종 specialist > architect > deep > standard > quick precedence
+  - 구조적으로 유효한 I01~I12 mutant
+  - capability snapshot, role boundary, fallback 자격표/상한, execution observation fixture
+- tests/test_compute_routing_contract.py
+  - 모든 정상/mutant를 동일 hermes_cli.compute_routing.route_task 키워드 인터페이스로 실행
+  - role/assignee/write_scope/workspace/approval/toolsets/master_forbidden 불변
+  - class/decision id/policy version 실행 전 명시 저장
+  - actual route 없는 verified 금지, quick 검증 필수, unattended architect 차단
+- tests/tools/test_kanban_compute_routing_contract.py
+  - kanban_create reasoning_effort 닫힌 enum
+  - HIGH 입력 → DB/event/show high → spawn --reasoning high parity
+  - hihg 입력 거부 및 DB 변화 0
+
+## 3. Commands + actual output
+
+Command:
+
+    G:labuntimehermes-bappenvScriptspython.exe -m pytest --basetemp <workspace>/tests/.pytest_compute_routing tests/test_compute_routing_contract.py::test_fixture_is_closed_complete_and_structurally_valid tests/test_compute_routing_contract.py::test_i12_expected_contracts_are_not_aliases -q
+
+Output:
+
+    ..                                                                       [100%]
+    2 passed in 2.48s
+
+Command:
+
+    G:labuntimehermes-bappenvScriptspython.exe -m pytest --basetemp <workspace>/tests/.pytest_compute_routing_result tests/test_compute_routing_contract.py tests/tools/test_kanban_compute_routing_contract.py -q --tb=no
+
+Output:
+
+    .FFFFFFFFFFFFFFFFFF.FFF                                                  [100%]
+    =========================== short test summary info ===========================
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N01-specialist-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N02-architect-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N03-deep-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N04-standard-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_normal_routes_use_precedence_and_preserve_role_boundary[N05-quick-precedence]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I01-role-boundary-mutation]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I02-posthoc-class-inference]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I03-provider-without-model]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I04-invalid-reasoning-default-fallback]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I05-catalog-only-capability]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I06-work-failure-model-fallback]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I07-third-spawn-chain]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I08-fallback-widens-safety-boundary]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I09-verified-without-actual-model]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I10-quick-skips-verification]
+    FAILED tests/test_compute_routing_contract.py::test_known_bad_mutant_is_dropped_through_route_task[I11-unattended-architect-spawn]
+    FAILED tests/test_compute_routing_contract.py::test_quota_and_work_failures_remain_distinct[I12-quota]
+    FAILED tests/test_compute_routing_contract.py::test_quota_and_work_failures_remain_distinct[I12-work]
+    FAILED tests/tools/test_kanban_compute_routing_contract.py::test_kanban_create_schema_exposes_closed_reasoning_effort_enum
+    FAILED tests/tools/test_kanban_compute_routing_contract.py::test_kanban_create_reasoning_effort_parity_to_db_event_show_and_spawn
+    FAILED tests/tools/test_kanban_compute_routing_contract.py::test_kanban_create_rejects_reasoning_typo_without_db_mutation
+    21 failed, 2 passed in 2.72s
+
+Command:
+
+    G:labuntimehermes-bappenvScriptspython.exe -m py_compile tests/test_compute_routing_contract.py tests/tools/test_kanban_compute_routing_contract.py
+
+Output:
+
+    PYCOMPILE_RC=0
+
+Command:
+
+    git diff --check
+
+Output:
+
+    DIFF_CHECK_RC=0
+
+## 4. Verification (known-bad)
+
+- I01 role/assignee/scope/workspace/approval mutation → rejected, spawn false.
+- I02 class/decision/policy 미저장 + actual model 사후 역추정 → rejected, verified 금지.
+- I03 provider-only route → provider_requires_model.
+- I04 hihg → invalid_reasoning_effort; 조용한 profile fallback 금지.
+- I05 catalog-only + auth/runtime 미관측 → prepared_not_observed.
+- I06 test_failed → work_failed + same_owner rework; model fallback 금지.
+- I07 fallback_index=1 이후 추가 spawn → fallback_exhausted.
+- I08 fallback의 write_scope/toolset/approval/master 확대 → rejected.
+- I09 actual provider/model/effort 없음 → observation_incomplete, verified 금지.
+- I10 quick도 verification_required.
+- I11 unattended architect → approval_required, spawn false.
+- I12 quota는 routing_unavailable/fallback_started, test failure는 work_failed/verification_failed.
+
+정상 fixture 5종과 mutant 12종을 모두 같은 route_task 인터페이스에 넣는다. I12는 quota/work 두 variant다. fixture 완전성 테스트가 precedence, I1~I12 연속성, 중복 없는 12개 ID, 공통 인자 구조를 별도로 검증한다.
+
+## 5. Issues / Caveats
+
+- RED는 의도된 구현 전 기준선이다.
+- 기존 DB/spawn builder에는 reasoning_effort 저장/argv 배선이 있으나 kanban_create schema/handler가 값을 받지 않는다. HIGH가 NULL로 저장되고 hihg도 task 생성에 성공한다. created event/show 표면도 parity가 없다.
+- 공유 venv에는 ruff 모듈이 없어 ruff는 실행하지 못했다. JSON parse, Python py_compile, git diff --check는 통과했다.
+- pytest 임시 디렉터리는 제거했다.
+- AGENTS.md가 참조한 RTK.md는 worktree와 인접 worktree에서 발견되지 않았다.
+- 지정 결과 경로 G:/lab/workspace/mas/tasks/compute-class-routing-arena/workers/quiz/result.md는 샌드박스에서 쓰기 거부되어 이 대체본을 tests/fixtures/quiz_result.md에 보존했다. 원래 경로로 복사가 필요하다.

--- a/tests/fixtures/sol_result.md
+++ b/tests/fixtures/sol_result.md
@@ -1,0 +1,113 @@
+# SOL implementation result
+
+## Outcome
+
+PASS. The sealed QUIZ contract at commit `bfc933073b` is implemented without
+changing any sealed test or fixture. The requested external result path is
+outside this worktree write scope, so this report is preserved at the specified
+fallback path.
+
+## Implementation
+
+- Added pure `hermes_cli.compute_routing.route_task` with deterministic
+  precedence for all five compute classes.
+- Preserved role, assignee, write scope, workspace, approval, toolsets, and
+  master prohibition byte-for-byte in the returned task contract.
+- Added explicit route metadata persistence output, capability gating,
+  availability-only fallback with a Core ceiling of one, attended routing,
+  verification requirements, and separate actual-route observations.
+- Added shadow behavior that records the recommendation while returning empty
+  dispatch overrides.
+- Connected `reasoning_effort` through the existing `kanban_create` schema and
+  handler to DB normalization, created event, show output, and worker argv.
+- Added no dependency and performed no delegation, commit, merge, or push.
+
+## Sealed artifact integrity
+
+Working-tree hashes equal the hashes in `bfc933073b`:
+
+```text
+tests/test_compute_routing_contract.py
+0a3d37e764f35357a2dd616ca24a342f10d94d00 == 0a3d37e764f35357a2dd616ca24a342f10d94d00
+tests/tools/test_kanban_compute_routing_contract.py
+e67470e2df2e95f03048f709376a8058c91621f4 == e67470e2df2e95f03048f709376a8058c91621f4
+tests/fixtures/compute_routing_contract_v1.json
+2ca4fdfb7bac121627ad34a358deb6e93e9c7cb0 == 2ca4fdfb7bac121627ad34a358deb6e93e9c7cb0
+tests/fixtures/quiz_result.md
+b0d05b3ec16d0f4c5af9379b89e114c09a22ba18 == b0d05b3ec16d0f4c5af9379b89e114c09a22ba18
+```
+
+## Normal and mutant raw result
+
+Command: `pytest -vv --tb=short tests/test_compute_routing_contract.py`
+
+```text
+collected 20 items
+test_fixture_is_closed_complete_and_structurally_valid PASSED
+N01-specialist-precedence PASSED
+N02-architect-precedence PASSED
+N03-deep-precedence PASSED
+N04-standard-precedence PASSED
+N05-quick-precedence PASSED
+I01-role-boundary-mutation PASSED
+I02-posthoc-class-inference PASSED
+I03-provider-without-model PASSED
+I04-invalid-reasoning-default-fallback PASSED
+I05-catalog-only-capability PASSED
+I06-work-failure-model-fallback PASSED
+I07-third-spawn-chain PASSED
+I08-fallback-widens-safety-boundary PASSED
+I09-verified-without-actual-model PASSED
+I10-quick-skips-verification PASSED
+I11-unattended-architect-spawn PASSED
+I12-quota PASSED
+I12-work PASSED
+test_i12_expected_contracts_are_not_aliases PASSED
+20 passed in 1.07s
+```
+
+The normal routes are 5/5 PASS and the known-bad invariant set is 12/12 DROP.
+I12 has two variants to prove quota and work failures remain distinct.
+
+## Verification
+
+```text
+Locked combined gate:
+23 passed in 3.35s
+
+Existing Kanban model/spawn regression:
+25 passed in 16.10s
+
+Direct shadow and positive actual-observation assertions:
+shadow_and_actual_observation: PASS
+
+Ruff:
+All checks passed!
+
+git diff --check:
+PASS
+```
+
+Regression files:
+
+- `tests/plugins/test_kanban_model_override.py`
+- `tests/hermes_cli/test_kanban_worker_spawn_toolsets.py`
+- `tests/hermes_cli/test_kanban_dispatch_tick_hook.py`
+
+## Production diff/stat
+
+```text
+hermes_cli/compute_routing.py | 345 insertions (new)
+hermes_cli/kanban_db.py       |   1 insertion
+tools/kanban_tools.py         |  14 insertions
+3 production files changed, 360 insertions
+```
+
+Changed files including this required report: 4.
+
+```text
+M  hermes_cli/kanban_db.py
+M  tools/kanban_tools.py
+?? hermes_cli/compute_routing.py
+?? tests/fixtures/sol_result.md
+```

--- a/tests/test_compute_routing_contract.py
+++ b/tests/test_compute_routing_contract.py
@@ -1,0 +1,197 @@
+"""Fixed RED oracle for compute-class model routing.
+
+Every normal and known-bad fixture enters the same pure public route_task
+interface. Missing production API is a failure, never a skip.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "compute_routing_contract_v1.json"
+BOUNDARY_FIELDS = (
+    "role",
+    "assignee",
+    "write_scope",
+    "workspace",
+    "approval",
+    "toolsets",
+    "master_forbidden",
+)
+REQUIRED_ROUTE_METADATA = (
+    "compute_class",
+    "route_decision_id",
+    "policy_version",
+)
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _deep_merge(base: dict, patch: Mapping) -> dict:
+    merged = copy.deepcopy(base)
+    for key, value in patch.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _materialize(case: Mapping, *, variant: Mapping | None = None) -> dict:
+    materialized = _deep_merge(_fixture()["common_input"], case.get("input_patch", {}))
+    if variant is not None:
+        materialized = _deep_merge(materialized, variant.get("input_patch", {}))
+    return materialized
+
+
+def _route_task(case_input: dict):
+    contract = _fixture()["public_interface"]
+    try:
+        module = importlib.import_module(contract["module"])
+    except ModuleNotFoundError:
+        pytest.fail(
+            f"required public routing module {contract['module']!r} is missing",
+            pytrace=False,
+        )
+    route_task = getattr(module, contract["callable"], None)
+    if not callable(route_task):
+        pytest.fail(
+            f"{contract['module']}.{contract['callable']} must be callable",
+            pytrace=False,
+        )
+    return route_task(**{name: case_input[name] for name in contract["arguments"]})
+
+
+def _assert_subset(actual: Mapping, expected: Mapping, path: str = "result") -> None:
+    assert isinstance(actual, Mapping), (
+        f"{path} must be a mapping, got {type(actual).__name__}"
+    )
+    for key, expected_value in expected.items():
+        assert key in actual, f"{path}.{key} is missing"
+        actual_value = actual[key]
+        if isinstance(expected_value, Mapping):
+            _assert_subset(actual_value, expected_value, f"{path}.{key}")
+        else:
+            assert actual_value == expected_value, (
+                f"{path}.{key}: expected {expected_value!r}, got {actual_value!r}"
+            )
+
+
+def _assert_boundary_unchanged(case_input: Mapping, result: Mapping) -> None:
+    contract = result.get("task_contract")
+    assert isinstance(contract, Mapping), (
+        "result.task_contract must expose role-owned fields"
+    )
+    original = case_input["role_decision"]
+    for field in BOUNDARY_FIELDS:
+        assert contract.get(field) == original[field], (
+            f"compute routing changed role boundary {field}"
+        )
+
+
+def test_fixture_is_closed_complete_and_structurally_valid():
+    data = _fixture()
+    assert data["schema_version"] == "compute_routing_contract/v1"
+    assert data["common_input"]["policy"]["precedence"] == [
+        "specialist",
+        "architect",
+        "deep",
+        "standard",
+        "quick",
+    ]
+    assert [
+        case["expected"]["compute_class"] for case in data["normal_cases"]
+    ] == ["specialist", "architect", "deep", "standard", "quick"]
+    assert [case["invariant"] for case in data["mutants"]] == [
+        f"I{i}" for i in range(1, 13)
+    ]
+    assert len({case["id"] for case in data["mutants"]}) == 12
+
+    required = set(data["public_interface"]["arguments"])
+    materialized_cases = [_materialize(case) for case in data["normal_cases"]]
+    materialized_cases.extend(
+        _materialize(case, variant=variant)
+        for case in data["mutants"]
+        for variant in (case.get("variants") or [None])
+    )
+    for case_input in materialized_cases:
+        assert set(case_input) == required
+        assert set(case_input["role_decision"]) >= set(BOUNDARY_FIELDS)
+        assert (
+            case_input["policy"]["schema_version"]
+            == "compute_routing_policy/v1"
+        )
+
+
+@pytest.mark.parametrize(
+    "case",
+    _fixture()["normal_cases"],
+    ids=lambda case: case["id"],
+)
+def test_normal_routes_use_precedence_and_preserve_role_boundary(case):
+    case_input = _materialize(case)
+    result = _route_task(case_input)
+
+    _assert_subset(result, case["expected"])
+    _assert_boundary_unchanged(case_input, result)
+    persisted = result.get("persisted_route")
+    assert isinstance(persisted, Mapping), (
+        "result.persisted_route must be explicit before dispatch"
+    )
+    assert persisted.get("compute_class") == case["expected"]["compute_class"]
+    assert (
+        persisted.get("policy_version")
+        == case_input["policy"]["policy_version"]
+    )
+    assert persisted.get("route_decision_id")
+    for key in REQUIRED_ROUTE_METADATA:
+        assert key in persisted
+
+
+@pytest.mark.parametrize(
+    "case",
+    [case for case in _fixture()["mutants"] if "variants" not in case],
+    ids=lambda case: case["id"],
+)
+def test_known_bad_mutant_is_dropped_through_route_task(case):
+    case_input = _materialize(case)
+    result = _route_task(case_input)
+
+    _assert_subset(result, case["expected"])
+    _assert_boundary_unchanged(case_input, result)
+    assert result.get("outcome") != "verified" or result.get("actual_route"), (
+        "verified requires actual provider/model/reasoning read-back"
+    )
+
+
+@pytest.mark.parametrize(
+    "variant",
+    _fixture()["mutants"][-1]["variants"],
+    ids=lambda variant: f"I12-{variant['name']}",
+)
+def test_quota_and_work_failures_remain_distinct(variant):
+    case = _fixture()["mutants"][-1]
+    case_input = _materialize(case, variant=variant)
+    result = _route_task(case_input)
+
+    _assert_subset(result, variant["expected"])
+    _assert_boundary_unchanged(case_input, result)
+
+
+def test_i12_expected_contracts_are_not_aliases():
+    variants = _fixture()["mutants"][-1]["variants"]
+    quota, work = (variant["expected"] for variant in variants)
+    assert quota["outcome"] == "routing_unavailable"
+    assert work["outcome"] == "work_failed"
+    assert quota["event_kind"] != work["event_kind"]
+    assert quota["spawn"] is True
+    assert work["spawn"] is False

--- a/tests/tools/test_kanban_compute_routing_contract.py
+++ b/tests/tools/test_kanban_compute_routing_contract.py
@@ -1,0 +1,113 @@
+"""Kanban public-surface contracts required by compute-class routing."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+def _isolated_home(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "router-orchestrator")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return kb
+
+
+def test_kanban_create_schema_exposes_closed_reasoning_effort_enum():
+    from hermes_constants import VALID_REASONING_EFFORTS
+    from tools.kanban_tools import KANBAN_CREATE_SCHEMA
+
+    prop = KANBAN_CREATE_SCHEMA["parameters"]["properties"]["reasoning_effort"]
+    assert prop["type"] == "string"
+    assert prop["enum"] == ["none", *VALID_REASONING_EFFORTS]
+
+
+def test_kanban_create_reasoning_effort_parity_to_db_event_show_and_spawn(
+    monkeypatch, tmp_path
+):
+    kb = _isolated_home(monkeypatch, tmp_path)
+    from tools import kanban_tools as kt
+
+    workspace = tmp_path / "worker"
+    workspace.mkdir()
+    created = json.loads(
+        kt._handle_create(
+            {
+                "title": "routed worker",
+                "assignee": "bmk",
+                "workspace_kind": "dir",
+                "workspace_path": str(workspace),
+                "model": "gpt-5.6-sol",
+                "provider": "openai-codex",
+                "reasoning_effort": "HIGH",
+            }
+        )
+    )
+    assert created.get("ok") is True, created
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, created["task_id"])
+        events = kb.list_events(conn, created["task_id"])
+    assert task.reasoning_effort == "high"
+    created_event = next(event for event in events if event.kind == "created")
+    assert created_event.payload["reasoning_effort"] == "high"
+    assert created_event.payload["model_override"] == "gpt-5.6-sol"
+    assert created_event.payload["provider_override"] == "openai-codex"
+
+    shown = json.loads(kt._handle_show({"task_id": created["task_id"]}))
+    assert shown["task"]["reasoning_effort"] == "high"
+    assert shown["task"]["model_override"] == "gpt-5.6-sol"
+    assert shown["task"]["provider_override"] == "openai-codex"
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    kb._default_spawn(task, str(workspace))
+
+    argv = captured["cmd"]
+    assert argv[argv.index("--reasoning") + 1] == "high"
+    assert argv[argv.index("-m") + 1] == "gpt-5.6-sol"
+    assert argv[argv.index("--provider") + 1] == "openai-codex"
+
+
+def test_kanban_create_rejects_reasoning_typo_without_db_mutation(
+    monkeypatch, tmp_path
+):
+    kb = _isolated_home(monkeypatch, tmp_path)
+    from tools import kanban_tools as kt
+
+    with kb.connect() as conn:
+        before = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+
+    result = json.loads(
+        kt._handle_create(
+            {
+                "title": "typo must not inherit",
+                "assignee": "bmk",
+                "reasoning_effort": "hihg",
+            }
+        )
+    )
+    assert "error" in result
+    assert "reasoning_effort" in result["error"]
+
+    with kb.connect() as conn:
+        after = conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+    assert after == before

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -34,6 +34,7 @@ import os
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
+from hermes_constants import VALID_REASONING_EFFORTS
 from hermes_cli.goals import judge_goal
 from tools.registry import registry, tool_error
 from hermes_cli.config import cfg_get, load_config
@@ -487,6 +488,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
     parents = kb.parent_ids(conn, task.id)
     children = kb.child_ids(conn, task.id)
     return {
+        "reasoning_effort": task.reasoning_effort,
         "id": task.id,
         "title": task.title,
         "assignee": task.assignee,
@@ -537,6 +539,7 @@ def _handle_show(args: dict, **kw) -> str:
 
             def _task_dict(t):
                 return {
+                    "reasoning_effort": t.reasoning_effort,
                     "id": t.id, "title": t.title, "body": t.body,
                     "assignee": t.assignee, "status": t.status,
                     "tenant": t.tenant, "priority": t.priority,
@@ -1411,6 +1414,7 @@ def _handle_create(args: dict, **kw) -> str:
     goal_max_turns = args.get("goal_max_turns")
     model_override = args.get("model")
     provider_override = args.get("provider")
+    reasoning_effort = args.get("reasoning_effort")
     if provider_override and not model_override:
         return tool_error("'provider' requires 'model' to be set as well")
     if isinstance(parents, str):
@@ -1454,6 +1458,7 @@ def _handle_create(args: dict, **kw) -> str:
                 skills=skills,
                 model_override=model_override,
                 provider_override=provider_override,
+                reasoning_effort=reasoning_effort,
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -2301,6 +2306,15 @@ KANBAN_CREATE_SCHEMA = {
                     "provider — a model name alone is resolved against "
                     "the profile's provider and will fail if it belongs "
                     "to a different one. Requires 'model'."
+                ),
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": ["none", *VALID_REASONING_EFFORTS],
+                "description": (
+                    "Pin the dispatched worker reasoning depth for this task. "
+                    "Values are case-insensitive in the handler; omit to "
+                    "inherit the assignee profile."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
## Summary
- Promotes only the approved Sol implementation from the fresh arena into a new PR worktree/branch.
- Adds pure compute-class routing in `hermes_cli/compute_routing.py` and wires `reasoning_effort` through `hermes_cli/kanban_db.py` and `tools/kanban_tools.py`.
- Includes/references the sealed QUIZ tests and fixtures plus the verification evidence from the approved virtual merge.

## Provenance and scope
- Approval card: `t_e8293058`; evidence card: `t_c1a2495b`.
- Approved source worktree: `G:/lab/orca/workspaces/hermes-b-runtime/app/compute-class-routing-sol`.
- PR worktree: `G:/lab/orca/workspaces/hermes-b-runtime/app/compute-class-routing-sol-promotion`.
- Source and PR branch HEAD: `d0a89597b9c9d228dc029a34b19fc163e126bf78`.
- Source parity read-back: PASS; PR branch was created without overwriting the candidate worktree.
- Base: `main`; master/canon merge and operational rollout were not performed.

## Sealed integrity
The sealed files are unchanged from the approved `bfc933073bf2d0eed7ccfbf70700d2ac67a34781` base (`git diff --quiet` exit 0):

| File | SHA-256 |
|---|---|
| `tests/test_compute_routing_contract.py` | `651a6621c6cc72343aa8eb73b04aeb2e4e23496c73956df257ebc496f8014ec1` |
| `tests/tools/test_kanban_compute_routing_contract.py` | `5c9f1afe81d5973deef192bf8d317d291f51ba59465303ba3924ebe930a53532` |
| `tests/fixtures/compute_routing_contract_v1.json` | `8cf5a236ca49f2d0851e8e0a9235e43407aad80088c0aea6b2fcf10a2c4fef25` |
| `tests/fixtures/quiz_result.md` | `845547ec753edda291d1141a1985e0df9fd6b165914dbdac4d077b76cec63afc` |

## Verification evidence
All commands ran in the PR worktree with the Hermes Windows venv and isolated basetemp directories.

- Sealed contract: `23 passed in 3.68s`.
- Existing Kanban regression command (the approved 57-case set): `57 passed in 34.66s`.
- Targeted I01 known-bad mutant: `1 failed in 0.71s`, with `expected 'rejected', got 'dispatchable'`; mutant was immediately restored.
- Post-restore sealed contract: `23 passed in 3.68s`.
- Post-restore existing Kanban regression: `57 passed in 34.66s`.
- `py_compile` for the three implementation files and two sealed test modules: exit 0.
- `git diff --check origin/main...HEAD`: exit 0.

Full approved virtual-merge logs and the original 23/57/mutant evidence are referenced at:
`G:/lab/workspace/mas/tasks/dm-0823b/artifacts/virtual-merge-report-r2.md`

## Boundaries
- No master/canon merge.
- No operational rollout or post-push promotion.
- No edits to the original Sol/Luna/Terra candidate worktrees.
