### PR TITLE
fix(gateway): ignore parent systemd service for transient scopes

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -343,18 +343,20 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     # Try to identify our unit name and ask systemctl for its config.
     unit_name: Optional[str] = None
     try:
-        # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
+        # /proc/self/cgroup may place the process below a delegated service
+        # subgroup. Walk upward to the nearest service, but stop at a scope so
+        # a transient worker cannot be misattributed to parent user@N.service.
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
             for line in fh:
-                # systemd cgroup line ends with the unit name
-                if ".service" in line:
-                    parts = line.strip().split("/")
-                    for p in reversed(parts):
-                        if p.endswith(".service"):
-                            unit_name = p
-                            break
-                    if unit_name:
+                parts = line.strip().split("/")
+                for p in reversed(parts):
+                    if p.endswith(".scope"):
                         break
+                    if p.endswith(".service"):
+                        unit_name = p
+                        break
+                if unit_name:
+                    break
     except (OSError, FileNotFoundError):
         pass
     if not unit_name:

--- a/tests/gateway/test_shutdown_forensics_cgroup.py
+++ b/tests/gateway/test_shutdown_forensics_cgroup.py
@@ -1,0 +1,97 @@
+"""Regression coverage for systemd unit detection from /proc/self/cgroup."""
+
+from __future__ import annotations
+
+import builtins
+import io
+from types import SimpleNamespace
+
+import pytest
+
+from gateway import shutdown_forensics as sf
+
+
+def _patch_cgroup(monkeypatch: pytest.MonkeyPatch, content: str) -> None:
+    original_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/self/cgroup":
+            return io.StringIO(content)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+
+def test_transient_scope_does_not_resolve_parent_user_service(monkeypatch):
+    monkeypatch.setenv("INVOCATION_ID", "test-invocation")
+    _patch_cgroup(
+        monkeypatch,
+        "0::/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-worker-abc.scope\n",
+    )
+
+    def unexpected_systemctl(*args, **kwargs):
+        pytest.fail("systemctl should not be queried for a transient scope")
+
+    monkeypatch.setattr(sf.subprocess, "run", unexpected_systemctl)
+
+    assert sf.check_systemd_timing_alignment(180.0) is None
+
+
+def test_direct_service_leaf_is_queried(monkeypatch):
+    monkeypatch.setenv("INVOCATION_ID", "test-invocation")
+    _patch_cgroup(
+        monkeypatch,
+        "0::/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway.service\n",
+    )
+    calls = []
+
+    def fake_systemctl(args, **kwargs):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="TimeoutStopUSec=240000000\n")
+
+    monkeypatch.setattr(sf.subprocess, "run", fake_systemctl)
+
+    result = sf.check_systemd_timing_alignment(180.0)
+
+    assert result is not None
+    assert result["unit"] == "hermes-gateway.service"
+    assert result["mismatch"] is False
+    assert calls == [
+        [
+            "systemctl",
+            "--user",
+            "show",
+            "hermes-gateway.service",
+            "--property=TimeoutStopUSec",
+        ]
+    ]
+
+
+def test_delegated_subgroup_resolves_owning_service(monkeypatch):
+    monkeypatch.setenv("INVOCATION_ID", "test-invocation")
+    _patch_cgroup(
+        monkeypatch,
+        "0::/user.slice/user-1000.slice/user@1000.service/app.slice/hermes-gateway.service/worker\n",
+    )
+    calls = []
+
+    def fake_systemctl(args, **kwargs):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="TimeoutStopUSec=240000000\n")
+
+    monkeypatch.setattr(sf.subprocess, "run", fake_systemctl)
+
+    result = sf.check_systemd_timing_alignment(180.0)
+
+    assert result is not None
+    assert result["unit"] == "hermes-gateway.service"
+    assert result["mismatch"] is False
+    assert calls == [
+        [
+            "systemctl",
+            "--user",
+            "show",
+            "hermes-gateway.service",
+            "--property=TimeoutStopUSec",
+        ]
+    ]


### PR DESCRIPTION
Fixes #92819

`check_systemd_timing_alignment()` previously walked upward through `/proc/self/cgroup` until it found any `.service` component. When Hermes runs inside a transient `.scope`, that can resolve the parent `user@N.service` manager and produce a false stale-unit warning.

This keeps the reverse cgroup walk but stops at the nearest `.scope`. That preserves directly owned/delegated service detection (for example `hermes-gateway.service/worker`) while preventing a transient scope from being misattributed to an ancestor user manager.

Regression coverage now pins three cases:
- transient `.scope` does not query `systemctl`
- direct `hermes-gateway.service` leaf resolves normally
- delegated `hermes-gateway.service/worker` resolves the owning service

The touched source file also retains a final newline.