### PR TITLE
docs(api-server): note multiplex run-status visibility

### DIFF
--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -622,6 +622,27 @@ to the routed profile**:
 - A named profile with no `API_SERVER_KEY` of its own fails closed — its
   prefix is unreachable until you set one.
 
+:::note Run status visibility
+`multiplex_profiles` isolates **execution** (secrets, files, session state)
+per routed profile. It does not make run polling a per-profile ownership
+check.
+
+`GET /p/<profile>/v1/runs/{run_id}` — and the matching `/events` and
+`/stop` routes — looks up the **process-level** run table for this
+gateway by `run_id`. The prefix only has to name a profile this listener
+already serves; an unknown profile still 404s.
+
+A client that already authenticates as another profile in that **same
+gateway's authorized profile set** (with that other profile's own
+`API_SERVER_KEY`) can therefore read a known `run_id` created under a
+different served prefix. On one multiplexed listener, profiles are
+routing handles, not a per-run authorization boundary. Callers outside
+that authorized set are out of scope.
+
+If tenants must not see each other's run status, give each tenant its
+own gateway process rather than multiplexing them on one API server.
+:::
+
 :::warning Breaking change (July 2026)
 Before this fix, a valid default-profile key was accepted on any
 `/p/<profile>/` prefix. If you relied on one shared key across profile


### PR DESCRIPTION
## What does this PR do?

Documents the existing run-status lookup boundary under `gateway.multiplex_profiles`.

Execution (secrets, files, session state) stays scoped to the routed profile. `GET /p/<profile>/v1/runs/{run_id}` (and the matching `/events` and `/stop` routes) looks up the process-level run table by `run_id` for this gateway. The prefix only has to name a profile this listener already serves; it is not a per-run ownership check.

This is expected API-server trust-model behavior (profiles on one multiplexed listener are routing handles), not a runtime or security change. The note is scoped to callers already in that gateway's authorized profile set.

## Related Issue

Fixes #90415

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/features/api-server.md`: add a `:::note` under **Multi-profile routing** describing run-status visibility vs execution isolation.

## How to Test

1. Open `website/docs/user-guide/features/api-server.md` on this branch and confirm the new note sits under **Multi-profile routing**, after the per-profile `API_SERVER_KEY` bullets and before the July 2026 breaking-change warning.
2. Confirm the note states:
   - execution remains isolated per routed profile;
   - run lookup is by `run_id` on the shared gateway process;
   - unknown profile prefixes still 404;
   - visibility is limited to the same gateway's authorized profile set;
   - separate gateway processes are the isolation path if tenants must not share run status.
3. `git grep -n multiplex_profiles website/docs/user-guide/features/api-server.md` shows the new note.
4. No Python / gateway files change (`git diff --name-only` should be this markdown file only).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (docs-only; no runtime change)
- [x] I've added tests for my changes — N/A (docs-only)
- [x] I've tested on my platform: documentation review against `gateway/platforms/api_server.py` run-status lookup (`_run_statuses` keyed by `run_id`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A