### PR TITLE
fix(tests): disable lazy installs inside the canonical runner's env -i block

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,6 +8,7 @@
 #     subprocess. No xdist, no shared workers, no module-level leakage
 #     between files.
 #   * TZ=UTC, LANG=C.UTF-8, PYTHONHASHSEED=0 (deterministic)
+#   * Lazy dependency installs disabled before test-module collection
 #   * Env vars blanked (conftest.py also does this, but this
 #     is belt-and-suspenders for anyone running pytest outside our
 #     conftest path — e.g. on a single file)
@@ -176,6 +177,7 @@ exec env -i \
   LC_ALL=C.UTF-8 \
   PYTHONHASHSEED=0 \
   PYTHONUTF8=1 \
+  HERMES_DISABLE_LAZY_INSTALLS=1 \
   ${HERMES_RUN_SLOW_PET_TESTS:+HERMES_RUN_SLOW_PET_TESTS="$HERMES_RUN_SLOW_PET_TESTS"} \
   ${HERMES_E2E_BROWSER:+HERMES_E2E_BROWSER="$HERMES_E2E_BROWSER"} \
   ${EXTRA_PYTHONPATH:+PYTHONPATH="$EXTRA_PYTHONPATH"} \

--- a/tests/test_run_tests_environment.py
+++ b/tests/test_run_tests_environment.py
@@ -1,0 +1,35 @@
+"""Behavioral tests for the canonical shell test runner environment."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_runner_disables_lazy_installs_before_collection(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    probe = tmp_path / "test_collection_environment.py"
+    probe.write_text(
+        "import os\n"
+        "assert os.environ.get('HERMES_DISABLE_LAZY_INSTALLS') == '1'\n\n"
+        "def test_probe():\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.pop("HERMES_DISABLE_LAZY_INSTALLS", None)
+    env["HERMES_PYTHON"] = sys.executable
+    env["HERMES_TEST_FILE_RETRIES"] = "0"
+    env["HERMES_TEST_WORKERS"] = "1"
+
+    result = subprocess.run(
+        [repo_root / "scripts" / "run_tests.sh", probe, "-q"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Symptom

Running `scripts/run_tests.sh` over multiple files can fail flakily during collection when two per-file pytest subprocesses trigger the same lazy dependency install concurrently. Exporting `HERMES_DISABLE_LAZY_INSTALLS=1` before the run does not help.

## Cause

The runner starts pytest with `exec env -i`, which scrubs the environment, so the variable never survives into the subprocesses. CI is protected because `.github/workflows/tests.yml` sets the variable in its own wrapper, but a local run of the canonical runner has no way to keep it.

## Fix

Add `HERMES_DISABLE_LAZY_INSTALLS=1` to the runner's `env -i` block (plus one header comment line), so the protection is baked into the runner itself. CI behavior is unchanged; only local runs of `scripts/run_tests.sh` gain the guarantee.

## Test

`tests/test_run_tests_environment.py` drives the real runner on a probe file whose module body asserts the variable is set at collection time. Red on main (probe fails at import), green with the fix. Verified both on current main (891ec3fb6c).