### PR TITLE
fix: desktop plugins over 512 KiB no longer load truncated

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14016,6 +14016,27 @@ ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
   }
 })
 
+// Runtime desktop plugins load their FULL source through this door.
+// `hermes:readFileText` is the *preview* read and silently truncates at
+// TEXT_PREVIEW_MAX_BYTES (512 KiB) — for a plugin that means evaluating half a
+// file. Dedicated generous cap, full read, and a hard EFBIG (via maxBytes)
+// instead of truncation when the source exceeds it.
+const PLUGIN_SOURCE_MAX_BYTES = 16 * 1024 * 1024
+
+ipcMain.handle('hermes:readPluginSource', async (_event: unknown, filePath: unknown) => {
+  const { resolvedPath, stat } = await resolveReadableFileForIpc(filePath, {
+    maxBytes: PLUGIN_SOURCE_MAX_BYTES,
+    purpose: 'Plugin source'
+  })
+
+  return {
+    byteSize: stat.size,
+    path: resolvedPath,
+    text: await fs.promises.readFile(resolvedPath, 'utf8'),
+    truncated: false
+  }
+})
+
 ipcMain.handle('hermes:selectPaths', async (_event, options: any = {}) => {
   const properties = options?.directories ? ['openDirectory'] : ['openFile']
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -196,6 +196,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     set: maxMb => ipcRenderer.invoke('hermes:data-url-read-max:set', maxMb)
   },
   readFileText: filePath => ipcRenderer.invoke('hermes:readFileText', filePath),
+  readPluginSource: (filePath: string) => ipcRenderer.invoke('hermes:readPluginSource', filePath),
   selectPaths: options => ipcRenderer.invoke('hermes:selectPaths', options),
   selectSavePath: options => ipcRenderer.invoke('hermes:selectSavePath', options),
   writeClipboard: text => ipcRenderer.invoke('hermes:writeClipboard', text),

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -18,7 +18,8 @@ vi.mock('@/hermes', async importActual => ({
 const desktopPluginsRoot = vi.fn<() => Promise<string>>()
 const agentPluginsRoot = vi.fn<() => Promise<string>>()
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
-const readFileText = vi.fn<(path: string) => Promise<{ text: string }>>()
+const readFileText = vi.fn<(path: string) => Promise<{ text: string; truncated?: boolean }>>()
+const readPluginSource = vi.fn<(path: string) => Promise<{ text: string; truncated?: boolean }>>()
 const watchDirectory = vi.fn<(path: string) => Promise<{ id: string }>>()
 const watchPreviewFile = vi.fn<(path: string) => Promise<{ id: string }>>()
 const onPreviewFileChanged = vi.fn()
@@ -28,6 +29,7 @@ beforeEach(() => {
   agentPluginsRoot.mockReset()
   readDir.mockReset()
   readFileText.mockReset()
+  readPluginSource.mockReset()
   watchDirectory.mockReset()
   watchPreviewFile.mockReset()
   onPreviewFileChanged.mockReset()
@@ -176,6 +178,127 @@ describe('watchRuntimePlugins dir watch (#66899)', () => {
     expect(watchDirectory).toHaveBeenCalledWith('/local/.hermes/plugins')
     expect(watchDirectory).not.toHaveBeenCalledWith('/remote/box/.hermes/desktop-plugins')
     expect(getStatus).not.toHaveBeenCalled()
+  })
+})
+
+describe('plugin source reads (512 KiB preview-cap bug)', () => {
+  const blobToDataUrl = () => {
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(
+        blob =>
+          `data:text/javascript;base64,${Buffer.from((blob as unknown as { parts: string[] }).parts.join('')).toString('base64')}`
+      )
+
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    const RealBlob = globalThis.Blob
+    vi.stubGlobal(
+      'Blob',
+      class {
+        parts: string[]
+        constructor(parts: string[]) {
+          this.parts = parts
+        }
+      }
+    )
+
+    return () => {
+      createObjectURL.mockRestore()
+      revokeObjectURL.mockRestore()
+      vi.stubGlobal('Blob', RealBlob)
+    }
+  }
+
+  it('loads the full source via readPluginSource when the shell offers it', async () => {
+    ;(window.hermesDesktop as unknown as { readPluginSource: unknown }).readPluginSource = readPluginSource
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('')
+    readDir.mockResolvedValue({
+      entries: [{ isDirectory: true, name: 'big', path: '/local/.hermes/desktop-plugins/big' }]
+    })
+    // The existence probe still uses the preview read (metadata is enough
+    // there) — it may report truncation without failing the scan.
+    readFileText.mockResolvedValue({ text: '// first 512 KiB only', truncated: true })
+
+    const register = vi.fn()
+
+    ;(globalThis as unknown as { __bigRegister: unknown }).__bigRegister = register
+    readPluginSource.mockResolvedValue({
+      text: 'export default { id: "big", register: globalThis.__bigRegister }'
+    })
+    watchPreviewFile.mockResolvedValue({ id: 'w-big' })
+
+    const restore = blobToDataUrl()
+
+    try {
+      await discoverRuntimePlugins()
+
+      // The EVALUATED source came from the full read, not the truncated preview.
+      expect(readPluginSource).toHaveBeenCalledWith('/local/.hermes/desktop-plugins/big/plugin.js')
+      expect(register).toHaveBeenCalledTimes(1)
+      expect($pluginRecords.get().big).toMatchObject({ kind: 'disk', status: 'loaded' })
+    } finally {
+      restore()
+      delete (globalThis as unknown as { __bigRegister?: unknown }).__bigRegister
+    }
+  })
+
+  it('older shell without readPluginSource: a truncated preview read fails LOUDLY, never evaluates', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('')
+    readDir.mockResolvedValue({
+      entries: [{ isDirectory: true, name: 'huge', path: '/local/.hermes/desktop-plugins/huge' }]
+    })
+    // 512 KiB window of a larger file — parses fine, but is NOT the plugin.
+    readFileText.mockResolvedValue({
+      text: 'export default { id: "huge", register: () => { throw new Error("must never evaluate") } }',
+      truncated: true
+    })
+    watchPreviewFile.mockResolvedValue({ id: 'w-huge' })
+
+    const restore = blobToDataUrl()
+
+    try {
+      await discoverRuntimePlugins()
+
+      // No live plugin — an error inventory row names the folder instead.
+      expect($pluginRecords.get().huge).toMatchObject({
+        kind: 'disk',
+        status: 'error',
+        file: '/local/.hermes/desktop-plugins/huge/plugin.js'
+      })
+      expect($pluginRecords.get().huge.error).toMatch(/512 KiB/)
+    } finally {
+      restore()
+    }
+  })
+
+  it('older shell, small plugin (not truncated): still loads through readFileText', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('')
+    readDir.mockResolvedValue({
+      entries: [{ isDirectory: true, name: 'small', path: '/local/.hermes/desktop-plugins/small' }]
+    })
+
+    const register = vi.fn()
+
+    ;(globalThis as unknown as { __smallRegister: unknown }).__smallRegister = register
+    readFileText.mockResolvedValue({
+      text: 'export default { id: "small", register: globalThis.__smallRegister }'
+    })
+    watchPreviewFile.mockResolvedValue({ id: 'w-small' })
+
+    const restore = blobToDataUrl()
+
+    try {
+      await discoverRuntimePlugins()
+
+      expect(register).toHaveBeenCalledTimes(1)
+      expect($pluginRecords.get().small).toMatchObject({ kind: 'disk', status: 'loaded' })
+    } finally {
+      restore()
+      delete (globalThis as unknown as { __smallRegister?: unknown }).__smallRegister
+    }
   })
 })
 

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -297,12 +297,37 @@ function dropOriginRecord(origin: string, except: DiskPlugin): void {
   dropPlugin(origin)
 }
 
-async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
+/** A plugin source that could not be read in FULL. Evaluating a truncated
+ *  file is never acceptable — half a module can still parse. */
+class PluginSourceOversizeError extends Error {}
+
+/** Read a plugin entry file in full. Prefers the dedicated readPluginSource
+ *  IPC (16 MiB cap, no truncation). Older shells predate it and only offer
+ *  the preview read, which silently truncates at 512 KiB — there the read
+ *  fails loudly instead of handing a partial file to the evaluator. */
+async function readPluginSourceText(file: string): Promise<string> {
   const desktop = window.hermesDesktop!
+
+  if (desktop.readPluginSource) {
+    return (await desktop.readPluginSource(file)).text
+  }
+
+  const result = await desktop.readFileText(file)
+
+  if (result.truncated) {
+    throw new PluginSourceOversizeError(
+      'plugin.js exceeds this shell\'s 512 KiB read limit — update Hermes Desktop to load larger plugins'
+    )
+  }
+
+  return result.text
+}
+
+async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
   const prevId = entry.id
 
   try {
-    const { text } = await desktop.readFileText(entry.file)
+    const text = await readPluginSourceText(entry.file)
 
     const id = await loadRuntimePlugin(text, entry.origin, {
       defaultEnabled: entry.defaultEnabled,
@@ -324,8 +349,23 @@ async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
     if (id && id !== entry.origin) {
       dropOriginRecord(entry.origin, entry)
     }
-  } catch {
-    // File vanished mid-read — the next scan reconciles.
+  } catch (error) {
+    // An oversize source is a REAL failure the user must see (the silent
+    // shape was the bug: a truncated file evaluated as a syntax error, or
+    // worse, as half a plugin). Everything else is a file vanishing
+    // mid-read — the next scan reconciles, stay quiet.
+    if (error instanceof PluginSourceOversizeError) {
+      console.error(`[plugins] ${entry.origin}: ${error.message}`)
+      notifyError(error, `Plugin "${entry.origin}" failed to load`)
+      publishPlugin({
+        id: entry.origin,
+        name: entry.origin,
+        kind: 'disk',
+        file: entry.file,
+        status: 'error',
+        error: error.message
+      })
+    }
   }
 }
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -207,6 +207,10 @@ declare global {
         set: (maxMb: number) => Promise<{ defaultMaxMb: number; maxBytes: number; maxMb: number }>
       }
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
+      /** Full-source read for runtime desktop plugins (readFileText truncates
+       *  at the 512 KiB preview cap). Absent on older shells — callers fall
+       *  back to readFileText and must reject a `truncated` result. */
+      readPluginSource?: (filePath: string) => Promise<HermesReadFileTextResult>
       selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
       /** Native save dialog; returns the chosen path or null on cancel. */
       selectSavePath?: (options?: {


### PR DESCRIPTION
## Summary

Desktop runtime plugins over 512 KiB now load their full source. Root cause: the loader read `plugin.js` through `hermes:readFileText` — the *preview* IPC, which silently truncates at `TEXT_PREVIEW_MAX_BYTES` (512 KiB) — so larger plugins evaluated as a partial file (cryptic syntax error, or worse, a half-module that parses).

## Changes

- `electron/main.ts`: new `hermes:readPluginSource` handler — full read, 16 MiB cap enforced as a hard `EFBIG` via `resolveReadableFileForIpc` (same path hardening + sensitive-file blocking), never truncation.
- `electron/preload.ts` / `src/global.d.ts`: bridge method + optional type (older shells lack it).
- `src/contrib/runtime-loader.ts`: `loadDiskPlugin` reads via `readPluginSource`; on older shells it falls back to `readFileText` but fails LOUDLY on `truncated: true` (error toast + error inventory row) instead of evaluating a partial file. The folder-scan existence probe keeps the preview read (metadata is enough there).
- `src/contrib/runtime-loader.test.ts`: 3 new tests — full-read path, loud old-shell truncation failure, small-plugin fallback.

## Validation

| | Before | After |
|---|---|---|
| plugin.js > 512 KiB | truncated at 512 KiB, evaluated partial | full source loads (up to 16 MiB) |
| > 512 KiB on old shell | silent partial evaluation | visible load error, never evaluates |
| runtime-loader tests | 7 | 10/10 green; both new regression tests fail under sabotage (old behavior restored) |

## Infographic

![Desktop plugins: full source loads](https://v3b.fal.media/files/b/0aa777ff/ODzCuXOjP-sBPFOdB0Ht0_bcoyVNPs.png)
