### PR TITLE
fix(vision): shrink oversized history embeds via JPEG quality, not halving

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -740,6 +740,70 @@ class TestResizeImageForVision:
                 # Should return the original (oversized) data url
                 assert len(result) > 100
 
+    def test_force_jpeg_keeps_resolution_of_dense_png(self, tmp_path):
+        """A dense PNG over the byte cap shrinks via JPEG quality, not halving.
+
+        PNG has no quality ladder — before force_jpeg, the only shrink lever
+        for a text-dense screenshot was halving dimensions (1568px → ~784px),
+        destroying text legibility (#92699 follow-up). With force_jpeg the
+        quality ladder absorbs the byte pressure and resolution survives.
+        """
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        import base64 as _b64
+        import random
+        from io import BytesIO
+
+        # Photo-like PNG at exactly the long-edge cap: a gradient with
+        # low-amplitude noise defeats PNG's lossless filters (no exact
+        # repeats → >256KB) but JPEG's DCT quantization absorbs it easily —
+        # the realistic screenshot shape, unlike pure noise which no codec
+        # can fit in-budget at full resolution.
+        rng = random.Random(42)
+        img = Image.new("RGB", (1568, 900))
+        img.putdata([
+            (
+                min(255, (x * 255) // 1568 + rng.randrange(12)),
+                min(255, (y * 255) // 900 + rng.randrange(12)),
+                min(255, ((x + y) * 255) // 2468 + rng.randrange(12)),
+            )
+            for y in range(900)
+            for x in range(1568)
+        ])
+        path = tmp_path / "dense.png"
+        img.save(path, "PNG")
+
+        budget = 256 * 1024
+        result = _resize_image_for_vision(
+            path, mime_type="image/png",
+            max_base64_bytes=budget, max_dimension=1568,
+            force_jpeg=True,
+        )
+        assert result.startswith("data:image/jpeg;base64,")
+        assert len(result) <= budget
+        with Image.open(BytesIO(_b64.b64decode(result.partition(",")[2]))) as out:
+            # Resolution preserved (the PNG path would have halved to 784px).
+            assert max(out.size) == 1568
+
+    def test_force_jpeg_leaves_small_png_untouched(self, tmp_path):
+        """Under-cap images skip the resize entirely — still PNG."""
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        img = Image.new("RGB", (10, 10), (0, 255, 0))
+        path = tmp_path / "tiny.png"
+        img.save(path, "PNG")
+
+        result = _resize_image_for_vision(
+            path, mime_type="image/png",
+            max_base64_bytes=256 * 1024, max_dimension=1568,
+            force_jpeg=True,
+        )
+        assert result.startswith("data:image/png;base64,")
+
 
 # ---------------------------------------------------------------------------
 # _image_exceeds_dimension — proactive embed-time pixel-cap detector

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -804,6 +804,42 @@ class TestResizeImageForVision:
         )
         assert result.startswith("data:image/png;base64,")
 
+    def test_force_jpeg_handles_alpha_and_exotic_modes(self, tmp_path):
+        """RGBA/LA/P PNGs must convert cleanly — JPEG can't encode alpha.
+
+        force_jpeg newly routes PNG inputs to the JPEG encoder, so modes
+        JPEG can't save (LA grayscale+alpha especially) must be normalized
+        to RGB instead of crashing img.save().
+        """
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not installed")
+        import random
+
+        rng = random.Random(7)
+        for mode, size in (("RGBA", (600, 400)), ("LA", (600, 400)), ("P", (600, 400))):
+            img = Image.new(mode, size)
+            # Noise so the PNG exceeds a tiny budget and the resize fires.
+            if mode == "P":
+                img.putpalette([i % 256 for i in range(768)])
+                img.putdata([rng.randrange(256) for _ in range(size[0] * size[1])])
+            else:
+                bands = len(img.getbands())
+                img.putdata([
+                    tuple(rng.randrange(256) for _ in range(bands))
+                    for _ in range(size[0] * size[1])
+                ])
+            path = tmp_path / f"img_{mode}.png"
+            img.save(path, "PNG")
+
+            result = _resize_image_for_vision(
+                path, mime_type="image/png",
+                max_base64_bytes=16 * 1024, max_dimension=1568,
+                force_jpeg=True,
+            )
+            assert result.startswith("data:image/jpeg;base64,"), mode
+
 
 # ---------------------------------------------------------------------------
 # _image_exceeds_dimension — proactive embed-time pixel-cap detector

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4745,6 +4745,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
                 mime_type="image/png",
                 max_base64_bytes=_EMBED_TARGET_BYTES,
                 max_dimension=_EMBED_MAX_DIMENSION,
+                force_jpeg=True,
             )
             native_result = _build_native_vision_tool_result(
                 image_url=str(screenshot_path),

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -418,13 +418,25 @@ def _native_screenshot_result(result: Dict[str, Any], path: str) -> Optional[Dic
         from pathlib import Path
 
         from tools.vision_tools import (
+            _EMBED_MAX_DIMENSION,
+            _EMBED_TARGET_BYTES,
             _resize_image_for_vision,
             _should_use_native_vision_fast_path,
         )
 
         if not _should_use_native_vision_fast_path():
             return None
-        data_url = _resize_image_for_vision(Path(path))
+        # History-reuse cap (#92699): this data URL bakes into the tool
+        # result and is re-sent on every later turn — same policy as the
+        # vision_analyze / browser_vision native embeds (256 KB / 1568 px,
+        # JPEG quality ladder instead of PNG dimension-halving).
+        data_url = _resize_image_for_vision(
+            Path(path),
+            mime_type="image/png",
+            max_base64_bytes=_EMBED_TARGET_BYTES,
+            max_dimension=_EMBED_MAX_DIMENSION,
+            force_jpeg=True,
+        )
         text = json.dumps(result, ensure_ascii=False)
         return {
             "_multimodal": True,

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -887,8 +887,10 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
         if data_url is None:
             data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
         return data_url  # fall through to size-check in caller
-    # Convert RGBA to RGB for JPEG output
-    if pil_format == "JPEG" and img.mode in {"RGBA", "P"}:
+    # JPEG cannot encode alpha or palette/grayscale-alpha modes; normalize
+    # anything that isn't already plain RGB/grayscale.  force_jpeg newly
+    # routes PNG inputs here, so exotic modes (LA/PA) must not crash save().
+    if pil_format == "JPEG" and img.mode not in {"RGB", "L"}:
         img = img.convert("RGB")
 
     # Strategy: halve dimensions until both base64 fits AND pixel dimensions

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -793,7 +793,8 @@ def _build_scale_note(
 def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
                               max_base64_bytes: int = _RESIZE_TARGET_BYTES,
                               max_dimension: Optional[int] = None,
-                              scale_out: Optional[dict] = None) -> str:
+                              scale_out: Optional[dict] = None,
+                              force_jpeg: bool = False) -> str:
     """Convert an image to a base64 data URL, auto-resizing if too large.
 
     Tries Pillow first to progressively downscale oversized images.  If Pillow
@@ -805,6 +806,13 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
             count are forcibly downscaled even if they're under the byte
             budget.  Anthropic enforces an 8000 px per-side cap independently
             of the 5 MB byte cap.
+        force_jpeg: Re-encode as JPEG even for PNG input when a resize is
+            needed.  PNG has no quality ladder — its only shrink lever is
+            halving dimensions, which destroys text legibility on dense
+            screenshots.  History-reuse embeds (#92699) opt in so a text-heavy
+            screenshot keeps its readable resolution and shrinks via JPEG
+            quality instead.  Images already under both caps are returned
+            unchanged (still PNG).
 
     Returns the base64 data URL string.
     """
@@ -862,8 +870,14 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
                 max_base64_bytes / (1024 * 1024), max_dimension)
 
     mime = mime_type or _determine_mime_type(image_path)
-    # Choose output format: JPEG for photos (smaller), PNG for transparency
-    pil_format = "PNG" if mime == "image/png" else "JPEG"
+    # Choose output format: JPEG for photos (smaller), PNG for transparency.
+    # force_jpeg overrides for history-reuse embeds: a resize-needing PNG
+    # screenshot re-encodes as JPEG so the quality ladder can shrink bytes
+    # without halving resolution (text legibility, #92699).
+    if force_jpeg:
+        pil_format = "JPEG"
+    else:
+        pil_format = "PNG" if mime == "image/png" else "JPEG"
     out_mime = "image/png" if pil_format == "PNG" else "image/jpeg"
 
     try:
@@ -1254,6 +1268,7 @@ async def _vision_analyze_native(
                 max_base64_bytes=_EMBED_TARGET_BYTES,
                 max_dimension=_EMBED_MAX_DIMENSION,
                 scale_out=_scale_info,
+                force_jpeg=True,
             )
             # If even resizing can't get under the absolute hard ceiling,
             # there's nothing more we can do — reject rather than embed a


### PR DESCRIPTION
## Summary

Text-dense screenshots over the 256 KB history-embed cap now keep their readable 1568 px resolution — the resize shrinks bytes via JPEG's quality ladder instead of halving PNG dimensions to ~784 px.

Follow-up to #92783 (fidelity trade-off flagged during its review; also raised by the AI review on #92725).

## Root cause

PNG has no quality ladder (`quality_steps = (None,)`), so a resize-needing PNG screenshot's only shrink lever was halving dimensions. A dense 1568 px browser screenshot as PNG routinely exceeds 256 KB base64 → halved to ~784 px → on-screen text unreadable, which is exactly what screenshot QA needs.

## Changes

- `tools/vision_tools.py`: `_resize_image_for_vision(..., force_jpeg=True)` — re-encode as JPEG when a resize is needed; under-cap images skip the resize and stay PNG.
- Both history-embed call sites opt in: `vision_analyze` native fast path and `browser_vision` native fast path. One-shot/reactive paths keep existing format behavior.
- Tests: dense photo-like PNG over-cap keeps `max(dims) == 1568` as JPEG within budget (fails with `784 == 1568` when force_jpeg is defeated — mutation-checked); under-cap PNG untouched.

## Validation

| 1568×900 dense PNG, 256 KB budget | Before | After |
|---|---|---|
| Output | PNG, 784×450 | JPEG, 1568×900 |
| Within budget | yes | yes |
| Text legibility | halved | preserved |

96/96 vision/browser/shrink-recovery tests green; ruff clean.

## Review follow-up (commit 2)

- JPEG mode guard broadened to `not in {RGB, L}` — LA-mode (grayscale+alpha) PNGs would crash `img.save(format="JPEG")` now that force_jpeg routes PNGs to the JPEG encoder.
- Third native history-embed site migrated: `browser_use_cli._native_screenshot_result` baked its data URL into a `_multimodal` tool result with the 5 MB one-shot default and no dimension cap — now uses the same 256 KB / 1568 px / force_jpeg policy.
- New test covers RGBA/LA/P modes end-to-end. 189/189 vision+browser tests green.
