### PR TITLE
fix(gateway): prevent delegated children from stealing parent routes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16347,6 +16347,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return session_entry
 
         prior_session_id = session_entry.session_id
+        if (
+            not follows_compression
+            and str(pinned_row.get("parent_session_id") or "")
+            == prior_session_id
+        ):
+            # A delegated child can inherit the gateway peer metadata while its
+            # task-local session id correctly points at the child.  A background
+            # process notification from that mixed context must never move the
+            # parent's route to the child: switch_session() would end the parent
+            # as a hard session_switch boundary, and the delegation's eventual
+            # aggregate completion would then be terminally dropped.  Genuine
+            # compression continuations use the verified lineage path above.
+            logger.warning(
+                "Async-delegation completion refused to move routing key %s "
+                "from parent session %s to its child %s.",
+                session_entry.session_key,
+                prior_session_id,
+                target_session_id,
+            )
+            return None
         if follows_compression:
             switched = await self.async_session_store.advance_compression_session(
                 session_entry.session_key,

--- a/tests/gateway/test_async_delegation_session_binding.py
+++ b/tests/gateway/test_async_delegation_session_binding.py
@@ -118,6 +118,26 @@ class TestGatewayPinningFailsClosed:
         )
 
     @pytest.mark.asyncio
+    async def test_delegated_child_cannot_replace_parent_route(self):
+        current = self._entry("sess_parent")
+        runner = self._make_runner(
+            {
+                "sess_child": {
+                    "id": "sess_child",
+                    "ended_at": None,
+                    "parent_session_id": "sess_parent",
+                }
+            }
+        )
+
+        resolved = await runner._resolve_async_delegation_session(
+            current, "sess_child"
+        )
+
+        assert resolved is None
+        self._assert_no_route_change(runner)
+
+    @pytest.mark.asyncio
     async def test_non_compression_ended_parent_drops(self):
         current = self._entry("sess_old")
         runner = self._make_runner(


### PR DESCRIPTION
## Summary

- refuse non-compression async completion routing that would replace a session with its direct child
- preserve the parent route so the delegation's aggregate completion remains deliverable
- keep verified compression continuation routing unchanged

## Root cause

A delegated child can emit a background completion carrying the gateway peer route inherited from its parent while its durable session id correctly identifies the child. The completion resolver previously treated that mixed identity as a valid owner rebind and called `switch_session()`. That ended the parent with the hard `session_switch` boundary, after which the batch's own final completion was classified as terminal and dropped.

## Testing

- `scripts/run_tests.sh tests/gateway/test_async_delegation_session_binding.py tests/gateway/test_delegation_session_id_leak.py tests/gateway/test_agents_command_delegations.py tests/gateway/test_relay_completion_injection_routing.py tests/gateway/test_completion_session_boundary.py tests/gateway/test_completion_delivery.py -q` (54 passed)

## Related Issue

N/A
