### PR TITLE
fix(feishu): gate interactive-card clicks by the card chat's admission rules

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2117,10 +2117,14 @@ class FeishuAdapter(BasePlatformAdapter):
 
             result = self._finalize_send_result(response, "send_exec_approval failed")
             if result.success:
+                # Record the chat type so click callbacks can gate under the
+                # chat's own admission rules (DM peer vs group policy).
+                chat_info = await self.get_chat_info(chat_id)
                 self._approval_state[approval_id] = {
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "chat_type": str(chat_info.get("type") or "").strip().lower(),
                 }
             return result
         except Exception as exc:
@@ -2185,10 +2189,12 @@ class FeishuAdapter(BasePlatformAdapter):
 
             result = self._finalize_send_result(response, "send_update_prompt failed")
             if result.success:
+                chat_info = await self.get_chat_info(chat_id)
                 self._update_prompt_state[prompt_id] = {
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "chat_type": str(chat_info.get("type") or "").strip().lower(),
                 }
             return result
         except Exception as exc:
@@ -2768,15 +2774,46 @@ class FeishuAdapter(BasePlatformAdapter):
         future.add_done_callback(self._log_background_failure)
         return True
 
-    def _is_interactive_operator_authorized(self, open_id: str) -> bool:
-        """Return whether this card-action operator may answer gated prompts."""
-        normalized = str(open_id or "").strip()
-        if not normalized:
-            return False
-        allowed_ids = set(self._admins) | set(self._allowed_group_users)
-        if not allowed_ids:
+    def _dm_sender_authorized(self, sender_ids: Any) -> bool:
+        """The DM branch of ``_admit``, shared with interactive-card clicks.
+
+        Platform/gateway allow-all flags first, then the empty-allowlist
+        pairing-mode default, then ``FEISHU_ALLOWED_USERS`` membership. Cards
+        answer under the same rules that admitted the conversation, so a DM
+        peer who can trigger an approval can always answer it.
+        """
+        if os.getenv("FEISHU_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
             return True
-        return "*" in allowed_ids or normalized in allowed_ids
+        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
+            return True
+        # Empty FEISHU_ALLOWED_USERS is the pairing-mode default from setup:
+        # forward DMs to gateway intake so the pairing handshake can run.
+        # Gateway auth fail-closes agent access until approval.
+        if not self._allowed_group_users:
+            return True
+        return bool(sender_ids and (sender_ids & self._allowed_group_users))
+
+    def _is_card_operator_authorized(
+        self, state: Dict[str, Any], open_id: str, user_id: str = ""
+    ) -> bool:
+        """May this operator answer an interactive card sent to ``state``'s chat?
+
+        The gate mirrors the admission rules of the chat the card was sent
+        to, not the group policy unconditionally: a DM card is visible only
+        to the DM peer, so it answers under ``_dm_sender_authorized`` (plus
+        the bot admins); a group card keeps the group policy gate. Chat type
+        comes from the state (recorded at send time), then the chat-info
+        cache, and fails closed to the group gate when unknown.
+        """
+        chat_type = str(state.get("chat_type") or "").strip().lower()
+        if not chat_type:
+            cached = self._chat_info_cache.get(str(state.get("chat_id") or "")) or {}
+            chat_type = str(cached.get("type") or "").strip().lower()
+        ids = {v for v in (open_id, user_id) if v}
+        if chat_type in {"dm", "p2p"}:
+            return bool(ids & self._admins) or self._dm_sender_authorized(ids)
+        sender = SimpleNamespace(open_id=open_id, user_id=user_id)
+        return self._allow_group_message(sender, str(state.get("chat_id") or ""), is_bot=False)
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -2792,8 +2829,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        operator_user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_card_operator_authorized(state, open_id, operator_user_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2852,8 +2889,8 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        operator_user_id = str(getattr(operator, "user_id", "") or "")
+        if not self._is_card_operator_authorized(state, open_id, operator_user_id):
             logger.warning("[Feishu] Unauthorized update prompt click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 
@@ -2905,7 +2942,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
             return
-        if not self._is_interactive_operator_authorized(open_id):
+        if open_id and not self._is_card_operator_authorized(state, open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s for approval %s", open_id or "<unknown>", approval_id)
             return
         expected_chat_id = str(state.get("chat_id", "") or "")
@@ -2959,11 +2996,9 @@ class FeishuAdapter(BasePlatformAdapter):
         if not state:
             logger.debug("[Feishu] Update prompt %s already resolved or unknown", prompt_id)
             return
-        if open_id:
-            sender_id = SimpleNamespace(open_id=open_id, user_id="")
-            if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
-                logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
-                return
+        if open_id and not self._is_card_operator_authorized(state, open_id):
+            logger.warning("[Feishu] Unauthorized update prompt click by %s for prompt %s", open_id, prompt_id)
+            return
         expected_chat_id = str(state.get("chat_id", "") or "")
         if expected_chat_id and chat_id and expected_chat_id != chat_id:
             logger.warning(
@@ -4371,16 +4406,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return "bot_not_mentioned"
 
         if not is_group:
-            if os.getenv("FEISHU_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
-                return None
-            if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in {"true", "1", "yes"}:
-                return None
-            # Empty FEISHU_ALLOWED_USERS is the pairing-mode default from setup:
-            # forward DMs to gateway intake so the pairing handshake can run.
-            # Gateway auth fail-closes agent access until approval.
-            if not self._allowed_group_users:
-                return None
-            if not (sender_ids and (sender_ids & self._allowed_group_users)):
+            if not self._dm_sender_authorized(sender_ids):
                 return "dm_policy_rejected"
             return None
 

--- a/tests/gateway/test_feishu_card_click_gate.py
+++ b/tests/gateway/test_feishu_card_click_gate.py
@@ -1,0 +1,306 @@
+"""Feishu interactive-card click authorization gates.
+
+Behavior contract: an interactive card (exec approval / update prompt) is
+answerable under the admission rules of the chat it was sent to. A DM card
+is visible only to the DM peer, so the peer who triggered the turn must be
+able to answer it — including under the empty-``FEISHU_ALLOWED_USERS``
+pairing default, where DM *messages* are admitted. Group cards keep the
+group policy gate (``_allow_group_message``).
+
+Regression (live incident, 2026-08-23 gateway.log): the click gate ran
+EVERY card through the group policy. ``FEISHU_GROUP_POLICY`` defaults to
+``allowlist`` and the allowlist was empty, so every DM approval click was
+discarded with "Unauthorized approval click" — the approval timed out as
+deny, the agent re-requested, and the user could never confirm a git
+clone. Meanwhile a second gate (``_is_interactive_operator_authorized``)
+had the OPPOSITE empty-set semantics (empty = allow) and was unreachable
+behind the first. The two gates are now one chat-aware predicate.
+"""
+
+import asyncio
+import os
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+try:
+    import lark_oapi  # noqa: F401
+    _HAS_LARK_OAPI = True
+except ImportError:
+    _HAS_LARK_OAPI = False
+
+
+def _make_adapter(**env):
+    """Construct a FeishuAdapter under a controlled environment.
+
+    Defaults reproduce the incident configuration: stock group policy
+    (``allowlist``) and an empty user allowlist (pairing-mode default).
+    """
+    from gateway.config import PlatformConfig
+    from plugins.platforms.feishu.adapter import FeishuAdapter
+
+    base = {
+        "FEISHU_APP_ID": "cli_test",
+        "FEISHU_APP_SECRET": "secret_test",
+        "FEISHU_ALLOWED_USERS": "",
+        "FEISHU_ALLOW_ALL_USERS": "",
+        "GATEWAY_ALLOW_ALL_USERS": "",
+        "FEISHU_GROUP_POLICY": "allowlist",
+    }
+    base.update(env)
+    with patch.dict(os.environ, base, clear=False):
+        return FeishuAdapter(PlatformConfig())
+
+
+def _dm_approval_state() -> dict:
+    return {
+        "session_key": "agent:main:feishu:dm:oc_dm",
+        "message_id": "om_1",
+        "chat_id": "oc_dm",
+        "chat_type": "dm",
+    }
+
+
+def _group_approval_state() -> dict:
+    return {
+        "session_key": "agent:main:feishu:group:oc_grp",
+        "message_id": "om_2",
+        "chat_id": "oc_grp",
+        "chat_type": "group",
+    }
+
+
+def _card_event(open_id: str, chat_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        operator=SimpleNamespace(open_id=open_id, user_id=""),
+        context=SimpleNamespace(open_chat_id=chat_id),
+    )
+
+
+class TestCardOperatorGate(unittest.TestCase):
+    """_is_card_operator_authorized mirrors the card chat's admission rules."""
+
+    def test_dm_card_click_authorized_under_pairing_default(self):
+        """Empty allowlist = pairing-mode default: the DM peer may answer.
+
+        This is the exact incident configuration — DM messages flow, so the
+        DM peer's approval clicks must flow too.
+        """
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        state = _dm_approval_state()
+        self.assertTrue(adapter._is_card_operator_authorized(state, "ou_peer"))
+
+    def test_dm_card_click_denied_when_allowlist_excludes_clicker(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="ou_alice")
+        state = _dm_approval_state()
+        self.assertFalse(adapter._is_card_operator_authorized(state, "ou_bob"))
+
+    def test_dm_card_click_authorized_when_clicker_in_allowlist(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="ou_alice")
+        state = _dm_approval_state()
+        self.assertTrue(adapter._is_card_operator_authorized(state, "ou_alice"))
+
+    def test_dm_card_click_authorized_by_gateway_allow_all(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="ou_alice")
+        state = _dm_approval_state()
+        with patch.dict(os.environ, {"GATEWAY_ALLOW_ALL_USERS": "true"}, clear=False):
+            self.assertTrue(adapter._is_card_operator_authorized(state, "ou_anyone"))
+
+    def test_dm_card_click_authorized_for_admin(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="ou_alice")
+        adapter._admins = {"ou_admin"}
+        state = _dm_approval_state()
+        self.assertTrue(adapter._is_card_operator_authorized(state, "ou_admin"))
+
+    def test_group_card_click_still_gated_by_group_policy(self):
+        """Group cards keep the fail-closed group gate: empty allowlist
+        under the default ``allowlist`` policy denies non-admin clickers."""
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        state = _group_approval_state()
+        self.assertFalse(adapter._is_card_operator_authorized(state, "ou_member"))
+
+    def test_group_card_click_authorized_for_allowlisted_member(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="ou_alice")
+        state = _group_approval_state()
+        self.assertTrue(adapter._is_card_operator_authorized(state, "ou_alice"))
+
+    def test_state_without_chat_type_falls_back_to_chat_info_cache(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        adapter._chat_info_cache["oc_dm"] = {"chat_id": "oc_dm", "name": "dm", "type": "dm"}
+        state = {"chat_id": "oc_dm"}  # legacy state: no chat_type recorded
+        self.assertTrue(adapter._is_card_operator_authorized(state, "ou_peer"))
+
+    def test_unknown_chat_type_fails_closed_to_group_gate(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="ou_alice")
+        state = {"chat_id": "oc_unresolved"}  # no state type, no cache entry
+        self.assertFalse(adapter._is_card_operator_authorized(state, "ou_bob"))
+
+
+class TestSendRecordsChatType(unittest.TestCase):
+    """Card sends record the chat type for the click gate."""
+
+    @staticmethod
+    def _adapter_with_send_mocked(chat_type: str, chat_id: str):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        adapter._client = object()
+        adapter._feishu_send_with_retry = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="om_x")
+        )
+        adapter._finalize_send_result = lambda response, ctx: SimpleNamespace(
+            success=True, message_id="om_x"
+        )
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": chat_id, "type": chat_type, "name": chat_id}
+        )
+        return adapter
+
+    def test_send_exec_approval_records_dm_chat_type(self):
+        adapter = self._adapter_with_send_mocked("dm", "oc_dm")
+        result = asyncio.run(
+            adapter.send_exec_approval(
+                "oc_dm", "git clone https://github.com/x/y", "agent:main:feishu:dm:oc_dm"
+            )
+        )
+        self.assertTrue(result.success)
+        state = adapter._approval_state[1]
+        self.assertEqual(state["chat_type"], "dm")
+        self.assertEqual(state["chat_id"], "oc_dm")
+
+    def test_send_update_prompt_records_group_chat_type(self):
+        adapter = self._adapter_with_send_mocked("group", "oc_grp")
+        result = asyncio.run(
+            adapter.send_update_prompt(
+                "oc_grp", "Proceed?", session_key="agent:main:feishu:group:oc_grp"
+            )
+        )
+        self.assertTrue(result.success)
+        state = adapter._update_prompt_state[1]
+        self.assertEqual(state["chat_type"], "group")
+
+
+class TestApprovalResolutionPath(unittest.TestCase):
+    """The click actually unblocks the waiting agent for DM-origin approvals."""
+
+    @staticmethod
+    def _cache_name(adapter, open_id: str, name: str) -> None:
+        adapter._sender_name_cache[open_id] = (name, time.time() + 300)
+
+    def test_dm_peer_click_resolves_approval(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        self._cache_name(adapter, "ou_peer", "Peer")
+        adapter._approval_state[1] = _dm_approval_state()
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+            asyncio.run(
+                adapter._resolve_approval(1, "once", "Peer", open_id="ou_peer", chat_id="oc_dm")
+            )
+        resolve.assert_called_once_with("agent:main:feishu:dm:oc_dm", "once")
+        self.assertNotIn(1, adapter._approval_state, "approved card state must be popped")
+
+    def test_group_click_without_allowlist_does_not_resolve(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        adapter._approval_state[1] = _group_approval_state()
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+            asyncio.run(
+                adapter._resolve_approval(1, "once", "Member", open_id="ou_member", chat_id="oc_grp")
+            )
+        resolve.assert_not_called()
+        self.assertIn(1, adapter._approval_state, "denied card state must stay pending")
+
+    def test_dm_update_prompt_click_persists_answer(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        adapter._update_prompt_state[1] = {
+            "session_key": "agent:main:feishu:dm:oc_dm",
+            "message_id": "om_3",
+            "chat_id": "oc_dm",
+            "chat_type": "dm",
+        }
+        with patch.object(adapter, "_write_update_prompt_response") as write:
+            asyncio.run(
+                adapter._resolve_update_prompt(1, "y", "Peer", open_id="ou_peer", chat_id="oc_dm")
+            )
+        write.assert_called_once_with("y")
+        self.assertNotIn(1, adapter._update_prompt_state)
+
+    def test_group_update_prompt_click_without_allowlist_is_dropped(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        adapter._update_prompt_state[1] = {
+            "session_key": "agent:main:feishu:group:oc_grp",
+            "message_id": "om_4",
+            "chat_id": "oc_grp",
+            "chat_type": "group",
+        }
+        with patch.object(adapter, "_write_update_prompt_response") as write:
+            asyncio.run(
+                adapter._resolve_update_prompt(1, "y", "Member", open_id="ou_member", chat_id="oc_grp")
+            )
+        write.assert_not_called()
+        self.assertIn(1, adapter._update_prompt_state)
+
+
+@unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
+class TestSyncCardActionHandler(unittest.TestCase):
+    """The synchronous card-action callback answers the DM peer inline."""
+
+    @classmethod
+    def setUpClass(cls):
+        from plugins.platforms.feishu import adapter as feishu_adapter
+
+        assert feishu_adapter._load_lark_oapi(), "lark_oapi import failed"
+
+    @staticmethod
+    def _drain(loop: asyncio.AbstractEventLoop) -> None:
+        async def _run_pending() -> None:
+            pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        loop.run_until_complete(_run_pending())
+
+    def test_dm_peer_click_resolves_inline(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        adapter._sender_name_cache["ou_peer"] = ("Peer", time.time() + 300)
+        loop = asyncio.new_event_loop()
+        adapter._loop = loop
+        adapter._approval_state[1] = _dm_approval_state()
+        try:
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+                response = adapter._handle_approval_card_action(
+                    event=_card_event("ou_peer", "oc_dm"),
+                    action_value={"hermes_action": "approve_once", "approval_id": 1},
+                    loop=loop,
+                )
+                self._drain(loop)
+        finally:
+            loop.close()
+        self.assertIsNotNone(response)
+        from plugins.platforms.feishu import adapter as feishu_adapter
+
+        if feishu_adapter.CallBackCard is not None:
+            self.assertIsNotNone(
+                getattr(response, "card", None),
+                "authorized DM click must resolve the card inline",
+            )
+        resolve.assert_called_once_with("agent:main:feishu:dm:oc_dm", "once")
+
+    def test_group_click_without_allowlist_is_dropped(self):
+        adapter = _make_adapter(FEISHU_ALLOWED_USERS="")
+        loop = asyncio.new_event_loop()
+        adapter._loop = loop
+        adapter._approval_state[1] = _group_approval_state()
+        try:
+            with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+                response = adapter._handle_approval_card_action(
+                    event=_card_event("ou_member", "oc_grp"),
+                    action_value={"hermes_action": "approve_once", "approval_id": 1},
+                    loop=loop,
+                )
+                self._drain(loop)
+        finally:
+            loop.close()
+        self.assertIsNone(getattr(response, "card", None), "unauthorized click must not resolve")
+        resolve.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Symptom (live incident, 2026-08-23)

User asks the agent over a Feishu **DM** to clone a GitHub repo. The agent sends the exec-approval card; the user clicks "Allow" — nothing happens. The approval times out as deny, the model re-requests, loop. `gateway.log` shows one warning per click:

```
WARNING hermes_plugins.feishu_platform.adapter: [Feishu] Unauthorized approval click by ou_xxx
```

Stock configuration: `FEISHU_GROUP_POLICY` unset (defaults to `allowlist`), `FEISHU_ALLOWED_USERS` unset — the pairing-mode default from setup, under which DM *intake* explicitly forwards empty-allowlist DMs so the pairing handshake can run (`adapter._admit`).

## Root cause

The click gate in `_handle_approval_card_action` / `_handle_update_prompt_card_action` (and both async resolvers) ran **every** card through `_allow_group_message` — the *group* policy gate — even for cards sent to a DM:

- `FEISHU_GROUP_POLICY` defaults to `allowlist`; with an empty allowlist, `sender_ids & allowlist` is always empty → **deny everyone**.
- Meanwhile the DM message intake passes the same user through (empty allowlist = pairing default), so a user can trigger an approval they can never answer. The card is a dead card by construction.
- A second gate, `_is_interactive_operator_authorized` in `_resolve_approval`, had the **opposite** empty-set semantics (empty = allow) but was unreachable behind the first — two gates, two rules, one dead feature.

## Fix

One chat-aware predicate, `_is_card_operator_authorized(state, open_id, user_id)`:

- `send_exec_approval` / `send_update_prompt` record the chat type in the pending-card state (`get_chat_info` is cached after the first message, so no extra API roundtrip in practice).
- **DM cards** answer under the DM admission rules — extracted from `_admit` into `_dm_sender_authorized` so message intake and card clicks share one semantics and cannot drift — plus the configured bot admins. A DM card is visible only to the DM peer, and the callback's `open_chat_id` is already validated against the state's chat.
- **Group cards** keep the group policy gate unchanged; unknown chat types fail closed to the group gate.

Security posture is unchanged where it was correct: groups stay fail-closed under the default `allowlist` policy; the DM rule is exactly what `_admit` already enforces for messages.

## Tests

`tests/gateway/test_feishu_card_click_gate.py` — 17 behavior-contract tests:

- gate matrix: pairing default / allowlist member & non-member / gateway allow-all flag / admin / group fail-closed / chat-info-cache fallback / unknown-chat fail-closed
- send paths record `chat_type` in the pending-card state
- async resolvers: DM click resolves (state popped, `resolve_gateway_approval` called with the right session+choice), group click without allowlist dropped
- synchronous card-action handler end-to-end: DM peer resolves inline, unauthorized group click dropped

Verified via `scripts/run_tests.sh`: 109/109 across the four Feishu test files (new file + `test_feishu.py` + `test_feishu_bot_admission.py` + `test_feishu_bot_auth_bypass.py`).