### PR TITLE
fix(desktop): right-sidebar toggle acts on the physical right column

### DIFF
--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -32,8 +32,8 @@ import { $capture, $comboIndex, endCapture, setBinding } from '@/store/keybinds'
 import {
   requestSessionSearchFocus,
   setFileBrowserOpen,
-  toggleFileBrowserOpen,
   togglePanesFlipped,
+  toggleRightSide,
   toggleSidebarOpen
 } from '@/store/layout'
 import { openBrowserTab } from '@/store/preview'
@@ -239,11 +239,11 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
 
     // Narrow-viewport reveal is handled inside the store toggles now.
     'view.toggleSidebar': toggleSidebarOpen,
-    // ⌘J toggles the right sidebar — but a layout with no right side (e.g.
-    // terminal-on-bottom) would leave it a dead key, so it falls back to the
-    // terminal there. The single "secondary panel" toggle.
+    // ⌘J toggles the physical right side — whatever column lives there in the
+    // live tree (the browser preview column, the files column). Falls back to
+    // the semantic branch when no right side exists (terminal-on-bottom).
     'view.toggleRightSidebar': () =>
-      layoutHasRootSide('right') ? toggleFileBrowserOpen() : togglePaneVisible('terminal'),
+      layoutHasRootSide('right') ? toggleRightSide() : togglePaneVisible('terminal'),
     'view.toggleReview': toggleReview,
     'view.toggleStatusbar': toggleStatusbarVisible,
     'view.toggleTabStrip': () => void toggleTargetZoneTabStrip(),

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -19,8 +19,8 @@ import {
   $fileBrowserOpen,
   $panesFlipped,
   $sidebarOpen,
-  toggleFileBrowserOpen,
   togglePanesFlipped,
+  toggleRightSide,
   toggleSidebarOpen
 } from '@/store/layout'
 import { $unreadSessionCount } from '@/store/session-dot-state'
@@ -154,10 +154,10 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   // POSITIONAL toggles: each button shows/hides everything on its physical
   // side of the main zone (the layout tree collapses the whole side), so they
   // stay correct through flips and rearranges. $sidebarOpen ≙ left side,
-  // $fileBrowserOpen ≙ right side. Never an active highlight — plain
-  // show/hide affordances.
+  // the right side resolves from the live tree (see toggleRightSide) — the
+  // browser column, the files column, whatever is physically right.
   const leftEdge = { open: sidebarOpen, toggle: toggleSidebarOpen }
-  const rightEdge = { open: fileBrowserOpen, toggle: toggleFileBrowserOpen }
+  const rightEdge = { open: fileBrowserOpen, toggle: toggleRightSide }
   const leftLabel = leftEdge.open ? t.titlebar.hideSidebar : t.titlebar.showSidebar
   const rightLabel = rightEdge.open ? t.titlebar.hideRightSidebar : t.titlebar.showRightSidebar
 

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -2,7 +2,14 @@ import { atom, computed, type ReadableAtom, type WritableAtom } from 'nanostores
 
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
-import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
+import {
+  allPaneIds as allPaneIdsOf,
+  type GroupNode,
+  type LayoutNode,
+  type SplitNode
+} from '@/components/pane-shell/tree/model'
+import { isPaneVisible, revealTreePane, setTreeGroupMinimized, $layoutTree } from '@/components/pane-shell/tree/store'
+import { registry } from '@/contrib/registry'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { connectionScopedAtom } from '@/lib/connection-scoped'
 import { type Codec, Codecs, persistentAtom } from '@/lib/persisted'
@@ -497,6 +504,114 @@ export function toggleSidebarOpen() {
   if (!revealNarrowPane(CHAT_SIDEBAR_PANE_ID, 'toggle')) {
     togglePane(CHAT_SIDEBAR_PANE_ID)
   }
+}
+
+// POSITIONAL right-side toggle. The titlebar button and ⌘J promise
+// "everything on your physical right" — but preview tiles (the Browser) dock
+// beside main with placement 'main', so the SEMANTIC side derivation never
+// classifies their column as a side column, and the old pane-bound toggle
+// (files) pressed a pane that had been dragged into the left stack. Resolve
+// the target from the TREE instead: the rightmost root-row column that isn't
+// the main column, whatever panes live there — then fold/unfold it through
+// the tree's own zone minimize, which keeps its tab on a persistent rail so
+// the toggle round-trips exactly like the zone chevron.
+export function toggleRightSide() {
+  if (revealNarrowPane(FILE_BROWSER_PANE_ID, 'toggle')) {
+    return
+  }
+
+  const group = rightSideGroup()
+
+  if (!group) {
+    // No side column on the right (e.g. terminal-deck): fall back to the
+    // semantic branch so ⌘J is never a dead key.
+    toggleFileBrowserOpen()
+
+    return
+  }
+
+  if (group.minimized) {
+    revealTreePane(group.active ?? group.panes[0])
+
+    return
+  }
+
+  setTreeGroupMinimized(group.id, true)
+}
+
+// Placement of a pane contribution ('left' | 'main' | 'right' | …) — panes
+// not yet registered (runtime plugins) read as undefined and skip the walk.
+function panePlacement(id: string): string | undefined {
+  return (registry.getArea('panes').find(p => p.id === id)?.data as { placement?: string } | undefined)?.placement
+}
+
+// The physically-rightmost foldable column of the root row — the POSITIONAL
+// right side, derived from the live tree. Unlike the semantic `rootChildSide`
+// (which sees only placement-tagged side panes), this ALSO catches a
+// preview-tile column (the Browser): its panes register `placement: 'main'`,
+// so the semantic walk classifies their zone as main and skips it. Here a
+// column qualifies when it is a leaf group, sits right of the main column,
+// and holds no main zone (the workspace/session-tile surfaces). Null when
+// nothing foldable lives there.
+function rightSideGroup(): GroupNode | null {
+  const tree = $layoutTree.get()
+
+  if (!tree) {
+    return null
+  }
+
+  const row = rootRowOf(tree)
+
+  for (let i = row.children.length - 1; i >= 0; i--) {
+    const child = row.children[i]!
+
+    // Only a leaf group folds; a nested split would strand inner zones.
+    if (child.type !== 'group') {
+      continue
+    }
+
+    const placements = child.panes.map(panePlacement)
+
+    // The main column itself (workspace / session tiles) is never a side.
+    if (placements.includes('main') && child.panes.some(isMainSurface)) {
+      continue
+    }
+
+    return child
+  }
+
+  return null
+}
+
+// Is `paneId` a main surface (the workspace or a session/route tile)? Those
+// are the panes whose `placement: 'main'` marks THE main column; preview
+// tiles share the placement but are docked side surfaces.
+function isMainSurface(paneId: string): boolean {
+  return paneId === 'workspace' || paneId.startsWith('session-tile:') || paneId.startsWith('route-tile:')
+}
+
+// Root row of the layout — the split the side-collapse system operates on:
+// a row root (Default/Focus) or the row child inside a column root that
+// contains main (Terminal deck/Quad), mirroring TreeSplit's `rootRow`
+// propagation.
+function rootRowOf(tree: LayoutNode): SplitNode {
+  if (tree.type === 'split' && tree.orientation === 'row') {
+    return tree
+  }
+
+  if (tree.type === 'split' && tree.orientation === 'column') {
+    const row = tree.children.find(
+      child => child.type === 'split' && child.orientation === 'row' && allPaneIdsOf(child).some(id => panePlacement(id) === 'main')
+    )
+
+    if (row && row.type === 'split') {
+      return row
+    }
+  }
+
+  // Defensive: a lone-group root (or an unexpected shape) — wrap it in a row
+  // so the caller's column walk still has a frame to walk.
+  return { type: 'split', orientation: 'row', children: [tree], weights: [1], id: 'fallback-row' } as SplitNode
 }
 
 export function toggleFileBrowserOpen() {

--- a/apps/desktop/src/store/right-side-toggle.test.ts
+++ b/apps/desktop/src/store/right-side-toggle.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { findGroupOfPane, split, group } from '@/components/pane-shell/tree/model'
+import type { LayoutNode } from '@/components/pane-shell/tree/model'
+
+// The right-side toggle must be POSITIONAL: it acts on whatever column is
+// physically rightmost in the root row — including a preview-tile column
+// (the Browser), whose panes register with `placement: 'main'` and are
+// therefore invisible to the semantic side derivation. Ground truth for the
+// "⌘J / titlebar toggle does nothing to the browser pane" bug: the old
+// pane-bound toggle pressed the files pane, which the user had dragged into
+// the left stack.
+
+describe('positional right-side toggle', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  async function setup() {
+    const tree = await import('@/components/pane-shell/tree/store')
+    const layout = await import('@/store/layout')
+    const { registry } = await import('@/contrib/registry')
+
+    // Mirror controller.tsx registrations: sessions left, files right, and a
+    // preview tile (Browser) that docks beside main with placement 'main'.
+    registry.register({ id: 'sessions', area: 'panes', title: 'sessions', data: { placement: 'left' }, render: () => null })
+    registry.register({ id: 'files', area: 'panes', title: 'files', data: { placement: 'right' }, render: () => null })
+    registry.register({ id: 'preview-tile:url:browser', area: 'panes', title: 'Browser', data: { placement: 'main' }, render: () => null })
+    registry.register({ id: 'workspace', area: 'panes', title: 'workspace', data: { placement: 'main' }, render: () => null })
+
+    // User's arrangement: left stack holds sessions+files (dragged), browser
+    // column is its own zone on the right of the root row.
+    tree.declareDefaultTree(
+      split('row', [
+        group(['sessions', 'files']),
+        group(['workspace']),
+        group(['preview-tile:url:browser'])
+      ])
+    )
+
+    return { tree, layout }
+  }
+
+  it('folds the rightmost side column (the browser) to a minimized rail', async () => {
+    const { tree, layout } = await setup()
+
+    layout.toggleRightSide()
+
+    const browserGroup = findGroupOfPane(tree.$layoutTree.get() as LayoutNode, 'preview-tile:url:browser')
+    expect(browserGroup?.minimized).toBe(true)
+  })
+
+  it('round-trips: a second press restores the zone', async () => {
+    const { tree, layout } = await setup()
+
+    layout.toggleRightSide()
+    layout.toggleRightSide()
+
+    const browserGroup = findGroupOfPane(tree.$layoutTree.get() as LayoutNode, 'preview-tile:url:browser')
+    expect(browserGroup?.minimized).toBe(false)
+  })
+
+  it('leaves the left stack (sessions+files) untouched', async () => {
+    const { tree, layout } = await setup()
+
+    layout.toggleRightSide()
+
+    const filesGroup = findGroupOfPane(tree.$layoutTree.get() as LayoutNode, 'files')
+    expect(Boolean(filesGroup?.minimized)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

The titlebar's right-sidebar toggle (and ⌘J) is documented as **positional** — *"each button shows/hides everything on its physical side of the main zone"* — but the implementation is pane-bound to the files pane. Two concrete breakages:

1. **The Browser column is invisible to the toggle.** Preview tiles dock beside main with `placement: 'main'`, so `rootChildSide` classifies their column as the main column (null side). The semantic side-collapse system can never reach the browser zone — pressing the toggle does nothing to it.
2. **Rearranged layouts strand the toggle.** Dragging the files pane into the left stack (a normal drag-and-drop operation the layout editor encourages) leaves the toggle pressing a pane that no longer owns the right side. It fronts the FILES tab instead of collapsing anything on the right.

## Fix

Resolve the toggle's target from the **live tree**: the rightmost foldable root-row column (a leaf group holding no workspace/session-tile surface), whatever panes live there. Fold/unfold through the tree's own zone minimize (`setTreeGroupMinimized`), so:

- the zone keeps its tab on a persistent rail — the toggle round-trips exactly like the zone chevron and the rail tab
- no new surface: reuses the existing zone-minimize primitive
- falls back to the existing semantic branch when no right-side column exists, so terminal-on-bottom layouts keep ⌘J alive (no behavior change for stock layouts beyond the browser column now being reachable)

## Verification

- New ground-truth test `apps/desktop/src/store/right-side-toggle.test.ts`: folds the browser column, round-trips, leaves the left stack untouched — with pane registrations mirroring controller.tsx (preview tile registered `placement: 'main'`, files dragged into the left stack)
- `npm run typecheck` clean on origin/main
- Existing suites still green: sidebar-collapse-persistence, reactive-unhide, pane-toggle-visibility
- Manually verified in a running build: button collapses the Browser column to its rail and restores it

## Notes

- The left toggle (⌘B) is unchanged — left columns are placement-tagged, so the semantic derivation already reaches them.
- The `open` state shown on the button still reads ``; the label can now disagree with a browser-only right side (says "Show right sidebar" while the files pane is open). Kept this PR minimal, but happy to derive the icon state from the tree in a follow-up if maintainers prefer.