### PR TITLE
fix(desktop): concurrent Bot Mode profile startups no longer mutually reap over SSH (#92008, salvage #91994)

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -838,6 +838,20 @@ def _lock_owned_serve_pids(base_dir: Path | None = None) -> set[int]:
     return owned
 
 
+# Grace window before an orphaned-looking backend may be reaped. Covers the
+# gap between process start and the Desktop client writing backend.lock.json.
+_REAP_MIN_AGE_SECONDS = 180.0
+
+
+def _process_age_seconds(pid: int) -> float:
+    """Return a process age using psutil's cross-platform start timestamp."""
+    import time as _time
+
+    import psutil as _psutil
+
+    return max(0.0, _time.time() - _psutil.Process(pid).create_time())
+
+
 def _reap_orphaned_desktop_local_serves(
     *,
     reason: str = "orphaned desktop-local hermes serve",
@@ -845,6 +859,7 @@ def _reap_orphaned_desktop_local_serves(
     signal_kill=None,
     sleep_fn=None,
     lock_owned_pids_fn=None,
+    process_age_seconds_fn=None,
 ) -> dict[str, list]:
     """Kill leftover Desktop-local ``hermes serve`` backends with no parent.
 
@@ -880,6 +895,8 @@ def _reap_orphaned_desktop_local_serves(
         sleep_fn = _time.sleep
     if lock_owned_pids_fn is None:
         lock_owned_pids_fn = _lock_owned_serve_pids
+    if process_age_seconds_fn is None:
+        process_age_seconds_fn = _process_age_seconds
 
     if sys.platform == "win32":
         # Windows desktop uses taskkill tree teardown; orphan scan here is POSIX.
@@ -925,6 +942,21 @@ def _reap_orphaned_desktop_local_serves(
             continue
         # Orphaned under init/launchd.
         if ppid not in (0, 1):
+            continue
+        # Spare backends that are still starting up. backend.lock.json is
+        # written by the *Desktop client* only after the backend reports
+        # HERMES_BACKEND_READY, so a sibling spawned seconds ago is not yet
+        # lock-owned and is invisible to the owned_now guard above. When
+        # Desktop opens several profiles at once (each its own SSH spawn),
+        # every new backend reaped its concurrently-starting siblings, whose
+        # clients then reconnected and reaped the next batch -- a mutual-reap
+        # storm. A genuine corpse from a previous Desktop session is always
+        # older than this grace window; anything younger is a live sibling.
+        try:
+            if process_age_seconds_fn(pid) < _REAP_MIN_AGE_SECONDS:
+                continue
+        except Exception:
+            # Never let a liveness probe failure widen the reap.
             continue
         targets.append((pid, cmd))
 

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -882,6 +882,13 @@ def _reap_orphaned_desktop_local_serves(
       by another client/machine* which legitimately sit at ppid 1 after sshd
       exits. Killing those is a production incident, not cleanup.
     - never fixed-port remote serves (e.g. ``--port 9119``)
+    - never a candidate younger than ``_REAP_MIN_AGE_SECONDS`` (or whose age
+      cannot be determined). The Desktop client writes ``backend.lock.json``
+      only after the backend reports HERMES_BACKEND_READY, so during
+      concurrent multi-profile startup a live sibling is briefly unowned and
+      otherwise indistinguishable from a corpse; sparing young processes
+      closes that mutual-reap window. A genuine corpse merely waits for a
+      later scan.
     - best-effort; failures never raise to the caller
     """
     import signal as _signal

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -84,6 +84,7 @@ def test_reap_only_kills_ppid1_local_serves():
             sleep_fn=lambda _s: None,
             signal_term=15,
             signal_kill=9,
+            process_age_seconds_fn=lambda _pid: 600.0,
         )
 
     assert set(result["matched"]) == {111, 444}
@@ -234,6 +235,7 @@ def test_reap_spare_lock_owned_ssh_remote_backend_of_foreign_client():
             signal_term=15,
             signal_kill=9,
             lock_owned_pids_fn=lambda: lock_owned,
+            process_age_seconds_fn=lambda _pid: 600.0,
         )
 
     # Only the genuine orphan (666) is reaped; the lock-owned remote (555) lives.
@@ -241,6 +243,107 @@ def test_reap_spare_lock_owned_ssh_remote_backend_of_foreign_client():
     assert set(terms) == {666}
     assert 555 not in terms
     assert set(result["killed"]) == {666}
+
+
+def test_reap_spares_young_backend_until_desktop_can_write_lock():
+    """A concurrently-starting sibling has no lock yet but is not an orphan."""
+    scanned = [(777, "hermes serve --isolated --host 127.0.0.1 --port 0")]
+    terms: list[int] = []
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            return None
+        if sig == 15:
+            terms.append(pid)
+        return None
+
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch("hermes_cli.dashboard_procs._process_ppid", return_value=1),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            process_age_seconds_fn=lambda _pid: 2.0,
+        )
+
+    assert result["matched"] == []
+    assert result["killed"] == []
+    assert terms == []
+
+
+def test_reap_spares_backend_when_process_age_is_unknown():
+    scanned = [(778, "hermes serve --isolated --host 127.0.0.1 --port 0")]
+    terms: list[int] = []
+
+    def fake_age(_pid):
+        raise RuntimeError("process disappeared during age probe")
+
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch("hermes_cli.dashboard_procs._process_ppid", return_value=1),
+        patch("os.kill", side_effect=lambda pid, sig: terms.append(pid) if sig == 15 else None),
+        patch("sys.platform", "darwin"),
+    ):
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            process_age_seconds_fn=fake_age,
+        )
+
+    assert result["matched"] == []
+    assert result["killed"] == []
+    assert terms == []
+
+
+def test_reap_age_boundary_makes_180_second_orphan_eligible():
+    scanned = [
+        (779, "hermes serve --isolated --host 127.0.0.1 --port 0"),
+        (780, "hermes serve --isolated --host 127.0.0.1 --port 0"),
+    ]
+    terms: list[int] = []
+    live = {779, 780}
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid in live:
+                return None
+            raise ProcessLookupError()
+        if sig == 15:
+            terms.append(pid)
+            live.discard(pid)
+        return None
+
+    ages = {779: 179.999, 780: 180.0}
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch("hermes_cli.dashboard_procs._process_ppid", return_value=1),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            process_age_seconds_fn=lambda pid: ages[pid],
+        )
+
+    assert result["matched"] == [780]
+    assert result["killed"] == [780]
+    assert terms == [780]
 
 
 def test_reap_spare_lock_owned_backend_even_without_exclude_match(tmp_path):


### PR DESCRIPTION
## Summary
Concurrent Bot Mode profile startups over Desktop SSH no longer kill each other: the orphan reaper now spares any unowned Desktop-local `serve` process younger than 180 seconds, closing the window where a live sibling has no `backend.lock.json` yet (Desktop writes the lock only after HERMES_BACKEND_READY) and is indistinguishable from a corpse.

Salvage of #91994 by @Ishman82 (authorship preserved), fixes #92008.

## Changes
- `hermes_cli/dashboard_procs.py`: `_REAP_MIN_AGE_SECONDS = 180.0` grace gate after all existing shape/PPID/lock-owner checks; `_process_age_seconds()` via `psutil.Process.create_time()`; unknown age fails closed (spared); injectable `process_age_seconds_fn` test seam
- `tests/hermes_cli/test_orphan_desktop_serve_reap.py`: 3 new regression tests (young sibling spared, unknown age spared, 179.999s spared / 180.0s eligible boundary pair); existing tests pin ages ≥ window so prior coverage is unchanged
- Follow-up commit: docstring records why the grace window exists so a future cleanup pass doesn't remove it as dead weight

## Validation
| | Result |
|---|---|
| `test_orphan_desktop_serve_reap.py` + `test_update_stale_dashboard.py` | 46 passed, 2 skipped |
| Red-green (independent reviewer, on main @9098f6777) | tests-only: 3 failed; with fix: 49 passed |
| E2E real-process probe | 1.5s-old child spared; pid 1 (4.6 days) eligible; dead pid raises → fail-closed spare |

Real-world impact per #92008 / #92742: mutual-reap storms produced up to 238 SSH connections/min, dead Bot Mode profiles, 825–840s stale `session_turn_leases` waits, and sshd `PerSourcePenalties` lockouts that presented as auth failure. Genuine orphans from crashed Desktop sessions remain reaped at ≥180s.

## Infographic

![Backends stop reaping each other](https://v3b.fal.media/files/b/0aa77687/E99ZiH_2wPrwzXBybdbuw_69awQ6P3.png)