### PR TITLE
fix(mattermost): bridge reply mode from config

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1252,6 +1252,8 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
     """
     if "require_mention" in mattermost_cfg and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
         os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
+    if "reply_mode" in mattermost_cfg and not os.getenv("MATTERMOST_REPLY_MODE"):
+        os.environ["MATTERMOST_REPLY_MODE"] = str(mattermost_cfg["reply_mode"]).lower()
     frc = mattermost_cfg.get("free_response_channels")
     if frc is not None and not os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS"):
         if isinstance(frc, list):

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -81,6 +81,15 @@ class TestMattermostConfigLoading:
         assert home.chat_id == "ch_abc123"
         assert home.name == "General"
 
+    def test_yaml_reply_mode_bridges_to_adapter_environment(self, monkeypatch):
+        """Configured thread replies must reach the adapter's env-based runtime."""
+        monkeypatch.delenv("MATTERMOST_REPLY_MODE", raising=False)
+
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+        _apply_yaml_config({}, {"reply_mode": "thread"})
+
+        assert os.environ["MATTERMOST_REPLY_MODE"] == "thread"
+
 
 # ---------------------------------------------------------------------------
 # Adapter format / truncate


### PR DESCRIPTION
## Summary\n- bridge `mattermost.reply_mode` into the Mattermost adapter's env-based runtime configuration\n- add a regression test for `thread` mode\n\n## Validation\n- `uv run pytest tests/gateway/test_mattermost.py -q` (24 passed)\n- `uv run ruff check plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py`\n- `git diff --check`\n\nCloses #92791