### PR TITLE
fix(reasoning): retain model switch overrides

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10852,6 +10852,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             "api_key": self.api_key,
             "base_url": self.base_url,
             "api_mode": self.api_mode,
+            "reasoning_config": copy.deepcopy(
+                getattr(self, "reasoning_config", None)
+            ),
             "agent_primary_runtime": copy.deepcopy(
                 getattr(agent, "_primary_runtime", None)
             ) if agent is not None else None,
@@ -10870,6 +10873,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             "api_key",
             "base_url",
             "api_mode",
+            "reasoning_config",
         ):
             if key in snapshot:
                 setattr(self, key, snapshot.get(key))

--- a/cli.py
+++ b/cli.py
@@ -11055,6 +11055,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 )
                 return
 
+        HermesCLI._sync_reasoning_config_after_model_switch(self, result.new_model)
+
         from hermes_cli.model_switch import format_model_for_display
         _display_old = format_model_for_display(old_model)
         _display_new = format_model_for_display(result.new_model)
@@ -11123,6 +11125,29 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # actually runs — otherwise a later resume would restore the stale
         # creation-time model over the user's new global choice.
         HermesCLI._persist_model_switch_to_session(self, result)
+
+    def _sync_reasoning_config_after_model_switch(self, model: str) -> None:
+        """Keep CLI reasoning state aligned with the switched model.
+
+        ``AIAgent.switch_model`` re-resolves per-model overrides, but the next
+        turn may rebuild that agent when the route signature changes. The new
+        agent is initialized from ``self.reasoning_config``, so leaving the
+        CLI-level value stale silently restores the previous model's effort.
+        """
+        if self.agent is not None:
+            resolved = getattr(self.agent, "reasoning_config", None)
+        else:
+            try:
+                from hermes_cli.config import load_config_readonly
+                from hermes_constants import resolve_reasoning_config
+
+                resolved = resolve_reasoning_config(load_config_readonly(), model)
+            except Exception as exc:
+                logger.debug(
+                    "model switch reasoning override resolution failed: %s", exc
+                )
+                return
+        self.reasoning_config = dict(resolved) if isinstance(resolved, dict) else None
 
     def _handle_model_picker_selection(self, persist_global: bool = False) -> None:
         state = self._model_picker_state
@@ -11442,6 +11467,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     f"staying on {old_model}."
                 )
                 return
+
+        HermesCLI._sync_reasoning_config_after_model_switch(self, result.new_model)
 
         # Store a note to prepend to the next user message so the model
         # knows a switch occurred (avoids injecting system messages mid-history

--- a/tests/hermes_cli/test_model_switch_confirm_thread.py
+++ b/tests/hermes_cli/test_model_switch_confirm_thread.py
@@ -191,3 +191,25 @@ def test_switch_before_agent_init_resolves_target_model_override(monkeypatch):
     )
 
     assert stub.reasoning_config == {"enabled": False}
+
+
+def test_one_turn_switch_restores_cli_reasoning_config(monkeypatch):
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    stub.agent = _FakeAgent()
+    stub._snapshot_model_runtime = cli_mod.HermesCLI._snapshot_model_runtime.__get__(stub)
+    printed = []
+    _patch_deps(monkeypatch, printed)
+
+    cli_mod.HermesCLI._handle_model_switch(
+        stub, "/model claude-sonnet-4.6 --provider anthropic --once"
+    )
+
+    assert stub.reasoning_config == {"enabled": False}
+    cli_mod.HermesCLI._restore_model_runtime_snapshot(
+        stub, stub._pending_one_turn_model_restore
+    )
+
+    assert stub.model == "old/model"
+    assert stub.reasoning_config == {"enabled": True, "effort": "medium"}

--- a/tests/hermes_cli/test_model_switch_confirm_thread.py
+++ b/tests/hermes_cli/test_model_switch_confirm_thread.py
@@ -25,11 +25,17 @@ class _FakeAgent:
         self.calls = []
         self.model = "old/model"
         self.provider = "openrouter"
+        self.reasoning_config = {"enabled": True, "effort": "medium"}
+        self._primary_runtime = {
+            "reasoning_config": {"enabled": True, "effort": "medium"}
+        }
 
     def switch_model(self, **kwargs):
         self.calls.append(kwargs)
         self.model = kwargs["new_model"]
         self.provider = kwargs["new_provider"]
+        self.reasoning_config = {"enabled": False}
+        self._primary_runtime["reasoning_config"] = dict(self.reasoning_config)
 
 
 class _StubCLI:
@@ -46,6 +52,7 @@ class _StubCLI:
     _pending_model_switch_note = None
     _pending_one_turn_model_restore = None
     _app = None
+    reasoning_config = {"enabled": True, "effort": "medium"}
 
     def _confirm_expensive_model_switch(self, result):
         return True
@@ -132,6 +139,7 @@ def test_confirm_runs_off_main_thread_when_tui_present(monkeypatch):
     assert stub.model == "claude-sonnet-4.6"
     assert stub.provider == "anthropic"
     assert stub.agent.calls[-1]["new_model"] == "claude-sonnet-4.6"
+    assert stub.reasoning_config == {"enabled": False}
 
 
 def test_confirm_stays_synchronous_without_app(monkeypatch):
@@ -159,3 +167,27 @@ def test_confirm_stays_synchronous_without_app(monkeypatch):
     assert called_on.get("is_main") is True
     assert stub.model == "claude-sonnet-4.6"
     assert stub.provider == "anthropic"
+    assert stub.reasoning_config == {"enabled": False}
+
+
+def test_switch_before_agent_init_resolves_target_model_override(monkeypatch):
+    """A /model command can be the first interaction in a CLI session."""
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    stub.agent = None
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "agent": {
+                "reasoning_effort": "medium",
+                "reasoning_overrides": {"qwen3-coder:30b": "none"},
+            }
+        },
+    )
+
+    cli_mod.HermesCLI._sync_reasoning_config_after_model_switch(
+        stub, "qwen3-coder:30b"
+    )
+
+    assert stub.reasoning_config == {"enabled": False}


### PR DESCRIPTION
## Summary

- synchronize CLI reasoning state with the model selected through `/model`
- resolve per-model overrides when switching before the first agent is initialized
- cover both threaded and synchronous model-switch application paths

## Root Cause

`AIAgent.switch_model()` correctly re-resolved the target model reasoning override, but the classic CLI kept its startup `reasoning_config`. On the next turn, the route-signature change rebuilt the agent and passed that stale CLI value into the constructor, restoring the previous model reasoning effort.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_confirm_thread.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_25106_global_switch_persists_base_url_api_mode.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_cli_model_once.py -q`

## Related Issue

Closes #92802