### PR TITLE
fix(desktop): kill all Hermes backends before updating on Windows

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -326,7 +326,7 @@ import {
   observeUpdaterHandoff,
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
-  resolveUpdateScriptHandoff,
+  resolveWindowsUpdateTransport,
   sandboxFallbackFromEnv,
   spawnUpdaterProcess,
   stagedUpdaterSupportsPrewrittenMarker,
@@ -3577,48 +3577,35 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
       return await applyUpdatesPosixHandoff(opts)
     }
 
-    if (!updater) {
-      // No staged updater binary — this is a CLI-installed user (they ran
-      // `hermes desktop`, never the Tauri installer that self-copies
-      // hermes-setup.exe into HERMES_HOME). On Windows the repo hand-off
-      // script serves them just as well as installer users — it only needs
-      // PowerShell and the checkout — so fall through to the normal hand-off
-      // when the script exists. Only when the checkout predates the script do
-      // we surface the manual one-liner.
+    const windowsUpdateTransport = IS_WINDOWS ? resolveWindowsUpdateTransport(resolveUpdateRoot()) : null
+
+    if (windowsUpdateTransport?.kind === 'manual') {
+      // The live checkout predates the repo-owned hand-off script. Do not fall
+      // back to the frozen staged installer for an ordinary update; surface the
+      // branch-pinned CLI command instead. Bootstrap recovery still owns the
+      // staged-binary path.
       const updateRoot = resolveUpdateRoot()
+      let command = 'hermes update'
 
-      if (!resolveUpdateScriptHandoff(updateRoot)) {
-        // They DO have a working `hermes` on PATH / in the venv, so the
-        // correct path is the one-liner in their native medium. We show the
-        // EXACT command, branch-pinned to the checkout they're on — bare
-        // `hermes update` defaults to main and would silently switch a
-        // bb/gui (or any non-main) install off-branch. Mirror the GUI
-        // button's contract: append --branch <current> for non-main
-        // checkouts, keep it bare for main so the card stays clean.
-        let command = 'hermes update'
+      try {
+        const head = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: updateRoot })
+        const current = (head.stdout || '').trim()
 
-        try {
-          const head = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: updateRoot })
-          const current = (head.stdout || '').trim()
+        if (head.code === 0 && current && current !== 'HEAD') {
+          const branch = await resolveHealedBranch(updateRoot, current)
 
-          if (head.code === 0 && current && current !== 'HEAD') {
-            const branch = await resolveHealedBranch(updateRoot, current)
-
-            if (branch !== 'main') {
-              command = `hermes update --branch ${branch}`
-            }
+          if (branch !== 'main') {
+            command = `hermes update --branch ${branch}`
           }
-        } catch {
-          // Best-effort: fall back to bare `hermes update` if branch detection fails.
         }
-
-        rememberLog(`[updates] no staged updater; surfacing manual \`${command}\` for CLI install at ${updateRoot}`)
-        emitUpdateProgress({ stage: 'manual', message: command, percent: null })
-
-        return { ok: true, manual: true, command, hermesRoot: updateRoot }
+      } catch {
+        // Best-effort: fall back to bare `hermes update` if branch detection fails.
       }
 
-      rememberLog('[updates] no staged updater; using repo hand-off script for CLI install')
+      rememberLog(`[updates] no repo hand-off script; surfacing manual \`${command}\` for ${updateRoot}`)
+      emitUpdateProgress({ stage: 'manual', message: command, percent: null })
+
+      return { ok: true, manual: true, command, hermesRoot: updateRoot }
     }
 
     const handoffConflict = updateHandoffConflict(HERMES_HOME)
@@ -3685,15 +3672,9 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     // Detached so the updater outlives this process — it needs us GONE before
     // `hermes update` will run (the venv shim is locked while we live).
     //
-    // Prefer the repo-owned hand-off script over the staged Tauri binary.
-    // The staged binary is frozen (no self-update path) and historically runs
-    // months-stale updater logic — pre-#67369 cache resolver, pre-#74782
-    // marker adoption — producing failures that were fixed on main long ago
-    // (2026-08-09 incident). scripts/desktop-update/windows.ps1 ships WITH the
-    // checkout, so each `hermes update` refreshes the code that drives the
-    // next one. Checkouts that predate the script fall back to the binary
-    // path unchanged.
-    const scriptHandoff = resolveUpdateScriptHandoff(updateRoot)
+    // Ordinary Windows updates use only the repo-owned script. POSIX keeps its
+    // existing staged-binary route; packaged bootstrap recovery is separate.
+    const scriptHandoff = windowsUpdateTransport?.kind === 'script' ? windowsUpdateTransport.handoff : null
     let child
 
     if (scriptHandoff) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -332,12 +332,6 @@ import {
   stagedUpdaterSupportsPrewrittenMarker,
   wrapHandoffForDetachedConsole
 } from './updater-process'
-import {
-  formatBlockerMessage,
-  formatProbeFailedMessage,
-  scanVenvBlockers,
-  stopSafeVenvBlockers
-} from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { enumerateWindowsFrontToBack, readWindowBelow } from './window-below'
@@ -3151,6 +3145,50 @@ function forceKillProcessTree(pid) {
   }
 }
 
+// Kill every non-Desktop process executing from this Hermes install. Selecting
+// tree roots keeps taskkill /T authoritative across Python/Node trampolines;
+// this is target collection only, never a holder-classification gate.
+function forceKillAllHermesBackendTrees(updateRoot: string) {
+  if (!IS_WINDOWS) {
+    return
+  }
+
+  const root = `${path.resolve(updateRoot).replace(/'/g, "''").replace(/[\\/]+$/, '')}\\`
+  const desktopExecutable = path.resolve(process.execPath).replace(/'/g, "''")
+  const script = `
+$ErrorActionPreference = 'SilentlyContinue'
+$root = '${root}'
+$desktopExecutable = '${desktopExecutable}'
+$processes = @(Get-CimInstance Win32_Process)
+$targets = @($processes | Where-Object {
+  $executable = [string]$_.ExecutablePath
+  $_.ProcessId -ne ${process.pid} -and
+    $executable.StartsWith($root, [StringComparison]::OrdinalIgnoreCase) -and
+    -not $executable.Equals($desktopExecutable, [StringComparison]::OrdinalIgnoreCase)
+})
+$targetIds = @{}
+foreach ($target in $targets) {
+  $targetIds[[int]$target.ProcessId] = $true
+}
+foreach ($target in $targets) {
+  if (-not $targetIds.ContainsKey([int]$target.ParentProcessId)) {
+    & taskkill.exe /PID ([string]$target.ProcessId) /T /F *> $null
+  }
+}
+`
+
+  try {
+    execFileSync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      hiddenWindowsChildOptions({ stdio: 'ignore' })
+    )
+  } catch {
+    // Each tree kill is best effort; the existing shim-unlock wait below is
+    // still the fail-closed hand-off gate.
+  }
+}
+
 function writeBackendOwnership(contents) {
   fs.mkdirSync(path.dirname(DESKTOP_BACKEND_OWNERSHIP_PATH), { recursive: true })
   const tempPath = `${DESKTOP_BACKEND_OWNERSHIP_PATH}.${process.pid}.tmp`
@@ -3625,6 +3663,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     // spawn the updater. Without this the updater races a still-locked
     // hermes.exe (held by the backend child / its grandchildren) and the update
     // bricks. See releaseBackendLockForUpdate for the full failure analysis.
+    forceKillAllHermesBackendTrees(updateRoot)
     const lock = await releaseBackendLockForUpdate(updateRoot)
 
     if (!lock.unlocked) {
@@ -3641,50 +3680,6 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
       startHermes().catch(() => {})
 
       return { ok: false, error: message }
-    }
-
-    // Preflight: after releasing our own backends, check for remaining
-    // Hermes processes running from this venv.  The updater normally refuses
-    // when it detects a holder, but because the updater is spawned detached
-    // with stdio:ignore, the user never sees that refusal and the update
-    // silently fails.  This preflight detects holders early and gives the
-    // user an actionable error.  Windows-only; the .pyd lock hazard is a
-    // Windows phenomenon.  ALL failures (blocked, missing python, timeout,
-    // malformed output, missing psutil) abort the handoff — never proceed
-    // to the detached updater when the venv state is unknown.
-    if (IS_WINDOWS) {
-      let scanOutcome = await scanVenvBlockers(updateRoot)
-
-      if (scanOutcome.kind === 'blocked' && opts.stopSafeBlockers) {
-        const stopResult = await stopSafeVenvBlockers(updateRoot, scanOutcome.result)
-        rememberLog(
-          `[updates] user-approved blocker cleanup: stopped=${stopResult.stopped.join(',') || 'none'} failed=${stopResult.failed.join(',') || 'none'}`
-        )
-        // Let verified process-tree termination finish unwinding wrapper shells,
-        // then make the scanner — not the stale renderer payload — authoritative.
-        await new Promise(resolve => setTimeout(resolve, 300))
-        scanOutcome = await scanVenvBlockers(updateRoot)
-      }
-
-      if (scanOutcome.kind === 'blocked') {
-        const message = formatBlockerMessage(scanOutcome.result)
-
-        rememberLog(`[updates] venv-blocked: ${scanOutcome.result.processes.length} process(es) hold the install`)
-        emitUpdateProgress({ stage: 'error', message, percent: null })
-        startHermes().catch(() => {})
-
-        return { ok: false, error: 'venv-blocked', message, blockers: scanOutcome.result.processes }
-      }
-
-      if (scanOutcome.kind === 'probe-failure') {
-        const message = formatProbeFailedMessage()
-
-        rememberLog(`[updates] venv-blocker probe failed: ${scanOutcome.error}`)
-        emitUpdateProgress({ stage: 'error', message, percent: null })
-        startHermes().catch(() => {})
-
-        return { ok: false, error: 'venv-probe-failed', message }
-      }
     }
 
     // Detached so the updater outlives this process — it needs us GONE before

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -11,6 +11,7 @@ import {
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
   resolveUpdateScriptHandoff,
+  resolveWindowsUpdateTransport,
   sandboxFallbackFromEnv,
   spawnUpdaterProcess,
   stagedUpdaterSupportsPrewrittenMarker,
@@ -216,6 +217,27 @@ test('resolveUpdateScriptHandoff is Windows-only (POSIX updates in place)', () =
   })
 
   assert.equal(handoff, null)
+})
+
+test('resolveWindowsUpdateTransport selects the live checkout script', () => {
+  const root = String.raw`C:\Users\hermes\AppData\Local\hermes\hermes-agent`
+  const scriptPath = path.join(root, 'scripts', 'desktop-update', 'windows.ps1')
+  const transport = resolveWindowsUpdateTransport(root, {
+    isWindows: true,
+    fileExists: candidate => candidate === scriptPath
+  })
+
+  assert.equal(transport.kind, 'script')
+  assert.equal(transport.kind === 'script' ? transport.handoff.scriptPath : null, scriptPath)
+})
+
+test('resolveWindowsUpdateTransport requires a manual update without a live script', () => {
+  const transport = resolveWindowsUpdateTransport(String.raw`C:\Users\hermes\AppData\Local\hermes\hermes-agent`, {
+    isWindows: true,
+    fileExists: () => false
+  })
+
+  assert.deepEqual(transport, { kind: 'manual' })
 })
 
 test('wrapHandoffForDetachedConsole routes through cmd start with own console', () => {

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -20,6 +20,8 @@ export interface UpdateScriptHandoff {
   scriptPath: string
 }
 
+export type WindowsUpdateTransport = { kind: 'script'; handoff: UpdateScriptHandoff } | { kind: 'manual' }
+
 /**
  * Repo-owned Windows update hand-off (frozen-binary escape hatch).
  *
@@ -66,6 +68,20 @@ export function resolveUpdateScriptHandoff(
   }
 
   return null
+}
+
+/**
+ * Ordinary Windows updates must use the updater logic shipped with the live
+ * checkout. The staged installer is frozen at build time and remains reserved
+ * for bootstrap recovery, where the checkout may not yet provide a script.
+ */
+export function resolveWindowsUpdateTransport(
+  updateRoot: string,
+  deps: ResolveUpdateScriptHandoffDeps = {}
+): WindowsUpdateTransport {
+  const handoff = resolveUpdateScriptHandoff(updateRoot, deps)
+
+  return handoff ? { kind: 'script', handoff } : { kind: 'manual' }
 }
 
 /**


### PR DESCRIPTION
## Problem

A Windows Desktop update cannot safely mutate Hermes' managed Python environment while any process from that install is still running. A surviving descendant can keep the venv shim or native `.pyd` files locked and make the update abort or leave a partially updated environment.

The previous Desktop path tried to identify and classify individual holders, then selectively stop the ones considered safe. That is the wrong boundary for this failure: Python, Node, shell, PTY, gateway, and MCP trampolines can change the visible parent or command line while the process tree still belongs to the same Hermes install. In the production reproduction, launching the update script without the Desktop pre-handoff left two `agent.transports.hermes_tools_mcp_server` processes alive and the updater correctly refused to mutate the venv.

The invariant we actually need is simpler: once the user chooses **Update now**, the active Hermes install must be quiescent before the updater starts.

## Approach

Immediately before releasing the Desktop backend lock, the Windows handoff now:

1. Takes one `Win32_Process` snapshot.
2. Selects every non-Desktop process whose executable is rooted under the exact active Hermes install.
3. Reduces that set to its top-level process-tree roots.
4. Runs `taskkill /PID <root> /T /F` for each root.
5. Keeps the existing shim-unlock wait as the fail-closed authority before handoff.

This is deliberately target collection, not holder classification. It handles Python/Node/shell trampolines by terminating their full trees, while bounding the action to executables under the selected install root. The Desktop executable is excluded because the detached handoff already waits for the app itself to exit.

## Update transport

Ordinary Windows updates must also use updater logic from the live checkout. A staged `hermes-setup.exe` is frozen at packaging time and has no reliable self-update path, so using it for routine updates can reintroduce months-old behavior after the source checkout has already moved forward.

This PR therefore makes the transport contract explicit:

- If `scripts/desktop-update/windows.ps1` exists, ordinary updates use it.
- If the live checkout predates that script, Desktop shows the branch-pinned manual `hermes update` command.
- The staged installer remains available for bootstrap recovery, where no usable live checkout may exist yet.

## Changes

- Add the install-root-scoped, process-tree kill-all immediately before the updater handoff.
- Remove Desktop's holder inventory/classification and selective-drain gate from this path.
- Add `resolveWindowsUpdateTransport()` so routine updates cannot silently fall back to the frozen staged installer.
- Pin both transport outcomes with focused regression coverage.

## Validation

Automated checks:

- `vitest run --project electron electron/updater-process.test.ts` — 28/28 passed.
- `tsc -p tsconfig.electron.json --noEmit` — passed.

Visible production Desktop proofs on Windows:

- **Run A:** kill-all baseline `afcb9aec10` updated through the real **Update now** flow to transport candidate `ae4cf1eda7`. The updater returned `0`, removed its ownership marker, cold-started the gateway, and relaunched Desktop on the new commit. The holder refusal reproduced by the standalone script did not occur through the Desktop handoff.
- **Run B:** `ae4cf1eda7` updated through the same visible flow to final candidate `9d52c89edc`. The updater returned `0`, reported `Update complete`, removed its marker, cold-started the gateway, relaunched and focused Desktop, and displayed `v0.20.5 9d52c89` with `Gateway ready`.
- Final live checkout: `fork-integration` at `9d52c89edc1d135f4abcb35e52785e7c4d83929b`, clean working tree, no update marker.

The production candidate is the canonical `fork-integration` composition: it contains this PR's updater changes plus additive fork-only branch-selection and shortcut-repair work, so its commit IDs differ from this PR. `updater-process.ts` and its focused tests are identical to the PR head; the additional `main.ts` differences do not replace the kill-all or live-transport mechanisms tested here.

Run A also exposed an unrelated optional `cua-driver` refresh prompt (`Read-Host`) inside a hidden non-interactive PowerShell process. Only that optional installer was terminated; Hermes treated its failure as non-fatal and completed the update. Run B found `cua-driver 0.22.0` current and completed without intervention.

## Scope

This changes the Desktop Electron handoff and its focused tests. It does not redesign the Python updater, add a new process supervisor, or preserve individual Hermes background processes after the user commits to an update. Safe venv mutation takes precedence at that explicit update boundary.