### PR TITLE
fix(telegram): admit allowed bot senders early

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1257,6 +1257,7 @@ class TelegramAdapter(BasePlatformAdapter):
         user = getattr(message, "from_user", None)
         chat = getattr(message, "chat", None)
         user_id = str(getattr(user, "id", "")).strip() or None
+        is_bot = bool(getattr(user, "is_bot", False)) if user is not None else False
         user_name = (
             str(getattr(user, "username", "") or getattr(user, "full_name", "") or "").strip()
             or None
@@ -1302,6 +1303,7 @@ class TelegramAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_id,
+            is_bot=is_bot,
         )
 
     def _source_from_reaction_for_auth(self, update):
@@ -1424,6 +1426,16 @@ class TelegramAdapter(BasePlatformAdapter):
         # they carry no authorizable identity, so let the normal
         # _should_process_message gating handle them.
         if not user_id:
+            return True
+
+        # Match AuthzMixin's bot-policy branch before the human allowlist.
+        # In multiplex mode the profile-scoped message handler is a closure, so
+        # ``__self__`` is absent and the runner auth mixin may be unreachable at
+        # this early intake gate. Bot-authored Telegram messages must still obey
+        # TELEGRAM_ALLOW_BOTS=mentions/all instead of being treated as humans.
+        if getattr(source, "is_bot", False) and _scoped_gate_env(
+            "TELEGRAM_ALLOW_BOTS", "none"
+        ).lower().strip() in {"mentions", "all"}:
             return True
 
         authorized: Optional[bool] = None

--- a/tests/gateway/test_telegram_auth_check.py
+++ b/tests/gateway/test_telegram_auth_check.py
@@ -47,7 +47,9 @@ def _make_adapter(allow_from=None, allowed_chats=None, group_allowed_chats=None,
     return adapter
 
 
-def _make_message(text="hello", *, from_user_id=111, chat_id=-100, chat_type="group"):
+def _make_message(
+    text="hello", *, from_user_id=111, chat_id=-100, chat_type="group", is_bot=False
+):
     return SimpleNamespace(
         message_id=42,
         text=text,
@@ -57,7 +59,12 @@ def _make_message(text="hello", *, from_user_id=111, chat_id=-100, chat_type="gr
         message_thread_id=None,
         is_topic_message=False,
         chat=SimpleNamespace(id=chat_id, type=chat_type, title="Test", is_forum=False),
-        from_user=SimpleNamespace(id=from_user_id, full_name="Test User", first_name="Test"),
+        from_user=SimpleNamespace(
+            id=from_user_id,
+            full_name="Test User",
+            first_name="Test",
+            is_bot=is_bot,
+        ),
         reply_to_message=None,
         date=None,
         location=None,
@@ -370,3 +377,31 @@ def test_multiplex_closure_handler_without_callback_falls_back_to_env(monkeypatc
     assert adapter._is_user_authorized_from_message(
         _make_message(from_user_id=555, chat_id=-100123, chat_type="group")
     ) is False
+
+
+def test_bot_authored_message_allowed_under_multiplex_closure_handler(monkeypatch):
+    """TELEGRAM_ALLOW_BOTS must survive the multiplex closure handler shape."""
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+
+    adapter = _make_adapter()
+    adapter._message_handler = lambda event: None  # closure, no __self__
+    assert getattr(adapter._message_handler, "__self__", None) is None
+
+    msg = _make_message(from_user_id=999, chat_id=-100123, chat_type="group", is_bot=True)
+
+    assert adapter._source_from_message_for_auth(msg).is_bot is True
+    assert adapter._is_user_authorized_from_message(msg) is True
+
+
+def test_allow_bots_does_not_authorize_human_under_multiplex_closure(monkeypatch):
+    """Bot policy is not a human allowlist bypass."""
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "all")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+
+    adapter = _make_adapter()
+    adapter._message_handler = lambda event: None  # closure, no __self__
+    msg = _make_message(from_user_id=999, chat_id=-100123, chat_type="group", is_bot=False)
+
+    assert adapter._source_from_message_for_auth(msg).is_bot is False
+    assert adapter._is_user_authorized_from_message(msg) is False


### PR DESCRIPTION
## Summary
Telegram early intake authorization built a `SessionSource` without preserving `from_user.is_bot`, then fell back to the human allowlist when the multiplex profile handler was a closure with no `__self__`. That meant bot-authored messages were rejected before the normal gateway bot policy could admit them, even when `TELEGRAM_ALLOW_BOTS` was `mentions` or `all`. This PR carries the Telegram sender's bot bit into the auth source and mirrors `AuthzMixin`'s bot-policy branch at the early prefilter before applying the human allowlist.

## Changes
plugins/platforms/telegram/adapter.py: propagates `message.from_user.is_bot` into `_source_from_message_for_auth()` and admits bot-authored messages early when scoped `TELEGRAM_ALLOW_BOTS` resolves to `mentions` or `all`.
tests/gateway/test_telegram_auth_check.py: extends the Telegram message fixture with `is_bot`, adds a multiplex-closure regression for allowed bot-authored messages, and adds a negative human-sender case proving bot policy does not bypass the human allowlist.

## How to Test
python -m pytest tests/gateway/test_telegram_auth_check.py tests/gateway/test_telegram_bot_auth_bypass.py -q
# ✅ 17/17 passed
ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_auth_check.py tests/gateway/test_telegram_bot_auth_bypass.py
# ✅ passed
git diff --check
# ✅ passed
python scripts/check-windows-footguns.py --diff upstream/main
# ✅ passed
scripts/run_tests.sh
# ⚠️ Termux runner/environment failure: 3197 PermissionError/permission-denied patterns in the full-suite log

## Notes
An open PR (#91483) also mentions `TELEGRAM_ALLOW_BOTS`, but it changes `gateway/authz_mixin.py` to add bot-loop protection for #91481. This PR is separate and scoped to Telegram adapter early-auth intake for #92840.

## Checklist
- [x] Targeted tests pass — 17/17
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

## Risk & Impact
Low. The new bypass only applies when Telegram marks the sender as a bot and the existing bot policy explicitly allows bots; human senders still go through the existing allowlist path.
Type: Bug fix
Closes: #92840
