### PR TITLE
feat(proxy): add authenticated loopback Codex OAuth adapter

### DIFF
--- a/contributors/emails/chris@batemancollective.com
+++ b/contributors/emails/chris@batemancollective.com
@@ -1,0 +1,2 @@
+BELGARATHbb
+# Chris Munn; replacement PR #92750 preserves #91199 authorship

--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -8,15 +8,19 @@ token. See :class:`UpstreamAdapter` for the contract.
 from typing import Dict, Type
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter
+from hermes_cli.proxy.adapters.codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
 # Registry of available adapter classes keyed by provider name as used on
 # the ``hermes proxy start --provider <name>`` CLI flag.
 ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
+    "openai-codex": OpenAICodexAdapter,
     "nous": NousPortalAdapter,
     "xai": XAIGrokAdapter,
 }
+
+_ALIASES = {"codex": "openai-codex"}
 
 
 def get_adapter(name: str) -> UpstreamAdapter:
@@ -26,6 +30,7 @@ def get_adapter(name: str) -> UpstreamAdapter:
         ValueError: if ``name`` is not a registered adapter.
     """
     key = (name or "").strip().lower()
+    key = _ALIASES.get(key, key)
     if key not in ADAPTERS:
         available = ", ".join(sorted(ADAPTERS)) or "(none)"
         raise ValueError(

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -86,6 +86,11 @@ class UpstreamAdapter(ABC):
         """Whether this credential must never bind beyond loopback."""
         return False
 
+    @property
+    def requires_client_auth(self) -> bool:
+        """Whether callers must authenticate before credentials are resolved."""
+        return False
+
     def get_owned_upstream_header_names(self) -> frozenset[str]:
         """Headers whose inbound client values must always be removed."""
         return frozenset()

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -81,6 +81,27 @@ class UpstreamAdapter(ABC):
               refresh fails. The proxy will return 401 to the client.
         """
 
+    @property
+    def loopback_only(self) -> bool:
+        """Whether this credential must never bind beyond loopback."""
+        return False
+
+    def get_owned_upstream_header_names(self) -> frozenset[str]:
+        """Headers whose inbound client values must always be removed."""
+        return frozenset()
+
+    def get_upstream_headers(
+        self,
+        credential: UpstreamCredential,
+    ) -> dict[str, str]:
+        """Return provider-required headers in addition to Authorization.
+
+        The server applies these after filtering inbound client headers, so an
+        untrusted loopback client cannot spoof provider identity/account fields.
+        """
+        _ = credential
+        return {}
+
     def get_retry_credential(
         self,
         *,

--- a/hermes_cli/proxy/adapters/codex.py
+++ b/hermes_cli/proxy/adapters/codex.py
@@ -14,9 +14,11 @@ logger = logging.getLogger(__name__)
 
 _POOL_PROVIDER = "openai-codex"
 _ALLOWED_PATHS: FrozenSet[str] = frozenset({"/responses", "/models"})
-_OWNED_HEADERS: FrozenSet[str] = frozenset(
-    {"User-Agent", "originator", "ChatGPT-Account-ID"}
-)
+_OWNED_HEADERS: FrozenSet[str] = frozenset({
+    "User-Agent",
+    "originator",
+    "ChatGPT-Account-ID",
+})
 
 
 class OpenAICodexAdapter(UpstreamAdapter):
@@ -38,6 +40,10 @@ class OpenAICodexAdapter(UpstreamAdapter):
 
     @property
     def loopback_only(self) -> bool:
+        return True
+
+    @property
+    def requires_client_auth(self) -> bool:
         return True
 
     @property
@@ -137,7 +143,9 @@ class OpenAICodexAdapter(UpstreamAdapter):
         try:
             return load_pool(_POOL_PROVIDER)
         except Exception:
-            logger.warning("proxy: failed to load Codex OAuth credential pool", exc_info=True)
+            logger.warning(
+                "proxy: failed to load Codex OAuth credential pool", exc_info=True
+            )
             return None
 
     def _credential_from_entry(self, entry: PooledCredential) -> UpstreamCredential:
@@ -147,9 +155,11 @@ class OpenAICodexAdapter(UpstreamAdapter):
                 "Codex OAuth pool entry has no access token. Re-authenticate "
                 "with `hermes auth add openai-codex --type oauth`."
             )
-        base_url = str(
-            entry.runtime_base_url or entry.base_url or DEFAULT_CODEX_BASE_URL
-        ).strip().rstrip("/")
+        base_url = (
+            str(entry.runtime_base_url or entry.base_url or DEFAULT_CODEX_BASE_URL)
+            .strip()
+            .rstrip("/")
+        )
         trusted_base = DEFAULT_CODEX_BASE_URL.rstrip("/")
         if base_url != trusted_base:
             raise RuntimeError(

--- a/hermes_cli/proxy/adapters/codex.py
+++ b/hermes_cli/proxy/adapters/codex.py
@@ -1,0 +1,166 @@
+"""OpenAI Codex OAuth upstream adapter for the loopback Hermes proxy."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import FrozenSet, Optional
+
+from agent.credential_pool import CredentialPool, PooledCredential, load_pool
+from hermes_cli.auth import DEFAULT_CODEX_BASE_URL
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+logger = logging.getLogger(__name__)
+
+_POOL_PROVIDER = "openai-codex"
+_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/responses", "/models"})
+_OWNED_HEADERS: FrozenSet[str] = frozenset(
+    {"User-Agent", "originator", "ChatGPT-Account-ID"}
+)
+
+
+class OpenAICodexAdapter(UpstreamAdapter):
+    """Attach the main Hermes Codex OAuth credential to Responses requests."""
+
+    auth_hint = "hermes auth add openai-codex --type oauth"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pool: Optional[CredentialPool] = None
+
+    @property
+    def name(self) -> str:
+        return "openai-codex"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenAI Codex OAuth"
+
+    @property
+    def loopback_only(self) -> bool:
+        return True
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return _ALLOWED_PATHS
+
+    def is_authenticated(self) -> bool:
+        """Check local pool state only; never call the network."""
+        pool = self._load_pool()
+        return bool(pool and pool.has_available())
+
+    def get_credential(self) -> UpstreamCredential:
+        with self._lock:
+            pool = self._load_pool()
+            if pool is None or not pool.has_credentials():
+                raise RuntimeError(
+                    "No OpenAI Codex OAuth credentials found. Run "
+                    "`hermes auth add openai-codex --type oauth` first."
+                )
+            entry = pool.select()
+            if entry is None:
+                raise RuntimeError(
+                    "No available OpenAI Codex OAuth credentials. Reset the "
+                    "pool cooldown or re-authenticate."
+                )
+            self._pool = pool
+            return self._credential_from_entry(entry)
+
+    def get_retry_credential(
+        self,
+        *,
+        failed_credential: UpstreamCredential,
+        status_code: int,
+    ) -> Optional[UpstreamCredential]:
+        if status_code not in {401, 429}:
+            return None
+
+        with self._lock:
+            pool = self._pool or self._load_pool()
+            if pool is None:
+                return None
+
+            if status_code == 401:
+                refreshed = pool.try_refresh_matching(
+                    api_key_hint=failed_credential.bearer
+                )
+                if refreshed is None:
+                    # A concurrent request may have queued behind the adapter
+                    # lock with the same now-stale bearer. If the first request
+                    # already refreshed/rotated the pool, coalesce onto that
+                    # current credential instead of failing or exhausting the
+                    # obsolete token a second time.
+                    current = pool.select()
+                    if (
+                        current is not None
+                        and str(current.runtime_api_key or "").strip()
+                        != failed_credential.bearer
+                    ):
+                        refreshed = current
+                if refreshed is None:
+                    refreshed = pool.mark_exhausted_and_rotate(
+                        status_code=401,
+                        api_key_hint=failed_credential.bearer,
+                    )
+            else:
+                refreshed = pool.mark_exhausted_and_rotate(
+                    status_code=429,
+                    api_key_hint=failed_credential.bearer,
+                )
+
+            if refreshed is None:
+                return None
+            retry = self._credential_from_entry(refreshed)
+            if retry.bearer == failed_credential.bearer:
+                return None
+            logger.info(
+                "proxy: Codex upstream returned %s; retrying with refreshed/rotated credential",
+                status_code,
+            )
+            return retry
+
+    def get_owned_upstream_header_names(self) -> frozenset[str]:
+        return _OWNED_HEADERS
+
+    def get_upstream_headers(
+        self,
+        credential: UpstreamCredential,
+    ) -> dict[str, str]:
+        # Reuse the native Codex request identity contract: originator and
+        # User-Agent avoid Cloudflare challenges on VPS traffic, while the
+        # account header is extracted from the JWT when present.
+        from agent.auxiliary_client import _codex_cloudflare_headers
+
+        return _codex_cloudflare_headers(credential.bearer)
+
+    def _load_pool(self) -> Optional[CredentialPool]:
+        try:
+            return load_pool(_POOL_PROVIDER)
+        except Exception:
+            logger.warning("proxy: failed to load Codex OAuth credential pool", exc_info=True)
+            return None
+
+    def _credential_from_entry(self, entry: PooledCredential) -> UpstreamCredential:
+        bearer = str(entry.runtime_api_key or "").strip()
+        if not bearer:
+            raise RuntimeError(
+                "Codex OAuth pool entry has no access token. Re-authenticate "
+                "with `hermes auth add openai-codex --type oauth`."
+            )
+        base_url = str(
+            entry.runtime_base_url or entry.base_url or DEFAULT_CODEX_BASE_URL
+        ).strip().rstrip("/")
+        trusted_base = DEFAULT_CODEX_BASE_URL.rstrip("/")
+        if base_url != trusted_base:
+            raise RuntimeError(
+                "Refusing to attach OpenAI Codex OAuth credentials to untrusted "
+                f"upstream {base_url!r}; expected {trusted_base!r}."
+            )
+        return UpstreamCredential(
+            bearer=bearer,
+            base_url=trusted_base,
+            expires_at=entry.expires_at,
+        )
+
+
+__all__ = ["OpenAICodexAdapter"]

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -24,6 +24,73 @@ logger = logging.getLogger(__name__)
 _MAX_CLIENT_AUTH_TOKEN_CHARS = 4096
 
 
+def _validate_windows_owner_only_acl(
+    *,
+    owner_sid: str,
+    allowed_sids: set[str],
+    allowed_aces: list[tuple[int, str]],
+) -> None:
+    """Reject Windows file ACLs that grant authority beyond owner and SYSTEM."""
+    if owner_sid not in allowed_sids:
+        raise ValueError("Proxy auth token file has the wrong owner on Windows.")
+    for mask, sid in allowed_aces:
+        if mask and sid not in allowed_sids:
+            raise ValueError("Proxy auth token file has a permissive DACL on Windows.")
+
+
+def _verify_windows_owner_only_descriptor(descriptor: int) -> None:
+    """Verify the opened Windows token file's owner and DACL via pywin32."""
+    if sys.platform != "win32":
+        raise RuntimeError("Windows token-file ACL verification requires Windows.")
+
+    import msvcrt
+
+    import win32api
+    import win32con
+    import win32security
+
+    process_token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(), win32con.TOKEN_QUERY
+    )
+    current_sid = win32security.GetTokenInformation(
+        process_token, win32security.TokenUser
+    )[0]
+    system_sid = win32security.ConvertStringSidToSid("S-1-5-18")
+    allowed_sids = {
+        win32security.ConvertSidToStringSid(current_sid),
+        win32security.ConvertSidToStringSid(system_sid),
+    }
+
+    handle = msvcrt.get_osfhandle(descriptor)
+    info = (
+        win32security.OWNER_SECURITY_INFORMATION
+        | win32security.DACL_SECURITY_INFORMATION
+    )
+    security = win32security.GetSecurityInfo(handle, win32security.SE_FILE_OBJECT, info)
+    owner = security.GetSecurityDescriptorOwner()
+    owner_sid = win32security.ConvertSidToStringSid(owner)
+    dacl = security.GetSecurityDescriptorDacl()
+    if dacl is None:
+        raise ValueError("Proxy auth token file has a null DACL on Windows.")
+
+    allow_types = {
+        win32security.ACCESS_ALLOWED_ACE_TYPE,
+        win32security.ACCESS_ALLOWED_OBJECT_ACE_TYPE,
+        getattr(win32security, "ACCESS_ALLOWED_CALLBACK_ACE_TYPE", 9),
+        getattr(win32security, "ACCESS_ALLOWED_CALLBACK_OBJECT_ACE_TYPE", 11),
+    }
+    allowed_aces: list[tuple[int, str]] = []
+    for index in range(dacl.GetAceCount()):
+        ace = dacl.GetAce(index)
+        if ace[0][0] in allow_types:
+            allowed_aces.append((ace[1], win32security.ConvertSidToStringSid(ace[-1])))
+    _validate_windows_owner_only_acl(
+        owner_sid=owner_sid,
+        allowed_sids=allowed_sids,
+        allowed_aces=allowed_aces,
+    )
+
+
 def _read_client_auth_token(path: str) -> str:
     """Read a bounded token from an owner-only regular file."""
     token_path = Path(path).expanduser()
@@ -58,7 +125,9 @@ def _read_client_auth_token(path: str) -> str:
             metadata.st_ino,
         ):
             raise ValueError("Proxy auth token file changed while it was opened.")
-        if os.name != "nt":
+        if os.name == "nt":
+            _verify_windows_owner_only_descriptor(descriptor)
+        else:
             if opened.st_mode & 0o077:
                 raise ValueError(
                     "Proxy auth token file must be owner-only (mode 0600)."

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import stat
 import sys
+from pathlib import Path
 from typing import Any
 
 from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
@@ -17,6 +20,68 @@ from hermes_cli.proxy.server import (
 )
 
 logger = logging.getLogger(__name__)
+
+_MAX_CLIENT_AUTH_TOKEN_CHARS = 4096
+
+
+def _read_client_auth_token(path: str) -> str:
+    """Read a bounded token from an owner-only regular file."""
+    token_path = Path(path).expanduser()
+    metadata = token_path.lstat()
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(
+            "Proxy auth token path must be a regular file (not a symlink)."
+        )
+    if os.name != "nt":
+        if metadata.st_mode & 0o077:
+            raise ValueError("Proxy auth token file must be owner-only (mode 0600).")
+        get_euid = getattr(os, "geteuid", None)
+        if get_euid is not None and metadata.st_uid != get_euid():
+            raise ValueError("Proxy auth token file must be owned by the current user.")
+
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(token_path, flags)
+    except OSError as exc:
+        raise ValueError(
+            "Proxy auth token path must be a readable regular file."
+        ) from exc
+    try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode) or (
+            opened.st_dev,
+            opened.st_ino,
+        ) != (
+            metadata.st_dev,
+            metadata.st_ino,
+        ):
+            raise ValueError("Proxy auth token file changed while it was opened.")
+        if os.name != "nt":
+            if opened.st_mode & 0o077:
+                raise ValueError(
+                    "Proxy auth token file must be owner-only (mode 0600)."
+                )
+            get_euid = getattr(os, "geteuid", None)
+            if get_euid is not None and opened.st_uid != get_euid():
+                raise ValueError(
+                    "Proxy auth token file must be owned by the current user."
+                )
+        with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+            descriptor = -1
+            token = handle.read(_MAX_CLIENT_AUTH_TOKEN_CHARS + 1).strip()
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+    if not token:
+        raise ValueError("Proxy auth token file is empty.")
+    if len(token) > _MAX_CLIENT_AUTH_TOKEN_CHARS:
+        raise ValueError("Proxy auth token exceeds the 4096-character limit.")
+    if any(character.isspace() for character in token):
+        raise ValueError("Proxy auth token must be a single value without whitespace.")
+    return token
 
 
 def _print_aiohttp_missing() -> None:
@@ -45,8 +110,7 @@ def cmd_proxy_start(args: Any) -> int:
     if not adapter.is_authenticated():
         auth_hint = getattr(adapter, "auth_hint", f"hermes auth add {adapter.name}")
         print(
-            f"Not logged into {adapter.display_name}. "
-            f"Run `{auth_hint}` first.",
+            f"Not logged into {adapter.display_name}. Run `{auth_hint}` first.",
             file=sys.stderr,
         )
         return 2
@@ -61,18 +125,47 @@ def cmd_proxy_start(args: Any) -> int:
         )
         return 2
 
+    token_file = getattr(args, "auth_token_file", None)
+    if adapter.requires_client_auth and not token_file:
+        print(
+            f"Error: {adapter.display_name} requires client authentication; "
+            "provide an owner-only regular file with --auth-token-file.",
+            file=sys.stderr,
+        )
+        return 2
+    client_auth_token = None
+    if token_file:
+        try:
+            client_auth_token = _read_client_auth_token(str(token_file))
+        except (OSError, UnicodeError, ValueError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+
+    client_auth_message = (
+        "  Client auth:    required (bearer from owner-only token file)\n"
+        if client_auth_token
+        else "  Client auth:    any bearer accepted\n"
+    )
+
     print(
         f"Starting Hermes proxy for {adapter.display_name}\n"
         f"  Listening on:  http://{host}:{port}/v1\n"
         f"  Forwarding to: (resolved per-request from your subscription)\n"
-        f"  Use any bearer token in the client — the proxy attaches your real credential.\n"
+        f"{client_auth_message}"
         f"\n"
         f"Press Ctrl+C to stop.",
         file=sys.stderr,
     )
 
     try:
-        asyncio.run(run_server(adapter, host=host, port=port))
+        asyncio.run(
+            run_server(
+                adapter,
+                host=host,
+                port=port,
+                client_auth_token=client_auth_token,
+            )
+        )
     except KeyboardInterrupt:
         print("\nproxy: stopped", file=sys.stderr)
     except OSError as exc:
@@ -99,9 +192,7 @@ def cmd_proxy_status(args: Any) -> int:
             continue
         expires = f" (bearer expires {cred.expires_at})" if cred.expires_at else ""
         print(f"  [{name:8s}] {adapter.display_name} — ready{expires}")
-    print(
-        "\nStart the proxy with: hermes proxy start [--provider <name>]"
-    )
+    print("\nStart the proxy with: hermes proxy start [--provider <name>]")
     return 0
 
 
@@ -130,6 +221,7 @@ def cmd_proxy(args: Any) -> int:
         "\n"
         "Subcommands:\n"
         "  hermes proxy start [--provider codex|nous|xai] [--host 127.0.0.1] [--port 8645]\n"
+        "      [--auth-token-file PATH]\n"
         "      Run the proxy in the foreground.\n"
         "  hermes proxy status\n"
         "      Show which upstream adapters are ready.\n"

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -12,6 +12,7 @@ from hermes_cli.proxy.server import (
     AIOHTTP_AVAILABLE,
     DEFAULT_HOST,
     DEFAULT_PORT,
+    is_loopback_host,
     run_server,
 )
 
@@ -52,6 +53,13 @@ def cmd_proxy_start(args: Any) -> int:
 
     host = getattr(args, "host", None) or DEFAULT_HOST
     port = getattr(args, "port", None) or DEFAULT_PORT
+    if adapter.loopback_only and not is_loopback_host(host):
+        print(
+            f"Error: {adapter.display_name} proxy is loopback-only; "
+            f"refusing bind host {host!r}.",
+            file=sys.stderr,
+        )
+        return 2
 
     print(
         f"Starting Hermes proxy for {adapter.display_name}\n"
@@ -121,7 +129,7 @@ def cmd_proxy(args: Any) -> int:
         "OAuth-authenticated provider credentials to outbound requests.\n"
         "\n"
         "Subcommands:\n"
-        "  hermes proxy start [--provider nous|xai] [--host 127.0.0.1] [--port 8645]\n"
+        "  hermes proxy start [--provider codex|nous|xai] [--host 127.0.0.1] [--port 8645]\n"
         "      Run the proxy in the foreground.\n"
         "  hermes proxy status\n"
         "      Show which upstream adapters are ready.\n"

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,6 +12,7 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import signal
 from typing import Optional
@@ -19,10 +20,12 @@ from typing import Optional
 try:
     import aiohttp
     from aiohttp import web
+    from yarl import URL
     AIOHTTP_AVAILABLE = True
 except ImportError:
     aiohttp = None  # type: ignore[assignment]
     web = None  # type: ignore[assignment]
+    URL = None  # type: ignore[assignment,misc]
     AIOHTTP_AVAILABLE = False
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
@@ -56,6 +59,17 @@ DEFAULT_HOST = "127.0.0.1"
 MAX_REQUEST_BYTES = 10_000_000
 
 
+def is_loopback_host(host: str) -> bool:
+    """True only for explicit loopback literals or localhost."""
+    value = str(host or "").strip().lower()
+    if value == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
 def _json_error(status: int, message: str, code: str = "proxy_error") -> "web.Response":
     """Return an OpenAI-style error JSON response."""
     body = {"error": {"message": message, "type": code, "code": code}}
@@ -72,6 +86,38 @@ def _filter_request_headers(headers: "aiohttp.typedefs.LooseHeaders") -> dict:
     return out
 
 
+def _strip_owned_headers(headers: dict, owned_names: frozenset[str]) -> dict:
+    """Remove all client spellings of adapter-owned identity headers."""
+    owned = {str(name).strip().lower() for name in owned_names if str(name).strip()}
+    return {
+        key: value
+        for key, value in headers.items()
+        if str(key).lower() not in owned
+    }
+
+
+def _merge_adapter_headers(
+    headers: dict,
+    adapter_headers: dict[str, str],
+) -> dict:
+    """Overlay trusted adapter headers case-insensitively.
+
+    Client-controlled values with alternate casing must not survive alongside
+    Codex account/originator headers. Authorization remains owned exclusively
+    by the server's credential path.
+    """
+    merged = dict(headers)
+    for key, value in adapter_headers.items():
+        normalized = str(key).strip()
+        if not normalized or normalized.lower() in _HOP_BY_HOP_HEADERS:
+            continue
+        for existing in list(merged):
+            if str(existing).lower() == normalized.lower():
+                merged.pop(existing, None)
+        merged[normalized] = str(value)
+    return merged
+
+
 def _filter_response_headers(headers) -> dict:
     """Strip hop-by-hop headers from the upstream response."""
     out = {}
@@ -83,6 +129,73 @@ def _filter_response_headers(headers) -> dict:
             continue
         out[key] = value
     return out
+
+
+async def _open_upstream_request(
+    *,
+    method: str,
+    url,
+    body: bytes,
+    headers: dict,
+    timeout,
+):
+    """Open one upstream request and close its session on every failed setup."""
+    try:
+        session = aiohttp.ClientSession(timeout=timeout)
+    except Exception as exc:  # pragma: no cover - aiohttp setup issue
+        raise RuntimeError(f"proxy session init failed: {exc}") from exc
+
+    try:
+        response = await session.request(
+            method,
+            url,
+            data=body if body else None,
+            headers=headers,
+            allow_redirects=False,
+        )
+    except asyncio.CancelledError:
+        await session.close()
+        raise
+    except Exception:
+        await session.close()
+        raise
+    return session, response
+
+
+async def _stream_upstream_response(
+    request: "web.Request",
+    upstream_resp,
+    session,
+) -> "web.StreamResponse":
+    """Bridge one upstream response and always release transport resources."""
+    resp = web.StreamResponse(
+        status=upstream_resp.status,
+        headers=_filter_response_headers(upstream_resp.headers),
+    )
+    try:
+        # Cleanup ownership starts before prepare: downstream disconnects while
+        # sending headers must still release the already-open upstream response.
+        await resp.prepare(request)
+        try:
+            async for chunk in upstream_resp.content.iter_any():
+                if chunk:
+                    await resp.write(chunk)
+        except asyncio.CancelledError:
+            raise
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            logger.warning(
+                "proxy: upstream stream interrupted; aborting downstream: %s",
+                exc,
+            )
+            transport = request.transport
+            if transport is not None:
+                transport.abort()
+            raise
+        await resp.write_eof()
+        return resp
+    finally:
+        upstream_resp.release()
+        await session.close()
 
 
 def create_app(adapter: UpstreamAdapter) -> "web.Application":
@@ -137,35 +250,42 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
 
         async def _send_upstream(active_cred: UpstreamCredential):
             upstream_url = f"{active_cred.base_url.rstrip('/')}{rel_path}"
-            # Preserve query string verbatim.
-            if request.query_string:
-                upstream_url = f"{upstream_url}?{request.query_string}"
+            # Preserve the raw percent-encoded query. ``request.query_string``
+            # is decoded by aiohttp and corrupts values when interpolated into
+            # a new URL (for example %252f -> /). Never log query contents.
+            raw_path = str(request.raw_path or "")
+            if "?" in raw_path:
+                raw_query = raw_path.split("?", 1)[1]
+                if raw_query:
+                    upstream_url = f"{upstream_url}?{raw_query}"
 
             fwd_headers = _filter_request_headers(request.headers)
+            fwd_headers = _strip_owned_headers(
+                fwd_headers,
+                adapter.get_owned_upstream_header_names(),
+            )
+            fwd_headers = _merge_adapter_headers(
+                fwd_headers,
+                adapter.get_upstream_headers(active_cred),
+            )
             fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
 
             logger.debug(
-                "proxy: forwarding %s %s -> %s (body=%d bytes)",
-                request.method, rel_path, upstream_url, len(body),
+                "proxy: forwarding %s %s -> %s%s (body=%d bytes)",
+                request.method,
+                rel_path,
+                active_cred.base_url.rstrip("/"),
+                rel_path,
+                len(body),
             )
 
-            try:
-                session = aiohttp.ClientSession(timeout=timeout)
-            except Exception as exc:  # pragma: no cover - aiohttp setup issue
-                raise RuntimeError(f"proxy session init failed: {exc}") from exc
-
-            try:
-                upstream_resp = await session.request(
-                    request.method,
-                    upstream_url,
-                    data=body if body else None,
-                    headers=fwd_headers,
-                    allow_redirects=False,
-                )
-            except Exception:
-                await session.close()
-                raise
-            return session, upstream_resp
+            return await _open_upstream_request(
+                method=request.method,
+                url=URL(upstream_url, encoded=True),
+                body=body,
+                headers=fwd_headers,
+                timeout=timeout,
+            )
 
         async def _open_upstream(active_cred: UpstreamCredential):
             try:
@@ -215,25 +335,7 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                     return session_or_response
                 session = session_or_response
 
-        # Stream response back. Headers first, then chunked body.
-        resp = web.StreamResponse(
-            status=upstream_resp.status,
-            headers=_filter_response_headers(upstream_resp.headers),
-        )
-        await resp.prepare(request)
-
-        try:
-            async for chunk in upstream_resp.content.iter_any():
-                if chunk:
-                    await resp.write(chunk)
-        except (aiohttp.ClientError, asyncio.CancelledError) as exc:
-            logger.warning("proxy: streaming interrupted: %s", exc)
-        finally:
-            upstream_resp.release()
-            await session.close()
-
-        await resp.write_eof()
-        return resp
+        return await _stream_upstream_response(request, upstream_resp, session)
 
     # /health doesn't go through the upstream
     app.router.add_get("/health", handle_health)
@@ -256,6 +358,11 @@ async def run_server(
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError(
             "aiohttp is required for `hermes proxy`. Run `hermes setup` to install it."
+        )
+
+    if adapter.loopback_only and not is_loopback_host(host):
+        raise RuntimeError(
+            f"{adapter.display_name} proxy is loopback-only; refusing bind host {host!r}."
         )
 
     app = create_app(adapter)

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,6 +12,7 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
+import hmac
 import ipaddress
 import logging
 import signal
@@ -21,6 +22,7 @@ try:
     import aiohttp
     from aiohttp import web
     from yarl import URL
+
     AIOHTTP_AVAILABLE = True
 except ImportError:
     aiohttp = None  # type: ignore[assignment]
@@ -35,21 +37,19 @@ logger = logging.getLogger(__name__)
 # Headers we strip when forwarding to the upstream. ``host``/``content-length``
 # are recomputed by aiohttp; ``authorization`` is replaced with our bearer.
 # Everything else (content-type, accept, user-agent, x-* headers) passes through.
-_HOP_BY_HOP_HEADERS = frozenset(
-    {
-        "host",
-        "content-length",
-        "connection",
-        "keep-alive",
-        "proxy-authenticate",
-        "proxy-authorization",
-        "te",
-        "trailers",
-        "transfer-encoding",
-        "upgrade",
-        "authorization",  # we replace this one
-    }
-)
+_HOP_BY_HOP_HEADERS = frozenset({
+    "host",
+    "content-length",
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "authorization",  # we replace this one
+})
 
 DEFAULT_PORT = 8645
 DEFAULT_HOST = "127.0.0.1"
@@ -90,9 +90,7 @@ def _strip_owned_headers(headers: dict, owned_names: frozenset[str]) -> dict:
     """Remove all client spellings of adapter-owned identity headers."""
     owned = {str(name).strip().lower() for name in owned_names if str(name).strip()}
     return {
-        key: value
-        for key, value in headers.items()
-        if str(key).lower() not in owned
+        key: value for key, value in headers.items() if str(key).lower() not in owned
     }
 
 
@@ -198,11 +196,19 @@ async def _stream_upstream_response(
         await session.close()
 
 
-def create_app(adapter: UpstreamAdapter) -> "web.Application":
+def create_app(
+    adapter: UpstreamAdapter,
+    *,
+    client_auth_token: Optional[str] = None,
+) -> "web.Application":
     """Build the aiohttp application bound to a specific upstream adapter."""
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError(
             "aiohttp is required for `hermes proxy`. Run `hermes setup` to install it."
+        )
+    if adapter.requires_client_auth and not client_auth_token:
+        raise RuntimeError(
+            f"{adapter.display_name} proxy requires client authentication."
         )
 
     app = web.Application(client_max_size=MAX_REQUEST_BYTES)
@@ -211,16 +217,39 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
     _adapter_key = web.AppKey("adapter", UpstreamAdapter)
     app[_adapter_key] = adapter
 
-    async def handle_health(request: "web.Request") -> "web.Response":
-        return web.json_response(
-            {
-                "status": "ok",
-                "upstream": adapter.display_name,
-                "authenticated": adapter.is_authenticated(),
-            }
+    def _client_is_authorized(request: "web.Request") -> bool:
+        if client_auth_token is None:
+            return True
+        authorization = request.headers.get("Authorization", "")
+        scheme, separator, supplied = authorization.partition(" ")
+        supplied = supplied.strip()
+        if not separator or scheme.lower() != "bearer" or not supplied:
+            return False
+        return hmac.compare_digest(
+            supplied.encode("utf-8"),
+            client_auth_token.encode("utf-8"),
         )
 
+    def _client_auth_error() -> "web.Response":
+        return _json_error(
+            401,
+            "A valid proxy bearer token is required.",
+            code="proxy_auth_failed",
+        )
+
+    async def handle_health(request: "web.Request") -> "web.Response":
+        if not _client_is_authorized(request):
+            return _client_auth_error()
+        return web.json_response({
+            "status": "ok",
+            "upstream": adapter.display_name,
+            "authenticated": adapter.is_authenticated(),
+        })
+
     async def handle_proxy(request: "web.Request") -> "web.StreamResponse":
+        if not _client_is_authorized(request):
+            return _client_auth_error()
+
         # Extract the path *after* /v1
         rel_path = request.match_info.get("tail", "")
         rel_path = "/" + rel_path.lstrip("/")
@@ -268,7 +297,9 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 fwd_headers,
                 adapter.get_upstream_headers(active_cred),
             )
-            fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
+            fwd_headers["Authorization"] = (
+                f"{active_cred.token_type} {active_cred.bearer}"
+            )
 
             logger.debug(
                 "proxy: forwarding %s %s -> %s%s (body=%d bytes)",
@@ -350,6 +381,8 @@ async def run_server(
     host: str = DEFAULT_HOST,
     port: int = DEFAULT_PORT,
     shutdown_event: Optional[asyncio.Event] = None,
+    *,
+    client_auth_token: Optional[str] = None,
 ) -> None:
     """Run the proxy in the current event loop until shutdown_event is set.
 
@@ -365,7 +398,7 @@ async def run_server(
             f"{adapter.display_name} proxy is loopback-only; refusing bind host {host!r}."
         )
 
-    app = create_app(adapter)
+    app = create_app(adapter, client_auth_token=client_auth_token)
     runner = web.AppRunner(app, access_log=None)
     await runner.setup()
     site = web.TCPSite(runner, host=host, port=port)
@@ -373,7 +406,9 @@ async def run_server(
 
     logger.info(
         "proxy: listening on http://%s:%d/v1 -> %s",
-        host, port, adapter.display_name,
+        host,
+        port,
+        adapter.display_name,
     )
 
     stop_event = shutdown_event or asyncio.Event()

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -331,7 +331,7 @@ def build_gateway_parser(
     proxy_start.add_argument(
         "--provider",
         default="nous",
-        help="Upstream provider: nous or xai (default: nous). See `hermes proxy providers`.",
+        help="Upstream provider: codex, nous, or xai (default: nous). See `hermes proxy providers`.",
     )
     proxy_start.add_argument(
         "--host",

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -30,7 +30,11 @@ def _add_compat_platform_flag(parser: argparse.ArgumentParser) -> None:
 
 
 def build_gateway_parser(
-    subparsers, *, cmd_gateway: Callable, cmd_proxy: Callable, cmd_gateway_enroll: Callable
+    subparsers,
+    *,
+    cmd_gateway: Callable,
+    cmd_proxy: Callable,
+    cmd_gateway_enroll: Callable,
 ) -> None:
     """Attach the ``gateway`` and ``proxy`` subcommands to ``subparsers``."""
     # =========================================================================
@@ -218,7 +222,9 @@ def build_gateway_parser(
     )
 
     # gateway list
-    gateway_subparsers.add_parser("list", help="List all profiles and their gateway status")
+    gateway_subparsers.add_parser(
+        "list", help="List all profiles and their gateway status"
+    )
 
     # gateway setup
     gateway_subparsers.add_parser("setup", help="Configure messaging platforms")
@@ -319,8 +325,8 @@ def build_gateway_parser(
         description=(
             "Run a local HTTP server that forwards OpenAI-compatible requests "
             "to an OAuth-authenticated provider (e.g. Nous Portal). External "
-            "apps can point at the proxy with any bearer token; the proxy "
-            "attaches your real credentials."
+            "apps authenticate as required by the selected provider; the proxy "
+            "replaces client authorization with your upstream credentials."
         ),
     )
     proxy_subparsers = proxy_parser.add_subparsers(dest="proxy_command")
@@ -336,7 +342,10 @@ def build_gateway_parser(
     proxy_start.add_argument(
         "--host",
         default=None,
-        help="Bind address (default: 127.0.0.1). Use 0.0.0.0 to expose on LAN.",
+        help=(
+            "Bind address (default: 127.0.0.1). Use 0.0.0.0 only for "
+            "providers that permit LAN exposure."
+        ),
     )
     proxy_start.add_argument(
         "--port",
@@ -344,10 +353,16 @@ def build_gateway_parser(
         default=None,
         help="Bind port (default: 8645)",
     )
-
-    proxy_subparsers.add_parser(
-        "status", help="Show which proxy upstreams are ready"
+    proxy_start.add_argument(
+        "--auth-token-file",
+        default=None,
+        help=(
+            "File containing the client bearer token. Required for Codex; "
+            "must be a regular owner-only file (mode 0600 on POSIX)."
+        ),
     )
+
+    proxy_subparsers.add_parser("status", help="Show which proxy upstreams are ready")
     proxy_subparsers.add_parser(
         "providers", help="List available proxy upstream providers"
     )

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -23,12 +23,6 @@ from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 # ---------------------------------------------------------------------------
 
 
-
-
-
-
-
-
 # ---------------------------------------------------------------------------
 # NousPortalAdapter
 # ---------------------------------------------------------------------------
@@ -37,21 +31,25 @@ from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 def _write_auth_store(hermes_home: Path, nous_state: Dict[str, Any]) -> Path:
     """Write an auth.json with the given nous state into a hermetic HERMES_HOME."""
     auth_path = hermes_home / "auth.json"
-    auth_path.write_text(json.dumps({
-        "version": 1,
-        "providers": {"nous": nous_state},
-    }))
+    auth_path.write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {"nous": nous_state},
+        })
+    )
     return auth_path
-
-
 
 
 def test_nous_adapter_concurrent_refresh_serialized(tmp_path, monkeypatch):
     """Two parallel get_credential() calls must serialize through the lock."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    _write_auth_store(tmp_path, {
-        "access_token": "a", "refresh_token": "r",
-    })
+    _write_auth_store(
+        tmp_path,
+        {
+            "access_token": "a",
+            "refresh_token": "r",
+        },
+    )
 
     call_log: list = []
     in_flight = threading.Event()
@@ -68,6 +66,7 @@ def test_nous_adapter_concurrent_refresh_serialized(tmp_path, monkeypatch):
             call_log.append(threading.current_thread().ident)
             # Simulate refresh latency so any race window is exposed.
             import time
+
             time.sleep(0.05)
             with counter_lock:
                 counter[0] += 1
@@ -122,34 +121,38 @@ def _write_xai_pool_entry(
 ) -> Path:
     """Write an xai-oauth pool entry into a hermetic HERMES_HOME."""
     auth_path = hermes_home / "auth.json"
-    auth_path.write_text(json.dumps({
-        "version": 1,
-        "providers": {},
-        "credential_pool": {
-            "xai-oauth": [
-                {
-                    "id": "xai123",
-                    "label": "xai-test",
-                    "auth_type": "oauth",
-                    "priority": 0,
-                    "source": source,
-                    "access_token": access_token,
-                    "refresh_token": refresh_token,
-                    "base_url": base_url,
-                }
-            ]
-        },
-    }))
+    auth_path.write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "xai-oauth": [
+                    {
+                        "id": "xai123",
+                        "label": "xai-test",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": source,
+                        "access_token": access_token,
+                        "refresh_token": refresh_token,
+                        "base_url": base_url,
+                    }
+                ]
+            },
+        })
+    )
     return auth_path
 
 
 def test_xai_adapter_not_authenticated_when_no_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    (tmp_path / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {},
-        "credential_pool": {},
-    }))
+    (tmp_path / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {},
+            "credential_pool": {},
+        })
+    )
     assert not XAIGrokAdapter().is_authenticated()
 
 
@@ -170,34 +173,36 @@ def test_xai_adapter_retry_rotates_pool_entry_on_429(tmp_path, monkeypatch):
 
     # Two pool entries so rotation has somewhere to go.
     auth_path = tmp_path / "auth.json"
-    auth_path.write_text(json.dumps({
-        "version": 1,
-        "providers": {},
-        "credential_pool": {
-            "xai-oauth": [
-                {
-                    "id": "xai-first",
-                    "label": "xai-first",
-                    "auth_type": "oauth",
-                    "priority": 0,
-                    "source": "manual:xai_pkce",
-                    "access_token": "first-access-token",
-                    "refresh_token": "first-refresh-token",
-                    "base_url": "https://api.x.ai/v1",
-                },
-                {
-                    "id": "xai-second",
-                    "label": "xai-second",
-                    "auth_type": "oauth",
-                    "priority": 1,
-                    "source": "manual:xai_pkce",
-                    "access_token": "second-access-token",
-                    "refresh_token": "second-refresh-token",
-                    "base_url": "https://api.x.ai/v1",
-                },
-            ]
-        },
-    }))
+    auth_path.write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "xai-oauth": [
+                    {
+                        "id": "xai-first",
+                        "label": "xai-first",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:xai_pkce",
+                        "access_token": "first-access-token",
+                        "refresh_token": "first-refresh-token",
+                        "base_url": "https://api.x.ai/v1",
+                    },
+                    {
+                        "id": "xai-second",
+                        "label": "xai-second",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:xai_pkce",
+                        "access_token": "second-access-token",
+                        "refresh_token": "second-refresh-token",
+                        "base_url": "https://api.x.ai/v1",
+                    },
+                ]
+            },
+        })
+    )
 
     # Refresh must NOT be called on the 429 path — guard against
     # the fix accidentally trying to refresh-on-rate-limit.
@@ -208,7 +213,9 @@ def test_xai_adapter_retry_rotates_pool_entry_on_429(tmp_path, monkeypatch):
 
     adapter = XAIGrokAdapter()
     failed = adapter.get_credential()
-    assert failed.bearer == "first-access-token", "starting bearer should be the first entry"
+    assert failed.bearer == "first-access-token", (
+        "starting bearer should be the first entry"
+    )
 
     retry = adapter.get_retry_credential(
         failed_credential=failed,
@@ -242,11 +249,16 @@ from hermes_cli.proxy.server import (  # noqa: E402
 class FakeAdapter(UpstreamAdapter):
     """A test adapter that returns a fixed credential without touching disk."""
 
-    def __init__(self, base_url: str, bearer: str = "test-bearer",
-                 allowed=None, raise_on_credential=False,
-                 retry_bearer: str | None = None,
-                 upstream_headers: dict[str, str] | None = None,
-                 owned_headers: set[str] | None = None):
+    def __init__(
+        self,
+        base_url: str,
+        bearer: str = "test-bearer",
+        allowed=None,
+        raise_on_credential=False,
+        retry_bearer: str | None = None,
+        upstream_headers: dict[str, str] | None = None,
+        owned_headers: set[str] | None = None,
+    ):
         self._base_url = base_url
         self._bearer = bearer
         self._allowed = frozenset(allowed or ["/chat/completions"])
@@ -255,25 +267,32 @@ class FakeAdapter(UpstreamAdapter):
         self._upstream_headers = dict(upstream_headers or {})
         self._owned_headers = frozenset(owned_headers or self._upstream_headers)
         self.calls = 0
+        self.auth_checks = 0
         self.retry_calls = 0
 
     @property
-    def name(self): return "fake"
+    def name(self):
+        return "fake"
 
     @property
-    def display_name(self): return "Fake Provider"
+    def display_name(self):
+        return "Fake Provider"
 
     @property
-    def allowed_paths(self): return self._allowed
+    def allowed_paths(self):
+        return self._allowed
 
-    def is_authenticated(self): return True
+    def is_authenticated(self):
+        self.auth_checks += 1
+        return True
 
     def get_credential(self):
         self.calls += 1
         if self._raise:
             raise RuntimeError("simulated auth failure")
         return UpstreamCredential(
-            bearer=self._bearer, base_url=self._base_url,
+            bearer=self._bearer,
+            base_url=self._base_url,
             expires_at="2099-01-01T00:00:00Z",
         )
 
@@ -322,7 +341,8 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
 
     async def sse(request):
         resp = web.StreamResponse(
-            status=200, headers={"Content-Type": "text/event-stream"},
+            status=200,
+            headers={"Content-Type": "text/event-stream"},
         )
         await resp.prepare(request)
         for chunk in [b"data: hello\n\n", b"data: world\n\n", b"data: [DONE]\n\n"]:
@@ -357,18 +377,12 @@ def _build_retrying_fake_upstream(captured: Dict[str, Any]) -> "web.Application"
     return app
 
 
-
-
-
-
 def _build_rate_limited_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
     async def rate_limited(request):
-        captured["requests"].append(
-            {
-                "auth": request.headers.get("Authorization"),
-                "path": request.path,
-            }
-        )
+        captured["requests"].append({
+            "auth": request.headers.get("Authorization"),
+            "path": request.path,
+        })
         return web.json_response({"error": "rate limited"}, status=429)
 
     app = web.Application()
@@ -457,9 +471,12 @@ def test_prepare_failure_releases_upstream_response_and_session():
 
 def test_server_strips_client_auth_header():
     """The client's Authorization header MUST NOT reach the upstream."""
+
     async def run():
         captured: Dict[str, Any] = {"requests": []}
-        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        upstream_runner, upstream_base = await _start_runner(
+            _build_fake_upstream(captured)
+        )
         adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
         proxy_runner, proxy_base = await _start_runner(create_app(adapter))
         try:
@@ -475,6 +492,99 @@ def test_server_strips_client_auth_header():
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_requires_client_authority_before_resolving_upstream_credential():
+    """Local reachability alone must not authorize subscription spending."""
+
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(
+            _build_fake_upstream(captured)
+        )
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="upstream-secret")
+        proxy_runner, proxy_base = await _start_runner(
+            create_app(adapter, client_auth_token="owner-client-secret")
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                for headers in (
+                    {},
+                    {"Authorization": "Bearer wrong-secret"},
+                ):
+                    async with session.post(
+                        f"{proxy_base}/v1/chat/completions",
+                        json={"model": "test"},
+                        headers=headers,
+                    ) as resp:
+                        body = await resp.json()
+                        assert resp.status == 401
+                        assert body["error"]["code"] == "proxy_auth_failed"
+
+                assert adapter.calls == 0
+                assert captured["requests"] == []
+
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"model": "test"},
+                    headers={
+                        "Authorization": "Bearer owner-client-secret",
+                    },
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+
+            assert adapter.calls == 1
+            assert captured["requests"][0]["auth"] == "Bearer upstream-secret"
+            assert "owner-client-secret" not in captured["requests"][0]["auth"]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_health_requires_client_authority_before_reading_auth_state():
+    """Protected health checks must not touch credential-pool state first."""
+
+    async def run():
+        adapter = FakeAdapter("http://127.0.0.1:1/v1")
+        proxy_runner, proxy_base = await _start_runner(
+            create_app(adapter, client_auth_token="owner-client-secret")
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                for headers in (
+                    {},
+                    {"Authorization": "Bearer wrong-secret"},
+                ):
+                    async with session.get(
+                        f"{proxy_base}/health",
+                        headers=headers,
+                    ) as resp:
+                        body = await resp.json()
+                        assert resp.status == 401
+                        assert body["error"]["code"] == "proxy_auth_failed"
+
+                assert adapter.auth_checks == 0
+                assert adapter.calls == 0
+
+                async with session.get(
+                    f"{proxy_base}/health",
+                    headers={
+                        "Authorization": "Bearer owner-client-secret",
+                    },
+                ) as resp:
+                    body = await resp.json()
+                    assert resp.status == 200
+                    assert body["authenticated"] is True
+
+                assert adapter.auth_checks == 1
+                assert adapter.calls == 0
+        finally:
+            await proxy_runner.cleanup()
 
     asyncio.run(run())
 
@@ -539,7 +649,9 @@ def test_server_returns_429_when_adapter_has_no_rotation():
 def test_server_preserves_raw_query_and_does_not_log_it(caplog):
     async def run():
         captured: Dict[str, Any] = {"requests": []}
-        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        upstream_runner, upstream_base = await _start_runner(
+            _build_fake_upstream(captured)
+        )
         adapter = FakeAdapter(
             f"{upstream_base}/v1",
             allowed=["/responses"],
@@ -552,9 +664,7 @@ def test_server_preserves_raw_query_and_does_not_log_it(caplog):
                 async with session.post(url, json={"model": "gpt-5.6-sol"}) as resp:
                     assert resp.status == 200
                     await resp.read()
-            assert captured["requests"][0]["raw_path"] == (
-                f"/v1/responses?{raw_query}"
-            )
+            assert captured["requests"][0]["raw_path"] == (f"/v1/responses?{raw_query}")
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()
@@ -568,7 +678,9 @@ def test_server_preserves_raw_query_and_does_not_log_it(caplog):
 def test_server_preserves_codex_responses_body_bytes():
     async def run():
         captured: Dict[str, Any] = {"requests": []}
-        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        upstream_runner, upstream_base = await _start_runner(
+            _build_fake_upstream(captured)
+        )
         adapter = FakeAdapter(
             f"{upstream_base}/v1",
             allowed=["/responses"],
@@ -637,13 +749,11 @@ def test_server_aborts_downstream_on_truncated_upstream_sse():
         proxy_runner, proxy_base = await _start_runner(create_app(adapter))
         try:
             async with aiohttp.ClientSession() as session:
-                with pytest.raises(
-                    (
-                        aiohttp.ClientPayloadError,
-                        aiohttp.ServerDisconnectedError,
-                        aiohttp.ClientConnectionError,
-                    )
-                ):
+                with pytest.raises((
+                    aiohttp.ClientPayloadError,
+                    aiohttp.ServerDisconnectedError,
+                    aiohttp.ClientConnectionError,
+                )):
                     async with session.post(
                         f"{proxy_base}/v1/responses",
                         json={"model": "gpt-5.6-sol", "stream": True, "input": []},
@@ -659,7 +769,9 @@ def test_server_aborts_downstream_on_truncated_upstream_sse():
 def test_codex_proxy_rejects_chat_completions():
     async def run():
         captured: Dict[str, Any] = {"requests": []}
-        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        upstream_runner, upstream_base = await _start_runner(
+            _build_fake_upstream(captured)
+        )
         adapter = FakeAdapter(
             f"{upstream_base}/v1",
             allowed=["/responses", "/models"],
@@ -685,7 +797,9 @@ def test_codex_proxy_rejects_chat_completions():
 def test_server_strips_owned_account_header_when_adapter_has_no_value():
     async def run():
         captured: Dict[str, Any] = {"requests": []}
-        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        upstream_runner, upstream_base = await _start_runner(
+            _build_fake_upstream(captured)
+        )
         adapter = FakeAdapter(
             f"{upstream_base}/v1",
             allowed=["/responses"],
@@ -705,7 +819,9 @@ def test_server_strips_owned_account_header_when_adapter_has_no_value():
                 ) as resp:
                     assert resp.status == 200
                     await resp.read()
-            headers = {k.lower(): v for k, v in captured["requests"][0]["headers"].items()}
+            headers = {
+                k.lower(): v for k, v in captured["requests"][0]["headers"].items()
+            }
             assert "chatgpt-account-id" not in headers
         finally:
             await proxy_runner.cleanup()
@@ -717,7 +833,9 @@ def test_server_strips_owned_account_header_when_adapter_has_no_value():
 def test_server_adapter_headers_override_spoofed_client_values():
     async def run():
         captured: Dict[str, Any] = {"requests": []}
-        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        upstream_runner, upstream_base = await _start_runner(
+            _build_fake_upstream(captured)
+        )
         adapter = FakeAdapter(
             f"{upstream_base}/v1",
             bearer="codex-token",
@@ -743,7 +861,9 @@ def test_server_adapter_headers_override_spoofed_client_values():
                 ) as resp:
                     assert resp.status == 200
                     await resp.read()
-            headers = {k.lower(): v for k, v in captured["requests"][0]["headers"].items()}
+            headers = {
+                k.lower(): v for k, v in captured["requests"][0]["headers"].items()
+            }
             assert headers["authorization"] == "Bearer codex-token"
             assert headers["user-agent"] == "codex_cli_rs/0.0.0 (Hermes Agent)"
             assert headers["originator"] == "codex_cli_rs"
@@ -758,9 +878,3 @@ def test_server_adapter_headers_override_spoofed_client_values():
 # ---------------------------------------------------------------------------
 # CLI handlers
 # ---------------------------------------------------------------------------
-
-
-
-
-
-

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -7,7 +7,7 @@ import json
 import threading
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict
+from typing import Any, Dict, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -455,7 +455,7 @@ def test_prepare_failure_releases_upstream_response_and_session():
     upstream.status = 200
     upstream.headers = {}
     session = SimpleNamespace(close=AsyncMock())
-    request = SimpleNamespace(transport=None)
+    request = cast(web.Request, SimpleNamespace(transport=None))
 
     with patch.object(
         web.StreamResponse,

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -6,8 +6,9 @@ import asyncio
 import json
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -229,8 +230,13 @@ def test_xai_adapter_retry_rotates_pool_entry_on_429(tmp_path, monkeypatch):
 
 aiohttp = pytest.importorskip("aiohttp")
 from aiohttp import web  # noqa: E402
+from yarl import URL  # noqa: E402
 
-from hermes_cli.proxy.server import create_app  # noqa: E402
+from hermes_cli.proxy.server import (  # noqa: E402
+    _open_upstream_request,
+    _stream_upstream_response,
+    create_app,
+)
 
 
 class FakeAdapter(UpstreamAdapter):
@@ -238,12 +244,16 @@ class FakeAdapter(UpstreamAdapter):
 
     def __init__(self, base_url: str, bearer: str = "test-bearer",
                  allowed=None, raise_on_credential=False,
-                 retry_bearer: str | None = None):
+                 retry_bearer: str | None = None,
+                 upstream_headers: dict[str, str] | None = None,
+                 owned_headers: set[str] | None = None):
         self._base_url = base_url
         self._bearer = bearer
         self._allowed = frozenset(allowed or ["/chat/completions"])
         self._raise = raise_on_credential
         self._retry_bearer = retry_bearer
+        self._upstream_headers = dict(upstream_headers or {})
+        self._owned_headers = frozenset(owned_headers or self._upstream_headers)
         self.calls = 0
         self.retry_calls = 0
 
@@ -266,6 +276,13 @@ class FakeAdapter(UpstreamAdapter):
             bearer=self._bearer, base_url=self._base_url,
             expires_at="2099-01-01T00:00:00Z",
         )
+
+    def get_owned_upstream_header_names(self):
+        return self._owned_headers
+
+    def get_upstream_headers(self, credential):
+        _ = credential
+        return dict(self._upstream_headers)
 
     def get_retry_credential(self, *, failed_credential, status_code):
         _ = failed_credential
@@ -296,7 +313,9 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
         captured["requests"].append({
             "method": request.method,
             "path": request.path,
+            "raw_path": request.raw_path,
             "auth": request.headers.get("Authorization"),
+            "headers": dict(request.headers),
             "body": body.decode("utf-8") if body else "",
         })
         return web.json_response({"echoed": True, "path": request.path})
@@ -313,6 +332,7 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
 
     app = web.Application()
     app.router.add_route("*", "/v1/chat/completions", echo)
+    app.router.add_route("*", "/v1/responses", echo)
     app.router.add_route("*", "/v1/embeddings", echo)
     app.router.add_route("*", "/v1/sse", sse)
     return app
@@ -341,6 +361,100 @@ def _build_retrying_fake_upstream(captured: Dict[str, Any]) -> "web.Application"
 
 
 
+def _build_rate_limited_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
+    async def rate_limited(request):
+        captured["requests"].append(
+            {
+                "auth": request.headers.get("Authorization"),
+                "path": request.path,
+            }
+        )
+        return web.json_response({"error": "rate limited"}, status=429)
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", rate_limited)
+    return app
+
+
+def _build_codex_sse_upstream(expected_chunks: list[bytes]) -> "web.Application":
+    async def responses(request):
+        await request.read()
+        resp = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream"},
+        )
+        await resp.prepare(request)
+        for chunk in expected_chunks:
+            await resp.write(chunk)
+        await resp.write_eof()
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/v1/responses", responses)
+    return app
+
+
+def _build_truncated_sse_upstream() -> "web.Application":
+    async def responses(request):
+        resp = web.StreamResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/event-stream",
+                "Content-Length": "512",
+            },
+        )
+        await resp.prepare(request)
+        await resp.write(b"event: response.output_text.delta\ndata: partial\n\n")
+        if request.transport is not None:
+            request.transport.abort()
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/v1/responses", responses)
+    return app
+
+
+def test_cancelled_upstream_request_closes_new_client_session():
+    session = SimpleNamespace(
+        request=AsyncMock(side_effect=asyncio.CancelledError()),
+        close=AsyncMock(),
+    )
+    with patch(
+        "hermes_cli.proxy.server.aiohttp.ClientSession",
+        return_value=session,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(
+                _open_upstream_request(
+                    method="POST",
+                    url=URL("http://127.0.0.1:1/v1/responses", encoded=True),
+                    body=b"{}",
+                    headers={},
+                    timeout=None,
+                )
+            )
+    session.close.assert_awaited_once_with()
+
+
+def test_prepare_failure_releases_upstream_response_and_session():
+    upstream = MagicMock()
+    upstream.status = 200
+    upstream.headers = {}
+    session = SimpleNamespace(close=AsyncMock())
+    request = SimpleNamespace(transport=None)
+
+    with patch.object(
+        web.StreamResponse,
+        "prepare",
+        new=AsyncMock(side_effect=ConnectionResetError("downstream gone")),
+    ):
+        with pytest.raises(ConnectionResetError, match="downstream gone"):
+            asyncio.run(_stream_upstream_response(request, upstream, session))
+
+    upstream.release.assert_called_once_with()
+    session.close.assert_awaited_once_with()
+
+
 def test_server_strips_client_auth_header():
     """The client's Authorization header MUST NOT reach the upstream."""
     async def run():
@@ -358,6 +472,282 @@ def test_server_strips_client_auth_header():
                     await resp.read()
             assert captured["requests"][0]["auth"] == "Bearer ours"
             assert "SHOULD_NOT_LEAK" not in captured["requests"][0]["auth"]
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_retries_once_with_adapter_credential_after_401():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(
+            _build_retrying_fake_upstream(captured)
+        )
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            bearer="jwt-bearer",
+            retry_bearer="refreshed-bearer",
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"model": "test"},
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            assert [row["auth"] for row in captured["requests"]] == [
+                "Bearer jwt-bearer",
+                "Bearer refreshed-bearer",
+            ]
+            assert adapter.retry_calls == 1
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_returns_429_when_adapter_has_no_rotation():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(
+            _build_rate_limited_fake_upstream(captured)
+        )
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="only-bearer")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"model": "test"},
+                ) as resp:
+                    assert resp.status == 429
+                    await resp.read()
+            assert len(captured["requests"]) == 1
+            assert adapter.retry_calls == 1
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_preserves_raw_query_and_does_not_log_it(caplog):
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        raw_query = "x=%252f&a=%2F&secret=do-not-log"
+        try:
+            async with aiohttp.ClientSession() as session:
+                url = URL(f"{proxy_base}/v1/responses?{raw_query}", encoded=True)
+                async with session.post(url, json={"model": "gpt-5.6-sol"}) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            assert captured["requests"][0]["raw_path"] == (
+                f"/v1/responses?{raw_query}"
+            )
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    caplog.set_level("DEBUG", logger="hermes_cli.proxy.server")
+    asyncio.run(run())
+    assert "do-not-log" not in caplog.text
+    assert "%252f" not in caplog.text
+
+
+def test_server_preserves_codex_responses_body_bytes():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        payload = (
+            b'{"model":"gpt-5.6-sol","input":['
+            b'{"type":"function_call_output","call_id":"call_1",'
+            b'"output":"exact bytes"}],"stream":false}'
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    data=payload,
+                    headers={"Content-Type": "application/json"},
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            assert captured["requests"][0]["body"].encode() == payload
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_preserves_codex_responses_sse_bytes():
+    async def run():
+        chunks = [
+            b'event: response.output_item.added\ndata: {"type":"response.output_item.added"}\n\n',
+            b'event: response.completed\ndata: {"type":"response.completed"}\n\n',
+        ]
+        upstream_runner, upstream_base = await _start_runner(
+            _build_codex_sse_upstream(chunks)
+        )
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6-sol", "stream": True, "input": []},
+                ) as resp:
+                    assert resp.status == 200
+                    assert await resp.read() == b"".join(chunks)
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_aborts_downstream_on_truncated_upstream_sse():
+    async def run():
+        upstream_runner, upstream_base = await _start_runner(
+            _build_truncated_sse_upstream()
+        )
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                with pytest.raises(
+                    (
+                        aiohttp.ClientPayloadError,
+                        aiohttp.ServerDisconnectedError,
+                        aiohttp.ClientConnectionError,
+                    )
+                ):
+                    async with session.post(
+                        f"{proxy_base}/v1/responses",
+                        json={"model": "gpt-5.6-sol", "stream": True, "input": []},
+                    ) as resp:
+                        await resp.read()
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_codex_proxy_rejects_chat_completions():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses", "/models"],
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"model": "gpt-5.6-sol"},
+                ) as resp:
+                    body = await resp.json()
+                    assert resp.status == 404
+                    assert body["error"]["code"] == "path_not_allowed"
+            assert captured["requests"] == []
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_strips_owned_account_header_when_adapter_has_no_value():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            allowed=["/responses"],
+            upstream_headers={
+                "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+                "originator": "codex_cli_rs",
+            },
+            owned_headers={"User-Agent", "originator", "ChatGPT-Account-ID"},
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6-sol", "input": []},
+                    headers={"chatgpt-account-id": "attacker"},
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            headers = {k.lower(): v for k, v in captured["requests"][0]["headers"].items()}
+            assert "chatgpt-account-id" not in headers
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_server_adapter_headers_override_spoofed_client_values():
+    async def run():
+        captured: Dict[str, Any] = {"requests": []}
+        upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
+        adapter = FakeAdapter(
+            f"{upstream_base}/v1",
+            bearer="codex-token",
+            allowed=["/responses"],
+            upstream_headers={
+                "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+                "originator": "codex_cli_rs",
+                "ChatGPT-Account-ID": "acct-real",
+            },
+        )
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    json={"model": "gpt-5.6-sol", "input": []},
+                    headers={
+                        "Authorization": "Bearer CLIENT",
+                        "User-Agent": "spoofed",
+                        "originator": "spoofed",
+                        "ChatGPT-Account-ID": "acct-spoofed",
+                    },
+                ) as resp:
+                    assert resp.status == 200
+                    await resp.read()
+            headers = {k.lower(): v for k, v in captured["requests"][0]["headers"].items()}
+            assert headers["authorization"] == "Bearer codex-token"
+            assert headers["user-agent"] == "codex_cli_rs/0.0.0 (Hermes Agent)"
+            assert headers["originator"] == "codex_cli_rs"
+            assert headers["chatgpt-account-id"] == "acct-real"
         finally:
             await proxy_runner.cleanup()
             await upstream_runner.cleanup()

--- a/tests/hermes_cli/test_proxy_codex.py
+++ b/tests/hermes_cli/test_proxy_codex.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
+from hermes_cli.proxy.adapters.codex import OpenAICodexAdapter
+from hermes_cli.proxy.cli import cmd_proxy_start
+from hermes_cli.proxy.server import is_loopback_host, run_server
+
+
+def _jwt_with_account(account_id: str = "acct-123") -> str:
+    payload = {
+        "exp": 4_102_444_800,
+        "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+def _entry(account_id: str = "acct-123"):
+    return SimpleNamespace(
+        runtime_api_key=_jwt_with_account(account_id),
+        runtime_base_url="https://chatgpt.com/backend-api/codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        expires_at="2099-01-01T00:00:00Z",
+    )
+
+
+def test_registry_exposes_one_canonical_codex_adapter_and_alias():
+    assert ADAPTERS["openai-codex"] is OpenAICodexAdapter
+    assert "codex" not in ADAPTERS
+    assert isinstance(get_adapter("openai-codex"), OpenAICodexAdapter)
+    assert isinstance(get_adapter("codex"), OpenAICodexAdapter)
+
+
+def test_codex_loopback_host_validation_and_cli_rejection(capsys):
+    assert is_loopback_host("127.0.0.1")
+    assert is_loopback_host("::1")
+    assert is_loopback_host("localhost")
+    assert not is_loopback_host("0.0.0.0")
+    assert not is_loopback_host("192.168.1.5")
+    assert not is_loopback_host("example.com")
+
+    adapter = OpenAICodexAdapter()
+    args = SimpleNamespace(provider="codex", host="0.0.0.0", port=8645)
+    with (
+        patch("hermes_cli.proxy.cli.get_adapter", return_value=adapter),
+        patch.object(adapter, "is_authenticated", return_value=True),
+        patch("hermes_cli.proxy.cli.run_server") as run,
+    ):
+        assert cmd_proxy_start(args) == 2
+    run.assert_not_called()
+    assert "loopback-only" in capsys.readouterr().err
+
+
+def test_codex_server_rejects_non_loopback_programmatic_bind():
+    adapter = OpenAICodexAdapter()
+    try:
+        asyncio.run(run_server(adapter, host="0.0.0.0", port=0))
+    except RuntimeError as exc:
+        assert "loopback-only" in str(exc)
+    else:
+        raise AssertionError("programmatic non-loopback Codex bind was accepted")
+
+
+def test_codex_adapter_authentication_is_pool_backed():
+    pool = MagicMock()
+    pool.has_available.return_value = True
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        assert OpenAICodexAdapter().is_authenticated() is True
+
+
+def test_codex_adapter_selects_responses_credential_and_required_headers():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.select.return_value = _entry()
+    adapter = OpenAICodexAdapter()
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        credential = adapter.get_credential()
+
+    assert credential.bearer == _jwt_with_account()
+    assert credential.base_url == "https://chatgpt.com/backend-api/codex"
+    assert adapter.allowed_paths == frozenset({"/responses", "/models"})
+    assert adapter.get_upstream_headers(credential) == {
+        "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+        "originator": "codex_cli_rs",
+        "ChatGPT-Account-ID": "acct-123",
+    }
+
+
+def test_codex_adapter_rejects_untrusted_upstream_before_returning_bearer():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    bad = _entry()
+    bad.runtime_base_url = "http://127.0.0.1:9999/steal"
+    bad.base_url = "http://127.0.0.1:9999/steal"
+    pool.select.return_value = bad
+    adapter = OpenAICodexAdapter()
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        try:
+            adapter.get_credential()
+        except RuntimeError as exc:
+            assert "untrusted" in str(exc).lower()
+        else:
+            raise AssertionError("untrusted Codex upstream was accepted")
+
+
+def test_codex_owned_account_header_survives_missing_jwt_claim_as_owned_only():
+    adapter = OpenAICodexAdapter()
+    credential = SimpleNamespace(bearer="malformed-token")
+    headers = adapter.get_upstream_headers(credential)
+    assert "ChatGPT-Account-ID" not in headers
+    assert "ChatGPT-Account-ID" in adapter.get_owned_upstream_header_names()
+
+
+def test_codex_adapter_401_refreshes_matching_credential():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.select.return_value = _entry("first")
+    pool.try_refresh_matching.return_value = _entry("refreshed")
+    adapter = OpenAICodexAdapter()
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        failed = adapter.get_credential()
+        retry = adapter.get_retry_credential(
+            failed_credential=failed,
+            status_code=401,
+        )
+
+    assert retry is not None
+    assert retry.bearer == _jwt_with_account("refreshed")
+    pool.try_refresh_matching.assert_called_once_with(api_key_hint=failed.bearer)
+    pool.mark_exhausted_and_rotate.assert_not_called()
+
+
+def test_codex_adapter_reuses_concurrently_refreshed_current_credential():
+    pool = MagicMock()
+    refreshed = _entry("new-token")
+    pool.try_refresh_matching.side_effect = [refreshed, None]
+    pool.select.return_value = refreshed
+    adapter = OpenAICodexAdapter()
+    adapter._pool = pool
+    failed = SimpleNamespace(bearer=_jwt_with_account("old-token"))
+
+    first = adapter.get_retry_credential(
+        failed_credential=failed,
+        status_code=401,
+    )
+    second = adapter.get_retry_credential(
+        failed_credential=failed,
+        status_code=401,
+    )
+
+    assert first is not None and first.bearer == refreshed.runtime_api_key
+    assert second is not None and second.bearer == refreshed.runtime_api_key
+    pool.mark_exhausted_and_rotate.assert_not_called()
+
+
+def test_codex_adapter_concurrent_401_refresh_is_serialized():
+    pool = MagicMock()
+    in_flight = threading.Event()
+    overlap = threading.Event()
+    counter = {"n": 0}
+
+    def refresh(*, api_key_hint):
+        _ = api_key_hint
+        if in_flight.is_set():
+            overlap.set()
+        in_flight.set()
+        try:
+            time.sleep(0.03)
+            counter["n"] += 1
+            return _entry(f"refreshed-{counter['n']}")
+        finally:
+            in_flight.clear()
+
+    pool.try_refresh_matching.side_effect = refresh
+    adapter = OpenAICodexAdapter()
+    adapter._pool = pool
+    failed = SimpleNamespace(bearer=_jwt_with_account("failed"))
+    results = []
+
+    def worker():
+        results.append(
+            adapter.get_retry_credential(
+                failed_credential=failed,
+                status_code=401,
+            )
+        )
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(results) == 3
+    assert not overlap.is_set()
+
+
+def test_codex_adapter_429_marks_failed_credential_and_rotates():
+    pool = MagicMock()
+    pool.has_credentials.return_value = True
+    pool.select.return_value = _entry("first")
+    pool.mark_exhausted_and_rotate.return_value = _entry("second")
+    adapter = OpenAICodexAdapter()
+    with patch("hermes_cli.proxy.adapters.codex.load_pool", return_value=pool):
+        failed = adapter.get_credential()
+        retry = adapter.get_retry_credential(
+            failed_credential=failed,
+            status_code=429,
+        )
+
+    assert retry is not None
+    assert retry.bearer == _jwt_with_account("second")
+    pool.mark_exhausted_and_rotate.assert_called_once_with(
+        status_code=429,
+        api_key_hint=failed.bearer,
+    )
+    pool.try_refresh_matching.assert_not_called()

--- a/tests/hermes_cli/test_proxy_codex.py
+++ b/tests/hermes_cli/test_proxy_codex.py
@@ -4,14 +4,19 @@ import asyncio
 import base64
 import json
 import os
+import sys
 import threading
 import time
+from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hermes_cli.proxy import cli as proxy_cli
 from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
+from hermes_cli.proxy.adapters.base import UpstreamCredential
 from hermes_cli.proxy.adapters.codex import OpenAICodexAdapter
 from hermes_cli.proxy.cli import _read_client_auth_token, cmd_proxy_start
 from hermes_cli.proxy.server import create_app, is_loopback_host, run_server
@@ -83,7 +88,9 @@ def test_codex_cli_requires_owner_only_client_auth_file(tmp_path, capsys):
 
     token_file = tmp_path / "proxy-token"
     token_file.write_text("owner-client-secret\n", encoding="utf-8")
-    if os.name != "nt":
+    if os.name == "nt":
+        _set_windows_client_auth_acl(token_file, allow_everyone=False)
+    else:
         token_file.chmod(0o644)
         with pytest.raises(ValueError, match="owner-only"):
             _read_client_auth_token(str(token_file))
@@ -92,10 +99,100 @@ def test_codex_cli_requires_owner_only_client_auth_file(tmp_path, capsys):
     assert _read_client_auth_token(str(token_file)) == "owner-client-secret"
 
 
+def test_windows_client_auth_acl_policy_rejects_other_owners_and_allowed_sids():
+    allowed = {"S-1-5-18", "S-1-5-21-owner"}
+
+    with pytest.raises(ValueError, match="wrong owner"):
+        proxy_cli._validate_windows_owner_only_acl(
+            owner_sid="S-1-5-21-other",
+            allowed_sids=allowed,
+            allowed_aces=[],
+        )
+
+    with pytest.raises(ValueError, match="permissive DACL"):
+        proxy_cli._validate_windows_owner_only_acl(
+            owner_sid="S-1-5-21-owner",
+            allowed_sids=allowed,
+            allowed_aces=[(0x1, "S-1-1-0")],
+        )
+
+    proxy_cli._validate_windows_owner_only_acl(
+        owner_sid="S-1-5-21-owner",
+        allowed_sids=allowed,
+        allowed_aces=[(0x1, "S-1-5-21-owner"), (0x1, "S-1-5-18")],
+    )
+
+
+def _set_windows_client_auth_acl(path: Path, *, allow_everyone: bool) -> None:
+    if sys.platform != "win32":
+        raise RuntimeError("Windows ACL fixtures require native Windows.")
+
+    import ntsecuritycon
+    import win32api
+    import win32con
+    import win32security
+
+    token = win32security.OpenProcessToken(
+        win32api.GetCurrentProcess(), win32con.TOKEN_QUERY
+    )
+    owner = win32security.GetTokenInformation(token, win32security.TokenUser)[0]
+    system = win32security.ConvertStringSidToSid("S-1-5-18")
+    acl = win32security.ACL()
+    for sid in (owner, system):
+        acl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION,
+            0,
+            ntsecuritycon.FILE_ALL_ACCESS,
+            sid,
+        )
+    if allow_everyone:
+        everyone = win32security.ConvertStringSidToSid("S-1-1-0")
+        acl.AddAccessAllowedAceEx(
+            win32security.ACL_REVISION,
+            0,
+            ntsecuritycon.FILE_GENERIC_READ,
+            everyone,
+        )
+    descriptor = win32security.SECURITY_DESCRIPTOR()
+    descriptor.SetSecurityDescriptorOwner(owner, False)
+    descriptor.SetSecurityDescriptorDacl(True, acl, False)
+    descriptor.SetSecurityDescriptorControl(
+        win32security.SE_DACL_PROTECTED,
+        win32security.SE_DACL_PROTECTED,
+    )
+    win32security.SetFileSecurity(
+        str(path),
+        win32security.OWNER_SECURITY_INFORMATION
+        | win32security.DACL_SECURITY_INFORMATION,
+        descriptor,
+    )
+
+
+@pytest.mark.windows_only
+def test_windows_client_auth_file_rejects_broadly_readable_dacl(tmp_path):
+    token_file = tmp_path / "proxy-token-broad"
+    token_file.write_text("owner-client-secret\n", encoding="utf-8")
+    _set_windows_client_auth_acl(token_file, allow_everyone=True)
+
+    with pytest.raises(ValueError, match="permissive DACL"):
+        _read_client_auth_token(str(token_file))
+
+
+@pytest.mark.windows_only
+def test_windows_client_auth_file_accepts_current_user_and_system_only(tmp_path):
+    token_file = tmp_path / "proxy-token-private"
+    token_file.write_text("owner-client-secret\n", encoding="utf-8")
+    _set_windows_client_auth_acl(token_file, allow_everyone=False)
+
+    assert _read_client_auth_token(str(token_file)) == "owner-client-secret"
+
+
 def test_codex_cli_passes_client_authority_without_logging_it(tmp_path, capsys):
     token_file = tmp_path / "proxy-token"
     token_file.write_text("owner-client-secret\n", encoding="utf-8")
-    if os.name != "nt":
+    if os.name == "nt":
+        _set_windows_client_auth_acl(token_file, allow_everyone=False)
+    else:
         token_file.chmod(0o600)
 
     adapter = OpenAICodexAdapter()
@@ -130,21 +227,27 @@ def test_codex_cli_passes_client_authority_without_logging_it(tmp_path, capsys):
 def test_client_auth_file_rejects_symlink_and_empty_file(tmp_path):
     empty = tmp_path / "empty-token"
     empty.write_text("\n", encoding="utf-8")
-    if os.name != "nt":
+    if os.name == "nt":
+        _set_windows_client_auth_acl(empty, allow_everyone=False)
+    else:
         empty.chmod(0o600)
     with pytest.raises(ValueError, match="empty"):
         _read_client_auth_token(str(empty))
 
     multiline = tmp_path / "multiline-token"
     multiline.write_text("first\nsecond\n", encoding="utf-8")
-    if os.name != "nt":
+    if os.name == "nt":
+        _set_windows_client_auth_acl(multiline, allow_everyone=False)
+    else:
         multiline.chmod(0o600)
     with pytest.raises(ValueError, match="without whitespace"):
         _read_client_auth_token(str(multiline))
 
     target = tmp_path / "real-token"
     target.write_text("secret", encoding="utf-8")
-    if os.name != "nt":
+    if os.name == "nt":
+        _set_windows_client_auth_acl(target, allow_everyone=False)
+    else:
         target.chmod(0o600)
     link = tmp_path / "token-link"
     try:
@@ -219,7 +322,10 @@ def test_codex_adapter_rejects_untrusted_upstream_before_returning_bearer():
 
 def test_codex_owned_account_header_survives_missing_jwt_claim_as_owned_only():
     adapter = OpenAICodexAdapter()
-    credential = SimpleNamespace(bearer="malformed-token")
+    credential = cast(
+        UpstreamCredential,
+        SimpleNamespace(bearer="malformed-token"),
+    )
     headers = adapter.get_upstream_headers(credential)
     assert "ChatGPT-Account-ID" not in headers
     assert "ChatGPT-Account-ID" in adapter.get_owned_upstream_header_names()
@@ -251,7 +357,10 @@ def test_codex_adapter_reuses_concurrently_refreshed_current_credential():
     pool.select.return_value = refreshed
     adapter = OpenAICodexAdapter()
     adapter._pool = pool
-    failed = SimpleNamespace(bearer=_jwt_with_account("old-token"))
+    failed = cast(
+        UpstreamCredential,
+        SimpleNamespace(bearer=_jwt_with_account("old-token")),
+    )
 
     first = adapter.get_retry_credential(
         failed_credential=failed,
@@ -288,7 +397,10 @@ def test_codex_adapter_concurrent_401_refresh_is_serialized():
     pool.try_refresh_matching.side_effect = refresh
     adapter = OpenAICodexAdapter()
     adapter._pool = pool
-    failed = SimpleNamespace(bearer=_jwt_with_account("failed"))
+    failed = cast(
+        UpstreamCredential,
+        SimpleNamespace(bearer=_jwt_with_account("failed")),
+    )
     results = []
 
     def worker():

--- a/tests/hermes_cli/test_proxy_codex.py
+++ b/tests/hermes_cli/test_proxy_codex.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
 import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
 from hermes_cli.proxy.adapters.codex import OpenAICodexAdapter
-from hermes_cli.proxy.cli import cmd_proxy_start
-from hermes_cli.proxy.server import is_loopback_host, run_server
+from hermes_cli.proxy.cli import _read_client_auth_token, cmd_proxy_start
+from hermes_cli.proxy.server import create_app, is_loopback_host, run_server
 
 
 def _jwt_with_account(account_id: str = "acct-123") -> str:
@@ -19,7 +22,9 @@ def _jwt_with_account(account_id: str = "acct-123") -> str:
         "exp": 4_102_444_800,
         "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
     }
-    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    encoded = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    )
     return f"header.{encoded}.signature"
 
 
@@ -59,6 +64,97 @@ def test_codex_loopback_host_validation_and_cli_rejection(capsys):
     assert "loopback-only" in capsys.readouterr().err
 
 
+def test_codex_cli_requires_owner_only_client_auth_file(tmp_path, capsys):
+    adapter = OpenAICodexAdapter()
+    args = SimpleNamespace(
+        provider="codex",
+        host="127.0.0.1",
+        port=8645,
+        auth_token_file=None,
+    )
+    with (
+        patch("hermes_cli.proxy.cli.get_adapter", return_value=adapter),
+        patch.object(adapter, "is_authenticated", return_value=True),
+        patch("hermes_cli.proxy.cli.run_server") as run,
+    ):
+        assert cmd_proxy_start(args) == 2
+    run.assert_not_called()
+    assert "--auth-token-file" in capsys.readouterr().err
+
+    token_file = tmp_path / "proxy-token"
+    token_file.write_text("owner-client-secret\n", encoding="utf-8")
+    if os.name != "nt":
+        token_file.chmod(0o644)
+        with pytest.raises(ValueError, match="owner-only"):
+            _read_client_auth_token(str(token_file))
+        token_file.chmod(0o600)
+
+    assert _read_client_auth_token(str(token_file)) == "owner-client-secret"
+
+
+def test_codex_cli_passes_client_authority_without_logging_it(tmp_path, capsys):
+    token_file = tmp_path / "proxy-token"
+    token_file.write_text("owner-client-secret\n", encoding="utf-8")
+    if os.name != "nt":
+        token_file.chmod(0o600)
+
+    adapter = OpenAICodexAdapter()
+    captured = {}
+
+    async def fake_run_server(adapter_arg, **kwargs):
+        captured["adapter"] = adapter_arg
+        captured.update(kwargs)
+
+    args = SimpleNamespace(
+        provider="codex",
+        host="127.0.0.1",
+        port=18645,
+        auth_token_file=str(token_file),
+    )
+    with (
+        patch("hermes_cli.proxy.cli.get_adapter", return_value=adapter),
+        patch.object(adapter, "is_authenticated", return_value=True),
+        patch("hermes_cli.proxy.cli.run_server", side_effect=fake_run_server),
+    ):
+        assert cmd_proxy_start(args) == 0
+
+    assert captured == {
+        "adapter": adapter,
+        "host": "127.0.0.1",
+        "port": 18645,
+        "client_auth_token": "owner-client-secret",
+    }
+    assert "owner-client-secret" not in capsys.readouterr().err
+
+
+def test_client_auth_file_rejects_symlink_and_empty_file(tmp_path):
+    empty = tmp_path / "empty-token"
+    empty.write_text("\n", encoding="utf-8")
+    if os.name != "nt":
+        empty.chmod(0o600)
+    with pytest.raises(ValueError, match="empty"):
+        _read_client_auth_token(str(empty))
+
+    multiline = tmp_path / "multiline-token"
+    multiline.write_text("first\nsecond\n", encoding="utf-8")
+    if os.name != "nt":
+        multiline.chmod(0o600)
+    with pytest.raises(ValueError, match="without whitespace"):
+        _read_client_auth_token(str(multiline))
+
+    target = tmp_path / "real-token"
+    target.write_text("secret", encoding="utf-8")
+    if os.name != "nt":
+        target.chmod(0o600)
+    link = tmp_path / "token-link"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks are unavailable on this platform")
+    with pytest.raises(ValueError, match="regular file"):
+        _read_client_auth_token(str(link))
+
+
 def test_codex_server_rejects_non_loopback_programmatic_bind():
     adapter = OpenAICodexAdapter()
     try:
@@ -67,6 +163,16 @@ def test_codex_server_rejects_non_loopback_programmatic_bind():
         assert "loopback-only" in str(exc)
     else:
         raise AssertionError("programmatic non-loopback Codex bind was accepted")
+
+
+def test_codex_server_requires_client_authority_programmatically():
+    adapter = OpenAICodexAdapter()
+    with pytest.raises(RuntimeError, match="client authentication"):
+        create_app(adapter)
+
+
+def test_codex_adapter_declares_client_auth_requirement():
+    assert OpenAICodexAdapter().requires_client_auth is True
 
 
 def test_codex_adapter_authentication_is_pool_backed():

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -529,7 +529,7 @@ Run a local OpenAI-compatible HTTP server that forwards requests to an OAuth-aut
 
 | Subcommand | Description |
 |------------|-------------|
-| `start` | Run the proxy in the foreground. Flags: `--provider <codex\|nous\|xai>` (default `nous`), `--host <addr>` (default `127.0.0.1`), `--port <int>` (default `8645`), `--auth-token-file <path>` (required for Codex; owner-only regular file, mode `0600` on POSIX). Codex refuses non-loopback binds. |
+| `start` | Run the proxy in the foreground. Flags: `--provider <codex\|nous\|xai>` (default `nous`), `--host <addr>` (default `127.0.0.1`), `--port <int>` (default `8645`), `--auth-token-file <path>` (required for Codex; owner-only regular file, mode `0600` on POSIX or a current-user/SYSTEM-only DACL on Windows). Codex refuses non-loopback binds. |
 | `status` | Show which proxy upstreams are ready (credentials present, OAuth valid). |
 | `providers` | List available proxy upstream providers. |
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -525,11 +525,11 @@ Common flags for migration subcommands:
 hermes proxy <subcommand>
 ```
 
-Run a local OpenAI-compatible HTTP server that forwards requests to an OAuth-authenticated upstream provider (e.g. Nous Portal, xAI). External apps can point at the proxy with any bearer token; the proxy attaches your real OAuth credentials on the way out. See [Subscription Proxy](../user-guide/features/subscription-proxy.md) for the full guide.
+Run a local OpenAI-compatible HTTP server that forwards requests to an OAuth-authenticated upstream provider (e.g. Nous Portal, OpenAI Codex, xAI). The proxy replaces the client's authorization with your OAuth credential on the way out. Providers may impose stricter client-authentication and bind rules. See [Subscription Proxy](../user-guide/features/subscription-proxy.md) for the full guide.
 
 | Subcommand | Description |
 |------------|-------------|
-| `start` | Run the proxy in the foreground. Flags: `--provider <nous\|xai>` (default `nous`), `--host <addr>` (default `127.0.0.1`; use `0.0.0.0` to expose on LAN), `--port <int>` (default `8645`). |
+| `start` | Run the proxy in the foreground. Flags: `--provider <codex\|nous\|xai>` (default `nous`), `--host <addr>` (default `127.0.0.1`), `--port <int>` (default `8645`), `--auth-token-file <path>` (required for Codex; owner-only regular file, mode `0600` on POSIX). Codex refuses non-loopback binds. |
 | `status` | Show which proxy upstreams are ready (credentials present, OAuth valid). |
 | `providers` | List available proxy upstream providers. |
 

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -97,6 +97,10 @@ On POSIX systems the token file must be owned by the current user and have mode
 `0600`; symlinks are rejected. Keep its contents out of logs, command arguments,
 and source-controlled configuration.
 
+On Windows the file owner must be the current user (or SYSTEM), and its DACL may
+grant access only to that user and SYSTEM. Inherited or explicit allow entries
+for principals such as `Everyone` or `BUILTIN\\Users` are rejected.
+
 Codex forwards only `/v1/responses` and `/v1/models`. The adapter attaches the
 native Codex `originator`, `User-Agent`, and JWT-derived
 `ChatGPT-Account-ID` headers after stripping client-supplied values, so a

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -18,7 +18,7 @@ This is different from the [API server](./api-server.md):
 |---|---|---|
 | What it serves | Your agent (full toolset, memory, skills) | Raw model inference |
 | Use case | "Use Hermes as a chat backend" | "Use my Portal sub from another app" |
-| Auth | Your `API_SERVER_KEY` | Any bearer (proxy attaches the real one) |
+| Auth | Your `API_SERVER_KEY` | Provider-specific; Codex requires an owner-only client bearer |
 | Tool calls | Yes — the agent runs tools | No — passthrough only |
 
 Use the API server when you want the **agent** as a backend. Use the
@@ -83,11 +83,19 @@ interface in `hermes_cli/proxy/adapters/`.
 
 ### OpenAI Codex / ChatGPT OAuth
 
-Start the proxy from the Hermes profile that owns the Codex OAuth credential:
+Create a client bearer in an owner-only regular file, then start the proxy from
+the Hermes profile that owns the Codex OAuth credential:
 
 ```bash
-hermes proxy start --provider codex
+umask 077
+python3 -c 'import secrets; print(secrets.token_urlsafe(32))' > ~/.hermes/codex-proxy.token
+hermes proxy start --provider codex \
+  --auth-token-file ~/.hermes/codex-proxy.token
 ```
+
+On POSIX systems the token file must be owned by the current user and have mode
+`0600`; symlinks are rejected. Keep its contents out of logs, command arguments,
+and source-controlled configuration.
 
 Codex forwards only `/v1/responses` and `/v1/models`. The adapter attaches the
 native Codex `originator`, `User-Agent`, and JWT-derived
@@ -100,13 +108,16 @@ Point a Responses-compatible client at:
 
 ```text
 Base URL: http://127.0.0.1:8645/v1
-API key:  any non-empty placeholder
+API key:  the bearer stored in ~/.hermes/codex-proxy.token
 Model:    a model available to your ChatGPT/Codex account
 Transport: OpenAI Responses API
 ```
 
-Keep this proxy on `127.0.0.1`. It accepts any inbound bearer and spends the
-OAuth account owned by the profile that started it.
+Keep this proxy on `127.0.0.1`. Loopback limits network reachability, while the
+required client bearer establishes authority to spend the OAuth account owned
+by the profile that started it. Missing or incorrect client credentials return
+HTTP 401 before Hermes reads credential-pool availability, resolves a bearer,
+or contacts the Codex upstream. This applies to `/health` as well as `/v1/*`.
 
 ## Check status
 
@@ -206,9 +217,9 @@ Use a firewall, VPN, or reverse proxy with proper auth if you expose
 this beyond your trusted network.
 
 The `openai-codex` adapter is stricter: it rejects every non-loopback bind,
-including `0.0.0.0`, because the proxy would otherwise expose a ChatGPT OAuth
-subscription to any reachable client. Codex must remain on `127.0.0.1`, `::1`,
-or `localhost`.
+including `0.0.0.0`, and requires an owner-only client bearer even on loopback.
+Loopback alone is not an identity boundary on a multi-user host. Codex must
+remain on `127.0.0.1`, `::1`, or `localhost`.
 
 ## Rate limits
 
@@ -221,10 +232,11 @@ subscription quota. Monitor usage at
 
 The proxy is intentionally minimal. Per request:
 
-1. Receive `POST /v1/chat/completions` from your app
-2. Look up the adapter's current credential (refresh if expiring)
-3. Forward the request body verbatim, with `Authorization: Bearer <minted-key>`
-4. Stream the response back unchanged (SSE preserved)
+1. Receive a request on an adapter-allowed `/v1/*` path
+2. Validate client authority when the adapter requires it
+3. Look up the adapter's current credential (refresh if expiring)
+4. Forward the request body verbatim, replacing `Authorization` with the upstream bearer
+5. Stream the response back unchanged (SSE preserved)
 
 No transformation. No logging of request bodies. No agent loop. The
 proxy is a credential-attaching pass-through.

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -72,9 +72,41 @@ automatically when the bearer approaches expiry.
 hermes proxy providers
 ```
 
-Currently shipped: `nous` (Nous Portal) and `xai` (xAI / Grok). More
-OAuth providers can be added by implementing the `UpstreamAdapter`
+Currently shipped:
+
+- `openai-codex` (`codex` alias) — OpenAI Codex / ChatGPT OAuth, Responses API only
+- `nous` — Nous Portal
+- `xai` — xAI / Grok OAuth
+
+More OAuth providers can be added by implementing the `UpstreamAdapter`
 interface in `hermes_cli/proxy/adapters/`.
+
+### OpenAI Codex / ChatGPT OAuth
+
+Start the proxy from the Hermes profile that owns the Codex OAuth credential:
+
+```bash
+hermes proxy start --provider codex
+```
+
+Codex forwards only `/v1/responses` and `/v1/models`. The adapter attaches the
+native Codex `originator`, `User-Agent`, and JWT-derived
+`ChatGPT-Account-ID` headers after stripping client-supplied values, so a
+loopback client cannot spoof account identity. A 401 refreshes the exact failed
+pool credential and rotates when refresh fails; a 429 marks the failed credential
+exhausted and rotates to another available account.
+
+Point a Responses-compatible client at:
+
+```text
+Base URL: http://127.0.0.1:8645/v1
+API key:  any non-empty placeholder
+Model:    a model available to your ChatGPT/Codex account
+Transport: OpenAI Responses API
+```
+
+Keep this proxy on `127.0.0.1`. It accepts any inbound bearer and spends the
+OAuth account owned by the profile that started it.
 
 ## Check status
 
@@ -172,6 +204,11 @@ hermes proxy start --host 0.0.0.0 --port 8645
 subscription. The proxy has no auth of its own — it accepts any bearer.
 Use a firewall, VPN, or reverse proxy with proper auth if you expose
 this beyond your trusted network.
+
+The `openai-codex` adapter is stricter: it rejects every non-loopback bind,
+including `0.0.0.0`, because the proxy would otherwise expose a ChatGPT OAuth
+subscription to any reachable client. Codex must remain on `127.0.0.1`, `::1`,
+or `localhost`.
 
 ## Rate limits
 


### PR DESCRIPTION
## Summary

Direct combined replacement for [#91199](https://github.com/NousResearch/hermes-agent/pull/91199). The first commit preserves Chris Munn’s original Codex OAuth adapter authorship; the following commits add cross-platform downstream-authority hardening.

- add a loopback OpenAI Codex OAuth proxy backed by Hermes credential-pool entries
- preserve raw Responses API request bytes, query strings, streaming, retry rotation, and adapter-owned identity headers
- pin the Codex upstream to the trusted OpenAI base URL
- require a separate downstream bearer for `/health` and `/v1/*` before any credential-pool lookup or upstream request
- load that bearer from a bounded owner-only regular file
- enforce current-user ownership and mode `0600` on POSIX
- enforce current-user-or-SYSTEM ownership and a current-user/SYSTEM-only DACL on Windows; reject null or permissive DACLs
- reject symlinks, file swaps, wrong ownership, insecure permissions, empty/multiline/oversized tokens, and client identity-header spoofing
- compare downstream credentials in constant time and never forward them upstream
- enforce the same authentication boundary through CLI and programmatic server paths

## Contributor lineage

- [#91199](https://github.com/NousResearch/hermes-agent/pull/91199) by Chris Munn (`@BELGARATHbb`) is the direct feature origin; his commit remains first with original authorship.
- [#62297](https://github.com/NousResearch/hermes-agent/pull/62297) by `@darkyy92` is the closest earlier native-Responses and owner-only per-client-authority precedent.
- [#62510](https://github.com/NousResearch/hermes-agent/pull/62510) by Dillon Townsel (`@dtownsel`) provided downstream-bearer precedent; his contribution is credited in the hardening commit.
- [#92409](https://github.com/NousResearch/hermes-agent/pull/92409) by `@phucnguyenquang` overlaps the Codex-proxy/inbound-auth delivery surface.
- [#54877](https://github.com/NousResearch/hermes-agent/pull/54877) by `@blazing-mj` is adjacent shared-pool/Cloudflare-header work with a different Chat-Completions translation design.

This PR is intended as the single hardened delivery object; maintainers can retire the overlapping PRs if this version is accepted.

## Security boundary

Loopback limits network reachability, but it does not prove caller authority on a multi-user host. Missing or incorrect downstream credentials return `401 proxy_auth_failed` before Hermes reads pool availability, resolves an OAuth bearer, or contacts OpenAI.

On Windows, the already-open file descriptor is inspected with pywin32. Only the current user and SYSTEM may own or receive allowed access. This preserves the existing symlink, swap, regular-file, and content-bound checks while closing the cross-user confused-deputy path.

## Verification

Fresh on the rebased branch:

- `scripts/run_tests.sh tests/hermes_cli/test_proxy.py tests/hermes_cli/test_proxy_codex.py` — **34 passed, 2 native-Windows tests skipped locally and selected for the Windows CI lane**
- Ruff check and format check — passed
- Python bytecode compilation — passed
- Windows-footgun scan across 1,005 files — passed
- exact base-vs-head Ruff/Ty diagnostic diff — no branch code-diagnostic delta
- full English + Chinese Docusaurus production build — passed
- `git diff --check` — passed
- sabotage proof — disabling the downstream-auth guard makes the adversarial regression return HTTP 200 instead of 401
- live Codex canary from the hardened implementation:
  - unauthenticated `/health` — HTTP 401 `proxy_auth_failed`
  - authenticated `/health` — HTTP 200, upstream authenticated
  - authenticated `/v1/responses` — HTTP 200, `response.completed`, exact marker returned

Hosted exact-head CI status is recorded in the PR checks.

No credential value, credential file, or production-service configuration is included.
