### PR TITLE
fix(bot-mode): fail closed on transient group-session resume failures

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5784,6 +5784,17 @@ async function ensureGroupChatSession(group, member) {
   const known = room.sessions && room.sessions[key]
 
   // Try resuming what we know (stored sid first, then title lookup).
+  //
+  // FAIL CLOSED on a transient lookup failure — mirrors the sibling fix in
+  // findExistingCanonicalChat (87b645f52c). session.resume signals "this
+  // target genuinely doesn't exist" with JSON-RPC code 4007; every other
+  // failure (network blip, the backend still warming up after a restart,
+  // an oversized-resume refusal) means the real session might still be
+  // there and must not be read as "no session, mint a new one" — that
+  // forks the member's real history, and the fork silently overwrites
+  // room.sessions[key] so the old session becomes unreachable from the
+  // room. Only a genuine 4007 on BOTH targets means there truly is nothing
+  // to resume yet, so the loop falls through to session.create below.
   for (const target of [known, title]) {
     if (!target || target === true) {
       continue
@@ -5809,8 +5820,12 @@ async function ensureGroupChatSession(group, member) {
 
         return { runtime: res.session_id, stored }
       }
-    } catch {
-      /* fall through to create */
+    } catch (error) {
+      if (error?.code !== 4007) {
+        const detail = error instanceof Error && error.message ? ` (${error.message})` : ''
+        throw new Error(`Could not check ${member?.name || 'member'}'s group session${detail} — not starting a new one`)
+      }
+      /* genuinely doesn't exist (4007) — try the next target / fall through to create */
     }
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
@@ -55,7 +55,13 @@ function load(turnScript = () => '(pass)') {
         if (method === 'session.resume') {
           const session = resolveSession(params.profile, params.session_id)
           if (!session) {
-            throw new Error(`session not found: ${params.session_id}`)
+            // Shaped like the real gateway's JsonRpcGatewayError (`.code`,
+            // apps/shared/src/json-rpc-gateway.ts) so ensureGroupChatSession's
+            // fail-closed `.code !== 4007` check sees the same "genuinely
+            // not found" signal production does.
+            const err = new Error(`session not found: ${params.session_id}`)
+            err.code = 4007
+            throw err
           }
           return {
             session_id: session.runtime,

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-attachments.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-attachments.test.mjs
@@ -50,7 +50,13 @@ function load(turnScript) {
         if (method === 'session.resume') {
           const session = resolveSession(params.profile, params.session_id)
           if (!session) {
-            throw new Error(`session not found: ${params.session_id}`)
+            // Shaped like the real gateway's JsonRpcGatewayError (`.code`,
+            // apps/shared/src/json-rpc-gateway.ts) so ensureGroupChatSession's
+            // fail-closed `.code !== 4007` check sees the same "genuinely
+            // not found" signal production does.
+            const err = new Error(`session not found: ${params.session_id}`)
+            err.code = 4007
+            throw err
           }
           return {
             session_id: session.runtime,

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -130,7 +130,15 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
         if (method === 'session.resume') {
           const session = resolveSession(params.profile, params.session_id)
           if (!session) {
-            throw new Error(`session not found: ${params.session_id}`)
+            // Shaped like the real gateway's JsonRpcGatewayError (a `.code`
+            // property, per apps/shared/src/json-rpc-gateway.ts) so
+            // ensureGroupChatSession's fail-closed `.code !== 4007` check
+            // exercises the same branch production sees. 4007 mirrors
+            // session.resume's own "session not found" JSON-RPC error code
+            // (tui_gateway/methods_session.py).
+            const err = new Error(`session not found: ${params.session_id}`)
+            err.code = 4007
+            throw err
           }
           const profile = params.profile
           const seen = (resumeCallCounts.get(profile) || 0) + 1
@@ -422,6 +430,71 @@ test('recreating a same-name group after disband mints fresh member sessions', a
   assert.notEqual(first.stored, second.stored, 'the recreated room must not resume the old member session')
   assert.equal(gc.sessions.get(first.stored).title, 'Group: r-one')
   assert.equal(gc.sessions.get(second.stored).title, 'Group: r-two')
+})
+
+test('a transient resume failure fails closed instead of forking the member session', async () => {
+  // Mirrors findExistingCanonicalChat's fix (87b645f52c): a resume that
+  // fails for any reason OTHER than "genuinely doesn't exist" (JSON-RPC
+  // code 4007) must surface, not be read as "no session, mint a new one" —
+  // that would fork the member's real history and silently overwrite
+  // room.sessions[key] so the old session becomes unreachable.
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+
+  gc.updateGroupChat('Alpha', r => {
+    r.roomId = 'r-one'
+    return r
+  })
+  const first = await gc.ensureGroupChatSession('Alpha', member)
+  const roomBefore = gc.$groupChats.get().Alpha
+
+  // Simulate a transient failure (backend still warming up after a restart,
+  // a network blip on a cross-connection lookup, ...) on the NEXT resume of
+  // the member's own stored session — a real gateway error, not "not found".
+  const originalRequest = gc.host.request
+  gc.host.request = async (method, params) => {
+    if (method === 'session.resume' && params.session_id === first.stored) {
+      const err = new Error('gateway temporarily unavailable')
+      err.code = 5000
+      throw err
+    }
+    return originalRequest(method, params)
+  }
+
+  await assert.rejects(
+    () => gc.ensureGroupChatSession('Alpha', member),
+    /Could not check .*group session/
+  )
+
+  gc.host.request = originalRequest
+
+  // Nothing was forked: the room's session pointer is untouched, and the
+  // original session is still the only one on record for this member.
+  assert.deepEqual(gc.$groupChats.get().Alpha.sessions, roomBefore.sessions)
+  assert.equal(gc.sessions.size, 1)
+})
+
+test('a genuinely nonexistent stored session (4007) still falls through to the title lookup, then create', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+
+  gc.updateGroupChat('Alpha', r => {
+    r.roomId = 'r-one'
+    return r
+  })
+
+  // A stored sid pointing at a session the gateway no longer has (e.g. an
+  // out-of-band deletion) is a genuine 4007 on the first target — the loop
+  // must still try the title lookup and, finding nothing there either,
+  // create a fresh session rather than throwing.
+  gc.updateGroupChat('Alpha', r => {
+    r.sessions = { research: 'sid-gone' }
+    return r
+  })
+
+  const result = await gc.ensureGroupChatSession('Alpha', member)
+  assert.ok(result.stored, 'a fresh session must be minted when nothing resumable exists')
+  assert.notEqual(result.stored, 'sid-gone')
 })
 
 test('group session titles are pinned to the roomId, with a legacy fallback to the display name', async () => {


### PR DESCRIPTION
## Summary

Sibling-gap: `findExistingCanonicalChat` was fixed for exactly this bug class hours earlier in this same file (87b645f52c) — "FAIL CLOSED. A failed registry lookup MUST NOT read as 'no Bot Chat exists' — that is the one remaining way to fork a bot's forever chat." `ensureGroupChatSession` (group-member sessions, not the 1:1 canonical chat) still has the pre-fix shape: its resume loop (stored sid, then title lookup) catches *any* `session.resume` error identically and falls through to `session.create`.

```js
for (const target of [known, title]) {
  ...
  try {
    const res = await requestForBot(member, 'session.resume', { session_id: target, ... })
    ...
  } catch {
    /* fall through to create */   // <- any error, not just "doesn't exist"
  }
}
```

A transient failure (the backend still warming up after a restart — the exact window `findExistingCanonicalChat`'s fix calls out — or a network blip on a cross-connection lookup) reads as "no session, mint a new one." That mints a fresh hidden session AND silently overwrites `room.sessions[key]` with the new id, orphaning the member's real prior history from the room. `ensureGroupChatSession` is actually *more* exposed than the 1:1 case it mirrors: it runs on every group turn (`runGroupChatMemberTurn`), with two independent swallow points instead of one.

## Fix

Distinguish "genuinely doesn't exist" from "transient failure" the same way the gateway itself does. `session.resume`'s own handler (`tui_gateway/methods_session.py`) returns JSON-RPC error code **4007** only when the target truly isn't found (checked by id, then by title); every other failure — including **4130** ("session too large to resume", `SessionResumeTooLargeError` — a session that genuinely *does* exist) — now surfaces as a thrown error instead of being silently read as "doesn't exist."

The call site already has a safety net for this: `runGroupChatMemberTurn`'s caller wraps it in `try { ... } catch { recordGroupActivity(group, { kind: 'failed', ... }); reply = null /* a failed turn is a pass, never a room error */ }`. So a transient hiccup now costs the member one skipped round (it retries from scratch next round, since nothing was persisted to `room.sessions[key]` on failure) instead of permanently forking the session.

## Testing

- `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs`: two new tests —
  - `a transient resume failure fails closed instead of forking the member session`: a `.code = 5000` (non-4007) resume error rejects `ensureGroupChatSession` and leaves `room.sessions` and the session count untouched (mutation-verified: fails on pre-fix code with "Missing expected rejection" — it silently created a second session instead).
  - `a genuinely nonexistent stored session (4007) still falls through to the title lookup, then create`: confirms the legitimate "nothing to resume yet" path still works.
- Updated the `session.resume` "not found" mocks in this test file plus the two sibling harnesses that independently mock the same RPC (`group-activity.test.mjs`, `group-chat-attachments.test.mjs`) to shape their thrown error like the real gateway's `JsonRpcGatewayError` (a `.code` property, per `apps/shared/src/json-rpc-gateway.ts`) — their old plain-`Error`, code-less mocks no longer matched what production now branches on, which surfaced as 3 failures across those two files until fixed the same way.
- Full `apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs` suite: 413/413 passing.
- `node --check` clean on all four changed files. `eslint` could not run (pre-existing, unrelated to this change — workspace-scoped `apps/desktop` install is missing the root-only `globals` peer dependency this repo's `eslint.config.mjs` requires).

## Competing PRs

Checked `gh pr list --search` across several keyword combinations. #90343 ("bot sessions always follow the profile's current config") touches `ensureGroupChatSession` but only adds new `session.create` parameters (`room_plumbing`, `follow_profile_config`) for a different bug (stale provider pin after a profile switch) — it doesn't touch the resume try/catch this PR changes. No other open PR addresses this gap.