### PR TITLE
Forward the gateway session key as MCP call meta

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3931,6 +3931,28 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     "error": f"MCP server '{server_name}' is not connected"
                 }, ensure_ascii=False)
 
+        # Resolve the gateway's per-chat session key *here*, on the agent's
+        # own task, where the HERMES_SESSION_KEY contextvar is current. `_call`
+        # below runs on the separate MCP event loop (see _run_on_mcp_loop at
+        # the bottom of this handler), so contextvars set on the agent's task
+        # are not visible inside it — closing over the value read now is the
+        # only way to get it there. See docs/superpowers/specs/
+        # 2026-08-22-spike2-caller-identity.md for the full mechanism.
+        #
+        # Fail open: this read happens before `_call()` is defined, i.e.
+        # outside the `try: result = _call_once()` block near the bottom of
+        # this handler that turns every other failure into the JSON error
+        # string callers expect. An uncaught ImportError here would escape
+        # as a raw exception instead. Degrading to no session key is exactly
+        # the CLI/cron behaviour already handled below (`meta=None`), so
+        # fail open rather than fail loud.
+        try:
+            from gateway.session_context import get_session_env
+
+            session_key = get_session_env("HERMES_SESSION_KEY", "")
+        except ImportError:
+            session_key = ""
+
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
@@ -3940,7 +3962,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    result = await server.session.call_tool(
+                        tool_name,
+                        arguments=args,
+                        meta={"hermes_session_key": session_key} if session_key else None,
+                    )
                 finally:
                     server._pending_call_context = None
             # MCP CallToolResult has .content (list of content blocks) and .isError


### PR DESCRIPTION
## What

`ClientSession.call_tool(...)` already accepts an optional `meta: dict |
None` kwarg (the MCP spec's per-request `_meta`), and `RequestContext.meta`
is already readable server-side — both ends of the SDK support it. The one
missing piece is that the agent's own tool-dispatch path
(`tools/mcp_tool.py`, inside `_make_tool_handler` → `_handler` → `_call`)
never populates it: `server.session.call_tool(tool_name, arguments=args)` is
called with no `meta`.

This PR forwards the gateway's existing per-chat session key
(`gateway.session_context.get_session_env("HERMES_SESSION_KEY", "")` — this
context var is already set on every session, nothing new is introduced) as
`meta={"hermes_session_key": session_key}` on every `tools/call` request,
falling back to `meta=None` when there is no session key (CLI, cron, and any
other session-less invocation keep today's behaviour byte-for-byte).

## Why

Any MCP server integrator who wants to attribute a tool call to the chat
session that triggered it currently has no reliable way to do so:

- MCP headers are static, set once per connection, and shared across every
  concurrent session on that connection — they can carry tenant-level
  identity but never per-call/per-user identity.
- Gateway hooks (`agent:start` etc.) see the right context but have no
  channel into individual MCP calls, and the gateway processes sessions
  concurrently, so anything that tries to correlate "current session" via
  a side channel (e.g. writing to shared state) is racy.
- `_meta` is the one channel that is already per-call, already part of the
  wire protocol, and already plumbed on both the client and server SDK
  surfaces — it's just not populated by this dispatch path.

This is a small, additive change: one read of an already-existing session
key, one new keyword argument on an existing call, gated so the no-session-key
case is behaviourally identical to today. No new dependencies, no schema
changes, no protocol changes — `_meta` is already optional per the MCP spec,
so servers that don't care simply never look at it.

## Change

One callsite in `tools/mcp_tool.py` (`_make_tool_handler`'s `_handler`):
reads the session key from `gateway.session_context.get_session_env` before
dispatch (on the agent's own task, where that contextvar is current — the
actual `_call()` coroutine runs on a separate MCP event loop, so this has to
be read and closed over beforehand, not read inside `_call`), then passes it
through as `_meta.hermes_session_key`. The import is wrapped in
`try/except ImportError: session_key = ""` — this read happens before
`_call()` is defined, i.e. outside the `try/except Exception` block near the
bottom of `_handler` that turns every other dispatch failure into the JSON
error string callers expect, so an unguarded ImportError here would escape
as a raw exception instead of degrading to the same `meta=None` behaviour
already used for the no-session-key case.

## Scope note for reviewers

This forwards `_meta.hermes_session_key` to **every** configured MCP server
unconditionally — there is no per-server opt-in in this PR. That is
deliberate for a first pass (the smallest change that proves the mechanism),
but it does mean any integrator running multiple MCP servers hands this
value to all of them, including third-party ones outside their own control.
A natural follow-up (happy to fold into this PR if preferred) is a
per-server allowlist or opt-in flag so an integrator can choose which
servers receive it.

## Testing

Verified against a local build of the agent image that the patched dispatch
still round-trips correctly with a live gateway session and that CLI/cron
invocations (no session key) are unaffected (`meta=None`, unchanged
`call_tool` signature usage).
