### PR TITLE
fix(desktop): restore Bot roster route resolution

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4104,6 +4104,30 @@ function PetTab({ image, onImage }) {
  *  Gates every SOUL.md protocol append below. */
 let serverInjectsProtocol = false
 
+/** Resolve the route that owns the gateway currently backing Bot Mode.
+ *  Multi-source requests must stay on that exact (connection, profile) pair;
+ *  older SDKs without route inventory keep using the active gateway door. */
+async function activeBotRoute() {
+  if (typeof host.profileRoutes !== 'function') {
+    return null
+  }
+
+  const profile = String(host.state.profile?.get?.() || 'default').trim() || 'default'
+  const connectionId = String(
+    host.state.connectionId?.get?.() ||
+    (typeof host.activeConnectionId === 'function' ? host.activeConnectionId() : '') ||
+    'local'
+  ).trim() || 'local'
+  const routes = await host.profileRoutes()
+  const route = routes.find(candidate => candidate?.connectionId === connectionId && candidate?.profile === profile)
+
+  if (!route && typeof host.agents === 'function') {
+    throw new Error(`No route for active bot ${connectionId}::${profile}`)
+  }
+
+  return route || null
+}
+
 function useRoster() {
   const activeConnectionId = useValue(host.state.connectionId)
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
@@ -51,7 +51,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__x = { botConnectionRoute, scopedBotParams, botBackendProfileScope, requestForBot, groupMemberKey, parseGroupChatMentions, resolveGroupResponders, formatGroupChatLine, buildGroupChatTurnPrompt };\n'
+      '\nglobalThis.__x = { activeBotRoute, botConnectionRoute, scopedBotParams, botBackendProfileScope, requestForBot, groupMemberKey, parseGroupChatMentions, resolveGroupResponders, formatGroupChatLine, buildGroupChatTurnPrompt };\n'
     )
   vm.runInNewContext(code, context, { filename: 'plugin.js' })
   return context
@@ -100,6 +100,35 @@ test('requestForBot: source-scoped members go through requestProfile', async () 
   assert.equal(calls[2][0], 'routed')
   assert.equal(calls[2][1], 'mac-mini')
   assert.equal(calls[2][2], 'prompt.submit')
+})
+
+test('activeBotRoute: resolves the live source/profile pair and fails closed when it is missing', async () => {
+  const ctx = runtime()
+  const { activeBotRoute } = ctx.__x
+
+  ctx.host.profileRoutes = async () => [
+    { connectionId: 'local', mode: 'local', profile: 'default', targetProfile: 'default' },
+    { connectionId: 'work', mode: 'remote', profile: 'reviewer', targetProfile: 'backend-reviewer' }
+  ]
+  ctx.host.state.connectionId.get = () => 'work'
+  ctx.host.state.profile.get = () => 'reviewer'
+
+  assert.deepEqual(JSON.parse(JSON.stringify(await activeBotRoute())), {
+    connectionId: 'work',
+    mode: 'remote',
+    profile: 'reviewer',
+    targetProfile: 'backend-reviewer'
+  })
+
+  ctx.host.state.profile.get = () => 'missing'
+  ctx.host.agents = async () => ({ agents: [] })
+  await assert.rejects(activeBotRoute(), /No route for active bot work::missing/)
+})
+
+test('activeBotRoute: older SDKs keep the active-gateway fallback', async () => {
+  const ctx = runtime()
+
+  assert.equal(await ctx.__x.activeBotRoute(), null)
 })
 
 test('requestForBot: non-identity aliases translate every backend profile RPC shape', async () => {


### PR DESCRIPTION
## Summary

- restore the active Bot route resolver removed during connection-routing reconciliation
- keep `profiles.list` pinned to the live `(connectionId, profile)` pair on multi-source desktops
- preserve the active-gateway fallback for older Desktop SDKs
- add regression coverage for routed, missing, and legacy route inventories

## Root cause

`useRoster()` called `activeBotRoute()` before requesting `profiles.list`, but the helper definition was absent. The resulting `ReferenceError` prevented the first roster request on every platform, leaving the roster empty and New Group Chat disabled.

## Testing

- `node --test src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs`
- `npm run check:test:plugins` (413 passed)
- `node --check src/plugins/hermes-bots/plugin.js`
- `node --check src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs`

## Related Issue

Closes #92843
