### PR TITLE
fix(desktop): localize the Bot Mode roster context menu

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -7855,6 +7855,75 @@ function botRowOwnsWorkspace(
 
 // ── bot row ──────────────────────────────────────────────────────────────────
 
+/**
+ * Bot-row context-menu copy (#91667) — the menu was hardcoded English while
+ * the rest of the app follows `display.language`. Registered under the plugin
+ * id via `ctx.i18n.register` (same channel as kanban); resolution follows the
+ * app's active locale with an English fallback, so locales this bundle
+ * doesn't ship keep today's strings.
+ */
+const BOT_ROW_MENU_LOCALES = {
+  en: {
+    pinTop: 'Pin to top',
+    unpin: 'Unpin',
+    hideBot: 'Hide',
+    unhideBot: 'Unhide',
+    editProfile: 'Edit Profile',
+    manageGroups: 'Manage groups…',
+    groups: names => `Groups: ${names.join(', ')}…`,
+    duplicate: 'Duplicate',
+    newChat: 'New chat with this agent',
+    delete: 'Delete'
+  },
+  ja: {
+    pinTop: 'ピン留め',
+    unpin: 'ピン留めを解除',
+    hideBot: 'ボットを非表示',
+    unhideBot: 'ボットを再表示',
+    editProfile: 'プロフィールを編集',
+    manageGroups: 'グループを管理…',
+    groups: names => `グループ：${names.join('、')}…`,
+    duplicate: '複製',
+    newChat: '新しいチャット',
+    delete: '削除'
+  },
+  zh: {
+    pinTop: '置顶',
+    unpin: '取消置顶',
+    hideBot: '隐藏机器人',
+    unhideBot: '取消隐藏机器人',
+    editProfile: '编辑资料',
+    manageGroups: '管理群组…',
+    groups: names => `群组：${names.join('、')}…`,
+    duplicate: '复制',
+    newChat: '新建对话',
+    delete: '删除'
+  },
+  'zh-hant': {
+    pinTop: '釘選',
+    unpin: '取消釘選',
+    hideBot: '隱藏機器人',
+    unhideBot: '取消隱藏機器人',
+    editProfile: '編輯資料',
+    manageGroups: '管理群組…',
+    groups: names => `群組：${names.join('、')}…`,
+    duplicate: '複製',
+    newChat: '新建對話',
+    delete: '刪除'
+  }
+}
+
+const botRowMenuEn = (key, ...args) => {
+  const value = BOT_ROW_MENU_LOCALES.en[key] ?? key
+  return typeof value === 'function' ? value(...args) : value
+}
+
+/** Reactive menu translator: plugin i18n when the SDK ships it, English
+ *  literals on older SDK builds (keeps today's behavior). A module constant,
+ *  so BotRow's call below stays an unconditional hook call. */
+const useBotRowMenuT =
+  typeof sdk === 'undefined' || typeof sdk.usePluginI18n !== 'function' ? () => botRowMenuEn : sdk.usePluginI18n
+
 function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
   const activeProfile = useValue(host.state.profile)
   const focusedOwner = focusedRosterOwner(useValue($focusedBotOwner))
@@ -7868,6 +7937,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
   const pinned = isBotPinned(bot, allMeta)
   const sourceStatus = botSourceStatus(bot)
   const groups = botGroups(meta)
+  const t = useBotRowMenuT(ID)
   const last = bot.last_session
   // Highlight follows the chat on screen (focused session's owner), not the
   // gateway socket's home — a focused tab doesn't swap the socket, and on the
@@ -8098,7 +8168,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
                 })
               }).catch(error => host.notifyError?.(error, 'Could not load bot metadata'))
             },
-            children: pinned ? 'Unpin' : 'Pin to top'
+            children: pinned ? t('unpin') : t('pinTop')
           }),
           jsx(ContextMenuItem, {
             onSelect: () => {
@@ -8118,16 +8188,16 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
                 })
               }).catch(error => host.notifyError?.(error, 'Could not load bot metadata'))
             },
-            children: hidden ? 'Unhide' : 'Hide'
+            children: hidden ? t('unhideBot') : t('hideBot')
           }),
           jsx(ContextMenuSeparator, {}),
           jsx(ContextMenuItem, {
             onSelect: () => void ensureBotMetadata(bot).then(() => onEdit(bot)).catch(error => host.notifyError?.(error, 'Could not load bot')),
-            children: 'Edit Profile'
+            children: t('editProfile')
           }),
           jsx(ContextMenuItem, {
             onSelect: () => void ensureBotMetadata(bot).then(() => onGroup(bot)).catch(error => host.notifyError?.(error, 'Could not load bot groups')),
-            children: groups.length ? `Groups: ${groups.join(', ')}…` : 'Manage groups…'
+            children: groups.length ? t('groups', groups) : t('manageGroups')
           }),
           jsx(ContextMenuItem, {
             onSelect: () => {
@@ -8139,7 +8209,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
                 })
                 .catch(err => host.notifyError(err, 'Duplicate failed'))
             },
-            children: 'Duplicate'
+            children: t('duplicate')
           }),
           jsx(ContextMenuSeparator, {}),
           jsx(ContextMenuItem, {
@@ -8148,7 +8218,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
               setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
               newBotChat(bot)
             },
-            children: 'New chat with this agent'
+            children: t('newChat')
           }),
           isDefaultBot(bot) ? null : jsx(ContextMenuSeparator, {}),
           isDefaultBot(bot)
@@ -8156,7 +8226,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
             : jsx(ContextMenuItem, {
                 onSelect: () => onDelete(bot),
                 variant: 'destructive',
-                children: 'Delete'
+                children: t('delete')
               })
         ]
       })
@@ -14405,6 +14475,13 @@ export default {
     if (typeof ctx.onDispose === 'function') {
       ctx.onDispose(stopFaceClock)
       ctx.onDispose(stopBotRelay)
+    }
+
+    // Bot-row context-menu copy (#91667): ship the strings with the plugin
+    // under its own id — same channel as kanban, no core en.ts edits. The
+    // guard keeps older hosts without the plugin-i18n surface on English.
+    if (ctx.i18n && typeof ctx.i18n.register === 'function') {
+      ctx.i18n.register(BOT_ROW_MENU_LOCALES)
     }
 
     // @-mention autocomplete: typing "@rese…" in ANY composer offers the

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
@@ -218,7 +218,7 @@ test('integration: a deleted bot is removed from plugin-local state and the rost
 })
 
 test('regression: the bot context menu exposes a destructive delete action and confirmation', () => {
-  assert.match(pluginSource, /ContextMenuItem, \{[\s\S]*?variant: 'destructive'[\s\S]*?children: 'Delete'/)
+  assert.match(pluginSource, /ContextMenuItem, \{[\s\S]*?variant: 'destructive'[\s\S]*?children: t\('delete'\)/)
   assert.match(pluginSource, /isDefaultBot\(bot\) \? null : jsx\(ContextMenuSeparator/)
   assert.match(pluginSource, /ConfirmDialog/)
   assert.match(pluginSource, /title: 'Delete bot and profile\?'/)

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
@@ -202,7 +202,7 @@ test('shape: Hidden section renders only when recovery is relevant', () => {
 test('shape: revealed hidden rows are flagged and can be restored', () => {
   const botRow = pluginSource.slice(pluginSource.indexOf('function BotRow('), pluginSource.indexOf('// ── model picker'))
   assert.match(botRow, /name: 'eye-closed'/)
-  assert.match(botRow, /children: hidden \? 'Unhide' : 'Hide'/)
+  assert.match(botRow, /children: hidden \? t\('unhideBot'\) : t\('hideBot'\)/)
   assert.match(botRow, /saveBotMeta\(bot, \{ hidden: !hidden \}\)/)
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -50,6 +50,10 @@ function renderBotRow(input = 'alpha') {
     Codicon: 'Codicon',
     Tip: 'Tip',
     ROSTER_KEY: ['hermes-bots', 'roster'],
+    ID: 'hermes-bots',
+    // The plugin's real hook resolves menu copy via the i18n registry; the
+    // sliced BotRow only exercises structure/behavior, so translate to keys.
+    useBotRowMenuT: () => key => key,
     $botMeta: atom({}),
     $botUnread: atom({}),
     $botAttention: atom({}),
@@ -249,6 +253,8 @@ test('behavior: remote default never opens the same-name local chat', async () =
     Codicon: 'Codicon',
     Tip: 'Tip',
     ROSTER_KEY: ['hermes-bots', 'roster'],
+    ID: 'hermes-bots',
+    useBotRowMenuT: () => key => key,
     $botMeta: atom({ default: { chat: 'this-device-chat' } }),
     $botUnread: atom({}),
     $botAttention: atom({}),

--- a/apps/desktop/src/plugins/hermes-bots/tests/roster-menu-i18n.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/roster-menu-i18n.test.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Bot-row context-menu i18n (#91667): the right-click menu was hardcoded
+// English while the app honors display.language. The plugin ships en/zh
+// bundles under its own id via ctx.i18n.register (the kanban channel) and
+// keeps working on hosts without that surface.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const atom = initial => {
+    const slot = { get: () => current, set: value => (current = value) }
+    let current = initial
+    return slot
+  }
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware', atCompletions: 'atCompletions' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        gateway: { get: () => 'open', listen: () => undefined }
+      },
+      request: async () => ({}),
+      notify: () => undefined
+    },
+    sdk: new Proxy({}, { get: () => undefined })
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context.plugin
+}
+
+function registerWithI18n() {
+  const registered = []
+  const ctx = {
+    storage: { get: () => null, set: () => undefined },
+    register: () => undefined,
+    i18n: { register: bundles => registered.push(bundles) }
+  }
+  load().register(ctx)
+  return registered
+}
+
+const MENU_KEYS = [
+  'pinTop',
+  'unpin',
+  'hideBot',
+  'unhideBot',
+  'editProfile',
+  'manageGroups',
+  'groups',
+  'duplicate',
+  'newChat',
+  'delete'
+]
+
+test('register ships the bot-row menu bundles under the plugin i18n channel', () => {
+  const registered = registerWithI18n()
+
+  assert.equal(registered.length, 1)
+  const bundles = registered[0]
+  for (const locale of ['en', 'ja', 'zh', 'zh-hant']) {
+    assert.ok(bundles[locale], `${locale} bundle registered`)
+    for (const key of MENU_KEYS) {
+      assert.ok(key in bundles[locale], `${locale}.${key} present`)
+    }
+  }
+})
+
+test('zh bundle replaces every hardcoded menu label', () => {
+  const { zh } = registerWithI18n()[0]
+
+  assert.equal(zh.pinTop, '置顶')
+  assert.equal(zh.unpin, '取消置顶')
+  assert.equal(zh.hideBot, '隐藏机器人')
+  assert.equal(zh.unhideBot, '取消隐藏机器人')
+  assert.equal(zh.editProfile, '编辑资料')
+  assert.equal(zh.manageGroups, '管理群组…')
+  assert.equal(zh.duplicate, '复制')
+  assert.equal(zh.newChat, '新建对话')
+  assert.equal(zh.delete, '删除')
+  assert.equal(typeof zh.groups, 'function')
+  assert.equal(zh.groups(['a', 'b']), '群组：a、b…')
+})
+
+test('zh-hant and ja bundles align with the core glossary', () => {
+  const bundles = registerWithI18n()[0]
+
+  assert.equal(bundles['zh-hant'].pinTop, '釘選')
+  assert.equal(bundles['zh-hant'].unpin, '取消釘選')
+  assert.equal(bundles['zh-hant'].delete, '刪除')
+  assert.equal(bundles.ja.pinTop, 'ピン留め')
+  assert.equal(bundles.ja.unpin, 'ピン留めを解除')
+  assert.equal(bundles.ja.delete, '削除')
+})
+
+test('register does not require ctx.i18n (older hosts stay on English)', () => {
+  // Same shape as the other vm tests: a ctx with no i18n surface must not
+  // throw during registration.
+  assert.doesNotThrow(() => {
+    load().register({ storage: { get: () => null, set: () => undefined }, register: () => undefined })
+  })
+})
+
+test('menu items resolve through the translator, not literals', () => {
+  const botRow = pluginSource.slice(pluginSource.indexOf('function BotRow('), pluginSource.indexOf('// ── model picker'))
+  assert.match(botRow, /children: pinned \? t\('unpin'\) : t\('pinTop'\)/)
+  assert.match(botRow, /children: t\('editProfile'\)/)
+  assert.match(botRow, /children: groups\.length \? t\('groups', groups\) : t\('manageGroups'\)/)
+  assert.match(botRow, /children: t\('duplicate'\)/)
+  assert.match(botRow, /children: t\('newChat'\)/)
+  assert.match(botRow, /children: t\('delete'\)/)
+})


### PR DESCRIPTION
Fixes #91667

## Problem

The bot-row right-click menu (Pin/Hide/Edit Profile/Groups/Duplicate/New chat/Delete) is hardcoded English, while the rest of the app follows `display.language` — reported with the app set to Chinese.

## Solution

Ship the menu copy as plugin-scoped i18n bundles (`en`/`ja`/`zh`/`zh-hant`) registered under the plugin id via `ctx.i18n.register` — the same channel the kanban plugin uses, so no core `en.ts` edits. `BotRow` resolves labels through the reactive `usePluginI18n` translator; on hosts without that SDK surface the menu falls back to today's English literals (registration is guarded, matching the plugin's existing `typeof ctx.onDispose === 'function'` pattern). Terminology matches the core glossaries (`zh.ts`/`zh-hant.ts`/`ja.ts`: 置顶/釘選/ピン留め, 删除/刪除/削除, …). Locales without a bundle (`ar`) fall back to English — same behavior as before this PR.

Note: the issue mentions 500+ existing `t(...)` calls in the plugin — the file actually has none; this is the first i18n hookup in hermes-bots, hence the bundle + registration scaffolding.

## Result

- All 7 menu items resolve through the translator; no other plugin strings touched (Edit Profile dialog titles etc. are out of scope).
- Shape assertions in `hide-bots.test.mjs` and `bot-delete.test.mjs` updated to the new form; `profile-prewarm.test.mjs` vm contexts gain the new module-level constants.
- New `roster-menu-i18n.test.mjs`: bundle registration, zh/zh-hant/ja copy, no-i18n-host fallback.
- Verified locally: `node --test src/plugins/*/tests/*.test.mjs` → 411 passed, 0 failed (includes `legacy-sdk-compat`, which loads the whole module under a minimal SDK); `eslint src/plugins/hermes-bots/` clean.