### PR TITLE
feat(update): planned runtimes the restart phase misses now fail the update — plan becomes the worklist (#91277 Phase 2, salvage #88949)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5461,6 +5461,51 @@ def launchd_restart():
         _clear_launchd_unsupported_marker()
 
 
+# launchd will not relaunch a KeepAlive job more than about once per 10s.  A
+# self-restart that exits promptly therefore leaves the label registered with
+# NO pid for most of that window, so any verification budget shorter than the
+# throttle reports a healthy restart as a failure.
+LAUNCHD_SUPERVISION_VERIFY_TIMEOUT = 20.0
+
+
+def wait_for_launchd_gateway_supervision(
+    *,
+    timeout: float = LAUNCHD_SUPERVISION_VERIFY_TIMEOUT,
+    label: str | None = None,
+    poll_interval: float = 0.5,
+) -> bool:
+    """Poll launchd until it is supervising a live gateway process.
+
+    :func:`launchd_restart` returns as soon as the restart has been *requested*.
+    The ``_request_gateway_self_restart`` branch hands the work to the running
+    gateway and returns immediately, and a plist reload is handed to a detached
+    helper.  Both are asynchronous, so a caller that reads "returned without
+    raising" as "the service is up" cannot see a helper that dies before its
+    first bootstrap (#88848) — nor a ``launchctl bootstrap`` that exits 0
+    without registering, which the reporter measured on macOS 26.6.1.
+
+    Judge the outcome the way #80491 taught the helper to judge it: by a live
+    supervised pid, never by an exit code.  :func:`_launchctl_label_supervising_process`
+    is already that predicate, so this only adds the wait.
+
+    Returns True immediately when the detached fallback is active.  On a host
+    where launchd cannot manage the domain the gateway runs unsupervised *by
+    design*, so the absence of a launchd pid there is the expected state and
+    not the silent failure this guards against.
+    """
+    if _launchd_unsupported_marker_exists():
+        return True
+
+    label = label or get_launchd_label()
+    deadline = time.monotonic() + max(timeout, 0.0)
+    while True:
+        if _launchctl_label_supervising_process(label):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(max(poll_interval, 0.01))
+
+
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5040,6 +5040,8 @@ def _service_unit_supports_graceful_sigusr1_restart(svc_name: str) -> bool:
 
 def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
     """Print an explicit incomplete-update warning for unrestarted units."""
+    from hermes_cli.gateway import is_macos
+
     if not failed_units:
         return
     # Preserve discovery order while de-duplicating.
@@ -5054,6 +5056,18 @@ def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
     print("⚠ Update incomplete — some units were not restarted:")
     for name in ordered:
         print(f"    - {name}")
+    if is_macos():
+        # A launchd label reaches this list when launchd was not supervising a
+        # live process after the restart (#88848), so the unit is not merely
+        # stale — it is very likely deregistered, and `launchctl kickstart`
+        # cannot revive a job launchd no longer knows about.
+        print("  Listed services may be deregistered from launchd, or still")
+        print("  running pre-update code (mixed sys.modules). Recover with:")
+        print("    hermes gateway status")
+        print("    launchctl list | grep <label>")
+        print("    launchctl bootstrap gui/$(id -u) "
+              "~/Library/LaunchAgents/<label>.plist")
+        return
     print("  Skipped units may still be running pre-update code (mixed")
     print("  sys.modules). Restart them manually, then verify:")
     print("    hermes gateway status")
@@ -5095,6 +5109,7 @@ def _restart_macos_launchd_gateways(
         _launchd_service_registered,
         _locate_launchd_gateway_service,
         _wait_for_launchd_service_pid,
+        wait_for_launchd_gateway_supervision,
     )
 
     # --- Current profile: unchanged single-service path ---------------------
@@ -5112,11 +5127,38 @@ def _restart_macos_launchd_gateways(
         ):
             try:
                 launchd_restart()
-                restarted_services.append(current_label)
             except subprocess.CalledProcessError as e:
                 stderr = (getattr(e, "stderr", "") or "").strip()
                 print(f"  ⚠ Gateway restart failed: {stderr}")
                 failed_or_stale_units.append(current_label)
+            else:
+                # Siblings below are only counted as restarted once launchd
+                # reports a fresh supervised pid; the invoking profile was
+                # counted on "launchd_restart() did not raise" alone. That is
+                # not the same claim: launchd_restart() returns as soon as the
+                # restart has been REQUESTED -- the self-restart branch hands
+                # the work to the running gateway and returns immediately, and
+                # a plist reload is handed to a detached helper. Both are
+                # asynchronous, so a helper that dies before its first
+                # bootstrap (#88848), or a `launchctl bootstrap` that exits 0
+                # without registering (measured on macOS 26.6.1), both reached
+                # "Update complete!" with nothing supervising the gateway.
+                #
+                # Verified domain-agnostically, NOT via
+                # _wait_for_launchd_service_pid: that needs an explicit domain,
+                # and the gate above deliberately avoids a domain locate
+                # because it fails on macOS-26 hosts whose per-user domains
+                # reject service management even though launchd_restart() owns
+                # that fallback.
+                if wait_for_launchd_gateway_supervision(label=current_label):
+                    restarted_services.append(current_label)
+                else:
+                    failed_or_stale_units.append(current_label)
+                    print(
+                        f"  ✗ {current_label} restarted but launchd is not "
+                        "supervising it.\n"
+                        "    Check logs, then: hermes gateway restart"
+                    )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5744,6 +5744,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # running Hermes runtime, its supervisor, and its running code version —
     # into the receipt, so a post-mortem can compare what the update SAW
     # against what it did. Read-only; a probe failure records nothing.
+    # ``_pre_update_plan`` is read again AFTER the restart phase to reconcile
+    # every planned runtime against the phase's bookkeeping (restart via
+    # declared mechanism — the plan is the worklist, not just a printout).
+    _pre_update_plan = None
     try:
         from hermes_cli.update_inventory import (
             collect_runtime_inventory,
@@ -8234,6 +8238,40 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 gateway_fleet_restart_incomplete = True
         except Exception as _fleet_exc:
             logger.debug("Fleet version verification failed: %s", _fleet_exc)
+
+        # Plan-vs-execution reconciliation (#91277 Phase 2, restart via
+        # declared mechanism): every runtime the PLAN saw must be accounted
+        # for by the restart phase's bookkeeping. An unaccounted runtime is
+        # the silent-miss class (a platform branch re-discovered its own
+        # targets and skipped one the inventory knew about) — escalate it
+        # exactly like a STALE/DOWN fleet row.
+        _runtime_outcomes: list = []
+        try:
+            if _pre_update_plan is not None and _pre_update_plan.runtimes:
+                from hermes_cli.update_inventory import (
+                    match_runtime_outcomes,
+                    report_unaccounted_runtimes,
+                )
+
+                _runtime_outcomes = match_runtime_outcomes(
+                    _pre_update_plan,
+                    restarted_services=restarted_services,
+                    relaunched_profiles=relaunched_profiles,
+                    externally_supervised_profiles=externally_supervised_profiles,
+                    killed_pids=killed_pids,
+                    failed_units=failed_or_stale_units,
+                )
+                if report_unaccounted_runtimes(_runtime_outcomes):
+                    gateway_fleet_restart_incomplete = True
+                try:
+                    import hermes_cli.update_receipt as _ur
+
+                    if _ur._current is not None:
+                        _ur._current.data["runtime_outcomes"] = _runtime_outcomes
+                except Exception:
+                    pass
+        except Exception as _outcome_exc:
+            logger.debug("Runtime-outcome reconciliation failed: %s", _outcome_exc)
 
         try:
             from hermes_cli.update_receipt import finalize_update_receipt

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -95,11 +95,30 @@ def _detect_supervisor_for_pid(pid: int, service_pids: set) -> str:
 
 
 def _restart_mechanism(supervisor: str, profile: str) -> str:
+    """Machine-readable restart mechanism id for a runtime.
+
+    THE policy table (#91277 Phase 2): restart execution consumes these ids
+    via :func:`match_runtime_outcomes` / the update's restart phase, and the
+    receipt records per-runtime outcomes against them. Display strings are
+    derived by :func:`describe_restart_mechanism` — never the other way
+    around.
+    """
     if supervisor == "systemd":
-        return "systemctl restart (drain-first SIGUSR1 when supported)"
+        return "systemd"
     if supervisor == "launchd":
-        return "launchctl kickstart -k (drain-first, per-label domain)"
+        return "launchd"
     if supervisor == "desktop":
+        return "desktop"
+    return "manual"
+
+
+def describe_restart_mechanism(mechanism: str, profile: str) -> str:
+    """Human-readable description of a restart mechanism id."""
+    if mechanism == "systemd":
+        return "systemctl restart (drain-first SIGUSR1 when supported)"
+    if mechanism == "launchd":
+        return "launchctl kickstart -k (drain-first, per-label domain)"
+    if mechanism == "desktop":
         return "Desktop app respawns its serve backend"
     if profile != "default":
         return f"hermes -p {profile} gateway restart"
@@ -301,7 +320,101 @@ def print_update_plan(plan: UpdatePlan) -> None:
             f"    • {runtime.kind} [{runtime.profile}] pid {runtime.pid}"
             f" — {runtime.supervisor}{sha}"
         )
-        print(f"      restart: {runtime.restart_via}")
+        print(
+            "      restart: "
+            f"{describe_restart_mechanism(runtime.restart_via, runtime.profile)}"
+        )
+
+
+def match_runtime_outcomes(
+    plan: "UpdatePlan",
+    *,
+    restarted_services: list,
+    relaunched_profiles: list,
+    externally_supervised_profiles: list,
+    killed_pids: set,
+    failed_units: list,
+) -> list[dict[str, Any]]:
+    """Reconcile the plan's runtimes against what the restart phase DID.
+
+    #91277 Phase 2 (restart via declared mechanism): the platform restart
+    branches each re-discover their own targets, so a runtime the plan saw
+    can be missed entirely with no signal. This cross-checks every planned
+    runtime against the phase's bookkeeping and returns one outcome row per
+    runtime::
+
+        {"kind", "profile", "pid", "mechanism", "outcome"}
+
+    outcome: ``restarted`` (service restarted / profile relaunched /
+    handed to external supervisor), ``stopped`` (pid killed, watcher or
+    operator relaunches), ``failed`` (in the phase's failed/stale list) or
+    ``unaccounted`` — the plan saw it and NO bookkeeping mentions it: the
+    blind-spot tripwire (same philosophy as the fleet matrix's DOWN row).
+    Never raises; on any probe error returns what it has.
+    """
+    outcomes: list[dict[str, Any]] = []
+    try:
+        failed_set = {str(u) for u in (failed_units or [])}
+        restarted_set = {str(s) for s in (restarted_services or [])}
+        relaunched = set(relaunched_profiles or [])
+        external = set(externally_supervised_profiles or [])
+        killed = {int(p) for p in (killed_pids or set())}
+
+        for runtime in plan.runtimes:
+            r = runtime if isinstance(runtime, RuntimeRecord) else None
+            if r is None:
+                continue
+            outcome = "unaccounted"
+            if r.profile in relaunched or r.profile in external:
+                outcome = "restarted"
+            elif r.pid is not None and r.pid in killed:
+                outcome = "stopped"
+            elif any(
+                r.profile in unit or (r.profile == "default" and "hermes-gateway" in unit)
+                for unit in failed_set
+            ):
+                outcome = "failed"
+            elif any(
+                r.profile in svc or (r.profile == "default" and "hermes-gateway" in svc)
+                for svc in restarted_set
+            ):
+                outcome = "restarted"
+            outcomes.append(
+                {
+                    "kind": r.kind,
+                    "profile": r.profile,
+                    "pid": r.pid,
+                    "mechanism": r.restart_via,
+                    "outcome": outcome,
+                }
+            )
+    except Exception as exc:
+        logger.debug("Runtime-outcome reconciliation failed: %s", exc)
+    return outcomes
+
+
+def report_unaccounted_runtimes(outcomes: list[dict[str, Any]]) -> bool:
+    """Print a loud warning for runtimes the restart phase never touched.
+
+    Returns True when at least one planned runtime is unaccounted — the
+    caller escalates exactly like a STALE/DOWN fleet row (exit 1): a runtime
+    the plan promised to restart, silently missed, is the class this phase
+    exists to kill.
+    """
+    missed = [o for o in outcomes if o.get("outcome") == "unaccounted"]
+    if not missed:
+        return False
+    print()
+    print("  ⚠ Planned runtimes the restart phase never touched:")
+    for o in missed:
+        print(
+            f"    ✗ {o['kind']} [{o['profile']}] pid {o['pid']}"
+            f" — planned mechanism: {o['mechanism']}"
+        )
+    print("    Restart them manually, then verify:")
+    print("      hermes gateway restart                # active profile")
+    print("      hermes -p <profile> gateway restart   # named profile")
+    return True
 
 
 def record_plan_in_receipt(plan: UpdatePlan) -> None:

--- a/tests/hermes_cli/test_plan_reconciliation_windows_live.py
+++ b/tests/hermes_cli/test_plan_reconciliation_windows_live.py
@@ -1,0 +1,95 @@
+"""LIVE Windows E2E for plan-reconciliation (#92902) on windows-latest.
+
+Real processes with real Hermes-shaped argv, real inventory collection
+(PID-file discovery + supervisor detection on REAL Windows), real
+reconciliation. No mocks on the components under test.
+
+ 1. Spawn a real process registered as a profile gateway (PID file + state
+    file in a temp HERMES_HOME) — real collect_runtime_inventory() must find
+    it, classify supervisor=manual, mechanism id 'manual'.
+ 2. Reconcile with bookkeeping that MISSES it -> unaccounted + escalation.
+ 3. Reconcile with it in killed_pids -> 'stopped', no escalation.
+ 4. Machine-id contract holds on Windows (no display strings leak in).
+"""
+import io, contextlib, json, os, subprocess, sys, tempfile, time
+from pathlib import Path
+
+WORKTREE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(WORKTREE))
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="live Windows E2E")
+
+
+def test_plan_reconciliation_live_windows(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # Real live process standing in for a manual gateway
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(120)"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    try:
+        time.sleep(0.5)
+        assert child.poll() is None
+
+        import psutil
+
+        create_time = psutil.Process(child.pid).create_time()
+        (home / "gateway_state.json").write_text(json.dumps({
+            "pid": child.pid,
+            "create_time": create_time,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "code_sha": "f" * 40,
+            "code_version": "0.20.5",
+        }), encoding="utf-8")
+
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_get_default_hermes_home", lambda: home)
+        monkeypatch.setattr(profiles_mod, "_get_profiles_root", lambda: tmp_path / "none")
+
+        from hermes_cli.update_inventory import (
+            collect_runtime_inventory,
+            match_runtime_outcomes,
+            report_unaccounted_runtimes,
+        )
+
+        plan = collect_runtime_inventory()
+        rows = [r for r in plan.runtimes if r.pid == child.pid]
+        assert rows, f"real inventory missed the live process: {plan.runtimes}"
+        rt = rows[0]
+        assert rt.supervisor == "manual"
+        assert rt.restart_via == "manual", "machine id, not display string"
+        assert rt.code_sha == "f" * 40
+
+        # 2. bookkeeping misses it -> unaccounted + escalation
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            outcomes = match_runtime_outcomes(
+                plan, restarted_services=[], relaunched_profiles=[],
+                externally_supervised_profiles=[], killed_pids=set(),
+                failed_units=[],
+            )
+            escalated = report_unaccounted_runtimes(outcomes)
+        mine = [o for o in outcomes if o["pid"] == child.pid]
+        assert mine and mine[0]["outcome"] == "unaccounted"
+        assert escalated is True
+        assert "never touched" in buf.getvalue()
+
+        # 3. accounted as stopped -> clean
+        outcomes2 = match_runtime_outcomes(
+            plan, restarted_services=[], relaunched_profiles=[],
+            externally_supervised_profiles=[], killed_pids={child.pid},
+            failed_units=[],
+        )
+        mine2 = [o for o in outcomes2 if o["pid"] == child.pid]
+        assert mine2 and mine2[0]["outcome"] == "stopped"
+        assert report_unaccounted_runtimes(outcomes2) is False
+    finally:
+        if child.poll() is None:
+            child.kill()
+        child.wait()

--- a/tests/hermes_cli/test_restart_plan_reconciliation.py
+++ b/tests/hermes_cli/test_restart_plan_reconciliation.py
@@ -1,0 +1,137 @@
+"""Plan-vs-execution reconciliation (#91277 Phase 2: restart via declared mechanism).
+
+Pins:
+- _restart_mechanism returns machine-readable ids; describe_restart_mechanism
+  derives display strings (policy table is data, not prose).
+- match_runtime_outcomes classifies every planned runtime against the restart
+  phase's bookkeeping: restarted / stopped / failed / unaccounted.
+- report_unaccounted_runtimes escalates (returns True) ONLY on unaccounted
+  rows — the silent-miss tripwire.
+"""
+
+from hermes_cli.update_inventory import (
+    RuntimeRecord,
+    UpdatePlan,
+    _restart_mechanism,
+    describe_restart_mechanism,
+    match_runtime_outcomes,
+    report_unaccounted_runtimes,
+)
+
+
+def _plan(*runtimes: RuntimeRecord) -> UpdatePlan:
+    plan = UpdatePlan()
+    plan.runtimes = list(runtimes)
+    return plan
+
+
+def _rt(profile: str, pid: int, supervisor: str = "manual") -> RuntimeRecord:
+    return RuntimeRecord(
+        kind="gateway",
+        profile=profile,
+        pid=pid,
+        supervisor=supervisor,
+        restart_via=_restart_mechanism(supervisor, profile),
+    )
+
+
+def test_mechanism_ids_are_machine_readable_and_described():
+    assert _restart_mechanism("systemd", "default") == "systemd"
+    assert _restart_mechanism("launchd", "work") == "launchd"
+    assert _restart_mechanism("desktop", "default") == "desktop"
+    assert _restart_mechanism("manual", "work") == "manual"
+    # display derives FROM the id
+    assert "systemctl" in describe_restart_mechanism("systemd", "default")
+    assert "kickstart" in describe_restart_mechanism("launchd", "work")
+    assert "-p work" in describe_restart_mechanism("manual", "work")
+    assert describe_restart_mechanism("manual", "default") == "hermes gateway restart"
+
+
+def test_relaunched_profile_is_restarted():
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("default", 100)),
+        restarted_services=[], relaunched_profiles=["default"],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert outcomes == [
+        {"kind": "gateway", "profile": "default", "pid": 100,
+         "mechanism": "manual", "outcome": "restarted"}
+    ]
+    assert report_unaccounted_runtimes(outcomes) is False
+
+
+def test_killed_pid_is_stopped():
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("work", 200)),
+        restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids={200}, failed_units=[],
+    )
+    assert outcomes[0]["outcome"] == "stopped"
+
+
+def test_failed_unit_is_failed():
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("work", 300, supervisor="systemd")),
+        restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(),
+        failed_units=["hermes-gateway-work.service"],
+    )
+    assert outcomes[0]["outcome"] == "failed"
+
+
+def test_restarted_service_unit_matches_profile():
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("default", 400, supervisor="systemd")),
+        restarted_services=["hermes-gateway.service"], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert outcomes[0]["outcome"] == "restarted"
+
+
+def test_untouched_runtime_is_unaccounted_and_escalates(capsys):
+    """The tripwire: plan saw it, NO bookkeeping mentions it."""
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("coder", 500)),
+        restarted_services=["hermes-gateway.service"],
+        relaunched_profiles=["default"],
+        externally_supervised_profiles=[], killed_pids={123}, failed_units=[],
+    )
+    assert outcomes[0]["outcome"] == "unaccounted"
+    assert report_unaccounted_runtimes(outcomes) is True
+    out = capsys.readouterr().out
+    assert "never touched" in out
+    assert "coder" in out and "500" in out
+    assert "hermes -p <profile> gateway restart" in out
+
+
+def test_external_supervisor_counts_as_restarted():
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("default", 600, supervisor="desktop")),
+        restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=["default"], killed_pids=set(),
+        failed_units=[],
+    )
+    assert outcomes[0]["outcome"] == "restarted"
+
+
+def test_mixed_fleet_only_the_missed_one_escalates(capsys):
+    outcomes = match_runtime_outcomes(
+        _plan(
+            _rt("default", 700, supervisor="systemd"),
+            _rt("work", 701),
+            _rt("ghost", 702),
+        ),
+        restarted_services=["hermes-gateway.service"],
+        relaunched_profiles=["work"],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    by_profile = {o["profile"]: o["outcome"] for o in outcomes}
+    assert by_profile == {
+        "default": "restarted", "work": "restarted", "ghost": "unaccounted"
+    }
+    assert report_unaccounted_runtimes(outcomes) is True
+    out = capsys.readouterr().out
+    missed_block = out.split("never touched")[1]
+    assert "ghost" in missed_block
+    assert "[default]" not in missed_block
+    assert "[work]" not in missed_block

--- a/tests/hermes_cli/test_update_inventory.py
+++ b/tests/hermes_cli/test_update_inventory.py
@@ -58,7 +58,12 @@ class TestCollectInventory:
         assert by_profile["work"].pid == 200
         assert by_profile["work"].supervisor == "manual"
         assert by_profile["work"].code_sha is None  # pre-stamp gateway
-        assert "hermes -p work gateway restart" in by_profile["work"].restart_via
+        assert by_profile["work"].restart_via == "manual"
+        from hermes_cli.update_inventory import describe_restart_mechanism
+
+        assert "hermes -p work gateway restart" in describe_restart_mechanism(
+            by_profile["work"].restart_via, "work"
+        )
 
     def test_docker_install_not_updatable_in_place(self, fleet, monkeypatch):
         monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda *a, **k: "docker")

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -245,7 +245,8 @@ class TestGetServicePidsScoping:
 
 def _fleet(monkeypatch, tmp_path, *, current, labels, located,
            registered=None, plist_exists=True,
-           drain_results=None, kick_errors=None, wait_results=None):
+           drain_results=None, kick_errors=None, wait_results=None,
+           current_supervised=True):
     """Wire a fake launchd fleet through hermes_cli.gateway seams.
 
     ``located`` maps label -> (domain, pid) as ``_locate_launchd_gateway_service``
@@ -259,7 +260,7 @@ def _fleet(monkeypatch, tmp_path, *, current, labels, located,
 
     rec = SimpleNamespace(
         kickstarts=[], drains=[], current_restarts=[], waits=[],
-        locates=[], registered_checks=[],
+        locates=[], registered_checks=[], current_verifies=[],
     )
 
     plist = tmp_path / f"{current}.plist"
@@ -310,6 +311,18 @@ def _fleet(monkeypatch, tmp_path, *, current, labels, located,
     monkeypatch.setattr(gw, "_wait_for_launchd_service_pid", fake_wait)
     monkeypatch.setattr(
         gw, "launchd_restart", lambda: rec.current_restarts.append(current)
+    )
+
+    # The current profile is now verified the same way siblings are: a
+    # successful launchd_restart() only counts once launchd reports it is
+    # supervising the job (#88848). Stubbed here so the fleet cases keep
+    # asserting on routing rather than on a real launchctl probe.
+    def fake_verify_current(*, label=None, **_kw):
+        rec.current_verifies.append(label)
+        return current_supervised
+
+    monkeypatch.setattr(
+        gw, "wait_for_launchd_gateway_supervision", fake_verify_current
     )
     return rec
 

--- a/tests/hermes_cli/test_update_launchd_restart_verification.py
+++ b/tests/hermes_cli/test_update_launchd_restart_verification.py
@@ -1,0 +1,317 @@
+"""Regression for #88848 - a launchd restart the update never verified.
+
+``hermes update`` on macOS printed ``Update complete!`` and exited 0 while the
+``ai.hermes.gateway`` LaunchAgent sat deregistered for 36 minutes.  The restart
+phase treated "``launchd_restart()`` returned without raising" as success and
+appended the label to ``restarted_services``.  Both of launchd_restart's normal
+outcomes are asynchronous - the ``_request_gateway_self_restart`` branch returns
+the instant the running gateway is *asked* to restart, and a plist reload is
+handed to a detached helper - so a helper that died before its first bootstrap
+was invisible to the caller.
+
+The systemd branch of the same phase has never drawn that inference: it polls
+``_wait_for_service_active`` before recording the unit and routes a unit that
+never came back into ``failed_or_stale_units``, which is what makes the update
+exit non-zero.  These tests pin the same contract for launchd.
+
+No macOS hardware is involved: every case drives the seam through mocked
+``launchctl`` outcomes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import hermes_cli.gateway as gateway_cli
+import hermes_cli.update_cmd as update_cmd
+from hermes_cli.update_cmd import _warn_incomplete_gateway_fleet_restart
+
+LABEL = "ai.hermes.gateway"
+
+
+class _FakeClock:
+    """Monotonic clock that only advances when the code under test sleeps.
+
+    Keeps the poll loop's wall-clock budget honest without spending it: a real
+    20s verification timeout would otherwise make this file the slowest in the
+    suite, and shortening the timeout would stop testing the throttle window.
+    """
+
+    def __init__(self):
+        self.now = 1000.0
+        self.slept = []
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    fake = _FakeClock()
+    monkeypatch.setattr(gateway_cli.time, "monotonic", fake.monotonic)
+    monkeypatch.setattr(gateway_cli.time, "sleep", fake.sleep)
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def _no_detached_fallback(monkeypatch):
+    """Default every test to "launchd can manage this domain"."""
+    monkeypatch.setattr(
+        gateway_cli, "_launchd_unsupported_marker_exists", lambda: False
+    )
+
+
+def _supervision_returning(*results):
+    """Fake ``_launchctl_label_supervising_process`` yielding ``results`` in order.
+
+    The final value repeats, so a test can say "False twenty times, then True
+    from then on".
+    """
+    seq = list(results)
+    calls = []
+
+    def probe(label):
+        calls.append(label)
+        return seq[min(len(calls) - 1, len(seq) - 1)]
+
+    probe.calls = calls
+    return probe
+
+
+class TestWaitForLaunchdGatewaySupervision:
+    def test_returns_true_when_already_supervised(self, monkeypatch, clock):
+        """The common case must not cost a single sleep."""
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchctl_label_supervising_process",
+            _supervision_returning(True),
+        )
+
+        assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
+        assert clock.slept == []
+
+    def test_waits_out_the_launchd_respawn_throttle(self, monkeypatch, clock):
+        """A pid that only appears after ~10s is a SUCCESS, not a failure.
+
+        launchd will not relaunch a KeepAlive job more than about once per 10
+        seconds, so a gateway that exits promptly leaves the label registered
+        with no pid for most of that window.  A one-shot check - or any budget
+        shorter than the throttle - would report a perfectly healthy restart as
+        a silent failure, which is a worse bug than the one being fixed.
+        """
+        # 0.5s poll interval: 20 misses is ~10s of throttle, then the pid lands.
+        probe = _supervision_returning(*([False] * 20 + [True]))
+        monkeypatch.setattr(
+            gateway_cli, "_launchctl_label_supervising_process", probe
+        )
+
+        assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
+        assert sum(clock.slept) == pytest.approx(10.0)
+
+    def test_gives_up_at_the_deadline(self, monkeypatch, clock):
+        """A job that never comes back must fail, and must fail bounded."""
+        probe = _supervision_returning(False)
+        monkeypatch.setattr(
+            gateway_cli, "_launchctl_label_supervising_process", probe
+        )
+
+        assert (
+            gateway_cli.wait_for_launchd_gateway_supervision(
+                label=LABEL, timeout=20.0
+            )
+            is False
+        )
+        assert sum(clock.slept) <= 20.0
+        # The deadline is enforced by wall clock, not by a probe count.
+        assert len(probe.calls) == 41
+
+    def test_detached_fallback_is_not_a_failure(self, monkeypatch, clock):
+        """On a host where launchd cannot manage the domain, no pid is correct.
+
+        ``_launchd_fallback_to_detached`` is a legitimate outcome (macOS 26+
+        unmanageable domains); the gateway runs unsupervised by design there.
+        Reporting that as an incomplete update would fail every update on those
+        hosts.
+        """
+        monkeypatch.setattr(
+            gateway_cli, "_launchd_unsupported_marker_exists", lambda: True
+        )
+        probe = _supervision_returning(False)
+        monkeypatch.setattr(
+            gateway_cli, "_launchctl_label_supervising_process", probe
+        )
+
+        assert gateway_cli.wait_for_launchd_gateway_supervision(label=LABEL) is True
+        assert probe.calls == []
+
+
+def _patch_launchd_env(
+    monkeypatch,
+    *,
+    plist_exists=True,
+    registered=True,
+    restart=None,
+    supervised=True,
+):
+    """Drive ``_restart_macos_launchd_gateways`` through the invoking profile only.
+
+    ``launchd_gateway_labels_for_install`` is pinned to the current label so the
+    sibling loop is a no-op: this file is about the invoking profile, which is
+    the one branch that was never verified.
+    """
+
+    class _Plist:
+        def exists(self):
+            return plist_exists
+
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: _Plist())
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: LABEL)
+    monkeypatch.setattr(
+        gateway_cli, "_launchd_service_registered", lambda label: registered
+    )
+    monkeypatch.setattr(
+        gateway_cli, "launchd_gateway_labels_for_install", lambda: [LABEL]
+    )
+
+    calls = {"restart": 0, "verify": 0, "label": None}
+
+    def _restart():
+        calls["restart"] += 1
+        if restart is not None:
+            raise restart
+
+    monkeypatch.setattr(gateway_cli, "launchd_restart", _restart)
+
+    def _verify(*, label=None, **_kw):
+        calls["verify"] += 1
+        calls["label"] = label
+        return supervised
+
+    monkeypatch.setattr(
+        gateway_cli, "wait_for_launchd_gateway_supervision", _verify
+    )
+    return calls
+
+
+def _run_fleet_restart():
+    """Run the real update-path helper and return its two accounting lists."""
+    restarted: list = []
+    failed_or_stale: list = []
+    update_cmd._restart_macos_launchd_gateways(restarted, failed_or_stale, 5.0)
+    return restarted, failed_or_stale
+
+
+class TestInvokingProfileIsVerifiedLikeItsSiblings:
+    """The sibling loop already polls for a fresh supervised pid before
+    counting a label as restarted.  The invoking profile did not, so the two
+    halves of the same function disagreed about what "restarted" means."""
+
+    def test_reports_restarted_only_after_supervision_is_confirmed(
+        self, monkeypatch
+    ):
+        calls = _patch_launchd_env(monkeypatch, supervised=True)
+
+        restarted, failed_or_stale = _run_fleet_restart()
+
+        assert restarted == [LABEL]
+        assert failed_or_stale == []
+        assert calls["restart"] == 1
+        assert calls["verify"] == 1
+        assert calls["label"] == LABEL
+
+    def test_unverified_restart_is_not_reported_as_restarted(
+        self, monkeypatch, capsys
+    ):
+        """THE regression (#88848).
+
+        ``launchd_restart()`` returns normally - that is the reported failure's
+        exact shape, since the ``_request_gateway_self_restart`` branch returns
+        without raising while the reload helper dies afterwards.  Before the
+        fix this appended the label to ``restarted_services`` and the update
+        reported the gateway as restarted, and exited 0, over a job that was
+        deregistered from launchd.
+        """
+        _patch_launchd_env(monkeypatch, supervised=False)
+
+        restarted, failed_or_stale = _run_fleet_restart()
+
+        assert restarted == []
+        # Routed into failed_or_stale_units, which sets
+        # gateway_fleet_restart_incomplete and makes the update exit 1.
+        assert failed_or_stale == [LABEL]
+        assert LABEL in capsys.readouterr().out
+
+    def test_verification_budget_clears_the_respawn_throttle(self):
+        """A budget under launchd's ~10s respawn throttle would false-alarm.
+
+        The call site takes the helper's default, so the default is the
+        contract that has to stay above the throttle.
+        """
+        assert gateway_cli.LAUNCHD_SUPERVISION_VERIFY_TIMEOUT >= 15.0
+
+    def test_raised_restart_failure_is_not_verified_and_is_reported(
+        self, monkeypatch, capsys
+    ):
+        """A raised restart is a failed restart, and must not be verified.
+
+        Every path in ``launchd_restart`` that can still leave a working
+        gateway - the detached fallback on an unmanageable domain - returns
+        rather than raising, so reaching the handler means neither kickstart
+        nor bootstrap brought the service back.
+
+        This matters for composition with the open PRs that add verification
+        *inside* ``launchd_restart`` (#63304, #72752): they convert this exact
+        failure from silent to raised, so the caller must keep routing it into
+        ``failed_or_stale_units`` rather than falling through to the verifier.
+        """
+        exc = subprocess.CalledProcessError(1, ["launchctl"], stderr="boom")
+        calls = _patch_launchd_env(monkeypatch, restart=exc)
+
+        restarted, failed_or_stale = _run_fleet_restart()
+
+        assert restarted == []
+        assert failed_or_stale == [LABEL]
+        assert calls["verify"] == 0
+        assert "boom" in capsys.readouterr().out
+
+    def test_no_plist_means_the_gateway_is_not_launchd_managed(self, monkeypatch):
+        calls = _patch_launchd_env(monkeypatch, plist_exists=False)
+
+        assert _run_fleet_restart() == ([], [])
+        assert calls["restart"] == 0
+        assert calls["verify"] == 0
+
+    def test_unregistered_label_is_left_alone(self, monkeypatch):
+        """No launchd registration on this host means nothing to restart."""
+        calls = _patch_launchd_env(monkeypatch, registered=False)
+
+        assert _run_fleet_restart() == ([], [])
+        assert calls["restart"] == 0
+        assert calls["verify"] == 0
+
+
+class TestIncompleteFleetWarningIsPlatformCorrect:
+    def test_macos_recovery_instructions_are_launchctl(self, monkeypatch, capsys):
+        """A launchd label must not be handed systemctl commands."""
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+
+        _warn_incomplete_gateway_fleet_restart([LABEL])
+
+        out = capsys.readouterr().out
+        assert "launchctl bootstrap" in out
+        assert "systemctl" not in out
+
+    def test_linux_recovery_instructions_are_unchanged(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+
+        _warn_incomplete_gateway_fleet_restart(["hermes-gateway.service"])
+
+        out = capsys.readouterr().out
+        assert "systemctl --user restart <unit>" in out
+        assert "launchctl" not in out


### PR DESCRIPTION
## Summary

The update plan is now the restart phase's worklist, not a printout — every runtime the inventory saw must be accounted for by the restart bookkeeping, or the update fails loudly (exit 1) with per-runtime remediation. This closes the last load-bearing gap in Phase 2's pipeline row (#91277): plan and execution could previously disagree with zero signal, because `restart_via` was a display string and the four platform restart branches each re-discovered their own targets. Also salvages @jackulau's launchd supervision verification (#88949 → #88848).

## Changes

- `hermes_cli/update_inventory.py`: `restart_via` becomes a machine-readable mechanism id (`systemd|launchd|desktop|manual`) — the policy table as data, display derived via `describe_restart_mechanism()`. New `match_runtime_outcomes()` reconciles every planned runtime against the restart phase's bookkeeping (`restarted`/`stopped`/`failed`/`unaccounted`); `report_unaccounted_runtimes()` is the silent-miss tripwire.
- `hermes_cli/update_cmd.py`: after the restart phase, the plan is reconciled; per-runtime outcomes land in the receipt (`runtime_outcomes`); any unaccounted runtime escalates exactly like a STALE/DOWN fleet row.
- `hermes_cli/update_cmd.py` + `hermes_cli/gateway.py` (@jackulau, salvage #88949): the current-profile launchd restart no longer marks success on "launchd_restart() returned" — success requires launchd reporting a fresh supervised PID (`wait_for_launchd_gateway_supervision`, domain-agnostic), with deregistration-aware recovery guidance (#88848).

## Validation

| Check | Result |
|---|---|
| New reconciliation suite + inventory + launchd + restart-fallback + receipt suites | 58/58 |
| Sabotage run (reconciliation forced to report everything restarted) | tripwire tests FAIL — proves the guard |
| **A/B for the launchd salvage:** @jackulau's verification suite vs merge-base product code → 11 failed (gap live) · vs head → 12 passed | proven |
| **Live E2E on this host's real fleet:** real inventory (systemd-supervised gateway classified with machine id), bookkeeping omitting it → unaccounted + escalation; fully accounted → clean | passed |

Structural note: this makes the #88654 silent-skip class impossible to reintroduce — any future restart-branch change that drops a planned runtime trips the reconciliation, not a user report. Remaining Phase-2 rows after this: fleet-wide config migration (#20438 class) and socket step 2.

## Infographic

![The plan is the worklist](https://v3b.fal.media/files/b/0aa77c47/g_U2wS1_g5ok_pr6I6yXr_5EmQYNcg.png)
