### PR TITLE
fix(desktop): define the missing activeBotRoute helper

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4593,6 +4593,33 @@ function persistBotMetaSnapshot(value, scoped = false) {
 
 /** Immutable owner descriptor for every source-scoped row. The active
  *  gateway is presentation state and is never consulted here. */
+/** The ACTIVE window's bot route, or null when the window rides the
+ *  unscoped local backend. Resolved from the freshest cached union roster:
+ *  the row whose name matches the live profile carries its route. Callers
+ *  fall back to the unscoped local path on null (#92830: useRoster and the
+ *  Bot Mode sweep called this without a definition, so every roster attempt
+ *  died on ReferenceError and `retry: true` spun the Bots pane forever).
+ *  Best-effort: any cache hiccup degrades to null (unscoped local), which
+ *  is the pre-#90006 behavior. */
+async function activeBotRoute() {
+  const profile = String(host.state.profile?.get?.() || 'default').trim() || 'default'
+
+  try {
+    const cached = cachedUnionRoster()
+    const profiles = Array.isArray(cached?.profiles) ? cached.profiles : []
+    const row = profiles.find(row => row?.name === profile)
+
+    if (row?.route) {
+      return { ...row.route }
+    }
+  } catch {
+    /* cache hiccup — fall through to unscoped local */
+  }
+
+  return null
+}
+
+
 function botConnectionRoute(bot) {
   if (!bot?.sourceScoped && !bot?.remoteSource) {
     return null

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -32,7 +32,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;'
+      '\nglobalThis.__mergeMultiSourceRoster = mergeMultiSourceRoster;\nglobalThis.__botHandle = botHandle;\nglobalThis.__botRosterKey = botRosterKey;\nglobalThis.__botRosterMeta = botRosterMeta;\nglobalThis.__displayName = displayName;\nglobalThis.__filterBots = filterBots;\nglobalThis.__resolveRosterMentions = resolveRosterMentions;\nglobalThis.__activeBotRoute = activeBotRoute;'
     )
   vm.runInNewContext(code, context)
   return context
@@ -660,4 +660,19 @@ test('resolveRosterMentions: @hermes in this chat is not a handoff to yourself',
 
   assert.equal(hits.length, 1)
   assert.equal(hits[0].connectionId, 'mac-mini')
+})
+
+
+test('#92830 activeBotRoute: defined, and null when no roster cache exists', async () => {
+  const { __activeBotRoute } = runtime()
+
+  assert.equal(typeof __activeBotRoute, 'function')
+
+  // No cached union roster in this harness (queryClient is undefined in the
+  // VM context, which cachedUnionRoster tolerates): the route must resolve
+  // to null so callers fall back to the unscoped local path — NOT throw the
+  // ReferenceError that blanked the Bots pane.
+  const route = await __activeBotRoute()
+
+  assert.equal(route, null)
 })


### PR DESCRIPTION
## Summary

Fixes #92830: `useRoster`'s queryFn and `sweepBotProfileSessions` call `activeBotRoute()` on the roster hot path, but no definition ever landed — every roster attempt dies on `ReferenceError`, and because the query is configured `retry: true` (unbounded backoff), the Bots pane spins forever and the plugin's own error card is unreachable. The Bot Mode session sweep also dies silently inside its `try/catch`.

## Fix

Defines `activeBotRoute()` as an async resolver over the freshest cached union roster:

- The cached row matching the live profile carries its route (`{ connectionId, mode, profile, targetProfile }`).
- A cache miss or hiccup degrades to `null` — callers fall back to the unscoped local path, which is the pre-#90006 behavior — so a transient cache state can never blank the pane.

## Validation

- Regression test in `multi-source-roster.test.mjs`: `activeBotRoute` is defined and resolves to `null` with no cached roster (the exact condition that previously threw). 22/22 tests pass in the file via `node --test`.
- Atomic commits: helper definition → regression test.
