### PR TITLE
fix(cli): fall back to input() when prompt_toolkit can't attach stdin

### DIFF
--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -59,7 +59,15 @@ def line_input(prompt_text: str) -> str:
     except ImportError:
         return input(prompt_text)
 
-    return prompt_toolkit_prompt(ANSI(prompt_text))
+    try:
+        return prompt_toolkit_prompt(ANSI(prompt_text))
+    except OSError:
+        # Some terminals report isatty() == True yet reject registering stdin
+        # with the asyncio event-loop selector (observed on macOS, where kqueue
+        # raises EINVAL / "Invalid argument" for fd 0). prompt_toolkit cannot
+        # attach its input there, so fall back to the built-in line reader,
+        # which needs no selector and works in cooked mode.
+        return input(prompt_text)
 
 
 def prompt(

--- a/tests/hermes_cli/test_cli_output.py
+++ b/tests/hermes_cli/test_cli_output.py
@@ -42,6 +42,34 @@ def test_line_input_preserves_builtin_input_for_redirected_stdin(monkeypatch):
     assert seen["prompt"] == "Enter model name: "
 
 
+def test_line_input_falls_back_to_input_when_prompt_toolkit_raises_oserror(monkeypatch):
+    """isatty() can report True while the asyncio selector still rejects stdin.
+
+    Under a `curl ... | bash` install the setup wizard reattaches stdin from
+    /dev/tty, so isatty() is True and the guard above passes. prompt_toolkit
+    then fails to register fd 0 with the event-loop selector (observed on
+    macOS, where kqueue raises OSError EINVAL / "Invalid argument"). line_input
+    must degrade to the built-in reader instead of letting the OSError abort
+    the whole wizard.
+    """
+    seen = {}
+
+    def raising_prompt(*_args, **_kwargs):
+        raise OSError(22, "Invalid argument")
+
+    def fake_input(prompt_text):
+        seen["prompt"] = prompt_text
+        return "fallback-value"
+
+    monkeypatch.setattr(cli_output.sys, "stdin", _TTY())
+    monkeypatch.setattr(cli_output.sys, "stdout", _TTY())
+    monkeypatch.setattr("prompt_toolkit.prompt", raising_prompt)
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    assert cli_output.line_input("Choice [1/2]: ") == "fallback-value"
+    assert seen["prompt"] == "Choice [1/2]: "
+
+
 def test_password_prompt_uses_masked_secret_prompt(monkeypatch):
     seen = {}
 


### PR DESCRIPTION
## Problem

`hermes setup` crashes at the first plain-text prompt on some terminals with:

```
OSError: [Errno 22] Invalid argument
  ...
  File ".../prompt_toolkit/input/vt100.py", line 165, in _attached_input
    loop.add_reader(fd, callback_wrapper)
  File ".../asyncio/selector_events.py", line 271, in _add_reader
    self._selector.register(fd, selectors.EVENT_READ, ...)
```

`line_input()` in `hermes_cli/cli_output.py` guards only against a missing
prompt_toolkit (`ImportError`), not against prompt_toolkit failing at runtime.
On some terminals `isatty()` returns `True`, yet the asyncio event-loop
selector rejects registering stdin: on macOS, kqueue raises `OSError` EINVAL
("Invalid argument") for fd 0. prompt_toolkit's `Application.run()` then crashes
while attaching its input, aborting the wizard.

Telegram setup surfaced it first because its automatic/manual selection uses
`prompt()` (→ prompt_toolkit) rather than the curses-based `prompt_choice()`
the other platforms use for menu selection, but every text prompt on an
affected terminal hits the same failure.

## Fix

Catch `OSError` from the prompt_toolkit path in `line_input()` and fall back to
the built-in `input()` reader, which needs no event-loop selector and works in
cooked mode. prompt_toolkit's raw-mode context manager restores terminal state
when the attach fails, so the fallback reads cleanly (arrow-key line editing is
lost on those terminals, but the wizard proceeds instead of crashing).

Secret prompts (`masked_secret_prompt`) already fall back to `getpass`, so only
the plain-text path needed this guard.

## Test

Simulated prompt_toolkit raising `OSError(22)` with a tty-reporting stdin;
`line_input()` now returns the value read via `input()` instead of propagating
the crash.