### PR TITLE
fix(agent): pop _DB_PERSISTED_MARKER in message-sanitization mutators

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4401,6 +4401,17 @@ def run_conversation(
                     # `prefill_messages` if present.  Mirrors the ASCII
                     # codec recovery below.
                     _surrogates_found = _sanitize_messages_surrogates(messages)
+                    if _surrogates_found:
+                        # The sanitizer just popped _DB_PERSISTED_MARKER from
+                        # one or more already-flushed dicts in `messages` (in
+                        # place, same identity) to force their sanitized
+                        # content to be re-persisted. The bounded flush-scan
+                        # cursor assumes no live dict loses the marker this
+                        # way and would otherwise skip past it unexamined —
+                        # invalidate it so the next flush re-scans from the
+                        # start. See run_agent.py's _DB_PERSISTED_MARKER
+                        # contract comment (#92231).
+                        agent._db_flush_scan_prefix = None
                     if isinstance(api_messages, list):
                         if _sanitize_messages_surrogates(api_messages):
                             _surrogates_found = True
@@ -4439,6 +4450,13 @@ def run_conversation(
                         # loop, which may contain extra fields like
                         # reasoning_content that are not in `messages`).
                         _messages_sanitized = _sanitize_messages_non_ascii(messages)
+                        if _messages_sanitized:
+                            # See the surrogate-recovery branch above: popping
+                            # _DB_PERSISTED_MARKER from an already-flushed
+                            # dict in `messages` in place requires
+                            # invalidating the bounded flush-scan cursor too,
+                            # or the sanitized content is never re-persisted.
+                            agent._db_flush_scan_prefix = None
                         if isinstance(api_messages, list):
                             _sanitize_messages_non_ascii(api_messages)
                         # Also sanitize the last api_kwargs if already built,
@@ -4618,6 +4636,13 @@ def run_conversation(
                 ):
                     agent._vision_supported = False
                     _imgs_removed = _strip_images_from_messages(messages)
+                    if _imgs_removed:
+                        # See the surrogate-recovery branch above: popping
+                        # _DB_PERSISTED_MARKER from an already-flushed dict
+                        # in `messages` in place requires invalidating the
+                        # bounded flush-scan cursor too, or the
+                        # image-stripped content is never re-persisted.
+                        agent._db_flush_scan_prefix = None
                     if isinstance(api_messages, list):
                         _strip_images_from_messages(api_messages)
                     agent._vprint(

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -20,6 +20,8 @@ import logging
 import re
 from typing import Any
 
+from agent.context_compressor import _DB_PERSISTED_MARKER
+
 logger = logging.getLogger(__name__)
 
 # Lone surrogate code points are invalid in UTF-8 and crash json.dumps
@@ -89,10 +91,12 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
     for msg in messages:
         if not isinstance(msg, dict):
             continue
+        msg_touched = False
         content = msg.get("content")
         if isinstance(content, str) and _SURROGATE_RE.search(content):
             msg["content"] = _SURROGATE_RE.sub('\ufffd', content)
             found = True
+            msg_touched = True
         elif isinstance(content, list):
             for part in content:
                 if isinstance(part, dict):
@@ -100,10 +104,12 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
                     if isinstance(text, str) and _SURROGATE_RE.search(text):
                         part["text"] = _SURROGATE_RE.sub('\ufffd', text)
                         found = True
+                        msg_touched = True
         name = msg.get("name")
         if isinstance(name, str) and _SURROGATE_RE.search(name):
             msg["name"] = _SURROGATE_RE.sub('\ufffd', name)
             found = True
+            msg_touched = True
         tool_calls = msg.get("tool_calls")
         if isinstance(tool_calls, list):
             for tc in tool_calls:
@@ -113,16 +119,19 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
                 if isinstance(tc_id, str) and _SURROGATE_RE.search(tc_id):
                     tc["id"] = _SURROGATE_RE.sub('\ufffd', tc_id)
                     found = True
+                    msg_touched = True
                 fn = tc.get("function")
                 if isinstance(fn, dict):
                     fn_name = fn.get("name")
                     if isinstance(fn_name, str) and _SURROGATE_RE.search(fn_name):
                         fn["name"] = _SURROGATE_RE.sub('\ufffd', fn_name)
                         found = True
+                        msg_touched = True
                     fn_args = fn.get("arguments")
                     if isinstance(fn_args, str) and _SURROGATE_RE.search(fn_args):
                         fn["arguments"] = _SURROGATE_RE.sub('\ufffd', fn_args)
                         found = True
+                        msg_touched = True
         # Walk any additional string / nested fields (reasoning,
         # reasoning_content, reasoning_details, etc.) — surrogates from
         # byte-level reasoning models (xiaomi/mimo, kimi, glm) can lurk
@@ -135,9 +144,22 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
                 if _SURROGATE_RE.search(value):
                     msg[key] = _SURROGATE_RE.sub('\ufffd', value)
                     found = True
+                    msg_touched = True
             elif isinstance(value, (dict, list)):
                 if _sanitize_structure_surrogates(value):
                     found = True
+                    msg_touched = True
+        if msg_touched:
+            # This dict may already carry _DB_PERSISTED_MARKER from an
+            # earlier incremental flush (hermes_state.py stamps resumed/
+            # flushed rows). Sanitizing in place without popping it leaves
+            # the marker True, so the flush logic (run_agent.py) treats the
+            # row as already persisted and never re-writes the sanitized
+            # content -- the same bad bytes come back on every future resume
+            # and re-trigger this exact sanitizer, forever. Mirrors
+            # turn_finalizer.py's pop of the same marker after an in-place
+            # content fix.
+            msg.pop(_DB_PERSISTED_MARKER, None)
     return found
 
 
@@ -347,6 +369,7 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
     for msg in messages:
         if not isinstance(msg, dict):
             continue
+        msg_touched = False
         # Sanitize content (string)
         content = msg.get("content")
         if isinstance(content, str):
@@ -354,6 +377,7 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
             if sanitized != content:
                 msg["content"] = sanitized
                 found = True
+                msg_touched = True
         elif isinstance(content, list):
             for part in content:
                 if isinstance(part, dict):
@@ -363,6 +387,7 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
                         if sanitized != text:
                             part["text"] = sanitized
                             found = True
+                            msg_touched = True
         # Sanitize name field (can contain non-ASCII in tool results)
         name = msg.get("name")
         if isinstance(name, str):
@@ -370,6 +395,7 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
             if sanitized != name:
                 msg["name"] = sanitized
                 found = True
+                msg_touched = True
         # Sanitize tool_calls
         tool_calls = msg.get("tool_calls")
         if isinstance(tool_calls, list):
@@ -383,6 +409,7 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
                             if sanitized != fn_args:
                                 fn["arguments"] = sanitized
                                 found = True
+                                msg_touched = True
         # Sanitize any additional top-level string fields (e.g. reasoning_content)
         for key, value in msg.items():
             if key in {"content", "name", "tool_calls", "role"}:
@@ -392,6 +419,12 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
                 if sanitized != value:
                     msg[key] = sanitized
                     found = True
+                    msg_touched = True
+        if msg_touched:
+            # See _sanitize_messages_surrogates for why this pop is required:
+            # without it, an already-flushed row's marker stays True and the
+            # sanitized content is never re-persisted.
+            msg.pop(_DB_PERSISTED_MARKER, None)
     return found
 
 
@@ -435,13 +468,21 @@ def _strip_images_from_messages(messages: list) -> bool:
         if len(new_parts) < len(content):
             if new_parts:
                 msg["content"] = new_parts
+                # See _sanitize_messages_surrogates for why this pop is
+                # required: without it, an already-flushed row's marker
+                # stays True and the image-stripped content is never
+                # re-persisted, so the same rejected image comes back on
+                # every future resume.
+                msg.pop(_DB_PERSISTED_MARKER, None)
             elif msg.get("role") == "tool":
                 # Preserve tool_call_id linkage — providers require every
                 # assistant tool_call to have a matching tool response.
                 msg["content"] = "[image content removed — server does not support images]"
+                msg.pop(_DB_PERSISTED_MARKER, None)
             else:
                 # Synthetic image-only user/assistant message with no text;
-                # safe to drop.
+                # safe to drop. The dict is discarded below, so no marker
+                # pop is needed here.
                 to_delete.append(i)
     for i in reversed(to_delete):
         del messages[i]

--- a/tests/run_agent/test_sanitize_marker_flush_contract.py
+++ b/tests/run_agent/test_sanitize_marker_flush_contract.py
@@ -1,0 +1,205 @@
+"""Regression tests for the _DB_PERSISTED_MARKER mutate-then-persist contract
+(#92231) as it applies to agent.message_sanitization's in-place mutators.
+
+CONTRACT (run_agent.py, _DB_PERSISTED_MARKER docstring): any code that
+mutates a loaded or flushed message dict's content in place and needs the
+change persisted MUST pop the marker (and invalidate _db_flush_scan_prefix
+if the dict may sit inside the bounded-scan prefix), or the change is
+silently never re-written to state.db.
+
+_sanitize_messages_surrogates, _sanitize_messages_non_ascii, and
+_strip_images_from_messages all mutate `messages` dicts in place (via
+conversation_loop.py's UnicodeEncodeError / image-rejection retry paths) and
+previously did neither half of the contract:
+
+  1. The sanitizer itself never popped _DB_PERSISTED_MARKER, so an
+     already-flushed dict kept the marker True after its content changed.
+  2. The conversation_loop.py call sites never invalidated
+     agent._db_flush_scan_prefix, so even a popped marker would go unnoticed
+     by the bounded-scan optimization (identity match on the dict ⇒ treated
+     as already-dispositioned, never re-examined).
+
+Both halves are required together: popping the marker without invalidating
+the cursor is not enough (the bounded scan skips right past the dict without
+looking at the marker), and invalidating the cursor without popping the
+marker is not enough (the marker itself gates re-persistence). This file
+proves each half is necessary and that fixed message_sanitization.py +
+fixed conversation_loop.py together close the gap.
+"""
+
+import copy
+
+import pytest
+
+from agent.context_compressor import _DB_PERSISTED_MARKER
+from agent.message_sanitization import (
+    _sanitize_messages_non_ascii,
+    _sanitize_messages_surrogates,
+    _strip_images_from_messages,
+)
+
+
+class _FakeDB:
+    """Minimal SessionDB stand-in — mirrors test_cursor_optimizations_parity.py."""
+
+    def __init__(self):
+        self.rows = []
+
+    def append_messages_batch(self, session_id, messages, **kw):
+        for m in messages:
+            row = {k: copy.deepcopy(v) for k, v in m.items()}
+            row["session_id"] = session_id
+            self.rows.append(row)
+        return list(range(1, len(messages) + 1))
+
+
+def _make_agent():
+    import run_agent as ra
+
+    a = ra.AIAgent.__new__(ra.AIAgent)
+    a.session_id = "s1"
+    a._session_db = _FakeDB()
+    a._session_db_created = True
+    a._last_flushed_db_idx = 0
+    a._flushed_db_message_ids = set()
+    a._persist_disabled = False
+    a._session_persist_lock = None
+    a._db_flush_scan_prefix = None
+    return a
+
+
+class TestSurrogateSanitizerPopsMarker:
+    """The sanitizer itself must pop the marker from any message it mutates,
+    and must NOT touch it on messages it leaves alone."""
+
+    def test_touched_message_loses_marker(self):
+        messages = [
+            {"role": "user", "content": "hi", _DB_PERSISTED_MARKER: True},
+            {"role": "assistant", "content": "bad \ud800 surrogate", _DB_PERSISTED_MARKER: True},
+        ]
+        found = _sanitize_messages_surrogates(messages)
+        assert found is True
+        assert _DB_PERSISTED_MARKER not in messages[1]
+        # The untouched message keeps its marker.
+        assert messages[0].get(_DB_PERSISTED_MARKER) is True
+
+    def test_no_surrogates_leaves_marker_untouched(self):
+        messages = [{"role": "user", "content": "clean", _DB_PERSISTED_MARKER: True}]
+        found = _sanitize_messages_surrogates(messages)
+        assert found is False
+        assert messages[0].get(_DB_PERSISTED_MARKER) is True
+
+
+class TestNonAsciiSanitizerPopsMarker:
+    def test_touched_message_loses_marker(self):
+        messages = [
+            {"role": "assistant", "content": "hello ⚕🤖 world", _DB_PERSISTED_MARKER: True},
+        ]
+        found = _sanitize_messages_non_ascii(messages)
+        assert found is True
+        assert _DB_PERSISTED_MARKER not in messages[0]
+
+    def test_untouched_message_keeps_marker(self):
+        messages = [{"role": "assistant", "content": "plain ascii", _DB_PERSISTED_MARKER: True}]
+        found = _sanitize_messages_non_ascii(messages)
+        assert found is False
+        assert messages[0].get(_DB_PERSISTED_MARKER) is True
+
+
+class TestStripImagesPopsMarker:
+    def test_partial_strip_pops_marker(self):
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": "data:..."}},
+            ],
+            _DB_PERSISTED_MARKER: True,
+        }]
+        found = _strip_images_from_messages(messages)
+        assert found is True
+        assert _DB_PERSISTED_MARKER not in messages[0]
+
+    def test_tool_placeholder_replace_pops_marker(self):
+        messages = [{
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": [{"type": "image_url", "image_url": {"url": "data:..."}}],
+            _DB_PERSISTED_MARKER: True,
+        }]
+        found = _strip_images_from_messages(messages)
+        assert found is True
+        assert _DB_PERSISTED_MARKER not in messages[0]
+        assert isinstance(messages[0]["content"], str)
+
+    def test_deleted_message_needs_no_pop(self):
+        """A synthetic image-only message is dropped entirely — nothing to pop."""
+        messages = [{
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": "data:..."}}],
+            _DB_PERSISTED_MARKER: True,
+        }]
+        found = _strip_images_from_messages(messages)
+        assert found is True
+        assert messages == []
+
+
+class TestFlushScanPrefixInvalidationContract:
+    """End-to-end: an already-flushed message sanitized in place must
+    actually reach state.db on the NEXT flush — proving both halves of the
+    fix (marker pop + cursor invalidation) work together, mirroring
+    conversation_loop.py's UnicodeEncodeError recovery block."""
+
+    def test_sanitized_content_is_re_persisted_when_cursor_is_invalidated(self):
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "bad \ud800 surrogate"},
+        ]
+        # First flush: both rows land, both dicts get the marker stamped.
+        assert agent._flush_messages_to_session_db_unlocked(messages, None) is True
+        assert agent._session_db.rows[-1]["content"] == "bad \ud800 surrogate"
+        assert messages[1].get(_DB_PERSISTED_MARKER) is True
+
+        # A later turn hits UnicodeEncodeError and sanitizes `messages` in
+        # place (conversation_loop.py's recovery block) — same identity as
+        # what's already in _db_flush_scan_prefix.
+        found = _sanitize_messages_surrogates(messages)
+        assert found is True
+        assert "\ud800" not in messages[1]["content"]
+        # Mirrors conversation_loop.py's fix: invalidate the cursor because
+        # the sanitizer just popped a marker from a dict that may sit inside
+        # the bounded-scan prefix.
+        agent._db_flush_scan_prefix = None
+
+        # Next flush must re-write the sanitized content.
+        assert agent._flush_messages_to_session_db_unlocked(messages, None) is True
+        assert "\ud800" not in agent._session_db.rows[-1]["content"]
+        assert agent._session_db.rows[-1]["content"] == messages[1]["content"]
+
+    def test_without_cursor_invalidation_the_sanitized_content_is_silently_dropped(self):
+        """Mutation-verify companion: proves the cursor-invalidation half of
+        the fix is load-bearing on its own, independent of the marker pop.
+        Popping the marker but leaving the stale cursor in place reproduces
+        the exact bug conversation_loop.py's fix closes — the bounded scan
+        skips the identity-matched dict without ever looking at its marker."""
+        agent = _make_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "bad \ud800 surrogate"},
+        ]
+        assert agent._flush_messages_to_session_db_unlocked(messages, None) is True
+
+        found = _sanitize_messages_surrogates(messages)
+        assert found is True
+        assert _DB_PERSISTED_MARKER not in messages[1]
+        # Deliberately do NOT invalidate agent._db_flush_scan_prefix here —
+        # this is the pre-fix conversation_loop.py behavior.
+
+        assert agent._flush_messages_to_session_db_unlocked(messages, None) is True
+        # The bounded scan identity-matched the stale prefix and skipped the
+        # dict entirely, so the DB still has the original bad bytes — the
+        # sanitized content never arrived. This is the silent-staleness bug;
+        # asserting it here documents why the cursor invalidation is
+        # required, not optional.
+        assert agent._session_db.rows[-1]["content"] == "bad \ud800 surrogate"


### PR DESCRIPTION
## Summary

`_sanitize_messages_surrogates`, `_sanitize_messages_non_ascii`, and `_strip_images_from_messages` (`agent/message_sanitization.py`) all mutate `messages` dicts in place, called from `conversation_loop.py`'s error-recovery retry paths (`UnicodeEncodeError`, ASCII-codec, image-rejection). None of the three referenced `_DB_PERSISTED_MARKER` at all.

On a resumed session, a message dict can already carry `_DB_PERSISTED_MARKER=True` — stamped at row-load time (`hermes_state._rows_to_conversation`, #92231) or by an earlier incremental flush this turn. Per the marker's own contract (`run_agent.py`, `_DB_PERSISTED_MARKER` docstring):

> any code that mutates a loaded or flushed dict's content in place and needs the change persisted MUST pop the marker (and invalidate `_db_flush_scan_prefix` if the dict may sit inside the bounded-scan prefix) ... Mutating without popping leaves the DB silently stale.

Sanitizing without popping the marker means `_flush_messages_to_session_db_unlocked` skips the row entirely on the next flush — the DB keeps the **original bad bytes**, and the exact same `UnicodeEncodeError`/ASCII-codec/vision-rejection condition re-fires on every future resume of that session, forever. Not the row-duplication class #92231 fixed (the marker stays `True`, nothing re-appends) — a quieter, "the DB never converges" gap that directly contradicts the just-formalized invariant from the same window.

## Fix

Two parts, matching the established two-part pattern (`agent/turn_finalizer.py`'s fill-empty-tail fix, `agent/context_compressor.py`'s micro-compaction defrag):

1. **`agent/message_sanitization.py`**: each of the three functions now tracks per-message mutation (`msg_touched`) and pops `_DB_PERSISTED_MARKER` from any message it actually changed — untouched messages keep their marker, so this doesn't force an unnecessary re-scan of clean history.
2. **`agent/conversation_loop.py`**: the bounded flush-scan cursor (`agent._db_flush_scan_prefix`) is a byte-for-byte snapshot of the previous flush's `messages` list; it skips the identity-matched prefix on the assumption that no live dict loses the marker in place. Popping the marker alone is not enough — the cursor would still identity-match the (now marker-less) dict and skip past it unexamined. All three call sites on the canonical `messages` list (not `api_messages`/`prefill_messages`, which are wire copies the cursor doesn't track) now invalidate `agent._db_flush_scan_prefix = None` when their sanitizer reports a change, mirroring `turn_finalizer.py:381-387`'s exact pattern.

## Testing

- New `tests/run_agent/test_sanitize_marker_flush_contract.py` (9 tests):
  - Per-function marker-pop tests for all three sanitizers (touched messages lose the marker, untouched messages keep it).
  - An end-to-end contract test using the same `AIAgent.__new__` + `FakeDB` harness as `tests/agent/test_cursor_optimizations_parity.py`: flush a session, sanitize an already-flushed dict in place, invalidate the cursor, flush again — the sanitized content is re-persisted.
  - A companion test proving the cursor-invalidation half is independently load-bearing: popping the marker *without* invalidating the cursor reproduces the exact silent-staleness bug (the bounded scan skips the dict and the stale bytes remain in the DB).
- Mutation-verified: reverting `message_sanitization.py` alone fails 6/9 new tests with the exact expected signal (marker still present / stale bytes reach the DB).
- Broad neighboring suite: `tests/run_agent/` full directory (1763 passed, 4 skipped, 2 deselected, 7 pre-existing failures — all `anthropic` package/env-gap related, confirmed identical on pre-fix `main` via `git stash`, unrelated to this change) + `tests/agent/test_message_sanitization_policy.py`, `test_cursor_optimizations_parity.py`, `test_turn_finalizer_final_response_persistence.py`, `test_micro_compaction.py` (130 passed).
- `ruff check` clean on all three changed/added files.

## Competing PRs

Checked `gh pr list --search` across several keyword combinations (`message_sanitization db_persisted marker`, `sanitize surrogates flush persisted`, `92231`) — no open PR touches this gap.