### PR TITLE
fix(whatsapp): recover silently stalled inbound sessions

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -455,6 +455,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             read_receipts if isinstance(read_receipts, bool)
             else str(read_receipts or "").strip().lower() in {"1", "true", "yes", "on"}
         )
+        self._inbound_stale_timeout_seconds = self._coerce_float_extra(
+            "inbound_stale_timeout_seconds", 600.0
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -648,7 +651,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
+                                desired_watchdog_ms = round(
+                                    getattr(self, "_inbound_stale_timeout_seconds", 600.0) * 1000
+                                )
+                                running_watchdog_ms = (
+                                    data.get("inboundWatchdog") or {}
+                                ).get("timeoutMs")
+                                config_matches = (
+                                    running_read_receipts == self._send_read_receipts
+                                    and running_watchdog_ms == desired_watchdog_ms
+                                )
                                 if (
                                     running_hash
                                     and disk_hash
@@ -664,7 +676,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 stale_reason = (
                                     f"running={running_hash or 'unversioned'}, disk={disk_hash}"
                                     if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
+                                    else "bridge config changed"
                                 )
                                 print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
@@ -694,6 +706,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
+            )
+            bridge_env["WHATSAPP_INBOUND_STALE_TIMEOUT_MS"] = str(
+                round(getattr(self, "_inbound_stale_timeout_seconds", 600.0) * 1000)
             )
             # Under multiplexing, the bridge subprocess runs with a copy of
             # os.environ that does NOT contain the secondary profile's .env

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -35,6 +35,7 @@ import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
   buildPollPayload,
+  createInboundActivityWatchdog,
   createReconnectScheduler,
   createVersionResolver,
   buildLocationPayload,
@@ -124,6 +125,13 @@ const CHUNK_DELAY_MS = parseInt(process.env.WHATSAPP_CHUNK_DELAY_MS || '300', 10
 // which pins the bridge's HTTP handler until the upstream aiohttp timeout
 // fires. Fail fast instead so the gateway can surface a real error and retry.
 const SEND_TIMEOUT_MS = parseInt(process.env.WHATSAPP_SEND_TIMEOUT_MS || '60000', 10);
+const inboundStaleTimeoutRaw = Number.parseInt(
+  process.env.WHATSAPP_INBOUND_STALE_TIMEOUT_MS || '600000',
+  10,
+);
+const INBOUND_STALE_TIMEOUT_MS = Number.isFinite(inboundStaleTimeoutRaw)
+  ? Math.max(0, inboundStaleTimeoutRaw)
+  : 600_000;
 
 // --- Send queue: serialise all sock.sendMessage() calls across concurrent
 //     HTTP handlers so a single Baileys socket never has overlapping sends.
@@ -388,6 +396,15 @@ function rememberSentId(id) {
 let sock = null;
 let connectionState = 'disconnected';
 
+const inboundWatchdog = createInboundActivityWatchdog({
+  timeoutMs: INBOUND_STALE_TIMEOUT_MS,
+  onStale: () => {
+    // A fresh socket in the same process can inherit a wedged Baileys receive
+    // pipeline, so let the gateway supervisor perform a process-level reset.
+    process.exit(1);
+  },
+});
+
 function emitPairEvent(event) {
   if (!PAIR_JSON) return;
   try {
@@ -402,7 +419,7 @@ async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
   const version = await getWAVersion();
 
-  sock = makeWASocket({
+  const socket = makeWASocket({
     ...(version ? { version } : {}),
     auth: state,
     logger,
@@ -418,10 +435,12 @@ async function startSocket() {
       return { conversation: '' };
     },
   });
+  sock = socket;
 
   sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });
 
   sock.ev.on('connection.update', (update) => {
+    if (sock !== socket) return;
     const { connection, lastDisconnect, qr } = update;
 
     if (qr) {
@@ -437,6 +456,7 @@ async function startSocket() {
     if (connection === 'close') {
       const reason = new Boom(lastDisconnect?.error)?.output?.statusCode;
       connectionState = 'disconnected';
+      inboundWatchdog.markDisconnected();
 
       if (reason === DisconnectReason.loggedOut) {
         emitPairEvent({ event: 'error', error: 'logged_out', reason });
@@ -458,6 +478,7 @@ async function startSocket() {
       }
     } else if (connection === 'open') {
       connectionState = 'connected';
+      inboundWatchdog.markConnected();
       const connectedUser = sock?.user
         ? {
             id: sock.user.id || null,
@@ -479,6 +500,8 @@ async function startSocket() {
   });
 
   sock.ev.on('messages.update', async (updates) => {
+    if (sock !== socket) return;
+    inboundWatchdog.markActivity();
     for (const { key, update } of updates || []) {
       if (!update?.pollUpdates) continue;
       const pollCreationId = key?.id || update.pollUpdates?.[0]?.pollCreationMessageKey?.id;
@@ -530,6 +553,8 @@ async function startSocket() {
   });
 
   sock.ev.on('messages.upsert', async ({ messages, type }) => {
+    if (sock !== socket) return;
+    inboundWatchdog.markActivity();
     // In self-chat mode, your own messages commonly arrive as 'append' rather
     // than 'notify'. Accept both and filter agent echo-backs below.
     if (type !== 'notify' && type !== 'append') return;
@@ -775,6 +800,10 @@ async function startSocket() {
         messageQueue.shift();
       }
     }
+  });
+
+  sock.ev.on('message-receipt.update', () => {
+    if (sock === socket) inboundWatchdog.markActivity();
   });
 }
 
@@ -1105,12 +1134,19 @@ app.get('/chat/:id', async (req, res) => {
 
 // Health check
 app.get('/health', (req, res) => {
+  const inboundHealth = inboundWatchdog.snapshot();
   res.json({
     status: connectionState,
     queueLength: messageQueue.length,
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
+    inboundWatchdog: {
+      timeoutMs: inboundHealth.timeoutMs,
+      lastActivityAt: inboundHealth.lastInboundActivityAt,
+      silentForMs: inboundHealth.silentForMs,
+      stale: inboundHealth.stale,
+    },
   });
 });
 
@@ -1150,6 +1186,7 @@ if (PAIR_ONLY) {
       console.log(`👤 WHATSAPP_FORWARD_OWNER_MESSAGES=true — owner-typed messages will be forwarded with fromOwner:true`);
     }
     console.log();
+    if (INBOUND_STALE_TIMEOUT_MS > 0) inboundWatchdog.start();
     scheduleReconnect(0);
   });
 }

--- a/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
@@ -16,12 +16,70 @@
 import { strict as assert } from 'node:assert';
 
 import {
+  createInboundActivityWatchdog,
   createReconnectScheduler,
   createVersionResolver,
 } from './bridge_helpers.js';
 
 const tick = () => new Promise(resolve => setImmediate(resolve));
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+// -- createInboundActivityWatchdog ----------------------------------------
+
+// A connected socket that stops producing inbound events is recovered once
+// the silence threshold is reached. Repeated checks do not trigger duplicate
+// process exits while the supervisor is still stopping the bridge.
+{
+  let now = 1_000;
+  const staleEvents = [];
+  const logs = [];
+  const watchdog = createInboundActivityWatchdog({
+    timeoutMs: 5_000,
+    nowFn: () => now,
+    onStale: event => staleEvents.push(event),
+    log: line => logs.push(line),
+  });
+
+  watchdog.markConnected();
+  now = 5_999;
+  assert.equal(watchdog.check(), false);
+  now = 6_000;
+  assert.equal(watchdog.check(), true);
+  assert.equal(staleEvents.length, 1);
+  assert.equal(staleEvents[0].silentForMs, 5_000);
+  assert.match(logs[0], /inbound activity stalled for 5s/);
+  assert.equal(watchdog.check(), false, 'stale recovery must be one-shot');
+}
+
+// Real inbound activity refreshes the deadline, while disconnected sockets
+// never trip regardless of how much wall time passes.
+{
+  let now = 10_000;
+  let staleCalls = 0;
+  const watchdog = createInboundActivityWatchdog({
+    timeoutMs: 2_000,
+    nowFn: () => now,
+    onStale: () => { staleCalls += 1; },
+    log: () => {},
+  });
+
+  watchdog.markConnected();
+  now = 11_500;
+  watchdog.markActivity();
+  now = 13_499;
+  assert.equal(watchdog.check(), false);
+  watchdog.markDisconnected();
+  now = 99_999;
+  assert.equal(watchdog.check(), false);
+  assert.equal(staleCalls, 0);
+  assert.deepEqual(watchdog.snapshot(), {
+    connected: false,
+    lastInboundActivityAt: null,
+    silentForMs: null,
+    timeoutMs: 2_000,
+    stale: false,
+  });
+}
 
 // -- createReconnectScheduler ---------------------------------------------
 

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -569,6 +569,85 @@ export function pollCreationMessageFromPayload(payload) {
 }
 
 /**
+ * Detect a Baileys socket whose connection stays open while its inbound event
+ * pipeline has gone silent. Keepalive responses only prove that the WebSocket
+ * is open; they do not prove that message events are still being delivered.
+ */
+export function createInboundActivityWatchdog({
+  timeoutMs,
+  checkIntervalMs = Math.min(30_000, timeoutMs),
+  nowFn = Date.now,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+  onStale,
+  log = console.log,
+}) {
+  let connected = false;
+  let lastInboundActivityAt = null;
+  let stale = false;
+  let timer = null;
+
+  function markConnected() {
+    connected = true;
+    stale = false;
+    lastInboundActivityAt = nowFn();
+  }
+
+  function markActivity() {
+    if (!connected) return;
+    stale = false;
+    lastInboundActivityAt = nowFn();
+  }
+
+  function markDisconnected() {
+    connected = false;
+    stale = false;
+    lastInboundActivityAt = null;
+  }
+
+  function snapshot() {
+    const silentForMs = connected && lastInboundActivityAt !== null
+      ? Math.max(0, nowFn() - lastInboundActivityAt)
+      : null;
+    return {
+      connected,
+      lastInboundActivityAt,
+      silentForMs,
+      timeoutMs,
+      stale,
+    };
+  }
+
+  function check() {
+    const state = snapshot();
+    if (!state.connected || stale || state.silentForMs < timeoutMs) return false;
+    stale = true;
+    log(`⚠️  WhatsApp inbound activity stalled for ${Math.round(state.silentForMs / 1000)}s; restarting bridge...`);
+    onStale({ ...state, stale: true });
+    return true;
+  }
+
+  function start() {
+    if (timer === null) timer = setIntervalFn(check, checkIntervalMs);
+  }
+
+  function stop() {
+    if (timer !== null) clearIntervalFn(timer);
+    timer = null;
+  }
+
+  return {
+    markConnected,
+    markActivity,
+    markDisconnected,
+    snapshot,
+    check,
+    start,
+    stop,
+  };
+}
+
+/**
  * Reconnect scheduling guard. startSocket() awaits network I/O before it
  * creates a socket or registers event handlers, so a bare
  * `setTimeout(startSocket, ...)` has two unrecoverable failure modes: a

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -54,6 +54,7 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
     adapter._bridge_process = None
     adapter._reply_prefix = None
     adapter._send_read_receipts = False
+    adapter._inbound_stale_timeout_seconds = 600.0
     adapter._running = False
     adapter._message_handler = None
     adapter._fatal_error_code = None
@@ -151,6 +152,40 @@ class TestStaleBridgeHandshake:
 
         mock_popen.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_when_inbound_watchdog_config_changed(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "scriptHash": disk_hash,
+                "sendReadReceipts": False,
+                "inboundWatchdog": {"timeoutMs": 300_000},
+            }
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()
+
 
 class TestDepRefreshStamp:
     @pytest.mark.asyncio
@@ -211,3 +246,4 @@ class TestCacheDirEnvPassthrough:
         assert env["HERMES_AUDIO_CACHE_DIR"] == str(get_audio_cache_dir())
         assert env["HERMES_DOCUMENT_CACHE_DIR"] == str(get_document_cache_dir())
         assert env["WHATSAPP_SEND_READ_RECEIPTS"] == "true"
+        assert env["WHATSAPP_INBOUND_STALE_TIMEOUT_MS"] == "600000"

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -238,6 +238,20 @@ gateway:
 
 Set `text_batch_delay_seconds: 0` to dispatch each message immediately (disables batching).
 
+### Inbound Activity Watchdog
+
+Baileys can rarely leave a socket connected for keepalives and outbound sends while inbound message events have stopped. The bridge tracks inbound message, update, and receipt events and exits after 10 minutes of connected silence so the gateway supervisor can start a clean process. Tune or disable the watchdog in `config.yaml`:
+
+```yaml
+gateway:
+  platforms:
+    whatsapp:
+      extra:
+        inbound_stale_timeout_seconds: 600  # set to 0 to disable
+```
+
+The bridge's `/health` response includes `inboundWatchdog.lastActivityAt`, `silentForMs`, `timeoutMs`, and `stale` for diagnostics. A shorter timeout recovers faster but can restart an otherwise healthy bridge during quiet periods.
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
## What does this PR do?

WhatsApp Baileys sessions can remain connected for keepalives and outbound sends after inbound message events silently stop, leaving users unable to reach the agent until the gateway is restarted. This change adds an inbound-activity watchdog that exposes its state through `/health` and exits a stale bridge after a configurable silence threshold so the existing gateway supervisor performs a clean process-level recovery.

### Symptom

`/health` continues to report `connected`, outbound sends still work, and the TCP connection remains established, but `messages.upsert` and other inbound events stop and `/messages` stays empty.

### Impact

Inbound WhatsApp messages can be silently lost until an operator restarts the gateway. The affected population is unknown; the reported environment reproduces the stall after every restart.

### Bug Cause

**Trigger:** `scripts/whatsapp-bridge/bridge.js:connection.update` only changes health and schedules reconnects after Baileys reports an explicit socket close.

**Causal chain:**
1. Baileys keeps its WebSocket and keepalive path open while its inbound event pipeline stops emitting message events.
2. The bridge receives no `connection: close` update, so `connectionState` remains `connected` and the reconnect scheduler is never invoked.
3. The gateway trusts `/health`, keeps polling an empty queue, and inbound messages never reach Hermes.

**Why it is wrong:** Transport-level liveness does not prove application-level inbound event delivery, but the bridge treated them as equivalent.

**Working sibling / contrast:** Explicit socket closes already enter `createReconnectScheduler`; the missing path is a connected socket whose inbound application events have stopped.

**Ruled out:** The report confirms one managed bridge process, current bridge sources, installed dependencies, active keepalives, and the existing reconnect-wedge fix, so orphaning, stale code, install failure, and ordinary disconnect handling do not explain the symptom.

### Fix

- Track `messages.upsert`, `messages.update`, and `message-receipt.update` activity for the current socket generation.
- After 10 minutes of connected silence, exit the Node bridge once so the gateway supervisor starts a fresh process instead of attempting an unreliable in-process socket recreation.
- Publish timeout, last-activity, silence, and stale state in `/health`.
- Add `gateway.platforms.whatsapp.extra.inbound_stale_timeout_seconds`; `0` disables the watchdog, and configuration changes restart a reused bridge.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/bridge_helpers.js` - add the deterministic inbound activity watchdog state machine.
- `scripts/whatsapp-bridge/bridge.js` - wire socket-generation activity, health diagnostics, and process-level recovery.
- `plugins/platforms/whatsapp/adapter.py` - pass the profile configuration into the bridge and restart reused bridges when it changes.
- `scripts/whatsapp-bridge/bridge.reconnect.test.mjs` - cover expiry, refresh, disconnected suppression, and one-shot recovery.
- `tests/gateway/test_whatsapp_stale_bridge.py` - cover configuration propagation and stale bridge replacement.
- `website/docs/user-guide/messaging/whatsapp.md` - document behavior, diagnostics, tuning, and disablement.

## How to Test

1. Run the Node bridge test suite and syntax checks.
2. Run the targeted gateway tests through the repository test wrapper.
3. In a paired real environment, allow a connected bridge to exceed the configured inbound silence threshold and confirm the gateway supervisor starts a fresh bridge process.

```bash
cd scripts/whatsapp-bridge
npm ci
node --test *.test.mjs
node --check bridge.js
node --check bridge_helpers.js

scripts/run_tests.sh tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_whatsapp_connect.py -q
```

Local result: 22 Node tests passed; 16 Python tests passed and 1 host-specific test was skipped on Windows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] `cli-config.yaml.example` update is N/A; the setting lives in the platform's open-ended `extra` mapping
- [x] `CONTRIBUTING.md` or `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] Tool description/schema updates are N/A; no model tool changed

## Screenshots / Logs

N/A. Automated tests cover the watchdog state transitions and adapter configuration handshake; real WhatsApp verification is delegated to the review environment.
