### PR TITLE
fix(gateway): control-socket clients refuse a socket they don't own

### DIFF
--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -52,6 +52,7 @@ import json
 import logging
 import os
 import socket
+import stat
 import sys
 import tempfile
 import time
@@ -131,10 +132,59 @@ def resolve_server_socket_path(home: Path) -> tuple[Path, Optional[Path]]:
     return _fallback_socket_path(home), _pointer_path(home)
 
 
+def _is_trustworthy_socket(candidate: Path) -> bool:
+    """True when *candidate* is a socket this user owns, with no group/other access.
+
+    The module's trust model is that filesystem ACLs are the auth boundary.
+    That holds for ``$HERMES_HOME/gateway.sock`` — the home directory is the
+    user's. It does NOT hold for the temp-dir fallback: on Linux
+    ``tempfile.gettempdir()`` is usually the shared, world-writable ``/tmp``,
+    and the filename is ``hermes-gw-<sha256(home)[:16]>.sock`` — unsalted, so
+    anyone who can guess the home path can compute it and bind there first.
+    A client that connects to whatever exists would then take its answers
+    from that process, and ``identify``/``status`` are exactly the answers
+    the updater and the fleet-version matrix act on.
+
+    The server already binds under ``umask(0o177)`` and chmods 0600, so a
+    genuine socket always passes. This is the client half of the same
+    property: refuse anything we do not own, or that anyone else can reach.
+
+    Windows named pipes live in a per-user namespace and carry no st_uid;
+    this check is POSIX-only by design.
+    """
+    if _IS_WINDOWS:
+        return True
+    try:
+        info = os.stat(candidate)
+    except OSError:
+        return False
+    if not stat.S_ISSOCK(info.st_mode):
+        logger.debug("Control socket %s is not a socket; ignoring", candidate)
+        return False
+    if info.st_uid != os.geteuid():
+        logger.warning(
+            "Ignoring control socket %s: owned by uid %d, not %d",
+            candidate, info.st_uid, os.geteuid(),
+        )
+        return False
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        logger.warning(
+            "Ignoring control socket %s: mode %o allows group/other access",
+            candidate, stat.S_IMODE(info.st_mode),
+        )
+        return False
+    return True
+
+
 def resolve_client_socket_path(home: Path) -> Optional[Path]:
-    """Where a client should connect for ``home``, or None when nothing exists."""
+    """Where a client should connect for ``home``, or None when nothing exists.
+
+    A candidate that fails :func:`_is_trustworthy_socket` is treated as
+    absent, which drops the caller onto the existing state-file/scan
+    fallback — the same path taken when no gateway is running.
+    """
     direct = _default_socket_path(home)
-    if direct.exists():
+    if direct.exists() and _is_trustworthy_socket(direct):
         return direct
     pointer = _pointer_path(home)
     try:
@@ -142,7 +192,7 @@ def resolve_client_socket_path(home: Path) -> Optional[Path]:
             target = pointer.read_text(encoding="utf-8").strip()
             if target:
                 candidate = Path(target)
-                if candidate.exists():
+                if candidate.exists() and _is_trustworthy_socket(candidate):
                     return candidate
     except OSError:
         pass

--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -132,6 +132,18 @@ def resolve_server_socket_path(home: Path) -> tuple[Path, Optional[Path]]:
     return _fallback_socket_path(home), _pointer_path(home)
 
 
+def _current_euid() -> Optional[int]:
+    """The effective uid, or None where the platform has no such concept.
+
+    ``os.geteuid`` is absent on Windows, so it is resolved through
+    ``getattr`` rather than referenced directly — the Windows-footgun lint
+    flags a bare call even inside a platform-gated branch, and looking it up
+    removes the hazard instead of annotating it.
+    """
+    getter = getattr(os, "geteuid", None)
+    return getter() if getter is not None else None
+
+
 def _is_trustworthy_socket(candidate: Path) -> bool:
     """True when *candidate* is a socket this user owns, with no group/other access.
 
@@ -161,10 +173,11 @@ def _is_trustworthy_socket(candidate: Path) -> bool:
     if not stat.S_ISSOCK(info.st_mode):
         logger.debug("Control socket %s is not a socket; ignoring", candidate)
         return False
-    if info.st_uid != os.geteuid():
+    euid = _current_euid()
+    if euid is not None and info.st_uid != euid:
         logger.warning(
             "Ignoring control socket %s: owned by uid %d, not %d",
-            candidate, info.st_uid, os.geteuid(),
+            candidate, info.st_uid, euid,
         )
         return False
     if stat.S_IMODE(info.st_mode) & 0o077:

--- a/gateway/control_socket.py
+++ b/gateway/control_socket.py
@@ -53,6 +53,7 @@ import logging
 import os
 import socket
 import stat
+import struct
 import sys
 import tempfile
 import time
@@ -144,6 +145,33 @@ def _current_euid() -> Optional[int]:
     return getter() if getter is not None else None
 
 
+def _peer_euid(sock: "socket.socket") -> Optional[int]:
+    """The connected peer's euid, where the platform reports it.
+
+    The path check is a filter, not a guarantee: a socket can be swapped
+    between the ``stat`` and the ``connect``. ``SO_PEERCRED`` answers for the
+    process actually on the other end, which closes that race regardless of
+    filesystem timing.
+
+    Linux-only in practice — and that is precisely the platform carrying the
+    exposure, because a shared ``/tmp`` is what makes the fallback path
+    reachable by another account at all (macOS hands each user a private
+    ``gettempdir()``). BSD/macOS report peer credentials through
+    ``LOCAL_PEERCRED`` with a different structure; returning None there
+    leaves the path check as the sole filter rather than guessing at a
+    layout.
+    """
+    opt = getattr(socket, "SO_PEERCRED", None)
+    if opt is None:
+        return None
+    try:
+        raw = sock.getsockopt(socket.SOL_SOCKET, opt, struct.calcsize("3i"))
+        _pid, uid, _gid = struct.unpack("3i", raw)
+        return uid
+    except (OSError, struct.error):
+        return None
+
+
 def _is_trustworthy_socket(candidate: Path) -> bool:
     """True when *candidate* is a socket this user owns, with no group/other access.
 
@@ -197,7 +225,7 @@ def resolve_client_socket_path(home: Path) -> Optional[Path]:
     fallback — the same path taken when no gateway is running.
     """
     direct = _default_socket_path(home)
-    if direct.exists() and _is_trustworthy_socket(direct):
+    if _is_trustworthy_socket(direct):
         return direct
     pointer = _pointer_path(home)
     try:
@@ -205,7 +233,7 @@ def resolve_client_socket_path(home: Path) -> Optional[Path]:
             target = pointer.read_text(encoding="utf-8").strip()
             if target:
                 candidate = Path(target)
-                if candidate.exists() and _is_trustworthy_socket(candidate):
+                if _is_trustworthy_socket(candidate):
                     return candidate
     except OSError:
         pass
@@ -546,6 +574,13 @@ def _query_unix_socket(home: Path, request: bytes, timeout: float) -> Optional[b
         try:
             sock.connect(str(path))
         except (ConnectionRefusedError, FileNotFoundError, OSError):
+            return None
+        peer, euid = _peer_euid(sock), _current_euid()
+        if peer is not None and euid is not None and peer != euid:
+            logger.warning(
+                "Refusing control socket %s: peer runs as uid %d, not %d",
+                path, peer, euid,
+            )
             return None
         sock.sendall(request)
         chunks: list[bytes] = []

--- a/tests/gateway/test_control_socket.py
+++ b/tests/gateway/test_control_socket.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import socket
+import os
 import sys
 from pathlib import Path
 
@@ -76,17 +77,48 @@ def test_long_home_uses_pointer_fallback(tmp_path: Path):
     assert pointer == deep / "gateway.sock.path"
 
 
-def test_client_resolution_prefers_direct_then_pointer(home: Path, tmp_path: Path):
-    assert resolve_client_socket_path(home) is None
-    # pointer file to an existing socket-ish file
-    target = tmp_path / "elsewhere.sock"
-    target.touch()
-    (home / "gateway.sock.path").write_text(str(target))
-    assert resolve_client_socket_path(home) == target
-    # direct file wins over pointer
-    direct = home / "gateway.sock"
-    direct.touch()
-    assert resolve_client_socket_path(home) == direct
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="AF_UNIX; Windows uses a named pipe"
+)
+def test_client_resolution_prefers_direct_then_pointer():
+    """Precedence: the in-home socket wins over the pointer's target.
+
+    Real sockets rather than ``touch()``-ed files: the client now verifies
+    a candidate is a socket this user owns with no group/other access, so a
+    placeholder regular file is (correctly) treated as absent. The home is
+    built short on purpose — pytest's tmp_path already exceeds ``sun_path``,
+    which is the very condition that makes production use the pointer.
+    """
+    import shutil
+    import socket as _socket
+    import tempfile
+
+    scratch = Path(tempfile.mkdtemp(prefix="hgw-", dir="/tmp"))
+    home = scratch / "h"
+    home.mkdir()
+    opened = []
+
+    def _bind(path: Path) -> Path:
+        srv = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        srv.bind(str(path))
+        srv.listen(1)
+        os.chmod(path, 0o600)
+        opened.append(srv)
+        return path
+
+    try:
+        assert resolve_client_socket_path(home) is None
+
+        target = _bind(scratch / "elsewhere.sock")
+        (home / "gateway.sock.path").write_text(str(target))
+        assert resolve_client_socket_path(home) == target
+
+        direct = _bind(home / "gateway.sock")
+        assert resolve_client_socket_path(home) == direct
+    finally:
+        for srv in opened:
+            srv.close()
+        shutil.rmtree(scratch, ignore_errors=True)
 
 
 def test_windows_pipe_name_is_stable_and_home_scoped(tmp_path: Path):

--- a/tests/gateway/test_control_socket.py
+++ b/tests/gateway/test_control_socket.py
@@ -52,7 +52,7 @@ def test_short_home_binds_in_home(tmp_path: Path):
     import tempfile
 
     try:
-        short_root = Path(tempfile.mkdtemp(prefix="hgw-", dir="/tmp"))
+        short_root = Path(tempfile.mkdtemp(prefix="hgw-", dir=tempfile.gettempdir()))
     except OSError:
         pytest.skip("/tmp not writable on this host")
     try:
@@ -93,7 +93,7 @@ def test_client_resolution_prefers_direct_then_pointer():
     import socket as _socket
     import tempfile
 
-    scratch = Path(tempfile.mkdtemp(prefix="hgw-", dir="/tmp"))
+    scratch = Path(tempfile.mkdtemp(prefix="hgw-", dir=tempfile.gettempdir()))
     home = scratch / "h"
     home.mkdir()
     opened = []
@@ -110,7 +110,7 @@ def test_client_resolution_prefers_direct_then_pointer():
         assert resolve_client_socket_path(home) is None
 
         target = _bind(scratch / "elsewhere.sock")
-        (home / "gateway.sock.path").write_text(str(target))
+        (home / "gateway.sock.path").write_text(str(target), encoding="utf-8")
         assert resolve_client_socket_path(home) == target
 
         direct = _bind(home / "gateway.sock")

--- a/tests/gateway/test_control_socket_client_trust.py
+++ b/tests/gateway/test_control_socket_client_trust.py
@@ -1,0 +1,136 @@
+"""A client must not take answers from a socket it does not own.
+
+`control_socket`'s stated trust model is that filesystem ACLs are the auth
+boundary. That holds for `$HERMES_HOME/gateway.sock` — the home is the
+user's. It does not hold for the temp-dir fallback used when the home path
+exceeds `sun_path`: on Linux `tempfile.gettempdir()` is normally the shared,
+world-writable `/tmp`, and the filename is `hermes-gw-<sha256(home)[:16]>.sock`
+— unsalted, so anyone who can guess the home path can compute it and bind
+there first.
+
+The server already binds under `umask(0o177)` and chmods 0600. These tests
+pin the client half: anything not owned by this user, or reachable by anyone
+else, is treated as absent so the caller falls back to the scan layer.
+"""
+
+import os
+import shutil
+import socket
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from gateway.control_socket import (
+    _home_hash,
+    _pointer_path,
+    _is_trustworthy_socket,
+    resolve_client_socket_path,
+)
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX ownership/mode check; Windows uses a per-user pipe namespace",
+)
+
+
+@pytest.fixture()
+def shortdir():
+    """A short-path scratch dir.
+
+    pytest's tmp_path lives under /private/var/folders/... on macOS, which
+    already exceeds sun_path — the very condition that makes production fall
+    back to the temp dir. Bind somewhere short instead.
+    """
+    d = Path(tempfile.mkdtemp(prefix="hgw-", dir="/tmp"))
+    try:
+        yield d
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture()
+def home(shortdir):
+    h = shortdir / "h"
+    h.mkdir()
+    return h
+
+
+def _bind(path, mode=0o600):
+    path.unlink(missing_ok=True)
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(str(path))
+    srv.listen(1)
+    os.chmod(path, mode)
+    return srv
+
+
+class TestDirectPath:
+    def test_a_socket_we_own_is_used(self, home):
+        sock = home / "gateway.sock"
+        srv = _bind(sock)
+        try:
+            assert resolve_client_socket_path(home) == sock
+        finally:
+            srv.close()
+
+    @pytest.mark.parametrize("mode", [0o777, 0o660, 0o606])
+    def test_a_reachable_socket_is_refused(self, home, mode):
+        srv = _bind(home / "gateway.sock", mode)
+        try:
+            assert resolve_client_socket_path(home) is None, (
+                f"mode {mode:o} lets another account answer identify/status"
+            )
+        finally:
+            srv.close()
+
+    def test_a_regular_file_is_not_a_socket(self, home):
+        f = home / "gateway.sock"
+        f.write_text("not a socket")
+        os.chmod(f, 0o600)
+        assert resolve_client_socket_path(home) is None
+
+
+class TestPointerFallback:
+    """The temp-dir path is the one a shared /tmp exposes."""
+
+    def test_a_decoy_at_the_predictable_path_is_refused(self, home, shortdir):
+        decoy = shortdir / f"hermes-gw-{_home_hash(home)}.sock"
+        srv = _bind(decoy, 0o777)
+        _pointer_path(home).write_text(str(decoy), encoding="utf-8")
+        try:
+            assert resolve_client_socket_path(home) is None, (
+                "client accepted a world-connectable socket at the "
+                "unsalted, guessable fallback path"
+            )
+        finally:
+            srv.close()
+
+    def test_a_genuine_fallback_socket_still_resolves(self, home, shortdir):
+        real = shortdir / f"hermes-gw-{_home_hash(home)}.sock"
+        srv = _bind(real, 0o600)
+        _pointer_path(home).write_text(str(real), encoding="utf-8")
+        try:
+            assert resolve_client_socket_path(home) == real
+        finally:
+            srv.close()
+
+    def test_a_pointer_to_nothing_is_absent(self, home, shortdir):
+        _pointer_path(home).write_text(str(shortdir / "gone.sock"), encoding="utf-8")
+        assert resolve_client_socket_path(home) is None
+
+
+class TestPredicate:
+    def test_a_missing_path_is_not_trustworthy(self, shortdir):
+        assert _is_trustworthy_socket(shortdir / "nope.sock") is False
+
+    def test_owner_only_socket_passes(self, shortdir):
+        p = shortdir / "ok.sock"
+        srv = _bind(p, 0o600)
+        try:
+            assert _is_trustworthy_socket(p) is True
+            assert stat.S_IMODE(os.stat(p).st_mode) & 0o077 == 0
+        finally:
+            srv.close()

--- a/tests/gateway/test_control_socket_client_trust.py
+++ b/tests/gateway/test_control_socket_client_trust.py
@@ -44,7 +44,7 @@ def shortdir():
     already exceeds sun_path — the very condition that makes production fall
     back to the temp dir. Bind somewhere short instead.
     """
-    d = Path(tempfile.mkdtemp(prefix="hgw-", dir="/tmp"))
+    d = Path(tempfile.mkdtemp(prefix="hgw-", dir=tempfile.gettempdir()))
     try:
         yield d
     finally:
@@ -88,7 +88,7 @@ class TestDirectPath:
 
     def test_a_regular_file_is_not_a_socket(self, home):
         f = home / "gateway.sock"
-        f.write_text("not a socket")
+        f.write_text("not a socket", encoding="utf-8")
         os.chmod(f, 0o600)
         assert resolve_client_socket_path(home) is None
 
@@ -134,3 +134,51 @@ class TestPredicate:
             assert stat.S_IMODE(os.stat(p).st_mode) & 0o077 == 0
         finally:
             srv.close()
+
+
+class TestPeerCredentials:
+    """Closes the stat-then-connect race the path check alone leaves open.
+
+    A socket can be swapped between the `stat` and the `connect`, so the
+    filesystem check is a filter, not a guarantee. `SO_PEERCRED` reports the
+    process actually on the other end.
+
+    Mocked rather than driven live: `SO_PEERCRED` is Linux-only, and that is
+    also the platform carrying the exposure — macOS gives each user a private
+    `gettempdir()`, so the shared-`/tmp` fallback never applies there.
+    """
+
+    def test_absent_support_reports_unknown_rather_than_failing(self, monkeypatch):
+        import socket as _socket
+
+        from gateway import control_socket as cs
+
+        monkeypatch.delattr(_socket, "SO_PEERCRED", raising=False)
+        assert cs._peer_euid(object()) is None
+
+    def test_the_peer_uid_is_unpacked(self, monkeypatch):
+        import socket as _socket
+        import struct as _struct
+
+        from gateway import control_socket as cs
+
+        monkeypatch.setattr(_socket, "SO_PEERCRED", 17, raising=False)
+
+        class _Sock:
+            def getsockopt(self, level, opt, size):
+                return _struct.pack("3i", 4242, 1000, 1000)
+
+        assert cs._peer_euid(_Sock()) == 1000
+
+    def test_a_refusing_kernel_is_not_an_error(self, monkeypatch):
+        import socket as _socket
+
+        from gateway import control_socket as cs
+
+        monkeypatch.setattr(_socket, "SO_PEERCRED", 17, raising=False)
+
+        class _Sock:
+            def getsockopt(self, *a):
+                raise OSError("not supported")
+
+        assert cs._peer_euid(_Sock()) is None


### PR DESCRIPTION
## The gap

`gateway/control_socket.py` states its own trust model:

> Never a TCP port. **Filesystem/pipe ACLs are the auth boundary** — the same trust model as `gateway_state.json` today.

That holds for the default path: `$HERMES_HOME/gateway.sock` sits in the user's home. It does **not** hold for the temp-dir fallback taken when the home path exceeds `sun_path` (~104 bytes):

```python
name = f"hermes-gw-{_home_hash(home)}.sock"
candidates = [Path(tempfile.gettempdir()) / name]
if not _IS_WINDOWS:
    candidates.append(Path("/tmp") / name)
```

On Linux `tempfile.gettempdir()` is normally the shared, world-writable `/tmp`, and `_home_hash` is an unsalted `sha256(resolved_home)[:16]` — anyone who can guess the home path (`/home/<user>/.hermes`) computes the filename and can bind there first. The sticky bit stops them deleting someone else's socket; it does not stop them creating one at an unused name.

`resolve_client_socket_path` accepted whatever was there on `candidate.exists()` alone — no owner check, no mode check, no socket-type check:

```
predictable path : /tmp/hermes-gw-2e75aae51f20525f.sock
decoy mode       : 0o777  (world-connectable)
client resolved  : /tmp/hermes-gw-2e75aae51f20525f.sock
VERDICT: ACCEPTED — no owner/mode check
```

## Why it matters

The v1 verbs are observation-only, but they are what other processes *decide* on. The module says so directly:

> A connectable socket with a well-formed `identify` answer **IS liveness** — no PID-reuse heuristics.

`hermes update --plan`'s inventory and the post-update fleet-version matrix read `identify`/`status`. A decoy fabricates liveness, pid, profile label and `code_sha` for another account's update tooling.

## The change

The server side is already right — it binds under `umask(0o177)` and chmods 0600 (the #92447 review). This adds the client half of the same property: a candidate must be a **socket**, owned by the **current euid**, with **no group/other bits**.

A candidate that fails is treated as absent, so the caller drops onto the existing state-file/scan fallback — precisely the path taken when no gateway is running. No behavior change for a legitimate socket, which always passes.

POSIX-only by design: Windows named pipes live in a per-user namespace and carry no `st_uid`.

I considered having the *server* bind inside a private 0700 subdirectory instead, which would remove the exposure rather than detect it. That changes the path layout and the pointer contract, so I left it — happy to do it that way if the maintainers prefer.

## One existing test changed

`test_client_resolution_prefers_direct_then_pointer` used `touch()`-ed regular files as socket stand-ins, which the type/mode checks now (correctly) reject. It binds real sockets instead — its intent, that the direct path wins over the pointer, is unchanged and now exercised against the real thing.

It also stops using pytest's `tmp_path`, which on macOS already exceeds `sun_path` — the very condition that puts production on the fallback path, and which made a real socket unbindable there.

## Tests

10 new in `tests/gateway/test_control_socket_client_trust.py`: an owned 0600 socket resolves (direct and via pointer), world-connectable / group-readable / group-writable ones are refused, a regular file at the socket path is refused, a dangling pointer is absent, and the predicate handles a missing path. Reverting the two guard calls fails five of them.