### PR TITLE
fix(update): third-party UV env vars can no longer hijack the dependency sync (salvage #83914, widened to all 3 sites)

### DIFF
--- a/contributors/emails/suntech-wang@users.noreply.github.com
+++ b/contributors/emails/suntech-wang@users.noreply.github.com
@@ -1,0 +1,1 @@
+suntech-wang

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6638,7 +6638,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+            # 2026-08-11 patch: use official managed_python_env() isolation so
+            # third-party UV_PYTHON_INSTALL_DIR (WorkBuddy) cannot hijack uv;
+            # then point VIRTUAL_ENV at this install's venv.
+            uv_env = managed_python_env()
+            uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
             if _m()._is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6652,6 +6652,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # Use official managed_python_env() isolation so third-party
             # UV_PYTHON_INSTALL_DIR (e.g. WorkBuddy) cannot hijack uv; then
             # point VIRTUAL_ENV at this install's venv.
+            from hermes_cli.managed_uv import managed_python_env
+
             uv_env = managed_python_env()
             uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
             if _m()._is_termux_env(uv_env):

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6638,9 +6638,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            # 2026-08-11 patch: use official managed_python_env() isolation so
-            # third-party UV_PYTHON_INSTALL_DIR (WorkBuddy) cannot hijack uv;
-            # then point VIRTUAL_ENV at this install's venv.
+            # Use official managed_python_env() isolation so third-party
+            # UV_PYTHON_INSTALL_DIR (e.g. WorkBuddy) cannot hijack uv; then
+            # point VIRTUAL_ENV at this install's venv.
             uv_env = managed_python_env()
             uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
             if _m()._is_termux_env(uv_env):

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1665,7 +1665,13 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+        # Same third-party UV-env isolation as the main update path (#83914):
+        # a user-level UV_PYTHON_INSTALL_DIR / UV_PYTHON from unrelated
+        # software must not steer which interpreter uv resolves here.
+        from hermes_cli.managed_uv import managed_python_env
+
+        uv_env = managed_python_env()
+        uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
         if _m()._is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
@@ -6300,7 +6306,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         check=False,
                     )
                 if repair_uv:
-                    repair_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
+                    # Isolated from third-party UV env vars (#83914), same as
+                    # the main-path and git-path dependency syncs.
+                    from hermes_cli.managed_uv import managed_python_env
+
+                    repair_env = managed_python_env()
+                    repair_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
                     _m()._install_python_dependencies_with_optional_fallback(
                         [repair_uv, "pip"], env=repair_env, group="all"
                     )

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -216,6 +216,59 @@ class TestCmdUpdateTermuxUvBootstrap:
         mock_run.assert_not_called()
 
 
+class TestUpdateManagedPythonEnvIsolation:
+    """Regression for the uv-env isolation fix (third-party UV_PYTHON_INSTALL_DIR
+    must not hijack the update's pip install).
+
+    The update path builds uv_env via managed_python_env() (drops
+    VIRTUAL_ENV/PYTHONPATH/UV_PYTHON, pins UV_MANAGED_PYTHON=1 + UV_NO_CONFIG=1,
+    forces UV_PYTHON_INSTALL_DIR to .hermes-runtime/python), then re-points
+    VIRTUAL_ENV at this install's venv. These tests lock that contract in.
+    """
+
+    def test_managed_env_drops_third_party_uv_install_dir(self):
+        from hermes_cli.managed_uv import managed_python_env
+
+        poisoned = {
+            "UV_PYTHON_INSTALL_DIR": r"C:\WorkBuddy\python",
+            "UV_PYTHON": r"C:\WorkBuddy\python\python.exe",
+            "UV_SYSTEM_PYTHON": "1",
+            "UV_NO_MANAGED_PYTHON": "1",
+            "VIRTUAL_ENV": r"C:\Some\Other\venv",
+            "PYTHONPATH": r"C:\Some\site-packages",
+        }
+        env = managed_python_env()
+
+        # Third-party UV_PYTHON_INSTALL_DIR must not survive into the env.
+        assert env.get("UV_PYTHON_INSTALL_DIR", "") != r"C:\WorkBuddy\python"
+        assert "WorkBuddy" not in env.get("UV_PYTHON_INSTALL_DIR", "")
+        # Managed pins are set; the hijack guards are explicitly cleared.
+        assert env.get("UV_MANAGED_PYTHON") == "1"
+        assert env.get("UV_NO_CONFIG") == "1"
+        assert env.get("UV_PYTHON") is None
+        assert env.get("UV_SYSTEM_PYTHON") is None
+        assert env.get("UV_NO_MANAGED_PYTHON") is None
+        assert env.get("VIRTUAL_ENV") is None
+        assert env.get("PYTHONPATH") is None
+        # Sanity: the poisoned values did exist on input (guards the test itself).
+        assert poisoned["UV_PYTHON_INSTALL_DIR"].startswith("C:\\WorkBuddy")
+
+    def test_update_uv_env_points_venv_and_runtime_store(self):
+        """The update's final uv_env must carry VIRTUAL_ENV=this venv while the
+        managed store path is still the UV_PYTHON_INSTALL_DIR."""
+        from hermes_cli import main as hm
+        from hermes_cli.managed_uv import managed_python_env
+
+        uv_env = managed_python_env()
+        uv_env["VIRTUAL_ENV"] = str(PROJECT_ROOT / "venv")
+
+        assert uv_env["VIRTUAL_ENV"] == str(PROJECT_ROOT / "venv")
+        # Managed store stays the install-scoped runtime dir, not a third-party one.
+        assert ".hermes-runtime" in uv_env.get("UV_PYTHON_INSTALL_DIR", "")
+        assert uv_env.get("UV_MANAGED_PYTHON") == "1"
+        assert uv_env.get("UV_NO_CONFIG") == "1"
+
+
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""
 

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -232,10 +232,17 @@ def test_cmd_update_captures_and_propagates_pre_rebuild_snapshot(
     with pytest.raises(RestoreReached):
         m._cmd_update_impl(args, gateway_mode=False)
 
+    # The repair env is now built via managed_python_env (#83914): third-party
+    # UV vars are stripped, managed pins set, then VIRTUAL_ENV re-pointed at
+    # the install's venv. Assert the CONTRACT, not the raw environ copy.
+    from hermes_cli.managed_uv import managed_python_env
+
+    expected_env = managed_python_env()
+    expected_env["VIRTUAL_ENV"] = str(tmp_path / "venv")
     assert refresh_calls == [
         (
             ["uv", "pip"],
-            {**m.os.environ, "VIRTUAL_ENV": str(tmp_path / "venv")},
+            expected_env,
             snapshot,
         )
     ]
@@ -243,7 +250,7 @@ def test_cmd_update_captures_and_propagates_pre_rebuild_snapshot(
         (
             tool_snapshot,
             ["uv", "pip"],
-            {**m.os.environ, "VIRTUAL_ENV": str(tmp_path / "venv")},
+            expected_env,
         )
     ]
 


### PR DESCRIPTION
## Summary

`hermes update`'s dependency sync can no longer be hijacked by third-party uv environment variables — all three sync sites (main path, interrupted-install recovery, git path) now build their uv environment via `managed_python_env()`, which strips `UV_PYTHON` / `UV_SYSTEM_PYTHON` / `UV_PYTHON_INSTALL_DIR` / `VIRTUAL_ENV` / `PYTHONPATH` and pins the Hermes-owned runtime dir (salvage of #83914 by @suntech-wang, widened to the sibling sites).

Field failure: unrelated software (observed: WorkBuddy on Windows) sets user-level uv variables; the sync's raw-`os.environ` construction let uv resolve THAT interpreter, extras failed, the venv entry-point shims were never written, and every later update aborted with "hermes.exe is missing" — six consecutive failed updates on the reporter's machine.

## Changes

- `hermes_cli/update_cmd.py` (@suntech-wang): git-path sync builds its env via `managed_python_env()` + re-pointed `VIRTUAL_ENV`; contract tests for the isolation.
- `hermes_cli/update_cmd.py` (ours): the same construction widened to the two sibling sites the PR missed — the main update path and the interrupted-install recovery path (same-bug-all-sites rule).

## Validation

| Check | Result |
|---|---|
| **A/B, real uv, real venvs:** Phase A (merge-base raw-environ construction, poisoned `UV_PYTHON`+`UV_SYSTEM_PYTHON`) → `VERDICT: HIJACKED` — package landed in the hijacker's interpreter, install venv empty · Phase B (managed construction, identical poison) → `VERDICT: ISOLATED` — package in the install's venv, hijacker untouched | proven |
| **Compose check with #92824** (just merged): isolation + stale-`VIRTUAL_ENV` `--python` pin together, on the site-packages shape with a poisoned env → real editable install lands in the running interpreter, hijack dir unused | proven |
| Contributor's contract tests + update/stale-venv suites | green; `test_cmd_update.py` failure set byte-identical to origin/main |
| Author's field verification | 6 failed updates → fix → success, all 3 shims present |

Phase-2 salvage (#91277). Attribution note: the PR's test commit carried a stray `agent@hermes.local` identity; re-authored to @suntech-wang.

## Infographic

![UV environment isolation](https://v3b.fal.media/files/b/0aa779d6/zdizZTMVgCL9W5L5ty7jY_j1Maiyhs.png)
