### PR TITLE
fix(gateway): stop idle heartbeat ticks from disappearing

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5896,6 +5896,21 @@ class BasePlatformAdapter(ABC):
             task.add_done_callback(self._expected_cancelled_tasks.discard)
         return True
 
+    def start_internal_turn(self, event: MessageEvent, session_key: str) -> bool:
+        """Atomically start an idle synthetic turn, or reject it for retry.
+
+        Internal schedulers already hold a durable routing key and must know
+        whether a turn was actually accepted. Unlike ``_pending_messages``,
+        this path starts a consumer when the session is idle. Real user input
+        or an active turn wins races: the scheduler remains due and retries at
+        its next poll instead of claiming a delivery that never ran.
+        """
+        if self._message_handler is None:
+            return False
+        if session_key in self._active_sessions or session_key in self._pending_messages:
+            return False
+        return self._start_session_processing(event, session_key)
+
     async def cancel_session_processing(
         self,
         session_key: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21565,41 +21565,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         async def _poll_loop():
             while True:
                 await asyncio.sleep(POLL_SECONDS)
-                watch = getattr(self, "_heartbeat_watch", None)
-                if not watch:
-                    continue
-                # Warm the cache off-loop once per poll. A watch can only
-                # be registered through the warmed /heartbeat command, so
-                # this covers only the degraded path where that warm-up
-                # failed.
-                await self._warm_goals_session_db("heartbeat poll")
-                for quick_key, (source, session_id) in list(watch.items()):
-                    try:
-                        # Busy sessions coalesce their tick to the next idle poll.
-                        if quick_key in self._running_agents:
-                            continue
-                        from hermes_cli.heartbeat import HeartbeatManager
-
-                        mgr = HeartbeatManager(session_id=session_id)
-                        if not mgr.has_heartbeat():
-                            watch.pop(quick_key, None)
-                            continue
-                        prompt = mgr.due_prompt()
-                        if not prompt:
-                            continue
-                        adapter = self._adapter_for_source(source)
-                        if adapter is None:
-                            continue
-                        hb_event = MessageEvent(
-                            text=prompt,
-                            message_type=MessageType.TEXT,
-                            source=source,
-                            message_id=None,
-                            channel_prompt=None,
-                        )
-                        self._enqueue_fifo(quick_key, hb_event, adapter)
-                    except Exception as exc:
-                        logger.debug("heartbeat poll for %s failed: %s", quick_key, exc)
+                await self._poll_heartbeat_watches_once()
 
         try:
             task = asyncio.create_task(_poll_loop())
@@ -21615,6 +21581,61 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 task.add_done_callback(_bg.discard)
         except Exception:
             logger.debug("Failed to start heartbeat poller", exc_info=True)
+
+    async def _poll_heartbeat_watches_once(self) -> None:
+        """Attempt one accepted turn for every due, idle heartbeat watch."""
+        watch = getattr(self, "_heartbeat_watch", None)
+        if not watch:
+            return
+        # Warm the cache off-loop once per poll. A watch can only be registered
+        # through the warmed /heartbeat command, so this covers the degraded
+        # path where that warm-up failed.
+        await self._warm_goals_session_db("heartbeat poll")
+        for quick_key, (source, session_id) in list(watch.items()):
+            manager = None
+            try:
+                # Busy sessions coalesce their tick to the next idle poll.
+                if quick_key in self._running_agents:
+                    continue
+                from hermes_cli.heartbeat import HeartbeatManager
+
+                manager = HeartbeatManager(session_id=session_id)
+                if not manager.has_heartbeat():
+                    watch.pop(quick_key, None)
+                    continue
+                prompt = manager.claim_due_prompt()
+                if not prompt:
+                    continue
+                adapter = self._adapter_for_source(source)
+                accepted = False
+                if adapter is not None:
+                    heartbeat_event = MessageEvent(
+                        text=prompt,
+                        message_type=MessageType.TEXT,
+                        source=source,
+                        message_id=None,
+                        channel_prompt=None,
+                        internal=True,
+                        allow_gateway_control=False,
+                        metadata={"gateway_session_key": quick_key},
+                    )
+                    accepted = adapter.start_internal_turn(heartbeat_event, quick_key)
+                if accepted:
+                    manager.confirm_claim()
+                    logger.info("heartbeat delivery accepted for session %s", quick_key)
+                    continue
+                manager.abandon_claim()
+                logger.warning(
+                    "heartbeat delivery was not accepted for session %s; tick remains due",
+                    quick_key,
+                )
+            except Exception as exc:
+                if manager is not None:
+                    try:
+                        manager.abandon_claim()
+                    except Exception:
+                        pass
+                logger.warning("heartbeat poll for %s failed: %s", quick_key, exc)
 
 
 

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -202,15 +202,16 @@ def save_heartbeat(session_id: str, state: HeartbeatState) -> None:
 class HeartbeatManager:
     """Per-session heartbeat state + due-tick decisions.
 
-    Drivers (CLI thread / gateway task) call :meth:`due_prompt` on a poll
-    cadence while the session is idle; a non-None return is the user-role
-    message to inject. Firing is recorded immediately so a slow turn can't
-    double-fire.
+    Drivers poll while the session is idle. CLI uses :meth:`due_prompt` for
+    its always-accepting local queue; gateway uses :meth:`claim_due_prompt`
+    and confirms only after an adapter accepts the turn. Claims are recorded
+    immediately so a slow turn can't double-fire.
     """
 
     def __init__(self, session_id: str):
         self.session_id = session_id
         self._state: Optional[HeartbeatState] = load_heartbeat(session_id)
+        self._fire_claim: Optional[tuple[float, int]] = None
 
     @property
     def state(self) -> Optional[HeartbeatState]:
@@ -281,21 +282,51 @@ class HeartbeatManager:
 
     # --- driver entry point --------------------------------------------
 
-    def due_prompt(self, now: Optional[float] = None) -> Optional[str]:
-        """Return the injection prompt if the heartbeat is due, else None.
+    def claim_due_prompt(self, now: Optional[float] = None) -> Optional[str]:
+        """Claim and return a due prompt pending delivery acceptance.
 
-        Records the fire immediately (before the turn runs) so overlapping
-        polls or a long turn can never double-fire the same tick. Missed
-        ticks coalesce into one — the anchor resets to NOW, not to the
-        theoretical schedule.
+        The claim is persisted immediately to prevent overlapping polls from
+        double-firing. Drivers that can reject delivery must call
+        :meth:`abandon_claim`; accepted deliveries call :meth:`confirm_claim`.
         """
         s = self._state
-        if s is None or not s.is_due(now):
+        if self._fire_claim is not None or s is None or not s.is_due(now):
             return None
+        self._fire_claim = (s.last_fired_at, s.fire_count)
         s.last_fired_at = now if now is not None else time.time()
         s.fire_count += 1
         save_heartbeat(self.session_id, s)
         return s.render_prompt()
+
+    def confirm_claim(self) -> bool:
+        """Confirm that the claimed prompt was accepted as a turn."""
+        if self._fire_claim is None:
+            return False
+        self._fire_claim = None
+        return True
+
+    def abandon_claim(self) -> bool:
+        """Roll back a claimed prompt that no turn accepted."""
+        if self._fire_claim is None or self._state is None:
+            return False
+        last_fired_at, fire_count = self._fire_claim
+        self._state.last_fired_at = last_fired_at
+        self._state.fire_count = fire_count
+        self._fire_claim = None
+        save_heartbeat(self.session_id, self._state)
+        return True
+
+    def due_prompt(self, now: Optional[float] = None) -> Optional[str]:
+        """Return and immediately confirm a due prompt.
+
+        CLI drivers enqueue into an unbounded local queue, so acceptance is
+        synchronous. Gateway drivers use the explicit claim lifecycle because
+        an adapter can reject an internal turn.
+        """
+        prompt = self.claim_due_prompt(now)
+        if prompt is not None:
+            self.confirm_claim()
+        return prompt
 
 
 def migrate_heartbeat_to_session(old_session_id: str, new_session_id: str) -> bool:

--- a/tests/gateway/test_heartbeat_delivery.py
+++ b/tests/gateway/test_heartbeat_delivery.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent
+from gateway.run import GatewayRunner
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, **kwargs):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return None
+
+
+def _idle_adapter():
+    adapter = object.__new__(_StubAdapter)
+    adapter._message_handler = MagicMock()
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._start_session_processing = MagicMock(return_value=True)
+    return adapter
+
+
+def _runner(adapter, source):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._heartbeat_watch = {"session-key": (source, "session-id")}
+    runner._running_agents = {}
+    runner._warm_goals_session_db = AsyncMock()
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    return runner
+
+
+def test_internal_turn_starts_a_consumer_only_when_session_is_idle():
+    adapter = _idle_adapter()
+    event = MagicMock()
+
+    assert adapter.start_internal_turn(event, "session-key") is True
+    adapter._start_session_processing.assert_called_once_with(event, "session-key")
+
+    adapter._active_sessions["session-key"] = MagicMock()
+    assert adapter.start_internal_turn(event, "session-key") is False
+
+
+def test_internal_turn_preserves_pending_user_input():
+    adapter = _idle_adapter()
+    adapter._pending_messages["session-key"] = MagicMock()
+
+    assert adapter.start_internal_turn(MagicMock(), "session-key") is False
+    adapter._start_session_processing.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_due_heartbeat_starts_idle_turn_before_confirming_fire(monkeypatch):
+    source = SimpleNamespace(chat_id="chat", thread_id="topic", platform="telegram")
+    manager = MagicMock()
+    manager.has_heartbeat.return_value = True
+    manager.claim_due_prompt.return_value = "heartbeat prompt"
+    adapter = MagicMock()
+    adapter.start_internal_turn.return_value = True
+    runner = _runner(adapter, source)
+    monkeypatch.setattr("hermes_cli.heartbeat.HeartbeatManager", lambda session_id: manager)
+
+    await runner._poll_heartbeat_watches_once()
+
+    event, session_key = adapter.start_internal_turn.call_args.args
+    assert isinstance(event, MessageEvent)
+    assert event.text == "heartbeat prompt"
+    assert event.internal is True
+    assert event.allow_gateway_control is False
+    assert session_key == "session-key"
+    manager.confirm_claim.assert_called_once_with()
+    manager.abandon_claim.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rejected_heartbeat_turn_is_not_counted(monkeypatch, caplog):
+    source = SimpleNamespace(chat_id="chat", thread_id="topic", platform="telegram")
+    manager = MagicMock()
+    manager.has_heartbeat.return_value = True
+    manager.claim_due_prompt.return_value = "heartbeat prompt"
+    adapter = MagicMock()
+    adapter.start_internal_turn.return_value = False
+    runner = _runner(adapter, source)
+    monkeypatch.setattr("hermes_cli.heartbeat.HeartbeatManager", lambda session_id: manager)
+
+    await runner._poll_heartbeat_watches_once()
+
+    manager.abandon_claim.assert_called_once_with()
+    manager.confirm_claim.assert_not_called()
+    assert "heartbeat delivery was not accepted" in caplog.text

--- a/tests/hermes_cli/test_heartbeat.py
+++ b/tests/hermes_cli/test_heartbeat.py
@@ -147,6 +147,34 @@ def test_due_prompt_fires_once_and_reanchors():
     assert mgr.due_prompt() is None
 
 
+def test_claimed_prompt_can_be_abandoned_without_counting_delivery():
+    mgr = HeartbeatManager(session_id="hb-abandoned-sid")
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+
+    prompt = mgr.claim_due_prompt(now=time.time())
+
+    assert prompt is not None
+    assert mgr.state.fire_count == 1
+    assert mgr.abandon_claim() is True
+    assert mgr.state.fire_count == 0
+    assert mgr.state.last_fired_at == 0.0
+    assert HeartbeatManager("hb-abandoned-sid").state.fire_count == 0
+
+
+def test_confirmed_claim_keeps_delivery_count():
+    mgr = HeartbeatManager(session_id="hb-confirmed-sid")
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+
+    assert mgr.claim_due_prompt(now=time.time()) is not None
+    assert mgr.confirm_claim() is True
+
+    persisted = HeartbeatManager("hb-confirmed-sid").state
+    assert persisted.fire_count == 1
+    assert persisted.last_fired_at > 0
+
+
 def test_missed_ticks_coalesce():
     mgr = HeartbeatManager(session_id="hb-coalesce-sid")
     mgr.set("tick", 600)


### PR DESCRIPTION
## What does this PR do?

Heartbeat ticks on an idle gateway could advance `fire_count` and `last_fired_at` without starting an agent turn. This change starts an accepted adapter turn before confirming the fire, and rolls the claim back with a warning when delivery is rejected.

### Symptom

A configured gateway heartbeat remains active and its persisted fire count advances, but no heartbeat turn starts while the session is idle.

### Impact

Operators see a healthy-looking heartbeat audit trail while recurring session work is silently skipped until unrelated inbound activity wakes the session.

### Bug Cause

**Trigger:** `gateway/run.py` / `GatewayRunner._start_heartbeat_poller()` when a heartbeat becomes due while no turn is active.

**Causal chain:**
1. `HeartbeatManager.due_prompt()` persisted the tick as fired before gateway delivery.
2. The poller passed the prompt to `_enqueue_fifo()`, which only stages follow-up input for an existing turn to drain.
3. An idle session had no drain consumer, so no turn started although the fire was already counted.

**Why it is wrong:** A pending follow-up slot is not an acceptance boundary for idle delivery, and the persisted count therefore described attempted polls rather than accepted turns.

**Working sibling / contrast:** The CLI heartbeat path uses an always-available local input queue, so enqueueing there immediately creates consumable work.

**Ruled out:** Agent-cache eviction does not directly stop the gateway heartbeat poller. The delivery gap exists before and after cache eviction because the adapter pending slot has no idle consumer.

### Fix

- Add an adapter acceptance boundary that atomically starts synthetic work only when the session is idle and preserves real pending user input.
- Split heartbeat fire recording into claim, confirm, and rollback operations.
- Make the gateway poller confirm a fire only after the adapter accepts the internal turn; otherwise leave the tick due and emit a warning.

## Related Issue

N/A
## Type of Change

- [x] Bug fix

## Changes Made

- `gateway/platforms/base.py` - add an accepted internal-turn entry point for idle sessions.
- `gateway/run.py` - dispatch due heartbeats through that entry point and roll back rejected claims.
- `hermes_cli/heartbeat.py` - add explicit fire claim, confirmation, and abandonment semantics.
- `tests/gateway/test_heartbeat_delivery.py` - cover idle acceptance, user-input priority, and rejected delivery.
- `tests/hermes_cli/test_heartbeat.py` - cover persisted claim confirmation and rollback.

## How to Test

1. Run the heartbeat and adapter regression tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_heartbeat.py tests/gateway/test_heartbeat_delivery.py tests/gateway/test_scale_to_zero_watcher.py -q
```

2. Confirm the suite reports 55 passing tests and no failures.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant docstrings were updated; user documentation is N/A
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no workflow changed
- [x] Cross-platform impact was considered; the implementation uses platform-neutral asyncio adapter primitives
- [x] Tool descriptions and schemas are N/A because no tool behavior changed
