### PR TITLE
feat(sessions): `sessions sweep` — archive stale-open sessions prune can't reach

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13609,6 +13609,43 @@ def main():
         "bare number of days, or ISO timestamp)",
     )
 
+    sessions_sweep = sessions_subparsers.add_parser(
+        "sweep",
+        help="Archive stale-open sessions prune can never reach (reversible)",
+        description=(
+            "Archive every session idle for --idle-days days, INCLUDING ones "
+            "that never ended (ended_at NULL) — the population `prune` and "
+            "`archive` structurally skip, left behind by hard kills, crashes, "
+            "or pre-v0.20.4 one-shot exits. Ages on real recency (freshest of "
+            "last activity, latest message, else start time). Reversible: "
+            "rows are hidden, not deleted. Pinned sessions are spared unless "
+            "--include-pinned; compression-lineage interiors are never "
+            "matched. Same selection as the config-gated sessions.auto_archive "
+            "startup hook, but with a preview and confirmation."
+        ),
+    )
+    sessions_sweep.add_argument(
+        "--idle-days",
+        type=float,
+        default=30.0,
+        help="Inactivity cutoff in days (default 30)",
+    )
+    sessions_sweep.add_argument(
+        "--include-pinned",
+        action="store_true",
+        help="Also archive pinned sessions (spared by default — pin is a keep flag)",
+    )
+    sessions_sweep.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List the sessions that would be archived, then exit",
+    )
+    sessions_sweep.add_argument(
+        "--yes", "-y",
+        action="store_true",
+        help="Skip the confirmation prompt",
+    )
+
     sessions_subparsers.add_parser(
         "optimize",
         help="Reclaim disk space: merge FTS5 segments + VACUUM (no data change)",

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1056,6 +1056,81 @@ def cmd_sessions(args, sessions_parser=None):
                 "but fully recoverable (nothing was deleted)."
             )
 
+    elif action == "sweep":
+        # Stale-OPEN sweep: the one population prune/archive can never reach
+        # (their shared selector pins `ended_at IS NOT NULL`). Ages on real
+        # recency — the freshest of last_activity_at, latest message
+        # timestamp, else started_at — so rows left open by hard kills,
+        # crashes, or pre-fix one-shot exits are matched by inactivity, not
+        # by their (missing) end state. Archives (reversible), never deletes;
+        # pinned sessions and compression-lineage interiors are spared. This
+        # is the same selection the config-gated `sessions.auto_archive`
+        # startup hook applies, exposed with a preview + confirmation.
+        from hermes_cli.session_filters import format_epoch
+
+        idle_days = float(getattr(args, "idle_days", 30) or 30)
+        include_pinned = bool(getattr(args, "include_pinned", False))
+
+        candidates = db.list_stale_archive_candidates(
+            idle_days, exclude_pinned=not include_pinned
+        )
+
+        if not candidates:
+            print(
+                f"No unarchived sessions idle for {idle_days:g} day(s) "
+                "(pinned sessions are spared by default)."
+            )
+            return
+
+        _oldest = candidates[0].get("last_active")
+        _newest = candidates[-1].get("last_active")
+        _span = (
+            f"oldest activity {format_epoch(_oldest)}, "
+            f"newest activity {format_epoch(_newest)}"
+        )
+        _open_n = sum(1 for c in candidates if c.get("ended_at") is None)
+        _open_note = (
+            f" ({_open_n} of them never ended — invisible to prune/archive)"
+            if _open_n
+            else ""
+        )
+
+        shown = candidates if args.dry_run else candidates[:15]
+        print(
+            f"{len(candidates)} session(s) idle for {idle_days:g} day(s) "
+            f"({_span}){_open_note}:"
+        )
+        for s in shown:
+            title = (s.get("title") or "")[:36]
+            model = (s.get("model") or "-").split("/")[-1][:24]
+            state = "open" if s.get("ended_at") is None else "ended"
+            print(
+                f"  {s['id']}  {format_epoch(s.get('last_active')):<17} "
+                f"{s['source']:<10} {model:<24} {state:<6} "
+                f"{s['message_count']:>4} msgs  {title}"
+            )
+        if len(candidates) > len(shown):
+            print(f"  … and {len(candidates) - len(shown)} more")
+
+        if args.dry_run:
+            print("Dry run — nothing archived.")
+            return
+
+        if not args.yes:
+            if not _confirm_prompt(
+                f"Archive these {len(candidates)} session(s) ({_span})? [y/N] "
+            ):
+                print("Cancelled.")
+                return
+
+        count = db.archive_stale_sessions(
+            idle_days, exclude_pinned=not include_pinned
+        )
+        print(
+            f"Archived {count} session(s). They're hidden from listings "
+            "but fully recoverable (nothing was deleted)."
+        )
+
     elif action == "rename":
         resolved_session_id = db.resolve_session_id(args.session_id)
         if not resolved_session_id:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -12471,6 +12471,38 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self.set_session_archived(row["id"], True)
         return len(rows)
 
+    def list_stale_archive_candidates(
+        self, idle_days: float, *, exclude_pinned: bool = True
+    ) -> List[Dict[str, Any]]:
+        """Return the rows :meth:`archive_stale_sessions` would sweep.
+
+        Same selection (idle on real recency, unarchived, lineage tips,
+        pin-guarded) but read-only — backs the ``sessions sweep --dry-run``
+        listing so an operator can preview the cutoff before anything is
+        hidden. Rows are ordered oldest-first and carry ``id, source, title,
+        model, started_at, last_active, ended_at, message_count``.
+        """
+        if idle_days is None or idle_days < 0:
+            return []
+        cutoff = time.time() - float(idle_days) * 86400.0
+        pin_clause = "AND s.pinned = 0" if exclude_pinned else ""
+        with self._lock:
+            cursor = self._conn.execute(
+                f"""
+                SELECT s.id, s.source, s.title, s.model, s.started_at,
+                       {_sql_session_last_active("s")} AS last_active,
+                       s.ended_at, s.message_count
+                FROM sessions s
+                WHERE s.archived = 0
+                  AND COALESCE(s.end_reason, '') <> 'compression'
+                  {pin_clause}
+                  AND {_sql_session_last_active("s")} < ?
+                ORDER BY s.started_at ASC
+                """,
+                (cutoff,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
     def archive_stale_sessions(
         self, idle_days: float, *, exclude_pinned: bool = True
     ) -> int:
@@ -12496,26 +12528,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Returns the number of sessions archived. Never raises for an empty or
         non-positive ``idle_days`` — it simply archives nothing.
         """
-        if idle_days is None or idle_days < 0:
-            return 0
-        cutoff = time.time() - float(idle_days) * 86400.0
-        pin_clause = "AND s.pinned = 0" if exclude_pinned else ""
-        with self._lock:
-            rows = self._conn.execute(
-                f"""
-                SELECT s.id FROM sessions s
-                WHERE s.archived = 0
-                  AND COALESCE(s.end_reason, '') <> 'compression'
-                  {pin_clause}
-                  AND {_sql_session_last_active("s")} < ?
-                ORDER BY s.started_at ASC
-                """,
-                (cutoff,),
-            ).fetchall()
-        ids = [(r["id"] if isinstance(r, sqlite3.Row) else r[0]) for r in rows]
-        for sid in ids:
-            self.set_session_archived(sid, True)
-        return len(ids)
+        rows = self.list_stale_archive_candidates(
+            idle_days, exclude_pinned=exclude_pinned
+        )
+        for row in rows:
+            self.set_session_archived(row["id"], True)
+        return len(rows)
 
     def prune_sessions(
         self,

--- a/tests/hermes_cli/test_sessions_sweep.py
+++ b/tests/hermes_cli/test_sessions_sweep.py
@@ -1,0 +1,136 @@
+"""Regression tests: `hermes sessions sweep` reaches stale-OPEN sessions.
+
+`prune`/`archive` select through `_prune_filter_where`, which hard-pins
+``s.ended_at IS NOT NULL`` — so sessions that never ended (hard kills,
+crashes, pre-v0.20.4 one-shot ``-q`` exits) are structurally invisible to
+both. ``sweep`` exposes ``SessionDB.archive_stale_sessions`` with a
+``--dry-run`` preview, aging on real recency (freshest of
+``last_activity_at`` / latest message timestamp / ``started_at``) instead of
+end state.
+
+Contract asserted here (see AGENTS.md: behavior contracts, not snapshots):
+  * an open-but-idle row IS a sweep candidate — and is NOT a prune candidate
+  * a recently-active open row is spared (recency, not end state, decides)
+  * dry-run lists but archives nothing; the real run archives exactly the
+    listed set; a repeat run is an idempotent no-op
+  * pinned rows are spared unless ``--include-pinned``
+"""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.sessions_cmd import cmd_sessions
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(tmp_path / "state.db")
+    yield d
+    try:
+        d.close()
+    except Exception:
+        pass
+
+
+def _mk_idle_open(db, sid, *, days_idle, msgs=1):
+    """An OPEN (ended_at NULL) session last active ``days_idle`` days ago."""
+    db.create_session(session_id=sid, source="cli")
+    for i in range(msgs):
+        db.append_message(session_id=sid, role="user", content=f"m{i}")
+    old = time.time() - days_idle * 86400
+    with db._lock:
+        db._conn.execute("UPDATE sessions SET started_at = ? WHERE id = ?", (old, sid))
+        db._conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE session_id = ?", (old, sid)
+        )
+        db._conn.commit()
+    row = db.get_session(sid)
+    assert row["ended_at"] is None  # precondition: never ended
+
+
+def _mk_active_open(db, sid):
+    """An OPEN session with a message right now — must never be swept."""
+    db.create_session(session_id=sid, source="cli")
+    db.append_message(session_id=sid, role="user", content="now")
+    assert db.get_session(sid)["ended_at"] is None
+
+
+def _sweep_args(**kw):
+    base = dict(
+        sessions_action="sweep", idle_days=30.0, include_pinned=False,
+        dry_run=False, yes=True,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_sweep_reaches_what_prune_cannot(db):
+    """The same row is invisible to prune and visible to sweep."""
+    _mk_idle_open(db, "leaked", days_idle=45)
+
+    # prune's selector pins ended_at IS NOT NULL -> zero candidates
+    assert db.list_prune_candidates(older_than_days=30) == []
+    assert db.count_open_prune_matches(older_than_days=30) == 1  # it sees, skips
+
+    # sweep's candidates include exactly that row
+    ids = [c["id"] for c in db.list_stale_archive_candidates(30)]
+    assert ids == ["leaked"]
+    assert db.archive_stale_sessions(30) == 1
+    assert db.get_session("leaked")["archived"] == 1
+
+
+def test_sweep_spares_recently_active_open(db):
+    """Recency, not end state, decides — a live conversation is never hidden."""
+    _mk_idle_open(db, "old", days_idle=60)
+    _mk_active_open(db, "live")
+
+    ids = [c["id"] for c in db.list_stale_archive_candidates(30)]
+    assert "live" not in ids
+    assert ids == ["old"]
+
+    assert db.archive_stale_sessions(30) == 1
+    assert db.get_session("live")["archived"] == 0
+
+
+def test_sweep_dry_run_archives_nothing_then_run_is_idempotent(db, capsys):
+    _mk_idle_open(db, "a", days_idle=40)
+    _mk_idle_open(db, "b", days_idle=50)
+
+    cands = db.list_stale_archive_candidates(30)
+    assert [c["id"] for c in cands] == ["b", "a"]  # oldest-first (50d before 40d)
+    for c in cands:  # dry-run semantics: list, never write
+        assert db.get_session(c["id"])["archived"] == 0
+
+    assert db.archive_stale_sessions(30) == 2
+    assert db.archive_stale_sessions(30) == 0  # idempotent repeat
+    assert db.get_session("a")["archived"] == 1
+    assert db.get_session("b")["archived"] == 1
+
+
+def test_sweep_pin_guard_and_opt_in(db):
+    _mk_idle_open(db, "keep", days_idle=90)
+    db.set_session_pinned("keep", True)
+
+    assert db.list_stale_archive_candidates(30) == []
+    assert db.archive_stale_sessions(30) == 0
+    assert db.get_session("keep")["archived"] == 0
+
+    opt_in = db.list_stale_archive_candidates(30, exclude_pinned=False)
+    assert [c["id"] for c in opt_in] == ["keep"]
+    assert db.archive_stale_sessions(30, exclude_pinned=False) == 1
+
+
+def test_null_last_activity_falls_back_to_started_at(db):
+    """Older rows with NULL last_activity_at still age via started_at."""
+    _mk_idle_open(db, "legacy", days_idle=100)
+    with db._lock:
+        db._conn.execute(
+            "UPDATE sessions SET last_activity_at = NULL WHERE id = 'legacy'"
+        )
+        db._conn.commit()
+
+    ids = [c["id"] for c in db.list_stale_archive_candidates(30)]
+    assert "legacy" in ids


### PR DESCRIPTION
### Summary

`hermes sessions prune` and `hermes sessions archive` both select through `_prune_filter_where`, which hard-pins `s.ended_at IS NOT NULL` (hermes_state.py ~L12253). Sessions that never ended — hard kills, crashes, OOM, and (pre-v0.20.4) every one-shot `-q` exit (#85680, fixed by 56de3c142) — are therefore structurally invisible to both verbs, and the backlog grows unbounded. Measured on a 24-profile deployment (read-only census over 20 unique stores): 5,931 of 10,210 rows open (58%) *after* a manual cleanup pass; 97% before it.

The DB-layer primitive to fix this already exists in-tree: `SessionDB.archive_stale_sessions()` reaches open rows, ages on real recency (freshest of `last_activity_at` / latest message timestamp / `started_at`), spares pinned rows and compression-lineage interiors, and archives reversibly. But its only call sites were config-gated startup hooks (`sessions.auto_archive`, default off) — no CLI surface, no preview, no confirmation.

This PR wires it up:

- `list_stale_archive_candidates()` — the shared read-only SELECT (extracted from `archive_stale_sessions`, which now delegates to it; behavior unchanged), returning id/source/title/model/started_at/last_active/ended_at/message_count, oldest-first
- `hermes sessions sweep [--idle-days N] [--dry-run] [--include-pinned] [--yes]` — preview listing (all rows on `--dry-run`, first 15 otherwise) with idle-span summary and a count of how many candidates never ended, then confirmation and the reversible archive
- `tests/hermes_cli/test_sessions_sweep.py` — behavior contracts (per AGENTS.md): sweep reaches what prune cannot; recency not end-state decides; dry-run never writes; repeat runs idempotent; pin guard + `--include-pinned` opt-in; NULL `last_activity_at` rows still age via `started_at`

Implements #92740. Complements — does not compete with — #87662 (`prune --include-live`) and #88256 (auto-close during maintenance): this verb is the reversible, preview-first surface for the existing accumulated backlog, reusing the same in-tree primitive those could build on.

### Verification

- [x] I have run the full new test file: `python3 -m pytest tests/hermes_cli/test_sessions_sweep.py -q` → **5 passed**
- [x] Regression suites stay green: `tests/test_hermes_state.py -k "TestSessionPinAndStaleArchive or stale or prune or archive"` → **23 passed**; `tests/hermes_cli/test_prune_spares_pinned.py` → **4 passed**; session browse/export/kanban-source suites → **21 passed**
- [x] Live end-to-end smoke via the real entrypoint (`python3 -m hermes_cli.main sessions sweep --dry-run` and `--yes`) against a temp SessionDB seeded with a 45-day-old leaked-open row and a fresh open row: dry-run listed exactly the leaked row and archived nothing; `--yes` archived it and spared the fresh row (both PASS)
- [x] No existing behavior changed: `archive_stale_sessions` delegates to the extracted SELECT with identical predicates and ordering

### Testing notes

The 11 collection errors under `tests/hermes_cli/` in this sandbox are pre-existing (missing `prompt_toolkit` in the dev environment), unrelated to this diff; the session-related modules that do collect all pass.

### Checklist

- [x] Follows the [contribution guidelines](CONTRIBUTING.md) (bug-fix/small-feature lane; searched open+merged PRs first — no existing PR exposes `archive_stale_sessions`)
- [x] Tests added that fail without the change (the sweep-reaches-what-prune-cannot contract fails on main: the method does not exist)
- [x] All tests pass locally
- [ ] Documentation — `docs/cli/sessions.md` mention can follow once the verb shape is agreed (happy to add)
