### PR TITLE
fix(computer-use): cap capture's native embed for history reuse

### DIFF
--- a/tests/tools/test_computer_use_capture_routing.py
+++ b/tests/tools/test_computer_use_capture_routing.py
@@ -95,6 +95,28 @@ def _stub_aux_analysis(text: str):
     return json.dumps({"success": True, "analysis": text})
 
 
+def _make_oversized_png_b64(*, side: int = 2000) -> str:
+    """A real PNG whose longest side exceeds vision_tools._EMBED_MAX_DIMENSION
+    (1568px), so the history-reuse cap in _capture_response's native path has
+    something to actually shrink. A striped fill (not a solid color) so it
+    isn't a degenerate near-zero-byte PNG, while staying cheap to generate
+    (C-level ImageDraw calls, no per-pixel Python loop).
+    """
+    import io
+
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", (side, side), "white")
+    draw = ImageDraw.Draw(img)
+    stripe = 37
+    for i, x in enumerate(range(0, side, stripe)):
+        color = (i * 53 % 256, i * 97 % 256, i * 151 % 256)
+        draw.rectangle([x, 0, x + stripe, side], fill=color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
 # ---------------------------------------------------------------------------
 # _capture_response: routing OFF (current/native behaviour)
 # ---------------------------------------------------------------------------
@@ -119,6 +141,67 @@ class TestCaptureResponseDefaultPath:
         url = image_part["image_url"]["url"]
         assert url.startswith("data:image/png;base64,")
         assert "vision_analysis" not in resp
+
+    def test_oversized_capture_is_resized_for_history_reuse(self, tmp_cache_dir):
+        """#92699/#92725's history-reuse cap must also apply to computer_use's
+        own native embed — a full-resolution capture baked into immutable
+        history uncapped can wedge the session exactly like the vision_analyze
+        and browser_vision paths it was already fixed for."""
+        import io
+
+        from PIL import Image
+
+        from tools.computer_use import tool as cu_tool
+        from tools.vision_tools import _EMBED_MAX_DIMENSION
+
+        oversized_b64 = _make_oversized_png_b64(side=2000)
+        cap = _make_capture(png_b64=oversized_b64, mode="som",
+                             width=2000, height=2000)
+
+        with patch.object(cu_tool, "_should_route_through_aux_vision",
+                          return_value=False):
+            resp = cu_tool._capture_response(cap)
+
+        assert isinstance(resp, dict)
+        image_part = next(
+            p for p in resp["content"] if p.get("type") == "image_url"
+        )
+        url = image_part["image_url"]["url"]
+        assert url.startswith("data:image/")
+        embedded_b64 = url.split(",", 1)[1]
+
+        # The embed must actually have shrunk — both in byte count and in
+        # decoded pixel dimensions (Anthropic enforces an 8000px cap
+        # independently of the byte cap; the model's tokenizer also
+        # downsamples past 1568px, so there is no fidelity gained by keeping
+        # the original resolution in history).
+        assert len(embedded_b64) < len(oversized_b64)
+        decoded = base64.b64decode(embedded_b64, validate=False)
+        with Image.open(io.BytesIO(decoded)) as resized_img:
+            assert max(resized_img.size) <= _EMBED_MAX_DIMENSION
+
+    def test_persist_failure_falls_back_to_unresized_embed(self):
+        """Persisting the shareable copy is best-effort (cache dir could be
+        unwritable, disk full, etc.) — a failure there must not block the
+        capture. Falling back to the original, unresized embed matches
+        pre-fix behaviour rather than raising."""
+        from tools.computer_use import tool as cu_tool
+
+        oversized_b64 = _make_oversized_png_b64(side=2000)
+        cap = _make_capture(png_b64=oversized_b64, mode="som",
+                             width=2000, height=2000)
+
+        with patch.object(cu_tool, "_should_route_through_aux_vision",
+                          return_value=False), \
+             patch.object(cu_tool, "_persist_capture_image", return_value=None):
+            resp = cu_tool._capture_response(cap)
+
+        assert isinstance(resp, dict)
+        image_part = next(
+            p for p in resp["content"] if p.get("type") == "image_url"
+        )
+        url = image_part["image_url"]["url"]
+        assert url == f"data:image/png;base64,{oversized_b64}"
 
 
     def test_ax_only_capture_returns_text_regardless_of_routing(self):

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -1303,6 +1303,34 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
         if not _mime:
             _b64_prefix = cap.png_b64[:8]
             _mime = "image/jpeg" if _b64_prefix.startswith("/9j/") else "image/png"
+        # History-reuse cap: this embed is baked into the tool result and
+        # re-sent on every later turn, exactly like the vision_analyze and
+        # browser_vision native fast paths (#92699/#92725/#92748) — apply the
+        # same proactive resize so full-resolution captures can't enter
+        # immutable history uncapped. Reuses the shareable copy already
+        # written by _persist_capture_image above instead of decoding
+        # cap.png_b64 a second time. Fail-open: if that copy is unavailable
+        # (persistence is best-effort), fall back to the unresized embed
+        # rather than blocking the capture.
+        _embed_data_url = f"data:{_mime};base64,{cap.png_b64}"
+        if screenshot_path:
+            try:
+                from pathlib import Path as _Path
+
+                from tools.vision_tools import (
+                    _EMBED_MAX_DIMENSION,
+                    _EMBED_TARGET_BYTES,
+                    _resize_image_for_vision,
+                )
+
+                _embed_data_url = _resize_image_for_vision(
+                    _Path(screenshot_path),
+                    mime_type=_mime,
+                    max_base64_bytes=_EMBED_TARGET_BYTES,
+                    max_dimension=_EMBED_MAX_DIMENSION,
+                )
+            except Exception as exc:
+                logger.debug("computer_use: history-reuse embed cap skipped: %s", exc)
         # The multimodal response carries the screenshot, not the AX
         # elements array, so a "response truncated to N of M elements"
         # note would be inaccurate — skip it on this branch.
@@ -1311,7 +1339,7 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
             "content": [
                 {"type": "text", "text": summary},
                 {"type": "image_url",
-                 "image_url": {"url": f"data:{_mime};base64,{cap.png_b64}"}},
+                 "image_url": {"url": _embed_data_url}},
             ],
             "text_summary": summary,
             "meta": {"mode": cap.mode, "width": response_width, "height": response_height,


### PR DESCRIPTION
## Summary

Today's sibling-gap. `_capture_response`'s native multimodal envelope (the default path when `auxiliary.vision` isn't explicitly routing to a separate model) bakes `cap.png_b64` into conversation history at full resolution with no size or dimension cap — the exact same history-reuse bug `vision_analyze` (#92699) and `browser_vision` (#92725) were just fixed for earlier today. `computer_use`'s own native fast path was never touched by that sweep, even though it embeds a live desktop screenshot the same way.

The only existing downscale in this file, `_shrink_capture_for_vision`, is scoped to the aux-vision *text-only* routing branch (`_should_route_through_aux_vision() == True`) and never runs on the native-embed branch this PR fixes.

## Fix

Reuse the shareable copy `_capture_response` already writes via `_persist_capture_image` (no extra decode of `cap.png_b64` needed) and resize it through `vision_tools._resize_image_for_vision` with the same `_EMBED_TARGET_BYTES` (256KB) / `_EMBED_MAX_DIMENSION` (1568px) caps, mirroring `browser_vision`'s call shape exactly (same helper, same constants, no `force_jpeg`).

Fail-open by design: if persisting that shareable copy failed (best-effort — cache dir unwritable, etc.), the fix falls back to the original unresized embed rather than blocking the capture, matching this file's existing error-handling philosophy elsewhere.

## Testing

- `tests/tools/test_computer_use_capture_routing.py`: two new tests —
  - `test_oversized_capture_is_resized_for_history_reuse`: a real 2000×2000 PNG capture is resized to ≤1568px before being embedded (mutation-verified: fails on pre-fix code with `assert 21868 < 21868`, i.e. the embed is byte-identical to the uncapped original).
  - `test_persist_failure_falls_back_to_unresized_embed`: when `_persist_capture_image` returns `None`, the capture still succeeds with the original unresized embed.
- Full `tests/tools/test_computer_use*.py tests/tools/test_vision_tools*.py tests/computer_use` suite run: 372 passed, 1 pre-existing unrelated failure (`test_linux_default_capture_skips_gnome_shell_helper`, a `cua_backend` PID-tracking test) confirmed failing identically on pre-fix `main` via `git stash`.
- `ruff check` clean on both changed files.

## Competing PRs

Checked `gh pr list --search` across several keyword combinations (`computer_use capture embed history`, `capture_response resize`, `_persist_capture_image resize vision`, `computer_use screenshot history reuse`, `92699`, `92725 92748`) — no open PR touches this specific gap. #64440 (screenshot *eviction*) and #77579 (cache-file *permissions*) are adjacent but address different concerns.