### PR TITLE
fix(cli): Linux hermes.desktop Exec escapes the venv via symlink resolution

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,7 +78,14 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            #
+            # Do NOT .resolve() it: a venv's bin/python is a SYMLINK to the
+            # base interpreter (uv, pyenv, python3 -m venv all do this).
+            # Resolving walks out of the venv to the base prefix, which has
+            # no site-packages of its own — so the entry dies on the first
+            # third-party import (`No module named 'yaml'`), silently,
+            # because Terminal=false. Keep the venv path verbatim.
+            argv = [str(Path(sys.executable)), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
@@ -106,8 +113,12 @@ def _needs_interpreter(bin_path: Path) -> bool:
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
     # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    # Compare against BOTH the venv bin dir and the resolved base bin dir:
+    # a shebang naming either one already lands in an environment that can
+    # import Hermes' dependencies.
+    exe = Path(sys.executable)
+    candidates = {str(exe.parent), str(exe.resolve().parent)}
+    return not any(d in shebang for d in candidates)
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -105,8 +105,8 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # Native binary (uv tool shim, PyInstaller, distro package) — its own
         # loader is self-sufficient.
         return False
-    shebang = head.decode("utf-8", errors="replace").strip().lower()
-    if "python" not in shebang:
+    shebang = head.decode("utf-8", errors="replace").strip()
+    if "python" not in shebang.lower():
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
@@ -116,9 +116,42 @@ def _needs_interpreter(bin_path: Path) -> bool:
     # Compare against BOTH the venv bin dir and the resolved base bin dir:
     # a shebang naming either one already lands in an environment that can
     # import Hermes' dependencies.
+    #
+    # Match on path COMPONENTS, not substrings: a sibling directory such as
+    # ``/srv/x/venv/bin-extra/python`` starts with ``/srv/x/venv/bin`` and a
+    # substring test would wrongly accept it as "inside the venv", skipping
+    # the interpreter prefix the entry needs.
     exe = Path(sys.executable)
-    candidates = {str(exe.parent), str(exe.resolve().parent)}
-    return not any(d in shebang for d in candidates)
+    candidates = {exe.parent, exe.resolve().parent}
+    interpreter = _shebang_interpreter(shebang)
+    if interpreter is None:
+        return True
+    return not any(_is_within(interpreter, d) for d in candidates)
+
+
+def _shebang_interpreter(shebang: str) -> Optional[Path]:
+    """The interpreter path out of a ``#!`` line, or ``None`` if unusable.
+
+    Handles the ``#!/usr/bin/env python3`` form by taking the argument after
+    ``env`` rather than ``env`` itself.
+    """
+    parts = shebang.lstrip("#!").split()
+    if not parts:
+        return None
+    candidate = parts[0]
+    if Path(candidate).name in ("env", "env.exe"):
+        # ``#!/usr/bin/env python3`` — the real interpreter is resolved from
+        # PATH at exec time, so it is NOT a known-good absolute path.
+        return None
+    return Path(candidate)
+
+
+def _is_within(path: Path, directory: Path) -> bool:
+    """Whether ``path`` sits directly inside ``directory`` (component-wise)."""
+    try:
+        return path.parent == directory or path.parent.resolve() == directory
+    except OSError:
+        return path.parent == directory
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,10 +107,46 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
-    assert exec_line.split(" ")[0].strip('"') == interpreter
+    # The interpreter must be the venv path VERBATIM, never .resolve()d: a
+    # venv's bin/python is a symlink to the base interpreter, and resolving
+    # it walks out of the venv into a prefix with no site-packages, which
+    # reintroduces the ModuleNotFoundError this test guards against.
+    assert exec_line.split(" ")[0].strip('"') == sys.executable
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
+
+
+# Regression guard for the venv-symlink escape: when the running interpreter
+# is a venv whose bin/python symlinks to a base interpreter, the Exec line
+# must keep the venv path (which can import Hermes' deps), not the base one.
+def test_exec_keeps_venv_interpreter_not_symlink_target(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+
+    base_bin = tmp_path / "base" / "bin"
+    base_bin.mkdir(parents=True)
+    base_python = base_bin / "python3.11"
+    base_python.write_text("#!/bin/false\n", encoding="utf-8")
+    base_python.chmod(0o755)
+
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_python = venv_bin / "python"
+    venv_python.symlink_to(base_python)
+
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line.split(" ")[0].strip('"') == str(venv_python)
+    assert str(base_python) not in exec_line
 
 
 def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypatch):

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -119,6 +119,7 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
 # Regression guard for the venv-symlink escape: when the running interpreter
 # is a venv whose bin/python symlinks to a base interpreter, the Exec line
 # must keep the venv path (which can import Hermes' deps), not the base one.
+@pytest.mark.linux_only
 def test_exec_keeps_venv_interpreter_not_symlink_target(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
 
@@ -147,6 +148,30 @@ def test_exec_keeps_venv_interpreter_not_symlink_target(tmp_path, xdg_home, monk
 
     assert exec_line.split(" ")[0].strip('"') == str(venv_python)
     assert str(base_python) not in exec_line
+
+
+# A shebang naming a SIBLING of the venv bin dir (``…/bin-extra/python``)
+# shares a string prefix with it but is a different directory, outside the
+# venv. Substring matching accepted it and skipped the interpreter prefix,
+# so the entry launched an interpreter that cannot import Hermes' deps.
+def test_needs_interpreter_rejects_sibling_of_venv_bin(tmp_path, monkeypatch):
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_python = venv_bin / "python"
+    venv_python.write_text("#!/bin/false\n", encoding="utf-8")
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+
+    sibling = tmp_path / "venv" / "bin-extra"
+    sibling.mkdir()
+    script = tmp_path / "hermes-sibling"
+    script.write_text(f"#!{sibling / 'python'}\nimport hermes_cli\n", encoding="utf-8")
+
+    # Outside the venv despite the shared ``…/venv/bin`` prefix.
+    assert lde._needs_interpreter(script) is True
+
+    inside = tmp_path / "hermes-inside"
+    inside.write_text(f"#!{venv_bin / 'python'}\nimport hermes_cli\n", encoding="utf-8")
+    assert lde._needs_interpreter(inside) is False
 
 
 def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Summary

On Linux, `hermes.desktop` can be generated with an `Exec=` interpreter that cannot import Hermes' dependencies, so clicking the menu item does nothing — silently, because `Terminal=false`.

`resolve_exec_command()` prefixes `sys.executable` when the resolved `hermes` launcher is a Python script whose shebang would escape the venv (the #90292 fix, d9d967e07). It writes `Path(sys.executable).resolve()` — but a venv's `bin/python` is a **symlink** to the base interpreter. `uv`, `pyenv`, and stdlib `venv` all do this:

```
venv/bin/python -> ~/.local/share/uv/python/cpython-3.11-linux-x86_64-gnu/bin/python3.11
```

Resolving it walks out of the venv into the base prefix, which has no `site-packages` of its own. The generated entry then dies on the first third-party import:

```
$ env -i HOME=$HOME <Exec line from hermes.desktop>
Traceback (most recent call last):
  File "~/.hermes/hermes-agent/hermes", line 10, in <module>
    from hermes_cli.main import main
  File "~/.hermes/hermes-agent/hermes_cli/main.py", line 723, in <module>
    from hermes_cli.config import get_hermes_home
  File "~/.hermes/hermes-agent/hermes_cli/config.py", line 331, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

Same repo, same script, only the interpreter differs:

```
venv/bin/python        hermes --version  ->  OpenAI SDK: 2.24.0
resolve()d base python hermes --version  ->  OpenAI SDK: Not installed
```

This reintroduces exactly the failure mode #90292 set out to fix, for any git/venv install where the entry is regenerated from a process whose `argv[0]` is the repo `hermes` script (e.g. the updater) rather than the installer's bash wrapper.

## Fix

- Keep `sys.executable` **verbatim** — do not `.resolve()` it. The venv path is the one that can import Hermes' dependencies.
- `_needs_interpreter()` now accepts a shebang naming **either** the venv `bin` dir or the resolved base `bin` dir; both already land in a working environment, so neither needs the prefix.

The bash-wrapper path (`~/.local/bin/hermes`) is unaffected — it still short-circuits before the interpreter prefix, since it `exec`s the venv python itself.

## Test plan

- `test_exec_prefixes_interpreter_for_env_shebang_python_script` asserted `Path(sys.executable).resolve()`, which froze the buggy behaviour. Replaced with the real invariant: the Exec interpreter is the venv path as-is.
- Added `test_exec_keeps_venv_interpreter_not_symlink_target`, which builds an actual venv-style symlink (`venv/bin/python -> base/bin/python3.11`), points `sys.executable` at it, and asserts the Exec line keeps the venv path and never contains the base path.

```
$ ./venv/bin/python -m pytest tests/hermes_cli/test_linux_desktop_entry.py -q
16 passed, 2 skipped

$ ./venv/bin/python -m pytest tests/hermes_cli/test_linux_desktop_entry.py \
    tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_gui_uninstall.py \
    tests/hermes_cli/test_desktop_exe_integrity.py \
    tests/hermes_cli/test_update_desktop_stale_warning.py -q
57 passed, 11 skipped
```

Verified end-to-end on Ubuntu 24.04.4 / GNOME 46 / Wayland, uv-managed venv, git install: regenerated the entry through the real `install_desktop_entry()` code path for both `argv[0]` shapes (installer wrapper and repo script), then launched the resulting `Exec` line under `env -i` to reproduce the bare environment a desktop environment provides. Fails with `ModuleNotFoundError` before the change, launches after. `desktop-file-validate` passes.
