### PR TITLE
fix(agent): bound native vision history payloads

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+from agent.context_compressor import _bound_inline_image_payloads
 from agent.error_classifier import (
     FailoverReason,
     PROVIDER_STREAM_NON_JSON_ERROR_CODE,
@@ -2949,6 +2950,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # _thinking_prefill must survive until here so the drop pass can
         # recognize stubs after reasoning fields are stripped.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+
+        # Max-iteration summaries build a second request outside the main
+        # conversation loop. Apply the same byte-budgeted image projection so
+        # this path cannot re-send every historical native-vision payload.
+        api_messages = _bound_inline_image_payloads(api_messages)
 
         # Strip all remaining underscore-prefixed scaffolding keys before the
         # wire. The summary path calls chat.completions.create() directly,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -38,6 +38,7 @@ from agent.model_metadata import (
     get_model_context_length,
     estimate_messages_tokens_rough,
     estimate_tokens_rough,
+    _inline_image_part_payload_bytes,
 )
 from agent.redact import redact_sensitive_text
 from agent.turn_context import drop_stale_api_content
@@ -1623,7 +1624,9 @@ def _is_image_part(part: Any) -> bool:
 
 
 def _content_has_images(content: Any) -> bool:
-    """True if a message's ``content`` is a multimodal list with image parts."""
+    """True if content carries a multimodal image part."""
+    if isinstance(content, dict) and content.get("_multimodal"):
+        return _content_has_images(content.get("content"))
     if not isinstance(content, list):
         return False
     return any(_is_image_part(p) for p in content)
@@ -1657,64 +1660,232 @@ def _strip_images_from_content(content: Any) -> Any:
     return new_parts
 
 
-def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Replace image parts in older messages with placeholder text.
+# Soft budget for historical inline image bytes in one request. The current
+# user image and the complete in-flight tool exchange are protected while
+# they fit; native vision embeds are capped separately at 256 KiB before they
+# enter history. Historical images larger than 128 KiB are not retained even
+# when aggregate room remains, which prevents one old screenshot from riding
+# every later request forever.
+_INLINE_IMAGE_REQUEST_BUDGET_BYTES = 512 * 1024
+_INLINE_IMAGE_HISTORY_MAX_BYTES = 128 * 1024
+_INLINE_IMAGE_REQUEST_PLACEHOLDER = (
+    "[image omitted from older context to save request bytes]"
+)
 
-    The anchor is the *last* user message that has any image content. Every
-    message before that anchor gets its image parts replaced with a short
-    placeholder so the outgoing request stops re-shipping the same multi-MB
-    base-64 image blobs on every turn.
 
-    If no user message carries images, the list is returned unchanged.
-    If the only user message with images is the very first one (nothing
-    earlier to strip), the list is returned unchanged.
+def _image_parts_in_content(content: Any) -> list[tuple[str, int, dict]]:
+    """Return ``(path, index, part)`` entries for image content parts."""
+    if isinstance(content, list):
+        return [
+            ("content", index, part)
+            for index, part in enumerate(content)
+            if _is_image_part(part)
+        ]
+    if isinstance(content, dict) and content.get("_multimodal"):
+        inner = content.get("content")
+        if isinstance(inner, list):
+            return [
+                ("envelope", index, part)
+                for index, part in enumerate(inner)
+                if _is_image_part(part)
+            ]
+    return []
 
-    Shallow copies of touched messages only; input is never mutated.
-    Port of Kilo-Org/kilocode#9434 (adapted for the OpenAI-style message
-    shape the hermes compressor emits).
+
+def _image_placeholder_part(part: dict) -> dict:
+    """Build a provider-compatible text replacement for one image part."""
+    text_type = "input_text" if part.get("type") == "input_image" else "text"
+    return {"type": text_type, "text": _INLINE_IMAGE_REQUEST_PLACEHOLDER}
+
+
+def _bound_inline_image_payloads(
+    messages: List[Dict[str, Any]],
+    *,
+    max_inline_bytes: int = _INLINE_IMAGE_REQUEST_BUDGET_BYTES,
+) -> List[Dict[str, Any]]:
+    """Project messages onto a bounded inline-image request payload.
+
+    The model-token estimator intentionally uses a flat image heuristic. This
+    separate projection uses the actual data-URL / base64 field length and
+    keeps an image on the current user message plus tool results that still
+    follow the latest user message; remaining inline images are retained
+    newest-first until the aggregate byte budget is full. Older parts become
+    text placeholders, while message rows and tool-call pairing remain intact.
+
+    ``messages`` is never mutated. Only touched message dictionaries and their
+    content containers are copied, and stale ``api_content`` sidecars are
+    discarded because they could restore the removed bytes on replay.
+    ``max_inline_bytes=0`` is used by compaction to age out every non-protected
+    image, regardless of its individual size.
     """
     if not messages:
         return messages
+    try:
+        budget = max(0, int(max_inline_bytes))
+    except (TypeError, ValueError):
+        budget = _INLINE_IMAGE_REQUEST_BUDGET_BYTES
 
-    # Find the newest user message that carries at least one image part.
-    # We anchor on image-bearing user messages (not all user messages) so
-    # a plain text follow-up after a big-image turn still strips the old
-    # image — matching the problem kilocode#9434 set out to solve.
-    anchor = -1
-    for i in range(len(messages) - 1, -1, -1):
-        msg = messages[i]
-        if not isinstance(msg, dict):
+    records: list[tuple[int, str, int, dict, int]] = []
+    latest_user_index = -1
+    latest_user_image_index = -1
+    latest_tool_index = -1
+    for message_index, message in enumerate(messages):
+        if not isinstance(message, dict):
             continue
-        if msg.get("role") != "user":
+        role = message.get("role")
+        if role == "user":
+            latest_user_index = message_index
+        parts = _image_parts_in_content(message.get("content"))
+        if not parts:
+            stashed = message.get("_anthropic_content_blocks")
+            if isinstance(stashed, list):
+                parts = [
+                    ("sidecar", index, part)
+                    for index, part in enumerate(stashed)
+                    if _is_image_part(part)
+                ]
+        if not parts:
             continue
-        if _content_has_images(msg.get("content")):
-            anchor = i
-            break
+        if role == "user":
+            latest_user_image_index = message_index
+        elif role == "tool":
+            latest_tool_index = message_index
+        for path, part_index, part in parts:
+            records.append(
+                (
+                    message_index,
+                    path,
+                    part_index,
+                    part,
+                    _inline_image_part_payload_bytes(part),
+                )
+            )
 
-    if anchor <= 0:
-        # No image-bearing user message, or it's the very first message —
-        # nothing before it to strip.
+    if not records:
         return messages
 
-    changed = False
-    result: List[Dict[str, Any]] = []
-    for i, msg in enumerate(messages):
-        if i >= anchor or not isinstance(msg, dict):
-            result.append(msg)
-            continue
-        content = msg.get("content")
-        if not _content_has_images(content):
-            result.append(msg)
-            continue
-        new_msg = msg.copy()
-        new_msg["content"] = _strip_images_from_content(content)
-        # Content rewritten → the api_content sidecar (exact bytes previously
-        # sent) is stale; drop it so replay can't resend the pre-rewrite bytes.
-        drop_stale_api_content(new_msg)
-        result.append(new_msg)
-        changed = True
+    current_user_keys = {
+        (message_index, path, part_index)
+        for message_index, path, part_index, _part, _size in records
+        if (
+            message_index == latest_user_image_index
+            and latest_user_image_index == latest_user_index
+        )
+    }
+    active_tool_records = [
+        record
+        for record in records
+        if messages[record[0]].get("role") == "tool"
+        and (latest_user_index < 0 or record[0] > latest_user_index)
+    ]
+    current_user_bytes = sum(
+        size
+        for message_index, path, part_index, _part, size in records
+        if (message_index, path, part_index) in current_user_keys
+    )
+    active_tool_bytes = sum(record[4] for record in active_tool_records)
+    protect_complete_active_exchange = (
+        budget > 0 and current_user_bytes + active_tool_bytes <= budget
+    )
 
-    return result if changed else messages
+    protected_keys: set[tuple[int, str, int]] = set(current_user_keys)
+    for message_index, path, part_index, _part, _size in records:
+        # Preserve the complete active exchange when it fits. If it does not,
+        # retain the newest active tool result as the continuity floor and let
+        # the byte budget remove older active screenshots deterministically.
+        is_active_tool = (
+            messages[message_index].get("role") == "tool"
+            and (latest_user_index < 0 or message_index > latest_user_index)
+        )
+        if is_active_tool and (
+            protect_complete_active_exchange or message_index == latest_tool_index
+        ):
+            protected_keys.add((message_index, path, part_index))
+
+    protected_bytes = sum(
+        size
+        for message_index, path, part_index, _part, size in records
+        if (message_index, path, part_index) in protected_keys
+    )
+    remaining = max(0, budget - protected_bytes)
+    kept_keys = set(protected_keys)
+    # Newest-first retention makes the projection stable as history grows: an
+    # image is replaced once when it falls outside the byte budget, not on
+    # every subsequent request.
+    for message_index, path, part_index, _part, size in reversed(records):
+        key = (message_index, path, part_index)
+        if key in kept_keys or (size == 0 and budget > 0):
+            kept_keys.add(key)
+        elif size > _INLINE_IMAGE_HISTORY_MAX_BYTES:
+            continue
+        elif size > 0 and size <= remaining:
+            kept_keys.add(key)
+            remaining -= size
+
+    replacements: dict[int, set[tuple[str, int]]] = {}
+    for message_index, path, part_index, _part, _size in records:
+        key = (message_index, path, part_index)
+        if key not in kept_keys:
+            replacements.setdefault(message_index, set()).add((path, part_index))
+    if not replacements:
+        return messages
+
+    result: List[Dict[str, Any]] = list(messages)
+    for message_index, paths in replacements.items():
+        message = messages[message_index]
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        new_message = message.copy()
+        if isinstance(content, list):
+            new_content = list(content)
+            for path, part_index in paths:
+                if path == "content":
+                    new_content[part_index] = _image_placeholder_part(content[part_index])
+            new_message["content"] = new_content
+        elif isinstance(content, dict) and content.get("_multimodal"):
+            inner = content.get("content")
+            if not isinstance(inner, list):
+                continue
+            new_inner = list(inner)
+            for path, part_index in paths:
+                if path == "envelope":
+                    new_inner[part_index] = _image_placeholder_part(inner[part_index])
+            new_content = content.copy()
+            new_content["content"] = new_inner
+            new_message["content"] = new_content
+        if any(path == "sidecar" for path, _part_index in paths):
+            stashed = message.get("_anthropic_content_blocks")
+            if isinstance(stashed, list):
+                new_stashed = list(stashed)
+                for path, part_index in paths:
+                    if path == "sidecar":
+                        new_stashed[part_index] = _image_placeholder_part(
+                            stashed[part_index]
+                        )
+                new_message["_anthropic_content_blocks"] = new_stashed
+        if not (
+            isinstance(content, list)
+            or (isinstance(content, dict) and content.get("_multimodal"))
+            or any(path == "sidecar" for path, _part_index in paths)
+        ):
+            continue
+        drop_stale_api_content(new_message)
+        result[message_index] = new_message
+
+    return result
+
+
+def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Age out non-current inline images during a compression boundary.
+
+    An image on the current user turn and the newest tool result from the
+    still-active exchange are retained for continuity. All older images are
+    replaced even when they sit inside ``protect_last_n``; the protected-tail
+    token estimator cannot see base64 bytes, so leaving those images untouched
+    is what made compression appear ineffective in native-vision sessions.
+    """
+    return _bound_inline_image_payloads(messages, max_inline_bytes=0)
 
 
 def _image_part_label(part: Dict[str, Any]) -> str:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -36,6 +36,7 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
 )
 from agent.context_engine import automatic_compaction_status_message
+from agent.context_compressor import _bound_inline_image_payloads
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_metadata import append_message
@@ -2435,6 +2436,13 @@ def run_conversation(
         # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
         # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
         _sanitize_messages_surrogates(api_messages)
+
+        # Keep the request's inline image payload bounded independently of the
+        # model-token estimate. Native vision embeds can remain cheap in token
+        # currency while dominating the serialized request; project the
+        # per-call copy before cache planning so old bytes cannot reach the
+        # provider or reappear through an api_content sidecar.
+        api_messages = _bound_inline_image_payloads(api_messages)
 
         # NOTE (empty-content class fix): no send-time pad loop here.  The
         # single owner for "never send a turn strict wire validation rejects

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3448,6 +3448,73 @@ def _count_image_tokens(msg: Dict[str, Any], cost_per_image: int) -> int:
     return count * cost_per_image
 
 
+_INLINE_IMAGE_PART_TYPES = frozenset({"image", "image_url", "input_image"})
+
+
+def _inline_image_part_payload_bytes(part: Any) -> int:
+    """Return the inline wire bytes carried by one image content part.
+
+    This is deliberately separate from ``_count_image_tokens``.  The latter
+    estimates model tokens and must not treat base64 transport bytes as model
+    tokens; this helper measures only embedded data that Hermes serializes into
+    the request. Remote URLs have no inline payload and therefore contribute
+    zero.
+    """
+    if not isinstance(part, dict) or part.get("type") not in _INLINE_IMAGE_PART_TYPES:
+        return 0
+
+    if part.get("type") == "image":
+        source = part.get("source")
+        if isinstance(source, dict) and source.get("type") == "base64":
+            data = source.get("data")
+            return len(data.encode("utf-8")) if isinstance(data, str) else 0
+        return 0
+
+    image_ref = part.get("image_url")
+    if isinstance(image_ref, dict):
+        image_ref = image_ref.get("url")
+    if not isinstance(image_ref, str) or not image_ref.startswith("data:"):
+        return 0
+    return len(image_ref.encode("utf-8"))
+
+
+def estimate_messages_inline_image_bytes(messages: List[Dict[str, Any]]) -> int:
+    """Return the total inline image payload carried by ``messages``.
+
+    The result is a wire-size diagnostic and budget currency, not a model-token
+    estimate. It understands the OpenAI chat/Responses shapes, Anthropic
+    ``source.data`` blocks, and the transient ``_multimodal`` envelope used by
+    native vision tools.
+    """
+    total = 0
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        parts = None
+        if isinstance(content, list):
+            parts = content
+        elif isinstance(content, dict) and content.get("_multimodal"):
+            inner = content.get("content")
+            if isinstance(inner, list):
+                parts = inner
+        if isinstance(parts, list):
+            total += sum(_inline_image_part_payload_bytes(part) for part in parts)
+
+        # This sidecar is only a pre-conversion cache for Anthropic-native
+        # messages. Count it when the canonical content did not already carry
+        # an image list so the diagnostic does not double-count one image.
+        stashed = message.get("_anthropic_content_blocks")
+        content_has_image = any(
+            isinstance(part, dict)
+            and part.get("type") in _INLINE_IMAGE_PART_TYPES
+            for part in (parts or [])
+        )
+        if not content_has_image and isinstance(stashed, list):
+            total += sum(_inline_image_part_payload_bytes(part) for part in stashed)
+    return total
+
+
 def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
     """Shadow of a message holding only what the provider actually receives.
 

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -892,6 +892,84 @@ class TestMaxIterationsSummaryReplay:
         assert messages[0]["content"] == "q1"
         assert messages[0]["api_content"] == "q1\n\nPLUGIN-CTX"
 
+    def test_summary_request_uses_the_same_inline_image_budget(self):
+        """The independently assembled summary request must age old images."""
+        from run_agent import AIAgent
+        from agent.chat_completion_helpers import handle_max_iterations
+
+        agent = AIAgent(
+            api_key="x",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._cached_system_prompt = "SYS"
+        captured = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return "RAW-RESPONSE"
+
+        client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=_Completions())
+        )
+        transport = types.SimpleNamespace(
+            normalize_response=lambda _r: types.SimpleNamespace(content="SUMMARY")
+        )
+
+        def _tool_turn(call_id: str) -> list[dict]:
+            return [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": "vision_analyze", "arguments": "{}"},
+                    }],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": [
+                        {"type": "text", "text": f"result {call_id}"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64," + ("x" * 300_000),
+                            },
+                        },
+                    ],
+                },
+            ]
+
+        messages = [
+            {"role": "user", "content": "inspect"},
+            *_tool_turn("old"),
+            *_tool_turn("middle"),
+            *_tool_turn("newest"),
+        ]
+        with (
+            patch.object(agent, "_ensure_primary_openai_client", return_value=client),
+            patch.object(agent, "_get_transport", return_value=transport),
+        ):
+            assert handle_max_iterations(agent, messages, 5) == "SUMMARY"
+
+        sent_tools = [
+            message
+            for message in captured["messages"]
+            if message.get("role") == "tool"
+        ]
+        assert all("data:image" not in str(tool["content"]) for tool in sent_tools)
+        assert all(
+            "data:image" in str(message["content"])
+            for message in messages
+            if message.get("role") == "tool"
+        )
+
 
 class TestSessionRowExistsBeforePreflightCompaction:
     """Moving the crash persist after prefetch/pre_llm_call (one write with

--- a/tests/agent/test_inline_image_payload_budget.py
+++ b/tests/agent/test_inline_image_payload_budget.py
@@ -1,0 +1,255 @@
+"""Regression tests for byte-bounded native vision history.
+
+The model-token estimator intentionally prices images with a model-oriented
+heuristic. These tests cover the separate wire-byte metric and the request /
+compression projection that prevents inline base64 from defeating compaction.
+"""
+
+from __future__ import annotations
+
+from agent.context_compressor import (
+    _bound_inline_image_payloads,
+    _content_has_images,
+    _strip_historical_media,
+)
+from agent.model_metadata import (
+    estimate_messages_inline_image_bytes,
+    estimate_messages_tokens_rough,
+)
+
+
+_PLACEHOLDER_MARKER = "image omitted"
+
+
+def _image_part(size: int, *, part_type: str = "image_url") -> dict:
+    url = "data:image/png;base64," + ("A" * size)
+    if part_type == "input_image":
+        return {"type": part_type, "image_url": url}
+    return {"type": part_type, "image_url": {"url": url}}
+
+
+def _tool_message(call_id: str, size: int, *, part_type: str = "image_url") -> dict:
+    return {
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": [
+            {"type": "text", "text": f"result {call_id}"},
+            _image_part(size, part_type=part_type),
+        ],
+    }
+
+
+def _user_message(size: int) -> dict:
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "inspect the image"},
+            _image_part(size),
+        ],
+    }
+
+
+class TestInlineImageByteMetric:
+    def test_wire_metric_scales_with_inline_payload_but_model_estimate_does_not(self):
+        small = [_tool_message("small", 1_000)]
+        huge = [_tool_message("huge", 3_000_000)]
+
+        small_bytes = estimate_messages_inline_image_bytes(small)
+        huge_bytes = estimate_messages_inline_image_bytes(huge)
+        small_tokens = estimate_messages_tokens_rough(small)
+        huge_tokens = estimate_messages_tokens_rough(huge)
+
+        assert huge_bytes > small_bytes * 2_000
+        # The flat model-oriented estimate is intentionally not the wire metric.
+        assert huge_tokens < small_tokens * 2
+
+    def test_remote_urls_are_not_counted_as_inline_payload(self):
+        messages = [{
+            "role": "tool",
+            "content": [{
+                "type": "image_url",
+                "image_url": {"url": "https://example.test/image.png"},
+            }],
+        }]
+        assert estimate_messages_inline_image_bytes(messages) == 0
+
+    def test_native_multimodal_envelope_is_measured(self):
+        messages = [{
+            "role": "tool",
+            "content": {
+                "_multimodal": True,
+                "content": [{"type": "image_url", "image_url": {
+                    "url": "data:image/png;base64," + ("A" * 1_000)
+                }}],
+            },
+        }]
+        assert estimate_messages_inline_image_bytes(messages) > 1_000
+
+    def test_anthropic_content_sidecar_is_measured(self):
+        messages = [{
+            "role": "tool",
+            "content": "image result",
+            "_anthropic_content_blocks": [{
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "A" * 1_000,
+                },
+            }],
+        }]
+        assert estimate_messages_inline_image_bytes(messages) == 1_000
+
+
+class TestRequestProjection:
+    def test_complete_active_tool_exchange_is_preserved_when_it_fits(self):
+        messages = [
+            {"role": "user", "content": "inspect both"},
+            _tool_message("first", 200_000),
+            _tool_message("second", 200_000),
+        ]
+
+        projected = _bound_inline_image_payloads(messages, max_inline_bytes=512_000)
+
+        assert _content_has_images(projected[1]["content"])
+        assert _content_has_images(projected[2]["content"])
+
+    def test_aggregate_budget_preserves_latest_user_and_tool_images(self):
+        messages = [
+            _user_message(200_000),
+            _tool_message("old", 200_000),
+            _tool_message("new", 200_000),
+        ]
+
+        projected = _bound_inline_image_payloads(
+            messages,
+            max_inline_bytes=450_000,
+        )
+
+        assert _content_has_images(projected[0]["content"])
+        assert not _content_has_images(projected[1]["content"])
+        assert _content_has_images(projected[2]["content"])
+        assert estimate_messages_inline_image_bytes(projected) <= 450_000
+
+    def test_projection_is_copy_on_write_and_drops_stale_sidecar(self):
+        messages = [
+            _user_message(200_000),
+            _tool_message("new", 200_000),
+            _tool_message("newest", 200_000),
+        ]
+        messages[1]["api_content"] = "stale multimodal sidecar"
+        original_url = messages[0]["content"][1]["image_url"]["url"]
+
+        projected = _bound_inline_image_payloads(
+            messages,
+            max_inline_bytes=450_000,
+        )
+
+        assert projected is not messages
+        assert "api_content" in messages[1]
+        assert "api_content" not in projected[1]
+        assert messages[0]["content"][1]["image_url"]["url"] == original_url
+
+    def test_responses_input_image_gets_input_text_placeholder(self):
+        messages = [
+            _tool_message("old", 300_000, part_type="input_image"),
+            _tool_message("new", 10_000, part_type="input_image"),
+        ]
+
+        projected = _bound_inline_image_payloads(
+            messages,
+            max_inline_bytes=100_000,
+        )
+
+        old_parts = projected[0]["content"]
+        assert any(
+            part.get("type") == "input_text"
+            and _PLACEHOLDER_MARKER in part.get("text", "")
+            for part in old_parts
+        )
+        assert _content_has_images(projected[1]["content"])
+
+    def test_anthropic_content_sidecar_is_projected_copy_on_write(self):
+        sidecar = [{
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": "A" * 300_000,
+            },
+        }]
+        messages = [
+            {
+                "role": "tool",
+                "content": "image result",
+                "_anthropic_content_blocks": sidecar,
+            },
+            {"role": "user", "content": "follow-up"},
+        ]
+
+        projected = _bound_inline_image_payloads(
+            messages,
+            max_inline_bytes=100_000,
+        )
+
+        assert projected is not messages
+        assert messages[0]["_anthropic_content_blocks"] is sidecar
+        assert projected[0]["_anthropic_content_blocks"][0]["type"] == "text"
+        assert "image omitted" in projected[0]["_anthropic_content_blocks"][0]["text"]
+
+    def test_tool_image_ages_out_after_a_text_follow_up(self):
+        messages = [
+            {"role": "user", "content": "first question"},
+            _tool_message("old", 300_000),
+            {"role": "user", "content": "follow-up question"},
+        ]
+
+        projected = _bound_inline_image_payloads(messages, max_inline_bytes=256_000)
+
+        assert not _content_has_images(projected[1]["content"])
+        assert "follow-up question" in projected[2]["content"]
+
+
+class TestCompressionProjection:
+    def test_historical_media_prunes_tool_images_inside_protected_tail(self):
+        messages = [
+            {"role": "user", "content": "look"},
+            _tool_message("a", 3_000_000),
+            _tool_message("b", 3_000_000),
+            _tool_message("c", 3_000_000),
+        ]
+
+        compressed = _strip_historical_media(messages)
+
+        assert not _content_has_images(compressed[1]["content"])
+        assert not _content_has_images(compressed[2]["content"])
+        assert _content_has_images(compressed[3]["content"])
+
+    def test_historical_media_prunes_old_remote_image_parts(self):
+        remote = {
+            "type": "image_url",
+            "image_url": {"url": "https://example.test/shot.png"},
+        }
+        messages = [
+            {"role": "user", "content": "look"},
+            {"role": "tool", "content": [{"type": "text", "text": "old"}, remote]},
+            {"role": "tool", "content": [{"type": "text", "text": "new"}, remote]},
+        ]
+
+        compressed = _strip_historical_media(messages)
+
+        assert not _content_has_images(compressed[1]["content"])
+        assert _content_has_images(compressed[2]["content"])
+
+    def test_first_user_image_does_not_block_tool_image_pruning(self):
+        messages = [
+            _user_message(100_000),
+            _tool_message("a", 100_000),
+            _tool_message("b", 100_000),
+        ]
+
+        compressed = _strip_historical_media(messages)
+
+        assert _content_has_images(compressed[0]["content"])
+        assert not _content_has_images(compressed[1]["content"])
+        assert _content_has_images(compressed[2]["content"])

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -248,6 +248,84 @@ class TestHTTP413Compression:
         assert "Screenshot of the dashboard" in str(retried_tool["content"])
         assert not getattr(agent, "_no_list_tool_content_models", set())
 
+    def test_pre_send_image_projection_bounds_the_real_request_copy(self, agent):
+        """The normal request path ages old images before the provider call.
+
+        The persisted/in-memory transcript keeps the original parts, while
+        the outgoing copy drops all tool images from the previous exchange
+        after the user sends a text follow-up.
+        """
+        request_payloads = []
+
+        def _side_effect(**kwargs):
+            request_payloads.append(kwargs)
+            return _mock_response(content="bounded", finish_reason="stop")
+
+        agent.client.chat.completions.create.side_effect = _side_effect
+        image_size = 300_000
+
+        def _tool_turn(call_id: str) -> list[dict]:
+            return [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": "vision_analyze", "arguments": "{}"},
+                    }],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id,
+                    "content": [
+                        {"type": "text", "text": f"result {call_id}"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64," + ("x" * image_size),
+                            },
+                        },
+                    ],
+                },
+            ]
+
+        prefill = [
+            {"role": "user", "content": "inspect these screenshots"},
+            *_tool_turn("old"),
+            *_tool_turn("middle"),
+            *_tool_turn("newest"),
+        ]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_model_supports_vision", return_value=True),
+            patch.object(
+                agent,
+                "_provider_supports_vision_tool_messages",
+                return_value=True,
+            ),
+        ):
+            result = agent.run_conversation("continue", conversation_history=prefill)
+
+        assert result["completed"] is True
+        assert result["final_response"] == "bounded"
+        sent = request_payloads[0]["messages"]
+        sent_tools = [m for m in sent if m.get("role") == "tool"]
+        assert len(sent_tools) == 3
+        assert all("data:image" not in str(tool["content"]) for tool in sent_tools)
+        assert all("result " in str(tool["content"]) for tool in sent_tools)
+
+        # Request projection is copy-on-write: the logical transcript still
+        # carries all three original image parts for persistence/UI use.
+        assert all(
+            "data:image" in str(message.get("content"))
+            for message in result["messages"]
+            if message.get("role") == "tool"
+        )
+
     def test_413_clears_conversation_history_on_persist(self, agent):
         """After 413-triggered compression, _persist_session must receive None history.
 

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -1,5 +1,6 @@
 """Tests for browser_console tool and browser_vision annotate param."""
 
+import base64
 import json
 import os
 import sys
@@ -248,7 +249,11 @@ class TestBrowserVisionConfig:
         shots_dir = tmp_path / "browser_screenshots"
         shots_dir.mkdir()
         screenshot = shots_dir / "shot.png"
-        screenshot.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        # The native vision history guard validates real image dimensions.
+        # Keep this fixture a valid 1x1 PNG instead of a header-only stub.
+        screenshot.write_bytes(base64.b64decode(
+            b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        ))
         return shots_dir, screenshot
 
     def test_browser_vision_uses_configured_temperature_and_timeout(self, tmp_path):

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+from io import BytesIO
 from unittest.mock import patch
 
 
 from tools.vision_tools import (
     _build_native_vision_tool_result,
     _handle_vision_analyze,
+    _prepare_native_vision_embed,
     _supports_media_in_tool_results,
     _vision_analyze_native,
 )
@@ -121,7 +123,7 @@ class TestVisionAnalyzeNative:
         except ImportError:
             pytest.skip("Pillow not installed — proactive resize is a no-op")
 
-        from tools.vision_tools import _EMBED_TARGET_BYTES
+        from tools.vision_tools import _EMBED_MAX_DIMENSION, _EMBED_TARGET_BYTES
 
         # Noisy PNG that base64-encodes to well over 5 MB (won't compress much).
         big = tmp_path / "big.png"
@@ -138,9 +140,62 @@ class TestVisionAnalyzeNative:
             if p.get("type") == "image_url"
         )
         assert len(url) <= _EMBED_TARGET_BYTES, (
-            f"embedded image {len(url) / 1024 / 1024:.1f} MB exceeds embed cap "
-            f"{_EMBED_TARGET_BYTES / 1024 / 1024:.0f} MB — would wedge sessions on Anthropic"
+            f"embedded image {len(url) / 1024:.0f} KiB exceeds embed cap "
+            f"{_EMBED_TARGET_BYTES / 1024:.0f} KiB — would wedge sessions on Anthropic"
         )
+        with Image.open(BytesIO(base64.b64decode(url.partition(",")[2]))) as resized:
+            assert max(resized.size) <= _EMBED_MAX_DIMENSION
+
+    def test_unresizable_image_is_rejected_before_history_embed(self, tmp_path, monkeypatch):
+        """A best-effort resize must not bypass the reusable-history cap."""
+        img = tmp_path / "unresizable.png"
+        img.write_bytes(_TINY_PNG)
+        from tools.vision_tools import _EMBED_TARGET_BYTES
+
+        oversized = "data:image/png;base64," + ("A" * (_EMBED_TARGET_BYTES + 1))
+        monkeypatch.setattr(
+            "tools.vision_tools._image_to_base64_data_url",
+            lambda *_args, **_kwargs: oversized,
+        )
+        monkeypatch.setattr(
+            "tools.vision_tools._resize_image_for_vision",
+            lambda *_args, **_kwargs: oversized,
+        )
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(img), "describe")
+        )
+
+        assert isinstance(result, str)
+        error = json.loads(result)
+        assert error["success"] is False
+        assert "history" in error["error"].lower()
+
+    def test_dimension_cap_is_verified_after_best_effort_resize(self, tmp_path, monkeypatch):
+        img = tmp_path / "extreme.png"
+        img.write_bytes(_TINY_PNG)
+        monkeypatch.setattr(
+            "tools.vision_tools._image_exceeds_dimension",
+            lambda *_args, **_kwargs: True,
+        )
+        monkeypatch.setattr(
+            "tools.vision_tools._resize_image_for_vision",
+            lambda *_args, **_kwargs: "data:image/png;base64,QUJD",
+        )
+        monkeypatch.setattr(
+            "tools.vision_tools._data_url_dimensions",
+            lambda *_args, **_kwargs: (64, 12_800),
+        )
+
+        bounded, error = _prepare_native_vision_embed(
+            img,
+            "data:image/png;base64,QUJD",
+            mime_type="image/png",
+        )
+
+        assert bounded is None
+        assert error is not None
+        assert "dimension" in error.lower()
 
 
 # ─── _handle_vision_analyze fast-path gating ─────────────────────────────────

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -768,18 +768,18 @@ class TestImageExceedsDimension:
         assert _image_exceeds_dimension(path, _EMBED_MAX_DIMENSION) is True
 
 
-    def test_undetectable_dimensions_return_false(self, tmp_path):
-        # Without Pillow — or with bytes Pillow can't parse — we can't inspect
-        # dimensions, so return False: the byte-based checks still apply and a
-        # missing soft dep never breaks the embed path.
+    def test_undetectable_dimensions_return_unknown(self, tmp_path):
+        # Without Pillow — or with bytes Pillow can't parse — dimensions are
+        # unknown. Native history embedding fails closed on this result rather
+        # than treating an unverified image as safe.
         path = tmp_path / "x.png"
         path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
         with patch.dict("sys.modules", {"PIL": None, "PIL.Image": None}):
-            assert _image_exceeds_dimension(path, _EMBED_MAX_DIMENSION) is False
+            assert _image_exceeds_dimension(path, _EMBED_MAX_DIMENSION) is None
 
         corrupt = tmp_path / "corrupt.png"
         corrupt.write_bytes(b"not an image at all")
-        assert _image_exceeds_dimension(corrupt, _EMBED_MAX_DIMENSION) is False
+        assert _image_exceeds_dimension(corrupt, _EMBED_MAX_DIMENSION) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4722,14 +4722,25 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         # turn — no aux call, no information loss. Consistent with vision_analyze.
         from tools.vision_tools import (
             _build_native_vision_tool_result,
+            _prepare_native_vision_embed,
             _should_use_native_vision_fast_path,
         )
 
         if _should_use_native_vision_fast_path():
+            bounded_data_url, embed_error = _prepare_native_vision_embed(
+                screenshot_path,
+                data_url,
+                mime_type="image/png",
+            )
+            if embed_error or bounded_data_url is None:
+                return json.dumps({
+                    "success": False,
+                    "error": embed_error or "Native vision history embed failed.",
+                }, ensure_ascii=False)
             native_result = _build_native_vision_tool_result(
                 image_url=str(screenshot_path),
                 question=question,
-                image_data_url=data_url,
+                image_data_url=bounded_data_url,
                 image_size_bytes=len(_screenshot_bytes),
             )
             meta = native_result.setdefault("meta", {})

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -33,6 +33,7 @@ import contextlib
 import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
 import logging
 import os
 import uuid
@@ -625,25 +626,19 @@ def _image_to_base64_data_url(image_path: Path, mime_type: Optional[str] = None)
 # provider accepts the image and we reject outright.
 _MAX_BASE64_BYTES = 20 * 1024 * 1024
 
-# Proactive embed cap (4 MB).  This is the size we resize an image DOWN to
-# before embedding it into conversation history, regardless of the 20 MB hard
-# ceiling.  Anthropic's per-image base64 limit is 5 MB; once an oversized image
-# is baked into history (e.g. a vision tool-result), it is re-sent on every
-# subsequent turn and permanently wedges the session with a 400 that retries
-# can't clear (the bad bytes are immutable history).  Capping at embed time —
-# with headroom under 5 MB — is the only durable fix.  Matches the post-failure
-# shrink target in agent.conversation_compression so behaviour is consistent
-# whether we resize proactively or reactively.
-_EMBED_TARGET_BYTES = 4 * 1024 * 1024
+# Proactive history embed cap (256 KiB).  Native vision results are stored in
+# the live conversation and replayed on every later request; the provider's
+# one-image ceiling is not a useful history budget.  A small bounded embed
+# keeps repeated screenshot turns from dominating the request before the
+# request-level image projection gets a chance to age older results out.
+_EMBED_TARGET_BYTES = 256 * 1024
 
-# Proactive embed dimension cap (px, longest side).  Anthropic enforces an
-# 8000px per-side ceiling INDEPENDENTLY of the 5 MB byte cap — a tall full-page
-# screenshot can be well under 5 MB yet far over 8000px (e.g. 1200×12000 at
-# 0.06 MB), so the byte-only embed check above lets it slip into immutable
-# history un-resized and the session bricks on a non-retryable 400.  We cap at
-# 7900 (headroom under 8000) so the proactive resize shrinks tall small-byte
-# images before they are embedded.
-_EMBED_MAX_DIMENSION = 7900
+# Proactive history dimension cap (px, longest side).  1568 px is enough for
+# ordinary screenshot reading while bounding the pixel work and encoded size
+# of every native result that enters immutable conversation history.  The
+# reactive path still uses provider-reported limits when recovering a rejected
+# request; this cap is specifically for reusable history payloads.
+_EMBED_MAX_DIMENSION = 1568
 
 # Target size when auto-resizing on API failure (5 MB).  After a provider
 # rejects an image, we downscale to this target and retry once.
@@ -660,22 +655,78 @@ def _is_image_size_error(error: Exception) -> bool:
     ))
 
 
-def _image_exceeds_dimension(image_path: Path, max_dimension: int) -> bool:
-    """True if the image's longest side exceeds ``max_dimension`` px.
-
-    Anthropic enforces an 8000px per-side cap independently of the 5 MB byte
-    cap, so a tall small-byte screenshot can pass every byte check yet trip a
-    non-retryable 400.  Returns False (don't force a resize) when Pillow is
-    unavailable or the file can't be read as an image — the byte-based checks
-    still apply, and we never want a missing soft dependency to break the
-    embed path.
-    """
+def _image_exceeds_dimension(image_path: Path, max_dimension: int) -> Optional[bool]:
+    """Return whether an image exceeds ``max_dimension`` px, or ``None``."""
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(image_path) as _img:
             return max(_img.size) > max_dimension
     except Exception:
-        return False
+        return None
+
+
+def _data_url_dimensions(data_url: str) -> Optional[tuple[int, int]]:
+    """Decode a data URL and return its pixel dimensions, or ``None``."""
+    try:
+        from PIL import Image
+
+        _header, separator, encoded = data_url.partition(",")
+        if not separator:
+            return None
+        raw = base64.b64decode(encoded, validate=True)
+        with Image.open(BytesIO(raw)) as image:
+            return image.size
+    except Exception:
+        return None
+
+
+def _prepare_native_vision_embed(
+    image_path: Path,
+    image_data_url: str,
+    *,
+    mime_type: Optional[str] = None,
+    scale_out: Optional[dict] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """Return a native embed that satisfies both history size constraints.
+
+    This is the single synchronous policy owner for native tool results. Both
+    ``vision_analyze`` and ``browser_vision`` use it, so browser screenshots
+    cannot bypass the cap by calling the result builder directly.
+    """
+    over_bytes = len(image_data_url) > _EMBED_TARGET_BYTES
+    over_dimensions = _image_exceeds_dimension(image_path, _EMBED_MAX_DIMENSION)
+    if over_dimensions is None:
+        return None, (
+            "Native vision history embed rejected: could not verify image "
+            "dimensions. Install Pillow and retry."
+        )
+    if not over_bytes and not over_dimensions:
+        return image_data_url, None
+
+    resized = _resize_image_for_vision(
+        image_path,
+        mime_type=mime_type,
+        max_base64_bytes=_EMBED_TARGET_BYTES,
+        max_dimension=_EMBED_MAX_DIMENSION,
+        scale_out=scale_out,
+    )
+    if len(resized) > _EMBED_TARGET_BYTES:
+        return None, (
+            "Image too large for native vision history: base64 payload remains "
+            f"{len(resized) / 1024:.0f} KiB (limit "
+            f"{_EMBED_TARGET_BYTES / 1024:.0f} KiB) after resizing. "
+            "Install Pillow or compress the image manually."
+        )
+
+    dimensions = _data_url_dimensions(resized)
+    if dimensions is None or max(dimensions) > _EMBED_MAX_DIMENSION:
+        actual = "unknown" if dimensions is None else f"{max(dimensions)} px"
+        return None, (
+            "Native vision history embed rejected: resized image dimensions "
+            f"remain unverifiable or exceed {_EMBED_MAX_DIMENSION} px "
+            f"(observed {actual}). Compress the image manually."
+        )
+    return resized, None
 
 
 def _crop_image_region(
@@ -1239,39 +1290,21 @@ async def _vision_analyze_native(
             temp_image_path, mime_type=detected_mime_type,
         )
 
-        # Proactive embed cap: this image gets baked into conversation
-        # history and re-sent on every subsequent turn.  Anthropic rejects
-        # any single base64 image over 5 MB OR over 8000px per side with a
-        # 400, and because history is immutable, an oversized embed
-        # permanently wedges the session — retries can't clear bytes (or
-        # pixels) that are already in the request.  Resize DOWN to the embed
-        # target (4 MB / 7900px, headroom under both ceilings) whenever the
-        # payload exceeds either limit, not just at the 20 MB hard ceiling.
-        _over_bytes = len(image_data_url) > _EMBED_TARGET_BYTES
-        _over_dims = await _run_encode_on_cpu_executor(
-            _image_exceeds_dimension, temp_image_path, _EMBED_MAX_DIMENSION,
+        # Proactive history cap: this image gets baked into conversation
+        # history and re-sent on every subsequent turn. The shared helper
+        # validates both the byte and pixel dimensions after resizing.
+        image_data_url, embed_error = await _run_encode_on_cpu_executor(
+            _prepare_native_vision_embed,
+            temp_image_path,
+            image_data_url,
+            mime_type=detected_mime_type,
+            scale_out=_scale_info,
         )
-        if _over_bytes or _over_dims:
-            image_data_url = await _run_encode_on_cpu_executor(
-                _resize_image_for_vision,
-                temp_image_path, mime_type=detected_mime_type,
-                max_base64_bytes=_EMBED_TARGET_BYTES,
-                max_dimension=_EMBED_MAX_DIMENSION,
-                scale_out=_scale_info,
+        if embed_error or image_data_url is None:
+            return tool_error(
+                embed_error or "Native vision history embed failed.",
+                success=False,
             )
-            # If even resizing can't get under the absolute hard ceiling,
-            # there's nothing more we can do — reject rather than embed a
-            # session-wedging payload.
-            if len(image_data_url) > _MAX_BASE64_BYTES:
-                return tool_error(
-                    f"Image too large for vision API: base64 payload is "
-                    f"{len(image_data_url) / (1024 * 1024):.1f} MB "
-                    f"(limit {_MAX_BASE64_BYTES / (1024 * 1024):.0f} MB) "
-                    f"even after resizing. Install Pillow "
-                    f"(`pip install Pillow`) for better auto-resize, "
-                    f"or compress the image manually.",
-                    success=False,
-                )
 
         return _build_native_vision_tool_result(
             image_url=image_url,


### PR DESCRIPTION
## Summary

Native-vision tool results could make long Hermes sessions exceed provider context, quota, or request-body limits even when the model-token estimate remained low.

This PR adds a shared, copy-on-write projection for inline image payloads, bounds native vision images before they enter reusable history, and applies the same policy to every request path that can resend conversation history.

Fixes #92699

## User-visible problem

When `vision_analyze` or native `browser_vision` handled a screenshot, Hermes could embed the image as a large base64/data URL inside a tool result. That tool result remained in the conversation history and was replayed on every later model request.

The previous history-entry limits were:

- approximately 4 MiB for the reusable image payload;
- approximately 7900 pixels on the longest edge.

Those values were reasonable as one-shot provider limits, but not as history-reuse limits. A multi-megabyte screenshot could therefore be transmitted again and again throughout a session.

The issue reported sessions where:

- a single native embed was hundreds of thousands of characters;
- real request usage grew from roughly 150K to 550K tokens in one turn;
- the rough preflight estimate stayed much lower because images used a flat token heuristic;
- compression appeared to run but could not remove images inside the protected tail;
- anti-thrash eventually disabled further compression after repeated low-savings passes;
- the provider ultimately returned request-size or usage-limit errors such as HTTP 413 and HTTP 429.

## Root cause

Five independent boundaries allowed the payload to escape protection:

1. **History admission was too permissive.** Native images entered reusable history at up to 4 MiB / 7900 px.
2. **Model-token estimation was not a wire-size metric.** Image parts were charged with a flat model-oriented heuristic, so multi-megabyte base64 payloads were almost invisible to preflight compression.
3. **Historical-media pruning was role- and position-dependent.** The old logic was anchored on user-role images and could miss native `tool` results, including images in the protected tail.
4. **The max-iteration summary built its own API payload.** That path could resend historical image payloads without going through the main request projection.
5. **Provider-specific representations could bypass a content-only guard.** OpenAI `image_url`, Responses `input_image`, Anthropic `source.data`, `_multimodal` envelopes, Anthropic sidecars, and native browser screenshots all needed coverage.

The core failure was not only that one image could be large. The deeper failure was allowing large visual data to become a persistent part of every future request without a shared aggregate byte policy.

## Implementation

### 1. Bound images before they enter reusable history

`tools/vision_tools.py` now uses history-specific limits:

```text
_EMBED_TARGET_BYTES = 256 KiB
_EMBED_MAX_DIMENSION = 1568 px
```

These are intentionally smaller than one-shot provider ceilings. The goal is to keep a native result cheap enough to reuse in a long conversation, not merely small enough to pass one individual API call.

A shared `_prepare_native_vision_embed()` function now owns this policy for both `vision_analyze` and native `browser_vision`.

The preparation flow is:

1. inspect the original payload size;
2. verify the original image dimensions with Pillow;
3. resize when the byte or dimension cap is exceeded;
4. verify the resized payload size;
5. decode the resized data URL;
6. verify the resized image dimensions again;
7. only then allow the image to be inserted into the native tool result.

If resizing cannot produce a payload within the history cap, the tool returns a structured error instead of inserting an unsafe image into reusable history.

If dimensions cannot be verified, the operation now fails closed. `_image_exceeds_dimension()` distinguishes:

- `True`: the image exceeds the dimension limit;
- `False`: the image was verified and is within the limit;
- `None`: the dimensions could not be verified.

This prevents malformed, corrupt, or undecodable images from bypassing the history guard.

### 2. Keep model-token estimation separate from wire-byte budgeting

`agent/model_metadata.py` adds:

- `_inline_image_part_payload_bytes()`;
- `estimate_messages_inline_image_bytes()`.

The byte metric understands:

- OpenAI Chat Completions `image_url` parts;
- OpenAI Responses `input_image` parts;
- Anthropic `image` blocks with `source.data`;
- transient `_multimodal` envelopes;
- `_anthropic_content_blocks` sidecars.

Remote HTTP image references do not contribute inline bytes because their binary contents are not serialized into the request.

The existing model-token estimator remains intentionally unchanged. Base64 transport bytes and model tokens are different currencies:

- model tokens approximate semantic context and model usage;
- inline bytes measure request-body pressure and transport limits.

The production protection uses the actual inline-byte measurement for projection instead of pretending that base64 length is a universal model-token count.

### 3. Add a shared copy-on-write request projection

`agent/context_compressor.py` adds `_bound_inline_image_payloads()` with these internal limits:

```text
_INLINE_IMAGE_REQUEST_BUDGET_BYTES = 512 KiB
_INLINE_IMAGE_HISTORY_MAX_BYTES = 128 KiB
```

The projection:

1. discovers image parts across all supported representations;
2. measures each inline payload;
3. identifies the current user image and the active tool exchange;
4. preserves the complete active exchange when it fits the budget;
5. retains the newest active tool result as the continuity floor when the active exchange is too large;
6. retains older images newest-first while the aggregate budget allows them;
7. does not retain historical images larger than 128 KiB solely because aggregate room remains;
8. replaces removed images with provider-compatible text placeholders;
9. preserves message rows, ordering, roles, and `tool_call_id` pairing;
10. removes stale `api_content` sidecars from rewritten copies.

The current user image has continuity priority. The 512 KiB budget is therefore a soft aggregate safety bound around the active exchange, rather than a rule that can delete the input currently being answered.

The projection never mutates the canonical transcript. Only the API-bound copy is rewritten, so persistence, UI replay, and session history retain the original logical messages.

### 4. Make compression remove images from the protected tail

`_strip_historical_media()` now delegates to the same projection with:

```text
max_inline_bytes=0
```

At a compression boundary, this explicitly ages out historical media even when it sits inside `protect_last_n`.

The compression projection retains the current user image and the newest active tool result for continuity, while replacing older image parts with text placeholders. This makes compression reclaim real payload bytes instead of reporting low savings while large screenshots remain protected.

Historical remote image references are also removed at this compression boundary even though they do not count as inline base64 bytes during ordinary request projection.

### 5. Apply the projection before prompt-cache planning

`agent/conversation_loop.py` applies `_bound_inline_image_payloads()` to the normal API message copy before prompt-cache planning and before the provider call.

This ordering is intentional:

```text
conversation history
    -> API-bound copy
    -> sanitization and normalization
    -> inline-image projection
    -> prompt-cache planning
    -> provider request
```

Cache planning therefore sees the same bounded message representation that will be sent to the provider.

A necessary image eviction may change the provider prefix once, but subsequent projections are deterministic and stable. The persisted transcript remains unchanged.

### 6. Apply the same policy to max-iteration summaries

`agent/chat_completion_helpers.py` applies the same projection to the independently assembled max-iteration summary request.

This closes a separate request path that previously bypassed the main conversation-loop projection and could reintroduce historical native-vision payloads at the point where the session was already under the most context pressure.

### 7. Enforce the same cap for native browser screenshots

`tools/browser_tool.py` now sends native browser screenshots through `_prepare_native_vision_embed()` before building the native tool result.

This prevents `browser_vision` from bypassing the history cap by constructing its own data URL and calling the result builder directly.

## Placeholder and compatibility behavior

When an image is removed from an outbound copy, the message itself remains present.

The replacement is a short text part:

```text
[image omitted from older context to save request bytes]
```

The replacement type is adapted to the input format:

- OpenAI Chat-style image parts become `text`;
- Responses-style `input_image` parts become `input_text`;
- Anthropic sidecar image blocks become text blocks.

This preserves:

- message ordering;
- role alternation;
- tool-result rows;
- `tool_call_id` pairing;
- enough textual context to explain that visual data was intentionally omitted.

When a message is rewritten, its stale `api_content` sidecar is dropped so an older exact-wire representation cannot restore the removed image later in the request pipeline.

## Tests added and updated

### Byte metric and projection tests

`tests/agent/test_inline_image_payload_budget.py` covers:

- large inline payloads producing a larger byte metric while the model-token estimate remains heuristic;
- remote URLs not being counted as inline payloads;
- `_multimodal` envelopes;
- Anthropic content sidecars;
- aggregate request budgeting;
- preservation of the active exchange when it fits;
- newest-first historical retention;
- copy-on-write behavior;
- stale `api_content` removal;
- Responses `input_image` placeholders;
- text follow-ups aging out old tool images;
- protected-tail image removal during compression;
- historical remote-image removal;
- user-role images remaining protected during the active turn.

### Production-path tests

`tests/run_agent/test_413_compression.py` verifies the real conversation path:

- the provider receives the bounded request copy;
- tool rows remain present;
- old image data is absent from the outgoing payload;
- the logical transcript returned by the agent still retains the original image parts.

`tests/agent/test_api_content_sidecar.py` verifies that the separately assembled summary request applies the same image projection.

### Native vision and browser tests

`tests/tools/test_vision_native_fast_path.py` verifies:

- resized embeds stay within the byte cap;
- post-resize dimensions stay within the long-edge cap;
- a resize that remains oversized is rejected;
- unverifiable resized dimensions are rejected.

`tests/tools/test_vision_tools.py` updates the dimension-validation contract so unknown dimensions return `None` instead of being treated as safe.

`tests/tools/test_browser_console.py` now uses a valid decodable 1x1 PNG fixture because the native history guard verifies real image dimensions.

## Verification

Focused canonical test runs recorded on Windows 11 / Python 3.11:

```text
scripts/run_tests.sh tests/agent/test_inline_image_payload_budget.py tests/agent/test_compressor_image_tokens.py tests/agent/test_compressor_historical_media.py tests/agent/test_api_content_sidecar.py tests/agent/test_model_metadata.py tests/tools/test_vision_native_fast_path.py tests/tools/test_vision_tools.py tests/run_agent/test_image_shrink_recovery.py tests/run_agent/test_413_compression.py -q
-> 236 passed, 0 failed

scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_compressor_media_stripping.py tests/agent/test_compressor_zero_user_guard.py tests/agent/test_compressor_tool_call_budget.py tests/agent/test_compression_progress.py tests/agent/test_compression_anti_thrash_persistence.py tests/agent/test_compression_anti_thrash_recovery.py tests/agent/test_preflight_compression_gate.py tests/run_agent/test_multimodal_tool_content_recovery.py tests/run_agent/test_vision_aware_preprocessing.py -q
-> 189 passed, 0 failed

scripts/run_tests.sh tests/tools/test_browser_console.py -k browser_vision -q
-> 3 passed, 0 failed

uv run ruff check <changed files>
-> passed

uv run python -m py_compile <changed files>
-> passed

uv run python scripts/check-windows-footguns.py --all
-> passed
```

The following local runs were not reported as green because they were blocked by unrelated environment issues:

- `tests/tools/test_browser_use_cli.py`: 70 passed and 22 failed because the Windows fixture attempted to launch POSIX shell scripts and received `[WinError 193]`.
- `tests/run_agent/test_run_agent.py`: 274 passed and one pre-existing test failed because the optional `anthropic` package was not installed locally.

The first remote CI run identified an invalid browser PNG fixture after the new fail-closed dimension validation. The follow-up commit replaces that header-only fixture with a valid decodable PNG.

The current PR head is `28fef2dcbce8c258d4ef1ba27f63a959a3f5a2df`.

Remote GitHub status for the current head:

- `All required checks pass`;
- Python tests passed;
- E2E passed;
- Windows-only tests passed;
- macOS-only tests passed;
- Ruff and type checks passed;
- Windows footgun checks passed;
- Docker builds passed;
- Nix checks passed;
- supply-chain checks passed;
- no blocking check failed.

## Behavioral trade-offs

- The byte budgets are internal safety bounds; no new user configuration key was added.
- The current user image is protected for continuity.
- A complete active tool exchange is protected when it fits the budget.
- If the active exchange is too large, the newest result is retained as the continuity floor and older active screenshots are degraded deterministically.
- Historical images larger than 128 KiB are not retained merely because aggregate room remains.
- Native new embeds are capped at 256 KiB / 1568 px before they enter reusable history.
- The original conversation history remains available for persistence and UI replay; only outbound request copies are projected.
- Model-token estimation remains separate from wire-byte accounting by design.

## Risk and rollback

The change consists of in-memory request projection plus the existing image resize machinery. The canonical conversation transcript is not destructively rewritten by normal request projection, and placeholders preserve message ordering and tool-call pairing in the outbound copy.

Reverting the two commits restores the previous image retention and native history behavior.

## Infographic

<img width="1672" height="941" alt="hermes-pr-92748-infographic" src="https://github.com/user-attachments/assets/354a8439-09ce-4cb1-8e46-24f00a092207" />
