### PR TITLE
fix(matrix): fetch replied-to event when a rich reply omits the inlin…

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3501,13 +3501,22 @@ class MatrixAdapter(BasePlatformAdapter):
         # gateway prompt layer can render "[Replying to: \"<original>\"]".
         # Other adapters (Signal, Slack, Telegram) populate reply_to_text
         # from their quote payload; Matrix stores it inline as `> <@user:srv>
-        # <text>\n\n<actual reply>` and discards it after stripping.
+        # <text>\n\n<actual reply>` and discards it after stripping. Clients
+        # that send only the event reference (no inline fallback) are handled
+        # by fetching the replied-to event from the homeserver below.
         reply_to_text: Optional[str] = None
         reply_to_author_id: Optional[str] = None
         reply_to_author_name: Optional[str] = None
-        if reply_to and body.startswith("> "):
-            reply_to_text, reply_to_author_id = _extract_reply_fallback(body)
-            body = _strip_reply_fallback(body)
+        if reply_to:
+            if body.startswith("> "):
+                reply_to_text, reply_to_author_id = _extract_reply_fallback(body)
+                body = _strip_reply_fallback(body)
+            else:
+                # No inline fallback: reconstruct the quote from the
+                # homeserver so the agent can see what is being replied to.
+                reply_to_text, reply_to_author_id = await self._fetch_reply_event(
+                    room_id, reply_to
+                )
 
             # Resolve the replied-to author's display name when we have the
             # state_store available — falls back to the localpart otherwise.
@@ -3738,9 +3747,14 @@ class MatrixAdapter(BasePlatformAdapter):
         reply_to_text: Optional[str] = None
         reply_to_author_id: Optional[str] = None
         reply_to_author_name: Optional[str] = None
-        if reply_to and body.startswith("> "):
-            reply_to_text, reply_to_author_id = _extract_reply_fallback(body)
-            body = _strip_reply_fallback(body)
+        if reply_to:
+            if body.startswith("> "):
+                reply_to_text, reply_to_author_id = _extract_reply_fallback(body)
+                body = _strip_reply_fallback(body)
+            else:
+                reply_to_text, reply_to_author_id = await self._fetch_reply_event(
+                    room_id, reply_to
+                )
 
             if reply_to_author_id:
                 reply_to_author_name = await self._get_display_name(
@@ -4975,6 +4989,40 @@ class MatrixAdapter(BasePlatformAdapter):
         body = re.sub(r'[ \t]{2,}', ' ', body)
         body = re.sub(r'\s+([,.;:!?])', r'\1', body)
         return body.strip()
+
+    async def _fetch_reply_event(
+        self, room_id: str, event_id: str
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Fetch the replied-to event's body and sender from the homeserver.
+
+        Modern Matrix clients (Beeper, Element X, etc.) send a "rich reply"
+        that references the original event via ``m.relates_to.m.in_reply_to``
+        but omit the inline ``> quote`` fallback in ``body``. Without it,
+        ``reply_to_text`` stays empty and the agent cannot see what the user
+        is replying to. Fetch the event to reconstruct the quote. Any failure
+        resolves to ``(None, None)`` so reply handling degrades gracefully to
+        the old behaviour.
+        """
+        client = self._client
+        if client is None:
+            return None, None
+        try:
+            event = await client.get_event(room_id, event_id)
+        except Exception:
+            logger.debug(
+                "Matrix: get_event failed for reply %s", event_id, exc_info=True
+            )
+            return None, None
+        if event is None:
+            return None, None
+        content = getattr(event, "content", None)
+        if not isinstance(content, dict):
+            return None, None
+        quoted_text = content.get("body")
+        author_id = getattr(event, "sender", None)
+        if not quoted_text or not str(quoted_text).strip():
+            return None, None
+        return str(quoted_text), str(author_id) if author_id else None
 
     async def _get_display_name(self, room_id: str, user_id: str) -> str:
         """Get a user's display name in a room, falling back to user_id."""

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -580,6 +580,84 @@ class TestMatrixBangCommandAlias:
 
 
 # ---------------------------------------------------------------------------
+# Reply quote reconstruction (rich replies without an inline fallback)
+# ---------------------------------------------------------------------------
+
+class TestMatrixReplyFetch:
+    """When a client sends a rich reply that references the original event but
+    omits the inline ``> quote`` fallback, the adapter must fetch the
+    replied-to event from the homeserver so ``reply_to_text`` is populated."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._is_dm_room = AsyncMock(return_value=True)
+        self.adapter._get_display_name = AsyncMock(return_value="Nagger")
+        self.adapter._background_read_receipt = MagicMock()
+        self.adapter._text_batch_delay_seconds = 0
+        self.adapter._client = MagicMock()
+        self.adapter._client.get_event = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_reply_without_fallback_fetches_quoted_text(self):
+        self.adapter._client.get_event = AsyncMock(
+            return_value=types.SimpleNamespace(
+                content={"body": "12 posts queued, target 14"},
+                sender="@nagger:example.org",
+            )
+        )
+        captured = None
+
+        async def capture(msg_event):
+            nonlocal captured
+            captured = msg_event
+
+        self.adapter.handle_message = capture
+        await self.adapter._handle_text_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$matrix-reply-fetch-test",
+            event_ts=0.0,
+            source_content={"msgtype": "m.text", "body": "Is this right?"},
+            relates_to={"m.in_reply_to": {"event_id": "$parent-event"}},
+        )
+
+        assert captured is not None
+        assert captured.text == "Is this right?"
+        assert captured.reply_to_text == "12 posts queued, target 14"
+        assert captured.reply_to_author_id == "@nagger:example.org"
+        assert captured.reply_to_author_name == "Nagger"
+        self.adapter._client.get_event.assert_awaited_once_with(
+            "!room:example.org", "$parent-event"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reply_fetch_failure_degrades_to_empty_quote(self):
+        self.adapter._client.get_event = AsyncMock(
+            side_effect=Exception("homeserver unreachable")
+        )
+        captured = None
+
+        async def capture(msg_event):
+            nonlocal captured
+            captured = msg_event
+
+        self.adapter.handle_message = capture
+        await self.adapter._handle_text_message(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            event_id="$matrix-reply-fetch-fail",
+            event_ts=0.0,
+            source_content={"msgtype": "m.text", "body": "Is this right?"},
+            relates_to={"m.in_reply_to": {"event_id": "$parent-event"}},
+        )
+
+        assert captured is not None
+        assert captured.text == "Is this right?"
+        assert captured.reply_to_text is None
+        assert captured.reply_to_author_id is None
+
+
+# ---------------------------------------------------------------------------
 # Thread detection
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
…e quote fallback

Modern Matrix clients (Beeper, Element X, etc.) send a rich reply that references the original event via m.relates_to.m.in_reply_to but omit the inline > quote fallback in body. The adapter only parsed the inline fallback, so reply_to_text stayed empty and the agent could not see what the user was replying to.

Add MatrixAdapter._fetch_reply_event, which calls client.get_event to reconstruct the quote (body + sender) when no fallback is present. Wire it into both _handle_text_message and _handle_media_message. Any failure degrades gracefully to the old empty-quote behaviour.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

