### PR TITLE
fix(desktop): constrain composer attachment row (unverified, #92664)

### DIFF
--- a/apps/desktop/src/app/chat/composer/attachments.tsx
+++ b/apps/desktop/src/app/chat/composer/attachments.tsx
@@ -23,7 +23,7 @@ export function AttachmentList({
   onRemove?: (id: string) => void
 }) {
   return (
-    <div className="flex max-w-full flex-wrap gap-1.5 px-1 pt-1" data-slot="composer-attachments">
+    <div className="flex max-w-full flex-shrink-0 flex-wrap gap-1.5 px-1 pt-1 overflow-hidden" data-slot="composer-attachments">
       {attachments.filter(Boolean).map(attachment => (
         <AttachmentPill
           attachment={attachment}


### PR DESCRIPTION
## Summary
Attempted layout fix for composer overflow when pasting an attachment with no prompt text.

`AttachmentList` sits in a `flex-col` composer. On Ubuntu, any attachment (image or file) with an empty prompt can blow the layout. This adds `flex-shrink-0` and `overflow-hidden` on the attachment row.

Related: #92664

## Test plan
- [ ] **Not verified in a live Electron window.** Dev Electron cannot start beside the installed Hermes (single-instance lock). Browser `vite` has no desktop IPC, so the composer is unreachable.
- [ ] Please check on Linux: paste image only, no text.
- [ ] Please check on Linux: attach a file only, no text.
- [ ] Please check that attachments + typed prompt still look normal.

## Notes
One-line CSS change only. Happy to iterate if this is the wrong constraint.
