### PR TITLE
fix(clarify): accept multi-select replies that match one comma-containing label

### DIFF
--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -380,6 +380,46 @@ class TestMultiSelectTextFallback:
         entry = cm.register("s4", "sk", "Q?", ["A", "B"])
         assert cm._coerce_text_response(entry, "b") == "B"
 
+    def test_multi_select_label_with_comma_resolves(self):
+        """A full reply that exactly matches one choice label resolves as that
+        single selection, even though the label itself contains a comma.
+
+        Regression: WhatsApp poll votes arrive verbatim as one label, and a
+        label like "Health, longevity and performance science" was being
+        comma-split into two unrecognised tokens and rejected as an invalid
+        selection, leaving the prompt pending until timeout.
+        """
+        import json
+        from tools import clarify_gateway as cm
+        choices = [
+            "Esports/gaming industry business (VALORANT ecosystem, org funding)",
+            "Health, longevity and performance science",
+            "Edtech specifically (funding, product, platform shifts)",
+        ]
+        entry = cm.register("m5", "sk", "Pick one", choices, multi_select=True)
+        coerced = cm._coerce_text_response(entry, choices[1])
+        assert coerced is not None
+        assert json.loads(coerced) == [choices[1]]
+
+    def test_multi_select_label_with_comma_still_allows_real_lists(self):
+        """Comma-separated numeric lists still work after the whole-label
+        fast path."""
+        import json
+        from tools import clarify_gateway as cm
+        entry = self._register_multi(cid="m6")
+        assert json.loads(cm._coerce_text_response(entry, "1,3")) == ["A", "C"]
+
+    def test_multi_select_out_of_range_native_rejection_unchanged(self):
+        """Out-of-range numbers on a native prompt are still rejected — the
+        whole-label fast path does not loosen invalid-selection handling."""
+        from tools import clarify_gateway as cm
+        entry = cm.register(
+            "m7", "sk", "Pick some", ["A", "B", "C"], multi_select=True,
+        )
+        coerced, reason = cm._coerce_text_response_detailed(entry, "99")
+        assert coerced is None
+        assert reason == "invalid_selection"
+
 
 class TestNativeRejectClassification:
     """Rejected typed replies must distinguish free prose from bad selections.

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -388,6 +388,15 @@ def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
         return None
     choices = entry.choices or []
 
+    # A full reply that exactly matches one choice label wins outright,
+    # before any comma-splitting heuristic. Choice labels legitimately
+    # contain commas ("Health, longevity and performance science"), and
+    # WhatsApp poll votes arrive verbatim as a single label, so splitting
+    # such a label on its comma must never reject the whole reply.
+    for choice in choices:
+        if _label_matches(text, choice):
+            return _json.dumps([str(choice).strip()], ensure_ascii=False)
+
     # Split on commas first; if no commas and every whitespace-separated
     # token is numeric, treat spaces as separators too ("1 3").
     if "," in text:


### PR DESCRIPTION
## Problem

A typed multi-select clarify reply that exactly matches a single choice label is comma-split before label matching. A choice label containing a comma — e.g. `Health, longevity and performance science` — gets parsed as two unrecognised tokens and rejected with `invalid_selection`.

On WhatsApp this is worse than a rejected retry: poll votes arrive verbatim as a single label (see `normalizePollUpdateOptions` in the WhatsApp bridge), so voting on such a poll silently left the clarify pending until timeout, with no feedback and no way to recover the vote.

Reproduced on current `main`: `_coerce_text_response_detailed(entry, "Health, longevity and performance science")` returns `(None, "invalid_selection")` for a multi-select entry containing that exact label.

## Fix

In `_coerce_multi_select_text`, try a whole-reply exact label match (`_label_matches`, which already ignores the `(Recommended)` suffix and casing) **before** any comma-splitting heuristic. If the full reply equals one choice label, resolve it as that single selection.

Unchanged behavior:
- numeric lists (`1,3`, `1 3`)
- comma-separated label lists
- out-of-range numbers / unrecognised lists still reject as `invalid_selection`
- single-select coercion untouched

## Testing

- New regression test using the real-world failing label asserts it resolves to that single selection.
- New guard test asserts native-prompt out-of-range rejection is unchanged.
- Existing list-handling tests pass; full `tests/tools/test_clarify_gateway.py`, `tests/tools/test_clarify_tool.py`, and the four gateway clarify suites: 97 passed.