### PR TITLE
fix(gateway): /p/<profile>/ on a non-multiplex gateway fails closed instead of serving the owner profile

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2081,12 +2081,13 @@ class APIServerAdapter(BasePlatformAdapter):
         """Resolve + validate the /p/<profile>/ URL prefix on an API request.
 
         Returns:
-          - ``None`` when no profile prefix is present, or multiplexing is off
-            (the prefix is ignored; request handled as the default profile).
+          - ``None`` when no profile prefix is present, or when multiplexing
+            is off and the prefix names this process's own profile (the
+            request is already scoped to the only agent served here).
           - the profile name (str) when present, multiplexing is on, and the
             profile is one this gateway serves.
-          - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
-            unknown/unconfigured (handler/middleware returns 404).
+          - ``_PROFILE_REJECTED`` when a prefix is present but names a profile
+            this process cannot serve (handler/middleware returns 404).
         """
         profile = (request.match_info.get("profile") or "").strip()
         if not profile:
@@ -2094,9 +2095,25 @@ class APIServerAdapter(BasePlatformAdapter):
         runner = getattr(self, "gateway_runner", None)
         cfg = getattr(runner, "config", None)
         if not getattr(cfg, "multiplex_profiles", False):
-            # Prefix supplied but multiplexing is off — ignore it, behave as
-            # the single-profile gateway (don't 404 a would-be valid route).
-            return None
+            # A prefix names a specific agent. With multiplexing off this
+            # process serves exactly one, so honor the prefix only when it
+            # names that one (peers address single-profile daemons this way
+            # without knowing the host's topology). Anything else must fail
+            # closed: answering as the local profile would deliver the
+            # request to a DIFFERENT agent than the one addressed — silent
+            # misdelivery, strictly worse than a 404. Observed live (Aug
+            # 2026): `hermes peer dm mini/researcher` answered by the mini's
+            # default agent, with no error anywhere.
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+
+                own = get_active_profile_name()
+            except Exception:
+                return _PROFILE_REJECTED
+            if profile == own:
+                # Scoped to self: same handling as no prefix at all.
+                return None
+            return _PROFILE_REJECTED
         try:
             from hermes_cli.profiles import profiles_to_serve
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -66,6 +66,23 @@ from typing import Any, Dict, List, Optional
 # (no prefix / multiplexing off → handle as the default profile).
 _PROFILE_REJECTED = object()
 
+
+def _prefix_names_served_profile(profile: str) -> bool:
+    """True when a /p/<profile>/ prefix names the profile this gateway serves.
+
+    Single-profile (non-multiplex) gateways historically ignored the prefix
+    and answered every /p/<x>/ request from their own profile's config —
+    which silently served the gateway owner's toolsets/capabilities under
+    another profile's URL (#91583 defect 2). Only a self-referential prefix
+    may fall through; anything else must be rejected. Fail closed.
+    """
+    try:
+        from hermes_cli.profiles import profile_matches_home
+
+        return profile_matches_home(profile)
+    except Exception:
+        return False
+
 # Profile selected by the /p/<profile>/ URL prefix for the current request.
 # Set by the profile-prefix middleware; read by handlers / _run_agent.
 _api_request_profile: ContextVar[Optional[str]] = ContextVar(
@@ -2082,12 +2099,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Returns:
           - ``None`` when no profile prefix is present, or when multiplexing
-            is off and the prefix names this process's own profile (the
-            request is already scoped to the only agent served here).
+            is off and the prefix names this gateway's own profile (the
+            request is handled as the serving profile).
           - the profile name (str) when present, multiplexing is on, and the
             profile is one this gateway serves.
-          - ``_PROFILE_REJECTED`` when a prefix is present but names a profile
-            this process cannot serve (handler/middleware returns 404).
+          - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
+            unknown/unconfigured, or names a profile this single-profile
+            gateway does not serve (handler/middleware returns 404).
         """
         profile = (request.match_info.get("profile") or "").strip()
         if not profile:
@@ -2095,25 +2113,19 @@ class APIServerAdapter(BasePlatformAdapter):
         runner = getattr(self, "gateway_runner", None)
         cfg = getattr(runner, "config", None)
         if not getattr(cfg, "multiplex_profiles", False):
-            # A prefix names a specific agent. With multiplexing off this
-            # process serves exactly one, so honor the prefix only when it
-            # names that one (peers address single-profile daemons this way
-            # without knowing the host's topology). Anything else must fail
-            # closed: answering as the local profile would deliver the
-            # request to a DIFFERENT agent than the one addressed — silent
-            # misdelivery, strictly worse than a 404. Observed live (Aug
-            # 2026): `hermes peer dm mini/researcher` answered by the mini's
-            # default agent, with no error anywhere.
-            try:
-                from hermes_cli.profiles import get_active_profile_name
-
-                own = get_active_profile_name()
-            except Exception:
-                return _PROFILE_REJECTED
-            if profile == own:
-                # Scoped to self: same handling as no prefix at all.
-                return None
-            return _PROFILE_REJECTED
+            # Prefix supplied but multiplexing is off. Only a self-referential
+            # prefix (naming the profile this gateway already serves) may fall
+            # through to the bare route. Silently ignoring ANY prefix served
+            # the gateway owner's config/toolsets/capabilities under another
+            # profile's URL — cross-profile capability leakage (#91583
+            # defect 2) and silently misdelivered peer DMs (observed live:
+            # `hermes peer dm mini/researcher` answered by the mini's default
+            # agent) — so anything else fails closed as unknown.
+            return (
+                None
+                if _prefix_names_served_profile(profile)
+                else _PROFILE_REJECTED
+            )
         try:
             from hermes_cli.profiles import profiles_to_serve
 

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -564,12 +564,14 @@ class WebhookAdapter(BasePlatformAdapter):
         """Resolve + validate the /p/<profile>/ URL prefix on a webhook request.
 
         Returns:
-          - ``None`` when no profile prefix is present, or multiplexing is off
-            (the prefix is ignored, request handled as the default profile).
+          - ``None`` when no profile prefix is present, or when multiplexing
+            is off and the prefix names this gateway's own profile (the
+            request is handled as the serving profile).
           - the profile name (str) when present, multiplexing is on, and the
             profile is one this gateway serves.
           - ``_PROFILE_REJECTED`` when a prefix is present but the profile is
-            unknown/unconfigured (handler returns 404).
+            unknown/unconfigured, or names a profile this single-profile
+            gateway does not serve (handler returns 404).
         """
         profile = (request.match_info.get("profile") or "").strip()
         if not profile:
@@ -577,9 +579,19 @@ class WebhookAdapter(BasePlatformAdapter):
         runner = self.gateway_runner
         cfg = getattr(runner, "config", None)
         if not getattr(cfg, "multiplex_profiles", False):
-            # Prefix supplied but multiplexing is off — ignore it, behave as
-            # the single-profile gateway (don't 404 a would-be valid route).
-            return None
+            # Prefix supplied but multiplexing is off. Only a self-referential
+            # prefix (naming this gateway's own profile) may fall through to
+            # the bare route; anything else fails closed — silently ignoring
+            # the prefix served the gateway owner's routes/config under
+            # another profile's URL (#91583 defect 2).
+            try:
+                from hermes_cli.profiles import profile_matches_home
+
+                if profile_matches_home(profile):
+                    return None
+            except Exception:
+                pass
+            return _PROFILE_REJECTED
         try:
             from hermes_cli.profiles import profiles_to_serve
             served = {

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -387,6 +387,38 @@ def profile_exists(name: str) -> bool:
     return get_profile_dir(canon).is_dir()
 
 
+def profile_matches_home(name: str, home: "Path | None" = None) -> bool:
+    """Return True when *name* refers to the profile served from *home*.
+
+    ``home`` defaults to the process's current Hermes home
+    (:func:`hermes_constants.get_hermes_home`).  Used by single-profile
+    gateways to decide whether a ``/p/<profile>/`` URL prefix is
+    self-referential (safe to serve on the bare route) or names a *different*
+    profile — in which case the request must fail closed rather than silently
+    resolve config/toolsets from the gateway owner (#91583 defect 2).
+
+    Invalid profile names return False (fail closed).
+    """
+    try:
+        target = get_profile_dir(name)
+    except Exception:
+        return False
+    if home is None:
+        try:
+            from hermes_constants import get_hermes_home
+
+            home = get_hermes_home()
+        except Exception:
+            return False
+    try:
+        return (
+            Path(target).expanduser().resolve(strict=False)
+            == Path(home).expanduser().resolve(strict=False)
+        )
+    except Exception:
+        return False
+
+
 def list_profile_names() -> List[str]:
     """Cheap name-only profile listing: ``default`` plus profile dirs.
 

--- a/tests/gateway/test_api_server_profile_prefix_misdelivery.py
+++ b/tests/gateway/test_api_server_profile_prefix_misdelivery.py
@@ -44,30 +44,33 @@ class TestResolverWithMultiplexOff:
 
     def test_prefix_naming_own_profile_is_honored(self, adapter, monkeypatch):
         monkeypatch.setattr(
-            "hermes_cli.profiles.get_active_profile_name", lambda: "researcher"
+            "hermes_cli.profiles.profile_matches_home",
+            lambda name, home=None: name == "researcher",
         )
         assert adapter._resolve_request_profile(_request("researcher")) is None
 
     def test_prefix_naming_default_on_default_home_is_honored(self, adapter, monkeypatch):
         monkeypatch.setattr(
-            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+            "hermes_cli.profiles.profile_matches_home",
+            lambda name, home=None: name == "default",
         )
         assert adapter._resolve_request_profile(_request("default")) is None
 
     def test_prefix_naming_another_agent_fails_closed(self, adapter, monkeypatch):
         """The misdelivery case: addressed to researcher, running as default."""
         monkeypatch.setattr(
-            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+            "hermes_cli.profiles.profile_matches_home",
+            lambda name, home=None: name == "default",
         )
         assert adapter._resolve_request_profile(_request("researcher")) is _PROFILE_REJECTED
 
     def test_unresolvable_own_identity_fails_closed(self, adapter, monkeypatch):
         """If the process cannot prove who it is, it must not answer as anyone."""
 
-        def boom():
+        def boom(name, home=None):
             raise RuntimeError("no home")
 
-        monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", boom)
+        monkeypatch.setattr("hermes_cli.profiles.profile_matches_home", boom)
         assert adapter._resolve_request_profile(_request("researcher")) is _PROFILE_REJECTED
 
 

--- a/tests/gateway/test_api_server_profile_prefix_misdelivery.py
+++ b/tests/gateway/test_api_server_profile_prefix_misdelivery.py
@@ -1,0 +1,115 @@
+"""A ``/p/<profile>/`` prefix on a non-multiplexed gateway must not misdeliver.
+
+The prefix is an address: the caller is naming WHICH agent the request is
+for. The old behavior ignored it whenever ``gateway.multiplex_profiles`` was
+off and answered as the process's own (single) profile — so a request
+explicitly addressed to one agent was silently answered by a different one.
+Observed live (Aug 2026): ``hermes peer dm mini/researcher`` was answered by
+the mini's *default* agent, with no error on either side, because the mini
+runs one LaunchDaemon per profile and only the default daemon hosted an
+api_server.
+
+The contract now: with multiplexing off, a prefix naming this process's own
+profile is honored (peers address single-profile daemons this way without
+knowing the host's topology); any other name fails closed with the existing
+404, because a wrong-agent answer is strictly worse than an error.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.platforms.api_server import _PROFILE_REJECTED, APIServerAdapter
+from gateway.config import PlatformConfig
+
+
+@pytest.fixture()
+def adapter():
+    # No gateway_runner configured -> multiplex_profiles is falsy, the exact
+    # shape of a standalone single-profile daemon.
+    return APIServerAdapter(PlatformConfig(enabled=True))
+
+
+def _request(profile: str | None):
+    return SimpleNamespace(match_info={} if profile is None else {"profile": profile})
+
+
+class TestResolverWithMultiplexOff:
+    def test_no_prefix_is_untouched(self, adapter):
+        assert adapter._resolve_request_profile(_request(None)) is None
+
+    def test_prefix_naming_own_profile_is_honored(self, adapter, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "researcher"
+        )
+        assert adapter._resolve_request_profile(_request("researcher")) is None
+
+    def test_prefix_naming_default_on_default_home_is_honored(self, adapter, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        assert adapter._resolve_request_profile(_request("default")) is None
+
+    def test_prefix_naming_another_agent_fails_closed(self, adapter, monkeypatch):
+        """The misdelivery case: addressed to researcher, running as default."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        assert adapter._resolve_request_profile(_request("researcher")) is _PROFILE_REJECTED
+
+    def test_unresolvable_own_identity_fails_closed(self, adapter, monkeypatch):
+        """If the process cannot prove who it is, it must not answer as anyone."""
+
+        def boom():
+            raise RuntimeError("no home")
+
+        monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", boom)
+        assert adapter._resolve_request_profile(_request("researcher")) is _PROFILE_REJECTED
+
+
+class TestMultiplexOnUnchanged:
+    def test_served_profile_resolves(self, adapter, monkeypatch):
+        adapter.gateway_runner = SimpleNamespace(
+            config=SimpleNamespace(
+                multiplex_profiles=True, multiplex_profile_allowlist=None
+            )
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex, profile_allowlist: [("worker", object())],
+        )
+        assert adapter._resolve_request_profile(_request("worker")) == "worker"
+        assert adapter._resolve_request_profile(_request("ghost")) is _PROFILE_REJECTED
+
+
+@pytest.mark.asyncio
+async def test_http_request_addressed_to_another_agent_is_404_not_answered(
+    adapter, monkeypatch
+):
+    """End to end through the real middleware: the wrong-agent request must
+    404 instead of being served — a body would mean the misdelivery is back."""
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+
+    async def handler(request):
+        return web.json_response({"served_by": "default"})
+
+    app = web.Application(middlewares=[adapter._make_profile_prefix_middleware()])
+    app.router.add_get("/p/{profile}/v1/test", handler)
+    app.router.add_get("/v1/test", handler)
+
+    async with TestClient(TestServer(app)) as cli:
+        # Addressed to a different agent: refused.
+        resp = await cli.get("/p/researcher/v1/test")
+        assert resp.status == 404
+        body = await resp.json()
+        assert "profile" in str(body.get("error", "")).lower()
+
+        # Addressed to this agent, and unaddressed: both served.
+        assert (await cli.get("/p/default/v1/test")).status == 200
+        assert (await cli.get("/v1/test")).status == 200

--- a/tests/gateway/test_multiplex_toolsets_profile_isolation.py
+++ b/tests/gateway/test_multiplex_toolsets_profile_isolation.py
@@ -1,0 +1,204 @@
+"""Per-profile toolset isolation on the multiplexed api_server (#91583 defect 2).
+
+Two defects covered:
+
+1. With multiplexing ON, ``/p/<x>/v1/toolsets`` must reflect profile *x*'s own
+   ``platform_toolsets.api_server`` — for both the gateway-owning default
+   profile and a secondary profile — never the listener owner's config.
+
+2. With multiplexing OFF, a ``/p/<other>/`` prefix used to be silently
+   ignored, serving the gateway owner's config under another profile's URL.
+   It must now be rejected (404); only a self-referential prefix (naming the
+   profile this gateway actually serves) falls through.
+
+E2E-style: real profile homes under a temp HERMES root, real config.yaml
+files read through the canonical loaders, and real aiohttp request routing
+(TestClient) through the profile-prefix middleware. No mocked config reads.
+"""
+from __future__ import annotations
+
+import pytest
+
+aiohttp = pytest.importorskip("aiohttp")
+from aiohttp import web  # noqa: E402
+from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
+
+from gateway.config import GatewayConfig, PlatformConfig  # noqa: E402
+from gateway.platforms.api_server import (  # noqa: E402
+    APIServerAdapter,
+    _PROFILE_REJECTED,
+)
+
+OWNER_KEY = "owner-key-1234567890abcdef"
+LOKAJ_KEY = "lokaj-key-1234567890abcdef"
+
+
+@pytest.fixture()
+def hermes_root(tmp_path, monkeypatch):
+    """Two real profile homes: default (owner) and 'lokaj' (secondary)."""
+    root = tmp_path / "hermes"
+    lokaj = root / "profiles" / "lokaj"
+    lokaj.mkdir(parents=True)
+    (root / "config.yaml").write_text(
+        "platform_toolsets:\n  api_server: [web, file]\n",
+        encoding="utf-8",
+    )
+    (lokaj / "config.yaml").write_text(
+        "platform_toolsets:\n  api_server: [web, file, computer_use]\n",
+        encoding="utf-8",
+    )
+    (lokaj / ".env").write_text(f"API_SERVER_KEY={LOKAJ_KEY}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    # get_default_hermes_root memoizes per (native_home, env_home) pair, so
+    # the env change alone re-keys it; no cache reset needed.
+    return root
+
+
+def _make_adapter(multiplex: bool) -> APIServerAdapter:
+    cfg = PlatformConfig(enabled=True, extra={"key": OWNER_KEY})
+    adapter = APIServerAdapter(cfg)
+
+    class _Runner:
+        config = GatewayConfig(multiplex_profiles=multiplex)
+
+    adapter.gateway_runner = _Runner()
+    return adapter
+
+
+def _make_app(adapter: APIServerAdapter) -> web.Application:
+    """Mirror connect()'s wiring: middleware + native and /p/ mirror routes."""
+    app = web.Application(middlewares=[adapter._make_profile_prefix_middleware()])
+    app["api_server_adapter"] = adapter
+    for method, path, handler in adapter._http_route_table():
+        app.router.add_route(method, path, handler)
+        app.router.add_route(method, f"/p/{{profile}}{path}", handler)
+    return app
+
+
+async def _enabled_toolsets(cli: TestClient, path: str, key: str):
+    resp = await cli.get(path, headers={"Authorization": f"Bearer {key}"})
+    if resp.status != 200:
+        return resp.status, None
+    body = await resp.json()
+    return resp.status, {d["name"] for d in body["data"] if d["enabled"]}
+
+
+class TestMultiplexOnToolsetIsolation:
+    @pytest.mark.asyncio
+    async def test_each_profile_sees_its_own_toolsets(self, hermes_root):
+        adapter = _make_adapter(multiplex=True)
+        async with TestClient(TestServer(_make_app(adapter))) as cli:
+            # Owner (default) profile: bare route and /p/default mirror.
+            for path in ("/v1/toolsets", "/p/default/v1/toolsets"):
+                status, enabled = await _enabled_toolsets(cli, path, OWNER_KEY)
+                assert status == 200, path
+                assert "computer_use" not in enabled, path
+                assert {"web", "file"} <= enabled, path
+
+            # Secondary profile: its own config, its own key.
+            status, enabled = await _enabled_toolsets(
+                cli, "/p/lokaj/v1/toolsets", LOKAJ_KEY
+            )
+            assert status == 200
+            # The exact repro from #91583 defect 2: computer_use enabled in
+            # lokaj's config must be reported enabled under /p/lokaj/…
+            assert "computer_use" in enabled
+
+    @pytest.mark.asyncio
+    async def test_owner_key_does_not_open_secondary_profile(self, hermes_root):
+        """Cross-profile auth stays closed: owner key must not read lokaj."""
+        adapter = _make_adapter(multiplex=True)
+        async with TestClient(TestServer(_make_app(adapter))) as cli:
+            status, _ = await _enabled_toolsets(
+                cli, "/p/lokaj/v1/toolsets", OWNER_KEY
+            )
+            assert status == 401
+
+    @pytest.mark.asyncio
+    async def test_unknown_profile_is_404(self, hermes_root):
+        adapter = _make_adapter(multiplex=True)
+        async with TestClient(TestServer(_make_app(adapter))) as cli:
+            resp = await cli.get(
+                "/p/ghost/v1/toolsets",
+                headers={"Authorization": f"Bearer {OWNER_KEY}"},
+            )
+            assert resp.status == 404
+
+
+class TestMultiplexOffPrefixFailsClosed:
+    """Single-profile gateways must not serve another profile's URL."""
+
+    def test_foreign_prefix_rejected(self, hermes_root):
+        adapter = _make_adapter(multiplex=False)
+
+        class _Req:
+            match_info = {"profile": "lokaj"}
+
+        assert adapter._resolve_request_profile(_Req()) is _PROFILE_REJECTED
+
+    def test_self_referential_prefix_falls_through(self, hermes_root):
+        """/p/default/ on the default-profile gateway keeps working."""
+        adapter = _make_adapter(multiplex=False)
+
+        class _Req:
+            match_info = {"profile": "default"}
+
+        assert adapter._resolve_request_profile(_Req()) is None
+
+    def test_own_named_profile_prefix_falls_through(self, hermes_root, monkeypatch):
+        """A gateway launched FOR profile lokaj accepts /p/lokaj/…"""
+        monkeypatch.setenv(
+            "HERMES_HOME", str(hermes_root / "profiles" / "lokaj")
+        )
+        adapter = _make_adapter(multiplex=False)
+
+        class _Req:
+            match_info = {"profile": "lokaj"}
+
+        assert adapter._resolve_request_profile(_Req()) is None
+
+    @pytest.mark.asyncio
+    async def test_foreign_prefix_is_404_end_to_end(self, hermes_root):
+        adapter = _make_adapter(multiplex=False)
+        async with TestClient(TestServer(_make_app(adapter))) as cli:
+            resp = await cli.get(
+                "/p/lokaj/v1/toolsets",
+                headers={"Authorization": f"Bearer {OWNER_KEY}"},
+            )
+            assert resp.status == 404
+            # Bare route unaffected.
+            status, enabled = await _enabled_toolsets(
+                cli, "/v1/toolsets", OWNER_KEY
+            )
+            assert status == 200
+            assert "computer_use" not in enabled
+
+
+class TestWebhookMultiplexOffPrefixFailsClosed:
+    """Same bug class in the webhook adapter's prefix resolver."""
+
+    def _adapter(self, multiplex: bool):
+        from gateway.platforms.webhook import WebhookAdapter, _PROFILE_REJECTED
+
+        class _Runner:
+            config = GatewayConfig(multiplex_profiles=multiplex)
+
+        adapter = WebhookAdapter.__new__(WebhookAdapter)
+        adapter.gateway_runner = _Runner()
+        return adapter, _PROFILE_REJECTED
+
+    def test_foreign_prefix_rejected(self, hermes_root):
+        adapter, rejected = self._adapter(multiplex=False)
+
+        class _Req:
+            match_info = {"profile": "lokaj"}
+
+        assert adapter._resolve_request_profile(_Req()) is rejected
+
+    def test_self_referential_prefix_falls_through(self, hermes_root):
+        adapter, _rejected = self._adapter(multiplex=False)
+
+        class _Req:
+            match_info = {"profile": "default"}
+
+        assert adapter._resolve_request_profile(_Req()) is None


### PR DESCRIPTION
## Outcome

`/p/<profile>/…` on an api_server gateway can no longer resolve another profile's toolsets/config: with multiplexing **on**, every `/p/<x>/` read already resolved from profile *x* (verified E2E); with multiplexing **off**, a foreign `/p/<x>/` prefix was silently ignored and served the **gateway owner's** config under x's URL — it now fails closed with 404. Same fix applied to the webhook adapter, which had the identical fallthrough.

Fixes #91583 defect 2 (per Teknium's ruling: per-profile capability isolation IS the intended design, so this was a routing bug, not host policy). Repro and live validation credit: @kubaboski.

## Root cause

The reported symptom — `hermes -p lokaj tools enable computer_use --platform api_server` shows enabled in lokaj's config while `/p/lokaj/v1/toolsets` reports `enabled:false`, and enabling on the owner profile flips it true — is the signature of the **non-multiplex prefix fallthrough**, not of the scoped loaders:

- On a multiplexed gateway, the profile-prefix middleware enters `_profile_runtime_scope(get_profile_dir(profile))`, and every canonical loader honors the HERMES_HOME override contextvar. Verified empirically with real profile homes: inside the scope, `get_config_path()`, `load_config()` **and** `gateway.run._load_gateway_config()` (via `_gateway_config_home()`) all resolve the target profile's `config.yaml`, and `_get_platform_tools` returns that profile's toolsets. The mtime cache is keyed on `str(config_path)`, so profiles don't collide.
- The leak was `_resolve_request_profile`'s multiplex-off branch: "Prefix supplied but multiplexing is off — ignore it, behave as the single-profile gateway." Ignoring the prefix means the request runs entirely in the owner profile's home — toolsets, skills, capabilities, model options, and agent-run toolset resolution all read the owner's config while answering under `/p/lokaj/…`. That is exactly the reporter's environment (app-managed `hermes serve` runtime addressed with `/p/lokaj/` URLs).

## Fix (one seam, whole class)

- `gateway/platforms/api_server.py::_resolve_request_profile` — multiplex-off + foreign prefix now returns `_PROFILE_REJECTED` (404). A **self-referential** prefix (`/p/default/` on the default gateway, `/p/lokaj/` on a gateway launched for lokaj) still falls through, so well-formed existing clients keep working.
- `gateway/platforms/webhook.py::_resolve_request_profile` — identical fallthrough, same fix. These are the only two `_resolve_request_profile` implementations in the tree.
- `hermes_cli/profiles.py::profile_matches_home` — new shared fail-closed helper comparing `get_profile_dir(name)` against the process's current Hermes home.

No per-call-site patches were needed: all `/p/<x>/`-scoped handlers and both agent-run paths (`_run_agent`, `/v1/runs`) already wrap their work in `self._profile_scope(request_profile)`, so once the prefix resolves to the right profile (or is rejected), every config read downstream is correct. Prompt caching and multiplex secret scope untouched.

## Verification

- New `tests/gateway/test_multiplex_toolsets_profile_isolation.py` (9 tests, E2E-style: two real profile homes + `config.yaml`s under a temp HERMES root, real aiohttp routing through the profile-prefix middleware, canonical config loaders — no mocked reads):
  - multiplex ON: `/p/<x>/v1/toolsets` reflects x's own `platform_toolsets` for both owner and secondary; the #91583 repro asserts `computer_use` true under `/p/lokaj/` only;
  - owner key does NOT open a secondary profile (401); unknown profile 404;
  - multiplex OFF: foreign prefix 404 end-to-end, self-referential prefix falls through, bare route unchanged — for both api_server and webhook.
- **Sabotage-verified**: stashing the adapter change fails exactly the 3 fail-closed tests.
- Full real-server E2E (`connect()` on a live port, urllib clients): multiplex on → `/p/lokaj` reports `computer_use: true` with lokaj's key while owner routes stay false; multiplex off → `/p/lokaj` 404.
- Neighboring suites green: `test_multiplex_api_server_routing.py`, `test_multiplex_http_routing.py`, `test_multiplex_profile_authz.py`, `test_api_server_toolset.py`, `test_profiles.py` (71 passed, 2 skipped), `test_api_server.py` + `test_webhook*.py` (173 passed).
- Ruff clean on all changed files; `audit_pr_attribution.py --fix` clean.

## Infographic

![The right agent answers](https://v3b.fal.media/files/b/0aa77b08/hfwT3-CAO-OME0TMWDmCh_Y7zQJxSn.png)



**Salvage note:** this PR now also carries @jonpol01's independent fix + misdelivery tests from #92773 (cherry-picked, authorship preserved) — same root cause found from the peer-DM direction; his live `hermes peer dm mini/researcher` misdelivery observation is folded into the guard comment.