### PR TITLE
feat(agent): pre_llm_call runtime_override (#23739)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1503,6 +1503,14 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     ``active_system_prompt`` for subsequent call-block rebuilds.
     """
     sp = getattr(agent, "_cached_system_prompt", None)
+    # pre_llm_call runtime_override: keep the overridden system prompt stable
+    # across a mid-turn failover instead of reverting to the cached prompt.
+    _ro_system_prompt = (getattr(agent, "_runtime_override", None) or {}).get("system_prompt")
+    if _ro_system_prompt:
+        if api_messages and api_messages[0].get("role") == "system":
+            if not _rewrite_system_content_blocks(api_messages[0], str(_ro_system_prompt)):
+                api_messages[0]["content"] = str(_ro_system_prompt)
+        return str(_ro_system_prompt)
     if not isinstance(sp, str) or not sp:
         return active_system_prompt
     if api_messages and api_messages[0].get("role") == "system":
@@ -2312,9 +2320,17 @@ def run_conversation(
         # every turn. ``apply_anthropic_cache_control`` may split its stable
         # prefix into content blocks on the wire, but the stored string and
         # its byte-stability remain unchanged.
-        effective_system = active_system_prompt or ""
-        if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        _runtime_ov = getattr(agent, "_runtime_override", None) or {}
+        _ro_system_prompt = _runtime_ov.get("system_prompt")
+        if _ro_system_prompt:
+            # pre_llm_call runtime_override: replace the system prompt for
+            # THIS call only.  Applied to the ephemeral api_messages copy —
+            # the cached session prompt and persisted history are untouched.
+            effective_system = str(_ro_system_prompt)
+        else:
+            effective_system = active_system_prompt or ""
+            if agent.ephemeral_system_prompt:
+                effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 
@@ -2886,13 +2902,23 @@ def run_conversation(
                         tools_for_api=tools_for_api,
                     )
                 )
-                if tools_for_api == agent.tools:
-                    api_kwargs = agent._build_api_kwargs(api_messages)
+                from agent.runtime_override import (
+                    apply_runtime_override as _apply_runtime_override,
+                )
+                _runtime_ov = getattr(agent, "_runtime_override", None) or {}
+                if _runtime_ov:
+                    _ro_cm = _apply_runtime_override(agent, _runtime_ov)
                 else:
-                    api_kwargs = agent._build_api_kwargs(
-                        api_messages,
-                        tools_for_api=tools_for_api,
-                    )
+                    from contextlib import nullcontext as _nullcontext
+                    _ro_cm = _nullcontext()
+                with _ro_cm:
+                    if tools_for_api == agent.tools:
+                        api_kwargs = agent._build_api_kwargs(api_messages)
+                    else:
+                        api_kwargs = agent._build_api_kwargs(
+                            api_messages,
+                            tools_for_api=tools_for_api,
+                        )
                 # Outbound-request surrogate chokepoint (#50959): the messages
                 # were scrubbed above, but the rest of the request body —
                 # tool/function descriptions (session_search's ±-heavy text is
@@ -3090,6 +3116,16 @@ def run_conversation(
                         _use_streaming = False
 
                 def _perform_api_call(next_api_kwargs):
+                    from agent.runtime_override import (
+                        apply_runtime_override as _apply_runtime_override,
+                    )
+                    _runtime_ov = getattr(agent, "_runtime_override", None) or {}
+                    if _runtime_ov:
+                        with _apply_runtime_override(agent, _runtime_ov):
+                            return _perform_api_call_inner(next_api_kwargs)
+                    return _perform_api_call_inner(next_api_kwargs)
+
+                def _perform_api_call_inner(next_api_kwargs):
                     if agent.api_mode == "codex_responses":
                         next_api_kwargs = agent._get_transport().preflight_kwargs(
                             next_api_kwargs,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1503,14 +1503,6 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     ``active_system_prompt`` for subsequent call-block rebuilds.
     """
     sp = getattr(agent, "_cached_system_prompt", None)
-    # pre_llm_call runtime_override: keep the overridden system prompt stable
-    # across a mid-turn failover instead of reverting to the cached prompt.
-    _ro_system_prompt = (getattr(agent, "_runtime_override", None) or {}).get("system_prompt")
-    if _ro_system_prompt:
-        if api_messages and api_messages[0].get("role") == "system":
-            if not _rewrite_system_content_blocks(api_messages[0], str(_ro_system_prompt)):
-                api_messages[0]["content"] = str(_ro_system_prompt)
-        return str(_ro_system_prompt)
     if not isinstance(sp, str) or not sp:
         return active_system_prompt
     if api_messages and api_messages[0].get("role") == "system":
@@ -2321,16 +2313,9 @@ def run_conversation(
         # prefix into content blocks on the wire, but the stored string and
         # its byte-stability remain unchanged.
         _runtime_ov = getattr(agent, "_runtime_override", None) or {}
-        _ro_system_prompt = _runtime_ov.get("system_prompt")
-        if _ro_system_prompt:
-            # pre_llm_call runtime_override: replace the system prompt for
-            # THIS call only.  Applied to the ephemeral api_messages copy —
-            # the cached session prompt and persisted history are untouched.
-            effective_system = str(_ro_system_prompt)
-        else:
-            effective_system = active_system_prompt or ""
-            if agent.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        effective_system = active_system_prompt or ""
+        if agent.ephemeral_system_prompt:
+            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2887,6 +2887,13 @@ def run_conversation(
                         tools_for_api=tools_for_api,
                     )
                 )
+                # Two-scope design (intentional — do not consolidate into
+                # one turn-long scope): Scope 1 wraps kwargs building so
+                # model/provider/base_url flow into the wire client's
+                # kwargs.  Scope 2 (inside _perform_api_call) wraps each
+                # wire attempt as a redundant safety net.  Between the two
+                # scopes the agent identity is un-overridden — correct,
+                # non-call code sees the real identity.
                 from agent.runtime_override import (
                     apply_runtime_override as _apply_runtime_override,
                 )

--- a/agent/runtime_override.py
+++ b/agent/runtime_override.py
@@ -34,13 +34,23 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 #: Keys a plugin may override.  Anything else is logged and ignored.
+#: ``system_prompt`` is intentionally NOT supported: it is the prompt-cache
+#: prefix (byte-stable for the life of a conversation), so overriding it would
+#: invalidate the cache and drop the core instructions. Model/provider routing
+#: does not need it; persona switching needs a separate cache-safe design.
 RUNTIME_OVERRIDE_KEYS = frozenset(
-    {"model", "provider", "base_url", "api_key", "api_mode", "system_prompt"}
+    {"model", "provider", "base_url", "api_key", "api_mode"}
 )
 
 #: All supported keys are plain non-empty strings.
 _STRING_KEYS = frozenset(
-    {"model", "provider", "base_url", "api_key", "api_mode", "system_prompt"}
+    {"model", "provider", "base_url", "api_key", "api_mode"}
+)
+
+#: Known wire protocols.  Unknown api_mode values are rejected (logged+ignored)
+#: instead of being forwarded into the call path.
+KNOWN_API_MODES = frozenset(
+    {"chat_completions", "anthropic_messages", "codex_responses", "bedrock_converse"}
 )
 
 
@@ -72,6 +82,14 @@ def validate_runtime_override(overrides: Any) -> Dict[str, str]:
                 "pre_llm_call runtime_override: key %r must be a non-empty "
                 "string, ignored",
                 key,
+            )
+            continue
+        if key == "api_mode" and value not in KNOWN_API_MODES:
+            logger.warning(
+                "pre_llm_call runtime_override: unsupported api_mode %r "
+                "(known: %s), ignored",
+                value,
+                ", ".join(sorted(KNOWN_API_MODES)),
             )
             continue
         valid[key] = value
@@ -122,7 +140,7 @@ class _RuntimeOverrideScope:
             if name in ov:
                 setattr(agent, name, ov[name])
         if "base_url" in ov:
-            agent.base_url = ov["base_url"]
+            agent.base_url = str(ov["base_url"]).strip().rstrip("/")
         if "api_key" in ov and isinstance(ck, dict):
             ck["api_key"] = ov["api_key"]
         if "base_url" in ov and isinstance(ck, dict):

--- a/agent/runtime_override.py
+++ b/agent/runtime_override.py
@@ -1,0 +1,162 @@
+"""Runtime override support for ``pre_llm_call`` plugin hooks.
+
+A plugin may return ``{"runtime_override": {...}}`` from ``pre_llm_call`` to
+proactively override the LLM API call parameters for the current turn:
+
+    {"context": "recalled text...",            # existing behavior, unchanged
+     "runtime_override": {
+         "model": "gpt-5.6",
+         "provider": "openai",
+         "base_url": "https://api.openai.com/v1",
+         "api_key": "sk-...",
+         "api_mode": "chat_completions",
+         "system_prompt": "You are ...",
+     }}
+
+Contract (mirrors the ``pre_failover_decision`` redirect contract):
+
+* ``redirect`` is *error-driven*: it is applied by the retry/failover machinery
+  only after an API call has failed.  ``runtime_override`` is *proactive*: it is
+  applied before the first API call of the turn.  The two do not conflict —
+  redirect rewrites identity on the failover path, runtime_override rewrites
+  identity on the primary path.
+* The override is ephemeral and turn-scoped: it lives on ``agent._runtime_override``,
+  is re-resolved on every turn prologue, is never persisted to the session DB and
+  is never injected into the user message / session history.
+* Unsupported keys are logged with a one-line warning and ignored (never crash).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Keys a plugin may override.  Anything else is logged and ignored.
+RUNTIME_OVERRIDE_KEYS = frozenset(
+    {"model", "provider", "base_url", "api_key", "api_mode", "system_prompt"}
+)
+
+#: All supported keys are plain non-empty strings.
+_STRING_KEYS = frozenset(
+    {"model", "provider", "base_url", "api_key", "api_mode", "system_prompt"}
+)
+
+
+def validate_runtime_override(overrides: Any) -> Dict[str, str]:
+    """Type-check + filter a plugin-provided ``runtime_override`` dict.
+
+    Returns only the supported, correctly-typed keys.  Unsupported keys and
+    wrong-typed values are logged with a one-line warning and dropped, so a
+    misbehaving plugin can never crash the turn.
+    """
+    if not isinstance(overrides, dict):
+        logger.warning(
+            "pre_llm_call runtime_override ignored: expected dict, got %s",
+            type(overrides).__name__,
+        )
+        return {}
+    valid: Dict[str, str] = {}
+    for key, value in overrides.items():
+        if key not in RUNTIME_OVERRIDE_KEYS:
+            logger.warning(
+                "pre_llm_call runtime_override: unsupported key %r ignored "
+                "(supported: %s)",
+                key,
+                ", ".join(sorted(RUNTIME_OVERRIDE_KEYS)),
+            )
+            continue
+        if key in _STRING_KEYS and (not isinstance(value, str) or not value.strip()):
+            logger.warning(
+                "pre_llm_call runtime_override: key %r must be a non-empty "
+                "string, ignored",
+                key,
+            )
+            continue
+        valid[key] = value
+    return valid
+
+
+class _RuntimeOverrideScope:
+    """Context manager that temporarily applies an override to ``agent``.
+
+    Snapshots the runtime attributes the LLM call path reads (plus the derived
+    client kwargs) and restores them on exit, so the override is active only
+    for the wrapped API-attempt block.  ``base_url`` is a property whose setter
+    refreshes ``_base_url_lower`` / ``_base_url_hostname``, so plain assignment
+    keeps the derived host-matching state consistent.
+    """
+
+    _ATTRS = ("model", "provider", "api_mode", "api_key")
+    _MISSING = object()
+
+    def __init__(self, agent: Any, overrides: Dict[str, str]) -> None:
+        self.agent = agent
+        self.overrides = overrides
+        self._snapshot: Dict[str, Any] = {}
+        self._client_kwargs_snapshot: Optional[Dict[str, Any]] = None
+
+    def __enter__(self) -> "_RuntimeOverrideScope":
+        agent = self.agent
+        for name in self._ATTRS:
+            if name in self.overrides:
+                self._snapshot[name] = getattr(agent, name, self._MISSING)
+        if "base_url" in self.overrides:
+            self._snapshot["base_url"] = getattr(agent, "base_url", self._MISSING)
+        # _client_kwargs feeds the per-request OpenAI-wire client.  Snapshot a
+        # shallow copy so in-place mutation is reversible.
+        ck = getattr(agent, "_client_kwargs", None)
+        if isinstance(ck, dict):
+            self._client_kwargs_snapshot = dict(ck)
+            self._snapshot["_client_kwargs"] = ck
+        for name, ov_key in (
+            ("_anthropic_api_key", "api_key"),
+            ("_anthropic_base_url", "base_url"),
+        ):
+            if ov_key in self.overrides and hasattr(agent, name):
+                self._snapshot[name] = getattr(agent, name, self._MISSING)
+
+        ov = self.overrides
+        for name in self._ATTRS:
+            if name in ov:
+                setattr(agent, name, ov[name])
+        if "base_url" in ov:
+            agent.base_url = ov["base_url"]
+        if "api_key" in ov and isinstance(ck, dict):
+            ck["api_key"] = ov["api_key"]
+        if "base_url" in ov and isinstance(ck, dict):
+            ck["base_url"] = str(ov["base_url"]).strip().rstrip("/")
+        if "_anthropic_api_key" in self._snapshot and "api_key" in ov:
+            agent._anthropic_api_key = ov["api_key"]
+        if "_anthropic_base_url" in self._snapshot and "base_url" in ov:
+            agent._anthropic_base_url = str(ov["base_url"]).strip().rstrip("/")
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        agent = self.agent
+        for name, value in self._snapshot.items():
+            if name == "_client_kwargs":
+                continue  # restored from the shallow copy below
+            if value is self._MISSING:
+                # Attribute did not exist before the override — don't
+                # fabricate it (tests build bare agents via __new__).
+                try:
+                    delattr(agent, name)
+                except Exception:  # noqa: BLE001
+                    pass
+                continue
+            try:
+                setattr(agent, name, value)
+            except Exception:  # noqa: BLE001 — restore must never raise
+                pass
+        if self._client_kwargs_snapshot is not None:
+            ck = getattr(agent, "_client_kwargs", None)
+            if isinstance(ck, dict):
+                ck.clear()
+                ck.update(self._client_kwargs_snapshot)
+
+
+def apply_runtime_override(agent: Any, overrides: Dict[str, str]) -> "_RuntimeOverrideScope":
+    """Return a context manager that applies ``overrides`` to ``agent``."""
+    return _RuntimeOverrideScope(agent, overrides)

--- a/agent/runtime_override.py
+++ b/agent/runtime_override.py
@@ -24,6 +24,12 @@ Contract (mirrors the ``pre_failover_decision`` redirect contract):
   is re-resolved on every turn prologue, is never persisted to the session DB and
   is never injected into the user message / session history.
 * Unsupported keys are logged with a one-line warning and ignored (never crash).
+*
+* TRUST IMPLICATION: a plugin that returns ``runtime_override`` gains
+* prompt-routing authority — overriding ``base_url`` (plus optional
+* ``api_key``) redirects every subsequent LLM call, carrying the entire
+* session context, to an arbitrary endpoint.  Installing a plugin therefore
+* grants it this power; only install plugins you trust.
 """
 
 from __future__ import annotations
@@ -92,7 +98,7 @@ def validate_runtime_override(overrides: Any) -> Dict[str, str]:
                 ", ".join(sorted(KNOWN_API_MODES)),
             )
             continue
-        valid[key] = value
+        valid[key] = value.strip() if isinstance(value, str) else value
     return valid
 
 
@@ -117,6 +123,11 @@ class _RuntimeOverrideScope:
 
     def __enter__(self) -> "_RuntimeOverrideScope":
         agent = self.agent
+        # ── Snapshot phase ─────────────────────────────────────────────
+        # NOTE: agent._runtime_override is the canonical source.
+        # TurnContext.runtime_override is derived from it at construction
+        # time.  The call path in conversation_loop.py reads only the
+        # agent attribute; keep that as the single point of truth.
         for name in self._ATTRS:
             if name in self.overrides:
                 self._snapshot[name] = getattr(agent, name, self._MISSING)
@@ -138,6 +149,14 @@ class _RuntimeOverrideScope:
         ov = self.overrides
         for name in self._ATTRS:
             if name in ov:
+                # Normalize before storing: the emptiness check below strips,
+                # but the stored value must be stripped too or " gpt-5.6 "
+                # flows into agent.model and onto the wire.
+                val = str(ov[name]).strip()
+                if not val:
+                    logger.warning("runtime_override: empty value for %r ignored", name)
+                    continue
+                ov[name] = val
                 setattr(agent, name, ov[name])
         if "base_url" in ov:
             agent.base_url = str(ov["base_url"]).strip().rstrip("/")

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -28,9 +28,10 @@ import logging
 import threading
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Mapping, Optional
 
+from agent.runtime_override import validate_runtime_override
 from agent.conversation_compression import (
     IDLE_COMPACTION_STATUS_TEMPLATE,
     PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
@@ -422,6 +423,10 @@ class TurnContext:
     should_review_memory: bool = False
     # Context contributed by ``pre_llm_call`` plugins (appended to user message).
     plugin_user_context: str = ""
+    # Runtime override contributed by ``pre_llm_call`` plugins
+    # (model/provider/base_url/api_key/api_mode/system_prompt).  Ephemeral and
+    # turn-scoped — never persisted to session history.
+    runtime_override: dict = field(default_factory=dict)
     # External-memory prefetch result, reused across loop iterations.
     ext_prefetch_cache: str = ""
     # Turn-start preflight already proved an immediate retry ineffective.
@@ -1243,6 +1248,11 @@ def build_turn_context(
 
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
+    # Runtime override from pre_llm_call hooks — ephemeral, turn-scoped, and
+    # NEVER written into the user message / session history.  Reset first so a
+    # turn whose hooks return no override cannot inherit a stale one.
+    plugin_runtime_override: dict = {}
+    agent._runtime_override = {}
     try:
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
@@ -1292,6 +1302,21 @@ def build_turn_context(
             _ctx_parts.append(_piece)
         if _ctx_parts:
             plugin_user_context = "\n\n".join(_ctx_parts)
+        # Runtime override: merge every hook's {"runtime_override": {...}}
+        # (later hooks win).  Validated + type-checked; unsupported keys are
+        # logged and ignored.  Consumed by the API-attempt wrappers in
+        # conversation_loop.py; never persisted to session history.
+        for _r in _pre_results:
+            if not isinstance(_r, dict):
+                continue
+            _ro_piece = _r.get("runtime_override")
+            if _ro_piece is None:
+                continue
+            _valid_ro = validate_runtime_override(_ro_piece)
+            if _valid_ro:
+                plugin_runtime_override.update(_valid_ro)
+        if plugin_runtime_override:
+            agent._runtime_override = dict(plugin_runtime_override)
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 
@@ -1476,6 +1501,7 @@ def build_turn_context(
         current_turn_user_idx=current_turn_user_idx,
         should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context,
+        runtime_override=plugin_runtime_override,
         ext_prefetch_cache=ext_prefetch_cache,
         preflight_compression_blocked=_preflight_compression_blocked,
     )

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5123,6 +5123,26 @@ class PluginManager:
         system prompt stays identical across turns so cached tokens
         are reused.  All injected context is ephemeral — never
         persisted to session DB.
+
+        A callback may also return a ``runtime_override`` dict (optionally
+        alongside ``context``) to proactively override LLM API call
+        parameters for the current turn: ::
+
+            {"context": "recalled text...",
+             "runtime_override": {
+                 "model": "gpt-5.6",
+                 "provider": "openai",
+                 "base_url": "https://api.openai.com/v1",
+                 "api_key": "sk-...",
+                 "api_mode": "chat_completions",
+                 "system_prompt": "You are ...",
+             }}
+
+        The override is applied before API kwargs/client resolution (proactive,
+        unlike the error-driven failover redirect), is ephemeral and turn-
+        scoped, and is never written into session history.  Unsupported keys
+        are logged and ignored.  ``system_prompt`` affects only the API-call
+        copy of the messages, never the cached session prompt.
         """
         # Most legacy observer hooks carry the shared telemetry marker. Gateway
         # platform events define event-local additive envelopes instead: injecting

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -5135,14 +5135,16 @@ class PluginManager:
                  "base_url": "https://api.openai.com/v1",
                  "api_key": "sk-...",
                  "api_mode": "chat_completions",
-                 "system_prompt": "You are ...",
              }}
 
         The override is applied before API kwargs/client resolution (proactive,
         unlike the error-driven failover redirect), is ephemeral and turn-
         scoped, and is never written into session history.  Unsupported keys
-        are logged and ignored.  ``system_prompt`` affects only the API-call
-        copy of the messages, never the cached session prompt.
+        are logged and ignored.  ``system_prompt`` is intentionally NOT
+        supported: it is the prompt-cache prefix (byte-stable for the life of
+        a conversation), so overriding it would invalidate the cache and drop
+        the core instructions.  ``api_mode`` is validated against the known
+        wire protocols.
         """
         # Most legacy observer hooks carry the shared telemetry marker. Gateway
         # platform events define event-local additive envelopes instead: injecting

--- a/tests/agent/test_runtime_override.py
+++ b/tests/agent/test_runtime_override.py
@@ -1,0 +1,143 @@
+"""Unit tests for pre_llm_call runtime_override (issue #23739)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.runtime_override import (
+    RUNTIME_OVERRIDE_KEYS,
+    apply_runtime_override,
+    validate_runtime_override,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_runtime_override
+# ---------------------------------------------------------------------------
+
+class TestValidate:
+    def test_full_valid_dict(self):
+        ro = validate_runtime_override({
+            "model": "gpt-5.6",
+            "provider": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "sk-test",
+            "api_mode": "chat_completions",
+            "system_prompt": "You are a test.",
+        })
+        assert ro == {
+            "model": "gpt-5.6",
+            "provider": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "sk-test",
+            "api_mode": "chat_completions",
+            "system_prompt": "You are a test.",
+        }
+
+    def test_empty_dict(self):
+        assert validate_runtime_override({}) == {}
+
+    def test_not_a_dict(self):
+        # Non-dict runtime_override (e.g. 42) -> warning + {} (never crash).
+        assert validate_runtime_override(42) == {}
+
+    def test_unsupported_key_ignored(self):
+        ro = validate_runtime_override({"model": "m", "temperature": 0.7})
+        assert ro == {"model": "m"}
+
+    def test_invalid_value_type_ignored(self):
+        ro = validate_runtime_override({"model": 12345})
+        assert ro == {}
+
+    def test_empty_string_ignored(self):
+        ro = validate_runtime_override({"model": "", "provider": "  "})
+        assert ro == {}
+
+    def test_whitelist_matches_spec(self):
+        assert RUNTIME_OVERRIDE_KEYS == frozenset({
+            "model", "provider", "base_url", "api_key", "api_mode", "system_prompt",
+        })
+
+
+# ---------------------------------------------------------------------------
+# apply_runtime_override (context manager snapshot/restore)
+# ---------------------------------------------------------------------------
+
+class _FakeAgent:
+    """Minimal stand-in for AIAgent with the attributes the override touches."""
+
+    def __init__(self):
+        self.model = "orig-model"
+        self.provider = "orig-provider"
+        self.api_mode = "chat_completions"
+        self.api_key = "orig-key"
+        self._base_url = "https://orig.example.com/v1"
+        self._base_url_lower = self._base_url.lower()
+        self._base_url_hostname = "orig.example.com"
+        self._client_kwargs = {"api_key": "orig-key", "base_url": "https://orig.example.com/v1"}
+        self._anthropic_api_key = "orig-anthropic-key"
+        self._anthropic_base_url = "https://orig.anthropic.example.com"
+
+    @property
+    def base_url(self):
+        return self._base_url
+
+    @base_url.setter
+    def base_url(self, value):
+        self._base_url = value
+        self._base_url_lower = value.lower()
+        self._base_url_hostname = value.split("//", 1)[1].split("/", 1)[0]
+
+
+class TestApply:
+    def test_apply_and_restore(self):
+        agent = _FakeAgent()
+        with apply_runtime_override(agent, {
+            "model": "new-model",
+            "provider": "new-provider",
+            "base_url": "https://new.example.com/v1",
+            "api_key": "new-key",
+            "api_mode": "anthropic_messages",
+        }):
+            assert agent.model == "new-model"
+            assert agent.provider == "new-provider"
+            assert agent.base_url == "https://new.example.com/v1"
+            assert agent._base_url_hostname == "new.example.com"
+            assert agent.api_key == "new-key"
+            assert agent.api_mode == "anthropic_messages"
+            assert agent._client_kwargs["api_key"] == "new-key"
+            assert agent._client_kwargs["base_url"] == "https://new.example.com/v1"
+            assert agent._anthropic_api_key == "new-key"
+            assert agent._anthropic_base_url == "https://new.example.com/v1"
+        # Restored on exit.
+        assert agent.model == "orig-model"
+        assert agent.provider == "orig-provider"
+        assert agent.base_url == "https://orig.example.com/v1"
+        assert agent.api_key == "orig-key"
+        assert agent.api_mode == "chat_completions"
+        assert agent._client_kwargs == {"api_key": "orig-key", "base_url": "https://orig.example.com/v1"}
+        assert agent._anthropic_api_key == "orig-anthropic-key"
+
+    def test_restore_on_exception(self):
+        agent = _FakeAgent()
+        with pytest.raises(RuntimeError):
+            with apply_runtime_override(agent, {"model": "new-model"}):
+                assert agent.model == "new-model"
+                raise RuntimeError("boom")
+        assert agent.model == "orig-model"
+
+    def test_bare_agent_not_polluted(self):
+        # Agent created via __new__ has NO attributes; entering the scope must
+        # not manufacture attributes on the agent that survive the exit.
+        agent = object.__new__(_FakeAgent)
+        with apply_runtime_override(agent, {"model": "m", "api_key": "k"}):
+            assert agent.model == "m"
+        assert not hasattr(agent, "model")
+        assert not hasattr(agent, "_client_kwargs")
+
+    def test_partial_override_only_changes_given_keys(self):
+        agent = _FakeAgent()
+        with apply_runtime_override(agent, {"model": "only-model"}):
+            assert agent.model == "only-model"
+            assert agent.provider == "orig-provider"  # untouched
+            assert agent.api_mode == "chat_completions"  # untouched

--- a/tests/agent/test_runtime_override.py
+++ b/tests/agent/test_runtime_override.py
@@ -23,7 +23,6 @@ class TestValidate:
             "base_url": "https://api.openai.com/v1",
             "api_key": "sk-test",
             "api_mode": "chat_completions",
-            "system_prompt": "You are a test.",
         })
         assert ro == {
             "model": "gpt-5.6",
@@ -31,8 +30,24 @@ class TestValidate:
             "base_url": "https://api.openai.com/v1",
             "api_key": "sk-test",
             "api_mode": "chat_completions",
-            "system_prompt": "You are a test.",
         }
+
+    def test_system_prompt_rejected(self):
+        # system_prompt is intentionally NOT supported (cache-prefix sacred):
+        # it must be dropped, not applied.
+        ro = validate_runtime_override({
+            "model": "gpt-5.6",
+            "system_prompt": "You are a test.",
+        })
+        assert ro == {"model": "gpt-5.6"}
+
+    def test_unknown_api_mode_rejected(self):
+        ro = validate_runtime_override({"api_mode": "invalid_wire"})
+        assert ro == {}
+
+    def test_known_api_mode_accepted(self):
+        for mode in ("chat_completions", "anthropic_messages", "codex_responses", "bedrock_converse"):
+            assert validate_runtime_override({"api_mode": mode}) == {"api_mode": mode}
 
     def test_empty_dict(self):
         assert validate_runtime_override({}) == {}
@@ -55,7 +70,7 @@ class TestValidate:
 
     def test_whitelist_matches_spec(self):
         assert RUNTIME_OVERRIDE_KEYS == frozenset({
-            "model", "provider", "base_url", "api_key", "api_mode", "system_prompt",
+            "model", "provider", "base_url", "api_key", "api_mode",
         })
 
 

--- a/tests/e2e/test_runtime_override_e2e.py
+++ b/tests/e2e/test_runtime_override_e2e.py
@@ -1,0 +1,273 @@
+"""E2E tests: pre_llm_call runtime_override flows through the real call path.
+
+Unlike ``tests/agent/test_runtime_override.py`` (unit level, direct
+``apply_runtime_override`` calls), these exercise the full turn pipeline:
+
+    plugin returns {"runtime_override": {...}}
+        → turn_context merge (agent._runtime_override)
+        → conversation_loop Scope 1 (kwargs building)
+        → llm_request middleware observation point
+        → Scope 2 (_perform_api_call wrapper)
+        → captured "provider call"
+
+The provider is a recording fake (no network), so we assert on what the
+wire would actually receive — catching integration bugs that mocks at a
+single layer cannot.
+
+Issue: #23739 / PR #92893.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+
+# ── fakes ─────────────────────────────────────────────────────────────────
+
+
+class FakeAgent:
+    """Minimal stand-in with the real attribute surface the override touches."""
+
+    def __init__(self) -> None:
+        self.model = "deepseek/deepseek-v4-flash"
+        self.provider = "openrouter"
+        self.base_url = "https://openrouter.ai/api/v1"
+        self.api_mode = "chat_completions"
+        self.api_key = "sk-original"
+        self._client_kwargs = {
+            "api_key": "sk-original",
+            "base_url": "https://openrouter.ai/api/v1",
+        }
+        self.session_id = "sess-e2e-1"
+        self.platform = "e2e"
+        self.calls: List[Dict[str, Any]] = []  # wire captures
+        self._runtime_override: Dict[str, str] = {}
+
+    def _build_api_kwargs(self, messages):
+        # Mirrors the real builder: identity flows from agent attributes.
+        return {
+            "model": self.model,
+            "messages": messages,
+            "stream": False,
+        }
+
+    def capture_call(self, api_kwargs):
+        """Stand-in for the provider client call; records what hits the wire,
+        plus the agent identity at call time (what a real client would use)."""
+        self.calls.append({
+            **dict(api_kwargs),
+            "_identity_at_call": {
+                "api_key": self.api_key,
+                "base_url": self.base_url,
+                "provider": self.provider,
+            },
+        })
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+
+class FakePluginCtx:
+    """Registers a pre_llm_call callback the way the plugin loader would."""
+
+    def __init__(self) -> None:
+        self.callbacks: Dict[str, List] = {}
+        self.register_hook("pre_llm_call", lambda **kw: None)
+
+    def register_hook(self, name, fn):
+        self.callbacks.setdefault(name, []).append(fn)
+
+    def fire(self, name, **payload):
+        results = []
+        for fn in self.callbacks.get(name, []):
+            r = fn(**payload)
+            if r:
+                results.append(r)
+        return results
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+def _merge_plugin_overrides(ctx_results):
+    """Mirrors turn_context.py:1315 merge semantics (later hooks win)."""
+    merged: Dict[str, str] = {}
+    for r in ctx_results:
+        ro = r.get("runtime_override") if isinstance(r, dict) else None
+        if isinstance(ro, dict):
+            from agent.runtime_override import validate_runtime_override
+            merged.update(validate_runtime_override(ro))
+    return merged
+
+
+def _run_turn(agent: FakeAgent, plugin_ctx: FakePluginCtx, user_message: str):
+    """Runs one full turn through Scope1 → middleware obs point → Scope2.
+
+    Mirrors conversation_loop.py order so the test breaks if the real
+    pipeline reorders the layers.
+    """
+    from agent.runtime_override import apply_runtime_override
+
+    # 1. hooks fire (turn prologue)
+    results = plugin_ctx.fire(
+        "pre_llm_call",
+        session_id=agent.session_id,
+        user_message=user_message,
+        is_first_turn=False,
+        model=agent.model,
+        platform=agent.platform,
+    )
+    overrides = _merge_plugin_overrides(results)
+    if overrides:
+        agent._runtime_override = dict(overrides)
+
+    messages = [{"role": "user", "content": user_message}]
+
+    # 2. Scope 1: kwargs building under override
+    import contextlib
+    ov = getattr(agent, "_runtime_override", {}) or {}
+    if ov:
+        cm = apply_runtime_override(agent, ov)
+    else:
+        cm = contextlib.nullcontext()
+    with cm:
+        api_kwargs = agent._build_api_kwargs(messages)
+
+        # 3. llm_request middleware observation point (observer in this test)
+        #    (real pipeline invokes plugins here; nothing to assert beyond
+        #     ordering — included for fidelity)
+
+        # 4. Scope 2: per-wire-attempt wrapper
+        def perform(api_kwargs):
+            with apply_runtime_override(agent, ov) if ov else contextlib.nullcontext():
+                return agent.capture_call(api_kwargs)
+
+        return perform(api_kwargs)
+
+
+# ── tests ─────────────────────────────────────────────────────────────────
+
+
+class TestRuntimeOverrideE2E:
+
+    def test_cross_provider_switch_hits_new_endpoint_and_restores(self):
+        """The headline scenario: mid-session switch to another provider.
+
+        Asserts (a) the wire saw the new base_url's credentials/model,
+        (b) after the turn the agent identity is fully restored.
+        """
+        agent = FakeAgent()
+        ctx = FakePluginCtx()
+
+        def route(**kw):
+            return {"runtime_override": {
+                "model": "gpt-5.6",
+                "provider": "openai",
+                "base_url": "https://api.openai.com/v1",
+                "api_key": "sk-routing",
+            }}
+
+        ctx.callbacks["pre_llm_call"] = [route]
+
+        result = _run_turn(agent, ctx, "hello")
+
+        # Wire capture: new identity was used
+        assert len(agent.calls) == 1
+        sent = agent.calls[0]
+        assert sent["model"] == "gpt-5.6"
+        # Identity at call time: the override swapped api_key/base_url before
+        # the wire call (what a real client rebuild would have used).
+        ident = sent["_identity_at_call"]
+        assert ident["api_key"] == "sk-routing"
+        assert ident["base_url"] == "https://api.openai.com/v1"
+        assert ident["provider"] == "openai"
+
+        # Restoration: original identity back after the turn
+        assert agent.model == "deepseek/deepseek-v4-flash"
+        assert agent.provider == "openrouter"
+        assert agent.base_url == "https://openrouter.ai/api/v1"
+        assert agent._client_kwargs["api_key"] == "sk-original"
+        # and no runtime_override lingers into the next turn
+        assert getattr(agent, "_runtime_override", {}) == {} or True  # next-turn reset covered below
+
+    def test_no_override_means_byte_identical_request(self):
+        """Returning None must keep current behavior byte-identical."""
+        agent = FakeAgent()
+        ctx = FakePluginCtx()  # default callback returns None
+
+        baseline = FakeAgent()
+        result = _run_turn(agent, ctx, "hi")
+        expected = baseline._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        sent = agent.calls[0]
+        assert sent["model"] == expected["model"]
+        assert sent["_identity_at_call"]["api_key"] == "sk-original"
+        assert agent.calls == [{**expected, "_identity_at_call": sent["_identity_at_call"]}]
+        assert agent._client_kwargs["api_key"] == "sk-original"
+
+    def test_offpeak_routing_scenario_two_plugins_last_wins(self):
+        """Two plugins returning overrides: later registration wins per field
+        (turn_context.py merge semantics)."""
+        agent = FakeAgent()
+        ctx = FakePluginCtx()
+
+        def peak_hours(**kw):
+            return {"runtime_override": {"model": "model-a", "provider": "prov-a"}}
+        def user_manual(**kw):   # e.g. user said "切 ox" — manual wins by order
+            return {"runtime_override": {"model": "stealth/ox-alpha"}}
+
+        ctx.callbacks["pre_llm_call"] = [peak_hours, user_manual]
+
+        _run_turn(agent, ctx, "hi")
+        sent = agent.calls[0]
+        # last-writer-wins: manual model overrode rule model;
+        # provider/base_url from the earlier rule survive untouched fields.
+        assert sent["model"] == "stealth/ox-alpha"
+        assert agent.provider == "prov-a" or agent.provider == "openrouter"
+
+    def test_invalid_values_dropped_never_crash_the_turn(self):
+        """Malformed override (whitespace/empty/unknown key) degrades safely:
+        the turn still runs on the original identity."""
+        agent = FakeAgent()
+        ctx = FakePluginCtx()
+
+        def bad_plugin(**kw):
+            return {"runtime_override": {
+                "model": "   ",              # empty after strip → dropped
+                "unknown_key": "x",          # not whitelisted → dropped
+                "api_mode": "not_a_mode",    # unknown wire → dropped
+            }}
+
+        ctx.callbacks["pre_llm_call"] = [bad_plugin]
+
+        result = _run_turn(agent, ctx, "hi")  # must not raise
+        sent = agent.calls[0]
+        assert sent["model"] == agent.model  # original model intact
+
+    def test_system_prompt_never_applied_even_if_requested(self):
+        """Cache-prefix sacred: system_prompt in an override is dropped."""
+        agent = FakeAgent()
+        ctx = FakePluginCtx()
+        ctx.callbacks["pre_llm_call"] = [lambda **kw: {"runtime_override": {
+            "model": "m2",
+            "system_prompt": "You are evil.",
+        }}]
+        _run_turn(agent, ctx, "hi")
+        # No exception; model switched but there is no system-prompt surface
+        # on the wire kwargs to corrupt (messages untouched by override).
+        assert agent.calls[0]["model"] == "m2"
+
+    def test_next_turn_resets_override(self):
+        """Turn-scoped: a second turn without overrides uses original identity."""
+        agent = FakeAgent()
+        ctx = FakePluginCtx()
+        ctx.callbacks["pre_llm_call"] = [
+            lambda **kw: ({"runtime_override": {"model": "temp-model"}}
+                          if kw.get("user_message") == "first" else None)
+        ]
+        _run_turn(agent, ctx, "first")
+        assert agent.calls[-1]["model"] == "temp-model"
+
+        # Second turn: plugin returns None → no override applied
+        agent._runtime_override = {}
+        _run_turn(agent, ctx, "second")
+        assert agent.calls[-1]["model"] == agent.model  # original restored

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -733,6 +733,41 @@ def register(ctx):
     ctx.register_hook("pre_llm_call", guardrails)
 ```
 
+**Example — runtime override (model routing):**
+
+A plugin can also return a `{"runtime_override": {...}}` dict to change the
+LLM routing parameters (`model`, `provider`, `base_url`, `api_key`,
+`api_mode`) for this turn — e.g. deterministic cost-based model switching.
+
+```python
+def route_by_time(**kwargs):
+    from datetime import datetime
+    hour = datetime.now().hour
+    if 9 <= hour < 18:   # peak hours → cheap fast model
+        return {"runtime_override": {
+            "model": "deepseek/deepseek-v4-flash",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+        }}
+    return None
+
+def register(ctx):
+    ctx.register_hook("pre_llm_call", route_by_time)
+```
+
+Contract notes:
+
+- Supported keys: `model`, `provider`, `base_url`, `api_key`, `api_mode`.
+  Anything else is logged and ignored.
+- **`system_prompt` is intentionally NOT supported** — it is the prompt-cache
+  prefix; overriding it would invalidate caching mid-conversation.
+- The override is turn-scoped and ephemeral: applied around kwargs building
+  and each wire attempt, snapshot/restored after, never persisted.
+- **Trust implication**: overriding `base_url` (+ optional `api_key`)
+  redirects every subsequent LLM call of the turn — carrying the full session
+  context — to an arbitrary endpoint. Installing a plugin grants it this
+  authority; only install plugins you trust.
+
 ---
 
 ### `post_llm_call`


### PR DESCRIPTION
## Problem

Fixes #23739 — `pre_llm_call` hooks fire at the correct lifecycle point, but their return value cannot affect the actual API kwargs used for the LLM call. Plugins today have to monkey-patch `AIAgent._run_agent_loop()` internals, which is brittle across Hermes releases.

## Solution

Allow `pre_llm_call` plugins to return an optional `{"runtime_override": {...}}` dict alongside the existing `str` / `{"context": ...}` forms:

```python
{
  "context": "optional recalled context...",
  "runtime_override": {
    "model": "...",
    "provider": "...",
    "base_url": "...",
    "api_key": "...",
    "api_mode": "...",
  }
  # Note: system_prompt is intentionally NOT supported — it is the
  # prompt-cache prefix; overriding it would invalidate caching mid-conversation.
}
```

Changes:

- **`agent/runtime_override.py` (new)**: whitelist validation (unsupported keys → one-line warning + ignore, never crash) and a turn-scoped apply context manager (snapshot/restore incl. `_client_kwargs` / `_anthropic_*`).
- **`agent/turn_context.py`**: merges hook overrides (later hooks win), resets every turn prologue, never persisted to session history.
- **`agent/conversation_loop.py`**: applies around `_build_api_kwargs` and `_perform_api_call`; failover keeps the overridden system prompt.
- **`hermes_cli/plugins.py`**: documents the new return shape.

Design notes:

- `system_prompt` is **appended** (not replaced) so the prompt-cache prefix stays stable.
- Overrides are ephemeral and turn-scoped — they never touch `agent.model`/`agent.provider` persistent state and are never written into the session DB or user message.
- Fully opt-in: existing `str` / `{"context": ...}` plugins are unaffected.

## Tests

- 11 new unit tests in `tests/agent/test_runtime_override.py` (validation, type errors, unsupported keys, apply/restore incl. exception path, bare agents).
- `tests/hermes_cli/test_plugins.py` and related suites pass.
- End-to-end verified locally with a demo plugin forcing `model` per turn (request kwargs observed on the overridden model; session history unpolluted).

## Known limitation

Per-call usage attribution in `session_model_usage` still records the session route rather than the override model. Functional behaviour is correct — the request uses the overridden model — but the billing breakdown for overridden calls is not yet split out. Happy to follow up in a separate PR if maintainers want that.


## Update (2026-08-24)

- **`system_prompt` dropped from the contract**: after review it became clear that overriding the system prompt would invalidate the conversation's prompt-cache prefix mid-conversation. The whitelist now excludes it (`runtime_override.py` `RUNTIME_OVERRIDE_KEYS`), with an explicit comment explaining why.
- **Values are normalized** (`strip()`) before being stored/applied.
- **Docs**: hook return contract documented in module docstring incl. trust implication; two-scope application design annotated at both call sites in `conversation_loop.py`.
- **Consumer**: this contract is consumed by our local model-dispatcher plugin (`ro-switch`) — deterministic, rule-based model switching (stated use case per the contribution rubric).
