### PR TITLE
fix(compression): -900k Codex variants keep the global 50% threshold; 85% autoraise stays on 272K bases

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -678,11 +678,19 @@ def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = Non
     ``compression.codex_gpt55_autoraise`` config key.) The exact
     ``gpt-daybreak-blue-latest`` Codex slug is also a verified Sol-family
     alias and receives the same autoraise.
+
+    ``-900k`` large-context picker variants are explicitly EXCLUDED: the
+    85% autoraise exists to stop wasting a small 272K window, and a 900K
+    window doesn't have that problem — those sessions keep the user's
+    global ``compression.threshold`` (default 50%, ~450K).
     """
     prov = (provider or "").strip().lower()
     if prov != "openai-codex":
         return False
     bare = (model or "").strip().lower().rsplit("/", 1)[-1]
+    from agent.model_metadata import is_codex_context_variant
+    if is_codex_context_variant(bare):
+        return False
     return (
         bare == "gpt-5.4"
         or bare.startswith("gpt-5.4-")

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -96,6 +96,31 @@ def test_compression_threshold_for_codex_gpt55() -> None:
     assert _compression_threshold_for_model("gpt-daybreak-blue-latest", "openai-codex") == 0.85
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5.6-sol-900k",
+        "gpt-5.6-terra-900k",
+        "gpt-5.6-luna-900k",
+        "gpt-5.4-900k",
+        "gpt-daybreak-blue-latest-900k",
+        "openai/gpt-5.6-sol-900k",
+    ],
+)
+def test_900k_variants_keep_global_threshold(model) -> None:
+    """The 85% autoraise compensates for the small 272K window; ``-900k``
+    opt-in variants run at ~900K, so they keep the user's global
+    ``compression.threshold`` (default 50%) — no override returned."""
+    assert _is_codex_gpt54_or_gpt55(model, "openai-codex") is False
+    assert _compression_threshold_for_model(model, "openai-codex") is None
+
+
+def test_base_slugs_still_autoraised_alongside_900k_variants() -> None:
+    """Sanity pair: the base slug autoraises while its variant does not."""
+    assert _compression_threshold_for_model("gpt-5.6-sol", "openai-codex") == 0.85
+    assert _compression_threshold_for_model("gpt-5.6-sol-900k", "openai-codex") is None
+
+
 
 
 

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -208,6 +208,11 @@ the model id is sent to the backend, and pricing/usage accounting treats them
 as the base model. Slugs that genuinely enforce 272K (gpt-5.5, gpt-5.4-mini)
 have no `-900k` variant.
 
+Compaction thresholds follow the window: base slugs (272K) get the **85%
+autoraise** described above, while `-900k` variants keep your global
+`compression.threshold` (default 50%, ~450K) — the autoraise exists to stop
+wasting a small window, which a 900K window doesn't need.
+
 ### Codex app-server thread compaction
 
 Codex app-server sessions (`api_mode: codex_app_server` — the codex CLI/agent


### PR DESCRIPTION
## Summary
Compaction now follows the window: `-900k` Codex picker variants keep the user's global `compression.threshold` (default 50%, ~450K), while the 272K base slugs keep the 85% autoraise (~231K trigger).

The 85% autoraise exists to stop wasting the small advertised 272K window. After #92797 the large window is an explicit `-900k` opt-in — autoraising those sessions to 85% (~765K) would delay compaction far past what the user configured, so they get the organic default instead.

## Changes
- `agent/auxiliary_client.py`: `_is_codex_gpt54_or_gpt55()` excludes valid `-900k` variants (via `is_codex_context_variant`), so both the 85% threshold override and the one-time autoraise notice skip large-context sessions. Base slugs unchanged.
- `tests/agent/test_arcee_trinity_overrides.py`: variant/base threshold pairs incl. vendor-namespaced ids.
- Docs: threshold note in the `-900k` section of `context-compression-and-caching.md`.

## Validation
| Model (openai-codex) | Threshold override |
|---|---|
| `gpt-5.6-sol` (272K) | 0.85 (unchanged) |
| `gpt-5.6-sol-900k` | None → global 50% |
| `gpt-5.4-900k` | None → global 50% |
| `gpt-5.5` | 0.85 (unchanged) |

38 targeted tests pass (autoraise predicate, notice gating, plugin-engine suppression) plus real-import E2E of the threshold resolver.

## Infographic

![Compaction follows the window](https://v3b.fal.media/files/b/0aa779c4/89p-eXPqOibMzNpcQ0seE_tlKvTOuI.png)
