### PR TITLE
feat(plugins): add atomic toolset snapshot replacement

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -102,6 +102,17 @@ class PluginToolOverrideError(PermissionError):
     """
 
 
+@dataclass(frozen=True)
+class SnapshotReplacement:
+    """Result of one public plugin toolset-snapshot publication."""
+
+    changed: bool
+    generation: int
+    source_revision: str
+    added: Tuple[str, ...] = ()
+    removed: Tuple[str, ...] = ()
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -1393,15 +1404,69 @@ class PluginState:
 class PluginContext:
     """Facade given to plugins so they can register tools and hooks."""
 
-    def __init__(self, manifest: PluginManifest, manager: "PluginManager"):
+    def __init__(
+        self,
+        manifest: PluginManifest,
+        manager: "PluginManager",
+        *,
+        registration_registry: Any = None,
+    ):
         self.manifest = manifest
         self._manager = manager
+        if registration_registry is None:
+            from tools.registry import registry as registration_registry
+        # Keep registration authority context-bound. Transactional plugin
+        # loaders can inject an isolated registry view without this facade
+        # reaching around it to the process singleton.
+        self._registration_registry = registration_registry
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
         self._state: PluginState | None = None
         # Lazy-built capability-gated platform action facade (#64176).
         self._platform_actions: Any = None
+        self._toolset_snapshot_owner = object()
+        self._toolset_snapshot_namespaces: Set[str] = set()
+        self._toolset_snapshots_closed = False
+        self._toolset_snapshot_lock = threading.RLock()
+        register_context = getattr(
+            self._manager, "_register_snapshot_context_identity", None
+        )
+        self._toolset_snapshot_epoch = (
+            register_context(self.plugin_id) if callable(register_context) else None
+        )
+
+    def _release_toolset_snapshots(self) -> None:
+        """Revoke this context and remove every snapshot it ever published."""
+        with (
+            self._toolset_snapshot_lock,
+            self._manager._plugin_tool_names_lock,
+        ):
+            self._toolset_snapshots_closed = True
+            removed_names: Set[str] = set()
+            for toolset in tuple(self._toolset_snapshot_namespaces):
+                removed_names.update(
+                    self._registration_registry._remove_plugin_toolset_snapshot(
+                        owner=self._toolset_snapshot_owner,
+                        scope=self._manager.scope_key,
+                        toolset=toolset,
+                    )
+                )
+            self._toolset_snapshot_namespaces.clear()
+            self._manager._plugin_tool_names.difference_update(removed_names)
+            plugin_key = self.manifest.key or self.manifest.name
+            snapshot_names = self._manager._plugin_snapshot_tool_names.get(plugin_key)
+            if snapshot_names is not None:
+                snapshot_names.difference_update(removed_names)
+                if not snapshot_names:
+                    self._manager._plugin_snapshot_tool_names.pop(plugin_key, None)
+            loaded = self._manager._plugins.get(plugin_key)
+            if loaded is not None:
+                loaded.tools_registered = [
+                    name
+                    for name in loaded.tools_registered
+                    if name not in removed_names
+                ]
 
     @property
     def plugin_id(self) -> str:
@@ -1701,6 +1766,65 @@ class PluginContext:
 
     # -- tool registration --------------------------------------------------
 
+    @property
+    def registry_generation(self) -> int:
+        """Return the current public tool-registry generation."""
+        return self._registration_registry.generation
+
+    @_serialized_replacement
+    def replace_toolset_snapshot(
+        self,
+        toolset: str,
+        source_revision: str,
+        entries: Iterable[Mapping[str, Any]],
+    ) -> SnapshotReplacement:
+        """Atomically replace one profile-scoped toolset owned by this context."""
+        with self._toolset_snapshot_lock:
+            if self._toolset_snapshots_closed:
+                raise RuntimeError("plugin snapshot context has been unloaded")
+            prepared_entries = list(entries)
+            if self._toolset_snapshots_closed:
+                raise RuntimeError("plugin snapshot context has been unloaded")
+            activate_context = getattr(
+                self._manager, "_activate_snapshot_context", None
+            )
+            if callable(activate_context):
+                activate_context(self, self._toolset_snapshot_epoch)
+            scope = self._manager.scope_key
+            registry = self._registration_registry
+            with self._manager._plugin_tool_names_lock:
+                result = registry._replace_plugin_toolset_snapshot(
+                    owner=self._toolset_snapshot_owner,
+                    owner_is_live=lambda: not self._toolset_snapshots_closed,
+                    scope=scope,
+                    toolset=toolset,
+                    source_revision=source_revision,
+                    entries=prepared_entries,
+                )
+                self._toolset_snapshot_namespaces.add(toolset)
+                self._manager._plugin_tool_names.difference_update(result["removed"])
+                self._manager._plugin_tool_names.update(result["added"])
+                plugin_key = self.manifest.key or self.manifest.name
+                snapshot_names = self._manager._plugin_snapshot_tool_names.setdefault(
+                    plugin_key, set()
+                )
+                snapshot_names.difference_update(result["removed"])
+                snapshot_names.update(result["added"])
+                loaded = self._manager._plugins.get(plugin_key)
+                if loaded is not None:
+                    loaded.tools_registered = sorted(
+                        (set(loaded.tools_registered) - set(result["removed"]))
+                        | set(result["added"])
+                    )
+
+            return SnapshotReplacement(
+                changed=result["changed"],
+                generation=result["generation"],
+                source_revision=source_revision,
+                added=result["added"],
+                removed=result["removed"],
+            )
+
     @_serialized_replacement
     def register_tool(
         self,
@@ -1742,51 +1866,53 @@ class PluginContext:
         from tools.registry import registry
 
         scope = self._manager.scope_key
-        previous = registry.snapshot_registration(name, scope=scope)
-        effective = registry.get_entry(name, scope=scope)
-        if previous is None and effective is not None and not override:
-            logger.warning(
-                "Plugin %s tried to shadow global tool %s without override=True",
-                self.manifest.name,
-                name,
-            )
-            return None
-        registry.register(
-            name=name,
-            toolset=toolset,
-            schema=schema,
-            handler=handler,
-            check_fn=check_fn,
-            requires_env=requires_env,
-            is_async=is_async,
-            description=description,
-            emoji=emoji,
-            override=override,
-            scope=scope,
-        )
-        registered = registry.snapshot_registration(name, scope=scope)
-        if (
-            registered is not None
-            and registered is not previous
-            and registered.handler is handler
-        ):
-            self._manager._plugin_tool_names.add(name)
-            def _restore_tool(replacement: Any) -> bool:
-                return registry.restore_registration(
-                    name, registered, replacement, scope=scope
+        with self._manager._plugin_tool_names_lock:
+            previous = registry.snapshot_registration(name, scope=scope)
+            effective = registry.get_entry(name, scope=scope)
+            if previous is None and effective is not None and not override:
+                logger.warning(
+                    "Plugin %s tried to shadow global tool %s without override=True",
+                    self.manifest.name,
+                    name,
                 )
-
-            handle = self._track_replacement(
-                "tool",
-                name,
-                slot=("tool", scope, name),
-                current=registered,
-                previous=previous,
-                restore=_restore_tool,
-                finalize=lambda: self._manager._remove_tool_name_if_unowned(name),
+                return None
+            registry.register(
+                name=name,
+                toolset=toolset,
+                schema=schema,
+                handler=handler,
+                check_fn=check_fn,
+                requires_env=requires_env,
+                is_async=is_async,
+                description=description,
+                emoji=emoji,
+                override=override,
+                scope=scope,
             )
-        else:
-            handle = None
+            registered = registry.snapshot_registration(name, scope=scope)
+            if (
+                registered is not None
+                and registered is not previous
+                and registered.handler is handler
+            ):
+                self._manager._plugin_tool_names.add(name)
+
+                def _restore_tool(replacement: Any) -> bool:
+                    return registry.restore_registration(
+                        name, registered, replacement, scope=scope
+                    )
+
+                handle = self._track_replacement(
+                    "tool",
+                    name,
+                    slot=("tool", scope, name),
+                    current=registered,
+                    previous=previous,
+                    restore=_restore_tool,
+                    finalize=lambda: self._manager._remove_tool_name_if_unowned(name),
+                )
+            else:
+                handle = None
         logger.debug(
             "Plugin %s registered tool: %s%s",
             self.manifest.name, name, " (override)" if override else "",
@@ -3403,7 +3529,13 @@ class PluginManager:
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
         self._middleware: Dict[str, List[Callable]] = {}
+        self._plugin_tool_names_lock = threading.RLock()
         self._plugin_tool_names: Set[str] = set()
+        self._snapshot_context_lock = threading.RLock()
+        self._snapshot_context_global_epoch = 0
+        self._snapshot_context_epochs: Dict[str, int] = {}
+        self._snapshot_context_keys: Set[str] = set()
+        self._active_snapshot_contexts: Dict[str, Set[PluginContext]] = {}
         self._plugin_platform_names: Set[str] = set()
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
@@ -3467,10 +3599,41 @@ class PluginManager:
         # full plugin loads.
         self._predeclared_modules: Dict[str, types.ModuleType] = {}
         self._predeclared_tools: Dict[str, List[str]] = {}
+        self._plugin_snapshot_tool_names: Dict[str, Set[str]] = {}
 
     # -----------------------------------------------------------------------
     # Registration ledger internals
     # -----------------------------------------------------------------------
+
+    def _register_snapshot_context_identity(self, plugin_key: str) -> tuple[int, int]:
+        """Record a context identity without retaining an unused context."""
+        with self._snapshot_context_lock:
+            self._snapshot_context_keys.add(plugin_key)
+            return (
+                self._snapshot_context_global_epoch,
+                self._snapshot_context_epochs.get(plugin_key, 0),
+            )
+
+    def _activate_snapshot_context(
+        self,
+        context: PluginContext,
+        epoch: tuple[int, int] | None,
+    ) -> None:
+        """Bind first publication to the manager generation that created it."""
+        plugin_key = context.plugin_id
+        with self._snapshot_context_lock:
+            current = (
+                self._snapshot_context_global_epoch,
+                self._snapshot_context_epochs.get(plugin_key, 0),
+            )
+            if epoch != current:
+                raise RuntimeError("plugin snapshot context has been unloaded")
+            self._active_snapshot_contexts.setdefault(plugin_key, set()).add(context)
+
+    def _snapshot_plugin_tool_names(self) -> Set[str]:
+        """Return coherent manager attribution for discovery/introspection."""
+        with self._plugin_tool_names_lock:
+            return set(self._plugin_tool_names)
 
     def _track_registration(
         self,
@@ -3545,13 +3708,14 @@ class PluginManager:
         return True
 
     def _remove_tool_name_if_unowned(self, name: str) -> None:
-        if not any(
-            registration.active
-            and registration.kind == "tool"
-            and registration.key == name
-            for registration in self._registration_order
-        ):
-            self._plugin_tool_names.discard(name)
+        with self._plugin_tool_names_lock:
+            if not any(
+                registration.active
+                and registration.kind == "tool"
+                and registration.key == name
+                for registration in self._registration_order
+            ):
+                self._plugin_tool_names.discard(name)
 
     def _remove_platform_name_if_unowned(self, name: str) -> None:
         if not any(
@@ -3637,14 +3801,24 @@ class PluginManager:
         Returns ``True`` when at least one plugin or registration was found.
         """
         unload_all = plugin is None
+        with self._snapshot_context_lock:
+            snapshot_context_keys = set(self._snapshot_context_keys)
         if unload_all:
-            target_keys = set(self._ownership_ledger) | set(self._plugins)
+            target_keys = (
+                set(self._ownership_ledger)
+                | set(self._plugins)
+                | snapshot_context_keys
+            )
             registrations = list(self._registration_order)
         else:
             requested = self._resolve_plugin_key(plugin)
             exact = {
                 requested,
-            } if requested in self._ownership_ledger or requested in self._plugins else set()
+            } if (
+                requested in self._ownership_ledger
+                or requested in self._plugins
+                or requested in snapshot_context_keys
+            ) else set()
             if exact:
                 target_keys = exact
             else:
@@ -3658,13 +3832,48 @@ class PluginManager:
                     for key in self._ownership_ledger
                     if key == requested
                 )
+                target_keys.update(
+                    key for key in snapshot_context_keys if key == requested
+                )
             registrations = [
                 registration
                 for registration in self._registration_order
                 if registration.plugin_key in target_keys
             ]
 
-        found = bool(target_keys or registrations)
+        with self._snapshot_context_lock:
+            if unload_all:
+                self._snapshot_context_global_epoch += 1
+                snapshot_contexts = [
+                    context
+                    for contexts in self._active_snapshot_contexts.values()
+                    for context in contexts
+                ]
+                self._active_snapshot_contexts.clear()
+                self._snapshot_context_keys.clear()
+                self._snapshot_context_epochs.clear()
+            else:
+                snapshot_contexts = []
+                for key in target_keys:
+                    self._snapshot_context_epochs[key] = (
+                        self._snapshot_context_epochs.get(key, 0) + 1
+                    )
+                    snapshot_contexts.extend(
+                        self._active_snapshot_contexts.pop(key, set())
+                    )
+                    self._snapshot_context_keys.discard(key)
+
+        found = bool(target_keys or registrations or snapshot_contexts)
+        for context in snapshot_contexts:
+            try:
+                context._release_toolset_snapshots()
+            except Exception as exc:  # pragma: no cover - defensive cleanup
+                logger.warning(
+                    "Failed to unload plugin snapshot context %s: %s",
+                    context.plugin_id,
+                    exc,
+                    exc_info=_PLUGINS_DEBUG,
+                )
         self._dispose_registrations(registrations)
         self._forget_registrations(registrations)
 
@@ -3732,6 +3941,7 @@ class PluginManager:
             self._slack_action_handlers.clear()
             self._predeclared_modules.clear()
             self._predeclared_tools.clear()
+            self._plugin_snapshot_tool_names.clear()
             self._context_engine = None
             self._discovered = False
         else:
@@ -4554,6 +4764,7 @@ class PluginManager:
 
         self._register_deferred_platform_tools(manifest, loaded)
 
+    @_serialized_replacement
     def _register_deferred_platform_tools(
         self, manifest: PluginManifest, loaded: LoadedPlugin
     ) -> None:
@@ -4604,7 +4815,7 @@ class PluginManager:
 
         # Snapshotted outside the try so the failure path can tell which tools
         # a partially-successful register_tools() left behind.
-        before = set(self._plugin_tool_names)
+        before = self._snapshot_plugin_tool_names()
         try:
             module = self._load_directory_module(manifest)
             # Record the module even if nothing below registers: the package
@@ -4626,9 +4837,7 @@ class PluginManager:
                 return
 
             register_tools(PluginContext(manifest, self))
-            registered = [
-                t for t in self._plugin_tool_names if t not in before
-            ]
+            registered = sorted(self._snapshot_plugin_tool_names() - before)
 
             loaded.tools_registered = registered
             self._predeclared_tools[lookup_key] = registered
@@ -4644,7 +4853,7 @@ class PluginManager:
             # `hermes plugins list` under-reports what the process is actually
             # carrying — and _load_plugin's own diff would miss them later
             # too, since they are already in its "before" snapshot.
-            partial = [t for t in self._plugin_tool_names if t not in before]
+            partial = sorted(self._snapshot_plugin_tool_names() - before)
             if partial:
                 loaded.tools_registered = partial
                 self._predeclared_tools[lookup_key] = partial
@@ -4836,9 +5045,10 @@ class PluginManager:
                 # above cannot see them and `hermes plugins list` would
                 # under-report once the deferred adapter materializes (#78050).
                 # Credit them back to the plugin that actually registered them.
+                active_tool_names = self._snapshot_plugin_tool_names()
                 _predeclared = [
                     t for t in self._predeclared_tools.pop(plugin_key, [])
-                    if t in self._plugin_tool_names
+                    if t in active_tool_names
                 ]
                 loaded.tools_registered = _predeclared + [
                     registration.key
@@ -4881,6 +5091,30 @@ class PluginManager:
                 )
 
         except Exception as exc:
+            # Snapshot contexts are generation-bound rather than ordinary
+            # ownership-ledger entries. Revoke this failed registration
+            # generation explicitly so a tool published before `register()`
+            # raised cannot survive as a callable zombie.
+            with self._snapshot_context_lock:
+                self._snapshot_context_epochs[plugin_key] = (
+                    self._snapshot_context_epochs.get(plugin_key, 0) + 1
+                )
+                failed_snapshot_contexts = tuple(
+                    self._active_snapshot_contexts.pop(plugin_key, set())
+                )
+                self._snapshot_context_keys.discard(plugin_key)
+            for failed_context in failed_snapshot_contexts:
+                try:
+                    failed_context._release_toolset_snapshots()
+                except Exception as cleanup_exc:  # pragma: no cover - defensive
+                    logger.warning(
+                        "Failed to clean up snapshot context for plugin %s: %s",
+                        plugin_key,
+                        cleanup_exc,
+                        exc_info=_PLUGINS_DEBUG,
+                    )
+            with self._plugin_tool_names_lock:
+                self._plugin_snapshot_tool_names.pop(plugin_key, None)
             owned = [
                 registration
                 for registration in self._registration_order
@@ -4907,7 +5141,16 @@ class PluginManager:
         # bookkeeping outlive the load attempt (#78050).
         if not loaded.enabled:
             self._predeclared_tools.pop(plugin_key, None)
-        self._plugins[manifest.key or manifest.name] = loaded
+        with self._plugin_tool_names_lock:
+            if loaded.enabled:
+                loaded.tools_registered = sorted(
+                    set(loaded.tools_registered)
+                    | self._plugin_snapshot_tool_names.get(plugin_key, set())
+                )
+            # Publish the loaded placeholder under the same lock snapshot
+            # refresh uses to update attribution. A refresh after this point
+            # sees `_plugins[plugin_key]` and updates the live record itself.
+            self._plugins[plugin_key] = loaded
 
     def _load_portable_plugin(
         self, manifest: PluginManifest, loaded: LoadedPlugin
@@ -6556,39 +6799,42 @@ def get_plugin_toolsets() -> List[tuple]:
     alongside the built-in ones and can be toggled on/off per platform.
     """
     manager = get_plugin_manager()
-    if not manager._plugin_tool_names:
-        return []
+    with manager._plugin_tool_names_lock:
+        if not manager._plugin_tool_names:
+            return []
 
-    try:
-        from tools.registry import registry
-    except Exception:
-        return []
+        try:
+            from tools.registry import registry
+        except Exception:
+            return []
 
-    # Group plugin tool names by their toolset
-    toolset_tools: Dict[str, List[str]] = {}
-    toolset_plugin: Dict[str, LoadedPlugin] = {}
-    for tool_name in manager._plugin_tool_names:
-        entry = registry.get_entry(tool_name)
-        if not entry:
-            continue
-        ts = entry.toolset
-        toolset_tools.setdefault(ts, []).append(entry.name)
-
-    # Map toolsets back to the plugin that registered them
-    for _name, loaded in manager._plugins.items():
-        for tool_name in loaded.tools_registered:
+        # Hold the attribution lock through registry reads so a dynamic
+        # replacement publishes registry state and manager metadata as one
+        # observable unit for this introspection surface.
+        toolset_tools: Dict[str, List[str]] = {}
+        toolset_plugin: Dict[str, LoadedPlugin] = {}
+        for tool_name in manager._plugin_tool_names:
             entry = registry.get_entry(tool_name)
-            if entry and entry.toolset in toolset_tools:
-                toolset_plugin.setdefault(entry.toolset, loaded)
+            if not entry:
+                continue
+            ts = entry.toolset
+            toolset_tools.setdefault(ts, []).append(entry.name)
 
-    result = []
-    for ts_key in sorted(toolset_tools):
-        plugin = toolset_plugin.get(ts_key)
-        label = f"🔌 {ts_key.replace('_', ' ').title()}"
-        if plugin and plugin.manifest.description:
-            desc = plugin.manifest.description
-        else:
-            desc = ", ".join(sorted(toolset_tools[ts_key]))
-        result.append((ts_key, label, desc))
+        # Map toolsets back to the plugin that registered them.
+        for _name, loaded in manager._plugins.items():
+            for tool_name in loaded.tools_registered:
+                entry = registry.get_entry(tool_name)
+                if entry and entry.toolset in toolset_tools:
+                    toolset_plugin.setdefault(entry.toolset, loaded)
 
-    return result
+        result = []
+        for ts_key in sorted(toolset_tools):
+            plugin = toolset_plugin.get(ts_key)
+            label = f"🔌 {ts_key.replace('_', ' ').title()}"
+            if plugin and plugin.manifest.description:
+                desc = plugin.manifest.description
+            else:
+                desc = ", ".join(sorted(toolset_tools[ts_key]))
+            result.append((ts_key, label, desc))
+
+        return result

--- a/model_tools.py
+++ b/model_tools.py
@@ -362,7 +362,10 @@ def get_tool_definitions(
         except (FileNotFoundError, OSError, ImportError):
             cfg_fp = None
         profile_scope = check_fn_cache_scope()
-        if profile_scope != CHECK_FN_CACHE_BYPASS:
+        if (
+            profile_scope != CHECK_FN_CACHE_BYPASS
+            and not registry.has_dynamic_snapshot_availability()
+        ):
             cache_key = (
                 registry.current_scope_key(),
                 frozenset(enabled_toolsets) if enabled_toolsets is not None else None,

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -3,6 +3,7 @@
 import logging
 import json
 import sys
+import threading
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1376,6 +1377,902 @@ class TestThreadToolWhitelist:
 class TestPluginContext:
     """Tests for the PluginContext facade."""
 
+    def test_replace_toolset_snapshot_publishes_one_generation(self, tmp_path):
+        """A complete plugin snapshot is published through one public mutation."""
+        from tools.registry import registry
+
+        scope = str(tmp_path / "profile")
+        manager = PluginManager(scope_key=scope)
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"),
+            manager,
+        )
+        generation_before = context.registry_generation
+
+        result = context.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-1",
+            [
+                {
+                    "name": "snapshot_alpha_v1",
+                    "schema": {
+                        "name": "snapshot_alpha_v1",
+                        "description": "Alpha v1",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"version": 1}',
+                },
+                {
+                    "name": "snapshot_beta_v1",
+                    "schema": {
+                        "name": "snapshot_beta_v1",
+                        "description": "Beta v1",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"version": 1}',
+                },
+            ],
+        )
+
+        assert result.changed is True
+        assert result.generation == generation_before + 1
+        assert context.registry_generation == result.generation
+        assert result.added == ("snapshot_alpha_v1", "snapshot_beta_v1")
+        assert result.removed == ()
+        assert registry.get_entry("snapshot_alpha_v1", scope=scope) is not None
+        assert registry.get_entry("snapshot_beta_v1", scope=scope) is not None
+
+        manager.unload()
+
+    def test_replace_toolset_snapshot_same_revision_is_idempotent(self, tmp_path):
+        """Re-publishing an equivalent source revision does not churn caches."""
+        scope = str(tmp_path / "profile")
+        manager = PluginManager(scope_key=scope)
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"),
+            manager,
+        )
+        handler = lambda args, **kwargs: '{"ok": true}'
+        entries = [
+            {
+                "name": "snapshot_stable_v1",
+                "schema": {
+                    "name": "snapshot_stable_v1",
+                    "description": "Stable schema",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                "handler": handler,
+            }
+        ]
+
+        first = context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-1", entries
+        )
+        second = context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-1", entries
+        )
+
+        assert first.changed is True
+        assert second.changed is False
+        assert second.generation == first.generation
+        assert context.registry_generation == first.generation
+
+        manager.unload()
+
+    def test_snapshot_name_cannot_be_reclaimed_by_another_plugin(self, tmp_path):
+        """A later per-tool registration cannot overwrite snapshot ownership."""
+        from tools.registry import registry
+
+        scope = str(tmp_path / "profile")
+        manager = PluginManager(scope_key=scope)
+        owner = PluginContext(
+            PluginManifest(name="snapshot-owner", source="user"), manager
+        )
+        contender = PluginContext(
+            PluginManifest(name="snapshot-contender", source="user"), manager
+        )
+        owner.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-1",
+            [
+                {
+                    "name": "snapshot_owned_tool",
+                    "schema": {
+                        "name": "snapshot_owned_tool",
+                        "description": "Owned",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"owner": "snapshot"}',
+                }
+            ],
+        )
+
+        handle = contender.register_tool(
+            name="snapshot_owned_tool",
+            toolset="plugin_snapshot",
+            schema={
+                "name": "snapshot_owned_tool",
+                "description": "Contender",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kwargs: '{"owner": "contender"}',
+        )
+
+        assert handle is None
+        assert registry.dispatch("snapshot_owned_tool", {}, scope=scope) == (
+            '{"owner": "snapshot"}'
+        )
+
+        manager.unload()
+
+    def test_initial_empty_snapshot_is_a_noop(self, tmp_path):
+        """Publishing absence over absence does not advance registry state."""
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        generation_before = context.registry_generation
+
+        result = context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-empty", []
+        )
+
+        assert result.changed is False
+        assert result.generation == generation_before
+        assert context.registry_generation == generation_before
+        assert manager._registration_order == []
+
+        manager.unload()
+
+    def test_equivalent_snapshot_with_new_revision_does_not_churn(self, tmp_path):
+        """A producer revision may advance without republishing equal entries."""
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        handler = lambda args, **kwargs: '{"ok": true}'
+        entries = [
+            {
+                "name": "snapshot_equal_tool",
+                "schema": {
+                    "name": "snapshot_equal_tool",
+                    "description": "Equal",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                "handler": handler,
+            }
+        ]
+        first = context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-1", entries
+        )
+
+        second = context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-2", entries
+        )
+
+        assert second.changed is False
+        assert second.generation == first.generation
+        assert context.registry_generation == first.generation
+
+        manager.unload()
+
+    def test_snapshot_schema_is_detached_from_caller_mutation(self, tmp_path):
+        """Published nested schema state cannot change outside a publication."""
+        import copy
+
+        from hermes_cli.plugins import _plugin_home_scope
+        from model_tools import get_tool_definitions
+        from tools.registry import registry
+
+        scope = str(tmp_path / "profile")
+        manager = PluginManager(scope_key=scope)
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        schema = {
+            "name": "snapshot_detached_schema",
+            "description": "Detached",
+            "parameters": {
+                "type": "object",
+                "properties": {"before": {"type": "string"}},
+            },
+        }
+        result = context.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-1",
+            [
+                {
+                    "name": "snapshot_detached_schema",
+                    "schema": schema,
+                    "handler": lambda args, **kwargs: '{"ok": true}',
+                }
+            ],
+        )
+
+        schema["parameters"]["properties"]["after"] = {"type": "integer"}
+
+        entry = registry.get_entry("snapshot_detached_schema", scope=scope)
+        assert entry is not None
+        assert set(entry.schema["parameters"]["properties"]) == {"before"}
+        with pytest.raises(TypeError, match="schemas are immutable"):
+            entry.schema["parameters"]["properties"]["after"] = {
+                "type": "integer"
+            }
+        copied_schema = copy.deepcopy(entry.schema)
+        copied_schema["parameters"]["properties"]["after"] = {"type": "integer"}
+        with _plugin_home_scope(Path(scope)):
+            [definition] = get_tool_definitions(
+                enabled_toolsets=["plugin_snapshot"],
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            )
+        definition["function"]["parameters"]["properties"]["after"] = {
+            "type": "integer"
+        }
+        assert set(entry.schema["parameters"]["properties"]) == {"before"}
+        assert context.registry_generation == result.generation
+
+        manager.unload()
+
+    def test_empty_snapshot_revision_cannot_be_reused_for_different_content(
+        self, tmp_path
+    ):
+        """An empty revision remains an identity-bearing source checkpoint."""
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-empty", []
+        )
+
+        with pytest.raises(ValueError, match="already identifies a different"):
+            context.replace_toolset_snapshot(
+                "plugin_snapshot",
+                "revision-empty",
+                [
+                    {
+                        "name": "snapshot_resurrected_tool",
+                        "schema": {
+                            "name": "snapshot_resurrected_tool",
+                            "description": "Resurrected",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                        "handler": lambda args, **kwargs: '{"ok": true}',
+                    }
+                ],
+            )
+
+        manager.unload()
+
+    def test_snapshot_uses_context_bound_registry(self, tmp_path):
+        """A loader can bind publication to an isolated transaction view."""
+        from tools.registry import ToolRegistry, registry
+
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        isolated = ToolRegistry()
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"),
+            manager,
+            registration_registry=isolated,
+        )
+        context.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-1",
+            [
+                {
+                    "name": "snapshot_isolated_tool",
+                    "schema": {
+                        "name": "snapshot_isolated_tool",
+                        "description": "Isolated",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"ok": true}',
+                }
+            ],
+        )
+
+        assert isolated.get_entry(
+            "snapshot_isolated_tool", scope=manager.scope_key
+        ) is not None
+        assert registry.get_entry(
+            "snapshot_isolated_tool", scope=manager.scope_key
+        ) is None
+
+        manager.unload()
+
+    def test_snapshot_refresh_removes_stale_name_and_empty_removes_all(self, tmp_path):
+        """Versioned names fail closed after refresh and disappear on empty."""
+        from tools.registry import registry
+
+        scope = str(tmp_path / "profile")
+        manager = PluginManager(scope_key=scope)
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        first = context.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-1",
+            [
+                {
+                    "name": "snapshot_schema_v1",
+                    "schema": {
+                        "name": "snapshot_schema_v1",
+                        "description": "Schema v1",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"version": 1}',
+                }
+            ],
+        )
+
+        second = context.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-2",
+            [
+                {
+                    "name": "snapshot_schema_v2",
+                    "schema": {
+                        "name": "snapshot_schema_v2",
+                        "description": "Schema v2",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"version": 2}',
+                }
+            ],
+        )
+
+        assert second.generation == first.generation + 1
+        assert second.added == ("snapshot_schema_v2",)
+        assert second.removed == ("snapshot_schema_v1",)
+        stale_result = registry.dispatch("snapshot_schema_v1", {}, scope=scope)
+        assert isinstance(stale_result, str)
+        assert json.loads(stale_result)["error"] == "Unknown tool: snapshot_schema_v1"
+        assert registry.dispatch("snapshot_schema_v2", {}, scope=scope) == (
+            '{"version": 2}'
+        )
+
+        empty = context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-empty", []
+        )
+        assert empty.generation == second.generation + 1
+        assert empty.removed == ("snapshot_schema_v2",)
+        assert registry.get_entry("snapshot_schema_v2", scope=scope) is None
+
+        manager.unload()
+
+    def test_invalid_candidate_leaves_prior_snapshot_unchanged(self, tmp_path):
+        """The complete candidate is validated before any live mutation."""
+        from tools.registry import registry
+
+        scope = str(tmp_path / "profile")
+        manager = PluginManager(scope_key=scope)
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        context.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-1",
+            [
+                {
+                    "name": "snapshot_survivor",
+                    "schema": {
+                        "name": "snapshot_survivor",
+                        "description": "Survivor",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"ok": true}',
+                }
+            ],
+        )
+        generation_before = context.registry_generation
+        duplicate = {
+            "name": "snapshot_duplicate",
+            "schema": {
+                "name": "snapshot_duplicate",
+                "description": "Duplicate",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            "handler": lambda args, **kwargs: '{"ok": true}',
+        }
+
+        with pytest.raises(ValueError, match="duplicate snapshot tool name"):
+            context.replace_toolset_snapshot(
+                "plugin_snapshot", "revision-invalid", [duplicate, duplicate]
+            )
+
+        assert context.registry_generation == generation_before
+        assert registry.dispatch("snapshot_survivor", {}, scope=scope) == (
+            '{"ok": true}'
+        )
+        assert registry.get_entry("snapshot_duplicate", scope=scope) is None
+
+        manager.unload()
+
+    def test_snapshot_entries_cannot_request_override(self, tmp_path):
+        """The snapshot surface has no path around ordinary collision policy."""
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        generation_before = context.registry_generation
+
+        with pytest.raises(ValueError, match="unsupported snapshot entry fields"):
+            context.replace_toolset_snapshot(
+                "plugin_snapshot",
+                "revision-1",
+                [
+                    {
+                        "name": "snapshot_override_attempt",
+                        "schema": {
+                            "name": "snapshot_override_attempt",
+                            "description": "Override attempt",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                        "handler": lambda args, **kwargs: '{"ok": true}',
+                        "override": True,
+                    }
+                ],
+            )
+
+        assert context.registry_generation == generation_before
+
+    @pytest.mark.parametrize("name", ["tool_search", "tool_describe", "tool_call"])
+    def test_snapshot_rejects_progressive_disclosure_bridge_names(
+        self, tmp_path, name
+    ):
+        """Dynamic snapshots cannot shadow Hermes's synthesized bridge tools."""
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        generation_before = context.registry_generation
+
+        with pytest.raises(ValueError, match="reserved by Hermes"):
+            context.replace_toolset_snapshot(
+                "plugin_snapshot",
+                "revision-1",
+                [
+                    {
+                        "name": name,
+                        "schema": {
+                            "name": name,
+                            "description": "Reserved",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                        "handler": lambda args, **kwargs: '{"ok": true}',
+                    }
+                ],
+            )
+
+        assert context.registry_generation == generation_before
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            ("requires_env", "TOKEN", "must be a list of strings"),
+            ("requires_env", ["TOKEN", 1], "must be a list of strings"),
+            ("is_async", "false", "must be a boolean"),
+            ("description", 1, "must be a string"),
+            ("emoji", 1, "must be a string"),
+        ],
+    )
+    def test_snapshot_rejects_mistyped_optional_fields(
+        self, tmp_path, field, value, message
+    ):
+        """Optional metadata is strict so malformed policy is not coerced."""
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        entry = {
+            "name": "snapshot_strict_tool",
+            "schema": {
+                "name": "snapshot_strict_tool",
+                "description": "Strict",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            "handler": lambda args, **kwargs: '{"ok": true}',
+            field: value,
+        }
+
+        with pytest.raises(TypeError, match=message):
+            context.replace_toolset_snapshot(
+                "plugin_snapshot", "revision-invalid", [entry]
+            )
+
+    def test_snapshot_availability_is_rechecked_for_definitions_and_dispatch(
+        self, tmp_path
+    ):
+        """A live snapshot check cannot leave a callable stale tool behind."""
+        from hermes_cli.plugins import _plugin_home_scope
+        from model_tools import get_tool_definitions
+        from tools.registry import no_cache_check_fn, registry
+
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        available = True
+
+        @no_cache_check_fn
+        def is_available():
+            return available
+
+        context.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-1",
+            [
+                {
+                    "name": "snapshot_available_tool",
+                    "schema": {
+                        "name": "snapshot_available_tool",
+                        "description": "Availability",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"executed": true}',
+                    "check_fn": is_available,
+                }
+            ],
+        )
+
+        with _plugin_home_scope(Path(manager.scope_key)):
+            first = get_tool_definitions(
+                enabled_toolsets=["plugin_snapshot"],
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            )
+        assert [item["function"]["name"] for item in first] == [
+            "snapshot_available_tool"
+        ]
+        available = False
+
+        with _plugin_home_scope(Path(manager.scope_key)):
+            second = get_tool_definitions(
+                enabled_toolsets=["plugin_snapshot"],
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            )
+        assert second == []
+        unavailable_result = registry.dispatch(
+            "snapshot_available_tool", {}, scope=manager.scope_key
+        )
+        assert isinstance(unavailable_result, str)
+        unavailable = json.loads(unavailable_result)
+        assert unavailable["error"] == "Tool unavailable: snapshot_available_tool"
+
+        manager.unload()
+
+    def test_snapshot_names_are_isolated_by_profile_scope(self, tmp_path):
+        """Two profiles may publish the same name without sharing handlers."""
+        from tools.registry import registry
+
+        first_scope = str(tmp_path / "first")
+        second_scope = str(tmp_path / "second")
+        first_manager = PluginManager(scope_key=first_scope)
+        second_manager = PluginManager(scope_key=second_scope)
+        first = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), first_manager
+        )
+        second = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), second_manager
+        )
+        schema = {
+            "name": "snapshot_scoped_tool",
+            "description": "Scoped",
+            "parameters": {"type": "object", "properties": {}},
+        }
+
+        first.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "first-revision",
+            [{"name": "snapshot_scoped_tool", "schema": schema,
+              "handler": lambda args, **kwargs: '"first"'}],
+        )
+        second.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "second-revision",
+            [{"name": "snapshot_scoped_tool", "schema": schema,
+              "handler": lambda args, **kwargs: '"second"'}],
+        )
+
+        assert registry.dispatch(
+            "snapshot_scoped_tool", {}, scope=first_scope
+        ) == '"first"'
+        assert registry.dispatch(
+            "snapshot_scoped_tool", {}, scope=second_scope
+        ) == '"second"'
+
+        first_manager.unload()
+        assert registry.get_entry("snapshot_scoped_tool", scope=first_scope) is None
+        assert registry.dispatch(
+            "snapshot_scoped_tool", {}, scope=second_scope
+        ) == '"second"'
+        second_manager.unload()
+
+    def test_concurrent_readers_see_old_or_new_complete_snapshot(self):
+        """Readers never observe a partially replaced projected toolset."""
+        from tools.registry import registry
+
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+
+        def entry(name):
+            return {
+                "name": name,
+                "schema": {
+                    "name": name,
+                    "description": name,
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                "handler": lambda args, **kwargs: '{"ok": true}',
+            }
+
+        old_names = frozenset({"snapshot_old_a", "snapshot_old_b"})
+        new_names = frozenset({"snapshot_new_a", "snapshot_new_b"})
+        all_names = set(old_names | new_names)
+        context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-old", [entry(name) for name in old_names]
+        )
+        start = threading.Barrier(2)
+        observed = set()
+        old_seen = threading.Event()
+        new_seen = threading.Event()
+
+        def read_snapshots():
+            start.wait(timeout=5)
+            for _ in range(10_000):
+                definitions = registry.get_definitions(all_names, quiet=True)
+                names = frozenset(
+                    item["function"]["name"] for item in definitions
+                )
+                observed.add(names)
+                if names == old_names:
+                    old_seen.set()
+                elif names == new_names:
+                    new_seen.set()
+                    return
+
+        reader = threading.Thread(target=read_snapshots)
+        reader.start()
+        start.wait(timeout=5)
+        assert old_seen.wait(timeout=5)
+        context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-new", [entry(name) for name in new_names]
+        )
+        assert new_seen.wait(timeout=5)
+        reader.join(timeout=10)
+
+        assert not reader.is_alive()
+        assert old_names in observed
+        assert new_names in observed
+        assert observed <= {old_names, new_names}
+
+        manager.unload()
+
+    def test_toolset_introspection_waits_for_complete_attribution_refresh(
+        self, monkeypatch
+    ):
+        """Registry and manager attribution are coherent to runtime readers."""
+        from hermes_cli import plugins as plugins_mod
+        from tools.registry import registry
+
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+
+        def entry(name):
+            return {
+                "name": name,
+                "schema": {
+                    "name": name,
+                    "description": name,
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                "handler": lambda args, **kwargs: '{"ok": true}',
+            }
+
+        context.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-old",
+            [entry("snapshot_introspection_old")],
+        )
+        committed = threading.Event()
+        release = threading.Event()
+        original_replace = registry._replace_plugin_toolset_snapshot
+
+        def blocking_replace(**kwargs):
+            result = original_replace(**kwargs)
+            committed.set()
+            assert release.wait(timeout=5)
+            return result
+
+        monkeypatch.setattr(
+            registry, "_replace_plugin_toolset_snapshot", blocking_replace
+        )
+        monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+        publisher = threading.Thread(
+            target=lambda: context.replace_toolset_snapshot(
+                "plugin_snapshot",
+                "revision-new",
+                [
+                    entry("snapshot_introspection_new_a"),
+                    entry("snapshot_introspection_new_b"),
+                ],
+            )
+        )
+        publisher.start()
+        assert committed.wait(timeout=5)
+        observed = []
+        reader = threading.Thread(
+            target=lambda: observed.extend(plugins_mod.get_plugin_toolsets())
+        )
+        reader.start()
+        release.set()
+        publisher.join(timeout=5)
+        reader.join(timeout=5)
+
+        assert not publisher.is_alive()
+        assert not reader.is_alive()
+        assert observed == [
+            (
+                "plugin_snapshot",
+                "🔌 Plugin Snapshot",
+                "snapshot_introspection_new_a, snapshot_introspection_new_b",
+            )
+        ]
+
+        manager.unload()
+
+    def test_unloaded_context_cannot_republish_snapshot(self, tmp_path):
+        """An ownership token is permanently revoked when its plugin unloads."""
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        context.replace_toolset_snapshot(
+            "plugin_snapshot",
+            "revision-1",
+            [
+                {
+                    "name": "snapshot_lifecycle_tool",
+                    "schema": {
+                        "name": "snapshot_lifecycle_tool",
+                        "description": "Lifecycle",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"ok": true}',
+                }
+            ],
+        )
+        manager.unload()
+
+        with pytest.raises(RuntimeError, match="context has been unloaded"):
+            context.replace_toolset_snapshot(
+                "plugin_snapshot", "revision-2", []
+            )
+
+    def test_unloaded_context_cannot_publish_after_initial_empty_snapshot(
+        self, tmp_path
+    ):
+        """An empty first publication still binds revocation to unload."""
+        manager = PluginManager(scope_key=str(tmp_path / "profile"))
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        context.replace_toolset_snapshot(
+            "plugin_snapshot", "revision-empty", []
+        )
+        manager.unload()
+
+        with pytest.raises(RuntimeError, match="context has been unloaded"):
+            context.replace_toolset_snapshot(
+                "plugin_snapshot",
+                "revision-1",
+                [
+                    {
+                        "name": "snapshot_late_tool",
+                        "schema": {
+                            "name": "snapshot_late_tool",
+                            "description": "Late",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                        "handler": lambda args, **kwargs: '{"ok": true}',
+                    }
+                ],
+            )
+
+    def test_unload_serializes_with_inflight_snapshot_materialization(
+        self, tmp_path
+    ):
+        """Unload during materialization revokes publication before commit."""
+        from tools.registry import registry
+
+        scope = str(tmp_path / "profile")
+        manager = PluginManager(scope_key=scope)
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+        entered = threading.Event()
+        release = threading.Event()
+        publisher_errors = []
+
+        class BlockingEntries:
+            def __iter__(self):
+                entered.set()
+                assert release.wait(timeout=5)
+                yield {
+                    "name": "snapshot_inflight_tool",
+                    "schema": {
+                        "name": "snapshot_inflight_tool",
+                        "description": "Inflight",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"ok": true}',
+                }
+
+        def publish():
+            try:
+                context.replace_toolset_snapshot(
+                    "plugin_snapshot", "revision-1", BlockingEntries()
+                )
+            except Exception as exc:
+                publisher_errors.append(exc)
+
+        publisher = threading.Thread(target=publish)
+        publisher.start()
+        assert entered.wait(timeout=5)
+        unloader = threading.Thread(target=manager.unload)
+        unloader.start()
+        release.set()
+        publisher.join(timeout=5)
+        unloader.join(timeout=5)
+
+        assert not publisher.is_alive()
+        assert not unloader.is_alive()
+        assert len(publisher_errors) == 1
+        assert isinstance(publisher_errors[0], RuntimeError)
+        assert "context has been unloaded" in str(publisher_errors[0])
+        assert registry.get_entry("snapshot_inflight_tool", scope=scope) is None
+        with pytest.raises(RuntimeError, match="context has been unloaded"):
+            context.replace_toolset_snapshot(
+                "plugin_snapshot", "revision-late", []
+            )
+
+    def test_reentrant_unload_during_materialization_cannot_publish(self, tmp_path):
+        """A plugin-controlled iterator cannot unload and then create zombies."""
+        from tools.registry import registry
+
+        scope = str(tmp_path / "profile")
+        manager = PluginManager(scope_key=scope)
+        context = PluginContext(
+            PluginManifest(name="snapshot-plugin", source="user"), manager
+        )
+
+        class UnloadingEntries:
+            def __iter__(self):
+                assert manager.unload() is True
+                yield {
+                    "name": "snapshot_reentrant_zombie",
+                    "schema": {
+                        "name": "snapshot_reentrant_zombie",
+                        "description": "Zombie",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                    "handler": lambda args, **kwargs: '{"ok": true}',
+                }
+
+        with pytest.raises(RuntimeError, match="context has been unloaded"):
+            context.replace_toolset_snapshot(
+                "plugin_snapshot", "revision-1", UnloadingEntries()
+            )
+
+        assert registry.get_entry("snapshot_reentrant_zombie", scope=scope) is None
+        assert manager.unload() is False
+
 
 
 
@@ -1603,6 +2500,79 @@ class TestPluginManagerList:
         # not by display name, so that category plugins group together.
         keys = [p["key"] for p in listing]
         assert keys == sorted(keys)
+
+    def test_discovered_plugin_reports_snapshot_tools(self, tmp_path, monkeypatch):
+        """Real discovery attributes atomically published tools to the plugin."""
+        from tools.registry import registry
+
+        home = tmp_path / "hermes_test"
+        plugins_dir = home / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "snapshot_catalog",
+            register_body=(
+                "ctx.replace_toolset_snapshot("
+                "'snapshot_catalog_tools', 'revision-1', [{"
+                "'name': 'snapshot_discovered_tool', "
+                "'schema': {'name': 'snapshot_discovered_tool', "
+                "'description': 'Discovered', "
+                "'parameters': {'type': 'object', 'properties': {}}}, "
+                "'handler': lambda args, **kwargs: '{\"ok\": true}'"
+                "}])"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        manager = PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins["snapshot_catalog"]
+        listing = {item["name"]: item for item in manager.list_plugins()}
+        assert loaded.tools_registered == ["snapshot_discovered_tool"]
+        assert listing["snapshot_catalog"]["tools"] == 1
+        assert registry.dispatch(
+            "snapshot_discovered_tool", {}, scope=manager.scope_key
+        ) == '{"ok": true}'
+
+        manager.unload()
+
+    def test_failed_plugin_registration_revokes_published_snapshot(
+        self, tmp_path, monkeypatch
+    ):
+        """A register() exception cannot leave snapshot tools callable."""
+        from tools.registry import registry
+
+        home = tmp_path / "hermes_test"
+        plugins_dir = home / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "failing_snapshot_catalog",
+            register_body=(
+                "ctx.replace_toolset_snapshot("
+                "'failing_snapshot_tools', 'revision-1', [{"
+                "'name': 'snapshot_failed_registration_tool', "
+                "'schema': {'name': 'snapshot_failed_registration_tool', "
+                "'description': 'Must be revoked', "
+                "'parameters': {'type': 'object', 'properties': {}}}, "
+                "'handler': lambda args, **kwargs: '{\"ok\": true}'"
+                "}]); raise RuntimeError('register failed')"
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        manager = PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins["failing_snapshot_catalog"]
+        assert loaded.enabled is False
+        assert loaded.error == "register failed"
+        assert registry.get_entry(
+            "snapshot_failed_registration_tool", scope=manager.scope_key
+        ) is None
+        assert "snapshot_failed_registration_tool" not in manager._plugin_tool_names
+        assert "failing_snapshot_catalog" not in manager._plugin_snapshot_tool_names
+
+        manager.unload()
 
 
     def test_shared_hook_name_credited_to_every_plugin(self, tmp_path, monkeypatch):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -23,7 +23,18 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    NoReturn,
+    Optional,
+    Self,
+    Set,
+    SupportsIndex,
+)
 
 from hermes_constants import hermes_home_key
 
@@ -231,6 +242,135 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+
+
+class _ToolsetSnapshotState:
+    """Host-owned state for one plugin context's dynamic toolset."""
+
+    __slots__ = ("source_revision", "signature", "entries")
+
+    def __init__(
+        self,
+        source_revision: str,
+        signature: tuple,
+        entries: Dict[str, ToolEntry],
+    ) -> None:
+        self.source_revision = source_revision
+        self.signature = signature
+        self.entries = entries
+
+
+_RESERVED_PROGRESSIVE_DISCLOSURE_NAMES = frozenset(
+    {"tool_search", "tool_describe", "tool_call"}
+)
+
+
+def _immutable_json(value: Any) -> Any:
+    """Recursively freeze a detached JSON value while preserving JSON shapes."""
+    if isinstance(value, dict):
+        return _ImmutableJsonDict(
+            {key: _immutable_json(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return _ImmutableJsonList(_immutable_json(item) for item in value)
+    return value
+
+
+def _mutable_json(value: Any) -> Any:
+    """Return ordinary detached containers for schema normalization callers."""
+    if isinstance(value, dict):
+        return {key: _mutable_json(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_mutable_json(item) for item in value]
+    return value
+
+
+class _ImmutableJsonDict(dict[str, Any]):
+    """A JSON-serializable dictionary that rejects post-publication mutation."""
+
+    @staticmethod
+    def _reject() -> NoReturn:
+        raise TypeError("published snapshot schemas are immutable")
+
+    def __setitem__(self, _key: str, _value: Any) -> None:
+        self._reject()
+
+    def __delitem__(self, _key: str) -> None:
+        self._reject()
+
+    def clear(self) -> None:
+        self._reject()
+
+    def pop(self, _key: str, _default: Any = None) -> Any:
+        self._reject()
+
+    def popitem(self) -> tuple[str, Any]:
+        self._reject()
+
+    def setdefault(self, _key: str, _default: Any = None) -> Any:
+        self._reject()
+
+    def update(self, *_args: Any, **_kwargs: Any) -> None:
+        self._reject()
+
+    def __ior__(self, _value: Any):
+        self._reject()
+
+    def __copy__(self):
+        return _mutable_json(self)
+
+    def __deepcopy__(self, _memo):
+        return _mutable_json(self)
+
+
+class _ImmutableJsonList(list[Any]):
+    """A JSON-serializable list that rejects post-publication mutation."""
+
+    @staticmethod
+    def _reject() -> NoReturn:
+        raise TypeError("published snapshot schemas are immutable")
+
+    def __setitem__(self, _index: Any, _value: Any) -> None:
+        self._reject()
+
+    def __delitem__(self, _index: Any) -> None:
+        self._reject()
+
+    def __iadd__(self, _value: Any):
+        self._reject()
+
+    def __imul__(self, _value: SupportsIndex) -> Self:
+        self._reject()
+
+    def append(self, _value: Any) -> None:
+        self._reject()
+
+    def clear(self) -> None:
+        self._reject()
+
+    def extend(self, _values: Any) -> None:
+        self._reject()
+
+    def insert(self, _index: SupportsIndex, _value: Any) -> None:
+        self._reject()
+
+    def pop(self, _index: SupportsIndex = -1) -> Any:
+        self._reject()
+
+    def remove(self, _value: Any) -> None:
+        self._reject()
+
+    def reverse(self) -> None:
+        self._reject()
+
+    def sort(self, *args: Any, **kwargs: Any) -> None:
+        self._reject()
+
+    def __copy__(self):
+        return _mutable_json(self)
+
+    def __deepcopy__(self, _memo):
+        return _mutable_json(self)
 
 
 class _PluginOverridePolicy:
@@ -469,6 +609,13 @@ class ToolRegistry:
         self._plugin_module_scopes: Dict[str, Set[Optional[str]]] = {}
         self._toolset_checks: Dict[str, Callable] = {}
         self._toolset_aliases: Dict[str, str] = {}
+        # Dynamic plugin snapshots are keyed by immutable context ownership,
+        # profile scope, and toolset. Entries remain private registry state;
+        # plugins mutate them only through PluginContext.
+        self._plugin_toolset_snapshots: Dict[
+            tuple[str, str, object], _ToolsetSnapshotState
+        ] = {}
+        self._plugin_snapshot_name_owners: Dict[tuple[str, str], object] = {}
         # MCP dynamic refresh can mutate the registry while other threads are
         # reading tool metadata, so keep mutations serialized and readers on
         # stable snapshots.
@@ -484,6 +631,24 @@ class ToolRegistry:
     def current_scope_key() -> str:
         """Return the active profile's canonical registry scope."""
         return hermes_home_key()
+
+    @property
+    def generation(self) -> int:
+        """Return the current registry generation through a public accessor."""
+        with self._lock:
+            return self._generation
+
+    def has_dynamic_snapshot_availability(self, scope: Optional[str] = None) -> bool:
+        """Return whether the active scope has snapshot callbacks to re-probe."""
+        active_scope = scope or self.current_scope_key()
+        with self._lock:
+            return any(
+                entry.check_fn is not None
+                for (snapshot_scope, _toolset, _owner), state
+                in self._plugin_toolset_snapshots.items()
+                if snapshot_scope == active_scope
+                for entry in state.entries.values()
+            )
 
     def _merged_tools(self, scope: Optional[str] = None) -> Dict[str, ToolEntry]:
         """Return global tools overlaid with one profile's plugin tools."""
@@ -594,6 +759,226 @@ class ToolRegistry:
     # ------------------------------------------------------------------
     # Registration
     # ------------------------------------------------------------------
+
+    def _replace_plugin_toolset_snapshot(
+        self,
+        *,
+        owner: object,
+        owner_is_live: Callable[[], bool],
+        scope: str,
+        toolset: str,
+        source_revision: str,
+        entries: List[Mapping[str, Any]],
+    ) -> dict:
+        """Atomically publish one context-owned, profile-scoped toolset."""
+        if not isinstance(toolset, str) or not toolset.strip():
+            raise ValueError("toolset must be a non-empty string")
+        if not isinstance(source_revision, str) or not source_revision.strip():
+            raise ValueError("source_revision must be a non-empty string")
+
+        prepared: Dict[str, ToolEntry] = {}
+        signatures = []
+        allowed_fields = {
+            "name",
+            "schema",
+            "handler",
+            "check_fn",
+            "requires_env",
+            "is_async",
+            "description",
+            "emoji",
+        }
+        for candidate in entries:
+            if not isinstance(candidate, Mapping):
+                raise TypeError("snapshot entries must be mappings")
+            unsupported = set(candidate) - allowed_fields
+            if unsupported:
+                raise ValueError(
+                    "unsupported snapshot entry fields: "
+                    + ", ".join(sorted(str(field) for field in unsupported))
+                )
+            name = candidate.get("name")
+            schema = candidate.get("schema")
+            handler = candidate.get("handler")
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError("snapshot entry name must be a non-empty string")
+            if name in _RESERVED_PROGRESSIVE_DISCLOSURE_NAMES:
+                raise ValueError(f"snapshot tool name is reserved by Hermes: {name}")
+            if name in prepared:
+                raise ValueError(f"duplicate snapshot tool name: {name}")
+            if not isinstance(schema, dict):
+                raise TypeError(f"snapshot schema for {name!r} must be a dictionary")
+            if not callable(handler):
+                raise TypeError(f"snapshot handler for {name!r} must be callable")
+            check_fn = candidate.get("check_fn")
+            if check_fn is not None and not callable(check_fn):
+                raise TypeError(f"snapshot check_fn for {name!r} must be callable")
+            requires_env_value = candidate.get("requires_env", [])
+            if (
+                not isinstance(requires_env_value, list)
+                or not all(isinstance(value, str) for value in requires_env_value)
+            ):
+                raise TypeError(
+                    f"snapshot requires_env for {name!r} must be a list of strings"
+                )
+            requires_env = list(requires_env_value)
+            is_async = candidate.get("is_async", False)
+            if not isinstance(is_async, bool):
+                raise TypeError(f"snapshot is_async for {name!r} must be a boolean")
+            description = candidate.get("description", schema.get("description", ""))
+            if not isinstance(description, str):
+                raise TypeError(f"snapshot description for {name!r} must be a string")
+            emoji = candidate.get("emoji", "")
+            if not isinstance(emoji, str):
+                raise TypeError(f"snapshot emoji for {name!r} must be a string")
+            try:
+                schema_signature = json.dumps(
+                    {**schema, "name": name},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
+            except (TypeError, ValueError) as exc:
+                raise TypeError(
+                    f"snapshot schema for {name!r} must be JSON-serializable"
+                ) from exc
+            # Round-trip through JSON so nested caller-owned dictionaries and
+            # lists cannot mutate a live schema without a generation bump.
+            schema_with_name = _immutable_json(json.loads(schema_signature))
+            prepared[name] = ToolEntry(
+                name=name,
+                toolset=toolset,
+                schema=schema_with_name,
+                handler=handler,
+                check_fn=check_fn,
+                requires_env=requires_env,
+                is_async=is_async,
+                description=description,
+                emoji=emoji,
+            )
+            signatures.append(
+                (
+                    name,
+                    schema_signature,
+                    id(handler),
+                    id(check_fn),
+                    tuple(requires_env),
+                    is_async,
+                    description,
+                    emoji,
+                )
+            )
+        signature = tuple(sorted(signatures))
+
+        key = (scope, toolset, owner)
+        with self._lock:
+            if not owner_is_live():
+                raise RuntimeError("plugin snapshot context has been unloaded")
+            previous = self._plugin_toolset_snapshots.get(key)
+            if previous is None and not prepared:
+                self._plugin_toolset_snapshots[key] = _ToolsetSnapshotState(
+                    source_revision, signature, prepared
+                )
+                return {
+                    "changed": False,
+                    "generation": self._generation,
+                    "added": (),
+                    "removed": (),
+                }
+            if previous is not None and previous.source_revision == source_revision:
+                if previous.signature != signature:
+                    raise ValueError(
+                        "source_revision already identifies a different toolset snapshot"
+                    )
+                return {
+                    "changed": False,
+                    "generation": self._generation,
+                    "added": (),
+                    "removed": (),
+                }
+            if previous is not None and previous.signature == signature:
+                self._plugin_toolset_snapshots[key] = _ToolsetSnapshotState(
+                    source_revision, signature, previous.entries
+                )
+                return {
+                    "changed": False,
+                    "generation": self._generation,
+                    "added": (),
+                    "removed": (),
+                }
+            previous_entries = previous.entries if previous is not None else {}
+            previous_names = set(previous_entries)
+            target = dict(self._scoped_tools.get(scope, {}))
+
+            for name, old_entry in previous_entries.items():
+                if target.get(name) is not old_entry:
+                    raise RuntimeError(
+                        f"snapshot tool {name!r} changed outside its owner context"
+                    )
+                target.pop(name)
+
+            for name in prepared:
+                name_owner = self._plugin_snapshot_name_owners.get((scope, name))
+                if name_owner is not None and name_owner is not owner:
+                    raise ValueError(
+                        f"snapshot tool name is owned by another context: {name}"
+                    )
+                if name in target or name in self._tools:
+                    raise ValueError(f"snapshot tool name is already registered: {name}")
+
+            target.update(prepared)
+            if target:
+                self._scoped_tools[scope] = target
+            else:
+                self._scoped_tools.pop(scope, None)
+            self._plugin_toolset_snapshots[key] = _ToolsetSnapshotState(
+                source_revision, signature, prepared
+            )
+            for name in previous_names - set(prepared):
+                if self._plugin_snapshot_name_owners.get((scope, name)) is owner:
+                    self._plugin_snapshot_name_owners.pop((scope, name), None)
+            for name in prepared:
+                self._plugin_snapshot_name_owners[(scope, name)] = owner
+            self._generation += 1
+            return {
+                "changed": True,
+                "generation": self._generation,
+                "added": tuple(sorted(set(prepared) - previous_names)),
+                "removed": tuple(sorted(previous_names - set(prepared))),
+            }
+
+    def _remove_plugin_toolset_snapshot(
+        self,
+        *,
+        owner: object,
+        scope: str,
+        toolset: str,
+    ) -> tuple[str, ...]:
+        """Remove a context-owned snapshot during plugin unload."""
+        key = (scope, toolset, owner)
+        with self._lock:
+            state = self._plugin_toolset_snapshots.get(key)
+            if state is None:
+                return ()
+            target = dict(self._scoped_tools.get(scope, {}))
+            for name, entry in state.entries.items():
+                if target.get(name) is not entry:
+                    raise RuntimeError(
+                        f"snapshot tool {name!r} changed outside its owner context"
+                    )
+            for name in state.entries:
+                target.pop(name, None)
+            if target:
+                self._scoped_tools[scope] = target
+            else:
+                self._scoped_tools.pop(scope, None)
+            self._plugin_toolset_snapshots.pop(key, None)
+            for name in state.entries:
+                if self._plugin_snapshot_name_owners.get((scope, name)) is owner:
+                    self._plugin_snapshot_name_owners.pop((scope, name), None)
+            if state.entries:
+                self._generation += 1
+            return tuple(sorted(state.entries))
 
     def register_plugin_override_policy(
         self,
@@ -790,6 +1175,16 @@ class ToolRegistry:
         if scope is None and owner is not None:
             scope = self._plugin_scope_of(owner)
         with self._lock:
+            if (
+                scope is not None
+                and (scope, name) in self._plugin_snapshot_name_owners
+            ):
+                logger.error(
+                    "Tool registration REJECTED: %r is owned by an atomic "
+                    "plugin toolset snapshot",
+                    name,
+                )
+                return
             target = (
                 self._tools
                 if scope is None
@@ -910,6 +1305,13 @@ class ToolRegistry:
                 if caller_scope is not None
                 else self._tools
             )
+            if (
+                caller_scope is not None
+                and (caller_scope, name) in self._plugin_snapshot_name_owners
+            ):
+                raise PermissionError(
+                    f"Tool {name!r} is owned by an atomic plugin toolset snapshot"
+                )
             entry = target.get(name)
             if entry is None and caller_scope is not None:
                 if name in self._tools:
@@ -1145,6 +1547,13 @@ class ToolRegistry:
         if not entry:
             return tool_error(f"Unknown tool: {name}")
         try:
+            active_scope = scope or self.current_scope_key()
+            with self._lock:
+                snapshot_owned = (
+                    active_scope, name
+                ) in self._plugin_snapshot_name_owners
+            if snapshot_owned and entry.check_fn and not _check_fn_cached(entry.check_fn):
+                return tool_error(f"Tool unavailable: {name}")
             if entry.is_async:
                 from model_tools import _run_async
                 result = _run_async(entry.handler(args, **kwargs))

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -508,6 +508,8 @@ def register(ctx):
 **What `register()` does:**
 - Called exactly once at startup
 - `ctx.register_tool()` puts your tool in the registry — the model sees it immediately
+- `ctx.replace_toolset_snapshot()` atomically refreshes a dynamic, profile-scoped
+  toolset without exposing registry internals
 - `ctx.register_hook()` subscribes to lifecycle events
 - `ctx.register_cli_command()` registers a CLI subcommand (e.g. `hermes my-plugin <subcommand>`)
 - `ctx.register_command()` registers an in-session slash command (e.g. `/myplugin <args>` inside CLI / gateway chat) — see [Register slash commands](#register-slash-commands) below
@@ -533,6 +535,80 @@ def register(ctx):
 ```
 
 The dispatched tool goes through the normal approval, redaction, and budget pipelines — it's a real tool invocation, not a shortcut around them.
+
+### Refresh a dynamic toolset atomically
+
+Use `ctx.replace_toolset_snapshot()` when a real external source can add,
+change, or remove a complete set of tools while Hermes is running. Static
+plugin tools should keep using `ctx.register_tool()` during `register(ctx)`.
+
+```python
+def publish_catalog(ctx, catalog):
+    result = ctx.replace_toolset_snapshot(
+        "plugin_remote_catalog",
+        source_revision=catalog.revision,
+        entries=[
+            {
+                "name": item.registration_name,
+                "schema": item.schema,
+                "handler": item.handler,
+                "check_fn": item.check_fn,
+                "requires_env": item.requires_env,
+                "is_async": item.is_async,
+                "description": item.description,
+                "emoji": item.emoji,
+            }
+            for item in catalog.tools
+        ],
+    )
+    return result.generation
+```
+
+The public contract is:
+
+- `toolset` and `source_revision` are non-empty strings. Each entry requires
+  `name`, `schema`, and a callable `handler`; the other fields shown above are
+  optional. `requires_env` must be a list of strings, `is_async` a boolean,
+  and `description` and `emoji` strings. Unknown or mistyped fields are
+  rejected so misspelled policy or schema fields cannot be silently ignored.
+- Hermes validates the complete candidate first, then replaces the old
+  context-owned snapshot under one registry lock. Readers observe the old or
+  new complete snapshot, never a partially removed or partially added set.
+  Published schemas are detached JSON values, so later mutation of the
+  producer's nested dictionaries cannot change live definitions.
+- Names cannot collide with built-in tools, ordinary plugin registrations, or
+  another context's snapshot. This surface intentionally has no `override`
+  option; use the separately gated `ctx.register_tool(..., override=True)`
+  path for an operator-authorized static override. Hermes also reserves its
+  synthesized `tool_search`, `tool_describe`, and `tool_call` names.
+- Reusing a `source_revision` with different entries is rejected. Repeating an
+  equivalent revision and snapshot is a no-op, as is advancing the revision
+  while the entries and callback identities remain equivalent. Empty
+  snapshots still retain their revision identity even though they do not bump
+  the registry generation when no tools were present.
+- Passing `entries=[]` atomically removes every tool in this context's prior
+  snapshot. Plugin unload performs the same owned cleanup and permanently
+  revokes that context's snapshot token. Publication is bound to the host's
+  context-lifecycle generation, so an in-flight or re-entrant unload cannot
+  leave zombie tools.
+- The result is an immutable `SnapshotReplacement` with `changed`,
+  `generation`, `source_revision`, `added`, and `removed` fields.
+  `ctx.registry_generation` exposes the current generation without requiring
+  access to `registry._generation`, `_tools`, or `_lock`.
+- Ownership and profile scope come from the host-created `PluginContext`; an
+  entry cannot claim either value. Handlers still execute through normal tool
+  dispatch, hooks, approval, and result normalization.
+- A snapshot `check_fn` participates in the normal Hermes availability cache,
+  is re-evaluated while definitions are assembled, and is checked again before
+  dispatch. An unavailable projected tool is therefore neither advertised nor
+  executed. Use the existing `no_cache_check_fn` marker only for cheap local
+  state whose availability must be reflected on every lookup.
+
+Keep handler and availability callback objects stable when republishing an
+equivalent snapshot. A new callback identity is executable behavior and
+therefore requires a new publication. If schemas are versioned, include that
+version in the registration name so a name described against an old schema no
+longer resolves after refresh.
 
 ### Store settings and runtime state
 


### PR DESCRIPTION
## Summary

Add a public plugin-host API for atomically replacing a dynamic, profile-scoped toolset:

```python
result = ctx.replace_toolset_snapshot(toolset, source_revision, entries)
generation = ctx.registry_generation
```

This is for standalone plugins whose external catalog can add, change, or remove tools while Hermes is running. Static plugins should continue to use `ctx.register_tool()`.

The motivating downstream is `agente-hermes-addon`, which projects an Electron-owned connector catalog into stock Hermes progressive disclosure (`tool_search` -> `tool_describe` -> `tool_call`) while keeping execution authority in Electron. The API and implementation here are generic Hermes surfaces; no Agente-specific code is included.

## Contract

- Complete candidate validation precedes mutation.
- One profile-scoped map swap and one registry-generation bump publish a changed snapshot.
- Readers see the complete old or complete new toolset, never a partial refresh.
- Plugin ownership and profile scope come from the host-created `PluginContext`, not payload fields.
- Built-in, ordinary-plugin, cross-context, and synthesized bridge-name collisions fail closed.
- Reusing a revision for different content is rejected; equivalent content is idempotent.
- Empty snapshots retain revision identity and atomically remove the prior owned toolset.
- Published schema JSON is detached and recursively immutable; sanitizer/deepcopy callers receive mutable detached copies.
- Availability callbacks are reflected in definition assembly and checked again before dispatch.
- Plugin unload, failed registration, concurrent unload, and re-entrant unload revoke the context generation and remove owned tools.
- Runtime introspection and plugin attribution are serialized with publication.
- `SnapshotReplacement` reports `changed`, `generation`, `source_revision`, `added`, and `removed`.

The entry surface intentionally has no override field. It accepts the existing `ToolEntry`-style fields documented in the plugin guide: `name`, `schema`, `handler`, and optional `check_fn`, `requires_env`, `is_async`, `description`, and `emoji`.

## Progressive-disclosure freshness

Hermes currently resolves deferred calls by registration name. A dynamic producer should therefore include its schema version/digest in the registration name. When a schema changes, atomic replacement removes the old name, and a call based on the stale description fails closed. The handler may still close over the producer's opaque identity and digest for downstream revalidation.

This is complementary to #72249's broader immutable route-capture work. It does not duplicate that PR.

## Transactional registration interaction

`PluginContext` stores an injected `registration_registry` authority instead of reaching through the new API to the process singleton. That provides the binding seam needed by an isolated transaction view.

#76568 is currently stale/conflicting against the newer profile-scoped registry architecture. When that work is rebased, its transaction snapshot/view must carry the snapshot ownership maps and rebind the context's registry authority at commit. This PR does not copy or partially merge #76568's much broader transaction implementation.

## Verification

- `ruff check hermes_cli/plugins.py tools/registry.py model_tools.py tests/hermes_cli/test_plugins.py`
- 231/231 focused registry, plugin lifecycle, ownership-ledger, deferred-platform, schema-sanitizer, and model-tools tests pass through `scripts/run_tests.sh`
- Unhandled thread warnings promoted to errors for the concurrency tests
- `git diff --check`
- Docusaurus English production build succeeds (the existing `/docs/llms.txt` and `/docs/llms-full.txt` warnings remain)
- Independent spec-fidelity and repository-standards reviews are clean

No installed Hermes profile, plugin configuration, Desktop application, or release artifact was modified while validating this change.
