### PR TITLE
fix(bot-mode): clean up message_agent DM tempfiles across local, peer, and relay paths

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30196,6 +30196,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         cleanup_video_cache,
     )
     from tools.tool_result_storage import cleanup_spillover_cache
+    from tools.bot_mode_dm import cleanup_bot_dm_cache
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -30215,6 +30216,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         ("Video", cleanup_video_cache),
         ("Screenshot", cleanup_screenshot_cache),
         ("Spillover", cleanup_spillover_cache),
+        ("Bot DM", cleanup_bot_dm_cache),
     )
 
     logger.info("Gateway housekeeping started (interval=%ds)", interval)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30197,6 +30197,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
     )
     from tools.tool_result_storage import cleanup_spillover_cache
     from tools.bot_mode_dm import cleanup_bot_dm_cache
+    from tools.bot_relay import cleanup_bot_relay_artifacts
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -30217,6 +30218,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         ("Screenshot", cleanup_screenshot_cache),
         ("Spillover", cleanup_spillover_cache),
         ("Bot DM", cleanup_bot_dm_cache),
+        ("Bot relay", cleanup_bot_relay_artifacts),
     )
 
     logger.info("Gateway housekeeping started (interval=%ds)", interval)

--- a/tests/tools/test_bot_dm_payload_cache.py
+++ b/tests/tools/test_bot_dm_payload_cache.py
@@ -1,0 +1,74 @@
+"""DM payload files must be reaped by gateway housekeeping, not only in-band.
+
+`message_agent` writes the message body to a file and hands the path to a
+*background* delivery, so it cannot be removed at the call site. The runner
+owns per-delivery cleanup, and `_write_dm_file` sweeps opportunistically —
+but a gateway that never sends another DM would still keep orphans forever.
+`cleanup_bot_dm_cache` follows the same contract as the other
+``cleanup_*_cache`` helpers (returns the number of files removed) so the
+gateway housekeeping loop in ``gateway/run.py`` prunes this cache on the
+same hourly cadence as the media caches.
+"""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from tools import bot_mode_dm
+
+
+@pytest.fixture()
+def temp_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    return tmp_path
+
+
+def _age(path: Path, seconds: float) -> None:
+    past = time.time() - seconds
+    os.utime(path, (past, past))
+
+
+class TestCleanupContract:
+    def test_expired_payloads_are_removed_and_counted(self, temp_root):
+        old = Path(bot_mode_dm._write_dm_file("stale"))
+        fresh = Path(bot_mode_dm._write_dm_file("recent"))
+        _age(old, bot_mode_dm._DM_STALE_SECONDS + 1)
+
+        removed = bot_mode_dm.cleanup_bot_dm_cache()
+
+        assert removed == 1
+        assert not old.exists()
+        assert fresh.exists(), "a payload still in flight was reaped"
+
+    def test_cleanup_reports_how_many_it_removed(self, temp_root):
+        # write all files first: _write_dm_file itself sweeps opportunistically
+        paths = [Path(bot_mode_dm._write_dm_file("x")) for _ in range(3)]
+        for p in paths:
+            _age(p, bot_mode_dm._DM_STALE_SECONDS + 1)
+        assert bot_mode_dm.cleanup_bot_dm_cache() == 3
+
+    def test_a_missing_dm_dir_is_not_an_error(self, temp_root):
+        assert bot_mode_dm.cleanup_bot_dm_cache() == 0
+
+    def test_legacy_and_relay_prefixed_orphans_are_swept(self, temp_root):
+        legacy = temp_root / "hermes-dm-legacy.txt"
+        relay = temp_root / "hermes-relay-dm-orphan.txt"
+        unrelated = temp_root / "other.txt"
+        for f in (legacy, relay, unrelated):
+            f.write_text("secret", encoding="utf-8")
+            _age(f, bot_mode_dm._DM_STALE_SECONDS + 1)
+
+        removed = bot_mode_dm.cleanup_bot_dm_cache()
+
+        assert removed == 2
+        assert not legacy.exists()
+        assert not relay.exists()
+        assert unrelated.exists()
+
+    def test_shorter_max_age_hours_is_honored(self, temp_root):
+        recent = Path(bot_mode_dm._write_dm_file("an hour old"))
+        _age(recent, 2 * 3600)
+        assert bot_mode_dm.cleanup_bot_dm_cache(max_age_hours=1) == 1
+        assert not recent.exists()

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -6,6 +6,9 @@ deliver from anywhere else even if a schema leaks.
 """
 
 import json
+import shlex
+import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -206,6 +209,12 @@ def _capture_spawn(monkeypatch):
     return calls
 
 
+def _runner_parts(command):
+    parts = shlex.split(command)
+    marker = parts.index("--run-delivery")
+    return parts[marker + 1], parts[marker + 2], parts[marker + 3 :]
+
+
 def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     calls = _capture_spawn(monkeypatch)
     home = _managed_home(tmp_path, teammates=("researcher",))
@@ -228,14 +237,25 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     assert call["background"] is True
     assert call["notify_on_complete"] is True
     command = call["command"]
-    assert command.startswith("hermes -p researcher chat --in ~ -c \"Bot Chat\"")
-    assert "--query-file" in command
+    mode, dm_file, transport_argv = _runner_parts(command)
+    assert mode == "query-file"
+    assert transport_argv == [
+        "hermes",
+        "-p",
+        "researcher",
+        "chat",
+        "--in",
+        "~",
+        "-c",
+        "Bot Chat",
+        "--create-if-missing",
+        "-Q",
+    ]
     # message body rides the temp file, never the command line
     assert "final" not in command
     assert "$(" not in command
 
     # attribution prefix applied server-side; body verbatim inside the file
-    dm_file = command.rsplit(" ", 1)[-1].strip("'")
     content = Path(dm_file).read_text(encoding="utf-8")
     assert content.startswith("Message from 🤖 hermes (@hermes): ")
     assert '$(and this is not shell)' in content
@@ -251,15 +271,18 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     )
     assert result["status"] == "sent"
     assert "spark" in result["to"]
-    command = calls[0]["command"]
-    assert command.startswith("hermes peer dm spark/researcher < ")
+    mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
+    assert mode == "stdin"
+    assert transport_argv == ["hermes", "peer", "dm", "spark/researcher"]
 
     # bare peer name targets the peer's main agent
     result2 = json.loads(
         bot_mode_dm.message_agent_tool(target="spark", message="ping", agent=agent)
     )
     assert result2["status"] == "sent"
-    assert calls[1]["command"].startswith("hermes peer dm spark < ")
+    mode, _dm_file, transport_argv = _runner_parts(calls[1]["command"])
+    assert mode == "stdin"
+    assert transport_argv == ["hermes", "peer", "dm", "spark"]
 
 
 def test_named_profile_sender_prefix(tmp_path, monkeypatch):
@@ -273,7 +296,7 @@ def test_named_profile_sender_prefix(tmp_path, monkeypatch):
         bot_mode_dm.message_agent_tool(target="researcher", message="hi", agent=agent)
     )
     assert result["status"] == "sent"
-    dm_file = calls[0]["command"].rsplit(" ", 1)[-1].strip("'")
+    _mode, dm_file, _transport_argv = _runner_parts(calls[0]["command"])
     assert Path(dm_file).read_text(encoding="utf-8").startswith(
         "Message from 🤖 coder (@coder): "
     )
@@ -294,3 +317,149 @@ def test_spawn_failure_reports_error(tmp_path, monkeypatch):
     )
     assert "error" in result
     assert "could not be started" in result["error"]
+
+
+# ── plaintext tempfile lifecycle ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("stdin_file", [False, True])
+def test_delivery_runner_keeps_file_for_child_then_unlinks(tmp_path, stdin_file):
+    dm_file = tmp_path / "message with spaces.txt"
+    dm_file.write_text("secret $(not shell)", encoding="utf-8")
+    observed = tmp_path / "observed.txt"
+    child = tmp_path / "child.py"
+    child.write_text(
+        textwrap.dedent(
+            """\
+            import pathlib
+            import sys
+
+            source = sys.stdin if sys.argv[1] == "-" else open(sys.argv[1], encoding="utf-8")
+            with source:
+                pathlib.Path(sys.argv[2]).write_text(source.read(), encoding="utf-8")
+            """
+        ),
+        encoding="utf-8",
+    )
+    source_arg = "-" if stdin_file else str(dm_file)
+
+    returncode = bot_mode_dm._run_delivery(
+        [sys.executable, str(child), source_arg, str(observed)],
+        str(dm_file),
+        stdin_file=stdin_file,
+    )
+
+    assert returncode == 0
+    assert observed.read_text(encoding="utf-8") == "secret $(not shell)"
+    assert not dm_file.exists()
+
+
+def test_delivery_runner_unlinks_when_child_launch_raises(tmp_path, monkeypatch):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("child launch failed")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    with pytest.raises(RuntimeError, match="child launch failed"):
+        bot_mode_dm._run_delivery(["hermes"], str(dm_file), stdin_file=False)
+    assert not dm_file.exists()
+
+
+def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    child = tmp_path / "fail.py"
+    child.write_text(
+        "import pathlib, sys\n"
+        "assert pathlib.Path(sys.argv[-1]).read_text(encoding='utf-8') == 'secret'\n"
+        "raise SystemExit(7)\n",
+        encoding="utf-8",
+    )
+
+    returncode = bot_mode_dm._run_delivery(
+        [sys.executable, str(child)], str(dm_file), stdin_file=False
+    )
+
+    assert returncode == 7
+    assert not dm_file.exists()
+
+
+@pytest.mark.parametrize(
+    ("terminal_result", "raises"),
+    [
+        (json.dumps({"error": "rejected"}), False),
+        ("not json", False),
+        (None, True),
+    ],
+)
+def test_spawn_failure_unlinks_untransferred_file(
+    tmp_path, monkeypatch, terminal_result, raises
+):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+
+    import tools.terminal_tool as terminal_tool_module
+
+    def fail_spawn(command, **kwargs):
+        assert dm_file.exists()
+        if raises:
+            raise RuntimeError("spawn failed")
+        return terminal_result
+
+    monkeypatch.setattr(terminal_tool_module, "terminal_tool", fail_spawn)
+    result = json.loads(
+        bot_mode_dm._spawn_delivery(
+            "unused", "@researcher", dm_file=str(dm_file), task_id=None, agent=None
+        )
+    )
+
+    assert "error" in result
+    assert not dm_file.exists()
+
+
+def test_successful_spawn_transfers_cleanup_to_runner(tmp_path, monkeypatch):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+
+    import tools.terminal_tool as terminal_tool_module
+
+    def launched(command, **kwargs):
+        assert dm_file.exists()
+        return json.dumps({"session_id": "proc_test1234"})
+
+    monkeypatch.setattr(terminal_tool_module, "terminal_tool", launched)
+    result = json.loads(
+        bot_mode_dm._spawn_delivery(
+            "unused", "@researcher", dm_file=str(dm_file), task_id=None, agent=None
+        )
+    )
+
+    assert result["status"] == "sent"
+    assert dm_file.exists(), "the parent must not delete before the background runner reads"
+
+
+def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeypatch):
+    dm_file = tmp_path / "partial.txt"
+    real_mkstemp = bot_mode_dm.tempfile.mkstemp
+
+    def fixed_mkstemp(**kwargs):
+        return real_mkstemp(dir=tmp_path, **kwargs)
+
+    class BrokenWriter:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def write(self, content):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(bot_mode_dm.tempfile, "mkstemp", fixed_mkstemp)
+    monkeypatch.setattr(bot_mode_dm.os, "fdopen", lambda *args, **kwargs: BrokenWriter())
+
+    with pytest.raises(OSError, match="disk full"):
+        bot_mode_dm._write_dm_file("secret")
+    assert list(tmp_path.glob("hermes-dm-*.txt")) == []

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -10,6 +10,7 @@ import shlex
 import subprocess
 import sys
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -386,6 +387,87 @@ def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
     assert not dm_file.exists()
 
 
+@pytest.mark.parametrize("args", [[], ["--run-delivery"], ["--run-delivery", "bad", "x"]])
+def test_delivery_main_rejects_invalid_cli(args):
+    assert bot_mode_dm._delivery_main(args) == 2
+
+
+@pytest.mark.parametrize("mode", ["stdin", "query-file"])
+def test_delivery_main_runs_valid_cli_and_unlinks(tmp_path, mode):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    observed = tmp_path / "observed.txt"
+    child = tmp_path / "child.py"
+    child.write_text(
+        "import pathlib, sys\n"
+        "source = sys.stdin if sys.argv[1] == '-' else open(sys.argv[1], encoding='utf-8')\n"
+        "with source:\n"
+        "    pathlib.Path(sys.argv[2]).write_text(source.read(), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    source_arg = "-" if mode == "stdin" else str(dm_file)
+
+    returncode = bot_mode_dm._delivery_main(
+        [
+            "--run-delivery",
+            mode,
+            str(dm_file),
+            sys.executable,
+            str(child),
+            source_arg,
+            str(observed),
+        ]
+    )
+
+    assert returncode == 0
+    assert observed.read_text(encoding="utf-8") == "secret"
+    assert not dm_file.exists()
+
+
+def test_delivery_main_maps_launch_exception_to_one_and_unlinks(tmp_path, monkeypatch):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("child launch failed")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert (
+        bot_mode_dm._delivery_main(
+            ["--run-delivery", "query-file", str(dm_file), "missing-transport"]
+        )
+        == 1
+    )
+    assert not dm_file.exists()
+
+
+@pytest.mark.parametrize("stdin_file", [False, True])
+def test_real_delivery_command_round_trip(tmp_path, stdin_file):
+    dm_file = tmp_path / "message with spaces.txt"
+    dm_file.write_text("secret λ\nsecond line", encoding="utf-8")
+    observed = tmp_path / "observed with spaces.txt"
+    child = tmp_path / "child with spaces.py"
+    child.write_text(
+        "import pathlib, sys\n"
+        "source = sys.stdin if sys.argv[1] == '-' else open(sys.argv[1], encoding='utf-8')\n"
+        "with source:\n"
+        "    pathlib.Path(sys.argv[2]).write_text(source.read(), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    source_arg = "-" if stdin_file else str(dm_file)
+    command = bot_mode_dm._delivery_command(
+        [sys.executable, str(child), source_arg, str(observed)],
+        str(dm_file),
+        stdin_file=stdin_file,
+    )
+
+    result = subprocess.run(shlex.split(command), check=False)
+
+    assert result.returncode == 0
+    assert observed.read_text(encoding="utf-8") == "secret λ\nsecond line"
+    assert not dm_file.exists()
+
+
 @pytest.mark.parametrize(
     ("terminal_result", "raises"),
     [
@@ -445,7 +527,8 @@ def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeyp
     real_mkstemp = bot_mode_dm.tempfile.mkstemp
 
     def fixed_mkstemp(**kwargs):
-        return real_mkstemp(dir=tmp_path, **kwargs)
+        kwargs["dir"] = tmp_path
+        return real_mkstemp(**kwargs)
 
     class BrokenWriter:
         def __enter__(self):
@@ -462,4 +545,29 @@ def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeyp
 
     with pytest.raises(OSError, match="disk full"):
         bot_mode_dm._write_dm_file("secret")
-    assert list(tmp_path.glob("hermes-dm-*.txt")) == []
+    assert list(tmp_path.glob("dm-*.txt")) == []
+
+
+def test_sweeper_removes_only_stale_dm_files(tmp_path, monkeypatch):
+    dm_dir = tmp_path / bot_mode_dm._DM_DIR_NAME
+    dm_dir.mkdir()
+    legacy_stale = tmp_path / "hermes-dm-stale.txt"
+    stale = dm_dir / "dm-stale.txt"
+    fresh = dm_dir / "dm-fresh.txt"
+    unrelated = tmp_path / "other.txt"
+    for path in (legacy_stale, stale, fresh, unrelated):
+        path.write_text("secret", encoding="utf-8")
+    now = time.time()
+    old = now - bot_mode_dm._DM_STALE_SECONDS - 1
+    import os
+
+    os.utime(legacy_stale, (old, old))
+    os.utime(stale, (old, old))
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    bot_mode_dm._sweep_stale_dm_files(now=now)
+
+    assert not legacy_stale.exists()
+    assert not stale.exists()
+    assert fresh.exists()
+    assert unrelated.exists()

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -6,6 +6,7 @@ deliver from anywhere else even if a schema leaks.
 """
 
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -549,8 +550,8 @@ def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeyp
 
 
 def test_sweeper_removes_only_stale_dm_files(tmp_path, monkeypatch):
-    dm_dir = tmp_path / bot_mode_dm._DM_DIR_NAME
-    dm_dir.mkdir()
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    dm_dir = bot_mode_dm._dm_dir()
     legacy_stale = tmp_path / "hermes-dm-stale.txt"
     stale = dm_dir / "dm-stale.txt"
     fresh = dm_dir / "dm-fresh.txt"
@@ -559,15 +560,47 @@ def test_sweeper_removes_only_stale_dm_files(tmp_path, monkeypatch):
         path.write_text("secret", encoding="utf-8")
     now = time.time()
     old = now - bot_mode_dm._DM_STALE_SECONDS - 1
-    import os
-
     os.utime(legacy_stale, (old, old))
     os.utime(stale, (old, old))
-    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
-
     bot_mode_dm._sweep_stale_dm_files(now=now)
 
     assert not legacy_stale.exists()
     assert not stale.exists()
     assert fresh.exists()
     assert unrelated.exists()
+
+
+def test_dm_dir_is_private_and_uid_scoped_on_posix(tmp_path, monkeypatch):
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    dm_dir = bot_mode_dm._dm_dir()
+
+    if hasattr(os, "getuid"):
+        assert dm_dir.name == f"{bot_mode_dm._DM_DIR_NAME}-{os.getuid()}"
+    else:
+        assert dm_dir.name == bot_mode_dm._DM_DIR_NAME
+    assert dm_dir.stat().st_mode & 0o777 == 0o700
+
+
+def test_dm_dir_repairs_restrictive_owner_mode(tmp_path, monkeypatch):
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    uid = os.getuid() if hasattr(os, "getuid") else None
+    dirname = f"{bot_mode_dm._DM_DIR_NAME}-{uid}" if uid is not None else bot_mode_dm._DM_DIR_NAME
+    dm_dir = tmp_path / dirname
+    dm_dir.mkdir(mode=0o500)
+    dm_dir.chmod(0o500)
+
+    assert bot_mode_dm._dm_dir() == dm_dir
+    assert dm_dir.stat().st_mode & 0o777 == 0o700
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX ownership contract")
+def test_dm_dir_rejects_precreated_symlink(tmp_path, monkeypatch):
+    target = tmp_path / "attacker-controlled"
+    target.mkdir()
+    expected = tmp_path / f"{bot_mode_dm._DM_DIR_NAME}-{os.getuid()}"
+    expected.symlink_to(target, target_is_directory=True)
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    with pytest.raises(PermissionError, match="not a directory"):
+        bot_mode_dm._dm_dir()

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -288,3 +288,40 @@ def test_capability_fingerprint_changes_with_relay_roster(tmp_path):
     ])
     after = bot_mode_probe.capability_fingerprint(home)
     assert before != after  # eternal Bot Chats refresh once on roster change
+
+
+# ── stale artifact sweep (housekeeping contract) ─────────────────────────────
+
+
+def test_cleanup_bot_relay_artifacts_sweeps_stale_plaintext(tmp_path, monkeypatch):
+    import os as _os
+    import time as _time
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    target = {"profile": "scout", "handle": "scout", "connection_id": "cloud-1",
+              "connection_label": "", "title": "", "description": ""}
+    stale_env = bot_relay.enqueue_envelope(
+        tmp_path, target=target, message="old secret",
+        sender_profile="default", sender_handle="hermes",
+    )
+    fresh_env = bot_relay.enqueue_envelope(
+        tmp_path, target=target, message="new secret",
+        sender_profile="default", sender_handle="hermes",
+    )
+    base = bot_relay.relay_root(tmp_path)
+    stale_reply = bot_relay.write_reply(tmp_path, stale_env["id"], reply="done")
+    old = _time.time() - bot_relay.STALE_AFTER_SECONDS - 1
+    _os.utime(base / bot_relay.OUTBOX_DIR / f"{stale_env['id']}.json", (old, old))
+    _os.utime(stale_reply, (old, old))
+
+    removed = bot_relay.cleanup_bot_relay_artifacts()
+
+    assert removed == 2
+    assert not (base / bot_relay.OUTBOX_DIR / f"{stale_env['id']}.json").exists()
+    assert not stale_reply.exists()
+    assert (base / bot_relay.OUTBOX_DIR / f"{fresh_env['id']}.json").exists()
+
+
+def test_cleanup_bot_relay_artifacts_missing_dir_is_zero(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "nope"))
+    assert bot_relay.cleanup_bot_relay_artifacts() == 0

--- a/tests/tui_gateway/test_bot_relay_methods.py
+++ b/tests/tui_gateway/test_bot_relay_methods.py
@@ -105,3 +105,36 @@ def test_reply_roundtrip_and_id_validation(home):
 
     err = srv._methods["bot_relay.reply"](2, {"id": "../evil"})
     assert "error" in err
+
+
+def test_deliver_write_failure_still_removes_tempfile(home, monkeypatch, tmp_path):
+    """A failed payload write must not leak the relay DM tempfile."""
+    import glob
+    import os
+    import tempfile as _tempfile
+
+    made = []
+    real_mkstemp = _tempfile.mkstemp
+
+    def _tracking_mkstemp(*args, **kwargs):
+        kwargs["dir"] = str(tmp_path)
+        fd, path = real_mkstemp(*args, **kwargs)
+        made.append(path)
+        return fd, path
+
+    class _BrokenWriter:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def write(self, content):
+            raise OSError("disk full")
+
+    monkeypatch.setattr("tempfile.mkstemp", _tracking_mkstemp)
+    monkeypatch.setattr("os.fdopen", lambda *a, **k: _BrokenWriter())
+    err = srv._methods["bot_relay.deliver"](1, {"profile": "ops", "message": "x"})
+    assert "error" in err
+    assert made, "mkstemp was never reached"
+    assert not glob.glob(str(tmp_path / "hermes-relay-dm-*")), "tempfile leaked"

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -45,6 +45,7 @@ import logging
 import os
 import re
 import shlex
+import stat
 import subprocess
 import sys
 import tempfile
@@ -420,8 +421,21 @@ def _try_relay_delivery(
 
 
 def _dm_dir() -> Path:
-    path = Path(tempfile.gettempdir()) / _DM_DIR_NAME
-    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    uid_getter = getattr(os, "getuid", None)
+    uid = uid_getter() if callable(uid_getter) else None
+    dirname = f"{_DM_DIR_NAME}-{uid}" if uid is not None else _DM_DIR_NAME
+    path = Path(tempfile.gettempdir()) / dirname
+    path.mkdir(mode=0o700, exist_ok=True)
+
+    # Shared POSIX temp roots need a per-user directory. Fail closed if an
+    # attacker pre-created the expected path or replaced it with a symlink.
+    info = path.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        raise PermissionError(f"DM temp path is not a directory: {path}")
+    if uid is not None and info.st_uid != uid:
+        raise PermissionError(f"DM temp directory is owned by another user: {path}")
+    if stat.S_IMODE(info.st_mode) != 0o700:
+        path.chmod(0o700)
     return path
 
 

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -439,22 +439,47 @@ def _dm_dir() -> Path:
     return path
 
 
-def _sweep_stale_dm_files(*, now: float | None = None) -> None:
-    """Best-effort cleanup for files orphaned before their runner started."""
-    cutoff = (time.time() if now is None else now) - _DM_STALE_SECONDS
-    # Include the legacy temp-root location so upgrades clean files created by
-    # versions predating the dedicated directory.
-    locations = ((Path(tempfile.gettempdir()), "hermes-dm-*.txt"), (_dm_dir(), "*.txt"))
+def cleanup_bot_dm_cache(
+    max_age_hours: float = _DM_STALE_SECONDS / 3600, *, now: float | None = None
+) -> int:
+    """Delete orphaned DM payload files older than *max_age_hours*.
+
+    Same contract as the other ``cleanup_*_cache`` helpers — returns the
+    number of files removed — so the gateway housekeeping loop can prune
+    this cache on the same hourly cadence as the media caches, even on
+    installs that never send another DM (the in-band sweep in
+    ``_write_dm_file`` only runs when a DM is written).
+    """
+    cutoff = (time.time() if now is None else now) - max_age_hours * 3600
+    removed = 0
+    # Include the legacy temp-root locations so upgrades clean files created
+    # by versions predating the dedicated directory.
+    temp_root = Path(tempfile.gettempdir())
+    locations: list[tuple[Path, str]] = [
+        (temp_root, "hermes-dm-*.txt"),
+        (temp_root, "hermes-relay-dm-*.txt"),
+    ]
+    try:
+        locations.append((_dm_dir(), "*.txt"))
+    except OSError:
+        pass
     for directory, pattern in locations:
         try:
             for candidate in directory.glob(pattern):
                 try:
                     if candidate.is_file() and candidate.stat().st_mtime < cutoff:
                         candidate.unlink()
+                        removed += 1
                 except OSError:
                     pass
         except OSError:
             pass
+    return removed
+
+
+def _sweep_stale_dm_files(*, now: float | None = None) -> None:
+    """Best-effort cleanup for files orphaned before their runner started."""
+    cleanup_bot_dm_cache(now=now)
 
 
 def _write_dm_file(content: str) -> str:

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -60,6 +60,12 @@ MESSAGE_AGENT_TOOL_NAME = "message_agent"
 # runaway paste can't turn one DM into a context bomb on the recipient.
 MESSAGE_MAX_CHARS = 16000
 
+# A runner normally owns and removes each file. This bounds the residual
+# plaintext lifetime if the machine dies after background-spawn acknowledgement
+# but before the runner reaches its ``finally`` block.
+_DM_DIR_NAME = "hermes-dm"
+_DM_STALE_SECONDS = 24 * 60 * 60
+
 _PEER_TARGET_RE = re.compile(r"^([a-z0-9][a-z0-9_-]{0,63})/([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})$")
 _LOCAL_TARGET_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
@@ -413,9 +419,34 @@ def _try_relay_delivery(
         return None
 
 
+def _dm_dir() -> Path:
+    path = Path(tempfile.gettempdir()) / _DM_DIR_NAME
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return path
+
+
+def _sweep_stale_dm_files(*, now: float | None = None) -> None:
+    """Best-effort cleanup for files orphaned before their runner started."""
+    cutoff = (time.time() if now is None else now) - _DM_STALE_SECONDS
+    # Include the legacy temp-root location so upgrades clean files created by
+    # versions predating the dedicated directory.
+    locations = ((Path(tempfile.gettempdir()), "hermes-dm-*.txt"), (_dm_dir(), "*.txt"))
+    for directory, pattern in locations:
+        try:
+            for candidate in directory.glob(pattern):
+                try:
+                    if candidate.is_file() and candidate.stat().st_mtime < cutoff:
+                        candidate.unlink()
+                except OSError:
+                    pass
+        except OSError:
+            pass
+
+
 def _write_dm_file(content: str) -> str:
     """The message rides a temp file — never inline shell text."""
-    fd, path = tempfile.mkstemp(prefix="hermes-dm-", suffix=".txt", text=True)
+    _sweep_stale_dm_files()
+    fd, path = tempfile.mkstemp(prefix="dm-", suffix=".txt", dir=_dm_dir(), text=True)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
@@ -442,6 +473,8 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
     """Run one DM transport and remove its plaintext file after consumption."""
     try:
         if stdin_file:
+            # Keep the file open until the transport exits; cleanup occurs
+            # after subprocess.run returns, not merely after stdin reaches EOF.
             with open(dm_file, "r", encoding="utf-8") as stream:
                 return subprocess.run(argv, stdin=stream, check=False).returncode
         return subprocess.run(
@@ -494,11 +527,16 @@ def _spawn_delivery(
     command: str,
     label: str,
     *,
-    dm_file: str,
+    dm_file: Optional[str] = None,
     task_id: Optional[str],
     agent: Any,
 ) -> str:
-    """Launch the cleanup-owning runner and transfer file ownership on ack."""
+    """Launch the cleanup-owning runner and transfer file ownership on ack.
+
+    ``dm_file`` is None for relay deliveries: the waiter command watches a
+    reply file, and the envelope artifacts are owned and swept by
+    ``tools/bot_relay.py`` — there is no plaintext DM tempfile to reclaim.
+    """
     transferred = False
     try:
         from tools.terminal_tool import terminal_tool
@@ -539,7 +577,7 @@ def _spawn_delivery(
         logger.error("message_agent delivery spawn failed: %s", exc, exc_info=True)
         return _err(f"Delivery to {label} could not be started: {exc}")
     finally:
-        if not transferred:
+        if dm_file and not transferred:
             _unlink_dm_file(dm_file)
 
 

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -45,6 +45,8 @@ import logging
 import os
 import re
 import shlex
+import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -290,9 +292,15 @@ def message_agent_tool(
                 f"No registered peer named '{peer_name}'.", roster=teammates, peers=peers
             )
         dm_target = f"{peer_name}/{peer_profile}" if peer_profile else peer_name
-        command = f"hermes peer dm {shlex.quote(dm_target)} < {shlex.quote(_write_dm_file(prefix + body))}"
         label = f"@{peer_profile or peer_name} on peer '{peer_name}'"
-        return _spawn_delivery(command, label, task_id=task_id, agent=agent)
+        return _start_delivery(
+            ["hermes", "peer", "dm", dm_target],
+            prefix + body,
+            label,
+            stdin_file=True,
+            task_id=task_id,
+            agent=agent,
+        )
 
     # ── local teammate ──
     if not _LOCAL_TARGET_RE.match(raw_target) and "@" not in raw_target:
@@ -326,12 +334,25 @@ def message_agent_tool(
             return relayed
         return _err("You can't message yourself. Pick a teammate from the roster.")
 
-    dm_file = _write_dm_file(prefix + body)
-    command = (
-        f"hermes -p {shlex.quote(resolved)} chat --in ~ -c \"Bot Chat\" "
-        f"--create-if-missing -Q --query-file {shlex.quote(dm_file)}"
+    return _start_delivery(
+        [
+            "hermes",
+            "-p",
+            resolved,
+            "chat",
+            "--in",
+            "~",
+            "-c",
+            "Bot Chat",
+            "--create-if-missing",
+            "-Q",
+        ],
+        prefix + body,
+        f"@{_handle(resolved)}",
+        stdin_file=False,
+        task_id=task_id,
+        agent=agent,
     )
-    return _spawn_delivery(command, f"@{_handle(resolved)}", task_id=task_id, agent=agent)
 
 
 def _try_relay_delivery(
@@ -395,13 +416,90 @@ def _try_relay_delivery(
 def _write_dm_file(content: str) -> str:
     """The message rides a temp file — never inline shell text."""
     fd, path = tempfile.mkstemp(prefix="hermes-dm-", suffix=".txt", text=True)
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(content)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+    except BaseException:
+        # fdopen owns the descriptor once it succeeds, but if fdopen itself
+        # failed the raw descriptor is still ours. Closing twice is harmless.
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        _unlink_dm_file(path)
+        raise
     return path
 
 
-def _spawn_delivery(command: str, label: str, *, task_id: Optional[str], agent: Any) -> str:
-    """Run the delivery command tracked + background, notify on completion."""
+def _unlink_dm_file(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
+    """Run one DM transport and remove its plaintext file after consumption."""
+    try:
+        if stdin_file:
+            with open(dm_file, "r", encoding="utf-8") as stream:
+                return subprocess.run(argv, stdin=stream, check=False).returncode
+        return subprocess.run(
+            [*argv, "--query-file", dm_file],
+            check=False,
+        ).returncode
+    finally:
+        _unlink_dm_file(dm_file)
+
+
+def _delivery_command(argv: list[str], dm_file: str, *, stdin_file: bool) -> str:
+    """Build an argv-safe command for the cleanup-owning background runner."""
+    runner_argv = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--run-delivery",
+        "stdin" if stdin_file else "query-file",
+        dm_file,
+        *argv,
+    ]
+    return shlex.join(runner_argv)
+
+
+def _start_delivery(
+    argv: list[str],
+    content: str,
+    label: str,
+    *,
+    stdin_file: bool,
+    task_id: Optional[str],
+    agent: Any,
+) -> str:
+    """Create a DM file and transfer its cleanup ownership to the runner."""
+    dm_file = _write_dm_file(content)
+    try:
+        command = _delivery_command(argv, dm_file, stdin_file=stdin_file)
+    except BaseException:
+        _unlink_dm_file(dm_file)
+        raise
+    return _spawn_delivery(
+        command,
+        label,
+        dm_file=dm_file,
+        task_id=task_id,
+        agent=agent,
+    )
+
+
+def _spawn_delivery(
+    command: str,
+    label: str,
+    *,
+    dm_file: str,
+    task_id: Optional[str],
+    agent: Any,
+) -> str:
+    """Launch the cleanup-owning runner and transfer file ownership on ack."""
+    transferred = False
     try:
         from tools.terminal_tool import terminal_tool
 
@@ -418,6 +516,11 @@ def _spawn_delivery(command: str, label: str, *, task_id: Optional[str], agent: 
         proc_id = parsed.get("session_id") or ""
         if parsed.get("error"):
             return _err(f"Delivery to {label} failed to start: {parsed['error']}")
+        if not proc_id:
+            return _err(f"Delivery to {label} failed to start: no process id returned")
+        # From this point the background runner owns the file and removes it
+        # only after the local query-file or peer stdin consumer has finished.
+        transferred = True
         return json.dumps(
             {
                 "status": "sent",
@@ -435,6 +538,26 @@ def _spawn_delivery(command: str, label: str, *, task_id: Optional[str], agent: 
     except Exception as exc:
         logger.error("message_agent delivery spawn failed: %s", exc, exc_info=True)
         return _err(f"Delivery to {label} could not be started: {exc}")
+    finally:
+        if not transferred:
+            _unlink_dm_file(dm_file)
+
+
+def _delivery_main(args: list[str]) -> int:
+    if len(args) < 3 or args[0] != "--run-delivery":
+        return 2
+    stdin_file = args[1] == "stdin"
+    if not stdin_file and args[1] != "query-file":
+        return 2
+    dm_file = args[2]
+    try:
+        return _run_delivery(args[3:], dm_file, stdin_file=stdin_file)
+    except Exception as exc:
+        print(
+            f"message_agent delivery failed: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
 
 
 # ── agent-context helpers (mirror system_prompt.py's resolution) ─────────────
@@ -464,3 +587,7 @@ def _session_title(agent: Any) -> str:
     except Exception:
         pass
     return ""
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a background process
+    raise SystemExit(_delivery_main(sys.argv[1:]))

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -270,18 +270,44 @@ def write_reply(
     return path
 
 
-def _sweep_stale(base: Path) -> None:
-    cutoff = time.time() - STALE_AFTER_SECONDS
+def _sweep_stale(base: Path, *, now: float | None = None) -> int:
+    cutoff = (time.time() if now is None else now) - STALE_AFTER_SECONDS
+    removed = 0
     for sub in (CLAIMED_DIR, REPLIES_DIR, OUTBOX_DIR):
         try:
             for path in (base / sub).glob("*.json"):
                 try:
                     if path.stat().st_mtime < cutoff:
                         path.unlink()
+                        removed += 1
                 except OSError:
                     continue
         except OSError:
             continue
+    return removed
+
+
+def cleanup_bot_relay_artifacts(max_age_hours: float | None = None) -> int:
+    """Sweep stale relay artifacts (envelopes/replies hold DM plaintext).
+
+    ``_sweep_stale`` otherwise runs only when the Desktop drains the outbox
+    (``claim_pending_envelopes``) — if the Desktop never reconnects, queued
+    plaintext envelopes would sit on disk forever. Same contract as the
+    ``cleanup_*_cache`` helpers so the gateway housekeeping loop can call it
+    hourly. ``max_age_hours`` is accepted for signature compatibility but the
+    relay's own ``STALE_AFTER_SECONDS`` governs staleness.
+    """
+    del max_age_hours  # relay staleness is governed by STALE_AFTER_SECONDS
+    try:
+        home = Path(os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+        root = home.parent.parent if home.parent.name == "profiles" else home
+        base = relay_root(root)
+        if not base.is_dir():
+            return 0
+        return _sweep_stale(base)
+    except Exception:
+        logger.debug("bot_relay artifact sweep failed", exc_info=True)
+        return 0
 
 
 # ── waiter (runs on the sender gateway via terminal background process) ─────

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -110,9 +110,9 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 4092, f"no profile '{profile}' on this gateway")
 
         fd, tmp = tempfile.mkstemp(prefix="hermes-relay-dm-", suffix=".txt", text=True)
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(message)
         try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(message)
             proc = subprocess.run(
                 local_delivery_command(resolved, tmp),
                 capture_output=True,


### PR DESCRIPTION
Every `message_agent` DM leaked a plaintext temp file for the life of the machine; this salvages the fix from #91902 (@tachyon-r, first), folds in the housekeeping half of #92407 (@mehmetkr-31), and widens cleanup to the relay sibling sites #92784 added.

## Changes

**Salvaged from #91902 (@tachyon-r — 3 commits cherry-picked with authorship preserved, rebased onto the post-#92784 relay-route code):**
- `_write_dm_file()` now writes into a private, uid-scoped `hermes-dm-<uid>/` dir (0700, symlink/ownership fail-closed) instead of littering the OS temp root, and unlinks the partial file if the write fails.
- Deliveries run through a cleanup-owning runner (`python bot_mode_dm.py --run-delivery …`) that unlinks the DM file in a `finally` after the transport exits — for both the local `--query-file` path and the peer stdin path. Spawn failures unlink immediately; ownership transfers to the runner only on a real process ack.
- 24h stale sweep (`_sweep_stale_dm_files`) covering the new dir and legacy `hermes-dm-*.txt` orphans from older versions.

**Folded in from #92407 (@mehmetkr-31 — committed with their authorship):**
- The sweep is exposed as `cleanup_bot_dm_cache()` with the same contract as the other `cleanup_*_cache` helpers and wired into the gateway housekeeping loop (hourly cadence), so orphans are reaped even on gateways that never send another DM. Also sweeps `hermes-relay-dm-*.txt` orphans. Their payload-cache test file is adapted to the merged design.

**Widened to the sibling sites from #92784 (this branch):**
- `tools/bot_relay.py`: the 6h stale sweep now has a public `cleanup_bot_relay_artifacts()` hooked into gateway housekeeping — previously it ran only when the Desktop drained the outbox, so plaintext envelopes/replies queued while the Desktop was away sat on disk forever.
- `tui_gateway/methods_bot_relay.py` (`bot_relay.deliver`): payload write moved inside the try/finally so a failed write no longer leaks the relay DM tempfile.
- `_spawn_delivery` accepts `dm_file=None` for relay waiter deliveries (no plaintext tempfile to reclaim; envelope artifacts are bot_relay-owned).
- `gateway/run.py`: `Bot DM` + `Bot relay` entries added to `MEDIA_CACHE_CLEANUPS` (the change #91902 proposed, updated to current main).

## Validation

| Check | Result |
| --- | --- |
| `pytest tests/tools/test_bot_mode_dm.py tests/tools/test_bot_dm_payload_cache.py tests/tools/test_bot_relay.py tests/tui_gateway/test_bot_relay_methods.py` | 65 passed |
| Sabotage: revert deliver write-inside-try | new test FAILS (catches leak) |
| Sabotage: no-op `cleanup_bot_relay_artifacts` | new test FAILS |
| Sabotage: no-op `cleanup_bot_dm_cache` cutoff | 4 tests FAIL |
| `ruff check` on all touched files | clean |
| `scripts/audit_pr_attribution.py --fix` | all contributor emails mapped |

Credit: @tachyon-r (#91902, earliest — primary), @mehmetkr-31 (#92407). Closes #91902. Closes #92407.

## Infographic

![DM tempfiles cleaned up](https://v3b.fal.media/files/b/0aa77a22/d56p-Dc3Mv83yq3whR7Uk_QRiFmNRu.png)

