### PR TITLE
feat(desktop): add Archive action to project menu

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx
@@ -23,6 +23,7 @@ import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import { $panesFlipped, dismissAutoProject } from '@/store/layout'
 import {
+  archiveProject,
   copyPath,
   deleteProject,
   openProjectAddFolder,
@@ -92,6 +93,12 @@ function useProjectActions({
           key: 'set-active',
           label: p.menuSetActive,
           onSelect: () => void setActiveProject(project.id)
+        },
+        {
+          icon: 'archive',
+          key: 'archive',
+          label: p.menuArchive,
+          onSelect: () => void archiveProject(project.id)
         }
       ]
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1680,6 +1680,7 @@ export const ar = defineLocale({
       noColor: 'بلا لون',
       menuAddFolder: 'إضافة مجلد',
       menuSetActive: 'تعيين كنشط',
+      menuArchive: 'أرشفة',
       menuDelete: 'حذف',
       reveal: 'إظهار في المجلد',
       copyPath: 'نسخ المسار',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2136,6 +2136,7 @@ export const en: Translations = {
       noColor: 'No color',
       menuAddFolder: 'Add folder',
       menuSetActive: 'Set active',
+      menuArchive: 'Archive',
       menuDelete: 'Delete',
       moveToProject: 'Move to project',
       movedTo: name => `Moved to ${name}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1848,6 +1848,7 @@ export const ja = defineLocale({
       noColor: '色なし',
       menuAddFolder: 'フォルダを追加',
       menuSetActive: 'アクティブに設定',
+      menuArchive: 'アーカイブ',
       menuDelete: '削除',
       reveal: 'フォルダで表示',
       copyPath: 'パスをコピー',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1809,6 +1809,7 @@ export interface Translations {
       noColor: string
       menuAddFolder: string
       menuSetActive: string
+      menuArchive: string
       menuDelete: string
       moveToProject: string
       movedTo: (name: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1788,6 +1788,7 @@ export const zhHant = defineLocale({
       noColor: '無顏色',
       menuAddFolder: '新增資料夾',
       menuSetActive: '設為使用中',
+      menuArchive: '封存',
       menuDelete: '刪除',
       reveal: '在資料夾中顯示',
       copyPath: '複製路徑',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2321,6 +2321,7 @@ export const zh: Translations = {
       noColor: '无颜色',
       menuAddFolder: '添加文件夹',
       menuSetActive: '设为活动',
+      menuArchive: '归档',
       menuDelete: '删除',
       moveToProject: '移动到项目',
       movedTo: name => `已移动到 ${name}`,

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -1119,6 +1119,35 @@ export async function deleteProject(id: string): Promise<void> {
   void refreshProjectTree()
 }
 
+// Optimistic: hide the project from the cached tree + list the instant it's
+// clicked (the entered-scope effect exits if you archived the project you were
+// inside), reconciling from the server payload. A failed archive restores
+// both. Unlike delete, archive is reversible (projects.restore).
+export async function archiveProject(id: string): Promise<void> {
+  const snap = snapshotProjects()
+  // Capture membership BEFORE removal — the project's folders (which determine
+  // ownership) are hidden once it's dropped from the cache.
+  const kickToIntro = openSessionBelongsToProject(id, snap.projects)
+
+  $projects.set(snap.projects.filter(project => project.id !== id))
+  $projectTree.set(snap.tree.filter(node => node.id !== id))
+
+  if (snap.active === id) {
+    $activeProjectId.set(null)
+  }
+
+  // The open session's project is hidden — reset to the intro draft (the
+  // session itself survives; it just falls back to Recents).
+  if (kickToIntro) {
+    requestFreshSession()
+  }
+
+  await persistOrRollback(snap, async () => {
+    applyPayload(await gatewayRequest<ProjectsPayload>('projects.archive', projectParams({ id })))
+  })
+  void refreshProjectTree()
+}
+
 export async function setActiveProject(id: null | string): Promise<void> {
   const res = await gatewayRequest<{ active_id: null | string }>('projects.set_active', projectParams({ id }))
   $activeProjectId.set(res.active_id ?? null)


### PR DESCRIPTION
## Summary
Adds an **Archive** action to the project menu (kebab / right-click) in the Hermes desktop sidebar, exposing the backend's existing-but-unexposed `projects.archive` capability in the UI.

## Motivation
The projects sidebar already lets you *delete* a project (hard-delete the saved entry, un-recoverable) and *set active*, but there was no way to simply set a project aside — you'd have to delete it. The backend has had `projects.archive` / `projects.restore` and an `archived` flag for a while, but the desktop UI never surfaced it, so "hide a project I'm not working on" was only reachable via the CLI.

## Changes
- `apps/desktop/src/store/projects.ts`: new `archiveProject(id)` store action — optimistic removal from the cached tree/list, mirrors `deleteProject`'s shape but calls the reversible `projects.archive` RPC and refreshes the tree.
- `apps/desktop/src/app/chat/sidebar/projects/project-menu.tsx`: new **Archive** item (archive codicon) in the explicit-project actions, placed after *Set active*, rendered in both the kebab dropdown and the right-click context menu.
- `apps/desktop/src/i18n/{types,ar,en,ja,zh,zh-hant}.ts`: new `menuArchive` copy in all six locales.

## Behavior
- **Default behavior unchanged**: this only *adds* a menu item; delete, set-active, rename, etc. are untouched. `projects.restore` / `hermes projects restore` remains the way back.
- Archive hides the project from the sidebar (reversible); it does **not** delete files, git repos, or worktrees.

## Testing
- `vitest run src/app/chat/sidebar/projects/project-menu.test.tsx src/store/projects.test.ts` → 2 files, 41 tests passed
- `tsc -p tsconfig.json --noEmit` → clean (exit 0)
