### PR TITLE
fix(buzz): require explicit group addressing

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1033,7 +1033,7 @@ class BuzzAdapter(BasePlatformAdapter):
         # In shared channels, respond only when addressed — unless
         # require_mention is disabled, in which case respond to every message.
         # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
+        if not is_dm and self.require_mention and not self._is_addressed(event):
             return
 
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
@@ -1061,43 +1061,42 @@ class BuzzAdapter(BasePlatformAdapter):
     # ── DM classification (issue #68871) ──────────────────────────────────
     #
     # ``buzz dms list`` returns [] on some hosted relays even when DM
-    # conversations exist, so DMs leak in via ``channels list`` and get
-    # watched as chat_type="group" — which wrongly puts them behind the
-    # channel mention gate.  Classification therefore keys off the Nostr
-    # tags of the messages themselves.  Observed on a live hosted relay:
-    #
-    #   * every message another user sends IN A DM carries a structural
-    #     ["p", <our pubkey>] tag, even when the text never mentions us
-    #     (recipient addressing);
-    #   * in a real channel, a ["p", <our pubkey>] tag appears only when the
-    #     text visibly @mentions us (typed mention, with or without a reply
-    #     ["e", ...] tag) — never on plain broadcasts.
-    #
-    # So "p-tagged to self WITHOUT a visible mention in the content" is the
-    # DM discriminator: in a channel that combination does not occur, and a
-    # channel reply/mention that p-tags us is excluded because the mention
-    # is right there in the text.  As a second, independent guard, a
-    # conversation whose ``channels list`` metadata looks like a real
-    # community channel (real name / non-empty description) is never
-    # reclassified at all, whereas relay-materialized DMs are always named
-    # "DM" with an empty description.  Nothing is lost while unlatched: a
-    # DM message that DOES mention us dispatches through the mention gate
-    # anyway, so the latch flips exactly on the first message that needs it.
+    # conversations exist, so DMs can leak in through ``channels list`` as
+    # chat_type="group".  Relay-materialized DMs are named "DM" with an empty
+    # description, and their messages carry a structural p-tag to us.  Only
+    # that explicit metadata shape may latch to DM; named channels and missing
+    # metadata fail closed.  In normal channels the same p-tag is an addressing
+    # signal and must wake the agent without changing the conversation type.
 
     def _may_reclassify_as_dm(self, channel_id: str) -> bool:
         """True when the conversation's metadata does not rule out a DM.
 
         Known real community channels (real name or non-empty description in
         ``channels list``) must never turn into DMs just because a message
-        p-tags us.  A conversation with no metadata at all is trusted only
-        when the user did not explicitly configure it as a watched channel.
+        p-tags us.  Missing metadata fails closed rather than allowing a named
+        channel to latch as a DM before its metadata arrives.
         """
         meta = self._channel_meta.get(channel_id)
         if meta is None:
-            return channel_id not in self.channels
+            return False
         name = str(meta.get("name") or "").strip()
         description = str(meta.get("description") or "").strip()
         return name == "DM" and not description
+
+    def _p_tagged_to_self(self, event: dict) -> bool:
+        """True when the signed event addresses this identity by pubkey."""
+        if not self._self_pubkey:
+            return False
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return False
+        return any(
+            isinstance(tag, (list, tuple))
+            and len(tag) > 1
+            and tag[0] == "p"
+            and str(tag[1]).lower() == self._self_pubkey
+            for tag in tags
+        )
 
     def _is_direct_message_event(self, channel_id: str, event: dict) -> bool:
         """True when ``event`` is shaped like a direct message to us: a chat
@@ -1111,17 +1110,7 @@ class BuzzAdapter(BasePlatformAdapter):
         pubkey = str(event.get("pubkey") or "").lower()
         if not pubkey or pubkey == self._self_pubkey:
             return False
-        tags = event.get("tags")
-        if not isinstance(tags, list):
-            return False
-        p_tagged_to_self = any(
-            isinstance(tag, (list, tuple))
-            and len(tag) > 1
-            and tag[0] == "p"
-            and str(tag[1]).lower() == self._self_pubkey
-            for tag in tags
-        )
-        if not p_tagged_to_self:
+        if not self._p_tagged_to_self(event):
             return False
         content = event.get("content")
         return isinstance(content, str) and not self._is_mentioned(content)
@@ -1137,17 +1126,32 @@ class BuzzAdapter(BasePlatformAdapter):
         logger.info("Buzz: conversation %s reclassified as DM (message p-tagged to self)", channel_id)
 
     def _is_mentioned(self, content: str) -> bool:
-        """True when the message addresses this agent (npub, hex, or name)."""
+        """True when text explicitly addresses this agent (npub, hex, or @name)."""
         lowered = content.lower()
-        if self._self_pubkey and self._self_pubkey in lowered:
-            return True
-        if self._self_npub and self._self_npub in lowered:
-            return True
+        if self._self_pubkey and re.fullmatch(r"[0-9a-f]{64}", self._self_pubkey):
+            pattern = rf"(?<![0-9a-f]){re.escape(self._self_pubkey)}(?![0-9a-f])"
+            if re.search(pattern, lowered):
+                return True
+        if self._self_npub:
+            pattern = rf"(?<![a-z0-9]){re.escape(self._self_npub.lower())}(?![a-z0-9])"
+            if re.search(pattern, lowered):
+                return True
         if self._display_name:
-            pattern = rf"(?<!\w)@?{re.escape(self._display_name.lower())}(?!\w)"
+            pattern = (
+                rf"(?<![\w@])@{re.escape(self._display_name.lower())}"
+                r"(?=$|[\s,;.!?:)\]}])"
+            )
             if re.search(pattern, lowered):
                 return True
         return False
+
+    def _is_addressed(self, event: dict) -> bool:
+        """True when a group event carries an explicit text or p-tag address."""
+        content = event.get("content")
+        return (
+            isinstance(content, str)
+            and (self._is_mentioned(content) or self._p_tagged_to_self(event))
+        )
 
     def _strip_mention(self, content: str) -> str:
         """Remove a leading @mention of this agent so the remaining text can be
@@ -1163,16 +1167,18 @@ class BuzzAdapter(BasePlatformAdapter):
         text = content.strip()
         candidates = []
         if self._display_name:
-            candidates.append(re.escape(self._display_name))
+            candidates.append(
+                rf"@{re.escape(self._display_name)}" + r"(?=$|[\s,;.!?:)\]}])"
+            )
         if self._self_npub:
-            candidates.append(re.escape(self._self_npub))
+            candidates.append(rf"@?{re.escape(self._self_npub)}(?![a-z0-9])")
         if self._self_pubkey:
-            candidates.append(re.escape(self._self_pubkey))
+            candidates.append(rf"@?{re.escape(self._self_pubkey)}(?![0-9a-f])")
         if not candidates:
             return text
-        # Optional leading '@', one of the identity forms, optional trailing
-        # ':' or ',' and surrounding whitespace.
-        pattern = rf"^@?(?:{'|'.join(candidates)})[\s:,]*"
+        # Display names require '@'; npub and hex identities are already
+        # unambiguous and may optionally include it.
+        pattern = rf"^(?:{'|'.join(candidates)})[\s:,]*"
         stripped = re.sub(pattern, "", text, count=1, flags=re.IGNORECASE)
         return stripped.strip()
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -953,10 +953,8 @@ class BuzzAdapter(BasePlatformAdapter):
         ``dms list`` is only a best-effort source: on some hosted relays it
         returns ``[]`` even when DM conversations exist (#68871).  Those DMs
         DO surface in ``channels list`` as entries named "DM" with an empty
-        description, so that listing is scanned as a fallback.  Fallback
-        finds are watched as ``group`` and latch to ``dm`` via p-tag
-        detection (_is_direct_message_event) rather than trusting the name
-        alone to unlock the mention-free DM path.
+        description, so that exact metadata shape is the fallback.  Named
+        rooms and missing metadata still fail closed as groups.
         """
         code, out, _err = await self._run_cli(["dms", "list"])
         if code == 0:
@@ -979,12 +977,17 @@ class BuzzAdapter(BasePlatformAdapter):
                 continue
             self._channel_meta[ch_id] = ch
             self._channel_names.setdefault(ch_id, str(ch.get("name") or ch_id))
-            if ch_id in self._channel_state or not self._may_reclassify_as_dm(ch_id):
+            if not self._may_reclassify_as_dm(ch_id):
+                continue
+            if ch_id in self._channel_state:
+                self._channel_state[ch_id]["chat_type"] = "dm"
                 continue
             if seed:
-                await self._seed_channel(ch_id, chat_type="group")
+                await self._seed_channel(ch_id, chat_type="dm")
             else:
-                self._channel_state[ch_id] = {"chat_type": "group", "last_ts": 0, "seen": OrderedDict()}
+                self._channel_state[ch_id] = {
+                    "chat_type": "dm", "last_ts": 0, "seen": OrderedDict()
+                }
 
     async def _poll_channel(self, channel_id: str) -> None:
         state = self._channel_state.get(channel_id)
@@ -1063,10 +1066,10 @@ class BuzzAdapter(BasePlatformAdapter):
     # ``buzz dms list`` returns [] on some hosted relays even when DM
     # conversations exist, so DMs can leak in through ``channels list`` as
     # chat_type="group".  Relay-materialized DMs are named "DM" with an empty
-    # description, and their messages carry a structural p-tag to us.  Only
-    # that explicit metadata shape may latch to DM; named channels and missing
-    # metadata fail closed.  In normal channels the same p-tag is an addressing
-    # signal and must wake the agent without changing the conversation type.
+    # description, which periodic discovery promotes to DM even when messages
+    # omit recipient p-tags.  Named channels and missing metadata fail closed.
+    # In normal channels a p-tag is only an addressing signal and must wake the
+    # agent without changing the conversation type.
 
     def _may_reclassify_as_dm(self, channel_id: str) -> bool:
         """True when the conversation's metadata does not rule out a DM.

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -242,6 +242,67 @@ class TestMentionGating:
     async def test_name_mention_dispatched(self, adapter):
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
+        assert adapter._dispatched[0]["text"] == "hey @Chip can you help?"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "Chip should stay silent",
+            "ask @Chipmunk instead",
+            "ask @Chip-bot instead",
+            "email chip@example.com",
+        ],
+    )
+    async def test_bare_or_prefix_name_does_not_dispatch(self, adapter, content):
+        await self._poll_with(adapter, _event("e1", content=content, created_at=10))
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("identity", [SELF_NPUB, SELF_PUBKEY])
+    async def test_identity_text_dispatches(self, adapter, identity):
+        await self._poll_with(
+            adapter,
+            _event("e1", content=f"please check {identity}", created_at=10),
+        )
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content",
+        [f"a{SELF_PUBKEY}b", f"x{SELF_NPUB}y"],
+    )
+    async def test_identity_substring_does_not_dispatch(self, adapter, content):
+        await self._poll_with(
+            adapter,
+            _event("e1", content=content, created_at=10),
+        )
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_signed_recipient_tag_dispatches_without_text_mention(self, adapter):
+        event = _event("e1", content="please take a look", created_at=10)
+        event["tags"].append(["p", SELF_PUBKEY])
+        await self._poll_with(adapter, event)
+        assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_other_recipient_tag_does_not_dispatch(self, adapter):
+        event = _event("e1", content="please take a look", created_at=10)
+        event["tags"].append(["p", "b" * 64])
+        await self._poll_with(adapter, event)
+        assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_require_mention_false_still_dispatches_unaddressed_message(self, adapter):
+        adapter.require_mention = False
+        await self._poll_with(adapter, _event("e1", content="just chatting", created_at=10))
+        assert len(adapter._dispatched) == 1
+
+    def test_strip_mention_requires_at_for_display_name(self, adapter):
+        assert adapter._strip_mention("@Chip: /whoami") == "/whoami"
+        assert adapter._strip_mention("Chip: please review") == "Chip: please review"
+        assert adapter._strip_mention("@Chip-bot: please review") == "@Chip-bot: please review"
 
 
     @pytest.mark.asyncio
@@ -346,9 +407,8 @@ class TestDmClassification:
 
 
     @pytest.mark.asyncio
-    async def test_channel_like_metadata_blocks_latch_even_without_mention(self, adapter):
-        """Second guard on its own: even a p-tagged, un-mentioned message
-        cannot reclassify a conversation whose metadata says real channel."""
+    async def test_channel_ptag_dispatches_without_latching(self, adapter):
+        """A signed recipient tag wakes a channel without turning it into a DM."""
         adapter._channel_meta[CHANNEL]["description"] = ""
         adapter._channel_meta[CHANNEL]["name"] = "announcements"
         await self._poll_with(
@@ -356,7 +416,26 @@ class TestDmClassification:
             _tagged_event("e1", CHANNEL, content="fyi everyone", p=SELF_PUBKEY),
         )
         assert adapter._channel_state[CHANNEL]["chat_type"] == "group"
-        assert adapter._dispatched == []
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+
+        await self._poll_with(
+            adapter, CHANNEL,
+            _tagged_event(
+                "e2", CHANNEL, content="plain follow-up", created_at=1001, p=None
+            ),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+
+    @pytest.mark.asyncio
+    async def test_missing_metadata_never_latches_group_as_dm(self, adapter):
+        adapter._channel_meta.pop(CHANNEL)
+        await self._poll_with(
+            adapter, CHANNEL,
+            _tagged_event("e1", CHANNEL, content="tag-only mention", p=SELF_PUBKEY),
+        )
+        assert adapter._channel_state[CHANNEL]["chat_type"] == "group"
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+        assert adapter._may_reclassify_as_dm(CHANNEL) is False
 
 
     @pytest.mark.asyncio
@@ -536,5 +615,3 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
-
-

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -441,7 +441,7 @@ class TestDmClassification:
     @pytest.mark.asyncio
     async def test_dm_shaped_channel_discovered_when_dms_list_empty(self):
         """Fallback discovery: with `dms list` broken (returns []), a
-        DM-shaped `channels list` entry gets watched; real channels not
+        DM-shaped `channels list` entry becomes a DM; real channels not
         already watched are left alone."""
         a = _make_adapter()
         cli = _ScriptedCli()
@@ -453,11 +453,26 @@ class TestDmClassification:
         ])
         a._run_cli = cli
         await a._discover_dms(seed=False)
-        # Watched as group; the p-tag latch flips it on the first real DM.
-        assert a._channel_state[DM_CHANNEL]["chat_type"] == "group"
+        assert a._channel_state[DM_CHANNEL]["chat_type"] == "dm"
         assert a._may_reclassify_as_dm(DM_CHANNEL) is True
         assert CHANNEL not in a._channel_state
         assert a._may_reclassify_as_dm(CHANNEL) is False
+
+    @pytest.mark.asyncio
+    async def test_dm_metadata_promotes_existing_group_without_recipient_tag(self, adapter):
+        cli = _ScriptedCli()
+        cli.script("dms", "list", [])
+        cli.script("channels", "list", [adapter._channel_meta[DM_CHANNEL]])
+        adapter._run_cli = cli
+        await adapter._discover_dms(seed=False)
+        assert adapter._channel_state[DM_CHANNEL]["chat_type"] == "dm"
+
+        await self._poll_with(
+            adapter, DM_CHANNEL,
+            _tagged_event("e1", DM_CHANNEL, content="no mention and no p tag"),
+        )
+        assert [d["message_id"] for d in adapter._dispatched] == ["e1"]
+        assert adapter._dispatched[0]["chat_type"] == "dm"
 
 
 # ── Sending ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- require explicit @display-name, npub, hex, or recipient p-tag in Buzz group channels
- keep named rooms and missing metadata fail-closed as groups
- preserve mention-free DMs when hosted relays return them only through channels list as name=DM with an empty description
- add regression coverage for bare names, prefixes, recipient tags, DM latching, and p-tag-free true DMs

## Tests
- scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py (41 passed)