### PR TITLE
fix(desktop): Bot Mode Cloud alias identity survives hosted handoff and Cloud-only rosters

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4120,6 +4120,18 @@ function useRoster() {
       // Chat is resolved server-side by NAME (the "Bot Chat" registry row),
       // so the roster never sends session pointers.
       const route = await activeBotRoute()
+      // Refresh the alias identity index alongside the roster: alias routes
+      // (Desktop profile → remote backend root) are what let a backend row
+      // keep its configured friendly identity after activation (#89131).
+      // Best-effort and feature-detected — a failed read keeps the last
+      // good index rather than dropping identities mid-session.
+      if (typeof host.profileRoutes === 'function') {
+        try {
+          indexAliasRoutes(await host.profileRoutes())
+        } catch {
+          /* keep the previous alias index */
+        }
+      }
       const activeBot = route
         ? { name: route.profile, sourceScoped: true, route }
         : { name: String(host.state.profile?.get?.() || 'default').trim() || 'default' }
@@ -4414,11 +4426,19 @@ function mentionNameForms(value) {
  *  (server-synced via ui_meta, locally stored, or persisted on a durable
  *  group descriptor) and the core profile display_name — in displayName's
  *  precedence order. Remote rows never borrow local meta (two `default`s
- *  must not share a title). */
+ *  must not share a title) — EXCEPT the connection-exact alias identity
+ *  (#89131): a backend row claimed by a configured alias route carries the
+ *  alias's friendly names, so @moxie keeps resolving after handoff. */
 function botFriendlyNames(bot) {
-  const localTitle = !bot?.remoteSource && typeof $botMeta !== 'undefined' ? $botMeta.get()?.[bot?.name]?.title : null
+  const metaByName = typeof $botMeta !== 'undefined' ? $botMeta.get() : null
+  const localTitle = !bot?.remoteSource ? metaByName?.[bot?.name]?.title : null
+  const alias = aliasIdentityFor(bot)
+  const aliasTitle = alias
+    ? alias.metaKeys.map(key => metaByName?.[key]?.title).find(title => typeof title === 'string' && title.trim()) ||
+      alias.name
+    : null
 
-  return [bot?.ui_meta?.['hermes-bots']?.title, localTitle, bot?.title, bot?.display_name]
+  return [bot?.ui_meta?.['hermes-bots']?.title, localTitle, aliasTitle, bot?.title, bot?.display_name]
 }
 
 /** The tag autocomplete inserts for a bot: the renamed (friendly) slug when
@@ -4723,18 +4743,125 @@ function groupSessionOwner(member) {
   }
 }
 
+// ── alias identity for connection rows (#89131) ─────────────────────────────
+// A Desktop per-profile alias (profile `moxie` with a Cloud/URL/SSH override)
+// routes to a remote backend's root profile: its route reads
+// { connectionId: C, profile: 'moxie', targetProfile: 'default' }. Once that
+// backend answers the roster itself, the row's identity is (C, 'default') —
+// a DIFFERENT key than the alias meta (C::moxie / 'moxie') — so the friendly
+// name fell off after source/session activation: the row regressed to the
+// raw Cloud hostname, or to generic 'Hermes' in Cloud-only mode.
+//
+// aliasRouteIndex bridges the backend row identity back to its configured
+// alias. It is keyed by (connectionId, targetProfile), so two same-named
+// `default` rows on different connections can never share a title, and it
+// fails closed when two aliases claim the same backend row (mirroring the
+// fail-closed route resolution). This is the one sanctioned exception to
+// "remote rows never borrow local meta": the alias IS the local identity of
+// exactly this connection row, proven by the configured route — never by a
+// bare name match.
+let aliasRouteIndex = new Map()
+
+/** Rebuild the alias index from the credential-free route inventory. Only
+ *  genuine aliases (route.profile !== route.targetProfile) participate. */
+function indexAliasRoutes(routes) {
+  const next = new Map()
+
+  for (const route of Array.isArray(routes) ? routes : []) {
+    const connectionId = String(route?.connectionId || '').trim()
+    const profile = String(route?.profile || '').trim()
+    const target = String(route?.targetProfile || '').trim()
+
+    if (!connectionId || !profile || !target || profile === target) {
+      continue
+    }
+
+    const key = `${connectionId}::${target}`
+
+    // Two aliases pointing at the same backend row are ambiguous — neither
+    // may claim the identity.
+    next.set(key, next.has(key) ? null : {
+      name: profile,
+      // Alias meta can live under the source-qualified v2 key or the bare
+      // v1 name key (aliases predate the v2 migration on mixed setups).
+      metaKeys: [`${connectionId}::${profile}`, profile]
+    })
+  }
+
+  aliasRouteIndex = next
+}
+
+/** The configured alias identity claiming this roster row, or null. Matches
+ *  strictly by (connectionId, backend target profile); the alias row itself
+ *  keeps resolving its own meta directly. */
+function aliasIdentityFor(bot) {
+  if (!aliasRouteIndex.size) {
+    return null
+  }
+
+  const connectionId = String(
+    bot?.connectionId ||
+      bot?.route?.connectionId ||
+      // Unannotated rich rows (no host.agents on this build) still belong to
+      // the ACTIVE gateway — Cloud-only mode must resolve the alias too.
+      (!bot?.remoteSource && !bot?.sourceScoped ? host.state.connectionId?.get?.() || '' : '')
+  ).trim()
+
+  if (!connectionId) {
+    return null
+  }
+
+  const target = String(bot?.targetProfile || bot?.route?.targetProfile || bot?.name || '').trim() || 'default'
+  const entry = aliasRouteIndex.get(`${connectionId}::${target}`) || null
+
+  return entry && entry.name !== String(bot?.name || '').trim() ? entry : null
+}
+
 // Bot metadata is scoped to the active gateway until the server exposes a
 // union of rich profile rows. Never paint that metadata onto a thin row from
 // another source: two `default` agents must not borrow each other's title,
-// pin, avatar, group, unread state, or canonical-chat pointer.
+// pin, avatar, group, unread state, or canonical-chat pointer. The ONE
+// exception is a configured alias route claiming the row — see
+// aliasRouteIndex above — which is connection-exact, never name-based.
 function botRosterMeta(bot, metaByName) {
   if (bot?.sourceScoped || bot?.remoteSource) {
     const route = botConnectionRoute(bot)
+    const direct = route ? metaByName?.[botRouteKey(route)] : null
 
-    return route ? metaByName?.[botRouteKey(route)] : null
+    if (direct) {
+      return direct
+    }
+
+    const alias = aliasIdentityFor(bot)
+
+    if (alias) {
+      for (const key of alias.metaKeys) {
+        if (metaByName?.[key]) {
+          return metaByName[key]
+        }
+      }
+    }
+
+    return direct
   }
 
-  return metaByName?.[bot?.name]
+  const own = metaByName?.[bot?.name]
+
+  if (own) {
+    return own
+  }
+
+  const alias = aliasIdentityFor(bot)
+
+  if (alias) {
+    for (const key of alias.metaKeys) {
+      if (metaByName?.[key]) {
+        return metaByName[key]
+      }
+    }
+  }
+
+  return own
 }
 
 function showsHandle(name, meta, bot) {
@@ -5023,12 +5150,17 @@ async function ensureBotMetadata(bot) {
 }
 
 function displayName(bot, meta) {
+  // A configured alias route claiming this row overrides source-derived
+  // identity: the friendly alias name must survive hosted-session
+  // activation and Cloud-only rosters (#89131).
+  const alias = aliasIdentityFor(bot)
+
   // Only THIN rows from another source trade the friendly name for their
   // connection label — the active gateway's own default must keep reading
   // "Hermes". Annotated active rows carry sourceScoped too, and keying this
   // off sourceScoped renamed the user's main agent to an IP-derived label
   // (community report, Aug 17 2026).
-  if (bot?.remoteSource && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel) {
+  if (bot?.remoteSource && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel && !alias && !meta?.title?.trim()) {
     return bot.connectionLabel
   }
 
@@ -5041,6 +5173,14 @@ function displayName(bot, meta) {
   // Mode title. Rides the profiles.list row; presentation-only.
   if (typeof bot?.display_name === 'string' && bot.display_name.trim()) {
     return bot.display_name.trim()
+  }
+
+  // An untitled backend row claimed by an alias reads as the alias name —
+  // never generic "Hermes" or a hostname-derived label.
+  if (alias) {
+    const raw = alias.name.replace(/[-_]+/g, ' ').trim()
+
+    return raw.replace(/\b\w/g, ch => ch.toUpperCase())
   }
 
   // The primary profile is literally named "default" — as a bot identity

--- a/apps/desktop/src/plugins/hermes-bots/tests/cloud-alias-identity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cloud-alias-identity.test.mjs
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// #89131: a Desktop per-profile Cloud alias ("moxie" → exact Cloud connection
+// → backend targetProfile "default") must keep its friendly identity after
+// the hosted session activates, and must render as the alias — not generic
+// "Hermes" or a hostname label — when Cloud is the only active source.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function runtime({ connectionId = 'local' } = {}) {
+  const atom = value => ({ get: () => value, set: next => { value = next } })
+  const jsx = (type, props = {}) => ({ type, props })
+  const context = {
+    atom,
+    jsx,
+    jsxs: jsx,
+    useQuery: () => ({}),
+    useValue: value => (value?.get ? value.get() : value),
+    useState: value => [value, () => undefined],
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      state: {
+        connectionId: { get: () => connectionId, listen: () => undefined },
+        profile: { get: () => 'default', listen: () => undefined }
+      },
+      request: () => undefined
+    },
+    sdk: new Proxy({}, { get: () => undefined })
+  }
+  const code = source
+    .replace(/^import \* as sdk from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(
+      '\nglobalThis.__indexAliasRoutes = indexAliasRoutes;' +
+        '\nglobalThis.__aliasIdentityFor = aliasIdentityFor;' +
+        '\nglobalThis.__displayName = displayName;' +
+        '\nglobalThis.__botRosterMeta = botRosterMeta;' +
+        '\nglobalThis.__botFriendlyNames = botFriendlyNames;' +
+        '\nglobalThis.__botMentionTag = botMentionTag;' +
+        '\nglobalThis.__botMeta = $botMeta;'
+    )
+  vm.runInNewContext(code, context)
+  return context
+}
+
+const MOXIE_ROUTE = { connectionId: 'cloud-abc', mode: 'remote', profile: 'moxie', targetProfile: 'default' }
+
+/** The hosted backend's own roster row after alias handoff: the Cloud
+ *  connection answers as its root profile, so the row identity is
+ *  (cloud-abc, default) — NOT the alias key. */
+const hostedRow = {
+  name: 'default',
+  connectionId: 'cloud-abc',
+  connectionLabel: 'cloud.example.com',
+  targetProfile: 'default',
+  remoteSource: true,
+  sourceScoped: true,
+  route: { connectionId: 'cloud-abc', mode: 'remote', profile: 'default', targetProfile: 'default' }
+}
+
+test('alias identity survives hosted-session activation (roster refresh)', () => {
+  const ctx = runtime()
+  ctx.__indexAliasRoutes([
+    { connectionId: 'local', mode: 'local', profile: 'default', targetProfile: 'default' },
+    MOXIE_ROUTE
+  ])
+
+  // No stored title anywhere: the alias NAME is still the identity.
+  assert.equal(ctx.__displayName(hostedRow, null), 'Moxie')
+
+  // The alias's Bot Mode title (either meta key generation) claims the row.
+  const metaV2 = { 'cloud-abc::moxie': { title: 'Moxie' } }
+  assert.equal(ctx.__botRosterMeta(hostedRow, metaV2), metaV2['cloud-abc::moxie'])
+  assert.equal(ctx.__displayName(hostedRow, ctx.__botRosterMeta(hostedRow, metaV2)), 'Moxie')
+
+  const metaV1 = { moxie: { title: 'Moxie ✨' } }
+  assert.equal(ctx.__displayName(hostedRow, ctx.__botRosterMeta(hostedRow, metaV1)), 'Moxie ✨')
+})
+
+test('Cloud-only mode: the sole active-gateway default renders as the alias, not Hermes', () => {
+  // Global route is Cloud: the active gateway IS the Cloud connection and
+  // profiles.list returns one unannotated rich `default` row.
+  const ctx = runtime({ connectionId: 'cloud-abc' })
+  ctx.__indexAliasRoutes([MOXIE_ROUTE])
+
+  const soleBot = { name: 'default' }
+  assert.equal(ctx.__displayName(soleBot, null), 'Moxie')
+
+  // A user-set title still wins over the alias name.
+  assert.equal(ctx.__displayName(soleBot, { title: 'Custom' }), 'Custom')
+})
+
+test('alias never leaks to same-named defaults on other connections', () => {
+  const ctx = runtime()
+  ctx.__indexAliasRoutes([MOXIE_ROUTE])
+
+  const otherDefault = { ...hostedRow, connectionId: 'other-conn', route: null, targetProfile: 'default', connectionLabel: 'Personal' }
+  // Different connection: no alias claim — hostname label behavior stands.
+  assert.equal(ctx.__aliasIdentityFor(otherDefault), null)
+  assert.equal(ctx.__displayName(otherDefault, null), 'Personal')
+
+  // Local default while the ACTIVE gateway is local: untouched "Hermes".
+  assert.equal(ctx.__displayName({ name: 'default' }, null), 'Hermes')
+})
+
+test('two aliases claiming one backend row fail closed', () => {
+  const ctx = runtime()
+  ctx.__indexAliasRoutes([
+    MOXIE_ROUTE,
+    { connectionId: 'cloud-abc', mode: 'remote', profile: 'roxie', targetProfile: 'default' }
+  ])
+
+  assert.equal(ctx.__aliasIdentityFor(hostedRow), null)
+  // Ambiguous: fall back to the source label, not a guessed alias.
+  assert.equal(ctx.__displayName(hostedRow, null), 'cloud.example.com')
+})
+
+test('the alias row itself never claims its own alias entry', () => {
+  const ctx = runtime()
+  ctx.__indexAliasRoutes([MOXIE_ROUTE])
+
+  const aliasRow = {
+    name: 'moxie',
+    connectionId: 'cloud-abc',
+    targetProfile: 'default',
+    sourceScoped: true,
+    route: { ...MOXIE_ROUTE }
+  }
+  assert.equal(ctx.__aliasIdentityFor(aliasRow), null)
+  assert.equal(ctx.__displayName(aliasRow, null), 'Moxie')
+})
+
+test('mentions keep resolving @moxie against the hosted row after handoff', () => {
+  const ctx = runtime()
+  ctx.__indexAliasRoutes([MOXIE_ROUTE])
+  ctx.__botMeta.set({ 'cloud-abc::moxie': { title: 'Moxie' } })
+
+  const friendly = ctx.__botFriendlyNames(hostedRow).filter(Boolean)
+  assert.equal(friendly.length, 1)
+  assert.equal(friendly[0], 'Moxie')
+  assert.equal(ctx.__botMentionTag(hostedRow), 'moxie')
+})
+
+test('non-alias routes never enter the index; index refresh replaces stale claims', () => {
+  const ctx = runtime()
+  ctx.__indexAliasRoutes([
+    { connectionId: 'local', mode: 'local', profile: 'rune', targetProfile: 'rune' },
+    MOXIE_ROUTE
+  ])
+  assert.ok(ctx.__aliasIdentityFor(hostedRow))
+
+  // Alias removed from config → next inventory drops the claim.
+  ctx.__indexAliasRoutes([{ connectionId: 'local', mode: 'local', profile: 'rune', targetProfile: 'rune' }])
+  assert.equal(ctx.__aliasIdentityFor(hostedRow), null)
+  assert.equal(ctx.__displayName(hostedRow, null), 'cloud.example.com')
+})


### PR DESCRIPTION
## Summary

Fixes #89131 — Bot Mode now keeps a per-profile Cloud alias's friendly identity ("Moxie") after the alias hands off to the hosted backend, and renders the configured alias instead of generic "Hermes" when Cloud is the only active source.

## Root cause

A Desktop per-profile alias routes to a remote backend's **root** profile: the route reads `{ connectionId: C, profile: 'moxie', targetProfile: 'default' }`. Once the hosted backend answers the roster itself, the row's identity is `(C, 'default')` — a *different* key than the alias's meta (`C::moxie` / `'moxie'`). Nothing bridged the two:

- `botRosterMeta` intentionally never let remote rows borrow local meta ("two `default`s must not share a title"), so the backend row lost the alias title on the first roster refresh after activation — regressing to the raw Cloud hostname / `@default-…` identity.
- In Cloud-only mode, the sole rich `default` row hit `displayName`'s untitled-default fallback and rendered as generic **Hermes**.

## Fix

Introduce a **connection-exact alias index** (`aliasRouteIndex`) rebuilt from the credential-free `host.profileRoutes()` inventory on every roster fetch, keyed by `(connectionId, targetProfile)` — never a bare name. Only genuine aliases (`profile !== targetProfile`) participate.

- `displayName`: a backend row claimed by an alias reads as the alias name (title, when set, still wins) — never "Hermes" or a hostname-derived label.
- `botRosterMeta`: the claimed row resolves the alias's meta (v2 `C::moxie` key, then legacy v1 `moxie` key) when it has none of its own — the one sanctioned, route-proven exception to "remote rows never borrow local meta".
- `botFriendlyNames`: the alias name/title rides the claimed row so `@moxie` keeps resolving in mentions after handoff.

Safety properties, aligned with the fail-closed design settled in #88680 / #90006:

- same-named `default` rows on **other** connections never borrow the identity (index is keyed by connection);
- two aliases claiming the same backend row fail closed (neither wins);
- the local default and un-aliased remote defaults keep existing behavior byte-for-byte;
- feature-detected and best-effort: no `host.profileRoutes` (older desktops) → empty index → prior behavior; a failed route read keeps the last good index.

## Tests

New `tests/cloud-alias-identity.test.mjs` (7 source-shape tests, vm-exec pattern) covering: identity persistence across the hosted handoff (v2 and legacy v1 meta keys), the Cloud-only "sole bot labeled Hermes" reproduction, no cross-connection leakage, ambiguous-alias fail-closed, the alias row not self-claiming, mention resolution after handoff, and index refresh dropping stale claims.

- Full plugin suite: **418/418 pass** (`node --test tests/*.test.mjs`)
- Sabotage-verified: disabling the alias claim fails 3 of the new tests
- `node --check plugin.js` clean

## Credit

Huge thanks to **@TheAirick** for the controlled candidate testing on #89131 — the isolated live test that proved correct Cloud routing while pinpointing the residual identity regression, and the clean-install Cloud-only reproduction that narrowed the failure to identity propagation rather than the alias/default collision.

## Infographic

![Cloud alias keeps its name](https://v3b.fal.media/files/b/0aa77a28/DRJI0eiBTwNdwuSwxv5gx_1HJiK36x.png)

