### PR TITLE
fix(tools): encode task ids used as sandbox/overlay path components

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -405,3 +405,49 @@ class TestCwdMarker:
         env1 = _TestableEnv()
         env2 = _TestableEnv()
         assert env1._cwd_marker != env2._cwd_marker
+
+
+class TestSafePathComponent:
+    """safe_path_component must yield mountable, collision-free segments.
+
+    A raw task id like ``session:20260822_221751_75e446`` used as a sandbox
+    directory name made docker -v split the bind-mount on the embedded colon
+    and the daemon rejected it with "invalid mode" (#92743).
+    """
+
+    def test_docker_unsafe_characters_are_encoded(self):
+        from tools.environments.base import safe_path_component
+
+        out = safe_path_component("session:20260822_221751_75e446")
+        assert out == "session%3A20260822_221751_75e446"
+        assert ":" not in out
+
+    def test_safe_characters_pass_through(self):
+        from tools.environments.base import safe_path_component
+
+        assert safe_path_component("task-01.abc_def") == "task-01.abc_def"
+
+    def test_encoding_is_reversible(self):
+        from urllib.parse import unquote
+
+        from tools.environments.base import safe_path_component
+
+        for raw in ("a:b/c", "x y/z", "ümlaut:id", "100%:done"):
+            assert unquote(safe_path_component(raw)) == raw
+
+    def test_deterministic_and_collision_free_for_distinct_inputs(self):
+        from tools.environments.base import safe_path_component
+
+        assert safe_path_component("a:b") == safe_path_component("a:b")
+        assert safe_path_component("a:b") != safe_path_component("a_b")
+
+    def test_oversized_input_truncates_with_unique_digest(self):
+        from tools.environments.base import _MAX_PATH_COMPONENT_LEN, safe_path_component
+
+        long_a = "a" * 300 + ":1"
+        long_b = "a" * 300 + ":2"
+        out_a = safe_path_component(long_a)
+        out_b = safe_path_component(long_b)
+        assert len(out_a) <= _MAX_PATH_COMPONENT_LEN + 9
+        assert ":" not in out_a
+        assert out_a != out_b

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1488,3 +1488,48 @@ def test_extra_args_set_shm_size_helper():
     assert docker_env._extra_args_set_shm_size(None) is False
     # non-string entries must not crash (config.yaml can be malformed)
     assert docker_env._extra_args_set_shm_size([42, None, "--shm-size=1g"]) is True
+
+
+def test_persistent_sandbox_dir_encodes_colon_in_task_id(monkeypatch, tmp_path):
+    """A task id containing ':' must never reach a bind-mount path raw.
+
+    docker -v splits on EVERY colon, so a sandbox directory named
+    ``session:2026…`` made the daemon parse the mount as
+    host=…/session, container=2026…/home, mode=/root and fail with
+    "invalid mode: /root" (exit 125) — issue #92743.
+    """
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path / "sandboxes"))
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+
+    task_id = "session:20260822_221751_75e446"
+    env = docker_env.DockerEnvironment(
+        image="python:3.11",
+        cwd="/root",
+        timeout=60,
+        task_id=task_id,
+        persistent_filesystem=True,
+    )
+
+    assert ":" not in os.path.basename(env._home_dir)
+    assert os.path.isdir(env._home_dir)
+    assert env._workspace_dir is not None
+    assert ":" not in os.path.basename(env._workspace_dir)
+
+    # Every -v mount must parse as host-path : container-path [: mode].
+    # Peel an optional trailing mode first ("…:/root/.hermes/skills:ro" is
+    # legal docker syntax) — a raw colon inside the HOST path instead makes
+    # the spec split into >2 non-mode parts, which is what the daemon
+    # rejected as "invalid mode" before the fix.
+    valid_modes = {"ro", "rw", "z", "ro+z", "nocopy"}
+    for flag, spec in zip(env._all_run_args, env._all_run_args[1:]):
+        if flag != "-v":
+            continue
+        body = spec
+        tail = spec.rsplit(":", 1)[-1]
+        if tail in valid_modes:
+            body = body[: -(len(tail) + 1)]
+        parts = body.split(":")
+        assert len(parts) == 2, f"mount spec {spec!r} splits into {len(parts)} parts"
+        assert parts[0] and parts[1]

--- a/tests/tools/test_singularity_persistent_overlay.py
+++ b/tests/tools/test_singularity_persistent_overlay.py
@@ -1,0 +1,39 @@
+"""Persistent-overlay path safety for the Singularity environment.
+
+A raw task id used as an overlay directory name could carry characters
+that break downstream consumers of the path (bind specs split on ``:``);
+overlay components must go through the shared path-component encoder.
+"""
+
+from tools.environments import singularity as singularity_env
+from tools.environments.base import safe_path_component
+
+
+def test_persistent_overlay_dir_encodes_colon_in_task_id(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        singularity_env, "_ensure_singularity_available", lambda: "/usr/bin/apptainer"
+    )
+    monkeypatch.setattr(
+        singularity_env,
+        "_get_or_build_sif",
+        lambda image, executable="apptainer": str(tmp_path / "image.sif"),
+    )
+    monkeypatch.setattr(singularity_env, "_get_scratch_dir", lambda: tmp_path / "scratch")
+    monkeypatch.setattr(
+        singularity_env.SingularityEnvironment, "_start_instance", lambda self: None
+    )
+    monkeypatch.setattr(
+        singularity_env.SingularityEnvironment, "init_session", lambda self: None
+    )
+
+    task_id = "session:20260822_221751_75e446"
+    env = singularity_env.SingularityEnvironment(
+        image="python:3.11",
+        persistent_filesystem=True,
+        task_id=task_id,
+    )
+
+    assert env._overlay_dir is not None
+    assert env._overlay_dir.name == f"overlay-{safe_path_component(task_id)}"
+    assert ":" not in env._overlay_dir.name
+    assert env._overlay_dir.is_dir()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -7,6 +7,7 @@ or a temp file (local).
 """
 
 import codecs
+import hashlib
 import json
 import logging
 import os
@@ -292,6 +293,34 @@ def get_sandbox_dir() -> Path:
         p = get_hermes_home() / "sandboxes"
     p.mkdir(parents=True, exist_ok=True)
     return p
+
+
+_SAFE_PATH_COMPONENT_RE = re.compile(r"[^A-Za-z0-9_.\-]")
+_MAX_PATH_COMPONENT_LEN = 200
+
+
+def safe_path_component(value: str) -> str:
+    """Coerce *value* into a single filesystem-safe path segment.
+
+    Percent-encodes every character outside ``[A-Za-z0-9_.-]`` so task ids
+    containing ``:`` or other separators can never break consumers that join
+    the component into a bind-mount spec — ``docker -v host:container[:mode]``
+    splits on EVERY colon, so one raw colon in a sandbox directory name makes
+    the daemon parse the mount as host=…/session, container=2026…/home,
+    mode=/root and fail with "invalid mode" (#92743).
+
+    The encoding is deterministic, reversible (urllib.parse.unquote), and
+    collision-free. Inputs long enough to threaten per-component filesystem
+    limits are truncated and suffixed with a short digest of the full
+    encoding, so distinct ids still map to distinct directories.
+    """
+    encoded = _SAFE_PATH_COMPONENT_RE.sub(
+        lambda m: "".join(f"%{b:02X}" for b in m.group().encode("utf-8")), value
+    )
+    if len(encoded) <= _MAX_PATH_COMPONENT_LEN:
+        return encoded
+    digest = hashlib.sha1(encoded.encode("utf-8")).hexdigest()[:8]
+    return f"{encoded[:_MAX_PATH_COMPONENT_LEN]}~{digest}"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -947,7 +947,7 @@ class DockerEnvironment(BaseEnvironment):
         # Persistent workspace via bind mounts from a configurable host directory
         # (TERMINAL_SANDBOX_DIR, default ~/.hermes/sandboxes/). Non-persistent
         # mode uses tmpfs (ephemeral, fast, gone on cleanup).
-        from tools.environments.base import get_sandbox_dir
+        from tools.environments.base import get_sandbox_dir, safe_path_component
 
         # User-configured volume mounts (from config.yaml docker_volumes)
         volume_args = []
@@ -980,7 +980,11 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            # task_id is attacker- and generator-controlled free text (e.g.
+            # "session:20260822_221751_75e446"); a raw colon here becomes a
+            # second -v separator and the daemon rejects the whole mount
+            # (#92743). Encode the directory component, not the id itself.
+            sandbox = get_sandbox_dir() / "docker" / safe_path_component(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -20,6 +20,7 @@ from tools.environments.base import (
     _load_json_store,
     _popen_bash,
     _save_json_store,
+    safe_path_component,
 )
 
 logger = logging.getLogger(__name__)
@@ -191,7 +192,7 @@ class SingularityEnvironment(BaseEnvironment):
         if self._persistent:
             overlay_base = _get_scratch_dir() / "hermes-overlays"
             overlay_base.mkdir(parents=True, exist_ok=True)
-            self._overlay_dir = overlay_base / f"overlay-{task_id}"
+            self._overlay_dir = overlay_base / f"overlay-{safe_path_component(task_id)}"
             self._overlay_dir.mkdir(parents=True, exist_ok=True)
 
         self._start_instance()


### PR DESCRIPTION
Fixes #92743

## What & why

Docker persistent sandboxes join the raw `task_id` into the host bind-mount
path (`get_sandbox_dir() / "docker" / task_id`). Task ids are generator-
controlled free text — e.g. the reported `session:20260822_221751_75e446` —
and `docker -v` splits on **every** colon, so the daemon parsed
`host=…/session`, `container=2026…/home`, `mode=/root` and failed with
`invalid mode: /root`, exit 125. The same class exists in the Singularity
backend's `overlay-{task_id}` directory.

Fix adds `tools.environments.base.safe_path_component()`: percent-encodes
every byte outside `[A-Za-z0-9_.-]`. Properties that matter for persistence:

- **deterministic** — same id → same directory across processes/restarts
- **collision-free** — distinct ids never collapse (no naive `_`-smashing:
  `session:1` vs `session_1` stay distinct)
- **reversible** — `urllib.parse.unquote` recovers the id
- oversized inputs truncate with a short digest suffix so distinct long ids
  still map to distinct directories

Both backends' persistent path construction route through it; container
names are uuid-derived and labels already pass through
`_sanitize_label_value`, so these were the only raw task_id → path consumers.

## How to test

```bash
docker run --rm -v '/tmp/sandboxes/docker/session:2026/home:/root' python:3.11-slim echo OK
# daemon error before fix; after fix the on-disk dir is session%3A2026 and mounts parse cleanly
```

New tests:
- `tests/tools/test_base_environment.py::TestSafePathComponent` — encoding, pass-through, reversibility, determinism/collision-freedom, oversized-input digest
- `tests/tools/test_docker_environment.py::test_persistent_sandbox_dir_encodes_colon_in_task_id` — real constructor run: home/workspace dirs created with colon-free names, every `-v` spec in `_all_run_args` parses as host:container[:mode]
- `tests/tools/test_singularity_persistent_overlay.py` — overlay dir name encoded, exists on disk

Suite: `scripts/run_tests.sh` over docker/base/singularity/session-isolation files → 106 passed, 0 failed at head. `scripts/check-windows-footguns.py <changed files>` → clean. No Docker daemon needed for tests.

## Platform

macOS 26, Python 3.11. Change touches POSIX+Windows-shared path building only via the shared encoder; no new OS-specific calls. Note: sandboxes created before this fix under colon-bearing ids keep their old directories (data preserved, just no longer mounted) — a fresh directory is minted per sanitized id, matching the issue's suggested outcome.

Closes #92743.
