### PR TITLE
fix(desktop): surface bot group turn failures

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -321,7 +321,22 @@ function groupActivityLabel(event) {
 
   const who = event?.member === 'You' ? 'You' : groupSpeakerLabel(event?.member || 'A bot')
 
+  if (kind === 'failed' && event?.error) {
+    return `${who} ${base}: ${event.error}`
+  }
+
   return `${who} ${base}`
+}
+
+function groupActivityErrorDetail(err) {
+  const raw =
+    typeof err === 'string' ? err : (err && (err.message || err.error || err.reason)) || ''
+  return (
+    String(raw || 'Unknown error')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 180) || 'Unknown error'
+  )
 }
 
 const GROUP_ACTIVITY_LABELS = {
@@ -6087,8 +6102,13 @@ async function runGroupChatRounds(group, members, thread) {
 
         try {
           reply = await runGroupChatMemberTurn(group, member, prompt, thread, deltaImages)
-        } catch {
-          recordGroupActivity(group, { kind: 'failed', member: member.name, thread })
+        } catch (err) {
+          recordGroupActivity(group, {
+            kind: 'failed',
+            member: member.name,
+            thread,
+            error: groupActivityErrorDetail(err)
+          })
           reply = null // a failed turn is a pass, never a room error
         }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
@@ -98,7 +98,8 @@ function load(turnScript = () => '(pass)') {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__ga = { sendToGroupChat, recordGroupActivity, currentGroupActivity, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, GROUP_ACTIVITY_LIMIT };\n'
+      '\nglobalThis.__ga = { sendToGroupChat, recordGroupActivity, currentGroupActivity, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, GROUP_ACTIVITY_LIMIT };\n',
+      'globalThis.__ga.groupActivityErrorDetail = groupActivityErrorDetail;\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -146,7 +147,7 @@ test('a settled turn records the full truthful arc: queued, working, replies and
 test('a failed member turn records failed instead of a phantom reply', async () => {
   const gc = load(profile => {
     if (profile === 'builder') {
-      throw new Error('gateway hiccup')
+      throw new Error('agent init failed: No usable credentials found')
     }
     return '(pass)'
   })
@@ -155,7 +156,21 @@ test('a failed member turn records failed instead of a phantom reply', async () 
   await drain(gc, 'Flaky')
 
   const events = feed(gc, 'Flaky')
-  assert.equal(events.some(e => e.kind === 'failed' && e.member === 'builder'), true)
+  const failed = events.find(e => e.kind === 'failed' && e.member === 'builder')
+  assert.ok(failed)
+  assert.equal(failed.error, 'agent init failed: No usable credentials found')
+  assert.equal(
+    gc.groupActivityLabel(failed),
+    'builder hit an error: agent init failed: No usable credentials found'
+  )
+})
+
+test('failed activity error details are single-line and bounded', () => {
+  const gc = load()
+  const detail = gc.groupActivityErrorDetail(new Error(`agent init failed:\n${'x'.repeat(300)}`))
+
+  assert.equal(detail.includes('\n'), false)
+  assert.equal(detail.length, 180)
 })
 
 test('a newer send interrupts the previous run and records cancelled in the CURRENT epoch', async () => {


### PR DESCRIPTION
Summary
Bot Mode group member turns already recorded a failed activity event when a member turn threw, but the UI discarded the actual failure reason. Credential/init failures such as "No usable credentials found" therefore looked like a silent bot stall. This PR carries a sanitized, bounded error detail into the group Activity feed so the collapsed/expanded activity row shows the real failure reason instead of only "hit an error".

Changes
apps/desktop/src/plugins/hermes-bots/plugin.js: adds a single-line bounded error-detail formatter, stores that detail on failed group activity events, and includes it in the human activity label.
apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs: extends the failed-turn regression to cover a visible credential/init error and adds a bounds/newline test for displayed failure details.

How to Test
node --test apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
# ✅ 9/9 passed
git diff --check
# ✅ passed
python scripts/check-windows-footguns.py --diff upstream/main
# ✅ passed
scripts/run_tests.sh
# ⚠️ environment failure on Termux runner: 3193 PermissionError/permission-denied patterns in the full-suite log

Notes
npm prettier/eslint checks are not authoritative in this Termux worktree: the workspace dependencies are not installed, npm exec attempted to fetch tool versions and the available Prettier would reformat the entire legacy plugin file. The committed diff stays scoped to the failure-visibility fix only.

Checklist
- [x] Targeted tests pass — 9/9
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

Risk & Impact
Low. This changes only runtime-only Activity presentation for already-failed group member turns; it does not alter turn scheduling, persistence, credentials, or provider selection.
Type: Bug fix
Closes: #92760
