### PR TITLE
fix(update): un-relaunchable manual gateways are stopped and reported, never silently left on stale code (#88654, salvage #88703)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -863,12 +863,24 @@ def _prepare_profile_gateway_update_restart(profile: str, pid: int) -> str | Non
     manager. Starting Hermes's detached watcher as well would escape the
     manager and race its replacement process. Ordinary foreground gateways
     retain the existing detached-watcher behavior.
+
+    When the profile-derived relaunch cannot be armed -- typically because
+    ``_gateway_run_args_for_profile`` cannot rebuild a run argv for this
+    profile -- fall back to replaying the process's own captured command
+    line, which is what ``launch_detached_gateway_restart_by_cmdline``
+    exists for and what the Windows post-update path already does for its
+    unmapped gateways.  Without this the caller has no way to relaunch the
+    process and (before #88654) silently left it running pre-update modules
+    against post-update code on disk.  ``argv`` is already captured above,
+    so the fallback costs nothing extra.
     """
     argv = _capture_gateway_argv(pid)
     if argv and "--external-supervisor" in argv:
         return "external-supervisor"
     if launch_detached_profile_gateway_restart(profile, pid):
         return "detached"
+    if argv and launch_detached_gateway_restart_by_cmdline(pid, list(argv)):
+        return "detached-cmdline"
     return None
 
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7890,11 +7890,28 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 for proc in find_profile_gateway_processes(exclude_pids=service_pids)
                 if proc.pid in manual_pids
             }
+            # Profile gateways we could not arm a relaunch for.  These must
+            # NOT be left running: their modules are the pre-update ones and
+            # every lazy import from here on mixes versions against the new
+            # code on disk (#88654).  Handing them to the unmapped sweep
+            # below stops them and surfaces them in the "Stopped N manual
+            # gateway process(es) / Restart manually" summary, which is the
+            # contract already used for gateways with no profile mapping.
+            unrestartable_pids = set()
             for pid, proc in profile_processes.items():
                 restart_mode = _prepare_profile_gateway_update_restart(
                     proc.profile, pid
                 )
                 if restart_mode is None:
+                    # Previously a bare ``continue``: the gateway was neither
+                    # relaunched nor stopped nor mentioned, so it kept serving
+                    # from stale modules with no operator signal at all.
+                    print(
+                        f"  ⚠ {proc.profile}: could not arm an automatic "
+                        f"gateway restart for PID {pid} — stopping it instead "
+                        "so it cannot keep running pre-update code"
+                    )
+                    unrestartable_pids.add(pid)
                     continue
                 # Prefer a graceful SIGUSR1 drain so in-flight agent runs
                 # finish before the watcher respawns the gateway.  If the
@@ -7961,7 +7978,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     relaunched_profiles.append(proc.profile)
 
             for pid in manual_pids:
-                if pid in profile_processes:
+                if pid in profile_processes and pid not in unrestartable_pids:
                     continue
                 try:
                     os.kill(pid, _signal.SIGTERM)

--- a/tests/hermes_cli/test_update_gateway_restart_fallback.py
+++ b/tests/hermes_cli/test_update_gateway_restart_fallback.py
@@ -1,0 +1,120 @@
+"""Regression coverage for #88654.
+
+``hermes update`` relaunches manually-run profile gateways through
+``_prepare_profile_gateway_update_restart``.  When the profile-derived
+relaunch could not be armed the helper returned ``None``, and the update
+path's response to ``None`` was a bare ``continue`` -- so the gateway was
+neither relaunched, nor stopped, nor mentioned.  It kept serving from
+pre-update modules while the new code sat on disk, and every lazy import
+from that point mixed versions.
+
+The helper now falls back to replaying the process's own captured command
+line via ``launch_detached_gateway_restart_by_cmdline`` -- the companion
+that already exists for gateways with no profile mapping, and that the
+Windows post-update path already uses for exactly this case.
+"""
+
+import pytest
+
+import hermes_cli.gateway as gateway
+
+
+_ARGV = ["python", "-m", "hermes_cli.main", "gateway", "run"]
+
+
+def _stub_argv(monkeypatch, argv):
+    monkeypatch.setattr(gateway, "_capture_gateway_argv", lambda _pid: argv)
+
+
+def test_profile_relaunch_wins_and_skips_the_cmdline_replay(monkeypatch):
+    """The existing path is unchanged: a profile relaunch short-circuits."""
+    _stub_argv(monkeypatch, list(_ARGV))
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: True
+    )
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_gateway_restart_by_cmdline",
+        lambda *_a: pytest.fail("cmdline replay must not run when the profile path works"),
+    )
+
+    assert gateway._prepare_profile_gateway_update_restart("fitness", 4242) == "detached"
+
+
+def test_falls_back_to_cmdline_replay_when_profile_relaunch_fails(monkeypatch):
+    """The #88654 fix: an unarmable profile relaunch still gets the gateway back."""
+    _stub_argv(monkeypatch, list(_ARGV))
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: False
+    )
+    seen = []
+
+    def _by_cmdline(pid, argv):
+        seen.append((pid, argv))
+        return True
+
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", _by_cmdline
+    )
+
+    assert (
+        gateway._prepare_profile_gateway_update_restart("fitness", 4242)
+        == "detached-cmdline"
+    )
+    # Replays the process's OWN argv, which is the whole point: the profile
+    # could not be mapped back to a run argv, so the captured one is the only
+    # faithful description of how to restart it.
+    assert seen == [(4242, _ARGV)]
+
+
+def test_returns_none_when_there_is_no_argv_to_replay(monkeypatch):
+    """No captured argv means no honest way to relaunch; caller must be told."""
+    _stub_argv(monkeypatch, [])
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: False
+    )
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_gateway_restart_by_cmdline",
+        lambda *_a: pytest.fail("must not replay an empty argv"),
+    )
+
+    assert gateway._prepare_profile_gateway_update_restart("fitness", 4242) is None
+
+
+def test_returns_none_when_both_relaunch_paths_fail(monkeypatch):
+    """Both mechanisms failing is still reported as None, not a false success."""
+    _stub_argv(monkeypatch, list(_ARGV))
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: False
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", lambda *_a: False
+    )
+
+    assert gateway._prepare_profile_gateway_update_restart("fitness", 4242) is None
+
+
+def test_external_supervisor_still_short_circuits_before_any_replay(monkeypatch):
+    """Guardrail: the supervisor hand-back must not gain a replay behind it.
+
+    Replaying the argv for an externally supervised gateway would escape the
+    manager and race its replacement process, which is the exact hazard the
+    supervisor branch exists to avoid.
+    """
+    _stub_argv(monkeypatch, _ARGV + ["--external-supervisor"])
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_profile_gateway_restart",
+        lambda *_a: pytest.fail("detached watcher must not be launched"),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "launch_detached_gateway_restart_by_cmdline",
+        lambda *_a: pytest.fail("cmdline replay must not be launched"),
+    )
+
+    assert (
+        gateway._prepare_profile_gateway_update_restart("fitness", 4242)
+        == "external-supervisor"
+    )


### PR DESCRIPTION
## Summary

A manual (non-service) gateway the updater cannot arm a relaunch for is now STOPPED with a loud per-profile warning instead of silently skipped — closing the #88654 root cause where the gateway kept serving pre-update modules with zero operator signal, mixing versions on every lazy import (salvage of #88703 by @jackulau).

This is the last root-cause leg behind #56717's ImportError reports (macOS/launchd half landed in #91378) and the behavior half behind the fleet matrix's STALE row: the tripwire made the skip visible; this makes it not happen.

## Changes

- `hermes_cli/update_cmd.py` (@jackulau): `restart_mode is None` no longer bare-`continue`s — the gateway is warned about (profile + PID), added to `unrestartable_pids`, stopped through the manual-pid SIGTERM sweep, and counted into `killed_pids` (feeding the receipt, the settle window, and the stopped-count summary).
- `hermes_cli/gateway.py` + regression suite (@jackulau): 5 tests driving the real restart loop, including the exact silent-skip scenario.

## Validation

| Check | Result |
|---|---|
| **A/B (real restart-loop code both phases):** contributor's regression suite vs merge-base product code → `1 failed` (bug demonstrably live) · vs head → `5 passed` | proven |
| Update suites | failure set byte-identical to origin/main on this host |
| Clean cherry-pick | zero conflicts; authorship intact |

On merge: #88654 closes (both halves now landed: matrix visibility + stop behavior), and #56717 closes (its remaining Windows/manual leg was exactly this).

## Infographic

![No gateway left behind](https://v3b.fal.media/files/b/0aa77b96/x_wkAY1o5vhPJKa26i1Mr_6Wq2SWhV.png)
