### PR TITLE
fix(desktop): reload runtime plugins after atomic replacement

### DIFF
--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -227,6 +227,86 @@ describe('scanDiskPlugins (#66899)', () => {
       delete (globalThis as unknown as { __uniRegister?: unknown }).__uniRegister
     }
   })
+
+  it('manual discovery reloads an existing plugin after its entry file is replaced', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('')
+    readDir.mockImplementation(async dir => {
+      if (dir === '/local/.hermes/desktop-plugins') {
+        return {
+          entries: [
+            {
+              isDirectory: true,
+              name: 'replaceable',
+              path: '/local/.hermes/desktop-plugins/replaceable'
+            }
+          ]
+        }
+      }
+
+      if (dir === '/local/.hermes/desktop-plugins/replaceable') {
+        return {
+          entries: [
+            {
+              isDirectory: false,
+              name: 'plugin.js',
+              path: '/local/.hermes/desktop-plugins/replaceable/plugin.js'
+            }
+          ]
+        }
+      }
+
+      return { entries: [] }
+    })
+
+    const registerV1 = vi.fn()
+    const registerV2 = vi.fn()
+
+    Object.assign(globalThis, { __replaceableV1: registerV1, __replaceableV2: registerV2 })
+
+    let source = 'export default { id: "replaceable", register: globalThis.__replaceableV1 }'
+
+    readFileText.mockImplementation(async () => ({ text: source }))
+    watchPreviewFile.mockResolvedValue({ id: 'w-replaceable' })
+
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(
+        blob =>
+          `data:text/javascript;base64,${Buffer.from((blob as unknown as { parts: string[] }).parts.join('')).toString('base64')}`
+      )
+
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    const RealBlob = globalThis.Blob
+    vi.stubGlobal(
+      'Blob',
+      class {
+        parts: string[]
+        constructor(parts: string[]) {
+          this.parts = parts
+        }
+      }
+    )
+
+    try {
+      await discoverRuntimePlugins()
+      expect(registerV1).toHaveBeenCalledTimes(1)
+
+      source = 'export default { id: "replaceable", register: globalThis.__replaceableV2 }'
+      await discoverRuntimePlugins()
+
+      expect(registerV2).toHaveBeenCalledTimes(1)
+      expect(readFileText).toHaveBeenCalledTimes(2)
+      expect(stopPreviewFileWatch).toHaveBeenCalledWith('w-replaceable')
+      expect(watchPreviewFile).toHaveBeenCalledTimes(2)
+    } finally {
+      createObjectURL.mockRestore()
+      revokeObjectURL.mockRestore()
+      vi.stubGlobal('Blob', RealBlob)
+      delete (globalThis as unknown as { __replaceableV1?: unknown }).__replaceableV1
+      delete (globalThis as unknown as { __replaceableV2?: unknown }).__replaceableV2
+    }
+  })
 })
 
 describe('watchRuntimePlugins dir watch (#66899)', () => {

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -286,6 +286,23 @@ const disk = new Map<string, DiskPlugin>()
 let watching = false
 let scanning = false
 
+async function restartDiskPluginWatch(
+  desktop: NonNullable<Window['hermesDesktop']>,
+  record: DiskPlugin
+): Promise<void> {
+  if (record.watchId) {
+    await desktop.stopPreviewFileWatch(record.watchId)
+    record.watchId = null
+  }
+
+  try {
+    record.watchId = (await desktop.watchPreviewFile(record.file)).id
+  } catch {
+    // Unwatchable — the poll still reconciles new folders; edits need a
+    // manual "Reload desktop plugins".
+  }
+}
+
 /** Drop a folder-named error record — unless that name is the live plugin id
  *  of ANOTHER disk entry (two roots can carry same-named folders; a broken one
  *  must not clobber its healthy namesake's inventory row). */
@@ -412,7 +429,7 @@ async function resolveDiskPluginEntry(
   return null
 }
 
-async function scanDiskPlugins(): Promise<void> {
+async function scanDiskPlugins(forceReload = false): Promise<void> {
   const desktop = window.hermesDesktop
 
   // Re-entrancy guard: the 5s poll must not overlap a slow in-flight scan
@@ -456,7 +473,15 @@ async function scanDiskPlugins(): Promise<void> {
 
         seen.add(file)
 
-        if (disk.has(file)) {
+        const existing = disk.get(file)
+
+        if (existing) {
+          if (forceReload && (await loadDiskPlugin(existing))) {
+            // Atomic replacement can leave the old watch attached to the
+            // unlinked file, so a manual reload must bind a fresh watch too.
+            await restartDiskPluginWatch(desktop, existing)
+          }
+
           continue
         }
 
@@ -476,12 +501,7 @@ async function scanDiskPlugins(): Promise<void> {
           continue
         }
 
-        try {
-          record.watchId = (await desktop.watchPreviewFile(file)).id
-        } catch {
-          // Unwatchable — the poll still reconciles new folders; edits need a
-          // manual "Reload desktop plugins".
-        }
+        await restartDiskPluginWatch(desktop, record)
       }
     }
 
@@ -512,7 +532,7 @@ async function scanDiskPlugins(): Promise<void> {
 }
 
 /** Manual rescan (the ⌘K "Reload desktop plugins" fallback). */
-export const discoverRuntimePlugins = scanDiskPlugins
+export const discoverRuntimePlugins = () => scanDiskPlugins(true)
 
 /** Start the self-maintaining disk door: initial scan, per-file hot reload,
  *  fs-watched folder reconciliation (poll fallback on older shells). Idempotent. */


### PR DESCRIPTION
Fixes #91503.

Summary:
- force manual plugin discovery to reread existing entries without changing background reconciliation
- restart file watches after atomic replacement
- add a regression test for same-path v1-to-v2 replacement

Tests:
- npm test -- --run src/contrib/runtime-loader.test.ts
- npm run typecheck
- npx eslint src/contrib/runtime-loader.ts src/contrib/runtime-loader.test.ts