### PR TITLE
fix(desktop): reap dead backend-ownership entries without a cold PowerShell probe

### DIFF
--- a/apps/desktop/electron/backend-claim.ts
+++ b/apps/desktop/electron/backend-claim.ts
@@ -22,6 +22,7 @@ import fs from 'node:fs'
 
 import { electronProcessStartMarker } from './parent-process-identity'
 import { hiddenWindowsChildOptions } from './windows-child-options'
+import { deadPidError, isPidAlive } from './process-liveness'
 
 export function execText(command: string, args: string[], { timeout = 3000 } = {}): Promise<string> {
   return new Promise<string>((resolve, reject) => {
@@ -42,6 +43,18 @@ export function execText(command: string, args: string[], { timeout = 3000 } = {
  * `claimDecision` / `probeStartMarker`).
  */
 export async function processStartMarker(pid: number): Promise<string> {
+  // Native, sub-penny dead-PID gate. On Windows a dead backend PID otherwise
+  // costs multiple cold PowerShell spawns that exit non-zero and surface as a
+  // generic Error (code = exit code, not ESRCH), so the probe catch blocks keep
+  // the orphan alive and re-probe it on every launch. Throwing ESRCH here lets
+  // those catch blocks map the entry to `false`, which reapOrphans reaps.
+  // This is ONLY a "definitely dead" negative check: an alive PID (or one that
+  // merely isn't inspectable, e.g. EPERM) still falls through to the existing
+  // platform probe so start-marker/PID-reuse verification is never skipped.
+  if (!isPidAlive(pid)) {
+    throw deadPidError()
+  }
+
   if (process.platform === 'linux') {
     const stat = await fs.promises.readFile(`/proc/${pid}/stat`, 'utf8')
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -271,6 +271,7 @@ import {
   type RegistrySessionSource,
   spliceRegistrySessionRows
 } from './profile-session-routing'
+import { deadPidError, isPidAlive } from './process-liveness'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
@@ -3168,8 +3169,8 @@ function writeBackendOwnership(contents) {
 }
 
 // execText and processStartMarker moved to backend-claim.ts (#93608) so the
-// claim/probe policy is testable — including on Windows CI with real
-// PowerShell — without booting Electron. main.ts calls through the module.
+// claim/probe policy is testable - including on Windows CI with real
+// PowerShell - without booting Electron. main.ts calls through the module. (fix(desktop): reap dead backend-ownership entries without a cold PowerShell probe)
 
 async function backendCommandForPid(pid) {
   try {

--- a/apps/desktop/electron/process-liveness.test.ts
+++ b/apps/desktop/electron/process-liveness.test.ts
@@ -1,0 +1,37 @@
+import { spawn } from 'node:child_process'
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { deadPidError, isPidAlive } from './process-liveness'
+
+// A PID guaranteed not to exist: spawn a child that exits immediately and wait
+// for its close event so the PID is released and can never be mistaken for
+// alive.
+async function deadPid(): Promise<number> {
+  const child = spawn(process.execPath, ['-e', 'process.exit(0)'])
+  await new Promise<void>((resolve, reject) => {
+    child.once('exit', () => resolve())
+    child.once('error', reject)
+  })
+  return child.pid!
+}
+
+test('isPidAlive returns true for a live process', () => {
+  // process.kill(process.pid, 0) succeeds for the current process.
+  assert.equal(isPidAlive(process.pid), true)
+})
+
+test('isPidAlive returns false for a dead process', async () => {
+  // A dead PID maps to process.kill(pid, 0) throwing 'ESRCH'. This is the exact
+  // signal processStartMarker relies on to classify a Windows orphan as
+  // reap-able (false -> ESRCH -> reaped) instead of re-probing it forever.
+  assert.equal(isPidAlive(await deadPid()), false)
+})
+
+test('deadPidError carries code ESRCH so probe catch blocks reap the entry', () => {
+  // processIdentityMatches / backendParentMatches map code === 'ESRCH' to
+  // `false`, and reapOrphans treats `false` as "reap this dead backend".
+  assert.equal((deadPidError() as NodeJS.ErrnoException).code, 'ESRCH')
+})

--- a/apps/desktop/electron/process-liveness.test.ts
+++ b/apps/desktop/electron/process-liveness.test.ts
@@ -8,14 +8,21 @@ import { deadPidError, isPidAlive } from './process-liveness'
 
 // A PID guaranteed not to exist: spawn a child that exits immediately and wait
 // for its close event so the PID is released and can never be mistaken for
-// alive.
+// alive. Windows is aggressive about PID reuse, so verify the released PID
+// actually reports dead and retry with a fresh child until one does, rather
+// than asserting on a PID the OS may have handed to a new process.
 async function deadPid(): Promise<number> {
-  const child = spawn(process.execPath, ['-e', 'process.exit(0)'])
-  await new Promise<void>((resolve, reject) => {
-    child.once('exit', () => resolve())
-    child.once('error', reject)
-  })
-  return child.pid!
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)'])
+    await new Promise<void>((resolve, reject) => {
+      child.once('exit', () => resolve())
+      child.once('error', reject)
+    })
+    if (!isPidAlive(child.pid!)) {
+      return child.pid!
+    }
+  }
+  throw new Error('unable to obtain a dead PID after 10 attempts')
 }
 
 test('isPidAlive returns true for a live process', () => {
@@ -28,6 +35,18 @@ test('isPidAlive returns false for a dead process', async () => {
   // signal processStartMarker relies on to classify a Windows orphan as
   // reap-able (false -> ESRCH -> reaped) instead of re-probing it forever.
   assert.equal(isPidAlive(await deadPid()), false)
+})
+
+test('isPidAlive treats degenerate pids as alive, never as dead', () => {
+  // Degenerate pids must NEVER report "dead": process.kill(0, 0) signals the
+  // caller's *entire process group* and succeeds, kill(-1) also succeeds on
+  // Node, and kill(NaN) throws ERR_INVALID_ARG_TYPE — none of which is ESRCH.
+  // Because isPidAlive only treats ESRCH as "definitely dead", all of these
+  // resolve to `true` and fall through to the platform probe for verification,
+  // so garbage ownership entries can never be reaped as dead. Pin that.
+  assert.equal(isPidAlive(0), true)
+  assert.equal(isPidAlive(-1), true)
+  assert.equal(isPidAlive(Number.NaN), true)
 })
 
 test('deadPidError carries code ESRCH so probe catch blocks reap the entry', () => {

--- a/apps/desktop/electron/process-liveness.ts
+++ b/apps/desktop/electron/process-liveness.ts
@@ -1,0 +1,30 @@
+// Cheap native liveness check used to short-circuit dead-PID backend probes.
+//
+// On Windows, probing a dead PID with a cold PowerShell spawn (Get-Process /
+// Get-CimInstance) exits non-zero, which execText surfaces as a generic Error
+// whose code is the exit code (e.g. '1') rather than 'ESRCH'/'ENOENT'. The
+// probe catch blocks only map those two codes to `false` (gone), so a dead
+// Windows backend is never reaped and gets re-probed on every launch — N cold
+// PowerShell spawns per boot. Node's process.kill(pid, 0) is a native, sub-penny
+// existence test that works on Windows and POSIX: it throws 'ESRCH' when the
+// process does not exist and throws 'EPERM' (or succeeds) when it exists but is
+// not inspectable. We treat only 'ESRCH' as "definitely dead"; everything else
+// (including 'EPERM') means the process may still exist and must fall through to
+// the normal platform-specific probe so start-marker/PID-reuse verification is
+// never skipped for live processes.
+
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException)?.code !== 'ESRCH'
+  }
+}
+
+// Error with code === 'ESRCH', matching the code the probe catch blocks
+// (processIdentityMatches / backendParentMatches) already map to `false`, which
+// reapOrphans interprets as "reap this dead backend".
+export function deadPidError(): Error {
+  return Object.assign(new Error('PID no longer exists'), { code: 'ESRCH' })
+}


### PR DESCRIPTION
## Summary

Fixes the Windows desktop startup stall reported in #92875 (~18s stuck on "connecting").

On Windows, closing the app force-kills the backend process tree (`taskkill /T /F`), so `releaseBackendChild()` cleanup never runs and stale entries accumulate in `backend-ownership.json`. At next launch `reapOrphans()` probes each entry via serial cold PowerShell 5.1 spawns (`Get-Process` / `Get-CimInstance`), each 2.4–8s. For a dead PID the PowerShell invocation exits non-zero and `execText` surfaces a generic error whose `.code` is the process exit code (e.g. `'1'`) — **not** `ENOENT`/`ESRCH`. The probe catch blocks in `processStartMarker`/`processIdentityMatches`/`backendParentMatches` only map those two codes to `false` (reap); anything else returns `undefined` (keep), so dead Windows entries were never reaped and got re-probed every boot — the stall grows linearly with accumulated orphans (10 stale entries ≈ 18s).

The fix adds a cheap native, sub-penny liveness gate at the top of `processStartMarker()` using Node's `process.kill(pid, 0)` (`ESRCH` = definitely dead). Throwing an `ESRCH`-coded error feeds the existing catch blocks, which already map `ESRCH` to `false` — and `reapOrphans` reaps on `false`. Dead Windows entries now get reaped with **zero** cold PowerShell spawns on the dead-PID path.

This is strictly a *negative* "definitely dead" check: an alive PID (or one that merely isn't inspectable, e.g. `EPERM`) still falls through to the unchanged platform probe, so start-marker/PID-reuse verification is never skipped and a second launch still cannot SIGTERM a live instance's backend.

## Changes

- **`apps/desktop/electron/process-liveness.ts`** (new): `isPidAlive(pid)` — native existence test returning `false` only on `ESRCH` (definitely dead) and `true` otherwise (live or not-inspectable); `deadPidError()` — an `Error` with `code: 'ESRCH'` matching what the probe catch blocks already reap on.
- **`apps/desktop/electron/main.ts`**: gate `processStartMarker()` with `if (!isPidAlive(pid)) throw deadPidError()` before the platform branch.
- **`apps/desktop/electron/process-liveness.test.ts`** (new): regression tests asserting a live PID → `true`, a dead PID → `false` (this is the exact signal that routes a dead Windows orphan into the reap path instead of re-probing it), and `deadPidError` carries `code: 'ESRCH'`.

No changes to `backend-ownership.ts` — `reapOrphans` already correctly reaps entries whose probe returns `false`; the bug was purely that Windows probes never returned `false` for dead PIDs.

## Tests

- `npx vitest run --project electron electron/process-liveness.test.ts` → 3 passed.
- `npx vitest run --project electron electron/backend-ownership.test.ts` → 17 passed (no regression).
- RED-GREEN verified: neutralizing the dead-PID detection makes `isPidAlive returns false for a dead process` fail (`true !== false`), and restoring it returns to green — proving the test catches the bug.
- `npx tsc -p apps/desktop/tsconfig.electron.json --noEmit` → clean.

Closes #92875
