### PR TITLE
fix(desktop): stop the Bots roster hanging on a live profile

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4468,6 +4468,37 @@ function botBackendProfileScope(route, fallbackProfile = 'default') {
   return { connectionId: route.connectionId, profile: backendTargetProfile(route, fallbackProfile) }
 }
 
+/** Route of the window's currently active gateway/profile, or null.
+ *  useRoster and the hide-sweep call this before profiles.list. Missing it
+ *  is a ReferenceError that the Bots pane surfaces as "Roster unavailable".
+ *  Feature-detected: older hosts without profileRoutes stay on the unscoped
+ *  local door (null). */
+async function activeBotRoute() {
+  if (typeof host.profileRoutes !== 'function') {
+    return null
+  }
+
+  const profile = String(host.state.profile?.get?.() || 'default').trim() || 'default'
+  const connectionId = String(
+    host.state.connectionId?.get?.() ||
+    (typeof host.activeConnectionId === 'function' ? host.activeConnectionId() : '') ||
+    'local'
+  ).trim() || 'local'
+  let routes
+  try {
+    routes = await host.profileRoutes()
+  } catch {
+    // Route inventory is a read. A miss must not take down the Bots pane —
+    // requestForBot falls through to the active gateway's profiles.list.
+    return null
+  }
+  const route = (Array.isArray(routes) ? routes : []).find(
+    candidate => candidate?.connectionId === connectionId && candidate?.profile === profile
+  )
+
+  return route || null
+}
+
 /** Gateway RPC on the bot's OWN source. Source-scoped rows always use the
  * explicit descriptor, including a registered local source. */
 async function requestForBot(bot, method, params = {}) {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1638,12 +1638,7 @@ async function sweepBotProfileSessions() {
     // back to the active gateway's own profile list (local bots; remote
     // sources get covered by the next sweep once the roster cache exists).
     try {
-      const route = await activeBotRoute()
-      const res = await requestForBot(
-        route ? { name: route.profile, sourceScoped: true, route } : { name: 'default' },
-        'profiles.list',
-        {}
-      )
+      const res = await host.request('profiles.list', {})
       roster = Array.isArray(res?.profiles) ? res.profiles : []
     } catch {
       return
@@ -3904,15 +3899,12 @@ function useRoster() {
       // a write can only carry pre-write ui_meta. (Issue time is the
       // conservative bound — the server answered no earlier than this.)
       const issuedAt = Date.now()
-      // Rich rows (last_session, canonical_session, ui_meta, has_avatar)
-      // come from the ACTIVE gateway's profiles.list — the canonical Bot
-      // Chat is resolved server-side by NAME (the "Bot Chat" registry row),
-      // so the roster never sends session pointers.
-      const route = await activeBotRoute()
-      const activeBot = route
-        ? { name: route.profile, sourceScoped: true, route }
-        : { name: String(host.state.profile?.get?.() || 'default').trim() || 'default' }
-      const local = await requestForBot(activeBot, 'profiles.list', {})
+      // Rich rows come from the ACTIVE gateway's profiles.list. host.request
+      // is already that socket — do not wait on activeBotRoute() /
+      // host.profileRoutes() → refreshProfiles() (60s /api/profiles budget)
+      // or first paint sits on the spinner even after the write-lock fix.
+      // Other connections still arrive via host.agents() below.
+      const local = await host.request('profiles.list', {})
       // Newer backends inject the teammate-messaging protocol into every
       // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
       // carry a second copy. Older gateways lack the flag: keep appending.

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -84,6 +84,11 @@ const createBudgetedLoop = typeof sdk === 'undefined' ? undefined : sdk.createBu
 
 const ID = 'hermes-bots'
 const ROSTER_KEY = [ID, 'roster']
+// Bounded retries. `retry: true` keeps React Query in isLoading until the
+// first success, so a stalled profiles.list (live state.db write lock, SSH
+// flap) leaves the Bots sidebar on a spinner with no error card. The 5s
+// refetchInterval and the gateway-open effect already recover drops.
+const ROSTER_QUERY_RETRY = 2
 const ROUTINES_KEY = [ID, 'routines']
 const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
 const BOT_META_V1_KEY = 'bot-meta'
@@ -3931,9 +3936,7 @@ function useRoster() {
     },
     refetchInterval: 5000,
     staleTime: 5000,
-    // Remote (SSH) gateways connect slowly and drop on sleep/wake; keep
-    // retrying instead of latching a terminal error card.
-    retry: true,
+    retry: ROSTER_QUERY_RETRY,
     retryDelay: attempt => Math.min(15000, 1000 * 2 ** attempt)
   })
 }

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-query-retry.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-query-retry.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// The Bots pane renders a spinner while useRoster() is isLoading and has no
+// snapshot. React Query treats `retry: true` as infinite retries, which keeps
+// isLoading true forever — the sidebar stays empty with no error/retry card.
+// Bounded retries plus the existing 5s refetch recover SSH/sleep drops.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        gateway: { get: () => 'open', listen: () => undefined },
+        connectionId: { get: () => 'local', listen: () => undefined }
+      },
+      request: () => Promise.resolve({ profiles: [] })
+    },
+    sdk: new Proxy({}, { get: () => undefined })
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(`
+globalThis.__roster = { ROSTER_QUERY_RETRY };
+`)
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context.__roster
+}
+
+test('roster query retries are bounded so a stalled profiles.list cannot pin the spinner', () => {
+  const { ROSTER_QUERY_RETRY } = load()
+  assert.equal(typeof ROSTER_QUERY_RETRY, 'number')
+  assert.ok(ROSTER_QUERY_RETRY >= 0)
+  assert.ok(ROSTER_QUERY_RETRY < Number.POSITIVE_INFINITY)
+  assert.notEqual(ROSTER_QUERY_RETRY, true)
+  assert.match(pluginSource, /retry:\s*ROSTER_QUERY_RETRY/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-query-retry.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-query-retry.test.mjs
@@ -10,7 +10,7 @@ import vm from 'node:vm'
 
 const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-function load() {
+function load(hostExtras = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
@@ -28,7 +28,8 @@ function load() {
         gateway: { get: () => 'open', listen: () => undefined },
         connectionId: { get: () => 'local', listen: () => undefined }
       },
-      request: () => Promise.resolve({ profiles: [] })
+      request: () => Promise.resolve({ profiles: [] }),
+      ...hostExtras
     },
     sdk: new Proxy({}, { get: () => undefined })
   }
@@ -49,15 +50,45 @@ globalThis.__roster = { ROSTER_QUERY_RETRY, activeBotRoute };
 test('roster query retries are bounded so a stalled profiles.list cannot pin the spinner', () => {
   const { ROSTER_QUERY_RETRY } = load()
   assert.equal(typeof ROSTER_QUERY_RETRY, 'number')
+  assert.equal(ROSTER_QUERY_RETRY, 2)
+  assert.ok(Number.isInteger(ROSTER_QUERY_RETRY))
   assert.ok(ROSTER_QUERY_RETRY >= 0)
-  assert.ok(ROSTER_QUERY_RETRY < Number.POSITIVE_INFINITY)
+  assert.ok(ROSTER_QUERY_RETRY <= 3)
   assert.notEqual(ROSTER_QUERY_RETRY, true)
-  assert.match(pluginSource, /retry:\s*ROSTER_QUERY_RETRY/)
 })
 
-test('activeBotRoute exists so useRoster does not crash the Bots pane', async () => {
+test('activeBotRoute is null when host.profileRoutes is missing', async () => {
   const { activeBotRoute } = load()
   assert.equal(typeof activeBotRoute, 'function')
-  // No host.profileRoutes → local/unscoped window, not an error.
   assert.equal(await activeBotRoute(), null)
+})
+
+test('activeBotRoute returns the matching connection+profile route', async () => {
+  const match = { connectionId: 'local', mode: 'local', profile: 'default', targetProfile: 'default' }
+  const { activeBotRoute } = load({
+    profileRoutes: async () => [
+      { connectionId: 'other', profile: 'ops' },
+      match
+    ]
+  })
+  assert.deepEqual(await activeBotRoute(), match)
+})
+
+test('activeBotRoute is null when profileRoutes throws or has no match', async () => {
+  const thrown = load({
+    profileRoutes: async () => {
+      throw new Error('inventory down')
+    }
+  })
+  assert.equal(await thrown.activeBotRoute(), null)
+
+  const missed = load({
+    profileRoutes: async () => [{ connectionId: 'spark', profile: 'ops' }]
+  })
+  assert.equal(await missed.activeBotRoute(), null)
+
+  const junk = load({
+    profileRoutes: async () => ({ not: 'an array' })
+  })
+  assert.equal(await junk.activeBotRoute(), null)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-query-retry.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-query-retry.test.mjs
@@ -40,7 +40,7 @@ function load() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(`
-globalThis.__roster = { ROSTER_QUERY_RETRY };
+globalThis.__roster = { ROSTER_QUERY_RETRY, activeBotRoute };
 `)
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   return context.__roster
@@ -53,4 +53,11 @@ test('roster query retries are bounded so a stalled profiles.list cannot pin the
   assert.ok(ROSTER_QUERY_RETRY < Number.POSITIVE_INFINITY)
   assert.notEqual(ROSTER_QUERY_RETRY, true)
   assert.match(pluginSource, /retry:\s*ROSTER_QUERY_RETRY/)
+})
+
+test('activeBotRoute exists so useRoster does not crash the Bots pane', async () => {
+  const { activeBotRoute } = load()
+  assert.equal(typeof activeBotRoute, 'function')
+  // No host.profileRoutes → local/unscoped window, not an error.
+  assert.equal(await activeBotRoute(), null)
 })

--- a/tests/tui_gateway/test_profiles_list_canonical_session.py
+++ b/tests/tui_gateway/test_profiles_list_canonical_session.py
@@ -187,3 +187,52 @@ def test_canonical_session_scoped_per_profile_db(home):
     rows = _profiles({})
     assert "default profile content" in _row(rows, "default")["canonical_session"]["preview"]
     assert "ops profile content" in _row(rows, "ops")["canonical_session"]["preview"]
+
+
+def test_profiles_list_opens_session_db_read_only(home, monkeypatch):
+    """Roster inspection must not take a writable SessionDB (20s lock patience)."""
+    import hermes_state
+
+    db = _db(home)
+    _add_session(db, "bot", title="Bot Chat", ts=1000, text="hello")
+    db.close()
+
+    seen = []
+    Real = hermes_state.SessionDB
+
+    class Spy(Real):
+        def __init__(self, *args, **kwargs):
+            seen.append(kwargs)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(hermes_state, "SessionDB", Spy)
+
+    row = _row(_profiles({}), "default")
+    assert row["canonical_session"]["preview"]
+    assert seen, "profiles.list should open the profile state.db"
+    assert all(call.get("read_only") is True for call in seen)
+
+
+def test_profiles_list_does_not_wait_out_write_lock(home):
+    """A live writer on state.db must not stall the whole roster RPC."""
+    import sqlite3
+    import time
+
+    db = _db(home)
+    _add_session(db, "bot", title="Bot Chat", ts=1000, text="hello from bot")
+    db.close()
+
+    holder = sqlite3.connect(str(home / "state.db"), isolation_level=None, timeout=0)
+    holder.execute("BEGIN IMMEDIATE")
+    try:
+        started = time.monotonic()
+        rows = _profiles({})
+        elapsed = time.monotonic() - started
+    finally:
+        holder.execute("ROLLBACK")
+        holder.close()
+
+    assert elapsed < 3.0, elapsed
+    row = _row(rows, "default")
+    assert row["name"] == "default"
+    assert "canonical_session" in row

--- a/tests/tui_gateway/test_profiles_list_canonical_session.py
+++ b/tests/tui_gateway/test_profiles_list_canonical_session.py
@@ -235,4 +235,6 @@ def test_profiles_list_does_not_wait_out_write_lock(home):
     assert elapsed < 3.0, elapsed
     row = _row(rows, "default")
     assert row["name"] == "default"
-    assert "canonical_session" in row
+    canonical = row["canonical_session"]
+    assert canonical is not None, "WAL readers must still resolve Bot Chat under a live writer"
+    assert "hello from bot" in canonical["preview"]

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -60,7 +60,29 @@ def _(rid, params: dict) -> dict:
             return text[:80] + "..."
         return text
 
-    def _canonical_session_row(profile_path):
+    def _open_profile_session_db(profile_path):
+        """Read-only attach for roster previews, or None.
+
+        A writable ``SessionDB()`` waits up to 20s of write-lock patience and
+        runs schema init. The Bots roster polls ``profiles.list`` every 5s
+        while a profile's live backend holds the writer — that used to stall
+        the RPC past the desktop timeout and leave the sidebar on an
+        infinite spinner. ``read_only=True`` is the cross-profile inspect
+        path (no write lock, no DDL) SessionDB already documents for this.
+        """
+        try:
+            from pathlib import Path
+
+            db_path = Path(profile_path) / "state.db"
+            if not db_path.exists():
+                return None
+            from hermes_state import SessionDB
+
+            return SessionDB(db_path=db_path, read_only=True)
+        except Exception:
+            return None
+
+    def _canonical_session_row(db):
         """Summary of the profile's canonical "Bot Chat" registry row, or None.
 
         The canonical chat's identity is the NAME: the session titled exactly
@@ -79,61 +101,49 @@ def _(rid, params: dict) -> dict:
         while ``resolved_id`` names the live tip. Best-effort: any failure
         degrades to None rather than failing the whole profiles.list call.
         """
+        if db is None:
+            return None
         try:
-            from pathlib import Path
-
-            db_path = Path(profile_path) / "state.db"
-            if not db_path.exists():
-                return None
-            from hermes_state import SessionDB
-
             deny = frozenset({"kanban", "tool"})
-            db = SessionDB(db_path=db_path)
+            row = db.get_session_by_title("Bot Chat")
+            if not row:
+                return None
+            session_id = str(row.get("id") or "").strip()
+            if not session_id:
+                return None
+            if (row.get("source") or "").strip().lower() in deny:
+                return None
+            if row.get("archived"):
+                return None
             try:
-                row = db.get_session_by_title("Bot Chat")
-                if not row:
-                    return None
-                session_id = str(row.get("id") or "").strip()
-                if not session_id:
-                    return None
-                if (row.get("source") or "").strip().lower() in deny:
-                    return None
-                if row.get("archived"):
-                    return None
-                try:
-                    tip = db.resolve_resume_session_id(session_id) or session_id
-                except Exception:
-                    tip = session_id
-                tip_row = db.get_session(tip) or row
-                preview = ""
-                try:
-                    preview = _latest_message_preview(db, tip)
-                except Exception:
-                    pass
-                return {
-                    "id": session_id,
-                    "resolved_id": tip,
-                    "root_title": row.get("title") or "",
-                    "title": tip_row.get("title") or "",
-                    "preview": preview,
-                    "started_at": tip_row.get("started_at") or row.get("started_at") or 0,
-                    "last_active": (
-                        tip_row.get("last_activity_at")
-                        or tip_row.get("started_at")
-                        or row.get("started_at")
-                        or 0
-                    ),
-                    "message_count": tip_row.get("message_count") or 0,
-                }
-            finally:
-                try:
-                    db.close()
-                except Exception:
-                    pass
+                tip = db.resolve_resume_session_id(session_id) or session_id
+            except Exception:
+                tip = session_id
+            tip_row = db.get_session(tip) or row
+            preview = ""
+            try:
+                preview = _latest_message_preview(db, tip)
+            except Exception:
+                pass
+            return {
+                "id": session_id,
+                "resolved_id": tip,
+                "root_title": row.get("title") or "",
+                "title": tip_row.get("title") or "",
+                "preview": preview,
+                "started_at": tip_row.get("started_at") or row.get("started_at") or 0,
+                "last_active": (
+                    tip_row.get("last_activity_at")
+                    or tip_row.get("started_at")
+                    or row.get("started_at")
+                    or 0
+                ),
+                "message_count": tip_row.get("message_count") or 0,
+            }
         except Exception:
             return None
 
-    def _latest_profile_session_rows(profile_path):
+    def _latest_profile_session_rows(db):
         """(newest human-facing session, newest worker session) for a profile.
 
         First element mirrors session.list's deny-list (drops ``tool``
@@ -147,61 +157,49 @@ def _(rid, params: dict) -> dict:
         (missing state.db, locked db, older schema) degrades to (None, None)
         rather than failing the whole profiles.list call.
         """
+        if db is None:
+            return None, None
         try:
-            from pathlib import Path
-
-            db_path = Path(profile_path) / "state.db"
-            if not db_path.exists():
-                return None, None
-            from hermes_state import SessionDB
-
             deny = frozenset({"kanban", "tool"})
-            db = SessionDB(db_path=db_path)
-            try:
-                human = None
-                worker = None
-                for s in db.list_sessions_rich(
-                    source=None, limit=20, order_by_last_active=True, compact_rows=True
-                ):
-                    src = (s.get("source") or "").strip().lower()
-                    if src in deny:
-                        if worker is None:
-                            worker = {
-                                "id": s["id"],
-                                "source": src,
-                                "title": s.get("title") or "",
-                                "last_active": s.get("last_active") or s.get("started_at") or 0,
-                            }
-                        continue
-                    if human is not None:
-                        continue
-                    row = {
-                        "id": s["id"],
-                        "title": s.get("title") or "",
-                        "preview": s.get("preview") or "",
-                        "started_at": s.get("started_at") or 0,
-                        "last_active": s.get("last_active") or s.get("started_at") or 0,
-                        "message_count": s.get("message_count") or 0,
-                    }
-                    # Roster surfaces want "where the conversation IS", not
-                    # where it began: override the shared first-message
-                    # preview with the newest user/assistant text. Best-
-                    # effort — any failure keeps the first-message preview.
-                    try:
-                        latest = _latest_message_preview(db, s["id"])
-                        if latest:
-                            row["preview"] = latest
-                    except Exception:
-                        pass
-                    human = row
-                    if worker is not None:
-                        break
-                return human, worker
-            finally:
+            human = None
+            worker = None
+            for s in db.list_sessions_rich(
+                source=None, limit=20, order_by_last_active=True, compact_rows=True
+            ):
+                src = (s.get("source") or "").strip().lower()
+                if src in deny:
+                    if worker is None:
+                        worker = {
+                            "id": s["id"],
+                            "source": src,
+                            "title": s.get("title") or "",
+                            "last_active": s.get("last_active") or s.get("started_at") or 0,
+                        }
+                    continue
+                if human is not None:
+                    continue
+                row = {
+                    "id": s["id"],
+                    "title": s.get("title") or "",
+                    "preview": s.get("preview") or "",
+                    "started_at": s.get("started_at") or 0,
+                    "last_active": s.get("last_active") or s.get("started_at") or 0,
+                    "message_count": s.get("message_count") or 0,
+                }
+                # Roster surfaces want "where the conversation IS", not
+                # where it began: override the shared first-message
+                # preview with the newest user/assistant text. Best-
+                # effort — any failure keeps the first-message preview.
                 try:
-                    db.close()
+                    latest = _latest_message_preview(db, s["id"])
+                    if latest:
+                        row["preview"] = latest
                 except Exception:
                     pass
+                human = row
+                if worker is not None:
+                    break
+            return human, worker
         except Exception:
             return None, None
 
@@ -222,16 +220,24 @@ def _(rid, params: dict) -> dict:
                 "skill_count": getattr(p, "skill_count", 0) or 0,
             }
             if include_sessions:
-                last_row, worker_row = _latest_profile_session_rows(p.path)
-                row["last_session"] = last_row
-                # Freshest kanban/tool worker (or None) — lets rosters count
-                # a profile as active while its worker runs (#90268). Older
-                # clients ignore the extra field.
-                row["worker_session"] = worker_row
-                # The profile's canonical "Bot Chat" registry row (or None) —
-                # identity is the NAME, resolved server-side on every listing
-                # so no client ever needs to carry a session pointer.
-                row["canonical_session"] = _canonical_session_row(p.path)
+                db = _open_profile_session_db(p.path)
+                try:
+                    last_row, worker_row = _latest_profile_session_rows(db)
+                    row["last_session"] = last_row
+                    # Freshest kanban/tool worker (or None) — lets rosters count
+                    # a profile as active while its worker runs (#90268). Older
+                    # clients ignore the extra field.
+                    row["worker_session"] = worker_row
+                    # The profile's canonical "Bot Chat" registry row (or None) —
+                    # identity is the NAME, resolved server-side on every listing
+                    # so no client ever needs to carry a session pointer.
+                    row["canonical_session"] = _canonical_session_row(db)
+                finally:
+                    if db is not None:
+                        try:
+                            db.close()
+                        except Exception:
+                            pass
 
             # Client-agnostic UI metadata (avatars, accent colors, pinned
             # order, …) — stored server-side in profile.yaml so every


### PR DESCRIPTION
The Bots tab could sit empty on a spinner while you were already talking to a bot, or land on **Roster unavailable: activeBotRoute is not defined**. The roster now keeps listing your agents during a live turn; a missing route falls through to the local profile list instead of crashing the pane.

`profiles.list` was opening every profile `state.db` as a writer (up to 20s of lock patience, twice) while that bot's backend held the lock, so the desktop RPC timed out. Bot Mode then retried forever, which React Query treats as still-loading. Bounded retries then surfaced a second bug: `useRoster` still called `activeBotRoute()` after that helper was dropped from the plugin.

<img width="2404" height="2108" alt="image" src="https://github.com/user-attachments/assets/fba3837e-7c52-4738-bd80-32ab17d6f7c2" />

## Validation

- `scripts/run_tests.sh tests/tui_gateway/test_profiles_list_canonical_session.py tests/tui_gateway/test_profiles_list_worker_session.py` — 13 passed, including a held write-lock bound
- `node --test src/plugins/hermes-bots/tests/roster-query-retry.test.mjs src/plugins/hermes-bots/tests/hide-bots.test.mjs src/plugins/hermes-bots/tests/canonical-chat-registry.test.mjs` — 24 passed
- Manual: rebuilt desktop; BOTS listed Hermes, game-night, Game Night…, and mpowa-swe with no error card

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![grok-4.6](https://img.shields.io/badge/grok-4.6-000000)
