### PR TITLE
fix(agent): nudge reasoning-only turns toward final output

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1163,6 +1163,12 @@ _CODEX_INCOMPLETE_NUDGE = (
     "you were planning).]"
 )
 
+# Chat-completions reasoning-only turns are removed from the per-call wire copy
+# by _drop_thinking_only_and_merge_users (required for strict Anthropic-style
+# endpoints). A user-role continuation therefore has to survive that cleanup;
+# otherwise every "prefill" retry is byte-identical to the failed request.
+_THINKING_PREFILL_NUDGE = _CODEX_INCOMPLETE_NUDGE
+
 
 # Re-prompt sent after a Codex/Responses turn ends with an acknowledgment-only
 # reply (no tool calls, no final answer) — named so
@@ -7683,12 +7689,14 @@ def run_conversation(
                         })
                         continue
 
-                    # ── Thinking-only prefill continuation ──────────
+                    # ── Thinking-only continuation ──────────────────
                     # The model produced structured reasoning (via API
-                    # fields) but no visible text content.  Rather than
-                    # giving up, append the assistant message as-is and
-                    # continue — the model will see its own reasoning
-                    # on the next turn and produce the text portion.
+                    # fields) but no visible text content. Keep the assistant
+                    # message internally, then append an explicit user-role
+                    # continuation. The per-call sanitizer intentionally drops
+                    # thinking-only assistants for strict providers, so without
+                    # the user nudge this retry would resend the original request
+                    # byte-for-byte and deterministically repeat the failure.
                     # Inspired by clawdbot's "incomplete-text" recovery.
                     # Also covers Qwen3/Ollama in-content <think> blocks
                     # (detected above as _has_inline_thinking).
@@ -7714,6 +7722,11 @@ def run_conversation(
                         )
                         interim_msg["_thinking_prefill"] = True
                         append_message(messages, interim_msg)
+                        append_message(messages, {
+                            "role": "user",
+                            "content": _THINKING_PREFILL_NUDGE,
+                            "_thinking_prefill": True,
+                        })
                         agent._session_messages = messages
                         continue
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2059,6 +2059,10 @@ class AIAgent:
             and (
                 messages[-1].get("_empty_recovery_synthetic")
                 or messages[-1].get("_empty_terminal_sentinel")
+                or (
+                    messages[-1].get("_thinking_prefill")
+                    and messages[-1].get("role") == "user"
+                )
             )
         ):
             messages.pop()

--- a/tests/run_agent/test_thinking_prefill_trailing_turn.py
+++ b/tests/run_agent/test_thinking_prefill_trailing_turn.py
@@ -1,8 +1,8 @@
 """Regression test for the thinking-only prefill reaching the wire.
 
 A thinking-only response (reasoning tokens, no visible text) makes the loop
-append an empty assistant turn and re-send so the model continues its own
-reasoning. On providers that don't echo reasoning back, the API copy has its
+append an internal assistant turn plus a user-role continuation so the model
+finishes with visible output. On providers that don't echo reasoning back, the API copy has its
 reasoning fields stripped before ``_drop_thinking_only_and_merge_users`` runs,
 so the drop pass used to see a bare ``{"role": "assistant", "content": ""}``
 and let it through. Gemini rejects that with
@@ -103,27 +103,43 @@ class TestThinkingPrefillTrailingTurn:
             f"dropped before send. Got roles: {[m['role'] for m in final_request]}"
         )
 
-    def test_prefill_stubs_are_absent_from_the_wire_payload(self, loop_agent):
-        """The stubs should be gone entirely, not merely trailed by a nudge."""
-        loop_agent.client.chat.completions.create.side_effect = [
-            _thinking_only_response(),
-            _final_response(),
-        ]
+    def test_prefill_retry_explicitly_requests_visible_output(self, loop_agent):
+        """Dropping the thinking stub must not make the retry byte-identical."""
+        requests = []
+
+        def respond(**kwargs):
+            requests.append(kwargs["messages"])
+            if "Produce your final answer as plain text now" in str(
+                kwargs["messages"][-1].get("content", "")
+            ):
+                return _final_response()
+            return _thinking_only_response()
+
+        loop_agent.client.chat.completions.create.side_effect = respond
 
         with (
             patch.object(loop_agent, "_persist_session"),
             patch.object(loop_agent, "_save_trajectory"),
             patch.object(loop_agent, "_cleanup_task_resources"),
         ):
-            loop_agent.run_conversation("do the thing")
+            result = loop_agent.run_conversation("do the thing")
 
-        sent = _sent_messages(loop_agent.client.chat.completions.create, 1)
+        assert loop_agent.client.chat.completions.create.call_count == 2
+        assert requests[0] != requests[1]
+        sent = requests[1]
         empty_assistants = [
             m for m in sent
             if m.get("role") == "assistant" and not (m.get("content") or "").strip()
         ]
         assert not empty_assistants, (
             f"Empty assistant stub(s) reached the wire: {empty_assistants}"
+        )
+        assert "Produce your final answer as plain text now" in sent[-1]["content"]
+        assert result["final_response"] == "Here is the answer."
+        assert all(
+            "Produce your final answer as plain text now"
+            not in str(message.get("content", ""))
+            for message in result["messages"]
         )
 
     def test_internal_marker_never_reaches_the_wire(self, loop_agent):


### PR DESCRIPTION
## Summary

- make reasoning-only Chat Completions recovery send an explicit user-role continuation instead of replaying the same request
- keep the continuation and reasoning-prefill messages out of durable session history after recovery
- add an end-to-end loop regression that only returns visible output after receiving the continuation

## Root Cause

The reasoning-only recovery appended an internal assistant prefill and retried. However, the unconditional wire sanitizer removes thinking-only assistant messages for strict provider compatibility. The next request therefore became byte-identical to the original prompt, so providers such as 9Router could repeat reasoning-only completions through the entire retry budget without ever being asked to emit visible output.

The recovery now appends a synthetic user-role instruction that survives the sanitizer. Once the model returns content or a tool call, both pieces of recovery scaffolding are removed from the live and durable transcript.

## Verification

- `scripts/run_tests.sh tests/run_agent/test_thinking_prefill_trailing_turn.py tests/run_agent/test_thinking_only_sanitizer.py tests/run_agent/test_empty_response_recovery_persistence.py tests/run_agent/test_empty_terminal_reasoning_surface.py -q` (29 passed)
- `uv run ruff check agent/conversation_loop.py run_agent.py tests/run_agent/test_thinking_prefill_trailing_turn.py`
- mutation check: the new loop regression failed on the pre-fix implementation after six repeated reasoning-only calls, then passed with two calls after the fix

## Related Issue

N/A
