### PR TITLE
fix(agent): keep resumed sessions from repeating empty responses

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -801,29 +801,30 @@ def _strip_persisted_empty_recovery_scaffolding(
     Prevention at the write boundary uses private in-memory flags, but builds
     predating that guard (and interrupted writes that lost private metadata)
     can leave the assistant failure sentinel and synthetic user nudge active in
-    ``state.db``. Replaying either row as genuine history teaches the model to
-    continue returning empty responses. Match only the exact role/content
-    signatures; similar user or assistant text remains ordinary conversation.
+    ``state.db``. Replaying the pair as genuine history teaches the model to
+    continue returning empty responses. Match only the exact adjacent pair;
+    either content signature on its own remains ordinary conversation.
     """
     repaired = 0
     restored: List[Dict[str, Any]] = []
-    for msg in messages:
-        role = msg.get("role") if isinstance(msg, dict) else None
-        content = msg.get("content") if isinstance(msg, dict) else None
-        is_empty_sentinel = (
-            role == "assistant"
-            and isinstance(content, str)
-            and content.strip() == _PERSISTED_EMPTY_RESPONSE_SENTINEL
+    index = 0
+    while index < len(messages):
+        msg = messages[index]
+        next_msg = messages[index + 1] if index + 1 < len(messages) else None
+        is_recovery_pair = (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and msg.get("content") == _PERSISTED_EMPTY_RESPONSE_SENTINEL
+            and isinstance(next_msg, dict)
+            and next_msg.get("role") == "user"
+            and next_msg.get("content") == _PERSISTED_EMPTY_RECOVERY_NUDGE
         )
-        is_recovery_nudge = (
-            role == "user"
-            and isinstance(content, str)
-            and content.strip() == _PERSISTED_EMPTY_RECOVERY_NUDGE
-        )
-        if is_empty_sentinel or is_recovery_nudge:
-            repaired += 1
+        if is_recovery_pair:
+            repaired += 2
+            index += 2
             continue
         restored.append(msg)
+        index += 1
     if repaired:
         logger.info(
             "Removed %d persisted empty-response recovery message(s) while "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -782,6 +782,57 @@ def _strip_background_review_harness(
     return out
 
 
+# Historical content signatures for empty-response recovery scaffolding.
+# Private ``_empty_*`` flags are intentionally not part of SessionDB's durable
+# schema, so load-time repair must recognize rows written by older/racing paths
+# after those flags have been projected away.
+_PERSISTED_EMPTY_RESPONSE_SENTINEL = "(empty)"
+_PERSISTED_EMPTY_RECOVERY_NUDGE = (
+    "You just executed tool calls but returned an empty response. "
+    "Please process the tool results above and continue with the task."
+)
+
+
+def _strip_persisted_empty_recovery_scaffolding(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Remove empty-response retry scaffolding from restored transcripts.
+
+    Prevention at the write boundary uses private in-memory flags, but builds
+    predating that guard (and interrupted writes that lost private metadata)
+    can leave the assistant failure sentinel and synthetic user nudge active in
+    ``state.db``. Replaying either row as genuine history teaches the model to
+    continue returning empty responses. Match only the exact role/content
+    signatures; similar user or assistant text remains ordinary conversation.
+    """
+    repaired = 0
+    restored: List[Dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role") if isinstance(msg, dict) else None
+        content = msg.get("content") if isinstance(msg, dict) else None
+        is_empty_sentinel = (
+            role == "assistant"
+            and isinstance(content, str)
+            and content.strip() == _PERSISTED_EMPTY_RESPONSE_SENTINEL
+        )
+        is_recovery_nudge = (
+            role == "user"
+            and isinstance(content, str)
+            and content.strip() == _PERSISTED_EMPTY_RECOVERY_NUDGE
+        )
+        if is_empty_sentinel or is_recovery_nudge:
+            repaired += 1
+            continue
+        restored.append(msg)
+    if repaired:
+        logger.info(
+            "Removed %d persisted empty-response recovery message(s) while "
+            "restoring session",
+            repaired,
+        )
+    return restored
+
+
 # Matches a bare protocol/tool-name marker such as "[memory]" or "[skill_manage]".
 _STALE_TOOL_CALL_MARKER_RE = re.compile(r"^\[[A-Za-z_][A-Za-z0-9_.-]*\]$")
 
@@ -11198,6 +11249,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # assistant reply immediately following it, so a polluted session
         # resumes clean even if stray rows exist.
         messages = _strip_background_review_harness(messages)
+        # Empty-response recovery markers are private in-memory metadata and do
+        # not survive SessionDB projection. Heal already-contaminated sessions
+        # by their narrow role/content signatures before they re-enter either
+        # the model replay or display history.
+        messages = _strip_persisted_empty_recovery_scaffolding(messages)
         # DEFENSE-IN-DEPTH against #78148: before that fix, a bare tool-call
         # marker (e.g. "[memory]") could get cached as a fallback and
         # persisted as if it were the model's real answer. Sessions written

--- a/tests/hermes_state/test_empty_recovery_scaffolding_repair.py
+++ b/tests/hermes_state/test_empty_recovery_scaffolding_repair.py
@@ -1,0 +1,93 @@
+"""Regression coverage for persisted empty-response scaffolding repair."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+_EMPTY_RECOVERY_NUDGE = (
+    "You just executed tool calls but returned an empty response. "
+    "Please process the tool results above and continue with the task."
+)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    yield session_db
+    session_db.close()
+
+
+def _seed_polluted_session(db, session_id="s1"):
+    db.create_session(session_id, "system prompt")
+    db.append_message(session_id, role="user", content="run the task")
+    db.append_message(
+        session_id,
+        role="assistant",
+        content="",
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ],
+    )
+    db.append_message(
+        session_id,
+        role="tool",
+        content="result",
+        tool_call_id="call_1",
+    )
+    # Private metadata flags are absent after durable projection.
+    db.append_message(session_id, role="assistant", content="(empty)")
+    db.append_message(session_id, role="user", content=_EMPTY_RECOVERY_NUDGE)
+    db.append_message(session_id, role="assistant", content="Recovered answer.")
+
+
+def test_resume_strips_persisted_empty_recovery_scaffolding(db):
+    _seed_polluted_session(db)
+
+    messages = db.get_messages_as_conversation("s1", repair_alternation=True)
+
+    assert [message["content"] for message in messages] == [
+        "run the task",
+        "",
+        "result",
+        "Recovered answer.",
+    ]
+
+
+def test_resume_views_both_hide_persisted_empty_recovery_scaffolding(db):
+    _seed_polluted_session(db)
+
+    model_history, display_history = db.get_resume_conversations("s1")
+
+    for history in (model_history, display_history):
+        contents = [message["content"] for message in history]
+        assert "(empty)" not in contents
+        assert _EMPTY_RECOVERY_NUDGE not in contents
+        assert "Recovered answer." in contents
+
+
+def test_similar_real_content_is_preserved(db):
+    db.create_session("clean", "system prompt")
+    db.append_message("clean", role="user", content="Explain an empty response")
+    db.append_message(
+        "clean",
+        role="assistant",
+        content="The set is (empty), but this is a real explanation.",
+    )
+    db.append_message(
+        "clean",
+        role="user",
+        content=_EMPTY_RECOVERY_NUDGE + " Please include details.",
+    )
+
+    messages = db.get_messages_as_conversation("clean")
+
+    assert [message["content"] for message in messages] == [
+        "Explain an empty response",
+        "The set is (empty), but this is a real explanation.",
+        _EMPTY_RECOVERY_NUDGE + " Please include details.",
+    ]

--- a/tests/hermes_state/test_empty_recovery_scaffolding_repair.py
+++ b/tests/hermes_state/test_empty_recovery_scaffolding_repair.py
@@ -83,11 +83,21 @@ def test_similar_real_content_is_preserved(db):
         role="user",
         content=_EMPTY_RECOVERY_NUDGE + " Please include details.",
     )
+    db.append_message("clean", role="assistant", content="(empty)")
+    db.append_message("clean", role="user", content="Continue the real conversation.")
+    db.append_message("clean", role="assistant", content="Still part of the answer.")
+    db.append_message("clean", role="user", content=_EMPTY_RECOVERY_NUDGE)
 
-    messages = db.get_messages_as_conversation("clean")
+    model_history, display_history = db.get_resume_conversations("clean")
 
-    assert [message["content"] for message in messages] == [
+    expected = [
         "Explain an empty response",
         "The set is (empty), but this is a real explanation.",
         _EMPTY_RECOVERY_NUDGE + " Please include details.",
+        "(empty)",
+        "Continue the real conversation.",
+        "Still part of the answer.",
+        _EMPTY_RECOVERY_NUDGE,
     ]
+    for history in (model_history, display_history):
+        assert [message["content"] for message in history] == expected

--- a/tests/hermes_state/test_empty_recovery_scaffolding_repair.py
+++ b/tests/hermes_state/test_empty_recovery_scaffolding_repair.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from hermes_state import SessionDB
+from agent.conversation_loop import _EMPTY_TOOL_RESPONSE_NUDGE
+from hermes_state import (
+    _PERSISTED_EMPTY_RECOVERY_NUDGE,
+    SessionDB,
+)
 
 
 _EMPTY_RECOVERY_NUDGE = (
@@ -43,6 +47,10 @@ def _seed_polluted_session(db, session_id="s1"):
     db.append_message(session_id, role="assistant", content="(empty)")
     db.append_message(session_id, role="user", content=_EMPTY_RECOVERY_NUDGE)
     db.append_message(session_id, role="assistant", content="Recovered answer.")
+
+
+def test_repair_signature_matches_live_empty_recovery_nudge():
+    assert _PERSISTED_EMPTY_RECOVERY_NUDGE == _EMPTY_TOOL_RESPONSE_NUDGE
 
 
 def test_resume_strips_persisted_empty_recovery_scaffolding(db):


### PR DESCRIPTION
## What does this PR do?

Resumed sessions that contain leaked empty-response recovery rows can repeatedly return no output because the model replays `assistant: (empty)` and Hermes' synthetic recovery nudge as genuine history. This change filters those exact historical signatures at the SessionDB projection boundary, healing contaminated sessions without rewriting their database rows or changing unaffected conversations.

### Symptom

After an empty completion following tool use is interrupted, a session can resume with active `assistant: (empty)` and synthetic user-nudge rows. Subsequent turns can keep producing empty completions across restarts.

### Impact

Affected sessions remain unusable until the leaked rows are manually deactivated. The measured blast radius is unknown.

### Bug Cause

**Trigger:** `hermes_state.py:11080` / `SessionDB._rows_to_conversation()` restoring active message rows that no longer carry private recovery metadata.

**Causal chain:**
1. Empty-response recovery creates a synthetic assistant sentinel and user nudge marked with private `_empty_*` fields in memory.
2. If those rows reach durable storage, SessionDB projection restores only schema-backed fields, so the private markers are unavailable on resume.
3. The structurally valid rows pass alternation repair and re-enter model context as genuine conversation, encouraging the same empty response on later turns.

**Why it is wrong:** recovery scaffolding exists only to drive an in-turn retry and must never become durable model history.

**Working sibling / contrast:** current write-boundary guards correctly skip live messages while their private flags are present. Load-time projection is the missing defense for already-contaminated rows whose flags are gone.

**Ruled out:** retry-budget exhaustion alone does not explain persistence across restart. A real temporary SessionDB reproduces the contaminated rows in both standard and resume projections before this patch.

### Fix

Recognize the exact assistant sentinel and synthetic user-nudge role/content signatures during SessionDB projection and exclude them from both model and display histories. Similar real assistant and user text remains unchanged.

## Related Issue

Closes #92877

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` - repair persisted empty-response recovery scaffolding at the shared conversation projection boundary.
- `tests/hermes_state/test_empty_recovery_scaffolding_repair.py` - cover standard resume, dual model/display projections, and negative controls with a real temporary SessionDB.

## How to Test

1. Seed a temporary SessionDB with a tool result, unmarked `assistant: (empty)`, the exact synthetic recovery nudge, and a later real response.
2. Restore it through `get_messages_as_conversation()` and `get_resume_conversations()`.
3. Confirm both scaffolding rows are absent while genuine content remains.

```bash
scripts/run_tests.sh tests/hermes_state/test_empty_recovery_scaffolding_repair.py -q
scripts/run_tests.sh tests/run_agent/test_empty_response_recovery_persistence.py tests/hermes_state/test_restore_alternation_repair.py tests/test_stale_tool_call_marker_session_repair.py -q
```

Locally verified: 24 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - behavior is internal and covered by code documentation
- [x] `cli-config.yaml.example`: N/A - no configuration changes
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no workflow or architecture changes
- [x] Cross-platform impact considered: pure Python and SQLite projection logic
- [x] Tool descriptions/schemas: N/A - no tool surface changes

## Screenshots / Logs

N/A - automated SessionDB regression tests cover the failure and repair path.
