### PR TITLE
fix(desktop): restore activeBotRoute dropped by merge 0404020f7b

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4467,6 +4467,31 @@ function botBackendProfileScope(route, fallbackProfile = 'default') {
 
 /** Gateway RPC on the bot's OWN source. Source-scoped rows always use the
  * explicit descriptor, including a registered local source. */
+/** Resolve the (connectionId, profile) route descriptor of the bot whose
+ *  gateway the renderer currently foregrounds — the routing key every
+ *  roster/sweep request needs. Definition restored from commit 9b7ab9d65a
+ *  after merge 0404020f7b dropped it (Bots pane eternal loading spinner). */
+async function activeBotRoute() {
+  if (typeof host.profileRoutes !== 'function') {
+    return null
+  }
+
+  const profile = String(host.state.profile?.get?.() || 'default').trim() || 'default'
+  const connectionId = String(
+    host.state.connectionId?.get?.() ||
+    (typeof host.activeConnectionId === 'function' ? host.activeConnectionId() : '') ||
+    'local'
+  ).trim() || 'local'
+  const routes = await host.profileRoutes()
+  const route = routes.find(candidate => candidate?.connectionId === connectionId && candidate?.profile === profile)
+
+  if (!route && typeof host.agents === 'function') {
+    throw new Error(`No route for active bot ${connectionId}::${profile}`)
+  }
+
+  return route || null
+}
+
 async function requestForBot(bot, method, params = {}) {
   const route = botConnectionRoute(bot)
 


### PR DESCRIPTION
## Symptom

The Desktop Bots pane shows an eternal loading spinner (no agents, no error card) on current `main`. Every 5s poll fails silently.

## Root cause

Merge 0404020f7b (PR #90006) kept **both call sites** of `activeBotRoute()` —

- `useRoster()`'s `queryFn` (line ~3906)
- `sweepBotProfileSessions()` (line ~1636)

— but **dropped the function definition** introduced in 9b7ab9d65a. The bundled plugin therefore throws `ReferenceError: activeBotRoute is not defined` on the roster's first fetch. Because `useRoster` sets `retry: true` (there for slow remote gateways), React Query retries forever and the pane never leaves the `isLoading && !roster.length` branch.

The sweep call site fails silently inside its try/catch, so bot-profile session cleanup (hiding 'Bot Chat' / 'Agent Inbox' plumbing rows) had also stopped running — a second, quieter casualty of the same drop.

## Fix

Restore the definition verbatim from 9b7ab9d65a. One file, +25 lines, no behavior change beyond un-breaking the two call sites.

## Verification

- `node --test src/plugins/hermes-bots/tests/*.test.mjs` — **406/406 pass**
- Rebuilt bundle carries the definition again (`No route for active bot` body present, 2 call sites resolve)
- Locally packaged the app (npm run build && npm run pack) and confirmed the Bots pane loads the roster on relaunch — was the eternal spinner before, on a machine with 3 profiles (default + 2 named)

Found while debugging a live install today; symptom appeared exactly when the auto-updater landed the merge range containing 0404020f7b.