### PR TITLE
fix(update): fork updates that pull upstream code now run the full post-update path (#73108, salvage #73679)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6181,12 +6181,31 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # not behind, fall through to the up-to-date path.
             commit_count = counted if counted is not None else -1
 
+        # A fork can match origin while still trailing upstream. The sync can
+        # therefore advance HEAD even though the origin comparison found no
+        # commits. Detect that BEFORE taking the no-update return so dependency
+        # refreshes, gateway restarts, AND the fleet version matrix still run
+        # for the pulled code (#73108 — previously the sync lived inside the
+        # commit_count == 0 branch, which returns immediately after: an update
+        # that pulled hundreds of upstream commits printed "Already up to
+        # date!" and verified nothing).
+        if commit_count == 0 and is_fork and branch == "main":
+            pre_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
+            _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
+            post_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
+            if pre_sync_sha and post_sync_sha and pre_sync_sha != post_sync_sha:
+                synced_count = _count_commits_between(
+                    git_cmd,
+                    _m().PROJECT_ROOT,
+                    pre_sync_sha,
+                    post_sync_sha,
+                )
+                # HEAD moving is itself proof of an update. Keep the update
+                # path active even if the informational count cannot be read.
+                commit_count = max(1, synced_count)
+
         if commit_count == 0:
             _invalidate_update_cache()
-
-            # Even if origin is up to date, the fork may be behind upstream
-            if is_fork and branch == "main":
-                _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
 
             # Restore stash and switch back to original branch if we moved.
             # EXCEPTION: a parked feature branch we verified clean + fully

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -252,6 +252,42 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_fork_upstream_sync_that_moves_head_runs_post_update_steps(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """A fork sync that pulls code must continue through post-update work."""
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        # The first two reads bracket the upstream sync; later reads see the
+        # new HEAD while the normal update path finishes.
+        shas = iter(["aaaaaaa", "bbbbbbb"])
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(
+            update_cmd,
+            "_capture_head_sha",
+            side_effect=lambda *_args, **_kwargs: next(shas, "bbbbbbb"),
+        ), patch.object(
+            hm, "_sync_with_upstream_if_needed"
+        ), patch.object(
+            hm, "_reload_updated_runtime_modules"
+        ) as post_update_step:
+            cmd_update(mock_args)
+
+        post_update_step.assert_called_once_with()
+        captured = capsys.readouterr()
+        assert "Already up to date!" not in captured.out
+
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""
         with patch("shutil.which", return_value=None), patch(

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -265,9 +265,12 @@ class TestCmdUpdateBranchFallback:
             branch="main", verify_ok=True, commit_count="0"
         )
 
-        # The first two reads bracket the upstream sync; later reads see the
-        # new HEAD while the normal update path finishes.
-        shas = iter(["aaaaaaa", "bbbbbbb"])
+        # The first two reads bracket the upstream sync (aaaaaaa -> bbbbbbb:
+        # the sync moved HEAD). The NEXT two bracket the pull inside the
+        # normal update path (bbbbbbb -> ccccccc) — the head-moved no-op
+        # guard added after this PR exits 1 when that pair is equal, so the
+        # mock must show the pull advancing HEAD too.
+        shas = iter(["aaaaaaa", "bbbbbbb", "bbbbbbb", "ccccccc"])
 
         with patch.object(
             hm,
@@ -276,14 +279,45 @@ class TestCmdUpdateBranchFallback:
         ), patch.object(
             update_cmd,
             "_capture_head_sha",
-            side_effect=lambda *_args, **_kwargs: next(shas, "bbbbbbb"),
+            side_effect=lambda *_args, **_kwargs: next(shas, "ccccccc"),
+        ), patch(
+            # The full post-update path runs the fleet version check, which
+            # reads the REAL machine's profile gateway_state.json files —
+            # live gateways on a dev box read as STALE vs this checkout and
+            # exit 1. Pin an empty fleet: this test asserts the post-update
+            # path RUNS, not the fleet's health.
+            "hermes_cli.update_receipt.collect_fleet_versions",
+            return_value=[],
+        ), patch(
+            # Same isolation for the restart phase: without these, the real
+            # machine's live gateways enter the restart discovery, the
+            # mocked-subprocess restart phase can't verify replacements, and
+            # the fail-closed contract (#78574) exits 1 (locally the
+            # live-system guard blocks the os.kill outright).
+            "hermes_cli.gateway.find_gateway_pids",
+            return_value=[],
+        ), patch(
+            "hermes_cli.gateway.find_profile_gateway_processes",
+            return_value=[],
+        ), patch(
+            "hermes_cli.gateway._get_service_pids",
+            return_value=set(),
         ), patch.object(
             hm, "_sync_with_upstream_if_needed"
         ), patch.object(
-            hm, "_reload_updated_runtime_modules"
+            hm,
+            "_reload_updated_runtime_modules",
+            # Reaching the reload step IS the proof the post-update path ran
+            # (the bug returned from "Already up to date!" before it). Abort
+            # the pipeline right here: everything past this point (skills
+            # sync, desktop rebuild, gateway restart, fleet check) would run
+            # for real against the host machine.
+            side_effect=SystemExit(0),
         ) as post_update_step:
-            cmd_update(mock_args)
+            with pytest.raises(SystemExit) as exit_info:
+                cmd_update(mock_args)
 
+        assert exit_info.value.code == 0
         post_update_step.assert_called_once_with()
         captured = capsys.readouterr()
         assert "Already up to date!" not in captured.out


### PR DESCRIPTION
## Summary

A fork's `hermes update` that pulls hundreds of upstream commits no longer prints "Already up to date!" and skips everything — the upstream sync now runs BEFORE the no-update decision, so a HEAD-moving sync flows through the full post-update path: dependency sync, gateway restart, and the fleet version matrix (#73108's remaining leg; salvage of #73679 by @francip).

Root cause: `_sync_with_upstream_if_needed` lived INSIDE the `commit_count == 0` branch, which returns immediately after — an update that pulled real code verified nothing (and on fork installs, bypassed the Phase-1 fleet matrix entirely).

## Changes

- `hermes_cli/update_cmd.py` (@francip): hoist the fork sync above the no-update decision; if HEAD moved across the sync, set `commit_count` from the moved range (min 1) so the normal update path runs. Reconciled with the shallow-repo commit-count block and the parked-branch stash handling that landed since his branch.
- `tests/hermes_cli/test_cmd_update.py` (@francip + ours): his regression test, hardened for host isolation — pinned fleet/gateway discovery (real dev-box gateways read STALE / trip the live-system guard) and the pipeline aborts at `_reload_updated_runtime_modules`, the exact proof point the bug never reached.

## Validation

| Check | Result |
|---|---|
| `test_cmd_update.py` | new test passes; failure set byte-identical to origin/main on this host (6 pre-existing env-shaped reds, CI is arbiter) |
| Sabotage run (hoist disabled = old behavior) | regression test FAILS — proves the fix |
| Attribution | @francip's commit cherry-picked with authorship intact |

Closes the fork leg of #73108; part of the Phase-1 completion pass on #91277 (the matrix now runs on fork updates too).

## Infographic

![The update that lied](https://v3b.fal.media/files/b/0aa7763b/QQ1RcGeLY_B6zWVqrE78x_ERU3PLPb.png)
