### PR TITLE
feat(web): add configured fallback backend

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -340,8 +340,11 @@ DEFAULT_CONFIG = {
     },
 
     "web": {
-        "backend": "",           # shared fallback — applies to both search and extract
+        "backend": "",           # shared selection — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
+        "fallback_backend": "",  # configured request-level secondary for both capabilities
+        "search_fallback_backend": "",  # per-capability secondary for search
+        "extract_fallback_backend": "",  # per-capability secondary for extract
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
         # per-page char budget for web_extract; larger pages truncate, full text kept in cache/web
         "extract_char_limit": 15000,

--- a/tests/tools/test_web_configured_fallback.py
+++ b/tests/tools/test_web_configured_fallback.py
@@ -1,0 +1,832 @@
+"""Request-level fallback from a failed primary web provider to a configured secondary."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+import tools.web_result_cache as web_result_cache
+import tools.web_tools as web_tools
+import tools.web_tools_rescue as web_rescue
+import tools.web_tools_extract as web_extract
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+from plugins.web import keyless_mcp
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path, monkeypatch):
+    """Keep memo and disk cache state local to each fallback test."""
+    cache_dir = tmp_path / "cache" / "web"
+    cache_dir.mkdir(parents=True)
+    monkeypatch.setattr(web_result_cache, "search_memo", web_result_cache.SearchMemo())
+    monkeypatch.setattr(web_result_cache, "_cache_dir", lambda: cache_dir)
+    monkeypatch.setattr(web_result_cache, "_web_config", lambda: {})
+
+
+def test_fallback_keys_are_recognized_configuration():
+    web = DEFAULT_CONFIG["web"]
+    assert web["fallback_backend"] == ""
+    assert web["search_fallback_backend"] == ""
+    assert web["extract_fallback_backend"] == ""
+
+
+class _Provider:
+    def __init__(
+        self, name, *, search_result=None, extract_result=None, available=True
+    ):
+        self.name = name
+        self.display_name = name.title()
+        self.search_result = search_result
+        self.extract_result = extract_result
+        self.available = available
+        self.search_calls = 0
+        self.extract_calls = 0
+        self.extract_urls = []
+
+    def supports_search(self):
+        return self.search_result is not None
+
+    def supports_extract(self):
+        return self.extract_result is not None
+
+    def is_available(self):
+        return self.available
+
+    def search(self, query, limit=5):
+        self.search_calls += 1
+        return self.search_result
+
+    def extract(self, urls, **kwargs):
+        self.extract_calls += 1
+        self.extract_urls.append(list(urls))
+        return self.extract_result
+
+
+class _RaisingSearchProvider(_Provider):
+    def search(self, query, limit=5):
+        self.search_calls += 1
+        raise RuntimeError("primary connection reset")
+
+
+def _search_ok(vendor):
+    return {
+        "success": True,
+        "data": {"web": [{"url": f"https://{vendor}.example", "title": vendor}]},
+    }
+
+
+def _extract_ok(url):
+    return [
+        {
+            "url": url,
+            "title": "Fallback",
+            "content": "fallback content",
+            "raw_content": "fallback content",
+            "metadata": {"sourceURL": url},
+        }
+    ]
+
+
+def _registry(monkeypatch, providers):
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(
+        "agent.web_search_registry.get_provider",
+        lambda name: providers.get(name),
+    )
+
+
+class TestKeyedSearchFallback:
+    def test_failed_primary_uses_configured_secondary_before_keyless(self, monkeypatch):
+        primary = _Provider(
+            "exa",
+            search_result={"success": False, "error": "HTTP 402 credits exhausted"},
+        )
+        secondary = _Provider("tavily", search_result=_search_ok("tavily"))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "search_backend": "exa",
+                "fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        first = json.loads(web_tools.web_search_tool("q", limit=2))
+        second = json.loads(web_tools.web_search_tool("q", limit=2))
+
+        for result in (first, second):
+            assert result["success"] is True
+            assert result["data"]["served_by"] == "tavily"
+            assert result["data"]["fallback_from"] == "exa"
+            assert "402" in result["data"]["backend_error"]
+        assert primary.search_calls == 2
+        assert secondary.search_calls == 2
+
+    def test_capability_specific_fallback_overrides_shared_fallback(self, monkeypatch):
+        primary = _Provider(
+            "exa",
+            search_result={"success": False, "error": "HTTP 402 credits exhausted"},
+        )
+        tavily = _Provider("tavily", search_result=_search_ok("tavily"))
+        parallel = _Provider("parallel", search_result=_search_ok("parallel"))
+        _registry(
+            monkeypatch,
+            {"exa": primary, "tavily": tavily, "parallel": parallel},
+        )
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "search_backend": "exa",
+                "fallback_backend": "parallel",
+                "search_fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        result = json.loads(web_tools.web_search_tool("q"))
+
+        assert result["success"] is True
+        assert result["data"]["served_by"] == "tavily"
+        assert tavily.search_calls == 1
+        assert parallel.search_calls == 0
+
+    def test_primary_exception_uses_configured_secondary(self, monkeypatch):
+        primary = _RaisingSearchProvider("exa", search_result={"unused": True})
+        secondary = _Provider("tavily", search_result=_search_ok("tavily"))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "search_backend": "exa",
+                "fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        result = json.loads(web_tools.web_search_tool("q"))
+
+        assert result["success"] is True
+        assert result["data"]["served_by"] == "tavily"
+        assert "connection reset" in result["data"]["backend_error"]
+
+    def test_failed_secondary_continues_to_keyless_rescue(self, monkeypatch):
+        primary = _Provider(
+            "exa", search_result={"success": False, "error": "HTTP 402 exhausted"}
+        )
+        secondary = _Provider(
+            "tavily", search_result={"success": False, "error": "HTTP 503 unavailable"}
+        )
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"search_backend": "exa", "fallback_backend": "tavily"},
+        )
+        monkeypatch.setattr(
+            "agent.web_search_provider.get_provider_env",
+            lambda name: "exa-key" if name == "EXA_API_KEY" else "",
+        )
+        monkeypatch.setattr(
+            "agent.web_search_registry._keyless_tier_enabled", lambda: True
+        )
+        monkeypatch.setattr(
+            keyless_mcp, "search_with_failover", lambda *args: _search_ok("free")
+        )
+
+        result = json.loads(web_tools.web_search_tool("q"))
+
+        assert result["success"] is True
+        assert result["data"]["rescued_from"] == "exa"
+        assert "tavily" in result["data"]["backend_error"]
+        assert primary.search_calls == 1
+        assert secondary.search_calls == 1
+
+    def test_free_tier_secondary_is_skipped(self, monkeypatch):
+        primary = _Provider(
+            "exa", search_result={"success": False, "error": "HTTP 402 exhausted"}
+        )
+        secondary = _Provider("tavily", search_result=_search_ok("tavily"))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"search_backend": "exa", "fallback_backend": "tavily"},
+        )
+        monkeypatch.setattr(
+            keyless_mcp,
+            "provider_tier",
+            lambda name: "free" if name == "tavily" else None,
+        )
+        monkeypatch.setattr(
+            "agent.web_search_provider.get_provider_env",
+            lambda name: "exa-key" if name == "EXA_API_KEY" else "tavily-key",
+        )
+        monkeypatch.setattr(
+            "agent.web_search_registry._keyless_tier_enabled", lambda: True
+        )
+
+        with patch.object(
+            keyless_mcp, "search_with_failover", return_value=_search_ok("free")
+        ) as keyless:
+            result = json.loads(web_tools.web_search_tool("q"))
+
+        assert result["success"] is True
+        assert secondary.search_calls == 0
+        keyless.assert_called_once()
+
+    def test_unavailable_secondary_is_skipped_instead_of_using_keyless(self, monkeypatch):
+        primary = _Provider(
+            "exa", search_result={"success": False, "error": "HTTP 402 exhausted"}
+        )
+        secondary = _Provider(
+            "tavily", search_result=_search_ok("tavily"), available=False
+        )
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"search_backend": "exa", "fallback_backend": "tavily"},
+        )
+        monkeypatch.setattr(
+            "agent.web_search_provider.get_provider_env",
+            lambda name: "exa-key" if name == "EXA_API_KEY" else "",
+        )
+        monkeypatch.setattr(
+            "agent.web_search_registry._keyless_tier_enabled", lambda: True
+        )
+
+        with patch.object(
+            keyless_mcp, "search_with_failover", return_value=_search_ok("free")
+        ) as keyless:
+            result = json.loads(web_tools.web_search_tool("q"))
+
+        assert result["success"] is True
+        assert secondary.search_calls == 0
+        keyless.assert_called_once_with("exa", "q", 10)
+
+    def test_same_provider_is_not_retried_as_its_own_fallback(self, monkeypatch):
+        primary = _Provider(
+            "exa", search_result={"success": False, "error": "HTTP 402 exhausted"}
+        )
+        _registry(monkeypatch, {"exa": primary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "search_backend": "exa",
+                "fallback_backend": "exa",
+                "keyless_fallback": False,
+            },
+        )
+
+        result = json.loads(web_tools.web_search_tool("q"))
+
+        assert result["success"] is False
+        assert primary.search_calls == 1
+
+
+class TestKeyedExtractFallback:
+    @pytest.mark.asyncio
+    async def test_failed_batch_uses_configured_secondary_before_keyless(
+        self, monkeypatch
+    ):
+        url = "https://example.com/page"
+        primary = _Provider(
+            "exa",
+            extract_result=[
+                {
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": "HTTP 402 credits exhausted",
+                }
+            ],
+        )
+        secondary = _Provider("tavily", extract_result=_extract_ok(url))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        async def _allow_all(candidate, **kwargs):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+        first = json.loads(await web_tools.web_extract_tool([url]))
+        second = json.loads(await web_tools.web_extract_tool([url]))
+
+        for result in (first, second):
+            rows = result["results"] if isinstance(result, dict) else result
+            assert rows[0]["content"] == "fallback content"
+        assert primary.extract_calls == 2
+        assert secondary.extract_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_partial_primary_failure_does_not_retry_secondary(self, monkeypatch):
+        urls = ["https://example.com/a", "https://example.com/b"]
+        primary = _Provider(
+            "exa",
+            extract_result=[
+                {"url": urls[0], "title": "A", "content": "ok", "raw_content": "ok"},
+                {"url": urls[1], "title": "", "content": "", "error": "404"},
+            ],
+        )
+        secondary = _Provider("tavily", extract_result=_extract_ok(urls[1]))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        async def _allow_all(candidate, **kwargs):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+        await web_tools.web_extract_tool(urls)
+
+        assert primary.extract_calls == 1
+        assert secondary.extract_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_policy_block_is_not_sent_to_secondary(self, monkeypatch):
+        url = "https://blocked.example"
+        primary = _Provider(
+            "exa",
+            extract_result=[
+                {
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": "Blocked by website policy",
+                    "blocked_by_policy": True,
+                }
+            ],
+        )
+        secondary = _Provider("tavily", extract_result=_extract_ok(url))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        async def _allow_all(candidate, **kwargs):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+        await web_tools.web_extract_tool([url])
+
+        assert primary.extract_calls == 1
+        assert secondary.extract_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_global_policy_block_never_reaches_any_provider(self, monkeypatch):
+        url = "https://blocked.example/private"
+        primary = _Provider(
+            "exa",
+            extract_result=[
+                {"url": url, "title": "", "content": "", "error": "primary outage"}
+            ],
+        )
+        secondary = _Provider("tavily", extract_result=_extract_ok(url))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        async def _allow_all(candidate, **kwargs):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+        blocked = {
+            "host": "blocked.example",
+            "rule": "blocked.example",
+            "source": "config",
+            "message": "Blocked by website policy",
+        }
+        with patch("tools.website_policy.check_website_access", return_value=blocked):
+            result = json.loads(await web_tools.web_extract_tool([url]))
+
+        rows = result["results"] if isinstance(result, dict) else result
+        assert rows[0]["blocked_by_policy"] is True
+        assert "Blocked by website policy" in rows[0]["error"]
+        assert primary.extract_calls == 0
+        assert secondary.extract_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_mixed_policy_batch_sends_only_allowed_urls(self, monkeypatch):
+        blocked_url = "https://blocked.example/private"
+        allowed_url = "https://allowed.example/article"
+        primary = _Provider(
+            "exa",
+            extract_result=[
+                {
+                    "url": allowed_url,
+                    "title": "",
+                    "content": "",
+                    "error": "primary outage",
+                }
+            ],
+        )
+        secondary = _Provider("tavily", extract_result=_extract_ok(allowed_url))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        async def _allow_all(candidate, **kwargs):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+        blocked = {
+            "host": "blocked.example",
+            "rule": "blocked.example",
+            "source": "config",
+            "message": "Blocked by website policy",
+        }
+
+        def _policy(url):
+            return blocked if url == blocked_url else None
+
+        with patch("tools.website_policy.check_website_access", side_effect=_policy):
+            result = json.loads(
+                await web_tools.web_extract_tool([blocked_url, allowed_url])
+            )
+
+        rows = result["results"] if isinstance(result, dict) else result
+        assert rows[0]["blocked_by_policy"] is True
+        assert rows[1]["content"] == "fallback content"
+        assert primary.extract_urls == [[allowed_url]]
+        assert secondary.extract_urls == [[allowed_url]]
+
+    @pytest.mark.asyncio
+    async def test_empty_primary_batch_retries_configured_secondary(self, monkeypatch):
+        url = "https://example.com/a"
+        primary = _Provider("exa", extract_result=[])
+        secondary = _Provider("tavily", extract_result=_extract_ok(url))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        async def _allow_all(candidate, **kwargs):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+        result = json.loads(await web_tools.web_extract_tool([url]))
+
+        rows = result["results"] if isinstance(result, dict) else result
+        assert rows[0]["content"] == "fallback content"
+        assert primary.extract_calls == 1
+        assert secondary.extract_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_partial_policy_result_suppresses_fallback(self, monkeypatch):
+        urls = ["https://blocked.example", "https://missing.example"]
+        primary = _Provider(
+            "exa",
+            extract_result=[
+                {
+                    "url": urls[0],
+                    "title": "",
+                    "content": "",
+                    "error": "Blocked by website policy",
+                    "blocked_by_policy": True,
+                }
+            ],
+        )
+        secondary = _Provider("tavily", extract_result=_extract_ok(urls[1]))
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {
+                "extract_backend": "exa",
+                "fallback_backend": "tavily",
+                "keyless_fallback": False,
+            },
+        )
+
+        async def _allow_all(candidate, **kwargs):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+        await web_tools.web_extract_tool(urls)
+
+        assert primary.extract_calls == 1
+        assert secondary.extract_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_secondary_policy_block_is_preserved_for_keyless_rescue(
+        self, monkeypatch
+    ):
+        url = "https://redirects-to-blocked.example"
+        primary_results = [
+            {"url": url, "title": "", "content": "", "error": "primary outage"}
+        ]
+        secondary_results = [
+            {
+                "url": url,
+                "title": "",
+                "content": "",
+                "error": "Blocked by website policy after redirect",
+                "blocked_by_policy": True,
+            }
+        ]
+        secondary = _Provider("tavily", extract_result=secondary_results)
+        _registry(monkeypatch, {"tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"extract_backend": "exa", "fallback_backend": "tavily"},
+        )
+
+        fallback_results, fallback_error = await web_rescue._try_fallback_extract(
+            "exa", [url], primary_results
+        )
+
+        assert fallback_error == ""
+        assert fallback_results == secondary_results
+        with patch.object(keyless_mcp, "extract_with_failover") as keyless:
+            returned = web_rescue._rescue_extract("exa", [url], fallback_results)
+        assert returned == secondary_results
+        keyless.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_secondary_policy_block_preserved_while_other_failure_is_rescued(
+        self, monkeypatch
+    ):
+        urls = [
+            "https://redirects-to-blocked.example",
+            "https://temporary-outage.example",
+        ]
+        primary = _Provider(
+            "exa",
+            extract_result=[
+                {"url": urls[0], "title": "", "content": "", "error": "primary outage"},
+                {"url": urls[1], "title": "", "content": "", "error": "primary outage"},
+            ],
+        )
+        secondary = _Provider(
+            "tavily",
+            extract_result=[
+                {
+                    "url": urls[0],
+                    "title": "",
+                    "content": "",
+                    "error": "Blocked by website policy after redirect",
+                    "blocked_by_policy": True,
+                },
+                {
+                    "url": urls[1],
+                    "title": "",
+                    "content": "",
+                    "error": "secondary outage",
+                },
+            ],
+        )
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"extract_backend": "exa", "fallback_backend": "tavily"},
+        )
+        monkeypatch.setattr(web_extract, "_rescue_eligible", lambda provider: True)
+
+        async def _allow_all(candidate, **kwargs):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+        rescued = _extract_ok(urls[1])
+        with patch.object(
+            keyless_mcp, "extract_with_failover", return_value=rescued
+        ) as keyless:
+            result = json.loads(await web_tools.web_extract_tool(urls))
+
+        rows = result["results"] if isinstance(result, dict) else result
+        assert rows[0]["blocked_by_policy"] is True
+        assert rows[1]["content"] == "fallback content"
+        keyless.assert_called_once_with("exa", [urls[1]])
+
+    @pytest.mark.asyncio
+    async def test_secondary_policy_block_with_other_success_does_not_rescue(
+        self, monkeypatch
+    ):
+        urls = [
+            "https://redirects-to-blocked.example",
+            "https://secondary-success.example",
+        ]
+        primary = _Provider(
+            "exa",
+            extract_result=[
+                {"url": url, "title": "", "content": "", "error": "primary outage"}
+                for url in urls
+            ],
+        )
+        secondary = _Provider(
+            "tavily",
+            extract_result=[
+                {
+                    "url": urls[0],
+                    "title": "",
+                    "content": "",
+                    "error": "Blocked by website policy after redirect",
+                    "blocked_by_policy": True,
+                },
+                _extract_ok(urls[1])[0],
+            ],
+        )
+        _registry(monkeypatch, {"exa": primary, "tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"extract_backend": "exa", "fallback_backend": "tavily"},
+        )
+        monkeypatch.setattr(web_extract, "_rescue_eligible", lambda provider: True)
+
+        async def _allow_all(candidate, **kwargs):
+            return True
+
+        monkeypatch.setattr(web_tools, "async_is_safe_url", _allow_all)
+        with patch.object(keyless_mcp, "extract_with_failover") as keyless:
+            result = json.loads(await web_tools.web_extract_tool(urls))
+
+        rows = result["results"] if isinstance(result, dict) else result
+        assert rows[0]["blocked_by_policy"] is True
+        assert rows[1]["content"] == "fallback content"
+        keyless.assert_not_called()
+
+    def test_policy_partition_preserved_when_rescue_returns_empty(self):
+        urls = ["https://blocked.example", "https://outage.example"]
+        results = [
+            {
+                "url": urls[0],
+                "error": "Blocked by website policy after redirect",
+                "blocked_by_policy": True,
+            },
+            {"url": urls[1], "error": "secondary outage"},
+        ]
+
+        with patch.object(
+            keyless_mcp, "extract_with_failover", return_value=[]
+        ) as keyless:
+            returned = web_rescue._rescue_extract("exa", urls, results)
+
+        assert returned == results
+        keyless.assert_called_once_with("exa", [urls[1]])
+
+    def test_policy_partition_preserved_when_rescue_returns_short_batch(self):
+        urls = [
+            "https://blocked.example",
+            "https://rescued.example",
+            "https://still-failed.example",
+        ]
+        results = [
+            {
+                "url": urls[0],
+                "error": "Blocked by website policy after redirect",
+                "blocked_by_policy": True,
+            },
+            {"url": urls[1], "error": "secondary outage"},
+            {"url": urls[2], "error": "secondary outage"},
+        ]
+        short_rescue = _extract_ok(urls[1])
+
+        with patch.object(
+            keyless_mcp, "extract_with_failover", return_value=short_rescue
+        ) as keyless:
+            returned = web_rescue._rescue_extract("exa", urls, results)
+
+        assert len(returned) == len(urls)
+        assert returned[0] == results[0]
+        assert returned[1]["content"] == "fallback content"
+        assert returned[2] == results[2]
+        keyless.assert_called_once_with("exa", urls[1:])
+
+    @pytest.mark.asyncio
+    async def test_short_secondary_policy_batch_preserves_unreturned_failures(
+        self, monkeypatch
+    ):
+        urls = ["https://blocked.example", "https://outage.example"]
+        primary_results = [
+            {"url": urls[0], "error": "primary outage"},
+            {"url": urls[1], "error": "primary outage"},
+        ]
+        secondary_results = [
+            {
+                "url": urls[0],
+                "error": "Blocked by website policy after redirect",
+                "blocked_by_policy": True,
+            }
+        ]
+        secondary = _Provider("tavily", extract_result=secondary_results)
+        _registry(monkeypatch, {"tavily": secondary})
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"extract_backend": "exa", "fallback_backend": "tavily"},
+        )
+
+        returned, fallback_error = await web_rescue._try_fallback_extract(
+            "exa", urls, primary_results
+        )
+
+        assert fallback_error == ""
+        assert len(returned) == len(urls)
+        assert returned[0] == secondary_results[0]
+        assert returned[1] == primary_results[1]
+
+    @pytest.mark.parametrize("malformed", [[None], {"results": []}])
+    def test_malformed_keyless_rescue_rows_preserve_original_batch(self, malformed):
+        urls = ["https://first.example", "https://second.example"]
+        results = [
+            {"url": urls[0], "error": "secondary outage"},
+            {"url": urls[1], "error": "secondary outage"},
+        ]
+
+        with patch.object(
+            keyless_mcp, "extract_with_failover", return_value=malformed
+        ):
+            returned = web_rescue._rescue_extract("exa", urls, results)
+
+        assert returned == results
+
+    def test_short_keyless_rescue_row_is_merged_by_url_not_position(self):
+        urls = [
+            "https://blocked.example",
+            "https://first-failure.example",
+            "https://later-rescued.example",
+        ]
+        results = [
+            {
+                "url": urls[0],
+                "error": "Blocked by website policy",
+                "blocked_by_policy": True,
+            },
+            {"url": urls[1], "error": "secondary outage"},
+            {"url": urls[2], "error": "secondary outage"},
+        ]
+        later_only = _extract_ok(urls[2])
+
+        with patch.object(
+            keyless_mcp, "extract_with_failover", return_value=later_only
+        ):
+            returned = web_rescue._rescue_extract("exa", urls, results)
+
+        assert returned[0] == results[0]
+        assert returned[1] == results[1]
+        assert returned[2]["url"] == urls[2]
+        assert returned[2]["content"] == "fallback content"
+
+    def test_keyless_rescue_also_suppresses_malformed_partial_policy_result(self):
+        urls = ["https://blocked.example", "https://missing.example"]
+        results = [
+            {
+                "url": urls[0],
+                "error": "Blocked by website policy",
+                "blocked_by_policy": True,
+            }
+        ]
+
+        with patch.object(keyless_mcp, "extract_with_failover") as keyless:
+            returned = web_rescue._rescue_extract("exa", urls, results)
+
+        assert returned == results
+        keyless.assert_not_called()

--- a/tests/tools/test_web_fallback_contract.py
+++ b/tests/tools/test_web_fallback_contract.py
@@ -31,6 +31,23 @@ class Provider:
         return self.response
 
 
+@pytest.fixture(autouse=True)
+def deny_network(monkeypatch):
+    import socket
+
+    attempts = []
+
+    def denied(*args, **kwargs):
+        attempts.append("unexpected network call")
+        raise AssertionError("Network access is not allowed in fallback contract tests")
+
+    monkeypatch.setattr(socket, "getaddrinfo", denied)
+    monkeypatch.setattr(socket.socket, "connect", denied)
+    monkeypatch.setattr(socket.socket, "connect_ex", denied)
+    yield
+    assert not attempts, "A caught exception hid an unexpected network call"
+
+
 @pytest.fixture
 def configured(tmp_path, monkeypatch):
     # Real YAML loader, real registry tool handler, isolated on-disk cache.
@@ -167,3 +184,85 @@ def test_extract_fallback_does_not_stick_in_primary_cache(configured):
         assert result["results"][0]["content"] == "fallback"
     assert primary.calls == [[url], [url]]
     assert secondary.calls == [[url], [url]]
+
+
+@pytest.mark.parametrize("primary_kind", ["none-row", "short", "duplicate", "unknown", "wrapper"])
+@pytest.mark.parametrize("blocked_index", [0, 1])
+@pytest.mark.parametrize("policy_marker", ["flag", "message"])
+def test_incomplete_primary_retains_short_secondary_policy(
+    configured, monkeypatch, primary_kind, blocked_index, policy_marker
+):
+    """A safely identified refusal survives even when neither batch is complete."""
+    urls = ["https://example.com/a", "https://example.com/b"]
+    failure = {"url": urls[1 - blocked_index], "error": "primary outage"}
+    primary_rows = {
+        "none-row": [None], "short": [failure],
+        "duplicate": [failure, dict(failure)],
+        "unknown": [{"url": "https://other.example", "error": "outage"}],
+        "wrapper": {"results": [failure]},
+    }[primary_kind]
+    blocked = {"url": urls[blocked_index], "error": "Blocked by website policy after redirect"}
+    if policy_marker == "flag":
+        blocked.update(error="refused", blocked_by_policy=True)
+    primary = Provider("primary", primary_rows)
+    secondary = Provider("secondary", [None, blocked, {"content": "unidentified"}])
+    configured.update(primary=primary, secondary=secondary)
+    monkeypatch.setattr("tools.web_tools_extract._rescue_eligible", lambda provider: True)
+    ring_calls = []
+
+    def ring(name, requested):
+        ring_calls.append(requested)
+        return [{"url": url, "content": "ring text"} for url in requested]
+
+    monkeypatch.setattr("plugins.web.keyless_mcp.extract_with_failover", ring)
+    entry = web_tools.registry.get_entry("web_extract")
+    assert entry is not None
+    for _ in range(2):
+        result = json.loads(asyncio.run(entry.handler({"urls": urls})))
+        assert all(urls[blocked_index] not in batch for batch in ring_calls)
+        rows = result["results"]
+        assert [row["url"] for row in rows] == urls
+        assert rows[blocked_index]["error"] == blocked["error"]
+        assert rows[1 - blocked_index]["content"] == "ring text"
+    assert ring_calls == [[urls[1 - blocked_index]]] * 2
+    assert primary.calls == [urls, urls]
+    assert secondary.calls == [urls, urls]
+
+
+@pytest.mark.parametrize("kind", ["empty", "none", "later", "unknown", "reordered", "partial-success"])
+def test_partial_policy_keeps_exact_failures_and_rescue_identity(configured, monkeypatch, kind):
+    urls = ["https://example.com/a", "https://example.com/b", "https://example.com/c"]
+    failure = {"url": urls[2], "error": "original C outage"}
+    blocked = {"url": urls[1], "error": "Blocked by website policy after redirect"}
+    a = {"url": urls[0], "content": "A"}
+    c = {"url": urls[2], "content": "C"}
+    primary = Provider("primary", [failure, None])
+    secondary_rows = [blocked, c] if kind == "partial-success" else [blocked]
+    configured.update(primary=primary, secondary=Provider("secondary", secondary_rows))
+    monkeypatch.setattr("tools.web_tools_extract._rescue_eligible", lambda provider: True)
+    calls = []
+
+    def ring(name, requested):
+        calls.append(requested)
+        return {
+            "empty": [], "none": None, "later": [None, c],
+            "unknown": [{"url": "https://other.example", "content": "wrong"}],
+            "reordered": [c, a], "partial-success": [a, c],
+        }[kind]
+
+    monkeypatch.setattr("plugins.web.keyless_mcp.extract_with_failover", ring)
+    entry = web_tools.registry.get_entry("web_extract")
+    assert entry is not None
+    result = json.loads(asyncio.run(entry.handler({"urls": urls})))
+    rows = result["results"]
+    assert [row["url"] for row in rows] == urls
+    assert rows[1]["error"] == blocked["error"]
+    assert calls == ([] if kind == "partial-success" else [[urls[0], urls[2]]])
+    if kind in {"later", "reordered", "partial-success"}:
+        assert rows[2]["content"] == "C"
+    else:
+        assert rows[2]["error"] == failure["error"]
+    if kind == "reordered":
+        assert rows[0]["content"] == "A"
+    else:
+        assert rows[0]["error"]

--- a/tests/tools/test_web_fallback_contract.py
+++ b/tests/tools/test_web_fallback_contract.py
@@ -1,0 +1,169 @@
+"""Public dispatch contracts shared with the comparison PR (both config dialects)."""
+import asyncio
+import json
+
+import pytest
+
+from tools import web_tools
+
+
+class Provider:
+    def __init__(self, name, response):
+        self.name = self.display_name = name
+        self.response = response
+        self.calls = []
+
+    def is_available(self):
+        return True
+
+    def supports_search(self):
+        return True
+
+    def supports_extract(self):
+        return True
+
+    def search(self, query, limit=5):
+        self.calls.append(query)
+        return self.response
+
+    def extract(self, urls, **kwargs):
+        self.calls.append(list(urls))
+        return self.response
+
+
+@pytest.fixture
+def configured(tmp_path, monkeypatch):
+    # Real YAML loader, real registry tool handler, isolated on-disk cache.
+    import tools.web_result_cache as cache
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(
+        "web:\n  search_backend: primary\n  extract_backend: primary\n"
+        "  fallback_backend: secondary\n  fallback_enabled: true\n"
+        "  fallback_backends: [secondary]\n  keyless_fallback: false\n"
+        "  keyless_rescue: false\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+    if hasattr(cache, "search_memo"):
+        monkeypatch.setattr(cache, "search_memo", cache.SearchMemo())
+    providers = {}
+    monkeypatch.setattr("agent.web_search_registry.get_provider", providers.get)
+    monkeypatch.setattr(web_tools, "_is_backend_available", lambda name: name in providers)
+
+    async def safe(*args, **kwargs):
+        return True
+
+    monkeypatch.setattr(web_tools, "async_is_safe_url", safe)
+    return providers
+
+
+@pytest.mark.parametrize("failed", [False, True], ids=["empty-success-is-terminal", "failed-primary-nonsticky"])
+def test_search_only_fails_over_after_failure(configured, failed):
+    response = {"success": False, "error": "outage"} if failed else {"success": True, "data": {"web": []}}
+    primary = Provider("primary", response)
+    secondary = Provider("secondary", {"success": True, "data": {"web": [{"url": "https://example.com", "title": "ok"}]}})
+    configured.update(primary=primary, secondary=secondary)
+    for _ in range(2):
+        result = json.loads(web_tools.registry.get_entry("web_search").handler({"query": "same"}))
+        assert result["success"]
+        assert bool(result["data"]["web"]) == failed
+    assert len(secondary.calls) == (2 if failed else 0)
+    if failed:
+        assert len(primary.calls) == 2
+
+
+@pytest.mark.parametrize("mode", ["provider-policy", "global-policy", "partial", "empty", "reordered-policy" ])
+def test_extract_policy_and_batch_identity(configured, monkeypatch, mode):
+    urls = ["https://example.com/a", "https://example.com/b"]
+    blocked = {"url": urls[0], "error": "Blocked by website policy", "blocked_by_policy": True}
+    failure = {"url": urls[1], "error": "outage"}
+    success = {"url": urls[0], "content": "primary text"}
+    primary_rows = {
+        "provider-policy": [blocked, failure],
+        "global-policy": [blocked, failure],
+        "partial": [success, failure],
+        "empty": [],
+        "reordered-policy": [failure, blocked],
+    }[mode]
+    primary = Provider("primary", primary_rows)
+    secondary = Provider("secondary", [{"url": url, "content": "secondary text"} for url in urls])
+    configured.update(primary=primary, secondary=secondary)
+    if mode == "global-policy":
+        monkeypatch.setattr("tools.website_policy.check_website_access", lambda url: {"message": "Blocked by website policy"})
+    result = json.loads(asyncio.run(web_tools.registry.get_entry("web_extract").handler({"urls": urls})))
+    rows = result["results"]
+    assert [r["url"] for r in rows] == urls
+    if mode == "global-policy":
+        assert not primary.calls and not secondary.calls
+        assert all(r["blocked_by_policy"] for r in rows)
+    elif mode in {"provider-policy", "reordered-policy"}:
+        assert rows[0]["blocked_by_policy"]
+        assert secondary.calls == [[urls[1]]]
+    elif mode == "partial":
+        assert rows[0]["content"] == "primary text" and rows[1]["error"] == "outage"
+        assert not secondary.calls
+    else:
+        assert all(r["content"] == "secondary text" for r in rows)
+        assert secondary.calls == [urls]
+
+
+@pytest.mark.parametrize("secondary", [False, True], ids=["ring", "configured"])
+@pytest.mark.parametrize("kind", ["none", "wrapper", "missing-id", "unknown", "duplicate", "reordered", "later-only", "short-policy"])
+def test_untrusted_retry_batches(configured, monkeypatch, secondary, kind):
+    from tools import web_tools_rescue as rescue
+    urls = ["https://example.com/a", "https://example.com/b", "https://example.com/c"]
+    original = [{"url": url, "error": "primary outage"} for url in urls]
+    original[0]["blocked_by_policy"] = True
+    b = {"url": urls[1], "content": "B"}
+    c = {"url": urls[2], "content": "C"}
+    batches = {
+        "none": None, "wrapper": {"results": [b]}, "missing-id": [None, {"content": "wrong"}],
+        "unknown": [{"url": "https://other.example", "content": "wrong"}],
+        "duplicate": [b, {"url": urls[1], "content": "wrong"}],
+        "reordered": [c, b], "later-only": [c],
+        "short-policy": [{"url": urls[2], "blocked_by_policy": True, "error": "policy"}],
+    }
+    batch = batches[kind]
+    if secondary:
+        provider = Provider("secondary", batch)
+        configured["secondary"] = provider
+        result, _ = asyncio.run(rescue._try_fallback_extract("primary", urls, original))
+        result = original if result is None else result
+        assert provider.calls == [urls[1:]]
+    else:
+        calls = []
+        def ring(name, requested):
+            calls.append(requested)
+            return batch
+        monkeypatch.setattr("plugins.web.keyless_mcp.extract_with_failover", ring)
+        result = rescue._rescue_extract("primary", urls, original)
+        assert calls == [urls[1:]]
+    assert [r["url"] for r in result] == urls
+    assert result[0] == original[0]
+    assert result[1] == (b if kind in {"duplicate", "reordered"} else original[1])
+    if kind in {"reordered", "later-only"}:
+        assert result[2]["content"] == "C"
+    elif kind == "short-policy":
+        assert result[2]["blocked_by_policy"]
+    else:
+        assert result[2] == original[2]
+
+
+def test_duplicate_requested_urls_keep_queue_identity():
+    from tools.web_tools_rescue import _map_extract_rows_by_url
+    url = "https://example.com"
+    rows = [{"url": url, "content": "first"}, {"url": url, "content": "second"}, {"url": url, "content": "excess"}]
+    assert _map_extract_rows_by_url([url, url], [0, 1], rows) == {0: rows[0], 1: rows[1]}
+
+
+def test_extract_fallback_does_not_stick_in_primary_cache(configured):
+    url = "https://example.com/nonsticky"
+    primary = Provider("primary", [{"url": url, "error": "outage"}])
+    secondary = Provider("secondary", [{"url": url, "content": "fallback"}])
+    configured.update(primary=primary, secondary=secondary)
+    for _ in range(2):
+        result = json.loads(asyncio.run(web_tools.registry.get_entry("web_extract").handler({"urls": [url]})))
+        assert result["results"][0]["content"] == "fallback"
+    assert primary.calls == [[url], [url]]
+    assert secondary.calls == [[url], [url]]

--- a/tests/tools/test_web_tools_perplexity.py
+++ b/tests/tools/test_web_tools_perplexity.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from tests.tools.conftest import register_all_web_providers
 
@@ -61,6 +61,7 @@ def test_extract_dispatch_snippets_per_url_and_missing_key():
     ]}
     with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "pplx-test"}), \
          patch.object(wt, "_get_extract_backend", return_value="perplexity"), \
+         patch.object(wt, "async_is_safe_url", new=AsyncMock(return_value=True)), \
          patch("plugins.web.perplexity.provider.httpx.post", return_value=_ok(payload)) as post:
         out = json.loads(asyncio.run(wt.web_extract_tool(urls)))
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -320,14 +320,28 @@ def _memoized_search(provider, query: str, limit: int) -> dict:
 
     def _paid_search() -> tuple[dict, bool]:
         fetch_limit = bucket_limit(limit)
+        from tools.web_tools_rescue import _get_fallback_backend, _try_fallback_search
+        primary_exception = None
         try:
             resp = provider.search(query, fetch_limit)
-        except Exception as exc:  # noqa: BLE001 — candidate for rescue
-            if not _rescue_eligible(provider):
-                raise
-            return _rescue_search(provider.name, str(exc), query, fetch_limit), True
-        if not resp.get("success") and _rescue_eligible(provider):
-            return _rescue_search(provider.name, str(resp.get("error", "")), query, fetch_limit), True
+        except Exception as exc:  # noqa: BLE001 — fallback/rescue candidate
+            primary_exception = exc
+            resp = {"success": False, "error": str(exc)}
+        if resp.get("success"):
+            return resp, False
+        original_error = str(resp.get("error", ""))
+        fallback, fallback_error = _try_fallback_search(provider.name, original_error, query, fetch_limit)
+        if fallback is not None:
+            return fallback, True
+        if _rescue_eligible(provider):
+            if fallback_error:
+                original_error += (
+                    f"; configured fallback '{_get_fallback_backend('search')}' also failed "
+                    f"({fallback_error[:200]})"
+                )
+            return _rescue_search(provider.name, original_error, query, fetch_limit), True
+        if primary_exception is not None:
+            raise primary_exception
         return resp, False
 
     response_data = search_memo.lookup(provider.name, query, limit)

--- a/tools/web_tools_extract.py
+++ b/tools/web_tools_extract.py
@@ -77,10 +77,12 @@ def _merge_in_order(
 ) -> List[dict]:
     """Rebuild a ``total``-long result list: *fixed* entries by position, fetched *results* at
     *fetch_positions* (a short provider list yields ``_NO_RESULT_ERROR`` entries for the rest)."""
+    from tools.web_tools_rescue import _map_extract_rows_by_url
+    mapped = _map_extract_rows_by_url(fetch_urls, list(range(len(fetch_urls))), results)
     merged = dict(fixed)
     for pos, position in enumerate(fetch_positions):
         missing = _result_entry(fetch_urls[pos], _NO_RESULT_ERROR)
-        merged[position] = results[pos] if pos < len(results) else missing
+        merged[position] = mapped.get(pos, missing)
     return [merged[i] for i in range(total)]
 
 
@@ -140,32 +142,45 @@ def _resolve_extract_provider(backend: str):
 
 
 async def _dispatch_extract(provider, fetch_urls: List[str], format: Optional[str]) -> List[dict]:
-    """Call ``provider.extract`` (async or sync-in-thread), with one-shot keyless rescue.
+    """Try the configured secondary before rescue on whole-batch failure only.
 
-    Rescue fires on a raised exception or when the WHOLE batch failed (backend outage, not per-page
-    problems). Rescued batches are never cached.
+    Neither secondary nor rescue responses belong in the primary cache.
     """
     import inspect
     from tools.web_result_cache import extract_cache_put
+    from tools.web_tools_rescue import (
+        _fallback_extract_needs_rescue, _map_extract_rows_by_url, _try_fallback_extract,
+    )
+    primary_exception = None
     try:
         if inspect.iscoroutinefunction(provider.extract):
             results = await provider.extract(fetch_urls, format=format)
-        else:  # sync extract() runs in a thread so network I/O never blocks the loop
+        else:
             results = await asyncio.to_thread(provider.extract, fetch_urls, format=format)
-    except Exception as exc:  # noqa: BLE001 — candidate for rescue
-        if not _rescue_eligible(provider):
-            raise
-        failed = [_result_entry(u, str(exc)) for u in fetch_urls]
-        return await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, failed)
-    if results and all(r.get("error") for r in results) and _rescue_eligible(provider):
-        return await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, results)
+    except Exception as exc:  # noqa: BLE001 — fallback/rescue candidate
+        primary_exception = exc
+        results = [_result_entry(u, str(exc)) for u in fetch_urls]
 
-    # Cache each successful fetch's full clean text (best-effort; oversized skipped).
-    for url, fetched in zip(fetch_urls, results):
-        _content = fetched.get("raw_content", "") or fetched.get("content", "")
-        if _content and not fetched.get("error"):
-            extract_cache_put(url, _content, fetched.get("title", ""), format=format, provider=provider.name)
-    return results
+    rows = results if isinstance(results, list) else []
+    if not rows or all(not isinstance(r, dict) or r.get("error") for r in rows):
+        failures = rows or [_result_entry(u, "Extract backend returned no results") for u in fetch_urls]
+        fallback, _ = await _try_fallback_extract(provider.name, fetch_urls, failures, format=format)
+        if fallback is not None:
+            if _rescue_eligible(provider) and _fallback_extract_needs_rescue(fetch_urls, fallback):
+                return await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, fallback)
+            return fallback
+        if _rescue_eligible(provider):
+            return await asyncio.to_thread(_rescue_extract, provider.name, fetch_urls, failures)
+        if primary_exception is not None:
+            raise primary_exception
+        return failures
+
+    # Cache by exact returned URL, never positional association of untrusted rows.
+    for index, fetched in _map_extract_rows_by_url(fetch_urls, list(range(len(fetch_urls))), rows).items():
+        content = fetched.get("raw_content", "") or fetched.get("content", "")
+        if content and not fetched.get("error") and not fetched.get("blocked_by_policy"):
+            extract_cache_put(fetch_urls[index], content, fetched.get("title", ""), format=format, provider=provider.name)
+    return rows
 
 
 async def _extract_safe_urls(provider, safe_urls: List[str], format: Optional[str]) -> List[dict]:
@@ -173,7 +188,7 @@ async def _extract_safe_urls(provider, safe_urls: List[str], format: Optional[st
 
     The disk cache (tools/web_result_cache.py) sits AFTER the secret-URL gate, SSRF gate, and provider
     resolution, and is gated per-URL on the website policy — a hit skips only the vendor call, never a
-    control; policy-blocked URLs are cache misses. Keys include provider and format, so switching either
+    control; policy-blocked URLs are terminal results and reach no provider. Keys include provider and format, so switching either
     within the TTL never serves the other's content."""
     from tools.web_result_cache import extract_cache_get
     from tools.website_policy import check_website_access as _check_site
@@ -183,7 +198,13 @@ async def _extract_safe_urls(provider, safe_urls: List[str], format: Optional[st
             _policy_block = _check_site(url)
         except Exception:  # noqa: BLE001 — policy errors fail open like dispatch
             _policy_block = None
-        hit = extract_cache_get(url, format=format, provider=provider.name) if _policy_block is None else None
+        if _policy_block is not None:
+            cached_results[position] = {
+                **_result_entry(url, _policy_block.get("message", "Blocked by website policy")),
+                "blocked_by_policy": True,
+            }
+            continue
+        hit = extract_cache_get(url, format=format, provider=provider.name)
         if hit is not None:
             cached_results[position] = hit
         else:

--- a/tools/web_tools_rescue.py
+++ b/tools/web_tools_rescue.py
@@ -351,6 +351,18 @@ async def _try_fallback_extract(
                 metadata["fallback_from"] = primary_name
                 metadata["backend_error"] = (original_error or "unknown error")[:300]
 
+    if ordered is None and any(_policy_blocked_result(row) for row in mapped.values()):
+        # Policy is terminal even if neither provider returned a complete batch.
+        # Retain exact-URL primary failures and fill only unidentified positions;
+        # dropping this partial secondary would let rescue fetch a refused URL.
+        from tools.web_tools_extract import _NO_RESULT_ERROR, _result_entry
+
+        original = _map_extract_rows_by_url(urls, list(range(len(urls))), results)
+        ordered = [
+            original.get(index, _result_entry(url, _NO_RESULT_ERROR))
+            for index, url in enumerate(urls)
+        ]
+
     if ordered is not None:
         # Preserve the complete original batch and replace only rows that can be
         # associated with an exact requested URL. This keeps policy signals,

--- a/tools/web_tools_rescue.py
+++ b/tools/web_tools_rescue.py
@@ -6,6 +6,7 @@ rescue-served response, or the one-shot rescue becomes sticky for a whole TTL. L
 (tools.web_tools) logger.
 """
 
+import asyncio
 import logging
 
 logger = logging.getLogger("tools.web_tools")
@@ -79,42 +80,319 @@ def _rescue_search(provider_name: str, original_error: str, query: str, limit: i
     }
 
 
+
+
 def _policy_blocked_result(result: dict) -> bool:
-    """True for a website-policy refusal — intentional, never rescued (it would fetch blocked content)."""
-    error = str(result.get("error") or "").lower()
-    return bool(result.get("blocked_by_policy")) or "blocked by website policy" in error
+    """True when an extract result failed because of the user's website
+    policy — an intentional refusal, never a backend outage. Policy blocks
+    must NOT be rescued: routing the same URL through the keyless ring
+    would fetch content the user explicitly blocked."""
+    if not isinstance(result, dict):
+        return False
+    if result.get("blocked_by_policy"):
+        return True
+    return "blocked by website policy" in str(result.get("error") or "").lower()
+
+
+def _map_extract_rows_by_url(
+    urls: list, indices: list[int], rows: object
+) -> dict[int, dict]:
+    """Map well-formed extract rows to requested positions by exact URL.
+
+    Provider batches are untrusted at this boundary: they may be short,
+    reordered, or malformed. Positional merging can therefore attach content to
+    the wrong URL. Missing and malformed rows are ignored so callers can retain
+    the corresponding original failure.
+    """
+    if not isinstance(rows, list):
+        return {}
+
+    pending: dict[str, list[int]] = {}
+    for index in indices:
+        if index >= len(urls) or not isinstance(urls[index], str):
+            continue
+        pending.setdefault(urls[index], []).append(index)
+
+    mapped: dict[int, dict] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        row_url = row.get("url")
+        if not isinstance(row_url, str):
+            continue
+        candidates = pending.get(row_url)
+        if not candidates:
+            continue
+        mapped[candidates.pop(0)] = row
+    return mapped
+
+
+def _ordered_extract_batch(urls: list, results: object) -> list | None:
+    """A complete, exact-URL primary batch, or None (never assume positional parity)."""
+    if not isinstance(results, list) or len(results) != len(urls):
+        return None
+    mapped = _map_extract_rows_by_url(urls, list(range(len(urls))), results)
+    return [mapped[i] for i in range(len(urls))] if len(mapped) == len(urls) else None
+
+
+def _retry_extract_indices(urls: list, results: object) -> tuple[list | None, list[int]]:
+    """Partition a trustworthy batch; an incomplete policy batch is fail-closed."""
+    ordered = _ordered_extract_batch(urls, results)
+    if ordered is not None:
+        return ordered, [i for i, row in enumerate(ordered) if row.get("error") and not _policy_blocked_result(row)]
+    rows = results if isinstance(results, list) else []
+    if any(_policy_blocked_result(row) for row in rows):
+        return None, []
+    return None, list(range(len(urls)))
+
+
+def _extract_failure_message(results: object) -> str:
+    rows = results if isinstance(results, list) else []
+    return next((str(r["error"]) for r in rows if isinstance(r, dict) and r.get("error")), "extract failed")
 
 
 def _rescue_extract(provider_name: str, urls: list, results: list) -> list:
-    """Rescue a whole-batch extract failure via the ring.
+    """One-shot keyless-ring rescue for a failed keyed/configured extract.
 
-    Only genuine failures are re-fetched; policy-blocked entries are preserved verbatim. If the provider
-    broke url/result order parity, every entry is treated as rescueable and the ring's list replaces the
-    batch wholesale.
+    Fires only when EVERY url failed (whole-backend failure); partial
+    results are page problems and pass through untouched. Stateless —
+    the next web_extract call attempts the chosen backend again.
+
+    Website-policy refusals are intentional, not failures: entries flagged
+    by ``_policy_blocked_result`` are never re-fetched through the ring and
+    their original (blocked) results are preserved verbatim.
     """
     from plugins.web.keyless_mcp import extract_with_failover
 
-    parity = len(results) == len(urls)
-    rescue_idx = [i for i, r in enumerate(results) if not parity or not _policy_blocked_result(r)]
+    ordered, rescue_idx = _retry_extract_indices(urls, results)
     if not rescue_idx:
-        return results  # every failure is an intentional policy block
-
-    rescue_urls = [urls[i] for i in rescue_idx] if parity else list(urls)
-    errors = (results[i].get("error") for i in rescue_idx if results[i].get("error"))
-    original_error = next(errors, "extract failed")
+        return ordered if ordered is not None else results
+    rescue_urls = [urls[i] for i in rescue_idx]
+    original_error = _extract_failure_message(results)
     logger.warning(
         "web_extract backend '%s' failed all %d URL(s) (%s); one-shot keyless rescue",
         provider_name, len(rescue_urls), (original_error or "")[:200],
     )
     rescued = extract_with_failover(provider_name, list(rescue_urls))
-    if rescued and all(r.get("error", "") for r in rescued):
-        return results  # rescue also failed everywhere: keep original errors
-    for r in rescued:
-        meta = None if r.get("error") else r.setdefault("metadata", {})
-        if isinstance(meta, dict):
-            meta["rescued_from"] = provider_name
-            meta["backend_error"] = (original_error or "")[:300]
-    if parity and len(rescued) == len(rescue_idx):
-        replacements = dict(zip(rescue_idx, rescued))
-        return [replacements.get(i, r) for i, r in enumerate(results)]
-    return rescued
+    mapped = _map_extract_rows_by_url(urls, rescue_idx, rescued)
+    replacements = {
+        index: result
+        for index, result in mapped.items()
+        if _policy_blocked_result(result) or not result.get("error")
+    }
+    if not replacements:
+        return results
+
+    for result in replacements.values():
+        if not result.get("error"):
+            meta = result.setdefault("metadata", {})
+            if isinstance(meta, dict):
+                meta["rescued_from"] = provider_name
+                meta["backend_error"] = (original_error or "")[:300]
+
+    if ordered is not None:
+        # Preserve policy rows, ordering, and ordinary failures. Replace only
+        # exact-URL rows that rescue successfully or add a new policy refusal.
+        merged = list(ordered)
+        for index, result in replacements.items():
+            merged[index] = result
+        return merged
+
+    # A malformed original batch has no trustworthy positional identity. Only
+    # return rescued rows when every input URL was mapped exactly; otherwise
+    # preserve the original response rather than collapsing or reordering it.
+    if len(mapped) == len(urls):
+        return [mapped[index] for index in range(len(urls))]
+    return results
+
+
+def _get_fallback_backend(capability: str) -> str:
+    """Return the configured request-level fallback for *capability*.
+
+    A capability-specific value wins over the shared fallback. Unlike
+    ``web.backend`` (a selection default), this backend is attempted only
+    after the selected primary provider fails a request.
+    """
+    from tools.web_tools import _load_web_config
+    cfg = _load_web_config()
+    return (
+        (cfg.get(f"{capability}_fallback_backend") or cfg.get("fallback_backend") or "")
+        .lower()
+        .strip()
+    )
+
+
+def _get_secondary_provider(primary_name: str, capability: str):
+    """Resolve a configured, distinct provider that supports *capability*."""
+    name = _get_fallback_backend(capability)
+    if not name or name == primary_name:
+        return None
+    try:
+        from agent.web_search_registry import get_provider
+
+        provider = get_provider(name)
+        supports = getattr(provider, f"supports_{capability}", None)
+        if provider is None or not callable(supports) or not supports():
+            logger.warning(
+                "web.%s_fallback_backend '%s' is unavailable or unsupported",
+                capability,
+                name,
+            )
+            return None
+        try:
+            from plugins.web.keyless_mcp import provider_tier
+
+            if provider_tier(name) == "free":
+                logger.warning(
+                    "Configured web.%s fallback '%s' is pinned to the keyless tier; skipping it",
+                    capability,
+                    name,
+                )
+                return None
+            if not provider.is_available():
+                logger.warning(
+                    "Configured web.%s fallback '%s' is unavailable in its configured mode; skipping it",
+                    capability,
+                    name,
+                )
+                return None
+        except Exception as exc:  # noqa: BLE001 — unavailable secondary is non-fatal
+            logger.warning(
+                "Configured web.%s fallback '%s' availability check failed: %s",
+                capability,
+                name,
+                exc,
+            )
+            return None
+        return provider
+    except Exception as exc:  # noqa: BLE001 — fallback is best-effort
+        logger.warning("web %s fallback '%s' could not load: %s", capability, name, exc)
+        return None
+
+
+def _try_fallback_search(
+    primary_name: str, original_error: str, query: str, limit: int
+) -> tuple[dict | None, str]:
+    """Try the configured secondary search provider once.
+
+    Returns ``(successful_result, fallback_error)``. A missing or invalid
+    secondary is represented by ``(None, "")`` so the existing keyless rescue
+    can still run unchanged.
+    """
+    provider = _get_secondary_provider(primary_name, "search")
+    if provider is None:
+        return None, ""
+    logger.warning(
+        "web_search backend '%s' failed (%s); trying configured fallback '%s'",
+        primary_name,
+        (original_error or "")[:200],
+        provider.name,
+    )
+    try:
+        result = provider.search(query, limit)
+    except Exception as exc:  # noqa: BLE001 — continue to keyless rescue
+        return None, str(exc)
+    if not isinstance(result, dict):
+        return None, "search returned an invalid response"
+    if not result.get("success"):
+        return None, str(result.get("error", "search failed"))
+    data = result.setdefault("data", {})
+    if not isinstance(data, dict):
+        return None, "search returned invalid data"
+    data["served_by"] = provider.name
+    data["fallback_from"] = primary_name
+    data["backend_error"] = (original_error or "unknown error")[:300]
+    return result, ""
+
+
+async def _try_fallback_extract(
+    primary_name: str, urls: list, results: list, *, format: str | None = None
+) -> tuple[list | None, str]:
+    """Try the configured secondary extract provider for genuine failures.
+
+    Policy-blocked URLs are never sent to another provider. A secondary that
+    fails the whole retry returns ``None`` so the existing keyless rescue can
+    still run.
+    """
+    provider = _get_secondary_provider(primary_name, "extract")
+    if provider is None:
+        return None, ""
+
+    ordered, retry_indices = _retry_extract_indices(urls, results)
+    if not retry_indices:
+        return None, ""
+    retry_urls = [urls[i] for i in retry_indices]
+    original_error = _extract_failure_message(results)
+    logger.warning(
+        "web_extract backend '%s' failed (%s); trying configured fallback '%s'",
+        primary_name,
+        (original_error or "")[:200],
+        provider.name,
+    )
+
+    import inspect
+
+    try:
+        if inspect.iscoroutinefunction(provider.extract):
+            retried = await provider.extract(retry_urls, format=format)
+        else:
+            retried = await asyncio.to_thread(
+                provider.extract, retry_urls, format=format
+            )
+    except Exception as exc:  # noqa: BLE001 — continue to keyless rescue
+        return None, str(exc)
+
+    mapped = _map_extract_rows_by_url(urls, retry_indices, retried)
+    for result in mapped.values():
+        if not result.get("error"):
+            metadata = result.setdefault("metadata", {})
+            if isinstance(metadata, dict):
+                metadata["served_by"] = provider.name
+                metadata["fallback_from"] = primary_name
+                metadata["backend_error"] = (original_error or "unknown error")[:300]
+
+    if ordered is not None:
+        # Preserve the complete original batch and replace only rows that can be
+        # associated with an exact requested URL. This keeps policy signals,
+        # ordering, and unreturned failures intact for later rescue partitioning.
+        merged = list(ordered)
+        for index, result in mapped.items():
+            if _policy_blocked_result(result) or not result.get("error"):
+                merged[index] = result
+        if any(_policy_blocked_result(result) for result in mapped.values()):
+            return merged, ""
+        if any(not result.get("error") for result in mapped.values()):
+            return merged, ""
+    else:
+        # Without a complete original batch, accept a fallback only when it
+        # supplies one safely mapped row for every requested URL.
+        if len(mapped) == len(urls):
+            ordered = [mapped[index] for index in range(len(urls))]
+            if any(_policy_blocked_result(result) for result in ordered):
+                return ordered, ""
+            if any(not result.get("error") for result in ordered):
+                return ordered, ""
+
+    fallback_error = next(
+        (
+            result.get("error")
+            for result in mapped.values()
+            if result.get("error")
+        ),
+        "extract returned no valid results",
+    )
+    return None, str(fallback_error)
+
+
+def _fallback_extract_needs_rescue(urls: list, results: list) -> bool:
+    """True when every non-policy fallback row is still a genuine failure.
+
+    A secondary can discover a redirect-time policy block for one URL while
+    failing another URL for an ordinary provider reason. Preserve the blocked
+    row, but allow keyless rescue for the remaining failures. Partial fallback
+    success remains terminal and is never expanded into per-page rescue.
+    """
+    if len(results) != len(urls):
+        return False
+    rescueable = [result for result in results if not _policy_blocked_result(result)]
+    return bool(rescueable) and all(result.get("error") for result in rescueable)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2413,6 +2413,11 @@ web:
   search_backend: "searxng"
   extract_backend: "firecrawl"
 
+  # Optional request-level secondary. Capability-specific values override it:
+  fallback_backend: "tavily"
+  # search_fallback_backend: "tavily"
+  # extract_fallback_backend: "tavily"
+
   # Keyless free-tier fallback (default: true). With no backend configured
   # and no API keys present, web tools rotate across the Exa/Parallel/
   # Firecrawl/Keenable free tiers. Set false to disable.
@@ -2441,6 +2446,8 @@ web:
 | **Exa** | `EXA_API_KEY` (optional — keyless free tier) | ✔ | ✔ |
 
 **Backend selection:** The runtime always uses the stored `web.backend` selection (set via `hermes tools`; `nous` routes through the managed Tool Gateway). Only if no web backend has ever been selected is one auto-detected from available API keys: if only `SEARXNG_URL` is set, SearXNG is used; if only `EXA_API_KEY` is set, Exa; if only `TAVILY_API_KEY` is set, Tavily; if only `PERPLEXITY_API_KEY` is set, Perplexity; if only `PARALLEL_API_KEY` is set, Parallel; if only `KEENABLE_API_KEY` is set, Keenable. With **no selection and no credentials at all**, requests rotate round-robin across the keyless free-tier ring (Exa / Parallel / Firecrawl / Keenable) with automatic next-in-line failover on rate limits — see the [Web Search guide](/user-guide/features/web-search) for details. Once a selection exists, adding a key to `.env` does not change the route. Selecting Tavily, Firecrawl, or Keenable in `hermes tools` also works without a key.
+
+**Request-level fallback:** `web.fallback_backend` retries a failed search or whole-batch extract once with a configured secondary provider before the keyless rescue runs. `web.search_fallback_backend` and `web.extract_fallback_backend` override the shared fallback per capability. The secondary must be available in its configured mode; ring providers pinned to their free tier skip this dedicated retry and remain part of the normal keyless rescue. This retry is non-sticky: every new call starts with the primary backend. Policy-blocked URLs and partial extract failures are not sent to the secondary.
 
 **SearXNG** is a free, self-hosted, privacy-respecting metasearch engine that queries 70+ search engines. No API key needed — just set `SEARXNG_URL` to your instance (e.g., `http://localhost:8080`). SearXNG is search-only; `web_extract` requires a separate extract provider (set `web.extract_backend`). See the [Web Search setup guide](/user-guide/features/web-search) for Docker setup instructions.
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -396,6 +396,10 @@ Use different providers for search vs extract. This lets you combine free search
 web:
   search_backend: "searxng"     # used by web_search
   extract_backend: "firecrawl"  # used by web_extract
+
+  # Optional request-level secondary for both capabilities. You can instead
+  # set search_fallback_backend / extract_fallback_backend independently.
+  fallback_backend: "tavily"
 ```
 
 When per-capability keys are empty, both fall through to `web.backend`. Only when no web selection has ever been written is the backend auto-detected from whichever API key/URL is present — once a selection exists, the runtime always uses it, and adding a key to `.env` does not reroute web traffic.
@@ -424,6 +428,15 @@ If no backend has **ever** been selected (no `web.backend` / per-capability key 
 **Keyless free-tier ring:** when *no* credential above is present, requests rotate across the ring vendors' public free tiers (Exa, Parallel, Firecrawl, Keenable) so web tools work on a fresh install with zero setup — and a rate-limited request fails over to the next vendor in the ring automatically. Pin one vendor in `hermes tools` to stop the rotation (the ring is then only used as failover succession on throttles). All free tiers are vendor-rate-limited under burst load; sustained normal usage goes through fine. Set `web.keyless_fallback: false` to turn the tier off — with it off and no credentials, web tools are unavailable until a provider is configured.
 
 **One-shot keyless rescue for keyed backends:** when your chosen/keyed backend fails a call (bad key, outage, upstream 5xx), that single call automatically retries on the keyless free-tier ring instead of erroring — the result notes which vendor served it and why (`rescued_from` / `backend_error`). The failover is never sticky: the very next `web_search`/`web_extract` call attempts your chosen backend again. Disable with `web.keyless_rescue: false` (also off whenever `keyless_fallback` is off).
+
+**Configured secondary backend:** set `web.fallback_backend` to retry a failed search or whole-batch extract with another configured provider before using the keyless ring. Use `web.search_fallback_backend` or `web.extract_fallback_backend` when the secondary should differ by capability; these capability-specific values override the shared fallback. The secondary must be available in its configured mode; ring providers pinned to their free tier skip this dedicated retry and remain part of the normal keyless rescue. It is request-level and non-sticky: the next call starts with the primary again. A secondary extract provider is never used to bypass website-policy blocks, and partial extract failures are not retried because they usually indicate page-specific problems.
+
+```yaml
+web:
+  search_backend: "exa"
+  extract_backend: "exa"
+  fallback_backend: "tavily"
+```
 
 xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
 


### PR DESCRIPTION
## Summary

- add `web.fallback_backend` for a shared request-level secondary provider
- add `web.search_fallback_backend` and `web.extract_fallback_backend` overrides
- try the configured secondary once before the existing keyless rescue
- keep fallback non-sticky: each new call starts with the primary provider
- preserve website-policy blocks, including blocks discovered by the secondary
- register and document the new configuration keys

## Why

A configured primary can be selected successfully but still fail at request time because its quota is exhausted or the service is unavailable. Previously Hermes could only rescue that call through the anonymous keyless ring. Users with a second configured provider could not use it automatically.

Example:

```yaml
web:
  search_backend: exa
  extract_backend: exa
  fallback_backend: tavily
```

With Exa and Tavily API keys present, this produces: keyed Exa → keyed Tavily → existing keyless rescue.

## Safety and behavior

- the secondary must be available in its configured mode
- ring providers explicitly pinned to `provider_tier: free` skip this dedicated retry and remain part of the normal keyless rescue
- an explicitly configured no-key provider such as DDGS can be used as the secondary
- a fallback is not retried when it is the same as the primary or lacks the capability
- partial extraction failures are not retried
- policy-blocked URLs are never sent to the secondary or keyless ring
- malformed provider result parity fails closed when a policy block cannot be mapped safely

## Verification

- `python -m pytest -q tests/tools/test_web*.py` — 216 passed
- `python -m ruff check tools/web_tools.py tests/tools/test_web_configured_fallback.py hermes_cli/config_defaults.py` — passed
- `git diff --check origin/main..HEAD` — passed
