### PR TITLE
fix(profiles): exclude lost+found and portal-recovery from clone-all

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -93,6 +93,11 @@ _CLONE_ALL_STRIP: list[str] = [
 #   bin           — installed binaries (tirith etc., ~10 MB) shared per-host
 #   node_modules  — npm packages (hundreds of MB)
 #
+#   lost+found    — filesystem-created recovery dir, root-owned 0700 on every
+#                   ext filesystem; copying it aborts the whole clone with
+#                   PermissionError (#91850) and it is never useful in a
+#                   profile.
+#
 # See ``_DEFAULT_EXPORT_EXCLUDE_ROOT`` below for the broader export-side
 # exclusion list (export also drops logs / caches because the archive is a
 # portable snapshot; clone-all keeps those because the cloned profile is
@@ -103,6 +108,7 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "profiles",
     "bin",
     "node_modules",
+    "lost+found",
 })
 
 # Per-profile history artifacts excluded from --clone-all regardless of the
@@ -119,6 +125,10 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
 #   backups             — `hermes backup` archives
 #   state-snapshots     — quick-backup snapshot trees
 #   checkpoints         — session checkpoint data
+#   portal-recovery     — platform-managed recovery snapshots, written by a
+#                         root-owned recovery process (root:root 0640 files
+#                         abort the clone with PermissionError, #91850); a
+#                         profile never restores from the host's snapshots
 _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "state.db",
     "state.db-wal",
@@ -127,6 +137,7 @@ _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "backups",
     "state-snapshots",
     "checkpoints",
+    "portal-recovery",
 })
 
 # Marker file written by `hermes profile create --no-skills`.  When present in

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1029,6 +1029,48 @@ class TestEdgeCases:
         assert cloned_config["model"] == "cloned"
         assert (target_dir / ".env").read_text().strip() == "SECRET=yes"
 
+    def test_clone_all_skips_root_owned_recovery_paths(self, profile_env):
+        """#91850: root-owned recovery paths must not abort a --clone-all.
+
+        `lost+found` (filesystem-created root:root 0700 on every ext
+        filesystem) and `portal-recovery` (root-owned recovery snapshots with
+        root:root 0640 files) previously hit PermissionError inside
+        shutil.copytree and aborted the entire profile clone, leaving a
+        partial directory. Both are excluded by name from the clone-all
+        ignore callback, so a --clone-all must neither fail on them nor copy
+        them into the new profile. We exercise the real copytree path
+        (clone_all=True) with unreadable dirs to prove the ignore filter —
+        not just the config-file clone path — drops them.
+        """
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        (default_home / "config.yaml").write_text("model: test")
+
+        # Simulate the root-only source shape: contents written first, then
+        # the parent dirs locked down so copytree could never read inside.
+        lost = default_home / "lost+found"
+        lost.mkdir()
+        (lost / "inside").write_text("unreachable")
+        recovery = default_home / "portal-recovery" / "snapshots" / "last-ready"
+        recovery.mkdir(parents=True)
+        (recovery / "config.yaml").write_text("root:root 0640 in reality")
+        lost.chmod(0o000)
+        (default_home / "portal-recovery" / "snapshots").chmod(0o000)
+
+        try:
+            profile_dir = create_profile("luna", clone_all=True, no_alias=True)
+        finally:
+            # Restore modes so tmp_path cleanup can delete the tree.
+            lost.chmod(0o700)
+            (default_home / "portal-recovery" / "snapshots").chmod(0o700)
+
+        # The clone succeeded and carried the readable config…
+        cloned_config = yaml.safe_load((profile_dir / "config.yaml").read_text())
+        assert cloned_config["model"] == "test"
+        # …and neither root-owned path was copied.
+        assert not (profile_dir / "lost+found").exists()
+        assert not (profile_dir / "portal-recovery").exists()
+
 
 
 class TestProfilesToServe:


### PR DESCRIPTION
Implements the fix from upstream PR #91855 against current main (HEAD 8b09a9d).

**Problem (#91850):** `--clone-all` runs `shutil.copytree` over the source profile home. Two root-owned paths there abort the entire clone with `PermissionError`, leaving a partial profile directory behind:

- `lost+found` — filesystem-created recovery dir, `root:root 0700` on every ext filesystem.
- `portal-recovery` — platform-managed recovery snapshots written by a root-owned process (`root:root 0640` files).

**Fix:** exclude both by name so copytree's ignore callback drops them — neither is ever useful in a cloned profile:
- `lost+found` -> `_CLONE_ALL_DEFAULT_EXCLUDE_ROOT` (only the default `~/.hermes` home ever contains it, matching that set's existing default-source gate).
- `portal-recovery` -> `_CLONE_ALL_HISTORY_EXCLUDE_ROOT` (source history a fresh clone must never inherit; applies to any source).

**Test:** adds `test_clone_all_skips_root_owned_recovery_paths` which exercises the real `clone_all` copytree path against unreadable recovery dirs, asserting the clone succeeds and neither path is copied. `tests/hermes_cli/test_profiles.py` + `test_profile_export_credentials.py`: 59 passed, 2 skipped.

Ref upstream PR #91855. Closes relevant issue #91850.