### PR TITLE
fix(worktree): branch reclaim honors the deepen result instead of assuming it

### DIFF
--- a/hermes_cli/worktree_gc.py
+++ b/hermes_cli/worktree_gc.py
@@ -314,8 +314,22 @@ def audit_branches(repo_root: str) -> List[BranchRecord]:
     """
     import cli as _cli
 
-    if _cli._repo_is_shallow(repo_root):
-        _cli._deepen_shallow_repo(repo_root)
+    # `_deepen_shallow_repo` returns whether the repo is actually non-shallow
+    # afterwards, and its contract is explicit that "on failure (offline, no
+    # remote) callers keep today's preserve-everything behavior". Branch
+    # reclaim has no second line of defence: unlike the tree path, which is
+    # backed by `_worktree_has_unpushed_commits` answering conservatively
+    # True on unverifiable history, every verdict below (`--merged`,
+    # `rev-list --count`, `git cherry`) is read as fact. `cli.py` says as
+    # much: "check `_repo_is_shallow` before presenting this verdict as
+    # fact". Offer nothing rather than delete refs on a truncated graph.
+    if _cli._repo_is_shallow(repo_root) and not _cli._deepen_shallow_repo(repo_root):
+        logger.info(
+            "Skipping branch reclaim in %s: repository is still shallow, so "
+            "merged/unique verdicts are not trustworthy",
+            repo_root,
+        )
+        return []
 
     upstream = None
     for candidate in ("origin/HEAD", "origin/main", "origin/master"):

--- a/hermes_cli/worktree_gc.py
+++ b/hermes_cli/worktree_gc.py
@@ -167,6 +167,35 @@ def _archive_untracked(tree: Path, untracked: List[str]) -> Optional[Path]:
         return None
 
 
+_SHALLOW_REASON = (
+    "repository is still shallow — merged/unpushed verdicts are not trustworthy"
+)
+
+
+def _history_is_trustworthy(repo_root: str, _cli) -> bool:
+    """Deepen a shallow repo, and report whether history can now be trusted.
+
+    ``_deepen_shallow_repo`` returns whether the repo is actually non-shallow
+    afterwards, and its contract is explicit that "on failure (offline, no
+    remote) callers keep today's preserve-everything behavior". Both audits
+    called it and discarded the answer, then read ``--merged`` /
+    ``rev-list --count`` / ``git cherry`` as fact — the verdicts that decide
+    whether a tree is reaped and whether a ref is deleted.
+
+    Logged at WARNING, not INFO: the user asked for a reclaim pass, and
+    "nothing was reclaimable" and "nothing could be judged" are different
+    answers.
+    """
+    if not _cli._repo_is_shallow(repo_root):
+        return True
+    if _cli._deepen_shallow_repo(repo_root):
+        return True
+    logger.warning(
+        "Worktree reclaim in %s is preserving everything: %s", repo_root, _SHALLOW_REASON
+    )
+    return False
+
+
 def audit_worktrees(repo_root: str, *, with_sizes: bool = True) -> List[TreeRecord]:
     """Classify every tree under ``.worktrees/`` without mutating anything."""
     import cli as _cli  # lazy: cli.py is heavy
@@ -175,8 +204,7 @@ def audit_worktrees(repo_root: str, *, with_sizes: bool = True) -> List[TreeReco
     if not worktrees_dir.exists():
         return []
 
-    if _cli._repo_is_shallow(repo_root):
-        _cli._deepen_shallow_repo(repo_root)
+    trustworthy = _history_is_trustworthy(repo_root, _cli)
 
     merge_cache = _cli._load_worktree_merge_cache()
     cache_size_before = len(merge_cache)
@@ -199,6 +227,11 @@ def audit_worktrees(repo_root: str, *, with_sizes: bool = True) -> List[TreeReco
             branch = ""
 
         def rec(verdict: str, reason: str, untracked: Optional[List[str]] = None):
+            # A shallow graft makes "merged"/"unpushed" unanswerable, and the
+            # reap path also deletes the tree's branch. Keep the tree, and say
+            # why, rather than dropping it from the listing entirely.
+            if not trustworthy and verdict != "keep":
+                verdict, reason, untracked = "keep", _SHALLOW_REASON, []
             records.append(TreeRecord(
                 name=entry.name, path=str(entry), branch=branch,
                 age_days=age_days, size_mb=size_mb,
@@ -314,22 +347,7 @@ def audit_branches(repo_root: str) -> List[BranchRecord]:
     """
     import cli as _cli
 
-    # `_deepen_shallow_repo` returns whether the repo is actually non-shallow
-    # afterwards, and its contract is explicit that "on failure (offline, no
-    # remote) callers keep today's preserve-everything behavior". Branch
-    # reclaim has no second line of defence: unlike the tree path, which is
-    # backed by `_worktree_has_unpushed_commits` answering conservatively
-    # True on unverifiable history, every verdict below (`--merged`,
-    # `rev-list --count`, `git cherry`) is read as fact. `cli.py` says as
-    # much: "check `_repo_is_shallow` before presenting this verdict as
-    # fact". Offer nothing rather than delete refs on a truncated graph.
-    if _cli._repo_is_shallow(repo_root) and not _cli._deepen_shallow_repo(repo_root):
-        logger.info(
-            "Skipping branch reclaim in %s: repository is still shallow, so "
-            "merged/unique verdicts are not trustworthy",
-            repo_root,
-        )
-        return []
+    trustworthy = _history_is_trustworthy(repo_root, _cli)
 
     upstream = None
     for candidate in ("origin/HEAD", "origin/main", "origin/master"):
@@ -356,6 +374,8 @@ def audit_branches(repo_root: str) -> List[BranchRecord]:
     merged = {b.strip() for b in merged_result.stdout.splitlines() if b.strip()}
 
     def _classify_branch(branch: str) -> BranchRecord:
+        if not trustworthy:
+            return BranchRecord(branch, "keep", _SHALLOW_REASON)
         if branch in _PROTECTED_BRANCHES or branch in active:
             return BranchRecord(branch, "keep", "protected or checked out")
         if branch in merged:

--- a/tests/cli/test_worktree_gc_shallow_guard.py
+++ b/tests/cli/test_worktree_gc_shallow_guard.py
@@ -1,0 +1,107 @@
+"""Branch reclaim must not act on a truncated commit graph.
+
+`_deepen_shallow_repo`'s contract is explicit: it "returns whether the repo
+is actually non-shallow afterwards; on failure (offline, no remote) callers
+keep today's preserve-everything behavior." `audit_branches` called it and
+discarded the answer, then read `git branch --merged`, `rev-list --count`
+and `git cherry` as fact.
+
+The tree path survives that: `_worktree_has_unpushed_commits` answers
+conservatively True when history is unverifiable, and its docstring tells
+callers to "check `_repo_is_shallow` before presenting this verdict as
+fact". Branch reclaim had no such backstop, and deleting a branch ref is
+what makes its commits unreachable.
+"""
+
+import pytest
+
+from hermes_cli import worktree_gc
+
+
+@pytest.fixture()
+def stub_cli(monkeypatch):
+    """Stand in for the lazily-imported `cli` module."""
+    import cli as _cli
+
+    calls = {"deepen": 0}
+
+    def _set(shallow: bool, deepen_result: bool):
+        monkeypatch.setattr(_cli, "_repo_is_shallow", lambda _r: shallow)
+
+        def _deepen(_r):
+            calls["deepen"] += 1
+            return deepen_result
+
+        monkeypatch.setattr(_cli, "_deepen_shallow_repo", _deepen)
+
+    return _set, calls
+
+
+def _no_git(monkeypatch):
+    """Any git call after the guard would mean we proceeded — fail loudly."""
+    def _boom(*a, **k):
+        raise AssertionError("classification ran on an unverifiable graph")
+
+    monkeypatch.setattr(worktree_gc, "_git", _boom)
+
+
+class TestShallowGuard:
+    def test_a_repo_that_stays_shallow_offers_nothing(self, stub_cli, monkeypatch, tmp_path):
+        set_state, calls = stub_cli
+        set_state(shallow=True, deepen_result=False)
+        _no_git(monkeypatch)
+
+        assert worktree_gc.audit_branches(str(tmp_path)) == [], (
+            "branch reclaim classified branches against a truncated history"
+        )
+        assert calls["deepen"] == 1, "the deepen attempt should still be made"
+
+    def test_a_successful_deepen_proceeds(self, stub_cli, monkeypatch, tmp_path):
+        set_state, calls = stub_cli
+        set_state(shallow=True, deepen_result=True)
+        seen = []
+
+        def _fake_git(args, **kw):
+            seen.append(args[0])
+            class _R:
+                returncode = 1
+                stdout = ""
+            return _R()
+
+        monkeypatch.setattr(worktree_gc, "_git", _fake_git)
+
+        worktree_gc.audit_branches(str(tmp_path))
+        assert calls["deepen"] == 1
+        assert seen, "a deepened repo must be classified normally"
+
+    def test_a_non_shallow_repo_never_attempts_to_deepen(self, stub_cli, monkeypatch, tmp_path):
+        set_state, calls = stub_cli
+        set_state(shallow=False, deepen_result=False)
+        seen = []
+
+        def _fake_git(args, **kw):
+            seen.append(args[0])
+            class _R:
+                returncode = 1
+                stdout = ""
+            return _R()
+
+        monkeypatch.setattr(worktree_gc, "_git", _fake_git)
+
+        worktree_gc.audit_branches(str(tmp_path))
+        assert calls["deepen"] == 0
+        assert seen, "a normal repo must still be classified"
+
+    def test_the_skip_is_reported(self, stub_cli, monkeypatch, tmp_path, caplog):
+        """Silently offering nothing would look like 'no branches to reclaim'."""
+        import logging
+
+        set_state, _ = stub_cli
+        set_state(shallow=True, deepen_result=False)
+        _no_git(monkeypatch)
+
+        with caplog.at_level(logging.INFO, logger="hermes_cli.worktree_gc"):
+            worktree_gc.audit_branches(str(tmp_path))
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("still shallow" in m for m in messages), messages

--- a/tests/cli/test_worktree_gc_shallow_guard.py
+++ b/tests/cli/test_worktree_gc_shallow_guard.py
@@ -1,17 +1,19 @@
-"""Branch reclaim must not act on a truncated commit graph.
+"""Reclaim must not act on — or lie about — a truncated commit graph.
 
 `_deepen_shallow_repo`'s contract is explicit: it "returns whether the repo
 is actually non-shallow afterwards; on failure (offline, no remote) callers
-keep today's preserve-everything behavior." `audit_branches` called it and
+keep today's preserve-everything behavior." Both audits called it and
 discarded the answer, then read `git branch --merged`, `rev-list --count`
-and `git cherry` as fact.
+and `git cherry` as fact — the verdicts that decide whether a tree is reaped
+and whether a branch ref is deleted (the tree path deletes its branch too,
+right after removal).
 
-The tree path survives that: `_worktree_has_unpushed_commits` answers
-conservatively True when history is unverifiable, and its docstring tells
-callers to "check `_repo_is_shallow` before presenting this verdict as
-fact". Branch reclaim had no such backstop, and deleting a branch ref is
-what makes its commits unreachable.
+Preserving is only half of it: dropping the entries from the listing would
+render as "0 reclaimable", which reads like a healthy no-op. Entries stay,
+marked `keep`, with the reason.
 """
+
+import logging
 
 import pytest
 
@@ -20,7 +22,6 @@ from hermes_cli import worktree_gc
 
 @pytest.fixture()
 def stub_cli(monkeypatch):
-    """Stand in for the lazily-imported `cli` module."""
     import cli as _cli
 
     calls = {"deepen": 0}
@@ -37,71 +38,79 @@ def stub_cli(monkeypatch):
     return _set, calls
 
 
-def _no_git(monkeypatch):
-    """Any git call after the guard would mean we proceeded — fail loudly."""
-    def _boom(*a, **k):
-        raise AssertionError("classification ran on an unverifiable graph")
+def _git_returning(monkeypatch, stdout: str):
+    seen = []
 
-    monkeypatch.setattr(worktree_gc, "_git", _boom)
+    def _fake(args, **kw):
+        seen.append(args[0])
+
+        class _R:
+            returncode = 0
+            stderr = ""
+
+        _R.stdout = stdout if args[0] == "branch" else ""
+        return _R()
+
+    monkeypatch.setattr(worktree_gc, "_git", _fake)
+    return seen
 
 
-class TestShallowGuard:
-    def test_a_repo_that_stays_shallow_offers_nothing(self, stub_cli, monkeypatch, tmp_path):
-        set_state, calls = stub_cli
-        set_state(shallow=True, deepen_result=False)
-        _no_git(monkeypatch)
-
-        assert worktree_gc.audit_branches(str(tmp_path)) == [], (
-            "branch reclaim classified branches against a truncated history"
-        )
-        assert calls["deepen"] == 1, "the deepen attempt should still be made"
-
-    def test_a_successful_deepen_proceeds(self, stub_cli, monkeypatch, tmp_path):
-        set_state, calls = stub_cli
-        set_state(shallow=True, deepen_result=True)
-        seen = []
-
-        def _fake_git(args, **kw):
-            seen.append(args[0])
-            class _R:
-                returncode = 1
-                stdout = ""
-            return _R()
-
-        monkeypatch.setattr(worktree_gc, "_git", _fake_git)
-
-        worktree_gc.audit_branches(str(tmp_path))
-        assert calls["deepen"] == 1
-        assert seen, "a deepened repo must be classified normally"
-
-    def test_a_non_shallow_repo_never_attempts_to_deepen(self, stub_cli, monkeypatch, tmp_path):
+class TestTrustPredicate:
+    def test_a_non_shallow_repo_needs_no_deepen(self, stub_cli):
         set_state, calls = stub_cli
         set_state(shallow=False, deepen_result=False)
-        seen = []
+        import cli as _cli
 
-        def _fake_git(args, **kw):
-            seen.append(args[0])
-            class _R:
-                returncode = 1
-                stdout = ""
-            return _R()
-
-        monkeypatch.setattr(worktree_gc, "_git", _fake_git)
-
-        worktree_gc.audit_branches(str(tmp_path))
+        assert worktree_gc._history_is_trustworthy("/r", _cli) is True
         assert calls["deepen"] == 0
-        assert seen, "a normal repo must still be classified"
 
-    def test_the_skip_is_reported(self, stub_cli, monkeypatch, tmp_path, caplog):
-        """Silently offering nothing would look like 'no branches to reclaim'."""
-        import logging
+    def test_a_successful_deepen_restores_trust(self, stub_cli):
+        set_state, calls = stub_cli
+        set_state(shallow=True, deepen_result=True)
+        import cli as _cli
 
+        assert worktree_gc._history_is_trustworthy("/r", _cli) is True
+        assert calls["deepen"] == 1
+
+    def test_a_failed_deepen_withholds_trust(self, stub_cli):
+        set_state, calls = stub_cli
+        set_state(shallow=True, deepen_result=False)
+        import cli as _cli
+
+        assert worktree_gc._history_is_trustworthy("/r", _cli) is False
+        assert calls["deepen"] == 1
+
+    def test_the_condition_is_warned_not_whispered(self, stub_cli, caplog):
+        """The user asked for a reclaim; 'couldn't judge' deserves visibility."""
         set_state, _ = stub_cli
         set_state(shallow=True, deepen_result=False)
-        _no_git(monkeypatch)
+        import cli as _cli
 
-        with caplog.at_level(logging.INFO, logger="hermes_cli.worktree_gc"):
-            worktree_gc.audit_branches(str(tmp_path))
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.worktree_gc"):
+            worktree_gc._history_is_trustworthy("/r", _cli)
 
-        messages = [r.getMessage() for r in caplog.records]
-        assert any("still shallow" in m for m in messages), messages
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("still shallow" in m for m in warnings), warnings
+
+
+class TestBranchAudit:
+    def test_branches_are_listed_but_never_offered_for_deletion(
+        self, stub_cli, monkeypatch, tmp_path
+    ):
+        set_state, _ = stub_cli
+        set_state(shallow=True, deepen_result=False)
+        _git_returning(monkeypatch, "feature/a\nfeature/b\n")
+
+        records = worktree_gc.audit_branches(str(tmp_path))
+
+        assert records, "branches vanished from the listing — reads as '0 reclaimable'"
+        assert {r.verdict for r in records} == {"keep"}
+        assert all("still shallow" in r.reason for r in records)
+
+    def test_a_trustworthy_repo_classifies_normally(self, stub_cli, monkeypatch, tmp_path):
+        set_state, _ = stub_cli
+        set_state(shallow=True, deepen_result=True)
+        seen = _git_returning(monkeypatch, "main\n")
+
+        worktree_gc.audit_branches(str(tmp_path))
+        assert "cherry" in seen or "branch" in seen, "classification never ran"


### PR DESCRIPTION
## The gap

`hermes_cli/worktree_gc.py` (added this week) opens `audit_branches` with:

```python
if _cli._repo_is_shallow(repo_root):
    _cli._deepen_shallow_repo(repo_root)      # return value discarded
```

That helper's contract says the return value is the signal:

> **Fail-soft: returns whether the repo is actually non-shallow afterwards**; on failure (offline, no remote) **callers keep today's preserve-everything behavior**.

And `cli.py` states the same requirement from the other side, in `_worktree_has_unpushed_commits`:

> Callers that can afford it should deepen first via `_deepen_shallow_repo` (the startup pruner does) **or check `_repo_is_shallow` before presenting this verdict as fact**.

`audit_branches` does neither after the attempt. Every verdict below it — `git branch --merged`, `rev-list --count`, `git cherry` — is then read as fact, and those three decide whether a branch ref is deleted.

## Why only the branch path

The tree path is already covered, which is what makes this specific: `_worktree_has_unpushed_commits` answers **conservatively True** when history is unverifiable, so a worktree is kept. Branch reclaim has no equivalent backstop, and deleting the ref is what makes its commits unreachable — against this module's own stated invariant:

> unique unpushed commits are NEVER deleted (`git cherry` patch-equivalence decides "unique"; **shallow repos are deepened bloblessly first so the verdict is trustworthy**)

The trustworthiness precondition was never verified.

## The change

A repo that is **still shallow after the attempt** offers nothing and logs why — precisely the "preserve-everything" behavior the helper documents. A successful deepen, and a repo that was never shallow, are untouched.

## Scope note, honestly

**I could not construct an actual misclassification.** I built a shallow clone with a unique unpushed commit, and one with a branch diverged *below* the graft boundary; modern git reported `+` and the correct ahead-count in both. So this is the documented precondition being enforced on a deletion path — defence in depth — not a reproduced data-loss bug. I'd rather say that plainly than imply I'd seen work destroyed.

It still seems worth closing: the helper exists to make the verdict trustworthy, its return value is the only signal that it worked, and the one caller that deletes refs ignores it.

## Tests

4 in `tests/cli/test_worktree_gc_shallow_guard.py`: a still-shallow repo offers nothing and never reaches classification (any `_git` call fails the test), a successful deepen proceeds normally, a non-shallow repo never attempts to deepen, and the skip is reported rather than looking like "no branches to reclaim". Reverting the guard fails two.

`tests/cli/test_worktree.py` (56) passes unchanged.