### PR TITLE
fix(web): portal the dashboard Select dropdown so the menu is never clipped

### DIFF
--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,0 +1,322 @@
+'use client'
+
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactElement,
+  type ReactNode
+} from 'react'
+import { createPortal } from 'react-dom'
+
+import { cn } from '@/lib/utils'
+
+const TRIGGER_CN =
+  'flex h-9 w-full items-center justify-between gap-2 ' +
+  'border border-midground/15 bg-background/40 px-3 py-1 ' +
+  'font-courier text-sm text-left text-midground transition-colors ' +
+  'hover:border-midground/25 ' +
+  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground/30 focus-visible:border-midground/30 ' +
+  'disabled:cursor-not-allowed disabled:opacity-50 ' +
+  'cursor-pointer'
+
+// Rendered through a portal onto document.body (see below), so position is
+// applied inline. `position: fixed` here only as a fallback for SSR.
+const LISTBOX_CN =
+  'z-50 max-h-60 overflow-auto ' +
+  'border border-midground/15 bg-background-base text-midground shadow-lg'
+
+/**
+ * Dashboard select styled with the shared design tokens.
+ *
+ * This is the dashboard's own copy of `@nous-research/ui`'s `Select`, wired in
+ * via Vite's resolve.alias (see `web/vite.config.ts`) so the dashboard no
+ * longer depends on the published component.
+ *
+ * Why a local copy: the upstream `@nous-research/ui` `Select` renders its
+ * option list as an `absolute` node *inside* the trigger's `relative`
+ * container. Whenever that container sits in a scrolling or `overflow`
+ * wrapper (the composer bar, sidebars, dialogs), a new stacking context is
+ * created and the menu gets clipped or pushed underneath — so expanding a
+ * multi-select shows nothing. The desktop app already avoids this by portaling
+ * (Radix `Portal`). This component does the same: the option list is rendered
+ * through `createPortal(document.body)` and positioned with `position: fixed`
+ * under the trigger, so it always paints above its ancestors.
+ */
+export function Select({
+  children,
+  className,
+  disabled,
+  id,
+  onValueChange,
+  placeholder,
+  style,
+  value
+}: SelectProps) {
+  const [open, setOpen] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const [menuRect, setMenuRect] = useState<{
+    top: number
+    left: number
+    width: number
+  } | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const options = useMemo(() => collectOptions(children), [children])
+  const selected = options.find(o => o.value === value)
+  const displayLabel = selected?.label ?? placeholder ?? value ?? ''
+
+  const close = useCallback(() => {
+    setOpen(false)
+    setHighlightedIndex(-1)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    // Measure the trigger every time the menu opens so the portaled listbox
+    // docks exactly under it, even if an ancestor scrolled/overflow container
+    // would otherwise clip it (the menu is not a DOM descendant of the trigger).
+    const r = triggerRef.current?.getBoundingClientRect()
+    if (r) setMenuRect({ top: r.bottom + 4, left: r.left, width: r.width })
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const ac = new AbortController()
+    document.addEventListener(
+      'mousedown',
+      e => {
+        const t = e.target as Node
+        // The listbox is portaled to body, so count it as "inside" too —
+        // clicking an option must not close the menu before its onClick runs.
+        const inside =
+          containerRef.current?.contains(t) || listRef.current?.contains(t)
+        if (!inside) close()
+      },
+      { signal: ac.signal }
+    )
+    return () => ac.abort()
+  }, [open, close])
+
+  useEffect(() => {
+    if (!open || highlightedIndex < 0) return
+    const el = listRef.current?.children[highlightedIndex] as
+      | HTMLElement
+      | undefined
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [open, highlightedIndex])
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (disabled) return
+    switch (e.key) {
+      case 'Enter':
+      case ' ':
+        e.preventDefault()
+        if (!open) {
+          setOpen(true)
+          setHighlightedIndex(options.findIndex(o => o.value === value))
+        } else if (highlightedIndex >= 0 && options[highlightedIndex]) {
+          onValueChange?.(options[highlightedIndex].value)
+          close()
+        }
+        break
+      case 'ArrowDown':
+        e.preventDefault()
+        if (!open) {
+          setOpen(true)
+          setHighlightedIndex(options.findIndex(o => o.value === value))
+        } else {
+          setHighlightedIndex(i => Math.min(i + 1, options.length - 1))
+        }
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        if (open) setHighlightedIndex(i => Math.max(i - 1, 0))
+        break
+      case 'Home':
+        if (open) {
+          e.preventDefault()
+          setHighlightedIndex(0)
+        }
+        break
+      case 'End':
+        if (open) {
+          e.preventDefault()
+          setHighlightedIndex(options.length - 1)
+        }
+        break
+      case 'Escape':
+        e.preventDefault()
+        close()
+        break
+    }
+  }
+
+  return (
+    <div
+      className={cn('relative', className)}
+      id={id}
+      ref={containerRef}
+      style={style}
+    >
+      <button
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className={TRIGGER_CN}
+        disabled={disabled}
+        onClick={() => !disabled && setOpen(o => !o)}
+        onKeyDown={handleKeyDown}
+        ref={triggerRef}
+        role="combobox"
+        type="button"
+      >
+        <span className={cn('truncate', !selected && 'text-midground/50')}>
+          {displayLabel}
+        </span>
+
+        <ChevronDownGlyph
+          className={cn(
+            'size-3 shrink-0 text-midground/60 transition-transform',
+            open && 'rotate-180'
+          )}
+        />
+      </button>
+
+      {open &&
+        menuRect &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            className={LISTBOX_CN}
+            ref={listRef}
+            role="listbox"
+            style={{
+              position: 'fixed',
+              top: menuRect.top,
+              left: menuRect.left,
+              width: menuRect.width
+            }}
+          >
+            {options.map((opt, i) => {
+              const isSelected = opt.value === value
+              const isHighlighted = i === highlightedIndex
+
+              return (
+                <div
+                  aria-selected={isSelected}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-2 px-3 py-2',
+                    'font-courier text-sm transition-colors',
+                    isHighlighted && 'bg-midground/10',
+                    isSelected ? 'text-midground' : 'text-midground/70'
+                  )}
+                  key={opt.value}
+                  onClick={() => {
+                    onValueChange?.(opt.value)
+                    close()
+                  }}
+                  onMouseEnter={() => setHighlightedIndex(i)}
+                  role="option"
+                >
+                  <CheckGlyph
+                    className={cn(
+                      'size-3 shrink-0',
+                      isSelected ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  <span className="truncate">{opt.label}</span>
+                </div>
+              )
+            })}
+          </div>,
+          document.body
+        )}
+    </div>
+  )
+}
+
+// Marker component — `Select` reads `value`/`children` from its tree.
+// Renders nothing on its own.
+export function SelectOption(_props: SelectOptionProps) {
+  return null
+}
+
+const ChevronDownGlyph = ({ className }: { className?: string }) => (
+  <svg
+    aria-hidden
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    strokeLinecap="square"
+    strokeWidth={1.5}
+    viewBox="0 0 12 12"
+  >
+    <path d="M2.5 4.5 6 8l3.5-3.5" />
+  </svg>
+)
+
+const CheckGlyph = ({ className }: { className?: string }) => (
+  <svg
+    aria-hidden
+    className={className}
+    fill="none"
+    stroke="currentColor"
+    strokeLinecap="square"
+    strokeWidth={1.5}
+    viewBox="0 0 12 12"
+  >
+    <path d="m2.5 6.5 2.5 2.5L9.5 3.5" />
+  </svg>
+)
+
+function collectOptions(children: ReactNode): SelectOptionData[] {
+  const out: SelectOptionData[] = []
+  Children.forEach(children, child => {
+    if (!isValidElement(child)) return
+    const el = child as ReactElement<{
+      children?: ReactNode
+      value?: unknown
+    }>
+    if (el.props.value !== undefined) {
+      out.push({
+        label:
+          typeof el.props.children === 'string'
+            ? el.props.children
+            : String(el.props.value),
+        value: String(el.props.value)
+      })
+    } else if (el.props.children) {
+      out.push(...collectOptions(el.props.children))
+    }
+  })
+  return out
+}
+
+interface SelectOptionData {
+  label: string
+  value: string
+}
+
+interface SelectOptionProps {
+  children: ReactNode
+  value: string
+}
+
+interface SelectProps {
+  children?: ReactNode
+  className?: string
+  disabled?: boolean
+  id?: string
+  onValueChange?: (value: string) => void
+  placeholder?: string
+  style?: CSSProperties
+  value?: string
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -63,6 +63,16 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
       "@hermes/shared": path.resolve(__dirname, "../apps/shared/src"),
+      // The dashboard ships its own corrected copy of the upstream
+      // `@nous-research/ui` `Select` (portal-based dropdown, see
+      // src/components/ui/select.tsx). Aliasing the published module keeps
+      // every existing `Select` usage working while ensuring the option menu
+      // is never clipped by / buried under an ancestor stacking context —
+      // the upstream component renders it `absolute` inside the trigger.
+      "@nous-research/ui/ui/components/select": path.resolve(
+        __dirname,
+        "src/components/ui/select.tsx",
+      ),
     },
     // When @nous-research/ui is symlinked via `file:../../design-language`,
     // Node's module resolution would pick up shared deps from


### PR DESCRIPTION
fix(web): portal the dashboard Select dropdown so the menu is never clipped

## Problem

The dashboard's `Select` widget comes from the `@nous-research/ui` npm package.
Its option list is rendered as an `absolute` node **inside** the trigger's
`relative` container:

```
<div class="relative ...">           <-- trigger container
  <button role="combobox">…</button>
  <div role="listbox" class="absolute z-50 …">…</div>
</div>
```

Any ancestor that creates its own stacking context or clips content — the
composer bar, sidebars, dialogs and panels with `overflow` — then clips the
menu or paints it behind those ancestors. On the affected screen (e.g. the
composer's multi-select / the sidebar "Reasoning" select), expanding the
dropdown shows **no choices at all**; the list silently appears underneath
the widget.

## Fix

Mirror what the desktop app already does: it renders its dropdown through a
portal (Radix `Portal`) so the menu escapes its ancestors. This PR ships a
corrected dashboard-local copy of `Select` at `web/src/components/ui/select.tsx`
that:

- renders the option list through `createPortal(...) → document.body`,
- positions it with `position: fixed` docked under the trigger (measured via
  `getBoundingClientRect()` on open), so it paints above every ancestor,
- counts the portaled listbox as "inside" for outside-click dismissal so an
  option click doesn't close the menu before its `onClick` runs.

The component is picked up through a Vite `resolve.alias` entry in
`web/vite.config.ts` that redirects
`@nous-research/ui/ui/components/select` → the local copy, so **every** existing
`Select` usage keeps working untouched.

## Why a local copy + alias (not a package change)

- The dashboard imports `Select` from the external `@nous-research/ui`
  package, whose source isn't tracked in this repo — a fix there can't live in
  a hermes-agent PR, and local `node_modules` edits are wiped by reinstalls.
- An in-repo, tracked component + alias survives `npm install` / updates and
  fixes the whole bug class (all dashboard selects) at once.
- It is a deliberate, small exception to "don't duplicate": the upstream
  component is dependency-provided and has a real defect; the desktop already
  keeps its own equivalent.

## Verification

- `cd web && npm run build` passes; the produced `web_dist` bundle now ships a
  dedicated `select-*.js` chunk containing the portal render
  (`position: fixed`, `top/left/width`, `createPortal`) and no longer contains
  the old `absolute … mt-1 w-full` listbox.
- No `node_modules` changes are committed.