### PR TITLE
fix: materialize command tokens for auxiliary clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6652,6 +6652,13 @@ def resolve_provider_client(
                 custom_key = build_command_token_provider(
                     custom_key_cmd, custom_entry.get("name") or provider
                 ) or custom_key
+            # OpenAI's client constructor expects a concrete string and calls
+            # ``strip()`` on it. Main-agent clients support a callable
+            # credential, but auxiliary clients are created per task, so mint
+            # the command credential at this boundary instead of passing the
+            # CommandTokenSource object into the SDK.
+            if callable(custom_key) and not isinstance(custom_key, str):
+                custom_key = custom_key()
             custom_key = custom_key or "no-key-required"
             if custom_key == "no-key-required":
                 logger.warning(

--- a/tests/agent/test_auxiliary_key_cmd_callable.py
+++ b/tests/agent/test_auxiliary_key_cmd_callable.py
@@ -1,0 +1,39 @@
+"""Regression: named custom providers may supply callable key_cmd credentials."""
+
+
+def test_named_custom_provider_mints_key_cmd_before_openai_client(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+    import agent.command_token_source as command_token_source
+    import hermes_cli.runtime_provider as runtime_provider
+
+    minted_key = lambda: "minted-token"
+    captured = {}
+
+    monkeypatch.setattr(
+        runtime_provider,
+        "_get_named_custom_provider",
+        lambda _provider: {
+            "name": "CLI Proxy API",
+            "base_url": "https://proxy.example/v1",
+            "api_mode": "chat_completions",
+            "model": "gpt-5.6-terra",
+            "key_cmd": "mint-key",
+        },
+    )
+    monkeypatch.setattr(
+        command_token_source,
+        "build_command_token_provider",
+        lambda *_args: minted_key,
+    )
+    monkeypatch.setattr(
+        auxiliary_client,
+        "_create_openai_client",
+        lambda **kwargs: captured.update(kwargs) or object(),
+    )
+
+    _client, model = auxiliary_client.resolve_provider_client(
+        "custom:cli-proxy-api", "gpt-5.6-terra"
+    )
+
+    assert model == "gpt-5.6-terra"
+    assert captured["api_key"] == "minted-token"


### PR DESCRIPTION
## Summary

Named custom providers can configure `key_cmd`, which resolves to a callable `CommandTokenSource`. The main-agent client supports callable credentials, but auxiliary OpenAI clients receive the object directly and the SDK calls `.strip()` on it.

This breaks auxiliary tasks such as vision analysis and title generation with:

`CommandTokenSource object has no attribute strip`

## Fix

Materialize the callable only at the auxiliary OpenAI client boundary. The resolver contract remains callable, preserving per-request token refresh behavior for other paths.

## Tests

- `tests/agent/test_auxiliary_key_cmd_callable.py`
- `tests/tools/test_vision_tools.py`
- `pytest-asyncio` enabled
- `38 passed`
- `compileall` passed

Closes the auxiliary custom-provider credential type mismatch.