### PR TITLE
feat(gateway): enrich runtime footer metadata

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6489,6 +6489,12 @@ class TurnRunner:
             _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
         _resolved_model = getattr(_agent, "model", None) if _agent else None
+        _reasoning_config = getattr(_agent, "reasoning_config", None) if _agent else None
+        _fallback_activated = bool(getattr(_agent, "_fallback_activated", False)) if _agent else False
+        from gateway.runtime_footer import count_turn_tool_calls as _count_turn_tool_calls
+        _turn_tool_calls = _count_turn_tool_calls(
+            result.get("messages", []), history_offset=len(agent_history)
+        )
 
         # Sync session_id immediately after run_conversation(). Compression
         # can rotate before a follow-up model call fails; the failure return
@@ -6625,6 +6631,9 @@ class TurnRunner:
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
                 "context_length": _context_length,
+                "reasoning_config": _reasoning_config,
+                "tool_calls": _turn_tool_calls,
+                "fallback_activated": _fallback_activated,
             }
 
         # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -6706,6 +6715,9 @@ class TurnRunner:
             "output_tokens": _output_toks,
             "model": _resolved_model,
             "context_length": _context_length,
+            "reasoning_config": _reasoning_config,
+            "tool_calls": _turn_tool_calls,
+            "fallback_activated": _fallback_activated,
             "session_id": effective_session_id,
             "response_previewed": result.get("response_previewed", False),
             "response_transformed": result.get("response_transformed", False),
@@ -20591,12 +20603,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _footer_line = ""
             try:
                 from gateway.runtime_footer import build_footer_line as _bfl
+                from hermes_cli.profiles import get_active_profile_name as _active_profile
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
+                    bot=_active_profile(),
                     model=agent_result.get("model"),
+                    reasoning_config=agent_result.get("reasoning_config"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
+                    tool_calls=agent_result.get("tool_calls"),
+                    fallback_activated=bool(agent_result.get("fallback_activated")),
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                     turn_seconds=_turn_seconds,
                 )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -12,9 +12,13 @@ Config (``~/.hermes/config.yaml``)::
         fields: [model, context_pct, cwd]   # order shown; drop any to hide
 
 Available fields:
+    bot          - active Hermes profile / bot name (``Dante``)
     model        — bare model id, vendor prefix dropped (``gpt-5.4``)
+    reasoning    - effective reasoning effort (``reasoning high``)
     context_pct  — last-call context occupancy as a percent (``5%``)
     latency      — wall-clock duration of the turn (``22s``, ``1m05s``)
+    tool_calls   - tool executions in this turn (``3 outils``)
+    fallback     - rendered only when the fallback route was activated
     cwd          — home-relative working dir (``~``)
 
 ``latency`` is opt-in: it is NOT in the default field set, so a footer whose
@@ -60,6 +64,47 @@ def _model_short(model: Optional[str]) -> str:
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def _bot_label(bot: Optional[str]) -> str:
+    """Humanize a profile identifier without inventing a separate bot name."""
+    if not bot:
+        return ""
+    return str(bot).replace("-", " ").replace("_", " ").strip().title()
+
+
+def _reasoning_level(reasoning_config: dict[str, Any] | None) -> str:
+    """Return the effective user-facing reasoning level."""
+    if reasoning_config and reasoning_config.get("enabled") is False:
+        return "none"
+    if reasoning_config:
+        effort = str(reasoning_config.get("effort") or "").strip().lower()
+        if effort:
+            return effort
+    return "medium"
+
+
+def count_turn_tool_calls(messages: Any, history_offset: int = 0) -> int:
+    """Count assistant tool calls produced after the prior-history boundary."""
+    if not isinstance(messages, list):
+        return 0
+    if 0 <= history_offset <= len(messages):
+        offset = history_offset
+    else:
+        offset = 0
+        for index in range(len(messages) - 1, -1, -1):
+            message = messages[index]
+            if isinstance(message, dict) and message.get("role") == "user":
+                offset = index + 1
+                break
+    count = 0
+    for message in messages[offset:]:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        calls = message.get("tool_calls")
+        if isinstance(calls, list):
+            count += len(calls)
+    return count
 
 
 def resolve_footer_config(
@@ -113,6 +158,10 @@ def format_runtime_footer(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    bot: Optional[str] = None,
+    reasoning_config: dict[str, Any] | None = None,
+    tool_calls: Optional[int] = None,
+    fallback_activated: bool = False,
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
@@ -124,14 +173,20 @@ def format_runtime_footer(
     """
     parts: list[str] = []
     for field in fields:
-        if field == "model":
+        if field in {"bot", "profile"}:
+            label = _bot_label(bot)
+            if label:
+                parts.append(label)
+        elif field == "model":
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "reasoning":
+            parts.append(f"reasoning {_reasoning_level(reasoning_config)}")
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
-                parts.append(f"{pct}%")
+                parts.append(f"{'⚠ ' if pct >= 70 else ''}{pct}%")
         elif field == "latency":
             # Wall-clock turn duration. Skipped when the caller supplied no
             # timing (call sites that don't measure) or the value is negative.
@@ -141,6 +196,12 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "tool_calls":
+            if tool_calls is not None and tool_calls >= 0:
+                parts.append(f"{tool_calls} outil{'s' if tool_calls != 1 else ''}")
+        elif field == "fallback":
+            if fallback_activated:
+                parts.append("fallback")
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -155,6 +216,10 @@ def build_footer_line(
     model: Optional[str],
     context_tokens: int,
     context_length: Optional[int],
+    bot: Optional[str] = None,
+    reasoning_config: dict[str, Any] | None = None,
+    tool_calls: Optional[int] = None,
+    fallback_activated: bool = False,
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
 ) -> str:
@@ -175,6 +240,10 @@ def build_footer_line(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
+        bot=bot,
+        reasoning_config=reasoning_config,
+        tool_calls=tool_calls,
+        fallback_activated=fallback_activated,
         cwd=cwd,
         turn_seconds=turn_seconds,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -11,6 +11,7 @@ from gateway.runtime_footer import (
     _home_relative_cwd,
     _model_short,
     build_footer_line,
+    count_turn_tool_calls,
     format_runtime_footer,
     resolve_footer_config,
 )
@@ -244,6 +245,104 @@ def test_build_footer_line_threads_turn_seconds(monkeypatch):
         turn_seconds=22.0,
     )
     assert out == "gpt-5.4 · 22s"
+
+
+def test_format_footer_operational_fields_in_requested_order():
+    out = format_runtime_footer(
+        bot="dante",
+        model="openai-codex/gpt-5.6",
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+        context_tokens=18_000,
+        context_length=100_000,
+        turn_seconds=24.0,
+        tool_calls=3,
+        fields=("profile", "model", "reasoning", "context_pct", "latency", "tool_calls"),
+    )
+    assert out == "Dante · gpt-5.6 · reasoning xhigh · 18% · 24s · 3 outils"
+
+
+@pytest.mark.parametrize(
+    "reasoning_config,expected",
+    [
+        ({"enabled": False}, "reasoning none"),
+        ({"enabled": True, "effort": "low"}, "reasoning low"),
+        (None, "reasoning medium"),
+    ],
+)
+def test_format_footer_reasoning_level(reasoning_config, expected):
+    out = format_runtime_footer(
+        model="m",
+        reasoning_config=reasoning_config,
+        context_tokens=0,
+        context_length=None,
+        fields=("reasoning",),
+    )
+    assert out == expected
+
+
+def test_format_footer_context_warns_only_near_compression():
+    normal = format_runtime_footer(
+        model="m", context_tokens=69, context_length=100, fields=("context_pct",)
+    )
+    warning = format_runtime_footer(
+        model="m", context_tokens=70, context_length=100, fields=("context_pct",)
+    )
+    assert normal == "69%"
+    assert warning == "⚠ 70%"
+
+
+def test_format_footer_marks_fallback_only_when_activated():
+    primary = format_runtime_footer(
+        model="gpt-5.6", context_tokens=0, context_length=None,
+        fallback_activated=False, fields=("fallback",),
+    )
+    fallback = format_runtime_footer(
+        model="gpt-5.6", context_tokens=0, context_length=None,
+        fallback_activated=True, fields=("fallback",),
+    )
+    assert primary == ""
+    assert fallback == "fallback"
+
+
+def test_count_turn_tool_calls_counts_batched_calls_after_history():
+    messages = [
+        {"role": "user", "content": "old"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "new"},
+        {"role": "assistant", "tool_calls": [{"id": "1"}, {"id": "2"}]},
+        {"role": "tool", "tool_call_id": "1", "content": "a"},
+        {"role": "tool", "tool_call_id": "2", "content": "b"},
+        {"role": "assistant", "tool_calls": [{"id": "3"}]},
+    ]
+    assert count_turn_tool_calls(messages, history_offset=2) == 3
+
+
+def test_count_turn_tool_calls_uses_latest_user_after_compaction():
+    messages = [
+        {"role": "user", "content": "compacted history"},
+        {"role": "assistant", "tool_calls": [{"id": "old"}]},
+        {"role": "user", "content": "current turn"},
+        {"role": "assistant", "tool_calls": [{"id": "new"}]},
+    ]
+    assert count_turn_tool_calls(messages, history_offset=99) == 1
+
+
+def test_build_footer_line_threads_operational_metadata():
+    out = build_footer_line(
+        user_config={"display": {"runtime_footer": {
+            "enabled": True,
+            "fields": ["bot", "model", "reasoning", "tool_calls", "fallback"],
+        }}},
+        platform_key="discord",
+        bot="dante",
+        model="gpt-5.6",
+        reasoning_config={"enabled": True, "effort": "high"},
+        context_tokens=0,
+        context_length=None,
+        tool_calls=2,
+        fallback_activated=True,
+    )
+    assert out == "Dante · gpt-5.6 · reasoning high · 2 outils · fallback"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add configurable footer fields for active profile, reasoning effort, per-turn tool calls, and fallback activation
- warn at 70% context occupancy without changing the default footer field set
- thread effective turn metadata from the agent result into final gateway delivery

## Why

Multiplex gateways can serve several profiles and model routes through one platform connection. The existing footer exposed model, context occupancy, latency, and working directory, but could not identify the responding profile or show reasoning, tool activity, and fallback state.

All new fields remain opt-in through `display.runtime_footer.fields`, preserving the existing default output.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_runtime_footer.py -q`
- [x] 46 tests passed
- [x] `git diff --check`

## Notes

Tool calls are counted from assistant tool-call batches after the prior history boundary. If compaction changes that boundary, counting falls back to the latest user turn.