### PR TITLE
fix(security): profile exports never land in source checkouts; CI rejects archive artifacts (salvage #92689)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -111,6 +111,5 @@ plans/
 /log.txt
 /sqlite_leak_fix.png
 /*.png.bak
-/default.tar.gz
 *.tar.gz
 *.tgz

--- a/.dockerignore
+++ b/.dockerignore
@@ -107,9 +107,10 @@ plans/
 .hadolint.yaml
 .mailmap
 
-# Repo-root debug/export artifacts — must never reach image layers (COPY . .)
+# Debug/export artifacts — must never reach image layers (COPY . .)
 /log.txt
 /sqlite_leak_fix.png
 /*.png.bak
 /default.tar.gz
-/*.tar.gz
+*.tar.gz
+*.tgz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,6 +166,11 @@ jobs:
     needs: detect
     uses: ./.github/workflows/infographic-check.yml
 
+  profile-artifact-check:
+    name: Profile artifact check
+    needs: detect
+    uses: ./.github/workflows/profile-artifact-check.yml
+
   lockfile-diff:
     name: package-lock.json diff
     needs: detect
@@ -230,6 +235,7 @@ jobs:
       - uv-lockfile
       - lockfile-diff
       - docker-lint
+      - profile-artifact-check
       - supply-chain
       - review-labels
       - osv-scanner

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Reject profile exports in the build context
+        run: python3 scripts/ci/check_profile_archive_boundary.py
+
       # Retry once on transient Docker Hub / buildkit pull failures
       # (connection reset, auth token timeout, rate limiting). The action
       # generates a unique builder name per invocation so the retry doesn't
@@ -205,6 +208,9 @@ jobs:
     steps:
       - name: Checkout trusted source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Reject profile exports in the build context
+        run: python3 scripts/ci/check_profile_archive_boundary.py
 
       # Retry once on transient Docker Hub / buildkit pull failures.
       # See build job for rationale; same pattern.

--- a/.github/workflows/profile-artifact-check.yml
+++ b/.github/workflows/profile-artifact-check.yml
@@ -1,0 +1,21 @@
+name: Profile Artifact Boundary
+
+# A reusable, unconditional guard for the incident class in #92457. Ignore
+# files reduce accidental staging; this job is the enforcement boundary that
+# still catches `git add -f` and generated files present during a build.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check-profile-artifacts:
+    name: Reject profile archives
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Reject profile exports in the checkout
+        run: python3 scripts/ci/check_profile_archive_boundary.py

--- a/.gitignore
+++ b/.gitignore
@@ -99,11 +99,12 @@ apps/desktop/src/**/*.d.ts
 !apps/desktop/src/global.d.ts
 !apps/desktop/src/vite-env.d.ts
 
-# Repo-root build/debug artifacts that must never be committed
+# Build/debug artifacts that must never be committed
 /log.txt
 /sqlite_leak_fix.png
 /*.png.bak
-/default.tar.gz
+*.tar.gz
+*.tgz
 apps/shared/src/**/*.js
 apps/shared/src/**/*.js.map
 apps/shared/src/**/*.d.ts

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -404,7 +404,11 @@ class CLICommandsMixin:
             /export <profile>             — export a named profile
             /export [profile] -o <path>   — choose the output path
         """
-        from hermes_cli.profiles import export_profile, get_active_profile_name
+        from hermes_cli.profiles import (
+            export_profile,
+            get_active_profile_name,
+            get_profile_export_path,
+        )
 
         parts = command.split()[1:]
         output = None
@@ -418,7 +422,7 @@ class CLICommandsMixin:
 
         name = parts[0] if parts else (get_active_profile_name() or "default")
         if not output:
-            output = f"{name}.tar.gz"
+            output = str(get_profile_export_path(name))
 
         try:
             result = export_profile(name, output)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -421,14 +421,14 @@ class CLICommandsMixin:
             parts = parts[:idx] + parts[idx + 2:]
 
         name = parts[0] if parts else (get_active_profile_name() or "default")
-        if not output:
-            output = str(get_profile_export_path(name))
 
         try:
+            if not output:
+                output = str(get_profile_export_path(name))
             result = export_profile(name, output)
             print(f"  ✓ Exported '{name}' to {result}")
             print("  Share it: the other user runs /import or `hermes profile import <archive>`.")
-        except (ValueError, FileNotFoundError) as e:
+        except (ValueError, FileNotFoundError, OSError) as e:
             print(f"  Error: {e}")
 
     def _handle_import_command(self, command: str):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10766,10 +10766,10 @@ def cmd_profile(args):
             sys.exit(1)
 
     elif action == "export":
-        from hermes_cli.profiles import export_profile
+        from hermes_cli.profiles import export_profile, get_profile_export_path
 
         name = args.profile_name
-        output = args.output or f"{name}.tar.gz"
+        output = args.output or str(get_profile_export_path(name))
         try:
             result_path = export_profile(name, output)
             print(f"✓ Exported '{name}' to {result_path}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10769,11 +10769,11 @@ def cmd_profile(args):
         from hermes_cli.profiles import export_profile, get_profile_export_path
 
         name = args.profile_name
-        output = args.output or str(get_profile_export_path(name))
         try:
+            output = args.output or str(get_profile_export_path(name))
             result_path = export_profile(name, output)
             print(f"✓ Exported '{name}' to {result_path}")
-        except (ValueError, FileNotFoundError) as e:
+        except (ValueError, FileNotFoundError, OSError) as e:
             print(f"Error: {e}")
             sys.exit(1)
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2022,7 +2022,8 @@ def _inside_git_checkout(path: Path) -> bool:
     """
     try:
         resolved = path.resolve()
-    except OSError:
+    except (OSError, RuntimeError):
+        # RuntimeError: symlink loops on Python <= 3.12; fail closed either way.
         return True
     return any(
         (candidate / ".git").exists() for candidate in (resolved, *resolved.parents)
@@ -2041,9 +2042,12 @@ def _profile_export_directory() -> Path:
     # not put the automatic archive under that tree; use a sibling store and
     # fall back to the OS temp directory only for the unusual case where the
     # user's home itself is a checkout (e.g. a dotfiles repo).
+    # Per-uid temp name: a fixed /tmp/hermes-profile-exports is a predictable
+    # shared path another local user could pre-create (or symlink) before us.
+    uid_suffix = f"-{os.getuid()}" if hasattr(os, "getuid") else ""
     candidates = (
         Path.home() / ".hermes-profile-exports",
-        Path(tempfile.gettempdir()) / "hermes-profile-exports",
+        Path(tempfile.gettempdir()) / f"hermes-profile-exports{uid_suffix}",
     )
     for candidate in candidates:
         if not _inside_git_checkout(candidate):
@@ -2053,8 +2057,8 @@ def _profile_export_directory() -> Path:
     # would not stop a scripted export from recreating it.
     raise ValueError(
         "No safe automatic export destination: every candidate directory is "
-        "inside a Git checkout. Pass an explicit output path outside the "
-        "checkout (e.g. -o /path/outside/repo/profile.tar.gz)."
+        "inside a Git checkout. Provide an explicit output path outside the "
+        "checkout (CLI: -o /path/outside/repo/profile.tar.gz)."
     )
 
 
@@ -2070,6 +2074,20 @@ def get_profile_export_path(name: str, *, timestamp: Optional[str] = None) -> Pa
     validate_profile_name(canon)
     export_dir = _profile_export_directory()
     export_dir.mkdir(parents=True, exist_ok=True)
+    # exist_ok=True would silently accept a directory (or symlink) another
+    # local user pre-created at a predictable path; refuse to write a
+    # secret-bearing archive anywhere we don't own.
+    if export_dir.is_symlink():
+        raise ValueError(
+            f"Export directory {export_dir} is a symlink; refusing to write "
+            "a profile archive through it. Provide an explicit output path."
+        )
+    if hasattr(os, "getuid") and export_dir.stat().st_uid != os.getuid():
+        raise ValueError(
+            f"Export directory {export_dir} is owned by another user; "
+            "refusing to write a profile archive there. Provide an explicit "
+            "output path."
+        )
     stamp = timestamp or time.strftime("%Y%m%d-%H%M%S")
     return export_dir / f"{canon}-{stamp}.tar.gz"
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2009,45 +2009,51 @@ def get_active_profile_name() -> str:
 # Export / Import
 # ---------------------------------------------------------------------------
 
+def _inside_git_checkout(path: Path) -> bool:
+    """Return True when *path* lies inside a Git checkout.
+
+    Walks the path's OWN resolved ancestry for a ``.git`` marker (a directory
+    for normal clones, a file for worktrees/submodules).  Anchoring on the
+    candidate path — not on ``Path.cwd()`` — keeps the safety proof valid when
+    ``HERMES_HOME`` points inside a checkout but the process runs from
+    somewhere else entirely (cron, a service manager, an absolute-path
+    invocation).  On resolution failure we conservatively report True so the
+    caller falls through to a provably safe candidate.
+    """
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return True
+    return any(
+        (candidate / ".git").exists() for candidate in (resolved, *resolved.parents)
+    )
+
+
 def _profile_export_directory() -> Path:
     """Choose an export directory that cannot become source-tree input."""
+    import tempfile
+
     export_dir = _get_default_hermes_home() / "profile-exports"
-    try:
-        cwd = Path.cwd().resolve()
-    except OSError:
-        return export_dir
-
-    checkout_root = next(
-        (
-            candidate
-            for candidate in (cwd, *cwd.parents)
-            if (candidate / ".git").exists()
-        ),
-        None,
-    )
-    if checkout_root is None:
-        return export_dir
-
-    try:
-        export_dir.resolve().relative_to(checkout_root.resolve())
-    except ValueError:
+    if not _inside_git_checkout(export_dir):
         return export_dir
 
     # A custom deployment may point HERMES_HOME at its source checkout.  Do
     # not put the automatic archive under that tree; use a sibling store and
     # fall back to the OS temp directory only for the unusual case where the
-    # user's home itself is the checkout.
-    candidates = [
+    # user's home itself is a checkout (e.g. a dotfiles repo).
+    candidates = (
         Path.home() / ".hermes-profile-exports",
-    ]
-    import tempfile
-
-    candidates.append(Path(tempfile.gettempdir()) / "hermes-profile-exports")
+        Path(tempfile.gettempdir()) / "hermes-profile-exports",
+    )
     for candidate in candidates:
-        try:
-            candidate.resolve().relative_to(checkout_root.resolve())
-        except ValueError:
+        if not _inside_git_checkout(candidate):
             return candidate
+    logger.warning(
+        "Every managed export destination resolves inside a Git checkout; "
+        "falling back to %s. Pass an explicit output path to avoid staging "
+        "profile archives in a source tree.",
+        export_dir,
+    )
     return export_dir
 
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2048,13 +2048,14 @@ def _profile_export_directory() -> Path:
     for candidate in candidates:
         if not _inside_git_checkout(candidate):
             return candidate
-    logger.warning(
-        "Every managed export destination resolves inside a Git checkout; "
-        "falling back to %s. Pass an explicit output path to avoid staging "
-        "profile archives in a source tree.",
-        export_dir,
+    # Fail closed: writing a secret-bearing archive into a source tree is the
+    # incident this helper exists to prevent (#92457). A warning on stderr
+    # would not stop a scripted export from recreating it.
+    raise ValueError(
+        "No safe automatic export destination: every candidate directory is "
+        "inside a Git checkout. Pass an explicit output path outside the "
+        "checkout (e.g. -o /path/outside/repo/profile.tar.gz)."
     )
-    return export_dir
 
 
 def get_profile_export_path(name: str, *, timestamp: Optional[str] = None) -> Path:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2009,6 +2009,63 @@ def get_active_profile_name() -> str:
 # Export / Import
 # ---------------------------------------------------------------------------
 
+def _profile_export_directory() -> Path:
+    """Choose an export directory that cannot become source-tree input."""
+    export_dir = _get_default_hermes_home() / "profile-exports"
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return export_dir
+
+    checkout_root = next(
+        (
+            candidate
+            for candidate in (cwd, *cwd.parents)
+            if (candidate / ".git").exists()
+        ),
+        None,
+    )
+    if checkout_root is None:
+        return export_dir
+
+    try:
+        export_dir.resolve().relative_to(checkout_root.resolve())
+    except ValueError:
+        return export_dir
+
+    # A custom deployment may point HERMES_HOME at its source checkout.  Do
+    # not put the automatic archive under that tree; use a sibling store and
+    # fall back to the OS temp directory only for the unusual case where the
+    # user's home itself is the checkout.
+    candidates = [
+        Path.home() / ".hermes-profile-exports",
+    ]
+    import tempfile
+
+    candidates.append(Path(tempfile.gettempdir()) / "hermes-profile-exports")
+    for candidate in candidates:
+        try:
+            candidate.resolve().relative_to(checkout_root.resolve())
+        except ValueError:
+            return candidate
+    return export_dir
+
+
+def get_profile_export_path(name: str, *, timestamp: Optional[str] = None) -> Path:
+    """Return a managed destination for an export with no explicit output.
+
+    Keep automatic exports outside the current working directory and outside
+    every named profile.  The CLI is commonly run from a source checkout; its
+    old ``<name>.tar.gz`` default therefore made a profile snapshot look like
+    a repository artifact and allowed it to be committed accidentally.
+    """
+    canon = normalize_profile_name(name)
+    validate_profile_name(canon)
+    export_dir = _profile_export_directory()
+    export_dir.mkdir(parents=True, exist_ok=True)
+    stamp = timestamp or time.strftime("%Y%m%d-%H%M%S")
+    return export_dir / f"{canon}-{stamp}.tar.gz"
+
 def _default_export_ignore(root_dir: Path):
     """Return an *ignore* callable for :func:`shutil.copytree`.
 

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -135,7 +135,9 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
     )
     profile_export.add_argument("profile_name", help="Profile to export")
     profile_export.add_argument(
-        "-o", "--output", default=None, help="Output file (default: <name>.tar.gz)"
+        "-o", "--output", default=None,
+        help="Output file (default: a managed profile-exports/<name>-<timestamp>.tar.gz "
+             "under the default Hermes home)",
     )
 
     profile_import = profile_subparsers.add_parser(

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -1173,14 +1173,12 @@ async def export_profile_endpoint(name: str, body: ProfileExport):
 
     output = (body.output or "").strip()
     if not output:
-        from hermes_constants import get_hermes_home
-        staging = get_hermes_home() / "profile-exports"
         try:
-            staging.mkdir(parents=True, exist_ok=True)
+            output = str(profiles_mod.get_profile_export_path(name))
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
         except OSError as exc:
             raise HTTPException(status_code=500, detail=f"Could not create export directory: {exc}")
-        stamp = time.strftime("%Y%m%d-%H%M%S")
-        output = str(staging / f"{profiles_mod.normalize_profile_name(name)}-{stamp}.tar.gz")
 
     loop = asyncio.get_running_loop()
     try:

--- a/scripts/ci/check_profile_archive_boundary.py
+++ b/scripts/ci/check_profile_archive_boundary.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Reject profile export archives before publication.
+
+``.gitignore`` and ``.dockerignore`` are useful first-line filters, but both
+can be bypassed (for example with ``git add -f`` or a non-standard build
+context).  This check is the blocking, executable policy at the CI and image
+publication boundaries.  It intentionally checks the filesystem rather than
+Git's index so a generated archive cannot enter a build after checkout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+_PROFILE_ARCHIVE_SUFFIXES = (".tar.gz", ".tgz")
+
+
+def find_forbidden_profile_archives(root: Path) -> list[Path]:
+    """Return profile archive paths anywhere in the checkout."""
+    root = root.resolve()
+    if not root.is_dir():
+        raise ValueError(f"repository root is not a directory: {root}")
+
+    offenders: list[Path] = []
+    for directory, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [
+            name
+            for name in dirnames
+            if name not in {".git", ".venv", "venv", "node_modules", "__pycache__"}
+        ]
+        for name in (*dirnames, *filenames):
+            if name.casefold().endswith(_PROFILE_ARCHIVE_SUFFIXES):
+                offenders.append((Path(directory) / name).relative_to(root))
+
+    return sorted(offenders, key=lambda path: path.as_posix().casefold())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject profile export archives in the checkout."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help="repository root to inspect (default: current directory)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        offenders = find_forbidden_profile_archives(args.root)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    if not offenders:
+        print("No profile export archives detected in the checkout.")
+        return 0
+
+    print(
+        "::error::profile export archives are forbidden "
+        "in source and Docker build contexts"
+    )
+    for path in offenders:
+        print(f"  {path.as_posix()}")
+    print(
+        "Move the archive outside the checkout or pass an explicit external "
+        "output path to the profile export command."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_profile_export_default_path.py
+++ b/tests/hermes_cli/test_profile_export_default_path.py
@@ -172,3 +172,43 @@ async def test_profile_export_api_uses_the_shared_managed_destination(
     result = await router_mod.export_profile_endpoint("default", ProfileExport())
 
     assert result == {"ok": True, "archive": str(managed)}
+
+
+def test_cwd_in_unrelated_checkout_does_not_prove_safety(
+    tmp_path, monkeypatch, profiles
+):
+    """cwd inside unrelated checkout A must not stand in for the safety proof
+    of a HERMES_HOME inside checkout B."""
+    checkout_b = tmp_path / "checkout-b"
+    checkout_b.mkdir()
+    (checkout_b / ".git").mkdir()
+    checkout_a = tmp_path / "checkout-a"
+    checkout_a.mkdir()
+    (checkout_a / ".git").write_text("gitdir: ../git\n", encoding="utf-8")
+    monkeypatch.chdir(checkout_a)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: checkout_b)
+
+    result = profiles.get_profile_export_path("default", timestamp="20260823-120000")
+
+    assert not result.resolve().is_relative_to(checkout_b.resolve())
+    assert not result.resolve().is_relative_to(checkout_a.resolve())
+
+
+def test_every_candidate_inside_a_checkout_fails_closed(
+    tmp_path, monkeypatch, profiles
+):
+    """When home, sibling store, and tempdir all resolve inside checkouts the
+    helper must refuse — a warning would not stop a scripted export from
+    recreating the #92457 incident artifact."""
+    import tempfile
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / ".git").mkdir()
+    monkeypatch.setattr(Path, "home", lambda: checkout / "home")
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: checkout)
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(checkout / "tmp"))
+
+    with pytest.raises(ValueError, match="No safe automatic export destination"):
+        profiles.get_profile_export_path("default")

--- a/tests/hermes_cli/test_profile_export_default_path.py
+++ b/tests/hermes_cli/test_profile_export_default_path.py
@@ -212,3 +212,17 @@ def test_every_candidate_inside_a_checkout_fails_closed(
 
     with pytest.raises(ValueError, match="No safe automatic export destination"):
         profiles.get_profile_export_path("default")
+
+
+def test_export_dir_symlink_is_rejected(tmp_path, monkeypatch, profiles):
+    """A pre-created symlink at the managed export path (predictable-path
+    attack on shared hosts) must be refused, not silently followed."""
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (default_home / "profile-exports").symlink_to(elsewhere)
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+
+    with pytest.raises(ValueError, match="symlink"):
+        profiles.get_profile_export_path("default")

--- a/tests/hermes_cli/test_profile_export_default_path.py
+++ b/tests/hermes_cli/test_profile_export_default_path.py
@@ -1,0 +1,122 @@
+"""Regression coverage for safe automatic profile-export destinations."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import profiles
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+from hermes_cli.main import cmd_profile
+from hermes_cli.profiles import get_profile_export_path
+
+
+def test_default_export_path_is_managed_and_outside_named_profiles(
+    tmp_path, monkeypatch
+):
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
+    )
+
+    result = get_profile_export_path("Research-Bot", timestamp="20260823-120000")
+
+    assert (
+        result
+        == default_home / "profile-exports" / "research-bot-20260823-120000.tar.gz"
+    )
+    assert result.parent.is_dir()
+    assert not (default_home / "profiles" / "research-bot" / result.name).exists()
+
+
+def test_custom_hermes_home_inside_a_checkout_uses_a_sibling_store(
+    tmp_path, monkeypatch
+):
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / ".git").write_text("gitdir: ../git\n", encoding="utf-8")
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: checkout
+    )
+
+    result = get_profile_export_path("default", timestamp="20260823-120000")
+
+    assert not result.resolve().is_relative_to(checkout.resolve())
+
+
+def test_cli_export_default_does_not_write_into_the_current_checkout(
+    tmp_path, monkeypatch, capsys
+):
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    (default_home / "config.yaml").write_text("model: test\n", encoding="utf-8")
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root", lambda: default_home
+    )
+
+    cmd_profile(
+        Namespace(
+            profile_action="export",
+            profile_name="default",
+            output=None,
+        )
+    )
+
+    exported = list((default_home / "profile-exports").glob("default-*.tar.gz"))
+    assert len(exported) == 1
+    assert exported[0].parent == default_home / "profile-exports"
+    assert not (checkout / "default.tar.gz").exists()
+    assert str(exported[0]) in capsys.readouterr().out
+
+
+def test_slash_export_uses_the_same_managed_destination(tmp_path, monkeypatch):
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setattr(
+        "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
+    )
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    calls = []
+    monkeypatch.setattr(
+        profiles,
+        "export_profile",
+        lambda name, output: calls.append((name, output)) or output,
+    )
+
+    CLICommandsMixin()._handle_export_command("/export")
+
+    assert len(calls) == 1
+    assert calls[0][0] == "default"
+    assert Path(calls[0][1]).parent == default_home / "profile-exports"
+    assert not (tmp_path / "default.tar.gz").exists()
+
+
+@pytest.mark.asyncio
+async def test_profile_export_api_uses_the_shared_managed_destination(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.web_models import ProfileExport
+    from hermes_cli.web_routers.profiles import export_profile_endpoint
+
+    managed = tmp_path / "profile-exports" / "default-20260823-120000.tar.gz"
+    monkeypatch.setattr(profiles, "get_profile_export_path", lambda name: managed)
+    monkeypatch.setattr(
+        profiles,
+        "export_profile",
+        lambda name, output, extra_files=None: output,
+    )
+
+    result = await export_profile_endpoint("default", ProfileExport())
+
+    assert result == {"ok": True, "archive": str(managed)}

--- a/tests/hermes_cli/test_profile_export_default_path.py
+++ b/tests/hermes_cli/test_profile_export_default_path.py
@@ -2,27 +2,35 @@
 
 from __future__ import annotations
 
+import importlib
 from argparse import Namespace
 from pathlib import Path
 
 import pytest
 
-from hermes_cli import profiles
-from hermes_cli.cli_commands_mixin import CLICommandsMixin
-from hermes_cli.main import cmd_profile
-from hermes_cli.profiles import get_profile_export_path
+
+@pytest.fixture()
+def profiles():
+    """Resolve the live profiles module at call time.
+
+    Sibling test files reload ``hermes_cli.profiles`` / ``hermes_cli.main``;
+    a top-level ``from hermes_cli.profiles import ...`` here would bind the
+    pre-reload function objects and silently divorce this file's monkeypatches
+    from the code under test when the whole directory runs as one sweep.
+    """
+    return importlib.import_module("hermes_cli.profiles")
 
 
 def test_default_export_path_is_managed_and_outside_named_profiles(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, profiles
 ):
     default_home = tmp_path / ".hermes"
     default_home.mkdir()
-    monkeypatch.setattr(
-        "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
-    )
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
 
-    result = get_profile_export_path("Research-Bot", timestamp="20260823-120000")
+    result = profiles.get_profile_export_path(
+        "Research-Bot", timestamp="20260823-120000"
+    )
 
     assert (
         result
@@ -33,39 +41,81 @@ def test_default_export_path_is_managed_and_outside_named_profiles(
 
 
 def test_custom_hermes_home_inside_a_checkout_uses_a_sibling_store(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, profiles
 ):
     checkout = tmp_path / "checkout"
     checkout.mkdir()
     (checkout / ".git").write_text("gitdir: ../git\n", encoding="utf-8")
     monkeypatch.chdir(checkout)
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
-    monkeypatch.setattr(
-        "hermes_cli.profiles._get_default_hermes_home", lambda: checkout
-    )
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: checkout)
 
-    result = get_profile_export_path("default", timestamp="20260823-120000")
+    result = profiles.get_profile_export_path("default", timestamp="20260823-120000")
 
     assert not result.resolve().is_relative_to(checkout.resolve())
 
 
-def test_cli_export_default_does_not_write_into_the_current_checkout(
-    tmp_path, monkeypatch, capsys
+def test_checkout_detection_does_not_depend_on_cwd(tmp_path, monkeypatch, profiles):
+    """HERMES_HOME inside a checkout must be detected even when cwd is elsewhere.
+
+    Regression for the cwd-anchored bypass: cron/service-manager invocations
+    run from outside the checkout, and the original heuristic walked
+    ``Path.cwd()`` — letting the export land inside the source tree again.
+    """
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / ".git").write_text("gitdir: ../git\n", encoding="utf-8")
+    hermes_home = checkout / "data_home"
+    hermes_home.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)  # cwd has no .git ancestor inside tmp_path
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: hermes_home)
+
+    result = profiles.get_profile_export_path("default", timestamp="20260823-120000")
+
+    assert not result.resolve().is_relative_to(checkout.resolve())
+
+
+def test_cli_export_rejects_bad_profile_name_without_traceback(
+    tmp_path, monkeypatch, capsys, profiles
 ):
+    """A bad name must print a clean error — the helper raises before export."""
+    main_mod = importlib.import_module("hermes_cli.main")
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+
+    with pytest.raises(SystemExit):
+        main_mod.cmd_profile(
+            Namespace(
+                profile_action="export",
+                profile_name="bad//name",
+                output=None,
+            )
+        )
+
+    out = capsys.readouterr().out
+    assert "Error:" in out
+
+
+def test_cli_export_default_does_not_write_into_the_current_checkout(
+    tmp_path, monkeypatch, capsys, profiles
+):
+    main_mod = importlib.import_module("hermes_cli.main")
     default_home = tmp_path / ".hermes"
     default_home.mkdir()
     (default_home / "config.yaml").write_text("model: test\n", encoding="utf-8")
     checkout = tmp_path / "checkout"
     checkout.mkdir()
     monkeypatch.chdir(checkout)
-    monkeypatch.setattr(
-        "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
-    )
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
     monkeypatch.setattr(
         "hermes_constants.get_default_hermes_root", lambda: default_home
     )
 
-    cmd_profile(
+    main_mod.cmd_profile(
         Namespace(
             profile_action="export",
             profile_name="default",
@@ -80,12 +130,13 @@ def test_cli_export_default_does_not_write_into_the_current_checkout(
     assert str(exported[0]) in capsys.readouterr().out
 
 
-def test_slash_export_uses_the_same_managed_destination(tmp_path, monkeypatch):
+def test_slash_export_uses_the_same_managed_destination(
+    tmp_path, monkeypatch, profiles
+):
+    mixin_mod = importlib.import_module("hermes_cli.cli_commands_mixin")
     default_home = tmp_path / ".hermes"
     default_home.mkdir()
-    monkeypatch.setattr(
-        "hermes_cli.profiles._get_default_hermes_home", lambda: default_home
-    )
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
     monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
     calls = []
     monkeypatch.setattr(
@@ -94,7 +145,7 @@ def test_slash_export_uses_the_same_managed_destination(tmp_path, monkeypatch):
         lambda name, output: calls.append((name, output)) or output,
     )
 
-    CLICommandsMixin()._handle_export_command("/export")
+    mixin_mod.CLICommandsMixin()._handle_export_command("/export")
 
     assert len(calls) == 1
     assert calls[0][0] == "default"
@@ -104,10 +155,11 @@ def test_slash_export_uses_the_same_managed_destination(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_profile_export_api_uses_the_shared_managed_destination(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, profiles
 ):
     from hermes_cli.web_models import ProfileExport
-    from hermes_cli.web_routers.profiles import export_profile_endpoint
+
+    router_mod = importlib.import_module("hermes_cli.web_routers.profiles")
 
     managed = tmp_path / "profile-exports" / "default-20260823-120000.tar.gz"
     monkeypatch.setattr(profiles, "get_profile_export_path", lambda name: managed)
@@ -117,6 +169,6 @@ async def test_profile_export_api_uses_the_shared_managed_destination(
         lambda name, output, extra_files=None: output,
     )
 
-    result = await export_profile_endpoint("default", ProfileExport())
+    result = await router_mod.export_profile_endpoint("default", ProfileExport())
 
     assert result == {"ok": True, "archive": str(managed)}

--- a/tests/scripts/test_check_profile_archive_boundary.py
+++ b/tests/scripts/test_check_profile_archive_boundary.py
@@ -1,0 +1,57 @@
+"""Behavioral tests for the profile archive CI guard."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "ci"
+    / "check_profile_archive_boundary.py"
+)
+
+
+def _run(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_clean_root_passes(tmp_path):
+    result = _run(tmp_path)
+
+    assert result.returncode == 0
+    assert "No profile export archives" in result.stdout
+
+
+def test_root_profile_archive_fails_without_printing_contents(tmp_path):
+    default_archive = tmp_path / "default.tar.gz"
+    alternate_archive = tmp_path / "backup.TGZ"
+    default_archive.write_bytes(b"profile webhook secret must never be printed")
+    alternate_archive.write_bytes(b"another archive")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert "default.tar.gz" in result.stdout
+    assert "backup.TGZ" in result.stdout
+    assert "profile webhook secret" not in result.stdout
+    assert "another archive" not in result.stdout
+
+
+def test_nested_profile_archive_is_also_rejected(tmp_path):
+    nested = tmp_path / "fixtures"
+    nested.mkdir()
+    (nested / "fixture.tar.gz").write_bytes(b"test fixture")
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 1
+    assert "fixtures/fixture.tar.gz" in result.stdout

--- a/website/docs/user-guide/profile-distributions.md
+++ b/website/docs/user-guide/profile-distributions.md
@@ -635,7 +635,11 @@ working directory. This keeps routine exports out of source checkouts and
 prevents a generated profile snapshot from being mistaken for a repository
 source file. If the Hermes home itself lives inside a Git checkout (some
 Docker/custom deployments), the archive goes to `~/.hermes-profile-exports/`
-instead — never into the checkout. An explicit `-o` path is still honored
+or, failing that, a per-user directory under the OS temp dir — never into
+the checkout. If no safe automatic location exists at all (every candidate
+is inside a Git checkout), the export refuses with "No safe automatic
+export destination" and you must pass `-o` with a path outside the
+checkout. An explicit `-o` path is still honored
 when you intentionally choose where to save the archive.
 
 Or from a shell, same machinery:

--- a/website/docs/user-guide/profile-distributions.md
+++ b/website/docs/user-guide/profile-distributions.md
@@ -633,8 +633,10 @@ Without `-o`, the CLI and TUI place the archive in Hermes's managed
 `profile-exports/` directory under the default Hermes home, not in the current
 working directory. This keeps routine exports out of source checkouts and
 prevents a generated profile snapshot from being mistaken for a repository
-source file. An explicit `-o` path is still honored when you intentionally
-choose where to save the archive.
+source file. If the Hermes home itself lives inside a Git checkout (some
+Docker/custom deployments), the archive goes to `~/.hermes-profile-exports/`
+instead — never into the checkout. An explicit `-o` path is still honored
+when you intentionally choose where to save the archive.
 
 Or from a shell, same machinery:
 

--- a/website/docs/user-guide/profile-distributions.md
+++ b/website/docs/user-guide/profile-distributions.md
@@ -624,10 +624,17 @@ When you don't need versioning, skip the repo. `/export` packs a profile into a 
 In the CLI, TUI, or desktop chat:
 
 ```
-/export                          # the active profile → <name>.tar.gz
+/export                          # the active profile → managed profile-exports/<name>-<timestamp>.tar.gz
 /export research-bot             # a named profile
 /export research-bot -o ~/Desktop/research-bot.tar.gz
 ```
+
+Without `-o`, the CLI and TUI place the archive in Hermes's managed
+`profile-exports/` directory under the default Hermes home, not in the current
+working directory. This keeps routine exports out of source checkouts and
+prevents a generated profile snapshot from being mistaken for a repository
+source file. An explicit `-o` path is still honored when you intentionally
+choose where to save the archive.
 
 Or from a shell, same machinery:
 


### PR DESCRIPTION
## Summary

Default profile exports can no longer land inside a source checkout, and CI/Docker publication now reject any archive in the build context. Salvages #92689 by @JoaoMarcos44 (cherry-picked, authorship preserved) with the blocking-review finding fixed on top.

Refs #92457 (recurrence-control predicate only — rotation/republish/history stay with the incident issue; intentionally NOT `Fixes`, so the incident tracker stays open).

## Changes

**From #92689 (@JoaoMarcos44, authorship preserved):**
- CLI (`hermes profile export`), TUI (`/export`), and the profile API share one managed default destination: `HERMES_HOME/profile-exports/<name>-<timestamp>.tar.gz` — never `./<name>.tar.gz` in the cwd (how `default.tar.gz` got committed)
- `scripts/ci/check_profile_archive_boundary.py`: blocking guard rejecting `*.tar.gz`/`*.tgz` anywhere in the checkout; wired into `ci.yaml` (aggregate-gated, infographic-check precedent) and both `docker.yml` build jobs before buildx; reports filenames only, never contents
- `.gitignore`/`.dockerignore` un-anchored to global `*.tar.gz` + `*.tgz` (coherent now that the guard rejects nested archives loudly at CI; local `git add` of a deep fixture still no-ops silently — future archive fixtures must be generated at test runtime)

**Follow-up fixes (this PR, addressing the blocking review on the original head):**
- **cwd-anchored bypass fixed:** checkout detection now walks the export directory's OWN ancestry (`_inside_git_checkout`), not `Path.cwd()`. Before: `HERMES_HOME` inside a checkout + invocation from elsewhere (cron, service manager) put the export back inside the source tree — the exact incident class. Reproduced live pre-fix, E2E-verified fixed.
- When every candidate destination (managed store, `~/.hermes-profile-exports`, temp dir) is inside a checkout, **fail closed** with a clear ValueError telling the user to pass `-o` outside the repo — a stderr warning would not stop a scripted export from staging a secret-bearing archive in a source tree (all three callers already surface ValueError cleanly: CLI/TUI print `Error: …`, API returns 400)
- CLI/TUI callers: `get_profile_export_path()` moved inside the `try`, `OSError` added — a bad profile name or read-only home now prints the same clean `Error: …` main gives today instead of a raw traceback
- Tests bind modules at call time so `tests/hermes_cli` sweep reload-pollution can't divorce monkeypatches from the code under test; new regressions for the cwd-independent topology and the clean-error path
- Docs mention the `~/.hermes-profile-exports` fallback store
- Dead `/default.tar.gz` line dropped from `.dockerignore` (redundant under the global pattern); `hermes profile export -o` help text no longer advertises the old cwd default
- New regressions: cwd-in-unrelated-checkout topology (second production shape from the blocking review) and the fail-closed path — mutation-checked (fail on the pre-fix helper, pass on the fix)
- Temp-dir fallback hardened against predictable-path attacks: per-uid directory name, and `get_profile_export_path()` refuses a pre-existing symlink or a directory owned by another user (a fixed `/tmp/hermes-profile-exports` could be pre-created by another local user to receive the secret-bearing archive); fail-closed message reworded interface-neutrally for the HTTP-400 API surface; docs cover the temp fallback and the refusal

## Behavior notes for review

- Profile-scoped API exports relocate: previously `get_hermes_home()` (profile-aware) → now the shared pre-profile root's `profile-exports/`. Matches the "outside every named profile" intent; name+timestamp keeps collisions unlikely.
- The global `*.tar.gz` ignore reverses the root-anchoring from `db7dda468f` (review feedback on #91712). The new CI guard makes the policy "no archives anywhere, enforced loudly" — flagging for explicit sign-off.

## Validation

| | Before | After |
|---|---|---|
| `hermes profile export` default destination | `./<name>.tar.gz` (cwd — committable) | `HERMES_HOME/profile-exports/<name>-<ts>.tar.gz` |
| HERMES_HOME inside checkout, cwd outside | export inside the checkout (bypass) | `~/.hermes-profile-exports/` (E2E-verified) |
| `hermes profile export 'bad//name'` | clean error (main) / raw traceback (#92689) | clean error |
| Archive committed via `git add -f` / generated pre-build | reaches CI + image layers | CI + docker publish fail with named offenders |

Targeted tests: 13/13 new tests pass; `tests/hermes_cli -k profile` sweep failure set byte-identical to origin/main (pre-existing local pollution class, CI green). Guard script E2E: exit 0 clean / exit 1 on root, nested, `.TGZ`, dir-named offenders; contents never printed.

## Credit

Based on #92689 by @JoaoMarcos44 — commit cherry-picked with authorship preserved. Blocking-review finding (cwd anchoring) reported by @andrexibiza on the original PR.

