### PR TITLE
fix(wecom): treat errcode 846609 as subscription-level failure — force reconnect + retry

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -115,8 +115,15 @@ NON_RESPONSE_COMMANDS = CALLBACK_COMMANDS | {APP_CMD_EVENT_CALLBACK}
 MAX_MESSAGE_LENGTH = 4000
 CONNECT_TIMEOUT_SECONDS = 20.0
 REQUEST_TIMEOUT_SECONDS = 15.0
+SEND_FRAME_TIMEOUT_SECONDS = 3.0
 HEARTBEAT_INTERVAL_SECONDS = 30.0
+HEARTBEAT_MAX_CONSECUTIVE_FAILURES = 3
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+
+# WeCom errcode: aibot websocket not subscribed (subscription-level failure,
+# NOT a plain send error — the WS may still be OPEN while the subscription is
+# dead). Must trigger reconnect + retry, otherwise replies are silently lost.
+WECOM_ERR_NOT_SUBSCRIBED = "846609"
 
 DEDUP_MAX_SIZE = 1000
 
@@ -309,6 +316,27 @@ class WeComAdapter(BasePlatformAdapter):
             await self._session.close()
         self._session = None
 
+    async def _invalidate_connection(self) -> None:
+        """Force-close a connection whose subscription the server invalidated.
+
+        Unlike disconnect(), this keeps the adapter running: _listen_loop
+        observes the closure and reconnects + resubscribes automatically.
+        Pending response futures are failed so no caller hangs on them.
+        """
+        self._fail_pending_responses(RuntimeError("WeCom subscription invalidated"))
+        try:
+            if self._ws and not self._ws.closed:
+                await self._ws.close(code=1012, message=b"subscription invalid")
+        except Exception as exc:
+            logger.warning("[%s] Invalidate-connection close failed: %s", self.name, exc)
+        # Give _listen_loop a moment to observe the closure and reconnect,
+        # then wait until the socket is usable again (bounded).
+        deadline = asyncio.get_running_loop().time() + CONNECT_TIMEOUT_SECONDS
+        while asyncio.get_running_loop().time() < deadline:
+            if self._ws and not self._ws.closed:
+                return
+            await asyncio.sleep(0.5)
+
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""
         await self._cleanup_ws()
@@ -404,11 +432,18 @@ class WeComAdapter(BasePlatformAdapter):
                 raise RuntimeError("WeCom websocket closed")
 
     async def _heartbeat_loop(self) -> None:
-        """Send lightweight application-level pings."""
+        """Send lightweight application-level pings.
+
+        A heartbeat proves the connection is still healthy. Consecutive
+        failures mean the WS is wedged (locally OPEN but functionally dead),
+        so force-close it to let _listen_loop reconnect — do NOT stay silent.
+        """
+        consecutive_failures = 0
         try:
             while self._running:
                 await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
                 if not self._ws or self._ws.closed:
+                    consecutive_failures = 0
                     continue
                 try:
                     await self._send_json(
@@ -418,8 +453,28 @@ class WeComAdapter(BasePlatformAdapter):
                             "body": {},
                         }
                     )
+                    consecutive_failures = 0
                 except Exception as exc:
-                    logger.debug("[%s] Heartbeat send failed: %s", self.name, exc)
+                    consecutive_failures += 1
+                    logger.warning(
+                        "[%s] Heartbeat send failed (%d/%d): %s",
+                        self.name,
+                        consecutive_failures,
+                        HEARTBEAT_MAX_CONSECUTIVE_FAILURES,
+                        exc,
+                    )
+                    if consecutive_failures >= HEARTBEAT_MAX_CONSECUTIVE_FAILURES:
+                        logger.warning(
+                            "[%s] Heartbeat failed %d times consecutively; force-closing wedged websocket to trigger reconnect",
+                            self.name,
+                            consecutive_failures,
+                        )
+                        try:
+                            if self._ws and not self._ws.closed:
+                                await self._ws.close(code=1011, message=b"heartbeat timeout")
+                        except Exception as close_exc:
+                            logger.warning("[%s] Force-close after heartbeat failures failed: %s", self.name, close_exc)
+                        break  # let _listen_loop observe the closure and reconnect
         except asyncio.CancelledError:
             pass
 
@@ -450,10 +505,16 @@ class WeComAdapter(BasePlatformAdapter):
             self._pending_responses.pop(req_id, None)
 
     async def _send_json(self, payload: Dict[str, Any]) -> None:
-        """Send a raw JSON frame over the active websocket."""
+        """Send a raw JSON frame over the active websocket.
+
+        Wrapped in a timeout: a wedged WS write must not hang the caller
+        forever (REQUEST_TIMEOUT_SECONDS only covers the response wait).
+        """
         if not self._ws or self._ws.closed:
             raise RuntimeError("WeCom websocket is not connected")
-        await self._ws.send_json(payload)
+        await asyncio.wait_for(
+            self._ws.send_json(payload), timeout=SEND_FRAME_TIMEOUT_SECONDS
+        )
 
     async def _send_request(self, cmd: str, body: Dict[str, Any], timeout: float = REQUEST_TIMEOUT_SECONDS) -> Dict[str, Any]:
         """Send a JSON request and await the correlated response."""
@@ -1432,6 +1493,7 @@ class WeComAdapter(BasePlatformAdapter):
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
 
+        reply_req_id: Optional[str] = None
         try:
             reply_req_id = self._reply_req_id_for_message(reply_to)
 
@@ -1452,12 +1514,72 @@ class WeComAdapter(BasePlatformAdapter):
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
-            logger.error("[%s] Send failed: %s", self.name, exc)
-            return SendResult(success=False, error=str(exc))
+            # The reply-markdown path raises RuntimeError (via
+            # _raise_for_wecom_error) instead of returning a response, so
+            # errcode 846609 can arrive here. Treat it exactly like the
+            # response-path case below: subscription died while the WS is
+            # still locally open — force reconnect + resubscribe, retry once.
+            if WECOM_ERR_NOT_SUBSCRIBED in str(exc):
+                logger.warning(
+                    "[%s] Send raised errcode %s (subscription dead while WS open); forcing reconnect and retrying once",
+                    self.name,
+                    WECOM_ERR_NOT_SUBSCRIBED,
+                )
+                await self._invalidate_connection()
+                try:
+                    if reply_req_id:
+                        response = await self._send_reply_markdown(reply_req_id, content)
+                    else:
+                        response = await self._send_request(
+                            APP_CMD_SEND,
+                            {
+                                "chatid": chat_id,
+                                "msgtype": "markdown",
+                                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
+                            },
+                        )
+                except Exception as retry_exc:
+                    logger.error("[%s] Post-reconnect send retry failed: %s", self.name, retry_exc)
+                    return SendResult(success=False, error=str(exc))
+            else:
+                logger.error("[%s] Send failed: %s", self.name, exc)
+                return SendResult(success=False, error=str(exc))
 
         error = self._response_error(response)
         if error:
-            return SendResult(success=False, error=error)
+            if WECOM_ERR_NOT_SUBSCRIBED in error:
+                # Subscription-level failure: the server has invalidated this
+                # connection's subscription while the WS may still be locally
+                # OPEN. Treating it as a plain send error silently drops the
+                # message. Force-close the wedged socket so _listen_loop
+                # reconnects + resubscribes, then retry once on the fresh
+                # connection.
+                logger.warning(
+                    "[%s] Send hit errcode %s (subscription dead while WS open); forcing reconnect and retrying once",
+                    self.name,
+                    WECOM_ERR_NOT_SUBSCRIBED,
+                )
+                await self._invalidate_connection()
+                try:
+                    if reply_req_id:
+                        response = await self._send_reply_markdown(reply_req_id, content)
+                    else:
+                        response = await self._send_request(
+                            APP_CMD_SEND,
+                            {
+                                "chatid": chat_id,
+                                "msgtype": "markdown",
+                                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
+                            },
+                        )
+                except Exception as retry_exc:
+                    logger.error("[%s] Post-reconnect send retry failed: %s", self.name, retry_exc)
+                    return SendResult(success=False, error=error)
+                error = self._response_error(response)
+                if error:
+                    return SendResult(success=False, error=error)
+            else:
+                return SendResult(success=False, error=error)
 
         return SendResult(
             success=True,

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -312,6 +312,136 @@ class TestSend:
             reply_to=None,
         )
 
+    @pytest.mark.asyncio
+    async def test_send_reconnects_and_retries_lost_subscription_response(self):
+        from plugins.platforms.wecom.adapter import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._invalidate_connection = AsyncMock()
+        calls = []
+
+        async def fake_send_request(cmd, body):
+            calls.append((cmd, body))
+            if len(calls) == 1:
+                return {
+                    "errcode": 846609,
+                    "errmsg": "aibot websocket not subscribed",
+                }
+            return {"headers": {"req_id": "req-2"}, "errcode": 0}
+
+        adapter._send_request = fake_send_request
+
+        result = await adapter.send("chat-123", "Hello WeCom")
+
+        assert result.success is True
+        assert result.message_id == "req-2"
+        adapter._invalidate_connection.assert_awaited_once()
+        assert [cmd for cmd, _body in calls] == [APP_CMD_SEND, APP_CMD_SEND]
+
+    @pytest.mark.asyncio
+    async def test_send_reconnects_and_retries_lost_subscription_exception(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_id_for_message = MagicMock(return_value="req-1")
+        adapter._invalidate_connection = AsyncMock()
+        adapter._send_reply_markdown = AsyncMock(
+            side_effect=[
+                RuntimeError(
+                    "send reply markdown failed: WeCom errcode 846609: "
+                    "aibot websocket not subscribed"
+                ),
+                {"headers": {"req_id": "req-2"}, "errcode": 0},
+            ]
+        )
+
+        result = await adapter.send("chat-123", "Hello WeCom", reply_to="msg-1")
+
+        assert result.success is True
+        assert result.message_id == "req-2"
+        adapter._invalidate_connection.assert_awaited_once()
+        assert adapter._send_reply_markdown.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_retry_failure_returns_original_error(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._invalidate_connection = AsyncMock()
+        calls = []
+
+        async def fake_send_request(cmd, body):
+            calls.append(cmd)
+            if len(calls) == 1:
+                return {
+                    "errcode": 846609,
+                    "errmsg": "aibot websocket not subscribed",
+                }
+            raise RuntimeError("reconnect succeeded but send still failed")
+
+        adapter._send_request = fake_send_request
+
+        result = await adapter.send("chat-123", "Hello WeCom")
+
+        assert result.success is False
+        assert "846609" in (result.error or "")
+        adapter._invalidate_connection.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_non_subscription_error_does_not_reconnect(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._invalidate_connection = AsyncMock()
+        adapter._send_request = AsyncMock(
+            return_value={"errcode": 40001, "errmsg": "invalid credential"}
+        )
+
+        result = await adapter.send("chat-123", "Hello WeCom")
+
+        assert result.success is False
+        assert "40001" in (result.error or "")
+        adapter._invalidate_connection.assert_not_awaited()
+        adapter._send_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_json_wraps_frame_write_with_timeout(self, monkeypatch):
+        import plugins.platforms.wecom.adapter as wecom_module
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setattr(wecom_module, "SEND_FRAME_TIMEOUT_SECONDS", 0.05)
+
+        async def wedged_write(_payload):
+            await asyncio.sleep(10)
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._ws = SimpleNamespace(closed=False, send_json=wedged_write)
+
+        start = asyncio.get_event_loop().time()
+        with pytest.raises(asyncio.TimeoutError):
+            await adapter._send_json({"cmd": 1})
+        elapsed = asyncio.get_event_loop().time() - start
+
+        assert elapsed < 1.0, "wedged frame write must not hang the caller"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_force_closes_after_consecutive_failures(self, monkeypatch):
+        import plugins.platforms.wecom.adapter as wecom_module
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setattr(wecom_module, "HEARTBEAT_INTERVAL_SECONDS", 0.01)
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+        ws = SimpleNamespace(closed=False, close=AsyncMock())
+        adapter._ws = ws
+        adapter._send_json = AsyncMock(side_effect=RuntimeError("send failed"))
+
+        task = asyncio.create_task(adapter._heartbeat_loop())
+        await asyncio.wait_for(task, timeout=2)
+
+        ws.close.assert_awaited_once_with(code=1011, message=b"heartbeat timeout")
+
 
 class TestInboundMessages:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes the WeCom outbound message loss described in #29667 and #47564 (both still open; earlier fix PRs #24790 / #31393 / #37257 were not merged).

## Problem

When the WeCom server invalidates a bot's subscription while the WebSocket remains locally OPEN, every outbound send fails with `errcode 846609` ("aibot websocket not subscribed"). The adapter treated this as a plain send error:

- the reply was **silently dropped** (no retry, no reconnect)
- the stale connection persisted until the server eventually closed the TCP socket, creating a 57–79s dead window where **all outbound messages were lost**
- `REQUEST_TIMEOUT_SECONDS` only wrapped the response wait, not the frame write — a wedged WS write could hang a send coroutine **forever** (observed in production: a send with no return and no timeout)
- heartbeat failures were logged at debug level with no consequence, so functionally-dead connections survived indefinitely

## Root cause

`ws.closed == False` does **not** imply the subscription is still valid. The adapter's readiness check (`if not self._ws or self._ws.closed`) only covers the transport layer, not the WeCom subscription lifecycle.

## Fixes

1. **send()**: on 846609 — both the response path and the raised-exception path from `_raise_for_wecom_error()` — invalidate the connection, let `_listen_loop` reconnect + resubscribe, then retry once on the fresh connection
2. **_invalidate_connection()** (new): fail all pending futures, close the WS with code 1012, wait (bounded) until the socket is usable again
3. **_send_json()**: wrap the frame write in `SEND_FRAME_TIMEOUT_SECONDS` (3s) so wedged writes can no longer hang callers forever
4. **_heartbeat_loop()**: count consecutive failures; after 3, force-close the socket (code 1011) to trigger reconnect instead of silently logging

## Production verification

Before the fix: ~10-minute disconnect cycles, every reply sent during the disconnect window silently lost (**24 × errcode 846609 in a single day**, one send hung forever).

After the fix: **2+ hours with zero disconnects, zero 846609 errors**, and one forced-reconnect path exercised without message loss.

## Test plan

- [x] Syntax + import verification on the patched adapter
- [x] Production soak: 2+ hours stable on a live WeCom bot
- [ ] Unit test for the 846609 retry path (happy to add if maintainers want it in this PR)