### PR TITLE
fix(agent): honor explicit model_overrides.supports_reasoning in the reasoning gate

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7623,7 +7623,19 @@ class AIAgent:
         OpenRouter forwards unknown extra_body fields to upstream providers.
         Some providers/routes reject `reasoning` with 400s, so gate it to
         known reasoning-capable model families and direct Nous Portal.
+
+        An explicit ``model_overrides.<provider>.<model>.supports_reasoning``
+        wins over every route-based heuristic below: the operator knows their
+        model's capability better than a hostname guess, and this is the only
+        way to express it for endpoints with no built-in probe (#92759).
         """
+        try:
+            from agent.models_dev import _explicit_model_override
+            override = _explicit_model_override(self.provider, self.model)
+        except Exception:
+            override = None
+        if override is not None and "supports_reasoning" in override:
+            return bool(override["supports_reasoning"])
         if base_url_host_matches(self._base_url_lower, "nousresearch.com"):
             return True
         if base_url_host_matches(self._base_url_lower, "ai-gateway.vercel.sh"):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6913,6 +6913,32 @@ class TestSupportsReasoningExtraBody:
             agent.model = model
             assert agent._supports_reasoning_extra_body() is True, model
 
+    def test_explicit_override_enables_reasoning_on_unrouted_host(self):
+        """model_overrides.<provider>.<model>.supports_reasoning=true wins
+        even for a host/provider none of the route heuristics recognize
+        (e.g. a local Ollama server reached through provider: custom)."""
+        agent = self._make_agent()
+        agent.provider = "custom"
+        agent.base_url = "http://127.0.0.1:11435/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "hermes-maritime:latest"
+        with patch(
+            "agent.models_dev._explicit_model_override",
+            return_value={"supports_reasoning": True},
+        ):
+            assert agent._supports_reasoning_extra_body() is True
+
+    def test_explicit_override_disables_reasoning_on_otherwise_capable_route(self):
+        """An explicit supports_reasoning: false overrides a route that
+        would otherwise say True (e.g. a deepseek/ model on OpenRouter)."""
+        agent = self._make_agent()
+        agent.model = "deepseek/deepseek-v4"
+        with patch(
+            "agent.models_dev._explicit_model_override",
+            return_value={"supports_reasoning": False},
+        ):
+            assert agent._supports_reasoning_extra_body() is False
+
 
 class TestMemoryContextSanitization:
     """sanitize_context() helper correctness — used at provider boundaries."""


### PR DESCRIPTION
## What

`AIAgent._supports_reasoning_extra_body()` (`run_agent.py`) decides whether to emit
reasoning parameters purely by route — hostname/provider checks (Nous Portal, Vercel
AI Gateway, GitHub Models/Copilot, LM Studio probe, `ollama.com` probe, OpenRouter
model-prefix list). Everything else falls through to `False`.

That leaves operators on a self-hosted or unrecognized OpenAI-compatible endpoint
(e.g. a local Ollama server behind `provider: custom`) with no way to say "this model
supports reasoning" even though `model_overrides.<provider>.<model>.supports_reasoning`
is already a documented, first-class override field (`agent/models_dev.py:860-884`)
that `get_model_capabilities()` already consults elsewhere in the codebase. There were
no references to `model_overrides` anywhere in `run_agent.py`.

## Fix

Consult the explicit override first, via the existing `_explicit_model_override()`
resolver in `agent/models_dev.py` (no new key space, no new machinery), before any
hostname/provider heuristic runs. Operator intent wins when set; everything falls
through to the unchanged existing route-based logic when it isn't. Only *explicit*
per-model overrides participate — the `_default` fill-gap entries are intentionally
not consulted here, matching the "operator intent wins" precedence the issue asks for.

This deliberately scopes to just the `model_overrides` half of the issue's proposal.
The issue's other ask — widening the Ollama `/api/show` probe beyond `ollama.com` to
any Ollama-compatible host — is already covered by other open PRs against this same
function (e.g. #86197, #83566) and is left untouched here to avoid overlapping edits
on the same lines.

## Testing

Added two tests to `TestSupportsReasoningExtraBody` in `tests/run_agent/test_run_agent.py`:

- `test_explicit_override_enables_reasoning_on_unrouted_host` — a `provider: custom`
  agent pointed at a local Ollama server (a host none of the existing route checks
  recognize) with `supports_reasoning: true` in `model_overrides` now reports
  reasoning-capable.
- `test_explicit_override_disables_reasoning_on_otherwise_capable_route` — an explicit
  `supports_reasoning: false` overrides a route that would otherwise say `True` (a
  `deepseek/` model on OpenRouter).

Confirmed both fail without the fix (`git checkout HEAD~1 -- run_agent.py`):

```
FAILED tests/run_agent/test_run_agent.py::TestSupportsReasoningExtraBody::test_explicit_override_enables_reasoning_on_unrouted_host - assert False is True
FAILED tests/run_agent/test_run_agent.py::TestSupportsReasoningExtraBody::test_explicit_override_disables_reasoning_on_otherwise_capable_route - assert True is False
2 failed, 1 passed, 274 deselected in 3.49s
```

And pass with it:

```
$ python -m pytest tests/run_agent/test_run_agent.py -k TestSupportsReasoningExtraBody -q
...                                                                      [100%]
3 passed, 274 deselected in 1.13s
```

Full existing suite, green:

```
$ python -m pytest tests/run_agent/test_run_agent.py -q
277 passed, 1 warning in 55.86s

$ python -m pytest tests/agent/test_models_dev.py -q
68 passed in 0.78s

$ ruff check run_agent.py tests/run_agent/test_run_agent.py
All checks passed!
```

Fixes #92759

## AI assistance disclosure

This change was authored with the assistance of an AI coding agent (Claude).
