### PR TITLE
fix(desktop): tick every Bot profile's cron store, not just default

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -271,16 +271,39 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     scheduler provider here (no live adapters; delivery falls back to the
     per-platform send path).
 
+    Bot Mode gives every named profile (Bot) its own cron store, but only the
+    resident desktop backend (bound to the default profile's HERMES_HOME)
+    runs continuously — a Bot's own backend is spawned transiently, only
+    while its chat is open. Without ticking every profile here, a Bot's
+    Routine only ever fires as a catch-up when its chat happens to be opened
+    (#92770). So, mirroring the gateway multiplexer's per-profile ticking
+    (#70646), tick every profile's store from this one resident process.
+
     Cross-process safe: the built-in provider's ``cron.scheduler.tick`` takes
     the ``cron/.tick.lock`` file lock, so this never double-fires alongside a
-    real gateway on the same HERMES_HOME — whichever process grabs the lock
-    first wins the tick.
+    real gateway (or a Bot's own transient backend) on the same HERMES_HOME —
+    whichever process grabs the lock first wins the tick.
     """
-    from cron.scheduler_provider import resolve_cron_scheduler
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        resolve_cron_scheduler,
+        scheduler_for_profile_mode,
+    )
+    from hermes_cli.profiles import profiles_to_serve
 
+    profile_homes = profiles_to_serve(multiplex=True)
+    multiplex = len(profile_homes) > 1
     provider = resolve_cron_scheduler()
-    _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
-    provider.start(stop_event, interval=interval)
+    start_kwargs: dict = {"interval": interval}
+    if multiplex:
+        provider = scheduler_for_profile_mode(provider, multiplex_profiles=True)
+        if isinstance(provider, InProcessCronScheduler):
+            start_kwargs["profile_homes"] = profile_homes
+    _log.info(
+        "Desktop cron scheduler started (provider=%s, interval=%ds, profiles=%d)",
+        provider.name, interval, len(profile_homes),
+    )
+    provider.start(stop_event, **start_kwargs)
 
 
 def _warm_gateway_module() -> None:

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -1040,6 +1040,44 @@ def test_desktop_lifespan_reaps_orphan_gateways_on_startup(
     assert called == [True]
 
 
+def test_desktop_cron_ticker_covers_every_bot_profile(monkeypatch, tmp_path):
+    """A Bot's Routine must fire on schedule even if its chat is never
+    opened (#92770).
+
+    The resident desktop backend is bound to the default profile's
+    HERMES_HOME; a non-default-profile Bot's own backend only exists
+    transiently, while its chat is open. Unless the resident ticker is told
+    about every Bot's profile home, a Bot's cron store is never ticked and
+    its Routine only ever fires as a catch-up on open.
+    """
+    import threading
+
+    import hermes_cli.web_server as ws
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    hermes_home = tmp_path / "hermes_home"
+    (hermes_home / "cron").mkdir(parents=True)
+    (hermes_home / "profiles" / "my-reader" / "cron").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    captured = {}
+
+    class _RecordingScheduler(InProcessCronScheduler):
+        def start(self, stop_event, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "cron.scheduler_provider.resolve_cron_scheduler",
+        lambda: _RecordingScheduler(),
+    )
+
+    ws._start_desktop_cron_ticker(threading.Event())
+
+    homes = captured.get("profile_homes")
+    assert homes is not None, "expected profile_homes when more than one profile exists"
+    assert {name for name, _home in homes} == {"default", "my-reader"}
+
+
 def test_desktop_lifespan_terminates_managed_gateway_restart(monkeypatch):
     """A Desktop-owned gateway child must not survive its serve backend."""
     import hermes_cli.web_server as ws


### PR DESCRIPTION
Fixes #92770.

## Bug

On Windows (and generally) with Bot Mode, a Routine (cron job) attached to a
non-default-profile Bot never fired at its scheduled time. It only ran — as
a catch-up — the moment the Bot was opened in the desktop app.

`hermes_cli/web_server.py::_start_desktop_cron_ticker()` is the ticker the
resident desktop dashboard backend runs (since that backend is a `serve`
process, not a `gateway run`, and has no scheduler otherwise). It called
`resolve_cron_scheduler()` and `provider.start(stop_event, interval=interval)`
with no `profile_homes`, so it only ticked the process-global `HERMES_HOME`
— the default profile. A Bot's own profile-scoped backend
(`serve --profile <bot>`) is only spawned transiently, while its chat is
open, so no resident process ever owned a non-default Bot's cron store.

This is the desktop analogue of #69377/#70646, which fixed the same class of
bug for the gateway multiplexer path by passing `profile_homes` into the
scheduler when `gateway.multiplex_profiles` is on.

## Fix

`_start_desktop_cron_ticker()` now computes every profile home via
`hermes_cli.profiles.profiles_to_serve(multiplex=True)` (the same chokepoint
the gateway multiplexer uses) and passes it to the scheduler provider when
more than one profile exists, forcing the built-in ticker via
`scheduler_for_profile_mode()` exactly as the gateway path does when an
external provider can't handle multiple profiles. `InProcessCronScheduler`
already knows how to tick multiple profile homes (`_start_multiplex`,
added for #70646) — this just wires the desktop backend into that existing
path. Each profile's tick still goes through the per-home `cron/.tick.lock`
file lock, so this cannot double-fire against a Bot's own transient backend.

No dependency, lockfile, or CI changes.

## Test

Added `test_desktop_cron_ticker_covers_every_bot_profile` in
`tests/hermes_cli/test_dashboard_admin_endpoints.py`, which creates a
second named profile on disk and asserts the scheduler provider is started
with `profile_homes` covering both `default` and the named profile.

Confirmed it fails without the fix (`git checkout HEAD~1 -- hermes_cli/web_server.py`, rerun, restore):

```
$ scripts/run_tests.sh tests/hermes_cli/test_dashboard_admin_endpoints.py -k test_desktop_cron_ticker_covers_every_bot_profile -v
FAILED tests/hermes_cli/test_dashboard_admin_endpoints.py::test_desktop_cron_ticker_covers_every_bot_profile
AssertionError: expected profile_homes when more than one profile exists
assert None is not None
```

And passes with the fix:

```
$ scripts/run_tests.sh tests/hermes_cli/test_dashboard_admin_endpoints.py -k test_desktop_cron_ticker_covers_every_bot_profile -v
=== Summary: 1 files, 1 tests passed, 0 failed (100% complete) in 2.2s (8 workers) ===
```

Full related suites pass:

```
$ scripts/run_tests.sh tests/hermes_cli/test_dashboard_admin_endpoints.py tests/cron/test_scheduler_provider.py tests/hermes_cli/test_profiles.py tests/gateway/test_multiplex_lifecycle.py
=== Summary: 4 files, 135 tests passed, 0 failed, 2 skipped (100% complete) ===
```

`ruff check` passes on both changed files.

## AI assistance disclosure

This PR was prepared with AI assistance (an autonomous coding agent), with the
diff reviewed against the issue and the referenced #70646 fix before opening.
