### PR TITLE
fix(agent): detect TTS/image/video loops by argument identity

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -56,6 +56,17 @@ MUTATING_TOOL_NAMES = frozenset(
         "cronjob",
         "delegate_task",
         "process",
+        "text_to_speech",
+        "image_generate",
+        "video_generate",
+    }
+)
+
+UNIQUE_OUTPUT_TOOL_NAMES = frozenset(
+    {
+        "text_to_speech",
+        "image_generate",
+        "video_generate",
     }
 )
 
@@ -104,6 +115,10 @@ def is_stall_guard_repeatable(tool_name: str) -> bool:
     if tool_name in STALL_GUARD_REPEATABLE_TOOLS:
         return True
     return tool_name.endswith(_STALL_GUARD_REPEATABLE_SUFFIXES)
+
+
+def is_unique_output_tool(tool_name: str) -> bool:
+    return tool_name in UNIQUE_OUTPUT_TOOL_NAMES
 
 
 @dataclass(frozen=True)
@@ -342,6 +357,7 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._unique_output_repeats: dict[ToolCallSignature, int] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
         # Identical-call loop-breaker state (agent.stall_guards): tracks the
         # CONSECUTIVE streak of identical (tool, canonical args) calls whose
@@ -354,6 +370,8 @@ class ToolCallGuardrailController:
         self._identical_streak_sig: ToolCallSignature | None = None
         self._identical_streak_result_hash: str = ""
         self._identical_streak_count: int = 0
+        self._args_streak_sig: ToolCallSignature | None = None
+        self._args_streak_count: int = 0
         # tool_call_id of the FIRST call in the current streak, so a
         # result-reference stub can point at the message that carries the
         # full payload.
@@ -426,6 +444,24 @@ class ToolCallGuardrailController:
                     self._halt_decision = decision
                     return decision
 
+        if is_unique_output_tool(tool_name):
+            repeat_count = self._unique_output_repeats.get(signature, 0)
+            if repeat_count >= self.config.no_progress_block_after:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="unique_output_no_progress_block",
+                    message=(
+                        f"Blocked {tool_name}: this call ran {repeat_count} times "
+                        "with identical arguments. A unique result is not progress; "
+                        "stop repeating it unchanged."
+                    ),
+                    tool_name=tool_name,
+                    count=repeat_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
     def after_call(
@@ -445,6 +481,7 @@ class ToolCallGuardrailController:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
             self._exact_failure_counts[signature] = exact_count
             self._no_progress.pop(signature, None)
+            self._unique_output_repeats.pop(signature, None)
 
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
@@ -492,6 +529,26 @@ class ToolCallGuardrailController:
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
+
+        if is_unique_output_tool(tool_name):
+            repeat_count = self._unique_output_repeats.get(signature, 0) + 1
+            self._unique_output_repeats[signature] = repeat_count
+            if self.config.warnings_enabled and repeat_count >= self.config.no_progress_warn_after:
+                return ToolGuardrailDecision(
+                    action="warn",
+                    code="unique_output_no_progress_warning",
+                    message=(
+                        f"{tool_name} ran {repeat_count} times with identical arguments. "
+                        "A unique generated path is not progress; change the input or "
+                        "use the result already delivered."
+                    ),
+                    tool_name=tool_name,
+                    count=repeat_count,
+                    signature=signature,
+                )
+            return ToolGuardrailDecision(
+                tool_name=tool_name, count=repeat_count, signature=signature
+            )
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)
@@ -591,20 +648,41 @@ class ToolCallGuardrailController:
             self._identical_streak_count = 1 if is_plain_str else 0
             self._identical_streak_first_call_id = tool_call_id or ""
 
+        if is_plain_str and is_unique_output_tool(tool_name):
+            if self._args_streak_sig == signature:
+                self._args_streak_count += 1
+            else:
+                self._args_streak_sig = signature
+                self._args_streak_count = 1
+        else:
+            self._args_streak_sig = None
+            self._args_streak_count = 0
+
         count = self._identical_streak_count
+        args_count = self._args_streak_count
+        unique_output = is_unique_output_tool(tool_name)
+        notice_count = args_count if unique_output else count
 
         notice = None
         if (
             not is_stall_guard_repeatable(tool_name)
-            and count >= STALL_GUARD_IDENTICAL_CALL_THRESHOLD
+            and notice_count >= STALL_GUARD_IDENTICAL_CALL_THRESHOLD
         ):
-            ordinal = f"{count}{'th' if 11 <= count % 100 <= 13 else {1: 'st', 2: 'nd', 3: 'rd'}.get(count % 10, 'th')}"
-            notice = (
-                f"[hermes note: this is the {ordinal} consecutive identical call to "
-                f"{tool_name} with identical arguments returning the same result. "
-                "Do not repeat it — change arguments, use a different tool, or "
-                "proceed with what you have.]"
-            )
+            ordinal = f"{notice_count}{'th' if 11 <= notice_count % 100 <= 13 else {1: 'st', 2: 'nd', 3: 'rd'}.get(notice_count % 10, 'th')}"
+            if unique_output:
+                notice = (
+                    f"[hermes note: this is the {ordinal} consecutive identical call to "
+                    f"{tool_name} with identical arguments. A unique generated path "
+                    "is not progress. Do not repeat it — change arguments, use a "
+                    "different tool, or proceed with what you have.]"
+                )
+            else:
+                notice = (
+                    f"[hermes note: this is the {ordinal} consecutive identical call to "
+                    f"{tool_name} with identical arguments returning the same result. "
+                    "Do not repeat it — change arguments, use a different tool, or "
+                    "proceed with what you have.]"
+                )
 
         stub = None
         if (

--- a/tests/agent/test_stall_guards.py
+++ b/tests/agent/test_stall_guards.py
@@ -20,8 +20,10 @@ from agent.tool_guardrails import (
     IDENTICAL_RESULT_STUB_MIN_CHARS,
     STALL_GUARD_IDENTICAL_CALL_THRESHOLD,
     STALL_GUARD_REPEATABLE_TOOLS,
+    UNIQUE_OUTPUT_TOOL_NAMES,
     ToolCallGuardrailController,
     is_stall_guard_repeatable,
+    is_unique_output_tool,
 )
 
 
@@ -104,6 +106,10 @@ def test_allowlist_membership_contract():
     assert is_stall_guard_repeatable("acme_get_result")
     assert not is_stall_guard_repeatable("web_search")
     assert not is_stall_guard_repeatable("terminal")
+    assert not is_stall_guard_repeatable("text_to_speech")
+    for tool in UNIQUE_OUTPUT_TOOL_NAMES:
+        assert is_unique_output_tool(tool)
+        assert not is_stall_guard_repeatable(tool)
 
 
 def test_resets_per_turn():
@@ -394,3 +400,36 @@ def test_ignores_conversational_future_offers():
     assert not trailing_continue_intent(
         "If you want, I will happily review the PR once CI is green. Just say so!"
     )
+
+
+def test_tts_notice_fires_when_only_the_generated_path_changes():
+    c = ToolCallGuardrailController()
+    args = {"text": "hi"}
+    notices = [
+        c.observe_identical_call("text_to_speech", args, f"/cache/tts_{i}.ogg")
+        for i in range(STALL_GUARD_IDENTICAL_CALL_THRESHOLD)
+    ]
+    assert notices[0] is None
+    assert notices[1] is None
+    assert notices[2] is not None
+    assert "text_to_speech" in notices[2]
+    assert "identical arguments" in notices[2]
+    assert "same result" not in notices[2]
+
+
+def test_unique_output_notice_resets_when_args_change():
+    c = ToolCallGuardrailController()
+    for i in range(5):
+        notice = c.observe_identical_call(
+            "text_to_speech", {"text": f"line {i}"}, f"/cache/tts_{i}.ogg"
+        )
+        assert notice is None
+
+
+def test_terminal_poll_with_changing_results_still_does_not_notice():
+    c = ToolCallGuardrailController()
+    for i in range(5):
+        notice = c.observe_identical_call(
+            "terminal", {"command": "poll-status"}, f"output {i}"
+        )
+        assert notice is None

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -131,6 +131,57 @@ def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_succes
         assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
 
 
+def test_unique_output_tools_warn_and_block_on_repeated_args_even_when_results_differ():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            warnings_enabled=True,
+            hard_stop_enabled=True,
+            no_progress_warn_after=2,
+            no_progress_block_after=5,
+            same_tool_failure_halt_after=99,
+        )
+    )
+    args = {"text": "hi"}
+    warns = 0
+    block = None
+    for i in range(8):
+        before = controller.before_call("text_to_speech", args)
+        if before.action in ("block", "halt"):
+            block = (i + 1, before.code)
+            break
+        after = controller.after_call(
+            "text_to_speech", args, f"/cache/tts_{i}.ogg", failed=False
+        )
+        if after.action == "warn":
+            warns += 1
+            assert after.code == "unique_output_no_progress_warning"
+    assert warns == 4
+    assert block == (6, "unique_output_no_progress_block")
+
+
+def test_image_and_video_generate_share_the_unique_output_contract():
+    from agent.tool_guardrails import is_unique_output_tool
+
+    for tool in ("image_generate", "video_generate"):
+        assert is_unique_output_tool(tool)
+        controller = ToolCallGuardrailController(
+            ToolCallGuardrailConfig(
+                hard_stop_enabled=True,
+                no_progress_warn_after=2,
+                no_progress_block_after=2,
+            )
+        )
+        args = {"prompt": "a cat"}
+        assert controller.before_call(tool, args).action == "allow"
+        first = controller.after_call(tool, args, f"/out/{tool}_1.bin", failed=False)
+        assert first.action == "allow"
+        second = controller.after_call(tool, args, f"/out/{tool}_2.bin", failed=False)
+        assert second.action == "warn"
+        blocked = controller.before_call(tool, args)
+        assert blocked.action == "block"
+        assert blocked.code == "unique_output_no_progress_block"
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`text_to_speech` (and `image_generate` / `video_generate`) succeed with a unique generated path every call. Result-identity stall guards and no-progress detectors therefore never fire, so identical TTS/image/video calls can loop with zero warnings, zero notices, and zero hard-stops.

Those tools now key repeats on **identical arguments**, not result bytes. `terminal` / `process` / `*_get_result` pollers are unchanged — they reuse args on purpose while the result changes.

Related but not a duplicate of #90496 (todo/`read_file` jitter). This is the unique-output filename case from #92472.

## Related Issue

Fixes #92472

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_guardrails.py` — classify `text_to_speech` / `image_generate` / `video_generate` as unique-output; warn/block and stall-notice on same-args repeats
- `tests/agent/test_tool_guardrails.py` — warn/block contract for TTS + image/video
- `tests/agent/test_stall_guards.py` — notice fires when only the generated path changes; terminal polling still silent

## How to Test

1. `scripts/run_tests.sh tests/agent/test_tool_guardrails.py tests/agent/test_stall_guards.py`
2. Confirm 47 passed (the #92472 repro: 8 identical `text_to_speech` calls now warn, notice, and hard-stop; `web_search` control unchanged)
3. `test_does_not_fire_when_results_differ` still covers `terminal` poll-status with changing output

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
