### PR TITLE
fix: authenticate local-server probes in vision capability lookup

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -332,7 +332,73 @@ def _resolve_inference_base_url(
     return ""
 
 
-def _should_probe_ollama_vision(provider: str, base_url: str) -> bool:
+def _resolve_inference_api_key(
+    cfg: Optional[Dict[str, Any]],
+    provider: str,
+    base_url: str = "",
+) -> str:
+    """Best-effort API key for the active inference provider.
+
+    Mirrors ``_resolve_inference_base_url`` so capability probes (e.g. the
+    Ollama server-type detection in ``_should_probe_ollama_vision``) can
+    authenticate against key-protected local endpoints instead of being
+    rejected with 401 before the probe completes.
+    """
+    try:
+        from agent.auxiliary_client import _runtime_main_value
+
+        runtime = str(_runtime_main_value("api_key") or "").strip()
+        runtime_provider = str(_runtime_main_value("provider") or "").strip().lower()
+        requested_provider = str(provider or "").strip().lower()
+        if runtime and (not requested_provider or requested_provider == runtime_provider):
+            return runtime
+    except Exception:
+        pass
+
+    if not isinstance(cfg, dict):
+        return ""
+
+    model_cfg_raw = cfg.get("model")
+    model_cfg: Dict[str, Any] = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
+    api_key = str(model_cfg.get("api_key") or "").strip()
+    if api_key:
+        return api_key
+
+    config_provider = str(model_cfg.get("provider") or "").strip()
+    candidate_names: set[str] = set()
+    for p in filter(None, (provider, config_provider)):
+        candidate_names.add(p)
+        if p.lower().startswith("custom:"):
+            candidate_names.add(p.split(":", 1)[1])
+        else:
+            candidate_names.add(f"custom:{p}")
+
+    providers_cfg = cfg.get("providers")
+    if isinstance(providers_cfg, dict):
+        for name in candidate_names:
+            entry = providers_cfg.get(name)
+            if isinstance(entry, dict):
+                key = str(entry.get("api_key") or "").strip()
+                if key:
+                    return key
+
+    custom_providers = cfg.get("custom_providers")
+    if isinstance(custom_providers, list):
+        lowered = {n.lower() for n in candidate_names}
+        for entry_raw in custom_providers:
+            if not isinstance(entry_raw, dict):
+                continue
+            entry_name = str(entry_raw.get("name") or "").strip()
+            if entry_name not in candidate_names and entry_name.lower() not in lowered:
+                continue
+            key = str(entry_raw.get("api_key") or "").strip()
+            if key:
+                return key
+
+    return ""
+
+
+def _should_probe_ollama_vision(provider: str, base_url: str, api_key: str = "") -> bool:
     """True when the active provider likely fronts a local Ollama server."""
     p = (provider or "").strip().lower()
     if p == "ollama":
@@ -342,7 +408,7 @@ def _should_probe_ollama_vision(provider: str, base_url: str) -> bool:
     try:
         from agent.model_metadata import detect_local_server_type
 
-        return detect_local_server_type(base_url) == "ollama"
+        return detect_local_server_type(base_url, api_key=api_key) == "ollama"
     except Exception:
         return False
 
@@ -448,11 +514,12 @@ def _lookup_supports_vision(
     base_url = _resolve_inference_base_url(cfg, provider)
     if not base_url and (provider or "").strip().lower() == "ollama":
         base_url = "http://localhost:11434/v1"
-    if _should_probe_ollama_vision(provider, base_url):
+    api_key = _resolve_inference_api_key(cfg, provider, base_url)
+    if _should_probe_ollama_vision(provider, base_url, api_key):
         try:
             from agent.model_metadata import query_ollama_supports_vision
 
-            ollama_vision = query_ollama_supports_vision(model, base_url)
+            ollama_vision = query_ollama_supports_vision(model, base_url, api_key)
             if ollama_vision is not None:
                 return ollama_vision
         except Exception as exc:  # pragma: no cover - defensive

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -497,8 +497,6 @@ class TestCustomProviderVisionAlias:
         assert _supports_vision_override(cfg, "custom", "llava-v1.6") is True
         assert decide_image_input_mode("custom", "llava-v1.6", cfg) == "native"
 
-
-
     def test_vision_alias_none_when_model_absent(self):
         cfg = {
             "custom_providers": [
@@ -506,3 +504,80 @@ class TestCustomProviderVisionAlias:
             ]
         }
         assert _supports_vision_override(cfg, "custom:my-vllm", "other") is None
+
+
+# ─── authenticated local-server probes ───────────────────────────────────────
+
+
+class TestAuthenticatedOllamaProbe:
+    """Capability probes against key-protected local servers must authenticate.
+
+    Regression: ``_should_probe_ollama_vision`` and the ``query_ollama_*``
+    fallback called ``detect_local_server_type(base_url)`` without an api_key,
+    so any key-protected llama.cpp/Ollama endpoint (server started with
+    ``--api-key``) rejected the whole 5-leg server-type waterfall with 401s
+    before the probe could identify the server — producing a burst of
+    ``unauthorized: Invalid API Key`` log lines on every session start.
+    """
+
+    def test_should_probe_passes_api_key(self):
+        from agent.image_routing import _should_probe_ollama_vision
+
+        with patch("agent.model_metadata.detect_local_server_type") as detect:
+            detect.return_value = "ollama"
+            assert _should_probe_ollama_vision("custom", "http://127.0.0.1:8000/v1", "secret-key") is True
+            detect.assert_called_once_with("http://127.0.0.1:8000/v1", api_key="secret-key")
+
+    def test_should_probe_defaults_to_empty_key(self):
+        from agent.image_routing import _should_probe_ollama_vision
+
+        with patch("agent.model_metadata.detect_local_server_type") as detect:
+            detect.return_value = None
+            _should_probe_ollama_vision("custom", "http://127.0.0.1:11434")
+            detect.assert_called_once_with("http://127.0.0.1:11434", api_key="")
+
+    def test_lookup_forwards_resolved_key_to_both_probes(self):
+        cfg = {
+            "model": {
+                "provider": "custom",
+                "base_url": "http://127.0.0.1:8000/v1",
+                "api_key": "secret-key",
+            }
+        }
+        with patch(
+            "agent.image_routing._resolve_inference_base_url",
+            return_value="http://127.0.0.1:8000/v1",
+        ), patch(
+            "agent.image_routing._resolve_inference_api_key",
+            return_value="secret-key",
+        ), patch(
+            "agent.model_metadata.detect_local_server_type",
+            return_value="ollama",
+        ), patch(
+            "agent.model_metadata.query_ollama_supports_vision",
+            return_value=True,
+        ) as q:
+            assert _lookup_supports_vision("custom", "llava", cfg) is True
+            q.assert_called_once_with("llava", "http://127.0.0.1:8000/v1", "secret-key")
+
+    def test_key_resolver_reads_custom_providers_entry(self):
+        from agent.image_routing import _resolve_inference_api_key
+
+        cfg = {
+            "model": {"provider": "Hog.legchekov.com"},
+            "custom_providers": [
+                {
+                    "name": "Hog.legchekov.com",
+                    "base_url": "http://127.0.0.1:8000/v1",
+                    "api_key": "secret-key",
+                }
+            ],
+        }
+        assert _resolve_inference_api_key(cfg, "custom") == "secret-key"
+        assert _resolve_inference_api_key(cfg, "Hog.legchekov.com") == "secret-key"
+
+    def test_key_resolver_returns_empty_when_unconfigured(self):
+        from agent.image_routing import _resolve_inference_api_key
+
+        assert _resolve_inference_api_key({}, "custom") == ""
+        assert _resolve_inference_api_key(None, "custom") == ""


### PR DESCRIPTION
## Problem

`_should_probe_ollama_vision` and the `query_ollama_supports_vision` fallback in `agent/image_routing.py` call `detect_local_server_type(base_url)` **without an api_key**. On any key-protected local server (e.g. llama.cpp started with `--api-key`, or an Ollama instance behind auth), every leg of the 5-request server-type waterfall (`/api/v1/models` → `/api/tags` → `/v1/props` → `/props` → `/version`) is rejected with `401 unauthorized: Invalid API Key` before the probe can identify the server.

Consequence: every Hermes session start that runs the vision capability lookup emits a burst of 10 `unauthorized` lines (5 probes × vision + browser_vision checks) against the local server log, and with retries under load this scales to hundreds of spurious 401s.

## Fix

Thread the provider's api_key through both probe call sites:

1. New `_resolve_inference_api_key(cfg, provider, base_url)` — a mirror of `_resolve_inference_base_url` following the same resolution order: runtime main override → `model.api_key` → `providers.<name>.api_key` → `custom_providers[].api_key` (matching by provider name, `custom:` prefix, or config `model.provider`).
2. `_should_probe_ollama_vision(provider, base_url, api_key="")` now passes the key to `detect_local_server_type`.
3. `_lookup_supports_vision` resolves the key and forwards it to both the server-type probe and `query_ollama_supports_vision`.

Unauthenticated endpoints are unaffected: `api_key` defaults to `""`, and `detect_local_server_type`/`query_ollama_supports_vision` already build their auth headers from the key parameter (empty key → no header, same as today).

## Verification

- 4 new unit tests in `tests/agent/test_image_routing.py` covering: key forwarding to the probe, the `""` default (unauthenticated path unchanged), both probe call sites receiving the resolved key, the resolver reading `custom_providers` entries (bare `custom` and named), and empty config.
- Full `tests/agent/test_image_routing.py` + related metadata/probe/vision suites: 207 passed, 0 regressions (2 pre-existing env-dependent failures in `test_vision_routing_31179.py` identical on clean main).
- E2E against a live key-protected llama.cpp server (real config): `_lookup_supports_vision` resolves the key and completes with **0** `unauthorized` lines in the server log (previously: 5+5 per startup).

## Test plan

- [x] Unit tests added
- [x] Related suites green (no regressions vs clean main)
- [x] E2E against live key-protected server: 0 unauthorized