### PR TITLE
fix(gateway): keep service paths anchored to the real home

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -106,41 +106,40 @@ def _get_service_pids(all_profiles: bool = False) -> set:
     the service manager having committed the new PID before the restart command
     returns (true for both systemd and launchd in practice).
 
-    ``all_profiles`` widens the launchd branch to every installed
-    ``ai.hermes.gateway*`` LaunchAgent — the update path needs the whole
-    fleet excluded from its sweep (#41403, #73626): sibling-profile launchd
-    gateways found by the (BSD-fixed) ps scan must not be misclassified as
-    manual processes and killed.  Default-scope callers (``gateway status``,
-    cron checks) keep seeing only the current profile's service; the orphan
-    reaper passes all_profiles=True for the same friendly-fire reason.  The
-    systemd branch has always been fleet-wide (``hermes-gateway*``) and is
-    unaffected.
+    ``all_profiles`` widens service-manager discovery to the whole gateway
+    fleet. Default-scope callers (``gateway status``, cron checks) see only the
+    current profile's exact systemd unit or launchd label; update/reaper paths
+    pass ``all_profiles=True`` when they need fleet-wide protection.
     """
     pids: set = set()
 
     # --- systemd (Linux): user and system scopes ---
-    # systemd always lists every hermes-gateway* unit regardless of scope.
     if supports_systemd_services():
         for scope_args in [["systemctl", "--user"], ["systemctl"]]:
             try:
-                result = subprocess.run(
-                    scope_args
-                    + [
-                        "list-units",
-                        "hermes-gateway*",
-                        "--plain",
-                        "--no-legend",
-                        "--no-pager",
-                    ],
-                    capture_output=True,
-                    text=True, encoding='utf-8', errors='replace',
-                    timeout=5,
-                )
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if not parts or not parts[0].endswith(".service"):
-                        continue
-                    svc = parts[0]
+                if all_profiles:
+                    result = subprocess.run(
+                        scope_args
+                        + [
+                            "list-units",
+                            "hermes-gateway*",
+                            "--plain",
+                            "--no-legend",
+                            "--no-pager",
+                        ],
+                        capture_output=True,
+                        text=True, encoding='utf-8', errors='replace',
+                        timeout=5,
+                    )
+                    services = [
+                        parts[0]
+                        for line in result.stdout.strip().splitlines()
+                        if (parts := line.split()) and parts[0].endswith(".service")
+                    ]
+                else:
+                    services = [f"{get_service_name()}.service"]
+
+                for svc in services:
                     try:
                         show = subprocess.run(
                             scope_args + ["show", svc, "--property=MainPID", "--value"],
@@ -1586,10 +1585,9 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
 
     from hermes_constants import is_container
 
-    if is_linux() and is_container():
+    containerized = is_linux() and is_container()
+    if containerized:
         # Phase 4: report s6 supervision when running under our /init.
-        # Other container runtimes (or containers built before Phase 2)
-        # still get the original "docker (foreground)" label.
         try:
             from hermes_cli.service_manager import detect_service_manager, get_service_manager
             if detect_service_manager() == "s6":
@@ -1617,21 +1615,28 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
                     service_scope="s6",
                 )
         except Exception:
-            pass  # Fall through to the legacy label on any detection error.
-        return GatewayRuntimeSnapshot(
-            manager="docker (foreground)",
-            gateway_pids=gateway_pids,
-        )
+            pass
 
     if supports_systemd_services():
         selected_system, service_running = _probe_systemd_service_running(system=system)
-        scope_label = _service_scope_label(selected_system)
+        unit_path = get_systemd_unit_path(system=selected_system)
+        service_installed = unit_path.exists()
+        # A containerized host can still run a real systemd user manager. Prefer
+        # that concrete installed service over the generic foreground label.
+        if service_installed or not containerized:
+            scope_label = _service_scope_label(selected_system)
+            return GatewayRuntimeSnapshot(
+                manager=f"systemd ({scope_label})",
+                service_installed=service_installed,
+                service_running=service_running,
+                gateway_pids=gateway_pids,
+                service_scope=scope_label,
+            )
+
+    if containerized:
         return GatewayRuntimeSnapshot(
-            manager=f"systemd ({scope_label})",
-            service_installed=get_systemd_unit_path(system=selected_system).exists(),
-            service_running=service_running,
+            manager="docker (foreground)",
             gateway_pids=gateway_pids,
-            service_scope=scope_label,
         )
 
     if is_macos():
@@ -2325,11 +2330,24 @@ def get_service_name() -> str:
     return f"{_SERVICE_BASE}-{suffix}"
 
 
+def _get_real_user_home_path() -> Path:
+    """Return the OS home without trusting a profile-isolated ``HOME``."""
+    try:
+        from hermes_constants import get_real_home
+    except ImportError:
+        # Update-boundary: the running process may have cached an older
+        # hermes_constants module while the checkout has already advanced.
+        from hermes_cli.managed_uv import _reload_hermes_constants
+
+        get_real_home = _reload_hermes_constants().get_real_home
+    return Path(get_real_home())
+
+
 def get_systemd_unit_path(system: bool = False) -> Path:
     name = get_service_name()
     if system:
         return Path("/etc/systemd/system") / f"{name}.service"
-    return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
+    return _get_real_user_home_path() / ".config" / "systemd" / "user" / f"{name}.service"
 
 
 class UserSystemdUnavailableError(RuntimeError):
@@ -2641,7 +2659,7 @@ def _legacy_unit_search_paths() -> list[tuple[bool, Path]]:
     real filesystem paths.
     """
     return [
-        (False, Path.home() / ".config" / "systemd" / "user"),
+        (False, _get_real_user_home_path() / ".config" / "systemd" / "user"),
         (True, Path("/etc/systemd/system")),
     ]
 
@@ -3589,7 +3607,7 @@ WantedBy=multi-user.target
         hermes_home
     )
     profile_arg = _profile_arg(hermes_home)
-    path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
+    path_entries.extend(_build_user_local_paths(_get_real_user_home_path(), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))
     path_entries.extend(common_bin_paths)
     sane_path = ":".join(path_entries)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1856,11 +1856,15 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
     old_home = os.environ.get("HERMES_HOME")
     try:
         os.environ["HERMES_HOME"] = str(profile_dir)
-        from hermes_cli.gateway import get_service_name, get_launchd_plist_path
+        from hermes_cli.gateway import (
+            get_launchd_plist_path,
+            get_service_name,
+            get_systemd_unit_path,
+        )
 
         if _platform.system() == "Linux":
             svc_name = get_service_name()
-            svc_file = Path.home() / ".config" / "systemd" / "user" / f"{svc_name}.service"
+            svc_file = get_systemd_unit_path(system=False)
             if svc_file.exists():
                 subprocess.run(
                     ["systemctl", "--user", "disable", svc_name],

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -253,6 +253,8 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
     monkeypatch.setenv("VERCEL_TOKEN", "super-secret-value")
     monkeypatch.delenv("VERCEL_PROJECT_ID", raising=False)
     monkeypatch.setenv("VERCEL_TEAM_ID", "team")
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "is_container", lambda: False)
     monkeypatch.setattr(doctor_mod.importlib.util, "find_spec", lambda name: object() if name == "vercel" else None)
 
     fake_model_tools = types.SimpleNamespace(

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -284,6 +284,35 @@ def test_s6_runtime_snapshot_reports_supervised_service(monkeypatch, tmp_path):
     assert snapshot.gateway_pids == (123,)
 
 
+def test_container_runtime_snapshot_prefers_installed_systemd_service(
+    monkeypatch, tmp_path
+):
+    unit_path = tmp_path / "hermes-gateway.service"
+    unit_path.write_text("[Unit]\n", encoding="utf-8")
+
+    monkeypatch.setattr(gateway, "is_linux", lambda: True)
+    monkeypatch.setattr("hermes_constants.is_container", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.service_manager.detect_service_manager", lambda: "none"
+    )
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(
+        gateway, "_probe_systemd_service_running", lambda system=False: (False, True)
+    )
+    monkeypatch.setattr(
+        gateway, "get_systemd_unit_path", lambda system=False: unit_path
+    )
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [123])
+
+    snapshot = gateway.get_gateway_runtime_snapshot()
+
+    assert snapshot.manager == "systemd (user)"
+    assert snapshot.service_installed is True
+    assert snapshot.service_running is True
+    assert snapshot.service_scope == "user"
+    assert snapshot.gateway_pids == (123,)
+
+
 
 
 

--- a/tests/hermes_cli/test_gateway_proc_fallback.py
+++ b/tests/hermes_cli/test_gateway_proc_fallback.py
@@ -180,6 +180,38 @@ class TestPsFallbackBsdCompat:
 class TestGetServicePidsAllProfiles:
     """_get_service_pids(all_profiles=...) discovery across profiles."""
 
+    def test_default_scope_systemd_uses_only_current_profile_unit(self):
+        calls = []
+
+        def _run_side_effect(args, **kwargs):
+            args_list = list(args)
+            calls.append(args_list)
+            if "list-units" in args_list:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "hermes-gateway.service loaded active running\n"
+                        "hermes-gateway-sol.service loaded active running\n"
+                    ),
+                    stderr="",
+                )
+            if "show" in args_list:
+                service = args_list[args_list.index("show") + 1]
+                pid = "222\n" if service == "hermes-gateway-sol.service" else "111\n"
+                return MagicMock(returncode=0, stdout=pid, stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("hermes_cli.gateway.is_macos", return_value=False),
+            patch("hermes_cli.gateway.supports_systemd_services", return_value=True),
+            patch("hermes_cli.gateway.get_service_name", return_value="hermes-gateway-sol"),
+            patch("subprocess.run", side_effect=_run_side_effect),
+        ):
+            pids = gateway_mod._get_service_pids(all_profiles=False)
+
+        assert pids == {222}
+        assert not any("list-units" in call for call in calls)
+
     def test_default_scope_uses_current_profile_label(self):
         """Without all_profiles, only the current profile's launchd agent is
         located (per-label domain-explicit probe, #73627)."""
@@ -307,9 +339,8 @@ class TestGetServicePidsAllProfiles:
 
         assert pids == {123}
 
-    def test_all_profiles_preserves_systemd_behavior(self):
-        """systemd scope is unaffected by the all_profiles switch — it already
-        lists every hermes-gateway* unit unconditionally."""
+    def test_all_profiles_enumerates_systemd_fleet(self):
+        """With all_profiles=True, systemd enumerates every gateway unit."""
         with (
             patch("hermes_cli.gateway.is_macos", return_value=False),
             patch("hermes_cli.gateway.supports_systemd_services", return_value=True),

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -3,8 +3,9 @@
 import os
 import plistlib
 import subprocess
+import sys
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -188,6 +189,68 @@ class TestGeneratedSystemdUnits:
     def _expected_timeout_stop_sec(self) -> str:
         timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT + 30))
         return f"TimeoutStopSec={timeout}"
+
+    def test_user_unit_path_uses_real_home_when_profile_home_is_active(
+        self, tmp_path, monkeypatch
+    ):
+        real_home = tmp_path / "real-home"
+        profile_root = tmp_path / "profiles" / "sol"
+        profile_home = profile_root / "home"
+        profile_home.mkdir(parents=True)
+        real_home.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_root))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_root)
+
+        assert gateway_cli.get_systemd_unit_path(system=False) == (
+            real_home
+            / ".config"
+            / "systemd"
+            / "user"
+            / "hermes-gateway-sol.service"
+        )
+
+    def test_user_unit_path_uses_real_home_for_local_bins(
+        self, tmp_path, monkeypatch
+    ):
+        real_home = tmp_path / "real-home"
+        profile_root = tmp_path / "profiles" / "sol"
+        profile_home = profile_root / "home"
+        real_local_bin = real_home / ".local" / "bin"
+        profile_local_bin = profile_home / ".local" / "bin"
+        real_local_bin.mkdir(parents=True)
+        profile_local_bin.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_root))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_root)
+        monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: [])
+        monkeypatch.setattr(
+            gateway_cli, "_append_node_dir_for_service", lambda entries: None
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert str(real_local_bin) in unit
+        assert str(profile_local_bin) not in unit
+
+    def test_real_user_home_path_reloads_constants_across_update_boundary(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_cli.managed_uv as managed_uv
+
+        stale_constants = ModuleType("hermes_constants")
+        monkeypatch.setitem(sys.modules, "hermes_constants", stale_constants)
+        monkeypatch.setattr(
+            managed_uv,
+            "_reload_hermes_constants",
+            lambda: SimpleNamespace(get_real_home=lambda: str(tmp_path)),
+        )
+
+        assert gateway_cli._get_real_user_home_path() == tmp_path
 
 
 
@@ -1285,7 +1348,7 @@ class TestGeneratedUnitIncludesLocalBin:
             "_build_user_local_paths",
             lambda home_path, existing: [str(home_path / ".local" / "bin")],
         )
-        unit = gateway_cli.generate_systemd_unit(system=True)
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="root")
         # System unit uses the resolved home dir from _system_service_identity
         assert "/.local/bin" in unit
 
@@ -1634,6 +1697,26 @@ class TestLegacyHermesUnitDetection:
         "[Unit]\nDescription=Hermes Gateway\n[Service]\n"
         "ExecStart=/usr/bin/python -m hermes_cli.main gateway run --replace\n"
     )
+
+    def test_user_scope_search_uses_real_home_when_profile_home_is_active(
+        self, tmp_path, monkeypatch
+    ):
+        real_home = tmp_path / "real-home"
+        profile_root = tmp_path / "profiles" / "sol"
+        profile_home = profile_root / "home"
+        real_home.mkdir()
+        profile_home.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_root))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        monkeypatch.setenv("HOME", str(profile_home))
+
+        paths = gateway_cli._legacy_unit_search_paths()
+
+        assert paths[0] == (
+            False,
+            real_home / ".config" / "systemd" / "user",
+        )
 
     @staticmethod
     def _setup_search_paths(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -259,6 +259,37 @@ class TestBackfillProfileEnvs:
 class TestDeleteProfile:
     """Tests for delete_profile()."""
 
+    def test_cleanup_gateway_service_uses_real_home_when_profile_home_is_active(
+        self, tmp_path, monkeypatch
+    ):
+        real_home = tmp_path / "real-home"
+        profile_dir = real_home / ".hermes" / "profiles" / "sol"
+        profile_home = profile_dir / "home"
+        service_dir = real_home / ".config" / "systemd" / "user"
+        service_file = service_dir / "hermes-gateway-sol.service"
+        profile_home.mkdir(parents=True)
+        service_dir.mkdir(parents=True)
+        service_file.write_text("[Unit]\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+        monkeypatch.setenv("HERMES_REAL_HOME", str(real_home))
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setattr("platform.system", lambda: "Linux")
+        calls = []
+        monkeypatch.setattr(
+            profiles.subprocess,
+            "run",
+            lambda args, **kwargs: calls.append(list(args))
+            or MagicMock(returncode=0),
+        )
+
+        profiles._cleanup_gateway_service("sol", profile_dir)
+
+        assert not service_file.exists()
+        assert ["systemctl", "--user", "disable", "hermes-gateway-sol"] in calls
+        assert ["systemctl", "--user", "stop", "hermes-gateway-sol"] in calls
+        assert ["systemctl", "--user", "daemon-reload"] in calls
+
 
     def test_rmtree_failure_raises(self, profile_env):
         profile_dir = create_profile("coder", no_alias=True)


### PR DESCRIPTION
## Summary
- Resolve user systemd gateway unit paths using the real OS home instead of profile-scoped `HOME`/`Path.home()`.
- Reuse the same resolver for profile cleanup so profile-isolated `HERMES_HOME` does not point service files at the wrong directory.
- Narrow gateway PID/service discovery for default-scope calls while preserving fleet-wide discovery for update/reaper paths.

## Tests
- `PYTHONPATH=<worktree> venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_proc_fallback.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_doctor.py -q`
  - 244 passed, 6 skipped
