### PR TITLE
fix(vision): stop native embeds from blowing context on screenshot QA (#92699 salvage)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3942,16 +3942,19 @@ class ContextCompressor(ContextEngine):
         threshold (≈100K tokens on a 1M window) and would protect the entire
         session, pruning nothing.
 
-        ``_prune_old_tool_results`` runs all three deterministic passes:
+        ``_prune_old_tool_results`` runs all deterministic passes:
         (1) dedup byte-identical tool results — keeps the newest full copy and
         back-references older exact duplicates ANYWHERE in the list (including
         the protected tail), so no unique content is ever lost; (2) summarize
         non-tail tool results larger than ``min_prune_chars``; (3) truncate
-        oversized tool_call arguments on non-tail assistant messages. Only
-        pass (2)'s floor is raised by ``proactive_prune_min_result_chars``;
-        passes (1) and (3) keep their own fixed floors. The recent-tail
-        protection applies to passes (2) and (3); pass (1) is tail-agnostic by
-        design because dedup is lossless.
+        oversized tool_call arguments on non-tail assistant messages;
+        (3.5) retire image payloads on all but the newest
+        ``_MAX_KEEP_TOOL_IMAGES`` image-bearing tool results — tail-agnostic
+        and lossy by design (#92699). Only pass (2)'s floor is raised by
+        ``proactive_prune_min_result_chars``; passes (1) and (3) keep their
+        own fixed floors. The recent-tail protection applies to passes (2)
+        and (3); pass (1) is tail-agnostic by design because dedup is
+        lossless.
 
         PROMPT-CACHE CONTRACT: a committed prune rewrites message bodies the
         provider has already seen, invalidating the cached prefix from the
@@ -3975,7 +3978,7 @@ class ContextCompressor(ContextEngine):
         before = sum(_estimate_msg_budget_tokens(m) for m in messages)
         if before < self._proactive_prune_rearm_tokens:
             return messages, 0
-        # Capability gate BEFORE the expensive 3-pass scan: a bound store that
+        # Capability gate BEFORE the expensive multi-pass scan: a bound store that
         # can't persist the prune atomically (duck-typed/plugin session store
         # without archive_and_compact) makes every prune a permanent no-op, so
         # don't pay the scan for it on every eligible iteration.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1220,6 +1220,13 @@ _FEASIBILITY_SKIP_MIDDLE_FRACTION = 0.10
 # protected region — but always keep this many trailing messages verbatim so
 # the active user ask / latest tool pair remain readable.  Issue #61932.
 _PRESSURE_KEEP_RECENT_MESSAGES = 3
+# Native vision_analyze / computer_use screenshots that sit inside the
+# protected tail cannot be demoted by pass 2, so they ride every later
+# request until anti-thrash disables compression (#92699).  Keep this many
+# newest image-bearing tool results verbatim; retire older image payloads
+# even when they fall inside ``protect_last_n``.  Matches the Anthropic
+# adapter's outbound keep-window.
+_MAX_KEEP_TOOL_IMAGES = 3
 
 # Models with context windows below this get their compression threshold
 # floored at ``_SMALL_CTX_THRESHOLD_PERCENT`` (raise-only — an explicitly
@@ -1558,6 +1565,60 @@ def _strip_image_parts_from_parts(parts: Any) -> Any:
         else:
             out.append(part)
     return out if had_image else None
+
+
+def _tool_content_has_images(content: Any) -> bool:
+    """True when a tool-result body carries embedded image bytes.
+
+    Handles both unwrapped OpenAI-style part lists and the native
+    ``{_multimodal: True, content: [...]}`` envelope vision_analyze returns.
+    """
+    if isinstance(content, dict) and content.get("_multimodal"):
+        return _content_has_images(content.get("content"))
+    return _content_has_images(content)
+
+
+def _retire_stale_tool_result_images(
+    result: List[Dict[str, Any]],
+    keep_newest: int = _MAX_KEEP_TOOL_IMAGES,
+) -> int:
+    """Replace image payloads on older tool results with text placeholders.
+
+    Walks newest-first, keeps the most recent ``keep_newest`` image-bearing
+    tool messages intact (follow-up screenshot QA still sees the latest
+    frames), and retires the rest.  User-role uploads are not touched.
+
+    Mutates ``result`` in place.  Returns the number of messages rewritten.
+    """
+    if keep_newest < 0:
+        keep_newest = 0
+    seen = 0
+    pruned = 0
+    for i in range(len(result) - 1, -1, -1):
+        msg = result[i]
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        content = msg.get("content")
+        if not _tool_content_has_images(content):
+            continue
+        seen += 1
+        if seen <= keep_newest:
+            continue
+        if isinstance(content, dict) and content.get("_multimodal"):
+            summary = content.get("text_summary") or "[screenshot removed to save context]"
+            new_msg = {**msg, "content": f"[screenshot removed] {summary[:200]}"}
+            drop_stale_api_content(new_msg)
+            result[i] = new_msg
+            pruned += 1
+            continue
+        stripped = _strip_image_parts_from_parts(content)
+        if stripped is None:
+            continue
+        new_msg = {**msg, "content": stripped}
+        drop_stale_api_content(new_msg)
+        result[i] = new_msg
+        pruned += 1
+    return pruned
 
 
 def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
@@ -3778,6 +3839,13 @@ class ContextCompressor(ContextEngine):
         # the window. See ``_truncate_tool_call_args_json`` docstring.
         for i in range(max(0, prune_boundary)):
             _truncate_tool_call_args_at(i)
+
+        # Pass 3.5 (#92699): retire image payloads that pass 2 cannot reach
+        # because they sit inside the protected tail.  Native vision_analyze
+        # embeds re-sent on every turn otherwise make compression look
+        # ineffective (savings < 10%) and anti-thrash disables it.  Newest
+        # frames stay live for follow-up QA; older ones become placeholders.
+        pruned += _retire_stale_tool_result_images(result)
 
         # Pass 4 (issue #61932): protected-tail pressure demotion.
         # After multiple in-place compactions the transcript can be short

--- a/tests/agent/test_compressor_stale_tool_images.py
+++ b/tests/agent/test_compressor_stale_tool_images.py
@@ -1,0 +1,140 @@
+"""Retire stale vision_analyze / screenshot tool images inside the protected tail.
+
+Issue #92699: native embeds sitting in protect_last_n ride every later
+request, compression savings stay tiny, and anti-thrash disables further
+compaction. Pass 2 of ``_prune_old_tool_results`` only strips images
+*outside* the tail; this suite pins the extra keep-newest pass.
+"""
+
+from __future__ import annotations
+
+from agent.context_compressor import (
+    ContextCompressor,
+    _MAX_KEEP_TOOL_IMAGES,
+    _content_has_images,
+    _tool_content_has_images,
+)
+
+
+def _compressor() -> ContextCompressor:
+    c = ContextCompressor.__new__(ContextCompressor)
+    c.quiet_mode = True
+    return c
+
+
+def _image_tool(i: int, *, blob: str = "A" * 400) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": f"call_{i}",
+                    "type": "function",
+                    "function": {
+                        "name": "vision_analyze",
+                        "arguments": f'{{"image_url":"shot{i}.png"}}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": f"call_{i}",
+            "content": [
+                {"type": "text", "text": f"Image attached natively shot {i}"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{blob}{i}"},
+                },
+            ],
+        },
+    ]
+
+
+def _image_bearing_tools(messages: list[dict]) -> list[dict]:
+    return [
+        m
+        for m in messages
+        if m.get("role") == "tool" and _tool_content_has_images(m.get("content"))
+    ]
+
+
+class TestRetireStaleToolImagesInProtectedTail:
+    def test_keep_newest_images_inside_a_large_protect_window(self):
+        """Five native embeds all fit in protect_last_n=20; only newest N stay."""
+        msgs: list[dict] = [{"role": "user", "content": "screenshot QA"}]
+        for i in range(5):
+            msgs.extend(_image_tool(i))
+        msgs.append({"role": "user", "content": "compare the last few"})
+
+        out, pruned = _compressor()._prune_old_tool_results(
+            msgs, protect_tail_count=20,
+        )
+        assert pruned >= 5 - _MAX_KEEP_TOOL_IMAGES
+        kept = _image_bearing_tools(out)
+        assert len(kept) == _MAX_KEEP_TOOL_IMAGES
+        kept_ids = [m["tool_call_id"] for m in kept]
+        assert kept_ids == [f"call_{i}" for i in range(5 - _MAX_KEEP_TOOL_IMAGES, 5)]
+
+    def test_multimodal_envelopes_outside_keep_window_become_text(self):
+        msgs: list[dict] = [{"role": "user", "content": "go"}]
+        for i in range(_MAX_KEEP_TOOL_IMAGES + 1):
+            msgs.append({
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": f"env_{i}",
+                    "type": "function",
+                    "function": {"name": "vision_analyze", "arguments": "{}"},
+                }],
+            })
+            msgs.append({
+                "role": "tool",
+                "tool_call_id": f"env_{i}",
+                "content": {
+                    "_multimodal": True,
+                    "content": [
+                        {"type": "text", "text": f"shot {i}"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/png;base64,XYZ{i}"},
+                        },
+                    ],
+                    "text_summary": f"native shot {i}",
+                },
+            })
+
+        out, _ = _compressor()._prune_old_tool_results(
+            msgs, protect_tail_count=20,
+        )
+        oldest = next(m for m in out if m.get("tool_call_id") == "env_0")
+        assert isinstance(oldest["content"], str)
+        assert "screenshot removed" in oldest["content"]
+        assert "native shot 0" in oldest["content"]
+        newest = next(
+            m for m in out
+            if m.get("tool_call_id") == f"env_{_MAX_KEEP_TOOL_IMAGES}"
+        )
+        assert _tool_content_has_images(newest["content"])
+
+    def test_user_uploads_are_not_retired(self):
+        user_img = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,USERUPLOAD"},
+                },
+            ],
+        }
+        msgs = [user_img]
+        for i in range(_MAX_KEEP_TOOL_IMAGES + 2):
+            msgs.extend(_image_tool(i))
+
+        out, _ = _compressor()._prune_old_tool_results(
+            msgs, protect_tail_count=20,
+        )
+        assert _content_has_images(out[0]["content"])
+        assert out[0]["content"][1]["image_url"]["url"].endswith("USERUPLOAD")

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -318,6 +318,68 @@ class TestBrowserVisionConfig:
         mock_get_vision_model.assert_not_called()
         mock_llm.assert_not_called()
 
+    def test_browser_vision_native_fast_path_caps_history_embed(self, tmp_path):
+        """Oversized screenshots are resized before entering history (#92699).
+
+        browser_vision's native fast path bakes the data URL into the tool
+        result exactly like vision_analyze — without the proactive resize a
+        full-res screenshot rides every later request uncapped.
+        """
+        pytest.importorskip("PIL")
+        import base64
+        from io import BytesIO
+
+        from PIL import Image
+
+        from agent.auxiliary_client import clear_runtime_main, set_runtime_main
+        from tools.browser_tool import browser_vision
+        from tools.vision_tools import _EMBED_MAX_DIMENSION, _EMBED_TARGET_BYTES
+
+        shots_dir = tmp_path / "browser_screenshots"
+        shots_dir.mkdir()
+        screenshot = shots_dir / "shot.png"
+        # Taller than the long-edge cap so the resize path must fire.
+        Image.new("RGB", (400, _EMBED_MAX_DIMENSION + 500), (0, 100, 0)).save(
+            screenshot, format="PNG"
+        )
+
+        set_runtime_main("brand-new-provider", "llava-v1.6")
+        try:
+            with (
+                patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+                patch("tools.browser_tool._cleanup_old_screenshots"),
+                patch(
+                    "tools.browser_tool._run_browser_command",
+                    return_value={
+                        "success": True,
+                        "data": {"path": str(screenshot)},
+                    },
+                ),
+                patch(
+                    "hermes_cli.config.load_config",
+                    return_value={"model": {"supports_vision": True}},
+                ),
+                patch("tools.browser_tool.call_llm") as mock_llm,
+            ):
+                result = browser_vision("what is on the page?", task_id="test")
+        finally:
+            clear_runtime_main()
+
+        assert isinstance(result, dict)
+        assert result["_multimodal"] is True
+        url = next(
+            p["image_url"]["url"]
+            for p in result["content"]
+            if p.get("type") == "image_url"
+        )
+        assert len(url) <= _EMBED_TARGET_BYTES, (
+            f"embedded browser screenshot {len(url) / 1024:.0f} KB exceeds the "
+            f"history-reuse cap {_EMBED_TARGET_BYTES / 1024:.0f} KB"
+        )
+        with Image.open(BytesIO(base64.b64decode(url.partition(",")[2]))) as img:
+            assert max(img.size) <= _EMBED_MAX_DIMENSION
+        mock_llm.assert_not_called()
+
     def test_browser_vision_text_mode_blocks_native_fast_path(self, tmp_path):
         """Explicit text routing → aux LLM used even with supports_vision."""
         from agent.auxiliary_client import clear_runtime_main, set_runtime_main

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -108,12 +108,10 @@ class TestVisionAnalyzeNative:
         """Regression for the wedged-session incident (May 2026).
 
         A vision tool-result image is baked into conversation history and
-        re-sent on every subsequent turn.  Anthropic rejects any single
-        base64 image over 5 MB with a 400, and immutable history means the
-        bad bytes can't be cleared by retrying — the session is permanently
-        wedged.  The native fast path must proactively resize down to the
-        embed cap (well under 5 MB) BEFORE embedding, not just at the 20 MB
-        hard ceiling.  Skips if Pillow isn't available (resize is a no-op).
+        re-sent on every subsequent turn.  The native fast path must
+        proactively resize down to the history-reuse embed cap BEFORE
+        embedding, not just at the 20 MB hard ceiling.  Skips if Pillow
+        isn't available (resize is a no-op).
         """
         pytest = __import__("pytest")
         try:
@@ -138,9 +136,17 @@ class TestVisionAnalyzeNative:
             if p.get("type") == "image_url"
         )
         assert len(url) <= _EMBED_TARGET_BYTES, (
-            f"embedded image {len(url) / 1024 / 1024:.1f} MB exceeds embed cap "
-            f"{_EMBED_TARGET_BYTES / 1024 / 1024:.0f} MB — would wedge sessions on Anthropic"
+            f"embedded image {len(url) / 1024:.0f} KB exceeds embed cap "
+            f"{_EMBED_TARGET_BYTES / 1024:.0f} KB — would bloat every later turn"
         )
+
+    def test_embed_caps_are_sized_for_history_reuse(self):
+        """Native embeds ride every later turn, so caps must stay well below
+        the Anthropic 5 MB / 8000px reject limits (#92699)."""
+        from tools.vision_tools import _EMBED_MAX_DIMENSION, _EMBED_TARGET_BYTES
+
+        assert _EMBED_TARGET_BYTES <= 512 * 1024
+        assert _EMBED_MAX_DIMENSION <= 2048
 
 
 # ─── _handle_vision_analyze fast-path gating ─────────────────────────────────

--- a/tests/tools/test_vision_region.py
+++ b/tests/tools/test_vision_region.py
@@ -142,7 +142,7 @@ class TestNativePathRegion:
         downscaled with the rest."""
         from tools.vision_tools import _EMBED_MAX_DIMENSION, _vision_analyze_native
 
-        # Taller than the 7900px embed cap — full shot would be downscaled.
+        # Taller than the embed long-edge cap — full shot would be downscaled.
         big = tmp_path / "big.png"
         Image.new("RGB", (200, _EMBED_MAX_DIMENSION + 500), (0, 100, 0)).save(
             big, format="PNG"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4711,26 +4711,46 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
                 ),
             }, ensure_ascii=False)
 
-        # Convert screenshot to base64 at full resolution.
-        _screenshot_bytes = screenshot_path.read_bytes()
-        _screenshot_b64 = base64.b64encode(_screenshot_bytes).decode("ascii")
-        data_url = f"data:image/png;base64,{_screenshot_b64}"
+        # NOTE: the full-resolution base64 encode is deliberately deferred.
+        # The native fast path below sizes its own history-reuse embed via
+        # _resize_image_for_vision (stat-based quick estimate — no full-res
+        # encode when oversized), and only the aux-LLM fallback path needs
+        # the one-shot full-res data URL.
 
         # Fast path: when native image routing is in effect for the active main
         # model, attach the screenshot directly instead of describing it through
         # an auxiliary vision LLM. The model inspects the pixels on its next
         # turn — no aux call, no information loss. Consistent with vision_analyze.
         from tools.vision_tools import (
+            _EMBED_MAX_DIMENSION,
+            _EMBED_TARGET_BYTES,
             _build_native_vision_tool_result,
+            _resize_image_for_vision,
             _should_use_native_vision_fast_path,
         )
 
         if _should_use_native_vision_fast_path():
+            # History-reuse cap (#92699): this embed is baked into the tool
+            # result and re-sent on every later turn, exactly like
+            # vision_analyze's native path — apply the same proactive resize
+            # so full-res screenshots can't enter immutable history uncapped.
+            # The helper's internal stat/dimension quick-estimate skips the
+            # resize (and encodes directly) when the screenshot is already
+            # under both caps, so no full-res base64 is built just to be
+            # thrown away. Fail-open: without Pillow it falls back to the
+            # raw bytes and the compressor's keep-newest pass still retires
+            # stale embeds.
+            data_url = _resize_image_for_vision(
+                screenshot_path,
+                mime_type="image/png",
+                max_base64_bytes=_EMBED_TARGET_BYTES,
+                max_dimension=_EMBED_MAX_DIMENSION,
+            )
             native_result = _build_native_vision_tool_result(
                 image_url=str(screenshot_path),
                 question=question,
                 image_data_url=data_url,
-                image_size_bytes=len(_screenshot_bytes),
+                image_size_bytes=screenshot_path.stat().st_size,
             )
             meta = native_result.setdefault("meta", {})
             meta["screenshot_path"] = str(screenshot_path)
@@ -4752,6 +4772,13 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
             f"or CAPTCHAs, describe what type they are and what action might be needed. "
             f"Focus on answering the user's specific question."
         )
+
+        # Aux-LLM path: one-shot analysis, not baked into history — encode at
+        # full resolution here (the pre-existing 5 MB oversize guard below
+        # still applies).
+        _screenshot_bytes = screenshot_path.read_bytes()
+        _screenshot_b64 = base64.b64encode(_screenshot_bytes).decode("ascii")
+        data_url = f"data:image/png;base64,{_screenshot_b64}"
 
         # Use the centralized LLM router
         vision_model = _get_vision_model()

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -625,25 +625,21 @@ def _image_to_base64_data_url(image_path: Path, mime_type: Optional[str] = None)
 # provider accepts the image and we reject outright.
 _MAX_BASE64_BYTES = 20 * 1024 * 1024
 
-# Proactive embed cap (4 MB).  This is the size we resize an image DOWN to
-# before embedding it into conversation history, regardless of the 20 MB hard
-# ceiling.  Anthropic's per-image base64 limit is 5 MB; once an oversized image
-# is baked into history (e.g. a vision tool-result), it is re-sent on every
-# subsequent turn and permanently wedges the session with a 400 that retries
-# can't clear (the bad bytes are immutable history).  Capping at embed time —
-# with headroom under 5 MB — is the only durable fix.  Matches the post-failure
-# shrink target in agent.conversation_compression so behaviour is consistent
-# whether we resize proactively or reactively.
-_EMBED_TARGET_BYTES = 4 * 1024 * 1024
+# Proactive embed cap for conversation-history reuse.  Native vision_analyze
+# bakes the data-URL into the tool result, which is re-sent on every later
+# turn.  The 20 MB hard ceiling / Anthropic 5 MB reject-cap still apply as
+# safety nets; those are one-shot viewing limits, not history-reuse sizes.
+# A 4 MB / 7900px embed was observed at ~400K chars and ~100–260K billed
+# tokens per image (#92699), so we size for model reading instead: 256 KB
+# is tens of KB after JPEG encode of a 1568px screenshot, well under every
+# provider's per-image limit, and cheap enough to ride the session.
+_EMBED_TARGET_BYTES = 256 * 1024
 
-# Proactive embed dimension cap (px, longest side).  Anthropic enforces an
-# 8000px per-side ceiling INDEPENDENTLY of the 5 MB byte cap — a tall full-page
-# screenshot can be well under 5 MB yet far over 8000px (e.g. 1200×12000 at
-# 0.06 MB), so the byte-only embed check above lets it slip into immutable
-# history un-resized and the session bricks on a non-retryable 400.  We cap at
-# 7900 (headroom under 8000) so the proactive resize shrinks tall small-byte
-# images before they are embedded.
-_EMBED_MAX_DIMENSION = 7900
+# Proactive embed dimension cap (px, longest side).  Anthropic still rejects
+# above 8000px independently of the byte cap, but its tokenizer downsamples
+# to a 1568px long edge — pixels past that cost wire bytes and never extra
+# model fidelity.  Cap at 1568 so history embeds match what the model sees.
+_EMBED_MAX_DIMENSION = 1568
 
 # Target size when auto-resizing on API failure (5 MB).  After a provider
 # rejects an image, we downscale to this target and retry once.
@@ -1240,13 +1236,12 @@ async def _vision_analyze_native(
         )
 
         # Proactive embed cap: this image gets baked into conversation
-        # history and re-sent on every subsequent turn.  Anthropic rejects
-        # any single base64 image over 5 MB OR over 8000px per side with a
-        # 400, and because history is immutable, an oversized embed
-        # permanently wedges the session — retries can't clear bytes (or
-        # pixels) that are already in the request.  Resize DOWN to the embed
-        # target (4 MB / 7900px, headroom under both ceilings) whenever the
-        # payload exceeds either limit, not just at the 20 MB hard ceiling.
+        # history and re-sent on every subsequent turn.  Resize DOWN to the
+        # history-reuse target whenever the payload exceeds either the byte
+        # or long-edge cap, not just at the 20 MB hard ceiling.  Anthropic
+        # still rejects >5 MB / >8000px with a non-retryable 400, but those
+        # are one-shot viewing limits — history embeds are sized smaller so
+        # repeated vision_analyze turns don't blow the context (#92699).
         _over_bytes = len(image_data_url) > _EMBED_TARGET_BYTES
         _over_dims = await _run_encode_on_cpu_executor(
             _image_exceeds_dimension, temp_image_path, _EMBED_MAX_DIMENSION,

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -631,8 +631,9 @@ _MAX_BASE64_BYTES = 20 * 1024 * 1024
 # safety nets; those are one-shot viewing limits, not history-reuse sizes.
 # A 4 MB / 7900px embed was observed at ~400K chars and ~100–260K billed
 # tokens per image (#92699), so we size for model reading instead: 256 KB
-# is tens of KB after JPEG encode of a 1568px screenshot, well under every
-# provider's per-image limit, and cheap enough to ride the session.
+# keeps a 1568px screenshot cheap enough to ride the session (PNGs that
+# exceed it are downscaled further by the byte-budget ladder), well under
+# every provider's per-image limit.
 _EMBED_TARGET_BYTES = 256 * 1024
 
 # Proactive embed dimension cap (px, longest side).  Anthropic still rejects


### PR DESCRIPTION
## Summary

Native-vision screenshot QA sessions no longer blow up context: history embeds are capped at 256 KB / 1568 px, and compression can retire stale screenshots even inside the protected tail so anti-thrash no longer disables it (issue #92699).

Salvage of #92725 by @HexLab98 (cherry-picked, authorship preserved) plus one follow-up commit closing the sibling gap in `browser_vision`.

## Changes

- `tools/vision_tools.py`: `_EMBED_TARGET_BYTES` 4 MB → 256 KB, `_EMBED_MAX_DIMENSION` 7900 px → 1568 px (Anthropic's effective long edge — pixels past that cost wire bytes with no model fidelity). One-shot viewing/reactive limits (20 MB hard ceiling, 5 MB post-failure shrink) unchanged.
- `agent/context_compressor.py`: new pass 3.5 in `_prune_old_tool_results` — keeps the newest 3 image-bearing tool results verbatim and replaces older embeds with text placeholders **even inside `protect_last_n`**. Matches the Anthropic adapter's `_MAX_KEEP_IMAGES = 3` outbound window. Retired bytes count toward measured savings, so compression stops looking ineffective and anti-thrash stops tripping. User-role uploads are never touched.
- `tools/browser_tool.py` (follow-up): `browser_vision`'s native fast path applied **no** cap — full-res screenshots entered immutable history uncapped, the exact sibling of the bug. It now applies the same proactive resize before building the tool result. Fail-open without Pillow (compressor pass still retires stale embeds). Shared-cap approach credited to #92748 by @JoaoMarcos44.

## Validation

| | Before | After |
|---|---|---|
| Native embed of a 27 MB screenshot | ~1.3 MB base64 in history forever | 84 KB, ≤1568 px |
| 6 vision embeds inside protected tail after compression | all 6 survive, savings <10%, anti-thrash disables compression | newest 3 survive, rest placeholders, savings counted |
| `browser_vision` native screenshot | full-res, uncapped | capped 256 KB / 1568 px |

- 84/84 targeted tests green (vision fast path, region, tools, browser_console, compressor stale-images) + 159 compressor-suite tests green.
- E2E probes with real worktree imports: prune keeps exactly the newest 3, `tool_call_id`/roles preserved, copy-on-write confirmed; same probe on main prunes 0.
- Image retirement runs only inside compression and the commit-gated proactive prune — no per-request history mutation, prompt caching preserved.
- ruff clean; ty diagnostics identical to main (all pre-existing).

## Credit

- Core fix: #92725 by @HexLab98 — cherry-picked with authorship preserved.
- #92748 by @JoaoMarcos44 explored a broader per-request byte-projection; its per-request history rewrite conflicts with the prompt-cache invariant and its 128 KB history cap vs 256 KB embed cap blinded the model to just-taken 128–256 KB screenshots (both probe-confirmed), so the narrower fix was taken — but its "one policy owner for both native embed paths" insight drove the follow-up commit here (co-authored).

Fixes #92699
Closes #92725
