### PR TITLE
fix(desktop): typing /voice now points at the composer's mic button instead of a generic shrug

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -45,6 +45,18 @@ describe('desktop slash command curation', () => {
     expect(isDesktopSlashSuggestion('/curator')).toBe(false)
   })
 
+  it('/voice points at the composer voice button instead of the generic advanced message', () => {
+    // /voice arms server-side capture — on the desktop the composer's own
+    // voice conversation (mic menu / Ctrl+B) is the surface. A user typing
+    // /voice must be told where the button IS, not shrugged at.
+    expect(resolveDesktopCommand('/voice')?.surface).toEqual({ kind: 'unavailable', reason: 'composer-voice' })
+    expect(isDesktopSlashCommand('/voice')).toBe(false)
+
+    const message = desktopSlashUnavailableMessage('/voice')
+    expect(message).toContain('microphone button')
+    expect(message).toContain('Ctrl+B')
+  })
+
   it('routes /compact to /compress (context compression), not the TUI display toggle', () => {
     expect(resolveDesktopCommand('/compact')?.name).toBe('/compress')
     expect(isDesktopSlashCommand('/compact')).toBe(true)

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -63,7 +63,7 @@ export type DesktopActionId =
 export type DesktopPickerId = 'model' | 'session'
 
 /** Why a known Hermes command has no desktop UI surface. */
-export type DesktopUnavailableReason = 'advanced' | 'messaging' | 'settings' | 'terminal'
+export type DesktopUnavailableReason = 'advanced' | 'composer-voice' | 'messaging' | 'settings' | 'terminal'
 
 /**
  * How the desktop fulfils a command. This is the single discriminator the
@@ -370,7 +370,12 @@ const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = 
   ],
   messaging: ['/approve', '/deny'],
   settings: ['/skills', '/pets'],
-  advanced: ['/curator', '/fast', '/insights', '/kanban', '/reasoning', '/voice']
+  advanced: ['/curator', '/fast', '/insights', '/kanban', '/reasoning'],
+  // /voice arms SERVER-side capture (voice.record → PortAudio on the backend
+  // host) — meaningless on desktop, which has its own composer-native voice
+  // conversation (mic menu / Ctrl+B) with client-side capture and playback.
+  // Point the user at the button instead of a generic "advanced" shrug.
+  'composer-voice': ['/voice']
 }
 
 const ALL_SPECS: readonly DesktopCommandSpec[] = [
@@ -389,6 +394,8 @@ const ALIAS_TO_CANONICAL = new Map<string, string>(
 const UNAVAILABLE_MESSAGE: Record<DesktopUnavailableReason, (command: string) => string> = {
   advanced: command =>
     `${command} is not shown in the desktop slash palette. Use the relevant desktop control or terminal interface instead.`,
+  'composer-voice': () =>
+    'Voice chat lives in the composer here: click the microphone button and choose "Start voice chat" (or press Ctrl+B).',
   messaging: command => `${command} is only used from messaging platforms.`,
   settings: command => `${command} is managed from the desktop sidebar.`,
   terminal: command => `${command} is only available in the terminal interface.`


### PR DESCRIPTION
## Summary
Typing `/voice` on the desktop now tells the user where voice chat actually lives — the composer's microphone button (Ctrl+B) — instead of the generic "advanced command" shrug.

`/voice` arms SERVER-side capture (`voice.record` → PortAudio on the backend host), which is meaningless on desktop: the composer's own voice conversation does client-side capture and playback. The command was already suppressed from the slash palette, but its rejection message never mentioned the button exists.

## Changes
- `apps/desktop/src/lib/desktop-slash-commands.ts`: new `composer-voice` unavailability reason; `/voice` moved out of the generic `advanced` bucket; message names the mic button and Ctrl+B.
- `apps/desktop/src/lib/desktop-slash-commands.test.ts`: pins the surface, the non-executability, and the message content.

## Validation
| | Before | After |
|---|---|---|
| Typing `/voice` on desktop | "…use the relevant desktop control or terminal interface instead." | "Voice chat lives in the composer here: click the microphone button and choose \"Start voice chat\" (or press Ctrl+B)." |
| Palette suggestion | hidden | hidden (unchanged) |
| Tests | — | 28/28; tsc + eslint clean |

## Infographic

![use the mic button](https://v3b.fal.media/files/b/0aa77c4e/vpbyYudlTsn6GBbzEYgZ7_x8AUgyw2.png)
