### PR TITLE
fix(tools): pass RFC 9207 iss through dashboard OAuth callback bridge

### DIFF
--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -338,6 +338,7 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    iss: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -360,7 +361,7 @@ async def mcp_oauth_callback(
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
     try:
-        flow.deliver_callback(code=code, state=state, error=error)
+        flow.deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         reason = str(exc)
         status_code = 409 if "already received" in reason else 400

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -26,8 +26,30 @@ def test_dashboard_flow_exposes_authorization_url_and_accepts_callback():
         "error": None,
     }
 
-    flow.deliver_callback(code="code-1", state="s1", error=None)
-    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1")
+    flow.deliver_callback(
+        code="code-1", state="s1", error=None, iss="https://idp.example"
+    )
+    assert asyncio.run(flow.wait_for_callback()) == (
+        "code-1",
+        "s1",
+        "https://idp.example",
+    )
+
+
+def test_dashboard_flow_callback_without_iss_returns_none_iss():
+    """Legacy callback producers that omit RFC 9207 iss still round-trip."""
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-iss-none",
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://agent.example/mcp/oauth/callback/flow-iss-none",
+    )
+    asyncio.run(flow.publish_authorization_url("https://idp.example/authorize?state=s9"))
+    flow.deliver_callback(code="code-9", state="s9", error=None)
+    assert asyncio.run(flow.wait_for_callback()) == ("code-9", "s9", None)
 
 
 def test_dashboard_flow_accepts_only_one_concurrent_callback():

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -33,6 +33,7 @@ class DashboardOAuthFlow:
     tools: list[dict] = field(default_factory=list)
     expected_state: str | None = field(default=None, init=False)
     _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    _callback_iss: str | None = field(default=None, init=False, repr=False)
     _callback_error: str | None = field(default=None, init=False, repr=False)
     _authorization_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
     _callback_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
@@ -65,6 +66,7 @@ class DashboardOAuthFlow:
         code: str | None,
         state: str | None,
         error: str | None,
+        iss: str | None = None,
     ) -> None:
         with self._lock:
             if self._callback_ready.is_set():
@@ -81,9 +83,15 @@ class DashboardOAuthFlow:
                 self._callback = (code, state)
             else:
                 self._callback_error = "OAuth callback did not include code or error"
+            # RFC 9207 issuer — the SDK validates it against discovered
+            # metadata when the server advertised
+            # `authorization_response_iss_parameter_supported` (e.g. Resend).
+            self._callback_iss = iss
             self._callback_ready.set()
 
-    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None]:
+    async def wait_for_callback(
+        self, timeout: float = 300.0
+    ) -> tuple[str, str | None, str | None]:
         ready = await asyncio.to_thread(self._callback_ready.wait, timeout)
         if not ready:
             raise TimeoutError("Timed out waiting for MCP OAuth callback")
@@ -91,7 +99,8 @@ class DashboardOAuthFlow:
             raise RuntimeError(f"OAuth authorization failed: {self._callback_error}")
         if self._callback is None:
             raise RuntimeError("OAuth callback did not include an authorization code")
-        return self._callback
+        code, state = self._callback
+        return code, state, self._callback_iss
 
     def mark_approved(self) -> None:
         with self._lock:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -953,8 +953,8 @@ def _make_callback_waiter(
         if dashboard_flow is not None:
             # The dashboard flow still speaks the legacy tuple; normalize it
             # here so both callback sources hand the SDK one shape.
-            dash_code, dash_state = await dashboard_flow.wait_for_callback()
-            return _authorization_code_result(dash_code, dash_state)
+            dash_code, dash_state, dash_iss = await dashboard_flow.wait_for_callback()
+            return _authorization_code_result(dash_code, dash_state, dash_iss)
 
         # Reject before binding the callback listener in non-interactive
         # contexts. Reaching here means the SDK entered the authorization-code

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -95,10 +95,11 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
             code = (qs.get("code") or [None])[0]
             state = (qs.get("state") or [None])[0]
             error = (qs.get("error") or [None])[0]
+            iss = (qs.get("iss") or [None])[0]  # RFC 9207
             body = b"<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>"
             status = 200
             try:
-                flow.deliver_callback(code=code, state=state, error=error)
+                flow.deliver_callback(code=code, state=state, error=error, iss=iss)
             except Exception:
                 body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
                 status = 400


### PR DESCRIPTION
fix(tools): pass RFC 9207 iss through dashboard OAuth callback bridge (#92758)

## What & why

MCP OAuth login initiated from the desktop app fails against any
authorization server advertising `authorization_response_iss_parameter_supported: true`
(RFC 9207) — e.g. Resend (`https://mcp.resend.com/mcp` → `api.resend.com`).
The mcp 2.x SDK validates the `iss` parameter on the authorization response
when the server advertises the flag
(`validate_authorization_response_iss()`), so dropping it rejects every login:

```
OAuthFlowError: Authorization response missing iss parameter advertised by the authorization server
```

The CLI loopback handler already parses `iss` (`tools/mcp_oauth.py`,
`_make_callback_handler()`), but the desktop/dashboard callback bridge does
not: `DashboardOAuthFlow.deliver_callback(code, state, error)` discards the
parameter, and `_make_callback_waiter()`'s dashboard branch calls
`_authorization_code_result(code, state)` without one.

This threads `iss` through the whole dashboard bridge:

- `tools/mcp_dashboard_oauth.py`: optional `iss` kwarg on `deliver_callback()`,
  stored field, `wait_for_callback()` now returns `(code, state, iss)`
- `tools/mcp_oauth.py`: dashboard branch unpacks the third element and passes
  it into `AuthorizationCodeResult`
- `tui_gateway/mcp_oauth_sessions.py`: loopback listener parses `iss` from the
  query string and forwards it
- `hermes_cli/web_routers/mcp.py`: `/api/mcp/oauth/callback/{server_name}`
  accepts the `iss` query param and forwards it

Producers that omit `iss` (servers not advertising the flag) round-trip as
`None`, which the SDK accepts unchanged — no behavior change for existing
providers (Linear, Vercel verified unaffected).

## How to test

```
scripts/run_tests.sh tests/tools/test_mcp_dashboard_oauth.py tests/tools/test_mcp_oauth.py \
    tests/tools/test_mcp_cimd.py tests/tools/test_mcp_oauth_bidirectional.py \
    tests/tools/test_mcp_oauth_integration.py tests/tools/test_mcp_oauth_manager.py
```

Manual repro (before fix fails, after fix succeeds):

1. `hermes mcp install resend`
2. Authorize from the desktop app → before: server parks with the
   OAuthFlowError above; after: connects.
3. Cross-check `hermes mcp test resend` reports connected + tools discovered.

New regression test:
`test_dashboard_flow_callback_without_iss_returns_none_iss` covers legacy
producers omitting `iss`; the existing callback test now asserts `iss`
round-trips end to end.

## Platforms tested

macOS 26.6.1 (arm64), Python 3.11.16. No platform-specific code touched;
the change only adds an already-parsed query parameter passthrough.

Fixes #92758
