### PR TITLE
fix(memory): serialize Honcho _flush_session per session to stop double-sends

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -151,6 +151,17 @@ class HonchoSessionManager:
         self._cache_lock = threading.RLock()
         self._peers_cache: dict[str, Any] = {}
         self._sessions_cache: dict[str, Any] = {}
+        # Per-session flush locks (#92458): the async writer thread and an
+        # exit-time flush_all() can both enter _flush_session for the same
+        # session back-to-back — in a short-lived process (one-shot CLI, -z)
+        # the enqueue and the exit flush land close enough together that both
+        # read the same unsynced messages before either marks them synced,
+        # and both POST the batch. Serializing per session (not globally —
+        # distinct sessions must still flush concurrently) closes the window:
+        # the second flusher enters after the first already marked _synced
+        # and finds nothing left to send. Created lazily under _cache_lock,
+        # like the other per-key caches on this manager.
+        self._flush_locks: dict[str, threading.Lock] = {}
         # Bumped (under _cache_lock) whenever _force_reauth rebuilds the client.
         # In-flight resolvers compare it around their SDK fetch so an object
         # bound to the discarded client is never stored into the fresh cache.
@@ -657,46 +668,65 @@ class HonchoSessionManager:
             self._cache[key] = session
         return session
 
+    def _get_flush_lock(self, session_key: str) -> threading.Lock:
+        """Get or create this session's flush lock (create step under _cache_lock)."""
+        with self._cache_lock:
+            lock = self._flush_locks.get(session_key)
+            if lock is None:
+                lock = threading.Lock()
+                self._flush_locks[session_key] = lock
+            return lock
+
     def _flush_session(self, session: HonchoSession) -> bool:
-        """Internal: write unsynced messages to Honcho synchronously."""
-        if not session.messages:
-            return True
+        """Internal: write unsynced messages to Honcho synchronously.
 
-        new_messages = [m for m in session.messages if not m.get("_synced")]
-        if not new_messages:
-            return True
+        Serialized per session (#92458): the read (unsynced messages) → send
+        (POST) → mark (_synced = True) sequence has no atomicity of its own,
+        so two flushers racing the same session — typically the async writer
+        thread against an exit-time flush_all() — can both read the same
+        unsynced messages before either marks them, and both send the batch.
+        Holding this lock across the whole body makes the second flusher wait
+        for the first to mark _synced, so it finds nothing left to send.
+        """
+        with self._get_flush_lock(session.key):
+            if not session.messages:
+                return True
 
-        # Resolved inside the operation so a retry after a client rebuild gets fresh objects.
-        def _sync_messages() -> int:
-            user_peer = self._get_or_create_peer(session.user_peer_id)
-            assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
-            honcho_session = self._sessions_cache.get(session.honcho_session_id)
-            if honcho_session is None:
-                honcho_session, _ = self._get_or_create_honcho_session(
-                    session.honcho_session_id, user_peer, assistant_peer
-                )
-            honcho_messages = [
-                (user_peer if m["role"] == "user" else assistant_peer).message(m["content"])
-                for m in new_messages
-            ]
-            honcho_session.add_messages(honcho_messages)
-            return len(honcho_messages)
+            new_messages = [m for m in session.messages if not m.get("_synced")]
+            if not new_messages:
+                return True
 
-        try:
-            synced = self._authed_call("message sync", _sync_messages)
-            for msg in new_messages:
-                msg["_synced"] = True
-            logger.debug("Synced %d messages to Honcho for %s", synced, session.key)
-            with self._cache_lock:
-                self._cache[session.key] = session
-            return True
-        except Exception as e:
-            for msg in new_messages:
-                msg["_synced"] = False
-            logger.error("Failed to sync messages to Honcho: %s", e)
-            with self._cache_lock:
-                self._cache[session.key] = session
-            return False
+            # Resolved inside the operation so a retry after a client rebuild gets fresh objects.
+            def _sync_messages() -> int:
+                user_peer = self._get_or_create_peer(session.user_peer_id)
+                assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
+                honcho_session = self._sessions_cache.get(session.honcho_session_id)
+                if honcho_session is None:
+                    honcho_session, _ = self._get_or_create_honcho_session(
+                        session.honcho_session_id, user_peer, assistant_peer
+                    )
+                honcho_messages = [
+                    (user_peer if m["role"] == "user" else assistant_peer).message(m["content"])
+                    for m in new_messages
+                ]
+                honcho_session.add_messages(honcho_messages)
+                return len(honcho_messages)
+
+            try:
+                synced = self._authed_call("message sync", _sync_messages)
+                for msg in new_messages:
+                    msg["_synced"] = True
+                logger.debug("Synced %d messages to Honcho for %s", synced, session.key)
+                with self._cache_lock:
+                    self._cache[session.key] = session
+                return True
+            except Exception as e:
+                for msg in new_messages:
+                    msg["_synced"] = False
+                logger.error("Failed to sync messages to Honcho: %s", e)
+                with self._cache_lock:
+                    self._cache[session.key] = session
+                return False
 
     def _async_writer_loop(self) -> None:
         """Background daemon thread: drains the async write queue."""

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -265,6 +265,119 @@ class TestFlushAll:
 
 
 # ---------------------------------------------------------------------------
+# _flush_session concurrency (#92458)
+# ---------------------------------------------------------------------------
+
+class TestConcurrentFlushSession:
+    """The async writer thread and an exit-time flush_all() can both enter
+    _flush_session for the same session back-to-back in a short-lived
+    process. Without serialization, both read the same unsynced messages
+    before either marks them synced, and both POST the batch — every turn
+    of a one-shot run gets stored twice."""
+
+    def _prime(self, mgr, sess, *, send_delay=0.05):
+        """Cache real peer/session objects (not MagicMocks that auto-track
+        calls independently of timing) so add_messages is the single choke
+        point both flushers race through."""
+        honcho_session = MagicMock()
+        call_log = []
+        call_lock = threading.Lock()
+
+        def _slow_add_messages(messages):
+            # Widen the race window: without the lock, both threads' reads
+            # (identical new_messages, since neither has marked _synced yet)
+            # land here before either returns.
+            import time
+            time.sleep(send_delay)
+            with call_lock:
+                call_log.append(len(messages))
+
+        honcho_session.add_messages.side_effect = _slow_add_messages
+        mgr._sessions_cache[sess.honcho_session_id] = honcho_session
+        mgr._peers_cache[sess.user_peer_id] = MagicMock(
+            message=lambda content: {"role": "user", "content": content}
+        )
+        mgr._peers_cache[sess.assistant_peer_id] = MagicMock(
+            message=lambda content: {"role": "assistant", "content": content}
+        )
+        return honcho_session, call_log
+
+    def test_racing_flushes_send_the_batch_once(self, make_manager):
+        mgr = make_manager(write_frequency="session")
+        sess = _make_session(key="one-shot", honcho_session_id="one-shot")
+        sess.add_message("user", "hi")
+        sess.add_message("assistant", "hello")
+        mgr._cache[sess.key] = sess
+
+        _honcho_session, call_log = self._prime(mgr, sess)
+
+        # Simulates the reported pair: the async writer thread draining the
+        # queue for this session, racing an exit-time flush_all() for the
+        # same session — both handed the SAME HonchoSession object, exactly
+        # as save()/flush_all() do (they don't clone it).
+        results = []
+        results_lock = threading.Lock()
+
+        def flush():
+            ok = mgr._flush_session(sess)
+            with results_lock:
+                results.append(ok)
+
+        t1 = threading.Thread(target=flush)
+        t2 = threading.Thread(target=flush)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert len(call_log) == 1, f"expected exactly one send, got {call_log}"
+        assert call_log[0] == 2, "the single send must carry both messages"
+        assert results == [True, True]
+        assert all(m["_synced"] for m in sess.messages)
+
+    def test_distinct_sessions_still_flush_concurrently(self, make_manager):
+        # The lock must be per-session, not global — two DIFFERENT sessions
+        # must not block on each other.
+        mgr = make_manager(write_frequency="session")
+        s1 = _make_session(key="s1", honcho_session_id="s1")
+        s2 = _make_session(key="s2", honcho_session_id="s2")
+        s1.add_message("user", "a")
+        s2.add_message("user", "b")
+        mgr._cache[s1.key] = s1
+        mgr._cache[s2.key] = s2
+
+        gate = threading.Barrier(2, timeout=5)
+
+        for sess in (s1, s2):
+            honcho_session = MagicMock()
+
+            def _gated_add_messages(messages, _gate=gate):
+                # Both sends must be inside add_messages AT THE SAME TIME —
+                # if the lock were global, the second thread would still be
+                # blocked waiting to ENTER _flush_session and never reach here.
+                _gate.wait()
+
+            honcho_session.add_messages.side_effect = _gated_add_messages
+            mgr._sessions_cache[sess.honcho_session_id] = honcho_session
+            mgr._peers_cache[sess.user_peer_id] = MagicMock(message=lambda c: {"content": c})
+            mgr._peers_cache[sess.assistant_peer_id] = MagicMock(message=lambda c: {"content": c})
+
+        results = {}
+
+        def flush(sess, name):
+            results[name] = mgr._flush_session(sess)
+
+        t1 = threading.Thread(target=flush, args=(s1, "s1"))
+        t2 = threading.Thread(target=flush, args=(s2, "s2"))
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert results == {"s1": True, "s2": True}
+
+
+# ---------------------------------------------------------------------------
 # async writer thread lifecycle
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

`HonchoSessionManager._flush_session` reads pending messages, POSTs them, and only then marks them `_synced` — with no mutual exclusion around that sequence. The async writer thread (draining the queue `sync_turn`/`save` feeds) can race an exit-time `flush_all()` (session end / shutdown) on the same session. In a long-lived gateway process the two rarely overlap, but in a short-lived run (one-shot CLI, `-z`, any process that writes a turn and exits) the enqueue and the exit flush are back-to-back and the window is hit almost every time — both flushers read the same unsynced messages before either marks them, and both POST the batch, storing every turn twice.

This adds a per-session `threading.Lock` (`self._flush_locks`, created lazily under the existing `_cache_lock` — same pattern already used for this manager's other per-key caches) held across the whole read→send→mark body of `_flush_session`. Distinct sessions still flush concurrently; the second flusher of the same session enters after the first already marked `_synced` and finds nothing left to send. This is the fix the issue reporter proposed and verified independently.

## Related Issue

Fixes #92458

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/session.py`: add `self._flush_locks: dict[str, threading.Lock]` to `__init__`, add `_get_flush_lock()`, wrap `_flush_session`'s body in the per-session lock.
- `tests/honcho_plugin/test_async_memory.py`: add `TestConcurrentFlushSession` with two regression tests.

## How to Test

1. `uv run pytest tests/honcho_plugin/test_async_memory.py::TestConcurrentFlushSession -v`
2. To see the bug reproduce: revert the lock (keep the test), rerun — `test_racing_flushes_send_the_batch_once` fails with `assert 2 == 1` (two sends instead of one). I did this locally to confirm the test is a real regression test before restoring the fix.
3. `test_distinct_sessions_still_flush_concurrently` confirms the lock doesn't serialize unrelated sessions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suite and it passes — see note below on which command
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (this fix is platform-agnostic — `threading.Lock`, no OS-specific calls; also ran `scripts/check-windows-footguns.py` against the diff, 0 hits in the files I touched)

**Test command note:** I ran `uv run pytest tests/honcho_plugin/ tests/test_honcho_client_concurrency.py tests/test_honcho_session_context.py -q` rather than the full `scripts/run_tests.sh`, since that hermetic `env -i` runner isn't a clean fit for this Windows dev environment. Result: 304 passed, 16 skipped, 9 pre-existing failures — all in `test_client.py`/`test_oauth_flow.py`, all Windows path-separator (`\` vs `/`) and home-directory-resolution issues unrelated to this change. I confirmed they're pre-existing by running the same files against unmodified `main` and getting the identical 9 failures.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A, internal implementation detail, no public API/docs change.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A, no config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — `threading.Lock` behaves identically across platforms; ran `check-windows-footguns.py` (0 hits in touched files; 3 pre-existing hits in this test file are outside my diff, on lines I didn't touch).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — N/A, not a tool.

## Screenshots / Logs

```
tests/honcho_plugin/test_async_memory.py::TestConcurrentFlushSession::test_racing_flushes_send_the_batch_once PASSED
tests/honcho_plugin/test_async_memory.py::TestConcurrentFlushSession::test_distinct_sessions_still_flush_concurrently PASSED
...
304 passed, 16 skipped in 31.04s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
