### PR TITLE
fix(discord): interrupt voice playback on barge-in

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -583,9 +583,13 @@ class VoiceReceiver:
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
 
-    def __init__(self, voice_client, allowed_user_ids: set = None):
+    def __init__(self, voice_client, allowed_user_ids: set = None,
+                 speech_start_callback: Optional[Callable[[int], None]] = None,
+                 speech_start_allowed: Optional[Callable[[int], bool]] = None):
         self._vc = voice_client
         self._allowed_user_ids = allowed_user_ids or set()
+        self._speech_start_callback = speech_start_callback
+        self._speech_start_allowed = speech_start_allowed
         self._running = False
 
         # Decryption
@@ -600,6 +604,7 @@ class VoiceReceiver:
         # Per-user audio buffers
         self._buffers: Dict[int, bytearray] = defaultdict(bytearray)
         self._last_packet_time: Dict[int, float] = {}
+        self._speech_started_ssrcs: set[int] = set()
 
         # Opus decoder per SSRC (each user needs own decoder state)
         self._decoders: Dict[int, object] = {}
@@ -636,6 +641,7 @@ class VoiceReceiver:
         with self._lock:
             self._buffers.clear()
             self._last_packet_time.clear()
+            self._speech_started_ssrcs.clear()
             self._decoders.clear()
             self._ssrc_to_user.clear()
         logger.info("VoiceReceiver stopped")
@@ -818,9 +824,49 @@ class VoiceReceiver:
             if ssrc not in self._decoders:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
+            speech_start_callback = None
+            speech_start_user_id = 0
+            should_authorize_speech_start = False
             with self._lock:
                 self._buffers[ssrc].extend(pcm)
                 self._last_packet_time[ssrc] = time.monotonic()
+                user_id = self._ssrc_to_user.get(ssrc, 0)
+                if (
+                    self._speech_start_callback
+                    and user_id
+                    and ssrc not in self._speech_started_ssrcs
+                ):
+                    self._speech_started_ssrcs.add(ssrc)
+                    should_authorize_speech_start = True
+                    speech_start_user_id = user_id
+            if should_authorize_speech_start:
+                try:
+                    allowed = self._allowed_user_ids
+                    is_allowed = (
+                        self._speech_start_allowed(speech_start_user_id)
+                        if self._speech_start_allowed
+                        else not allowed
+                        or "*" in allowed
+                        or str(speech_start_user_id) in allowed
+                    )
+                except Exception as e:
+                    logger.debug(
+                        "Voice speech-start authorization failed for user %s: %s",
+                        speech_start_user_id,
+                        e,
+                    )
+                    is_allowed = False
+                if is_allowed:
+                    speech_start_callback = self._speech_start_callback
+            if speech_start_callback:
+                try:
+                    speech_start_callback(speech_start_user_id)
+                except Exception as e:
+                    logger.debug(
+                        "Voice speech-start callback failed for user %s: %s",
+                        speech_start_user_id,
+                        e,
+                    )
         except Exception as e:
             with self._lock:
                 self._decoders.pop(ssrc, None)
@@ -887,10 +933,12 @@ class VoiceReceiver:
                         completed.append((user_id, bytes(buf)))
                     self._buffers[ssrc] = bytearray()
                     self._last_packet_time.pop(ssrc, None)
+                    self._speech_started_ssrcs.discard(ssrc)
                 elif silence_duration >= self.SILENCE_THRESHOLD * 2:
                     # Stale buffer with no valid user — discard
                     self._buffers.pop(ssrc, None)
                     self._last_packet_time.pop(ssrc, None)
+                    self._speech_started_ssrcs.discard(ssrc)
 
         return completed
 
@@ -911,6 +959,7 @@ class VoiceReceiver:
                         completed.append((user_id, bytes(buf)))
                 self._buffers.pop(ssrc, None)
                 self._last_packet_time.pop(ssrc, None)
+                self._speech_started_ssrcs.discard(ssrc)
 
         return completed
 
@@ -1102,6 +1151,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
+        self._voice_barge_in_enabled = self._load_voice_barge_in_enabled()
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
         # the bot in the channel when the user deliberately picked text-only
@@ -4335,6 +4385,22 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.debug("Could not load discord.voice_fx config: %s", e)
         return defaults
 
+    def _load_voice_barge_in_enabled(self) -> bool:
+        """Return whether inbound speech may interrupt Discord voice playback.
+
+        ``voice.barge_in`` is the shared voice-mode setting used by the CLI,
+        TUI, desktop, and gateway.  Keep Discord on that same contract rather
+        than inventing a platform-local duplicate under ``discord.voice``.
+        """
+        try:
+            from hermes_cli.config import read_raw_config
+            cfg = read_raw_config() or {}
+            voice = cfg.get("voice") or {}
+            return voice.get("barge_in", True) is True
+        except Exception as e:
+            logger.debug("Could not load voice.barge_in config: %s", e)
+            return True
+
     def _load_discord_int_config(self, key: str, default: int, *, minimum: int = 0) -> int:
         """Read a non-secret integer from the top-level ``discord`` config."""
         try:
@@ -4551,6 +4617,23 @@ class DiscordAdapter(BasePlatformAdapter):
         mixers = getattr(self, "_voice_mixers", None)
         return bool(mixers) and mixers.get(guild_id) is not None
 
+    def _on_voice_speech_start(self, guild_id: int, user_id: int) -> None:
+        """Synchronously interrupt active speech when an allowed user starts."""
+        mixer = getattr(self, "_voice_mixers", {}).get(guild_id)
+        if mixer is not None:
+            if mixer.speech_active:
+                mixer.stop_speech()
+            return
+
+        vc = getattr(self, "_voice_clients", {}).get(guild_id)
+        if vc is not None and vc.is_playing():
+            vc.stop()
+
+    def _is_voice_speech_start_allowed(self, guild_id: int, user_id: int) -> bool:
+        """Apply the canonical Discord authorization union to voice speech."""
+        guild = self._client.get_guild(guild_id) if self._client is not None else None
+        return self._is_allowed_user(str(user_id), guild=guild, is_dm=False)
+
     async def join_voice_channel(self, channel, *, text_channel_id: int = None, source: dict = None) -> bool:
         """Join a Discord voice channel. Returns True on success.
 
@@ -4588,7 +4671,21 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Start voice receiver (Phase 2: listen to users)
             try:
-                receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
+                speech_start_callback = None
+                speech_start_allowed = None
+                if self._voice_barge_in_enabled:
+                    speech_start_callback = lambda user_id: self._on_voice_speech_start(
+                        guild_id, user_id
+                    )
+                    speech_start_allowed = lambda user_id: self._is_voice_speech_start_allowed(
+                        guild_id, user_id
+                    )
+                receiver = VoiceReceiver(
+                    vc,
+                    allowed_user_ids=self._allowed_user_ids,
+                    speech_start_callback=speech_start_callback,
+                    speech_start_allowed=speech_start_allowed,
+                )
                 receiver.start()
                 self._voice_receivers[guild_id] = receiver
                 self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
@@ -4690,7 +4787,10 @@ class DiscordAdapter(BasePlatformAdapter):
             # ── Legacy one-shot path (no mixer) ─────────────────────────
             # Pause voice receiver while playing (echo prevention)
             receiver = self._voice_receivers.get(guild_id)
-            if receiver:
+            pause_receiver = receiver and not getattr(
+                self, "_voice_barge_in_enabled", False
+            )
+            if pause_receiver:
                 receiver.pause()
 
             try:
@@ -4735,7 +4835,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     vc.stop()
                 return True
             finally:
-                if receiver:
+                if pause_receiver:
                     receiver.resume()
         finally:
             self._reset_voice_timeout(guild_id)

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -8,7 +8,9 @@ integration (install on join, play routing, ack) is tested with the standard
 """
 
 import os
+import struct
 import sys
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,6 +29,155 @@ if _DISCORD_DIR not in sys.path:
     sys.path.insert(0, _DISCORD_DIR)
 
 import voice_mixer as vm  # noqa: E402
+
+
+def _build_rtp_packet(ssrc, seq=1):
+    header = struct.pack(">BBHII", 0x80, 0x78, seq, 960 * seq, ssrc)
+    return header + (b"\x00" * 20) + b"\x00\x00\x00\x01"
+
+
+def _make_receiver(
+    *,
+    allowed_user_ids=None,
+    speech_start_callback=None,
+    speech_start_allowed=None,
+):
+    from plugins.platforms.discord.adapter import VoiceReceiver
+
+    vc = MagicMock()
+    vc._connection.secret_key = [0] * 32
+    vc._connection.dave_session = None
+    vc._connection.ssrc = 9999
+    vc._connection.add_socket_listener = MagicMock()
+    vc._connection.remove_socket_listener = MagicMock()
+    vc._connection.hook = None
+    receiver = VoiceReceiver(
+        vc,
+        allowed_user_ids=allowed_user_ids,
+        speech_start_callback=speech_start_callback,
+        speech_start_allowed=speech_start_allowed,
+    )
+    receiver.start()
+    return receiver
+
+
+def _send_decoded_packet(receiver, ssrc, *, pcm=b"\x00" * 3840, seq=1):
+    pytest.importorskip("nacl")
+    decoder = receiver._decoders.setdefault(ssrc, MagicMock())
+    decoder.decode.return_value = pcm
+    with patch("nacl.secret.Aead") as aead:
+        aead.return_value.decrypt.return_value = b"\xf8\xff\xfe"
+        receiver._on_packet(_build_rtp_packet(ssrc, seq))
+
+
+class TestVoiceReceiverSpeechStart:
+    def test_authorized_mapped_user_only(self):
+        callback = MagicMock()
+        receiver = _make_receiver(
+            allowed_user_ids={"42"},
+            speech_start_callback=callback,
+        )
+        receiver.map_ssrc(100, 42)
+        receiver.map_ssrc(200, 7)
+
+        _send_decoded_packet(receiver, 100)
+        _send_decoded_packet(receiver, 200)
+        _send_decoded_packet(receiver, 300)
+
+        callback.assert_called_once_with(42)
+
+    @pytest.mark.parametrize(
+        ("allowed_user_ids", "canonical_result", "expected_calls"),
+        [(set(), False, 0), ({"7"}, True, 1)],
+    )
+    def test_canonical_authorization_overrides_raw_user_ids(
+        self,
+        allowed_user_ids,
+        canonical_result,
+        expected_calls,
+    ):
+        callback = MagicMock()
+        allowed = MagicMock(return_value=canonical_result)
+        receiver = _make_receiver(
+            allowed_user_ids=allowed_user_ids,
+            speech_start_callback=callback,
+            speech_start_allowed=allowed,
+        )
+        receiver.map_ssrc(100, 42)
+
+        _send_decoded_packet(receiver, 100)
+
+        allowed.assert_called_once_with(42)
+        assert callback.call_count == expected_calls
+
+    @pytest.mark.parametrize(
+        "reset_path",
+        ["silence_emit", "silence_discard", "flush", "stop"],
+    )
+    def test_fires_once_per_utterance_and_resets(self, reset_path):
+        callback = MagicMock()
+        receiver = _make_receiver(
+            allowed_user_ids={"42"},
+            speech_start_callback=callback,
+        )
+        receiver.map_ssrc(100, 42)
+        pcm = b"\x00" * (96000 if reset_path == "silence_emit" else 3840)
+
+        _send_decoded_packet(receiver, 100, pcm=pcm, seq=1)
+        _send_decoded_packet(receiver, 100, pcm=pcm, seq=2)
+        callback.assert_called_once_with(42)
+
+        if reset_path.startswith("silence_"):
+            receiver._last_packet_time[100] = time.monotonic() - 4.0
+            receiver.check_silence()
+        elif reset_path == "flush":
+            receiver.flush_pending()
+        else:
+            receiver.stop()
+            receiver.start()
+            receiver.map_ssrc(100, 42)
+
+        _send_decoded_packet(receiver, 100, pcm=pcm, seq=3)
+        assert callback.call_count == 2
+        assert all(args == (42,) for args, _kwargs in callback.call_args_list)
+
+    def test_authorization_runs_outside_receiver_lock(self):
+        callback = MagicMock()
+        lock_was_available = []
+        receiver = None
+
+        def allowed(_user_id):
+            acquired = receiver._lock.acquire(blocking=False)
+            lock_was_available.append(acquired)
+            if acquired:
+                receiver._lock.release()
+            return True
+
+        receiver = _make_receiver(
+            allowed_user_ids={"42"},
+            speech_start_callback=callback,
+            speech_start_allowed=allowed,
+        )
+        receiver.map_ssrc(100, 42)
+
+        _send_decoded_packet(receiver, 100)
+
+        assert lock_was_available == [True]
+        callback.assert_called_once_with(42)
+
+    def test_callback_exception_does_not_escape_socket_reader(self):
+        callback = MagicMock(side_effect=RuntimeError("boom"))
+        receiver = _make_receiver(
+            allowed_user_ids={"42"},
+            speech_start_callback=callback,
+        )
+        receiver.map_ssrc(100, 42)
+
+        _send_decoded_packet(receiver, 100, seq=1)
+        _send_decoded_packet(receiver, 100, seq=2)
+
+        callback.assert_called_once_with(42)
+        assert len(receiver._buffers[100]) == 7680
 
 
 # =====================================================================
@@ -105,6 +256,116 @@ class TestVoiceMixerActive:
         assert bare.voice_mixer_active(111) is False
 
 
+class TestVoiceBargeIn:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("enabled", [True, False])
+    async def test_receiver_callback_is_wired_only_when_enabled(self, enabled):
+        from plugins.platforms.discord import adapter as discord_adapter
+        from gateway.config import PlatformConfig
+
+        with patch("hermes_cli.config.read_raw_config", return_value={
+            "voice": {"barge_in": enabled},
+        }):
+            adapter = discord_adapter.DiscordAdapter(
+                PlatformConfig(enabled=True, token="fake-token")
+            )
+        adapter._client = MagicMock()
+        adapter._allowed_user_ids = {"42"}
+        adapter._reset_voice_timeout = MagicMock()
+        channel = MagicMock()
+        channel.guild.id = 111
+        channel.connect = AsyncMock(return_value=MagicMock())
+
+        def discard_listen_loop(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch.object(discord_adapter, "DISCORD_AVAILABLE", True), \
+                patch.object(discord_adapter, "VoiceReceiver") as receiver_cls, \
+                patch.object(
+                    discord_adapter.asyncio,
+                    "ensure_future",
+                    side_effect=discard_listen_loop,
+                ):
+            await adapter.join_voice_channel(channel)
+
+        callback = receiver_cls.call_args.kwargs.get("speech_start_callback")
+        allowed = receiver_cls.call_args.kwargs.get("speech_start_allowed")
+        assert callable(callback) is enabled
+        assert callable(allowed) is enabled
+        if enabled:
+            guild = adapter._client.get_guild.return_value
+            adapter._is_allowed_user = MagicMock(return_value=False)
+            assert allowed(42) is False
+            adapter._is_allowed_user.assert_called_once_with(
+                "42", guild=guild, is_dm=False
+            )
+
+    def test_active_mixer_speech_is_interrupted_before_legacy_playback(self):
+        adapter = _make_adapter()
+        mixer = MagicMock()
+        mixer.speech_active = True
+        adapter._voice_mixers[111] = mixer
+        vc = MagicMock()
+        vc.is_playing.return_value = True
+        adapter._voice_clients[111] = vc
+
+        adapter._on_voice_speech_start(111, 42)
+
+        mixer.stop_speech.assert_called_once_with()
+        vc.stop.assert_not_called()
+
+    def test_active_legacy_playback_is_interrupted_without_mixer_speech(self):
+        adapter = _make_adapter()
+        vc = MagicMock()
+        vc.is_playing.return_value = True
+        adapter._voice_clients[111] = vc
+
+        adapter._on_voice_speech_start(111, 42)
+
+        vc.stop.assert_called_once_with()
+
+    @pytest.mark.parametrize("with_idle_mixer", [False, True])
+    def test_noop_without_active_speech(self, with_idle_mixer):
+        adapter = _make_adapter()
+        vc = MagicMock()
+        vc.is_playing.return_value = False
+        adapter._voice_clients[111] = vc
+        if with_idle_mixer:
+            mixer = MagicMock()
+            mixer.speech_active = False
+            adapter._voice_mixers[111] = mixer
+
+        adapter._on_voice_speech_start(111, 42)
+
+        vc.stop.assert_not_called()
+        if with_idle_mixer:
+            mixer.stop_speech.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_legacy_playback_keeps_capture_live_when_enabled(self):
+        adapter = _make_adapter()
+        adapter._voice_barge_in_enabled = True
+        adapter._playback_timeout_for_audio = AsyncMock(return_value=30.0)
+        adapter._cancel_voice_timeout = MagicMock()
+        adapter._reset_voice_timeout = MagicMock()
+        receiver = MagicMock()
+        adapter._voice_receivers[111] = receiver
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        vc.is_playing.return_value = False
+        vc.play.side_effect = lambda _source, after: after(None)
+        adapter._voice_clients[111] = vc
+
+        with patch("plugins.platforms.discord.adapter.discord") as discord_mock:
+            discord_mock.FFmpegPCMAudio.return_value = MagicMock()
+            discord_mock.PCMVolumeTransformer.return_value = MagicMock()
+            assert await adapter.play_in_voice_channel(111, "/tmp/speech.mp3") is True
+
+        receiver.pause.assert_not_called()
+        receiver.resume.assert_not_called()
+
+
 class TestPlayInVoiceChannelMixerPath:
     @pytest.mark.asyncio
     async def test_routes_through_mixer_when_present(self):
@@ -161,5 +422,3 @@ class TestPlayAckInVoice:
         adapter = _make_adapter({"ack_enabled": False})
         adapter._voice_mixers[111] = MagicMock()
         assert await adapter.play_ack_in_voice(111) is False
-
-


### PR DESCRIPTION
## Summary

- let an authorized Discord voice participant interrupt active Hermes speech on the first decoded packet of an utterance
- preserve continuous voice capture while barge-in is enabled, including the legacy playback path
- reset the once-per-utterance latch on emit, discard, flush, and receiver stop
- use the existing top-level `voice.barge_in` setting and isolate callback/authorization failures from the socket reader

## Root cause

Discord voice already kept receiving PCM during outbound speech, and the continuous mixer already exposed a thread-safe `stop_speech()` method. The adapter never connected inbound speech start to that playback-control seam, so replies always played to completion.

## Test plan

- `python -m pytest tests/gateway/test_discord_voice_mixer.py tests/gateway/test_voice_command.py tests/gateway/test_discord_race_polish.py -q` — 103 passed
- `python -m pytest -m integration tests/integration/test_voice_channel_flow.py -q` — 34 passed
- `git diff --check origin/main...HEAD`

## Notes

The callback fires once per mapped, authorized utterance and executes outside the receiver lock. Unknown or unauthorized users cannot interrupt playback. Mixer speech is stopped without tearing down the continuous stream; the legacy fallback calls `VoiceClient.stop()` only when playback is active.
