### PR TITLE
feat(desktop): default detached attachment picker to Downloads

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -211,6 +211,7 @@ import {
   electronProcessStartMarker,
   parentWatchdogEnv
 } from './parent-process-identity'
+import { resolvePickerStartPath } from './path-picker'
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
 import {
   buildRegistryProfileRoutes,
@@ -14045,18 +14046,20 @@ ipcMain.handle('hermes:selectPaths', async (_event, options: any = {}) => {
 
   let resolvedDefaultPath
 
-  if (options?.defaultPath) {
-    try {
+  try {
+    const requestedDefaultPath = resolvePickerStartPath(options, () => app.getPath('downloads'))
+
+    if (requestedDefaultPath) {
       // On a Windows host with a WSL backend the cwd may be a POSIX/WSL path;
       // bridge it to a UNC/drive form the native dialog can actually open.
       const bridged = IS_WINDOWS
-        ? resolvePickerDefaultPath(String(options.defaultPath), undefined, options?.profile)
-        : String(options.defaultPath)
+        ? resolvePickerDefaultPath(requestedDefaultPath, undefined, options?.profile)
+        : requestedDefaultPath
 
       resolvedDefaultPath = bridged ? path.resolve(bridged) : undefined
-    } catch {
-      resolvedDefaultPath = undefined
     }
+  } catch {
+    resolvedDefaultPath = undefined
   }
 
   const result = await dialog.showOpenDialog(mainWindow, {

--- a/apps/desktop/electron/path-picker.test.ts
+++ b/apps/desktop/electron/path-picker.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { resolvePickerStartPath } from './path-picker'
+
+test('resolvePickerStartPath uses Downloads only when the caller requests the fallback', () => {
+  const downloadsPath = vi.fn(() => '/Users/test/Downloads')
+
+  assert.equal(resolvePickerStartPath({ fallbackToDownloads: true }, downloadsPath), '/Users/test/Downloads')
+  assert.equal(resolvePickerStartPath({}, downloadsPath), undefined)
+  assert.equal(downloadsPath.mock.calls.length, 1)
+})
+
+test('resolvePickerStartPath keeps an explicit default path ahead of Downloads', () => {
+  const downloadsPath = vi.fn(() => '/Users/test/Downloads')
+
+  assert.equal(
+    resolvePickerStartPath({ defaultPath: '/Users/test/project', fallbackToDownloads: true }, downloadsPath),
+    '/Users/test/project'
+  )
+  assert.equal(downloadsPath.mock.calls.length, 0)
+})
+
+test('resolvePickerStartPath leaves native dialog behavior intact when Downloads cannot be resolved', () => {
+  assert.equal(
+    resolvePickerStartPath({ fallbackToDownloads: true }, () => ''),
+    undefined
+  )
+  assert.equal(
+    resolvePickerStartPath({ fallbackToDownloads: true }, () => {
+      throw new Error('Downloads unavailable')
+    }),
+    undefined
+  )
+})

--- a/apps/desktop/electron/path-picker.ts
+++ b/apps/desktop/electron/path-picker.ts
@@ -1,0 +1,23 @@
+interface PickerStartPathOptions {
+  defaultPath?: unknown
+  fallbackToDownloads?: unknown
+}
+
+export function resolvePickerStartPath(
+  options: PickerStartPathOptions,
+  downloadsPath: () => string
+): string | undefined {
+  if (options.defaultPath) {
+    return String(options.defaultPath)
+  }
+
+  if (options.fallbackToDownloads !== true) {
+    return undefined
+  }
+
+  try {
+    return downloadsPath() || undefined
+  } catch {
+    return undefined
+  }
+}

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.test.ts
@@ -248,6 +248,67 @@ describe('attachmentPreviewDataUrl', () => {
   })
 })
 
+describe('useComposerActions attachment picker defaults', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'hermesDesktop')
+    vi.clearAllMocks()
+    $connection.set(null)
+  })
+
+  it('requests the Downloads fallback for detached file, folder, and image pickers', async () => {
+    const selectPaths = vi.fn(async () => [] as string[])
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { selectPaths }
+    })
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '', requestGateway: vi.fn() })
+    )
+
+    await act(async () => {
+      await result.current.pickContextPaths('file')
+      await result.current.pickContextPaths('folder')
+      await result.current.pickImages()
+    })
+
+    expect(selectPaths).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ defaultPath: undefined, directories: false, fallbackToDownloads: true })
+    )
+    expect(selectPaths).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ defaultPath: undefined, directories: true, fallbackToDownloads: true })
+    )
+    expect(selectPaths).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ defaultPath: undefined, fallbackToDownloads: true })
+    )
+  })
+
+  it('keeps the session cwd as the requested attachment location', async () => {
+    const selectPaths = vi.fn(async () => [] as string[])
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { selectPaths }
+    })
+
+    const { result } = renderHook(() =>
+      useComposerActions({ activeSessionId: null, currentCwd: '/Users/test/project', requestGateway: vi.fn() })
+    )
+
+    await act(async () => {
+      await result.current.pickContextPaths('file')
+    })
+
+    expect(selectPaths).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: '/Users/test/project', fallbackToDownloads: true })
+    )
+  })
+})
+
 describe('useComposerActions native image drops', () => {
   afterEach(() => {
     Reflect.deleteProperty(window, 'hermesDesktop')

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -399,7 +399,8 @@ export function useComposerActions({
       const paths = await selectDesktopPaths({
         title: kind === 'file' ? 'Add files as context' : 'Add folders as context',
         defaultPath: currentCwd || undefined,
-        directories: kind === 'folder'
+        directories: kind === 'folder',
+        fallbackToDownloads: true
       })
 
       if (!paths?.length) {
@@ -540,6 +541,7 @@ export function useComposerActions({
     const paths = await selectDesktopPaths({
       title: copy.attachImages,
       defaultPath: currentCwd || undefined,
+      fallbackToDownloads: true,
       filters: [
         {
           name: t.composer.images,

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1320,6 +1320,8 @@ export interface HermesPreviewFileChanged {
 export interface HermesSelectPathsOptions {
   title?: string
   defaultPath?: string
+  /** Use the host Downloads directory only when defaultPath is absent. */
+  fallbackToDownloads?: boolean
   directories?: boolean
   multiple?: boolean
   /** Backend profile that produced defaultPath; Electron uses it for WSL gating. */


### PR DESCRIPTION
## What does this PR do?

A detached Desktop chat has no workspace or cwd, so its attach dialog currently receives no starting path and opens wherever the OS last left it. This change starts the Files, Folders, and Images pickers in the host Downloads directory for that case.

If the session has a cwd, that path still wins. The Downloads fallback is opt-in from the composer, so other native pickers such as Open Folder and profile import keep their current behavior. Existing Windows and WSL path handling is unchanged.

## Related Issue

Fixes #91074

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/hooks/use-composer-actions.ts`: opt the Files, Folders, and Images attachment actions into the Downloads fallback.
- `apps/desktop/electron/path-picker.ts`: keep an explicit cwd first, use Downloads only when requested, and fall back to native dialog behavior if Downloads cannot be resolved.
- `apps/desktop/electron/main.ts`: apply the selected start path before the existing Windows/WSL path conversion.
- Tests cover detached sessions, sessions with a cwd, non-opted-in pickers, and failed Downloads resolution.

## How to Test

1. Open a new Desktop chat without attaching a workspace.
2. Open the Files, Folders, and Images attachment pickers. Each native dialog should start in Downloads.
3. Open a chat with a workspace cwd and open the same pickers. Each dialog should still start in that cwd.
4. Run:

```text
npm --workspace apps/desktop run test:ui -- src/app/chat/hooks/use-composer-actions.test.ts src/lib/desktop-fs.test.ts src/store/projects.test.ts
npm --workspace apps/desktop run test:desktop:platforms -- electron/path-picker.test.ts electron/wsl-path-bridge.test.ts
npm --workspace apps/desktop run typecheck
npm --workspace apps/desktop run lint
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; this is a Desktop TypeScript-only change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.1 with the focused Desktop tests, full UI suite, typecheck, and ESLint

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; the existing attach action keeps the same user-facing controls
- [x] I've updated `cli-config.yaml.example` — N/A; no config key was added
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the existing Windows/WSL conversion remains in place
- [x] I've updated tool descriptions/schemas — N/A; no model tool changed

## For New Skills

N/A

## Screenshots / Logs

Automated validation on the latest `main` base:

```text
Focused UI tests:       72 passed
Focused Electron tests: 16 passed
Full Desktop UI suite:  5,469 passed
Desktop typecheck:      passed
Desktop ESLint:         0 errors
Prettier / diff check:  passed
```

The full Electron suite also passed 1,600 tests with 3 skipped. One untouched macOS process-wrapper case in `electron/remote-lifecycle.test.ts` failed locally; the attachment picker and WSL suites passed in every run.
