### PR TITLE
feat(desktop): drag a sidebar session onto a project row to move it

### DIFF
--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -3,10 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { group } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
+import { moveSessionToProject, projectIdForCwd } from '@/store/projects'
+import { $sessions } from '@/store/session'
 import { openSessionTile } from '@/store/session-states'
 
 import { requestComposerInsertRefs } from './composer/focus'
 import { startSessionDrag } from './session-drag'
+import { NO_PROJECT_ID } from './sidebar/projects/workspace-groups'
 
 /**
  * A session drop resolves its target by rect-testing the chat surfaces in the
@@ -17,6 +20,11 @@ import { startSessionDrag } from './session-drag'
 
 vi.mock('@/store/session-states', () => ({ openSessionTile: vi.fn() }))
 vi.mock('./composer/focus', () => ({ requestComposerInsertRefs: vi.fn() }))
+vi.mock('@/store/projects', () => ({
+  moveSessionToProject: vi.fn().mockResolvedValue(undefined),
+  projectIdForCwd: vi.fn(() => null)
+}))
+vi.mock('@/store/notifications', () => ({ notifyError: vi.fn() }))
 
 const ZONE = { left: 0, top: 0, right: 1000, bottom: 800 }
 const COMPOSER = { left: 100, top: 700, right: 900, bottom: 780 }
@@ -81,6 +89,7 @@ beforeEach(() => {
 afterEach(() => {
   document.body.innerHTML = ''
   $layoutTree.set(null)
+  $sessions.set([])
 })
 
 describe('session drop targeting across stacked tabs', () => {
@@ -124,5 +133,56 @@ describe('session drop targeting across stacked tabs', () => {
 
     expect(requestComposerInsertRefs).not.toHaveBeenCalled()
     expect(openSessionTile).not.toHaveBeenCalled()
+  })
+})
+
+/** A sidebar project row, exactly as `ProjectOverviewRow` tags it. */
+function mountProjectRow(id: string, box = { left: 0, top: 0, right: 200, bottom: 40 }) {
+  const row = document.createElement('div')
+  row.dataset.sessionsProject = id
+  document.body.appendChild(row)
+  stubRect(row, box)
+
+  return row
+}
+
+describe('session drop targeting onto a sidebar project row', () => {
+  beforeEach(() => {
+    $sessions.set([{ id: 'dragged', cwd: '', _lineage_root_id: null } as never])
+  })
+
+  it('moves the dragged session to the project row it is dropped on', () => {
+    mountStackedTabs()
+    $layoutTree.set(group(['sessions'], { id: 'g1' }))
+    mountProjectRow('proj-a')
+
+    dragTo(document.getElementById('row')!, 100, 20)
+
+    expect(moveSessionToProject).toHaveBeenCalledWith('dragged', 'proj-a', 'default')
+    // A resolved project-row target takes priority: nothing else commits.
+    expect(openSessionTile).not.toHaveBeenCalled()
+    expect(requestComposerInsertRefs).not.toHaveBeenCalled()
+  })
+
+  it('is not a target for Home — there is no folder to move into', () => {
+    mountStackedTabs()
+    $layoutTree.set(group(['sessions'], { id: 'g1' }))
+    mountProjectRow(NO_PROJECT_ID)
+
+    dragTo(document.getElementById('row')!, 100, 20)
+
+    expect(moveSessionToProject).not.toHaveBeenCalled()
+  })
+
+  it('is not a target for the session’s own current project', () => {
+    mountStackedTabs()
+    $layoutTree.set(group(['sessions'], { id: 'g1' }))
+    mountProjectRow('proj-a')
+    vi.mocked(projectIdForCwd).mockReturnValue('proj-a')
+    $sessions.set([{ id: 'dragged', cwd: '/repos/proj-a', _lineage_root_id: null } as never])
+
+    dragTo(document.getElementById('row')!, 100, 20)
+
+    expect(moveSessionToProject).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -10,7 +10,9 @@
  *     that edge (the zone sheet morphs to the half);
  *   - a chat zone's CENTER / the composer → link: insert an `@session` chip
  *     into that surface's composer (ChatDropOverlay owns the visual);
- *   - anything else (sidebar, terminal, gutters) → deny.
+ *   - a sidebar PROJECT ROW → move: re-home the session under that project
+ *     (same call the row's own "Move to project" menu item makes);
+ *   - anything else (terminal, gutters) → deny.
  *
  * Zones that don't host a chat surface are NOT targets — the overlay never
  * lights them, so a release there must not commit either (one truth).
@@ -48,10 +50,34 @@ import {
   SESSION_TILE_DRAG
 } from '@/components/pane-shell/tree/store'
 import type { EngineZone, ZoneRect } from '@/components/pane-shell/tree/zones-engine'
+import { translateNow } from '@/i18n'
+import { notifyError } from '@/store/notifications'
+import { moveSessionToProject, projectIdForCwd } from '@/store/projects'
+import { $sessions, sessionMatchesStoredId } from '@/store/session'
 import { openSessionTile, type TileDock } from '@/store/session-states'
 
 import { requestComposerInsertRefs } from './composer/focus'
 import { type SessionDragPayload, sessionInlineRef, sessionLabel } from './composer/inline-refs'
+import { NO_PROJECT_ID } from './sidebar/projects/workspace-groups'
+
+const PROJECT_ROW_DROP_ATTR = 'data-drop-hover'
+
+/** A sidebar project row's drop geometry — tagged by `ProjectOverviewRow` via
+ *  `data-sessions-project`. */
+interface ProjectRowSnapshot {
+  el: HTMLElement
+  id: string
+  rect: ZoneRect
+}
+
+function snapshotProjectRows(excludeId: null | string): ProjectRowSnapshot[] {
+  return queryAllVisible<HTMLElement>('[data-sessions-project]')
+    .map(el => ({ el, id: el.dataset.sessionsProject || '', rect: snapRect(el) }))
+    // Home (no folder to move into) and the session's own current project
+    // (nothing to move) aren't drop targets — same exclusion the row's
+    // "Move to project" menu applies to its own list.
+    .filter(row => row.id !== NO_PROJECT_ID && row.id !== excludeId)
+}
 
 /** A chat surface's drag-start geometry: the anchor pane id it advertises
  *  (`data-session-anchor`) and the composer a link drop routes to
@@ -109,11 +135,23 @@ export function startSessionDrag(
   let surfaces: SurfaceSnapshot[] = []
   let composers: ZoneRect[] = []
   let zoneHost = new Map<string, ReturnType<typeof tileZoneHost>>()
+  let projectRows: ProjectRowSnapshot[] = []
 
   // Commit intent, updated per resolved move (the machinery flushes the final
   // move before commit, so these always match the released-at position).
   let split: { anchor: string; before?: null | string; pos: TileDock } | null = null
   let link: null | string = null
+  let moveToProject: null | string = null
+  // The project row currently painted as the drop target, so a move to a
+  // different row (or off any row) clears the one it left — imperative like
+  // the source's own opacity, not React state (a repaint here shouldn't
+  // re-render the sidebar on every pixel of pointer travel).
+  let hoveredProjectRow: HTMLElement | null = null
+
+  const clearProjectHover = () => {
+    hoveredProjectRow?.removeAttribute(PROJECT_ROW_DROP_ATTR)
+    hoveredProjectRow = null
+  }
 
   // The drag SOURCE (sidebar row or tile tab). Captured synchronously — React
   // clears `currentTarget` after the pointerdown handler returns, but this runs
@@ -132,6 +170,11 @@ export function startSessionDrag(
       surfaces = snapshotSurfaces()
       composers = queryAllVisible('[data-slot="composer-root"]').map(snapRect)
       zoneHost = new Map(zones.map(zone => [zone.id, tileZoneHost(zone.id)]))
+      // Resolved fresh per drag (not passed in as payload): a stale value would
+      // survive the row's own reorder/rename churn while a drag is armed.
+      const draggedSession = $sessions.get().find(s => sessionMatchesStoredId(s, payload.id))
+      const cwd = draggedSession?.cwd?.trim() || ''
+      projectRows = snapshotProjectRows(cwd ? projectIdForCwd(cwd) : null)
       source?.style.setProperty('opacity', '0.45')
       // The same sentinel the zone overlay + chat surfaces key off — the
       // whole drop language (sheets, pills, caret, link overlay) lights up.
@@ -142,9 +185,34 @@ export function startSessionDrag(
       if (source) {
         source.style.opacity = restoreOpacity
       }
+
+      clearProjectHover()
     },
 
     resolveMove(x, y): DropHint | null {
+      // The sidebar hosts no MAIN tile, so it's outside every pane-shell
+      // zone — a project row is the one thing in that dead space a session
+      // drop still resolves against. Checked first: it's a flat, disjoint
+      // hit-test, not a fallback off the zone lookup below.
+      const projectRow = projectRows.find(p => rectContains(p.rect, x, y))
+
+      if (projectRow) {
+        split = null
+        link = null
+        moveToProject = projectRow.id
+
+        if (hoveredProjectRow !== projectRow.el) {
+          clearProjectHover()
+          hoveredProjectRow = projectRow.el
+          hoveredProjectRow.setAttribute(PROJECT_ROW_DROP_ATTR, 'true')
+        }
+
+        return null
+      }
+
+      moveToProject = null
+      clearProjectHover()
+
       const zone = zones.find(z => rectContains(z.rect, x, y))
       const host = zone ? zoneHost.get(zone.id) : null
 
@@ -199,6 +267,12 @@ export function startSessionDrag(
       } else if (link) {
         // The "link to chat" drop: an @session chip in that surface's composer.
         requestComposerInsertRefs([sessionInlineRef(payload)], { target: link })
+      } else if (moveToProject) {
+        // Same RPC the row's own "Move to project" menu item calls — the drop
+        // is a shortcut onto that existing path, not a parallel one.
+        void moveSessionToProject(payload.id, moveToProject, payload.profile).catch(err =>
+          notifyError(err, translateNow('sidebar.projects.moveFailed'))
+        )
       }
     }
   })

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -163,7 +163,18 @@ export function ProjectOverviewRow({
     // project in the overview — the parallel to the entered-project wrapper's
     // `data-sessions-project` (index.tsx), which only fires once you've drilled
     // in. Here it's present on every row of the list.
-    <div className={cn(dragging && 'relative z-10')} data-sessions-project={project.id} ref={ref} style={style}>
+    <div
+      className={cn(
+        dragging && 'relative z-10',
+        // Painted imperatively by session-drag.ts while a dragged session
+        // hovers this row — a live "drop here to move" cue, not React state
+        // (it must not repaint the sidebar on every pixel of pointer travel).
+        'rounded-[6px] data-[drop-hover=true]:outline-2 data-[drop-hover=true]:-outline-offset-2 data-[drop-hover=true]:outline-sidebar-ring'
+      )}
+      data-sessions-project={project.id}
+      ref={ref}
+      style={style}
+    >
       {/* Home has no per-project actions, so it gets no right-click menu. */}
       {project.isNoProject ? (
         shell


### PR DESCRIPTION
## Summary
- Adds drag-and-drop support in the desktop sidebar: dragging a session row onto a project row moves that session into the project via the existing `moveSessionToProject` RPC (same one used by the "Move to project" context menu action).
- Home and the session's current project are excluded as valid drop targets, matching the existing context-menu behavior.
- The target project row shows a visible highlight while a session is dragged over it.

## Test plan
- `npx tsc --noEmit` across the desktop workspace — 0 errors
- `eslint` on the two changed files — clean
- Existing test suite for the touched files — all passing
- Added 3 new tests: moves session correctly, rejects drop on Home, rejects drop on session's own current project — all passing
- Full test suite run as a final sanity check