### PR TITLE
fix(desktop): CJK emphasis via the official @streamdown/cjk plugin

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -97,6 +97,7 @@
     "@lezer/highlight": "1.2.3",
     "@nanostores/react": "1.1.0",
     "@nous-research/ui": "0.18.2",
+    "@streamdown/cjk": "1.0.3",
     "@streamdown/code": "1.1.1",
     "@streamdown/math": "1.0.2",
     "@tabler/icons-react": "3.44.0",

--- a/apps/desktop/src/components/assistant-ui/markdown-text.cjk.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.cjk.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MarkdownTextContent } from './markdown-text'
+
+afterEach(() => cleanup())
+
+// Regression for #92814: CommonMark's Unicode-punctuation delimiter rules
+// reject a `**` closing run when the preceding char is closing punctuation
+// and the following char is a CJK letter (e.g. the Korean particle 는 right
+// after a closing quote), so the markers leak into the transcript as literal
+// text. The @streamdown/cjk plugin is wired into MarkdownTextSurface's plugin
+// table to make those delimiters accepted.
+describe('MarkdownTextContent CJK emphasis', () => {
+  it('bolds a quoted Korean span followed by a particle', async () => {
+    render(<MarkdownTextContent isRunning={false} text={'**“공개 문서는 점검한다”**는 원칙입니다.'} />)
+
+    const strong = await screen.findByText('“공개 문서는 점검한다”')
+    expect(strong.getAttribute('data-streamdown')).toBe('strong')
+    expect(strong.parentElement).not.toBeNull()
+    expect(document.body.textContent).not.toContain('**')
+  })
+
+  it('bolds CJK spans ending with parentheses or full-stop punctuation', async () => {
+    render(
+      <MarkdownTextContent
+        isRunning={false}
+        text={
+          '**한국어 구문(괄호 포함)**을 강조합니다.\n**日本語の文章（括弧付き）。**この文が続きます。\n**中文文本（带括号）。**这句话继续。'
+        }
+      />
+    )
+
+    expect(await screen.findByText('한국어 구문(괄호 포함)')).toBeTruthy()
+    expect(await screen.findByText('日本語の文章（括弧付き）。')).toBeTruthy()
+    expect(await screen.findByText('中文文本（带括号）。')).toBeTruthy()
+    expect(document.body.textContent).not.toContain('**')
+  })
+
+  it('does not regress plain emphasis', async () => {
+    render(<MarkdownTextContent isRunning={false} text="**bold** and normal text" />)
+
+    const strong = await screen.findByText('bold')
+    expect(strong.getAttribute('data-streamdown')).toBe('strong')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -7,6 +7,7 @@ import {
   type SyntaxHighlighterProps,
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
+import { cjk as streamdownCjk } from '@streamdown/cjk'
 import type { code as streamdownCode } from '@streamdown/code'
 import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 
@@ -537,7 +538,15 @@ function MarkdownTextSurface({
   // `SyntaxHighlighter` below when `isStreaming` is true, and the code plugin
   // itself arrives async (useCodePlugin) so shiki never blocks cold start.
   const code = useCodePlugin()
-  const plugins = useMemo(() => (code ? { math: mathPlugin, code } : { math: mathPlugin }), [code])
+
+  // CJK-friendly emphasis (#92814): without the plugin, CommonMark's Unicode
+  // punctuation delimiter rules reject `**…**는`-style closings (Korean
+  // particles, CJK quote-adjacent spans), so bold markers leak as literal
+  // `**`. The official @streamdown/cjk plugin fixes delimiter acceptance.
+  const plugins = useMemo(
+    () => (code ? { math: mathPlugin, code, cjk: streamdownCjk } : { math: mathPlugin, cjk: streamdownCjk }),
+    [code]
+  )
 
   const components = useMemo(
     () =>

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -543,6 +543,9 @@ function MarkdownTextSurface({
   // punctuation delimiter rules reject `**…**는`-style closings (Korean
   // particles, CJK quote-adjacent spans), so bold markers leak as literal
   // `**`. The official @streamdown/cjk plugin fixes delimiter acceptance.
+  // Deps note: `streamdownCjk` is a stable module-level import (~2KB chain),
+  // so [code] remains exhaustive — unlike the async code plugin it never
+  // changes identity between renders.
   const plugins = useMemo(
     () => (code ? { math: mathPlugin, code, cjk: streamdownCjk } : { math: mathPlugin, cjk: streamdownCjk }),
     [code]

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "@lezer/highlight": "1.2.3",
         "@nanostores/react": "1.1.0",
         "@nous-research/ui": "0.18.2",
+        "@streamdown/cjk": "1.0.3",
         "@streamdown/code": "1.1.1",
         "@streamdown/math": "1.0.2",
         "@tabler/icons-react": "3.44.0",
@@ -2137,7 +2138,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,7 +2154,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2171,7 +2170,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2188,7 +2186,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2205,7 +2202,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2222,7 +2218,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2239,7 +2234,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2256,7 +2250,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2273,7 +2266,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2290,7 +2282,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2307,7 +2298,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2324,7 +2314,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2341,7 +2330,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2358,7 +2346,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2375,7 +2362,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2392,7 +2378,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2409,7 +2394,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2426,7 +2410,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2443,7 +2426,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2460,7 +2442,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2477,7 +2458,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2494,7 +2474,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2511,7 +2490,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2528,7 +2506,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2545,7 +2522,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2562,7 +2538,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5595,6 +5570,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">= 16.3.0"
+      }
+    },
+    "node_modules/@streamdown/cjk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@streamdown/cjk/-/cjk-1.0.3.tgz",
+      "integrity": "sha512-WRg8HR/gHbBoTgsMd91OKFUClIoDcEFVofJvluvEAyjx3KpU0aGgD9tGDqHkHj14ShoMSkX0IYetWGegTcwIJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "remark-cjk-friendly": "^2.0.1",
+        "remark-cjk-friendly-gfm-strikethrough": "^2.0.1",
+        "unist-util-visit": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@streamdown/code": {
@@ -13879,6 +13868,51 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-to-markdown-cjk-friendly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown-cjk-friendly/-/mdast-util-to-markdown-cjk-friendly-1.0.0.tgz",
+      "integrity": "sha512-BoaAm8mlJ+LAYz0Qs532Y3ciTuQYgBUPZcSFbvC/ZKmEMAKgulw84YvQK1gI34t/vL2euSfuaWlqczkTBgamkw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "^2.1.2",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough/-/mdast-util-to-markdown-cjk-friendly-gfm-strikethrough-1.0.0.tgz",
+      "integrity": "sha512-1ePVfB4P/vz3xSsm6H3D32r6VYGErxclnuLLFK02/2ReF+UdEKm7caulK6Vm0LBIp5gPRtB2Z1OYDznCkX3k2w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.2",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
@@ -14016,6 +14050,77 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-2.0.1.tgz",
+      "integrity": "sha512-OkzoYVTL1ChbvQ8Cc1ayTIz7paFQz8iS9oIYmewncweUSwmWR+hkJF9spJ1lxB90XldJl26A1F4IkPOKS3bDXw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-gfm-strikethrough": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-gfm-strikethrough/-/micromark-extension-cjk-friendly-gfm-strikethrough-2.0.1.tgz",
+      "integrity": "sha512-wVC0zwjJNqQeX+bb07YTPu/CvSAyCTafyYb7sMhX1r62/Lw5M/df3JyYaANyp8g15c1ypJRFSsookTqA1IDsUg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "get-east-asian-width": "^1.4.0",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-3.0.1.tgz",
+      "integrity": "sha512-GcbXqTTHOsiZHyF753oIddP/J2eH8j9zpyQPhkof6B2JNxfEJabnQqxbCgzJNuNes0Y2jTNJ3LiYPSXr6eJA8w==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.4.0",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -16566,6 +16671,50 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-cjk-friendly": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/remark-cjk-friendly/-/remark-cjk-friendly-2.3.1.tgz",
+      "integrity": "sha512-f+pKZRxCRwNEGFBKNRAZAqU91GIK1SAo3ZyFHWRUgC9zcxRR0BXKd6YwqgSsxtW0rNpUDtONj7H5nje2WL3fcA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown-cjk-friendly": "1.0.0",
+        "micromark-extension-cjk-friendly": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/remark-cjk-friendly-gfm-strikethrough": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/remark-cjk-friendly-gfm-strikethrough/-/remark-cjk-friendly-gfm-strikethrough-2.3.1.tgz",
+      "integrity": "sha512-JE3TGgouk/sy92SemNMEUhO5mNP4on04cmzOV3s3R5Dbk160ewmpM4tgPiinKKvoJ5UW2fTu7FOYsjVbusSA9w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown-cjk-friendly-gfm-strikethrough": "1.0.0",
+        "micromark-extension-cjk-friendly-gfm-strikethrough": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -18047,7 +18196,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2138,6 +2138,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,6 +2155,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2170,6 +2172,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2186,6 +2189,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2202,6 +2206,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2218,6 +2223,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2234,6 +2240,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2250,6 +2257,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2266,6 +2274,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2282,6 +2291,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2298,6 +2308,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2314,6 +2325,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2330,6 +2342,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2346,6 +2359,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2362,6 +2376,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2378,6 +2393,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2394,6 +2410,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2410,6 +2427,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2426,6 +2444,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2442,6 +2461,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2458,6 +2478,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2474,6 +2495,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2490,6 +2512,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2506,6 +2529,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2522,6 +2546,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2538,6 +2563,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18196,6 +18222,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }


### PR DESCRIPTION
Fixes #92814

## Problem

CJK emphasis fails when the closing `**` run sits between closing punctuation and a CJK letter (CommonMark's Unicode-punctuation delimiter rules reject it). The issue's repros — `**“공개 문서는 점검한다”**는 원칙입니다.` and the Korean/Japanese/Chinese paren- and full-stop variants — render with literal `**` markers instead of bold text.

## Solution

Wire Streamdown's official CJK plugin into the assistant Markdown surface's plugin table:

- `apps/desktop/package.json`: add `@streamdown/cjk` 1.0.3 (pinned, matching `@streamdown/code`/`@streamdown/math` style).
- `markdown-text.tsx`: include `cjk: streamdownCjk` in the `plugins` memo passed to `StreamdownTextPrimitive`.

Streamdown 2.5.0 (current pin) defines the `CjkPlugin` shape natively (`name: "cjk"`, `remarkPluginsBefore/After`), so no renderer internals are touched. Chose the official plugin over a regex rewrite, per the issue's suggestion. The issue's step 3 (CompactMarkdown / file-preview surfaces) is left out — keeping this PR to the reported main-assistant surface; happy to follow up if wanted.

## Result

Verified locally (streamdown 2.5.0 + plugin 1.0.3):
- Before: all 4 issue repros leak literal `**` (rendered server-side through the real pipeline to confirm the bug exists on current main).
- After: all 4 render as bold; plain emphasis unchanged.
- New `markdown-text.cjk.test.tsx`: end-to-end regression for the exact issue cases + a plain-emphasis guard. Full UI suite: 571 files / 5470 tests passed; `tsc --noEmit` and `eslint` clean (2 pre-existing `document` warnings only, same pattern as `markdown-text.filelinks.test.tsx`).
- Lockfile diff is additions only: `@streamdown/cjk` + its `remark-cjk-friendly` chain, zero version changes to existing packages.