### PR TITLE
fix(agent): price dated Anthropic snapshot ids as their family alias

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1151,6 +1151,8 @@ def _normalize_anthropic_model_name(model: str) -> str:
       - Dot notation: claude-opus-4.7 → claude-opus-4-7
       - Short aliases: claude-opus-4.7 → claude-opus-4-7
       - Strips anthropic/ prefix if present
+      - Strips dated snapshot suffixes: claude-haiku-4-5-20251001 →
+        claude-haiku-4-5
     """
     name = model.lower().strip()
     if name.startswith("anthropic/"):
@@ -1158,6 +1160,13 @@ def _normalize_anthropic_model_name(model: str) -> str:
     # Normalize dots to dashes in version numbers (e.g. 4.7 → 4-7, 4.6 → 4-6)
     # But preserve the rest of the name structure
     name = re.sub(r"(\d+)\.(\d+)", r"\1-\2", name)
+    # Dated snapshot ids (claude-sonnet-4-5-20250929, claude-opus-4-1-…,
+    # …) are documented pinned aliases of the same SKU at the same price,
+    # but the pricing table keys the family alias — strip only the trailing
+    # snapshot date so the alias resolves (#92673). Mirrors the Bedrock
+    # normalizer: trailing forms only, never a mid-name continuation that
+    # could be a distinct SKU.
+    name = re.sub(r"-\d{8}$", "", name)
     return name
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -212,6 +212,44 @@ def test_bedrock_versioned_inference_profile_resolves_to_bare_pricing():
         assert scoped.cache_write_cost_per_million == bare.cache_write_cost_per_million
 
 
+def test_anthropic_dated_snapshot_ids_price_as_family_alias():
+    """Dated Anthropic snapshot ids must price as their family alias (#92673).
+
+    The pricing table keys the family alias (``claude-haiku-4-5``), but the
+    4.5 generation shipped without dated keys — anyone running a pinned
+    snapshot id got ``cost_status='unknown'`` and zero spend. A dated suffix
+    is a documented pinned alias of the same SKU at the same price, so the
+    lookup must resolve it to the alias entry.
+    """
+    for alias, dated in (
+        ("claude-haiku-4-5", "claude-haiku-4-5-20251001"),
+        ("claude-sonnet-4-5", "claude-sonnet-4-5-20250929"),
+    ):
+        ref = get_pricing_entry(alias, provider="anthropic")
+        assert ref is not None, alias
+        entry = get_pricing_entry(dated, provider="anthropic")
+        assert entry is not None, dated
+        assert entry.input_cost_per_million == ref.input_cost_per_million, dated
+        assert entry.output_cost_per_million == ref.output_cost_per_million, dated
+        assert entry.cache_read_cost_per_million == ref.cache_read_cost_per_million, dated
+        assert entry.cache_write_cost_per_million == ref.cache_write_cost_per_million, dated
+
+
+def test_anthropic_dated_direct_keys_still_win_over_normalization():
+    """Generations with explicitly keyed dated rows keep resolving directly.
+
+    Older tables carry both forms (claude-opus-4-6 / -4-6-20250414); the
+    date-strip fallback in the normalizer must not change what those
+    resolve to — direct lookup fires before any normalization retry.
+    """
+    bare = get_pricing_entry("claude-opus-4-6", provider="anthropic")
+    dated = get_pricing_entry("claude-opus-4-6-20250414", provider="anthropic")
+    assert bare is not None
+    assert dated is not None
+    assert dated.input_cost_per_million == bare.input_cost_per_million
+    assert dated.output_cost_per_million == bare.output_cost_per_million
+
+
 
 
 


### PR DESCRIPTION
Fixes #92673

## What & why

Usage accounting prices `claude-haiku-4-5` but not dated snapshot ids like
`claude-haiku-4-5-20251001` or `claude-sonnet-4-5-20250929`: the pricing
table keys the family alias, and `_normalize_anthropic_model_name` never
stripped a trailing `-YYYYMMDD`. Every usage row for a pinned dated model was
written with `cost_status='unknown'` and zero estimated spend — silently, in
`/usage`, the dashboard, and the state.db usage table.

The fix mirrors the in-file precedent: `_normalize_bedrock_model_name`
already strips trailing `-\d{8}` (the #50295 class fix), with a documented
"trailing forms only — never a mid-name continuation that could be a distinct
SKU" rule. `_normalize_anthropic_model_name` now applies the same trailing
snapshot-date strip. Dated ids are Anthropic's documented pinned aliases of
the same SKU at the same price, so resolving them to the alias entry is
semantically exact.

Older generations that carry explicitly keyed dated rows (e.g.
`claude-opus-4-6-20250414`) are unaffected: direct lookup fires before the
normalization retry.

## How to test

```python
from agent.usage_pricing import _lookup_official_docs_pricing, BillingRoute

_lookup_official_docs_pricing(BillingRoute(provider="anthropic", model="claude-haiku-4-5"))            # priced (unchanged)
_lookup_official_docs_pricing(BillingRoute(provider="anthropic", model="claude-haiku-4-5-20251001"))   # None → now priced
_lookup_official_docs_pricing(BillingRoute(provider="anthropic", model="claude-sonnet-4-5-20250929"))  # None → now priced
```

New regressions in `tests/agent/test_usage_pricing.py`:
- `test_anthropic_dated_snapshot_ids_price_as_family_alias` — dated ids price field-equal to their alias
- `test_anthropic_dated_direct_keys_still_win_over_normalization` — explicitly-keyed dated rows keep direct-hit semantics
- `test_anthropic_dated_snapshot_session_estimates_cost_not_unknown` — end-to-end at `estimate_usage_cost`: a pinned snapshot yields `status='estimated'` with a dollar amount, mirroring the #50295 Bedrock estimate-level regression

Suite: `scripts/run_tests.sh tests/agent/test_usage_pricing.py tests/agent/test_billing_usage.py tests/agent/test_account_usage.py` → 55 passed, 0 failed at head 7f4679ad1e. `scripts/check-windows-footguns.py --diff origin/main` → clean (pure table/lookup change, no platform surface). macOS 26, Python 3.11.

## Known scope note

`claude-opus-4-1` has no row in the pricing table at all (no alias, no dated key — the table jumps opus-4 → opus-4-5), so its dated id still prices unknown after this fix. Adding that row requires maintainer-sourced official pricing data; this PR deliberately does not fabricate it.

Same bug class as closed #50295 (Bedrock region prefix) and #32400 (Gemini dated ids).

