### PR TITLE
fix(update): stop discarding local commits on the update branch itself

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2292,6 +2292,87 @@ def _count_commits_between(git_cmd: list[str], cwd: Path, base: str, head: str) 
         pass
     return -1
 
+
+def _recover_same_branch_divergence(
+    git_cmd: list[str], cwd: Path, branch: str
+) -> bool:
+    """Recover after ``merge --ff-only origin/<branch>`` fails while checked
+    out ON ``branch`` itself (the branch being updated, not a parked custom
+    branch).
+
+    That failure is ambiguous: it can mean upstream force-pushed or rebased
+    (HEAD has nothing unique — resetting to match the remote is safe and
+    correct), or it can mean the checkout has local commits made directly on
+    this branch (e.g. a fix committed here before it was ever pushed
+    anywhere) — resetting would silently destroy those. Distinguish by
+    counting commits on HEAD that origin/<branch> doesn't have, the same
+    signal already used for the parked-custom-branch case.
+
+    Returns True if the checkout is safely resolved (merged or reset) and
+    the update can continue; False if a merge conflict stopped things and
+    the caller should abort the update without touching anything further.
+
+    Note: for a full clone, ff-only failing already implies the count is
+    >= 1 (ff-only succeeding is equivalent to the count being 0), so the
+    reset branch below is mainly a defensive fallback for shallow clones,
+    where the count can be unreliable (see ``apply_is_shallow`` above).
+    """
+    local_unique_count = _count_commits_between(git_cmd, cwd, f"origin/{branch}", "HEAD")
+    if local_unique_count > 0:
+        print(
+            f"  ⚠ {local_unique_count} local commit(s) on '{branch}' "
+            f"not on origin — merging origin/{branch} instead of "
+            "resetting so local commits survive..."
+        )
+        # Best-effort safety tag; recovery anchor if anything goes wrong.
+        subprocess.run(
+            git_cmd + ["tag", f"pre-update-{_time.strftime('%Y%m%d-%H%M%S')}"],
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+        )
+        merge_result = subprocess.run(
+            git_cmd + ["merge", "--no-edit", f"origin/{branch}"],
+            cwd=cwd,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if merge_result.returncode != 0:
+            subprocess.run(
+                git_cmd + ["merge", "--abort"],
+                cwd=cwd,
+                capture_output=True,
+                check=False,
+            )
+            print(
+                "✗ Merge conflict between local commits and upstream — "
+                "update stopped, nothing was changed."
+            )
+            print(f"  Resolve manually: cd {cwd} && git merge origin/{branch}")
+            print("  Then re-run the update. Local work is untouched.")
+            return False
+        return True
+    else:
+        # No unique local commits — a true upstream force-push/rebase.
+        # Local changes are already stashed; reset to match the remote
+        # exactly (original behaviour).
+        print(
+            "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+        )
+        reset_result = subprocess.run(
+            git_cmd + ["reset", "--hard", f"origin/{branch}"],
+            cwd=cwd,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if reset_result.returncode != 0:
+            print(f"✗ Failed to reset to origin/{branch}.")
+            if reset_result.stderr.strip():
+                print(f"  {reset_result.stderr.strip()}")
+            print(f"  Try manually: git fetch origin && git reset --hard origin/{branch}")
+            return False
+        return True
+
 def _should_skip_upstream_prompt() -> bool:
     """Check if user previously declined to add upstream."""
     from hermes_constants import get_hermes_home
@@ -6413,25 +6494,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         )
                         sys.exit(1)
                 else:
-                    # Same branch as the update target — a true upstream
-                    # force-push/rebase. Local changes are already stashed;
-                    # reset to match the remote exactly (original behaviour).
-                    print(
-                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
-                    )
-                    reset_result = subprocess.run(
-                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                        cwd=_m().PROJECT_ROOT,
-                        capture_output=True,
-                        text=True, encoding="utf-8", errors="replace",
-                    )
-                    if reset_result.returncode != 0:
-                        print(f"✗ Failed to reset to origin/{branch}.")
-                        if reset_result.stderr.strip():
-                            print(f"  {reset_result.stderr.strip()}")
-                        print(
-                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
-                        )
+                    if not _recover_same_branch_divergence(
+                        git_cmd, _m().PROJECT_ROOT, branch
+                    ):
                         sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually

--- a/tests/hermes_cli/test_update_same_branch_local_commits_guard.py
+++ b/tests/hermes_cli/test_update_same_branch_local_commits_guard.py
@@ -1,0 +1,153 @@
+"""Regression tests for ``_recover_same_branch_divergence``.
+
+Live incident (2026-08-23): a checkout on ``main`` (the update target
+itself, not a parked custom branch) had one local commit not yet pushed
+anywhere. ``origin/main`` had also moved forward, so
+``git merge --ff-only origin/main`` failed with "not possible to
+fast-forward". The old code treated *any* such failure while on the
+target branch as proof of an upstream force-push/rebase and unconditionally
+ran ``git reset --hard origin/main`` — silently discarding the local
+commit with no tag, no stash, nothing. It was only recoverable via
+``git reflog`` because the object happened not to be garbage collected yet.
+
+The fix (``_recover_same_branch_divergence``): before resetting, count
+commits on HEAD that ``origin/<branch>`` doesn't have. If there are any,
+merge instead (tagging HEAD first as a recovery anchor) and stop cleanly
+on conflict rather than ever discarding them.
+
+Note on the reset --hard branch (count == 0): for a full, non-shallow
+clone this is provably unreachable — ``merge --ff-only`` succeeding is
+logically equivalent to ``rev-list origin/<branch>..HEAD --count`` being
+0, so if ff-only already failed (the precondition for calling this
+function at all), the count is always >= 1 and the merge path is always
+taken. It's kept as a defensive fallback for shallow-clone states, where
+this file elsewhere notes the commit count can be unreliable
+(``apply_is_shallow`` / "Shallow checkout, exact count unrecoverable").
+Not covered here since it isn't constructible with plain git commands
+against a full clone.
+
+These tests run against REAL git repositories (init, commit, clone) — not
+mocked subprocess.run — matching test_update_parked_branch_guard.py.
+"""
+
+import subprocess
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+GIT = ["git"]
+
+
+def _git(cwd, *args, check=True):
+    return subprocess.run(
+        GIT + list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def _head_sha(cwd):
+    return _git(cwd, "rev-parse", "HEAD").stdout.strip()
+
+
+@pytest.fixture()
+def origin_and_clone(tmp_path):
+    """A real origin repo + local clone, both starting on ``main`` at the
+    same commit."""
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "-q", "-b", "main")
+    _git(origin, "config", "user.email", "test@example.com")
+    _git(origin, "config", "user.name", "Test")
+    (origin / "a.txt").write_text("one\n")
+    _git(origin, "add", "a.txt")
+    _git(origin, "commit", "-qm", "c1")
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(origin), str(clone))
+    _git(clone, "config", "user.email", "test@example.com")
+    _git(clone, "config", "user.name", "Test")
+    return origin, clone
+
+
+def test_local_only_commit_is_merged_not_reset(origin_and_clone):
+    """The exact incident shape: clone has a local commit directly on
+    ``main`` that was never pushed; origin/main also advanced. The local
+    commit must survive."""
+    origin, clone = origin_and_clone
+
+    # Local, unpushed commit directly on main.
+    (clone / "local.txt").write_text("local fix\n")
+    _git(clone, "add", "local.txt")
+    _git(clone, "commit", "-qm", "local fix, not yet pushed")
+    local_sha = _head_sha(clone)
+
+    # Origin advances independently.
+    (origin / "b.txt").write_text("upstream\n")
+    _git(origin, "add", "b.txt")
+    _git(origin, "commit", "-qm", "upstream advance")
+
+    _git(clone, "fetch", "-q", "origin", "main")
+    assert _git(clone, "merge", "--ff-only", "origin/main", check=False).returncode != 0
+
+    ok = update_cmd._recover_same_branch_divergence(GIT, clone, "main")
+
+    assert ok is True
+    # The local commit's content must still be reachable from HEAD.
+    assert local_sha in _git(clone, "log", "--format=%H").stdout.splitlines()
+    assert (clone / "local.txt").exists()
+    assert (clone / "b.txt").exists()  # upstream's commit also merged in
+
+
+def test_merge_conflict_stops_cleanly_without_reset(origin_and_clone):
+    """Local-only commit conflicts with upstream's change to the same
+    line: must abort the merge and report failure — never fall back to
+    reset --hard, which would still destroy the local commit."""
+    origin, clone = origin_and_clone
+
+    (clone / "a.txt").write_text("local change\n")
+    _git(clone, "commit", "-aqm", "local change")
+    local_sha = _head_sha(clone)
+
+    (origin / "a.txt").write_text("conflicting upstream change\n")
+    _git(origin, "commit", "-aqm", "upstream change")
+
+    _git(clone, "fetch", "-q", "origin", "main")
+    assert _git(clone, "merge", "--ff-only", "origin/main", check=False).returncode != 0
+
+    ok = update_cmd._recover_same_branch_divergence(GIT, clone, "main")
+
+    assert ok is False
+    # Local commit must still be exactly where it was — no reset occurred.
+    assert _head_sha(clone) == local_sha
+    # No merge left half-applied.
+    status = _git(clone, "status", "--porcelain").stdout
+    assert status == ""
+
+
+def test_local_only_commit_tags_a_recovery_anchor(origin_and_clone):
+    """A pre-update-<timestamp> tag is created before the merge attempt,
+    so the pre-merge state stays recoverable even in edge cases the merge
+    itself doesn't handle cleanly."""
+    origin, clone = origin_and_clone
+
+    (clone / "local.txt").write_text("local fix\n")
+    _git(clone, "add", "local.txt")
+    _git(clone, "commit", "-qm", "local fix")
+
+    (origin / "b.txt").write_text("upstream\n")
+    _git(origin, "add", "b.txt")
+    _git(origin, "commit", "-qm", "upstream advance")
+
+    _git(clone, "fetch", "-q", "origin", "main")
+
+    before_tags = set(_git(clone, "tag", "-l").stdout.split())
+    update_cmd._recover_same_branch_divergence(GIT, clone, "main")
+    after_tags = set(_git(clone, "tag", "-l").stdout.split())
+
+    new_tags = after_tags - before_tags
+    assert any(t.startswith("pre-update-") for t in new_tags)


### PR DESCRIPTION
## Summary
Live incident today: a checkout on `main` had one local commit not yet pushed anywhere (see #92704). `origin/main` had also moved forward, so `merge --ff-only origin/main` failed with "not possible to fast-forward". The existing code treated any such failure while checked out ON the update target branch as proof of an upstream force-push, and unconditionally ran `git reset --hard origin/<branch>` — silently discarding the local commit with no tag or stash. It was only recoverable via `git reflog` because the object hadn't been garbage-collected yet.

The parked-custom-branch case a few lines above already guards against exactly this by checking for local-only commits before ever resetting; the same-branch case never got that check, on the assumption that diverging while already on the target branch could only mean a force-push. That assumption is false — ordinary local commits made directly on the branch produce the identical "can't fast-forward" signal.

- Extracted the same-branch recovery into a standalone `_recover_same_branch_divergence(git_cmd, cwd, branch)` (mirroring `_assess_parked_branch_switch`'s testable style).
- Before resetting, it now counts commits on HEAD that `origin/<branch>` doesn't have (reusing the existing `_count_commits_between` helper). If there are any, it merges instead — tagging HEAD first as a `pre-update-<timestamp>` recovery anchor — and stops cleanly on conflict rather than ever discarding them.
- `reset --hard` is kept as a defensive fallback for shallow clones (where this file elsewhere notes the commit count can be unreliable — `apply_is_shallow`). For a full clone it's provably unreachable: `ff-only` succeeding is logically equivalent to the count being 0, so if `ff-only` already failed, the count is always >= 1.

## Test plan
- [x] New `tests/hermes_cli/test_update_same_branch_local_commits_guard.py`, run against real git repos (matching `test_update_parked_branch_guard.py`'s style rather than mocking `subprocess.run`): local-only commit survives via merge, merge conflict stops cleanly without falling back to reset, and a `pre-update-*` recovery tag is created.
- [x] `python3 -m py_compile hermes_cli/update_cmd.py`
- [x] `pytest tests/hermes_cli/test_update_same_branch_local_commits_guard.py tests/hermes_cli/test_update_parked_branch_guard.py` — 25 passed
- [x] `ruff check` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019npKeyFC5bsKqUwTCjLcyy