### PR TITLE
fix(dashboard): count active child sessions (Fixes #15722)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1871,7 +1871,9 @@ def _count_status_active_sessions() -> int:
 
     db = _open_session_db_for_profile(None, read_only=True)
     try:
-        sessions = db.list_sessions_rich(limit=50, compact_rows=True)
+        sessions = db.list_sessions_rich(
+            limit=50, compact_rows=True, include_children=True
+        )
         now = time.time()
         return sum(
             1 for s in sessions

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -259,6 +259,26 @@ class TestWebServerEndpoints:
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
+    def test_status_active_session_count_includes_child_sessions(self):
+        from hermes_cli import web_server
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=get_hermes_home() / "state.db")
+        try:
+            db.create_session("parent", source="cli")
+            db.create_session(
+                "active-child",
+                source="cli",
+                parent_session_id="parent",
+                model_config={"_delegate_from": "parent"},
+            )
+            db.end_session("parent", end_reason="completed")
+        finally:
+            db.close()
+
+        assert web_server._count_status_active_sessions() == 1
+
     @pytest.mark.requires_wal
     def test_get_sessions_poll_preserves_pending_wal(self):
         """Repeated GET-only polls must not checkpoint another writer's WAL."""


### PR DESCRIPTION
## What does this PR do?

The dashboard status counter calls `SessionDB.list_sessions_rich()` with its default `include_children=False`, so an active delegate/subagent child is omitted when its parent has already ended. This can make `/api/status` report `active_sessions: 0` while work is still running.

This PR includes child sessions in that status-only query and adds a regression test using a real isolated `SessionDB`: the parent is ended, the delegate child remains active, and the counter must return `1`.

This carries the production fix from #15773 by @briandevans onto current `main`. The original fix commit remains authored by @briandevans; the new test directly exercises `_count_status_active_sessions()` instead of duplicating its counting logic.

## Related Issue

Fixes #15722

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: pass `include_children=True` in `_count_status_active_sessions()`.
- `tests/hermes_cli/test_web_server.py`: cover an ended parent with an active delegate child against the real status-counting helper and an isolated state database.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_status_active_session_count_includes_child_sessions -q`.
2. Without the production change, the regression test fails with `assert 0 == 1`; with the change, it passes.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q`; all 168 tests in the file pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -q` and all 168 tests in that file pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no documented behavior changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral database query only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix, the new regression test reproduced the issue:

```text
AssertionError: assert 0 == 1
```

After the fix, the related test file passes:

```text
168 tests passed, 0 failed
```
