### PR TITLE
fix(picker): surface model_aliases entries with no provider row

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3986,4 +3986,47 @@ def list_picker_providers(
             continue
         filtered.append(p)
 
+    # Surface ``model_aliases:`` entries that have no matching provider row.
+    # A dict-based alias pointing at a custom endpoint (e.g. a local
+    # llama.cpp/Ollama server) resolves correctly via the typed
+    # ``/model <alias>`` command, but was otherwise invisible here because
+    # this function only enumerates providers, never DIRECT_ALIASES / the
+    # ``model_aliases:`` config section. Add a minimal row per unshadowed
+    # alias so it is discoverable and selectable (#92763).
+    _picker_slugs = {str(p.get("slug", "")).strip().lower() for p in filtered}
+    try:
+        from hermes_cli.config import load_config
+        alias_cfg = load_config().get("model_aliases")
+    except Exception:
+        alias_cfg = None
+    if isinstance(alias_cfg, dict):
+        for alias_name, alias_entry in alias_cfg.items():
+            slug = str(alias_name).strip()
+            if not slug or slug.lower() in _picker_slugs or not isinstance(alias_entry, dict):
+                continue
+            model = str(alias_entry.get("model", "")).strip()
+            if not model:
+                continue
+            base_url = str(alias_entry.get("base_url", "")).strip()
+            is_current = (
+                bool(current_model)
+                and model == current_model
+                and (
+                    not base_url
+                    or base_url.strip().rstrip("/").lower()
+                    == str(current_base_url or "").strip().rstrip("/").lower()
+                )
+            )
+            filtered.append({
+                "slug": slug,
+                "name": slug,
+                "is_current": is_current,
+                "is_user_defined": True,
+                "models": [model],
+                "total_models": 1,
+                "source": "user-config",
+                "api_url": base_url,
+            })
+            _picker_slugs.add(slug.lower())
+
     return filtered

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1513,6 +1513,29 @@ def switch_model(
         if pdef is None and explicit_provider.strip().lower() == "custom":
             pdef = _bare_custom_provider_def(current_base_url)
         if pdef is None:
+            # explicit_provider may be a `model_aliases:` name rather than a
+            # real provider — the interactive picker surfaces alias rows with
+            # their alias name as the "provider" slug (#92763). Resolve the
+            # alias's own provider/base_url so selecting that row switches
+            # instead of erroring with "Unknown provider". The alias's model
+            # name is picked back up as `resolved_alias` a few lines down via
+            # resolve_alias()'s model-id reverse lookup, which also applies
+            # the alias's exact base_url/credentials further below.
+            _ensure_direct_aliases()
+            _direct_alias = DIRECT_ALIASES.get(explicit_provider.strip().lower())
+            if _direct_alias is not None:
+                pdef = resolve_provider_full(
+                    _direct_alias.provider,
+                    user_providers,
+                    custom_providers,
+                )
+                if pdef is None and _direct_alias.provider.strip().lower() == "custom":
+                    pdef = _bare_custom_provider_def(
+                        _direct_alias.base_url or current_base_url
+                    )
+                if pdef is not None and not new_model:
+                    new_model = _direct_alias.model
+        if pdef is None:
             _switch_err = (
                 f"Unknown provider '{explicit_provider}'. "
                 f"Check 'hermes model' for available providers, or define it "

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -133,6 +133,69 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     assert row["models"] == ["glm-5.1", "qwen3"]
 
 
+def test_model_alias_with_no_provider_row_gets_a_picker_row(monkeypatch):
+    """A ``model_aliases:`` entry not also registered under ``providers:``
+    must still surface in the interactive picker (#92763).
+
+    Before the fix, ``list_picker_providers`` only enumerated providers, so a
+    local endpoint configured purely via ``model_aliases:`` (e.g. a
+    llama.cpp/Ollama server) was reachable via typed ``/model local`` but
+    never appeared as a selectable row.
+    """
+    monkeypatch.setattr(model_switch, "list_authenticated_providers", lambda **kw: [])
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model_aliases": {
+                "local": {
+                    "model": "qwen3-30b-a3b",
+                    "provider": "custom",
+                    "base_url": "http://localhost:8080/v1",
+                },
+            },
+        },
+    )
+
+    result = model_switch.list_picker_providers()
+
+    alias_rows = [p for p in result if p.get("slug") == "local"]
+    assert len(alias_rows) == 1
+    row = alias_rows[0]
+    assert row["is_user_defined"] is True
+    assert row["models"] == ["qwen3-30b-a3b"]
+
+
+def test_model_alias_shadowed_by_provider_row_is_not_duplicated(monkeypatch):
+    """An alias sharing a slug with an existing provider row must not double up."""
+    monkeypatch.setattr(
+        model_switch, "list_authenticated_providers",
+        lambda **kw: [_make_provider("local", models=["already-here"],
+                                      is_user_defined=True, api_url="http://x")],
+    )
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model_aliases": {
+                "local": {
+                    "model": "qwen3-30b-a3b",
+                    "provider": "custom",
+                    "base_url": "http://localhost:8080/v1",
+                },
+            },
+        },
+    )
+
+    result = model_switch.list_picker_providers()
+
+    matching = [p for p in result if p.get("slug") == "local"]
+    assert len(matching) == 1
+    assert matching[0]["models"] == ["already-here"]
+
+
 
 # ---------------------------------------------------------------------------
 # list_authenticated_providers: alias/canonical de-dup for Kimi (#49439)

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -196,6 +196,60 @@ def test_model_alias_shadowed_by_provider_row_is_not_duplicated(monkeypatch):
     assert matching[0]["models"] == ["already-here"]
 
 
+def test_model_alias_picker_row_selection_switches_model(monkeypatch):
+    """Selecting the alias row end-to-end must switch the model, not error (#92763).
+
+    Telegram/Discord treat a picker row's ``slug`` as a provider identifier:
+    they call back into ``switch_model(raw_input=<row's model>,
+    explicit_provider=<row's slug>)``. For an alias-only row that slug is the
+    alias *name* (e.g. "local"), not a registered provider, so this exercises
+    the actual selection callback rather than just the row's shape in the
+    picker list.
+    """
+    alias_cfg = {
+        "model_aliases": {
+            "local": {
+                "model": "qwen3-30b-a3b",
+                "provider": "custom",
+                "base_url": "http://localhost:8080/v1",
+            },
+        },
+    }
+    monkeypatch.setattr(model_switch, "list_authenticated_providers", lambda **kw: [])
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: alias_cfg)
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: {
+            "accepted": True, "persist": True, "recognized": True, "message": None,
+        },
+    )
+    model_switch.DIRECT_ALIASES.clear()
+
+    rows = model_switch.list_picker_providers()
+    row = next(p for p in rows if p.get("slug") == "local")
+
+    # Mirrors plugins/platforms/{telegram,discord}/adapter.py's picker
+    # callback: model_id comes from the clicked row's models[idx], and
+    # provider_slug from the row's own slug.
+    model_id = row["models"][0]
+    provider_slug = row["slug"]
+
+    result = model_switch.switch_model(
+        raw_input=model_id,
+        current_provider="openrouter",
+        current_model="",
+        explicit_provider=provider_slug,
+        user_providers=None,
+        custom_providers=None,
+    )
+
+    assert result.success, result.error_message
+    assert result.new_model == "qwen3-30b-a3b"
+    assert result.target_provider == "custom"
+    assert result.base_url == "http://localhost:8080/v1"
+
 
 # ---------------------------------------------------------------------------
 # list_authenticated_providers: alias/canonical de-dup for Kimi (#49439)


### PR DESCRIPTION
## What does this PR do?

A `model_aliases:` entry that points at a custom endpoint (e.g. a local
llama.cpp / Ollama server) resolves correctly via the typed `/model <alias>`
command, but never showed up as a row in the interactive `/model` picker.

`list_picker_providers()` (via `list_authenticated_providers()`) only
enumerates *providers* (the `providers:` dict and `custom_providers:` list)
and their model catalogs — it never iterated `DIRECT_ALIASES` /
`model_aliases`. So an alias that isn't also registered as a provider was
invisible to the picker, even though `/model <alias>` resolves it fine. The
only workaround was registering the same endpoint a second time under
`providers:`.

**Update after review:** the first version of this PR only added the picker
*row* (`list_picker_providers()`) and stopped there. A reviewer found that
made the alias visible but not actually selectable: Telegram/Discord treat a
clicked row's `slug` as a provider identifier and call
`switch_model(raw_input=<model>, explicit_provider=<slug>)`. For an
alias-only row the slug is the alias *name* (e.g. `"local"`), not a
registered provider, and `switch_model`'s explicit-provider path
(`resolve_provider_full`) never consults `model_aliases` / `DIRECT_ALIASES`.
Clicking the row threw `Unknown provider 'local'` instead of switching.

This PR now also fixes `switch_model()` (`hermes_cli/model_switch.py`,
explicit-provider path): when `resolve_provider_full(explicit_provider, ...)`
comes back empty, it's checked against `DIRECT_ALIASES` before erroring. If
it matches an alias, the alias's own `provider` (falling back to a bare
custom endpoint using the alias's `base_url` when the provider is `custom`)
is used to resolve a provider definition, and the model defaults to the
alias's `model` when none was given. From there the existing alias-resolution
machinery (`resolve_alias()`'s model-id reverse lookup sets
`resolved_via_alias`, and the existing "direct alias override" block a few
lines later applies the alias's exact `base_url`/credentials) takes over
unchanged — the same mechanism the typed `/model <alias>` path already relied
on.

## Related Issue

Fixes #92763

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`:
  - `list_picker_providers()` reads the `model_aliases:` config section
    after building the provider rows and appends one row per alias whose
    slug doesn't already match an existing provider row (dedup by slug), so
    no endpoint is listed twice.
  - `switch_model()`'s explicit-provider path now falls back to
    `DIRECT_ALIASES` when `explicit_provider` doesn't resolve to a real
    provider, so selecting an alias-only picker row actually switches
    instead of erroring with "Unknown provider".
- `tests/hermes_cli/test_list_picker_providers.py`: added
  `test_model_alias_with_no_provider_row_gets_a_picker_row` (alias surfaces),
  `test_model_alias_shadowed_by_provider_row_is_not_duplicated` (no dup when
  a provider row already exists), and
  `test_model_alias_picker_row_selection_switches_model` (exercises the
  actual selection callback contract — `switch_model(raw_input=<row's
  model>, explicit_provider=<row's slug>)` — and asserts a successful switch
  to the alias's model/base_url, not just that the row is present).

## How to Test

1. Configure `~/.hermes/config.yaml`:
   ```yaml
   model_aliases:
     local:
       model: qwen3-30b-a3b
       provider: custom
       base_url: http://localhost:8080/v1
   ```
2. Open the interactive model picker — `local` now appears as a row, and
   clicking it (then its one model) actually switches to it instead of
   erroring.
3. Or run the unit tests:
   ```
   $ python3 -m pytest tests/hermes_cli/test_list_picker_providers.py -q
   .......                                                                  [100%]
   7 passed in 1.51s
   ```

Confirmed the new selection-callback test fails without the `switch_model`
fix (reverted `hermes_cli/model_switch.py` to the pre-fix commit and
re-ran):
```
$ python3 -m pytest tests/hermes_cli/test_list_picker_providers.py -q
.......F                                                                 [100%]
FAILED tests/hermes_cli/test_list_picker_providers.py::test_model_alias_picker_row_selection_switches_model
AssertionError: Unknown provider 'local'. Check 'hermes model' for available providers, or define it in config.yaml under 'providers:'.
1 failed, 6 passed in 1.73s
```

Also reproduced the reviewer's exact repro directly:
```python
from hermes_cli.model_switch import switch_model
result = switch_model(
    raw_input="qwen3-30b-a3b", current_provider="openrouter",
    current_model="", explicit_provider="local",
    user_providers=None, custom_providers=None,
)
```
- Before this fix: `success=False`, `"Unknown provider 'local'"`.
- After this fix: resolves through to `target_provider="custom"`,
  `base_url="http://localhost:8080/v1"`, `resolved_via_alias="local"` (fails
  only on the final network probe when no server is actually listening on
  `localhost:8080`, which is expected/unrelated).

Also ran the broader picker/model-switch/alias test suites to check for
regressions:
```
$ python3 -m pytest tests/hermes_cli/ -q -k "model_switch or picker or alias or providers"
4 failed, 549 passed, 2 skipped, ...
```
The 4 failures (`test_model_switch_context_offload.py` x3,
`test_pre_command_hook.py::test_gateway_reports_canonical_name_for_alias`)
are pre-existing and unrelated: they need the `pytest-asyncio` plugin, which
isn't installed in this environment, and fail identically on this branch's
base commit with no changes applied.

`ruff check` passes on both changed files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` (scoped to the affected suites, see above) and they pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested in this repo's CI-style Linux container only

### Documentation & Housekeeping

- [x] No config keys added — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform impact — none, this only changes in-memory picker row construction and the explicit-provider resolution fallback in `switch_model()`
- [x] No tool schema change — N/A

## AI assistance disclosure

This PR was authored with AI assistance (an autonomous coding agent), with
the diff reviewed against the issue's own root-cause analysis, and — after
an independent review caught that the original version only made the alias
visible but not selectable — revised and re-verified end-to-end (including
tracing the actual Telegram/Discord picker selection callback contract)
before being committed and pushed.
