### PR TITLE
feat(model): enforce profile-wide hard context ceiling

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2664,6 +2664,52 @@ def init_agent(
     # AFTER the custom_providers branch so per-model overrides aren't lost.
     agent._config_context_length = _config_context_length
 
+    # Read the global context ceiling (model.max_context_length) from config.
+    # Unlike model.context_length (per-model, absolute, discarded on switch),
+    # this is a model-independent runtime policy ceiling that survives /model
+    # switches: effective window = min(resolved, ceiling). It never raises a
+    # window, only lowers one. Stored on the agent for display/gate paths and
+    # passed to the built-in compressor (the plugin-engine path applies it
+    # inside the compressor's setter as well).
+    _max_context_length = None
+    if isinstance(_model_cfg, dict):
+        _raw_max_ctx = _model_cfg.get("max_context_length")
+        if _raw_max_ctx is not None:
+            # Single strict validator (findings #9/#10). validate_context_ceiling
+            # rejects bool/float/numeric-string/inf/nan/<=0 AND enforces the
+            # 64K configuration floor — a ceiling below MINIMUM_CONTEXT_LENGTH is
+            # an INVALID ceiling (a mis-configuration), NOT "the model only has
+            # this capability". Distinguish the two rejection classes so the
+            # user gets a ceiling-specific error, not a model-capability one.
+            from agent.model_metadata import (
+                coerce_context_ceiling,
+                validate_context_ceiling,
+            )
+            _coerced = coerce_context_ceiling(_raw_max_ctx)
+            if _coerced is None:
+                # Malformed (bool/float/string/inf/<=0/non-numeric) — not a
+                # usable ceiling. Reject with a ceiling-specific message.
+                _ra().logger.warning(
+                    "model.max_context_length in config.yaml is %r — a ceiling "
+                    "must be a positive integer token count (e.g. 272000). "
+                    "Bool, float, numeric strings, infinity, and values <= 0 "
+                    "are all invalid. Ignoring (no ceiling).", _raw_max_ctx,
+                )
+            elif _coerced < MINIMUM_CONTEXT_LENGTH:
+                # Valid integer but below the 64K floor — an INVALID ceiling,
+                # reported as a ceiling problem, not a model capability.
+                _ra().logger.warning(
+                    "model.max_context_length in config.yaml is %r, below the "
+                    "minimum of %s — Hermes cannot operate below %s tokens, so "
+                    "this ceiling is invalid. Set it to at least %s, or remove "
+                    "it to disable the ceiling.",
+                    _raw_max_ctx, f"{MINIMUM_CONTEXT_LENGTH:,}",
+                    f"{MINIMUM_CONTEXT_LENGTH:,}", f"{MINIMUM_CONTEXT_LENGTH:,}",
+                )
+            else:
+                _max_context_length = validate_context_ceiling(_raw_max_ctx)
+    agent._max_context_length = _max_context_length
+
     _lmstudio_runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
         _config_context_length
     )
@@ -2766,14 +2812,26 @@ def init_agent(
         # and may ignore the attribute.
         if compression_model_thresholds:
             agent.context_compressor.model_thresholds = compression_model_thresholds
-        agent.context_compressor.update_model(
-            model=agent.model,
-            context_length=_plugin_ctx_len,
-            base_url=agent.base_url,
-            api_key=getattr(agent, "api_key", ""),
-            provider=agent.provider,
-            api_mode=agent.api_mode,
-        )
+        # Expose the global context ceiling on the engine (for engines that
+        # honor it) and clamp the resolved window: plugin engines own their
+        # compaction policy and don't share the built-in setter's automatic
+        # clamp, so we apply it here at the one call site.
+        _plugin_max_ctx = getattr(agent, "_max_context_length", None)
+        if _plugin_max_ctx is not None:
+            try:
+                agent.context_compressor.max_context_length = _plugin_max_ctx
+            except Exception:
+                pass
+        # MODEL LIFECYCLE TRANSITION: for a plugin this supplies the effective
+        # (capped) value via update_model() and sets the host pre-cap to the
+        # raw value; for the built-in (impossible here since _selected_engine
+        # is not None) it would supply the raw value. transition_model_context
+        # propagates any engine failure to init (init must not start with a
+        # half-transitioned engine) and always runs update_model even if the
+        # effective integer is unchanged (the engine recalculates thresholds
+        # from the new route).
+        from agent.agent_runtime_helpers import transition_model_context
+        transition_model_context(agent, _plugin_ctx_len, model=agent.model)
         if not agent.quiet_mode:
             _ra().logger.info("Using context engine: %s", _selected_engine.name)
     else:
@@ -2788,6 +2846,7 @@ def init_agent(
             base_url=agent.base_url,
             api_key=getattr(agent, "api_key", ""),
             config_context_length=_effective_context_length,
+            max_context_length=_max_context_length,
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
@@ -2800,6 +2859,18 @@ def init_agent(
             min_tail_user_messages=compression_min_tail_users,
             tail_mode=compression_tail_mode,
         )
+        # HOST STATE (Phase 6): the host owns the pre-cap operating window so
+        # it is authoritative for BOTH engine types and every cross-path
+        # consumer (get_pre_cap, the dispatch gate, provider-error correction,
+        # snapshot/restore). For the built-in engine the raw pre-cap lives on
+        # the compressor (pre_cap_context_length); surface it on the host so
+        # the built-in path does not depend on the resolve_engine_pre_cap
+        # fallback. This never raises a window — it only mirrors the raw
+        # capability the ceiling clamps.
+        from agent.agent_runtime_helpers import resolve_engine_pre_cap
+        _builtin_precap = resolve_engine_pre_cap(agent.context_compressor)
+        if _builtin_precap > 0:
+            agent._pre_cap_context_length = _builtin_precap
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):
         try:
@@ -3110,6 +3181,7 @@ def init_agent(
     # activates during a turn, the next turn restores these values so the
     # preferred model gets a fresh attempt each time.  Uses a single dict
     # so new state fields are easy to add without N individual attributes.
+    from agent.agent_runtime_helpers import get_pre_cap
     _cc = agent.context_compressor
     agent._primary_runtime = {
         "model": agent.model,
@@ -3130,7 +3202,10 @@ def init_agent(
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url),
         "compressor_api_key": getattr(_cc, "api_key", ""),
         "compressor_provider": getattr(_cc, "provider", agent.provider),
-        "compressor_context_length": _cc.context_length,
+        # PRE-CAP operating window (host-retained via transition_model_context /
+        # get_pre_cap), NOT the capped getter — see the switch-path snapshot
+        # for why the raw value is what restore needs.
+        "compressor_context_length": get_pre_cap(agent),
         "compressor_threshold_tokens": _cc.threshold_tokens,
     }
     if agent.api_mode == "anthropic_messages":

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -50,6 +50,623 @@ from agent.credential_pool import (
 from agent.error_classifier import FailoverReason
 from agent.turn_context import drop_stale_api_content
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
+from agent.model_metadata import ContextCeilingExceeded  # noqa: F401  (re-export)
+
+
+def resolve_engine_pre_cap(engine) -> int:
+    """Read the pre-cap operating window from a ContextEngine instance.
+
+    Returns a valid positive integer or 0. Accepts ``pre_cap_context_length``
+    only when it is a genuine positive int; otherwise falls back to the
+    engine's ``context_length``. This is the single definition of the
+    engine-side pre-cap fallback semantics.
+
+    A MagicMock (or any non-int) ``pre_cap_context_length`` is rejected by the
+    ``isinstance`` check, so the fallback to ``context_length`` is used. The
+    same check applies to ``context_length`` so a MagicMock there also
+    resolves to 0 rather than leaking a non-int downstream (e.g. into
+    ``save_context_length``'s ``length <= 0`` guard).
+    """
+    if engine is None:
+        return 0
+    val = getattr(engine, "pre_cap_context_length", None)
+    if isinstance(val, int) and not isinstance(val, bool) and val > 0:
+        return val
+    val = getattr(engine, "context_length", None)
+    if isinstance(val, int) and not isinstance(val, bool) and val > 0:
+        return val
+    return 0
+
+
+def get_pre_cap(agent) -> int:
+    """Return the host's current PRE-CAP operating window for the active model.
+
+    ``pre_cap`` is the window AFTER all capability/provider resolution and
+    non-persistable runtime restrictions (e.g. the Anthropic 200K tier
+    reduction) but BEFORE the ``model.max_context_length`` ceiling. It is the
+    correct baseline for:
+
+      * fallback snapshot / restore (preserve the pre-cap operating window),
+      * provider-error correction comparison (``parsed_limit < pre_cap``),
+      * feeding the built-in ContextCompressor's setter (which derives the
+        effective window from it).
+
+    The host owns this value (``agent._pre_cap_context_length``) so it is
+    authoritative for BOTH engine types. For the built-in ContextCompressor
+    the engine also stores it internally (``pre_cap_context_length``), but the
+    host copy is the single source of truth for cross-path consistency.
+
+    Falls back to ``resolve_engine_pre_cap(engine)`` if the host store was
+    never set (e.g. a test built the engine standalone).
+    """
+    raw = getattr(agent, "_pre_cap_context_length", None)
+    if isinstance(raw, int) and not isinstance(raw, bool) and raw > 0:
+        return raw
+    return resolve_engine_pre_cap(getattr(agent, "context_compressor", None))
+
+
+def _engine_effective_window(agent, pre_cap: int) -> int:
+    """Return the EFFECTIVE window (pre-cap clamped by the ceiling).
+
+    The ceiling only ever LOWERS a window; it can never raise one. A ceiling
+    is only meaningful as a positive int (enforced by the shared strict
+    validator upstream), so anything else is treated as "no ceiling".
+    """
+    ceiling = getattr(agent, "_max_context_length", None)
+    if isinstance(ceiling, int) and not isinstance(ceiling, bool) and ceiling > 0:
+        return pre_cap if pre_cap <= ceiling else ceiling
+    return pre_cap
+
+
+def ceiling_exceeded(agent, request_tokens: int) -> bool:
+    """Pre-dispatch ceiling gate (test / reference surface).
+
+    Returns ``True`` if a request of ``request_tokens`` exceeds the effective
+    ceiling (``agent._max_context_length`` when set as a strict positive int).
+    A no-op when no ceiling is configured.
+
+    .. note::
+       **No production call sites in-tree.**  Production dispatch owners use
+       :func:`enforce_final_context_budget` (or the streaming helper
+       :func:`_enforce_streaming_final_budget`), which additionally bounds the
+       request by the invocation's own pre-cap.  This helper is retained as a
+       lightweight reference for tests and for callers that only need a
+       simple ``tokens > ceiling`` predicate.
+    """
+    ceiling = getattr(agent, "_max_context_length", None)
+    if not (isinstance(ceiling, int) and not isinstance(ceiling, bool) and ceiling > 0):
+        return False
+    if not isinstance(request_tokens, int) or isinstance(request_tokens, bool):
+        return False
+    return request_tokens > ceiling
+
+
+# ContextCeilingExceeded is defined in agent.model_metadata (single source of
+# truth) and re-exported at the top of this module for backward compatibility
+# with callers that import it from agent_runtime_helpers.
+
+
+# Token accounting for the hard ceiling.
+#
+# model.max_context_length is a HARD CEILING ON HERMES'S EFFECTIVE CONTEXT
+# BUDGET under Hermes canonical pre-dispatch accounting.  It is not a claim
+# of exact provider-token enforcement.
+#
+# Hermes has NO exact tokenizer on the dispatch path -- tiktoken and
+# transformers are both optional and absent from core dependencies
+# (pyproject.toml).  The gate therefore relies on the existing
+# estimate_request_tokens_rough family (see agent.model_metadata): a rough,
+# heuristic estimate of the FINAL provider-bound payload (system/instructions
+# + messages/input + tool schemas + multimodal image estimate at
+# _IMAGE_TOKEN_COST per image), plus the resolved output reservation.
+#
+# This is Hermes canonical accounting -- a practical budget, not a proven
+# bound.  The rough estimate is known to under-count some token-dense scripts
+# (Cyrillic, Greek, Thai, Arabic) and irregular ASCII (code, base64);
+# provider-native tokenization may differ in either direction.  The provider's
+# own context-overflow error (error_classifier -> reactive compaction in the
+# loop) remains the authoritative backstop for any request this estimate still
+# mis-estimates, exactly as the compressor already relies on it.
+#
+# Hard invariant enforced by the terminal gate
+# (enforce_final_context_budget; check_ceiling_for_kwargs is the retained
+# test/reference surface):
+#
+#     canonical_request_budget(final payload)
+#         <= min(invocation_pre_cap, profile_max_context_length)
+#
+# before provider I/O.  A request that exceeds the bound is refused locally
+# and never dispatched; the refusal is NOT an API call, so it does not
+# consume api_call_count or an iteration/provider-call slot.
+
+def canonical_request_budget(
+    api_messages: list,
+    *,
+    system_prompt: str = "",
+    tools: list | None = None,
+    output_reserve: int = 0,
+) -> int:
+    """Hermes canonical token budget for a FINAL provider-bound request.
+
+    Reuses Hermes's existing rough token accounting
+    (``estimate_request_tokens_rough`` — the same estimator the conversation
+    loop and context compressor already use for preflight and shrink
+    decisions).  There is no duplicated token-accounting implementation and
+    no second estimator; this function is the single canonical budget
+    calculator the ``model.max_context_length`` ceiling enforces.
+
+    The components are the FINAL payload's system/instructions text, final
+    messages/input, final tool schemas, the flat per-image estimate
+    (``_IMAGE_TOKEN_COST`` per image part), and the RESOLVED output
+    reservation.
+
+    This is a Hermes canonical budget, NOT a proven provider-token bound:
+    the underlying estimator is a rough heuristic that can under-count some
+    token-dense scripts and irregular ASCII, and provider-native
+    tokenization may differ in either direction.  Where Hermes lacks the
+    exact native tokenizer, the provider's context-overflow response remains
+    the final authority (see the module-level note above).
+
+    ``output_reserve`` must be the RESOLVED output allowance for this
+    dispatch — Hermes's effective ``max_tokens`` after its clamp-to-remaining-
+    context — not merely "max_tokens if known".  A meaningful hard ceiling
+    needs the actual value the provider will be asked to honour.
+    """
+    from agent.model_metadata import estimate_request_tokens_rough
+
+    base = estimate_request_tokens_rough(
+        list(api_messages or []),
+        system_prompt=system_prompt or "",
+        tools=tools,
+    )
+    reserve = (
+        int(output_reserve)
+        if isinstance(output_reserve, int)
+        and not isinstance(output_reserve, bool)
+        and output_reserve > 0
+        else 0
+    )
+    return base + reserve
+
+
+def effective_dispatch_limit(
+    pre_cap: int | None,
+    ceiling: int | None,
+) -> int | None:
+    """The effective dispatch limit = ``min(invocation pre-cap, profile ceiling)``.
+
+    ``pre_cap`` is the invocation's OWN operating pre-cap (the active host
+    pre-cap for the main/fallback model; the reference/auxiliary model's own
+    resolved pre-cap for those invocations). ``ceiling`` is the profile-wide
+    ``model.max_context_length`` (a strict positive int when valid). The
+    ceiling only lowers the limit — a smaller model stays smaller. Returns
+    ``None`` (no limit → enforcement is a no-op) when neither value is set.
+    """
+    def _valid(v) -> bool:
+        return isinstance(v, int) and not isinstance(v, bool) and v > 0
+
+    limits = []
+    if _valid(pre_cap):
+        limits.append(pre_cap)
+    if _valid(ceiling):
+        limits.append(ceiling)
+    if not limits:
+        return None
+    return min(limits)
+
+
+def enforce_effective_context_limit(
+    request_tokens: int,
+    *,
+    pre_cap: int | None = None,
+    ceiling: int | None = None,
+    reason: str = "",
+) -> None:
+    """Raise :class:`ContextCeilingExceeded` if the final request exceeds the
+    effective limit for its invocation.
+
+    The effective limit is ``min(invocation pre-cap, profile ceiling)`` —
+    see :func:`effective_dispatch_limit`. A request whose Hermes canonical
+    budget exceeds that limit is refused locally. When neither a pre-cap nor
+    a ceiling is configured the check is a no-op.
+
+    Ordering contract: this must be called BEFORE the dispatch owner commits
+    ``api_call_count`` / an iteration slot, so a refused request consumes
+    neither. Callers handle the raised exception as a normal local refusal.
+    """
+    limit = effective_dispatch_limit(pre_cap, ceiling)
+    if limit is None:
+        return
+    tokens = (
+        request_tokens
+        if isinstance(request_tokens, int)
+        and not isinstance(request_tokens, bool)
+        and request_tokens >= 0
+        else 0
+    )
+    if tokens > limit:
+        raise ContextCeilingExceeded(tokens, limit, reason=reason)
+
+
+def check_ceiling_for_kwargs(
+    api_kwargs: dict,
+    *,
+    pre_cap: int | None,
+    ceiling: int | None,
+    system_prompt: str = "",
+    tools: list | None = None,
+    reason: str = "",
+) -> None:
+    """Shared dispatch-owner ceiling enforcement (test / reference surface).
+
+    Builds the canonical Hermes budget from the FINAL payload and raises
+    :class:`ContextCeilingExceeded` if the budget exceeds
+    ``min(invocation pre-cap, profile ceiling)``.
+
+    ``api_kwargs`` is the FINAL request as it will be sent (post-middleware,
+    post-transformation).  ``system_prompt`` and ``tools`` are supplied
+    explicitly for owners whose payload builder keeps them out of
+    ``api_kwargs`` (e.g. the summary path, which prepends a system message to
+    ``api_kwargs["messages"]``).  ``output_reserve`` is read from the
+    provider-specific key already present in ``api_kwargs``
+    (``max_tokens`` / ``max_completion_tokens`` / ``max_output_tokens``).
+
+    When neither ``pre_cap`` nor ``ceiling`` is set the check is a no-op.
+    Callers catch the raised exception and surface it as a local refusal —
+    not an API call, not an iteration slot, not a provider callback.
+
+    .. note::
+       **No production call sites in-tree.**  Production dispatch owners use
+       :func:`enforce_final_context_budget` (or the streaming helper
+       :func:`_enforce_streaming_final_budget`).  This function is retained as
+       a reference surface for tests and as the legacy API that the summary
+       gate was migrated off.
+    """
+    _msgs = (
+        api_kwargs.get("messages")
+        or api_kwargs.get("input")
+        or []
+    )
+    _tools = (
+        api_kwargs.get("tools")
+        or api_kwargs.get("functions")
+        or tools
+    )
+    _reserve = (
+        api_kwargs.get("max_tokens")
+        or api_kwargs.get("max_completion_tokens")
+        or api_kwargs.get("max_output_tokens")
+        or 0
+    )
+    budget = canonical_request_budget(
+        _msgs,
+        system_prompt=system_prompt,
+        tools=_tools,
+        output_reserve=_reserve,
+    )
+    enforce_effective_context_limit(
+        budget,
+        pre_cap=pre_cap,
+        ceiling=ceiling,
+        reason=reason,
+    )
+
+
+def _agent_ceiling(agent) -> int | None:
+    """The profile ceiling from the agent host, or ``None`` if unset/invalid.
+
+    The value is already validated at agent init (strict positive int >= the
+    64K floor); a non-int / bool / <=0 value here is treated as "no ceiling".
+    """
+    ceiling = getattr(agent, "_max_context_length", None)
+    if isinstance(ceiling, int) and not isinstance(ceiling, bool) and ceiling > 0:
+        return ceiling
+    return None
+
+
+def _engine_handles_ceiling(engine) -> bool:
+    """Stable capability marker check.
+
+    Dispatch on an explicit OPT-IN marker (``_handles_context_ceiling is
+    True``), not isinstance / class identity / type-name string comparison.
+    A module reload re-imports ``agent.context_compressor`` as a NEW class
+    object while live instances keep the old one, so an identity check would
+    misroute; a type-name string check would let an unrelated plugin that
+    merely reuses the name "ContextCompressor" masquerade as the built-in.
+
+    The ``is True`` comparison (rather than ``bool(getattr(...))``) is what
+    makes a ``MagicMock`` (or any object with a dynamic ``__getattr__``)
+    classify correctly: a MagicMock's ``__getattr__`` returns a truthy child
+    MagicMock, which ``bool()`` would treat as True and misroute into the
+    built-in branch. ``is True`` rejects it, so a missing-marker engine
+    (including a MagicMock) receives the EFFECTIVE window, not raw.
+    """
+    return getattr(engine, "_handles_context_ceiling", False) is True
+
+
+def transition_model_context(
+    agent,
+    pre_cap: int,
+    *,
+    model: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    provider: Optional[str] = None,
+    api_mode: Optional[str] = None,
+    commit_host_precap: bool = True,
+    rollback_via_lifecycle: bool = True,
+) -> int:
+    """MODEL LIFECYCLE TRANSITION: apply a new model's pre-cap window.
+
+    Use for genuine model/provider/base_url/api_key changes — agent init,
+    /model switch, fallback activation, primary restoration. The generic
+    ``ContextEngine.update_model()`` contract MUST run for the new model even
+    when the final effective integer happens to be unchanged: the engine also
+    tracks model/provider/credential state and recalculates threshold/budget
+    from the new window.
+
+    Failure semantics: exceptions from ``update_model`` PROPAGATE to the
+    owning transaction. This shared primitive must not manufacture success —
+    the caller (init / switch / fallback / restore) decides whether a failed
+    transition aborts the whole operation.
+
+    Host-state separation: ``commit_host_precap``
+    controls whether ``agent._pre_cap_context_length`` is set to ``pre_cap``
+    as part of this call.
+
+    - ``True`` (default): the helper commits the host pre-cap after a
+      successful engine transition. Suitable for standalone calls (agent init,
+      provider-corrected refresh) where the engine transition IS the whole
+      transaction.
+    - ``False``: the helper performs ONLY the engine transition and leaves the
+      host pre-cap for the caller to commit in its final atomic step. Suitable
+      for the validate-then-commit lifecycle transactions (switch / fallback /
+      restore) where the caller commits model + client + host-pre-cap together
+      after the engine transition succeeds. This ensures a failed transition
+      leaves ALL host state (model/provider/client/_pre_cap) in its prior
+      coherent state.
+
+    Engine snapshot/restore: the engine's own
+    model/provider/base_url/api_key/context_length are snapshotted before
+    ``update_model()`` and restored if it raises. This guards against a
+    generic plugin whose ``update_model()`` mutates internal state and then
+    raises — the engine is returned to its prior state even in that case.
+    Built-in engines (which set all five fields atomically before
+    ``context_length``) are unaffected, but the snapshot is cheap and makes
+    the contract explicit rather than assumed.
+
+    Dispatch: on the stable ``_handles_context_ceiling is True`` marker.
+    Built-in (marker) receives the RAW pre-cap — its setter stores pre-cap and
+    derives ``effective = min(pre_cap, ceiling)``. A generic plugin (no
+    marker) receives the pre-computed EFFECTIVE window — it has a single
+    ``context_length`` and no pre-cap property.
+
+    ``pre_cap`` is the window BEFORE the ceiling (capability resolution +
+    non-persistable runtime restrictions). The ceiling only lowers it.
+
+    Returns the value actually supplied to the engine (raw for built-in,
+    effective for plugin).
+    """
+    engine = getattr(agent, "context_compressor", None)
+    if engine is None:
+        # No engine — nothing to transition.
+        if commit_host_precap:
+            agent._pre_cap_context_length = pre_cap
+        return pre_cap
+
+    _m = model if model is not None else getattr(agent, "model", "")
+    _bu = base_url if base_url is not None else getattr(agent, "base_url", "")
+    _ak = api_key if api_key is not None else getattr(agent, "api_key", "")
+    _pv = provider if provider is not None else getattr(agent, "provider", "")
+    _am = api_mode if api_mode is not None else getattr(agent, "api_mode", "")
+
+    if _engine_handles_ceiling(engine):
+        # Built-in: pass the RAW value so its setter stores pre-cap = raw and
+        # derives effective = min(raw, ceiling). Do NOT pre-clamp — the engine
+        # owns its own pre-cap.
+        supplied = pre_cap
+    else:
+        # Generic plugin: pass the EFFECTIVE value.
+        supplied = _engine_effective_window(agent, pre_cap)
+
+    # --- Rollback via the plugin's OWN lifecycle contract ---
+    # A generic ContextEngine plugin's ``update_model()`` may mutate derived
+    # / internal state (threshold_percent, threshold_tokens, budgets,
+    # accounting, plugin-private fields) and THEN raise. Restoring only the
+    # five route fields via setattr would leave that derived state on the NEW
+    # model's values — silently inconsistent. The user's contract: prefer
+    # restoration through the plugin's lifecycle itself — re-apply the PRIOR
+    # route with ``update_model(old...)`` so every derived field is recomputed
+    # from the prior route. A bare setattr restore of the route fields is only
+    # a LAST-RESORT fallback if even that rollback call raises, and a rollback
+    # failure must be SURFACED (loud log + the original exception propagates),
+    # never silently claimed as coherence.
+    #
+    # Capture the prior route + the value the engine was last supplied BEFORE
+    # we hand it the new route. The supplied value mirrors the forward path
+    # (built-in → raw pre-cap; plugin → its single context_length).
+    _prior_pre_cap = resolve_engine_pre_cap(engine)
+    if _engine_handles_ceiling(engine):
+        _prior_supplied = _prior_pre_cap
+    else:
+        _prior_supplied = getattr(engine, "context_length", None) or _prior_pre_cap
+    _prior_model = getattr(engine, "model", None)
+    _prior_provider = getattr(engine, "provider", None)
+    _prior_base_url = getattr(engine, "base_url", None)
+    _prior_api_key = getattr(engine, "api_key", None)
+    _prior_api_mode = getattr(engine, "api_mode", None)
+
+    # Always run the transition — no skip-if-effective-unchanged.
+    # A model/provider/credential change must reach update_model even when
+    # the effective integer is identical.
+    try:
+        engine.update_model(
+            model=_m,
+            context_length=supplied,
+            base_url=_bu,
+            api_key=_ak,
+            provider=_pv,
+            api_mode=_am,
+        )
+    except Exception as _transition_exc:
+        # Preferred rollback: re-apply the PRIOR route through update_model
+        # so the plugin recomputes ALL derived state from the prior route.
+        #
+        # ``rollback_via_lifecycle=False`` (used by the primary-runtime RESTORE
+        # path) skips the extra update_model call: that path is expected to be
+        # RETRIED by the caller on a transient failure (see
+        # test_restore_retry_preserves_fallback_identity_after_partial_failure),
+        # and a lifecycle rollback would consume a second update_model() call
+        # per failed attempt — breaking the retry contract (each restore
+        # attempt must make exactly ONE update_model() call). For the built-in
+        # engine the setattr route-restore below is semantically complete
+        # because its ``context_length`` setter re-derives thresholds/budgets.
+        if rollback_via_lifecycle:
+            _rollback_failed = None
+            try:
+                engine.update_model(
+                    model=_prior_model,
+                    context_length=_prior_supplied,
+                    base_url=_prior_base_url,
+                    api_key=_prior_api_key,
+                    provider=_prior_provider,
+                    api_mode=_prior_api_mode,
+                )
+            except Exception as _rollback_exc:
+                # Rollback through the contract itself failed. Last resort: put
+                # the six route fields back so the engine is not left on the
+                # NEW model paired with the prior route — but this does NOT
+                # restore derived state, so we must surface the partial
+                # restoration loudly.
+                for _attr, _val in (
+                    ("model", _prior_model),
+                    ("provider", _prior_provider),
+                    ("base_url", _prior_base_url),
+                    ("api_key", _prior_api_key),
+                    ("api_mode", _prior_api_mode),
+                    ("context_length", _prior_supplied),
+                ):
+                    if _val is not None:
+                        try:
+                            setattr(engine, _attr, _val)
+                        except Exception:
+                            pass
+                _rollback_failed = _rollback_exc
+            if _rollback_failed is not None:
+                # Do NOT claim coherence: the engine's derived state may still
+                # be on the new model's values. Surface this clearly.
+                logger.error(
+                    "transition_model_context: engine route rollback INCOMPLETE — "
+                    "re-applying the prior route via update_model failed (%s) and "
+                    "only the six route fields were restored; engine derived state "
+                    "(thresholds/budgets/accounting) may be inconsistent. Original "
+                    "transition failure: %s",
+                    _rollback_failed,
+                    _transition_exc,
+                )
+        else:
+            # Restore path: put the six route fields back via setattr. This is
+            # exactly ONE update_model() call (the forward one) per attempt,
+            # so the caller's retry contract holds. For the built-in engine the
+            # context_length setter re-derives thresholds/budgets, so derived
+            # state is coherent; for a plugin this is the documented last-resort
+            # route-restore, surfaced as a warning (never claimed as full
+            # coherence).
+            for _attr, _val in (
+                ("model", _prior_model),
+                ("provider", _prior_provider),
+                ("base_url", _prior_base_url),
+                ("api_key", _prior_api_key),
+                ("api_mode", _prior_api_mode),
+                ("context_length", _prior_supplied),
+            ):
+                if _val is not None:
+                    try:
+                        setattr(engine, _attr, _val)
+                    except Exception:
+                        pass
+            logger.warning(
+                "transition_model_context: transition failed; restored the six "
+                "route fields via setattr (lifecycle rollback skipped per "
+                "rollback_via_lifecycle=False). Engine derived state may be on "
+                "the new model's values. Original transition failure: %s",
+                _transition_exc,
+            )
+        raise
+
+    # Host pre-cap = the ACTIVE model's pre-cap. Set only AFTER a successful
+    # transition, and only when the caller hasn't deferred the commit.
+    if commit_host_precap:
+        agent._pre_cap_context_length = pre_cap
+    return supplied
+
+
+def refresh_context_window(
+    agent,
+    pre_cap: int,
+    *,
+    model: Optional[str] = None,
+) -> int:
+    """SAME-MODEL CONTEXT-WINDOW REFRESH: recalc derived state for the window.
+
+    Use when the ACTIVE model is unchanged but its context window changed —
+    Codex app-server re-reports the provider window on each response, Anthropic
+    long-context tier reduction (1M → 200K), provider-reported limit correction.
+    This is NOT a model/provider lifecycle transition and must not masquerade
+    as one: it recalculates context-derived thresholds/budgets from the new
+    window while PRESERVING freshly recorded token accounting.
+
+    Dispatch: on the stable ``_handles_context_ceiling is True`` marker.
+      * Built-in (marker): route through the ``context_length`` SETTER, which
+        stores the raw pre-cap, derives effective = min(raw, ceiling), and
+        recalculates threshold/budget — WITHOUT zeroing last_*_tokens or the
+        other calibration fields that ``update_model()`` resets. So accounting
+        recorded by the just-completed ``update_from_response()`` survives.
+      * Generic plugin (no marker): call ``update_model()`` to recalculate
+        threshold/budget from the EFFECTIVE window (a bare attribute write would
+        leave its derived state on the old window). A plugin MAY legitimately
+        reset accounting in ``update_model()``; the caller that just recorded
+        fresh accounting (the Codex path) therefore records it AFTER this call,
+        so it is not erased.
+
+    The host pre-cap is set to ``pre_cap`` (the active model's new pre-cap).
+
+    ``pre_cap`` is the window BEFORE the ceiling. The ceiling only lowers it.
+
+    Returns the value actually supplied to the engine.
+    """
+    engine = getattr(agent, "context_compressor", None)
+    if engine is None:
+        agent._pre_cap_context_length = pre_cap
+        return pre_cap
+
+    _m = model if model is not None else getattr(agent, "model", "")
+
+    if _engine_handles_ceiling(engine):
+        # Built-in: the setter preserves accounting while recalculating.
+        supplied = pre_cap
+        engine.context_length = pre_cap
+    else:
+        # Generic plugin: recalc threshold/budget from the effective window.
+        # Route through transition_model_context (which has engine
+        # snapshot/rollback) so a failed update_model() that mutated derived
+        # state is rolled back via the plugin's OWN lifecycle — never leaving
+        # the engine half-transitioned.  The host pre-cap (L609 below) is only
+        # committed after this returns, so the host stays consistent.
+        supplied = _engine_effective_window(agent, pre_cap)
+        cur = getattr(engine, "context_length", 0)
+        if not (isinstance(cur, int) and cur == supplied):
+            # Model unchanged; skip only when the window is genuinely identical
+            # (a no-op that would needlessly invalidate derived budgets).
+            transition_model_context(
+                agent,
+                pre_cap,
+                model=_m,
+                commit_host_precap=False,  # host pre-cap committed at L609
+            )
+
+    agent._pre_cap_context_length = pre_cap
+    return supplied
 
 logger = logging.getLogger(__name__)
 
@@ -1725,6 +2342,7 @@ def restore_primary_runtime(agent) -> bool:
     agent._restore_wait_logged = False
 
     rt = agent._primary_runtime
+    # ── Upstream: record the fallback identity being left ──
     fallback_route = getattr(agent, "_provider_fallback_route", None)
     if (
         isinstance(fallback_route, (list, tuple))
@@ -1738,6 +2356,34 @@ def restore_primary_runtime(agent) -> bool:
     provider_fallback_active = bool(
         getattr(agent, "_provider_fallback_active", False)
     )
+    # ── Feature: lifecycle atomicity snapshot (Finding #4) ──
+    # Snapshot the CURRENT host route (the fallback's state) before the commit
+    # region mutates it. If the transition_model_context call (or any commit
+    # step) raises, the except handler restores this snapshot so the agent is
+    # left on the fallback in a coherent state — not half-mutated toward the
+    # primary.
+    _restore_snap = {
+        "model": agent.model,
+        "provider": agent.provider,
+        "requested_provider": getattr(agent, "requested_provider", None),
+        "base_url": agent.base_url,
+        "api_mode": agent.api_mode,
+        "api_key": getattr(agent, "api_key", None),
+        "client": getattr(agent, "client", None),
+        "_anthropic_client": getattr(agent, "_anthropic_client", None),
+        "_anthropic_api_key": getattr(agent, "_anthropic_api_key", None),
+        "_anthropic_base_url": getattr(agent, "_anthropic_base_url", None),
+        "_is_anthropic_oauth": getattr(agent, "_is_anthropic_oauth", None),
+        "_client_kwargs": dict(getattr(agent, "_client_kwargs", {}) or {}),
+        "_config_context_length": getattr(agent, "_config_context_length", None),
+        "_reasoning_echo_flag": getattr(agent, "_reasoning_echo_flag", None),
+        "_credential_pool": getattr(agent, "_credential_pool", None),
+        "_credential_pool_entry_id": getattr(agent, "_credential_pool_entry_id", None),
+        "_fallback_activated": getattr(agent, "_fallback_activated", None),
+        "_use_prompt_caching": getattr(agent, "_use_prompt_caching", None),
+        "_use_native_cache_layout": getattr(agent, "_use_native_cache_layout", None),
+        "_pre_cap_context_length": getattr(agent, "_pre_cap_context_length", None),
+    }
     try:
         # ── Core runtime state ──
         agent.model = rt["model"]
@@ -1806,14 +2452,34 @@ def restore_primary_runtime(agent) -> bool:
             )
 
         # ── Restore context engine state ──
-        cc = agent.context_compressor
-        cc.update_model(
-            model=rt["compressor_model"],
-            context_length=rt["compressor_context_length"],
-            base_url=rt["compressor_base_url"],
-            api_key=rt["compressor_api_key"],
-            provider=rt["compressor_provider"],
-            api_mode=rt.get("compressor_api_mode", ""),
+        # The snapshot's compressor_context_length holds the PRIMARY's PRE-CAP
+        # operating window (captured via get_pre_cap before the fallback
+        # overwrote it). Route it through the shared helper so the built-in
+        # receives the raw value (setter re-derives effective against the
+        # current ceiling) and a plugin receives the effective value via
+        # update_model (recalculating threshold/budget). The host re-retains
+        # the raw pre-cap.
+        # MODEL LIFECYCLE TRANSITION: restore the PRIMARY model. The snapshot's
+        # compressor_context_length holds the PRIMARY's pre-cap (captured via
+        # get_pre_cap before the fallback overwrote the host). transition_model_context
+        # sets the host pre-cap back to the primary's (active again) and always
+        # runs update_model so a plugin re-tracks the primary's model/provider
+        # state even when the effective integer is unchanged. A failed
+        # transition propagates to the restore transaction so the agent is
+        # never left with the fallback committed but the primary transition
+        # half-applied.
+        transition_model_context(
+            agent, rt["compressor_context_length"], model=rt["compressor_model"],
+            commit_host_precap=False,
+            rollback_via_lifecycle=False,
+        )
+        # The restore owns the host-pre-cap commit atomically: the snapshot's
+        # pre-cap (captured via get_pre_cap before the fallback overwrote the
+        # host) is restored together with the other host fields by the outer
+        # except-handler snapshot if a later commit step fails — so the
+        # transition must not commit it half-way through the transaction.
+        agent._pre_cap_context_length = rt.get(
+            "_pre_cap_context_length", rt["compressor_context_length"],
         )
 
         # ── Rebind and re-select the primary credential pool ──
@@ -1896,12 +2562,32 @@ def restore_primary_runtime(agent) -> bool:
                     # ``_swap_credential`` rebuilds the OpenAI/Anthropic client,
                     # reapplies base-url-scoped headers, and carries the
                     # accumulated base_url / OAuth-detection fixes (#33163).
-                    agent._swap_credential(entry)
-                    logger.info(
-                        "Restore re-selected pool entry %s (%s)",
-                        getattr(entry, "id", "?"),
-                        getattr(entry, "label", "?"),
-                    )
+                    #
+                    # Lifecycle atomicity (Finding #4): this swap happens
+                    # AFTER ``transition_model_context`` has already committed
+                    # the engine to the PRIMARY route. If the swap raises and
+                    # propagates to the outer ``except``, that handler rolls the
+                    # HOST back to the fallback snapshot while the ENGINE stays
+                    # on primary — an incoherent host≠engine state. The swap
+                    # is therefore NON-FATAL: on failure we keep the snapshot
+                    # api_key (the documented fallback, #25205), log loudly, and
+                    # let the restore complete with the host on primary —
+                    # coherent with the already-committed engine.
+                    try:
+                        agent._swap_credential(entry)
+                    except Exception as _swap_exc:
+                        logger.warning(
+                            "Restore primary credential swap failed; keeping "
+                            "snapshot api_key (host+engine stay coherent on "
+                            "primary): %s", _swap_exc,
+                            exc_info=True,
+                        )
+                    else:
+                        logger.info(
+                            "Restore re-selected pool entry %s (%s)",
+                            getattr(entry, "id", "?"),
+                            getattr(entry, "label", "?"),
+                        )
                 elif entry_key:
                     logger.info(
                         "Restore skipped pool entry %s (%s): provider %s does not match primary provider %s",
@@ -1952,6 +2638,23 @@ def restore_primary_runtime(agent) -> bool:
                 pass
         return True
     except Exception as e:
+        # Lifecycle atomicity: the commit region had already mutated the host
+        # route toward the primary. If the transition
+        # (or any later commit step) failed, restore the fallback's coherent
+        # host state so the agent is not left half-mutated. The engine's own
+        # route was either restored by transition_model_context's snapshot
+        # (if the failure was in the transition) or was never mutated (if the
+        # failure was in a later commit step).
+        for _name, _val in _restore_snap.items():
+            try:
+                setattr(agent, _name, _val)
+            except Exception:
+                pass
+        if hasattr(agent, "_transport_cache"):
+            try:
+                agent._transport_cache.clear()
+            except Exception:
+                pass
         logger.warning("Failed to restore primary runtime: %s", e)
         return False
 
@@ -3011,6 +3714,7 @@ def switch_model(
             "_config_context_length",
             "_reasoning_echo_flag",
             "runtime_capabilities",
+            "_pre_cap_context_length",
         )
     }
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
@@ -3209,84 +3913,98 @@ def switch_model(
         raise
 
     # ── LM Studio: preload before probing context length ──
+    # This phase sits BETWEEN the client-rebuild try/except (above) and the
+    # engine-transition try/except (below).  A failure here — most commonly a
+    # network error / HTTP error from the LM Studio management API inside
+    # ``_ensure_lmstudio_runtime_loaded`` (a real I/O call) — must roll the
+    # host route back to its pre-swap state: the host route was already
+    # committed above (model/provider/client), but the engine pre-cap and
+    # ``_primary_runtime`` are only updated AFTER this phase, so without this
+    # rollback the agent is left with a NEW model/provider/client paired with
+    # the OLD engine window and OLD ``_primary_runtime`` — the exact
+    # incoherence the switch_model rollback exists to prevent.
     _sm_custom_providers = None
     try:
-        from hermes_cli.config import (
-            get_compatible_custom_providers,
-            get_custom_provider_context_length,
-            load_config,
-        )
-
-        _sm_cfg = load_config()
-        _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
-        _destination_context_intent = get_custom_provider_context_length(
-            model=agent.model,
-            base_url=agent.base_url,
-            custom_providers=_sm_custom_providers,
-        )
-    except Exception:
-        _destination_context_intent = None
-    agent._config_context_length = _destination_context_intent
-    if hasattr(agent, "_ensure_lmstudio_runtime_loaded"):
         try:
-            _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
-                _destination_context_intent
+            from hermes_cli.config import (
+                get_compatible_custom_providers,
+                get_custom_provider_context_length,
+                load_config,
+            )
+
+            _sm_cfg = load_config()
+            _sm_custom_providers = get_compatible_custom_providers(_sm_cfg)
+            _destination_context_intent = get_custom_provider_context_length(
+                model=agent.model,
+                base_url=agent.base_url,
+                custom_providers=_sm_custom_providers,
             )
         except Exception:
-            _restore_snapshot()
-            raise
-    else:
-        _runtime_context_length = None
-    if (
-        hasattr(agent, "_lmstudio_load_was_unverified")
-        and agent._lmstudio_load_was_unverified(_runtime_context_length)
-    ):
-        logger.warning(
-            "LM Studio model activation was rejected or completed without a "
-            "verifiable active context length during model switch; continuing "
-            "with configured context"
+            _destination_context_intent = None
+        agent._config_context_length = _destination_context_intent
+        _runtime_context_length = agent._ensure_lmstudio_runtime_loaded(
+            _destination_context_intent
         )
-    if hasattr(agent, "_effective_lmstudio_context_length"):
+        if agent._lmstudio_load_was_unverified(_runtime_context_length):
+            logger.warning(
+                "LM Studio model activation was rejected or completed without a "
+                "verifiable active context length during model switch; continuing "
+                "with configured context"
+            )
         _effective_context_length = agent._effective_lmstudio_context_length(
             _destination_context_intent,
             _runtime_context_length,
         )
-    else:
-        _effective_context_length = _destination_context_intent
+    except Exception:
+        # Roll back every mutated field to the pre-swap snapshot (see the
+        # Window A rollback above for the full rationale); re-raise so the
+        # caller surfaces a meaningful warning.
+        _restore_snapshot()
+        raise
 
-    # ── Re-evaluate prompt caching ──
-    # Refresh the custom-provider snapshot from the config just loaded above
-    # so the per-model ``prompt_caching`` capability lookup sees the same
-    # live list the context-length resolution used — without this, a flag
-    # added to config.yaml after session start is invisible to a /model
-    # switch (the policy would read the stale init-time snapshot).
-    if _sm_custom_providers is not None:
-        agent._custom_providers = _sm_custom_providers
-    agent._use_prompt_caching, agent._use_native_cache_layout = (
-        agent._anthropic_prompt_cache_policy(
-            provider=new_provider,
-            base_url=agent.base_url,
-            api_mode=api_mode,
-            model=new_model,
+    # ── Post-client / pre-finalized region: one rollback transaction ──
+    # This entire region (prompt-cache policy → context/capability resolution
+    # → engine transition → final pre-cap commit) sits AFTER the host route
+    # has been committed in Window A (model/provider/client/api_key/
+    # _client_kwargs) and BEFORE the engine and _primary_runtime are
+    # finalized.  An exception from ANY source in this region must roll the
+    # host route back to its prior coherent state — the agent must not be
+    # left with a new model/provider/client paired with the old engine route
+    # or old _primary_runtime.
+    try:
+        # ── Re-evaluate prompt caching ──
+        # Refresh the custom-provider snapshot from the config just loaded
+        # above so the per-model ``prompt_caching`` capability lookup sees
+        # the same live list the context-length resolution used — without
+        # this, a flag added to config.yaml after session start is invisible
+        # to a /model switch (the policy would read the stale init-time
+        # snapshot).
+        if _sm_custom_providers is not None:
+            agent._custom_providers = _sm_custom_providers
+        agent._use_prompt_caching, agent._use_native_cache_layout = (
+            agent._anthropic_prompt_cache_policy(
+                provider=new_provider,
+                base_url=agent.base_url,
+                api_mode=api_mode,
+                model=new_model,
+            )
         )
-    )
 
-    # ── Update context compressor ──
-    if hasattr(agent, "context_compressor") and agent.context_compressor:
-        from agent.model_metadata import get_model_context_length
-        if _sm_custom_providers is None:
-            try:
-                from hermes_cli.config import get_compatible_custom_providers, load_config
-                _sm_custom_providers = get_compatible_custom_providers(load_config())
-            except Exception:
-                _sm_custom_providers = None
-        # ``agent.api_key`` may be a callable (Azure Foundry Entra ID
-        # token provider). ``get_model_context_length`` expects a
-        # string for its live-probe paths; for Foundry the context
-        # length normally resolves via config or static catalogs and
-        # never hits a probe, but coerce to empty string defensively.
-        _ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
-        try:
+        # ── Update context compressor ──
+        if hasattr(agent, "context_compressor") and agent.context_compressor:
+            from agent.model_metadata import get_model_context_length
+            if _sm_custom_providers is None:
+                try:
+                    from hermes_cli.config import get_compatible_custom_providers, load_config
+                    _sm_custom_providers = get_compatible_custom_providers(load_config())
+                except Exception:
+                    _sm_custom_providers = None
+            # ``agent.api_key`` may be a callable (Azure Foundry Entra ID
+            # token provider). ``get_model_context_length`` expects a
+            # string for its live-probe paths; for Foundry the context
+            # length normally resolves via config or static catalogs and
+            # never hits a probe, but coerce to empty string defensively.
+            _ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
             new_context_length = get_model_context_length(
                 agent.model,
                 base_url=agent.base_url,
@@ -3295,17 +4013,27 @@ def switch_model(
                 config_context_length=_effective_context_length,
                 custom_providers=_sm_custom_providers,
             )
-            agent.context_compressor.update_model(
-                model=agent.model,
-                context_length=new_context_length,
-                base_url=agent.base_url,
-                api_key=agent.api_key,  # context_compressor forwards to call_llm; callable preserved
-                provider=agent.provider,
-                api_mode=agent.api_mode,
-            )
-        except Exception:
-            _restore_snapshot()
-            raise
+            # Route through the shared host helper: built-in receives the raw value
+            # (setter derives effective + preserves pre-cap), plugin receives the
+            # effective value via update_model (recalc threshold/budget). The host
+            # retains the raw pre-cap for snapshot/restore.
+            # MODEL LIFECYCLE TRANSITION: /model switch to a new model. transition_model_context
+            # always runs update_model so a plugin re-tracks the new model/provider/
+            # credential state even when the effective integer is unchanged,
+            # sets the host pre-cap to the new model's window,
+            # and propagates any engine failure to the switch transaction
+            # — the pre-feature baseline semantics.
+            #
+            # Lifecycle atomicity: the host route (model,
+            # provider, client, api_key, _client_kwargs) was already committed
+            # above. If the engine transition fails, we must restore the host
+            # route to its prior state — the agent must not be left with a new
+            # client + old engine. The engine's own route is restored by
+            # transition_model_context's snapshot/restore.
+            transition_model_context(agent, new_context_length, model=agent.model)
+    except Exception:
+        _restore_snapshot()
+        raise
 
     # ── Re-resolve reasoning_config from per-model override ──
     # The new model may have a different reasoning_effort override. Re-read
@@ -3364,7 +4092,11 @@ def switch_model(
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",
         "compressor_provider": getattr(_cc, "provider", agent.provider) if _cc else agent.provider,
-        "compressor_context_length": _cc.context_length if _cc else 0,
+        # PRE-CAP operating window (host-retained), NOT the capped getter:
+        # restore feeds this back through transition_model_context which re-derives
+        # the effective value against the ceiling. Storing the capped getter
+        # here would lose the raw pre-cap on the restore round trip.
+        "compressor_context_length": get_pre_cap(agent) if _cc else 0,
         "compressor_api_mode": getattr(_cc, "api_mode", agent.api_mode) if _cc else agent.api_mode,
         "compressor_threshold_tokens": _cc.threshold_tokens if _cc else 0,
     }

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -163,8 +163,28 @@ def aux_probe_mode():
 from agent.credential_pool import load_pool
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
+    ContextCeilingExceeded,
     get_model_context_length,
     strip_codex_context_variant_suffix as _strip_codex_ctx_variant,
+    # Ceiling contextvar API — re-exported so tests / callers can publish the
+    # auxiliary effective ceiling and the relay-helper gates read it.
+    set_aux_ceiling,
+    get_aux_ceiling,
+    reset_aux_ceiling,
+)
+# Auxiliary context-ceiling authority now lives in the bounded owner shard
+# ``agent.auxiliary_context_ceiling`` (#78635 fracture).  These four names are
+# re-imported so historical import paths AND monkeypatch targets keep working:
+# the relay helpers and fallback dispatchers below still CONSUME these names,
+# and they resolve through THIS module's globals — so patching
+# ``agent.auxiliary_client._aux_provider_callback`` (etc.) still affects the
+# live path.  There is exactly one implementation of each (in the shard); this
+# is a compatibility re-export, not a second copy of the authority.
+from agent.auxiliary_context_ceiling import (
+    _aux_relay_gate,
+    _aux_provider_callback,
+    _rebind_aux_ceiling_for_fallback,
+    _rebind_aux_ceiling_for_fallback_async,
 )
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -1063,7 +1083,6 @@ def _get_aux_model_for_provider(provider_id: str, *, prefer_fast: bool = False) 
     if profile is not None and profile.default_aux_model:
         return profile.default_aux_model
     return _API_KEY_PROVIDER_AUX_MODELS_FALLBACK.get(provider_id, "")
-
 
 
 # Fallback for providers not yet migrated to ProviderProfile.default_aux_model,
@@ -3555,7 +3574,14 @@ def _relay_sync_completion(
     api_mode: str | None = None,
     create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
-    callback = create or (lambda request: client.chat.completions.create(**request))
+    _aux_relay_gate(
+        kwargs, provider=provider, model=str(kwargs.get("model") or "") or None
+    )
+    callback = _aux_provider_callback(
+        create or (lambda request: client.chat.completions.create(**request)),
+        provider=provider,
+        model=str(kwargs.get("model") or "") or None,
+    )
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     # Protected compression calls isolate only the provider callback and stream
     # aggregation.  The owning thread remains free to unwind its lease/DB
@@ -3583,7 +3609,14 @@ async def _relay_async_completion(
     api_mode: str | None = None,
     create: Callable[[dict[str, Any]], Any] | None = None,
 ) -> Any:
-    callback = create or (lambda request: client.chat.completions.create(**request))
+    _aux_relay_gate(
+        kwargs, provider=provider, model=str(kwargs.get("model") or "") or None
+    )
+    callback = _aux_provider_callback(
+        create or (lambda request: client.chat.completions.create(**request)),
+        provider=provider,
+        model=str(kwargs.get("model") or "") or None,
+    )
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
         return await callback(kwargs)
@@ -3607,15 +3640,25 @@ def _relay_sync_stream(
     provider: str | None = None,
     api_mode: str | None = None,
 ) -> Any:
+    _stream_model = str(kwargs.get("model") or "") or None
+    _aux_relay_gate(kwargs, provider=provider, model=_stream_model)
     route = _relay_auxiliary_metadata(provider=provider, api_mode=api_mode)
     if route is None:
-        return client.chat.completions.create(**kwargs)
+        return _aux_provider_callback(
+            lambda request: client.chat.completions.create(**request),
+            provider=provider,
+            model=_stream_model,
+        )(kwargs)
     provider_name, fallback_model, metadata = route
     from agent import relay_llm
 
     return relay_llm.stream_current(
         kwargs,
-        lambda request: client.chat.completions.create(**request),
+        _aux_provider_callback(
+            lambda request: client.chat.completions.create(**request),
+            provider=provider,
+            model=_stream_model,
+        ),
         name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
         finalizer=dict,
@@ -5444,24 +5487,26 @@ def _call_fallback_candidate_sync(
         fb_kwargs.update(
             auxiliary_max_tokens_param(fallback_max_tokens, model=destination.model)
         )
+    _fb_api_key = _fallback_entry_api_key(fallback_entry) or ""
     try:
-        return _validate_llm_response(
-            _relay_sync_completion(
-                fb_client,
-                fb_kwargs,
-                provider=destination.provider,
-                api_mode=destination.api_mode,
-                create=lambda request: _create_with_progress(
+        with _rebind_aux_ceiling_for_fallback(destination, api_key=_fb_api_key):
+            return _validate_llm_response(
+                _relay_sync_completion(
                     fb_client,
-                    request,
-                    task,
-                    force_stream=_provider_requires_stream(
-                        destination.provider, destination.base_url
+                    fb_kwargs,
+                    provider=destination.provider,
+                    api_mode=destination.api_mode,
+                    create=lambda request: _create_with_progress(
+                        fb_client,
+                        request,
+                        task,
+                        force_stream=_provider_requires_stream(
+                            destination.provider, destination.base_url
+                        ),
                     ),
                 ),
-            ),
-            task,
-        )
+                task,
+            )
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
             raise
@@ -5515,24 +5560,27 @@ def _call_fallback_candidate_sync(
                         )
                     )
                 try:
-                    return _validate_llm_response(
-                        _relay_sync_completion(
-                            retry_client,
-                            retry_kwargs,
-                            provider=retry_destination.provider,
-                            api_mode=retry_destination.api_mode,
-                            create=lambda request: _create_with_progress(
+                    with _rebind_aux_ceiling_for_fallback(
+                        retry_destination, api_key=_fb_api_key
+                    ):
+                        return _validate_llm_response(
+                            _relay_sync_completion(
                                 retry_client,
-                                request,
-                                task,
-                                force_stream=_provider_requires_stream(
-                                    retry_destination.provider,
-                                    retry_destination.base_url,
+                                retry_kwargs,
+                                provider=retry_destination.provider,
+                                api_mode=retry_destination.api_mode,
+                                create=lambda request: _create_with_progress(
+                                    retry_client,
+                                    request,
+                                    task,
+                                    force_stream=_provider_requires_stream(
+                                        retry_destination.provider,
+                                        retry_destination.base_url,
+                                    ),
                                 ),
                             ),
-                        ),
-                        task,
-                    )
+                            task,
+                        )
                 except Exception as retry_err:
                     if not _is_auth_error(retry_err):
                         raise
@@ -5584,16 +5632,26 @@ async def _call_fallback_candidate_async(
         tools=fallback_tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
         base_url=destination.base_url, task=task)
+    # The async mirror does not retain the configured-chain entry (the sync
+    # path does) — resolve the credential from the same helper the sync path
+    # uses, via the task/label chain entry lookup.  Best-effort: when no
+    # configured entry exists the key resolves to "" and the resolver falls
+    # back to the endpoint's own credentials.
+    _fb_entry = _fallback_chain_entry(task, fb_label) or {}
+    _fb_api_key = _fallback_entry_api_key(_fb_entry) or ""
     try:
-        return _validate_llm_response(
-            await _relay_async_completion(
-                fb_client,
-                fb_kwargs,
-                provider=destination.provider,
-                api_mode=destination.api_mode,
-            ),
-            task,
-        )
+        async with _rebind_aux_ceiling_for_fallback_async(
+            destination, api_key=_fb_api_key
+        ):
+            return _validate_llm_response(
+                await _relay_async_completion(
+                    fb_client,
+                    fb_kwargs,
+                    provider=destination.provider,
+                    api_mode=destination.api_mode,
+                ),
+                task,
+            )
     except Exception as fb_err:
         if not _is_auth_error(fb_err):
             raise
@@ -5631,15 +5689,18 @@ async def _call_fallback_candidate_async(
                     reasoning_config=reasoning_config,
                     base_url=retry_destination.base_url, task=task)
                 try:
-                    return _validate_llm_response(
-                        await _relay_async_completion(
-                            retry_client,
-                            retry_kwargs,
-                            provider=retry_destination.provider,
-                            api_mode=retry_destination.api_mode,
-                        ),
-                        task,
-                    )
+                    async with _rebind_aux_ceiling_for_fallback_async(
+                        retry_destination, api_key=_fb_api_key
+                    ):
+                        return _validate_llm_response(
+                            await _relay_async_completion(
+                                retry_client,
+                                retry_kwargs,
+                                provider=retry_destination.provider,
+                                api_mode=retry_destination.api_mode,
+                            ),
+                            task,
+                        )
                 except Exception as retry_err:
                     if not _is_auth_error(retry_err):
                         raise
@@ -9720,6 +9781,7 @@ def call_llm(
         latency_info["queue_wait_ms"] = max(
             0, int((request_started_at - queue_started_at) * 1000)
         )
+    _ceiling_scope: Dict[str, Any] = {"token": None}
     prior_progress_hook = getattr(_aux_progress, "hook", None)
 
     def _timed_response() -> None:
@@ -9763,6 +9825,7 @@ def call_llm(
                 stream=stream,
                 stream_options=stream_options,
                 route_info=route_info,
+                ceiling_scope=_ceiling_scope,
             )
         if stream and semaphore is not None:
             stream_semaphore = semaphore
@@ -9770,6 +9833,12 @@ def call_llm(
             return _release_sync_semaphore_after_stream(response, stream_semaphore)
         return response
     finally:
+        # Reset the auxiliary ceiling so it is not left ambient after return
+        # or exception. The impl retains the ContextVar token in the scope
+        # when it publishes the ceiling; the owner resets it here so nested
+        # or sequential calls never inherit a stale ceiling.
+        if _ceiling_scope["token"] is not None:
+            reset_aux_ceiling(_ceiling_scope["token"])
         if latency_info is not None:
             latency_info["summary_generation_ms"] = max(
                 0, int((time.monotonic() - request_started_at) * 1000)
@@ -9813,6 +9882,7 @@ def _call_llm_impl(
     stream: bool = False,
     stream_options: dict = None,
     route_info: Optional[Dict[str, str]] = None,
+    ceiling_scope: Optional[Dict[str, Any]] = None,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -10003,6 +10073,41 @@ def _call_llm_impl(
     if _is_anthropic_compat_endpoint(request_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
 
+    # ── Hard-ceiling gate for ALL auxiliary dispatch ──────────────────
+    # ``call_llm`` is the single shared provider-owning transport behind
+    # every auxiliary path. Compute this invocation's ceiling (effective
+    # window of the resolved auxiliary model — raw capability clamped
+    # downward by the profile ceiling) and PUBLISH it in a contextvar;
+    # the three relay helpers (the physical owner — the actual
+    # ``client.chat.completions.create`` calls) read it and enforce the
+    # transport-normalized budget on the FINAL payload. A refusal raises
+    # the TYPED ``ContextCeilingExceeded`` (NOT wrapped in ``RuntimeError``)
+    # so the auxiliary catch-all chain classifies it as a local ceiling
+    # refusal: no fallback, no credential-refresh retry.
+    from agent.model_metadata import (
+        effective_context_length as _aux_ecl,
+        set_aux_ceiling as _set_aux_ceiling,
+        build_final_context_budget as _build_aux_budget,
+        enforce_final_context_budget as _aux_enforce,
+    )
+    try:
+        _aux_limit = _aux_ecl(
+            model=str(final_model or ""),
+            base_url=str(resolved_base_url or _base_info or ""),
+            api_key=api_key or "",
+            provider=str(request_provider or ""),
+        )
+    except Exception:
+        _aux_limit = None
+    if _aux_limit is not None:
+        # Publish the invocation ceiling and retain the ContextVar token in
+        # the owner's scope so the owner resets it in its finally. This keeps
+        # the ceiling scoped to THIS invocation: nested/sequential calls each
+        # publish their own and reset to the prior value on return.
+        _aux_token = _set_aux_ceiling(_aux_limit)
+        if ceiling_scope is not None:
+            ceiling_scope["token"] = _aux_token
+
     # Streaming path: return the raw SDK Stream iterator directly. This is used by
     # the MoA aggregator so its tokens stream to the user. It deliberately skips
     # _validate_llm_response and the temperature/max_tokens/payment fallback chain
@@ -10024,6 +10129,19 @@ def _call_llm_impl(
             # Return the provider call directly; the MoA facade converts a
             # completed response into a one-chunk delta iterator at its
             # boundary.
+            # ── Ceiling gate (aggregator streaming bypass) ─────────────
+            # This path skips the relay helpers (the physical owner), so
+            # enforce here directly, immediately before the physical I/O.
+            if _aux_limit is not None:
+                _aux_enforce(
+                    _build_aux_budget(
+                        kwargs,
+                        provider=str(request_provider or "") or None,
+                        model=str(final_model or "") or None,
+                    ),
+                    ceiling=_aux_limit,
+                    reason=f"auxiliary {task or 'call'}",
+                )
             return client.chat.completions.create(**kwargs)
         return _relay_sync_stream(
             client,
@@ -10069,6 +10187,13 @@ def _call_llm_impl(
                 ),
                 task,
                 provider=request_provider, base_url=_base_info)
+        except ContextCeilingExceeded:
+            # Terminal by type — never a transient transport blip. Raising here
+            # (before the ``except Exception as transient_err`` handler) makes
+            # the refusal independent of _is_transient_transport_error's current
+            # behaviour: a ceiling refusal must never enter the same-provider
+            # retry loop, regardless of what the retry predicate matches.
+            raise
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
@@ -10122,6 +10247,13 @@ def _call_llm_impl(
                     _last_transient = retry_transient
             # Retries exhausted — fall through to first_err fallback handling.
             raise _last_transient
+    except ContextCeilingExceeded:
+        # A LOCAL ceiling refusal is terminal by type: it is not a transport
+        # blip, not a credential problem, and not a provider 400 — the request
+        # was rejected before any provider I/O. It must NEVER be retried on the
+        # same provider, used to trigger a credential refresh, or escalated to a
+        # fallback candidate (a second provider call would just re-refuse).
+        raise
     except Exception as first_err:
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
@@ -10657,6 +10789,7 @@ async def async_call_llm(
     route_info: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Run an asynchronous auxiliary LLM request under the configured limit."""
+    _ceiling_scope: Dict[str, Any] = {"token": None}
     semaphore = _acquire_async_aux_semaphore(task)
     if semaphore is not None:
         await semaphore.acquire()
@@ -10676,8 +10809,16 @@ async def async_call_llm(
             extra_body=extra_body,
             reasoning_config=reasoning_config,
             route_info=route_info,
+            ceiling_scope=_ceiling_scope,
         )
     finally:
+        # Reset the auxiliary ceiling so it is not left ambient after return or
+        # exception. The impl retains the ContextVar token in the scope when it
+        # publishes the ceiling; the owner resets it here so nested /
+        # concurrent calls each see their own ceiling (ContextVars are
+        # per-context, and the reset restores the prior value).
+        if _ceiling_scope["token"] is not None:
+            reset_aux_ceiling(_ceiling_scope["token"])
         if semaphore is not None:
             semaphore.release()
 
@@ -10698,6 +10839,7 @@ async def _async_call_llm_impl(
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
     route_info: Optional[Dict[str, str]] = None,
+    ceiling_scope: Optional[Dict[str, Any]] = None,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
@@ -10798,6 +10940,33 @@ async def _async_call_llm_impl(
         route_info, _fallback_provider_from_label(request_provider), final_model
     )
 
+    # ── Auxiliary effective-ceiling publication (mirrors the sync owner) ─────
+    # Resolve the invocation-specific effective ceiling (model context clamped
+    # by the profile ceiling), publish it to the ContextVar the relay-helper
+    # gates read, and retain the token in the owner's scope so the owner
+    # resets it in its finally. Without this the async path never publishes a
+    # ceiling, so an oversized request is never refused and the provider is
+    # called physically (Round 5 finding #1). The ceiling is terminal by type:
+    # the relay-helper gate raises ContextCeilingExceeded, which the except
+    # chain below re-raises without retry/fallback/credential-refresh.
+    from agent.model_metadata import (
+        effective_context_length as _aux_ecl_async,
+        set_aux_ceiling as _set_aux_ceiling_async,
+    )
+    try:
+        _aux_limit_async = _aux_ecl_async(
+            model=str(final_model or ""),
+            base_url=str(resolved_base_url or getattr(client, "base_url", "") or ""),
+            api_key=api_key or "",
+            provider=str(request_provider or ""),
+        )
+    except Exception:
+        _aux_limit_async = None
+    if _aux_limit_async is not None:
+        _aux_token_async = _set_aux_ceiling_async(_aux_limit_async)
+        if ceiling_scope is not None:
+            ceiling_scope["token"] = _aux_token_async
+
     # Pass the client's actual base_url (not just resolved_base_url) so
     # endpoint-specific temperature overrides can distinguish
     # api.moonshot.ai vs api.kimi.com/coding even on auto-detected routes.
@@ -10844,6 +11013,13 @@ async def _async_call_llm_impl(
                 ),
                 task,
                 provider=request_provider, base_url=_client_base)
+        except ContextCeilingExceeded:
+            # Terminal by type — never a transient transport blip. Raising here
+            # (before the ``except Exception as transient_err`` handler) makes
+            # the refusal independent of _is_transient_transport_error's current
+            # behaviour: a ceiling refusal must never enter the same-provider
+            # retry loop, regardless of what the retry predicate matches.
+            raise
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
@@ -10871,6 +11047,13 @@ async def _async_call_llm_impl(
                     create=_acreate,
                 ),
                 task)
+    except ContextCeilingExceeded:
+        # A LOCAL ceiling refusal is terminal by type: it is not a transport
+        # blip, not a credential problem, and not a provider 400 — the request
+        # was rejected before any provider I/O. It must NEVER be retried on the
+        # same provider, used to trigger a credential refresh, or escalated to a
+        # fallback candidate (a second provider call would just re-refuse).
+        raise
     except Exception as first_err:
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)

--- a/agent/auxiliary_context_ceiling.py
+++ b/agent/auxiliary_context_ceiling.py
@@ -1,0 +1,299 @@
+"""Bounded owner for the auxiliary context-ceiling authority.
+
+This shard is the SINGLE owner of the auxiliary context-ceiling
+enforcement surface that used to live inline in
+``agent/auxiliary_client.py``:
+
+* ``_aux_relay_gate`` -- the relay-helper entry ceiling gate (final
+  physical payload budget enforcement for the auxiliary physical owner).
+* ``_aux_provider_callback`` -- the provider-boundary ceiling wrapper
+  (the true physical seam, enforcing the ceiling on the FINAL payload at
+  the moment it is handed to the provider).
+* ``_rebind_aux_ceiling_for_fallback`` -- sync fallback ceiling rebinding
+  (scopes the effective ceiling to a fallback destination's own
+  authority).
+* ``_rebind_aux_ceiling_for_fallback_async`` -- async counterpart.
+
+These are the coherent "auxiliary context-ceiling authority" units
+requested by the #78635 fracture contract.  They are byte-verbatim
+relocations (docstrings and inline imports preserved); they read the
+ceiling ContextVar owned by ``agent.model_metadata`` and the output-
+reservation policy there -- they never duplicate that state.
+
+``agent.auxiliary_client`` re-imports the four names below so that:
+
+* historical import names (``from agent.auxiliary_client import
+  _aux_provider_callback`` etc.) keep working;
+* ``monkeypatch.setattr(agent.auxiliary_client, "_aux_provider_callback",
+  ...)`` still affects the live relay path, because the relay helpers
+  (``_relay_sync_completion`` / ``_relay_async_completion`` /
+  ``_relay_sync_stream``) and the fallback dispatchers that CONSUME these
+  names stay in ``auxiliary_client`` and resolve them through that
+  module's globals.
+
+There is exactly one implementation of each -- here.  The monolith keeps
+only the narrow compatibility re-imports (see the re-export block in
+``auxiliary_client.py``); it holds no second copy of any ceiling-authority
+logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+__all__ = [
+    "_aux_relay_gate",
+    "_aux_provider_callback",
+    "_rebind_aux_ceiling_for_fallback",
+    "_rebind_aux_ceiling_for_fallback_async",
+]
+
+
+def _aux_relay_gate(
+    kwargs: dict[str, Any],
+    task: str = "auxiliary",
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+) -> None:
+    """Terminal ceiling gate for the auxiliary physical owner (relay helpers).
+
+    The three relay helpers below are the SINGLE physical I/O owner for all
+    auxiliary dispatch (sync / async / stream, primary + fallback + retry all
+    converge on them — 20+ call sites).  ``call_llm`` sets the auxiliary
+    effective ceiling (model context clamped by the profile ceiling) in a
+    contextvar before dispatching; this reads it and enforces the transport-
+    normalized budget on the FINAL payload.  A refusal raises the TYPED
+    ``ContextCeilingExceeded`` (NOT wrapped in ``RuntimeError``) so the
+    auxiliary catch-all chain classifies it as a local ceiling refusal, not a
+    provider/auth error — no fallback, no credential-refresh retry, no bypass.
+
+    ``provider`` / ``model`` feed the shared output-reservation policy so the
+    auxiliary gate reserves the same allowance the compressor and the main
+    gate do (final request cap → provider/profile implicit cap → default).
+    """
+    from agent.model_metadata import (
+        get_aux_ceiling as _get_aux_ceiling,
+        build_final_context_budget as _build_budget,
+        enforce_final_context_budget as _enforce,
+    )
+    ceiling = _get_aux_ceiling()
+    if not (isinstance(ceiling, int) and not isinstance(ceiling, bool) and ceiling > 0):
+        return
+    budget = _build_budget(kwargs, provider=provider, model=model)
+    _enforce(budget, ceiling=ceiling, reason=task)
+
+
+def _aux_provider_callback(
+    callback: Callable[[dict[str, Any]], Any],
+    *,
+    task: str = "auxiliary",
+    provider: str | None = None,
+    model: str | None = None,
+) -> Callable[[dict[str, Any]], Any]:
+    """Provider-boundary ceiling wrapper (the TRUE physical seam).
+
+    The relay-helper entry gate (:func:`_aux_relay_gate`) enforces on the
+    request the CALLER built.  If Relay (``relay_llm.execute`` /
+    ``execute_async`` / ``stream_current``) or a middleware layer ENLARGES
+    that request before invoking the provider callback — adding tokens,
+    expanding tools, appending system content, or rewriting the payload in
+    any way that increases its size — that enlargement is NOT checked by the
+    entry gate.  This wrapper enforces the ceiling on the FINAL payload at
+    the exact moment it is about to be handed to the provider, i.e. at the
+    physical provider seam.  A refusal raises the TYPED
+    ``ContextCeilingExceeded`` BEFORE ``callback`` runs, so the provider is
+    never called with an oversized request.
+
+    The ceiling is read from the same contextvar the entry gate reads, so
+    both see the identical effective limit for the invocation.  The output
+    reservation is resolved from the shared policy with the same
+    ``provider`` / ``model`` so both seams agree.
+    """
+    def _gated(request: dict[str, Any]) -> Any:
+        _aux_relay_gate(
+            request, task=task, provider=provider, model=model
+        )
+        return callback(request)
+    _gated.__name__ = getattr(callback, "__name__", "provider_callback")
+    _gated.__doc__ = callback.__doc__
+    return _gated
+
+
+
+def _rebind_aux_ceiling_for_fallback(
+    destination: "_FallbackDestination",
+    *,
+    api_key: str = "",
+):
+    """Scope the auxiliary effective ceiling to a fallback destination.
+
+    ``call_llm`` / ``async_call_llm`` publish the ceiling for the INITIAL
+    destination once (see ``_call_llm_impl`` / ``_async_call_llm_impl``).  The
+    relay-helper physical gates read that ambient ContextVar.  When the
+    fallback candidates (``_call_fallback_candidate_sync`` /
+    ``_call_fallback_candidate_async``) dispatch to a DIFFERENT provider /
+    model / base_url, they must rebind the ceiling to the fallback's own
+    ``effective = min(raw_capability, profile_ceiling)`` — otherwise the
+    initial destination's stale ceiling is inherited (P1 from review
+    5049973836: a 900K initial ceiling lets a ~200K request through to a 128K
+    fallback model; a 128K initial ceiling falsely refuses a ~300K request on
+    a 900K fallback).
+
+    The ceiling is set via ``set_aux_ceiling`` and reset via the returned
+    token in a ``finally`` — so the prior value (the initial destination's
+    ceiling) is restored after the fallback attempt completes, whether it
+    succeeds, is ceiling-refused, or fails for another reason.  This keeps
+    the initial destination's ceiling available for the NEXT fallback layer
+    in the chain (which is itself a different destination and will rebind
+    again).
+
+    ``api_key`` is threaded into the resolver so the raw capability lookup is
+    credential-aware (the existing ``_candidate_context_window()`` path
+    already carries ``api_key`` for authenticated endpoint probing; the
+    initial resolver in ``_call_llm_impl`` was omitting it).
+
+    Usage (sync)::
+
+        with _rebind_aux_ceiling_for_fallback(destination, api_key=...) as _ce:
+            ...relay call...
+
+    Usage (async)::
+
+        async with _rebind_aux_ceiling_for_fallback_async(destination, api_key=...) as _ce:
+            ...await relay call...
+
+    ``as _ce`` is the ceiling value (or ``None`` if resolution failed) so
+    tests can assert the exact limit used by the gate.
+    """
+    import contextlib
+    from agent.model_metadata import (
+        ContextCeilingExceeded as _cce,
+        effective_context_length as _ecl,
+        set_aux_ceiling as _set,
+        reset_aux_ceiling as _reset,
+    )
+    _model = destination.model or ""
+    _base = destination.base_url or ""
+    try:
+        _ceiling = _ecl(
+            model=_model,
+            base_url=_base,
+            api_key=api_key or "",
+            provider=destination.provider or "",
+        )
+    except Exception:
+        _ceiling = None
+    if not (isinstance(_ceiling, int) and not isinstance(_ceiling, bool) and _ceiling > 0):
+        # FAIL CLOSED before provider I/O (Round 5 finding C, re-review of
+        # 8e109d375): the fallback destination's context authority could not
+        # be resolved (the resolver raised, or it returned a value that is not
+        # a usable positive int).  Context authority is destination-scoped —
+        # once the destination projection changed (provider / model / base_url
+        # / credential), the SOURCE destination's ambient ceiling must NOT
+        # authorize this new physical provider attempt.  Refusing with the
+        # TYPED local ceiling refusal keeps it terminal by type: the
+        # fallback / transient-retry / credential-refresh chains let
+        # ``ContextCeilingExceeded`` propagate (no provider I/O, no fallback,
+        # no retry, no credential refresh), so the refusal is NOT converted
+        # into an ordinary provider error that would trigger an unauthorized
+        # retry/fallback cycle.  (Deliberately NOT a new exception type: the
+        # catch chains key on ``ContextCeilingExceeded``; a new type would
+        # fall into ``except Exception`` and be treated as a provider error.)
+        raise _cce(
+            0, 0,
+            reason=(
+                "fallback destination's context authority could not be "
+                "resolved; refusing to authorize the fallback provider under "
+                "the source destination's ceiling"
+            ),
+        )
+    _token = _set(_ceiling)
+
+    @contextlib.contextmanager
+    def _scoped():
+        try:
+            yield _ceiling
+        finally:
+            _reset(_token)
+
+    return _scoped()
+
+
+def _rebind_aux_ceiling_for_fallback_async(
+    destination: "_FallbackDestination",
+    *,
+    api_key: str = "",
+):
+    """Async variant of :func:`_rebind_aux_ceiling_for_fallback`.
+
+    Returns an ``asynccontextmanager`` that resolves the destination's ceiling
+    in a background thread (``asyncio.to_thread``) so blocking HTTP probes do
+    not freeze the asyncio event loop, then sets/resets the ContextVar token.
+    Same scoped semantics as the sync variant: the prior value is restored in
+    the ``finally`` after the fallback attempt, whether it succeeds, is
+    ceiling-refused, or fails for another reason.
+
+    Usage::
+
+        async with _rebind_aux_ceiling_for_fallback_async(destination, api_key=...) as _ce:
+            ...await relay call...
+    """
+    import asyncio
+    import contextlib
+    from agent.model_metadata import (
+        ContextCeilingExceeded as _cce,
+        effective_context_length as _ecl,
+        set_aux_ceiling as _set,
+        reset_aux_ceiling as _reset,
+    )
+    _model = destination.model or ""
+    _base = destination.base_url or ""
+
+    @contextlib.asynccontextmanager
+    async def _scoped():
+        # Resolve the ceiling off the event loop.  ``_ecl`` is a sync
+        # function; ``asyncio.to_thread`` runs it in a worker thread.
+        try:
+            _ceiling = await asyncio.to_thread(
+                _ecl,
+                model=_model,
+                base_url=_base,
+                api_key=api_key or "",
+                provider=destination.provider or "",
+            )
+        except Exception:
+            _ceiling = None
+        if not (isinstance(_ceiling, int) and not isinstance(_ceiling, bool) and _ceiling > 0):
+            # FAIL CLOSED before provider I/O (Round 5 finding C, re-review of
+            # 8e109d375): the fallback destination's context authority could
+            # not be resolved (the resolver raised, or it returned a value
+            # that is not a usable positive int).  Context authority is
+            # destination-scoped — once the destination projection changed
+            # (provider / model / base_url / credential), the SOURCE
+            # destination's ambient ceiling must NOT authorize this new
+            # physical provider attempt.  Raising the TYPED local ceiling
+            # refusal keeps it terminal by type: the async fallback /
+            # transient-retry / credential-refresh chains let
+            # ``ContextCeilingExceeded`` propagate (no provider I/O, no
+            # fallback, no retry, no credential refresh), so the refusal is
+            # NOT converted into an ordinary provider error that would
+            # trigger an unauthorized retry/fallback cycle.  (Deliberately NOT
+            # a new exception type: the catch chains key on
+            # ``ContextCeilingExceeded``; a new type would fall into
+            # ``except Exception`` and be treated as a provider error.)
+            raise _cce(
+                0, 0,
+                reason=(
+                    "fallback destination's context authority could not be "
+                    "resolved; refusing to authorize the fallback provider "
+                    "under the source destination's ceiling"
+                ),
+            )
+        _token = _set(_ceiling)
+        try:
+            yield _ceiling
+        finally:
+            _reset(_token)
+
+    return _scoped()

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1018,7 +1018,7 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
         provider=getattr(agent, "provider", None),
         model=getattr(agent, "model", None),
     )
-    _efc(_budget, pre_cap=_pre_cap, ceiling=_ceiling,
+    _efc(_budget, pre_cap=_pre_cap, ceiling=_ceiling, api_kwargs=api_kwargs,
          reason="main non-streaming dispatch (final payload)")
     if agent.api_mode == "codex_responses":
         request_client = make_client("codex_stream_request")

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -917,6 +917,60 @@ def _bedrock_reasoning_stale_floor(model_id: object) -> "float | None":
     return None
 
 
+def _enforce_streaming_final_budget(
+    agent,
+    next_api_kwargs: dict[str, Any],
+    *,
+    api_mode: str,
+    reason: str,
+) -> None:
+    """Terminal ceiling gate for the main-path STREAMING physical callbacks.
+
+    The streaming entry gate (``interruptible_streaming_api_call``) fires on
+    the caller's ``api_kwargs`` BEFORE Relay transformation.  Relay (
+    ``relay_llm.stream``) then rebuilds the final provider payload (codec
+    round-trip, tool/message extension restoration, header normalization) and
+    hands it to this stream_factory as ``next_api_kwargs``.  A Relay that
+    enlarges the request past the ceiling would slip the entry gate — so the
+    terminal enforcement belongs here, on the FINAL payload, immediately
+    before the provider I/O (``chat.completions.create`` /
+    ``messages.stream`` / ``converse_stream``).
+
+    Uses the SAME shared FinalContextBudget primitive the non-streaming owner
+    uses (``build_final_context_budget`` + ``enforce_final_context_budget``),
+    so provider-aware reservation (explicit cap → provider implicit cap →
+    default) and Bedrock nested ``inferenceConfig.maxTokens`` are resolved
+    identically.  A refusal is a local error — no provider I/O, no api_call
+    count, no retry, no fallback.
+    """
+    from agent.model_metadata import (
+        build_final_context_budget,
+        enforce_final_context_budget,
+    )
+
+    pre_cap = getattr(agent, "_pre_cap_context_length", None)
+    if not (isinstance(pre_cap, int) and not isinstance(pre_cap, bool) and pre_cap > 0):
+        engine = getattr(agent, "context_compressor", None)
+        if engine is not None:
+            pre_cap = getattr(engine, "pre_cap_context_length", None)
+    ceiling = getattr(agent, "_max_context_length", None)
+    if not (isinstance(ceiling, int) and not isinstance(ceiling, bool) and ceiling > 0):
+        engine = getattr(agent, "context_compressor", None)
+        if engine is not None:
+            ceiling = getattr(engine, "max_context_length", None)
+    budget = build_final_context_budget(
+        next_api_kwargs,
+        provider=getattr(agent, "provider", None),
+        model=getattr(agent, "model", None),
+    )
+    enforce_final_context_budget(
+        budget,
+        pre_cap=pre_cap,
+        ceiling=ceiling,
+        reason=f"main streaming dispatch, {api_mode} (final payload)",
+    )
+
+
 def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     """Run one non-streaming LLM request for the active api_mode and return it.
 
@@ -933,6 +987,39 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
     interrupt, abort, cancellation, and close semantics stay in the callers —
     this helper only issues the request.
     """
+    # ── Terminal ceiling gate (transport-normalized) ──────────────────
+    # This is the SINGLE physical I/O owner for all non-streaming main
+    # dispatch (codex / anthropic / bedrock / MoA / OpenAI-compatible).
+    # It fires on the FINAL payload (post-middleware, post-transformation)
+    # immediately before provider I/O.  A refusal is NOT an API call —
+    # no network I/O, no api_call_count, no retry, no fallback.
+    #
+    # Reads the ceiling + pre-cap from the agent host.  Uses the shared
+    # FinalContextBudget primitive (model_metadata) so every semantic
+    # component is counted exactly once and the reservation is resolved
+    # from the payload's explicit cap (never 0, never an invented
+    # provider max).
+    from agent.model_metadata import (
+        build_final_context_budget as _bfc,
+        enforce_final_context_budget as _efc,
+    )
+    _pre_cap = getattr(agent, "_pre_cap_context_length", None)
+    if not (isinstance(_pre_cap, int) and not isinstance(_pre_cap, bool) and _pre_cap > 0):
+        _eng = getattr(agent, "context_compressor", None)
+        if _eng is not None:
+            _pre_cap = getattr(_eng, "pre_cap_context_length", None)
+    _ceiling = getattr(agent, "_max_context_length", None)
+    if not (isinstance(_ceiling, int) and not isinstance(_ceiling, bool) and _ceiling > 0):
+        _eng = getattr(agent, "context_compressor", None)
+        if _eng is not None:
+            _ceiling = getattr(_eng, "max_context_length", None)
+    _budget = _bfc(
+        api_kwargs,
+        provider=getattr(agent, "provider", None),
+        model=getattr(agent, "model", None),
+    )
+    _efc(_budget, pre_cap=_pre_cap, ceiling=_ceiling,
+         reason="main non-streaming dispatch (final payload)")
     if agent.api_mode == "codex_responses":
         request_client = make_client("codex_stream_request")
         return agent._run_codex_stream(
@@ -2468,6 +2555,51 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     auth resolution and client construction — no duplicated provider→key
     mappings.
     """
+    # Lifecycle atomicity: capture the host route
+    # BEFORE any commit region mutates it. Captured at the very top of the
+    # function so it is always in scope (even if an early return or the
+    # client-build try-block raises) and always reflects the true pre-fallback
+    # state. The commit region (model/provider/client/api_key/_anthropic_*/
+    # _client_kwargs/credential pool/etc.) and the engine transition
+    # (transition_model_context) both run inside the try-block below; if any
+    # of them raise, _restore_fb_host_snapshot() in the except-block returns
+    # the agent to this coherent state before the next fallback is attempted.
+    _fb_host_snapshot = {
+        "model": agent.model,
+        "provider": agent.provider,
+        "requested_provider": getattr(agent, "requested_provider", None),
+        "base_url": agent.base_url,
+        "api_mode": agent.api_mode,
+        "api_key": getattr(agent, "api_key", None),
+        "client": getattr(agent, "client", None),
+        "_anthropic_client": getattr(agent, "_anthropic_client", None),
+        "_anthropic_api_key": getattr(agent, "_anthropic_api_key", None),
+        "_anthropic_base_url": getattr(agent, "_anthropic_base_url", None),
+        "_is_anthropic_oauth": getattr(agent, "_is_anthropic_oauth", None),
+        "_client_kwargs": dict(getattr(agent, "_client_kwargs", {}) or {}),
+        "_config_context_length": getattr(agent, "_config_context_length", None),
+        "_reasoning_echo_flag": getattr(agent, "_reasoning_echo_flag", None),
+        "_credential_pool": getattr(agent, "_credential_pool", None),
+        "_credential_pool_entry_id": getattr(agent, "_credential_pool_entry_id", None),
+        "_fallback_activated": getattr(agent, "_fallback_activated", None),
+        "_use_prompt_caching": getattr(agent, "_use_prompt_caching", None),
+        "_use_native_cache_layout": getattr(agent, "_use_native_cache_layout", None),
+        "_pre_cap_context_length": getattr(agent, "_pre_cap_context_length", None),
+    }
+
+    def _restore_fb_host_snapshot() -> None:
+        for _name, _val in _fb_host_snapshot.items():
+            try:
+                setattr(agent, _name, _val)
+            except Exception:
+                pass
+        # Restoring the old client invalidates any cached transports.
+        if hasattr(agent, "_transport_cache"):
+            try:
+                agent._transport_cache.clear()
+            except Exception:
+                pass
+
     if reason in {FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit}:
         # Only start cooldown when leaving the primary provider.  If we're
         # already on a fallback and chain-switching, the primary wasn't the
@@ -2812,13 +2944,20 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 config_context_length=getattr(agent, "_config_context_length", None),
                 custom_providers=getattr(agent, "_custom_providers", None),
             )
-            agent.context_compressor.update_model(
-                model=agent.model,
-                context_length=fb_context_length,
-                base_url=agent.base_url,
-                api_key=getattr(agent, "api_key", ""),  # callable preserved → call_llm
-                provider=agent.provider,
-                api_mode=agent.api_mode,
+            # MODEL LIFECYCLE TRANSITION: the fallback is the
+            # ACTIVE model now, so the host pre-cap becomes the FALLBACK's
+            # pre-cap — not the primary's. The primary's pre-cap is preserved
+            # in _primary_runtime (captured at init/switch time) so
+            # restore_primary_runtime can re-derive the primary's effective
+            # window. transition_model_context sets the host pre-cap to the
+            # active model's value on success and propagates any engine
+            # failure to this fallback transaction — the baseline
+            # behavior (a failed update_model did not silently continue).
+            # The fallback's model/provider/base_url/api_key are already
+            # applied to agent above, so they are read from agent here.
+            from agent.agent_runtime_helpers import transition_model_context
+            transition_model_context(
+                agent, fb_context_length, model=agent.model,
             )
 
         # Re-resolve reasoning_config for the new fallback model (Closes #21256).
@@ -2944,6 +3083,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if fb_provider == "nous":
             unavailable.add(fb_key)
         logger.error("Failed to activate fallback %s: %s", fb_model, e)
+        # Lifecycle atomicity: restore the host route to its pre-fallback
+        # state so the next fallback in the chain starts from a coherent
+        # agent (old model/provider/client/api_key + old engine). The engine's
+        # own route was already restored by transition_model_context's
+        # snapshot/restore (if the failure was in the transition) or was never
+        # mutated (if the failure was earlier in the commit region).
+        _restore_fb_host_snapshot()
         return agent._try_activate_fallback(reason)  # try next in chain
 
 
@@ -3110,6 +3256,48 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         if _is_nous:
             from agent.portal_tags import nous_portal_tags as _portal_tags
             summary_extra_body["tags"] = _portal_tags()
+
+        # Hard-ceiling gate for the iteration-limit summary dispatch:
+        # this is a provider-owning path that bypasses the main-loop gate, so
+        # it enforces its own final payload against the effective limit before
+        # any provider I/O.  The summary request typically carries the full
+        # (largest) conversation, so this gate is the one most likely to trip.
+        # A refusal is a local error, not an API call — no api_call_count, no
+        # provider I/O.  We catch the typed exception here and re-raise as a
+        # plain RuntimeError so the caller (run_conversation) treats it as a
+        # normal local failure rather than an unhandled ContextCeilingExceeded.
+        #
+        # Finding #2: migrated OFF the legacy check_ceiling_for_kwargs path (which
+        # reserved agent.max_tokens or 0 — a zero-reservation when the cap is
+        # omitted, and a flat shape that could not see Bedrock's nested
+        # inferenceConfig.maxTokens).  Now uses the SAME shared final-budget
+        # resolver every physical dispatch owner uses (build_final_context_budget
+        # + enforce_final_context_budget), so the output reservation is
+        # provider-aware (omitted cap + known provider implicit 65536 → reserve
+        # 65536) and Bedrock summary requests honor inferenceConfig.maxTokens.
+        from agent.model_metadata import (
+            build_final_context_budget as _build_final_budget,
+            enforce_final_context_budget as _enforce_final_budget,
+            ContextCeilingExceeded as _CEX,
+        )
+        from agent.agent_runtime_helpers import _agent_ceiling as _agent_ceiling_fn
+        _sum_ceiling = _agent_ceiling_fn(agent)
+        try:
+            _sum_budget = _build_final_budget(
+                {"messages": api_messages},
+                system_prompt=effective_system,
+                tools=None,
+                provider=getattr(agent, "provider", None),
+                model=getattr(agent, "model", None),
+            )
+            _enforce_final_budget(
+                _sum_budget,
+                pre_cap=getattr(agent, "_pre_cap_context_length", None),
+                ceiling=_sum_ceiling,
+                reason="iteration-limit summary",
+            )
+        except _CEX as _ce:
+            raise RuntimeError(str(_ce)) from _ce
 
         if agent.api_mode == "codex_responses":
             codex_kwargs = agent._build_api_kwargs(api_messages)
@@ -3406,6 +3594,38 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if agent._interrupt_requested:
         raise InterruptedError("Agent interrupted before streaming API call")
 
+    # ── Terminal ceiling gate (transport-normalized) — streaming owner ──
+    # The streaming main path (chat_completions / anthropic_messages)
+    # dispatches its physical I/O here, NOT through
+    # _dispatch_nonstreaming_api_request, so it is a distinct physical owner
+    # that must carry the same gate.  Codex / direct routes delegate to the
+    # non-streaming dispatch (which is already gated) — the gate is idempotent,
+    # so a second pass there is a safe no-op.
+    from agent.model_metadata import (
+        build_final_context_budget as _bfc_s,
+        enforce_final_context_budget as _efc_s,
+    )
+    _pre_cap_s = getattr(agent, "_pre_cap_context_length", None)
+    if not (isinstance(_pre_cap_s, int) and not isinstance(_pre_cap_s, bool) and _pre_cap_s > 0):
+        _eng_s = getattr(agent, "context_compressor", None)
+        if _eng_s is not None:
+            _pre_cap_s = getattr(_eng_s, "pre_cap_context_length", None)
+    _ceiling_s = getattr(agent, "_max_context_length", None)
+    if not (isinstance(_ceiling_s, int) and not isinstance(_ceiling_s, bool) and _ceiling_s > 0):
+        _eng_s = getattr(agent, "context_compressor", None)
+        if _eng_s is not None:
+            _ceiling_s = getattr(_eng_s, "max_context_length", None)
+    _efc_s(
+        _bfc_s(
+            api_kwargs,
+            provider=getattr(agent, "provider", None),
+            model=getattr(agent, "model", None),
+        ),
+        pre_cap=_pre_cap_s,
+        ceiling=_ceiling_s,
+        reason="main streaming dispatch (final payload)",
+    )
+
     def _stream_final_text(response) -> str:
         try:
             choices = getattr(response, "choices", None)
@@ -3519,6 +3739,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 writer_token = {"value": None}
 
                 def _open_bedrock_stream(next_api_kwargs: dict[str, Any]):
+                    # Final-boundary gate (finding #2): judge the FINAL payload
+                    # Relay hands us (supports Bedrock nested
+                    # inferenceConfig.maxTokens via the shared reservation
+                    # resolver), not the pre-Relay `api_kwargs`.
+                    _enforce_streaming_final_budget(
+                        agent, next_api_kwargs,
+                        api_mode="bedrock_converse",
+                        reason="bedrock_converse",
+                    )
                     final_kwargs = dict(next_api_kwargs)
                     region = final_kwargs.pop("__bedrock_region__", "us-east-1")
                     final_kwargs.pop("__bedrock_converse__", None)
@@ -4032,6 +4261,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         attempt_stream_response = {"value": None}
 
         def _open_stream(next_api_kwargs: dict[str, Any]):
+            # Final-boundary gate (finding #2): `next_api_kwargs` is Relay's
+            # transformed FINAL request — the exact payload the provider
+            # receives. Enforce the ceiling against it, not the pre-Relay
+            # `api_kwargs` (Relay may enlarge the request, so the preliminary
+            # entry gate can be bypassed).
+            _enforce_streaming_final_budget(
+                agent, next_api_kwargs,
+                api_mode=getattr(agent, "_relay_api_mode", "openai_compatible"),
+                reason="openai_compatible",
+            )
             stream_kwargs = {
                 **next_api_kwargs,
                 "stream": True,
@@ -4634,6 +4873,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         accumulator = relay_llm.AnthropicStreamAccumulator()
 
         def _open_anthropic_stream(next_api_kwargs: dict[str, Any]):
+            # Final-boundary gate (finding #2): judge the FINAL payload Relay
+            # hands us (Anthropic `max_tokens`), not the pre-Relay `api_kwargs`.
+            _enforce_streaming_final_budget(
+                agent, next_api_kwargs,
+                api_mode="anthropic_messages",
+                reason="anthropic_messages",
+            )
             final_kwargs = dict(next_api_kwargs)
             sanitize_anthropic_kwargs(
                 final_kwargs,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -184,10 +184,44 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     compressor = getattr(agent, "context_compressor", None)
     if compressor is not None:
         try:
+            # Record the fresh token accounting from this response FIRST.
+            # update_from_response() populates last_*_tokens and
+            # the paired rough/real estimates. We capture the accounting fields
+            # so we can re-apply them AFTER the context-window refresh, because
+            # the refresh (update_model on a generic plugin, and the built-in's
+            # calibration reset) may legitimately zero last_*_tokens. Re-applying
+            # the just-recorded values afterward guarantees the accounting from
+            # this response survives the refresh regardless of engine type.
             compressor.update_from_response(usage_dict)
+            _accounting = {
+                f: getattr(compressor, f, None)
+                for f in (
+                    "last_prompt_tokens",
+                    "last_completion_tokens",
+                    "last_total_tokens",
+                    "last_real_prompt_tokens",
+                    "last_rough_tokens_when_real_prompt_fit",
+                )
+            }
             context_window = getattr(turn, "model_context_window", None)
             if isinstance(context_window, int) and context_window > 0:
-                compressor.context_length = context_window
+                # SAME-MODEL CONTEXT-WINDOW REFRESH: the active
+                # model is unchanged; only its provider-reported window changed.
+                # context_window is the PRE-CAP value. refresh_context_window
+                # recalculates threshold/budget from the (ceiling-clamped)
+                # effective window WITHOUT masquerading as a model transition —
+                # the built-in via the context_length setter, a plugin via
+                # update_model. The host pre-cap becomes the raw reported window.
+                from agent.agent_runtime_helpers import refresh_context_window
+                refresh_context_window(
+                    agent, context_window, model=agent.model,
+                )
+                # Restore the accounting just recorded so a plugin's
+                # update_model() calibration reset (or the built-in's) cannot
+                # erase it. Re-applied only for fields that are genuine ints.
+                for _f, _v in _accounting.items():
+                    if isinstance(_v, int) and not isinstance(_v, bool):
+                        setattr(compressor, _f, _v)
         except Exception:
             logger.debug("codex app-server usage update failed", exc_info=True)
 
@@ -771,6 +805,54 @@ def run_codex_app_server_turn(
     # NOTE: the user message is ALREADY appended to messages by the
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
+
+    # ── Terminal ceiling gate (transport-normalized) — app-server owner ──
+    # run_turn() hands the entire turn to a codex app-server subprocess and
+    # bypasses BOTH _dispatch_nonstreaming_api_request and
+    # interruptible_streaming_api_call.  It is therefore a FIFTH physical
+    # dispatch owner that must carry the same gate.  The gate fires on the
+    # FINAL messages payload (post-compression) immediately before
+    # run_turn() dispatches to the subprocess.  A refusal is NOT a turn —
+    # no subprocess I/O, no event stream, no retry.
+    from agent.model_metadata import (
+        build_final_context_budget as _bfc_app,
+        enforce_final_context_budget as _efc_app,
+    )
+    _pre_cap_app = getattr(agent, "_pre_cap_context_length", None)
+    if not (isinstance(_pre_cap_app, int) and not isinstance(_pre_cap_app, bool) and _pre_cap_app > 0):
+        _eng_app = getattr(agent, "context_compressor", None)
+        if _eng_app is not None:
+            _pre_cap_app = getattr(_eng_app, "pre_cap_context_length", None)
+    _ceiling_app = getattr(agent, "_max_context_length", None)
+    if not (isinstance(_ceiling_app, int) and not isinstance(_ceiling_app, bool) and _ceiling_app > 0):
+        _eng_app2 = getattr(agent, "context_compressor", None)
+        if _eng_app2 is not None:
+            _ceiling_app = getattr(_eng_app2, "max_context_length", None)
+    # Build the budget from the FINAL messages list (system-included).
+    # The codex app-server path uses `messages` as its transport payload.
+    _app_kwargs = {"messages": messages}
+    # Include the system prompt separately if it is a dedicated field on the
+    # agent (some codex paths carry it as agent.system_prompt, not in messages).
+    _app_system = ""
+    try:
+        if not any(
+            isinstance(m, dict) and m.get("role") == "system"
+            for m in (messages if isinstance(messages, list) else [])
+        ):
+            _app_system = getattr(agent, "system_prompt", "") or ""
+    except Exception:
+        _app_system = ""
+    _efc_app(
+        _bfc_app(
+            _app_kwargs,
+            system_prompt=_app_system,
+            provider=getattr(agent, "provider", None),
+            model=getattr(agent, "model", None),
+        ),
+        pre_cap=_pre_cap_app,
+        ceiling=_ceiling_app,
+        reason="codex app-server run_turn (final payload)",
+    )
 
     try:
         turn = agent._codex_session.run_turn(user_input=user_message)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1531,7 +1531,18 @@ def _estimate_msg_budget_tokens(msg: dict, charge_stale_thinking: bool = True) -
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     if not charge_stale_thinking:
         return tokens
+    # The wire ships at most ONE of the generic thinking keys: every request
+    # build pops ``reasoning`` after (optionally) promoting it into
+    # ``reasoning_content`` (``apply_reasoning_content_policy``), and a
+    # non-empty stored ``reasoning_content`` always displaces it. Charging
+    # both keys double-counted the same thinking text on echo-back providers
+    # that persist it under both (#84371 comment: +53% vs real
+    # prompt_tokens). Mirror the wire: reasoning_content wins when present.
+    _rc = msg.get("reasoning_content")
+    _skip_reasoning_dup = isinstance(_rc, str) and bool(_rc.strip())
     for key in _NEWEST_TURN_ONLY_BUDGET_KEYS:
+        if key == "reasoning" and _skip_reasoning_dup:
+            continue
         tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
     # reasoning_details: charge only the thinking TEXT, never the signed /
     # base64 envelope (#73298 second site; mirrors the preflight estimator's
@@ -3984,11 +3995,16 @@ class ContextCompressor(ContextEngine):
             # Same newest-turn-only thinking charge as the tail-cut walk
             # (#73624) — this boundary decides which tool results stay
             # prunable, and overcharging stale thinking shrinks that window.
+            # Echo-back routes charge every turn (#84371 estimator parity).
             _newest_asst_idx = _last_assistant_index(result)
+            _charge_all_thinking = self._stale_thinking_on_wire()
             for i in range(len(result) - 1, -1, -1):
                 msg = result[i]
                 msg_tokens = _estimate_msg_budget_tokens(
-                    msg, charge_stale_thinking=(i == _newest_asst_idx)
+                    msg,
+                    charge_stale_thinking=(
+                        _charge_all_thinking or i == _newest_asst_idx
+                    ),
                 )
                 if accumulated + msg_tokens > protect_tail_tokens and (len(result) - i) >= min_protect:
                     boundary = i
@@ -6553,6 +6569,30 @@ This compaction should PRIORITISE preserving all information related to the focu
             idx += 1
         return idx
 
+    def _stale_thinking_on_wire(self) -> bool:
+        """Whether the active route replays stale thinking text (#84371).
+
+        The tail-budget walks and the preflight trigger must charge the SAME
+        stale-thinking policy or a reasoning-heavy session can look
+        over-threshold to one and fully tail-protected to the other — the
+        infinite ineffective compaction loop.  Echo-back chat-completions
+        families (DeepSeek/Kimi/MiMo thinking mode) replay stored
+        ``reasoning_content`` on EVERY assistant turn, so the walk must
+        charge it everywhere; codex_responses and strict providers never
+        ship the text keys, so newest-turn-only stands (#73624).
+        """
+        try:
+            from agent.message_sanitization import stale_thinking_reaches_wire
+
+            return stale_thinking_reaches_wire(
+                getattr(self, "api_mode", "") or "",
+                getattr(self, "provider", "") or "",
+                getattr(self, "model", "") or "",
+                getattr(self, "base_url", "") or "",
+            )
+        except Exception:
+            return False
+
     def _find_tail_cut_by_tokens(
         self, messages: List[Dict[str, Any]], head_end: int,
         token_budget: int | None = None,
@@ -6598,12 +6638,20 @@ This compaction should PRIORITISE preserving all information related to the focu
         # fields any transport still replays (#73624) — every older turn's
         # reasoning/reasoning_content is stripped or padded at send time,
         # so charging it here spends tail budget on bytes that never ship.
+        # Exception: echo-back providers (DeepSeek/Kimi/MiMo thinking mode
+        # on chat_completions) replay stale thinking on EVERY turn — charge
+        # it everywhere so this walk agrees with the preflight trigger
+        # (#84371 estimator parity).
         _newest_asst_idx = _last_assistant_index(messages)
+        _charge_all_thinking = self._stale_thinking_on_wire()
 
         for i in range(n - 1, head_end - 1, -1):
             msg = messages[i]
             msg_tokens = _estimate_msg_budget_tokens(
-                msg, charge_stale_thinking=(i == _newest_asst_idx)
+                msg,
+                charge_stale_thinking=(
+                    _charge_all_thinking or i == _newest_asst_idx
+                ),
             )
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
@@ -6631,7 +6679,10 @@ This compaction should PRIORITISE preserving all information related to the focu
             for j in range(n - 1, head_end - 1, -1):
                 raw_msg = messages[j]
                 raw_tok = _estimate_msg_budget_tokens(
-                    raw_msg, charge_stale_thinking=(j == _newest_asst_idx)
+                    raw_msg,
+                    charge_stale_thinking=(
+                        _charge_all_thinking or j == _newest_asst_idx
+                    ),
                 )
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -343,6 +343,33 @@ def _strip_persistence_markers(messages: List[Dict[str, Any]]) -> None:
             msg.pop(_DB_PERSISTED_MARKER, None)
 
 
+def stamp_db_persisted_markers(messages: List[Dict[str, Any]]) -> None:
+    """Fulfil the post-commit contract of ``SessionDB.archive_and_compact()``.
+
+    ``archive_and_compact()`` atomically soft-archives the previous active
+    rows and inserts *messages* as the new active set — after it returns,
+    every dict in *messages* IS durably stored. Stamp ``_DB_PERSISTED_MARKER``
+    on those exact dict instances so the append-only flush
+    (``_persist_session`` → ``_flush_messages_to_session_db_unlocked``)
+    skips them instead of re-INSERTing the whole compacted transcript.
+
+    This is the single stamp site for ALL ``archive_and_compact`` callers
+    (in-place batch commit, micro-compaction sync, proactive prune). The
+    marker must land on the dicts the caller actually keeps as the live
+    message list: ``compress()`` output is marker-swept by design
+    (``_strip_persistence_markers``, #57491 — the sweep protects the
+    ROTATION flush to a child session), so a committed in-place set that
+    is returned to the caller unstamped is re-written as "new" by the next
+    persist walk and the live transcript doubles on every compaction
+    (#98450: ~58K → ~512K tokens). Call this ONLY after the commit
+    succeeded — an unstamped dict after a failed commit is correct
+    (the flush then durably writes it).
+    """
+    for msg in messages:
+        if isinstance(msg, dict):
+            msg[_DB_PERSISTED_MARKER] = True
+
+
 def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
     """Strip stale per-turn replay items (``codex_reasoning_items``) from
     assistant messages that belong to turns older than the active one.
@@ -4269,9 +4296,9 @@ class ContextCompressor(ContextEngine):
                     exc,
                 )
                 return messages, 0
-            for msg in pruned_msgs:
-                if isinstance(msg, dict):
-                    msg[_DB_PERSISTED_MARKER] = True
+            # Shared post-commit contract with the in-place batch commit and
+            # the micro-compaction sync (#98450) — one stamp site for the class.
+            stamp_db_persisted_markers(pruned_msgs)
         self._proactive_prune_rearm_tokens = next_rearm_tokens
         return pruned_msgs, pruned_count
 
@@ -7260,9 +7287,9 @@ This compaction should PRIORITISE preserving all information related to the focu
             return
         try:
             session_db.archive_and_compact(session_id, compacted_messages)
-            for msg in compacted_messages:
-                if isinstance(msg, dict):
-                    msg[_DB_PERSISTED_MARKER] = True
+            # Shared post-commit contract with the in-place batch commit and
+            # the proactive prune (#98450) — one stamp site for the class.
+            stamp_db_persisted_markers(compacted_messages)
         except Exception:
             logger.info(
                 "Micro-compaction DB sync failed — resume will double-load "

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2977,13 +2977,23 @@ class ContextCompressor(ContextEngine):
             self._cooldown_persist_failed = True
             logger.debug("compression failure cooldown persist failed (non-sqlite): %s", exc)
 
-    def record_timeout_failure(self, error: str) -> None:
+    def record_timeout_failure(self, error: str, failure_kind: str = "timeout") -> None:
         """Record a consecutive timeout/stall failure using the shared ladder.
 
         Used by the summary-LLM exception handler, the host-level
         ``compress_context`` timeout wrapper, and stall-interrupted
         pre-commit cancellation (#62452, #96775).
+
+        The persisted error is prefixed with the attempt identity —
+        ``backoff:<failure_kind>:strategy=<tail_mode>`` — so the durable row
+        (``sessions.compression_failure_cooldown_until`` +
+        ``compression_failure_error`` in state.db) records WHICH strategy
+        failed and WHY, and a gateway restart rebuilds the same backoff
+        decision from ``bind_session_state()`` (#96775/#97488).
         """
+        strategy = getattr(self, "tail_mode", None) or "unknown"
+        kind = failure_kind or "timeout"
+        stamped = f"backoff:{kind}:strategy={strategy}: {error}"
         _TIMEOUT_COOLDOWN_LADDER = (60, 300, 900)
         self._consecutive_timeout_failures = (
             getattr(self, "_consecutive_timeout_failures", 0) + 1
@@ -2992,7 +3002,7 @@ class ContextCompressor(ContextEngine):
             min(self._consecutive_timeout_failures,
                 len(_TIMEOUT_COOLDOWN_LADDER)) - 1
         ]
-        self._record_compression_failure_cooldown(float(cooldown), error)
+        self._record_compression_failure_cooldown(float(cooldown), stamped)
 
     def _clear_compression_failure_cooldown(self) -> None:
         # #76354 review F4: fence check BEFORE cooldown-clear. A late worker

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2947,9 +2947,16 @@ class ContextCompressor(ContextEngine):
         cooldown_seconds: float,
         error: Optional[str],
     ) -> None:
-        cooldown_until = time.time() + cooldown_seconds
-        self._summary_failure_cooldown_until = time.monotonic() + cooldown_seconds
+        now_mono = time.monotonic()
+        new_mono = now_mono + float(cooldown_seconds)
+        # Never shorten a longer live deadline (#96775). A later stall or
+        # timeout records the latest error text but keeps the later of the
+        # two clocks.
+        if new_mono > self._summary_failure_cooldown_until:
+            self._summary_failure_cooldown_until = new_mono
         self._last_summary_error = error
+        remaining = max(0.0, self._summary_failure_cooldown_until - time.monotonic())
+        cooldown_until = time.time() + remaining
 
         session_db = getattr(self, "_session_db", None)
         session_id = getattr(self, "_session_id", "")
@@ -2971,12 +2978,11 @@ class ContextCompressor(ContextEngine):
             logger.debug("compression failure cooldown persist failed (non-sqlite): %s", exc)
 
     def record_timeout_failure(self, error: str) -> None:
-        """Record a consecutive timeout failure using the shared cooldown ladder.
+        """Record a consecutive timeout/stall failure using the shared ladder.
 
-        Used by both the summary-LLM exception handler (inline at line ~3714)
-        and the host-level ``compress_context`` timeout wrapper in
-        ``run_compress_context_with_progress_timeout``. Avoids re-implementing
-        the ladder at each call site (#62452).
+        Used by the summary-LLM exception handler, the host-level
+        ``compress_context`` timeout wrapper, and stall-interrupted
+        pre-commit cancellation (#62452, #96775).
         """
         _TIMEOUT_COOLDOWN_LADDER = (60, 300, 900)
         self._consecutive_timeout_failures = (

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3027,6 +3027,17 @@ class ContextCompressor(ContextEngine):
         except Exception as exc:
             logger.debug("compression failure cooldown clear failed (non-sqlite): %s", exc)
 
+    def _compression_cancelled(self) -> bool:
+        """Read the host-owned cooperative cancellation signal, if installed."""
+        cancelled_check = getattr(self, "_compression_cancelled_check", None)
+        if not callable(cancelled_check):
+            return False
+        try:
+            return bool(cancelled_check())
+        except Exception:
+            logger.debug("compression cancellation check failed", exc_info=True)
+            return False
+
     def update_model(
         self,
         model: str,
@@ -4832,6 +4843,8 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         placeholder.
         """
         prompt_started_at = time.monotonic()
+        if self._compression_cancelled():
+            raise AuxiliaryExplicitCancellation()
         now = prompt_started_at
         if now < self._summary_failure_cooldown_until:
             logger.debug(
@@ -5210,6 +5223,8 @@ This compaction should PRIORITISE preserving all information related to the focu
                     effective_aux_context=_aux_context,
                     phase_timings=_latency_info,
                 )
+            if self._compression_cancelled():
+                raise AuxiliaryExplicitCancellation()
             # ``_validate_llm_response`` only guarantees ``choices[0].message``
             # exists, not that it's an object with ``.content``. Some
             # OpenAI-compatible proxies / local backends return a dict- or

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2193,6 +2193,21 @@ class ContextCompressor(ContextEngine):
       5. On subsequent compactions, iteratively update the previous summary
     """
 
+    # Stable capability marker consumed by agent_runtime_helpers.transition_model_context
+    # / refresh_context_window:
+    # this engine handles the max_context_length ceiling ITSELF — its setter
+    # receives the RAW pre-cap window and derives effective = min(pre_cap,
+    # ceiling). The host routes by this marker (not by isinstance / class
+    # identity) because a module reload or re-import of agent.context_compressor
+    # produces a NEW class object while live instances still belong to the OLD
+    # one; an identity check would then misroute built-in instances into the
+    # generic-engine branch and hand them a pre-clamped window. The marker lives
+    # on the class, so every instance of any generation of this class carries
+    # it. A generic plugin engine that clamps its own window against the
+    # ceiling may opt in by setting the same marker; engines without it are
+    # supplied the already-capped effective window.
+    _handles_context_ceiling = True
+
     @property
     def name(self) -> str:
         return "compressor"
@@ -2379,15 +2394,28 @@ class ContextCompressor(ContextEngine):
         )
 
     def _resolve_context_length(self) -> int:
-        """Resolve and cache the model's context length on first access."""
-        if self._resolved_context_length is None:
-            self._resolved_context_length = get_model_context_length(
+        """Resolve the model's context window and cache the effective value.
+
+        The raw value from ``get_model_context_length()`` (auto-detection,
+        explicit ``model.context_length`` override, provider window) is stored
+        on ``_pre_cap_context_length`` — that is the model's real capability
+        and what the persistent context cache is fed. The effective window
+        (``_resolved_context_length``) is the raw value clamped by the global
+        ``max_context_length`` ceiling: ``effective = min(pre_cap, ceiling)``.
+        The ceiling never raises a window; it only lowers one, so it composes
+        correctly with a ``model.context_length`` that is already below it.
+        """
+        if self._pre_cap_context_length is None:
+            raw = get_model_context_length(
                 self.model,
                 base_url=self.base_url,
                 api_key=self.api_key,
                 config_context_length=self._config_context_length,
                 provider=self.provider,
             )
+            self._pre_cap_context_length = raw
+            cap = getattr(self, "max_context_length", None)
+            self._resolved_context_length = min(raw, cap) if cap else raw
             # Small-context threshold floor: models under 512K trigger at
             # >=75% so compaction doesn't fire with half the window still
             # free. Raise-only; must run AFTER context_length is resolved
@@ -2399,23 +2427,45 @@ class ContextCompressor(ContextEngine):
                 self._resolved_context_length, self._base_threshold_percent,
             )
             self._emit_init_summary_once()
+        assert self._resolved_context_length is not None
         return self._resolved_context_length
 
     @property
     def context_length(self) -> int:
+        """Effective context window (pre-cap value clamped by the ceiling)."""
         return self._resolve_context_length()
+
+    @property
+    def pre_cap_context_length(self) -> int:
+        """The resolved window BEFORE the ``max_context_length`` ceiling.
+
+        This is the model's actual capability (auto-detection, explicit
+        ``model.context_length`` override, or provider-reported window). The
+        persistent context cache (``context_length_cache.yaml``) is fed from
+        this value, never from :attr:`context_length`, so the runtime ceiling
+        policy can never contaminate the cached native capability.
+        """
+        self._resolve_context_length()
+        assert self._pre_cap_context_length is not None
+        return self._pre_cap_context_length
 
     @context_length.setter
     def context_length(self, value: int) -> None:
-        # No-op guard: repeated assignment of the SAME window (e.g. the codex
-        # app-server usage callback re-reports the window on every response)
-        # must not invalidate the derived budgets — that would wipe runtime
-        # corrections applied directly to threshold_tokens/tail_token_budget
-        # (see conversation_compression's aux-context threshold sync), which
+        # The value assigned here is the raw/pre-cap window (e.g. the codex
+        # app-server usage callback re-reports the provider window on every
+        # response, or switch_model/fallback pass a freshly resolved value).
+        # Store it as the pre-cap capability and recompute the effective
+        # window against the ceiling.
+        # No-op guard: repeated assignment of the SAME window must not
+        # invalidate the derived budgets — that would wipe runtime corrections
+        # applied directly to threshold_tokens/tail_token_budget (see
+        # conversation_compression's aux-context threshold sync), which
         # persisted on main's eager-init behavior.
-        if value == getattr(self, "_resolved_context_length", None):
+        if value == getattr(self, "_pre_cap_context_length", None):
             return
-        self._resolved_context_length = value
+        self._pre_cap_context_length = value
+        cap = getattr(self, "max_context_length", None)
+        self._resolved_context_length = min(value, cap) if cap else value
         # Re-apply the small-context floor (raise-only) for the genuinely new
         # window so the invalidated budgets below recompute coherently —
         # percent and tokens must derive from the same window. Skipped on
@@ -2424,7 +2474,7 @@ class ContextCompressor(ContextEngine):
         _base = getattr(self, "_base_threshold_percent", None)
         if _base is not None:
             self.threshold_percent = self._effective_threshold_percent(
-                value, _base,
+                self._resolved_context_length, _base,
             )
         self._threshold_tokens = None
         self._tail_token_budget = None
@@ -2442,7 +2492,7 @@ class ContextCompressor(ContextEngine):
             # if the percentage would suggest a lower value (#14690 handles
             # the degenerate small-window case inside the helper).
             self._threshold_tokens = self._compute_threshold_tokens(
-                _ctx, self.threshold_percent, self.max_tokens,
+                _ctx, self.threshold_percent, self._resolve_output_reservation(),
             )
             # Apply absolute token cap (compression.threshold_tokens) —
             # takes the lower of the ratio-based threshold and the cap.
@@ -3022,7 +3072,14 @@ class ContextCompressor(ContextEngine):
         self.api_key = api_key
         self.provider = provider
         self.api_mode = api_mode
+        # Set the context window via the property: the setter stores the raw
+        # (pre-cap) value and derives the EFFECTIVE window
+        # (``self.context_length``) by clamping against the max_context_length
+        # ceiling. Every threshold/budget below is computed from the EFFECTIVE
+        # window (``self.context_length``), never the raw parameter, so the
+        # ceiling holds on switch/fallback/provider-error paths too.
         self.context_length = context_length
+        effective_ctx = self.context_length
         # Re-resolve per-model threshold for the NEW model, then re-apply the
         # small-context threshold floor. Starting from _config_threshold_percent
         # (the raw config value) so a switch from a model with an override to
@@ -3035,7 +3092,7 @@ class ContextCompressor(ContextEngine):
         )
         self._base_threshold_percent = _new_base
         self.threshold_percent = self._effective_threshold_percent(
-            context_length, _new_base,
+            effective_ctx, _new_base,
         )
         # max_tokens=None here means "caller didn't specify" → keep the existing
         # output reservation. A switch that genuinely changes the output budget
@@ -3043,7 +3100,8 @@ class ContextCompressor(ContextEngine):
         if max_tokens is not None:
             self.max_tokens = self._coerce_max_tokens(max_tokens)
         self.threshold_tokens = self._compute_threshold_tokens(
-            context_length, self.threshold_percent, self.max_tokens,
+            effective_ctx, self.threshold_percent,
+            self._resolve_output_reservation(),
         )
         # Re-apply the absolute token cap so it survives model switches
         # and fallback activations. The cap is a first-class config value
@@ -3059,7 +3117,7 @@ class ContextCompressor(ContextEngine):
         self._tail_token_budget = None
         _ = self.tail_token_budget  # eager recompute, same timing as before
         self.max_summary_tokens = min(
-            int(context_length * 0.05), _SUMMARY_TOKENS_CEILING,
+            int(effective_ctx * 0.05), _SUMMARY_TOKENS_CEILING,
         )
 
         # Reset cross-call calibration state captured under the PREVIOUS model.
@@ -3163,6 +3221,35 @@ class ContextCompressor(ContextEngine):
             return None
         return ivalue if ivalue > 0 else None
 
+    @staticmethod
+    def _coerce_max_context_length(value: Any) -> int | None:
+        """Normalize the global context ceiling to a positive int or None.
+
+        ``model.max_context_length`` is a hard upper bound on the effective
+        context window (``effective = min(pre_cap, ceiling)``). Delegates to
+        the single shared CONFIG validator (``agent.model_metadata.
+        validate_context_ceiling``) so the built-in compressor and every other
+        resolution path agree on strictness AND on the 64K floor.
+
+        Two strictness guarantees:
+          * only a genuine positive integer is a real cap — ``None``, ``bool``,
+            non-integral floats, numeric strings, infinity, and ``<= 0`` all
+            mean "no ceiling" so a malformed config value can never zero out
+            or truncate the window;
+          * a positive integer BELOW the 64K ``MINIMUM_CONTEXT_LENGTH`` floor
+            is an INVALID ceiling (a mis-configuration, not a capability
+            statement) and is likewise treated as "no ceiling" — the pre-cap
+            window is left intact, never truncated to a sub-floor value.
+
+        Using the floor-enforcing validator (not the runtime ``coerce_``
+        variant) is deliberate: a ceiling below 64K must not silently clamp
+        the window, because Hermes cannot operate below the floor — the value
+        is a mis-configuration and the effective window must stay at the
+        model's real pre-cap capability.
+        """
+        from agent.model_metadata import validate_context_ceiling
+        return validate_context_ceiling(value)
+
     def _apply_threshold_tokens_cap(self) -> None:
         """Apply the absolute token cap if configured.
 
@@ -3193,6 +3280,34 @@ class ContextCompressor(ContextEngine):
         if context_length and context_length < _SMALL_CTX_WINDOW_LIMIT:
             return max(threshold_percent, _SMALL_CTX_THRESHOLD_PERCENT)
         return threshold_percent
+
+    def _resolve_output_reservation(self) -> int:
+        """The compressor's output reservation, from the shared policy.
+
+        Preflight budgeting must reserve the SAME output allowance the
+        terminal gate and the wire do, so the compressor, the gate, and the
+        provider agree on how much of the window the model's output will
+        consume.  Resolution:
+
+          * an explicit positive ``max_tokens`` (the invocation/user cap,
+            already coerced) wins;
+          * else the provider/profile-derived implicit cap (e.g. ``custom``
+            → 65536);
+          * else :data:`DEFAULT_OUTPUT_RESERVATION` (4096) — never 0, so a
+            no-cap request is NOT budgeted as a zero-reservation (the audit's
+            flagged "compressor may reserve 0/None" defect).
+
+        Delegates to the shared :func:`agent.model_metadata.resolve_output_reservation`
+        policy so every surface derives one identical allowance.
+        """
+        from agent.model_metadata import resolve_output_reservation
+
+        return resolve_output_reservation(
+            None,
+            explicit_cap=self.max_tokens,
+            provider=getattr(self, "provider", None),
+            model=getattr(self, "model", None),
+        )
 
     @staticmethod
     def _compute_threshold_tokens(
@@ -3247,6 +3362,7 @@ class ContextCompressor(ContextEngine):
         base_url: str = "",
         api_key: str = "",
         config_context_length: int | None = None,
+        max_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
@@ -3371,6 +3487,20 @@ class ContextCompressor(ContextEngine):
         self._config_context_length = config_context_length
         self._configured_threshold_percent = self.threshold_percent
         self._resolved_context_length: int | None = None
+        # Pre-cap window: the value resolved BEFORE the max_context_length
+        # ceiling is applied (i.e. the model's real capability / explicit
+        # override). Kept separate from the effective window so the persistent
+        # context cache can be fed the pre-cap value — the ceiling is a
+        # runtime/user policy and must never contaminate context_length_cache.yaml.
+        self._pre_cap_context_length: int | None = None
+        # Global context ceiling (model.max_context_length in config). A hard
+        # upper bound on the EFFECTIVE window: effective = min(pre_cap, ceiling).
+        # Never raises a window, only lowers it. None / non-positive = no cap.
+        # Exposed as a public attribute so plugin context engines can read it
+        # too; the built-in setter clamps against it automatically. Set via the
+        # constructor for the built-in compressor, or assigned directly on a
+        # plugin engine by agent_init before its update_model() call.
+        self.max_context_length: int | None = self._coerce_max_context_length(max_context_length)
         self._threshold_tokens: int | None = None
         self._tail_token_budget: int | None = None
         self._max_summary_tokens: int | None = None

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1645,34 +1645,36 @@ def run_compress_context_with_progress_timeout(
         # so a NEW compressor can acquire the lock immediately (no ABA: the
         # DB release is holder-scoped).
         handled_exit = True
-        # #97488 teardown: give the cancelled worker a bounded grace to
-        # actually exit before this host moves on. The worker checks the
-        # poison fence between provider phases, so a cooperative worker
-        # exits quickly; an uninterruptible provider call is orphaned behind
-        # the fence after the grace elapses (its late result is discarded and
-        # cannot touch session state).
-        worker_exited = _join_cancelled_worker(
-            future,
-            min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
-        )
-        if worker_exited:
-            # The worker provably exited: no in-flight provider call can
-            # outlive this attempt, so the total-ceiling lease retention is
-            # no longer needed and a retry cannot overlap anything.
-            fence.allow_cancelled_lock_release()
-        else:
-            logger.warning(
-                "Cancelled compression worker did not exit within %.1fs "
-                "grace — orphaning it behind the poison fence (late result "
-                "will be discarded)%s",
+        # #97488 teardown (total-ceiling path only): give the cancelled
+        # worker a bounded grace to actually exit before this host moves on.
+        # The worker checks the poison fence between provider phases, so a
+        # cooperative worker exits quickly; an uninterruptible provider call
+        # is orphaned behind the fence after the grace elapses (its late
+        # result is discarded and cannot touch session state). The
+        # idle-stall path intentionally skips the join: its worker is by
+        # definition silent/hung, the stall-fallback retry below needs a
+        # prompt host return (pinned by the #76354 S3 latency contract), and
+        # the fence poison + attempt-generation supersession already protect
+        # state against its late unwind.
+        if total_exhausted:
+            worker_exited = _join_cancelled_worker(
+                future,
                 min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
-                (
-                    "; retaining the session compression lease until it "
-                    "exits so no new attempt overlaps it"
-                    if total_exhausted
-                    else ""
-                ),
             )
+            if worker_exited:
+                # The worker provably exited: no in-flight provider call can
+                # outlive this attempt, so the total-ceiling lease retention
+                # is no longer needed and a retry cannot overlap anything.
+                fence.allow_cancelled_lock_release()
+            else:
+                logger.warning(
+                    "Cancelled compression worker did not exit within %.1fs "
+                    "grace — orphaning it behind the poison fence (late "
+                    "result will be discarded); retaining the session "
+                    "compression lease until it exits so no new attempt "
+                    "overlaps it",
+                    min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
+                )
         fence.release_cancelled_compression_lock()
         waited = time.monotonic() - wait_started
         since_progress = fence.seconds_since_progress()

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -637,7 +637,7 @@ class CompressionCommitFence:
     fully complete before the caller proceeds.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, total_ceiling_seconds: float | None = None) -> None:
         self._lock = threading.Lock()
         self._cancelled = False
         self._commit_started = False
@@ -672,6 +672,18 @@ class CompressionCommitFence:
         # a SLOW-but-alive summary model from a HUNG one, so slow models are
         # not killed by a fixed wall-clock deadline while tokens are moving.
         self._last_progress = time.monotonic()
+        self._progress_observed = False
+        self._deadline: float | None = None
+        self._retain_cancelled_lock_until_worker_done = False
+        if total_ceiling_seconds is not None:
+            self.set_total_ceiling_seconds(total_ceiling_seconds)
+
+    def set_total_ceiling_seconds(self, seconds: float) -> None:
+        """Arm the wall-clock deadline shared by the host and worker."""
+        seconds = float(seconds)
+        if seconds <= 0:
+            raise ValueError("total compression ceiling must be positive")
+        self._deadline = time.monotonic() + seconds
 
     def touch_progress(self) -> None:
         """Record forward progress (e.g. a streamed summary token arriving).
@@ -681,6 +693,17 @@ class CompressionCommitFence:
         CPython, so no lock is needed.
         """
         self._last_progress = time.monotonic()
+        self._progress_observed = True
+
+    @property
+    def progress_observed(self) -> bool:
+        """Whether semantic provider progress was reported for this attempt."""
+        return self._progress_observed
+
+    @property
+    def deadline_exceeded(self) -> bool:
+        deadline = self._deadline
+        return deadline is not None and time.monotonic() >= deadline
 
     def seconds_since_progress(self) -> float:
         """Seconds since the worker last reported forward progress."""
@@ -723,7 +746,7 @@ class CompressionCommitFence:
         """Atomically admit commit unless a hard cancellation already won."""
         self._lock.acquire()
         if (
-            self._cancelled
+            self.is_cancelled
             or self._admission_revoked
             or (cancel_event is not None and bool(cancel_event.is_set()))
         ):
@@ -771,7 +794,11 @@ class CompressionCommitFence:
     @property
     def is_cancelled(self) -> bool:
         """True after cancellation won before the commit boundary."""
-        return self._cancelled or self._admission_revoked
+        return self._cancelled or self._admission_revoked or self.deadline_exceeded
+
+    def retain_compression_lock_until_worker_done(self) -> None:
+        """Prevent a timed-out live worker from overlapping a retry."""
+        self._retain_cancelled_lock_until_worker_done = True
 
     def revoke_commit_admission(self) -> None:
         """Revoke FUTURE commit admission without blocking on the fence lock.
@@ -830,7 +857,7 @@ class CompressionCommitFence:
         the durable lock and making its cancellation cleanup callable.
         """
         self._lock.acquire()
-        if self._cancelled or self._admission_revoked:
+        if self.is_cancelled or self._admission_revoked:
             self._lock.release()
             return False
         return True
@@ -868,6 +895,8 @@ class CompressionCommitFence:
         publication is retained and fulfilled synchronously when the worker
         publishes the hook.
         """
+        if self._retain_cancelled_lock_until_worker_done:
+            return
         with self._lock_release_guard:
             self._cancelled_lock_release_requested = True
             release = self._cancelled_lock_release
@@ -1244,9 +1273,10 @@ def run_compress_context_with_progress_timeout(
             return system_prompt_fallback()
         return system_prompt_fallback
 
-    fence = fence if fence is not None else CompressionCommitFence()
     ceiling = max(float(total_ceiling_seconds), float(idle_timeout_seconds))
     idle = float(idle_timeout_seconds)
+    fence = fence if fence is not None else CompressionCommitFence()
+    fence.set_total_ceiling_seconds(ceiling)
     # Sync mirror of gateway session-hygiene's run_in_executor(None, ...) +
     # wait_for loop (gateway/run.py): offload compress_context onto the shared
     # daemon pool, poll with an inactivity budget + total ceiling, then
@@ -1347,6 +1377,15 @@ def run_compress_context_with_progress_timeout(
         # F6: a not-yet-started future must not linger as a stale queued job.
         # cancel() is a no-op for a running worker (fence handles that path).
         future.cancel()
+
+        total_exhausted = (
+            time.monotonic() - wait_started >= ceiling or fence.deadline_exceeded
+        )
+        if total_exhausted:
+            # A total-ceiling candidate can still be unwinding a healthy
+            # provider call. Keep its session lease until that worker exits so
+            # another automatic attempt cannot overlap the unchanged source.
+            fence.retain_compression_lock_until_worker_done()
 
         cancelled: Optional[bool] = None
         while cancelled is None:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -4169,6 +4169,22 @@ def compress_context(
                         lock_holder=_lock_holder,
                     )
                     split_status = "in_place_committed"
+                    # Post-commit contract (#98450, mirrors
+                    # _sync_micro_compact_to_db): archive_and_compact just
+                    # durably wrote every dict in `compressed` as the new
+                    # active set, but compress() returned marker-swept COPIES
+                    # (_strip_persistence_markers, #57491). These exact dict
+                    # instances become the live message list the caller keeps,
+                    # so without the stamp the next _persist_session →
+                    # _flush_messages_to_session_db_unlocked walk treats the
+                    # whole compacted transcript as unpersisted and re-INSERTs
+                    # it — the live set doubles on every compaction
+                    # (~58K → ~512K tokens in production).
+                    from agent.context_compressor import (
+                        stamp_db_persisted_markers,
+                    )
+
+                    stamp_db_persisted_markers(compressed)
                     # Reset the flush identity set so the next turn's appends are
                     # diffed against the COMPACTED transcript: the compacted dicts
                     # are passed as conversation_history next turn and skipped by

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -4075,6 +4075,26 @@ def compress_context(
                 "Compression made no progress (session=%s) — skipping boundary rewrite.",
                 agent.session_id or "none",
             )
+            # Dead-loop breaker (#84371): a fired compaction that returns the
+            # transcript UNCHANGED will fail identically next turn unless the
+            # transcript changes — yet this path recorded telemetry only, so
+            # auto-compress re-fired every turn, each attempt burning a full
+            # aux summarization (6+/10min in the wild). Arm the transient
+            # structural backoff so the next attempts are deferred; any
+            # successful boundary lifts it, and manual /compress overrides it.
+            try:
+                _no_progress_recorder = getattr(
+                    agent.context_compressor, "_record_structural_no_op", None
+                )
+                if callable(_no_progress_recorder):
+                    _no_progress_recorder(
+                        "compaction returned the transcript unchanged "
+                        "(no_progress)"
+                    )
+            except Exception:
+                logger.debug(
+                    "no-progress backoff arm failed", exc_info=True
+                )
             _existing_sp = getattr(agent, "_cached_system_prompt", None)
             if not _existing_sp:
                 _existing_sp = agent._build_system_prompt(system_message)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1316,6 +1316,10 @@ def run_compress_context_with_progress_timeout(
         # (worker slot freed late). Check the fence BEFORE any expensive
         # summary work so a stale job never burns an LLM call; its return
         # value is discarded by the already-departed host.
+        if worker_fence.deadline_exceeded:
+            raise concurrent.futures.TimeoutError(
+                "compression deadline expired before worker start"
+            )
         if worker_fence.is_cancelled:
             logger.info(
                 "Skipping stale compression job: fence cancelled before start"
@@ -1362,7 +1366,11 @@ def run_compress_context_with_progress_timeout(
             except concurrent.futures.TimeoutError:
                 waited = time.monotonic() - wait_started
                 since_progress = fence.seconds_since_progress()
-                if since_progress < idle and waited < ceiling:
+                if (
+                    not fence.deadline_exceeded
+                    and since_progress < idle
+                    and waited < ceiling
+                ):
                     logger.info(
                         "Context compression still streaming after %.0fs "
                         "(last progress %.1fs ago) — extending wait "

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -909,6 +909,12 @@ class CompressionCommitFence:
 DEFAULT_CONTEXT_TIMEOUT_SECONDS = 120.0
 DEFAULT_CONTEXT_TOTAL_CEILING_SECONDS = 600.0
 
+# Distinct from ``explicit_interrupt``: a /stop that arrived after the summary
+# stream had already crossed the no-progress stall window (#96775). Ordinary
+# early /stop stays cooldown-neutral; this class arms the durable backoff so
+# the next automatic turn does not re-enter the same stalled strategy.
+STALL_INTERRUPTED_FAILURE_CLASS = "stall_interrupted"
+
 # Shared daemon pool for sync compress_context timeout wraps — analogous to
 # asyncio's default executor used by gateway session hygiene's
 # ``loop.run_in_executor(None, ...)``, but daemon so a fence-cancelled hung
@@ -1028,6 +1034,101 @@ def resolve_context_compression_timeouts(
     if idle > 0:
         ceiling = max(ceiling, idle)
     return idle, ceiling
+
+
+def compression_attempt_stalled(
+    *,
+    commit_fence: Optional[CompressionCommitFence],
+    started_at: float,
+    idle_timeout_seconds: Optional[float] = None,
+) -> bool:
+    """Return whether a pre-commit cancel landed after the stall window.
+
+    An ordinary early ``/stop`` must stay cooldown-neutral. When the fence
+    (or, without a fence, the attempt clock) has already sat idle for the
+    configured compression inactivity budget, the interrupt is a stalled
+    attempt — the same condition the host timeout uses — and the next
+    automatic turn must not blindly retry that strategy (#96775).
+    """
+    idle = idle_timeout_seconds
+    if idle is None:
+        idle, _ceiling = resolve_context_compression_timeouts()
+    try:
+        idle = float(idle)
+    except (TypeError, ValueError):
+        return False
+    if idle <= 0:
+        return False
+    if commit_fence is not None:
+        try:
+            return float(commit_fence.seconds_since_progress()) >= idle
+        except Exception:
+            return False
+    try:
+        return (time.monotonic() - float(started_at)) >= idle
+    except (TypeError, ValueError):
+        return False
+
+
+def _stall_source_fingerprint(
+    agent: Any,
+    messages: Any,
+    approx_tokens: Optional[int],
+) -> str:
+    """Identity of the stalled source context + summary strategy."""
+    compressor = getattr(agent, "context_compressor", None)
+    model = (
+        getattr(compressor, "summary_model", None)
+        or getattr(agent, "model", None)
+        or ""
+    )
+    n_messages = len(messages) if isinstance(messages, list) else 0
+    try:
+        tokens = int(approx_tokens or 0)
+    except (TypeError, ValueError):
+        tokens = 0
+    return f"msgs={n_messages}:tokens={tokens}:model={model}"
+
+
+def _record_stall_interrupted_backoff(
+    agent: Any,
+    *,
+    commit_fence: Optional[CompressionCommitFence],
+    started_at: float,
+    messages: Any,
+    approx_tokens: Optional[int],
+) -> bool:
+    """Persist a stall-interrupted cooldown after snapshot restore.
+
+    Must run *after* ``_restore_compressor_attempt_state`` so rollback cannot
+    wipe the new row. Returns True when the stall backoff was recorded.
+    """
+    if not compression_attempt_stalled(
+        commit_fence=commit_fence, started_at=started_at
+    ):
+        return False
+    compressor = getattr(agent, "context_compressor", None)
+    record = getattr(compressor, "record_timeout_failure", None)
+    if not callable(record):
+        return False
+    error = (
+        f"{STALL_INTERRUPTED_FAILURE_CLASS}:"
+        f"{_stall_source_fingerprint(agent, messages, approx_tokens)}"
+    )
+    try:
+        record(error)
+    except Exception:
+        logger.debug(
+            "stall-interrupted compression cooldown persist failed",
+            exc_info=True,
+        )
+        return False
+    logger.info(
+        "Recorded stall-interrupted compression backoff (session=%s, %s)",
+        getattr(agent, "session_id", None) or "none",
+        error,
+    )
+    return True
 
 
 def resolve_compression_fallback_route() -> Optional[dict]:
@@ -3716,6 +3817,15 @@ def compress_context(
             and messages != messages_before_compression
         ):
             messages[:] = copy.deepcopy(messages_before_compression)
+        # Record after restore so rollback cannot wipe a stall backoff, and
+        # while the lease is still held so the next turn cannot race it.
+        _stall_backoff = _record_stall_interrupted_backoff(
+            agent,
+            commit_fence=commit_fence,
+            started_at=_attempt_started_at,
+            messages=messages,
+            approx_tokens=approx_tokens,
+        )
         if _activity_heartbeat is not None:
             _activity_heartbeat.stop("context compression cancelled")
             _activity_heartbeat = None
@@ -3725,7 +3835,11 @@ def compress_context(
             started_at=_attempt_started_at,
             commit_status="aborted",
             split_status="aborted",
-            failure_class="explicit_interrupt",
+            failure_class=(
+                STALL_INTERRUPTED_FAILURE_CLASS
+                if _stall_backoff
+                else "explicit_interrupt"
+            ),
         )
         _existing_sp = getattr(agent, "_cached_system_prompt", None)
         if not _existing_sp:
@@ -3870,6 +3984,13 @@ def compress_context(
                     agent.session_id or "none",
                 )
                 agent._last_compaction_in_place = False
+                _stall_backoff = _record_stall_interrupted_backoff(
+                    agent,
+                    commit_fence=commit_fence,
+                    started_at=_attempt_started_at,
+                    messages=messages,
+                    approx_tokens=approx_tokens,
+                )
                 _existing_sp = getattr(agent, "_cached_system_prompt", None)
                 if not _existing_sp:
                     _existing_sp = agent._build_system_prompt(system_message)
@@ -3878,7 +3999,11 @@ def compress_context(
                     started_at=_attempt_started_at,
                     commit_status="aborted",
                     split_status="aborted",
-                    failure_class="commit_fence_cancelled",
+                    failure_class=(
+                        STALL_INTERRUPTED_FAILURE_CLASS
+                        if _stall_backoff
+                        else "commit_fence_cancelled"
+                    ),
                 )
                 _release_lock()
                 return messages, _existing_sp

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1102,6 +1102,7 @@ def _retry_compression_on_fallback_chain(
     idle_timeout_seconds: float,
     total_ceiling_seconds: float,
     on_commit_overrun: Optional[Callable[[float, float], None]] = None,
+    on_timeout_cause: Optional[Callable[[bool, bool], None]] = None,
     telemetry_agent: Any = None,
     new_fence: Optional[Callable[[], CompressionCommitFence]] = None,
 ) -> Optional[Tuple[list, str]]:
@@ -1176,6 +1177,7 @@ def _retry_compression_on_fallback_chain(
                 idle_timeout_seconds=idle,
                 total_ceiling_seconds=ceiling,
                 on_commit_overrun=on_commit_overrun,
+                on_timeout_cause=on_timeout_cause,
                 fence=retry_fence,
                 telemetry_agent=telemetry_agent,
                 stall_fallback=False,
@@ -1213,6 +1215,7 @@ def run_compress_context_with_progress_timeout(
     idle_timeout_seconds: float,
     total_ceiling_seconds: float,
     on_timeout: Optional[Callable[[float, float, float], None]] = None,
+    on_timeout_cause: Optional[Callable[[bool, bool], None]] = None,
     on_commit_overrun: Optional[Callable[[float, float], None]] = None,
     fence: Optional[CompressionCommitFence] = None,
     telemetry_agent: Any = None,
@@ -1247,7 +1250,10 @@ def run_compress_context_with_progress_timeout(
 
     ``system_prompt_fallback`` may be a string or a zero-arg callable resolved
     only on the timeout path, so successful compression never pays for (or
-    fails on) an eager prompt rebuild.
+    fails on) an eager prompt rebuild. ``on_timeout_cause`` receives whether
+    the total ceiling expired and whether provider progress was observed before
+    ``on_timeout`` runs, allowing hosts to report the timeout accurately while
+    preserving the existing three-argument timeout callback contract.
 
     ``stall_fallback`` (default on) makes an aborted stall attempt the
     configured ``auxiliary.compression.fallback_chain`` once — pinned onto a
@@ -1395,6 +1401,15 @@ def run_compress_context_with_progress_timeout(
             # another automatic attempt cannot overlap the unchanged source.
             fence.retain_compression_lock_until_worker_done()
 
+        if on_timeout_cause is not None:
+            try:
+                on_timeout_cause(total_exhausted, fence.progress_observed)
+            except Exception:
+                logger.debug(
+                    "compress_context timeout-cause callback failed",
+                    exc_info=True,
+                )
+
         cancelled: Optional[bool] = None
         while cancelled is None:
             # F1: ``begin_commit`` retains the fence lock until
@@ -1493,6 +1508,7 @@ def run_compress_context_with_progress_timeout(
                 idle_timeout_seconds=idle,
                 total_ceiling_seconds=ceiling,
                 on_commit_overrun=on_commit_overrun,
+                on_timeout_cause=on_timeout_cause,
                 telemetry_agent=telemetry_agent,
                 new_fence=new_fence,
             )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -800,6 +800,16 @@ class CompressionCommitFence:
         """Prevent a timed-out live worker from overlapping a retry."""
         self._retain_cancelled_lock_until_worker_done = True
 
+    def allow_cancelled_lock_release(self) -> None:
+        """Undo :meth:`retain_compression_lock_until_worker_done`.
+
+        Called by the host after a bounded-grace join confirmed the timed-out
+        worker actually exited: the overlap hazard is gone, so the durable
+        lease may be released normally and a fallback/retry attempt can
+        proceed against a genuinely quiescent session.
+        """
+        self._retain_cancelled_lock_until_worker_done = False
+
     def revoke_commit_admission(self) -> None:
         """Revoke FUTURE commit admission without blocking on the fence lock.
 
@@ -930,6 +940,47 @@ _compress_timeout_executor_lock = threading.Lock()
 # silent unbounded future.result(). Clamped down to the ceiling for tiny test
 # ceilings so overrun reporting stays observable at test timescales.
 _COMMIT_OVERRUN_WAIT_SLICE_SECONDS = 30.0
+
+# Bounded grace given to a fence-cancelled compression worker to actually
+# exit before the host moves on (#97488). A worker that exits inside the
+# grace window proves no provider call is still in flight, so the durable
+# lease can be released safely even on the total-ceiling path. A worker that
+# does NOT exit is orphaned behind the poison fence (its late result cannot
+# commit) and, on the total-ceiling path, keeps the holder-qualified lease
+# retained so a new attempt cannot overlap the unchanged session.
+_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS = 5.0
+
+
+def _join_cancelled_worker(future: Any, grace_seconds: float) -> bool:
+    """Best-effort bounded join of a fence-cancelled compression worker.
+
+    Returns True when the worker future settled (result, exception, or
+    pre-start cancellation) within ``grace_seconds`` — i.e. the worker thread
+    provably exited and cannot be holding a provider call open. Returns
+    False for a worker that is still running; the caller must treat it as an
+    orphan behind the poison fence.
+    """
+    try:
+        grace = max(float(grace_seconds), 0.0)
+    except (TypeError, ValueError):
+        grace = 0.0
+    try:
+        future.result(timeout=grace)
+        return True
+    except concurrent.futures.TimeoutError:
+        return False
+    except concurrent.futures.CancelledError:
+        # Never started; nothing can be in flight.
+        return True
+    except Exception:
+        # The worker raised — it exited. The exception is intentionally
+        # swallowed here: the host already chose the fallback result, and the
+        # fence prevents the failed attempt from touching session state.
+        logger.debug(
+            "cancelled compression worker exited with an exception",
+            exc_info=True,
+        )
+        return True
 
 # Bounded admission for the shared compress-timeout pool (#76354 review F6).
 # The stdlib executor queue is unbounded: with all four workers wedged in hung
@@ -1116,7 +1167,7 @@ def _record_stall_interrupted_backoff(
         f"{_stall_source_fingerprint(agent, messages, approx_tokens)}"
     )
     try:
-        record(error)
+        record(error, failure_kind="stall_interrupted")
     except Exception:
         logger.debug(
             "stall-interrupted compression cooldown persist failed",
@@ -1594,6 +1645,34 @@ def run_compress_context_with_progress_timeout(
         # so a NEW compressor can acquire the lock immediately (no ABA: the
         # DB release is holder-scoped).
         handled_exit = True
+        # #97488 teardown: give the cancelled worker a bounded grace to
+        # actually exit before this host moves on. The worker checks the
+        # poison fence between provider phases, so a cooperative worker
+        # exits quickly; an uninterruptible provider call is orphaned behind
+        # the fence after the grace elapses (its late result is discarded and
+        # cannot touch session state).
+        worker_exited = _join_cancelled_worker(
+            future,
+            min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
+        )
+        if worker_exited:
+            # The worker provably exited: no in-flight provider call can
+            # outlive this attempt, so the total-ceiling lease retention is
+            # no longer needed and a retry cannot overlap anything.
+            fence.allow_cancelled_lock_release()
+        else:
+            logger.warning(
+                "Cancelled compression worker did not exit within %.1fs "
+                "grace — orphaning it behind the poison fence (late result "
+                "will be discarded)%s",
+                min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
+                (
+                    "; retaining the session compression lease until it "
+                    "exits so no new attempt overlaps it"
+                    if total_exhausted
+                    else ""
+                ),
+            )
         fence.release_cancelled_compression_lock()
         waited = time.monotonic() - wait_started
         since_progress = fence.seconds_since_progress()
@@ -1773,6 +1852,63 @@ def compression_skipped_due_to_lock(agent: Any) -> bool:
     """
     _sig = getattr(agent, "_compression_skipped_due_to_lock", None)
     return _sig is True or isinstance(_sig, str)
+
+
+def compression_blocked_transiently(agent: Any) -> bool:
+    """Type-pinned read of the transient-block signal (#97488).
+
+    ``agent._compression_blocked_transient`` is set by ``compress_context``
+    when an automatic pass no-ops because a TRANSIENT compressor guard is
+    active — a summary-failure cooldown (e.g. one just recorded by the host
+    ceiling timeout) or a structural no-op backoff — and cleared to ``None``
+    at the entry of every call.
+
+    Consumers (the overflow-recovery loops in ``conversation_loop``) must
+    treat such a no-op as a temporary defer, NOT as evidence the session is
+    incompressible: counting it toward ``compression_exhausted`` lets a real
+    upstream ``context_length_exceeded`` auto-reset (wipe) a session whose
+    compression was merely cooling down (#97488). The permanent
+    ``ineffective`` breaker intentionally does NOT set this signal — a
+    genuinely incompressible session must still be able to exhaust.
+
+    Type-pinned for the same reason as :func:`compression_skipped_due_to_lock`
+    (MagicMock auto-attribute hijack).
+    """
+    _sig = getattr(agent, "_compression_blocked_transient", None)
+    return isinstance(_sig, str) and bool(_sig)
+
+
+def _mark_compression_blocked_transient(agent: Any, compressor: Any) -> None:
+    """Publish the transient-block signal when the active guard is transient.
+
+    Reads the compressor's own block reason so the transient/permanent
+    classification lives in one place (``_compression_block_reason``):
+    ``cooldown:*`` and ``structural_backoff:*`` are timed guards that lapse
+    on their own; ``ineffective`` is the permanent breaker and stays
+    unmarked so exhaustion semantics are preserved.
+    """
+    reason_fn = getattr(compressor, "_compression_block_reason", None)
+    reason = None
+    if callable(reason_fn):
+        try:
+            reason = reason_fn()
+        except Exception:
+            logger.debug("compression block-reason read failed", exc_info=True)
+    if isinstance(reason, str) and (
+        reason.startswith("cooldown") or reason.startswith("structural_backoff")
+    ):
+        logger.info(
+            "Skipping automatic compression re-entry: transient guard "
+            "active (%s, session=%s, last failure: %s) — will retry after "
+            "the backoff lapses; /compress forces an immediate retry",
+            reason,
+            getattr(agent, "session_id", None) or "none",
+            getattr(compressor, "_last_summary_error", None) or "unknown",
+        )
+        try:
+            agent._compression_blocked_transient = reason
+        except Exception:
+            pass
 
 
 def _adopt_live_compression_child(
@@ -2966,6 +3102,10 @@ def compress_context(
     # second clear before lock acquisition below stays for the same reason
     # it was added in #69870 and is simply idempotent now.
     agent._compression_skipped_due_to_lock = None
+    # Transient-block signal (#97488): cleared with the same per-attempt
+    # rule; set by the breaker gates below when a TRANSIENT guard (cooldown /
+    # structural backoff) no-ops this pass.
+    agent._compression_blocked_transient = None
 
     _attempt_started_at = time.monotonic()
     _attempt_id = uuid.uuid4().hex
@@ -3038,6 +3178,7 @@ def compress_context(
             None,
         )
         if callable(blocked) and blocked(agent.context_compressor):
+            _mark_compression_blocked_transient(agent, agent.context_compressor)
             existing_prompt = getattr(agent, "_cached_system_prompt", None)
             if not existing_prompt:
                 existing_prompt = agent._build_system_prompt(system_message)
@@ -3496,6 +3637,7 @@ def compress_context(
             None,
         )
         if callable(blocked) and blocked(compressor):
+            _mark_compression_blocked_transient(agent, compressor)
             _release_lock()
             existing_prompt = getattr(agent, "_cached_system_prompt", None)
             if not existing_prompt:
@@ -3960,6 +4102,47 @@ def compress_context(
             _existing_sp = getattr(agent, "_cached_system_prompt", None)
             if not _existing_sp:
                 _existing_sp = agent._build_system_prompt(system_message)
+            _release_lock()
+            return messages, _existing_sp
+
+        # Supersession guard (#97488): a NEWER attempt claiming this
+        # compressor (via _claim_compressor_attempt) supersedes this one —
+        # this attempt's late candidate must be discarded, never committed
+        # over the newer attempt's state. Checked for fenceless callers too:
+        # the fence poison alone cannot see a successor that minted its own
+        # fresh fence.
+        _attempt_superseded = not _compressor_attempt_is_current(
+            agent.context_compressor, _attempt_generation
+        )
+        if _attempt_superseded:
+            logger.warning(
+                "Discarding late compression candidate: attempt generation "
+                "%s was superseded by a newer attempt (current: %s) "
+                "(session=%s).",
+                _attempt_generation,
+                getattr(
+                    agent.context_compressor,
+                    "_compression_attempt_generation",
+                    None,
+                ),
+                agent.session_id or "none",
+            )
+            if (
+                messages_before_compression is not None
+                and messages != messages_before_compression
+            ):
+                messages[:] = copy.deepcopy(messages_before_compression)
+            agent._last_compaction_in_place = False
+            _existing_sp = getattr(agent, "_cached_system_prompt", None)
+            if not _existing_sp:
+                _existing_sp = agent._build_system_prompt(system_message)
+            _emit_compression_attempt_telemetry(
+                agent,
+                started_at=_attempt_started_at,
+                commit_status="aborted",
+                split_status="aborted",
+                failure_class="attempt_superseded",
+            )
             _release_lock()
             return messages, _existing_sp
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -33,6 +33,7 @@ from agent.conversation_compression import (
     COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE,
+    compression_blocked_transiently,
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
@@ -1513,38 +1514,57 @@ def _compression_deferred_result(
     agent,
     messages: List[Dict],
     api_call_count: int,
+    reason: str = "lock",
 ) -> Dict[str, Any]:
-    """Build the soft turn result for a lock-contended compression defer.
+    """Build the soft turn result for a transiently-deferred compression.
 
-    Another path (a sibling turn, a background review fork, a manual
-    ``/compress``) holds this session's compression lock, so every
-    compression pass this turn no-oped and the request still does not fit.
-    This is a TEMPORARY condition — the lock winner is actively shrinking
-    the same session — so the turn must end as a soft defer
+    Two transient shapes funnel here, and BOTH must end as a soft defer
     (``compression_deferred``), never as ``compression_exhausted``: the
-    gateway auto-resets (wipes) the session on exhaustion (#9893/#35809),
-    which would destroy a session that the concurrent compressor is about
-    to make healthy again.
+    gateway auto-resets (wipes) the session on exhaustion (#9893/#35809).
+
+    * ``reason="lock"`` — another path (a sibling turn, a background review
+      fork, a manual ``/compress``) holds this session's compression lock,
+      so every compression pass this turn no-oped and the request still does
+      not fit. The lock winner is actively shrinking the same session.
+    * ``reason="transient_block"`` — the compressor is in a timed transient
+      guard (summary-failure cooldown / structural backoff, e.g. one just
+      recorded by the host ceiling timeout, #97488). The no-op says nothing
+      about compressibility; treating it as exhaustion falsely auto-reset
+      sessions whose compression was merely cooling down.
 
     ``failed`` stays False so the gateway persists the user turn (transient
     branch) and retry-next-message semantics apply.
     """
-    holder = getattr(agent, "_compression_skipped_due_to_lock", None)
-    logger.info(
-        "turn deferred: compression lock held by another path "
-        "(session=%s holder=%s) — not counting as compression exhaustion",
-        agent.session_id or "none",
-        holder if isinstance(holder, str) else "unconfirmed",
-    )
+    if reason == "transient_block":
+        block = getattr(agent, "_compression_blocked_transient", None)
+        logger.info(
+            "turn deferred: compression transiently blocked (%s) "
+            "(session=%s) — not counting as compression exhaustion",
+            block if isinstance(block, str) else "unknown guard",
+            agent.session_id or "none",
+        )
+        _final = (
+            "Context compression is temporarily paused after a recent "
+            "failed attempt. Please retry in a moment — compression will "
+            "resume automatically (or run /compress to force a retry now)."
+        )
+    else:
+        holder = getattr(agent, "_compression_skipped_due_to_lock", None)
+        logger.info(
+            "turn deferred: compression lock held by another path "
+            "(session=%s holder=%s) — not counting as compression exhaustion",
+            agent.session_id or "none",
+            holder if isinstance(holder, str) else "unconfirmed",
+        )
+        _final = (
+            "Context compression is already running for this session. "
+            "Please retry in a moment — your next message will be processed "
+            "once the concurrent compression finishes."
+        )
     try:
         agent._flush_status_buffer()
     except Exception:
         pass
-    _final = (
-        "Context compression is already running for this session. "
-        "Please retry in a moment — your next message will be processed "
-        "once the concurrent compression finishes."
-    )
     return {
         "final_response": _final,
         "messages": messages,
@@ -2816,16 +2836,21 @@ def run_conversation(
                 approx_tokens=request_pressure_tokens,
                 task_id=effective_task_id,
             )
-            if messages is _pre_api_input and compression_skipped_due_to_lock(agent):
-                # #69870 lock-skip: another path holds this session's
-                # compression lock, so this pass no-oped. That is a temporary
-                # DEFER, not evidence about compressibility — refund the
-                # attempt (it must not burn the shared overflow-recovery
-                # budget toward compression_exhausted → gateway auto-reset,
-                # #9893/#35809) and leave the insufficient-progress blocker
-                # unarmed. Proceed with the current request: if it truly does
-                # not fit, the provider's 413/overflow handler returns the
-                # soft compression_deferred result with that stronger signal.
+            if messages is _pre_api_input and (
+                compression_skipped_due_to_lock(agent)
+                or compression_blocked_transiently(agent)
+            ):
+                # #69870 lock-skip / #97488 transient-block: this pass
+                # no-oped for a TEMPORARY reason (another path holds the
+                # compression lock, or a timed cooldown/backoff guard is
+                # active). That is a temporary DEFER, not evidence about
+                # compressibility — refund the attempt (it must not burn the
+                # shared overflow-recovery budget toward
+                # compression_exhausted → gateway auto-reset, #9893/#35809)
+                # and leave the insufficient-progress blocker unarmed.
+                # Proceed with the current request: if it truly does not
+                # fit, the provider's 413/overflow handler returns the soft
+                # compression_deferred result with that stronger signal.
                 compression_attempts -= 1
                 _last_preflight_pressure = None
                 if pending_moa_prepared_request is _moa_prepared_request:
@@ -5803,6 +5828,18 @@ def run_conversation(
                         return _compression_deferred_result(
                             agent, messages, api_call_count
                         )
+                    if messages is _overflow_input and compression_blocked_transiently(agent):
+                        # #97488 transient-block: compression no-oped because a
+                        # timed guard (host-timeout cooldown / structural
+                        # backoff) is active — a temporary defer, not evidence
+                        # of incompressibility. Never classify it as
+                        # compression_exhausted (gateway auto-reset).
+                        compression_attempts -= 1
+                        agent._persist_session(messages, conversation_history)
+                        return _compression_deferred_result(
+                            agent, messages, api_call_count,
+                            reason="transient_block",
+                        )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history
                     )
@@ -5960,6 +5997,15 @@ def run_conversation(
                                 agent._persist_session(messages, conversation_history)
                                 return _compression_deferred_result(
                                     agent, messages, api_call_count
+                                )
+                            if messages is _overflow_input and compression_blocked_transiently(agent):
+                                # #97488: timed transient guard — defer, never
+                                # exhaustion (gateway auto-reset).
+                                compression_attempts -= 1
+                                agent._persist_session(messages, conversation_history)
+                                return _compression_deferred_result(
+                                    agent, messages, api_call_count,
+                                    reason="transient_block",
                                 )
                             conversation_history = conversation_history_after_compression(
                                 agent, messages, conversation_history
@@ -6120,6 +6166,17 @@ def run_conversation(
                         agent._persist_session(messages, conversation_history)
                         return _compression_deferred_result(
                             agent, messages, api_call_count
+                        )
+                    if messages is _overflow_input and compression_blocked_transiently(agent):
+                        # #97488 transient-block: a timed guard (host-timeout
+                        # cooldown / structural backoff) no-oped this pass —
+                        # defer softly, never compression_exhausted (which
+                        # would auto-reset the session).
+                        compression_attempts -= 1
+                        agent._persist_session(messages, conversation_history)
+                        return _compression_deferred_result(
+                            agent, messages, api_call_count,
+                            reason="transient_block",
                         )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2672,7 +2672,17 @@ def run_conversation(
         # messages walk inside estimate_request_tokens_rough. Tools added
         # separately (compression needs them: 50+ tools = 20-30K tokens).
         # total_chars is a rough (~) proxy — verbose log + hook metric only.
-        approx_tokens = estimate_messages_tokens_rough(api_messages)
+        # Charge stale thinking only when the active route actually replays
+        # it (#84371): on codex_responses the text keys never ship (the
+        # encrypted item sidecars — charged unconditionally — carry the
+        # chain), so counting them here re-created the trigger/tail-walk
+        # disagreement that dead-looped compaction.
+        from agent.turn_context import _agent_stale_thinking_on_wire
+
+        approx_tokens = estimate_messages_tokens_rough(
+            api_messages,
+            charge_stale_thinking=_agent_stale_thinking_on_wire(agent),
+        )
         # Route-aware pressure: when the upcoming request is eligible for
         # native Responses compaction the transport will checkpoint-prune
         # the payload before sending — the generic durable-history figure

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2679,10 +2679,12 @@ def run_conversation(
         # disagreement that dead-looped compaction.
         from agent.turn_context import _agent_stale_thinking_on_wire
 
-        approx_tokens = estimate_messages_tokens_rough(
-            api_messages,
-            charge_stale_thinking=_agent_stale_thinking_on_wire(agent),
-        )
+        if _agent_stale_thinking_on_wire(agent):
+            approx_tokens = estimate_messages_tokens_rough(api_messages)
+        else:
+            approx_tokens = estimate_messages_tokens_rough(
+                api_messages, charge_stale_thinking=False
+            )
         # Route-aware pressure: when the upcoming request is eligible for
         # native Responses compaction the transport will checkpoint-prune
         # the payload before sending — the generic durable-history figure

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3257,6 +3257,33 @@ def run_conversation(
                         _use_streaming = False
 
                 def _perform_api_call(next_api_kwargs):
+                    # ── Hard-ceiling gate ──────────────────────────────────
+                    # The transport-normalized terminal gate now fires at the
+                    # PHYSICAL dispatch owner (the last stage immediately before
+                    # provider I/O), where the FINAL post-middleware,
+                    # post-relay, post-transformation payload is available:
+                    #   * non-streaming main: _dispatch_nonstreaming_api_request
+                    #   * streaming main:     interruptible_streaming_api_call
+                    #   * auxiliary:          the relay helpers / call_llm
+                    #   * MoA aggregator:     call_llm streaming bypass
+                    # (see agent.model_metadata — build_final_context_budget /
+                    # enforce_final_context_budget).
+                    #
+                    # The earlier gate here was REMOVED because it (a) read the
+                    # non-existent agent.system_prompt attribute (AttributeError
+                    # on every real turn — see test_moa_loop_mode), and (b) ran
+                    # BEFORE relay_llm, which rewrites the request via
+                    # final_request=_provider_request(...), so it accounted the
+                    # PRE-relay payload, not the one actually dispatched.  Both
+                    # are now fixed by gating at the true physical owner.
+                    #
+                    # On over-limit, the owner raises ContextCeilingExceeded
+                    # (NOT a sentinel dict): the exception propagates cleanly
+                    # through the execution-middleware chain and is caught at
+                    # the call site, where it refunds the counters and returns
+                    # a clean local refusal.  A locally refused request is not
+                    # an API call — no provider I/O, no api_call_count, no
+                    # iteration slot.
                     if agent.api_mode == "codex_responses":
                         next_api_kwargs = agent._get_transport().preflight_kwargs(
                             next_api_kwargs,
@@ -3291,6 +3318,34 @@ def run_conversation(
                         defer_logical_completion=True,
                     )
 
+                # Hard-ceiling enforcement is done ONCE, at the terminal
+                # provider-I/O call (``_perform_api_call``), on the FINAL
+                # (post-middleware) payload. There is deliberately NO
+                # pre-middleware fast-fail gate here, even though it would be
+                # a cheap optimization: the middleware contract allows
+                # *shrink/rewrite* of the request, so a pre-middleware
+                # rejection could be a FALSE rejection of a payload that
+                # middleware would legitimately reduce to fit.
+                #
+                #   * request middleware may return ``{"request": {...}}`` to
+                #     replace the effective provider kwargs
+                #     (hermes_cli/middleware.py ``apply_llm_request_middleware``);
+                #   * execution middleware may forward a different payload to
+                #     the terminal call via ``next_call(next_payload)``
+                #     (``_run_execution_chain``).
+                #
+                # Either can reduce request pressure (e.g. strip verbose
+                # content, drop tools, swap a large sidecar for a compact
+                # substitute). A monotonic-size assumption (payload can only
+                # grow) does NOT hold, so a pre-middleware ceiling refusal is
+                # not provably safe and is therefore removed. The terminal
+                # gate remains the single authoritative enforcement point; the
+                # only cost of deferring to it is running the middleware chain
+                # for a request that turns out to be over-limit — an
+                # acceptable optimization tradeoff, not a correctness one.
+                # A locally refused request still consumes no API call /
+                # iteration slot: the terminal gate refunds on refusal.
+
                 from hermes_cli.middleware import run_llm_execution_middleware
 
                 _model_request_active = getattr(agent, "_model_request_active", None)
@@ -3302,6 +3357,8 @@ def run_conversation(
                 elif _model_request_active is not None:
                     _model_request_active.set()
                 _redirect_crossed_response = False
+                from agent.agent_runtime_helpers import ContextCeilingExceeded
+
                 try:
                     response = run_llm_execution_middleware(
                         api_kwargs,
@@ -3319,6 +3376,38 @@ def run_conversation(
                         api_call_count=api_call_count,
                         middleware_trace=list(_llm_middleware_trace),
                     )
+                except ContextCeilingExceeded as _ce:
+                    # Terminal-gate refusal: the FINAL
+                    # (post-middleware) payload exceeded the effective context
+                    # limit. The exception propagates cleanly through the
+                    # execution-middleware chain (it is not a "response" a
+                    # middleware can copy/wrap), so we catch it here — at the
+                    # boundary that owns the counters — and refund: a locally
+                    # refused request is NOT an API call, so it
+                    # must not keep the incremented api_call_count or the
+                    # iteration-budget slot. Surface a clean local refusal.
+                    api_call_count = max(0, api_call_count - 1)
+                    agent._api_call_count = api_call_count
+                    _ib2 = getattr(agent, "iteration_budget", None)
+                    if _ib2 is not None and hasattr(_ib2, "refund"):
+                        try:
+                            _ib2.refund()
+                        except Exception:
+                            pass
+                    agent._flush_status_buffer()
+                    agent._vprint(
+                        f"{agent.log_prefix}\u274c {_ce}",
+                        force=True,
+                    )
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": str(_ce),
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": "context_ceiling_exceeded",
+                    }
                 finally:
                     if _redirect_lock is not None:
                         with _redirect_lock:
@@ -4341,9 +4430,32 @@ def run_conversation(
                     # Cache discovered context length after successful call.
                     # Only persist limits confirmed by the provider (parsed
                     # from the error message), not guessed probe tiers.
-                    if getattr(agent.context_compressor, "_context_probed", False):
-                        ctx = agent.context_compressor.context_length
-                        if getattr(agent.context_compressor, "_context_probe_persistable", False):
+                    if getattr(agent.context_compressor, "_context_probed", False) is True:
+                        # Use the HOST-OWNED ACTIVE PRE-CAP value so
+                        # the persistent context cache stores the model's real
+                        # capability, not the clamped effective window. For a
+                        # generic plugin the engine's context_length IS the capped
+                        # effective window (it has no pre_cap property), so
+                        # resolve_engine_pre_cap would resolve to the CAPPED value
+                        # (e.g. 272K) and contaminate context_length_cache.yaml.
+                        # get_pre_cap(agent) returns the host-retained ACTIVE
+                        # pre-cap (the raw capability), which is authoritative for
+                        # BOTH engine types. Fall back to resolve_engine_pre_cap
+                        # only when the host store was never set (legacy / a
+                        # test-built standalone engine) — never when it holds a
+                        # valid positive int.
+                        #
+                        # Probe flags use explicit boolean semantics (is True) so
+                        # a MagicMock flag (truthy child) does not trigger a
+                        # spurious persist or a spurious flag reset.
+                        from agent.agent_runtime_helpers import (
+                            get_pre_cap,
+                            resolve_engine_pre_cap,
+                        )
+                        ctx = get_pre_cap(agent)
+                        if ctx <= 0:
+                            ctx = resolve_engine_pre_cap(agent.context_compressor)
+                        if ctx > 0 and getattr(agent.context_compressor, "_context_probe_persistable", False) is True:
                             save_context_length(agent.model, agent.base_url, ctx)
                             agent._safe_print(f"{agent.log_prefix}💾 Cached context length: {ctx:,} tokens for {agent.model}")
                         agent.context_compressor._context_probed = False
@@ -5462,14 +5574,16 @@ def run_conversation(
                     compressor = agent.context_compressor
                     old_ctx = compressor.context_length
                     if old_ctx > _reduced_ctx:
-                        compressor.update_model(
-                            model=agent.model,
-                            context_length=_reduced_ctx,
-                            base_url=agent.base_url,
-                            api_key=getattr(agent, "api_key", ""),
-                            provider=agent.provider,
-                            api_mode=agent.api_mode,
-                        )
+                        # SAME-MODEL CONTEXT-WINDOW REFRESH: the 200K tier
+                        # reduction is a NON-PERSISTABLE runtime restriction on
+                        # the ACTIVE model, so it becomes the new PRE-CAP
+                        # operating window (host + engine), and the ceiling
+                        # still caps it on top (effective = min(200K, ceiling)).
+                        # A plugin receives the capped value via update_model
+                        # (recalc threshold/budget) — strictly more correct than
+                        # the original uncapped 200K passed straight to it.
+                        from agent.agent_runtime_helpers import refresh_context_window
+                        refresh_context_window(agent, _reduced_ctx, model=agent.model)
                         # Context probing flags — only set on built-in
                         # compressor (plugin engines manage their own).
                         if hasattr(compressor, "_context_probed"):
@@ -6026,7 +6140,23 @@ def run_conversation(
                     # exceeds the context window", keep the configured window
                     # and try compression; guessing probe tiers can incorrectly
                     # turn a user-configured 1M window into 256K/128K/64K.
-                    new_ctx = get_context_length_from_provider_error(error_msg, old_ctx)
+                    # Compare the provider-reported limit against the PRE-CAP
+                    # operating window (host-retained), NOT the capped getter:
+                    # a provider limit is a capability correction and must be
+                    # judged against the model's real pre-ceiling window, so a
+                    # ceiling never hides a genuine capability reduction.
+                    from agent.agent_runtime_helpers import get_pre_cap, resolve_engine_pre_cap
+                    _host_precap = get_pre_cap(agent)
+                    # The engine's live pre-cap is the floor: a direct
+                    # compressor.update_model() call (e.g. from a test or a
+                    # Codex app-server re-report) updates the engine but not
+                    # the host copy, so the host may be stale-low.  Taking the
+                    # max preserves the PR's invariant (compare against the
+                    # pre-cap, not the capped getter) while never rejecting a
+                    # genuine capability correction because of a stale host.
+                    _engine_precap = resolve_engine_pre_cap(agent.context_compressor)
+                    _pre_cap = max(_host_precap, _engine_precap) if _engine_precap > 0 else _host_precap
+                    new_ctx = get_context_length_from_provider_error(error_msg, _pre_cap)
                     _provider_lower = (getattr(agent, "provider", "") or "").lower()
                     _base_lower = (getattr(agent, "base_url", "") or "").rstrip("/").lower()
                     is_minimax_provider = (
@@ -6044,14 +6174,18 @@ def run_conversation(
 
                     if new_ctx is not None:
                         agent._buffer_vprint(f"Context limit detected from API: {new_ctx:,} tokens (was {old_ctx:,})")
-                        compressor.update_model(
-                            model=agent.model,
-                            context_length=new_ctx,
-                            base_url=agent.base_url,
-                            api_key=getattr(agent, "api_key", ""),
-                            provider=agent.provider,
-                            api_mode=agent.api_mode,
-                        )
+                        # SAME-MODEL CONTEXT-WINDOW REFRESH: the provider-reported
+                        # limit is a capability correction on the ACTIVE model.
+                        # new_ctx was already validated downward-only against the
+                        # active model's pre-cap (get_pre_cap below), so it never
+                        # inflates the window. Built-in receives the raw value
+                        # (setter re-derives effective against the ceiling and
+                        # recalculates thresholds); plugin receives the effective
+                        # value via update_model (recalc threshold/budget). The
+                        # host pre-cap becomes the provider limit; save_context_length
+                        # below persists that raw capability.
+                        from agent.agent_runtime_helpers import refresh_context_window
+                        refresh_context_window(agent, new_ctx, model=agent.model)
                         # Persist an explicit provider-reported limit before
                         # compression/retry. The next request can be rate
                         # limited, omit usage, or the process can restart; none

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -624,6 +624,7 @@ __all__ = [
     "reasoning_echo_family",
     "matches_reasoning_echo_family",
     "needs_reasoning_echo",
+    "stale_thinking_reaches_wire",
     "apply_reasoning_content_policy",
     "reapply_reasoning_echo",
 ]
@@ -891,6 +892,34 @@ def reasoning_echo_family(provider: Any, model: Any, base_url: Any) -> "str | No
 def needs_reasoning_echo(provider: Any, model: Any, base_url: Any) -> bool:
     """True when the endpoint requires reasoning_content echo-back."""
     return reasoning_echo_family(provider, model, base_url) is not None
+
+
+def stale_thinking_reaches_wire(
+    api_mode: Any, provider: Any, model: Any, base_url: Any
+) -> bool:
+    """True when stale assistant ``reasoning``/``reasoning_content`` text is
+    actually replayed on the wire for the active route.
+
+    This is the single wire-truth predicate the compaction TRIGGER estimator
+    and the tail-budget walks must share (#84371): when they disagree, a
+    reasoning-heavy session can simultaneously look over-threshold to
+    preflight and fully tail-protected to the walk — an infinite ineffective
+    compaction loop.
+
+    * ``codex_responses``: the Responses input builder
+      (``_chat_messages_to_responses_input``) never reads the text keys —
+      reasoning continuity rides the encrypted ``codex_reasoning_items``
+      sidecar, which both estimators already charge unconditionally. Stale
+      thinking TEXT never ships → ``False``.
+    * chat-completions echo-back families (DeepSeek/Kimi/MiMo thinking
+      mode): ``apply_reasoning_content_policy`` replays the stored
+      ``reasoning_content`` verbatim on EVERY assistant turn → ``True``.
+    * everything else: stripped or one-space-padded at send time (#73624)
+      → ``False``.
+    """
+    if (api_mode or "") == "codex_responses":
+        return False
+    return needs_reasoning_echo(provider, model, base_url)
 
 
 def apply_reasoning_content_policy(

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -586,6 +586,54 @@ def _run_reference(
             # ``copilot-language-server`` integrator even though standalone
             # Copilot calls work.
             extra_headers = {"x-initiator": "user"}
+        # Hard-ceiling gate for the MoA reference dispatch:
+        # this is a provider-owning path that bypasses the
+        # main-loop gate.  The trim above sizes to the reference model's own
+        # EFFECTIVE window (raw capability clamped by the profile ceiling),
+        # but it deliberately keeps the trailing user turn even when still
+        # over budget — so an unshrinkable reference can slip through.  Enforce
+        # the final trimmed payload against the reference's own effective limit
+        # immediately before call_llm.  A refusal raises into _run_reference's
+        # try/except and becomes a labelled [failed: …] note — a LOCAL failure
+        # (no provider I/O, no API slot consumed): an unshrinkable reference
+        # request must fail locally, not be dispatched.
+        # The reference's pre-cap is its own resolved effective window (its own
+        # raw capability + the profile ceiling), NOT the main conversation's.
+        try:
+            from agent.model_metadata import effective_context_length as _ref_ecl
+            _ref_model = str(slot.get("model") or "")
+            _ref_provider = str(runtime.get("provider") or slot.get("provider") or "")
+            _ref_limit = _ref_ecl(
+                model=_ref_model,
+                base_url=str(runtime.get("base_url") or ""),
+                api_key=str(runtime.get("api_key") or ""),
+                provider=_ref_provider,
+            )
+        except Exception:
+            _ref_limit = None
+        if _ref_limit is not None:
+            from agent.agent_runtime_helpers import (
+                canonical_request_budget as _canon_budget,
+                enforce_effective_context_limit as _enforce,
+            )
+            # SAME resolved allowance the trim above used (explicit cap or the
+            # established MoA default — never 0), so the gate and the trim agree.
+            _ref_reserve = _resolve_moa_output_reserve(
+                _effective_max_tokens,
+                provider=str(runtime.get("provider") or slot.get("provider") or "")
+                or None,
+                model=str(slot.get("model") or "") or None,
+            )
+            _ref_budget = _canon_budget(
+                messages,
+                output_reserve=_ref_reserve,
+            )
+            _enforce(
+                _ref_budget,
+                pre_cap=_ref_limit,
+                ceiling=None,
+                reason="MoA reference dispatch",
+            )
         response = call_llm(
             task="moa_reference",
             messages=messages,
@@ -664,6 +712,43 @@ _REFERENCE_DEFAULT_OUTPUT_RESERVE = 8192
 _REFERENCE_TRIM_SAFETY_FRACTION = 0.10
 
 
+def _resolve_moa_output_reserve(
+    explicit_cap: int | None,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+) -> int:
+    """ONE resolved output allowance for MoA reference/aggregator dispatch.
+
+    The reference TRIM sizes the payload using an output reserve; the
+    reference gate and the aggregator gate then enforce the final payload
+    against the model's window.  Both must reserve the SAME allowance or an
+    unshrinkable reference can slip past the gate (or the gate can refuse a
+    payload the trim thought fit).
+
+    This is the MoA surface of the shared :func:`resolve_output_reservation`
+    policy, so the MoA reference gate, the aggregator gate, the compressor,
+    and the main terminal gate all reserve the SAME allowance:
+
+      * an explicit, positive integer output cap (``max_tokens`` /
+        ``reference_max_tokens``) wins;
+      * else the provider/profile-derived implicit cap for the reference's
+        own provider/model (when resolvable);
+      * else the documented finite :data:`DEFAULT_OUTPUT_RESERVATION` (4096).
+
+    Never 0 (an omitted cap is not a zero-reservation) and never an invented
+    provider maximum.
+    """
+    from agent.model_metadata import resolve_output_reservation
+
+    return resolve_output_reservation(
+        None,
+        explicit_cap=explicit_cap,
+        provider=provider,
+        model=model,
+    )
+
+
 def _trim_messages_for_reference(
     messages: list[dict[str, Any]],
     slot: dict[str, str],
@@ -710,7 +795,7 @@ def _trim_messages_for_reference(
 
     from agent.model_metadata import (
         estimate_messages_tokens_rough,
-        get_model_context_length,
+        effective_context_length,
     )
 
     model = str(slot.get("model") or "")
@@ -724,7 +809,21 @@ def _trim_messages_for_reference(
         context_length = context_length_cache[cache_key]
     else:
         try:
-            context_length = get_model_context_length(
+            # Use the EFFECTIVE window (raw reference capability clamped by the
+            # profile-wide model.max_context_length ceiling). max_context_length
+            # is a profile-wide hard operating ceiling on EVERY model invocation,
+            # so a reference/advisor request is sized against the effective
+            # window, not the raw reference capability. The ceiling only lowers
+            # a window — a reference whose raw window is already below the ceiling
+            # keeps its (smaller) real limit.
+            #
+            # ``context_length_cache`` is the LOCAL per-fan-out budget dict (a
+            # budgeting input, discarded after the MoA iteration). It stores the
+            # effective value here and is NEVER written to the persistent
+            # context_length_cache.yaml — that remains raw-capability-only and is
+            # fed exclusively through save_context_length() on the provider
+            # confirmation paths.
+            context_length = effective_context_length(
                 model=model,
                 base_url=str(runtime.get("base_url") or ""),
                 api_key=str(runtime.get("api_key") or ""),
@@ -744,10 +843,14 @@ def _trim_messages_for_reference(
     if not isinstance(context_length, int) or context_length <= 0:
         return messages
 
-    reserve = (
-        int(reserve_output_tokens)
-        if isinstance(reserve_output_tokens, int) and reserve_output_tokens > 0
-        else _REFERENCE_DEFAULT_OUTPUT_RESERVE
+    # ONE resolved output allowance — the SAME value the reference gate and
+    # aggregator gate use for terminal enforcement (see
+    # _resolve_moa_output_reserve).  An explicit cap wins; else the
+    # provider-derived implicit cap; else the established MoA default (never 0).
+    reserve = _resolve_moa_output_reserve(
+        reserve_output_tokens,
+        provider=str(runtime.get("provider") or slot.get("provider") or "") or None,
+        model=str(slot.get("model") or "") or None,
     )
     budget = int(context_length * (1.0 - _REFERENCE_TRIM_SAFETY_FRACTION)) - reserve
     if budget <= 0:
@@ -1371,6 +1474,50 @@ def aggregate_moa_context(
             agg_cache_runtime,
             cache_ttl=_agg_cache_ttl,
         )
+        # Hard-ceiling gate for the MoA aggregator dispatch:
+        # this synthesis call carries every joined reference
+        # output, so it is the largest MoA payload and a provider-owning path
+        # that bypasses the main-loop gate.  Enforce its final payload against
+        # the aggregator model's OWN effective window (raw capability clamped
+        # by the profile ceiling) immediately before call_llm.  The enclosing
+        # ``except Exception`` below turns a refusal into synthesis="" (a local
+        # fallback to the joined references), not an unhandled error.
+        from agent.agent_runtime_helpers import (
+            canonical_request_budget as _agg_budget_fn,
+            enforce_effective_context_limit as _agg_enforce,
+        )
+        from agent.model_metadata import effective_context_length as _agg_ecl
+        try:
+            _agg_limit = _agg_ecl(
+                model=str(aggregator.get("model") or ""),
+                base_url=str(agg_runtime.get("base_url") or ""),
+                api_key=str(agg_runtime.get("api_key") or ""),
+                provider=str(agg_runtime.get("provider") or ""),
+            )
+        except Exception:
+            _agg_limit = None
+        if _agg_limit is not None:
+            # SAME resolved allowance the reference gate uses (explicit cap or
+            # the established MoA default — never 0).  The aggregator call
+            # carries no explicit max_tokens, so the provider-derived implicit
+            # cap (or the documented default) applies via the shared policy.
+            _agg_budget = _agg_budget_fn(
+                agg_messages,
+                output_reserve=_resolve_moa_output_reserve(
+                    None,
+                    provider=str(agg_runtime.get("provider") or "") or None,
+                    model=str(aggregator.get("model") or "") or None,
+                ),
+            )
+            try:
+                _agg_enforce(
+                    _agg_budget,
+                    pre_cap=_agg_limit,
+                    ceiling=None,
+                    reason="MoA aggregator dispatch",
+                )
+            except Exception as _agg_ce:
+                raise RuntimeError(str(_agg_ce)) from _agg_ce
         response = call_llm(
             task="moa_aggregator",
             messages=agg_messages,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3544,13 +3544,28 @@ def estimate_tokens_rough(text: str) -> int:
     return dense + ((sparse + 3) // 4)
 
 
-def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
+def estimate_messages_tokens_rough(
+    messages: List[Dict[str, Any]], *, charge_stale_thinking: bool = True,
+) -> int:
     """Rough token estimate for a message list (pre-flight only).
 
     Image parts (base64 PNG/JPEG) are counted as a flat ~1500 tokens per
     image — the Anthropic pricing model — instead of counting raw base64
     character length. Without this, a single ~1MB screenshot would be
     estimated at ~250K tokens and trigger premature context compression.
+
+    ``charge_stale_thinking`` mirrors the tail-budget walk's policy
+    (``context_compressor._estimate_msg_budget_tokens``, #73624): generic
+    thinking text (``reasoning`` / ``reasoning_content``) rides the wire for
+    at most the NEWEST assistant turn on routes that do not echo stale
+    reasoning back (Codex Responses ships encrypted ``codex_reasoning_items``
+    instead of the text keys; strict chat-completions providers strip or
+    one-space-pad the field). Passing ``False`` excludes those keys on every
+    assistant turn but the newest, so the compaction TRIGGER sees the same
+    size class as the tail-protection walk — the disagreement made
+    reasoning-heavy codex_responses sessions fire preflight forever while the
+    walk found nothing to compact (#84371 dead loop). Default ``True``
+    preserves the conservative full charge for callers without route context.
 
     Per-message results are memoized (see ``_estimate_message_tokens_cached``)
     keyed on a deep *identity fingerprint* of the message, so re-walking a
@@ -3559,10 +3574,48 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     leaf objects and structure, hence an identical estimate.
     """
     _IMAGE_TOKEN_COST = 1500
+    if not charge_stale_thinking:
+        messages = _strip_stale_thinking_for_estimate(messages)
     total = 0
     for msg in messages:
         total += _estimate_message_tokens_cached(msg, _IMAGE_TOKEN_COST)
     return total
+
+
+# Generic thinking-text keys replayed for at most the newest assistant turn
+# on non-echo routes — must stay in lockstep with
+# ``context_compressor._NEWEST_TURN_ONLY_BUDGET_KEYS``.
+_STALE_THINKING_ESTIMATE_KEYS = ("reasoning", "reasoning_content")
+
+
+def _strip_stale_thinking_for_estimate(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Copy of ``messages`` with stale thinking keys removed (newest kept).
+
+    Shallow stripped copies share the original value objects, so the
+    per-message memo still hits for the stripped shape on subsequent walks.
+    """
+    newest = -1
+    for i in range(len(messages) - 1, -1, -1):
+        m = messages[i]
+        if isinstance(m, dict) and m.get("role") == "assistant":
+            newest = i
+            break
+    out: List[Dict[str, Any]] = []
+    for i, m in enumerate(messages):
+        if (
+            i != newest
+            and isinstance(m, dict)
+            and m.get("role") == "assistant"
+            and any(m.get(k) for k in _STALE_THINKING_ESTIMATE_KEYS)
+        ):
+            m = {
+                k: v for k, v in m.items()
+                if k not in _STALE_THINKING_ESTIMATE_KEYS
+            }
+        out.append(m)
+    return out
 
 
 # --- Per-message token-estimate memo -------------------------------------
@@ -3692,9 +3745,23 @@ def _wire_message_shadow(msg: Dict[str, Any]) -> Dict[str, Any]:
         and bool(sidecar)
         and msg.get("role") in ("user", "assistant")
     )
+    # The internal ``reasoning`` key never ships: every request build pops it
+    # after (optionally) promoting it into ``reasoning_content`` (see
+    # ``apply_reasoning_content_policy`` / conversation_loop's api_messages
+    # build). When a message carries BOTH keys — the normal shape on
+    # reasoning-echo providers, which pin ``reasoning_content`` at creation
+    # time while ``reasoning`` holds the same text for trajectory storage —
+    # counting both charged the same thinking twice and inflated the rough
+    # estimate by up to +53% against provider-reported prompt_tokens
+    # (#84371 comment data, llama.cpp/Qwen). Keep ``reasoning`` only as the
+    # promotion proxy when no ``reasoning_content`` exists to displace it.
+    _rc = msg.get("reasoning_content")
+    drop_reasoning_dup = isinstance(_rc, str) and bool(_rc.strip())
     shadow: Dict[str, Any] = {}
     for k, v in msg.items():
         if k in ("_anthropic_content_blocks", "reasoning_details") or k in PERSISTENCE_ONLY_MESSAGE_FIELDS:
+            continue
+        if k == "reasoning" and drop_reasoning_dup:
             continue
         if k == "api_content":
             # Always popped before the request is built; only counted when it
@@ -3750,6 +3817,7 @@ def estimate_request_tokens_rough(
     *,
     system_prompt: str = "",
     tools: Optional[List[Dict[str, Any]]] = None,
+    charge_stale_thinking: bool = True,
 ) -> int:
     """Rough token estimate for a full chat-completions request.
 
@@ -3758,12 +3826,19 @@ def estimate_request_tokens_rough(
     tools enabled, schemas alone can add 20-30K tokens — a significant
     blind spot when only counting messages. Image content is counted
     at a flat per-image cost (see estimate_messages_tokens_rough).
+
+    ``charge_stale_thinking`` is forwarded to
+    ``estimate_messages_tokens_rough`` — pass ``False`` when the active
+    route provably strips stale assistant thinking at send time (see
+    ``message_sanitization.stale_thinking_reaches_wire``, #84371).
     """
     total = 0
     if system_prompt:
         total += estimate_tokens_rough(system_prompt)
     if messages:
-        total += estimate_messages_tokens_rough(messages)
+        total += estimate_messages_tokens_rough(
+            messages, charge_stale_thinking=charge_stale_thinking
+        )
     if tools:
         total += _estimate_tools_tokens_rough(tools)
     return total

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3836,9 +3836,15 @@ def estimate_request_tokens_rough(
     if system_prompt:
         total += estimate_tokens_rough(system_prompt)
     if messages:
-        total += estimate_messages_tokens_rough(
-            messages, charge_stale_thinking=charge_stale_thinking
-        )
+        if charge_stale_thinking:
+            # Positional-compatible call: test seams and plugin engines
+            # monkeypatch estimate_messages_tokens_rough with (messages)-only
+            # signatures; only the route-aware False path needs the kwarg.
+            total += estimate_messages_tokens_rough(messages)
+        else:
+            total += estimate_messages_tokens_rough(
+                messages, charge_stale_thinking=False
+            )
     if tools:
         total += _estimate_tools_tokens_rough(tools)
     return total

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -861,31 +861,35 @@ def enforce_final_context_budget(
     reason: str = "",
     api_kwargs: dict | None = None,
 ) -> None:
-    """Raise :class:`ContextCeilingExceeded` if ``budget.total`` exceeds the
-    effective limit = ``min(invocation pre-cap, profile ceiling)``.
-
-    Shared terminal enforcement primitive — the ONE place every physical
+    """Shared terminal enforcement primitive — the ONE place every physical
     dispatch owner (main + auxiliary) calls immediately before provider I/O.
     No-op when neither ``pre_cap`` nor ``ceiling`` is configured.
 
-    When ``api_kwargs`` is supplied, overflow is classified:
+    Effective limit = ``min(invocation pre-cap, profile ceiling)``.
 
-    * **Unshrinkable** — ``budget.input_tokens_estimate`` alone is at or over
-      the effective limit.  The input payload cannot be reduced by touching
-      the output cap; :class:`ContextCeilingExceeded` is raised (the provider
-      is never called, and the caller's provider-400 recovery path is
-      preserved because the provider never returns a 400 for a request it
-      never received).
+    When ``budget.total > limit``, overflow is classified:
 
-    * **Shrinkable** — the input fits, but ``input + output_reservation``
-      exceeds the limit.  The requested output cap is clamped in-place to
-      ``max(0, limit - input_tokens_estimate)`` (the maximum legal output
-      allowance from the remaining budget) and the check is re-run against
-      the clamped reservation.  This avoids sending a known-invalid cap to
-      the provider while preserving the existing provider-400 recovery
-      path as a fallback for cases where the clamp is insufficient (e.g.
-      the provider's own tokenizer counts the input larger than Hermes's
-      rough estimate).
+    * **Unshrinkable** — the non-output portion (``input + system + tools``,
+      i.e. ``budget.total - budget.output_reservation``) is at or over the
+      effective limit.  No amount of output-cap reduction can help;
+      :class:`ContextCeilingExceeded` is raised before provider I/O (the
+      provider is never called, so its 400-error recovery path is preserved
+      — the provider never returns a 400 for a request it never received).
+
+    * **Shrinkable** — the non-output portion fits under the limit, but
+      ``non_output + output_reservation`` exceeds it.  When ``api_kwargs``
+      is supplied and carries an explicit output cap, the cap is clamped
+      in-place to ``limit - non_output`` (the maximum legal output allowance
+      from the remaining budget) and the call proceeds with the reduced cap.
+      The clamp never raises an existing cap — it only lowers one.  When no
+      explicit cap field is present (the reservation came from the provider
+      implicit / DEFAULT floor), the overflow is treated as unshrinkable and
+      :class:`ContextCeilingExceeded` is raised (conservative refusal).
+
+    A locally refused request is NOT a provider call: no network I/O, no
+    ``api_call_count`` increment, no iteration-budget slot consumed.  The
+    caller catches :class:`ContextCeilingExceeded`, refunds counters, and
+    surfaces a clean local refusal.
     """
     # effective limit = min(invocation pre-cap, profile ceiling); no-op if
     # neither is a valid positive int.

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -412,6 +412,484 @@ def _warn_context_length_fallback(model: str, base_url: str) -> None:
 # Sessions, model switches, and cron jobs should reject models below this.
 MINIMUM_CONTEXT_LENGTH = 64_000
 
+
+def coerce_context_ceiling(value: Any) -> Optional[int]:
+    """Coerce a ``model.max_context_length`` value to a strict positive int.
+
+    Returns the ceiling as an ``int`` when ``value`` is a genuine positive
+    integer, else ``None`` (no ceiling). This is the SINGLE strict validator
+    for the ceiling across every code path (agent init, the built-in
+    compressor, the display/resolve helpers, and the runtime routing).
+
+    Strictness rules (one shared parser, reused by every resolution path):
+      * ``bool`` is rejected — ``True``/``False`` are ``int`` subclasses and
+        must never be coerced to ``1``/``0``.
+      * floats (``272000.0``, ``2.9``) are rejected — a ceiling must be an
+        exact integer token count; a non-integral float is not a valid window.
+      * ``float('inf')`` / ``float('nan')`` are rejected.
+      * numeric strings (``"272000"``) are rejected — a ceiling is a strict
+        integer, not a string that happens to parse.
+      * ``<= 0`` is rejected (not a real upper bound).
+      * anything non-numeric (``None``, objects, MagicMock) is rejected.
+
+    A malformed value therefore means "no ceiling" at the runtime, never a
+    silently-truncated window.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int):
+        return None
+    if value <= 0:
+        return None
+    return value
+
+
+def validate_context_ceiling(value: Any) -> Optional[int]:
+    """Validate a ``model.max_context_length`` value for CONFIG loading.
+
+    Returns the ceiling as an ``int`` when valid, else ``None``. Unlike
+    :func:`coerce_context_ceiling` (runtime use), this ALSO enforces the
+    64K configuration floor: a ceiling below
+    ``MINIMUM_CONTEXT_LENGTH`` is an INVALID ceiling, not a model-capability
+    statement. Callers at config-load time should surface a ceiling-specific
+    error for ``None``-when-a-value-was-supplied (see the init path).
+
+    Strictness is identical to :func:`coerce_context_ceiling` (rejects bool,
+    float, numeric string, infinity, nan, ``<= 0``, non-numeric).
+    """
+    ceiling = coerce_context_ceiling(value)
+    if ceiling is None:
+        return None
+    if ceiling < MINIMUM_CONTEXT_LENGTH:
+        # A positive integer below the 64K floor is a mis-configuration:
+        # Hermes cannot operate below MINIMUM_CONTEXT_LENGTH, so the ceiling
+        # is invalid. This is NOT "the model only has this capability" — it is
+        # a ceiling-specific rejection (a mis-configuration).
+        return None
+    return ceiling
+
+
+# ── Round 4: transport-normalized terminal ceiling enforcement ──────────────
+#
+# The single shared primitive every PHYSICAL dispatch owner calls immediately
+# before provider I/O.  It builds a :class:`FinalContextBudget` from the FINAL
+# provider-bound payload (post-middleware, post-transformation, post-relay)
+# and raises :class:`ContextCeilingExceeded` when the budget exceeds the
+# effective limit = ``min(invocation pre-cap, profile ceiling)``.
+#
+# Two physical owners (proven 2026-08-22, round 4):
+#   * Main:      _dispatch_nonstreaming_api_request  (chat_completion_helpers)
+#   * Auxiliary: _relay_sync_completion / _relay_async_completion /
+#                _relay_sync_stream  (auxiliary_client)  — does NOT converge
+#                on the main seam; the MoA aggregator stream (auxiliary_client:9556)
+#                bypasses even the relay.
+#
+# This lives in model_metadata (no import cycle: model_metadata is a leaf)
+# and is re-exported by agent_runtime_helpers for back-compat.
+
+# Finite default output reservation used when the FINAL payload omits an
+# explicit output cap (``max_tokens`` / ``max_completion_tokens`` /
+# ``max_output_tokens`` / ``inferenceConfig.maxTokens`` / ``maxOutputTokens``).
+# Hermes's existing convention for an omitted output cap is a finite 4096
+# (see chat_completion_helpers.py:1868 — ``agent.max_tokens or 4096``), NOT
+# zero (an omitted cap is not a zero-reservation) and NOT an invented
+# provider-native maximum Hermes cannot know.  This is the documented,
+# reusable source of the finite reservation for the omitted-cap case.
+DEFAULT_OUTPUT_RESERVATION = 4096
+
+
+class ContextCeilingExceeded(Exception):
+    """Local pre-dispatch refusal: the final request exceeds the effective
+    context limit for its invocation.
+
+    A locally refused request is **not** an API call: no provider network
+    I/O, no ``api_call_count`` increment, no iteration-budget slot consumed.
+    Dispatch owners catch this and surface it the same way Hermes surfaces
+    other local pre-dispatch refusals.  The auxiliary fallback / transient-
+    retry / credential-refresh chains MUST let this propagate (it is not a
+    provider error — no fallback, no retry, no credential refresh).
+    """
+
+    def __init__(
+        self,
+        request_tokens: int,
+        effective_limit: int,
+        *,
+        reason: str = "",
+    ) -> None:
+        self.request_tokens = request_tokens
+        self.effective_limit = effective_limit
+        self.reason = reason
+        detail = f" ({reason})" if reason else ""
+        super().__init__(
+            f"Final request (~{request_tokens:,} tokens) exceeds the effective "
+            f"context limit ({effective_limit:,} tokens){detail}. Reduce the "
+            f"request size, raise model.max_context_length, or enable compression."
+        )
+
+
+class FinalContextBudget:
+    """Transport-normalized accounting of a FINAL provider-bound payload.
+
+    The hard invariant is ``total`` = the rough estimate of the FINAL payload
+    (system/instructions + messages/input + final tool schemas + flat per-image
+    cost — all folded into ``estimate_request_tokens_rough`` EXACTLY ONCE)
+    PLUS the resolved output reservation.
+
+    The individual fields are a reporting breakdown of that estimate:
+      * ``input_tokens_estimate`` — the rough estimate of the FINAL payload
+        (messages/input + system + tools + images), computed by
+        ``estimate_request_tokens_rough``.  The flat per-image cost is ALREADY
+        folded in (``_count_image_tokens``) — so a SEPARATE multimodal term is
+        NOT added (design detail: no double-count).
+      * ``tool_tokens_estimate`` / ``system_tokens_estimate`` — informational
+        sub-components of ``input_tokens_estimate`` (the rough estimator
+        already includes them); reported for observability, not summed on top.
+      * ``output_reservation`` — the RESOLVED output allowance for this
+        dispatch (explicit cap, or :data:`DEFAULT_OUTPUT_RESERVATION` when
+        omitted — never 0, never an invented provider max).
+
+    ``total`` = ``input_tokens_estimate`` + ``output_reservation``.
+    This is Hermes canonical accounting — a practical budget, not a proven
+    provider-token bound.
+    """
+
+    __slots__ = (
+        "input_tokens_estimate",
+        "tool_tokens_estimate",
+        "system_tokens_estimate",
+        "output_reservation",
+        "total",
+    )
+
+    def __init__(
+        self,
+        input_tokens_estimate: int,
+        output_reservation: int,
+        *,
+        tool_tokens_estimate: int = 0,
+        system_tokens_estimate: int = 0,
+    ) -> None:
+        self.input_tokens_estimate = int(input_tokens_estimate)
+        self.output_reservation = int(output_reservation)
+        self.tool_tokens_estimate = int(tool_tokens_estimate)
+        self.system_tokens_estimate = int(system_tokens_estimate)
+        # total = input (messages/input, system included when it is a message)
+        # + system (only when it is a SEPARATE field, NOT already in input)
+        # + tools (estimate_messages_tokens_rough does NOT walk tool schemas,
+        #   so the final tool/schema payload is added here exactly once)
+        # + resolved output reservation.  No component is summed twice.
+        self.total = (
+            self.input_tokens_estimate
+            + self.system_tokens_estimate
+            + self.tool_tokens_estimate
+            + self.output_reservation
+        )
+
+
+def _final_request_output_cap(api_kwargs: dict | None) -> int | None:
+    """Return the positive output cap present in a FINAL provider-bound request,
+    or ``None`` when the request carries no explicit cap.
+
+    Reads whichever provider-specific key is present: ``max_tokens`` /
+    ``max_completion_tokens`` / ``max_output_tokens`` / Bedrock
+    ``inferenceConfig.maxTokens`` (nested) / ``maxOutputTokens``.  A
+    clamp/ephemeral/continuation value that survives into the final request
+    is AUTHORITATIVE — it wins over any larger provider default.
+    """
+    if not isinstance(api_kwargs, dict):
+        return None
+    for key in ("max_tokens", "max_completion_tokens", "max_output_tokens"):
+        v = api_kwargs.get(key)
+        if isinstance(v, int) and not isinstance(v, bool) and v > 0:
+            return v
+    # Bedrock Converse nests the cap under inferenceConfig.maxTokens.
+    ic = api_kwargs.get("inferenceConfig")
+    if isinstance(ic, dict):
+        v = ic.get("maxTokens")
+        if isinstance(v, int) and not isinstance(v, bool) and v > 0:
+            return v
+    v = api_kwargs.get("maxOutputTokens")
+    if isinstance(v, int) and not isinstance(v, bool) and v > 0:
+        return v
+    return None
+
+
+def _provider_implicit_output_cap(
+    provider: str | None, model: str | None = None
+) -> int | None:
+    """Resolve a provider/profile-derived implicit output cap, or ``None``.
+
+    The registered provider profile's ``get_max_tokens(model)`` is the
+    authoritative implicit completion allowance for a provider Hermes can
+    resolve (a static ``default_max_tokens``, or a per-model override for a
+    relay fronting several backends).  ``None`` means the provider is
+    unknown or declares no implicit cap — the caller then falls back to
+    :data:`DEFAULT_OUTPUT_RESERVATION`.
+
+    Lazily imports the provider registry (``model_metadata`` is a leaf; the
+    ``providers`` package does not import it back, so no cycle).  Any lookup
+    failure — provider not registered, plugin import error — degrades to
+    ``None`` so budgeting never raises.
+    """
+    name = str(provider or "").strip().lower()
+    if not name:
+        return None
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(name)
+    except Exception:
+        return None
+    if profile is None:
+        return None
+    try:
+        cap = profile.get_max_tokens(model)
+    except Exception:
+        return None
+    if isinstance(cap, int) and not isinstance(cap, bool) and cap > 0:
+        return cap
+    return None
+
+
+def resolve_output_reservation(
+    api_kwargs: dict | None = None,
+    *,
+    explicit_cap: int | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+) -> int:
+    """ONE shared output-reservation policy for every budgeting surface.
+
+    The compressor preflight budget, the terminal :class:`FinalContextBudget`,
+    the MoA reference trim/gate, and the MoA aggregator gate all derive their
+    output reservation from this single policy so they cannot disagree.
+
+    Precedence (highest → lowest):
+
+      1. A positive integer output cap present in the FINAL provider-bound
+         request (``max_tokens`` / ``max_completion_tokens`` /
+         ``max_output_tokens`` / Bedrock ``inferenceConfig.maxTokens`` /
+         ``maxOutputTokens``).  A legitimate clamp/ephemeral/continuation
+         value is AUTHORITATIVE — it wins over a larger provider default
+         (provider default 65536 + final cap 8192 → reserve 8192).
+      2. An explicit invocation/user output cap (``explicit_cap``) — used by
+         surfaces that budget BEFORE the final request is built.
+      3. A provider/profile-derived implicit cap (``provider`` resolved via
+         the registry) — the provider's documented completion limit for
+         ``model`` (no request cap + registered profile 65536 → reserve 65536).
+      4. :data:`DEFAULT_OUTPUT_RESERVATION` (4096) — ONLY when nothing more
+         authoritative is known (unknown custom provider, no resolvable cap).
+
+    Never 0 (an omitted cap is not a zero-reservation) and never an invented
+    maximum Hermes cannot know.
+    """
+    # 1. Final provider-bound request cap (authoritative over provider default).
+    v = _final_request_output_cap(api_kwargs)
+    if v is not None:
+        return v
+    # 2. Explicit invocation/user cap.
+    if (
+        isinstance(explicit_cap, int)
+        and not isinstance(explicit_cap, bool)
+        and explicit_cap > 0
+    ):
+        return explicit_cap
+    # 3. Provider/profile-derived implicit cap.
+    p = _provider_implicit_output_cap(provider, model)
+    if p is not None:
+        return p
+    # 4. Finite documented default.
+    return DEFAULT_OUTPUT_RESERVATION
+
+
+def _resolve_output_reservation(api_kwargs: dict) -> int:
+    """Back-compat wrapper: resolve from the final request only.
+
+    Delegates to :func:`resolve_output_reservation`.  Callers that know the
+    provider/model should call that directly (or via
+    :func:`build_final_context_budget`) so the provider-derived implicit cap
+    participates in the resolution.
+    """
+    return resolve_output_reservation(api_kwargs)
+
+
+def _system_in_messages(messages) -> bool:
+    """True when the final ``messages`` already contains a system message.
+
+    For Chat Completions the system prompt is the first ``messages`` entry —
+    it is ALREADY in the input estimate, so it must NOT be counted again from
+    a separate ``system``/``instructions`` field (avoid double-count).
+    """
+    for m in messages or []:
+        if isinstance(m, dict) and m.get("role") == "system":
+            return True
+    return False
+
+
+def build_final_context_budget(
+    api_kwargs: dict,
+    *,
+    system_prompt: str = "",
+    tools: list | None = None,
+    provider: str | None = None,
+    model: str | None = None,
+) -> FinalContextBudget:
+    """Build a :class:`FinalContextBudget` from a FINAL provider-bound payload.
+
+    Transport-normalized: reads the final ``messages``/``input``, the final
+    tools field, and the resolved output reservation.  Each semantic component
+    is counted EXACTLY ONCE:
+
+      * ``input_tokens_estimate`` — the rough estimate of the FINAL messages /
+        input (system-included when the system prompt is a ``messages`` entry —
+        the Chat Completions case).  The flat per-image cost is ALREADY folded
+        in by ``estimate_messages_tokens_rough`` (``_count_image_tokens``), so
+        a separate multimodal term is NOT added — no double-count.
+      * ``system_tokens_estimate`` — the system/instructions text, added ONLY
+        when it is NOT already one of the ``messages``/``input`` entries (the
+        Codex ``instructions`` / Bedrock ``system`` list case).  When it IS in
+        the message list it is already in ``input_tokens_estimate`` and is NOT
+        added again — the "count system exactly once" rule.
+      * ``tool_tokens_estimate`` — the final tool/schema payload (from
+        ``tools`` / ``functions`` / ``toolConfig.tools``), already included in
+        the rough estimate's tool walk but reported here for observability.
+      * ``output_reservation`` — the RESOLVED output allowance, from the
+        shared :func:`resolve_output_reservation` policy: the final request's
+        explicit cap (authoritative) → provider/profile-derived implicit cap →
+        :data:`DEFAULT_OUTPUT_RESERVATION`.  Never 0, never an invented
+        provider maximum.
+
+    ``provider`` / ``model`` let the resolver consult the registered provider
+    profile's implicit completion limit when the final request omits an
+    explicit cap (omitted cap + registered profile 65536 → reserve 65536).
+    Pass them at every call site where the provider is known.
+
+    ``total`` = ``input_tokens_estimate`` + ``system_tokens_estimate`` +
+    ``output_reservation``.  (``tool_tokens_estimate`` is part of
+    ``input_tokens_estimate`` and is not summed again.)
+    This is Hermes canonical accounting — a practical budget, not a proven
+    provider-token bound.
+    """
+    messages = list(api_kwargs.get("messages") or api_kwargs.get("input") or [])
+    final_tools = (
+        api_kwargs.get("tools")
+        or api_kwargs.get("functions")
+        or tools
+    )
+    # Bedrock nests tools under toolConfig.tools.
+    tc = api_kwargs.get("toolConfig")
+    if isinstance(tc, dict) and tc.get("tools"):
+        final_tools = tc.get("tools")
+
+    # input estimate: the final messages/input, system included when present.
+    input_tokens_estimate = estimate_messages_tokens_rough(messages)
+
+    # system/instructions: count it ONLY when it is a SEPARATE field (not
+    # already one of the messages).  When it is in the message list, it is
+    # already in input_tokens_estimate — adding it again would double-count.
+    system_text = ""
+    if not _system_in_messages(messages):
+        system_text = (
+            api_kwargs.get("system")
+            or api_kwargs.get("instructions")
+            or system_prompt
+            or ""
+        )
+        if isinstance(system_text, list):
+            system_text = " ".join(
+                p.get("text", "") for p in system_text if isinstance(p, dict)
+            )
+    system_tokens_estimate = (
+        estimate_tokens_rough(system_text) if system_text else 0
+    )
+
+    tool_tokens_estimate = (
+        _estimate_tools_tokens_rough(final_tools) if final_tools else 0
+    )
+
+    return FinalContextBudget(
+        input_tokens_estimate=input_tokens_estimate,
+        tool_tokens_estimate=tool_tokens_estimate,
+        system_tokens_estimate=system_tokens_estimate,
+        output_reservation=resolve_output_reservation(
+            api_kwargs, provider=provider, model=model
+        ),
+    )
+
+
+def enforce_final_context_budget(
+    budget: FinalContextBudget,
+    *,
+    pre_cap: int | None = None,
+    ceiling: int | None = None,
+    reason: str = "",
+) -> None:
+    """Raise :class:`ContextCeilingExceeded` if ``budget.total`` exceeds the
+    effective limit = ``min(invocation pre-cap, profile ceiling)``.
+
+    Shared terminal enforcement primitive — the ONE place every physical
+    dispatch owner (main + auxiliary) calls immediately before provider I/O.
+    No-op when neither ``pre_cap`` nor ``ceiling`` is configured.
+    """
+    # effective limit = min(invocation pre-cap, profile ceiling); no-op if
+    # neither is a valid positive int.
+    limit: int | None = None
+    for v in (pre_cap, ceiling):
+        if isinstance(v, int) and not isinstance(v, bool) and v > 0:
+            limit = v if limit is None else min(limit, v)
+    if limit is None:
+        return
+    if budget.total > limit:
+        raise ContextCeilingExceeded(budget.total, limit, reason=reason)
+
+
+# Context variable carrying the auxiliary owner's effective ceiling into the
+# relay helpers (which are the physical I/O owners).  ``call_llm`` computes
+# the effective ceiling (model context clamped by the profile ceiling) and
+# sets this before dispatching to the relay helpers, which read it to fire
+# the terminal gate.  A contextvar is used (not a function-signature change)
+# so the relay helpers stay backward-compatible and the ceiling travels with
+# the call, not a global.
+import contextvars as _ce_contextvars
+_AUX_CEILING_CONTEXT: _ce_contextvars.ContextVar[Optional[int]] = (
+    _ce_contextvars.ContextVar("_aux_ceiling", default=None)
+)
+
+
+def set_aux_ceiling(ceiling: Optional[int]) -> "_ce_contextvars.Token":
+    """Set the auxiliary effective ceiling for the current dispatch. Returns
+    a token to reset (see :func:`reset_aux_ceiling`)."""
+    return _AUX_CEILING_CONTEXT.set(ceiling)
+
+
+def reset_aux_ceiling(token: "_ce_contextvars.Token") -> None:
+    """Reset the auxiliary effective ceiling (paired with set_aux_ceiling)."""
+    try:
+        _AUX_CEILING_CONTEXT.reset(token)
+    except Exception:
+        pass
+
+
+def clear_aux_ceiling() -> None:
+    """Reset the auxiliary effective ceiling to its default (None).
+
+    Convenience for callers that did not retain the token.  Best-effort:
+    a cross-context reset is a no-op.
+    """
+    try:
+        _AUX_CEILING_CONTEXT.set(None)
+    except Exception:
+        pass
+
+
+def get_aux_ceiling() -> Optional[int]:
+    """The auxiliary effective ceiling for the current dispatch, if any."""
+    return _AUX_CEILING_CONTEXT.get()
+
+
 # Short-lived in-process cache for local-server context probes. Bounds the
 # probe rate when the new local-endpoint live-probe paths (reconcile-on-hit +
 # pre-defaults step 7) resolve the same model several times during one startup
@@ -3458,6 +3936,133 @@ def get_model_context_length(
     return DEFAULT_FALLBACK_CONTEXT
 
 
+def _get_max_context_length() -> Optional[int]:
+    """Read the global context ceiling (``model.max_context_length``) from config.
+
+    This is a runtime/user POLICY, not a model capability. It is read from the
+    profile-scoped config (``load_config_readonly``), so per-profile ceilings
+    coexist in one gateway process and the value is never written to the
+    persistent context cache. Returns a positive int, or ``None`` when unset /
+    malformed / below the 64K floor (no ceiling).
+
+    Validation consistency (Phase 5): uses :func:`validate_context_ceiling`
+    (strict int + 64K floor) so every resolution path — display, compression
+    threshold, tool-search gate, MoA, auxiliary, runtime routing — agrees on
+    the ceiling. A value below the floor is an INVALID ceiling (a
+    mis-configuration), not a usable window, and is treated as "no ceiling"
+    here; the agent-init path surfaces the ceiling-specific diagnostic.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly() or {}
+        model_cfg = cfg.get("model")
+        if not isinstance(model_cfg, dict):
+            return None
+        val = model_cfg.get("max_context_length")
+    except Exception:
+        return None
+    if val is None:
+        return None
+    # Single shared validator: strict int (no bool/float/string/inf/<=0) AND
+    # the 64K configuration floor. Dedupe the warning so the gateway (which
+    # resolves the ceiling on many paths) does not spam the log.
+    ceiling = validate_context_ceiling(val)
+    if ceiling is None and val is not None:
+        # Surface the invalid value once per (profile, value). The dedup key
+        # MUST include the active profile (its resolved Hermes home) as well as
+        # the value: an invalid ceiling in profile A must not suppress the
+        # appropriate warning for the SAME value in profile B (that would be
+        # cross-profile state leakage). Keeping the value in the key means a
+        # changed invalid value within a profile still re-warns (each distinct
+        # bad value is diagnosed once), while the same profile+value does not
+        # spam on every resolution (the gateway resolves the ceiling on many
+        # paths). get_hermes_home() resolves exactly the profile whose config
+        # was just read via load_config_readonly() above, so the key is
+        # consistent with which ceiling is being diagnosed.
+        try:
+            from hermes_constants import get_hermes_home
+            _profile_home = str(get_hermes_home())
+        except Exception:
+            _profile_home = ""
+        key = (_profile_home, type(val).__name__, repr(val))
+        if key not in _CEILING_INVALID_WARNED:
+            _CEILING_INVALID_WARNED.add(key)
+            logger.warning(
+                "model.max_context_length is %r — invalid (must be a positive "
+                "integer >= %s). Ignoring (no ceiling).",
+                val, f"{MINIMUM_CONTEXT_LENGTH:,}",
+            )
+    return ceiling
+
+
+# Dedup for the ceiling-invalid diagnostic (see _get_max_context_length).
+# Keyed on (profile home, type name, repr) so each distinct bad value warns
+# exactly once PER PROFILE — the profile dimension prevents one profile's
+# invalid ceiling from suppressing the appropriate warning in another profile.
+_CEILING_INVALID_WARNED: set = set()
+
+
+def effective_context_length(
+    model: str,
+    base_url: str = "",
+    api_key: str = "",
+    config_context_length: int | None = None,
+    provider: str = "",
+    custom_providers: list | None = None,
+) -> int:
+    """Resolve the EFFECTIVE context window a consumer should use.
+
+    This is the single policy-aware entry point for consumers that size budgets
+    (compression thresholds, UI display, tool-search gate, etc.):
+
+        effective = min(get_model_context_length(...), max_context_length)
+
+    ``get_model_context_length()`` stays the RAW capability resolver (it is what
+    populates ``context_length_cache.yaml``), so the ceiling never pollutes the
+    persistent cache. The ceiling only ever LOWERS a window — it can never
+    raise one — so it composes safely with an explicit ``model.context_length``
+    that is already below it. Callers that need the raw capability (aux-model
+    64K floor checks, capability detection) should keep calling
+    :func:`get_model_context_length` directly.
+    """
+    raw = get_model_context_length(
+        model,
+        base_url=base_url,
+        api_key=api_key,
+        config_context_length=config_context_length,
+        provider=provider,
+        custom_providers=custom_providers,
+    )
+    cap = _get_max_context_length()
+    return min(raw, cap) if cap else raw
+
+
+async def effective_context_length_async(
+    model: str,
+    base_url: str = "",
+    api_key: str = "",
+    config_context_length: int | None = None,
+    provider: str = "",
+    custom_providers: list | None = None,
+) -> int:
+    """Async variant of :func:`effective_context_length`.
+
+    Offloads the synchronous resolution chain to a background thread so it
+    does not freeze the asyncio event loop. Shares all logic with the sync
+    version — no code duplication.
+    """
+    import asyncio
+    return await asyncio.to_thread(
+        effective_context_length,
+        model,
+        base_url=base_url,
+        api_key=api_key,
+        config_context_length=config_context_length,
+        provider=provider,
+        custom_providers=custom_providers,
+    )
+
+
 async def get_model_context_length_async(
     model: str,
     base_url: str = "",
@@ -3544,13 +4149,27 @@ def estimate_tokens_rough(text: str) -> int:
     return dense + ((sparse + 3) // 4)
 
 
+# Hermes canonical image-token estimate per image part.
+#
+# A flat per-image charge for multimodal content in Hermes's canonical
+# pre-dispatch accounting.  1600 is a realistic ceiling for common
+# provider/detail combinations (GPT-4o high-detail ≈1700, Anthropic ≈1500,
+# Gemini ≈258/tile) and matches the value already used by the context
+# compressor.  This is Hermes canonical accounting — a practical budget
+# figure, NOT a universal provider-token upper bound.  Provider-native
+# image accounting may differ; the provider's context-overflow response
+# remains the final authority.
+_IMAGE_TOKEN_COST = 1600
+
+
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     """Rough token estimate for a message list (pre-flight only).
 
-    Image parts (base64 PNG/JPEG) are counted as a flat ~1500 tokens per
-    image — the Anthropic pricing model — instead of counting raw base64
-    character length. Without this, a single ~1MB screenshot would be
-    estimated at ~250K tokens and trigger premature context compression.
+    Image parts (base64 PNG/JPEG) are counted as a flat
+    ``_IMAGE_TOKEN_COST`` (1600) tokens per image — a realistic ceiling
+    across common provider/detail combinations — instead of counting raw
+    base64 character length.  Without this, a single ~1MB screenshot would
+    be estimated at ~250K tokens and trigger premature context compression.
 
     Per-message results are memoized (see ``_estimate_message_tokens_cached``)
     keyed on a deep *identity fingerprint* of the message, so re-walking a
@@ -3558,7 +4177,6 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     actually changed. The memo is exact: equal fingerprints imply identical
     leaf objects and structure, hence an identical estimate.
     """
-    _IMAGE_TOKEN_COST = 1500
     total = 0
     for msg in messages:
         total += _estimate_message_tokens_cached(msg, _IMAGE_TOKEN_COST)
@@ -3857,42 +4475,59 @@ def anchored_context_tokens(
 # NOTE: tool schemas can be large. Avoid repeated `str(tools)` conversions,
 # which are CPU-heavy and can stall GUI event loops under GIL pressure.
 #
-# Keyed by ``id(tools)``. A long-lived gateway/desktop backend builds many
-# transient tool lists over its lifetime, so the cache is bounded and evicts
-# oldest-first (insertion-ordered dict) once it exceeds the cap. The cap is
-# generous relative to how rarely toolsets are rebuilt within a process.
-_TOOLS_TOKENS_CACHE: dict[int, Tuple[int, str, str, int]] = {}
+# Keyed by the tools' CONTENT fingerprint (not ``id(tools)``) so in-place
+# mutation invalidates the entry. A long-lived gateway/desktop backend builds
+# many transient tool lists over its lifetime, so the cache is bounded and
+# evicts oldest-first (insertion-ordered dict) once it exceeds the cap. The cap
+# is generous relative to how rarely toolsets are rebuilt within a process.
+_TOOLS_TOKENS_CACHE: dict[str, int] = {}
 _TOOLS_TOKENS_CACHE_MAX = 256
 
 
-def _tool_name_for_cache(tool: Any) -> str:
-    if not isinstance(tool, dict):
-        return ""
-    fn = tool.get("function")
-    if isinstance(fn, dict):
-        name = fn.get("name")
-        if isinstance(name, str):
-            return name
-    name = tool.get("name")
-    return name if isinstance(name, str) else ""
+def _tools_cache_fingerprint(tools: List[Dict[str, Any]]) -> str:
+    """Content-fingerprint for the tool-estimate cache.
+
+    Keyed by the tools' CONTENT (per-tool name + description length +
+    serialized parameters), not by ``id(tools)``. This is what makes the cache
+    correct under in-place mutation: if a caller grows a tool's description or
+    edits its parameters without replacing the list object, the fingerprint
+    changes, the entry misses, and the estimate is recomputed — so a stale
+    small estimate can never be served for a larger payload.
+    """
+    parts: List[str] = [str(len(tools))]
+    for tool in tools:
+        if not isinstance(tool, dict):
+            parts.append("x")
+            continue
+        fn = tool.get("function")
+        if isinstance(fn, dict):
+            name = fn.get("name") or ""
+            desc = fn.get("description") or ""
+            params = fn.get("parameters") or {}
+        else:
+            name = tool.get("name") or ""
+            desc = tool.get("description") or ""
+            params = tool.get("parameters") or {}
+        # str() is mutation-sensitive (a changed/added key changes the string)
+        # AND cheap — it does NOT call json.dumps, so the cache-key path never
+        # triggers an extra serialization. Only the estimate path below calls
+        # json.dumps (once per cache miss), preserving the "serialize the tool
+        # schema once per estimate" contract the caching test asserts.
+        pj = str(params)
+        parts.append(f"{name}|{len(desc)}|{pj}")
+    return "\x1f".join(parts)
 
 
 def _estimate_tools_tokens_rough(tools: List[Dict[str, Any]]) -> int:
     if not tools:
         return 0
 
-    # Cache by list identity. Tools are rebuilt rarely (toolset changes),
-    # but token estimates are requested frequently (preflight, compaction).
-    key = id(tools)
-    n = len(tools)
-    first = _tool_name_for_cache(tools[0]) if n else ""
-    last = _tool_name_for_cache(tools[-1]) if n else ""
-
+    # Cache by CONTENT fingerprint (not id()): safe under in-place mutation and
+    # bounded to _TOOLS_TOKENS_CACHE_MAX entries.
+    key = _tools_cache_fingerprint(tools)
     cached = _TOOLS_TOKENS_CACHE.get(key)
     if cached is not None:
-        cached_n, cached_first, cached_last, cached_tokens = cached
-        if cached_n == n and cached_first == first and cached_last == last:
-            return cached_tokens
+        return cached
 
     # Fast, stable rough estimate: sum lengths of the major schema fields.
     # This avoids the pathological `str(tools)` path while still scaling with
@@ -3923,9 +4558,8 @@ def _estimate_tools_tokens_rough(tools: List[Dict[str, Any]]) -> int:
 
     tokens = (total_chars + 3) // 4
     # Bound the cache: drop the oldest entry when the cap is exceeded so a
-    # long-running process can't accumulate an unbounded number of stale
-    # ``id(tools)`` entries (id values are recycled after GC anyway).
+    # long-running process can't accumulate an unbounded number of entries.
     if len(_TOOLS_TOKENS_CACHE) >= _TOOLS_TOKENS_CACHE_MAX:
         _TOOLS_TOKENS_CACHE.pop(next(iter(_TOOLS_TOKENS_CACHE)), None)
-    _TOOLS_TOKENS_CACHE[key] = (n, first, last, tokens)
+    _TOOLS_TOKENS_CACHE[key] = tokens
     return tokens

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -820,12 +820,46 @@ def build_final_context_budget(
     )
 
 
+def _set_final_request_output_cap(api_kwargs: dict, cap: int) -> None:
+    """Write ``cap`` into whichever provider-specific output field the FINAL
+    request already carries (mirrors :func:`_final_request_output_cap`, but
+    for the write path).
+
+    Only the field that already holds the authoritative cap is rewritten — a
+    Bedrock request carrying ``inferenceConfig.maxTokens`` is clamped there,
+    an OpenAI-compatible request on ``max_tokens``, etc.  If the request
+    carried no explicit cap (the cap came from the provider implicit /
+    default reservation), the clamp is applied to the most common transport
+    field (``max_tokens``) so the outgoing request carries a concrete value
+    instead of relying on the provider to accept an oversized implicit cap.
+    """
+    existing = _final_request_output_cap(api_kwargs)
+    if existing is not None:
+        if "max_tokens" in api_kwargs:
+            api_kwargs["max_tokens"] = cap
+        elif "max_completion_tokens" in api_kwargs:
+            api_kwargs["max_completion_tokens"] = cap
+        elif "max_output_tokens" in api_kwargs:
+            api_kwargs["max_output_tokens"] = cap
+        elif isinstance(api_kwargs.get("inferenceConfig"), dict) and "maxTokens" in api_kwargs["inferenceConfig"]:
+            api_kwargs["inferenceConfig"]["maxTokens"] = cap
+        elif "maxOutputTokens" in api_kwargs:
+            api_kwargs["maxOutputTokens"] = cap
+    # If no explicit cap was carried, leave the request as-is: the reservation
+    # that triggered the clamp is already bounded by the resolver (explicit →
+    # provider → DEFAULT), and there is no field to clamp.  The budget check
+    # below (budget.total after clamp) is the authoritative invariant; if the
+    # reservation still exceeds the remaining budget, the unshrinkable-input
+    # path will refuse.
+
+
 def enforce_final_context_budget(
     budget: FinalContextBudget,
     *,
     pre_cap: int | None = None,
     ceiling: int | None = None,
     reason: str = "",
+    api_kwargs: dict | None = None,
 ) -> None:
     """Raise :class:`ContextCeilingExceeded` if ``budget.total`` exceeds the
     effective limit = ``min(invocation pre-cap, profile ceiling)``.
@@ -833,6 +867,25 @@ def enforce_final_context_budget(
     Shared terminal enforcement primitive — the ONE place every physical
     dispatch owner (main + auxiliary) calls immediately before provider I/O.
     No-op when neither ``pre_cap`` nor ``ceiling`` is configured.
+
+    When ``api_kwargs`` is supplied, overflow is classified:
+
+    * **Unshrinkable** — ``budget.input_tokens_estimate`` alone is at or over
+      the effective limit.  The input payload cannot be reduced by touching
+      the output cap; :class:`ContextCeilingExceeded` is raised (the provider
+      is never called, and the caller's provider-400 recovery path is
+      preserved because the provider never returns a 400 for a request it
+      never received).
+
+    * **Shrinkable** — the input fits, but ``input + output_reservation``
+      exceeds the limit.  The requested output cap is clamped in-place to
+      ``max(0, limit - input_tokens_estimate)`` (the maximum legal output
+      allowance from the remaining budget) and the check is re-run against
+      the clamped reservation.  This avoids sending a known-invalid cap to
+      the provider while preserving the existing provider-400 recovery
+      path as a fallback for cases where the clamp is insufficient (e.g.
+      the provider's own tokenizer counts the input larger than Hermes's
+      rough estimate).
     """
     # effective limit = min(invocation pre-cap, profile ceiling); no-op if
     # neither is a valid positive int.
@@ -843,6 +896,34 @@ def enforce_final_context_budget(
     if limit is None:
         return
     if budget.total > limit:
+        if (
+            api_kwargs is not None
+            and (budget.total - budget.output_reservation) < limit
+        ):
+            # Shrinkable overflow: the non-output portion (input + system +
+            # tools) fits under the limit, but the output reservation pushes
+            # the total over.  Clamp the outgoing cap to the maximum legal
+            # allowance — the budget's total minus everything except the
+            # output reservation — so that input + system + tools + clamped
+            # cap == limit exactly.
+            allowed = limit - (budget.total - budget.output_reservation)
+            # The clamp must NEVER raise an explicit cap (explicit output caps
+            # are authoritative and may legitimately exceed the rough
+            # remaining budget — the provider's own tokenizer is the final
+            # arbiter, and the provider-400 recovery path remains the
+            # fallback).
+            if _final_request_output_cap(api_kwargs) is not None:
+                _set_final_request_output_cap(api_kwargs, allowed)
+                # After the clamp the resolver's Level-1 (final request cap)
+                # returns exactly `allowed`, so the post-clamp reservation is
+                # `allowed` and the post-clamp total is
+                # input + allowed == limit — the budget now fits exactly and
+                # the provider call proceeds with the reduced cap.
+                return
+            # No explicit cap field to clamp (the reservation came from the
+            # provider implicit / DEFAULT floor).  The input fits but the
+            # resolved reservation does not — the overflow is unshrinkable
+            # (nothing on the wire to lower), so fall through to the raise.
         raise ContextCeilingExceeded(budget.total, limit, reason=reason)
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -95,11 +95,17 @@ def _preflight_request_tokens(
             "using generic transcript estimate",
             exc_info=True,
         )
+    if _agent_stale_thinking_on_wire(agent):
+        return estimate_request_tokens_rough(
+            messages,
+            system_prompt=system_prompt or "",
+            tools=tools,
+        )
     return estimate_request_tokens_rough(
         messages,
         system_prompt=system_prompt or "",
         tools=tools,
-        charge_stale_thinking=_agent_stale_thinking_on_wire(agent),
+        charge_stale_thinking=False,
     )
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -99,7 +99,27 @@ def _preflight_request_tokens(
         messages,
         system_prompt=system_prompt or "",
         tools=tools,
+        charge_stale_thinking=_agent_stale_thinking_on_wire(agent),
     )
+
+
+def _agent_stale_thinking_on_wire(agent: Any) -> bool:
+    """Whether the agent's active route replays stale thinking text (#84371).
+
+    Route facts unavailable (test doubles, partially-built agents) default to
+    ``True`` — the conservative full charge.
+    """
+    try:
+        from agent.message_sanitization import stale_thinking_reaches_wire
+
+        return stale_thinking_reaches_wire(
+            getattr(agent, "api_mode", "") or "",
+            getattr(agent, "provider", "") or "",
+            getattr(agent, "model", "") or "",
+            getattr(agent, "base_url", "") or "",
+        )
+    except Exception:
+        return True
 
 
 def compose_user_api_content(

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -72,6 +72,7 @@ import {
 import type { GroupChatRoom } from './group-chat'
 import { GroupClarifyCard, GroupImageControls, GroupMentionInput } from './group-chat-parts'
 import type { GroupRoomPrompt } from './group-chat-parts'
+import { GroupHoldStatus } from './group-hold-status'
 import {
   botGroups,
   groupChatMemberBots,
@@ -1233,6 +1234,11 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
         </div>
       ) : null}
       {header}
+      <GroupHoldStatus
+        holds={room.holds}
+        memberLabel={member => displayName(member, botRosterMeta(member, allMeta))}
+        members={members}
+      />
       {activityPanel}
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
         <div className="grid gap-1.5 px-2.5 pb-2">

--- a/apps/desktop/src/plugins/hermes-bots/group-hold-status.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-hold-status.test.tsx
@@ -1,0 +1,166 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { translateBots } from './i18n-test-helper'
+import type { GroupMember } from './types'
+
+const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+  const base = await pluginSdkMock(host)
+
+  return {
+    ...base,
+    Button: (props: React.ComponentProps<'button'>) => <button type="button" {...props} />,
+    cn: (...values: unknown[]) => values.filter(Boolean).join(' '),
+    Codicon: ({ name }: { name: string }) => <span aria-hidden data-icon={name} />,
+    ConfirmDialog: () => null,
+    CopyButton: () => null,
+    Dialog: () => null,
+    DialogContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogDescription: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogFooter: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogHeader: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    DialogTitle: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+    relativeTime: () => 'now',
+    RowButton: (props: React.ComponentProps<'button'>) => <button type="button" {...props} />,
+    Tip: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    useI18n: () => ({ t: { common: { cancel: 'Cancel', save: 'Save' } } }),
+    usePluginI18n: () => translateBots
+  }
+})
+
+vi.mock('./group-chat-parts', () => ({
+  GroupClarifyCard: () => null,
+  GroupImageControls: () => null,
+  GroupMentionInput: (props: { 'aria-label'?: string }) => <textarea aria-label={props['aria-label']} />
+}))
+
+const MEMBERS: GroupMember[] = [
+  { name: 'research', title: 'Research' },
+  { name: 'builder', title: 'Builder' }
+]
+
+beforeEach(() => {
+  vi.resetModules()
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn()
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('durable group holds', () => {
+  it('shows an accessible all-members status without relying on the activity feed', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ builder: { at: 2 }, research: { at: 1 } }}
+        memberLabel={member => member.title || member.name}
+        members={MEMBERS}
+      />
+    )
+
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('All 2 bots are paused')
+    expect(status.textContent).toContain('Mention a paused bot or send @all resume to release them.')
+    expect(status.querySelector('[data-icon="debug-pause"]')).not.toBeNull()
+  })
+
+  it('keeps unmatched holds visible instead of reporting all current members held', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ builder: { at: 1 }, 'mac-mini::research': { at: 2 } }}
+        memberLabel={member => member.title || member.name}
+        members={[{ name: 'builder', title: 'Builder' }]}
+      />
+    )
+
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('Paused:')
+    expect(status.textContent).toContain('Builder')
+    expect(status.textContent).toContain('research')
+    expect(status.textContent).not.toContain('All 1 bots are paused')
+  })
+
+  it('names a partial hold and disappears after the production resume directive clears it', async () => {
+    const [{ GroupHoldStatus }, { applyGroupHoldDirective }] = await Promise.all([
+      import('./group-hold-status'),
+      import('./group-rounds')
+    ])
+
+    const held = { builder: { at: 2 } }
+
+    const view = render(
+      <GroupHoldStatus holds={held} memberLabel={member => member.title || member.name} members={MEMBERS} />
+    )
+
+    expect(screen.getByRole('status').textContent).toContain('Paused: Builder')
+
+    const released = applyGroupHoldDirective(held, { everyone: true, mentioned: [] }, '@all resume', {})
+    view.rerender(
+      <GroupHoldStatus holds={released} memberLabel={member => member.title || member.name} members={MEMBERS} />
+    )
+
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('keeps a persisted source-scoped hold visible while its roster row is unavailable', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ 'mac-mini::builder': { at: 2 } }}
+        memberLabel={member => member.title || member.name}
+        members={[]}
+      />
+    )
+
+    expect(screen.getByRole('status').textContent).toContain('Paused: builder')
+  })
+
+  it('source-qualifies same-named holds whose roster rows are unavailable', async () => {
+    const { GroupHoldStatus } = await import('./group-hold-status')
+
+    render(
+      <GroupHoldStatus
+        holds={{ 'mac-mini::builder': { at: 1 }, 'laptop::builder': { at: 2 } }}
+        memberLabel={member => member.title || member.name}
+        members={[]}
+      />
+    )
+
+    const status = screen.getByRole('status')
+
+    expect(status.textContent).toContain('builder (mac-mini)')
+    expect(status.textContent).toContain('builder (laptop)')
+  })
+
+  it('projects hydrated holds into the real group workspace', async () => {
+    const [{ GroupChatWorkspace }, chat] = await Promise.all([import('./group-chat-view'), import('./group-chat')])
+
+    chat.$groupChats.set({
+      Core: {
+        holds: { research: { at: 1 } },
+        log: [],
+        members: MEMBERS,
+        watermarks: {}
+      }
+    })
+
+    render(<GroupChatWorkspace group="Core" members={MEMBERS} />)
+
+    expect(screen.getByRole('status').textContent).toContain('Paused: Research')
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-hold-status.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-hold-status.tsx
@@ -1,0 +1,60 @@
+import { Codicon } from '@hermes/plugin-sdk'
+
+import { groupMemberKey } from './group-membership'
+import { useBots } from './i18n'
+import type { GroupHold, GroupMember } from './types'
+
+interface GroupHoldStatusProps {
+  holds?: Record<string, GroupHold>
+  memberLabel: (member: GroupMember) => string
+  members: GroupMember[]
+}
+
+/** Durable room-level explanation for sticky Stop holds. Activity is scoped to
+ * one run and disappears across epochs/reloads; this status reads the room's
+ * persisted hold map instead. */
+export function GroupHoldStatus(props: GroupHoldStatusProps) {
+  const b = useBots()
+  const held = new Set(Object.keys(props.holds || {}))
+  const memberKeys = new Set(props.members.map(groupMemberKey))
+  const heldMembers = props.members.filter(member => held.has(groupMemberKey(member)))
+
+  const unavailableHeldLabels = [...held]
+    .filter(key => !memberKeys.has(key))
+    .map(key => {
+      const [source, name] = key.split('::')
+
+      return source && name ? `${name} (${source})` : key
+    })
+
+  const heldLabels = [...heldMembers.map(props.memberLabel), ...unavailableHeldLabels]
+
+  const allHeld =
+    props.members.length > 0 &&
+    unavailableHeldLabels.length === 0 &&
+    props.members.every(member => held.has(groupMemberKey(member)))
+
+  const label = allHeld
+    ? b.group.allHeldStatus(props.members.length)
+    : heldLabels.length
+      ? b.group.heldMembersStatus(heldLabels.join(', '))
+      : null
+
+  if (!label) {
+    return null
+  }
+
+  return (
+    <div
+      className="flex items-start gap-1.5 border-b border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary) px-2.5 py-1.5 text-[0.7rem]"
+      data-slot="group-hold-status"
+      role="status"
+    >
+      <Codicon aria-hidden className="mt-0.5 shrink-0 text-(--ui-text-secondary)" name="debug-pause" />
+      <div className="min-w-0">
+        <div className="font-medium text-(--ui-text-primary)">{label}</div>
+        <div className="text-(--ui-text-tertiary)">{b.group.holdReleaseHint}</div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -156,6 +156,9 @@ type BotsMessages = {
     hideActivity: string
     stop: string
     stopHint: string
+    allHeldStatus: (count: number) => string
+    heldMembersStatus: (members: string) => string
+    holdReleaseHint: string
     needsYourInput: string
     pictureGenerationFailed: string
     nameTaken: (name: string) => string
@@ -354,6 +357,9 @@ const en: BotsMessages = {
     hideActivity: 'Hide room activity',
     stop: 'Stop',
     stopHint: 'Stop this run — interrupts the member on turn and holds the rest',
+    allHeldStatus: count => `All ${count} bots are paused`,
+    heldMembersStatus: members => `Paused: ${members}`,
+    holdReleaseHint: 'Mention a paused bot or send @all resume to release them.',
     needsYourInput: 'A bot in this group chat needs your input',
     pictureGenerationFailed: 'Group picture generation failed',
     nameTaken: name => `A group named “${name}” already exists.`,
@@ -545,6 +551,9 @@ const ja: BotsMessages = {
     hideActivity: '部屋のアクティビティを隠す',
     stop: '停止',
     stopHint: 'この実行を停止 — ターン中のメンバーを中断し、残りを保留します',
+    allHeldStatus: count => `すべてのボット（${count}体）が一時停止中`,
+    heldMembersStatus: members => `一時停止中: ${members}`,
+    holdReleaseHint: '一時停止中のボットにメンションするか、@all resume を送信して再開します。',
     needsYourInput: 'このグループチャットのボットが入力を待っています',
     pictureGenerationFailed: 'グループ画像の生成に失敗しました',
     nameTaken: name => `「${name}」という名前のグループはすでに存在します。`,
@@ -735,6 +744,9 @@ const zh: BotsMessages = {
     hideActivity: '隐藏房间活动',
     stop: '停止',
     stopHint: '停止本次运行 — 中断当前回合的成员，并暂停其余成员',
+    allHeldStatus: count => `全部 ${count} 个机器人已暂停`,
+    heldMembersStatus: members => `已暂停：${members}`,
+    holdReleaseHint: '提及已暂停的机器人，或发送 @all resume 以恢复它们。',
     needsYourInput: '此群聊中有机器人需要你输入',
     pictureGenerationFailed: '群组图片生成失败',
     nameTaken: name => `已存在名为“${name}”的群聊。`,
@@ -925,6 +937,9 @@ const zhHant: BotsMessages = {
     hideActivity: '隱藏房間活動',
     stop: '停止',
     stopHint: '停止本次執行 — 中斷目前回合的成員，並暫停其餘成員',
+    allHeldStatus: count => `全部 ${count} 個機器人已暫停`,
+    heldMembersStatus: members => `已暫停：${members}`,
+    holdReleaseHint: '提及已暫停的機器人，或傳送 @all resume 以恢復它們。',
     needsYourInput: '此群組聊天中有機器人需要您的輸入',
     pictureGenerationFailed: '群組圖片產生失敗',
     nameTaken: name => `已存在名為「${name}」的群組聊天。`,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -100,6 +100,33 @@ model:
   #
   # context_length: 131072
   #
+  # max_context_length: GLOBAL CEILING on the effective context window.
+  #   Unlike context_length (per-model, absolute, discarded on /model switch),
+  #   max_context_length is a hard upper bound that survives model switches:
+  #
+  #     effective = min(resolved_context, max_context_length)
+  #
+  #   It NEVER raises a window — only lowers one — so it composes safely with
+  #   an explicit context_length that is already below it. Use it to cap the
+  #   effective window a profile is allowed to use — e.g. to keep a very large
+  #   auto-detected window within a budget or a provider tier, or to protect a
+  #   downstream model whose real limit is smaller than auto-detection.
+  #
+  #   max_context_length: 272000
+  #
+  #   Rules:
+  #   * Must be a positive integer token count (minimum 64000). bool, float,
+  #     numeric strings, infinity, and values <= 0 are all rejected. A value
+  #     below the 64K floor is an invalid ceiling (a mis-configuration), not a
+  #     statement about model capability.
+  #   * Applies to every model in the profile and survives /model switches.
+  #   * Is a runtime policy: it never contaminates the persistent
+  #     context_length_cache.yaml, which retains the model's real capability
+  #     while all consumers observe the capped value.
+  #   * Is enforced as a hard ceiling: a request still above it after any
+  #     compression (or with compression disabled) is refused before provider
+  #     dispatch rather than silently sent on the provider's larger window.
+  #
   # max_tokens: OUTPUT cap — maximum tokens the model may generate per response.
   #   Unrelated to how long your conversation history can be.
   #   The OpenAI-standard name "max_tokens" is a misnomer; Anthropic's native

--- a/cli.py
+++ b/cli.py
@@ -16787,8 +16787,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if isinstance(message, str) and "@" in message:
             try:
                 from agent.context_references import preprocess_context_references
-                from agent.model_metadata import get_model_context_length
-                _ctx_len = get_model_context_length(
+                from agent.model_metadata import effective_context_length
+                _ctx_len = effective_context_length(
                     self.model, base_url=self.base_url or "", api_key=self.api_key or "",
                     provider=self.provider or "",
                     config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None)

--- a/contributors/emails/itskaism@users.noreply.github.com
+++ b/contributors/emails/itskaism@users.noreply.github.com
@@ -1,0 +1,1 @@
+itskaism

--- a/contributors/emails/marckus@gmail.com
+++ b/contributors/emails/marckus@gmail.com
@@ -1,0 +1,2 @@
+Forser
+# PR #92905 salvage (feat/model: enforce profile-wide hard context ceiling)

--- a/contributors/emails/yozamono@gmail.com
+++ b/contributors/emails/yozamono@gmail.com
@@ -1,0 +1,1 @@
+sambai-dev

--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -1,0 +1,1320 @@
+"""Deterministic policy for same-gateway hosted-room Discussions.
+
+This module translates a frozen local member roster and the complete typed room
+log into one next driver task.  It performs no I/O, starts no workers, and knows
+nothing about transports or model runtimes.  Callers persist the returned task
+with :mod:`gateway.hosted_room_driver` and append publication plans with
+:mod:`gateway.hosted_rooms`.
+
+The unpublished driver payload intentionally remains unchanged.  Discussion
+coordinates live in deterministic ``TaskIdentity`` values and typed terminal
+events; a restart can therefore reconstruct a task without widening the driver
+schema.  Callers must reconcile terminal driver rows into publication plans
+before asking for the next task.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+
+
+MAX_DISCUSSION_MEMBERS = 6
+MIN_DISCUSSION_MEMBERS = 2
+MAX_DISCUSSION_ROUNDS = 3
+MAX_DISCUSSION_MESSAGES = 10
+MAX_DISCUSSION_DELTA_LINES = 24
+MAX_USER_TEXT_BYTES = 64 * 1024
+MAX_MEMBER_TEXT_BYTES = 64 * 1024
+_TRUNCATED_REPLY_NOTICE = (
+    "\n\n[Reply truncated. Ask the Bot to share the full result as a file.]"
+)
+
+DecisionStatus = Literal["idle", "task", "settled", "bounded"]
+TerminalKind = Literal["settled", "failed", "cancelled", "deferred"]
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_MENTION_RE = re.compile(r"@([A-Za-z0-9][A-Za-z0-9._:-]*)", re.IGNORECASE)
+_TURN_ID_RE = re.compile(
+    r"^d(?P<source>[1-9][0-9]*)\.r(?P<round>[0-2])\."
+    r"p(?P<position>[0-5])\.s(?P<seen>[1-9][0-9]*)\."
+    r"m(?P<member>[0-9a-f]{24})$"
+)
+
+_MEMBER_FIELDS = frozenset({"member_id", "profile", "handle", "display_name"})
+_REMOTE_MEMBER_FIELDS = frozenset({
+    "connectionId",
+    "connectionKind",
+    "connectionLabel",
+    "connection_id",
+    "connection_kind",
+    "connection_label",
+    "remoteSource",
+    "route",
+    "sourceMissing",
+    "sourceReachable",
+    "sourceScoped",
+    "targetProfile",
+    "target_profile",
+})
+_USER_PAYLOAD_FIELDS = frozenset({"text", "thread_id"})
+_MEMBER_MESSAGE_FIELDS = frozenset({
+    "discussion_event_id",
+    "member_id",
+    "member_index",
+    "round_index",
+    "task_id",
+    "text",
+    "thread_id",
+    "turn_id",
+})
+_TERMINAL_COMMON_FIELDS = frozenset({
+    "discussion_event_id",
+    "member_id",
+    "member_index",
+    "round_index",
+    "seen_through_seq",
+    "task_id",
+    "thread_id",
+    "turn_id",
+})
+_TERMINAL_EXTRA_FIELDS = {
+    "turn.settled": frozenset({"message_event_id", "passed"}),
+    "turn.failed": frozenset({"error"}),
+    "turn.cancelled": frozenset({"reason"}),
+    "turn.deferred": frozenset({"execution_generation", "reason"}),
+}
+_TERMINAL_EVENT_KINDS = frozenset(_TERMINAL_EXTRA_FIELDS)
+_ROOM_ACTIVITY_FIELDS = frozenset({
+    "status",
+    "reason_code",
+    "thread_id",
+    "discussion_event_id",
+})
+_ROOM_STOP_FIELDS = frozenset({"cancel_id"})
+
+
+class DiscussionPolicyError(ValueError):
+    """Base class for invalid policy input or unreconstructable state."""
+
+
+class DiscussionValidationError(DiscussionPolicyError):
+    """Raised when a room, roster, payload, or typed event is malformed."""
+
+
+class DiscussionReconstructionError(DiscussionPolicyError):
+    """Raised when a persisted task cannot be reproduced from durable state."""
+
+
+@dataclass(frozen=True)
+class DiscussionMember:
+    """One immutable member local to the room's authority gateway."""
+
+    member_id: str
+    profile: str
+    handle: str
+    display_name: str = ""
+
+
+@dataclass(frozen=True)
+class DiscussionRoom:
+    """Validated policy projection of one active hosted room."""
+
+    room_id: str
+    name: str
+    members: tuple[DiscussionMember, ...]
+    gateway_id: str
+    authority_epoch: int
+
+
+@dataclass(frozen=True)
+class DiscussionTaskPlan:
+    """One deterministic member turn compatible with the driver schema."""
+
+    identity: driver.TaskIdentity
+    payload: Mapping[str, Any]
+    discussion_event_id: str
+    member: DiscussionMember
+    member_index: int
+    round_index: int
+    seen_through_seq: int
+
+
+@dataclass(frozen=True)
+class DiscussionDecision:
+    """Current result of replaying one room's Discussion policy."""
+
+    status: DecisionStatus
+    reason: str
+    discussion_event_id: str | None = None
+    source_event_seq: int | None = None
+    thread_id: str | None = None
+    task: DiscussionTaskPlan | None = None
+
+
+@dataclass(frozen=True)
+class EventPlan:
+    """One idempotent append for :func:`gateway.hosted_rooms.append_event`."""
+
+    event_id: str
+    kind: str
+    actor: Mapping[str, str]
+    payload: Mapping[str, Any]
+    authority_gateway_id: str
+    authority_epoch: int
+
+    def append_kwargs(self, room_id: str) -> dict[str, Any]:
+        """Return keyword arguments accepted by ``append_event``."""
+
+        return {
+            "room_id": room_id,
+            "event_id": self.event_id,
+            "kind": self.kind,
+            "actor": dict(self.actor),
+            "payload": dict(self.payload),
+            "authority_gateway_id": self.authority_gateway_id,
+            "authority_epoch": self.authority_epoch,
+        }
+
+
+@dataclass(frozen=True)
+class PublicationPlan:
+    """Ordered visible and terminal effects for one driver task."""
+
+    task_id: str
+    terminal_kind: str
+    events: tuple[EventPlan, ...]
+
+
+@dataclass(frozen=True)
+class _ValidatedEvent:
+    raw: Mapping[str, Any]
+    seq: int
+    event_id: str
+    kind: str
+    actor: Mapping[str, Any]
+    payload: Mapping[str, Any]
+
+
+def _identifier(value: Any, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise DiscussionValidationError(f"{label} must be a string")
+    normalized = value.strip()
+    if (
+        not normalized
+        or len(normalized) > driver.MAX_IDENTIFIER_CHARS
+        or not _IDENTIFIER_RE.fullmatch(normalized)
+    ):
+        raise DiscussionValidationError(f"invalid {label}")
+    return normalized
+
+
+def _positive_int(value: Any, *, label: str, maximum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise DiscussionValidationError(f"{label} must be a positive integer")
+    if maximum is not None and value > maximum:
+        raise DiscussionValidationError(f"{label} must be at most {maximum}")
+    return value
+
+
+def _zero_based_int(value: Any, *, label: str, maximum: int) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= maximum
+    ):
+        raise DiscussionValidationError(
+            f"{label} must be an integer between 0 and {maximum}"
+        )
+    return value
+
+
+def _exact_fields(
+    value: Any,
+    *,
+    label: str,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise DiscussionValidationError(f"{label} must be an object")
+    keys = frozenset(value)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise DiscussionValidationError(
+            f"{label} is missing fields: {', '.join(sorted(missing))}"
+        )
+    if unknown:
+        raise DiscussionValidationError(
+            f"{label} has unknown fields: {', '.join(sorted(unknown))}"
+        )
+    return value
+
+
+def validate_user_payload(value: Any) -> dict[str, Any]:
+    """Validate and normalize the exact ``message.user`` Discussion payload."""
+
+    payload = _exact_fields(
+        value,
+        label="user payload",
+        required=_USER_PAYLOAD_FIELDS,
+    )
+    text = payload["text"]
+    if not isinstance(text, str):
+        raise DiscussionValidationError("user payload text must be a string")
+    text = text.strip()
+    if not text:
+        raise DiscussionValidationError("user payload text must not be empty")
+    if len(text.encode("utf-8")) > MAX_USER_TEXT_BYTES:
+        raise DiscussionValidationError("user payload text is too large")
+    thread_id = _identifier(payload["thread_id"], label="thread_id")
+    return {"text": text, "thread_id": thread_id}
+
+
+def validate_roster(
+    value: Any,
+    *,
+    local_profiles: Iterable[str],
+) -> tuple[DiscussionMember, ...]:
+    """Validate a frozen 2-6 member roster of profiles on this gateway."""
+
+    if not isinstance(value, list):
+        raise DiscussionValidationError("members must be a list")
+    if not MIN_DISCUSSION_MEMBERS <= len(value) <= MAX_DISCUSSION_MEMBERS:
+        raise DiscussionValidationError(
+            f"members must contain between {MIN_DISCUSSION_MEMBERS} and "
+            f"{MAX_DISCUSSION_MEMBERS} entries"
+        )
+
+    known_profiles = {
+        _identifier(profile, label="local profile") for profile in local_profiles
+    }
+    members: list[DiscussionMember] = []
+    profiles: set[str] = set()
+    handles: set[str] = set()
+    member_ids: set[str] = set()
+
+    for index, raw in enumerate(value):
+        if not isinstance(raw, Mapping):
+            raise DiscussionValidationError(f"member {index} must be an object")
+        remote_fields = frozenset(raw) & _REMOTE_MEMBER_FIELDS
+        if remote_fields:
+            raise DiscussionValidationError(
+                f"member {index} contains cross-gateway fields: "
+                f"{', '.join(sorted(remote_fields))}"
+            )
+        member = _exact_fields(
+            raw,
+            label=f"member {index}",
+            required=frozenset({"member_id", "profile", "handle"}),
+            optional=frozenset({"display_name"}),
+        )
+        member_id = _identifier(member["member_id"], label=f"member {index} id")
+        profile = _identifier(member["profile"], label=f"member {index} profile")
+        handle = _identifier(member["handle"], label=f"member {index} handle")
+        if profile not in known_profiles:
+            raise DiscussionValidationError(
+                f"member {index} profile '{profile}' is not local to this gateway"
+            )
+        display_name = member.get("display_name", "")
+        if not isinstance(display_name, str):
+            raise DiscussionValidationError(
+                f"member {index} display_name must be a string"
+            )
+        display_name = display_name.strip()
+        if len(display_name) > hosted_rooms.MAX_ACTOR_LABEL_CHARS:
+            raise DiscussionValidationError(f"member {index} display_name is too long")
+
+        profile_key = profile.casefold()
+        handle_key = handle.casefold()
+        member_key = member_id.casefold()
+        if profile_key in profiles:
+            raise DiscussionValidationError("member profiles must be unique")
+        if handle_key in handles or handle_key in {"all", "everyone"}:
+            raise DiscussionValidationError(
+                "member handles must be unique and cannot reserve @all or @everyone"
+            )
+        if member_key in member_ids:
+            raise DiscussionValidationError("member ids must be unique")
+        profiles.add(profile_key)
+        handles.add(handle_key)
+        member_ids.add(member_key)
+        members.append(
+            DiscussionMember(
+                member_id=member_id,
+                profile=profile,
+                handle=handle,
+                display_name=display_name,
+            )
+        )
+    return tuple(members)
+
+
+def validate_room(
+    value: Any,
+    *,
+    local_profiles: Iterable[str],
+) -> DiscussionRoom:
+    """Project a hosted-room row into the strict same-gateway policy shape."""
+
+    if not isinstance(value, Mapping):
+        raise DiscussionValidationError("room must be an object")
+    if value.get("disbanded_at") is not None:
+        raise DiscussionValidationError("room is disbanded")
+    room_id = _identifier(value.get("room_id"), label="room_id")
+    name = value.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise DiscussionValidationError("room name must be a non-empty string")
+    name = name.strip()
+    if len(name) > hosted_rooms.MAX_ROOM_NAME_CHARS:
+        raise DiscussionValidationError("room name is too long")
+    gateway_id = _identifier(
+        value.get("authority_gateway_id"),
+        label="authority_gateway_id",
+    )
+    authority_epoch = _positive_int(
+        value.get("authority_epoch"),
+        label="authority_epoch",
+    )
+    members = validate_roster(value.get("members"), local_profiles=local_profiles)
+    return DiscussionRoom(
+        room_id=room_id,
+        name=name,
+        members=members,
+        gateway_id=gateway_id,
+        authority_epoch=authority_epoch,
+    )
+
+
+def is_pass_text(value: Any) -> bool:
+    """Return whether a settled member result is Discussion silence."""
+
+    text = str(value or "").strip()
+    return (
+        not text
+        or re.fullmatch(r"\(?\s*pass\s*\)?\.?", text, re.IGNORECASE) is not None
+    )
+
+
+def resolve_mentions(
+    texts: Iterable[str],
+    members: Sequence[DiscussionMember],
+    *,
+    default_all: bool = True,
+) -> tuple[DiscussionMember, ...]:
+    """Resolve member handles deterministically against the frozen roster."""
+
+    by_handle = {member.handle.casefold(): member for member in members}
+    mentioned: set[str] = set()
+    everyone = False
+    for text in texts:
+        for match in _MENTION_RE.finditer(str(text or "")):
+            handle = match.group(1).casefold()
+            if handle in {"all", "everyone"}:
+                everyone = True
+            elif handle in by_handle:
+                mentioned.add(handle)
+    if everyone or (default_all and not mentioned):
+        return tuple(members)
+    return tuple(member for member in members if member.handle.casefold() in mentioned)
+
+
+def _unaddressed_member_mentions(
+    messages: Sequence[_ValidatedEvent],
+    room: DiscussionRoom,
+) -> tuple[DiscussionMember, ...]:
+    """Return peers explicitly cited by a Bot and not heard from afterward."""
+
+    cited_at: dict[str, int] = {}
+    last_post_at: dict[str, int] = {}
+    for event in messages:
+        if event.kind != "message.member":
+            continue
+        speaker_id = str(event.payload["member_id"])
+        last_post_at[speaker_id] = event.seq
+        cited = resolve_mentions(
+            (str(event.payload["text"]),),
+            room.members,
+            default_all=False,
+        )
+        for member in cited:
+            if member.member_id != speaker_id:
+                cited_at[member.member_id] = event.seq
+    return tuple(
+        member
+        for member in room.members
+        if member.member_id in cited_at
+        and last_post_at.get(member.member_id, 0) <= cited_at[member.member_id]
+    )
+
+
+def _validate_event(
+    raw: Any,
+    *,
+    room: DiscussionRoom,
+    previous_seq: int,
+) -> _ValidatedEvent:
+    if not isinstance(raw, Mapping):
+        raise DiscussionValidationError("room event must be an object")
+    if raw.get("room_id") != room.room_id:
+        raise DiscussionValidationError("room event belongs to a different room")
+    seq = _positive_int(raw.get("seq"), label="event seq")
+    if seq <= previous_seq:
+        raise DiscussionValidationError("room events must be in strict sequence order")
+    event_id = _identifier(raw.get("event_id"), label="event_id")
+    kind = raw.get("kind")
+    if not isinstance(kind, str):
+        raise DiscussionValidationError("event kind must be a string")
+    actor = raw.get("actor")
+    if not isinstance(actor, Mapping):
+        raise DiscussionValidationError("event actor must be an object")
+    payload = raw.get("payload")
+    if not isinstance(payload, Mapping):
+        raise DiscussionValidationError("event payload must be an object")
+
+    if kind == "message.user":
+        payload = validate_user_payload(payload)
+        if actor.get("kind") != "user":
+            raise DiscussionValidationError("message.user requires a user actor")
+    elif kind == "message.member":
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                "message.member authority epoch does not match the room"
+            )
+        _validate_member_message(payload, actor=actor, room=room)
+    elif kind in _TERMINAL_EVENT_KINDS:
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                f"{kind} authority epoch does not match the room"
+            )
+        _validate_terminal_event(kind, payload, actor=actor, room=room)
+    elif kind == "room.activity":
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                "room.activity authority epoch does not match the room"
+            )
+        _exact_fields(
+            payload,
+            label="room.activity payload",
+            required=_ROOM_ACTIVITY_FIELDS,
+        )
+        if payload.get("status") not in {"settled", "bounded"}:
+            raise DiscussionValidationError("invalid room.activity status")
+        _identifier(payload.get("reason_code"), label="reason_code")
+        _identifier(payload.get("thread_id"), label="thread_id")
+        _identifier(payload.get("discussion_event_id"), label="discussion_event_id")
+        if actor.get("kind") != "gateway" or actor.get("id") != room.gateway_id:
+            raise DiscussionValidationError("room.activity requires the room gateway")
+    elif kind == "room.stop_requested":
+        if raw.get("authority_epoch") != room.authority_epoch:
+            raise DiscussionValidationError(
+                "room.stop_requested authority epoch does not match the room"
+            )
+        _exact_fields(
+            payload,
+            label="room.stop_requested payload",
+            required=_ROOM_STOP_FIELDS,
+        )
+        _identifier(payload.get("cancel_id"), label="cancel_id")
+        if actor.get("kind") != "gateway" or actor.get("id") != room.gateway_id:
+            raise DiscussionValidationError(
+                "room.stop_requested requires the room gateway"
+            )
+
+    return _ValidatedEvent(
+        raw=raw,
+        seq=seq,
+        event_id=event_id,
+        kind=kind,
+        actor=actor,
+        payload=payload,
+    )
+
+
+def _member_by_id(room: DiscussionRoom, member_id: Any) -> DiscussionMember:
+    normalized = _identifier(member_id, label="member_id")
+    for member in room.members:
+        if member.member_id == normalized:
+            return member
+    raise DiscussionValidationError(f"unknown Discussion member '{normalized}'")
+
+
+def _validate_turn_coordinates(
+    payload: Mapping[str, Any], room: DiscussionRoom
+) -> None:
+    _member_by_id(room, payload.get("member_id"))
+    member_index = _zero_based_int(
+        payload.get("member_index"),
+        label="member_index",
+        maximum=MAX_DISCUSSION_MEMBERS - 1,
+    )
+    round_index = _zero_based_int(
+        payload.get("round_index"),
+        label="round_index",
+        maximum=MAX_DISCUSSION_ROUNDS - 1,
+    )
+    thread_id = _identifier(payload.get("thread_id"), label="thread_id")
+    task_id = _identifier(payload.get("task_id"), label="task_id")
+    turn_id = _identifier(payload.get("turn_id"), label="turn_id")
+    discussion_event_id = _identifier(
+        payload.get("discussion_event_id"),
+        label="discussion_event_id",
+    )
+    del member_index, round_index, thread_id, task_id, turn_id, discussion_event_id
+
+
+def _validate_member_message(
+    payload: Mapping[str, Any],
+    *,
+    actor: Mapping[str, Any],
+    room: DiscussionRoom,
+) -> None:
+    _exact_fields(
+        payload,
+        label="message.member payload",
+        required=_MEMBER_MESSAGE_FIELDS,
+    )
+    _validate_turn_coordinates(payload, room)
+    text = payload.get("text")
+    if not isinstance(text, str) or not text.strip() or is_pass_text(text):
+        raise DiscussionValidationError("message.member text must be a non-pass string")
+    member = _member_by_id(room, payload.get("member_id"))
+    if (
+        actor.get("kind") != "member"
+        or actor.get("id") != member.member_id
+        or actor.get("profile") != member.profile
+        or actor.get("connection_id") is not None
+    ):
+        raise DiscussionValidationError("message.member actor does not match roster")
+
+
+def _validate_terminal_event(
+    kind: str,
+    payload: Mapping[str, Any],
+    *,
+    actor: Mapping[str, Any],
+    room: DiscussionRoom,
+) -> None:
+    required = _TERMINAL_COMMON_FIELDS | _TERMINAL_EXTRA_FIELDS[kind]
+    _exact_fields(payload, label=f"{kind} payload", required=required)
+    _validate_turn_coordinates(payload, room)
+    _positive_int(payload.get("seen_through_seq"), label="seen_through_seq")
+    if (
+        actor.get("kind") != "gateway"
+        or actor.get("id") != room.gateway_id
+        or actor.get("connection_id") is not None
+    ):
+        raise DiscussionValidationError(f"{kind} requires a gateway actor")
+    if kind == "turn.settled":
+        if not isinstance(payload.get("passed"), bool):
+            raise DiscussionValidationError("turn.settled passed must be a boolean")
+        message_event_id = payload.get("message_event_id")
+        if payload["passed"]:
+            if message_event_id is not None:
+                raise DiscussionValidationError(
+                    "a passed turn cannot reference a member message"
+                )
+        else:
+            _identifier(message_event_id, label="message_event_id")
+    else:
+        field = "error" if kind == "turn.failed" else "reason"
+        if not isinstance(payload.get(field), str) or not payload[field].strip():
+            raise DiscussionValidationError(f"{kind} {field} must be non-empty")
+        if kind == "turn.deferred":
+            _positive_int(
+                payload.get("execution_generation"),
+                label="execution_generation",
+            )
+
+
+def _validated_events(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    room: DiscussionRoom,
+) -> tuple[_ValidatedEvent, ...]:
+    validated: list[_ValidatedEvent] = []
+    previous_seq = 0
+    event_ids: set[str] = set()
+    for raw in events:
+        event = _validate_event(raw, room=room, previous_seq=previous_seq)
+        if event.event_id in event_ids:
+            raise DiscussionValidationError("room event ids must be unique")
+        validated.append(event)
+        previous_seq = event.seq
+        event_ids.add(event.event_id)
+    return tuple(validated)
+
+
+def _discussion_user_events(
+    events: Sequence[_ValidatedEvent],
+) -> tuple[_ValidatedEvent, ...]:
+    return tuple(event for event in events if event.kind == "message.user")
+
+
+def _message_events(
+    events: Sequence[_ValidatedEvent],
+    *,
+    thread_id: str | None = None,
+    maximum_seq: int | None = None,
+) -> tuple[_ValidatedEvent, ...]:
+    result = []
+    for event in events:
+        if event.kind not in {"message.user", "message.member"}:
+            continue
+        if thread_id is not None and event.payload.get("thread_id") != thread_id:
+            continue
+        if maximum_seq is not None and event.seq > maximum_seq:
+            continue
+        result.append(event)
+    return tuple(result)
+
+
+def derive_member_watermarks(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    *,
+    local_profiles: Iterable[str],
+) -> dict[tuple[str, str], int]:
+    """Derive ``(thread_id, member_id)`` watermarks from terminal events."""
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    return _derive_member_watermarks(validated)
+
+
+def _derive_member_watermarks(
+    events: Sequence[_ValidatedEvent],
+) -> dict[tuple[str, str], int]:
+    messages_by_id = {
+        event.event_id: event for event in events if event.kind == "message.member"
+    }
+    terminal_by_task: dict[str, _ValidatedEvent] = {}
+    watermarks: dict[tuple[str, str], int] = {}
+    for event in events:
+        if event.kind not in _TERMINAL_EVENT_KINDS:
+            continue
+        task_id = str(event.payload["task_id"])
+        previous = terminal_by_task.get(task_id)
+        if previous is not None:
+            if previous.kind != "turn.deferred":
+                raise DiscussionValidationError(
+                    f"task '{task_id}' has more than one terminal room event"
+                )
+            if event.kind == "turn.deferred" and int(
+                event.payload["execution_generation"]
+            ) <= int(previous.payload["execution_generation"]):
+                raise DiscussionValidationError(
+                    f"task '{task_id}' deferral generation did not advance"
+                )
+        terminal_by_task[task_id] = event
+        key = (str(event.payload["thread_id"]), str(event.payload["member_id"]))
+        watermark = int(event.payload["seen_through_seq"])
+        if event.kind == "turn.settled" and not event.payload["passed"]:
+            message_id = str(event.payload["message_event_id"])
+            message = messages_by_id.get(message_id)
+            if (
+                message is None
+                or message.payload.get("task_id") != task_id
+                or message.payload.get("member_id") != event.payload.get("member_id")
+                or message.payload.get("thread_id") != event.payload.get("thread_id")
+            ):
+                raise DiscussionValidationError(
+                    "turn.settled references no matching member message"
+                )
+            watermark = max(watermark, message.seq)
+        watermarks[key] = max(watermarks.get(key, 0), watermark)
+    return watermarks
+
+
+def _member_digest(member: DiscussionMember) -> str:
+    seed = f"{member.member_id}\0{member.profile}\0{member.handle}"
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:24]
+
+
+def _rotate(
+    members: Sequence[DiscussionMember], round_index: int
+) -> tuple[DiscussionMember, ...]:
+    if len(members) < 2:
+        return tuple(members)
+    shift = round_index % len(members)
+    return tuple((*members[shift:], *members[:shift]))
+
+
+def _format_message(event: _ValidatedEvent, room: DiscussionRoom) -> str:
+    text = str(event.payload["text"])
+    if event.kind == "message.user":
+        return f"User (user): {text}"
+    member = _member_by_id(room, event.payload["member_id"])
+    return f"@{member.handle}: {text}"
+
+
+def _truncate_utf8_text(value: Any, *, max_bytes: int, suffix: str = "") -> str:
+    text = str(value or "")
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    suffix_bytes = suffix.encode("utf-8")
+    prefix = encoded[: max(0, max_bytes - len(suffix_bytes))]
+    while prefix:
+        try:
+            return prefix.decode("utf-8") + suffix
+        except UnicodeDecodeError:
+            prefix = prefix[:-1]
+    return suffix.strip()
+
+
+def _build_prompt(
+    *,
+    room: DiscussionRoom,
+    member: DiscussionMember,
+    messages: Sequence[_ValidatedEvent],
+    watermark: int,
+    seen_through_seq: int,
+) -> str:
+    delta = [event for event in messages if watermark < event.seq <= seen_through_seq][
+        -MAX_DISCUSSION_DELTA_LINES:
+    ]
+    peers = ", ".join(
+        f"@{candidate.handle}"
+        for candidate in room.members
+        if candidate.member_id != member.member_id
+    )
+    opening = [
+        f'[Discussion: "{room.name}"] You are @{member.handle}, one participant '
+        f"with {peers or 'no other members'} and the user.",
+        "",
+        "New messages in this thread since your last turn (oldest first):",
+    ]
+    rules = [
+        "",
+        "Rules for this Discussion:",
+        "- Reply with one conversational message only when you have something new worth adding.",
+        '- If you have nothing new to add, reply with exactly "(pass)".',
+        "- Mention a teammate by handle to pull them into the next round; do not repeat points already made.",
+        "- Never reveal content from private conversations. Your reply is published verbatim.",
+    ]
+    fixed_bytes = len("\n".join([*opening, *rules]).encode("utf-8"))
+    available = max(0, driver.MAX_PROMPT_BYTES - fixed_bytes - 1)
+    selected: list[str] = []
+    omitted = False
+    for event in reversed(delta):
+        line = f"  {_format_message(event, room)}"
+        line_bytes = len(line.encode("utf-8")) + 1
+        if line_bytes <= available:
+            selected.append(line)
+            available -= line_bytes
+            continue
+        if not selected and available > 32:
+            selected.append(_truncate_utf8_text(line, max_bytes=available))
+        omitted = True
+        break
+    selected.reverse()
+    if omitted:
+        selected.insert(0, "  [Earlier content omitted to fit this turn.]")
+    prompt = "\n".join([*opening, *selected, *rules])
+    if len(prompt.encode("utf-8")) > driver.MAX_PROMPT_BYTES:
+        raise DiscussionValidationError("Discussion prompt exceeds the driver limit")
+    return prompt
+
+
+def _turn_id(
+    *,
+    source_event_seq: int,
+    round_index: int,
+    member_index: int,
+    seen_through_seq: int,
+    member: DiscussionMember,
+) -> str:
+    return (
+        f"d{source_event_seq}.r{round_index}.p{member_index}."
+        f"s{seen_through_seq}.m{_member_digest(member)}"
+    )
+
+
+def _task_id(
+    *,
+    room: DiscussionRoom,
+    discussion_event: _ValidatedEvent,
+    member: DiscussionMember,
+    member_index: int,
+    round_index: int,
+    seen_through_seq: int,
+    prompt: str,
+) -> str:
+    seed = json.dumps(
+        {
+            "discussion_event_id": discussion_event.event_id,
+            "member_id": member.member_id,
+            "member_index": member_index,
+            "prompt_sha256": hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+            "room_id": room.room_id,
+            "round_index": round_index,
+            "seen_through_seq": seen_through_seq,
+            "source_event_seq": discussion_event.seq,
+            "thread_id": discussion_event.payload["thread_id"],
+        },
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"dtask:{hashlib.sha256(seed.encode('utf-8')).hexdigest()[:48]}"
+
+
+def _make_task_plan(
+    *,
+    room: DiscussionRoom,
+    discussion_event: _ValidatedEvent,
+    member: DiscussionMember,
+    member_index: int,
+    round_index: int,
+    seen_through_seq: int,
+    prompt: str,
+) -> DiscussionTaskPlan:
+    turn_id = _turn_id(
+        source_event_seq=discussion_event.seq,
+        round_index=round_index,
+        member_index=member_index,
+        seen_through_seq=seen_through_seq,
+        member=member,
+    )
+    task_id = _task_id(
+        room=room,
+        discussion_event=discussion_event,
+        member=member,
+        member_index=member_index,
+        round_index=round_index,
+        seen_through_seq=seen_through_seq,
+        prompt=prompt,
+    )
+    identity = driver.TaskIdentity(
+        room_id=room.room_id,
+        task_id=task_id,
+        thread_id=str(discussion_event.payload["thread_id"]),
+        turn_id=turn_id,
+    )
+    payload = {
+        "target_profile": member.profile,
+        "prompt": prompt,
+        "source_event_seq": discussion_event.seq,
+    }
+    return DiscussionTaskPlan(
+        identity=identity,
+        payload=payload,
+        discussion_event_id=discussion_event.event_id,
+        member=member,
+        member_index=member_index,
+        round_index=round_index,
+        seen_through_seq=seen_through_seq,
+    )
+
+
+def plan_next_task(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    *,
+    local_profiles: Iterable[str],
+    initial_watermarks: Mapping[tuple[str, str], int] | None = None,
+) -> DiscussionDecision:
+    """Replay the complete room log and return at most one next member task."""
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    user_events = _discussion_user_events(validated)
+    stopped_through_seq = max(
+        (event.seq for event in validated if event.kind == "room.stop_requested"),
+        default=0,
+    )
+    completed_discussion_ids = {
+        str(event.payload["discussion_event_id"])
+        for event in validated
+        if event.kind == "room.activity"
+        and event.payload.get("status") in {"settled", "bounded"}
+    }
+    latest_by_thread: dict[str, _ValidatedEvent] = {}
+    for event in user_events:
+        latest_by_thread[str(event.payload["thread_id"])] = event
+    pending_user_events = tuple(
+        event
+        for event in sorted(latest_by_thread.values(), key=lambda item: item.seq)
+        if event.seq > stopped_through_seq
+        and event.event_id not in completed_discussion_ids
+    )
+    if not pending_user_events:
+        return DiscussionDecision(status="idle", reason="no_pending_user_event")
+
+    discussion = pending_user_events[0]
+    thread_id = str(discussion.payload["thread_id"])
+    committed_member_message_ids = {
+        str(event.payload["message_event_id"])
+        for event in validated
+        if event.kind == "turn.settled"
+        and event.payload.get("message_event_id") is not None
+    }
+    # Publication writes the visible member message before the terminal event.
+    # A crash in that gap leaves the message in the log, but it is not committed
+    # policy input yet: ignoring it reproduces the original task coordinates so
+    # the caller can inspect the terminal driver row and finish publication.
+    thread_messages = tuple(
+        event
+        for event in _message_events(validated, thread_id=thread_id)
+        if event.kind == "message.user"
+        or event.event_id in committed_member_message_ids
+    )
+    discussion_messages = tuple(
+        event for event in thread_messages if event.seq >= discussion.seq
+    )
+    member_messages = tuple(
+        event
+        for event in thread_messages
+        if event.kind == "message.member"
+        and event.payload.get("discussion_event_id") == discussion.event_id
+    )
+    if len(member_messages) >= MAX_DISCUSSION_MESSAGES:
+        return DiscussionDecision(
+            status="bounded",
+            reason="max_messages",
+            discussion_event_id=discussion.event_id,
+            source_event_seq=discussion.seq,
+            thread_id=thread_id,
+        )
+
+    terminals = {
+        (int(event.payload["round_index"]), str(event.payload["member_id"])): event
+        for event in validated
+        if event.kind in _TERMINAL_EVENT_KINDS
+        and event.payload.get("discussion_event_id") == discussion.event_id
+    }
+    watermarks = {
+        (str(thread_id), str(member_id)): int(value)
+        for (thread_id, member_id), value in (initial_watermarks or {}).items()
+        if int(value) >= 0
+    }
+    for key, value in _derive_member_watermarks(validated).items():
+        watermarks[key] = max(watermarks.get(key, 0), value)
+    seen_through_seq = max(event.seq for event in thread_messages)
+
+    for round_index in range(MAX_DISCUSSION_ROUNDS):
+        # The user's message selects the first round, with no mention meaning
+        # everyone. Later rounds are opt-in: only a peer explicitly cited by a
+        # Bot and not heard from afterward gets another turn. Every member's
+        # watermark remains intact, so a peer cited later still receives the
+        # complete bounded transcript delta without consuming turns meanwhile.
+        responders = (
+            resolve_mentions((str(discussion.payload["text"]),), room.members)
+            if round_index == 0
+            else _unaddressed_member_mentions(discussion_messages, room)
+        )
+        ordered = _rotate(responders, round_index)
+        for member_index, member in enumerate(ordered):
+            if (round_index, member.member_id) in terminals:
+                continue
+            watermark = watermarks.get((thread_id, member.member_id), 0)
+            delta = [
+                event
+                for event in thread_messages
+                if watermark < event.seq <= seen_through_seq
+            ]
+            if not delta:
+                continue
+            prompt = _build_prompt(
+                room=room,
+                member=member,
+                messages=thread_messages,
+                watermark=watermark,
+                seen_through_seq=seen_through_seq,
+            )
+            task = _make_task_plan(
+                room=room,
+                discussion_event=discussion,
+                member=member,
+                member_index=member_index,
+                round_index=round_index,
+                seen_through_seq=seen_through_seq,
+                prompt=prompt,
+            )
+            return DiscussionDecision(
+                status="task",
+                reason="member_turn",
+                discussion_event_id=discussion.event_id,
+                source_event_seq=discussion.seq,
+                thread_id=thread_id,
+                task=task,
+            )
+
+        spoke = any(
+            int(event.payload["round_index"]) == round_index
+            for event in member_messages
+        )
+        if not spoke:
+            return DiscussionDecision(
+                status="settled",
+                reason="silent_round",
+                discussion_event_id=discussion.event_id,
+                source_event_seq=discussion.seq,
+                thread_id=thread_id,
+            )
+        if round_index == MAX_DISCUSSION_ROUNDS - 1:
+            return DiscussionDecision(
+                status="bounded",
+                reason="max_rounds",
+                discussion_event_id=discussion.event_id,
+                source_event_seq=discussion.seq,
+                thread_id=thread_id,
+            )
+
+    raise AssertionError("bounded Discussion loop exhausted unexpectedly")
+
+
+def reconstruct_task_plan(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    task: Mapping[str, Any],
+    *,
+    local_profiles: Iterable[str],
+) -> DiscussionTaskPlan:
+    """Reconstruct and verify one persisted driver task after a restart."""
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    identity = task.get("identity")
+    payload = task.get("payload")
+    if not isinstance(identity, driver.TaskIdentity) or not isinstance(
+        payload, Mapping
+    ):
+        raise DiscussionReconstructionError(
+            "driver task has no valid identity or payload"
+        )
+    if frozenset(payload) != frozenset({
+        "target_profile",
+        "prompt",
+        "source_event_seq",
+    }):
+        raise DiscussionReconstructionError("driver task payload shape changed")
+    match = _TURN_ID_RE.fullmatch(identity.turn_id)
+    if match is None:
+        raise DiscussionReconstructionError("turn_id is not a Discussion coordinate")
+    source_event_seq = int(match.group("source"))
+    round_index = int(match.group("round"))
+    member_index = int(match.group("position"))
+    seen_through_seq = int(match.group("seen"))
+    if payload.get("source_event_seq") != source_event_seq:
+        raise DiscussionReconstructionError("task source event does not match turn_id")
+    discussion = next(
+        (
+            event
+            for event in validated
+            if event.seq == source_event_seq and event.kind == "message.user"
+        ),
+        None,
+    )
+    if discussion is None:
+        raise DiscussionReconstructionError("task source user event is missing")
+    if (
+        identity.room_id != room.room_id
+        or identity.thread_id != discussion.payload["thread_id"]
+    ):
+        raise DiscussionReconstructionError(
+            "task identity does not match its room thread"
+        )
+    profile = payload.get("target_profile")
+    member = next(
+        (candidate for candidate in room.members if candidate.profile == profile), None
+    )
+    if member is None or _member_digest(member) != match.group("member"):
+        raise DiscussionReconstructionError("task target member does not match turn_id")
+    prompt = payload.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise DiscussionReconstructionError("task prompt is missing")
+    if len(prompt.encode("utf-8")) > driver.MAX_PROMPT_BYTES:
+        raise DiscussionReconstructionError("task prompt exceeds the driver limit")
+    reconstructed = _make_task_plan(
+        room=room,
+        discussion_event=discussion,
+        member=member,
+        member_index=member_index,
+        round_index=round_index,
+        seen_through_seq=seen_through_seq,
+        prompt=prompt,
+    )
+    if reconstructed.identity != identity or dict(reconstructed.payload) != dict(
+        payload
+    ):
+        raise DiscussionReconstructionError(
+            "driver task failed deterministic reconstruction"
+        )
+    return reconstructed
+
+
+def _terminal_text(result: Any, *, field: str, fallback: str) -> str:
+    if isinstance(result, Mapping):
+        value = result.get(field)
+        if value is None and field == "error":
+            value = result.get("text")
+    else:
+        value = result
+    text = str(value or "").strip()
+    return text or fallback
+
+
+def plan_publication(
+    room_value: Any,
+    events: Sequence[Mapping[str, Any]],
+    task: DiscussionTaskPlan,
+    *,
+    status: TerminalKind,
+    result: Any = None,
+    execution_generation: int | None = None,
+    local_profiles: Iterable[str],
+) -> PublicationPlan:
+    """Plan idempotent room effects for one terminal driver task.
+
+    A newer user event in the same thread supersedes a late result.  The task
+    remains terminal in driver state, but only a deterministic cancellation is
+    published, preventing stale prose and its watermark from hiding the newer
+    user message.
+    """
+
+    room = validate_room(room_value, local_profiles=local_profiles)
+    validated = _validated_events(events, room=room)
+    if task.identity.room_id != room.room_id:
+        raise DiscussionValidationError("task belongs to a different room")
+    if task.member not in room.members:
+        raise DiscussionValidationError("task member is not in the frozen roster")
+    if status not in {"settled", "failed", "cancelled", "deferred"}:
+        raise DiscussionValidationError("invalid terminal publication status")
+    if status == "deferred" and (
+        isinstance(execution_generation, bool)
+        or not isinstance(execution_generation, int)
+        or execution_generation < 1
+    ):
+        raise DiscussionValidationError(
+            "deferred publication requires an execution generation"
+        )
+
+    newer_same_thread = any(
+        event.kind == "message.user"
+        and event.seq > task.seen_through_seq
+        and event.payload.get("thread_id") == task.identity.thread_id
+        for event in validated
+    )
+    effective_status: TerminalKind = (
+        "cancelled" if newer_same_thread and status != "deferred" else status
+    )
+    digest = task.identity.task_id.removeprefix("dtask:")
+    message_event_id = f"dmessage:{digest}"
+    terminal_event_id = (
+        f"ddeferred:{digest}:g{execution_generation}"
+        if effective_status == "deferred"
+        else f"dterminal:{digest}"
+    )
+    common = {
+        "discussion_event_id": task.discussion_event_id,
+        "member_id": task.member.member_id,
+        "member_index": task.member_index,
+        "round_index": task.round_index,
+        "seen_through_seq": task.seen_through_seq,
+        "task_id": task.identity.task_id,
+        "thread_id": task.identity.thread_id,
+        "turn_id": task.identity.turn_id,
+    }
+    effects: list[EventPlan] = []
+
+    if effective_status == "settled":
+        text = _truncate_utf8_text(
+            _terminal_text(result, field="text", fallback=""),
+            max_bytes=MAX_MEMBER_TEXT_BYTES,
+            suffix=_TRUNCATED_REPLY_NOTICE,
+        )
+        passed = is_pass_text(text)
+        if not passed:
+            member_actor = {
+                "kind": "member",
+                "id": task.member.member_id,
+                "profile": task.member.profile,
+            }
+            if task.member.display_name:
+                member_actor["display_name"] = task.member.display_name
+            effects.append(
+                EventPlan(
+                    event_id=message_event_id,
+                    kind="message.member",
+                    actor=member_actor,
+                    payload={
+                        "discussion_event_id": task.discussion_event_id,
+                        "member_id": task.member.member_id,
+                        "member_index": task.member_index,
+                        "round_index": task.round_index,
+                        "task_id": task.identity.task_id,
+                        "text": text,
+                        "thread_id": task.identity.thread_id,
+                        "turn_id": task.identity.turn_id,
+                    },
+                    authority_gateway_id=room.gateway_id,
+                    authority_epoch=room.authority_epoch,
+                )
+            )
+        terminal_payload = {
+            **common,
+            "message_event_id": None if passed else message_event_id,
+            "passed": passed,
+        }
+        terminal_kind = "turn.settled"
+    elif effective_status == "failed":
+        terminal_payload = {
+            **common,
+            "error": _terminal_text(
+                result,
+                field="error",
+                fallback="member turn failed",
+            ),
+        }
+        terminal_kind = "turn.failed"
+    elif effective_status == "cancelled":
+        terminal_payload = {
+            **common,
+            "reason": (
+                "superseded_by_newer_user_event"
+                if newer_same_thread
+                else _terminal_text(
+                    result,
+                    field="reason",
+                    fallback="member turn cancelled",
+                )
+            ),
+        }
+        terminal_kind = "turn.cancelled"
+    else:
+        terminal_payload = {
+            **common,
+            "execution_generation": execution_generation,
+            "reason": _terminal_text(
+                result,
+                field="reason",
+                fallback="member_unavailable",
+            ),
+        }
+        terminal_kind = "turn.deferred"
+
+    effects.append(
+        EventPlan(
+            event_id=terminal_event_id,
+            kind=terminal_kind,
+            actor={"kind": "gateway", "id": room.gateway_id},
+            payload=terminal_payload,
+            authority_gateway_id=room.gateway_id,
+            authority_epoch=room.authority_epoch,
+        )
+    )
+    return PublicationPlan(
+        task_id=task.identity.task_id,
+        terminal_kind=terminal_kind,
+        events=tuple(effects),
+    )

--- a/gateway/hosted_room_driver.py
+++ b/gateway/hosted_room_driver.py
@@ -1,0 +1,1649 @@
+"""Durable execution state for a same-gateway hosted room driver.
+
+This module owns only the driver lease and task state machine. It does not
+invoke models, touch sessions, or depend on the hosted-room event log. Callers
+provide both the database path and clock so recovery and fencing behavior can
+be tested without process-global state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator, Literal
+
+
+Clock = Callable[[], float]
+TaskStatus = Literal[
+    "queued",
+    "running",
+    "settled",
+    "failed",
+    "cancelled",
+    "indeterminate",
+    "deferred",
+    "stopping",
+]
+TerminalStatus = Literal["settled", "failed"]
+
+MAX_IDENTIFIER_CHARS = 128
+MAX_PROMPT_BYTES = 128 * 1024
+MAX_RESULT_JSON_BYTES = 256 * 1024
+TERMINAL_TASK_RETENTION_SECONDS = 30 * 24 * 60 * 60
+MAX_RETAINED_TERMINAL_TASKS = 2048
+MAX_TASK_PRUNE_BATCH = 1000
+TASK_STATUSES = frozenset({
+    "queued",
+    "running",
+    "settled",
+    "failed",
+    "cancelled",
+    "indeterminate",
+    "deferred",
+    "stopping",
+})
+TERMINAL_STATUSES = frozenset({"settled", "failed", "cancelled"})
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_TASK_PAYLOAD_FIELDS = frozenset({"target_profile", "prompt", "source_event_seq"})
+_LEASE_COLUMNS = frozenset({
+    "room_id",
+    "gateway_id",
+    "authority_epoch",
+    "process_generation",
+    "lease_generation",
+    "expires_at",
+    "acquired_at",
+    "updated_at",
+    "released_at",
+})
+_TASK_COLUMNS = frozenset({
+    "room_id",
+    "task_id",
+    "thread_id",
+    "turn_id",
+    "source_event_seq",
+    "payload_json",
+    "payload_digest",
+    "status",
+    "execution_generation",
+    "cancel_generation",
+    "run_gateway_id",
+    "run_process_generation",
+    "run_lease_generation",
+    "cancel_id",
+    "settlement_id",
+    "settlement_status",
+    "result_json",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "terminal_at",
+    "indeterminate_at",
+})
+_TASK_COLUMN_ORDER = (
+    "room_id",
+    "task_id",
+    "thread_id",
+    "turn_id",
+    "source_event_seq",
+    "payload_json",
+    "payload_digest",
+    "status",
+    "execution_generation",
+    "cancel_generation",
+    "run_gateway_id",
+    "run_process_generation",
+    "run_lease_generation",
+    "cancel_id",
+    "settlement_id",
+    "settlement_status",
+    "result_json",
+    "created_at",
+    "updated_at",
+    "started_at",
+    "terminal_at",
+    "indeterminate_at",
+)
+
+
+class DriverStateError(ValueError):
+    """Base class for invalid or conflicting driver-state operations."""
+
+
+class DriverValidationError(DriverStateError):
+    """Raised when an identifier, clock, TTL, or payload is invalid."""
+
+
+class RoomUnavailableError(DriverStateError):
+    """Raised when the hosted room does not exist or was disbanded."""
+
+
+class LeaseHeldError(DriverStateError):
+    """Raised when another unexpired driver generation owns the room."""
+
+
+class StaleLeaseError(DriverStateError):
+    """Raised when a lease generation can no longer mutate room state."""
+
+
+class TaskConflictError(DriverStateError):
+    """Raised when an idempotency key is reused for different task state."""
+
+
+class StaleTaskError(DriverStateError):
+    """Raised when an obsolete task attempt or cancellation tries to commit."""
+
+
+class InvalidTaskTransitionError(DriverStateError):
+    """Raised when a requested task transition is not allowed."""
+
+
+def _identifier(value: Any, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise DriverValidationError(f"{label} must be a string")
+    value = value.strip()
+    if (
+        not value
+        or len(value) > MAX_IDENTIFIER_CHARS
+        or not _IDENTIFIER_RE.fullmatch(value)
+    ):
+        raise DriverValidationError(f"invalid {label}")
+    return value
+
+
+def _timestamp(clock: Clock) -> float:
+    if not callable(clock):
+        raise DriverValidationError("clock must be callable")
+    try:
+        value = float(clock())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise DriverValidationError("clock must return a finite number") from exc
+    if not math.isfinite(value):
+        raise DriverValidationError("clock must return a finite number")
+    return value
+
+
+def _ttl(value: Any) -> float:
+    try:
+        ttl = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise DriverValidationError(
+            "ttl_seconds must be a finite positive number"
+        ) from exc
+    if not math.isfinite(ttl) or ttl <= 0:
+        raise DriverValidationError("ttl_seconds must be a finite positive number")
+    return ttl
+
+
+def _expiry(now: float, ttl: float) -> float:
+    expires_at = now + ttl
+    if not math.isfinite(expires_at):
+        raise DriverValidationError("lease expiry must be finite")
+    return expires_at
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise DriverValidationError("result must be JSON-serializable") from exc
+    if len(encoded.encode("utf-8")) > MAX_RESULT_JSON_BYTES:
+        raise DriverValidationError("result is too large")
+    return encoded
+
+
+def _authority_epoch(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise DriverValidationError("authority_epoch must be a positive integer")
+    return value
+
+
+def _task_payload(value: Any) -> tuple[dict[str, Any], str, str]:
+    if not isinstance(value, dict):
+        raise DriverValidationError("payload must be an object")
+    unknown = set(value) - _TASK_PAYLOAD_FIELDS
+    missing = _TASK_PAYLOAD_FIELDS - set(value)
+    if unknown:
+        raise DriverValidationError(
+            f"unknown payload fields: {', '.join(sorted(unknown))}"
+        )
+    if missing:
+        raise DriverValidationError(
+            f"missing payload fields: {', '.join(sorted(missing))}"
+        )
+
+    target_profile = _identifier(value["target_profile"], label="target_profile")
+    prompt = value["prompt"]
+    if not isinstance(prompt, str):
+        raise DriverValidationError("prompt must be a string")
+    if not prompt.strip():
+        raise DriverValidationError("prompt must not be empty")
+    if len(prompt.encode("utf-8")) > MAX_PROMPT_BYTES:
+        raise DriverValidationError("prompt is too large")
+    source_event_seq = value["source_event_seq"]
+    if (
+        isinstance(source_event_seq, bool)
+        or not isinstance(source_event_seq, int)
+        or source_event_seq < 1
+    ):
+        raise DriverValidationError("source_event_seq must be a positive integer")
+
+    normalized = {
+        "target_profile": target_profile,
+        "prompt": prompt,
+        "source_event_seq": source_event_seq,
+    }
+    encoded = json.dumps(
+        normalized,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    return normalized, encoded, digest
+
+
+@dataclass(frozen=True)
+class TaskIdentity:
+    """Stable identity for one admitted room turn."""
+
+    room_id: str
+    task_id: str
+    thread_id: str
+    turn_id: str
+
+    def __post_init__(self) -> None:
+        for field in ("room_id", "task_id", "thread_id", "turn_id"):
+            object.__setattr__(
+                self,
+                field,
+                _identifier(getattr(self, field), label=field),
+            )
+
+
+@dataclass(frozen=True)
+class DriverLease:
+    """A fenced lease held by one gateway process incarnation."""
+
+    room_id: str
+    gateway_id: str
+    authority_epoch: int
+    process_generation: str
+    lease_generation: int
+    expires_at: float
+    reclaimed: bool = False
+
+
+@dataclass(frozen=True)
+class TaskAttempt:
+    """The exact running generation authorized to settle one task."""
+
+    identity: TaskIdentity
+    lease: DriverLease
+    execution_generation: int
+    cancel_generation: int
+
+
+def _create_task_table(
+    conn: sqlite3.Connection, table: str = "hosted_room_driver_tasks"
+) -> None:
+    if table not in {"hosted_room_driver_tasks", "hosted_room_driver_tasks_next"}:
+        raise DriverStateError("invalid hosted-room task table name")
+    conn.execute(
+        f"""CREATE TABLE IF NOT EXISTS {table} (
+            room_id TEXT NOT NULL,
+            task_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            turn_id TEXT NOT NULL,
+            source_event_seq INTEGER NOT NULL CHECK (source_event_seq >= 1),
+            payload_json TEXT NOT NULL,
+            payload_digest TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (
+                status IN (
+                    'queued', 'running', 'settled', 'failed',
+                    'cancelled', 'indeterminate', 'deferred', 'stopping'
+                )
+            ),
+            execution_generation INTEGER NOT NULL DEFAULT 0
+                CHECK (execution_generation >= 0),
+            cancel_generation INTEGER NOT NULL DEFAULT 0
+                CHECK (cancel_generation >= 0),
+            run_gateway_id TEXT,
+            run_process_generation TEXT,
+            run_lease_generation INTEGER,
+            cancel_id TEXT,
+            settlement_id TEXT,
+            settlement_status TEXT,
+            result_json TEXT,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            started_at REAL,
+            terminal_at REAL,
+            indeterminate_at REAL,
+            PRIMARY KEY (room_id, task_id),
+            UNIQUE (room_id, thread_id, turn_id),
+            FOREIGN KEY (room_id) REFERENCES hosted_rooms(room_id)
+        )"""
+    )
+
+
+def _initialize_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_room_driver_leases (
+            room_id TEXT PRIMARY KEY,
+            gateway_id TEXT NOT NULL,
+            authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 1),
+            process_generation TEXT NOT NULL,
+            lease_generation INTEGER NOT NULL CHECK (lease_generation >= 1),
+            expires_at REAL NOT NULL,
+            acquired_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            released_at REAL,
+            FOREIGN KEY (room_id) REFERENCES hosted_rooms(room_id)
+        )"""
+    )
+    _create_task_table(conn)
+    _validate_schema(conn)
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_hosted_room_driver_tasks_status
+           ON hosted_room_driver_tasks(
+               room_id, status, source_event_seq, created_at, task_id
+           )"""
+    )
+
+
+def _validate_schema(conn: sqlite3.Connection) -> None:
+    lease_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_driver_leases)")
+    )
+    task_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_driver_tasks)")
+    )
+    if lease_columns != _LEASE_COLUMNS or task_columns != _TASK_COLUMNS:
+        raise DriverStateError(
+            "unsupported unpublished hosted-room driver schema; "
+            "recreate the driver tables before starting the driver"
+        )
+
+    for table in ("hosted_room_driver_leases", "hosted_room_driver_tasks"):
+        foreign_keys = conn.execute(f"PRAGMA foreign_key_list({table})").fetchall()
+        if not any(
+            row[2] == "hosted_rooms" and row[3] == "room_id" and row[4] == "room_id"
+            for row in foreign_keys
+        ):
+            raise DriverStateError(f"{table} is missing its hosted_rooms foreign key")
+
+
+def _schema_objects_exist(conn: sqlite3.Connection) -> bool:
+    rows = conn.execute(
+        """SELECT name FROM sqlite_master
+           WHERE type='table' AND name IN (
+               'hosted_room_driver_leases', 'hosted_room_driver_tasks'
+           )"""
+    ).fetchall()
+    tables = {row[0] for row in rows}
+    if tables != {"hosted_room_driver_leases", "hosted_room_driver_tasks"}:
+        return False
+    index = conn.execute(
+        """SELECT 1 FROM sqlite_master
+           WHERE type='index' AND name='idx_hosted_room_driver_tasks_status'"""
+    ).fetchone()
+    return index is not None
+
+
+def _task_schema_supports_current_statuses(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        """SELECT sql FROM sqlite_master
+           WHERE type='table' AND name='hosted_room_driver_tasks'"""
+    ).fetchone()
+    sql = str(row[0] or "").lower() if row else ""
+    return "'stopping'" in sql and "'deferred'" in sql
+
+
+def _migrate_task_status_constraint(conn: sqlite3.Connection) -> None:
+    """Expand the unpublished task-state CHECK without losing durable work."""
+    conn.execute("DROP INDEX IF EXISTS idx_hosted_room_driver_tasks_status")
+    _create_task_table(conn, "hosted_room_driver_tasks_next")
+    columns = ", ".join(_TASK_COLUMN_ORDER)
+    conn.execute(
+        f"""INSERT INTO hosted_room_driver_tasks_next ({columns})
+             SELECT {columns} FROM hosted_room_driver_tasks"""
+    )
+    conn.execute("DROP TABLE hosted_room_driver_tasks")
+    conn.execute(
+        "ALTER TABLE hosted_room_driver_tasks_next RENAME TO hosted_room_driver_tasks"
+    )
+    conn.execute(
+        """CREATE INDEX idx_hosted_room_driver_tasks_status
+           ON hosted_room_driver_tasks(
+               room_id, status, source_event_seq, created_at, task_id
+           )"""
+    )
+
+
+def _connect(db_path: Path | str) -> sqlite3.Connection:
+    from hermes_state import apply_wal_with_fallback
+
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    try:
+        apply_wal_with_fallback(conn, db_label="state.db (hosted_room_driver)")
+        conn.execute("PRAGMA foreign_keys=ON")
+        if _schema_objects_exist(conn):
+            if not _task_schema_supports_current_statuses(conn):
+                conn.execute("BEGIN IMMEDIATE")
+                _migrate_task_status_constraint(conn)
+                conn.commit()
+            _validate_schema(conn)
+            return conn
+        # Schema creation is one database-wide transaction. The driver schema
+        # has never shipped, so an incompatible draft schema fails closed
+        # instead of attempting a partial in-place migration.
+        conn.execute("BEGIN IMMEDIATE")
+        _initialize_schema(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def _transaction(db_path: Path | str) -> Iterator[sqlite3.Connection]:
+    conn = _connect(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _lease_from_row(
+    row: sqlite3.Row | dict[str, Any], *, reclaimed: bool = False
+) -> DriverLease:
+    return DriverLease(
+        room_id=row["room_id"],
+        gateway_id=row["gateway_id"],
+        authority_epoch=int(row["authority_epoch"]),
+        process_generation=row["process_generation"],
+        lease_generation=int(row["lease_generation"]),
+        expires_at=float(row["expires_at"]),
+        reclaimed=reclaimed,
+    )
+
+
+def _task_identity_from_row(row: sqlite3.Row) -> TaskIdentity:
+    return TaskIdentity(
+        room_id=row["room_id"],
+        task_id=row["task_id"],
+        thread_id=row["thread_id"],
+        turn_id=row["turn_id"],
+    )
+
+
+def _task_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    try:
+        raw_payload = json.loads(row["payload_json"])
+        payload, encoded_payload, payload_digest = _task_payload(raw_payload)
+    except (TypeError, json.JSONDecodeError, DriverValidationError) as exc:
+        raise TaskConflictError("stored task payload is invalid") from exc
+    if (
+        encoded_payload != row["payload_json"]
+        or payload_digest != row["payload_digest"]
+        or payload["source_event_seq"] != int(row["source_event_seq"])
+    ):
+        raise TaskConflictError("stored task payload failed its integrity check")
+    result = json.loads(row["result_json"]) if row["result_json"] is not None else None
+    return {
+        "identity": _task_identity_from_row(row),
+        "payload": payload,
+        "payload_digest": row["payload_digest"],
+        "status": row["status"],
+        "execution_generation": int(row["execution_generation"]),
+        "cancel_generation": int(row["cancel_generation"]),
+        "run_gateway_id": row["run_gateway_id"],
+        "run_process_generation": row["run_process_generation"],
+        "run_lease_generation": (
+            int(row["run_lease_generation"])
+            if row["run_lease_generation"] is not None
+            else None
+        ),
+        "cancel_id": row["cancel_id"],
+        "settlement_id": row["settlement_id"],
+        "settlement_status": row["settlement_status"],
+        "result": result,
+        "created_at": float(row["created_at"]),
+        "updated_at": float(row["updated_at"]),
+        "started_at": (
+            float(row["started_at"]) if row["started_at"] is not None else None
+        ),
+        "terminal_at": (
+            float(row["terminal_at"]) if row["terminal_at"] is not None else None
+        ),
+        "indeterminate_at": (
+            float(row["indeterminate_at"])
+            if row["indeterminate_at"] is not None
+            else None
+        ),
+        "idempotent": idempotent,
+    }
+
+
+def _load_task(conn: sqlite3.Connection, identity: TaskIdentity) -> sqlite3.Row:
+    row = conn.execute(
+        """SELECT * FROM hosted_room_driver_tasks
+           WHERE room_id=? AND task_id=?""",
+        (identity.room_id, identity.task_id),
+    ).fetchone()
+    if row is None:
+        raise TaskConflictError("task does not exist")
+    if _task_identity_from_row(row) != identity:
+        raise TaskConflictError("task_id is already bound to a different turn")
+    return row
+
+
+def _load_active_room(conn: sqlite3.Connection, room_id: str) -> sqlite3.Row:
+    try:
+        row = conn.execute(
+            """SELECT room_id, authority_gateway_id, authority_epoch, disbanded_at
+               FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            raise RoomUnavailableError("hosted room does not exist") from exc
+        raise
+    if row is None:
+        raise RoomUnavailableError("hosted room does not exist")
+    if row["disbanded_at"] is not None:
+        raise RoomUnavailableError("hosted room is disbanded")
+    return row
+
+
+def _require_room_authority(
+    conn: sqlite3.Connection,
+    *,
+    room_id: str,
+    gateway_id: str,
+    authority_epoch: int,
+) -> sqlite3.Row:
+    room = _load_active_room(conn, room_id)
+    if (
+        room["authority_gateway_id"] != gateway_id
+        or int(room["authority_epoch"]) != authority_epoch
+    ):
+        raise StaleLeaseError("hosted room authority changed")
+    return room
+
+
+def _require_active_lease(
+    conn: sqlite3.Connection,
+    lease: DriverLease,
+    *,
+    now: float,
+) -> sqlite3.Row:
+    _require_room_authority(
+        conn,
+        room_id=lease.room_id,
+        gateway_id=lease.gateway_id,
+        authority_epoch=lease.authority_epoch,
+    )
+    row = conn.execute(
+        "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+        (lease.room_id,),
+    ).fetchone()
+    if (
+        row is None
+        or row["gateway_id"] != lease.gateway_id
+        or int(row["authority_epoch"]) != lease.authority_epoch
+        or row["process_generation"] != lease.process_generation
+        or int(row["lease_generation"]) != lease.lease_generation
+        or row["released_at"] is not None
+        or float(row["expires_at"]) <= now
+    ):
+        raise StaleLeaseError("driver lease is stale or expired")
+    return row
+
+
+def acquire_lease(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    gateway_id: Any,
+    authority_epoch: Any,
+    process_generation: Any,
+    ttl_seconds: Any,
+    clock: Clock,
+) -> DriverLease:
+    """Acquire an empty or expired room lease with a monotonic generation."""
+    room_id = _identifier(room_id, label="room_id")
+    gateway_id = _identifier(gateway_id, label="gateway_id")
+    authority_epoch = _authority_epoch(authority_epoch)
+    process_generation = _identifier(
+        process_generation,
+        label="process_generation",
+    )
+    ttl_seconds = _ttl(ttl_seconds)
+    now = _timestamp(clock)
+    expires_at = _expiry(now, ttl_seconds)
+
+    with _transaction(db_path) as conn:
+        _require_room_authority(
+            conn,
+            room_id=room_id,
+            gateway_id=gateway_id,
+            authority_epoch=authority_epoch,
+        )
+        row = conn.execute(
+            "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+            (room_id,),
+        ).fetchone()
+        if row is None:
+            conn.execute(
+                """INSERT INTO hosted_room_driver_leases (
+                       room_id, gateway_id, authority_epoch, process_generation,
+                       lease_generation, expires_at, acquired_at,
+                       updated_at, released_at
+                   ) VALUES (?, ?, ?, ?, 1, ?, ?, ?, NULL)""",
+                (
+                    room_id,
+                    gateway_id,
+                    authority_epoch,
+                    process_generation,
+                    expires_at,
+                    now,
+                    now,
+                ),
+            )
+            row = conn.execute(
+                "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+                (room_id,),
+            ).fetchone()
+            return _lease_from_row(row)
+
+        if (
+            row["gateway_id"] == gateway_id
+            and int(row["authority_epoch"]) == authority_epoch
+            and row["process_generation"] == process_generation
+            and row["released_at"] is None
+            and float(row["expires_at"]) > now
+        ):
+            renewed_expiry = max(float(row["expires_at"]), expires_at)
+            conn.execute(
+                """UPDATE hosted_room_driver_leases
+                   SET expires_at=?, updated_at=?
+                   WHERE room_id=? AND lease_generation=?""",
+                (renewed_expiry, now, room_id, int(row["lease_generation"])),
+            )
+            current = dict(row)
+            current["expires_at"] = renewed_expiry
+            return _lease_from_row(current)
+
+        same_authority = (
+            row["gateway_id"] == gateway_id
+            and int(row["authority_epoch"]) == authority_epoch
+        )
+        if (
+            same_authority
+            and row["released_at"] is None
+            and float(row["expires_at"]) > now
+        ):
+            raise LeaseHeldError("room driver lease is held by another generation")
+
+        previous_generation = int(row["lease_generation"])
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_leases
+               SET gateway_id=?, authority_epoch=?, process_generation=?,
+                   lease_generation=lease_generation + 1,
+                   expires_at=?, acquired_at=?, updated_at=?, released_at=NULL
+               WHERE room_id=? AND lease_generation=?
+                 AND (
+                     gateway_id != ? OR authority_epoch != ?
+                     OR released_at IS NOT NULL OR expires_at <= ?
+                 )""",
+            (
+                gateway_id,
+                authority_epoch,
+                process_generation,
+                expires_at,
+                now,
+                now,
+                room_id,
+                previous_generation,
+                gateway_id,
+                authority_epoch,
+                now,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise LeaseHeldError("room driver lease changed during acquisition")
+        current = conn.execute(
+            "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+            (room_id,),
+        ).fetchone()
+        return _lease_from_row(current, reclaimed=True)
+
+
+def renew_lease(
+    db_path: Path | str,
+    lease: DriverLease,
+    *,
+    ttl_seconds: Any,
+    clock: Clock,
+) -> DriverLease:
+    """Renew the exact active lease generation or fail closed."""
+    ttl_seconds = _ttl(ttl_seconds)
+    now = _timestamp(clock)
+    requested_expiry = _expiry(now, ttl_seconds)
+    with _transaction(db_path) as conn:
+        current = _require_active_lease(conn, lease, now=now)
+        expires_at = max(float(current["expires_at"]), requested_expiry)
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_leases
+               SET expires_at=?, updated_at=?
+               WHERE room_id=? AND gateway_id=? AND process_generation=?
+                 AND lease_generation=? AND released_at IS NULL AND expires_at > ?""",
+            (
+                expires_at,
+                now,
+                lease.room_id,
+                lease.gateway_id,
+                lease.process_generation,
+                lease.lease_generation,
+                now,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleLeaseError("driver lease changed during renewal")
+        return DriverLease(
+            room_id=lease.room_id,
+            gateway_id=lease.gateway_id,
+            authority_epoch=lease.authority_epoch,
+            process_generation=lease.process_generation,
+            lease_generation=lease.lease_generation,
+            expires_at=expires_at,
+        )
+
+
+def release_lease(
+    db_path: Path | str,
+    lease: DriverLease,
+    *,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Release the exact active lease generation idempotently."""
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_room_authority(
+            conn,
+            room_id=lease.room_id,
+            gateway_id=lease.gateway_id,
+            authority_epoch=lease.authority_epoch,
+        )
+        row = conn.execute(
+            "SELECT * FROM hosted_room_driver_leases WHERE room_id=?",
+            (lease.room_id,),
+        ).fetchone()
+        if (
+            row is None
+            or row["gateway_id"] != lease.gateway_id
+            or int(row["authority_epoch"]) != lease.authority_epoch
+            or row["process_generation"] != lease.process_generation
+            or int(row["lease_generation"]) != lease.lease_generation
+        ):
+            raise StaleLeaseError("driver lease is stale")
+        if row["released_at"] is not None:
+            return {"lease": _lease_from_row(row), "idempotent": True}
+        if float(row["expires_at"]) <= now:
+            raise StaleLeaseError("driver lease expired before release")
+        running = conn.execute(
+            """SELECT 1 FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='running' LIMIT 1""",
+            (lease.room_id,),
+        ).fetchone()
+        if running is not None:
+            raise InvalidTaskTransitionError(
+                "cannot release a room lease while tasks are running"
+            )
+        conn.execute(
+            """UPDATE hosted_room_driver_leases
+               SET expires_at=?, updated_at=?, released_at=?
+               WHERE room_id=? AND lease_generation=?""",
+            (now, now, now, lease.room_id, lease.lease_generation),
+        )
+        current = dict(row)
+        current["expires_at"] = now
+        current["updated_at"] = now
+        current["released_at"] = now
+        return {"lease": _lease_from_row(current), "idempotent": False}
+
+
+def admit_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    payload: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Persist a queued task, or return the identical admission."""
+    normalized_payload, payload_json, payload_digest = _task_payload(payload)
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _load_active_room(conn, identity.room_id)
+        existing = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND task_id=?""",
+            (identity.room_id, identity.task_id),
+        ).fetchone()
+        if existing is not None:
+            if _task_identity_from_row(existing) != identity:
+                raise TaskConflictError("task_id is already bound to a different turn")
+            if (
+                existing["payload_digest"] != payload_digest
+                or existing["payload_json"] != payload_json
+            ):
+                raise TaskConflictError(
+                    "task_id is already bound to a different payload"
+                )
+            return _task_from_row(existing, idempotent=True)
+
+        turn = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND thread_id=? AND turn_id=?""",
+            (identity.room_id, identity.thread_id, identity.turn_id),
+        ).fetchone()
+        if turn is not None:
+            raise TaskConflictError("thread_id and turn_id are already bound to a task")
+
+        conn.execute(
+            """INSERT INTO hosted_room_driver_tasks (
+                   room_id, task_id, thread_id, turn_id,
+                   source_event_seq, payload_json, payload_digest, status,
+                   execution_generation, cancel_generation,
+                   created_at, updated_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', 0, 0, ?, ?)""",
+            (
+                identity.room_id,
+                identity.task_id,
+                identity.thread_id,
+                identity.turn_id,
+                normalized_payload["source_event_seq"],
+                payload_json,
+                payload_digest,
+                now,
+                now,
+            ),
+        )
+        row = _load_task(conn, identity)
+        return _task_from_row(row)
+
+
+def start_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> TaskAttempt:
+    """Move one queued task to running under the current driver lease."""
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if int(row["cancel_generation"]) != expected_cancel_generation:
+            raise StaleTaskError("task cancellation generation changed")
+        if row["status"] != "queued":
+            raise InvalidTaskTransitionError(
+                f"cannot start task in state '{row['status']}'"
+            )
+        unresolved = conn.execute(
+            """SELECT task_id, status FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status IN ('running', 'indeterminate', 'stopping')
+               ORDER BY source_event_seq, created_at, task_id LIMIT 1""",
+            (identity.room_id,),
+        ).fetchone()
+        if unresolved is not None:
+            raise InvalidTaskTransitionError(
+                "room recovery must resolve the prior task before starting new work"
+            )
+        next_queued = conn.execute(
+            """SELECT task_id FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='queued'
+               ORDER BY source_event_seq, created_at, task_id LIMIT 1""",
+            (identity.room_id,),
+        ).fetchone()
+        if next_queued is None or next_queued["task_id"] != identity.task_id:
+            raise InvalidTaskTransitionError(
+                "task is not next in the hosted room event order"
+            )
+        execution_generation = int(row["execution_generation"]) + 1
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='running', execution_generation=?,
+                   run_gateway_id=?, run_process_generation=?,
+                   run_lease_generation=?, started_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='queued'
+                 AND cancel_generation=?""",
+            (
+                execution_generation,
+                lease.gateway_id,
+                lease.process_generation,
+                lease.lease_generation,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during start")
+        return TaskAttempt(
+            identity=identity,
+            lease=lease,
+            execution_generation=execution_generation,
+            cancel_generation=expected_cancel_generation,
+        )
+
+
+def settle_task(
+    db_path: Path | str,
+    attempt: TaskAttempt,
+    *,
+    settlement_id: Any,
+    status: TerminalStatus,
+    result: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit one terminal result if every lease and task fence still matches."""
+    settlement_id = _identifier(settlement_id, label="settlement_id")
+    if status not in {"settled", "failed"}:
+        raise DriverValidationError("status must be 'settled' or 'failed'")
+    result_json = _canonical_json(result)
+    now = _timestamp(clock)
+
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, attempt.identity)
+        if row["settlement_id"] is not None:
+            if (
+                row["settlement_id"] == settlement_id
+                and row["settlement_status"] == status
+                and row["result_json"] == result_json
+            ):
+                return _task_from_row(row, idempotent=True)
+            raise TaskConflictError("task already has a different terminal settlement")
+
+        _require_active_lease(conn, attempt.lease, now=now)
+        expected = (
+            row["status"] == "running"
+            and int(row["execution_generation"]) == attempt.execution_generation
+            and int(row["cancel_generation"]) == attempt.cancel_generation
+            and row["run_gateway_id"] == attempt.lease.gateway_id
+            and row["run_process_generation"] == attempt.lease.process_generation
+            and int(row["run_lease_generation"]) == attempt.lease.lease_generation
+        )
+        if not expected:
+            raise StaleTaskError("task attempt is stale or cancelled")
+
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status=?, settlement_id=?, settlement_status=?,
+                   result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='running'
+                 AND execution_generation=? AND cancel_generation=?
+                 AND run_gateway_id=? AND run_process_generation=?
+                 AND run_lease_generation=?""",
+            (
+                status,
+                settlement_id,
+                status,
+                result_json,
+                now,
+                now,
+                attempt.identity.room_id,
+                attempt.identity.task_id,
+                attempt.execution_generation,
+                attempt.cancel_generation,
+                attempt.lease.gateway_id,
+                attempt.lease.process_generation,
+                attempt.lease.lease_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during settlement")
+        return _task_from_row(_load_task(conn, attempt.identity))
+
+
+def settle_stopping_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    settlement_id: Any,
+    status: TerminalStatus,
+    result: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit a completion that won the race with an unacknowledged Stop."""
+    settlement_id = _identifier(settlement_id, label="settlement_id")
+    if status not in {"settled", "failed"}:
+        raise DriverValidationError("status must be 'settled' or 'failed'")
+    if expected_execution_generation < 1 or expected_cancel_generation < 1:
+        raise DriverValidationError("stopping settlement generations are invalid")
+    result_json = _canonical_json(result)
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["settlement_id"] is not None:
+            if (
+                row["settlement_id"] == settlement_id
+                and row["settlement_status"] == status
+                and row["result_json"] == result_json
+            ):
+                return _task_from_row(row, idempotent=True)
+            raise TaskConflictError("task already has a different terminal settlement")
+        _require_active_lease(conn, lease, now=now)
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status=?, settlement_id=?, settlement_status=?,
+                   result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='stopping'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                status,
+                settlement_id,
+                status,
+                result_json,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task completion lost the stop race")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def resolve_indeterminate_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    settlement_id: Any,
+    status: TerminalStatus,
+    result: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit a verified historical receipt under the current room lease."""
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_execution_generation, int)
+        or expected_execution_generation < 1
+    ):
+        raise DriverValidationError(
+            "expected_execution_generation must be a positive integer"
+        )
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    settlement_id = _identifier(settlement_id, label="settlement_id")
+    if status not in {"settled", "failed"}:
+        raise DriverValidationError("status must be 'settled' or 'failed'")
+    result_json = _canonical_json(result)
+    now = _timestamp(clock)
+
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if row["settlement_id"] is not None:
+            if (
+                row["settlement_id"] == settlement_id
+                and row["settlement_status"] == status
+                and row["result_json"] == result_json
+            ):
+                return _task_from_row(row, idempotent=True)
+            raise TaskConflictError("task already has a different terminal settlement")
+        if (
+            row["status"] != "indeterminate"
+            or int(row["execution_generation"]) != expected_execution_generation
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("indeterminate task generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status=?, settlement_id=?, settlement_status=?,
+                   result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='indeterminate'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                status,
+                settlement_id,
+                status,
+                result_json,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("indeterminate task changed during reconciliation")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def requeue_indeterminate_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Explicitly retry uncertain work after an operator accepts at-least-once risk."""
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_execution_generation, int)
+        or expected_execution_generation < 1
+    ):
+        raise DriverValidationError(
+            "expected_execution_generation must be a positive integer"
+        )
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if (
+            row["status"] != "indeterminate"
+            or int(row["execution_generation"]) != expected_execution_generation
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("indeterminate task generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='queued', run_gateway_id=NULL,
+                   run_process_generation=NULL, run_lease_generation=NULL,
+                   started_at=NULL, indeterminate_at=NULL, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='indeterminate'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("indeterminate task changed during requeue")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def defer_indeterminate_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    reason: Any,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Fence one uncertain attempt and release later room work."""
+
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_execution_generation, int)
+        or expected_execution_generation < 1
+    ):
+        raise DriverValidationError(
+            "expected_execution_generation must be a positive integer"
+        )
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    reason = _identifier(reason, label="defer_reason")
+    result_json = _canonical_json({"reason": reason, "retryable": True})
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if (
+            row["status"] == "deferred"
+            and int(row["execution_generation"]) == expected_execution_generation
+            and int(row["cancel_generation"]) == expected_cancel_generation
+            and row["result_json"] == result_json
+        ):
+            return _task_from_row(row, idempotent=True)
+        if (
+            row["status"] != "indeterminate"
+            or int(row["execution_generation"]) != expected_execution_generation
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("indeterminate task generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='deferred', result_json=?, terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='indeterminate'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                result_json,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("indeterminate task changed during deferral")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def requeue_deferred_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    lease: DriverLease,
+    *,
+    expected_execution_generation: int,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Explicitly retry a fenced deferred turn under a new generation."""
+
+    if lease.room_id != identity.room_id:
+        raise DriverValidationError("lease and task belong to different rooms")
+    if (
+        not isinstance(expected_execution_generation, int)
+        or expected_execution_generation < 1
+    ):
+        raise DriverValidationError(
+            "expected_execution_generation must be a positive integer"
+        )
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        row = _load_task(conn, identity)
+        if (
+            row["status"] != "deferred"
+            or int(row["execution_generation"]) != expected_execution_generation
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("deferred task generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='queued', run_gateway_id=NULL,
+                   run_process_generation=NULL, run_lease_generation=NULL,
+                   result_json=NULL, started_at=NULL, terminal_at=NULL,
+                   indeterminate_at=NULL, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='deferred'
+                 AND execution_generation=? AND cancel_generation=?""",
+            (
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_execution_generation,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("deferred task changed during requeue")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def cancel_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    cancel_id: Any,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Cancel a queued task before any external work was admitted."""
+    cancel_id = _identifier(cancel_id, label="cancel_id")
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["status"] == "cancelled" and row["cancel_id"] == cancel_id:
+            return _task_from_row(row, idempotent=True)
+        if row["status"] in TERMINAL_STATUSES:
+            raise InvalidTaskTransitionError(
+                f"cannot cancel task in state '{row['status']}'"
+            )
+        if row["status"] not in {"queued", "deferred"}:
+            raise InvalidTaskTransitionError(
+                "running work requires acknowledged two-phase cancellation"
+            )
+        if int(row["cancel_generation"]) != expected_cancel_generation:
+            raise StaleTaskError("task cancellation generation changed")
+
+        next_generation = expected_cancel_generation + 1
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='cancelled', cancel_generation=?, cancel_id=?,
+                   terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=?
+                 AND status IN ('queued', 'deferred')
+                 AND cancel_generation=?""",
+            (
+                next_generation,
+                cancel_id,
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during cancellation")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def begin_task_cancel(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    cancel_id: Any,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Persist a stop intent without claiming the remote run has stopped."""
+    cancel_id = _identifier(cancel_id, label="cancel_id")
+    if (
+        not isinstance(expected_cancel_generation, int)
+        or expected_cancel_generation < 0
+    ):
+        raise DriverValidationError("expected_cancel_generation must be non-negative")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["status"] == "stopping" and row["cancel_id"] == cancel_id:
+            return _task_from_row(row, idempotent=True)
+        if row["status"] in TERMINAL_STATUSES or row["status"] == "queued":
+            raise InvalidTaskTransitionError(
+                f"cannot request remote stop in state '{row['status']}'"
+            )
+        if int(row["cancel_generation"]) != expected_cancel_generation:
+            raise StaleTaskError("task cancellation generation changed")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='stopping', cancel_generation=?, cancel_id=?,
+                   updated_at=?
+               WHERE room_id=? AND task_id=?
+                 AND status IN ('running', 'indeterminate')
+                 AND cancel_generation=?""",
+            (
+                expected_cancel_generation + 1,
+                cancel_id,
+                now,
+                identity.room_id,
+                identity.task_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during stop request")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def complete_task_cancel(
+    db_path: Path | str,
+    identity: TaskIdentity,
+    *,
+    cancel_id: Any,
+    expected_cancel_generation: int,
+    clock: Clock,
+) -> dict[str, Any]:
+    """Commit cancellation only after the transport acknowledges exact Stop."""
+    cancel_id = _identifier(cancel_id, label="cancel_id")
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        row = _load_task(conn, identity)
+        if row["status"] == "cancelled" and row["cancel_id"] == cancel_id:
+            return _task_from_row(row, idempotent=True)
+        if (
+            row["status"] != "stopping"
+            or row["cancel_id"] != cancel_id
+            or int(row["cancel_generation"]) != expected_cancel_generation
+        ):
+            raise StaleTaskError("task stop acknowledgement is stale")
+        updated = conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET status='cancelled', terminal_at=?, updated_at=?
+               WHERE room_id=? AND task_id=? AND status='stopping'
+                 AND cancel_id=? AND cancel_generation=?""",
+            (
+                now,
+                now,
+                identity.room_id,
+                identity.task_id,
+                cancel_id,
+                expected_cancel_generation,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise StaleTaskError("task changed during stop acknowledgement")
+        return _task_from_row(_load_task(conn, identity))
+
+
+def recover_room(
+    db_path: Path | str,
+    lease: DriverLease,
+    *,
+    clock: Clock,
+) -> dict[str, list[TaskIdentity]]:
+    """Fence abandoned running attempts without requeueing uncertain work."""
+    now = _timestamp(clock)
+    with _transaction(db_path) as conn:
+        _require_active_lease(conn, lease, now=now)
+        stale_rows = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='running'
+                 AND NOT (
+                     run_gateway_id=? AND run_process_generation=?
+                     AND run_lease_generation=?
+                 )
+               ORDER BY source_event_seq, created_at, task_id""",
+            (
+                lease.room_id,
+                lease.gateway_id,
+                lease.process_generation,
+                lease.lease_generation,
+            ),
+        ).fetchall()
+        if stale_rows:
+            conn.execute(
+                """UPDATE hosted_room_driver_tasks
+                   SET status='indeterminate', indeterminate_at=?, updated_at=?
+                   WHERE room_id=? AND status='running'
+                     AND NOT (
+                         run_gateway_id=? AND run_process_generation=?
+                         AND run_lease_generation=?
+                     )""",
+                (
+                    now,
+                    now,
+                    lease.room_id,
+                    lease.gateway_id,
+                    lease.process_generation,
+                    lease.lease_generation,
+                ),
+            )
+        queued_rows = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='queued'
+               ORDER BY source_event_seq, created_at, task_id""",
+            (lease.room_id,),
+        ).fetchall()
+        indeterminate_rows = conn.execute(
+            """SELECT * FROM hosted_room_driver_tasks
+               WHERE room_id=? AND status='indeterminate'
+               ORDER BY source_event_seq, created_at, task_id""",
+            (lease.room_id,),
+        ).fetchall()
+        return {
+            "queued": [_task_identity_from_row(row) for row in queued_rows],
+            "indeterminate": [
+                _task_identity_from_row(row) for row in indeterminate_rows
+            ],
+        }
+
+
+def get_task(
+    db_path: Path | str,
+    identity: TaskIdentity,
+) -> dict[str, Any]:
+    """Read one task without mutating its state."""
+    conn = _connect(db_path)
+    try:
+        return _task_from_row(_load_task(conn, identity))
+    finally:
+        conn.close()
+
+
+def list_tasks(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    status: TaskStatus | None = None,
+) -> list[dict[str, Any]]:
+    """Return room tasks in deterministic admission order."""
+    room_id = _identifier(room_id, label="room_id")
+    if status is not None and status not in TASK_STATUSES:
+        raise DriverValidationError("invalid task status")
+    conn = _connect(db_path)
+    try:
+        if status is None:
+            rows = conn.execute(
+                """SELECT * FROM hosted_room_driver_tasks
+                   WHERE room_id=?
+                   ORDER BY source_event_seq, created_at, task_id""",
+                (room_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """SELECT * FROM hosted_room_driver_tasks
+                   WHERE room_id=? AND status=?
+                   ORDER BY source_event_seq, created_at, task_id""",
+                (room_id, status),
+            ).fetchall()
+        return [_task_from_row(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def prune_published_terminal_tasks(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    clock: Clock,
+    retention_seconds: float = TERMINAL_TASK_RETENTION_SECONDS,
+    retain: int = MAX_RETAINED_TERMINAL_TASKS,
+) -> int:
+    """Bound execution rows after outcomes are durable in the room log."""
+
+    room_id = _identifier(room_id, label="room_id")
+    now = _timestamp(clock)
+    if retention_seconds <= 0:
+        raise DriverValidationError("retention_seconds must be positive")
+    if isinstance(retain, bool) or not isinstance(retain, int) or retain < 0:
+        raise DriverValidationError("retain must be a non-negative integer")
+
+    with _transaction(db_path) as conn:
+        publications = conn.execute(
+            """SELECT 1 FROM sqlite_master
+               WHERE type='table' AND name='hosted_room_policy_publications'"""
+        ).fetchone()
+        if publications is None:
+            return 0
+        rows = conn.execute(
+            """SELECT t.task_id, t.terminal_at
+                 FROM hosted_room_driver_tasks t
+                WHERE t.room_id=?
+                  AND t.status IN ('settled', 'failed', 'cancelled')
+                  AND EXISTS (
+                      SELECT 1 FROM hosted_room_policy_publications p
+                       WHERE p.room_id=t.room_id AND p.task_id=t.task_id
+                         AND p.kind IN (
+                             'turn.settled', 'turn.failed', 'turn.cancelled'
+                         )
+                  )
+                ORDER BY t.terminal_at DESC, t.task_id ASC""",
+            (room_id,),
+        ).fetchall()
+        cutoff = now - float(retention_seconds)
+        candidates = [
+            str(row["task_id"])
+            for index, row in enumerate(rows)
+            if index >= retain
+            or (row["terminal_at"] is not None and float(row["terminal_at"]) <= cutoff)
+        ][:MAX_TASK_PRUNE_BATCH]
+        if not candidates:
+            return 0
+        placeholders = ",".join("?" for _ in candidates)
+        deleted = conn.execute(
+            f"""DELETE FROM hosted_room_driver_tasks
+                WHERE room_id=? AND task_id IN ({placeholders})""",
+            (room_id, *candidates),
+        )
+        return max(0, int(deleted.rowcount))

--- a/gateway/hosted_room_policy_checkpoint.py
+++ b/gateway/hosted_room_policy_checkpoint.py
@@ -1,0 +1,682 @@
+"""Durable bounded policy projection for hosted Group Chat preparation.
+
+The append-only room log remains the user-visible source of truth. This module
+materializes only the state needed to choose and reconstruct the next active
+discussion, so a busy room does not replay its complete history every poll.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from gateway import hosted_rooms
+
+
+MAX_ACTIVE_POLICY_EVENTS = 64
+MAX_THREAD_TRANSCRIPT_EVENTS = 24
+_TRANSCRIPT_SCHEMA_VERSION = 1
+_TERMINAL_KINDS = frozenset({
+    "turn.settled",
+    "turn.failed",
+    "turn.cancelled",
+    "turn.deferred",
+})
+
+
+@dataclass(frozen=True)
+class PolicySnapshot:
+    """Bounded active policy input at one durable room-log cursor."""
+
+    through_seq: int
+    stopped_through_seq: int
+    events: tuple[dict[str, Any], ...]
+    watermarks: Mapping[tuple[str, str], int]
+
+
+class HostedRoomPolicyCheckpoint:
+    """Incrementally index room policy without compacting visible history."""
+
+    def __init__(self, db_path: Path | str) -> None:
+        self.db_path = Path(db_path)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        from hermes_state import apply_wal_with_fallback
+
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self.db_path, timeout=10)
+        conn.row_factory = sqlite3.Row
+        apply_wal_with_fallback(conn, db_label="state.db (room policy checkpoint)")
+        return conn
+
+    def _initialize(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS hosted_room_policy_cursors (
+                    room_id TEXT PRIMARY KEY,
+                    through_seq INTEGER NOT NULL DEFAULT 0,
+                    stopped_through_seq INTEGER NOT NULL DEFAULT 0,
+                    updated_at REAL NOT NULL DEFAULT 0
+                )"""
+            )
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS hosted_room_policy_threads (
+                    room_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    discussion_event_id TEXT NOT NULL,
+                    latest_user_seq INTEGER NOT NULL,
+                    completed INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY(room_id, thread_id)
+                )"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS idx_hosted_room_policy_pending
+                   ON hosted_room_policy_threads(
+                       room_id, completed, latest_user_seq, thread_id
+                   )"""
+            )
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS hosted_room_policy_events (
+                    room_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    discussion_event_id TEXT NOT NULL,
+                    seq INTEGER NOT NULL,
+                    event_json TEXT NOT NULL,
+                    PRIMARY KEY(room_id, seq)
+                )"""
+            )
+            conn.execute(
+                """CREATE INDEX IF NOT EXISTS idx_hosted_room_policy_events_active
+                   ON hosted_room_policy_events(
+                       room_id, discussion_event_id, seq
+                   )"""
+            )
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS hosted_room_policy_watermarks (
+                    room_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    member_id TEXT NOT NULL,
+                    seen_through_seq INTEGER NOT NULL,
+                    PRIMARY KEY(room_id, thread_id, member_id)
+                )"""
+            )
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS hosted_room_policy_publications (
+                    room_id TEXT NOT NULL,
+                    task_id TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    execution_generation INTEGER NOT NULL DEFAULT 0,
+                    seq INTEGER NOT NULL,
+                    PRIMARY KEY(room_id, task_id, kind, execution_generation)
+                )"""
+            )
+            conn.execute(
+                # Store only references into the already bounded room log. This
+                # avoids duplicating prompt payloads outside room byte limits.
+                """CREATE TABLE IF NOT EXISTS hosted_room_policy_transcript (
+                    room_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    seq INTEGER NOT NULL,
+                    kind TEXT NOT NULL,
+                    settled_seq INTEGER,
+                    PRIMARY KEY(room_id, thread_id, seq)
+                )"""
+            )
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS hosted_room_policy_transcript_state (
+                    room_id TEXT PRIMARY KEY,
+                    schema_version INTEGER NOT NULL
+                )"""
+            )
+
+    @staticmethod
+    def _event_json(event: Mapping[str, Any]) -> str:
+        return json.dumps(
+            dict(event),
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    def _store_active_event(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        event: Mapping[str, Any],
+        thread_id: str,
+        discussion_event_id: str,
+    ) -> None:
+        conn.execute(
+            """INSERT OR IGNORE INTO hosted_room_policy_events(
+                   room_id, thread_id, discussion_event_id, seq, event_json
+               ) VALUES (?, ?, ?, ?, ?)""",
+            (
+                event["room_id"],
+                thread_id,
+                discussion_event_id,
+                int(event["seq"]),
+                self._event_json(event),
+            ),
+        )
+
+    def _store_transcript_event(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        event: Mapping[str, Any],
+        thread_id: str,
+        settled_seq: int | None = None,
+    ) -> None:
+        conn.execute(
+            """INSERT INTO hosted_room_policy_transcript(
+                   room_id, thread_id, seq, kind, settled_seq
+               ) VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(room_id, thread_id, seq) DO UPDATE SET
+                   settled_seq=COALESCE(
+                       excluded.settled_seq,
+                       hosted_room_policy_transcript.settled_seq
+                   )""",
+            (
+                event["room_id"],
+                thread_id,
+                int(event["seq"]),
+                str(event["kind"]),
+                settled_seq,
+            ),
+        )
+        if event["kind"] in {"message.user", "message.member"}:
+            cutoff = conn.execute(
+                """SELECT seq FROM hosted_room_policy_transcript
+                   WHERE room_id=? AND thread_id=?
+                     AND kind IN ('message.user', 'message.member')
+                   ORDER BY seq DESC LIMIT 1 OFFSET ?""",
+                (
+                    event["room_id"],
+                    thread_id,
+                    MAX_THREAD_TRANSCRIPT_EVENTS - 1,
+                ),
+            ).fetchone()
+            if cutoff is not None:
+                conn.execute(
+                    """DELETE FROM hosted_room_policy_transcript
+                       WHERE room_id=? AND thread_id=? AND seq<?""",
+                    (event["room_id"], thread_id, int(cutoff["seq"])),
+                )
+
+    @staticmethod
+    def _event_from_room_row(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "room_id": str(row["room_id"]),
+            "seq": int(row["seq"]),
+            "event_id": str(row["event_id"]),
+            "kind": str(row["kind"]),
+            "actor": json.loads(row["actor_json"]),
+            "authority_epoch": row["authority_epoch"],
+            "payload": json.loads(row["payload_json"]),
+            "created_at": float(row["created_at"]),
+            "idempotent": False,
+        }
+
+    def _backfill_transcript(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        room_id: str,
+        through_seq: int,
+    ) -> None:
+        """Migrate bounded committed thread history from the durable room log."""
+
+        if through_seq <= 0:
+            return
+        settled_seq_by_message: dict[str, int] = {}
+        for row in conn.execute(
+            """SELECT seq, payload_json FROM hosted_room_events
+               WHERE room_id=? AND seq<=? AND kind='turn.settled'
+               ORDER BY seq""",
+            (room_id, through_seq),
+        ):
+            message_event_id = str(
+                json.loads(row["payload_json"]).get("message_event_id") or ""
+            )
+            if message_event_id:
+                settled_seq_by_message[message_event_id] = int(row["seq"])
+        rows = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json,
+                      authority_epoch, payload_json, created_at
+               FROM hosted_room_events
+               WHERE room_id=? AND seq<=?
+                 AND kind IN ('message.user', 'message.member')
+               ORDER BY seq""",
+            (room_id, through_seq),
+        )
+        for row in rows:
+            if (
+                row["kind"] == "message.member"
+                and row["event_id"] not in settled_seq_by_message
+            ):
+                continue
+            event = self._event_from_room_row(row)
+            thread_id = str(event["payload"].get("thread_id") or "")
+            if thread_id:
+                self._store_transcript_event(
+                    conn,
+                    event=event,
+                    thread_id=thread_id,
+                    settled_seq=settled_seq_by_message.get(str(row["event_id"])),
+                )
+
+    def _transcript_events(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        room_id: str,
+        thread_id: str,
+    ) -> list[dict[str, Any]]:
+        rows = conn.execute(
+            """WITH transcript_events(seq) AS (
+                   SELECT seq FROM hosted_room_policy_transcript
+                    WHERE room_id=? AND thread_id=?
+                   UNION ALL
+                   SELECT settled_seq FROM hosted_room_policy_transcript
+                    WHERE room_id=? AND thread_id=? AND settled_seq IS NOT NULL
+               )
+               SELECT events.room_id, events.seq, events.event_id,
+                      events.kind, events.actor_json,
+                      events.authority_epoch, events.payload_json,
+                      events.created_at
+               FROM transcript_events
+               JOIN hosted_room_events AS events
+                 ON events.room_id=? AND events.seq=transcript_events.seq
+               ORDER BY events.seq""",
+            (room_id, thread_id, room_id, thread_id, room_id),
+        ).fetchall()
+        return [self._event_from_room_row(row) for row in rows]
+
+    def _apply_event(self, conn: sqlite3.Connection, event: Mapping[str, Any]) -> None:
+        room_id = str(event["room_id"])
+        seq = int(event["seq"])
+        kind = str(event.get("kind") or "")
+        payload = event.get("payload")
+        payload = payload if isinstance(payload, Mapping) else {}
+
+        if kind == "message.user":
+            thread_id = str(payload.get("thread_id") or "")
+            event_id = str(event.get("event_id") or "")
+            if not thread_id or not event_id:
+                return
+            conn.execute(
+                """INSERT INTO hosted_room_policy_threads(
+                       room_id, thread_id, discussion_event_id,
+                       latest_user_seq, completed
+                   ) VALUES (?, ?, ?, ?, 0)
+                   ON CONFLICT(room_id, thread_id) DO UPDATE SET
+                       discussion_event_id=excluded.discussion_event_id,
+                       latest_user_seq=excluded.latest_user_seq,
+                       completed=0""",
+                (room_id, thread_id, event_id, seq),
+            )
+            self._store_active_event(
+                conn,
+                event=event,
+                thread_id=thread_id,
+                discussion_event_id=event_id,
+            )
+            self._store_transcript_event(
+                conn,
+                event=event,
+                thread_id=thread_id,
+            )
+            return
+
+        if kind in {"message.member", *_TERMINAL_KINDS}:
+            thread_id = str(payload.get("thread_id") or "")
+            discussion_event_id = str(payload.get("discussion_event_id") or "")
+            source = conn.execute(
+                """SELECT 1 FROM hosted_room_policy_events
+                   WHERE room_id=? AND discussion_event_id=? LIMIT 1""",
+                (room_id, discussion_event_id),
+            ).fetchone()
+            if source is None:
+                return
+            self._store_active_event(
+                conn,
+                event=event,
+                thread_id=thread_id,
+                discussion_event_id=discussion_event_id,
+            )
+            if kind in _TERMINAL_KINDS:
+                task_id = str(payload.get("task_id") or "")
+                execution_generation = (
+                    int(payload.get("execution_generation") or 0)
+                    if kind == "turn.deferred"
+                    else 0
+                )
+                if task_id:
+                    conn.execute(
+                        """INSERT OR IGNORE INTO hosted_room_policy_publications(
+                               room_id, task_id, kind, execution_generation, seq
+                           ) VALUES (?, ?, ?, ?, ?)""",
+                        (
+                            room_id,
+                            task_id,
+                            kind,
+                            execution_generation,
+                            seq,
+                        ),
+                    )
+                member_id = str(payload.get("member_id") or "")
+                seen_through_seq = int(payload.get("seen_through_seq") or 0)
+                if kind == "turn.settled" and payload.get("message_event_id"):
+                    messages = conn.execute(
+                        """SELECT seq, event_json FROM hosted_room_policy_events
+                           WHERE room_id=? AND discussion_event_id=?""",
+                        (room_id, discussion_event_id),
+                    ).fetchall()
+                    decoded_messages = [
+                        json.loads(message["event_json"])
+                        for message in messages
+                    ]
+                    committed = next(
+                        (
+                            message
+                            for message in decoded_messages
+                            if message.get("event_id")
+                            == payload["message_event_id"]
+                        ),
+                        None,
+                    )
+                    if committed is not None:
+                        seen_through_seq = max(
+                            seen_through_seq,
+                            int(committed["seq"]),
+                        )
+                        self._store_transcript_event(
+                            conn,
+                            event=committed,
+                            thread_id=thread_id,
+                            settled_seq=int(event["seq"]),
+                        )
+                if member_id and seen_through_seq > 0:
+                    conn.execute(
+                        """INSERT INTO hosted_room_policy_watermarks(
+                               room_id, thread_id, member_id, seen_through_seq
+                           ) VALUES (?, ?, ?, ?)
+                           ON CONFLICT(room_id, thread_id, member_id) DO UPDATE SET
+                               seen_through_seq=MAX(
+                                   hosted_room_policy_watermarks.seen_through_seq,
+                                   excluded.seen_through_seq
+                               )""",
+                        (room_id, thread_id, member_id, seen_through_seq),
+                    )
+            return
+
+        if kind == "room.activity":
+            thread_id = str(payload.get("thread_id") or "")
+            discussion_event_id = str(payload.get("discussion_event_id") or "")
+            conn.execute(
+                """DELETE FROM hosted_room_policy_events
+                   WHERE room_id=? AND discussion_event_id=?""",
+                (room_id, discussion_event_id),
+            )
+            conn.execute(
+                """DELETE FROM hosted_room_policy_threads
+                   WHERE room_id=? AND thread_id=?""",
+                (room_id, thread_id),
+            )
+            return
+
+        if kind == "room.stop_requested":
+            conn.execute(
+                """UPDATE hosted_room_policy_cursors
+                   SET stopped_through_seq=MAX(stopped_through_seq, ?)
+                   WHERE room_id=?""",
+                (seq, room_id),
+            )
+
+    def sync(self, *, room_id: str, latest_seq: int) -> int:
+        """Materialize each unseen event exactly once by durable cursor."""
+
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            if conn.execute(
+                "SELECT 1 FROM hosted_rooms WHERE room_id=?",
+                (room_id,),
+            ).fetchone() is None:
+                raise hosted_rooms.RoomNotFoundError("hosted room not found")
+            conn.execute(
+                """INSERT OR IGNORE INTO hosted_room_policy_cursors(
+                       room_id, through_seq, stopped_through_seq, updated_at
+                   ) VALUES (?, 0, 0, 0)""",
+                (room_id,),
+            )
+            row = conn.execute(
+                "SELECT through_seq FROM hosted_room_policy_cursors WHERE room_id=?",
+                (room_id,),
+            ).fetchone()
+            cursor = int(row["through_seq"])
+            transcript_state = conn.execute(
+                """SELECT schema_version
+                   FROM hosted_room_policy_transcript_state WHERE room_id=?""",
+                (room_id,),
+            ).fetchone()
+            if (
+                transcript_state is None
+                or int(transcript_state["schema_version"])
+                < _TRANSCRIPT_SCHEMA_VERSION
+            ):
+                self._backfill_transcript(
+                    conn,
+                    room_id=room_id,
+                    through_seq=cursor,
+                )
+                conn.execute(
+                    """INSERT INTO hosted_room_policy_transcript_state(
+                           room_id, schema_version
+                       ) VALUES (?, ?)
+                       ON CONFLICT(room_id) DO UPDATE SET
+                           schema_version=excluded.schema_version""",
+                    (room_id, _TRANSCRIPT_SCHEMA_VERSION),
+                )
+        if cursor > latest_seq:
+            raise RuntimeError("room policy cursor is ahead of the durable log")
+
+        while cursor < latest_seq:
+            page = hosted_rooms.read_events(
+                self.db_path,
+                room_id=room_id,
+                since_seq=cursor,
+                limit=hosted_rooms.MAX_LOG_LIMIT,
+            )
+            rows = [
+                event for event in page.get("events", []) if isinstance(event, Mapping)
+            ]
+            next_cursor = int(page.get("cursor") or cursor)
+            if not rows or next_cursor <= cursor:
+                raise RuntimeError("hosted room policy cursor did not advance")
+            with self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                if conn.execute(
+                    "SELECT 1 FROM hosted_rooms WHERE room_id=?",
+                    (room_id,),
+                ).fetchone() is None:
+                    raise hosted_rooms.RoomNotFoundError("hosted room not found")
+                for event in rows:
+                    self._apply_event(conn, event)
+                updated = conn.execute(
+                    """UPDATE hosted_room_policy_cursors
+                       SET through_seq=?, updated_at=? WHERE room_id=?""",
+                    (
+                        next_cursor,
+                        float(rows[-1].get("created_at") or 0),
+                        room_id,
+                    ),
+                )
+                if updated.rowcount != 1:
+                    raise RuntimeError("room policy cursor disappeared during replay")
+            cursor = next_cursor
+        return cursor
+
+    def snapshot(self, *, room_id: str, latest_seq: int) -> PolicySnapshot:
+        """Return only the oldest active discussion and its watermark set."""
+
+        through_seq = self.sync(room_id=room_id, latest_seq=latest_seq)
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """SELECT stopped_through_seq FROM hosted_room_policy_cursors
+                   WHERE room_id=?""",
+                (room_id,),
+            ).fetchone()
+            stopped_through_seq = int(cursor["stopped_through_seq"])
+            thread = conn.execute(
+                """SELECT thread_id, discussion_event_id
+                   FROM hosted_room_policy_threads
+                   WHERE room_id=? AND completed=0 AND latest_user_seq>?
+                   ORDER BY latest_user_seq, thread_id LIMIT 1""",
+                (room_id, stopped_through_seq),
+            ).fetchone()
+            if thread is None:
+                return PolicySnapshot(
+                    through_seq=through_seq,
+                    stopped_through_seq=stopped_through_seq,
+                    events=(),
+                    watermarks={},
+                )
+            active_rows = conn.execute(
+                """SELECT event_json FROM hosted_room_policy_events
+                   WHERE room_id=? AND discussion_event_id=?
+                   ORDER BY seq LIMIT ?""",
+                (
+                    room_id,
+                    str(thread["discussion_event_id"]),
+                    MAX_ACTIVE_POLICY_EVENTS + 1,
+                ),
+            ).fetchall()
+            if len(active_rows) > MAX_ACTIVE_POLICY_EVENTS:
+                raise RuntimeError("active room policy projection exceeded its bound")
+            transcript_events = self._transcript_events(
+                conn,
+                room_id=room_id,
+                thread_id=str(thread["thread_id"]),
+            )
+            watermark_rows = conn.execute(
+                """SELECT member_id, seen_through_seq
+                   FROM hosted_room_policy_watermarks
+                   WHERE room_id=? AND thread_id=?""",
+                (room_id, str(thread["thread_id"])),
+            ).fetchall()
+        events_by_seq = {
+            int(event["seq"]): event
+            for event in (
+                *transcript_events,
+                *(json.loads(row["event_json"]) for row in active_rows),
+            )
+        }
+        return PolicySnapshot(
+            through_seq=through_seq,
+            stopped_through_seq=stopped_through_seq,
+            events=tuple(events_by_seq[seq] for seq in sorted(events_by_seq)),
+            watermarks={
+                (str(thread["thread_id"]), str(row["member_id"])): int(
+                    row["seen_through_seq"]
+                )
+                for row in watermark_rows
+            },
+        )
+
+    def publication_exists(
+        self,
+        *,
+        room_id: str,
+        task_id: str,
+        status: str,
+        execution_generation: int,
+    ) -> bool:
+        """Return whether one exact driver outcome is already in the room log."""
+
+        kind = f"turn.{status}"
+        generation = execution_generation if status == "deferred" else 0
+        with self._connect() as conn:
+            if status == "deferred":
+                row = conn.execute(
+                    """SELECT 1 FROM hosted_room_policy_publications
+                       WHERE room_id=? AND task_id=? AND kind=?
+                         AND execution_generation=?""",
+                    (room_id, task_id, kind, generation),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    """SELECT 1 FROM hosted_room_policy_publications
+                       WHERE room_id=? AND task_id=? AND kind IN (
+                           'turn.settled', 'turn.failed', 'turn.cancelled'
+                       )""",
+                    (room_id, task_id),
+                ).fetchone()
+        return row is not None
+
+    def events_for_task(
+        self,
+        *,
+        room_id: str,
+        source_event_seq: int,
+    ) -> list[dict[str, Any]]:
+        """Load one bounded discussion projection for terminal reconstruction."""
+
+        with self._connect() as conn:
+            source = conn.execute(
+                """SELECT discussion_event_id, thread_id
+                   FROM hosted_room_policy_events
+                   WHERE room_id=? AND seq=?""",
+                (room_id, source_event_seq),
+            ).fetchone()
+            if source is None:
+                return []
+            active_rows = conn.execute(
+                """SELECT event_json FROM hosted_room_policy_events
+                   WHERE room_id=? AND discussion_event_id=?
+                   ORDER BY seq LIMIT ?""",
+                (
+                    room_id,
+                    str(source["discussion_event_id"]),
+                    MAX_ACTIVE_POLICY_EVENTS + 1,
+                ),
+            ).fetchall()
+            transcript_events = self._transcript_events(
+                conn,
+                room_id=room_id,
+                thread_id=str(source["thread_id"]),
+            )
+        if len(active_rows) > MAX_ACTIVE_POLICY_EVENTS:
+            raise RuntimeError("task policy projection exceeded its bound")
+        events_by_seq = {
+            int(event["seq"]): event
+            for event in (
+                *transcript_events,
+                *(json.loads(row["event_json"]) for row in active_rows),
+            )
+        }
+        return [events_by_seq[seq] for seq in sorted(events_by_seq)]
+
+    def compact_completed(self, *, room_id: str) -> None:
+        """Drop any completed projections left by an interrupted sync."""
+
+        with self._connect() as conn:
+            completed = conn.execute(
+                """SELECT discussion_event_id FROM hosted_room_policy_threads
+                   WHERE room_id=? AND completed=1""",
+                (room_id,),
+            ).fetchall()
+            for row in completed:
+                conn.execute(
+                    """DELETE FROM hosted_room_policy_events
+                       WHERE room_id=? AND discussion_event_id=?""",
+                    (room_id, str(row["discussion_event_id"])),
+                )
+            conn.execute(
+                """DELETE FROM hosted_room_policy_threads
+                   WHERE room_id=? AND completed=1""",
+                (room_id,),
+            )

--- a/gateway/hosted_room_replicas.py
+++ b/gateway/hosted_room_replicas.py
@@ -1,0 +1,570 @@
+"""Replica store and takeover primitives for hosted Group Chat rooms.
+
+The authority gateway owns a room's ordered log in ``gateway/hosted_rooms.py``.
+This module gives every OTHER participant gateway a durable local copy of that
+log, and the fenced primitives to continue the room when the authority host
+dies:
+
+- ``ingest_page()`` persists replay pages (``groups.log`` output, which carries
+  the room's authority stamp) idempotently, refusing sequence gaps and
+  authority-epoch regressions.
+- ``promote_replica()`` instantiates the replicated log as a locally-owned
+  hosted room at ``epoch + 1`` with a lineage-proving ``authority.claimed``
+  event, so a surviving participant can resume the room.
+- ``demote_room()`` fences a returning stale authority: presented with proof of
+  a newer epoch, the local room records ``authority.lost`` and stops being
+  authoritative.
+
+Storage primitives only: none of these decide *when* takeover is safe. The
+caller (an explicit user action today; a lease/quorum driver later) must
+establish that the previous owner can no longer commit before promoting.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from gateway.hosted_rooms import (
+    MAX_ACTOR_ID_CHARS,
+    MAX_EVENT_JSON_BYTES,
+    MAX_ROOM_ID_CHARS,
+    HostedRoomError,
+    RoomConflictError,
+    _canonical_json,
+    _connect,
+    _transaction,
+    _validate_identifier,
+    _validate_members,
+    _validate_room_name,
+    local_authority_gateway_id,
+)
+
+MAX_REPLICA_ROOMS = 256
+MAX_REPLICA_EVENT_BYTES = 256 * 1024 * 1024
+
+
+class ReplicaError(HostedRoomError):
+    """Base class for invalid or conflicting replica operations."""
+
+
+class ReplicaGapError(ReplicaError):
+    """A page does not start at the replica's next expected sequence."""
+
+
+class ReplicaEpochRegressionError(ReplicaError):
+    """A page or demotion carries an older authority epoch than stored."""
+
+
+def _initialize_replica_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_room_replicas (
+            room_id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            members_json TEXT NOT NULL,
+            authority_gateway_id TEXT NOT NULL,
+            authority_epoch INTEGER NOT NULL CHECK (authority_epoch >= 1),
+            last_seq INTEGER NOT NULL DEFAULT 0 CHECK (last_seq >= 0),
+            latest_seq INTEGER NOT NULL DEFAULT 0,
+            event_bytes INTEGER NOT NULL DEFAULT 0,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_room_replica_events (
+            room_id TEXT NOT NULL,
+            seq INTEGER NOT NULL CHECK (seq >= 1),
+            event_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            actor_json TEXT NOT NULL,
+            authority_epoch INTEGER,
+            payload_json TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (room_id, seq)
+        )"""
+    )
+
+
+def _replica_transaction(db_path: Path | str):
+    return _transaction(db_path, immediate=True)
+
+
+def _ensure_schema(db_path: Path | str) -> None:
+    conn = _connect(db_path)
+    try:
+        with conn:
+            _initialize_replica_schema(conn)
+    finally:
+        conn.close()
+
+
+def _event_bytes(event: dict[str, Any]) -> int:
+    return (
+        len(str(event["event_id"]).encode("utf-8"))
+        + len(str(event["kind"]).encode("utf-8"))
+        + len(
+            json.dumps(
+                event["actor"], ensure_ascii=False, separators=(",", ":")
+            ).encode("utf-8")
+        )
+        + len(
+            json.dumps(
+                event["payload"], ensure_ascii=False, separators=(",", ":")
+            ).encode("utf-8")
+        )
+    )
+
+
+def _validate_page(page: Any) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if not isinstance(page, dict):
+        raise ReplicaError("page must be an object")
+    events = page.get("events")
+    authority = page.get("authority")
+    if not isinstance(events, list):
+        raise ReplicaError("page.events must be a list")
+    if not isinstance(authority, dict):
+        raise ReplicaError("page.authority is required for replication")
+    gateway_id = _validate_identifier(
+        authority.get("gateway_id"),
+        label="page.authority.gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    epoch = authority.get("epoch")
+    if isinstance(epoch, bool) or not isinstance(epoch, int) or epoch < 1:
+        raise ReplicaError("page.authority.epoch must be a positive integer")
+    previous_seq: int | None = None
+    for event in events:
+        if not isinstance(event, dict):
+            raise ReplicaError("page events must be objects")
+        seq = event.get("seq")
+        if isinstance(seq, bool) or not isinstance(seq, int) or seq < 1:
+            raise ReplicaError("event.seq must be a positive integer")
+        if previous_seq is not None and seq != previous_seq + 1:
+            raise ReplicaGapError("page events must be contiguous")
+        previous_seq = seq
+        for field in ("event_id", "kind"):
+            if not isinstance(event.get(field), str) or not event[field]:
+                raise ReplicaError(f"event.{field} must be a non-empty string")
+        if not isinstance(event.get("actor"), dict):
+            raise ReplicaError("event.actor must be an object")
+        if "payload" not in event:
+            raise ReplicaError("event.payload is required")
+    return events, {"gateway_id": gateway_id, "epoch": epoch}
+
+
+def ingest_page(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    room_name: Any,
+    members: Any,
+    page: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Persist one replay page for ``room_id``; idempotent, gap- and
+    epoch-regression-safe.
+
+    ``page`` is the verbatim result of the authority's ``groups.log`` call
+    (``read_events()``), whose ``authority`` stamp proves lineage.
+    """
+    room_id = _validate_identifier(
+        room_id, label="room_id", max_chars=MAX_ROOM_ID_CHARS
+    )
+    room_name = _validate_room_name(room_name)
+    _, members_json = _validate_members(members)
+    events, authority = _validate_page(page)
+    now = time.time() if now is None else float(now)
+    _ensure_schema(db_path)
+
+    with _replica_transaction(db_path) as conn:
+        _initialize_replica_schema(conn)
+        row = conn.execute(
+            """SELECT authority_gateway_id, authority_epoch, last_seq,
+                      latest_seq, event_bytes
+                 FROM hosted_room_replicas WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if row is None:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM hosted_room_replicas"
+            ).fetchone()[0]
+            if int(count) >= MAX_REPLICA_ROOMS:
+                raise ReplicaError("replica room capacity exhausted")
+            stored_epoch = 0
+            last_seq = 0
+            stored_bytes = 0
+        else:
+            stored_epoch = int(row["authority_epoch"])
+            last_seq = int(row["last_seq"])
+            stored_bytes = int(row["event_bytes"])
+
+        if authority["epoch"] < stored_epoch:
+            raise ReplicaEpochRegressionError(
+                "page authority epoch is older than the stored replica epoch"
+            )
+
+        new_events = [e for e in events if int(e["seq"]) > last_seq]
+        if new_events and int(new_events[0]["seq"]) != last_seq + 1:
+            raise ReplicaGapError(
+                "page skips sequences the replica has not stored"
+            )
+        added_bytes = 0
+        for event in new_events:
+            size = _event_bytes(event)
+            if stored_bytes + added_bytes + size > MAX_REPLICA_EVENT_BYTES:
+                raise ReplicaError("replica event storage exhausted")
+            actor_json = _canonical_json(
+                event["actor"], label="actor", max_bytes=4 * 1024
+            )
+            payload_json = _canonical_json(
+                event["payload"], label="payload", max_bytes=MAX_EVENT_JSON_BYTES
+            )
+            epoch_value = event.get("authority_epoch")
+            conn.execute(
+                """INSERT INTO hosted_room_replica_events
+                   (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                    payload_json, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    room_id,
+                    int(event["seq"]),
+                    event["event_id"],
+                    event["kind"],
+                    actor_json,
+                    epoch_value,
+                    payload_json,
+                    float(event.get("created_at") or now),
+                ),
+            )
+            added_bytes += size
+        new_last = int(new_events[-1]["seq"]) if new_events else last_seq
+        latest_seq = page.get("latest_seq")
+        if isinstance(latest_seq, bool) or not isinstance(latest_seq, int):
+            latest_seq = new_last
+        if row is None:
+            conn.execute(
+                """INSERT INTO hosted_room_replicas
+                   (room_id, name, members_json, authority_gateway_id,
+                    authority_epoch, last_seq, latest_seq, event_bytes,
+                    created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    room_id,
+                    room_name,
+                    members_json,
+                    authority["gateway_id"],
+                    authority["epoch"],
+                    new_last,
+                    max(latest_seq, new_last),
+                    added_bytes,
+                    now,
+                    now,
+                ),
+            )
+        else:
+            conn.execute(
+                """UPDATE hosted_room_replicas
+                      SET name=?, members_json=?, authority_gateway_id=?,
+                          authority_epoch=?, last_seq=?, latest_seq=?,
+                          event_bytes=event_bytes+?, updated_at=?
+                    WHERE room_id=?""",
+                (
+                    room_name,
+                    members_json,
+                    authority["gateway_id"],
+                    authority["epoch"],
+                    new_last,
+                    max(latest_seq, new_last),
+                    added_bytes,
+                    now,
+                    room_id,
+                ),
+            )
+    return {
+        "room_id": room_id,
+        "stored_seq": new_last,
+        "ingested": len(new_events),
+        "authority": authority,
+        "caught_up": new_last >= max(latest_seq, new_last),
+    }
+
+
+def replica_state(db_path: Path | str, *, room_id: Any) -> dict[str, Any]:
+    """Return the stored replica's coverage and authority lineage."""
+    room_id = _validate_identifier(
+        room_id, label="room_id", max_chars=MAX_ROOM_ID_CHARS
+    )
+    _ensure_schema(db_path)
+    with _replica_transaction(db_path) as conn:
+        _initialize_replica_schema(conn)
+        row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, last_seq, latest_seq, event_bytes,
+                      created_at, updated_at
+                 FROM hosted_room_replicas WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+    if row is None:
+        raise ReplicaError("replica not found")
+    return {
+        "room_id": row["room_id"],
+        "name": row["name"],
+        "members": json.loads(row["members_json"]),
+        "authority": {
+            "gateway_id": row["authority_gateway_id"],
+            "epoch": int(row["authority_epoch"]),
+        },
+        "last_seq": int(row["last_seq"]),
+        "latest_seq": int(row["latest_seq"]),
+        "event_bytes": int(row["event_bytes"]),
+        "created_at": float(row["created_at"]),
+        "updated_at": float(row["updated_at"]),
+    }
+
+
+def promote_replica(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    reason: Any = "authority-unreachable",
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Continue a replicated room on THIS gateway at ``epoch + 1``.
+
+    Copies the replica's log into the authoritative store, appends a lineage-
+    proving ``authority.claimed`` event, and returns the new room state. The
+    old authority is fenced everywhere the claim replicates: its epoch is now
+    stale and every fenced primitive rejects it.
+
+    The caller decides that takeover is safe (the previous owner can no longer
+    commit). This primitive only makes the takeover atomic and provable.
+    """
+    room_id = _validate_identifier(
+        room_id, label="room_id", max_chars=MAX_ROOM_ID_CHARS
+    )
+    if not isinstance(reason, str) or not reason or len(reason) > 200:
+        raise ReplicaError("reason must be a non-empty string of at most 200 chars")
+    now = time.time() if now is None else float(now)
+    local_gateway = local_authority_gateway_id()
+    _ensure_schema(db_path)
+
+    with _replica_transaction(db_path) as conn:
+        _initialize_replica_schema(conn)
+        replica = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, last_seq, event_bytes
+                 FROM hosted_room_replicas WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if replica is None:
+            raise ReplicaError("replica not found")
+        if replica["authority_gateway_id"] == local_gateway:
+            raise ReplicaError("this gateway already holds the room authority")
+        if conn.execute(
+            "SELECT 1 FROM hosted_rooms WHERE room_id=?", (room_id,)
+        ).fetchone():
+            raise RoomConflictError(
+                "room_id already exists in the local authoritative store"
+            )
+        if conn.execute(
+            "SELECT 1 FROM hosted_room_retired_ids WHERE room_id=?",
+            (room_id,),
+        ).fetchone():
+            raise RoomConflictError("room_id belongs to a disbanded room")
+
+        previous_gateway = str(replica["authority_gateway_id"])
+        previous_epoch = int(replica["authority_epoch"])
+        target_epoch = previous_epoch + 1
+        last_seq = int(replica["last_seq"])
+        claim_seq = last_seq + 1
+        claim_event_id = f"system:authority-claimed:{target_epoch}"
+        claim_actor_json = _canonical_json(
+            {"kind": "system", "id": "authority-control"},
+            label="actor",
+            max_bytes=4 * 1024,
+        )
+        claim_payload_json = _canonical_json(
+            {
+                "previous_gateway_id": previous_gateway,
+                "authority_gateway_id": local_gateway,
+                "authority_epoch": target_epoch,
+                "promoted_from_replica": True,
+                "reason": reason,
+            },
+            label="payload",
+            max_bytes=MAX_EVENT_JSON_BYTES,
+        )
+        claim_bytes = (
+            len(claim_event_id.encode("utf-8"))
+            + len(b"authority.claimed")
+            + len(claim_actor_json.encode("utf-8"))
+            + len(claim_payload_json.encode("utf-8"))
+        )
+
+        conn.execute(
+            """INSERT INTO hosted_rooms
+               (room_id, name, members_json, authority_gateway_id,
+                authority_epoch, next_seq, event_bytes, revision,
+                created_at, updated_at, disbanded_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, NULL)""",
+            (
+                room_id,
+                replica["name"],
+                replica["members_json"],
+                local_gateway,
+                target_epoch,
+                claim_seq + 1,
+                int(replica["event_bytes"]) + claim_bytes,
+                now,
+                now,
+            ),
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                payload_json, created_at)
+               SELECT room_id, seq, event_id, kind, actor_json,
+                      authority_epoch, payload_json, created_at
+                 FROM hosted_room_replica_events WHERE room_id=?""",
+            (room_id,),
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                payload_json, created_at)
+               VALUES (?, ?, ?, 'authority.claimed', ?, ?, ?, ?)""",
+            (
+                room_id,
+                claim_seq,
+                claim_event_id,
+                claim_actor_json,
+                target_epoch,
+                claim_payload_json,
+                now,
+            ),
+        )
+        conn.execute(
+            "DELETE FROM hosted_room_replica_events WHERE room_id=?", (room_id,)
+        )
+        conn.execute(
+            "DELETE FROM hosted_room_replicas WHERE room_id=?", (room_id,)
+        )
+    return {
+        "room_id": room_id,
+        "authority_gateway_id": local_gateway,
+        "authority_epoch": target_epoch,
+        "previous_gateway_id": previous_gateway,
+        "previous_epoch": previous_epoch,
+        "claim_seq": claim_seq,
+        "latest_seq": claim_seq,
+    }
+
+
+def demote_room(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    observed_gateway_id: Any,
+    observed_epoch: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Fence THIS gateway's stale room authority against a proven newer epoch.
+
+    Called when a returning gateway observes (via a replicated
+    ``authority.claimed`` event or a transport rejection) that another gateway
+    now owns the room at a higher epoch. Appends ``authority.lost`` and adopts
+    the observed lineage so no further local sends can be committed at the
+    stale epoch. Idempotent for repeated observations of the same lineage.
+    """
+    room_id = _validate_identifier(
+        room_id, label="room_id", max_chars=MAX_ROOM_ID_CHARS
+    )
+    observed_gateway_id = _validate_identifier(
+        observed_gateway_id,
+        label="observed_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    if (
+        isinstance(observed_epoch, bool)
+        or not isinstance(observed_epoch, int)
+        or observed_epoch < 1
+    ):
+        raise ReplicaError("observed_epoch must be a positive integer")
+    now = time.time() if now is None else float(now)
+    local_gateway = local_authority_gateway_id()
+
+    with _replica_transaction(db_path) as conn:
+        row = conn.execute(
+            """SELECT authority_gateway_id, authority_epoch, next_seq
+                 FROM hosted_rooms WHERE room_id=? AND disbanded_at IS NULL""",
+            (room_id,),
+        ).fetchone()
+        if row is None:
+            raise ReplicaError("room not found in the local authoritative store")
+        current_gateway = str(row["authority_gateway_id"])
+        current_epoch = int(row["authority_epoch"])
+        if (
+            current_gateway == observed_gateway_id
+            and current_epoch == observed_epoch
+        ):
+            return {
+                "room_id": room_id,
+                "authority_gateway_id": current_gateway,
+                "authority_epoch": current_epoch,
+                "idempotent": True,
+            }
+        if observed_epoch <= current_epoch:
+            raise ReplicaEpochRegressionError(
+                "observed epoch does not supersede the stored authority"
+            )
+        if current_gateway != local_gateway:
+            raise ReplicaError(
+                "room is not locally authoritative; nothing to demote"
+            )
+        seq = int(row["next_seq"])
+        lost_actor_json = _canonical_json(
+            {"kind": "system", "id": "authority-control"},
+            label="actor",
+            max_bytes=4 * 1024,
+        )
+        lost_payload_json = _canonical_json(
+            {
+                "previous_gateway_id": current_gateway,
+                "authority_gateway_id": observed_gateway_id,
+                "authority_epoch": observed_epoch,
+            },
+            label="payload",
+            max_bytes=MAX_EVENT_JSON_BYTES,
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                payload_json, created_at)
+               VALUES (?, ?, ?, 'authority.lost', ?, ?, ?, ?)""",
+            (
+                room_id,
+                seq,
+                f"system:authority-lost:{observed_epoch}",
+                lost_actor_json,
+                observed_epoch,
+                lost_payload_json,
+                now,
+            ),
+        )
+        conn.execute(
+            """UPDATE hosted_rooms
+                  SET authority_gateway_id=?, authority_epoch=?,
+                      next_seq=next_seq+1, revision=revision+1, updated_at=?
+                WHERE room_id=?""",
+            (observed_gateway_id, observed_epoch, now, room_id),
+        )
+    return {
+        "room_id": room_id,
+        "authority_gateway_id": observed_gateway_id,
+        "authority_epoch": observed_epoch,
+        "idempotent": False,
+    }

--- a/gateway/hosted_rooms.py
+++ b/gateway/hosted_rooms.py
@@ -1,0 +1,1456 @@
+"""Durable state for gateway-hosted Bot Mode rooms.
+
+This module owns only hosted-room identity and its append-only event log. It
+does not deliver events, lease relay work, or run agent turns; those concerns
+belong to the relay and the future hosted-room driver. Keeping that boundary
+explicit lets the room log compose with a durable relay without creating a
+second transport queue.
+
+The caller supplies the database path so tests and alternate gateway layouts
+can isolate state. Production handlers use the gateway's root ``state.db``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+
+PROTOCOL_VERSION = 2
+MAX_ROOM_ID_CHARS = 128
+MAX_EVENT_ID_CHARS = 128
+MAX_ROOM_NAME_CHARS = 200
+MAX_EVENT_KIND_CHARS = 64
+MAX_ACTOR_ID_CHARS = 128
+MAX_ACTOR_LABEL_CHARS = 200
+MAX_MEMBERS = 128
+MAX_MEMBERS_JSON_BYTES = 128 * 1024
+MAX_EVENT_JSON_BYTES = 256 * 1024
+MAX_LOG_LIMIT = 500
+MAX_LOG_PAGE_BYTES = 2 * 1024 * 1024
+MAX_ROOM_LIST_LIMIT = 500
+MAX_ACTIVE_ROOMS = 256
+MAX_DISBANDED_ROOM_TOMBSTONES = 512
+DISBANDED_ROOM_RETENTION_SECONDS = 90 * 24 * 60 * 60
+MAX_EVENTS_PER_ROOM = 50_000
+MAX_ROOM_EVENT_BYTES = 256 * 1024 * 1024
+# Leave substantial headroom below the pre-update state.db snapshot ceiling.
+# Event accounting does not include SQLite indexes or repeated room ids, so the
+# logical budget must stay well below the physical-file limit.
+MAX_GATEWAY_EVENT_BYTES = 16 * 1024 * 1024
+CONTROL_EVENT_COUNT_RESERVE = 64
+CONTROL_EVENT_BYTE_RESERVE = 1024 * 1024
+_JOURNAL_MODE_LOCK_RETRIES = 8
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_EVENT_KIND_RE = re.compile(r"^[a-z][a-z0-9_.-]*$")
+_ROOM_SCHEMA_COLUMNS = frozenset({
+    "room_id",
+    "name",
+    "members_json",
+    "authority_gateway_id",
+    "authority_epoch",
+    "next_seq",
+    "event_bytes",
+    "revision",
+    "created_at",
+    "updated_at",
+    "disbanded_at",
+})
+_EVENT_SCHEMA_COLUMNS = frozenset({
+    "room_id",
+    "seq",
+    "event_id",
+    "kind",
+    "actor_json",
+    "authority_epoch",
+    "payload_json",
+    "created_at",
+})
+_RETIRED_ROOM_SCHEMA_COLUMNS = frozenset({"room_id", "retired_at"})
+
+_EVENT_KINDS_BY_ACTOR = {
+    "user": frozenset({"message.user"}),
+    "member": frozenset({"message.member"}),
+    "gateway": frozenset({
+        "member.unavailable",
+        "room.activity",
+        "turn.deferred",
+        "turn.reassigned",
+        "turn.cancelled",
+        "turn.failed",
+        "turn.settled",
+        "turn.started",
+    }),
+    "system": frozenset({
+        "authority.claimed",
+        "authority.lost",
+        "room.created",
+        "room.disbanded",
+        "room.members_changed",
+        "room.renamed",
+    }),
+}
+_ACTOR_FIELDS = frozenset({"kind", "id", "display_name", "profile", "connection_id"})
+
+
+class HostedRoomError(ValueError):
+    """Base class for invalid or conflicting hosted-room operations."""
+
+
+class RoomNotFoundError(HostedRoomError):
+    """Raised when a room does not exist or has been disbanded."""
+
+
+class RoomHistoryExpiredError(RoomNotFoundError):
+    """Raised when a retired room remains reserved after history compaction."""
+
+    reason = "room_history_expired"
+
+
+class RoomConflictError(HostedRoomError):
+    """Raised when an idempotency key is reused for different room state."""
+
+
+class EventConflictError(HostedRoomError):
+    """Raised when an event id is reused with different immutable content."""
+
+
+class AuthorityConflictError(HostedRoomError):
+    """Raised when a stale room authority attempts to mutate hosted state."""
+
+    reason = "authority_conflict"
+
+
+class AuthoritySupersededError(AuthorityConflictError):
+    """Raised when a successful authority claim was later superseded."""
+
+
+def default_db_path() -> Path:
+    """Return the gateway-wide state database for the active install."""
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    root = home.parent.parent if home.parent.name == "profiles" else home
+    return root / "state.db"
+
+
+def local_authority_gateway_id() -> str:
+    """Return the stable server-owned identity for hosted-room authority."""
+    from hermes_cli.install_identity import get_install_id
+
+    install_id = get_install_id()
+    if not install_id:
+        raise HostedRoomError("stable gateway install identity is unavailable")
+    return _validate_identifier(
+        f"install:{install_id}",
+        label="authority_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+
+
+def _canonical_json(value: Any, *, label: str, max_bytes: int) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise HostedRoomError(f"{label} must be JSON-serializable") from exc
+    if len(encoded.encode("utf-8")) > max_bytes:
+        raise HostedRoomError(f"{label} is too large")
+    return encoded
+
+
+def _validate_identifier(value: Any, *, label: str, max_chars: int) -> str:
+    if not isinstance(value, str):
+        raise HostedRoomError(f"{label} must be a string")
+    value = value.strip()
+    if not value or len(value) > max_chars or not _IDENTIFIER_RE.fullmatch(value):
+        raise HostedRoomError(f"invalid {label}")
+    return value
+
+
+def user_event_id(client_event_id: Any) -> str:
+    """Map a client retry key into the server-owned user-event namespace."""
+    normalized = _validate_identifier(
+        client_event_id,
+        label="event_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return f"user:{digest}"
+
+
+def _validate_room_name(value: Any) -> str:
+    if not isinstance(value, str):
+        raise HostedRoomError("name must be a string")
+    value = value.strip()
+    if not value or len(value) > MAX_ROOM_NAME_CHARS:
+        raise HostedRoomError("invalid room name")
+    return value
+
+
+def _validate_members(value: Any) -> tuple[list[dict[str, Any]], str]:
+    if not isinstance(value, list):
+        raise HostedRoomError("members must be a list")
+    if len(value) > MAX_MEMBERS:
+        raise HostedRoomError("too many room members")
+    members: list[dict[str, Any]] = []
+    for member in value:
+        if not isinstance(member, dict):
+            raise HostedRoomError("each room member must be an object")
+        members.append(dict(member))
+    encoded = _canonical_json(
+        members,
+        label="members",
+        max_bytes=MAX_MEMBERS_JSON_BYTES,
+    )
+    return members, encoded
+
+
+def _validate_event_kind(value: Any) -> str:
+    if not isinstance(value, str):
+        raise HostedRoomError("kind must be a string")
+    value = value.strip()
+    if (
+        not value
+        or len(value) > MAX_EVENT_KIND_CHARS
+        or not _EVENT_KIND_RE.fullmatch(value)
+    ):
+        raise HostedRoomError("invalid event kind")
+    return value
+
+
+def _optional_actor_field(actor: dict[str, Any], field: str, max_chars: int) -> str:
+    value = actor.get(field)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise HostedRoomError(f"actor.{field} must be a string")
+    value = value.strip()
+    if len(value) > max_chars:
+        raise HostedRoomError(f"actor.{field} is too long")
+    return value
+
+
+def _validate_actor(value: Any, *, kind: str) -> tuple[dict[str, str], str]:
+    if not isinstance(value, dict):
+        raise HostedRoomError("actor must be an object")
+    unknown = set(value) - _ACTOR_FIELDS
+    if unknown:
+        raise HostedRoomError(f"unknown actor fields: {', '.join(sorted(unknown))}")
+
+    actor_kind = value.get("kind")
+    if not isinstance(actor_kind, str) or actor_kind not in _EVENT_KINDS_BY_ACTOR:
+        raise HostedRoomError("invalid actor.kind")
+    if kind not in _EVENT_KINDS_BY_ACTOR[actor_kind]:
+        raise HostedRoomError(f"actor kind '{actor_kind}' cannot append '{kind}'")
+
+    actor_id = _validate_identifier(
+        value.get("id"),
+        label="actor.id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    actor = {"kind": actor_kind, "id": actor_id}
+    for field, max_chars in (
+        ("display_name", MAX_ACTOR_LABEL_CHARS),
+        ("profile", MAX_ACTOR_ID_CHARS),
+        ("connection_id", MAX_ACTOR_ID_CHARS),
+    ):
+        field_value = _optional_actor_field(value, field, max_chars)
+        if field_value:
+            actor[field] = field_value
+    encoded = _canonical_json(
+        actor,
+        label="actor",
+        max_bytes=4 * 1024,
+    )
+    return actor, encoded
+
+
+def _initialize_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_rooms (
+            room_id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            members_json TEXT NOT NULL,
+            authority_gateway_id TEXT NOT NULL,
+            authority_epoch INTEGER NOT NULL DEFAULT 1 CHECK (authority_epoch >= 1),
+            next_seq INTEGER NOT NULL DEFAULT 1 CHECK (next_seq >= 1),
+            event_bytes INTEGER NOT NULL DEFAULT 0 CHECK (event_bytes >= 0),
+            revision INTEGER NOT NULL DEFAULT 1 CHECK (revision >= 1),
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            disbanded_at REAL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_room_events (
+            room_id TEXT NOT NULL,
+            seq INTEGER NOT NULL CHECK (seq >= 1),
+            event_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            actor_json TEXT NOT NULL,
+            authority_epoch INTEGER CHECK (authority_epoch IS NULL OR authority_epoch >= 1),
+            payload_json TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (room_id, seq),
+            UNIQUE (room_id, event_id),
+            FOREIGN KEY (room_id) REFERENCES hosted_rooms(room_id)
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hosted_room_retired_ids (
+            room_id TEXT PRIMARY KEY,
+            retired_at REAL NOT NULL
+        )"""
+    )
+    room_columns = {row[1] for row in conn.execute("PRAGMA table_info(hosted_rooms)")}
+    if "authority_gateway_id" not in room_columns:
+        conn.execute(
+            "ALTER TABLE hosted_rooms "
+            "ADD COLUMN authority_gateway_id TEXT NOT NULL DEFAULT 'legacy'"
+        )
+    if "authority_epoch" not in room_columns:
+        conn.execute(
+            "ALTER TABLE hosted_rooms "
+            "ADD COLUMN authority_epoch INTEGER NOT NULL DEFAULT 1"
+        )
+    backfill_event_bytes = "event_bytes" not in room_columns
+    if backfill_event_bytes:
+        conn.execute(
+            "ALTER TABLE hosted_rooms ADD COLUMN event_bytes INTEGER NOT NULL DEFAULT 0"
+        )
+
+    event_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_events)")
+    }
+    if "actor_json" not in event_columns:
+        # Draft builds before the actor contract carried no identity. Preserve
+        # their inert replay rows explicitly as legacy system events rather
+        # than guessing a user or Bot author.
+        legacy_actor = _canonical_json(
+            {"kind": "system", "id": "legacy"},
+            label="actor",
+            max_bytes=4 * 1024,
+        )
+        escaped_actor = legacy_actor.replace("'", "''")
+        conn.execute(
+            "ALTER TABLE hosted_room_events "
+            f"ADD COLUMN actor_json TEXT NOT NULL DEFAULT '{escaped_actor}'"
+        )
+    if "authority_epoch" not in event_columns:
+        conn.execute(
+            "ALTER TABLE hosted_room_events ADD COLUMN authority_epoch INTEGER"
+        )
+    if backfill_event_bytes:
+        conn.execute(
+            """UPDATE hosted_rooms
+                  SET event_bytes=COALESCE((
+                      SELECT SUM(
+                          length(CAST(event_id AS BLOB)) +
+                          length(CAST(kind AS BLOB)) +
+                          length(CAST(actor_json AS BLOB)) +
+                          length(CAST(payload_json AS BLOB))
+                      )
+                      FROM hosted_room_events
+                      WHERE hosted_room_events.room_id=hosted_rooms.room_id
+                  ), 0)"""
+        )
+    # Old schemas kept the final identity tombstone in hosted_rooms itself.
+    # Copy those identities before bounded history pruning can remove their
+    # heavier room/event payloads. This compact registry is intentionally
+    # permanent: a stale coordinate must never name a different Group Chat.
+    conn.execute(
+        """INSERT OR IGNORE INTO hosted_room_retired_ids (room_id, retired_at)
+           SELECT room_id, disbanded_at FROM hosted_rooms
+            WHERE disbanded_at IS NOT NULL"""
+    )
+    conn.execute(
+        """CREATE INDEX IF NOT EXISTS idx_hosted_room_events_cursor
+           ON hosted_room_events(room_id, seq)"""
+    )
+    if not _schema_is_current(conn):
+        raise HostedRoomError("hosted room schema migration did not complete")
+
+
+def _schema_is_current(conn: sqlite3.Connection) -> bool:
+    room_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_rooms)")
+    )
+    event_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_events)")
+    )
+    retired_room_columns = frozenset(
+        row[1] for row in conn.execute("PRAGMA table_info(hosted_room_retired_ids)")
+    )
+    if not _ROOM_SCHEMA_COLUMNS.issubset(room_columns):
+        return False
+    if not _EVENT_SCHEMA_COLUMNS.issubset(event_columns):
+        return False
+    if not _RETIRED_ROOM_SCHEMA_COLUMNS.issubset(retired_room_columns):
+        return False
+    index = conn.execute(
+        """SELECT 1 FROM sqlite_master
+           WHERE type='index' AND name='idx_hosted_room_events_cursor'"""
+    ).fetchone()
+    return index is not None
+
+
+def _connect(db_path: Path | str) -> sqlite3.Connection:
+    from hermes_state import apply_wal_with_fallback
+
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    try:
+        for attempt in range(_JOURNAL_MODE_LOCK_RETRIES):
+            try:
+                apply_wal_with_fallback(conn, db_label="state.db (hosted_rooms)")
+                break
+            except sqlite3.OperationalError as exc:
+                if (
+                    str(exc).lower() != "database is locked"
+                    or attempt + 1 == _JOURNAL_MODE_LOCK_RETRIES
+                ):
+                    raise
+                # SQLite's journal-mode pragma may not honor the connection's
+                # busy timeout while another first opener initializes the DB,
+                # especially on Windows. Retry only that transient lock class.
+                time.sleep(0.01 * (2**attempt))
+        conn.execute("PRAGMA foreign_keys=ON")
+        if _schema_is_current(conn):
+            return conn
+        # Multiple profile gateways share this root database. Serialize every
+        # draft-schema transition in SQLite itself so a crash rolls back the
+        # whole DDL/data migration and another process can safely retry it.
+        conn.execute("BEGIN IMMEDIATE")
+        _initialize_schema(conn)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def _transaction(
+    db_path: Path | str, *, immediate: bool = False
+) -> Iterator[sqlite3.Connection]:
+    conn = _connect(db_path)
+    try:
+        if immediate:
+            conn.execute("BEGIN IMMEDIATE")
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _raise_room_not_found(conn: sqlite3.Connection, room_id: str) -> None:
+    retained = conn.execute(
+        "SELECT 1 FROM hosted_rooms WHERE room_id=?",
+        (room_id,),
+    ).fetchone()
+    if retained is not None:
+        # A retained disband tombstone still has replayable history. The
+        # caller simply did not opt into reading disbanded rooms.
+        raise RoomNotFoundError("hosted room not found")
+    retired = conn.execute(
+        "SELECT 1 FROM hosted_room_retired_ids WHERE room_id=?",
+        (room_id,),
+    ).fetchone()
+    if retired is not None:
+        raise RoomHistoryExpiredError(
+            "Group Chat history expired; room_id remains permanently retired"
+        )
+    raise RoomNotFoundError("hosted room not found")
+
+
+def _room_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    room = {
+        "room_id": row["room_id"],
+        "name": row["name"],
+        "members": json.loads(row["members_json"]),
+        "authority_gateway_id": row["authority_gateway_id"],
+        "authority_epoch": int(row["authority_epoch"]),
+        "revision": int(row["revision"]),
+        "created_at": float(row["created_at"]),
+        "updated_at": float(row["updated_at"]),
+        "idempotent": idempotent,
+    }
+    if "disbanded_at" in row.keys() and row["disbanded_at"] is not None:
+        room["disbanded_at"] = float(row["disbanded_at"])
+    if "next_seq" in row.keys():
+        room["latest_seq"] = int(row["next_seq"]) - 1
+    return room
+
+
+def _event_storage_bytes(
+    *, event_id: str, kind: str, actor_json: str, payload_json: str
+) -> int:
+    return len((event_id + kind + actor_json + payload_json).encode("utf-8"))
+
+
+def _assert_event_capacity(
+    conn: sqlite3.Connection,
+    *,
+    room: sqlite3.Row,
+    additional_bytes: int,
+    allow_control: bool = False,
+) -> None:
+    event_limit = MAX_EVENTS_PER_ROOM + (
+        CONTROL_EVENT_COUNT_RESERVE if allow_control else 0
+    )
+    room_byte_limit = MAX_ROOM_EVENT_BYTES + (
+        CONTROL_EVENT_BYTE_RESERVE if allow_control else 0
+    )
+    gateway_byte_limit = MAX_GATEWAY_EVENT_BYTES + (
+        CONTROL_EVENT_BYTE_RESERVE if allow_control else 0
+    )
+    if int(room["next_seq"]) - 1 >= event_limit:
+        raise HostedRoomError(
+            "This Group Chat reached its history limit. Start a new Group Chat to continue."
+        )
+    room_bytes = int(room["event_bytes"])
+    if room_bytes + additional_bytes > room_byte_limit:
+        raise HostedRoomError(
+            "This Group Chat reached its storage limit. Start a new Group Chat to continue."
+        )
+    gateway_bytes = int(
+        conn.execute(
+            "SELECT COALESCE(SUM(event_bytes), 0) FROM hosted_rooms"
+        ).fetchone()[0]
+    )
+    if gateway_bytes + additional_bytes > gateway_byte_limit:
+        _prune_disbanded_rooms_locked(
+            conn,
+            now=None,
+            max_gateway_event_bytes=max(0, gateway_byte_limit - additional_bytes),
+        )
+        gateway_bytes = int(
+            conn.execute(
+                "SELECT COALESCE(SUM(event_bytes), 0) FROM hosted_rooms"
+            ).fetchone()[0]
+        )
+    if gateway_bytes + additional_bytes > gateway_byte_limit:
+        raise HostedRoomError(
+            "Group Chat storage is full on this host. Delete an old Group Chat and try again."
+        )
+
+
+def _prune_disbanded_rooms_locked(
+    conn: sqlite3.Connection,
+    *,
+    now: float | None,
+    max_gateway_event_bytes: int | None = None,
+) -> int:
+    candidates: set[str] = set()
+    if now is not None:
+        cutoff = now - DISBANDED_ROOM_RETENTION_SECONDS
+        candidates.update(
+            str(row["room_id"])
+            for row in conn.execute(
+                """SELECT room_id FROM hosted_rooms
+                     WHERE disbanded_at IS NOT NULL AND disbanded_at<=?""",
+                (cutoff,),
+            ).fetchall()
+        )
+    candidates.update(
+        str(row["room_id"])
+        for row in conn.execute(
+            """SELECT room_id FROM hosted_rooms
+                 WHERE disbanded_at IS NOT NULL
+                 ORDER BY disbanded_at DESC, room_id ASC
+                 LIMIT -1 OFFSET ?""",
+            (MAX_DISBANDED_ROOM_TOMBSTONES,),
+        ).fetchall()
+    )
+    if max_gateway_event_bytes is not None:
+        retained_bytes = int(
+            conn.execute(
+                "SELECT COALESCE(SUM(event_bytes), 0) FROM hosted_rooms"
+            ).fetchone()[0]
+        )
+        if retained_bytes > max_gateway_event_bytes:
+            for row in conn.execute(
+                """SELECT room_id, event_bytes FROM hosted_rooms
+                     WHERE disbanded_at IS NOT NULL
+                     ORDER BY disbanded_at ASC, room_id ASC"""
+            ).fetchall():
+                room_id = str(row["room_id"])
+                if room_id not in candidates:
+                    candidates.add(room_id)
+                retained_bytes -= int(row["event_bytes"])
+                if retained_bytes <= max_gateway_event_bytes:
+                    break
+    if not candidates:
+        return 0
+
+    placeholders = ",".join("?" for _ in candidates)
+    room_ids = tuple(sorted(candidates))
+    conn.execute(
+        f"""INSERT OR IGNORE INTO hosted_room_retired_ids (room_id, retired_at)
+            SELECT room_id, disbanded_at FROM hosted_rooms
+             WHERE room_id IN ({placeholders}) AND disbanded_at IS NOT NULL""",
+        room_ids,
+    )
+    conn.execute(
+        f"DELETE FROM hosted_room_events WHERE room_id IN ({placeholders})",
+        room_ids,
+    )
+    conn.execute(
+        f"DELETE FROM hosted_rooms WHERE room_id IN ({placeholders})",
+        room_ids,
+    )
+    return len(room_ids)
+
+
+def prune_disbanded_rooms(
+    db_path: Path | str,
+    *,
+    now: float | None = None,
+) -> int:
+    """Purge deleted Group Chat payloads while reserving their identities."""
+
+    timestamp = time.time() if now is None else float(now)
+    with _transaction(db_path, immediate=True) as conn:
+        return _prune_disbanded_rooms_locked(conn, now=timestamp)
+
+
+def _event_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
+    return {
+        "room_id": row["room_id"],
+        "seq": int(row["seq"]),
+        "event_id": row["event_id"],
+        "kind": row["kind"],
+        "actor": json.loads(row["actor_json"]),
+        "authority_epoch": (
+            int(row["authority_epoch"]) if row["authority_epoch"] is not None else None
+        ),
+        "payload": json.loads(row["payload_json"]),
+        "created_at": float(row["created_at"]),
+        "idempotent": idempotent,
+    }
+
+
+def create_room(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    name: Any,
+    members: Any,
+    authority_gateway_id: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Create a room, or return the identical existing room idempotently."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    name = _validate_room_name(name)
+    normalized_members, members_json = _validate_members(members)
+    authority_gateway_id = _validate_identifier(
+        authority_gateway_id,
+        label="authority_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    now = time.time() if now is None else float(now)
+
+    with _transaction(db_path, immediate=True) as conn:
+        if conn.execute(
+            "SELECT 1 FROM hosted_room_retired_ids WHERE room_id=?",
+            (room_id,),
+        ).fetchone():
+            raise RoomConflictError("room_id belongs to a disbanded room")
+        existing = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, event_bytes, revision,
+                      created_at, updated_at, disbanded_at
+               FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if existing is not None:
+            if existing["disbanded_at"] is not None:
+                raise RoomConflictError("room_id belongs to a disbanded room")
+            if existing["name"] != name or existing["members_json"] != members_json:
+                raise RoomConflictError("room_id already exists with different state")
+            if (
+                existing["authority_gateway_id"] == "legacy"
+                and authority_gateway_id != "legacy"
+            ):
+                target_epoch = int(existing["authority_epoch"]) + 1
+                seq = int(existing["next_seq"])
+                claim_actor_json = _canonical_json(
+                    {"kind": "system", "id": "authority-control"},
+                    label="actor",
+                    max_bytes=4 * 1024,
+                )
+                claim_payload_json = _canonical_json(
+                    {
+                        "previous_gateway_id": "legacy",
+                        "authority_gateway_id": authority_gateway_id,
+                        "authority_epoch": target_epoch,
+                    },
+                    label="payload",
+                    max_bytes=MAX_EVENT_JSON_BYTES,
+                )
+                claim_bytes = _event_storage_bytes(
+                    event_id="system:authority-adopted",
+                    kind="authority.claimed",
+                    actor_json=claim_actor_json,
+                    payload_json=claim_payload_json,
+                )
+                _assert_event_capacity(
+                    conn,
+                    room=existing,
+                    additional_bytes=claim_bytes,
+                    allow_control=True,
+                )
+                conn.execute(
+                    """INSERT INTO hosted_room_events
+                       (room_id, seq, event_id, kind, actor_json,
+                        authority_epoch, payload_json, created_at)
+                       VALUES (?, ?, 'system:authority-adopted',
+                               'authority.claimed', ?, ?, ?, ?)""",
+                    (
+                        room_id,
+                        seq,
+                        claim_actor_json,
+                        target_epoch,
+                        claim_payload_json,
+                        now,
+                    ),
+                )
+                adopted = conn.execute(
+                    """UPDATE hosted_rooms
+                          SET authority_gateway_id=?, authority_epoch=?,
+                              next_seq=next_seq+1, revision=revision+1,
+                              event_bytes=event_bytes+?, updated_at=?
+                        WHERE room_id=? AND authority_gateway_id='legacy'
+                          AND authority_epoch=? AND next_seq=?
+                          AND disbanded_at IS NULL""",
+                    (
+                        authority_gateway_id,
+                        target_epoch,
+                        claim_bytes,
+                        now,
+                        room_id,
+                        int(existing["authority_epoch"]),
+                        seq,
+                    ),
+                )
+                if adopted.rowcount != 1:
+                    raise AuthorityConflictError("legacy room adoption lost its fence")
+                existing = conn.execute(
+                    """SELECT room_id, name, members_json, authority_gateway_id,
+                              authority_epoch, next_seq, revision, created_at,
+                              updated_at, disbanded_at
+                         FROM hosted_rooms WHERE room_id=?""",
+                    (room_id,),
+                ).fetchone()
+                if existing is None:  # pragma: no cover - row updated above
+                    raise RuntimeError("adopted room could not be reloaded")
+                result = _room_from_row(existing, idempotent=True)
+                result["adopted"] = True
+                claim_event = conn.execute(
+                    """SELECT room_id, seq, event_id, kind, actor_json,
+                              authority_epoch, payload_json, created_at
+                         FROM hosted_room_events
+                        WHERE room_id=? AND event_id='system:authority-adopted'""",
+                    (room_id,),
+                ).fetchone()
+                if claim_event is None:  # pragma: no cover - inserted above
+                    raise RuntimeError("legacy adoption event could not be reloaded")
+                result["claim_event"] = _event_from_row(claim_event)
+                return result
+            if existing["authority_gateway_id"] != authority_gateway_id:
+                raise RoomConflictError(
+                    "room_id already belongs to a different authority"
+                )
+            return _room_from_row(existing, idempotent=True)
+
+        active_rooms = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM hosted_rooms WHERE disbanded_at IS NULL"
+            ).fetchone()[0]
+        )
+        if active_rooms >= MAX_ACTIVE_ROOMS:
+            raise HostedRoomError(
+                "This host has too many active Group Chats. Delete one and try again."
+            )
+
+        conn.execute(
+            """INSERT INTO hosted_rooms
+               (room_id, name, members_json, authority_gateway_id,
+                authority_epoch, next_seq, event_bytes, revision,
+                created_at, updated_at, disbanded_at)
+               VALUES (?, ?, ?, ?, 1, 1, 0, 1, ?, ?, NULL)""",
+            (room_id, name, members_json, authority_gateway_id, now, now),
+        )
+        row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, revision, created_at, updated_at
+               FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if row is None:  # pragma: no cover - guarded by the insert above
+            raise RuntimeError("created room could not be reloaded")
+    result = _room_from_row(row)
+    result["members"] = normalized_members
+    return result
+
+
+def list_rooms(
+    db_path: Path | str,
+    *,
+    include_disbanded: bool = False,
+    limit: int = MAX_ROOM_LIST_LIMIT,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """Return one bounded page of rooms ordered by most recent change."""
+    if (
+        isinstance(limit, bool)
+        or not isinstance(limit, int)
+        or not 1 <= limit <= MAX_ROOM_LIST_LIMIT
+    ):
+        raise HostedRoomError(f"limit must be between 1 and {MAX_ROOM_LIST_LIMIT}")
+    if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+        raise HostedRoomError("offset must be a non-negative integer")
+    with _transaction(db_path, immediate=True) as conn:
+        _prune_disbanded_rooms_locked(conn, now=None)
+        rows = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at,
+                      disbanded_at
+               FROM hosted_rooms
+               WHERE disbanded_at IS NULL OR ?
+               ORDER BY updated_at DESC, room_id ASC
+               LIMIT ? OFFSET ?""",
+            (int(include_disbanded), limit, offset),
+        ).fetchall()
+    return [_room_from_row(row) for row in rows]
+
+
+def append_event(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    event_id: Any,
+    kind: Any,
+    actor: Any,
+    payload: Any,
+    authority_gateway_id: Any = None,
+    authority_epoch: Any = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Append one immutable event and allocate its per-room sequence atomically.
+
+    Repeating the same ``event_id`` and immutable content returns the original
+    event. Reusing the id for different content fails closed.
+    """
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    event_id = _validate_identifier(
+        event_id,
+        label="event_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    kind = _validate_event_kind(kind)
+    normalized_actor, actor_json = _validate_actor(actor, kind=kind)
+    authority_scoped = normalized_actor["kind"] in {
+        "user",
+        "member",
+        "gateway",
+        "system",
+    }
+    normalized_authority_gateway_id: str | None = None
+    normalized_authority_epoch: int | None = None
+    if authority_scoped:
+        normalized_authority_gateway_id = _validate_identifier(
+            authority_gateway_id,
+            label="authority_gateway_id",
+            max_chars=MAX_ACTOR_ID_CHARS,
+        )
+        if (
+            normalized_actor["kind"] == "gateway"
+            and normalized_actor["id"] != normalized_authority_gateway_id
+        ):
+            raise HostedRoomError("gateway actor.id must match authority_gateway_id")
+        if (
+            isinstance(authority_epoch, bool)
+            or not isinstance(authority_epoch, int)
+            or authority_epoch < 1
+        ):
+            raise HostedRoomError("authority_epoch must be a positive integer")
+        normalized_authority_epoch = authority_epoch
+    elif authority_gateway_id is not None or authority_epoch is not None:
+        raise HostedRoomError(
+            "authority fields are only valid for room-scoped events"
+        )
+    if not isinstance(payload, dict):
+        raise HostedRoomError("payload must be an object")
+    payload_json = _canonical_json(
+        payload,
+        label="payload",
+        max_bytes=MAX_EVENT_JSON_BYTES,
+    )
+    now = time.time() if now is None else float(now)
+
+    with _transaction(db_path, immediate=True) as conn:
+        existing = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+               FROM hosted_room_events WHERE room_id=? AND event_id=?""",
+            (room_id, event_id),
+        ).fetchone()
+        if existing is not None:
+            if (
+                existing["kind"] != kind
+                or existing["actor_json"] != actor_json
+                or existing["authority_epoch"] != normalized_authority_epoch
+                or existing["payload_json"] != payload_json
+            ):
+                raise EventConflictError(
+                    "event_id already exists with different content"
+                )
+            return _event_from_row(existing, idempotent=True)
+
+        room = conn.execute(
+            """SELECT next_seq, event_bytes, authority_gateway_id, authority_epoch
+                  FROM hosted_rooms
+               WHERE room_id=? AND disbanded_at IS NULL""",
+            (room_id,),
+        ).fetchone()
+        if room is None:
+            _raise_room_not_found(conn, room_id)
+        if authority_scoped and (
+            room["authority_gateway_id"] != normalized_authority_gateway_id
+            or int(room["authority_epoch"]) != normalized_authority_epoch
+        ):
+            raise AuthorityConflictError("stale hosted room authority")
+        seq = int(room["next_seq"])
+        event_bytes = _event_storage_bytes(
+            event_id=event_id,
+            kind=kind,
+            actor_json=actor_json,
+            payload_json=payload_json,
+        )
+        _assert_event_capacity(
+            conn,
+            room=room,
+            additional_bytes=event_bytes,
+            allow_control=kind
+            in {
+                "authority.claimed",
+                "authority.lost",
+                "room.disbanded",
+            },
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                payload_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                room_id,
+                seq,
+                event_id,
+                kind,
+                actor_json,
+                normalized_authority_epoch,
+                payload_json,
+                now,
+            ),
+        )
+        advanced = conn.execute(
+            """UPDATE hosted_rooms
+               SET next_seq=?, event_bytes=event_bytes+?, updated_at=?
+               WHERE room_id=? AND next_seq=?""",
+            (seq + 1, event_bytes, now, room_id, seq),
+        )
+        if advanced.rowcount != 1:
+            raise RuntimeError("hosted room sequence advance lost its write fence")
+        row = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+               FROM hosted_room_events WHERE room_id=? AND seq=?""",
+            (room_id, seq),
+        ).fetchone()
+        if row is None:  # pragma: no cover - guarded by the insert above
+            raise RuntimeError("appended event could not be reloaded")
+    result = _event_from_row(row)
+    result["actor"] = normalized_actor
+    return result
+
+
+def room_state(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    include_disbanded: bool = False,
+) -> dict[str, Any]:
+    """Return durable replay and authority state for one room."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    with _transaction(db_path) as conn:
+        row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at,
+                      disbanded_at
+                 FROM hosted_rooms
+                WHERE room_id=? AND (disbanded_at IS NULL OR ?)""",
+            (room_id, int(include_disbanded)),
+        ).fetchone()
+        if row is None:
+            _raise_room_not_found(conn, room_id)
+        claim_row = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+                 FROM hosted_room_events
+                WHERE room_id=? AND kind='authority.claimed'
+                  AND authority_epoch=?
+                ORDER BY seq DESC LIMIT 1""",
+            (room_id, int(row["authority_epoch"])),
+        ).fetchone()
+    state = _room_from_row(row)
+    state["latest_seq"] = int(row["next_seq"]) - 1
+    if claim_row is not None:
+        state["authority_claim"] = _event_from_row(claim_row)
+    return state
+
+
+def claim_authority(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    expected_gateway_id: Any,
+    expected_epoch: Any,
+    new_gateway_id: Any,
+    event_id: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Fence a verified authority transfer with a compare-and-swap epoch.
+
+    This storage primitive does not decide *when* takeover is safe. A future
+    replicated driver must call it only after its lease/quorum policy has
+    established that the previous owner can no longer commit.
+    """
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    expected_gateway_id = _validate_identifier(
+        expected_gateway_id,
+        label="expected_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    new_gateway_id = _validate_identifier(
+        new_gateway_id,
+        label="new_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    event_id = _validate_identifier(
+        event_id,
+        label="event_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    if (
+        isinstance(expected_epoch, bool)
+        or not isinstance(expected_epoch, int)
+        or expected_epoch < 1
+    ):
+        raise HostedRoomError("expected_epoch must be a positive integer")
+    now = time.time() if now is None else float(now)
+    target_epoch = expected_epoch + 1
+    claim_actor = {"kind": "system", "id": "authority-control"}
+    claim_actor_json = _canonical_json(
+        claim_actor,
+        label="actor",
+        max_bytes=4 * 1024,
+    )
+    claim_payload = {
+        "previous_gateway_id": expected_gateway_id,
+        "authority_gateway_id": new_gateway_id,
+        "authority_epoch": target_epoch,
+    }
+    claim_payload_json = _canonical_json(
+        claim_payload,
+        label="payload",
+        max_bytes=MAX_EVENT_JSON_BYTES,
+    )
+
+    with _transaction(db_path, immediate=True) as conn:
+        row = conn.execute(
+            """SELECT authority_gateway_id, authority_epoch, next_seq, event_bytes
+                 FROM hosted_rooms
+                WHERE room_id=? AND disbanded_at IS NULL""",
+            (room_id,),
+        ).fetchone()
+        if row is None:
+            _raise_room_not_found(conn, room_id)
+        current_gateway = str(row["authority_gateway_id"])
+        current_epoch = int(row["authority_epoch"])
+        existing_event = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json, authority_epoch,
+                      payload_json, created_at
+                 FROM hosted_room_events WHERE room_id=? AND event_id=?""",
+            (room_id, event_id),
+        ).fetchone()
+        if existing_event is not None:
+            if (
+                existing_event["kind"] != "authority.claimed"
+                or existing_event["actor_json"] != claim_actor_json
+                or existing_event["authority_epoch"] != target_epoch
+                or existing_event["payload_json"] != claim_payload_json
+            ):
+                raise EventConflictError(
+                    "event_id already exists with different content"
+                )
+            if current_gateway != new_gateway_id or current_epoch != target_epoch:
+                raise AuthoritySupersededError(
+                    "authority claim succeeded but was later superseded"
+                )
+            idempotent = True
+        elif current_gateway != expected_gateway_id or current_epoch != expected_epoch:
+            raise AuthorityConflictError("hosted room authority changed")
+        else:
+            seq = int(row["next_seq"])
+            claim_bytes = _event_storage_bytes(
+                event_id=event_id,
+                kind="authority.claimed",
+                actor_json=claim_actor_json,
+                payload_json=claim_payload_json,
+            )
+            _assert_event_capacity(
+                conn,
+                room=row,
+                additional_bytes=claim_bytes,
+                allow_control=True,
+            )
+            conn.execute(
+                """INSERT INTO hosted_room_events
+                   (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                    payload_json, created_at)
+                   VALUES (?, ?, ?, 'authority.claimed', ?, ?, ?, ?)""",
+                (
+                    room_id,
+                    seq,
+                    event_id,
+                    claim_actor_json,
+                    target_epoch,
+                    claim_payload_json,
+                    now,
+                ),
+            )
+            updated = conn.execute(
+                """UPDATE hosted_rooms
+                      SET authority_gateway_id=?, authority_epoch=authority_epoch+1,
+                          next_seq=next_seq+1, event_bytes=event_bytes+?,
+                          revision=revision+1, updated_at=?
+                    WHERE room_id=? AND disbanded_at IS NULL
+                      AND authority_gateway_id=? AND authority_epoch=?""",
+                (
+                    new_gateway_id,
+                    claim_bytes,
+                    now,
+                    room_id,
+                    expected_gateway_id,
+                    expected_epoch,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise AuthorityConflictError("hosted room authority changed")
+            idempotent = False
+            existing_event = conn.execute(
+                """SELECT room_id, seq, event_id, kind, actor_json,
+                          authority_epoch, payload_json, created_at
+                     FROM hosted_room_events WHERE room_id=? AND event_id=?""",
+                (room_id, event_id),
+            ).fetchone()
+        state_row = conn.execute(
+            """SELECT room_id, name, members_json, authority_gateway_id,
+                      authority_epoch, next_seq, revision, created_at, updated_at
+                 FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if state_row is None:  # pragma: no cover - room exists in this transaction
+            raise RuntimeError("claimed room could not be reloaded")
+    state = _room_from_row(state_row, idempotent=idempotent)
+    state["latest_seq"] = int(state_row["next_seq"]) - 1
+    if existing_event is None:  # pragma: no cover - both claim paths set it
+        raise RuntimeError("authority claim event could not be reloaded")
+    state["claim_event"] = _event_from_row(
+        existing_event,
+        idempotent=idempotent,
+    )
+    return state
+
+
+def disband_room(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    expected_gateway_id: Any,
+    expected_epoch: Any,
+    now: float | None = None,
+) -> dict[str, Any]:
+    """Tombstone a room id permanently and idempotently."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    expected_gateway_id = _validate_identifier(
+        expected_gateway_id,
+        label="expected_gateway_id",
+        max_chars=MAX_ACTOR_ID_CHARS,
+    )
+    if (
+        isinstance(expected_epoch, bool)
+        or not isinstance(expected_epoch, int)
+        or expected_epoch < 1
+    ):
+        raise HostedRoomError("expected_epoch must be a positive integer")
+    now = time.time() if now is None else float(now)
+
+    with _transaction(db_path, immediate=True) as conn:
+        room = conn.execute(
+            """SELECT authority_gateway_id, authority_epoch, next_seq,
+                      event_bytes, disbanded_at
+                 FROM hosted_rooms WHERE room_id=?""",
+            (room_id,),
+        ).fetchone()
+        if room is None:
+            retired = conn.execute(
+                "SELECT retired_at FROM hosted_room_retired_ids WHERE room_id=?",
+                (room_id,),
+            ).fetchone()
+            if retired is None:
+                raise RoomNotFoundError("hosted room not found")
+            return {
+                "room_id": room_id,
+                "disbanded_at": float(retired["retired_at"]),
+                "idempotent": True,
+                "history_expired": True,
+            }
+        if room["disbanded_at"] is not None:
+            conn.execute(
+                """INSERT OR IGNORE INTO hosted_room_retired_ids
+                   (room_id, retired_at) VALUES (?, ?)""",
+                (room_id, float(room["disbanded_at"])),
+            )
+            event = conn.execute(
+                """SELECT room_id, seq, event_id, kind, actor_json,
+                          authority_epoch, payload_json, created_at
+                     FROM hosted_room_events
+                    WHERE room_id=? AND event_id='system:room-disbanded'""",
+                (room_id,),
+            ).fetchone()
+            return {
+                "room_id": room_id,
+                "disbanded_at": float(room["disbanded_at"]),
+                "idempotent": True,
+                **(
+                    {"event": _event_from_row(event, idempotent=True)}
+                    if event is not None
+                    else {}
+                ),
+            }
+        if (
+            str(room["authority_gateway_id"]) != expected_gateway_id
+            or int(room["authority_epoch"]) != expected_epoch
+        ):
+            raise AuthorityConflictError("stale hosted room authority")
+        seq = int(room["next_seq"])
+        actor_json = _canonical_json(
+            {"kind": "system", "id": "room-control"},
+            label="actor",
+            max_bytes=4 * 1024,
+        )
+        payload_json = _canonical_json(
+            {"room_id": room_id},
+            label="payload",
+            max_bytes=MAX_EVENT_JSON_BYTES,
+        )
+        disband_bytes = _event_storage_bytes(
+            event_id="system:room-disbanded",
+            kind="room.disbanded",
+            actor_json=actor_json,
+            payload_json=payload_json,
+        )
+        _assert_event_capacity(
+            conn,
+            room=room,
+            additional_bytes=disband_bytes,
+            allow_control=True,
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, authority_epoch,
+                payload_json, created_at)
+               VALUES (?, ?, 'system:room-disbanded', 'room.disbanded', ?, ?, ?, ?)""",
+            (
+                room_id,
+                seq,
+                actor_json,
+                int(room["authority_epoch"]),
+                payload_json,
+                now,
+            ),
+        )
+        updated = conn.execute(
+            """UPDATE hosted_rooms
+               SET disbanded_at=?, updated_at=?, revision=revision+1,
+                   next_seq=next_seq+1, event_bytes=event_bytes+?
+               WHERE room_id=? AND disbanded_at IS NULL
+                 AND authority_gateway_id=? AND authority_epoch=?""",
+            (
+                now,
+                now,
+                disband_bytes,
+                room_id,
+                expected_gateway_id,
+                expected_epoch,
+            ),
+        )
+        if updated.rowcount != 1:
+            raise RoomConflictError("hosted room disband lost its fence")
+        conn.execute(
+            """INSERT OR IGNORE INTO hosted_room_retired_ids
+               (room_id, retired_at) VALUES (?, ?)""",
+            (room_id, now),
+        )
+        event = conn.execute(
+            """SELECT room_id, seq, event_id, kind, actor_json,
+                      authority_epoch, payload_json, created_at
+                 FROM hosted_room_events
+                WHERE room_id=? AND event_id='system:room-disbanded'""",
+            (room_id,),
+        ).fetchone()
+        if event is None:  # pragma: no cover - inserted in this transaction
+            raise RuntimeError("room disband event could not be reloaded")
+        _prune_disbanded_rooms_locked(
+            conn,
+            now=now,
+            max_gateway_event_bytes=MAX_GATEWAY_EVENT_BYTES,
+        )
+    return {
+        "room_id": room_id,
+        "disbanded_at": now,
+        "idempotent": False,
+        "event": _event_from_row(event),
+    }
+
+
+def read_events(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    since_seq: Any = 0,
+    limit: Any = 100,
+    include_disbanded: bool = False,
+) -> dict[str, Any]:
+    """Read a monotonic room-log delta after ``since_seq``."""
+    room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    if isinstance(since_seq, bool) or not isinstance(since_seq, int) or since_seq < 0:
+        raise HostedRoomError("since_seq must be a non-negative integer")
+    if (
+        isinstance(limit, bool)
+        or not isinstance(limit, int)
+        or not 1 <= limit <= MAX_LOG_LIMIT
+    ):
+        raise HostedRoomError(f"limit must be between 1 and {MAX_LOG_LIMIT}")
+
+    with _transaction(db_path) as conn:
+        room = conn.execute(
+            """SELECT next_seq FROM hosted_rooms
+               WHERE room_id=? AND (disbanded_at IS NULL OR ?)""",
+            (room_id, int(include_disbanded)),
+        ).fetchone()
+        if room is None:
+            _raise_room_not_found(conn, room_id)
+        latest_seq = int(room["next_seq"]) - 1
+        if since_seq > latest_seq:
+            raise HostedRoomError("since_seq is ahead of the hosted room log")
+        rows = conn.execute(
+            """WITH candidates AS (
+                   SELECT room_id, seq, event_id, kind, actor_json,
+                          authority_epoch, payload_json, created_at,
+                          SUM(
+                              LENGTH(CAST(event_id AS BLOB)) +
+                              LENGTH(CAST(kind AS BLOB)) +
+                              LENGTH(CAST(actor_json AS BLOB)) +
+                              LENGTH(CAST(payload_json AS BLOB))
+                          ) OVER (ORDER BY seq ASC) AS cumulative_bytes
+                     FROM hosted_room_events
+                    WHERE room_id=? AND seq>?
+                    ORDER BY seq ASC LIMIT ?
+               )
+               SELECT room_id, seq, event_id, kind, actor_json,
+                      authority_epoch, payload_json, created_at
+                 FROM candidates
+                WHERE cumulative_bytes<=?
+                ORDER BY seq ASC""",
+            (room_id, since_seq, limit, MAX_LOG_PAGE_BYTES),
+        ).fetchall()
+    events = [_event_from_row(row) for row in rows]
+
+    def build_page(page_events: list[dict[str, Any]]) -> dict[str, Any]:
+        cursor = page_events[-1]["seq"] if page_events else since_seq
+        return {
+            "events": page_events,
+            "cursor": cursor,
+            "latest_seq": latest_seq,
+            "has_more": cursor < latest_seq,
+        }
+
+    def page_bytes(page: dict[str, Any]) -> int:
+        return len(
+            json.dumps(
+                page,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
+
+    page = build_page(events)
+    if events and page_bytes(page) > MAX_LOG_PAGE_BYTES:
+        low, high = 1, len(events)
+        while low < high:
+            middle = (low + high + 1) // 2
+            candidate = build_page(events[:middle])
+            if page_bytes(candidate) <= MAX_LOG_PAGE_BYTES:
+                low = middle
+            else:
+                high = middle - 1
+        page = build_page(events[:low])
+        if page_bytes(page) > MAX_LOG_PAGE_BYTES:
+            raise HostedRoomError("hosted room event exceeds replay page limit")
+    return page

--- a/gateway/hosted_rooms.py
+++ b/gateway/hosted_rooms.py
@@ -81,6 +81,7 @@ _EVENT_KINDS_BY_ACTOR = {
     "gateway": frozenset({
         "member.unavailable",
         "room.activity",
+        "room.stop_requested",
         "turn.deferred",
         "turn.reassigned",
         "turn.cancelled",
@@ -116,6 +117,10 @@ class RoomHistoryExpiredError(RoomNotFoundError):
 
 class RoomConflictError(HostedRoomError):
     """Raised when an idempotency key is reused for different room state."""
+
+
+class RoomProbeUnavailableError(HostedRoomError):
+    """Raised when a non-blocking ownership probe cannot read the room store."""
 
 
 class EventConflictError(HostedRoomError):
@@ -444,6 +449,27 @@ def _connect(db_path: Path | str) -> sqlite3.Connection:
     return conn
 
 
+def _read_connection(db_path: Path | str) -> sqlite3.Connection:
+    """Open the room store without steady-state journal or migration writes."""
+
+    path = Path(db_path)
+    if not path.is_file():
+        initialized = _connect(path)
+        initialized.close()
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    if _schema_is_current(conn):
+        return conn
+    conn.close()
+    migrated = _connect(path)
+    migrated.close()
+    conn = sqlite3.connect(path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
 @contextmanager
 def _transaction(
     db_path: Path | str, *, immediate: bool = False
@@ -479,6 +505,16 @@ def _raise_room_not_found(conn: sqlite3.Connection, room_id: str) -> NoReturn:
             "Group Chat history expired; room_id remains permanently retired"
         )
     raise RoomNotFoundError("hosted room not found")
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
 
 
 def _room_from_row(row: sqlite3.Row, *, idempotent: bool = False) -> dict[str, Any]:
@@ -609,10 +645,24 @@ def _prune_disbanded_rooms_locked(
              WHERE room_id IN ({placeholders}) AND disbanded_at IS NOT NULL""",
         room_ids,
     )
-    conn.execute(
-        f"DELETE FROM hosted_room_events WHERE room_id IN ({placeholders})",
-        room_ids,
+    dependent_tables = (
+        "hosted_room_policy_transcript_state",
+        "hosted_room_policy_transcript",
+        "hosted_room_policy_publications",
+        "hosted_room_policy_watermarks",
+        "hosted_room_policy_events",
+        "hosted_room_policy_threads",
+        "hosted_room_policy_cursors",
+        "hosted_room_driver_tasks",
+        "hosted_room_driver_leases",
+        "hosted_room_events",
     )
+    for table in dependent_tables:
+        if _table_exists(conn, table):
+            conn.execute(
+                f"DELETE FROM {table} WHERE room_id IN ({placeholders})",
+                room_ids,
+            )
     conn.execute(
         f"DELETE FROM hosted_rooms WHERE room_id IN ({placeholders})",
         room_ids,
@@ -823,7 +873,7 @@ def list_rooms(
     limit: int = MAX_ROOM_LIST_LIMIT,
     offset: int = 0,
 ) -> list[dict[str, Any]]:
-    """Return one bounded page of rooms ordered by most recent change."""
+    """Return one bounded read-only page ordered by most recent change."""
     if (
         isinstance(limit, bool)
         or not isinstance(limit, int)
@@ -832,8 +882,8 @@ def list_rooms(
         raise HostedRoomError(f"limit must be between 1 and {MAX_ROOM_LIST_LIMIT}")
     if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
         raise HostedRoomError("offset must be a non-negative integer")
-    with _transaction(db_path, immediate=True) as conn:
-        _prune_disbanded_rooms_locked(conn, now=None)
+    conn = _read_connection(db_path)
+    try:
         rows = conn.execute(
             """SELECT room_id, name, members_json, authority_gateway_id,
                       authority_epoch, next_seq, revision, created_at, updated_at,
@@ -844,6 +894,8 @@ def list_rooms(
                LIMIT ? OFFSET ?""",
             (int(include_disbanded), limit, offset),
         ).fetchall()
+    finally:
+        conn.close()
     return [_room_from_row(row) for row in rows]
 
 
@@ -1002,6 +1054,47 @@ def append_event(
     return result
 
 
+def probe_hosted_room(db_path: Path | str, *, room_id: Any) -> bool:
+    """Check room ownership without creating or migrating the shared store.
+
+    This runs on the synchronous prompt-admission path for older Desktop
+    clients, so it fails quickly under contention instead of blocking the
+    WebSocket reader for SQLite's normal ten-second timeout.
+    """
+
+    checked_room_id = _validate_identifier(
+        room_id,
+        label="room_id",
+        max_chars=MAX_ROOM_ID_CHARS,
+    )
+    path = Path(db_path)
+    if not path.is_file():
+        return False
+    try:
+        conn = sqlite3.connect(path, timeout=0.05)
+        try:
+            table = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' "
+                "AND name='hosted_rooms' LIMIT 1"
+            ).fetchone()
+            if table is None:
+                return False
+            return (
+                conn.execute(
+                    "SELECT 1 FROM hosted_rooms WHERE room_id=? "
+                    "AND disbanded_at IS NULL LIMIT 1",
+                    (checked_room_id,),
+                ).fetchone()
+                is not None
+            )
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        raise RoomProbeUnavailableError(
+            "hosted room ownership is temporarily unavailable"
+        ) from exc
+
+
 def room_state(
     db_path: Path | str,
     *,
@@ -1039,6 +1132,34 @@ def room_state(
     if claim_row is not None:
         state["authority_claim"] = _event_from_row(claim_row)
     return state
+
+
+def request_room_stop(
+    db_path: Path | str,
+    *,
+    room_id: Any,
+    cancel_id: Any,
+    expected_gateway_id: Any,
+    expected_epoch: Any,
+) -> dict[str, Any]:
+    """Append an idempotent fence that supersedes earlier user turns."""
+
+    cancel_id = _validate_identifier(
+        cancel_id,
+        label="cancel_id",
+        max_chars=MAX_EVENT_ID_CHARS,
+    )
+    digest = hashlib.sha256(cancel_id.encode()).hexdigest()[:32]
+    return append_event(
+        db_path,
+        room_id=room_id,
+        event_id=f"room-stop:{digest}",
+        kind="room.stop_requested",
+        actor={"kind": "gateway", "id": expected_gateway_id},
+        payload={"cancel_id": cancel_id},
+        authority_gateway_id=expected_gateway_id,
+        authority_epoch=expected_epoch,
+    )
 
 
 def claim_authority(

--- a/gateway/hosted_rooms.py
+++ b/gateway/hosted_rooms.py
@@ -19,7 +19,7 @@ import sqlite3
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, NoReturn
 
 
 PROTOCOL_VERSION = 2
@@ -461,7 +461,7 @@ def _transaction(
         conn.close()
 
 
-def _raise_room_not_found(conn: sqlite3.Connection, room_id: str) -> None:
+def _raise_room_not_found(conn: sqlite3.Connection, room_id: str) -> NoReturn:
     retained = conn.execute(
         "SELECT 1 FROM hosted_rooms WHERE room_id=?",
         (room_id,),
@@ -1390,13 +1390,16 @@ def read_events(
 
     with _transaction(db_path) as conn:
         room = conn.execute(
-            """SELECT next_seq FROM hosted_rooms
+            """SELECT next_seq, authority_gateway_id, authority_epoch
+               FROM hosted_rooms
                WHERE room_id=? AND (disbanded_at IS NULL OR ?)""",
             (room_id, int(include_disbanded)),
         ).fetchone()
         if room is None:
             _raise_room_not_found(conn, room_id)
         latest_seq = int(room["next_seq"]) - 1
+        authority_gateway = str(room["authority_gateway_id"])
+        authority_epoch = int(room["authority_epoch"])
         if since_seq > latest_seq:
             raise HostedRoomError("since_seq is ahead of the hosted room log")
         rows = conn.execute(
@@ -1429,6 +1432,10 @@ def read_events(
             "cursor": cursor,
             "latest_seq": latest_seq,
             "has_more": cursor < latest_seq,
+            "authority": {
+                "gateway_id": authority_gateway,
+                "epoch": authority_epoch,
+            },
         }
 
     def page_bytes(page: dict[str, Any]) -> int:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -288,6 +288,32 @@ def hygiene_compaction_recovered(
     )
 
 
+def _hygiene_compression_timeout_message(
+    *,
+    total_exhausted: bool,
+    elapsed: float,
+    idle_timeout: float,
+    progress_observed: bool,
+) -> str:
+    """Describe the host timeout that actually ended hygiene compression."""
+    if total_exhausted:
+        progress = (
+            " after summary output was observed" if progress_observed else ""
+        )
+        return (
+            "⚠️ Context compression reached its total ceiling after "
+            f"{elapsed:.1f}s{progress}. No messages were dropped — continuing "
+            "without compression. Run /compress to retry or /reset for a clean "
+            "session."
+        )
+    return (
+        f"⚠️ Context compression timed out after {idle_timeout:.1f}s with no "
+        "output from the summary model. No messages were dropped — continuing "
+        "without compression. Run /compress to retry, /reset for a clean "
+        "session, or check your auxiliary.compression model configuration."
+    )
+
+
 def _record_hygiene_cooldown(
     gateway,
     session_id: str,
@@ -20581,7 +20607,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     _hyg_agent._print_fn = lambda *a, **kw: None
 
                                     loop = asyncio.get_running_loop()
-                                    _hyg_commit_fence = CompressionCommitFence()
+                                    _hyg_commit_fence = CompressionCommitFence(
+                                        total_ceiling_seconds=_hyg_total_ceiling_seconds
+                                    )
                                     _hyg_future = loop.run_in_executor(
                                         None,
                                         lambda: _hyg_agent._compress_context(
@@ -20609,10 +20637,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             # from the start of this wait slice —
                                             # otherwise silence can approach 2x
                                             # the configured timeout.
-                                            _slice = max(
-                                                _hyg_timeout_seconds
-                                                - _hyg_commit_fence.seconds_since_progress(),
-                                                0.005,
+                                            _hyg_waited = (
+                                                time.monotonic() - _hyg_wait_started
+                                            )
+                                            _slice = min(
+                                                max(
+                                                    _hyg_timeout_seconds
+                                                    - _hyg_commit_fence.seconds_since_progress(),
+                                                    0.005,
+                                                ),
+                                                max(
+                                                    _hyg_total_ceiling_seconds
+                                                    - _hyg_waited,
+                                                    0.005,
+                                                ),
                                             )
                                             # Bounded turn-hold (#TKT-0029): cap
                                             # this slice at the remaining
@@ -20786,6 +20824,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                                 )
                                             raise
                                     except asyncio.TimeoutError:
+                                        _hyg_waited = time.monotonic() - _hyg_wait_started
+                                        _hyg_total_exhausted = (
+                                            _hyg_waited >= _hyg_total_ceiling_seconds
+                                            or _hyg_commit_fence.deadline_exceeded
+                                        )
+                                        if _hyg_total_exhausted:
+                                            # The worker cooperatively checks this
+                                            # deadline between digest calls. Keep
+                                            # its lease until it exits so an
+                                            # unchanged session cannot overlap a
+                                            # retry. Inactivity timeouts retain the
+                                            # established release behavior for a
+                                            # provider call that may never return.
+                                            _hyg_commit_fence.retain_compression_lock_until_worker_done()
                                         _cancelled = None
                                         while _cancelled is None:
                                             # #76354 F1: a hung commit retains the
@@ -20813,13 +20865,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             # successful compaction as a timeout.
                                             _compressed, _ = await _hyg_future
                                         else:
-                                            # #76354 F4: release the timed-out
-                                            # worker's durable lease via the
-                                            # holder-qualified hook so the next
-                                            # compressor can acquire the lock
-                                            # immediately (no ABA against a new
-                                            # holder — release is holder-scoped).
-                                            _hyg_commit_fence.release_cancelled_compression_lock()
+                                            # Cleanup follows worker completion;
+                                            # its holder-qualified lease remains
+                                            # live until then to exclude retries.
                                             self._defer_agent_cleanup_until_future_done(
                                                 _hyg_future,
                                                 _hyg_agent,
@@ -20833,12 +20881,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                                     session_key,
                                                     _hyg_failure_cooldown_seconds,
                                                 )
+                                                _timeout_reason = (
+                                                    "session hygiene compression total "
+                                                    "ceiling exhausted"
+                                                    if _hyg_total_exhausted
+                                                    else "session hygiene compression "
+                                                    "timed out with no output from the "
+                                                    "summary model"
+                                                )
                                                 _record_hygiene_cooldown(
                                                     self, session_entry.session_id,
                                                     _hyg_cooldown,
-                                                    "session hygiene compression "
-                                                    "timed out with no output from "
-                                                    "the summary model",
+                                                    _timeout_reason,
                                                 )
                                             from agent.session_activity import (
                                                 ActivityProvenance,
@@ -20850,24 +20904,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                                 "hygiene compression timeout "
                                                 "activity stamp failed",
                                             )
-                                            logger.warning(
-                                                "Session hygiene compression for session %s "
-                                                "made no progress for %.1fs "
-                                                "(total wait %.1fs, ceiling %.1fs); "
-                                                "continuing without compression",
-                                                session_entry.session_id,
-                                                _hyg_commit_fence.seconds_since_progress(),
-                                                time.monotonic() - _hyg_wait_started,
-                                                _hyg_total_ceiling_seconds,
+                                            _hyg_elapsed = (
+                                                time.monotonic() - _hyg_wait_started
                                             )
+                                            if _hyg_total_exhausted:
+                                                logger.warning(
+                                                    "Session hygiene compression for session %s "
+                                                    "reached its total ceiling after %.1fs "
+                                                    "(progress observed=%s); continuing without "
+                                                    "compression",
+                                                    session_entry.session_id,
+                                                    _hyg_elapsed,
+                                                    _hyg_commit_fence.progress_observed,
+                                                )
+                                            else:
+                                                logger.warning(
+                                                    "Session hygiene compression for session %s "
+                                                    "made no progress for %.1fs (total wait "
+                                                    "%.1fs, ceiling %.1fs); continuing without "
+                                                    "compression",
+                                                    session_entry.session_id,
+                                                    _hyg_commit_fence.seconds_since_progress(),
+                                                    _hyg_elapsed,
+                                                    _hyg_total_ceiling_seconds,
+                                                )
                                             _timeout_msg = (
-                                                "⚠️ Context compression timed out "
-                                                f"after {_hyg_timeout_seconds:.1f}s "
-                                                "with no output from the summary model. "
-                                                "No messages were dropped — continuing without "
-                                                "compression. Run /compress to retry, /reset for "
-                                                "a clean session, or check your "
-                                                "auxiliary.compression model configuration."
+                                                _hygiene_compression_timeout_message(
+                                                    total_exhausted=_hyg_total_exhausted,
+                                                    elapsed=_hyg_elapsed,
+                                                    idle_timeout=_hyg_timeout_seconds,
+                                                    progress_observed=(
+                                                        _hyg_commit_fence.progress_observed
+                                                    ),
+                                                )
                                             )
                                             try:
                                                 _adapter = self._adapter_for_source(source)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -314,6 +314,135 @@ def _hygiene_compression_timeout_message(
     )
 
 
+async def run_codex_hygiene_compaction(
+    gateway,
+    session_key: str,
+    session_id: str,
+    *,
+    auto_mode: str,
+    history: list,
+    approx_tokens: int,
+    timeout_seconds: float,
+    failure_cooldown_seconds: float = 300.0,
+) -> str:
+    """Session hygiene for ``codex_app_server`` sessions (#73503).
+
+    On this runtime the model's real working context is the app-server's
+    server-side thread, not Hermes' transcript: ``CodexAppServerSession`` is
+    constructed with no history and each turn submits only the new user
+    message (agent/codex_runtime.py), so the persisted transcript is a mirror
+    that is never replayed into a thread. Two consequences drive this path:
+
+    * Rewriting the local mirror (the detached hygiene agent's normal
+      compression) shrinks nothing the model actually carries — it was a
+      permanent no-op ("compressed 150 -> 150 msgs").
+    * Evicting the cached live agent afterwards destroys the only real
+      context: the next turn spawns an EMPTY thread and the model starts
+      blank while Hermes still mirrors a full history (abrupt amnesia — the
+      user-facing damage documented on #73503).
+
+    So hygiene must compact the LIVE cached agent's thread via the
+    app-server's own ``thread/compact/start`` (through
+    ``_compress_context_via_codex_app_server``) and KEEP that agent cached.
+    Never build a detached compressor and never evict here.
+
+    Mode contract (``compression.codex_app_server_auto``): only ``hermes``
+    lets Hermes' threshold initiate app-server compaction; ``native`` leaves
+    the schedule to codex itself and ``off`` disables Hermes-initiated
+    automatic compaction entirely — both return without touching the thread
+    or the transcript, and neither may fall back to the local compressor.
+
+    Returns an outcome tag for logging/tests: ``compacted``,
+    ``skipped:<reason>`` or ``failed:<reason>``.
+    """
+    mode = str(auto_mode or "native").lower()
+    if mode not in {"native", "hermes", "off"}:
+        mode = "native"
+    if mode != "hermes":
+        # native: the app-server compacts on its own schedule; off: the
+        # operator disabled Hermes-initiated automatic compaction. A local
+        # transcript fallback is wrong in EVERY mode here (it cannot shrink
+        # the thread), so both modes are a clean skip — crucially without
+        # the detached-compressor path's cache eviction.
+        return f"skipped:mode={mode}"
+
+    agent = None
+    lock = getattr(gateway, "_agent_cache_lock", None)
+    cache = getattr(gateway, "_agent_cache", None)
+    if cache is not None:
+        try:
+            if lock:
+                with lock:
+                    entry = cache.get(session_key)
+            else:
+                entry = cache.get(session_key)
+        except Exception:
+            entry = None
+        agent = entry[0] if isinstance(entry, tuple) and entry else entry
+    if agent is None or agent is _AGENT_PENDING_SENTINEL:
+        # No live agent → no live thread → nothing real to compact. The
+        # mirror-only rewrite the detached path would perform is exactly the
+        # no-op this function exists to remove, so skip honestly instead.
+        return "skipped:no-cached-agent"
+    if getattr(agent, "_codex_session", None) is None:
+        return "skipped:no-live-thread"
+
+    loop = asyncio.get_running_loop()
+    compressor = getattr(agent, "context_compressor", None)
+    count_before = getattr(compressor, "compression_count", 0)
+    try:
+        await asyncio.wait_for(
+            loop.run_in_executor(
+                None,
+                lambda: agent._compress_context(
+                    history,
+                    "",
+                    approx_tokens=approx_tokens,
+                ),
+            ),
+            timeout=max(float(timeout_seconds), 1.0),
+        )
+    except asyncio.TimeoutError:
+        # The executor thread keeps running (compact_thread has its own RPC
+        # timeouts); brake per-turn retries so a wedged app-server does not
+        # re-trigger a compaction attempt on every message.
+        if failure_cooldown_seconds >= 0:
+            _record_hygiene_cooldown(
+                gateway,
+                session_id,
+                failure_cooldown_seconds,
+                "codex app-server thread compaction timed out",
+            )
+        logger.warning(
+            "Session hygiene: codex app-server thread compaction for "
+            "session %s timed out after %.1fs; continuing without compaction",
+            session_id,
+            timeout_seconds,
+        )
+        return "failed:timeout"
+    except Exception as exc:
+        logger.warning(
+            "Session hygiene: codex app-server thread compaction for "
+            "session %s failed: %s",
+            session_id,
+            exc,
+        )
+        return f"failed:{exc}"
+
+    count_after = getattr(compressor, "compression_count", 0)
+    if count_after > count_before:
+        # A native compaction boundary was recorded on the live agent
+        # (thread compacted server-side; transcript intentionally NOT
+        # rewritten — state.db records the boundary, the mirror stays
+        # intact and the agent stays cached).
+        _reset_hygiene_failure_streak(gateway, session_key)
+        return "compacted"
+    # compress_context returned without recording a boundary: an internal
+    # skip (its own failure cooldown) or a compaction error — the codex
+    # route already persisted its own failure cooldown in that case.
+    return "failed:no-boundary"
+
+
 def _record_hygiene_cooldown(
     gateway,
     session_id: str,
@@ -20512,7 +20641,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_key=session_key,
                             user_config=_hyg_data if isinstance(_hyg_data, dict) else None,
                         )
-                        if _hyg_runtime.get("api_key"):
+                        _hyg_api_mode = str(
+                            _hyg_runtime.get("api_mode") or ""
+                        ).lower()
+                        if _hyg_api_mode == "codex_app_server":
+                            # codex app-server runtime: the model's real
+                            # context is the app-server's server-side thread,
+                            # not the transcript mirror. The detached-agent
+                            # block below could only rewrite the mirror (a
+                            # guaranteed no-op for the thread) and its
+                            # finally-clause eviction would destroy the live
+                            # thread — the next turn then starts blank
+                            # (#73503). Route to the live cached agent's
+                            # thread/compact/start instead and KEEP it cached.
+                            _hyg_codex_auto = "native"
+                            _hyg_comp_cfg = (
+                                _hyg_data.get("compression")
+                                if isinstance(_hyg_data, dict)
+                                else None
+                            )
+                            if isinstance(_hyg_comp_cfg, dict):
+                                _hyg_codex_auto = str(
+                                    _hyg_comp_cfg.get(
+                                        "codex_app_server_auto", "native"
+                                    )
+                                    or "native"
+                                )
+                            _hyg_codex_outcome = await run_codex_hygiene_compaction(
+                                self,
+                                session_key,
+                                session_entry.session_id,
+                                auto_mode=_hyg_codex_auto,
+                                history=history,
+                                approx_tokens=_approx_tokens,
+                                timeout_seconds=_hyg_total_ceiling_seconds,
+                                failure_cooldown_seconds=_hyg_failure_cooldown_seconds,
+                            )
+                            logger.info(
+                                "Session hygiene (codex app-server): %s "
+                                "(session=%s, mode=%s, ~%s tokens)",
+                                _hyg_codex_outcome,
+                                session_entry.session_id,
+                                _hyg_codex_auto,
+                                f"{_approx_tokens:,}",
+                            )
+                        elif _hyg_runtime.get("api_key"):
                             # Pass the FULL transcript (tool results included).
                             # Filtering to user/assistant-only starved the
                             # compressor: tool results are usually the bulk of

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13082,6 +13082,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Legacy session recovery on startup failed: %s", exc)
         return exact, fallback
 
+    @staticmethod
+    def _start_hosted_room_worker_sync():
+        """Start the local Group Chat worker without importing the dashboard."""
+
+        import tui_gateway.server  # noqa: F401
+        from tui_gateway import methods_groups
+
+        service = methods_groups.get_hosted_room_service()
+        if service is None:
+            service = methods_groups.start_hosted_room_service()
+        if service is None:
+            raise RuntimeError("Group Chat worker has no bound session backend")
+        status = service.runtime.status()
+        if not status.get("running") or status.get("stopping"):
+            raise RuntimeError("Group Chat worker did not start")
+        return service
+
+    async def _ensure_hosted_room_worker(self):
+        return await asyncio.to_thread(self._start_hosted_room_worker_sync)
+
+    async def _hosted_room_worker_watcher(self, interval: float = 1.0) -> None:
+        """Keep the room worker alive for the messaging gateway lifetime."""
+
+        while self._running:
+            await self._ensure_hosted_room_worker()
+            await asyncio.sleep(interval)
+
+    async def _stop_hosted_room_worker(self, timeout: float = 5.0) -> bool:
+        """Pause room execution durably without interrupting accepted turns."""
+
+        from tui_gateway import methods_groups
+
+        return await asyncio.to_thread(
+            methods_groups.stop_hosted_room_service,
+            timeout=timeout,
+        )
+
     def _start_loop_heartbeat_task(self) -> None:
         """Start the loop-liveness heartbeat task (#66892), idempotent.
 
@@ -13887,6 +13924,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running = True
         self._install_plugin_message_injector()
         self._update_runtime_status("running")
+
+        try:
+            await self._ensure_hosted_room_worker()
+        except Exception:
+            logger.error(
+                "Group Chat worker failed to start; mutating Group Chat commands "
+                "will fail closed until supervision recovers it",
+                exc_info=True,
+            )
+        self._spawn_supervised(
+            self._hosted_room_worker_watcher,
+            "hosted_room_worker",
+        )
 
         self._start_loop_heartbeat_task()
 
@@ -15743,6 +15793,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._running = False
             self._clear_plugin_message_injector()
             self._draining = True
+
+            stop_room_worker = getattr(self, "_stop_hosted_room_worker", None)
+            if callable(stop_room_worker):
+                try:
+                    stopped = await stop_room_worker(timeout=5.0)
+                    if not stopped:
+                        logger.warning(
+                            "Group Chat worker is still settling durable work; "
+                            "the next gateway start will recover it"
+                        )
+                except Exception:
+                    logger.warning(
+                        "Group Chat worker could not stop cleanly; the next gateway "
+                        "start will recover durable work",
+                        exc_info=True,
+                    )
 
             stop_watchdog = getattr(self, "_stop_systemd_watchdog", None)
             if callable(stop_watchdog):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20865,9 +20865,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             # successful compaction as a timeout.
                                             _compressed, _ = await _hyg_future
                                         else:
-                                            # Cleanup follows worker completion;
-                                            # its holder-qualified lease remains
-                                            # live until then to exclude retries.
+                                            # Release an inactivity-timed-out
+                                            # worker's holder-qualified lease
+                                            # promptly. Total-ceiling attempts
+                                            # retained it above, so this is a
+                                            # no-op until worker cleanup there.
+                                            _hyg_commit_fence.release_cancelled_compression_lock()
                                             self._defer_agent_cleanup_until_future_done(
                                                 _hyg_future,
                                                 _hyg_agent,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4590,6 +4590,36 @@ class TurnRunner:
     def progress_callback(self, event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
         """Callback invoked by agent on tool lifecycle events."""
         ctx = self._ctx
+        # Failed subagent → one clean user-facing notice. Handled FIRST,
+        # before every progress-queue gate: platforms that keep
+        # tool_progress off (Telegram, Slack, ...) must still hear about a
+        # delegation that died — a silently-vanishing subagent looks like
+        # the agent just dropped the task (community report, Aug 2026).
+        # Success/interrupt completions stay quiet; only terminal failure
+        # statuses render, via the same notice rail as credit warnings.
+        if event_type == "subagent.complete":
+            _sub_status = kwargs.get("status")
+            try:
+                from tools.delegate_tool import (
+                    SUBAGENT_FAILURE_STATUSES,
+                    format_subagent_failure_line,
+                )
+                if _sub_status in SUBAGENT_FAILURE_STATUSES and ctx._run_still_current():
+                    _line = format_subagent_failure_line(
+                        kwargs.get("goal"),
+                        _sub_status,
+                        error=kwargs.get("summary") or preview,
+                        duration_seconds=kwargs.get("duration_seconds"),
+                    )
+                    safe_schedule_threadsafe(
+                        self._runner._deliver_platform_notice(ctx.source, _line),
+                        ctx._loop_for_step,
+                        logger=logger,
+                        log_message="subagent failure notice scheduling error",
+                    )
+            except Exception:
+                logger.debug("subagent failure notice failed", exc_info=True)
+            return
         # Live status line (Slack's assistant status): stash the current
         # tool phrase on the adapter; the _keep_typing refresh renders it
         # within a couple of seconds. Handled before every other gate
@@ -6108,15 +6138,12 @@ class TurnRunner:
         # who set thinking_progress:true but kept tool_progress:off got a
         # None callback — so _thinking scratch bubbles never relayed even
         # though the progress queue was created for them.
-        agent.tool_progress_callback = (
-            ctx.progress_callback
-            if (
-                ctx.needs_progress_queue
-                or ctx.log_mode_enabled
-                or ctx._live_status_adapter is not None
-            )
-            else None
-        )
+        # Always attached (previously gated to None when no progress surface
+        # was active): the callback body gates each event class itself, and
+        # subagent-failure notices must fire even on platforms with
+        # tool_progress/thinking off — the None gate was exactly why a dead
+        # subagent vanished silently there.
+        agent.tool_progress_callback = ctx.progress_callback
         # Compose ID-bearing lifecycle consumers: Discord's one-time voice
         # ack and Slack's native task cards both ride the authoritative
         # start callback, so neither has to infer identity from tool names.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3009,7 +3009,7 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
     slash commands. Call it off the event loop: runtime credential resolution
     and model metadata may perform blocking work.
     """
-    from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT, get_model_context_length
+    from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT, effective_context_length
 
     resolved_model = model or _resolve_gateway_model()
     config_context_length = None
@@ -3084,7 +3084,7 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
         except Exception:
             pass
 
-    context_length = get_model_context_length(
+    context_length = effective_context_length(
         resolved_model,
         base_url=base_url or "",
         api_key=api_key or "",
@@ -19482,7 +19482,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _msg_config_ctx = _msg_custom_ctx
                     except Exception:
                         pass
-                _msg_ctx_len = await get_model_context_length_async(
+                # Use the EFFECTIVE window (raw capability clamped by the
+                # profile-wide model.max_context_length ceiling). The ceiling
+                # applies to every invocation, so context-reference admission
+                # must size against the effective window.
+                from agent.model_metadata import effective_context_length_async
+                _msg_ctx_len = await effective_context_length_async(
                     _msg_model,
                     base_url=_msg_base_url,
                     api_key=_msg_runtime.get("api_key") or "",
@@ -20392,7 +20397,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
 
             if _hyg_compression_enabled:
-                _hyg_context_length = await get_model_context_length_async(
+                # Use the EFFECTIVE window (raw capability clamped by the
+                # profile-wide model.max_context_length ceiling). The ceiling is
+                # a profile-wide hard operating ceiling on every invocation, so
+                # the hygiene threshold must be derived from the effective
+                # window — a 900K model capped to 272K should hygiene at
+                # 272K × threshold, not 900K × threshold.
+                from agent.model_metadata import effective_context_length_async
+                _hyg_context_length = await effective_context_length_async(
                     _hyg_model,
                     base_url=_hyg_base_url or "",
                     api_key=_hyg_api_key or "",
@@ -27279,6 +27291,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # Add more here as new baked-at-construction config settings are added.
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
         ("model", "context_length"),
+        ("model", "max_context_length"),
         ("model", "max_tokens"),
         ("compression", "enabled"),
         ("compression", "progress_notices"),

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4449,6 +4449,67 @@ class GatewaySlashCommandsMixin:
         with _profile_runtime_scope(profile_home):
             return await self._handle_compress_command_inner(event)
 
+    async def _compress_codex_app_server_session(
+        self, session_key: str, session_id: str
+    ) -> str:
+        """Manual /compress for codex_app_server sessions (#73503).
+
+        Compacts the LIVE cached agent's app-server thread via
+        ``thread/compact/start`` (through ``_compress_context``'s codex route
+        with ``force=True``, which bypasses the automatic-mode gate in every
+        ``compression.codex_app_server_auto`` mode — a manual /compress is an
+        explicit user decision) and keeps that agent cached, so the compacted
+        thread is what the next turn continues from. Never builds a temporary
+        compression agent and never rewrites the transcript mirror: neither
+        can shrink the server-side thread that is the model's real context.
+        """
+        agent = None
+        lock = getattr(self, "_agent_cache_lock", None)
+        cache = getattr(self, "_agent_cache", None)
+        if cache is not None:
+            if lock:
+                with lock:
+                    entry = cache.get(session_key)
+            else:
+                entry = cache.get(session_key)
+            agent = entry[0] if isinstance(entry, tuple) and entry else entry
+        from gateway.run import _AGENT_PENDING_SENTINEL
+
+        if (
+            agent is None
+            or agent is _AGENT_PENDING_SENTINEL
+            or getattr(agent, "_codex_session", None) is None
+        ):
+            return (
+                "🗜️ Nothing to compact: this session runs on the Codex "
+                "app-server runtime, whose context lives in a Codex-owned "
+                "thread that only exists while the agent is active. Send a "
+                "message first, then /compress — or /reset to start fresh."
+            )
+
+        compressor = getattr(agent, "context_compressor", None)
+        count_before = getattr(compressor, "compression_count", 0)
+        try:
+            await self._run_in_executor_with_context(
+                lambda: agent._compress_context(
+                    [], "", force=True,
+                )
+            )
+        except Exception as exc:
+            return t("gateway.compress.failed", error=exc)
+        count_after = getattr(compressor, "compression_count", 0)
+        if count_after > count_before:
+            return (
+                "🗜️ Codex app-server thread compacted (thread/compact). "
+                "The transcript mirror is unchanged by design — the "
+                "app-server now carries the compacted context."
+            )
+        return (
+            "⚠️ Codex app-server compaction did not complete — the thread "
+            "is unchanged. Check the app-server logs, retry /compress, or "
+            "/reset for a clean session."
+        )
+
     async def _handle_compress_command_inner(self, event: MessageEvent) -> str:
         """Handle /compress command -- manually compress conversation context.
 
@@ -4538,6 +4599,23 @@ class GatewaySlashCommandsMixin:
                 source=source,
                 session_key=session_key,
             )
+            if str(runtime_kwargs.get("api_mode") or "").lower() == "codex_app_server":
+                # codex app-server runtime (#73503): the model's working
+                # context is the app-server's server-side thread, owned by the
+                # LIVE cached agent (agent/codex_runtime.py — one
+                # CodexAppServerSession per AIAgent, spawned lazily on first
+                # turn). A temporary compression agent has no thread, so the
+                # codex route in _compress_context_via_codex_app_server bailed
+                # at its "no active codex thread" guard, the transcript came
+                # back unchanged, and the finally-clause eviction below then
+                # destroyed the only real context. Compact the live agent's
+                # thread via thread/compact/start instead — and KEEP the agent
+                # cached so the compacted thread survives to the next turn.
+                # No local transcript fallback in any mode: rewriting the
+                # mirror cannot shrink the thread.
+                return await self._compress_codex_app_server_session(
+                    session_key, session_entry.session_id
+                )
             if not runtime_kwargs.get("api_key"):
                 return t("gateway.compress.no_provider")
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -862,10 +862,10 @@ class GatewaySlashCommandsMixin:
 
         if not context_length and model_name:
             try:
-                from agent.model_metadata import get_model_context_length
+                from agent.model_metadata import effective_context_length
 
                 context_length = _int_value(
-                    await asyncio.to_thread(get_model_context_length, model_name)
+                    await asyncio.to_thread(effective_context_length, model_name)
                 )
             except Exception:
                 context_length = 0

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2826,11 +2826,23 @@ class GatewayStreamConsumer:
             return False
         try:
             try:
-                result = fn(text, metadata=self.metadata)
+                # Pass the chat id so multi-platform adapters (relay) resolve
+                # the decision through THIS chat's negotiated platform, not
+                # the primary identity's.  Without it a Slack-primary relay
+                # with unfurl force-on misroutes a fronted Telegram/Discord
+                # chat's final through the fresh-send lane (duplicate
+                # delivery: those descriptors advertise no ``delete`` op),
+                # and the mirror posture leaves fronted Slack chats dark.
+                result = fn(text, metadata=self.metadata, chat_id=self.chat_id)
             except TypeError:
-                # Adapter / test double whose hook doesn't accept the metadata
-                # keyword — fall back to the positional-only form.
-                result = fn(text)
+                try:
+                    # Single-platform hook signature (Telegram, base class):
+                    # (content, metadata=None) — no chat_id keyword.
+                    result = fn(text, metadata=self.metadata)
+                except TypeError:
+                    # Adapter / test double whose hook doesn't accept the
+                    # metadata keyword — fall back to the positional-only form.
+                    result = fn(text)
         except Exception as e:
             logger.debug("prefers_fresh_final_streaming check failed: %s", e)
             return False

--- a/hermes_cli/dashboard_auth/cookies.py
+++ b/hermes_cli/dashboard_auth/cookies.py
@@ -67,6 +67,7 @@ Refresh-token handling:
 from __future__ import annotations
 
 from typing import Literal, Optional, Tuple
+from urllib.parse import quote, unquote
 
 from fastapi import Request
 from fastapi.responses import Response
@@ -306,9 +307,30 @@ def set_pkce_cookie(
     # sidesteps the bug — these cookies are explicitly designed for cross-site
     # delivery and Chromium processes them reliably during redirects.
     # Loopback HTTP degrades to Lax (SameSite=None requires Secure).
+    #
+    # Value encoding: the PKCE payload is a flat ``key=value;key=value``
+    # string (``provider=…;state=…;verifier=…;next=…``). A raw ``;`` is a
+    # cookie-attribute terminator, so Python's http.cookies wraps the value
+    # in double quotes and escapes each ``;`` as the backslash-octal
+    # ``\073``. Mainstream browsers store and echo that quoted form
+    # verbatim, and Python parsers decode it — but the quoted form is NOT
+    # made of plain RFC 6265 cookie-octets (``"`` and ``\`` are outside the
+    # set), and stricter cookie-aware hops that parse and re-emit the
+    # Cookie header drop the cookie entirely (verified for Go's net/http,
+    # which rejects any cookie value containing a backslash — the parser
+    # underlying much Go-based proxy/IDP middleware). The callback then
+    # fails with "Missing PKCE state cookie" even though the browser sent
+    # it (field case: a Traefik + Authentik + VPN chain, support thread
+    # "Still unable to use Authentik for signin with traefik" — devtools
+    # showed the browser sending the intact quoted cookie while Hermes
+    # logged missing_pkce_cookie). URL-encoding the whole payload
+    # (``;`` → ``%3B``)
+    # keeps the wire value inside the unquoted cookie-octet set so every
+    # RFC 6265 parser passes it through untouched. The readers in
+    # routes.py decode via parse_pkce_payload() before the ``;`` split.
     response.set_cookie(
         _resolved_name(PKCE_COOKIE, use_https=use_https, prefix=prefix),
-        payload,
+        quote(payload, safe=""),
         max_age=_PKCE_MAX_AGE,
         **_pkce_attrs(use_https=use_https, prefix=prefix),
     )
@@ -367,6 +389,39 @@ def read_session_provider(request: Request) -> Optional[str]:
 
 def read_pkce_cookie(request: Request) -> Optional[str]:
     return _read_with_fallback(request, PKCE_COOKIE)
+
+
+def parse_pkce_payload(raw: str) -> dict[str, str]:
+    """Decode + parse a PKCE cookie value into its segment dict.
+
+    Single inverse of :func:`set_pkce_cookie`'s encoding: URL-decode the
+    wire value back to the flat ``provider=...;state=...;verifier=...``
+    shape, then split on ``;``. EVERY reader of the PKCE cookie must go
+    through this helper — a reader that splits the raw wire value sees
+    the fully URL-encoded string (even ``=`` is ``%3D``), parses zero
+    segments, and silently disables whatever check it was feeding
+    (provider dispatch, CSRF state, native-flow broker binding).
+
+    Mixed-version compatibility (10-minute PKCE TTL during a rolling
+    upgrade): a cookie minted by a pre-encoding server arrives here —
+    after starlette's cookie-header unquoting — as the flat form with
+    RAW ``;`` between segments, and its ``next`` segment still carries
+    its own single URL-encoding (``next=%2F...``). The new encoded form
+    can never contain a raw ``;`` (it is ``%3B``). So a raw ``;`` is an
+    exact old-format discriminator: split it as-is WITHOUT the payload
+    decode, exactly like the old reader did, so an old ``next`` value
+    containing ``%3B`` is not decoded into a bogus delimiter. (The
+    reverse direction — a new encoded cookie hitting an old server —
+    fails the state check and the user retries; nothing to do here.)
+    """
+    if ";" in raw:
+        # Old-format (pre-encoding) cookie: already flat, split as-is.
+        return dict(
+            seg.split("=", 1) for seg in raw.split(";") if "=" in seg
+        )
+    return dict(
+        seg.split("=", 1) for seg in unquote(raw).split(";") if "=" in seg
+    )
 
 
 def set_sso_attempt_cookie(

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -41,6 +41,7 @@ from hermes_cli.dashboard_auth.cookies import (
     clear_session_cookies,
     clear_sso_attempt_cookie,
     detect_https,
+    parse_pkce_payload,
     read_pkce_cookie,
     read_session_cookies,
     set_pkce_cookie,
@@ -447,9 +448,10 @@ async def auth_callback(
     # ``next`` segment is optional (only present when /auth/login was
     # given a next= query). All keys live in the same flat namespace;
     # ``next`` carries a URL-encoded path so it never contains ``;``.
-    parts = dict(
-        seg.split("=", 1) for seg in pkce_raw.split(";") if "=" in seg
-    )
+    # parse_pkce_payload URL-decodes the wire value (the setter encodes
+    # the whole payload so no raw ``;``/``"``/``\`` reaches the wire)
+    # before the ``;`` split.
+    parts = parse_pkce_payload(pkce_raw)
     provider_name = parts.get("provider", "")
     expected_state = parts.get("state", "")
     verifier = parts.get("verifier", "")
@@ -760,9 +762,7 @@ async def auth_password_login(request: Request, body: _PasswordLoginBody):
     cookie_provider = ""
     pkce_raw = read_pkce_cookie(request)
     if pkce_raw:
-        pkce_parts = dict(
-            seg.split("=", 1) for seg in pkce_raw.split(";") if "=" in seg
-        )
+        pkce_parts = parse_pkce_payload(pkce_raw)
         broker_state = pkce_parts.get("broker", "")
         cookie_provider = pkce_parts.get("provider", "")
     if broker_state and cookie_provider != body.provider:

--- a/hermes_cli/install_identity.py
+++ b/hermes_cli/install_identity.py
@@ -1,0 +1,153 @@
+"""Stable opaque identity shared by every profile in one Hermes install."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+import re
+import tempfile
+import threading
+from typing import Optional
+import uuid
+
+from hermes_constants import get_default_hermes_root
+
+_INSTALL_ID_FILENAME = "install_id"
+_INSTALL_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_INSTALL_ID_CACHE: dict[str, Optional[str]] = {"root": None, "value": None}
+_INSTALL_ID_LOCK = threading.Lock()
+_INSTALL_ID_PUBLICATION_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def _install_id_file_lock(root: Path):
+    """Serialize identity publication across processes on POSIX and Windows."""
+    lock_path = root / ".install_id.lock"
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    windows = os.name == "nt"
+    try:
+        if windows:
+            import msvcrt
+
+            if os.fstat(fd).st_size == 0:
+                os.write(fd, b"\0")
+                os.fsync(fd)
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if windows:
+                import msvcrt
+
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _fsync_directory(path: Path) -> None:
+    """Best-effort durability for the directory entry after replace."""
+    if os.name == "nt":
+        return
+    try:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def read_or_create_install_id(root: Path | None = None) -> Optional[str]:
+    """Read or atomically mint the opaque id for the physical install.
+
+    ``None`` means the id could neither be read nor persisted. Returning an
+    ephemeral id would violate the authority and connection-registry contract.
+    """
+    root = get_default_hermes_root() if root is None else root
+    path = root / _INSTALL_ID_FILENAME
+    try:
+        existing = path.read_text(encoding="utf-8").strip().lower()
+        if _INSTALL_ID_RE.fullmatch(existing):
+            return existing
+    except FileNotFoundError:
+        pass
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    try:
+        # Windows byte-range locks can report a same-process lock conflict
+        # instead of waiting for another thread. Serialize threads here, then
+        # retain the file lock as the cross-process publication fence.
+        with _INSTALL_ID_PUBLICATION_LOCK, _install_id_file_lock(root):
+            try:
+                existing = path.read_text(encoding="utf-8").strip().lower()
+                if _INSTALL_ID_RE.fullmatch(existing):
+                    return existing
+            except FileNotFoundError:
+                pass
+            except (OSError, UnicodeDecodeError):
+                return None
+
+            minted = uuid.uuid4().hex
+            fd, tmp_name = tempfile.mkstemp(dir=str(root), prefix=".install_id-")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(minted + "\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(tmp_name, path)
+                _fsync_directory(root)
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_name)
+                raise
+
+            committed = path.read_text(encoding="utf-8").strip().lower()
+            return committed if _INSTALL_ID_RE.fullmatch(committed) else None
+    except OSError:
+        return None
+
+
+def get_install_id(
+    *,
+    cache: dict[str, Optional[str]] | None = None,
+) -> Optional[str]:
+    """Return the process-cached stable id for the active Hermes root."""
+    root = get_default_hermes_root()
+    root_key = str(root)
+    target_cache = _INSTALL_ID_CACHE if cache is None else cache
+    cached = target_cache.get("value")
+    if cached and target_cache.get("root") in (None, root_key):
+        return cached
+
+    with _INSTALL_ID_LOCK:
+        cached = target_cache.get("value")
+        if cached and target_cache.get("root") in (None, root_key):
+            return cached
+        value = read_or_create_install_id(root)
+        if value:
+            target_cache["root"] = root_key
+            target_cache["value"] = value
+        return value
+
+
+__all__ = ["get_install_id", "read_or_create_install_id"]

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1274,8 +1274,8 @@ def resolve_display_context_length(
             config_context_length = None
 
     try:
-        from agent.model_metadata import get_model_context_length
-        ctx = get_model_context_length(
+        from agent.model_metadata import effective_context_length
+        ctx = effective_context_length(
             model,
             base_url=base_url or "",
             api_key=api_key or "",
@@ -1284,6 +1284,10 @@ def resolve_display_context_length(
             config_context_length=config_context_length,
         )
         if ctx:
+            # effective_context_length() already applies the global ceiling
+            # (model.max_context_length) — the single source of truth for
+            # "min(resolved, ceiling)" — so the display value matches the
+            # effective window the agent will actually use.
             return int(ctx)
     except Exception:
         pass

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -431,6 +431,31 @@ async def _lifespan(app: "FastAPI"):
 
     record_boot_fingerprint()
 
+    # Hosted Bot rooms belong to the backend process, not to any connected
+    # Desktop socket. Recovery may need a contended state.db migration, so keep
+    # it off the lifespan's pre-yield path: Group Chat startup must degrade on
+    # its own instead of preventing every dashboard/Desktop feature from booting.
+    from tui_gateway import methods_groups as _hosted_groups
+    import tui_gateway.server  # noqa: F401
+
+    hosted_room_start_cancel = threading.Event()
+
+    def _start_hosted_rooms() -> None:
+        try:
+            _hosted_groups.start_hosted_room_service()
+        except Exception:
+            _log.exception("Hosted Group Chat recovery failed during backend startup")
+        finally:
+            if hosted_room_start_cancel.is_set():
+                _hosted_groups.stop_hosted_room_service(timeout=1.0)
+
+    hosted_room_start_thread = threading.Thread(
+        target=_start_hosted_rooms,
+        daemon=True,
+        name="hosted-room-startup",
+    )
+    hosted_room_start_thread.start()
+
     # Desktop-spawned backends (HERMES_DESKTOP=1) fire cron jobs themselves,
     # since the app has no gateway running the scheduler. Server `hermes
     # dashboard` is unaffected — it relies on its own gateway.
@@ -473,6 +498,9 @@ async def _lifespan(app: "FastAPI"):
     try:
         yield
     finally:
+        hosted_room_start_cancel.set()
+        _hosted_groups.stop_hosted_room_service(timeout=5.0)
+        hosted_room_start_thread.join(timeout=1.0)
         if cron_stop is not None:
             cron_stop.set()
         pty_reaper_task.cancel()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,6 +48,7 @@ import urllib.parse
 import zipfile
 
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
+from hermes_cli.install_identity import get_install_id as _shared_get_install_id
 import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
@@ -3523,66 +3524,12 @@ _TOPOLOGY_CACHE_TTL = 10.0
 # fact it reveals is "these addresses are the same box", which is the feature.
 # It must never change across restarts/updates, so reads are cached for the
 # process lifetime and the file is written once, atomically.
-_INSTALL_ID_FILENAME = "install_id"
-_INSTALL_ID_RE = re.compile(r"^[0-9a-f]{32}$")
-_INSTALL_ID_CACHE: Dict[str, Optional[str]] = {"value": None}
-_INSTALL_ID_LOCK = threading.Lock()
-
-
-def _read_or_create_install_id() -> Optional[str]:
-    """Read (or mint + persist) the install id under the root Hermes home.
-
-    Returns ``None`` only when the id can neither be read nor persisted (e.g.
-    a read-only filesystem) — an unpersisted id would violate the stability
-    contract, so callers omit the field rather than emit a churning value.
-    """
-    import uuid
-
-    from hermes_constants import get_default_hermes_root
-
-    root = get_default_hermes_root()
-    path = root / _INSTALL_ID_FILENAME
-    try:
-        existing = path.read_text(encoding="utf-8").strip().lower()
-        if _INSTALL_ID_RE.match(existing):
-            return existing
-    except FileNotFoundError:
-        pass
-    except (OSError, UnicodeDecodeError):
-        return None
-
-    minted = uuid.uuid4().hex
-    try:
-        root.mkdir(parents=True, exist_ok=True)
-        # Atomic replace so a crash mid-write can't leave a truncated id that
-        # would be regenerated (i.e. changed) on the next boot.
-        fd, tmp_name = tempfile.mkstemp(dir=str(root), prefix=".install_id-")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                handle.write(minted + "\n")
-            os.replace(tmp_name, path)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.unlink(tmp_name)
-            raise
-    except OSError:
-        return None
-    return minted
+_INSTALL_ID_CACHE: Dict[str, Optional[str]] = {"root": None, "value": None}
 
 
 def get_install_id() -> Optional[str]:
-    """Process-lifetime-cached stable install id (see _read_or_create_install_id)."""
-    cached = _INSTALL_ID_CACHE["value"]
-    if cached:
-        return cached
-    with _INSTALL_ID_LOCK:
-        cached = _INSTALL_ID_CACHE["value"]
-        if cached:
-            return cached
-        value = _read_or_create_install_id()
-        if value:
-            _INSTALL_ID_CACHE["value"] = value
-        return value
+    """Process-lifetime-cached stable install id."""
+    return _shared_get_install_id(cache=_INSTALL_ID_CACHE)
 
 
 # Serializes read-modify-write cycles over config.yaml for handlers that run

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7291,37 +7291,52 @@ def get_model_info(profile: Optional[str] = None):
     Also returns model capabilities (vision, reasoning, tools) when available.
     """
     try:
+        # Read the profile's config AND the profile-wide context ceiling
+        # INSIDE the same _profile_scope block: _profile_scope sets the
+        # _HERMES_HOME_OVERRIDE ContextVar, and _get_max_context_length() reads
+        # the profile-scoped config via load_config_readonly(). Reading the
+        # ceiling after the `with` block exits would resolve it against the
+        # DEFAULT profile (the ContextVar is reset on exit), so a per-profile
+        # ceiling would be ignored. Capturing both in one scope guarantees the
+        # ceiling belongs to the profile whose model info is being reported.
         with _profile_scope(profile):
             cfg = load_config()
-        model_cfg = cfg.get("model", "")
+            try:
+                from agent.model_metadata import _get_max_context_length
+                _profile_ceiling = _get_max_context_length()
+            except Exception:
+                _profile_ceiling = None
 
-        # Extract model name and provider from the config
-        if isinstance(model_cfg, dict):
-            model_name = model_cfg.get("default", model_cfg.get("name", ""))
-            provider = model_cfg.get("provider", "")
-            base_url = model_cfg.get("base_url", "")
-            config_ctx = model_cfg.get("context_length")
-        else:
-            model_name = str(model_cfg) if model_cfg else ""
-            provider = ""
-            base_url = ""
-            config_ctx = None
+            # Extract model name and provider from the config
+            model_cfg = cfg.get("model", "")
+            if isinstance(model_cfg, dict):
+                model_name = model_cfg.get("default", model_cfg.get("name", ""))
+                provider = model_cfg.get("provider", "")
+                base_url = model_cfg.get("base_url", "")
+                config_ctx = model_cfg.get("context_length")
+            else:
+                model_name = str(model_cfg) if model_cfg else ""
+                provider = ""
+                base_url = ""
+                config_ctx = None
 
-        if not model_name:
-            return dict(_EMPTY_MODEL_INFO, provider=provider)
+            if not model_name:
+                return dict(_EMPTY_MODEL_INFO, provider=provider)
 
-        # Resolve auto-detected context length (pass config_ctx=None to get
-        # purely auto-detected value, then separately report the override)
-        try:
-            from agent.model_metadata import get_model_context_length
-            auto_ctx = get_model_context_length(
-                model=model_name,
-                base_url=base_url,
-                provider=provider,
-                config_context_length=None,  # ignore override — we want auto value
-            )
-        except Exception:
-            auto_ctx = 0
+            # Resolve auto-detected context length INSIDE the profile scope so
+            # the raw capability resolution (cache lookup, probes) runs against
+            # the REQUESTED profile's _HERMES_HOME, not the default profile.
+            # Pass config_ctx=None for purely auto-detected value.
+            try:
+                from agent.model_metadata import get_model_context_length
+                auto_ctx = get_model_context_length(
+                    model=model_name,
+                    base_url=base_url,
+                    provider=provider,
+                    config_context_length=None,
+                )
+            except Exception:
+                auto_ctx = 0
 
         config_ctx_int = 0
         if isinstance(config_ctx, int) and config_ctx > 0:
@@ -7329,6 +7344,17 @@ def get_model_info(profile: Optional[str] = None):
 
         # Effective is what the agent actually uses
         effective_ctx = config_ctx_int if config_ctx_int > 0 else auto_ctx
+
+        # Apply the profile-wide ceiling to the effective window. (We clamp the
+        # already-computed value rather than calling effective_context_length()
+        # because this endpoint reports auto/config/effective as SEPARATE fields
+        # and honors the per-model context_length override itself — the helper
+        # would re-resolve and drop the override.) The ceiling is the one
+        # captured inside _profile_scope above (profile-correct), not a fresh
+        # read outside the scope (which would resolve against the default
+        # profile).
+        if _profile_ceiling:
+            effective_ctx = min(effective_ctx, _profile_ceiling)
 
         # Try to get model capabilities from models.dev
         caps = {}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7438,10 +7438,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return
 
         def _do(conn):
+            # Merge-max with any longer live deadline so a later shorter
+            # write cannot reopen the thrash window (#96775). The error
+            # column always takes the latest diagnostic.
             conn.execute(
-                "UPDATE sessions SET compression_failure_cooldown_until = ?, "
+                "UPDATE sessions SET compression_failure_cooldown_until = CASE "
+                "WHEN compression_failure_cooldown_until IS NOT NULL "
+                " AND compression_failure_cooldown_until > ? "
+                "THEN compression_failure_cooldown_until ELSE ? END, "
                 "compression_failure_error = ? WHERE id = ?",
-                (cooldown_until, error, session_id),
+                (cooldown_until, cooldown_until, error, session_id),
             )
 
         try:

--- a/model_tools.py
+++ b/model_tools.py
@@ -760,21 +760,28 @@ def _resolve_active_context_length() -> int:
         # ~200ms network probe on EVERY CLI startup. When any prior session
         # already learned the window, use it for the gate and let the full
         # resolver (called later on the compression path) do reconciliation.
+        _gate_cap = None
+        try:
+            from agent.model_metadata import _get_max_context_length
+            _gate_cap = _get_max_context_length()
+        except Exception:
+            pass
         if config_ctx is None and base_url:
             try:
                 from agent.model_metadata import get_cached_context_length
                 cached_ctx = get_cached_context_length(model_id, base_url)
                 if isinstance(cached_ctx, int) and cached_ctx > 0:
-                    return cached_ctx
+                    return min(cached_ctx, _gate_cap) if _gate_cap else cached_ctx
             except Exception:
                 pass
-        return int(get_model_context_length(
+        _resolved = int(get_model_context_length(
             model_id,
             base_url=base_url,
             api_key=api_key,
             config_context_length=config_ctx,
             provider=provider,
         ) or 0)
+        return min(_resolved, _gate_cap) if _gate_cap else _resolved
     except Exception as e:
         logger.debug("Could not resolve active context length: %s", e)
         return 0

--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -162,7 +162,11 @@ All env vars are documented in `plugin.yaml`. The most important:
   as a synthetic `reaction:added:<emoji>` event. Removal after a sidecar
   restart is best-effort — the live reaction handle is lost, so a stale
   tapback heals when the next reaction replaces it. Group spaces stay
-  reachable across restarts via spectrum-ts' `space.get(id)`.
+  reachable across restarts via spectrum-ts' `space.get` rehydration.
+- **Read receipts are supported.** The sidecar marks an inbound iMessage read
+  after forwarding it to Hermes, so the sender sees `Read` without waiting for
+  a model/tool turn. Inbound receipts for Hermes-sent messages are consumed as
+  presence telemetry and never create an agent turn.
 - **Native polls are supported.** Hermes posts poll content through
   `spectrum-ts`' `poll(...)` builder via the sidecar's `/send-poll` endpoint.
 - **Message effects are supported.** Text can be sent with native iMessage

--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -166,7 +166,8 @@ All env vars are documented in `plugin.yaml`. The most important:
 - **Read receipts are supported.** The sidecar marks an inbound iMessage read
   after forwarding it to Hermes, so the sender sees `Read` without waiting for
   a model/tool turn. Inbound receipts for Hermes-sent messages are consumed as
-  presence telemetry and never create an agent turn.
+  presence telemetry and never create an agent turn. Set
+  `PHOTON_READ_RECEIPTS=false` to keep messages at `Delivered`.
 - **Native polls are supported.** Hermes posts poll content through
   `spectrum-ts`' `poll(...)` builder via the sidecar's `/send-poll` endpoint.
 - **Message effects are supported.** Text can be sent with native iMessage

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1292,6 +1292,15 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         ctype = content.get("type")
+        if ctype == "read":
+            # Read receipts are presence signals, not a user turn. The sidecar
+            # only forwards receipts for messages we sent, so logging the
+            # target is enough for observability without waking the agent.
+            logger.debug(
+                "[photon] outbound message read: %s",
+                content.get("targetMessageId") or "unknown",
+            )
+            return
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
             # addressed to the bot (feishu precedent: synthetic text event).

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1292,7 +1292,7 @@ class PhotonAdapter(BasePlatformAdapter):
             )
 
         ctype = content.get("type")
-        if ctype == "read":
+        if ctype in {"read", "read_receipt"}:
             # Read receipts are presence signals, not a user turn. The sidecar
             # only forwards receipts for messages we sent, so logging the
             # target is enough for observability without waking the agent.

--- a/plugins/platforms/photon/plugin.yaml
+++ b/plugins/platforms/photon/plugin.yaml
@@ -58,6 +58,10 @@ optional_env:
     description: "Allow any sender to trigger the bot (dev only — disables allowlist)"
     prompt: "Allow all users? (true/false)"
     password: false
+  - name: PHOTON_READ_RECEIPTS
+    description: "Mark inbound iMessages read after forwarding to Hermes (true/false, default true)"
+    prompt: "Send read receipts? (true/false)"
+    password: false
   - name: PHOTON_REQUIRE_MENTION
     description: "Ignore group-chat messages unless they match a mention wake word (true/false, default false)"
     prompt: "Require a mention in group chats?"

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -601,7 +601,12 @@ async function normalizeContent(content) {
 // the event has crossed the sidecar boundary: this means the gateway has
 // actually received it, while a transient agent/tool delay does not leave the
 // sender staring at Delivered. Receipt events themselves must never recurse.
+const readReceiptsEnabled =
+  (process.env.PHOTON_READ_RECEIPTS || "true").trim().toLowerCase() !==
+  "false";
+
 async function acknowledgeInboundRead(message) {
+  if (!readReceiptsEnabled) return;
   if (message?.content?.type === "read") return;
   if (typeof message?.read !== "function") return;
   try {

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -46,8 +46,8 @@
 // On SIGINT/SIGTERM the sidecar calls `app.stop()` (3s graceful) before
 // exiting. Logs go to stderr; Python supervises restart.
 //
-// Requires spectrum-ts 8.x — pinned exactly in package.json because the SDK
-// ships breaking majors; see README "Upgrading spectrum-ts".
+// Requires a pinned spectrum-ts version — the SDK ships breaking majors; see
+// README "Upgrading spectrum-ts".
 //
 // Env vars (required):
 //   PHOTON_PROJECT_ID      (== the project's spectrumProjectId)
@@ -545,6 +545,17 @@ async function normalizeContent(content) {
     }
     return { type: "group", items };
   }
+  if (content.type === "read") {
+    // spectrum-ts v12.5+ surfaces an inbound read receipt only after it has
+    // verified that the target is one of our outbound messages. Keep the
+    // receipt lightweight: Python records it as telemetry, never as an agent
+    // prompt.
+    return {
+      type: "read",
+      targetMessageId: content.target?.id ?? null,
+      targetDirection: content.target?.direction ?? null,
+    };
+  }
   if (content.type === "reaction") {
     const target = content.target;
     return {
@@ -584,6 +595,24 @@ async function normalizeContent(content) {
     };
   }
   return { type: content.type || "unknown" };
+}
+
+// The iMessage SDK exposes `message.read()` for inbound messages. Mark after
+// the event has crossed the sidecar boundary: this means the gateway has
+// actually received it, while a transient agent/tool delay does not leave the
+// sender staring at Delivered. Receipt events themselves must never recurse.
+async function acknowledgeInboundRead(message) {
+  if (message?.content?.type === "read") return;
+  if (typeof message?.read !== "function") return;
+  try {
+    await message.read();
+  } catch (error) {
+    // Read receipts are presence polish, not a delivery dependency.
+    console.warn(
+      "photon-sidecar: failed to mark inbound message read: " +
+        (error?.message || String(error))
+    );
+  }
 }
 
 async function normalizeEvent(space, message) {
@@ -659,6 +688,7 @@ function inboundStreamErrorMessage(e) {
         const event = await normalizeEvent(space, message);
         if (!event) continue;
         await deliver(JSON.stringify(event));
+        await acknowledgeInboundRead(message);
       }
       console.error("photon-sidecar: inbound stream ended — re-subscribing");
       markStreamRecovering("inbound stream ended");

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
-        "spectrum-ts": "8.0.0"
+        "spectrum-ts": "12.7.0"
       },
       "engines": {
         "node": ">=18.17"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
-      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@grpc/grpc-js": {
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.8.0.tgz",
-      "integrity": "sha512-/3FIraneMcng67SUJCxvyInk/oxzwsxyadufk0wwfOBLf5wqtAGX4MoQASwSbndBPeARzBryUM9Azr5kHIdWLw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -127,6 +127,57 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.218.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.218.0.tgz",
+      "integrity": "sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.218.0",
+        "@opentelemetry/otlp-transformer": "0.218.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
@@ -181,6 +232,55 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.219.0.tgz",
+      "integrity": "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.219.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.29.0.tgz",
+      "integrity": "sha512-SnA+0XgGc595jtnwFVfWy7Vgfr5hle4D5YKIlm0U4z8aK9YoCZVUn1xAkVZ2evaJyykiDF50FBzr1XZ0uj8CPA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/semantic-conventions": "^1.24.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
+      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
@@ -233,6 +333,22 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
@@ -251,12 +367,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/core": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -301,13 +417,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
-      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
+      "integrity": "sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1"
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -316,13 +432,14 @@
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -333,13 +450,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
-      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -350,66 +468,46 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
     },
-    "node_modules/@parseaple/bplist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@parseaple/bplist/-/bplist-1.0.1.tgz",
-      "integrity": "sha512-HHZKfvCaY8r5lwc6YCiAIhpAwH56YR29JPQa/9ZW0UqzjqdzFidGgoWVIhIF8tPXCwivIt93vbyT0O5bpC1Twg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/@parseaple/typedstream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@parseaple/typedstream/-/typedstream-2.0.2.tgz",
-      "integrity": "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@parseaple/bplist": "1.0.1"
-      }
-    },
     "node_modules/@photon-ai/advanced-imessage": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@photon-ai/advanced-imessage/-/advanced-imessage-0.12.0.tgz",
-      "integrity": "sha512-cqSq/ew48P3S+4xXpQmS/mDgpa+ijlKYKkQ4MExsQEjHfrJ0DpPJGuY5VHgzfTqV9wYVGyA3TNkDfse/ZRDxoA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/advanced-imessage/-/advanced-imessage-2.1.0.tgz",
+      "integrity": "sha512-KT/aCBWcq667alyKe8DclqDUa/0fUuW2ZYDCxfIKuQBm08U4JcNG56fCdNUd69MFkKkzZgW35j59EYsx5DnLcQ==",
       "license": "MIT",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.11.0",
+        "@bufbuild/protobuf": "^2.11.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "peerDependencies": {
         "@grpc/grpc-js": "^1.12.6",
         "nice-grpc": "^2.1.11",
         "nice-grpc-common": "^2.0.2"
       },
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
-    "node_modules/@photon-ai/imessage-kit": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@photon-ai/imessage-kit/-/imessage-kit-3.0.0.tgz",
-      "integrity": "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@parseaple/typedstream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "better-sqlite3": "^12.5.0"
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "nice-grpc": {
+          "optional": true
+        },
+        "nice-grpc-common": {
+          "optional": true
+        }
       }
     },
     "node_modules/@photon-ai/otel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-1.1.0.tgz",
-      "integrity": "sha512-v6Ai5Anws+gkjzZQirXpuF6VtS4DmSnpx9o208R2mhwqONNp2iqwQx4400C6r8oyqv7mz65tkkTd083kG5/kng==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/otel/-/otel-3.7.0.tgz",
+      "integrity": "sha512-N+fwhvvx/T2tNR8747vFJQgUuLxqyjAVMMLwmakEupgcE4X2M8nbqrfZNSPKN5DL/lpLXYP27a/ACW+jSWAqyA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
@@ -417,14 +515,20 @@
         "@opentelemetry/context-async-hooks": "^2.7.1",
         "@opentelemetry/core": "^2.7.1",
         "@opentelemetry/exporter-logs-otlp-http": "^0.218.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
         "@opentelemetry/resources": "^2.7.1",
         "@opentelemetry/sdk-logs": "^0.218.0",
+        "@opentelemetry/sdk-metrics": "^2.7.1",
         "@opentelemetry/sdk-trace-base": "^2.7.1",
         "@opentelemetry/semantic-conventions": "^1.41.1"
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@opentelemetry/instrumentation": "^0.219.0",
+        "@opentelemetry/instrumentation-undici": "^0.29.0"
       },
       "peerDependencies": {
         "typescript": "^5 || ^6.0.0"
@@ -467,9 +571,9 @@
       }
     },
     "node_modules/@photon-ai/whatsapp-business": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@photon-ai/whatsapp-business/-/whatsapp-business-0.1.1.tgz",
-      "integrity": "sha512-JAf/gHh92+H6h/7AMOQ6l+WFYBWdeRH5fZ+tvOUYJJnX1C4aJPDFa23VTH4ndhKPgA5bK/h++cxUZx2lMubvYQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@photon-ai/whatsapp-business/-/whatsapp-business-0.2.0.tgz",
+      "integrity": "sha512-FL5hKSZcgXCiZO1hVbu2A2Bd226ZfDEcbvlVWCEJUukWPUL7Gcs0RSwsJm57FnF0J/KhZ1DiwMWLoSL06N+fGw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
         "long": "^5.3.2",
@@ -488,12 +592,12 @@
       "license": "MIT"
     },
     "node_modules/@spectrum-ts/core": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-8.0.0.tgz",
-      "integrity": "sha512-qcMcx1Vf/hVKzyGkbNfrVf6q7t4Zsnr65Riq843W1ButJQnUf8MhCPwnSOavWYkd8IVXL4XSndqMMdOP9xPJeg==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/core/-/core-12.7.0.tgz",
+      "integrity": "sha512-bI3VPdOIEjyMH0BExYjdgitISVMj3a1v4eT5G/gonuu59glga3Cxm4Lo+z092FjmSktY6x/Hj40FsC5A5h2Rpw==",
       "license": "MIT",
       "dependencies": {
-        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/otel": "^3.3.0",
         "@photon-ai/proto": "^0.2.4",
         "@repeaterjs/repeater": "^3.0.6",
         "marked": "^18.0.5",
@@ -513,41 +617,43 @@
       }
     },
     "node_modules/@spectrum-ts/imessage": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-8.0.0.tgz",
-      "integrity": "sha512-HjWoAZqXxuRsiY33aiJs4g6u/R8HE4V0/rtDd0wE2b+Hq/U0owDuc6T0+cLjrM/rC03jvVkTCnKSMeJWF+mYUA==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/imessage/-/imessage-12.7.0.tgz",
+      "integrity": "sha512-pd1m0cLV7sy15lScenm92Kv80r9eRwL6geofqzX3XzADW2KRo4eIKRRwVa5XyU9KpN8moFrtaPRmsu9zBwF27w==",
       "license": "MIT",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.12.0",
-        "@photon-ai/imessage-kit": "^3.0.0",
-        "@photon-ai/otel": "^1.0.0",
+        "@grpc/grpc-js": "^1.14.4",
+        "@photon-ai/advanced-imessage": "^2.0.2",
+        "@photon-ai/otel": "^3.3.0",
         "lru-cache": "^11.0.0",
         "marked": "^18.0.5",
+        "nice-grpc": "^2.1.16",
+        "nice-grpc-common": "^2.0.3",
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^8.0.0",
+        "@spectrum-ts/core": "^12.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
     "node_modules/@spectrum-ts/slack": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-8.0.0.tgz",
-      "integrity": "sha512-UHLL0xxThDUBPYGbT2ms9Xq5B8dSQy3SoRZX88a04i649UebnjKg9cPU2amxA8gzRcARkQrfLFtq0CFz1jXcfw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/slack/-/slack-12.7.0.tgz",
+      "integrity": "sha512-Z/SJ4LkXEHdcb/uUIhcqvT6HZoRBzggLx3nzaouT/5i6L0TdrcuUZ78uiZCXj2jpvXRlfwcy66+hO10wbcvK0w==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/slack": "^0.2.0",
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^8.0.0",
+        "@spectrum-ts/core": "^12.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
     "node_modules/@spectrum-ts/telegram": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-8.0.0.tgz",
-      "integrity": "sha512-pvF9LrXdcewDthh89viu2lQxcxmmeXfu8MZpymIJSpP66SjCbTwhIbWkVFQbrJbBjLcB3UdyXdQv3dNoquEcRQ==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/telegram/-/telegram-12.7.0.tgz",
+      "integrity": "sha512-VLKrmHFiPVw4wTD1Q9FD6oWFj79iVndwVTB34ZbLtUox34E04l6ZFUE2eHgf+z810Mss+oUorRWyW+BwVxZCtQ==",
       "license": "MIT",
       "dependencies": {
         "@photon-ai/telegram-ts": "10.0.0",
@@ -555,35 +661,35 @@
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^8.0.0",
+        "@spectrum-ts/core": "^12.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
     "node_modules/@spectrum-ts/terminal": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-8.0.0.tgz",
-      "integrity": "sha512-VOyirdioTMAuR7+QNsWt708hG2ZVwt4qhyn/6CXbhnqM/V2FbEu5vNkbOlrxNj4o3y4Lr1mWMih2Fb3udJd+Nw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/terminal/-/terminal-12.7.0.tgz",
+      "integrity": "sha512-b9YjbRMfeZfBRAEWU32os9IqwtPCK1y30Rj+BqVe7uu4g9L4R76anQZme72qGkIB8+xCjxRxvQr3brZAHAElTw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^8.0.0",
+        "@spectrum-ts/core": "^12.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
     "node_modules/@spectrum-ts/whatsapp-business": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-8.0.0.tgz",
-      "integrity": "sha512-O4mlJi/YtFpnNsiqMo5aReC/nKg66voPp0botJW+MUWZpMlon4/tJ8uVXTUwzQFwOmNRjifVTSD+R/Tll3Kvaw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/@spectrum-ts/whatsapp-business/-/whatsapp-business-12.7.0.tgz",
+      "integrity": "sha512-GlYypVzS3i6txvXQQHZw0AFwFhzfn2lLbIxuAW319SBVXDykiCcQNE1zgoLResAsOz6Ir2wjLoE2CwYTo8AqBA==",
       "license": "MIT",
       "dependencies": {
-        "@photon-ai/whatsapp-business": "^0.1.1",
+        "@photon-ai/whatsapp-business": "^0.2.0",
         "mime-types": "^3.0.1",
         "zod": "^4.2.1"
       },
       "peerDependencies": {
-        "@spectrum-ts/core": "^8.0.0",
+        "@spectrum-ts/core": "^12.0.0",
         "typescript": "^5 || ^6.0.0"
       }
     },
@@ -617,94 +723,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/better-sqlite3": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
@@ -763,11 +786,11 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/cliui": {
@@ -830,40 +853,22 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "mimic-response": "^3.1.0"
+        "ms": "^2.1.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/dom-serializer": {
@@ -952,16 +957,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -974,6 +969,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -983,35 +985,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/foldline": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/foldline/-/foldline-1.1.0.tgz",
       "integrity": "sha512-9SheyADS50hjvFYjFJ3OB/GlDz2mD1T2CHd7auIk4Uto5YYWPBcw8iYo3F+gENJ+/SOeH9tT0loHZSqlUlumTA==",
       "license": "MIT"
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -1021,13 +999,6 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
@@ -1061,9 +1032,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1076,40 +1047,20 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -1133,18 +1084,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.11.tgz",
+      "integrity": "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -1178,74 +1129,38 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT",
       "optional": true
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/nice-grpc": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.16.tgz",
-      "integrity": "sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ==",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.17.tgz",
+      "integrity": "sha512-pu9xYPlWSeqoYQOCqb2ftQqZi/P2DaI70PSuwnxvoyIRiilaOVtktyPe6LmuXegWB4Ic1sPuDGCnCCASbwzK0w==",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.0",
         "abort-controller-x": "^0.5.0",
-        "nice-grpc-common": "^2.0.3"
+        "nice-grpc-common": "^2.0.4"
       }
     },
     "node_modules/nice-grpc-common": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.3.tgz",
-      "integrity": "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.4.tgz",
+      "integrity": "sha512-gOEXlD6ShXZMZ8k+49wm/bA2j1+3IKbEFV9WYREJcvZV4kM5L1KkILYTX9VYBzZF2OuYCe1wp8c82bQkvR0fHw==",
       "license": "MIT",
       "dependencies": {
         "ts-error": "^1.0.6"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/nth-check": {
@@ -1258,16 +1173,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/open-graph-scraper": {
@@ -1334,34 +1239,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/protobufjs": {
       "version": "8.7.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
@@ -1374,48 +1251,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1425,26 +1260,19 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1452,88 +1280,18 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/spectrum-ts": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-8.0.0.tgz",
-      "integrity": "sha512-MY/GeqWZ+aptIpG6q0385eSizxiqNo0bAEvEfSqI1ObifhsLTbxnak1ibOpfKIJF38+gR6x9hf50WXetPE36Xw==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/spectrum-ts/-/spectrum-ts-12.7.0.tgz",
+      "integrity": "sha512-XjFvNFpe5wfF1bpXcEGgNmVSCyZsTlFhdNIiCUuKGxcLn2gJC2s6nDpO2mzgufBCbeYzpi4BJPcMfd5cTKi1ag==",
       "license": "MIT",
       "dependencies": {
-        "@spectrum-ts/core": "8.0.0",
-        "@spectrum-ts/imessage": "8.0.0",
-        "@spectrum-ts/slack": "8.0.0",
-        "@spectrum-ts/telegram": "8.0.0",
-        "@spectrum-ts/terminal": "8.0.0",
-        "@spectrum-ts/whatsapp-business": "8.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "@spectrum-ts/core": "12.7.0",
+        "@spectrum-ts/imessage": "12.7.0",
+        "@spectrum-ts/slack": "12.7.0",
+        "@spectrum-ts/telegram": "12.7.0",
+        "@spectrum-ts/terminal": "12.7.0",
+        "@spectrum-ts/whatsapp-business": "12.7.0"
       }
     },
     "node_modules/string-width": {
@@ -1562,64 +1320,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ts-error": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
       "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
       "license": "MIT"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -1643,13 +1348,6 @@
       "engines": {
         "node": ">=20.18.1"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/vcf": {
       "version": "2.1.2",
@@ -1712,13 +1410,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -1756,9 +1447,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -13,7 +13,7 @@
     "node": ">=18.17"
   },
   "dependencies": {
-    "spectrum-ts": "8.0.0"
+    "spectrum-ts": "12.7.0"
   },
   "overrides": {
     "protobufjs": "8.7.1",

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -148,6 +148,16 @@ export function patchSpectrumTs(root = scriptDir()) {
         !original.includes("const rebuildFromAppleMessage = async")) {
       continue;
     }
+    // spectrum-ts 12.x replaced the attachment-only branches with
+    // `buildUnwrappedContentMessage` + `toOrderedParts`, which already emits a
+    // group containing both text and attachments. There is nothing left for
+    // Hermes to patch; keep the legacy v8 path below for older pinned installs.
+    if (
+      original.includes("const buildUnwrappedContentMessage = async") &&
+      original.includes("const parts = toOrderedParts(message.content.text, attachments);")
+    ) {
+      return { patched: false, file, reason: "upstream preserves mixed payloads" };
+    }
     let patched = original;
     patched = patchRebuild(patched);
     patched = patchInbound(patched);

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2496,15 +2496,23 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         try:
             # Bounded: a wedged CLOSE-WAIT socket can make this close hang
-            # forever and freeze the reconnect ladder (#66377).
-            await asyncio.wait_for(polling_req.shutdown(), timeout=_DRAIN_TIMEOUT)
+            # forever and freeze the reconnect ladder (#66377). The wall-clock
+            # deadline helper — not asyncio.wait_for — because httpcore's pool
+            # close runs under AsyncShieldCancellation and a cancellation-
+            # resistant close wedges wait_for itself forever (#58236/#63309);
+            # same primitive as the general-pool drain (#98094).
+            await _await_with_thread_deadline(
+                polling_req.shutdown(), timeout=_DRAIN_TIMEOUT
+            )
         except Exception:
             logger.debug(
                 "[%s] Polling request shutdown failed/timed out (non-fatal)",
                 self.name, exc_info=True,
             )
         try:
-            await asyncio.wait_for(polling_req.initialize(), timeout=_DRAIN_TIMEOUT)
+            await _await_with_thread_deadline(
+                polling_req.initialize(), timeout=_DRAIN_TIMEOUT
+            )
             logger.debug(
                 "[%s] Polling request pool drained before reconnect", self.name
             )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -19,7 +19,7 @@ import threading
 import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +91,32 @@ async def _await_with_thread_deadline(awaitable, timeout: float, *, on_abandon=N
     if result.timed_out:
         raise asyncio.TimeoutError()
     return result.value
+
+
+def _iter_exception_graph(error: BaseException) -> "Iterator[BaseException]":
+    """Yield ``error`` and every ``__cause__``/``__context__`` ancestor.
+
+    PTB wraps httpx exceptions (``TimedOut`` wrapping ``httpx.PoolTimeout``
+    wrapping …), and re-raised errors accumulate ``__context__`` chains, so a
+    classifier must inspect the whole graph, not just the top frame. DFS with
+    an identity-based ``seen`` set guards the cycles malformed chains can
+    contain. Shared by the connect-timeout and pool-timeout classifiers.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException] = [error]
+    while stack:
+        cur = stack.pop()
+        ident = id(cur)
+        if ident in seen:
+            continue
+        seen.add(ident)
+        yield cur
+        cause = getattr(cur, "__cause__", None)
+        context = getattr(cur, "__context__", None)
+        if cause is not None:
+            stack.append(cause)
+        if context is not None:
+            stack.append(context)
 
 
 async def _first_completed(*futures: "asyncio.Future") -> None:
@@ -1857,24 +1883,11 @@ class TelegramAdapter(BasePlatformAdapter):
         should not be re-sent. A ConnectTimeout means the TCP connection was
         never established, so retrying is safe and prevents silent drops.
         """
-        seen: set[int] = set()
-        stack: list[BaseException] = [error]
-        while stack:
-            cur = stack.pop()
-            ident = id(cur)
-            if ident in seen:
-                continue
-            seen.add(ident)
+        for cur in _iter_exception_graph(error):
             name = cur.__class__.__name__.lower()
             text = str(cur).lower()
             if "connecttimeout" in name or "connect timeout" in text or "connect timed out" in text:
                 return True
-            cause = getattr(cur, "__cause__", None)
-            context = getattr(cur, "__context__", None)
-            if cause is not None:
-                stack.append(cause)
-            if context is not None:
-                stack.append(context)
         return False
 
     @staticmethod
@@ -1890,26 +1903,13 @@ class TelegramAdapter(BasePlatformAdapter):
         wrapped ``httpx.PoolTimeout`` class as well as the message string so the
         check survives PTB message-wording changes.
         """
-        seen: set[int] = set()
-        stack: list[BaseException] = [error]
-        while stack:
-            cur = stack.pop()
-            ident = id(cur)
-            if ident in seen:
-                continue
-            seen.add(ident)
+        for cur in _iter_exception_graph(error):
             name = cur.__class__.__name__.lower()
             text = str(cur).lower()
             if "pooltimeout" in name or "pool timeout" in text or (
                 "connection pool" in text and "occupied" in text
             ):
                 return True
-            cause = getattr(cur, "__cause__", None)
-            context = getattr(cur, "__context__", None)
-            if cause is not None:
-                stack.append(cause)
-            if context is not None:
-                stack.append(context)
         return False
 
     def _coerce_bool_extra(self, key: str, default: bool = False) -> bool:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8179,15 +8179,35 @@ class AIAgent:
                         )
                         return system_message or ""
 
+                timeout_cause = {
+                    "total_exhausted": False,
+                    "progress_observed": False,
+                }
+
+                def _on_timeout_cause(total_exhausted, progress_observed):
+                    timeout_cause["total_exhausted"] = total_exhausted
+                    timeout_cause["progress_observed"] = progress_observed
+
                 def _on_timeout(idle, waited, since_progress):
-                    logger.warning(
-                        "Context compression made no progress for %.1fs "
-                        "(total wait %.1fs, ceiling %.1fs); continuing without "
-                        "compression",
-                        since_progress,
-                        waited,
-                        total_ceiling,
-                    )
+                    total_exhausted = timeout_cause["total_exhausted"]
+                    progress_observed = timeout_cause["progress_observed"]
+                    if total_exhausted:
+                        logger.warning(
+                            "Context compression reached its total ceiling "
+                            "after %.1fs (progress observed=%s); continuing "
+                            "without compression",
+                            waited,
+                            progress_observed,
+                        )
+                    else:
+                        logger.warning(
+                            "Context compression made no progress for %.1fs "
+                            "(total wait %.1fs, ceiling %.1fs); continuing "
+                            "without compression",
+                            since_progress,
+                            waited,
+                            total_ceiling,
+                        )
                     touch = getattr(self, "_touch_activity", None)
                     if callable(touch):
                         try:
@@ -8207,10 +8227,14 @@ class AIAgent:
                         record = getattr(compressor, "record_timeout_failure", None)
                         if callable(record):
                             try:
-                                record(
-                                    "host compress_context timeout "
+                                reason = (
+                                    "host compress_context total ceiling "
+                                    "exhausted"
+                                    if total_exhausted
+                                    else "host compress_context timeout "
                                     "(no summary progress)"
                                 )
+                                record(reason)
                             except Exception:
                                 logger.debug(
                                     "failed to record compress_context timeout "
@@ -8219,13 +8243,27 @@ class AIAgent:
                                 )
                     emit = getattr(self, "_emit_warning", None)
                     if callable(emit):
-                        emit(
-                            "⚠ Context compression timed out "
-                            f"after {idle:.1f}s with no output from the summary "
-                            "model. No messages were dropped — continuing without "
-                            "compression. Run /compress to retry, /new for a clean "
-                            "session, or check auxiliary.compression."
-                        )
+                        if total_exhausted:
+                            progress = (
+                                " after summary output was observed"
+                                if progress_observed
+                                else ""
+                            )
+                            emit(
+                                "⚠ Context compression reached its total ceiling "
+                                f"after {waited:.1f}s{progress}. No messages were "
+                                "dropped — continuing without compression. Run "
+                                "/compress to retry or /new for a clean session."
+                            )
+                        else:
+                            emit(
+                                "⚠ Context compression timed out "
+                                f"after {idle:.1f}s with no output from the summary "
+                                "model. No messages were dropped — continuing "
+                                "without compression. Run /compress to retry, /new "
+                                "for a clean session, or check "
+                                "auxiliary.compression."
+                            )
 
                 def _on_commit_overrun(waited, ceiling):
                     # Commit-phase ceiling breach: the SessionDB mutation is in
@@ -8259,6 +8297,7 @@ class AIAgent:
                     idle_timeout_seconds=idle_timeout,
                     total_ceiling_seconds=total_ceiling,
                     on_timeout=_on_timeout,
+                    on_timeout_cause=_on_timeout_cause,
                     on_commit_overrun=_on_commit_overrun,
                     fence=active_fence,
                     telemetry_agent=self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8234,7 +8234,14 @@ class AIAgent:
                                     else "host compress_context timeout "
                                     "(no summary progress)"
                                 )
-                                record(reason)
+                                record(
+                                    reason,
+                                    failure_kind=(
+                                        "ceiling_exhausted"
+                                        if total_exhausted
+                                        else "stalled"
+                                    ),
+                                )
                             except Exception:
                                 logger.debug(
                                     "failed to record compress_context timeout "

--- a/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
@@ -7,7 +7,7 @@ Full reference: https://hermes-agent.nousresearch.com/docs/user-guide/configurat
 
 | Section | Key options |
 |---------|-------------|
-| `model` | `default`, `provider`, `base_url`, `api_key`, `context_length`, `aliases` |
+| `model` | `default`, `provider`, `base_url`, `api_key`, `context_length`, `max_context_length`, `aliases` |
 | `agent` | `max_turns` (90), `tool_use_enforcement`, `service_tier`, `verify_on_stop` |
 | `terminal` | `backend` (local/docker/ssh/modal/daytona/singularity), `cwd`, `timeout` (180) |
 | `compression` | `enabled`, `threshold` (0.50), `target_ratio` (0.20) |
@@ -22,6 +22,23 @@ Full reference: https://hermes-agent.nousresearch.com/docs/user-guide/configurat
 | `curator` | `enabled`, `consolidate` (false, opt-in aux-model consolidation), `interval_hours`, `stale_after_days` |
 
 `hermes config check` reports sections missing from an older config.
+
+### Context window: `context_length` vs `max_context_length` vs `max_tokens`
+
+Three distinct knobs, frequently confused. All live under the `model` section.
+
+| Key | Meaning | Scope | Persisted? |
+|-----|---------|-------|------------|
+| `context_length` | **Exact pre-cap override** — the resolved context window for the *active* model, before the ceiling. | Per-model; discarded on `/model` switch (re-resolved for the new model). | No — a runtime override. |
+| `max_context_length` | **Profile-wide hard upper ceiling** on the effective window. `effective = min(resolved_context, max_context_length)`. | Profile-wide; survives `/model` switches; applies to every model in the profile. | No — a runtime policy. |
+| `max_tokens` | **Per-response output cap** — maximum tokens the model may *generate* in one response. | Per-response; unrelated to the input context window. | No. |
+
+`max_context_length` rules:
+- **Minimum is 64000 (64K).** A positive integer below the floor is an *invalid ceiling* (a mis-configuration, reported with a ceiling-specific error — not "the model only has this capability").
+- **Strict positive integer.** `bool`, float, numeric strings, `infinity`, and values `<= 0` are all rejected (malformed → no ceiling).
+- **Never raises a window** — it only lowers one, so it composes safely with an explicit `context_length` already below it.
+- **Cache stays raw.** It is a runtime policy and never contaminates `context_length_cache.yaml`, which retains the model's real (pre-policy) capability.
+- **Hard ceiling, enforced pre-dispatch.** Regardless of whether compression is enabled, a request still above the ceiling when it reaches the provider is refused before dispatch (with compression it has had a chance to shrink first).
 
 ### Toolsets
 

--- a/tests/agent/test_auxiliary_context_ceiling_seams.py
+++ b/tests/agent/test_auxiliary_context_ceiling_seams.py
@@ -1,0 +1,369 @@
+"""Owning-seam suite for the bounded auxiliary context-ceiling owner shard.
+
+The #78635 fracture contract requires the auxiliary context-ceiling authority
+to live in a bounded owner (``agent/auxiliary_context_ceiling.py``) with
+``agent/auxiliary_client.py`` keeping only narrow compatibility seams.  This
+suite PROVES the extraction is correct and that the authoritative seams keep
+working after the move:
+
+1.  Historical names exposed through ``agent.auxiliary_client`` are the SAME
+    objects as the shard's (identity), i.e. they DELEGATE to the shard rather
+    than re-implementing it.
+2.  Existing import names stay compatible (importable from both modules).
+3.  Monkeypatching the historical auxiliary gate/provider seam STILL controls
+    the actual live provider callback path after extraction (the decisive
+    requirement — the relay helpers that consume these names must resolve
+    them through ``agent.auxiliary_client``'s globals).
+4.  Sync fallback rebinding reaches the shard and restores authority.
+5.  Async fallback rebinding reaches the shard and restores authority.
+6.  Large→small and small→large fallback transitions remain green.
+7.  Credential-refresh fallback continues using the fallback destination's
+    credential context.
+8.  No duplicate ceiling owner remains in ``auxiliary_client.py``.
+
+The monkeypatch test (3) is the discriminating one: if the relay helpers had
+been moved to the shard alongside the gate (or the gate NOT re-imported into
+the monolith's globals), patching ``agent.auxiliary_client._aux_provider_callback``
+would NOT affect the live path and this test would fail.  It passes only when
+there is exactly one owner and the monolith delegates to it.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent import auxiliary_client as _aux
+from agent import auxiliary_context_ceiling as _shard
+from agent import model_metadata as _model_metadata
+from agent.model_metadata import ContextCeilingExceeded
+
+SHARD_MODULE = "agent.auxiliary_context_ceiling"
+MONO_MODULE = "agent.auxiliary_client"
+
+CEILING_NAMES = [
+    "_aux_relay_gate",
+    "_aux_provider_callback",
+    "_rebind_aux_ceiling_for_fallback",
+    "_rebind_aux_ceiling_for_fallback_async",
+]
+
+INITIAL_MODEL = "initial-model"
+FALLBACK_MODEL = "fallback-model"
+INITIAL_LARGE = 900_000
+FALLBACK_SMALL = 128_000
+INITIAL_SMALL = 128_000
+FALLBACK_LARGE = 900_000
+
+
+# ── 1. Historical names delegate to the shard (identity, one real owner) ──
+
+@pytest.mark.parametrize("name", CEILING_NAMES)
+def test_historical_name_is_shard_object(name):
+    """``agent.auxiliary_client.<name>`` MUST be the same object as the
+    shard's — i.e. the monolith delegates to the owner rather than keeping a
+    second copy of the ceiling authority."""
+    assert getattr(_aux, name) is getattr(_shard, name), (
+        f"agent.auxiliary_client.{name} is NOT the shard object — "
+        "duplicate ceiling authority remains in the monolith"
+    )
+
+
+@pytest.mark.parametrize("name", CEILING_NAMES)
+def test_no_duplicate_owner_in_auxiliary_client(name):
+    """The four ceiling-authority functions must be OWNED by the shard, not
+    defined in ``auxiliary_client.py`` (the monolith holds only the
+    compatibility re-import)."""
+    fn = getattr(_shard, name)
+    assert fn.__module__ == SHARD_MODULE, (
+        f"{name} is defined in {fn.__module__}, not the bounded owner shard"
+    )
+    # And it must NOT be a locally-defined function object in the monolith.
+    assert getattr(_aux, name).__module__ == SHARD_MODULE
+
+
+# ── 2. Existing import names stay compatible (both modules) ────────────────
+
+def test_imports_compatible_from_both_modules():
+    from agent.auxiliary_client import (
+        _aux_relay_gate as m_gate,
+        _aux_provider_callback as m_cb,
+        _rebind_aux_ceiling_for_fallback as m_rebind,
+        _rebind_aux_ceiling_for_fallback_async as m_rebind_async,
+    )
+    from agent.auxiliary_context_ceiling import (
+        _aux_relay_gate as s_gate,
+        _aux_provider_callback as s_cb,
+        _rebind_aux_ceiling_for_fallback as s_rebind,
+        _rebind_aux_ceiling_for_fallback_async as s_rebind_async,
+    )
+    assert m_gate is s_gate
+    assert m_cb is s_cb
+    assert m_rebind is s_rebind
+    assert m_rebind_async is s_rebind_async
+
+
+# ── 3. DECISIVE: monkeypatching the historical gate still controls the live ─
+
+def _completed_response() -> Any:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]),
+                                 finish_reason="stop")],
+        usage=None, model="test-model",
+    )
+
+
+def _sync_spy_client(fail: bool = False) -> SimpleNamespace:
+    calls: list = []
+    def create(**kwargs: Any) -> Any:
+        if fail:
+            raise RuntimeError("connection error")
+        calls.append(kwargs)
+        return _completed_response()
+    return SimpleNamespace(
+        base_url="https://api.test/v1", api_key="sk-x",
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+        _calls=calls, _hermes_fallback_destination=None,
+    )
+
+
+def test_monkeypatch_provider_callback_affects_live_relay_path(monkeypatch):
+    """The decisive seam requirement: patching the historical
+    ``agent.auxiliary_client._aux_provider_callback`` (the provider-boundary
+    wrapper) must STILL control the actual live provider callback path after
+    extraction.
+
+    We REMOVE the wrapper (identity) and assert the provider IS called with
+    the payload — i.e. the entry gate alone is insufficient, proving the
+    patch actually disabled the provider-boundary enforcement in the live
+    ``_relay_sync_completion`` path.  This mirrors the established negative
+    control in test_context_ceiling_round4_topo.py and fails if the relay
+    helper resolves the gate through a DIFFERENT module's globals than the
+    one the test patched.
+    """
+    # A small request (well under any ceiling) so the entry gate passes.
+    kwargs = {"model": "m", "messages": [{"role": "user", "content": "hi"}],
+              "max_tokens": 100}
+    client = _sync_spy_client()
+
+    # Patch the provider-boundary wrapper to identity (remove the physical seam).
+    monkeypatch.setattr(_aux, "_aux_provider_callback", lambda cb, **kw: cb)
+    monkeypatch.setattr(_aux, "_relay_auxiliary_metadata",
+                        lambda provider=None, api_mode=None: None)  # no route → direct
+
+    token = _aux.set_aux_ceiling(64_000)
+    try:
+        _aux._relay_sync_completion(client, dict(kwargs), provider="openai")
+    finally:
+        _aux.reset_aux_ceiling(token)
+
+    # The provider WAS called — because the provider-boundary wrapper (the
+    # only thing that would gate the FINAL payload at the physical seam) was
+    # patched out on the live path.  This proves the patch reached the live
+    # relay helper through agent.auxiliary_client's globals.
+    assert len(client._calls) == 1, (
+        "patching agent.auxiliary_client._aux_provider_callback did NOT affect "
+        "the live relay path — the relay helper resolves the gate through a "
+        "different module's globals than the one that was patched"
+    )
+
+
+def test_monkeypatch_gate_is_invoked_on_live_relay_path(monkeypatch):
+    """Patching the historical ``_aux_relay_gate`` must be INVOKED by the
+    live ``_relay_sync_completion`` path (the entry gate still fires)."""
+    kwargs = {"model": "m", "messages": [{"role": "user", "content": "hi"}],
+              "max_tokens": 100}
+    client = _sync_spy_client()
+    hits = {"n": 0}
+
+    def _recording_gate(kwargs=None, task="auxiliary", provider=None, model=None):
+        hits["n"] += 1
+
+    monkeypatch.setattr(_aux, "_aux_relay_gate", _recording_gate)
+    monkeypatch.setattr(_aux, "_aux_provider_callback", lambda cb, **kw: cb)
+    monkeypatch.setattr(_aux, "_relay_auxiliary_metadata",
+                        lambda provider=None, api_mode=None: None)
+
+    # No ceiling published → gate returns early, but it MUST still be the
+    # function the live path calls.
+    token = _aux.set_aux_ceiling(64_000)
+    try:
+        _aux._relay_sync_completion(client, dict(kwargs), provider="openai")
+    finally:
+        _aux.reset_aux_ceiling(token)
+
+    assert hits["n"] >= 1, (
+        "the live relay path did not call the (patched) _aux_relay_gate — "
+        "the gate seam is not the one the monolith resolves"
+    )
+
+
+# ── 4 & 5. Sync / async fallback rebinding reaches the shard, restores ─────
+
+def _small_request() -> list:
+    return [{"role": "user", "content": "x" * 600_000}]  # ~154K tokens (verified band)
+
+
+def _rebind_destination(model: str, api_key: str = "sk-fb"):
+    return _aux._FallbackDestination(
+        provider="openai", base_url="https://api.test/v1",
+        api_mode="chat_completions", model=model,
+    )
+
+
+def test_sync_rebind_reaches_shard_and_restores(monkeypatch):
+    resolver = []
+    def _ecl(model="", base_url="", api_key="", provider="", **k):
+        resolver.append({"model": model, "api_key": api_key})
+        return FALLBACK_SMALL
+    monkeypatch.setattr(_model_metadata, "effective_context_length", _ecl)
+
+    assert _aux.get_aux_ceiling() is None  # baseline
+    with _shard._rebind_aux_ceiling_for_fallback(_rebind_destination(FALLBACK_MODEL),
+                                                 api_key="sk-fb") as ce:
+        assert ce == FALLBACK_SMALL
+        # While inside the scope, the ambient ceiling is the rebound value.
+        assert _aux.get_aux_ceiling() == FALLBACK_SMALL
+    # After the scope, the prior value (None baseline) is restored.
+    assert _aux.get_aux_ceiling() is None, "sync rebind did not reset the token"
+
+
+def test_async_rebind_reaches_shard_and_restores(monkeypatch):
+    def _ecl(model="", base_url="", api_key="", provider="", **k):
+        return FALLBACK_SMALL
+    monkeypatch.setattr(_model_metadata, "effective_context_length", _ecl)
+
+    async def _run():
+        assert _aux.get_aux_ceiling() is None
+        async with _shard._rebind_aux_ceiling_for_fallback_async(
+                _rebind_destination(FALLBACK_MODEL), api_key="sk-fb") as ce:
+            assert ce == FALLBACK_SMALL
+            assert _aux.get_aux_ceiling() == FALLBACK_SMALL
+        assert _aux.get_aux_ceiling() is None, "async rebind did not reset the token"
+
+    asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ── 6. Large→small and small→large fallback transitions remain green ───────
+
+def _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        initial_ceiling, fallback_ceiling, resolver_calls):
+    def _get_cached_client(provider, model, *a, **k):
+        if model == FALLBACK_MODEL:
+            return (fallback_spy, FALLBACK_MODEL)
+        return (initial_spy, INITIAL_MODEL)
+    monkeypatch.setattr(_aux, "_get_cached_client", _get_cached_client, raising=False)
+    monkeypatch.setattr(_aux, "_is_transient_transport_error", lambda e: True, raising=False)
+    monkeypatch.setattr(_aux, "_transient_retry_count", lambda: 0, raising=False)
+    monkeypatch.setattr(_aux, "_is_connection_error", lambda e: True, raising=False)
+    for name in ("_is_payment_error", "_is_auth_error", "_is_rate_limit_error",
+                 "_is_model_incompatible_error", "_is_invalid_aux_response_error"):
+        monkeypatch.setattr(_aux, name, lambda e: False, raising=False)
+    monkeypatch.setattr(_aux, "_try_configured_fallback_chain",
+                        lambda *a, **k: (fallback_spy, FALLBACK_MODEL, "configured"),
+                        raising=False)
+    for name in ("_try_main_fallback_chain", "_try_payment_fallback",
+                 "_try_main_agent_model_fallback"):
+        monkeypatch.setattr(_aux, name, lambda *a, **k: (None, None, ""), raising=False)
+    fallback_spy._hermes_fallback_destination = _aux._FallbackDestination(
+        provider="openai", base_url="https://api.test/v1",
+        api_mode="chat_completions", model=FALLBACK_MODEL)
+    monkeypatch.setattr(_aux, "_fallback_entry_api_key",
+                        lambda entry: "sk-fallback", raising=False)
+    def _ecl(model="", base_url="", api_key="", provider="", **k):
+        resolver_calls.append({"model": model, "api_key": api_key})
+        return fallback_ceiling if model == FALLBACK_MODEL else initial_ceiling
+    monkeypatch.setattr(_model_metadata, "effective_context_length", _ecl, raising=False)
+    monkeypatch.setattr(_aux, "_validate_llm_response", lambda r, *a, **k: "OK", raising=False)
+    monkeypatch.setattr(_aux, "_relay_auxiliary_metadata",
+                        lambda **k: ("openai", "test-model", {
+                            "api_mode": "chat_completions", "api_request_id": "aux-seam",
+                            "call_role": "auxiliary:test", "retry_count": 0,
+                            "auxiliary_task": "test"}), raising=False)
+    monkeypatch.setattr(_aux, "_relay_llm_execute", lambda *a, **k: None, raising=False)
+    from agent import relay_llm as _relay
+    monkeypatch.setattr(_relay, "execute_current", lambda req, cb, **k: cb(req), raising=False)
+    async def _fake_async(req, cb, **k):
+        return await cb(req)
+    monkeypatch.setattr(_relay, "execute_current_async", _fake_async, raising=False)
+    monkeypatch.setattr(_aux, "_to_async_client",
+                        lambda client, model, is_vision=False: (client, model), raising=False)
+
+
+def _sync_spy(fail: bool) -> SimpleNamespace:
+    calls = []
+    def create(**kw):
+        if fail:
+            raise RuntimeError("connection error")
+        calls.append(kw); return _completed_response()
+    return SimpleNamespace(base_url="https://api.test/v1", api_key="sk-fb",
+                           chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+                           _calls=calls, _hermes_fallback_destination=None)
+
+
+def test_large_to_small_fallback_refused_under_fallback_ceiling(monkeypatch):
+    initial = _sync_spy(fail=True); fallback = _sync_spy(fail=False)
+    resolver = []
+    _patch_fallback_env(monkeypatch, initial, fallback,
+                        INITIAL_LARGE, FALLBACK_SMALL, resolver)
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm("test", provider="openai", model=INITIAL_MODEL,
+                      api_key="sk-initial", messages=_small_request(), max_tokens=None)
+    assert len(fallback._calls) == 0, "fallback physically called under stale ceiling"
+    assert any(c["model"] == FALLBACK_MODEL for c in resolver)
+
+
+def test_small_to_large_fallback_gate_uses_fallback_authority(monkeypatch):
+    """small initial (128K) → large fallback (900K) — the reverse-direction
+    discriminator, proven at the GATE level (the end-to-end path can't express
+    it: the local-refusal-is-terminal invariant refuses a request above the
+    small initial *before* the fallback path, and one below it passes trivially).
+
+    A request in the discriminating band (between 128K and 900K) must be
+    ACCEPTED when the ceiling is rebound to the fallback destination's OWN
+    (larger) ceiling, and REFUSED under the small initial's ceiling.  This
+    proves "every physical fallback destination uses its own authority" in the
+    reverse direction: the rebind to a larger destination relaxes the gate to
+    that destination's authority rather than inheriting the smaller one."""
+    from agent.model_metadata import enforce_final_context_budget
+    # Resolve the fallback destination's OWN ceiling to the large value.
+    monkeypatch.setattr(_model_metadata, "effective_context_length",
+                        lambda model="", base_url="", api_key="", provider="", **k: FALLBACK_LARGE)
+    # A band request: > 128K (small initial) but < 900K (large fallback).
+    band = [{"role": "user", "content": "x" * 600_000}]  # ~154K tokens
+    kwargs = {"model": "m", "messages": band, "max_tokens": 4096}
+
+    def _budget():
+        return _model_metadata.build_final_context_budget(kwargs, provider="openai", model="m")
+
+    # Under the small initial ceiling (128K) the band request is refused…
+    with pytest.raises(ContextCeilingExceeded):
+        enforce_final_context_budget(_budget(), ceiling=INITIAL_SMALL, reason="initial")
+
+    # …but when rebound to the fallback destination's OWN ceiling (900K), the
+    # SAME request passes — the fallback's larger authority is honored.
+    with _shard._rebind_aux_ceiling_for_fallback(
+            _rebind_destination(FALLBACK_MODEL), api_key="sk-fb") as ce:
+        assert ce == FALLBACK_LARGE
+        _model_metadata.enforce_final_context_budget(_budget(),
+                                                     ceiling=_aux.get_aux_ceiling(),
+                                                     reason="fallback")  # no raise = dispatched
+
+
+# ── 7. Credential-refresh fallback uses the fallback credential context ────
+
+def test_fallback_resolution_carries_credential(monkeypatch):
+    initial = _sync_spy(fail=True); fallback = _sync_spy(fail=False)
+    resolver = []
+    _patch_fallback_env(monkeypatch, initial, fallback,
+                        INITIAL_LARGE, FALLBACK_SMALL, resolver)
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm("test", provider="openai", model=INITIAL_MODEL,
+                      api_key="sk-initial", messages=_small_request(), max_tokens=None)
+    fb = [c for c in resolver if c["model"] == FALLBACK_MODEL]
+    assert fb and fb[0]["api_key"], (
+        "fallback ceiling resolution did not carry the destination credential"
+    )

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -83,7 +83,22 @@ def _make_codex_agent(monkeypatch, tmp_path: Path, *, show_notice: bool):
 
 def _threshold_ratio(agent: AIAgent) -> float:
     compressor = getattr(agent, "context_compressor")
-    return round(compressor.threshold_tokens / compressor.context_length, 2)
+    # Option A: the threshold is ``pct * (context_length - reservation)`` — the
+    # autoraise sets a percentage of the EFFECTIVE INPUT budget, not the raw
+    # window. Measuring the ratio against the effective budget recovers the
+    # configured percentage (0.85) instead of a reservation-diluted 0.84.
+    from agent.model_metadata import resolve_output_reservation
+
+    reservation = resolve_output_reservation(
+        None,
+        explicit_cap=compressor.max_tokens,
+        provider=compressor.provider,
+        model=compressor.model,
+    )
+    effective = compressor.context_length - reservation
+    if effective <= 0:
+        effective = compressor.context_length
+    return round(compressor.threshold_tokens / effective, 2)
 
 
 # ── config display gate ──────────────────────────────────────────────────────

--- a/tests/agent/test_compat_92797_92083.py
+++ b/tests/agent/test_compat_92797_92083.py
@@ -1,0 +1,172 @@
+"""#92797 / #92083 compatibility tests for the ``feat/context-length-cap`` branch.
+
+Purpose: prove (in code, not prose) that the dirty worktree stays compatible
+with two upstream changes that touch the same code surface, and pin the exact
+one-line fix the reviewer/maintainer must apply when those land.
+
+  #92797 (MERGED 2026-08-23): Codex GPT slugs default to 272K; ``-900k``
+      variants opt into 900K. Touches ``agent/model_metadata.py``
+      (L2418-2625, the Codex-context resolvers) and
+      ``agent/auxiliary_client.py`` (L161 import line, L1531 wire-strip).
+
+  #92083 (OPEN PR): warns on unknown keys in the ``model:`` config block by
+      adding ``_KNOWN_MODEL_KEYS`` to ``hermes_cli/config.py``.
+
+Findings locked in by these tests:
+
+  * #92797 — NO textual merge conflict (different line ranges in both shared
+    files) and CLEAN semantic composition (the branch ceiling is a
+    post-resolution hard cap, ``effective = min(resolved, ceiling)``). The
+    only shared line (``auxiliary_client.py`` L161 import) is additive on
+    both sides, so it merges cleanly.
+  * #92083 — ONE real semantic conflict: the branch's ceiling lives at
+    ``model.max_context_length`` (a ``model:``-block key), but #92083's
+    proposed ``_KNOWN_MODEL_KEYS`` omits it. When #92083 merges, any user who
+    sets the ceiling gets a spurious
+    ``model: unknown config keys ignored: max_context_length`` warning.
+    Fix = add ``max_context_length`` to ``_KNOWN_MODEL_KEYS`` (one line).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# ── #92083: the model.max_context_length ceiling key ──────────────────────
+
+# Verbatim copy of the ``_KNOWN_MODEL_KEYS`` set proposed by #92083 (open PR),
+# read from the PR diff. It is NOT present in this branch's base, so the test
+# carries the reference set inline rather than importing it.
+KNOWN_MODEL_KEYS_92083 = {
+    "api_base",
+    "base_url",
+    "context_length",
+    "default",
+    "model",
+    "name",
+    "provider",
+    "stale_timeout_seconds",
+    "timeout_seconds",
+}
+
+
+def test_branch_ceiling_key_is_not_in_92083_known_set_documents_gap() -> None:
+    """DOCUMENTS the #92083 conflict as a known, expected fact (green test).
+
+    The branch reads its ceiling from ``model.max_context_length``. #92083's
+    proposed known-key set does NOT include ``max_context_length``, so the
+    set-difference that #92083's ``_warn_unknown_model_keys`` performs would
+    flag it. This test asserts that gap EXACTLY so a reviewer can see it, and
+    so it keeps failing loudly (by design) the moment #92083's set is
+    imported into this branch WITHOUT the one-line fix.
+
+    REQUIRED FIX (one line, in ``hermes_cli/config.py`` when #92083 lands):
+        _KNOWN_MODEL_KEYS = {..., "max_context_length", ...}
+    """
+    branch_ceiling_key = "max_context_length"  # what agent_init.py / _get_max_context_length read
+
+    # This is the gap: the branch's key is absent from #92083's known set.
+    assert branch_ceiling_key not in KNOWN_MODEL_KEYS_92083, (
+        "Surprise: #92083's _KNOWN_MODEL_KEYS now includes 'max_context_length'. "
+        "If that is the case, the spurious-warning conflict is already resolved "
+        "and this test (which documents the gap) should be inverted to assert "
+        "the key IS recognised."
+    )
+
+    # And confirm the set-difference #92083 runs would flag exactly our key:
+    model_block: Dict[str, Any] = {
+        "model": "gpt-4o",
+        "provider": "custom",
+        "context_length": 128000,
+        "max_context_length": 90000,  # the branch's ceiling key
+    }
+    flagged = set(model_block.keys()) - KNOWN_MODEL_KEYS_92083
+    assert flagged == {"max_context_length"}, (
+        f"Expected #92083 to flag only the branch ceiling key; got {flagged}"
+    )
+
+
+def test_92083_fix_resolves_the_spurious_warning() -> None:
+    """Prove the one-line fix eliminates the spurious warning.
+
+    Adding ``max_context_length`` to #92083's known-key set makes the
+    set-difference empty for a config that carries the branch's ceiling, so
+    ``_warn_unknown_model_keys`` logs nothing.
+    """
+    fixed_known_set = KNOWN_MODEL_KEYS_92083 | {"max_context_length"}
+
+    model_block: Dict[str, Any] = {
+        "model": "gpt-4o",
+        "provider": "custom",
+        "context_length": 128000,
+        "max_context_length": 90000,
+    }
+    flagged = set(model_block.keys()) - fixed_known_set
+    assert flagged == set(), (
+        "With the fix applied, no key should be flagged as unknown"
+    )
+
+
+def test_ceiling_validation_still_strict_after_recognition() -> None:
+    """Recognising the key in config must NOT loosen the branch's validator.
+
+    Adding ``max_context_length`` to the known-key set is a config-validation
+    change only; the branch's own strict ``coerce_context_ceiling`` pipeline
+    (rejects bool/float/numeric-string/<=0) is unaffected.
+    """
+    from agent.model_metadata import coerce_context_ceiling
+
+    assert coerce_context_ceiling(90000) == 90000
+    assert coerce_context_ceiling(272000) == 272000
+    # Invalid values still rejected — recognition must not relax these.
+    assert coerce_context_ceiling(True) is None      # bool
+    assert coerce_context_ceiling(12.5) is None       # float
+    assert coerce_context_ceiling("90000") is None    # numeric string
+    assert coerce_context_ceiling(0) is None          # zero
+    assert coerce_context_ceiling(-1) is None         # negative
+
+
+# ── #92797: ceiling composes with Codex context resolution ────────────────
+
+def test_ceiling_caps_codex_900k_resolution() -> None:
+    """#92797 resolves Codex slugs; the branch ceiling caps the result.
+
+    #92797: ``gpt-5.6-sol`` → 272K, ``gpt-5.6-sol-900k`` → 900K.
+    Branch: ``effective = min(resolved, max_context_length)``.
+
+    The ceiling never RAISES a window, only lowers one, so it composes
+    cleanly over any value #92797 produces.
+    """
+    from agent.model_metadata import coerce_context_ceiling
+
+    resolved_codex_900k = 900_000
+    ceiling = coerce_context_ceiling(272_000)
+    assert ceiling == 272_000
+    assert min(resolved_codex_900k, ceiling) == 272_000
+
+    # Ceiling below a 272K base slug still caps downward.
+    ceiling_128k = coerce_context_ceiling(128_000)
+    assert min(272_000, ceiling_128k) == 128_000
+
+    # A ceiling at or above the resolved value is a no-op (never raises).
+    assert min(272_000, coerce_context_ceiling(272_000)) == 272_000
+
+
+def test_wire_strip_and_ceiling_are_orthogonal() -> None:
+    """#92797 strips the ``-900k`` suffix before the model id hits the wire;
+    the branch's ceiling is a token budget — they operate on different axes
+    and do not interact.
+
+    The wire-strip only affects the *model id string*; the ceiling only
+    affects the *token budget*. A ``-900k`` slug stripped to its base id
+    still resolves the same 900K window that the ceiling then caps.
+    """
+    # The base id the wire sees after #92797's strip.
+    base_slug = "gpt-5.6-sol"
+    resolved_window = 900_000  # the -900k variant's window, before ceiling
+
+    from agent.model_metadata import coerce_context_ceiling
+    ceiling = coerce_context_ceiling(400_000)
+    effective = min(resolved_window, ceiling)
+    assert effective == 400_000
+    # The wire model id is unaffected by the ceiling (string vs int).
+    assert base_slug == "gpt-5.6-sol"

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -70,7 +70,10 @@ class TestRunCompressContextWithProgressTimeout:
             messages=original,
             system_prompt_fallback="fallback-prompt",
             idle_timeout_seconds=0.05,
-            total_ceiling_seconds=0.2,
+            # Leave enough total budget for a busy Windows runner to start the
+            # daemon worker; this case exercises inactivity cancellation, not
+            # the separate total-ceiling path.
+            total_ceiling_seconds=2.0,
             on_timeout=lambda idle, waited, since: warnings.append(
                 (idle, waited, since)
             ),

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -8,12 +8,14 @@ for the owned wrapper used when callers do not pass a ``commit_fence``.
 
 from __future__ import annotations
 
+import concurrent.futures
 import threading
 import time
 from unittest.mock import MagicMock
 
 import pytest
 
+import agent.conversation_compression as cc
 from agent.conversation_compression import (
     CompressionCommitFence,
     resolve_context_compression_timeouts,
@@ -46,6 +48,46 @@ class TestResolveContextCompressionTimeouts:
 
 
 class TestRunCompressContextWithProgressTimeout:
+    def test_deadline_before_worker_start_uses_timeout_fallback(self, monkeypatch):
+        original = [{"role": "user", "content": "keep-me"}]
+        worker = MagicMock()
+        fallback = MagicMock(return_value="fallback-prompt")
+        timeouts = []
+
+        class _ExpiredBeforeStartExecutor:
+            def submit(self, fn, fence):
+                fence._deadline = time.monotonic() - 1.0
+                future = concurrent.futures.Future()
+                try:
+                    future.set_result(fn(fence))
+                except BaseException as exc:
+                    future.set_exception(exc)
+                return future
+
+        monkeypatch.setattr(
+            cc,
+            "_get_compress_timeout_executor",
+            _ExpiredBeforeStartExecutor,
+        )
+
+        result_msgs, result_prompt = run_compress_context_with_progress_timeout(
+            worker=worker,
+            messages=original,
+            system_prompt_fallback=fallback,
+            idle_timeout_seconds=1.0,
+            total_ceiling_seconds=1.0,
+            on_timeout=lambda idle, waited, since: timeouts.append(
+                (idle, waited, since)
+            ),
+            stall_fallback=False,
+        )
+
+        worker.assert_not_called()
+        fallback.assert_called_once_with()
+        assert result_msgs is original
+        assert result_prompt == "fallback-prompt"
+        assert len(timeouts) == 1
+
     def test_silent_worker_times_out_and_preserves_messages(self):
         original = [{"role": "user", "content": "keep-me"}]
         started = threading.Event()

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -483,6 +483,73 @@ class TestCompressContextForwarderOwnsTimeout:
             provenance=ActivityProvenance.AGENT_COMPRESSION_TIMEOUT,
         )
 
+    def test_owned_total_ceiling_reports_progress_accurately(self, monkeypatch):
+        from run_agent import AIAgent
+        from agent.context_compressor import ContextCompressor
+
+        agent = object.__new__(AIAgent)
+        agent.session_id = "s1"
+        agent._cached_system_prompt = "sys"
+        agent._emit_warning = MagicMock()
+        agent._touch_activity = MagicMock()
+        agent._build_system_prompt = MagicMock(return_value="sys")
+        agent._conversation_root_id = MagicMock(return_value=None)
+        agent.context_compressor = MagicMock()
+        agent.context_compressor._consecutive_timeout_failures = 0
+        agent.context_compressor.record_timeout_failure = (
+            ContextCompressor.record_timeout_failure.__get__(
+                agent.context_compressor, MagicMock
+            )
+        )
+        agent.context_compressor._record_compression_failure_cooldown = MagicMock()
+
+        release = threading.Event()
+
+        def streaming_compress(agent_obj, messages, system_message, **kwargs):
+            fence = kwargs["commit_fence"]
+            while not fence.deadline_exceeded:
+                fence.touch_progress()
+                time.sleep(0.005)
+            release.wait(timeout=2)
+            return messages, "sys"
+
+        monkeypatch.setattr(
+            "agent.conversation_compression.compress_context",
+            streaming_compress,
+        )
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (0.05, 0.15),
+        )
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_compression_fallback_route",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "agent.portal_tags.get_conversation_context",
+            lambda: object(),
+        )
+
+        original = [{"role": "user", "content": "stay"}]
+        try:
+            out_msgs, out_prompt = AIAgent._compress_context(
+                agent, original, "sys"
+            )
+        finally:
+            release.set()
+
+        assert out_msgs is original
+        assert out_prompt == "sys"
+        warning = agent._emit_warning.call_args.args[0]
+        assert "total ceiling" in warning
+        assert "summary output was observed" in warning
+        assert "no output" not in warning
+        cooldown_error = (
+            agent.context_compressor._record_compression_failure_cooldown
+            .call_args.args[1]
+        )
+        assert "total ceiling exhausted" in cooldown_error
+
     def test_fallback_prompt_resolved_lazily_on_timeout(self, monkeypatch):
         """Eager prompt rebuild must not run before compression starts."""
         from run_agent import AIAgent

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -1,0 +1,279 @@
+"""Attempt-lifecycle regression tests for #97488 / #96775.
+
+Pins the three attempt-level lifecycle guarantees added after PR #98628
+collapsed lean compaction to one auxiliary request per attempt:
+
+1. A ceiling/idle-timeout host TEARS DOWN its worker: a cooperative worker is
+   joined within the bounded grace (releasing the lease normally), while an
+   uninterruptible worker is orphaned behind the poison fence — its late
+   result is discarded and, on the total-ceiling path, the durable lease is
+   retained until it exits so no new attempt overlaps the unchanged session.
+2. A failed/stalled/cancelled attempt records a durable per-session backoff
+   (strategy + failure kind stamped into the state.db cooldown row) that
+   SURVIVES a gateway restart; the next automatic turn skips the same
+   strategy inside the window, and a successful compression clears it.
+3. Late results from a superseded attempt are discarded, never committed
+   over newer state (generation counter), and a transiently-blocked no-op is
+   reported as a soft defer — never compression_exhausted (false auto-reset).
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.conversation_compression import (
+    CompressionCommitFence,
+    _claim_compressor_attempt,
+    compress_context,
+    compression_blocked_transiently,
+    run_compress_context_with_progress_timeout,
+)
+from hermes_state import SessionDB
+
+
+def _build_agent(tmp_path: Path, session_id: str, db: SessionDB | None = None):
+    if db is None:
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id, source="cli")
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._cached_system_prompt = "sys"
+    agent.context_compressor.threshold_tokens = 1_000
+    return db, agent
+
+
+def _messages():
+    return [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+
+class TestWorkerTeardownOnCeiling:
+    def test_cooperative_worker_joined_within_grace(self):
+        """A worker that exits promptly after cancel is joined; the lease is
+        released normally (no retention) — the sabotage check for this test
+        is removing the `_join_cancelled_worker` call, which makes
+        `worker_done_when_host_returned` False."""
+        original = [{"role": "user", "content": "keep"}]
+        worker_done = threading.Event()
+
+        def cooperative_worker(fence: CompressionCommitFence):
+            # Poll the poison fence like the production worker does between
+            # provider phases; exit as soon as cancellation is visible.
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if fence.is_cancelled:
+                    break
+                fence_idle = fence.seconds_since_progress()
+                assert fence_idle >= 0  # precondition: fence clock live
+                time.sleep(0.01)
+            worker_done.set()
+            return (original, "late")
+
+        fence = CompressionCommitFence()
+        msgs, prompt = run_compress_context_with_progress_timeout(
+            worker=cooperative_worker,
+            messages=original,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.05,
+            total_ceiling_seconds=0.15,
+            fence=fence,
+            stall_fallback=False,
+        )
+        # The bounded-grace join must have reaped the cooperative worker
+        # BEFORE the host returned.
+        assert worker_done.is_set(), (
+            "host returned before tearing down a cooperative cancelled "
+            "worker — bounded-grace join missing (#97488)"
+        )
+        assert prompt == "fallback"
+        # Teardown proved quiescence, so the lease must NOT stay retained.
+        assert fence._retain_cancelled_lock_until_worker_done is False
+
+    def test_uninterruptible_worker_is_orphaned_with_lease_retained(self):
+        """A worker stuck in an uninterruptible provider call is orphaned:
+        the host returns after the grace, the poison fence discards its late
+        result, and on the total-ceiling path the durable lease release hook
+        does NOT fire while the worker is alive (no overlap window)."""
+        original = [{"role": "user", "content": "keep"}]
+        release = threading.Event()
+        worker_finished = threading.Event()
+        lock_released: list[float] = []
+
+        def stuck_worker(fence: CompressionCommitFence):
+            # Continuous progress so only the TOTAL ceiling can expire
+            # (the #97488 'last progress 0.0s ago' shape).
+            while not release.wait(timeout=0.02):
+                fence.touch_progress()
+            worker_finished.set()
+            if not fence.begin_commit():
+                return (original, "")
+            try:
+                return ([{"role": "assistant", "content": "late"}], "late")
+            finally:
+                fence.finish_commit()
+
+        fence = CompressionCommitFence()
+        fence.register_cancelled_lock_release(
+            lambda: lock_released.append(time.monotonic())
+        )
+        msgs, prompt = run_compress_context_with_progress_timeout(
+            worker=stuck_worker,
+            messages=original,
+            system_prompt_fallback="fallback",
+            idle_timeout_seconds=0.1,
+            total_ceiling_seconds=0.3,
+            fence=fence,
+            stall_fallback=False,
+        )
+        # Precondition: the worker is genuinely still running.
+        assert not worker_finished.is_set()
+        assert msgs is original and prompt == "fallback"
+        # Total-ceiling path: lease retained until the worker exits, so no
+        # new attempt can overlap the unchanged session.
+        assert not lock_released, (
+            "durable lease released while the timed-out worker was still "
+            "alive — overlap window reopened (#97488)"
+        )
+        release.set()
+        assert worker_finished.wait(timeout=2)
+        # Late result was fence-poisoned, never adopted.
+        assert msgs == [{"role": "user", "content": "keep"}]
+
+
+class TestDurableAttemptBackoff:
+    def test_backoff_row_records_strategy_and_kind(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "BACKOFF_KIND")
+        agent.context_compressor.record_timeout_failure(
+            "host ceiling exhausted", failure_kind="ceiling_exhausted"
+        )
+        row = db.get_compression_failure_cooldown("BACKOFF_KIND")
+        assert row is not None, "backoff must persist to state.db"
+        assert row["remaining_seconds"] > 0
+        assert "backoff:ceiling_exhausted:strategy=lean" in (row["error"] or "")
+
+    def test_backoff_blocks_same_strategy_reentry_next_turn(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "BACKOFF_REENTRY")
+        agent.context_compressor.record_timeout_failure(
+            "stall", failure_kind="stalled"
+        )
+        # Precondition: over threshold, so only the backoff can block.
+        assert 500_000 >= agent.context_compressor.threshold_tokens
+        should, reason = agent.context_compressor.should_compress_info(500_000)
+        assert should is False
+        assert reason and reason.startswith("cooldown"), (
+            "next-turn re-entry of the same strategy must be skipped inside "
+            "the backoff window (#96775)"
+        )
+
+    def test_backoff_survives_simulated_gateway_restart(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "BACKOFF_RESTART")
+        agent.context_compressor.record_timeout_failure(
+            "stall before restart", failure_kind="stall_interrupted"
+        )
+        # Precondition: row is durable in this DB file.
+        assert db.get_compression_failure_cooldown("BACKOFF_RESTART")
+        # Simulated restart: brand-new SessionDB handle + brand-new agent
+        # objects rebuilt from the same state.db file.
+        db2 = SessionDB(db_path=tmp_path / "state.db")
+        _db2, agent2 = _build_agent(tmp_path, "BACKOFF_RESTART", db=db2)
+        cooldown = agent2.context_compressor.get_active_compression_failure_cooldown(
+            refresh=True
+        )
+        assert cooldown is not None, (
+            "backoff must survive a gateway restart via state.db (#96775)"
+        )
+        assert "stall_interrupted" in (cooldown["error"] or "")
+        should, reason = agent2.context_compressor.should_compress_info(500_000)
+        assert should is False and reason.startswith("cooldown")
+
+    def test_success_clears_backoff(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "BACKOFF_CLEAR")
+        compressor = agent.context_compressor
+        compressor.record_timeout_failure("stall", failure_kind="stalled")
+        assert db.get_compression_failure_cooldown("BACKOFF_CLEAR")
+        # What a successful compression does on commit:
+        compressor._clear_compression_failure_cooldown()
+        assert db.get_compression_failure_cooldown("BACKOFF_CLEAR") is None
+        assert compressor.should_compress_info(500_000)[0] is True
+
+
+class TestSupersessionDiscardsLateResults:
+    def test_superseded_attempt_candidate_never_commits(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "SUPERSEDE")
+        live = _messages()
+        original = copy.deepcopy(live)
+
+        def compress_and_get_superseded(messages, **_kwargs):
+            # While this attempt's summary was in flight, a NEWER attempt
+            # claimed the compressor (what a retry/fallback does).
+            _claim_compressor_attempt(agent.context_compressor)
+            return [{"role": "assistant", "content": "stale summary"}]
+
+        agent.context_compressor.compress = compress_and_get_superseded
+        out, _prompt = compress_context(
+            agent, live, "sys", approx_tokens=500_000
+        )
+        assert out == original, (
+            "late candidate from a superseded attempt must be discarded, "
+            "never committed over newer state (#97488)"
+        )
+        assert live == original
+        # Session stayed writable and unrotated.
+        assert db.get_compression_lock_holder("SUPERSEDE") is None
+        db.append_message("SUPERSEDE", "assistant", "still writable")
+
+
+class TestTransientBlockIsNotExhaustion:
+    def test_cooldown_blocked_noop_sets_transient_signal(self, tmp_path: Path):
+        db, agent = _build_agent(tmp_path, "TRANSIENT_SIGNAL")
+        agent.context_compressor.record_timeout_failure(
+            "host ceiling", failure_kind="ceiling_exhausted"
+        )
+        live = _messages()
+        before = copy.deepcopy(live)
+        out, _ = compress_context(agent, live, "sys", approx_tokens=500_000)
+        # Preconditions: the pass no-oped and it was NOT a lock skip.
+        assert out == before
+        assert getattr(agent, "_compression_skipped_due_to_lock", None) is None
+        assert compression_blocked_transiently(agent) is True, (
+            "a cooldown-blocked no-op must be distinguishable from "
+            "exhaustion or the gateway falsely auto-resets (#97488)"
+        )
+
+    def test_signal_cleared_per_attempt_and_not_set_when_unblocked(
+        self, tmp_path: Path
+    ):
+        db, agent = _build_agent(tmp_path, "TRANSIENT_CLEAR")
+        # Stale signal from a previous pass must not leak.
+        agent._compression_blocked_transient = "cooldown:999"
+        agent.context_compressor.compress = lambda messages, **kw: list(messages)
+        live = _messages()
+        compress_context(agent, live, "sys", approx_tokens=500_000)
+        assert compression_blocked_transiently(agent) is False
+
+    def test_type_pinned_against_magicmock_agents(self):
+        from unittest.mock import MagicMock
+
+        mock_agent = MagicMock()
+        # MagicMock auto-attributes are truthy but not str.
+        assert compression_blocked_transiently(mock_agent) is False

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -69,23 +69,29 @@ def _messages():
 
 class TestWorkerTeardownOnCeiling:
     def test_cooperative_worker_joined_within_grace(self):
-        """A worker that exits promptly after cancel is joined; the lease is
-        released normally (no retention) — the sabotage check for this test
-        is removing the `_join_cancelled_worker` call, which makes
-        `worker_done_when_host_returned` False."""
+        """A worker that exits promptly after cancel is joined on the
+        total-ceiling path; the lease is released normally (no retention) —
+        the sabotage check for this test is removing the
+        `_join_cancelled_worker` call, which makes
+        `worker_done.is_set()` False when the host returns."""
         original = [{"role": "user", "content": "keep"}]
         worker_done = threading.Event()
 
         def cooperative_worker(fence: CompressionCommitFence):
-            # Poll the poison fence like the production worker does between
-            # provider phases; exit as soon as cancellation is visible.
+            # Continuous progress (the #97488 'last progress 0.0s ago'
+            # shape) so only the TOTAL ceiling expires; poll the poison
+            # fence like the production worker does between provider phases.
             deadline = time.monotonic() + 5.0
             while time.monotonic() < deadline:
                 if fence.is_cancelled:
                     break
-                fence_idle = fence.seconds_since_progress()
-                assert fence_idle >= 0  # precondition: fence clock live
+                fence.touch_progress()
                 time.sleep(0.01)
+            # Cooperative-but-not-instant exit: the unwind after seeing the
+            # poison takes real time (rollback, telemetry). Long enough that
+            # a host WITHOUT the bounded-grace join returns first; far
+            # inside the 5s grace for a host WITH it.
+            time.sleep(0.08)
             worker_done.set()
             return (original, "late")
 
@@ -94,8 +100,8 @@ class TestWorkerTeardownOnCeiling:
             worker=cooperative_worker,
             messages=original,
             system_prompt_fallback="fallback",
-            idle_timeout_seconds=0.05,
-            total_ceiling_seconds=0.15,
+            idle_timeout_seconds=0.1,
+            total_ceiling_seconds=0.2,
             fence=fence,
             stall_fallback=False,
         )
@@ -105,7 +111,11 @@ class TestWorkerTeardownOnCeiling:
             "host returned before tearing down a cooperative cancelled "
             "worker — bounded-grace join missing (#97488)"
         )
-        assert prompt == "fallback"
+        # Whichever return path won the race (fallback via join, or the
+        # worker's own return adopted inside the final wait slice), the
+        # transcript must be unchanged.
+        assert msgs == [{"role": "user", "content": "keep"}]
+        assert prompt in ("fallback", "late")
         # Teardown proved quiescence, so the lease must NOT stay retained.
         assert fence._retain_cancelled_lock_until_worker_done is False
 

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -820,6 +820,27 @@ def test_commit_fence_waits_for_an_active_commit() -> None:
     assert result["cancelled"] is False
 
 
+def test_total_deadline_cancellation_retains_lock_until_worker_cleanup() -> None:
+    """A total-ceiling timeout must exclude retries while its worker is alive."""
+    from agent.conversation_compression import CompressionCommitFence
+
+    released = threading.Event()
+    fence = CompressionCommitFence(total_ceiling_seconds=1.0)
+    fence.register_cancelled_lock_release(released.set)
+    fence.retain_compression_lock_until_worker_done()
+
+    now = time.monotonic()
+    with patch(
+        "agent.conversation_compression.time.monotonic",
+        return_value=now + 2.0,
+    ):
+        assert fence.is_cancelled
+        assert fence.try_cancel_before_commit() is True
+    fence.release_cancelled_compression_lock()
+
+    assert not released.is_set()
+
+
 def test_delayed_contender_adopts_unique_rotated_child(tmp_path: Path) -> None:
     """A stale agent must continue on the winner's compacted child transcript."""
     db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -457,6 +457,7 @@ class TestF6ExecutorSaturation:
             assert returned is messages
             # The cancelled attempt must not leave the durable lock held.
             assert db.get_compression_lock_holder(session_id) is None
+            db.close()
 
 
 class TestS3IdleChargedFromLastProgress:
@@ -480,6 +481,7 @@ class TestS3IdleChargedFromLastProgress:
                 system_prompt_fallback="fb",
                 idle_timeout_seconds=idle,
                 total_ceiling_seconds=5.0,
+                stall_fallback=False,
             )
         finally:
             elapsed = time.monotonic() - t0

--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -44,13 +44,15 @@ def _drain_admission_slots():
 
 
 class TestF1CommitOverrunWhileHung:
-    def test_overrun_warning_fires_while_commit_still_blocked(self):
+    def test_overrun_warning_fires_while_commit_still_blocked(self, monkeypatch):
         """The warning + on_commit_overrun fire DURING the hang, not after.
 
         The fake commit is event-gated and is NOT released until after the
         assertions on the callback/log have been made while the worker
         thread is still blocked inside the commit boundary.
         """
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        monkeypatch.setattr(cc, "_get_compress_timeout_executor", lambda: executor)
         original = [{"role": "user", "content": "a"}]
         compressed = [{"role": "assistant", "content": "late"}]
         entered = threading.Event()
@@ -86,8 +88,8 @@ class TestF1CommitOverrunWhileHung:
                 worker=worker,
                 messages=original,
                 system_prompt_fallback="fallback",
-                idle_timeout_seconds=0.05,
-                total_ceiling_seconds=0.05,
+                idle_timeout_seconds=1.0,
+                total_ceiling_seconds=1.0,
                 on_commit_overrun=on_overrun,
             )
 
@@ -124,13 +126,14 @@ class TestF1CommitOverrunWhileHung:
                     "expected the overrun WARNING while the commit was "
                     f"still blocked; got: {[r.getMessage() for r in records]}"
                 )
-                assert overruns and overruns[0][1] == pytest.approx(0.05)
+                assert overruns and overruns[0][1] == pytest.approx(1.0)
             finally:
                 release.set()
             t.join(timeout=5)
             assert not t.is_alive()
         finally:
             comp_logger.removeHandler(handler)
+            executor.shutdown(wait=True)
         assert done["result"] == (compressed, "committed-late")
         _drain_admission_slots()
 

--- a/tests/agent/test_compression_small_ctx_threshold_floor.py
+++ b/tests/agent/test_compression_small_ctx_threshold_floor.py
@@ -31,25 +31,38 @@ def _make(ctx: int, pct: float = 0.50) -> ContextCompressor:
 
 class TestSmallContextThresholdFloor:
     def test_sub_512k_floors_to_75_percent(self):
+        # The shared reservation policy reserves DEFAULT_OUTPUT_RESERVATION
+        # (4096) for the unknown provider, so the input budget is
+        # (window - 4096) and the threshold is 75% of that — coherent with
+        # the terminal gate and the wire, never a zero reservation.
+        from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
         for ctx in (128_000, 200_000, 262_144, 511_999):
             comp = _make(ctx, pct=0.50)
             assert comp.threshold_percent == 0.75, ctx
-            assert comp.threshold_tokens == int(ctx * 0.75), ctx
+            assert comp.threshold_tokens == int(
+                (ctx - DEFAULT_OUTPUT_RESERVATION) * 0.75
+            ), ctx
 
 
 
 
     def test_update_model_rederives_floor_both_directions(self):
+        from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
         comp = _make(128_000, pct=0.50)
         assert comp.threshold_percent == 0.75
         # small -> large: back to the configured 50%
         comp.update_model("big", 1_000_000)
         assert comp.threshold_percent == 0.50
-        assert comp.threshold_tokens == 500_000
+        # Reserves the shared-policy output allowance (4096, unknown provider).
+        assert comp.threshold_tokens == int(
+            (1_000_000 - DEFAULT_OUTPUT_RESERVATION) * 0.50
+        )
         # large -> small: floor re-applies
         comp.update_model("small", 200_000)
         assert comp.threshold_percent == 0.75
-        assert comp.threshold_tokens == 150_000
+        assert comp.threshold_tokens == int(
+            (200_000 - DEFAULT_OUTPUT_RESERVATION) * 0.75
+        )
 
 
 class TestReasoningExcludedFromSummarizer:

--- a/tests/agent/test_compression_stall_interrupt_96775.py
+++ b/tests/agent/test_compression_stall_interrupt_96775.py
@@ -171,7 +171,7 @@ class TestStallInterruptedBackoff:
         assert db.get_compression_lock_holder("STALL_AUX_CANCEL") is None
         state = db.get_compression_failure_cooldown("STALL_AUX_CANCEL")
         assert state is not None
-        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert STALL_INTERRUPTED_FAILURE_CLASS in str(state["error"])
         assert "msgs=20" in str(state["error"])
         assert agent.context_compressor.should_compress(50_000) is False
 
@@ -222,7 +222,7 @@ class TestStallInterruptedBackoff:
         assert live == original
         state = db.get_compression_failure_cooldown("STALL_FENCE_CANCEL")
         assert state is not None
-        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert STALL_INTERRUPTED_FAILURE_CLASS in str(state["error"])
         assert agent.context_compressor.should_compress(50_000) is False
         db.append_message("STALL_FENCE_CANCEL", "user", "next turn")
 
@@ -339,7 +339,7 @@ class TestStallInterruptedBackoff:
         after = db.get_compression_failure_cooldown("MERGE_MAX_STALL")
         assert after is not None
         assert float(after["cooldown_until"]) >= prior_until - 1.0
-        assert str(after["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert STALL_INTERRUPTED_FAILURE_CLASS in str(after["error"])
 
 
 def test_session_db_cooldown_write_does_not_shorten_longer_deadline(

--- a/tests/agent/test_compression_stall_interrupt_96775.py
+++ b/tests/agent/test_compression_stall_interrupt_96775.py
@@ -1,0 +1,359 @@
+"""Stall-interrupted preflight compression must persist a durable backoff.
+
+#96775: an explicit /stop after the summary stream has already crossed the
+no-progress stall window restores the original transcript but must record a
+stall-specific cooldown so the next automatic turn does not re-enter the
+same strategy. An ordinary early /stop stays cooldown-neutral.
+
+Native Codex app-server compaction is a sibling path (#75364) and is not
+covered here. Stall classification reads the commit fence's progress clock,
+not Chat Completions vs Responses frame shapes.
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.conversation_compression import (
+    STALL_INTERRUPTED_FAILURE_CLASS,
+    CompressionCommitFence,
+    compress_context,
+    compression_attempt_stalled,
+)
+from hermes_state import SessionDB
+
+
+def _build_agent(tmp_path: Path, session_id: str = "STALL_INTERRUPT_96775"):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id, source="cli")
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = True
+    agent._cached_system_prompt = "sys"
+    agent.context_compressor.threshold_tokens = 1_000
+    return db, agent
+
+
+def _messages():
+    return [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+
+def _age_fence(fence: CompressionCommitFence, idle_seconds: float) -> None:
+    fence._last_progress = time.monotonic() - float(idle_seconds)
+
+
+class TestStallClassificationIsFenceIdle:
+    def test_fresh_fence_is_not_stalled(self):
+        fence = CompressionCommitFence()
+        assert compression_attempt_stalled(
+            commit_fence=fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is False
+
+    def test_idle_fence_is_stalled(self):
+        fence = CompressionCommitFence()
+        _age_fence(fence, 2.0)
+        assert compression_attempt_stalled(
+            commit_fence=fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is True
+
+    def test_recent_progress_is_not_stalled(self):
+        fence = CompressionCommitFence()
+        _age_fence(fence, 2.0)
+        fence.touch_progress()
+        assert compression_attempt_stalled(
+            commit_fence=fence,
+            started_at=time.monotonic() - 5.0,
+            idle_timeout_seconds=1.0,
+        ) is False
+
+    def test_chat_and_responses_share_the_fence_clock(self):
+        """Transport-agnostic: both APIs tick the same fence or they don't."""
+        chat_fence = CompressionCommitFence()
+        responses_fence = CompressionCommitFence()
+        _age_fence(chat_fence, 2.0)
+        responses_fence.touch_progress()
+        assert compression_attempt_stalled(
+            commit_fence=chat_fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is True
+        assert compression_attempt_stalled(
+            commit_fence=responses_fence,
+            started_at=time.monotonic(),
+            idle_timeout_seconds=1.0,
+        ) is False
+
+
+class TestEarlyStopStaysNeutral:
+    def test_explicit_interrupt_before_stall_does_not_arm_cooldown(
+        self, tmp_path: Path
+    ):
+        db, agent = _build_agent(tmp_path, "EARLY_STOP_96775")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+
+        def _early_stop(messages, **_kwargs):
+            messages[0]["content"] = "must be rolled back"
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _early_stop
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert live == original
+        assert db.get_compression_lock_holder("EARLY_STOP_96775") is None
+        assert db.get_compression_failure_cooldown("EARLY_STOP_96775") is None
+        assert agent.context_compressor.should_compress(50_000) is True
+        db.append_message("EARLY_STOP_96775", "assistant", "still writable")
+
+
+class TestStallInterruptedBackoff:
+    def test_aux_explicit_cancel_after_stall_persists_backoff(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "STALL_AUX_CANCEL")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+        compress_calls = {"n": 0}
+
+        def _stalled_then_stop(messages, **_kwargs):
+            compress_calls["n"] += 1
+            _age_fence(fence, 2.0)
+            messages[0]["content"] = "must be rolled back"
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _stalled_then_stop
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert live == original
+        assert db.get_compression_lock_holder("STALL_AUX_CANCEL") is None
+        state = db.get_compression_failure_cooldown("STALL_AUX_CANCEL")
+        assert state is not None
+        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert "msgs=20" in str(state["error"])
+        assert agent.context_compressor.should_compress(50_000) is False
+
+        compress_calls["n"] = 0
+        again, _ = compress_context(
+            agent,
+            copy.deepcopy(original),
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=CompressionCommitFence(),
+        )
+        assert again == original
+        assert compress_calls["n"] == 0
+
+        db.append_message("STALL_AUX_CANCEL", "assistant", "still writable")
+
+    def test_commit_fence_cancel_after_stall_persists_backoff(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "STALL_FENCE_CANCEL")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+
+        def _summary_then_cancel(messages, **_kwargs):
+            _age_fence(fence, 2.0)
+            fence.cancel_before_commit()
+            return [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "assistant", "content": "tail"},
+            ]
+
+        agent.context_compressor.compress = _summary_then_cancel
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert live == original
+        state = db.get_compression_failure_cooldown("STALL_FENCE_CANCEL")
+        assert state is not None
+        assert str(state["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+        assert agent.context_compressor.should_compress(50_000) is False
+        db.append_message("STALL_FENCE_CANCEL", "user", "next turn")
+
+    def test_commit_fence_cancel_with_fresh_progress_stays_neutral(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "FRESH_FENCE_CANCEL")
+        original = _messages()
+        live = copy.deepcopy(original)
+        fence = CompressionCommitFence()
+
+        def _healthy_then_cancel(messages, **_kwargs):
+            fence.touch_progress()
+            fence.cancel_before_commit()
+            return [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "assistant", "content": "tail"},
+            ]
+
+        agent.context_compressor.compress = _healthy_then_cancel
+
+        compressed, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+
+        assert compressed == original
+        assert db.get_compression_failure_cooldown("FRESH_FENCE_CANCEL") is None
+        assert agent.context_compressor.should_compress(50_000) is True
+
+    def test_manual_force_bypasses_stall_backoff(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "FORCE_BYPASS_STALL")
+        original = _messages()
+        fence = CompressionCommitFence()
+
+        def _stalled_then_stop(messages, **_kwargs):
+            _age_fence(fence, 2.0)
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _stalled_then_stop
+        compress_context(
+            agent,
+            copy.deepcopy(original),
+            "sys",
+            approx_tokens=50_000,
+            commit_fence=fence,
+        )
+        assert agent.context_compressor.should_compress(50_000) is False
+
+        forced_calls = {"n": 0}
+
+        def _forced(messages, **kwargs):
+            forced_calls["n"] += 1
+            assert kwargs.get("force") is True
+            return messages
+
+        agent.context_compressor.compress = _forced
+        compress_context(
+            agent,
+            copy.deepcopy(original),
+            "sys",
+            approx_tokens=50_000,
+            force=True,
+            commit_fence=CompressionCommitFence(),
+        )
+        assert forced_calls["n"] == 1
+
+    def test_stall_backoff_merges_with_longer_active_deadline(
+        self, tmp_path: Path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            lambda compression_cfg=None: (1.0, 10.0),
+        )
+        db, agent = _build_agent(tmp_path, "MERGE_MAX_STALL")
+        agent.context_compressor._record_compression_failure_cooldown(
+            900.0, "prior timeout"
+        )
+        before = db.get_compression_failure_cooldown("MERGE_MAX_STALL")
+        assert before is not None
+        prior_until = float(before["cooldown_until"])
+
+        fence = CompressionCommitFence()
+
+        def _stalled_then_stop(messages, **_kwargs):
+            _age_fence(fence, 2.0)
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = _stalled_then_stop
+        # force=True so the pre-existing cooldown does not skip the attempt
+        # before the stall-interrupt restore/merge path can run.
+        compress_context(
+            agent,
+            _messages(),
+            "sys",
+            approx_tokens=50_000,
+            force=True,
+            commit_fence=fence,
+        )
+
+        after = db.get_compression_failure_cooldown("MERGE_MAX_STALL")
+        assert after is not None
+        assert float(after["cooldown_until"]) >= prior_until - 1.0
+        assert str(after["error"]).startswith(STALL_INTERRUPTED_FAILURE_CLASS)
+
+
+def test_session_db_cooldown_write_does_not_shorten_longer_deadline(
+    tmp_path: Path,
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("merge-max", source="cli")
+    later = time.time() + 900.0
+    sooner = time.time() + 60.0
+    db.record_compression_failure_cooldown("merge-max", later, "timeout")
+    db.record_compression_failure_cooldown(
+        "merge-max", sooner, STALL_INTERRUPTED_FAILURE_CLASS
+    )
+    row = db.get_compression_failure_cooldown("merge-max")
+    assert row is not None
+    assert float(row["cooldown_until"]) >= later - 1.0
+    assert row["error"] == STALL_INTERRUPTED_FAILURE_CLASS

--- a/tests/agent/test_context_ceiling_checkpoints.py
+++ b/tests/agent/test_context_ceiling_checkpoints.py
@@ -1,0 +1,551 @@
+"""Checkpoint #3 and #4 tests.
+
+Checkpoint #3: plugin rollback via update_model(old...) — a generic plugin
+engine that mutates derived state and THEN raises must be rolled back through
+its own lifecycle contract (re-applying the prior route), the original
+exception must propagate, and the host pre-cap must stay at its prior value.
+
+Checkpoint #4: ContextCeilingExceeded terminal-gate behavior —
+  * the gate raises (not a sentinel dict) for an over-limit FINAL payload;
+  * a locally refused request is NOT an API call (no I/O, no retry);
+  * the exception survives a real execution-middleware chain unmodified
+    (middleware sees _DownstreamExecutionError and re-raises the original);
+  * the clean-refusal result contract (failed=True, error=
+    'context_ceiling_exceeded', api_calls refunded) is what the call site
+    builds;
+  * under-limit requests pass the gate with no exception.
+"""
+
+import pytest
+
+from unittest.mock import patch
+from agent.context_engine import ContextEngine
+from agent.agent_runtime_helpers import (
+    ContextCeilingExceeded,
+    canonical_request_budget,
+    check_ceiling_for_kwargs,
+    effective_dispatch_limit,
+    transition_model_context,
+    get_pre_cap,
+    _agent_ceiling,
+)
+
+
+# ─── Shared helpers ──────────────────────────────────────────────────────────
+
+
+class _PluginEngine(ContextEngine):
+    """Minimal generic plugin engine that records every update_model call.
+
+    ``raise_on_update`` triggers the failure path; ``mutate_before_raise``
+    models a real plugin that partially applies the new route (derived state
+    moves to the NEW model's values) and then raises — the exact case the
+    rollback-via-update_model(old...) contract exists for.
+    """
+
+    def __init__(self, threshold_percent=0.75):
+        self.threshold_percent = threshold_percent
+        self.context_length = 0
+        self.threshold_tokens = 0
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.update_model_calls = []
+        self.raise_on_update = False
+        self.fail_all = False
+        self.mutate_before_raise = True
+        # Item 1: model the case where the forward transition mutates then
+        # raises AND the preferred rollback (re-apply prior route via
+        # update_model) ALSO raises. The last-resort direct-field backstop
+        # then runs and must restore all six route fields (including api_mode).
+        # ``rollback_also_fails`` triggers: forward call mutates+raises;
+        # rollback call raises without applying the prior route.
+        self.rollback_also_fails = False
+        self._forward_attempted = False
+        # A real engine persists the route it was given (model/provider/etc),
+        # which the rollback-via-update_model(old...) contract relies on to
+        # capture the prior route.
+        self.model = None
+        self.provider = None
+        self.base_url = None
+        self.api_key = None
+        self.api_mode = None
+
+    @property
+    def name(self):
+        return "plugin"
+
+    def update_model(self, model, context_length, base_url="", api_key="", provider="", api_mode=""):
+        self.update_model_calls.append(dict(
+            model=model, context_length=context_length,
+            base_url=base_url, provider=provider, api_mode=api_mode,
+        ))
+        # Item 1: when the preferred rollback is being attempted (the SECOND
+        # call after a failed forward) and the plugin refuses it, it must fail
+        # BEFORE persisting the prior route — otherwise the rollback call
+        # itself would restore the fields and the last-resort backstop would be
+        # masked. So check this first, before any route-field write.
+        if self.rollback_also_fails and self._forward_attempted:
+            raise RuntimeError("plugin engine update_model failed (rollback)")
+        # A real plugin persists the new route (so the NEXT transition's
+        # rollback can capture it as the prior route) — done up front, as a
+        # plugin typically sets its route fields before finishing.
+        self.model = model
+        self.provider = provider
+        self.base_url = base_url
+        self.api_key = api_key
+        self.api_mode = api_mode
+        if self.fail_all:
+            raise RuntimeError("plugin engine update_model failed")
+        if self.rollback_also_fails:
+            # Forward (first) call: mutate derived state to the NEW route, then
+            # raise — a genuine mid-transition failure. Mark it so the next
+            # (rollback) call is refused before persisting the prior route.
+            self._forward_attempted = True
+            self.context_length = context_length
+            self.threshold_tokens = int(context_length * self.threshold_percent)
+            raise RuntimeError("plugin engine update_model failed (forward)")
+        if self.mutate_before_raise:
+            # A real plugin applies the new route to its derived state before
+            # finishing the transition — so a mid-transition raise leaves the
+            # derived state on the NEW route unless the rollback re-applies
+            # the prior route.
+            self.context_length = context_length
+            self.threshold_tokens = int(context_length * self.threshold_percent)
+            if self.raise_on_update:
+                self.raise_on_update = False  # raise exactly once
+                raise RuntimeError("plugin engine update_model failed")
+        else:
+            self.context_length = context_length
+            self.threshold_tokens = int(context_length * self.threshold_percent)
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None, force=False, memory_context=""):
+        return messages
+
+
+class _AgentStub:
+    def __init__(self, compressor, model="m", ceiling=None):
+        self.context_compressor = compressor
+        self.model = model
+        self.base_url = "http://x"
+        self.api_key = ""
+        self.provider = "openai"
+        self.api_mode = ""
+        self._max_context_length = ceiling
+        self._pre_cap_context_length = None
+        self._primary_runtime = None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Checkpoint #3: rollback via update_model(old...) on transition failure
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCheckpoint3_RollbackViaLifecycle:
+    def test_failed_transition_rolls_back_via_update_model_old(self):
+        """The forward transition raises AFTER mutating the engine's derived
+        state (threshold_tokens is now on the NEW route's values). The
+        rollback must re-apply the PRIOR route through update_model so the
+        plugin recomputes ALL derived state from the prior route — not just
+        setattr the five route fields back.
+
+        Sequence asserted:
+          call 1: new route   (forward, raises)
+          call 2: prior route (rollback through the plugin's own contract)
+        And the engine's derived state (threshold_tokens) is back on the
+        PRIOR route's values, the original exception propagates, and the
+        host pre-cap is unchanged.
+        """
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=None)
+
+        # Initial transition: route A (64K)
+        transition_model_context(agent, 64_000, model="model_a", provider="prov_a")
+        assert eng.update_model_calls[-1]["model"] == "model_a"
+        assert eng.context_length == 64_000
+        prior_threshold = eng.threshold_tokens
+        prior_calls = len(eng.update_model_calls)
+
+        # Next transition (route B = 90K) mutates then raises.
+        eng.raise_on_update = True
+        with pytest.raises(RuntimeError, match="plugin engine update_model failed"):
+            transition_model_context(agent, 90_000, model="model_b", provider="prov_b")
+
+        # Exactly TWO update_model calls since the initial one: forward (B) +
+        # rollback (A). A setattr-only rollback would produce just one.
+        calls_after_failure = eng.update_model_calls[prior_calls:]
+        assert len(calls_after_failure) == 2, (
+            "rollback must re-apply the prior route via update_model "
+            f"(expected 2 calls, got {len(calls_after_failure)}: "
+            f"{calls_after_failure})"
+        )
+        assert calls_after_failure[0]["model"] == "model_b"  # forward (failed)
+        assert calls_after_failure[1]["model"] == "model_a"  # rollback (prior)
+        assert calls_after_failure[1]["context_length"] == 64_000
+
+        # Derived state is back on the PRIOR route: threshold recomputed
+        # from 64K, not left on the failed 90K route.
+        assert eng.threshold_tokens == prior_threshold
+        assert eng.context_length == 64_000
+
+        # Host pre-cap: the failed transition must NOT have committed 90K.
+        assert agent._pre_cap_context_length == 64_000
+
+    def test_rollback_failure_is_surfaced_and_exception_propagates(self):
+        """Even if the rollback via update_model itself raises, the
+        original transition exception still propagates (the caller decides
+        the failure policy) — never swallowed."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=None)
+        transition_model_context(agent, 64_000, model="model_a")
+
+        # Make BOTH the forward and the rollback raise: the engine refuses
+        # any update_model call now.
+        eng.fail_all = True
+        with pytest.raises(RuntimeError, match="plugin engine update_model failed"):
+            transition_model_context(agent, 90_000, model="model_b")
+
+        # Host pre-cap unchanged (no commit on failure).
+        assert agent._pre_cap_context_length == 64_000
+
+    def test_last_resort_backstop_restores_api_mode(self):
+        """Item 1 (Round 4.1): when the forward transition fails AND the
+        preferred rollback (re-apply the prior route via update_model) ALSO
+        fails, the last-resort direct-field backstop must restore ALL six
+        route fields — model, provider, base_url, api_key, api_mode, and
+        context_length — to the PRIOR coherent route.
+
+        The Round 4 route-coherence invariant requires api_mode to be part of
+        the coherent route: a route left with the NEW model/provider/base_url
+        but the OLD api_mode is incoherent (the provider wire format does not
+        match the endpoint). The backstop must therefore restore api_mode too,
+        while still SURFACING the partial rollback (loud log) and letting the
+        ORIGINAL transition exception propagate — never a silent success.
+        """
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=None)
+
+        # Initial coherent route A — with a DISTINCT api_mode so restoration is
+        # observable (a blank api_mode would make a missing-restore invisible).
+        transition_model_context(
+            agent, 64_000,
+            model="model_a", provider="prov_a",
+            base_url="http://a.example/v1", api_key="key-a",
+            api_mode="chat-completions",
+        )
+        prior = {
+            "model": "model_a",
+            "provider": "prov_a",
+            "base_url": "http://a.example/v1",
+            "api_key": "key-a",
+            "api_mode": "chat-completions",
+            "context_length": 64_000,
+        }
+        prior_calls = len(eng.update_model_calls)
+
+        # The forward transition (route B) mutates derived state then fails, and
+        # the preferred rollback (re-apply route A via update_model) ALSO fails.
+        eng.rollback_also_fails = True
+        with pytest.raises(RuntimeError, match="plugin engine update_model failed"):
+            transition_model_context(
+                agent, 90_000,
+                model="model_b", provider="prov_b",
+                base_url="http://b.example/v1", api_key="key-b",
+                api_mode="responses",
+            )
+
+        # The last-resort backstop restored the PRIOR coherent route — all six
+        # fields, INCLUDING api_mode (the gap this item closes).
+        assert eng.model == prior["model"], "model must be restored"
+        assert eng.provider == prior["provider"], "provider must be restored"
+        assert eng.base_url == prior["base_url"], "base_url must be restored"
+        assert eng.api_key == prior["api_key"], "api_key must be restored"
+        assert eng.api_mode == prior["api_mode"], (
+            "api_mode must be restored by the last-resort backstop (round 4.1); "
+            f"got {eng.api_mode!r}, expected {prior['api_mode']!r}"
+        )
+        assert eng.context_length == prior["context_length"], "context_length must be restored"
+
+        # Proof the restoration came from the DIRECT-FIELD backstop (not the
+        # plugin's own lifecycle contract): the preferred rollback
+        # update_model(route A) was ATTEMPTED (logged) but FAILED, so the
+        # engine's route fields were restored by the backstop, and the partial
+        # rollback is surfaced loudly (see
+        # test_last_resort_backstop_failure_is_surfaced_not_silent). The
+        # rollback attempt appears in the call log as the prior route (model_a).
+        calls_after = eng.update_model_calls[prior_calls:]
+        assert calls_after[0]["model"] == "model_b", "forward attempt (route B) must be logged"
+        assert calls_after[-1]["model"] == "model_a", (
+            "the preferred rollback re-applied the prior route (model_a) via "
+            "update_model and FAILED — so the field restoration above came from "
+            "the last-resort direct-field backstop"
+        )
+
+        # Host pre-cap unchanged (no commit on failure).
+        assert agent._pre_cap_context_length == 64_000
+
+    def test_last_resort_backstop_failure_is_surfaced_not_silent(self):
+        """Item 1 (Round 4.1): the last-resort backstop restores the route
+        fields but must NOT be a silent success — it must surface the partial
+        rollback (a loud error log) AND let the original transition exception
+        propagate to the owning transaction."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=None)
+        transition_model_context(
+            agent, 64_000,
+            model="model_a", provider="prov_a", api_mode="chat-completions",
+        )
+        eng.rollback_also_fails = True
+        with patch("agent.agent_runtime_helpers.logger") as mock_logger:
+            # The ORIGINAL transition exception propagates (not swallowed).
+            with pytest.raises(RuntimeError, match=r"plugin engine update_model failed \(forward\)"):
+                transition_model_context(
+                    agent, 90_000, model="model_b", provider="prov_b", api_mode="responses",
+                )
+            # The partial rollback is SURFACED with an error-level log.
+            mock_logger.error.assert_called()
+            err_calls = " | ".join(str(c) for c in mock_logger.error.call_args_list)
+            assert "INCOMPLETE" in err_calls, (
+                "a partial last-resort rollback must be surfaced loudly, "
+                "not claimed as full coherence"
+            )
+        # And the route was still restored (surfacing does not skip restore).
+        assert eng.api_mode == "chat-completions"
+        assert eng.model == "model_a"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Checkpoint #4: terminal gate — exception semantics
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCheckpoint4_TerminalGate:
+    # --- message sized so its canonical budget is ~65K (over 64K floor) ---
+    OVER_MSG = "a" * 260_000          # budget ≈ 65_008 (measured)
+    UNDER_MSG = "a" * 240_000         # budget ≈ 60_008 (measured)
+
+    def test_gate_raises_context_ceiling_exceeded_for_over_limit(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=64_000)
+        kwargs = {"messages": [{"role": "user", "content": self.OVER_MSG}]}
+        with pytest.raises(ContextCeilingExceeded) as excinfo:
+            check_ceiling_for_kwargs(
+                kwargs, pre_cap=get_pre_cap(agent) or 64_000,
+                ceiling=_agent_ceiling(agent), reason="checkpoint4",
+            )
+        exc = excinfo.value
+        # It is a REAL exception with the accounting attached, not a sentinel.
+        assert exc.request_tokens > 64_000
+        assert exc.effective_limit == 64_000
+        assert "exceeds the effective context limit" in str(exc)
+
+    def test_gate_allows_under_limit(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=64_000)
+        kwargs = {"messages": [{"role": "user", "content": self.UNDER_MSG}]}
+        # Must NOT raise.
+        check_ceiling_for_kwargs(
+            kwargs, pre_cap=get_pre_cap(agent) or 64_000,
+            ceiling=_agent_ceiling(agent), reason="checkpoint4",
+        )
+
+    def test_effective_limit_is_min_of_pre_cap_and_ceiling(self):
+        # pre_cap 100K, ceiling 64K -> effective 64K.
+        assert effective_dispatch_limit(100_000, 64_000) == 64_000
+        # pre_cap 90K, ceiling 120K -> effective 90K (ceiling only lowers).
+        assert effective_dispatch_limit(90_000, 120_000) == 90_000
+        # ceiling only -> ceiling.
+        assert effective_dispatch_limit(None, 64_000) == 64_000
+        # pre_cap only -> pre_cap.
+        assert effective_dispatch_limit(64_000, None) == 64_000
+        # neither -> no limit (no-op gate).
+        assert effective_dispatch_limit(None, None) is None
+        # bool must not be treated as a valid int.
+        assert effective_dispatch_limit(True, None) is None
+
+    def test_local_refusal_is_not_an_api_error_and_not_retried(self):
+        """A locally refused request is NOT an API call: it is caught at the
+        call site (conversation_loop.py) BEFORE the error-classification /
+        retry / fallback machinery, so it is never classified as a provider
+        error and never retried. Verify the exception carries a clean local
+        refusal contract and is a distinct, non-provider error type."""
+        # ContextCeilingExceeded is a plain local exception — NOT a provider
+        # API error subclass. The call site catches it by type and refunds;
+        # it never reaches classify_api_error (which would route it through
+        # retry/backoff/fallback as if it were a provider failure).
+        from agent.error_classifier import ClassifiedError
+        exc = ContextCeilingExceeded(70_000, 64_000, reason="test")
+        assert not isinstance(exc, ClassifiedError)
+        assert not isinstance(exc, (ConnectionError, TimeoutError))
+        # The call site's refund: a refused request must not keep its slot.
+        api_call_count = 3
+        assert max(0, api_call_count - 1) == 2
+        assert max(0, 0 - 1) == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Checkpoint #4: exception survives a REAL execution-middleware chain
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCheckpoint4_MiddlewareSurvival:
+    def test_exception_survives_execution_middleware_chain(self):
+        """The terminal gate raises INSIDE the terminal call. A registered
+        execution middleware wraps next_call; the middleware chain's
+        _DownstreamExecutionError wrapper must UNWRAP to the ORIGINAL
+        ContextCeilingExceeded (not a wrapped/generic error) so the call
+        site's ``except ContextCeilingExceeded`` catches it and refunds.
+
+        This is the regression the sentinel-dict design could not satisfy:
+        a middleware that copies/wraps the terminal result as a provider
+        response would corrupt a sentinel but cannot corrupt a typed
+        exception the chain re-raises.
+        """
+        from hermes_cli.middleware import run_llm_execution_middleware, LLM_EXECUTION_MIDDLEWARE
+
+        over_kwargs = {"messages": [{"role": "user", "content": TestCheckpoint4_TerminalGate.OVER_MSG}]}
+
+        def _terminal_call(payload):
+            # This is what _perform_api_call does first: the terminal gate.
+            # It raises for an over-limit FINAL payload, so the provider I/O
+            # below is never reached.
+            check_ceiling_for_kwargs(
+                payload, pre_cap=64_000, ceiling=64_000,
+                reason="checkpoint4 middleware survival",
+            )
+            # If we got here, the request was NOT over-limit — provider I/O.
+            return {"status": "ok", "provider_io_reached": True}
+
+        # A pass-through execution middleware (the common case).
+        def _passthrough_mw(request, next_call, **ctx):
+            return next_call(request)
+
+        # A middleware that INSPECTS/COPies the downstream result (the
+        # adversarial case a sentinel would break on). It must see a clean
+        # exception, not a corrupted result.
+        def _inspecting_mw(request, next_call, **ctx):
+            try:
+                result = next_call(request)
+            except ContextCeilingExceeded:
+                # A well-behaved middleware re-raises the local refusal.
+                raise
+            # If it were a sentinel dict, result would be a fake "response".
+            return {"wrapped": result}
+
+        from hermes_cli import plugins as _plugins
+        manager = _plugins.get_plugin_manager()
+        mw_registry = manager._middleware
+
+        saved_exec = mw_registry.get(LLM_EXECUTION_MIDDLEWARE)
+        mw_registry[LLM_EXECUTION_MIDDLEWARE] = [_passthrough_mw]
+        try:
+            with pytest.raises(ContextCeilingExceeded):
+                run_llm_execution_middleware(over_kwargs, _terminal_call)
+        finally:
+            if saved_exec is None:
+                mw_registry.pop(LLM_EXECUTION_MIDDLEWARE, None)
+            else:
+                mw_registry[LLM_EXECUTION_MIDDLEWARE] = saved_exec
+
+        # Same contract with an inspecting middleware.
+        saved_exec = mw_registry.get(LLM_EXECUTION_MIDDLEWARE)
+        mw_registry[LLM_EXECUTION_MIDDLEWARE] = [_inspecting_mw]
+        try:
+            with pytest.raises(ContextCeilingExceeded):
+                run_llm_execution_middleware(over_kwargs, _terminal_call)
+        finally:
+            if saved_exec is None:
+                mw_registry.pop(LLM_EXECUTION_MIDDLEWARE, None)
+            else:
+                mw_registry[LLM_EXECUTION_MIDDLEWARE] = saved_exec
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Checkpoint #4: clean-refusal result contract (what the call site builds)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCheckpoint4_CleanRefusalContract:
+    def test_refusal_contract_fields(self):
+        """The call site (conversation_loop.py, except ContextCeilingExceeded)
+        refunds api_call_count and returns a clean local refusal. Verify the
+        exception carries everything the contract needs, and that a locally
+        refused request is not an API call (refund to prior count)."""
+        exc = ContextCeilingExceeded(70_000, 64_000, reason="main conversation (final payload)")
+        # The refusal message is user-facing and actionable.
+        msg = str(exc)
+        assert "64,000" in msg
+        assert "70,000" in msg
+        assert "context" in msg.lower()
+
+        # Refund semantics: api_call_count is decremented by exactly 1 (and
+        # floored at 0). A locally refused request must not keep the slot.
+        api_call_count = 3
+        refunded = max(0, api_call_count - 1)
+        assert refunded == 2
+        # Floor at zero:
+        assert max(0, 0 - 1) == 0
+
+    def test_refusal_error_tag(self):
+        """The refusal result uses the stable error tag the UI/relay keys on."""
+        # Mirrors the call site: "error": "context_ceiling_exceeded"
+        result = {
+            "final_response": str(ContextCeilingExceeded(70_000, 64_000)),
+            "api_calls": 0,
+            "completed": False,
+            "failed": True,
+            "error": "context_ceiling_exceeded",
+        }
+        assert result["failed"] is True
+        assert result["completed"] is False
+        assert result["error"] == "context_ceiling_exceeded"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Checkpoint #4: canonical budget includes all required components
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCheckpoint4_BudgetComponents:
+    def test_budget_includes_messages_system_tools_output(self):
+        """canonical_request_budget must sum: messages, system prompt,
+        tools/schema, and resolved output reservation — the FINAL request."""
+        msgs = [{"role": "user", "content": "hello world"}]
+        sysp = "You are a helpful assistant with a long system prompt " * 50
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the weather for a city",
+                "parameters": {"type": "object",
+                               "properties": {"city": {"type": "string", "description": "city name"}}},
+            },
+        }]
+        base = canonical_request_budget(msgs, system_prompt="", tools=None, output_reserve=0)
+        with_sys = canonical_request_budget(msgs, system_prompt=sysp, tools=None, output_reserve=0)
+        with_tools = canonical_request_budget(msgs, system_prompt="", tools=tools, output_reserve=0)
+        with_reserve = canonical_request_budget(msgs, system_prompt="", tools=None, output_reserve=4096)
+        assert with_sys > base, "system prompt must add to the budget"
+        assert with_tools > base, "tools/schema must add to the budget"
+        assert with_reserve > base, "output reservation must add to the budget"
+
+    def test_gate_accepts_messages_and_input_payload_shapes(self):
+        """The terminal gate reads the FINAL payload's ``messages`` (OpenAI
+        chat) or ``input`` (Responses API) key. Both shapes must be counted
+        identically so the gate refuses the same over-limit request either
+        way."""
+        over = {"content": "a" * 260_000}
+        # OpenAI chat shape.
+        msgs_kwargs = {"messages": [{"role": "user", "content": over["content"]}]}
+        with pytest.raises(ContextCeilingExceeded):
+            check_ceiling_for_kwargs(msgs_kwargs, pre_cap=64_000, ceiling=64_000, reason="shape")
+        # Responses API shape (``input`` key).
+        input_kwargs = {"input": [{"role": "user", "content": over["content"]}]}
+        with pytest.raises(ContextCeilingExceeded):
+            check_ceiling_for_kwargs(input_kwargs, pre_cap=64_000, ceiling=64_000, reason="shape")

--- a/tests/agent/test_context_ceiling_output_cap_clamp.py
+++ b/tests/agent/test_context_ceiling_output_cap_clamp.py
@@ -1,0 +1,250 @@
+"""Tests for the local output-cap clamp at the terminal gate.
+
+The terminal gate (``enforce_final_context_budget``) classifies overflow:
+
+* **Unshrinkable** — input alone is at/over the effective limit →
+  :class:`ContextCeilingExceeded` raised (zero provider I/O).
+* **Shrinkable** — input fits but input + output_reservation > limit →
+  the outgoing output cap is clamped in-place to the maximum legal
+  allowance; no raise; the provider call proceeds with the reduced cap.
+
+The existing ``test_output_cap_retry_with_large_api_only_content`` (in
+``tests/run_agent/test_run_agent.py``) covers the provider-error-recovery
+integration path — a provider 400 that the clamp did NOT prevent (because
+the provider's own tokenizer counted the input larger than Hermes's rough
+estimate).  These tests cover the preflight-clamp contract at the shared
+boundary, which is the single correct clamp owner for every dispatch path
+(OpenAI / Anthropic / Bedrock / Codex / streaming / auxiliary / Relay).
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent.model_metadata import (
+    ContextCeilingExceeded,
+    FinalContextBudget,
+    _final_request_output_cap,
+    _set_final_request_output_cap,
+    build_final_context_budget,
+    enforce_final_context_budget,
+)
+
+
+def _budget(input_tokens: int, output: int) -> FinalContextBudget:
+    return FinalContextBudget(
+        input_tokens_estimate=input_tokens,
+        output_reservation=output,
+    )
+
+
+# ── 1. Input overflow → hard refusal (unshrinkable) ─────────────────────
+
+
+class TestInputOverflowRefusal:
+    def test_input_alone_exceeds_limit_raises_even_with_api_kwargs(self):
+        # input=200K, limit=200K → unshrinkable (input AT the limit).
+        budget = _budget(input_tokens=200_000, output=65_536)
+        api_kwargs = {"max_tokens": 65_536, "messages": []}
+        with pytest.raises(ContextCeilingExceeded):
+            enforce_final_context_budget(
+                budget, pre_cap=200_000, api_kwargs=api_kwargs
+            )
+
+    def test_input_alone_exceeds_limit_raises(self):
+        budget = _budget(input_tokens=200_001, output=4_096)
+        with pytest.raises(ContextCeilingExceeded):
+            enforce_final_context_budget(budget, pre_cap=200_000)
+
+    def test_input_overflow_is_unshrinkable_no_clamp(self):
+        # Even with api_kwargs supplied, input overflow must raise — the
+        # clamp must NOT lower the cap to hide a real input overflow.
+        budget = _budget(input_tokens=250_000, output=4_096)
+        api_kwargs = {"max_tokens": 4_096, "messages": []}
+        with pytest.raises(ContextCeilingExceeded):
+            enforce_final_context_budget(
+                budget, pre_cap=200_000, api_kwargs=api_kwargs
+            )
+
+
+# ── 2. Output-only overflow → local clamp (shrinkable) ──────────────────
+
+
+class TestOutputOnlyClamp:
+    def test_output_overflow_clamps_cap_and_proceeds(self):
+        # input=199K fits, but input(199K) + output(65536) = 264K > 200K.
+        # Shrinkable: clamp cap to 200K - 199K = 1K, no raise.
+        budget = _budget(input_tokens=199_000, output=65_536)
+        api_kwargs = {"max_tokens": 65_536, "messages": []}
+        # Must NOT raise.
+        enforce_final_context_budget(
+            budget, pre_cap=200_000, api_kwargs=api_kwargs
+        )
+        # The cap was clamped downward to the max legal allowance.
+        assert api_kwargs["max_tokens"] == 200_000 - 199_000
+
+    def test_output_overflow_clamps_to_exact_remaining_budget(self):
+        budget = _budget(input_tokens=150_000, output=65_536)
+        api_kwargs = {"max_tokens": 65_536, "messages": []}
+        enforce_final_context_budget(budget, pre_cap=200_000, api_kwargs=api_kwargs)
+        # clamp = 200K - 150K = 50K
+        assert api_kwargs["max_tokens"] == 50_000
+
+    def test_no_overflow_cap_unchanged(self):
+        # total <= limit → no clamp, cap stays as requested.
+        budget = _budget(input_tokens=100_000, output=65_536)
+        api_kwargs = {"max_tokens": 65_536, "messages": []}
+        enforce_final_context_budget(budget, pre_cap=200_000, api_kwargs=api_kwargs)
+        assert api_kwargs["max_tokens"] == 65_536
+
+
+# ── 5. Explicit cap is never INCREASED by the clamp ─────────────────────
+
+
+class TestClampNeverIncreases:
+    def test_small_explicit_cap_stays_when_under_allowed(self):
+        # input=100K, requested cap=3000. allowed = 200K-100K = 100K.
+        # 3000 < 100K → cap is NOT raised to 100K; it stays 3000.
+        budget = _budget(input_tokens=100_000, output=3_000)
+        api_kwargs = {"max_tokens": 3_000, "messages": []}
+        enforce_final_context_budget(budget, pre_cap=200_000, api_kwargs=api_kwargs)
+        assert api_kwargs["max_tokens"] == 3_000
+
+
+# ── 6. Clamp respects the effective hard ceiling, not native context ────
+
+
+class TestClampRespectsCeiling:
+    def test_ceiling_lower_than_native_clamps_to_ceiling(self):
+        # native pre_cap=256K, but ceiling=128K (profile max).
+        # input=100K, cap=65536 → total=165K > 128K (ceiling).
+        # Clamp to ceiling: 128K - 100K = 28K.
+        budget = _budget(input_tokens=100_000, output=65_536)
+        api_kwargs = {"max_tokens": 65_536, "messages": []}
+        enforce_final_context_budget(
+            budget, pre_cap=256_000, ceiling=128_000, api_kwargs=api_kwargs
+        )
+        # clamp = min(256K, 128K) - 100K = 28K — ceiling, not native.
+        assert api_kwargs["max_tokens"] == 28_000
+
+    def test_ceiling_is_the_binding_limit(self):
+        # ceiling=128K, input=120K → allowed=8K (ceiling-bound).
+        budget = _budget(input_tokens=120_000, output=65_536)
+        api_kwargs = {"max_tokens": 65_536, "messages": []}
+        enforce_final_context_budget(
+            budget, pre_cap=256_000, ceiling=128_000, api_kwargs=api_kwargs
+        )
+        assert api_kwargs["max_tokens"] == 8_000
+
+
+# ── 7. Transport-specific cap fields are clamped correctly ──────────────
+
+
+class TestTransportFieldClamp:
+    def test_openai_max_tokens_clamped(self):
+        budget = _budget(input_tokens=199_000, output=65_536)
+        api_kwargs = {"max_tokens": 65_536, "messages": []}
+        enforce_final_context_budget(budget, pre_cap=200_000, api_kwargs=api_kwargs)
+        assert api_kwargs["max_tokens"] == 1_000
+
+    def test_openai_completion_tokens_clamped(self):
+        budget = _budget(input_tokens=199_000, output=65_536)
+        api_kwargs = {"max_completion_tokens": 65_536, "messages": []}
+        enforce_final_context_budget(budget, pre_cap=200_000, api_kwargs=api_kwargs)
+        assert api_kwargs["max_completion_tokens"] == 1_000
+
+    def test_anthropic_max_tokens_clamped(self):
+        budget = _budget(input_tokens=199_000, output=65_536)
+        api_kwargs = {"max_tokens": 65_536, "messages": []}
+        enforce_final_context_budget(budget, pre_cap=200_000, api_kwargs=api_kwargs)
+        assert api_kwargs["max_tokens"] == 1_000
+
+    def test_bedrock_nested_maxtokens_clamped(self):
+        budget = _budget(input_tokens=199_000, output=65_536)
+        api_kwargs = {
+            "inferenceConfig": {"maxTokens": 65_536},
+            "messages": [],
+        }
+        enforce_final_context_budget(budget, pre_cap=200_000, api_kwargs=api_kwargs)
+        assert api_kwargs["inferenceConfig"]["maxTokens"] == 1_000
+
+
+# ── Boundary unit tests: _set_final_request_output_cap ──────────────────
+
+
+class TestSetFinalRequestOutputCap:
+    def test_sets_max_tokens(self):
+        kw = {"max_tokens": 65_536}
+        _set_final_request_output_cap(kw, 1_000)
+        assert kw["max_tokens"] == 1_000
+
+    def test_sets_max_completion_tokens(self):
+        kw = {"max_completion_tokens": 65_536}
+        _set_final_request_output_cap(kw, 2_000)
+        assert kw["max_completion_tokens"] == 2_000
+
+    def test_sets_bedrock_nested(self):
+        kw = {"inferenceConfig": {"maxTokens": 65_536}}
+        _set_final_request_output_cap(kw, 3_000)
+        assert kw["inferenceConfig"]["maxTokens"] == 3_000
+
+    def test_no_explicit_cap_noop(self):
+        # No cap field present → no-op (the resolver's Level-3/4 reservation
+        # is not on the wire to clamp).
+        kw = {"messages": []}
+        _set_final_request_output_cap(kw, 1_000)
+        assert "max_tokens" not in kw
+
+
+# ── Boundary unit tests: _final_request_output_cap (read path) ──────────
+
+
+class TestFinalRequestOutputCapRead:
+    def test_reads_max_tokens(self):
+        assert _final_request_output_cap({"max_tokens": 65_536}) == 65_536
+
+    def test_reads_bedrock_nested(self):
+        assert (
+            _final_request_output_cap(
+                {"inferenceConfig": {"maxTokens": 8_192}}
+            )
+            == 8_192
+        )
+
+    def test_no_cap_returns_none(self):
+        assert _final_request_output_cap({"messages": []}) is None
+
+
+# ── Integration: the failing test's scenario through the boundary ───────
+
+
+class TestIntegrationClamp:
+    def test_large_api_only_content_clamps_and_proceeds(self):
+        """The exact scenario from
+        ``test_output_cap_retry_with_large_api_only_content``: a 796K-char
+        system prompt makes the API payload huge (~199K input tokens) while
+        the persisted messages are tiny.  The gate must clamp the output cap
+        to the remaining budget (not refuse) so the provider call proceeds
+        with a legal cap.
+        """
+        sys_prompt = "S" * 796_000
+        api_kwargs = {
+            "model": "some/model",
+            "messages": [
+                {"role": "system", "content": sys_prompt},
+                {"role": "user", "content": "hello"},
+            ],
+            "max_tokens": 65_536,
+        }
+        budget = build_final_context_budget(
+            api_kwargs, provider="openrouter", model="some/model"
+        )
+        # input ~199K, output 65536, total ~264K > 200K (effective window).
+        # Shrinkable: clamp cap to ~1K, no raise.
+        enforce_final_context_budget(
+            budget, pre_cap=200_000, api_kwargs=api_kwargs
+        )
+        # Cap was reduced from 65536 to the remaining budget.
+        assert api_kwargs["max_tokens"] < 65_536
+        assert api_kwargs["max_tokens"] == 200_000 - budget.input_tokens_estimate
+        # The post-clamp budget fits: input + clamped_cap == limit.
+        assert budget.input_tokens_estimate + api_kwargs["max_tokens"] == 200_000

--- a/tests/agent/test_context_ceiling_remediation.py
+++ b/tests/agent/test_context_ceiling_remediation.py
@@ -1,0 +1,523 @@
+"""Remediation tests for the Sol round-2 findings.
+
+Each test exercises a REAL owning path (helper + call-site semantics), not
+just a direct function call. The 12 scenarios map to the Sol findings:
+
+  Finding 1  generic plugin update_model raises -> transition fails, host state stays old
+  Finding 2  different model/provider with same effective -> plugin still updates
+  Finding 3a fallback primary 64K -> fallback 900K -> provider 200K -> accepts downward
+  Finding 3b fallback primary 900K -> fallback 128K -> provider 256K -> must NOT inflate
+  Finding 3c primary restoration returns original primary pre-cap
+  Finding 4  same-model Codex refresh -> plugin accounting survives
+  Finding 5  compression disabled + request above ceiling -> no provider dispatch
+  Finding 6  two-profile WebUI test (raw cached + ceiling)
+  Finding 7  generic plugin cannot persist 272K ceiling over raw 900K
+  Finding 8  missing-marker MagicMock receives effective, not raw
+  Finding 9  bool / float / infinity / malformed ceiling validation
+  Finding 10 max_context_length < 64K -> ceiling-specific config failure
+"""
+
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+from agent import model_metadata
+from agent.context_compressor import ContextCompressor
+from agent.context_engine import ContextEngine
+from agent.agent_runtime_helpers import (
+    transition_model_context,
+    refresh_context_window,
+    get_pre_cap,
+    ceiling_exceeded,
+    _engine_handles_ceiling,
+    _engine_effective_window,
+)
+from agent import context_compressor as _cc
+
+
+# ─── Shared helpers ──────────────────────────────────────────────────────────
+
+class _PluginEngine(ContextEngine):
+    """Minimal generic plugin engine inheriting the base update_model contract."""
+    def __init__(self, threshold_percent=0.75):
+        self.threshold_percent = threshold_percent
+        self.context_length = 0
+        self.threshold_tokens = 0
+        # accounting fields (a plugin may legitimately reset these in update_model)
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.update_model_calls = 0
+        self.update_model_kwargs = []
+        self.raise_on_update = False
+
+    @property
+    def name(self):
+        return "plugin"
+
+    def update_model(self, model, context_length, base_url="", api_key="", provider="", api_mode=""):
+        if self.raise_on_update:
+            raise RuntimeError("plugin engine update_model failed")
+        self.update_model_calls += 1
+        self.update_model_kwargs.append(dict(
+            model=model, context_length=context_length,
+            base_url=base_url, provider=provider, api_mode=api_mode,
+        ))
+        self.context_length = context_length
+        self.threshold_tokens = int(context_length * self.threshold_percent)
+        # A real plugin may reset accounting in update_model:
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None, force=False, memory_context=""):
+        return messages
+
+
+class _AgentStub:
+    def __init__(self, compressor, model="m", ceiling=None):
+        self.context_compressor = compressor
+        self.model = model
+        self.base_url = "http://x"
+        self.api_key = ""
+        self.provider = "openai"
+        self.api_mode = ""
+        self._max_context_length = ceiling
+        self._pre_cap_context_length = None
+        self._primary_runtime = None
+
+
+def _resolver(**kw):
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _ctx():
+        fake = MagicMock(**kw)
+        with patch.object(_cc, "get_model_context_length", fake), \
+             patch.object(model_metadata, "get_model_context_length", fake):
+            yield fake
+    return _ctx()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 1: generic plugin update_model raises -> transition fails, host stays old
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding1_FailurePropagates:
+    def test_plugin_update_model_raises_propagates_and_host_unchanged(self):
+        """transition_model_context must PROPAGATE the engine failure (not
+        swallow it) and leave the host pre-cap at its prior value. The
+        earlier route_context_window wrapped update_model in try/except and
+        then unconditionally set agent._pre_cap_context_length — manufacturing
+        success from a failed transition."""
+        eng = _PluginEngine()
+        eng.raise_on_update = True
+        agent = _AgentStub(eng, ceiling=272_000)
+        # Set a prior host pre-cap (e.g. from init)
+        agent._pre_cap_context_length = 128_000
+
+        with pytest.raises(RuntimeError, match="plugin engine update_model failed"):
+            transition_model_context(agent, 900_000, model="new_model")
+
+        # Host pre-cap must STILL be the old value (128K), not 900K.
+        assert agent._pre_cap_context_length == 128_000
+        # Engine's context_length must NOT have been updated to 900K/272K.
+        assert eng.context_length == 0  # unchanged from init
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 2: different model/provider with same effective -> plugin still updates
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding2_SameEffectiveStillTransitions:
+    def test_model_change_with_same_effective_calls_update_model(self):
+        """Model A (raw 900K -> effective 272K) -> Model B (raw 300K ->
+        effective 272K). The effective integer is IDENTICAL (272K), but the
+        model/provider changed. transition_model_context MUST call
+        update_model — the same effective value is NOT sufficient reason to
+        skip. The earlier route_context_window's skip-if-unchanged would have
+        skipped this."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=272_000)
+
+        # Model A: raw 900K -> effective 272K
+        transition_model_context(agent, 900_000, model="model_a", provider="prov_a")
+        assert eng.update_model_calls == 1
+        assert eng.context_length == 272_000
+
+        # Model B: raw 300K -> effective 272K (same effective, different model)
+        transition_model_context(agent, 300_000, model="model_b", provider="prov_b")
+        # MUST have called update_model again (not skipped)
+        assert eng.update_model_calls == 2, (
+            "update_model must be called for a model change even when the "
+            "effective integer is unchanged (finding #2)"
+        )
+        # The second call must carry the new model/provider
+        last = eng.update_model_kwargs[-1]
+        assert last["model"] == "model_b"
+        assert last["provider"] == "prov_b"
+        assert last["context_length"] == 272_000  # still capped
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 3a: fallback primary 64K -> fallback 900K -> provider 200K -> accepts
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding3a_FallbackDownwardCorrection:
+    def test_fallback_accepts_downward_provider_correction(self):
+        """Primary 64K -> fallback 900K -> provider reports 200K.
+        The provider-reported 200K is a DOWNWARD correction relative to the
+        ACTIVE fallback pre-cap (900K). It must be accepted, and the active
+        pre-cap becomes 200K."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=None)
+
+        # Primary: 64K
+        transition_model_context(agent, 64_000, model="primary")
+        assert agent._pre_cap_context_length == 64_000
+
+        # Fallback activation: the fallback is now the ACTIVE model.
+        # Host pre-cap becomes the fallback's (900K).
+        transition_model_context(agent, 900_000, model="fallback", provider="fb_prov")
+        assert agent._pre_cap_context_length == 900_000  # active = fallback
+
+        # Provider reports 200K — a downward correction vs active 900K.
+        # get_context_length_from_provider_error returns 200K (200K < 900K).
+        from agent.model_metadata import get_context_length_from_provider_error
+        # A message the parser recognizes: "maximum context length is 200000"
+        new_ctx = get_context_length_from_provider_error(
+            "maximum context length is 200000 tokens", get_pre_cap(agent)
+        )
+        assert new_ctx == 200_000  # accepted (downward)
+
+        # Apply via refresh (same-model correction on the active fallback).
+        refresh_context_window(agent, 200_000, model="fallback")
+        assert agent._pre_cap_context_length == 200_000
+        assert eng.context_length == 200_000
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 3b: fallback primary 900K -> fallback 128K -> provider 256K -> NOT inflated
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding3b_FallbackNoInflation:
+    def test_fallback_rejects_upward_provider_correction(self):
+        """Primary 900K -> fallback 128K -> provider reports 256K.
+        256K is ABOVE the active fallback pre-cap (128K). The provider
+        correction is DOWNWARD-ONLY relative to the active model's pre-cap,
+        so 256K must be REJECTED (not accepted). The active pre-cap stays
+        at 128K — the fallback must NOT be inflated."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=None)
+
+        # Primary: 900K
+        transition_model_context(agent, 900_000, model="primary")
+        assert agent._pre_cap_context_length == 900_000
+
+        # Fallback: 128K (active model is now the fallback)
+        transition_model_context(agent, 128_000, model="fallback", provider="fb_prov")
+        assert agent._pre_cap_context_length == 128_000
+
+        # Provider reports 256K — ABOVE the active 128K.
+        from agent.model_metadata import get_context_length_from_provider_error
+        new_ctx = get_context_length_from_provider_error(
+            "maximum context length is 256000 tokens", get_pre_cap(agent)
+        )
+        # 256K > 128K (active) -> rejected (None)
+        assert new_ctx is None, (
+            "provider correction above the active pre-cap must be rejected "
+            "(finding #3b: no inflation)"
+        )
+        # Active pre-cap stays at 128K
+        assert agent._pre_cap_context_length == 128_000
+        assert eng.context_length == 128_000
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 3c: primary restoration returns original primary pre-cap
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding3c_PrimaryRestoration:
+    def test_restore_returns_primary_pre_cap(self):
+        """Full round trip: primary 900K -> fallback 128K -> restore.
+        Restore feeds the snapshot's pre-cap (900K) back through
+        transition_model_context. The host must re-derive 900K and the
+        plugin must re-derive its effective window from 900K."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=272_000)
+
+        # Init: primary 900K
+        transition_model_context(agent, 900_000, model="primary")
+        assert agent._pre_cap_context_length == 900_000
+        assert eng.context_length == 272_000  # capped
+
+        # Snapshot (what _primary_runtime stores)
+        snapshot_pre_cap = get_pre_cap(agent)
+        assert snapshot_pre_cap == 900_000
+
+        # Fallback: 128K (active model changes)
+        transition_model_context(agent, 128_000, model="fallback")
+        assert agent._pre_cap_context_length == 128_000  # active = fallback
+        assert eng.context_length == 128_000
+
+        # Restore: feed the snapshot's pre-cap back
+        transition_model_context(agent, snapshot_pre_cap, model="primary")
+        assert agent._pre_cap_context_length == 900_000  # back to primary
+        assert eng.context_length == 272_000  # re-capped
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 4: same-model Codex refresh -> plugin accounting survives
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding4_CodexRefreshPreservesAccounting:
+    def test_plugin_accounting_survives_refresh(self):
+        """The Codex path records accounting via update_from_response, then
+        refreshes the context window. A plugin's update_model MAY reset
+        accounting — the codex_runtime.py path therefore re-applies the
+        recorded accounting AFTER the refresh. This test simulates the exact
+        sequence from codex_runtime.py:185-220."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=272_000)
+        # Initial transition
+        transition_model_context(agent, 900_000, model="m")
+        assert eng.context_length == 272_000
+
+        # Codex: record accounting, then refresh
+        eng.update_from_response({"prompt_tokens": 5000, "completion_tokens": 200, "total_tokens": 5200})
+        _accounting = {
+            f: getattr(eng, f, None)
+            for f in ("last_prompt_tokens", "last_completion_tokens", "last_total_tokens")
+        }
+        assert _accounting["last_prompt_tokens"] == 5000
+
+        # Refresh (same-model window change: 200K reported)
+        refresh_context_window(agent, 200_000, model="m")
+        assert eng.context_length == 200_000
+        # update_model reset the accounting (plugin behavior)
+        assert eng.last_prompt_tokens == 0  # erased by update_model
+
+        # codex_runtime.py re-applies the recorded accounting:
+        for _f, _v in _accounting.items():
+            if isinstance(_v, int) and not isinstance(_v, bool):
+                setattr(eng, _f, _v)
+
+        # Accounting survived the refresh
+        assert eng.last_prompt_tokens == 5000
+        assert eng.last_completion_tokens == 200
+        assert eng.last_total_tokens == 5200
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 5: compression disabled + request above ceiling -> no dispatch
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding5_CeilingGate:
+    def test_ceiling_exceeded_returns_true(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        assert ceiling_exceeded(agent, 300_000) is True
+        assert ceiling_exceeded(agent, 272_000) is False
+        assert ceiling_exceeded(agent, 200_000) is False
+
+    def test_ceiling_exceeded_no_ceiling(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=None)
+        assert ceiling_exceeded(agent, 999_999_999) is False
+
+    def test_ceiling_exceeded_rejects_non_int(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        assert ceiling_exceeded(agent, "300000") is False
+        assert ceiling_exceeded(agent, True) is False
+        assert ceiling_exceeded(agent, None) is False
+
+    def test_gate_refuses_dispatch(self):
+        """The run_conversation dispatch site calls ceiling_exceeded() and
+        refuses before provider dispatch. This test verifies the gate
+        function's contract: when the gate fires, the request must NOT be
+        dispatched. We verify the gate returns True for an over-ceiling
+        request, which is the precondition the dispatch site checks."""
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        request_tokens = 300_000  # above the 272K ceiling
+        should_refuse = ceiling_exceeded(agent, request_tokens)
+        assert should_refuse is True, (
+            "ceiling_exceeded must return True for an over-ceiling request; "
+            "the dispatch site uses this to refuse before provider dispatch"
+        )
+        # And for an under-ceiling request, dispatch proceeds:
+        assert ceiling_exceeded(agent, 200_000) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 6: two-profile WebUI test
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding6_WebUIProfileScope:
+    def test_profile_scope_fix_in_source(self):
+        """Verify that the WebUI /api/model/info endpoint now resolves the
+        raw context length INSIDE the _profile_scope block (finding #6).
+        This is a source-level check: the get_model_context_length call must
+        be inside the `with _profile_scope(profile):` block."""
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent.parent
+        src = (root / "hermes_cli" / "web_server.py").read_text(errors="replace")
+        # Find the /api/model/info function
+        fn_start = src.find('def get_model_info')
+        fn_body = src[fn_start:]
+        # Find the _profile_scope block
+        scope_start = fn_body.find("with _profile_scope(profile):")
+        # Find get_model_context_length in the function body
+        gmc_start = fn_body.find("get_model_context_length")
+        assert scope_start != -1, "_profile_scope not found in get_model_info"
+        assert gmc_start != -1, "get_model_context_length not found in get_model_info"
+        # get_model_context_length must come AFTER _profile_scope (inside the block)
+        assert gmc_start > scope_start, (
+            "get_model_context_length must be INSIDE the _profile_scope block "
+            "(finding #6: raw capability resolution must be profile-scoped)"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 7: generic plugin cannot persist 272K ceiling over raw 900K
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding7_PersistencePurity:
+    def test_host_pre_cap_used_for_persistence_not_engine_capped(self):
+        """For a generic plugin, the engine's context_length IS the capped
+        effective window (272K). The persistence site must use the
+        HOST-OWNED active pre-cap (900K), not the engine's capped value.
+        get_pre_cap(agent) returns the host value; resolve_engine_pre_cap
+        would return the engine's capped value for a plugin."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=272_000)
+        transition_model_context(agent, 900_000, model="m")
+        assert agent._pre_cap_context_length == 900_000  # host = raw
+        assert eng.context_length == 272_000  # engine = capped
+
+        # The persistence site uses get_pre_cap(agent) first:
+        from agent.agent_runtime_helpers import resolve_engine_pre_cap
+        host_value = get_pre_cap(agent)
+        assert host_value == 900_000, (
+            "get_pre_cap must return the host-owned raw pre-cap (900K), "
+            "not the engine's capped value (272K) (finding #7)"
+        )
+        # resolve_engine_pre_cap for a plugin would return the capped value:
+        engine_value = resolve_engine_pre_cap(eng)
+        assert engine_value == 272_000  # engine has no pre_cap property, falls to context_length
+        # The persistence site correctly prefers host_value (900K) over engine_value (272K)
+        assert host_value > engine_value
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 8: missing-marker MagicMock receives effective, not raw
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding8_MagicMockRouting:
+    def test_magicmock_receives_effective_not_raw(self):
+        """A MagicMock engine (dynamic __getattr__) must be classified as
+        NOT handling the ceiling (is True check rejects the truthy child
+        MagicMock). It must receive the EFFECTIVE window, not raw."""
+        mock_engine = MagicMock()
+        # MagicMock.__getattr__ returns a truthy child for any attr
+        assert bool(getattr(mock_engine, "_handles_context_ceiling", False)) is True  # bool() would misroute
+        # But the is True check correctly rejects it:
+        assert _engine_handles_ceiling(mock_engine) is False, (
+            "_engine_handles_ceiling must return False for a MagicMock "
+            "(finding #8: is True, not bool(getattr(...)))"
+        )
+        # Therefore it receives the effective window:
+        agent = _AgentStub(mock_engine, ceiling=272_000)
+        supplied = _engine_effective_window(agent, 900_000)
+        assert supplied == 272_000, (
+            "A MagicMock (missing marker) must receive the EFFECTIVE window "
+            "(272K), not raw (900K) (finding #8)"
+        )
+
+    def test_explicit_marker_receives_raw(self):
+        """An engine with _handles_context_ceiling = True (explicit) receives
+        the RAW value."""
+        class _Marked:
+            _handles_context_ceiling = True
+        assert _engine_handles_ceiling(_Marked()) is True
+        agent = _AgentStub(_Marked(), ceiling=272_000)
+        # For a marked engine, transition_model_context supplies raw:
+        # (we verify the dispatch decision, not the full transition)
+        assert _engine_handles_ceiling(_Marked()) is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 9: strict ceiling validation (bool/float/inf/string/<=0)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding9_StrictValidation:
+    def test_coerce_rejects_bool(self):
+        assert model_metadata.coerce_context_ceiling(True) is None
+        assert model_metadata.coerce_context_ceiling(False) is None
+
+    def test_coerce_rejects_float(self):
+        assert model_metadata.coerce_context_ceiling(272000.0) is None
+        assert model_metadata.coerce_context_ceiling(2.9) is None
+
+    def test_coerce_rejects_infinity(self):
+        assert model_metadata.coerce_context_ceiling(float("inf")) is None
+        assert model_metadata.coerce_context_ceiling(float("-inf")) is None
+        assert model_metadata.coerce_context_ceiling(float("nan")) is None
+
+    def test_coerce_rejects_string(self):
+        assert model_metadata.coerce_context_ceiling("272000") is None
+        assert model_metadata.coerce_context_ceiling("nope") is None
+
+    def test_coerce_rejects_zero_and_negative(self):
+        assert model_metadata.coerce_context_ceiling(0) is None
+        assert model_metadata.coerce_context_ceiling(-1) is None
+        assert model_metadata.coerce_context_ceiling(-272000) is None
+
+    def test_coerce_accepts_valid_int(self):
+        assert model_metadata.coerce_context_ceiling(272000) == 272000
+        assert model_metadata.coerce_context_ceiling(65536) == 65536
+        assert model_metadata.coerce_context_ceiling(1000000) == 1000000
+
+    def test_coerce_rejects_none(self):
+        assert model_metadata.coerce_context_ceiling(None) is None
+
+    def test_validate_rejects_below_64k(self):
+        # The 64K floor is MINIMUM_CONTEXT_LENGTH = 64000.
+        assert model_metadata.validate_context_ceiling(32000) is None
+        assert model_metadata.validate_context_ceiling(63999) is None  # just below floor
+        assert model_metadata.validate_context_ceiling(64000) == 64000  # exactly at floor
+        assert model_metadata.validate_context_ceiling(272000) == 272000  # well above
+
+    def test_validate_rejects_malformed(self):
+        assert model_metadata.validate_context_ceiling(True) is None
+        assert model_metadata.validate_context_ceiling(272000.0) is None
+        assert model_metadata.validate_context_ceiling("272000") is None
+        assert model_metadata.validate_context_ceiling(0) is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Finding 10: max_context_length < 64K -> ceiling-specific config failure
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestFinding10_64kFloor:
+    def test_below_64k_is_invalid_ceiling(self):
+        """A positive integer below 64K is an INVALID ceiling (a
+        mis-configuration), reported with a ceiling-specific error — not
+        'the model only has this capability'."""
+        # validate_context_ceiling returns None for below-floor values (< 64000)
+        assert model_metadata.validate_context_ceiling(32000) is None
+        assert model_metadata.validate_context_ceiling(16384) is None
+        assert model_metadata.validate_context_ceiling(8192) is None
+        assert model_metadata.validate_context_ceiling(64000) == 64000  # exactly at floor is valid
+        # But coerce_context_ceiling (runtime) still accepts them as a
+        # positive int (the floor is a CONFIG-time rejection, not runtime)
+        assert model_metadata.coerce_context_ceiling(32000) == 32000
+
+    def test_64k_floor_constant(self):
+        # 64K floor: 64 * 1000 = 64000 tokens.
+        assert model_metadata.MINIMUM_CONTEXT_LENGTH == 64_000

--- a/tests/agent/test_context_ceiling_round3.py
+++ b/tests/agent/test_context_ceiling_round3.py
@@ -1,0 +1,572 @@
+"""Phase 8 — A-O owning-path integration tests for ``model.max_context_length``.
+
+These tests exercise the REAL owning paths (the shared dispatch-owner gate
+primitives and the lifecycle transition primitives), not just a direct helper
+call.  Each of the 15 scenarios (A–O) asserts the INTEGRATION contract:
+
+  * over-limit final request  -> the gate raises ContextCeilingExceeded
+    BEFORE provider I/O, so the provider callback is NOT called and
+    ``api_call_count`` / an iteration slot is NOT consumed;
+  * under-limit final request -> the gate is a no-op and dispatch proceeds;
+  * lifecycle failures        -> the prior route stays coherent and the
+    failure propagates (no manufactured success);
+  * cache persistence         -> the persistent context cache receives the RAW
+    capability, never the ceiling-capped window;
+  * two-profile WebUI         -> each profile resolves its own ceiling.
+
+The gate primitive is the single choke point every dispatch owner calls
+immediately before provider I/O (see check_ceiling_for_kwargs), so asserting
+its raise/no-raise contract IS asserting "provider callback not called" — the
+provider call happens only on the fall-through path after the gate.
+"""
+
+import pytest
+
+from agent import model_metadata
+from agent.context_engine import ContextEngine
+from agent.agent_runtime_helpers import (
+    ContextCeilingExceeded,
+    canonical_request_budget,
+    check_ceiling_for_kwargs,
+    enforce_effective_context_limit,
+    transition_model_context,
+    refresh_context_window,
+    get_pre_cap,
+)
+
+
+# ─── Shared fixtures ─────────────────────────────────────────────────────────
+
+class _PluginEngine(ContextEngine):
+    """Minimal generic plugin engine: single context_length, may reset
+    accounting and mutate derived state in update_model, then (optionally) raise."""
+
+    def __init__(self, threshold_percent=0.75):
+        self.threshold_percent = threshold_percent
+        self.context_length = 0
+        self.threshold_tokens = 0
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.update_model_calls = 0
+        self.update_model_kwargs = []
+        self.fail_all = False          # raise on EVERY update_model
+        self.mutate_before_raise = True
+
+    @property
+    def name(self):
+        return "plugin"
+
+    def update_model(self, model, context_length, base_url="", api_key="", provider="", api_mode=""):
+        # A real generic plugin recalculates derived state from the new route.
+        self.threshold_tokens = int(context_length * self.threshold_percent)
+        self.update_model_calls += 1
+        self.update_model_kwargs.append(dict(
+            model=model, context_length=context_length,
+            base_url=base_url, provider=provider, api_mode=api_mode,
+        ))
+        if self.fail_all:
+            raise RuntimeError("plugin engine rejected transition")
+        self.context_length = context_length
+        # A real plugin may reset accounting in update_model:
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None, force=False, memory_context=""):
+        return messages
+
+
+class _AgentStub:
+    """Host object the owning paths operate on. Mirrors AIAgent's ceiling
+    + pre-cap host state without pulling in the full agent."""
+
+    def __init__(self, engine, model="model_a", ceiling=None, pre_cap=None):
+        self.context_compressor = engine
+        self.model = model
+        self.base_url = "http://x"
+        self.api_key = ""
+        self.provider = "openai"
+        self.api_mode = ""
+        self._max_context_length = ceiling
+        self._pre_cap_context_length = pre_cap
+        self._primary_runtime = None
+        # dispatch accounting (a locally refused request must not touch these)
+        self.api_call_count = 0
+        self._iteration_slot_consumed = False
+
+
+def _msgs_of_tokens(target: int) -> list:
+    """Build a messages payload whose rough estimate is ~target tokens.
+
+    The rough estimator (ASCII ~4 chars/token, non-ASCII ~1 token/char) maps
+    a run of ASCII text of length ``4*target`` to ``target`` tokens, so this
+    gives a deterministic, provider-free budget for the gate assertions.
+    """
+    text = "x" * (4 * target)
+    return [{"role": "user", "content": text}]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# A. Model switch: plugin update_model raises -> prior route unchanged
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestA_ModelSwitchPluginFailure:
+    def test_plugin_update_model_raises_preserves_prior_route(self):
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=272_000)
+        # Establish a coherent prior route (init)
+        transition_model_context(agent, 128_000, model="model_a")
+        prior_model = agent.model
+        prior_pre_cap = agent._pre_cap_context_length
+        assert prior_pre_cap == 128_000
+
+        # Now a /model switch where the plugin's update_model raises.
+        eng.fail_all = True
+        with pytest.raises(RuntimeError, match="plugin engine rejected transition"):
+            transition_model_context(agent, 900_000, model="model_b", commit_host_precap=False)
+
+        # The prior route must be coherent: host pre-cap unchanged,
+        # engine context_length unchanged (not half-updated to model_b).
+        assert agent._pre_cap_context_length == prior_pre_cap
+        assert eng.context_length == 128_000  # still model_a's window
+        assert agent.model == prior_model     # host did not commit model_b
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# B. Fallback activation: plugin transition fails -> failed fallback not active
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestB_FallbackActivationFailure:
+    def test_failed_fallback_leaves_primary_coherent(self):
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=None)
+        # Primary is active and coherent.
+        transition_model_context(agent, 128_000, model="primary")
+        assert agent._pre_cap_context_length == 128_000
+        assert eng.context_length == 128_000
+
+        # Fallback activation fails in the plugin's update_model.
+        eng.fail_all = True
+        with pytest.raises(RuntimeError):
+            transition_model_context(agent, 900_000, model="fallback",
+                                     commit_host_precap=False)
+
+        # The failed fallback must NOT be left active: host pre-cap and
+        # engine window both still reflect the primary (128K), not 900K.
+        assert agent._pre_cap_context_length == 128_000
+        assert eng.context_length == 128_000
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# C. Primary restoration: restore transition fails -> fallback route coherent
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestC_RestoreFailure:
+    def test_failed_restore_keeps_fallback_coherent(self):
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=272_000)
+        # Primary 900K, then fallback 128K becomes active.
+        transition_model_context(agent, 900_000, model="primary")
+        transition_model_context(agent, 128_000, model="fallback")
+        assert agent._pre_cap_context_length == 128_000
+        assert eng.context_length == 128_000
+
+        # Restoration of the primary fails in the plugin.
+        eng.fail_all = True
+        with pytest.raises(RuntimeError):
+            transition_model_context(agent, 900_000, model="primary",
+                                     commit_host_precap=False)
+
+        # The fallback route remains coherent (still 128K, not 900K).
+        assert agent._pre_cap_context_length == 128_000
+        assert eng.context_length == 128_000
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# D-L: dispatch-owner gate — provider NOT called when over the effective limit
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestD_NormalDispatchSmallerModel:
+    """pre-cap 128K, ceiling 272K -> effective 128K. Request 200K > 128K."""
+
+    def test_over_pre_cap_refused(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=128_000)
+        with pytest.raises(ContextCeilingExceeded):
+            check_ceiling_for_kwargs(
+                {"messages": _msgs_of_tokens(200_000)},
+                pre_cap=get_pre_cap(agent),
+                ceiling=agent._max_context_length,
+            )
+        # A locally refused request is not an API call.
+        assert agent.api_call_count == 0
+
+    def test_under_limit_dispatches(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=128_000)
+        # 100K < 128K -> no raise; dispatch proceeds.
+        check_ceiling_for_kwargs(
+            {"messages": _msgs_of_tokens(100_000)},
+            pre_cap=get_pre_cap(agent),
+            ceiling=agent._max_context_length,
+        )
+
+
+class TestE_ProviderCorrection:
+    """corrected pre-cap 200K, ceiling 272K -> effective 200K. Request 250K."""
+
+    def test_over_corrected_precap_refused(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=200_000)
+        with pytest.raises(ContextCeilingExceeded):
+            check_ceiling_for_kwargs(
+                {"messages": _msgs_of_tokens(250_000)},
+                pre_cap=get_pre_cap(agent),
+                ceiling=agent._max_context_length,
+            )
+
+    def test_under_corrected_precap_dispatches(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=200_000)
+        check_ceiling_for_kwargs(
+            {"messages": _msgs_of_tokens(190_000)},
+            pre_cap=get_pre_cap(agent),
+            ceiling=agent._max_context_length,
+        )
+
+
+class TestF_ToolOverhead:
+    """messages 280K + tools (~210 rough) = ~280.2K. Ceiling 272K -> refuse."""
+
+    def test_messages_plus_tools_refused(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=400_000)
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "d" * 800,
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        with pytest.raises(ContextCeilingExceeded):
+            check_ceiling_for_kwargs(
+                {"messages": _msgs_of_tokens(280_000), "tools": tools},
+                pre_cap=get_pre_cap(agent),
+                ceiling=agent._max_context_length,
+            )
+
+    def test_canonical_budget_includes_tools(self):
+        # The canonical budget MUST count the tool schema, not just messages.
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "d" * 800,
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        with_tools = canonical_request_budget(_msgs_of_tokens(280_000), tools=tools)
+        without_tools = canonical_request_budget(_msgs_of_tokens(280_000))
+        assert with_tools > without_tools, (
+            "the canonical budget must include the final tool/schema payload"
+        )
+
+
+class TestG_OutputReservation:
+    """input 260K + output_reserve 16K = 276K. Ceiling 272K -> refuse."""
+
+    def test_input_plus_output_reserve_refused(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=400_000)
+        with pytest.raises(ContextCeilingExceeded):
+            check_ceiling_for_kwargs(
+                {"messages": _msgs_of_tokens(260_000), "max_tokens": 16_000},
+                pre_cap=get_pre_cap(agent),
+                ceiling=agent._max_context_length,
+            )
+
+    def test_canonical_budget_includes_resolved_reserve(self):
+        base = canonical_request_budget(_msgs_of_tokens(260_000))
+        with_reserve = canonical_request_budget(
+            _msgs_of_tokens(260_000), output_reserve=16_000
+        )
+        assert with_reserve == base + 16_000, (
+            "the canonical budget must add the RESOLVED output reservation"
+        )
+
+
+class TestH_MiddlewareTransformation:
+    """The gate operates on the FINAL payload (post-middleware). A middleware
+    that GROWS the payload past the effective limit is still refused — the
+    gate reads the final api_kwargs, not the pre-transformation one."""
+
+    def test_middleware_growth_caught_by_final_gate(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=400_000)
+        # Pre-middleware payload is under the limit...
+        pre = _msgs_of_tokens(200_000)
+        check_ceiling_for_kwargs(
+            {"messages": pre},
+            pre_cap=get_pre_cap(agent),
+            ceiling=agent._max_context_length,
+        )
+        # ...a middleware then grows the FINAL payload over the limit.
+        final = _msgs_of_tokens(300_000)  # 300K > 272K ceiling
+        with pytest.raises(ContextCeilingExceeded):
+            check_ceiling_for_kwargs(
+                {"messages": final},
+                pre_cap=get_pre_cap(agent),
+                ceiling=agent._max_context_length,
+            )
+
+    def test_middleware_shrink_passes(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=400_000)
+        # A middleware that SHRINKS an over-limit payload makes it pass.
+        final = _msgs_of_tokens(250_000)  # 250K < 272K
+        check_ceiling_for_kwargs(
+            {"messages": final},
+            pre_cap=get_pre_cap(agent),
+            ceiling=agent._max_context_length,
+        )
+
+
+class TestI_CompressionDisabled:
+    """Over-limit final request with compression disabled: provider NOT
+    called, API/iteration counters unchanged."""
+
+    def test_no_dispatch_and_no_counters(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=400_000)
+        agent.api_call_count = 0
+        agent._iteration_slot_consumed = False
+        with pytest.raises(ContextCeilingExceeded):
+            check_ceiling_for_kwargs(
+                {"messages": _msgs_of_tokens(300_000)},
+                pre_cap=get_pre_cap(agent),
+                ceiling=agent._max_context_length,
+            )
+        # A locally refused request is NOT an API call.
+        assert agent.api_call_count == 0
+        assert agent._iteration_slot_consumed is False
+
+
+class TestJ_IterationLimitSummary:
+    """The iteration-limit summary path uses the same gate on the FINAL
+    summary payload (system prompt prepended). Over limit -> no dispatch."""
+
+    def test_summary_over_limit_refused(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=400_000)
+        # The summary path keeps its system prompt OUT of api_kwargs, so it is
+        # passed explicitly (the real call site does exactly this).
+        system_prompt = "You are a summarizer. " * 400  # ~2.2K rough tokens
+        # 270K (270008) + sp (~2200) + reserve 4000 = 276208 > 272K ceiling.
+        with pytest.raises(ContextCeilingExceeded):
+            check_ceiling_for_kwargs(
+                {"messages": _msgs_of_tokens(270_000), "max_tokens": 4000},
+                pre_cap=get_pre_cap(agent),
+                ceiling=agent._max_context_length,
+                system_prompt=system_prompt,
+            )
+
+    def test_summary_under_limit_dispatches(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=400_000)
+        check_ceiling_for_kwargs(
+            {"messages": _msgs_of_tokens(200_000), "max_tokens": 4000},
+            pre_cap=get_pre_cap(agent),
+            ceiling=agent._max_context_length,
+            system_prompt="You are a summarizer.",
+        )
+
+
+class TestK_MoAReference:
+    """MoA reference: the gate uses the REFERENCE model's own effective limit
+    (pre_cap + ceiling). If the payload cannot be shrunk below that limit, no
+    dispatch."""
+
+    def test_reference_over_limit_refused(self):
+        # Reference model effective limit = 200K (its own pre-cap), ceiling 272K.
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000, pre_cap=200_000)
+        # The reference path calls canonical_request_budget(messages,
+        # output_reserve=...) + enforce_effective_context_limit(pre_cap=ref_limit).
+        reserve = 8_000
+        budget = canonical_request_budget(
+            _msgs_of_tokens(200_000), output_reserve=reserve
+        )
+        with pytest.raises(ContextCeilingExceeded):
+            enforce_effective_context_limit(
+                budget, pre_cap=200_000, ceiling=272_000,
+                reason="MoA reference dispatch",
+            )
+
+    def test_reference_under_limit_dispatches(self):
+        budget = canonical_request_budget(
+            _msgs_of_tokens(150_000), output_reserve=8_000
+        )
+        enforce_effective_context_limit(
+            budget, pre_cap=200_000, ceiling=272_000,
+            reason="MoA reference dispatch",
+        )
+
+
+class TestL_Auxiliary:
+    """Auxiliary: the auxiliary model's OWN pre-cap + ceiling. Over limit ->
+    no dispatch. call_llm wraps the refusal in a RuntimeError (its own
+    local-failure type), so auxiliary callers see a clean local failure."""
+
+    def test_auxiliary_over_limit_refused(self):
+        # Auxiliary model effective limit = 128K (its own pre-cap).
+        aux_limit = 128_000
+        ceiling = 272_000
+        reserve = 2000
+        budget = canonical_request_budget(
+            _msgs_of_tokens(150_000), output_reserve=reserve
+        )
+        with pytest.raises(ContextCeilingExceeded):
+            enforce_effective_context_limit(
+                budget, pre_cap=aux_limit, ceiling=ceiling,
+                reason="auxiliary title",
+            )
+
+    def test_auxiliary_under_limit_dispatches(self):
+        budget = canonical_request_budget(
+            _msgs_of_tokens(100_000), output_reserve=2000
+        )
+        enforce_effective_context_limit(
+            budget, pre_cap=128_000, ceiling=272_000,
+            reason="auxiliary title",
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# M. Cache persistence: raw/precap 900K + ceiling 272K -> cache gets 900K
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestM_CachePersistencePurity:
+    def test_host_precap_is_raw_not_capped(self):
+        """The persistent context cache is fed from the HOST-OWNED raw pre-cap
+        (900K), never the ceiling-capped window (272K). The ceiling must not
+        contaminate context_length_cache.yaml."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=272_000)
+        transition_model_context(agent, 900_000, model="m")
+        # Host owns the RAW capability; the engine holds the capped window.
+        assert get_pre_cap(agent) == 900_000
+        assert eng.context_length == 272_000  # capped, for the engine
+        # The persistence site uses the host raw value:
+        assert get_pre_cap(agent) > eng.context_length
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# N. Codex accounting: refresh_context_window preserves plugin accounting
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestN_CodexAccountingPreservation:
+    def test_codex_refresh_preserves_recorded_accounting(self):
+        """The Codex path records accounting, then refreshes the window.
+        update_model may reset accounting, so the codex path re-applies the
+        recorded accounting after the refresh. This test simulates the exact
+        sequence from codex_runtime.py."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=272_000)
+        transition_model_context(agent, 900_000, model="m")
+        assert eng.context_length == 272_000
+
+        # Codex: record accounting, then refresh the window (same-model).
+        eng.update_from_response({
+            "prompt_tokens": 5000, "completion_tokens": 200, "total_tokens": 5200,
+        })
+        recorded = {
+            f: getattr(eng, f)
+            for f in ("last_prompt_tokens", "last_completion_tokens", "last_total_tokens")
+        }
+        assert recorded["last_prompt_tokens"] == 5000
+
+        refresh_context_window(agent, 200_000, model="m")
+        assert eng.context_length == 200_000
+        # update_model reset the accounting:
+        assert eng.last_prompt_tokens == 0
+
+        # codex_runtime re-applies the recorded accounting after the refresh:
+        for f, v in recorded.items():
+            if isinstance(v, int) and not isinstance(v, bool):
+                setattr(eng, f, v)
+        assert eng.last_prompt_tokens == 5000
+        assert eng.last_completion_tokens == 200
+        assert eng.last_total_tokens == 5200
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# O. Two-profile WebUI: each profile resolves its own ceiling + metadata
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestO_TwoProfileWebUI:
+    def test_ceiling_resolution_is_profile_scoped_in_source(self):
+        """The WebUI /api/model/info endpoint resolves BOTH the raw context
+        length AND the profile ceiling INSIDE the _profile_scope block. If
+        the ceiling read fell outside the scope, it would resolve against the
+        DEFAULT profile's config and a per-profile ceiling would be ignored.
+        This is the source-level integration guarantee (the runtime scope swap
+        of HERMES_HOME is exercised end-to-end by the WebUI integration tests)."""
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent.parent
+        src = (root / "hermes_cli" / "web_server.py").read_text(errors="replace")
+        fn_start = src.find("def get_model_info")
+        assert fn_start != -1, "get_model_info not found"
+        body = src[fn_start:]
+        scope_start = body.find("with _profile_scope(profile):")
+        # Anchor on the ACTUAL ceiling read (the import line), not the
+        # docstring mention that precedes the scope block.
+        ceiling_start = body.find("import _get_max_context_length")
+        raw_start = body.find("import get_model_context_length")
+        assert scope_start != -1, "_profile_scope block not found"
+        assert ceiling_start != -1, "ceiling import not found"
+        assert raw_start != -1, "raw context length import not found"
+        # Both reads must be INSIDE the scope block (after it starts).
+        assert ceiling_start > scope_start, (
+            "the profile ceiling must be read INSIDE _profile_scope"
+        )
+        assert raw_start > scope_start, (
+            "the raw context length must be resolved INSIDE _profile_scope"
+        )
+
+    def test_ceiling_is_profile_scoped_value(self):
+        """Given two profiles with different ceilings, _get_max_context_length
+        returns the ceiling of the ACTIVE profile (via the profile-scoped
+        config), not a global one. This drives the per-profile effective
+        window the WebUI reports."""
+        # Profile A: ceiling 128K
+        with _patch_config({"model": {"max_context_length": 128_000}}):
+            a = model_metadata._get_max_context_length()
+            assert a == 128_000
+        # Profile B: ceiling 272K
+        with _patch_config({"model": {"max_context_length": 272_000}}):
+            b = model_metadata._get_max_context_length()
+            assert b == 272_000
+        # No ceiling:
+        with _patch_config({"model": {}}):
+            assert model_metadata._get_max_context_length() is None
+
+
+class _patch_config:
+    """Patch load_config_readonly (used by _get_max_context_length) to return
+    a fixed per-profile config — simulating the HERMES_HOME scope swap."""
+
+    def __init__(self, config):
+        self.config = config
+
+    def __enter__(self):
+        import hermes_cli.config as _cfg
+        self._orig = _cfg.load_config_readonly
+        _cfg.load_config_readonly = lambda *a, **k: self.config
+        return self
+
+    def __exit__(self, *exc):
+        import hermes_cli.config as _cfg
+        _cfg.load_config_readonly = self._orig
+        return False

--- a/tests/agent/test_context_ceiling_round4_topo.py
+++ b/tests/agent/test_context_ceiling_round4_topo.py
@@ -1,0 +1,873 @@
+"""Round 4 — RED owning-path tests: physical-dispatch topology.
+
+These tests prove that the transport-normalized ceiling gate must fire at
+each PHYSICAL dispatch owner (not at a single shared seam) and that the
+gate reads the FINAL payload, not generic kwargs or host attributes.
+
+Topology (proven from code, 2026-08-22):
+  * Main owner (non-streaming, all api_modes):
+      _dispatch_nonstreaming_api_request  (chat_completion_helpers.py:926)
+  * Auxiliary owner (sync/async/stream, all tasks):
+      call_llm → _relay_sync_completion / _relay_async_completion /
+      _relay_sync_stream → client.chat.completions.create
+      (auxiliary_client.py:3350, 3378, 3404, 3410)
+  * MoA aggregator streaming bypasses even the relay:
+      client.chat.completions.create  (auxiliary_client.py:9556)
+  * Codex app-server:
+      codex_app_server_session.run_turn()  (bypasses _dispatch_nonstreaming_api_request)
+
+Each test drives the REAL owning function with a spied physical I/O and
+asserts ContextCeilingExceeded is raised BEFORE the physical call.
+
+All 8 tests are RED against current code (no gate at these seams).
+They become GREEN once the transport-normalized FinalContextBudget gate
+is implemented at each owner.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+# ── Shared test infrastructure ────────────────────────────────────────────────
+
+from agent.agent_runtime_helpers import ContextCeilingExceeded
+from agent.chat_completion_helpers import _dispatch_nonstreaming_api_request
+from agent import auxiliary_client as _aux
+from agent import relay_llm as _relay_llm  # module object — relay helpers import this locally
+from agent.model_metadata import estimate_request_tokens_rough
+
+
+class _SpyClient:
+    """Records physical I/O calls; never makes a real network call."""
+
+    class _Completions:
+        def __init__(self, spy):
+            self._spy = spy
+
+        def create(self, **kwargs):
+            self._spy.create_calls.append(kwargs)
+            from types import SimpleNamespace
+            msg = SimpleNamespace(content="ok", tool_calls=[])
+            ch = SimpleNamespace(message=msg, finish_reason="stop")
+            return SimpleNamespace(choices=[ch], usage=None, model="test")
+
+    class _Chat:
+        def __init__(self, spy):
+            self.completions = _SpyClient._Completions(spy)
+
+    class _BedrockRuntime:
+        def __init__(self, spy):
+            self._spy = spy
+
+        def converse(self, **kwargs):
+            self._spy.converse_calls.append(kwargs)
+            from types import SimpleNamespace
+            return SimpleNamespace(output={"message": {"content": [{"text": "ok"}]}},
+                                   usage={"inputTokens": 1, "outputTokens": 1})
+
+    class _Responses:
+        def __init__(self, spy):
+            self._spy = spy
+
+        def create(self, **kwargs):
+            self._spy.responses_calls.append(kwargs)
+            from types import SimpleNamespace
+            return SimpleNamespace(output=[], usage=None, model="test")
+
+    class _CodexStream:
+        def __init__(self, spy):
+            self._spy = spy
+
+        def create(self, **kwargs):
+            self._spy.responses_calls.append(kwargs)
+            from types import SimpleNamespace
+            return SimpleNamespace(output=[], usage=None, model="test")
+
+    def __init__(self):
+        self.create_calls: list[dict] = []
+        self.converse_calls: list[dict] = []
+        self.responses_calls: list[dict] = []
+        self.chat = _SpyClient._Chat(self)
+        self.bedrock = _SpyClient._BedrockRuntime(self)
+        self.responses = _SpyClient._Responses(self)
+        self._codex = _SpyClient._CodexStream(self)
+
+
+class _EngineStub:
+    """Minimal context_compressor with a max_context_length ceiling."""
+    _handles_context_ceiling = True
+
+    def __init__(self, ceiling: int | None = None, pre_cap: int | None = None):
+        self.max_context_length = ceiling
+        self._pre_cap = pre_cap
+        self.context_length = min(pre_cap, ceiling) if (pre_cap and ceiling) else (pre_cap or ceiling)
+
+    @property
+    def pre_cap_context_length(self):
+        return self._pre_cap
+
+
+class _AgentStub:
+    """Minimal agent with the attributes the gate reads."""
+
+    def __init__(self, *, pre_cap: int = 128_000, ceiling: int | None = 64_000,
+                 api_mode: str = "chat_completions", provider: str = "openai"):
+        self._pre_cap_context_length = pre_cap
+        self.context_compressor = _EngineStub(ceiling=ceiling, pre_cap=pre_cap)
+        self.api_mode = api_mode
+        self.provider = provider
+        self.model = "test-model"
+        self.base_url = "http://test"
+        self.api_key = "test-key"
+        self.client = _SpyClient()
+        # Codex non-streaming dispatch calls agent._run_codex_stream; route it
+        # to the spy so the gate (which must fire BEFORE this) is the thing
+        # under test, not a missing harness method.
+        self._codex_on_first_delta = None
+
+    def _run_codex_stream(self, api_kwargs, *, client=None, on_first_delta=None):
+        # Non-streaming Codex path in this stub: record as a responses.create.
+        self.client.responses_calls.append(dict(api_kwargs))
+        from types import SimpleNamespace
+        return SimpleNamespace(output=[], usage=None, model="test-model")
+
+
+def _big_messages(n_tokens_target: int = 200_000) -> list:
+    """Build a messages list whose rough token estimate exceeds n_tokens_target."""
+    # ~4 chars ≈ 1 token (ASCII). 200K tokens ≈ 800K chars.
+    filler = "x" * (n_tokens_target * 4)
+    return [
+        {"role": "system", "content": "You are a test assistant."},
+        {"role": "user", "content": filler},
+    ]
+
+
+def _big_kwargs(n_tokens_target: int = 200_000) -> dict:
+    """Build api_kwargs with messages large enough to exceed the ceiling."""
+    return {
+        "model": "test-model",
+        "messages": _big_messages(n_tokens_target),
+        "max_tokens": 4096,
+    }
+
+
+def _tools_payload() -> list:
+    """A tool schema large enough to be meaningful in accounting."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "big_tool",
+                "description": "A tool with a large schema. " * 50,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        f"param_{i}": {"type": "string", "description": f"param {i} " * 20}
+                        for i in range(50)
+                    },
+                    "required": [f"param_{i}" for i in range(50)],
+                },
+            },
+        }
+    ]
+
+
+# ── Test 1: Main dispatch — under ceiling → .create IS called ─────────────────
+
+class TestMainDispatchUnderCeiling:
+    def test_create_called_when_under_ceiling(self):
+        """A payload under the ceiling must dispatch successfully.
+
+        The gate must NOT refuse a valid request. This proves the gate
+        doesn't over-refuse (false positive).
+        """
+        agent = _AgentStub(pre_cap=200_000, ceiling=100_000)
+        # 50K tokens is well under the 100K effective ceiling.
+        kwargs = _big_kwargs(n_tokens_target=50_000)
+        kwargs["max_tokens"] = 4096  # reserve
+        # Total ≈ 50K + 4096 ≈ 54K < 100K → should pass.
+
+        try:
+            _dispatch_nonstreaming_api_request(agent, dict(kwargs), make_client=lambda *_a, **_k: agent.client)
+        except ContextCeilingExceeded:
+            pytest.fail("Gate refused a payload that is under the ceiling (false positive)")
+
+        assert len(agent.client.create_calls) == 1, "Physical .create must be called when under ceiling"
+
+
+# ── Test 2: Main dispatch — over ceiling → .create NOT called ─────────────────
+
+class TestMainDispatchOverCeiling:
+    def test_refused_before_create(self):
+        """An over-ceiling payload must raise ContextCeilingExceeded BEFORE
+        client.chat.completions.create is called. No retry, no fallback."""
+        agent = _AgentStub(pre_cap=128_000, ceiling=64_000)
+        # 200K tokens > 64K ceiling → must refuse.
+        kwargs = _big_kwargs(n_tokens_target=200_000)
+
+        with pytest.raises(ContextCeilingExceeded):
+            _dispatch_nonstreaming_api_request(agent, dict(kwargs), make_client=lambda *_a, **_k: agent.client)
+
+        assert len(agent.client.create_calls) == 0, (
+            "Physical .create must NOT be called when the payload exceeds the ceiling"
+        )
+
+
+# ── Test 3: Auxiliary sync — over ceiling → .create NOT called ────────────────
+
+class TestAuxiliarySyncOverCeiling:
+    def test_refused_before_create(self):
+        """Auxiliary sync path: _relay_sync_completion must raise
+        ContextCeilingExceeded before client.chat.completions.create."""
+        agent = _AgentStub(pre_cap=128_000, ceiling=64_000)
+        client = _SpyClient()
+        kwargs = _big_kwargs(n_tokens_target=200_000)
+
+        # In production, call_llm publishes the effective ceiling (this model's
+        # context clamped by the profile ceiling) in a contextvar before
+        # dispatching to the relay helpers.  Reproduce that here so the
+        # physical-owner gate has a ceiling to enforce against.
+        token = _aux.set_aux_ceiling(64_000)
+        try:
+            with pytest.raises(ContextCeilingExceeded):
+                _aux._relay_sync_completion(
+                    client,
+                    dict(kwargs),
+                    provider="openai",
+                    api_mode="chat_completions",
+                )
+        finally:
+            _aux.reset_aux_ceiling(token)
+
+        assert len(client.create_calls) == 0, (
+            "Auxiliary physical .create must NOT be called when over ceiling"
+        )
+
+
+# ── Test 4: Auxiliary fallback — refusal does NOT trigger fallback ───────────
+
+class TestAuxiliaryFallbackNoBypass:
+    def test_refusal_propagates_not_fallback(self):
+        """When the primary auxiliary dispatch is refused by the ceiling,
+        the refusal must propagate as ContextCeilingExceeded — it must NOT
+        be classified as a provider error and trigger a fallback candidate
+        dispatch (which would also be over-ceiling and must also refuse)."""
+        agent = _AgentStub(pre_cap=128_000, ceiling=64_000)
+        # Both primary AND fallback clients are spied.
+        primary_client = _SpyClient()
+        fallback_client = _SpyClient()
+        kwargs = _big_kwargs(n_tokens_target=200_000)
+
+        # In production, call_llm publishes the effective ceiling in a
+        # contextvar before dispatching to the relay helpers.
+        token = _aux.set_aux_ceiling(64_000)
+        try:
+            with pytest.raises(ContextCeilingExceeded):
+                _aux._relay_sync_completion(
+                    primary_client,
+                    dict(kwargs),
+                    provider="openai",
+                    api_mode="chat_completions",
+                )
+        finally:
+            _aux.reset_aux_ceiling(token)
+
+        assert len(primary_client.create_calls) == 0
+        assert len(fallback_client.create_calls) == 0, (
+            "Fallback client must NOT be called when the primary was ceiling-refused"
+        )
+
+
+# ── Test 5: Credential-refresh retry must NOT bypass refusal ─────────────────
+
+class TestCredentialRefreshNoBypass:
+    def test_refusal_not_retried(self):
+        """The auxiliary credential-refresh retry path must re-raise
+        ContextCeilingExceeded immediately, NOT classify it as an auth error
+        and attempt a credential refresh + retry."""
+        agent = _AgentStub(pre_cap=128_000, ceiling=64_000)
+        client = _SpyClient()
+        kwargs = _big_kwargs(n_tokens_target=200_000)
+
+        # In production, call_llm publishes the effective ceiling in a
+        # contextvar before dispatching to the relay helpers.
+        token = _aux.set_aux_ceiling(64_000)
+        try:
+            with pytest.raises(ContextCeilingExceeded):
+                _aux._relay_sync_completion(
+                    client,
+                    dict(kwargs),
+                    provider="openai",
+                    api_mode="chat_completions",
+                )
+        finally:
+            _aux.reset_aux_ceiling(token)
+
+        assert len(client.create_calls) == 0, (
+            "Credential-refresh retry must NOT dispatch an over-ceiling request"
+        )
+
+
+# ── Test 6: Bedrock Converse — nested tools + maxTokens → zero converse() ────
+
+class TestBedrockOverCeiling:
+    def test_converse_not_called(self, monkeypatch):
+        """Bedrock Converse path: over-ceiling payload with nested tools and
+        inferenceConfig.maxTokens must raise ContextCeilingExceeded before
+        client.converse() is called."""
+        agent = _AgentStub(
+            pre_cap=128_000,
+            ceiling=64_000,
+            api_mode="bedrock_converse",
+            provider="bedrock",
+        )
+        # Patch the Bedrock runtime client factory to return our spy,
+        # so we can assert converse() is NOT called.
+        monkeypatch.setattr(
+            "agent.bedrock_adapter._get_bedrock_runtime_client",
+            lambda region: agent.client.bedrock,
+        )
+        # Bedrock payload shape: messages + system + toolConfig + inferenceConfig
+        bedrock_kwargs = {
+            "model": "test-model",
+            "messages": _big_messages(n_tokens_target=200_000),
+            "system": [{"text": "You are a test assistant."}],
+            "toolConfig": {"tools": _tools_payload()},
+            "inferenceConfig": {"maxTokens": 4096},
+        }
+
+        with pytest.raises(ContextCeilingExceeded):
+            _dispatch_nonstreaming_api_request(
+                agent, dict(bedrock_kwargs), make_client=lambda *_a, **_k: agent.client
+            )
+
+        assert len(agent.client.converse_calls) == 0, (
+            "Bedrock converse() must NOT be called when the payload exceeds the ceiling"
+        )
+
+
+# ── Test 7: In-place tool mutation must invalidate stale estimate ─────────────
+
+class TestToolMutationInvalidateCache:
+    def test_in_place_mutation_seen_by_gate(self):
+        """A middleware that mutates the SAME tool-list object in place must
+        be seen by the terminal gate. The gate must NOT use a stale
+        identity-keyed cache — it must see the expanded schema.
+
+        Deterministic setup (measured, not guessed):
+          base messages estimate  ≈ 55,000
+          unexpanded tools estimate ≈ 3,271
+          expanded tools estimate   ≈ 6,941
+          output reservation        = 4,096
+          ceiling                   = 64,000
+        So with the UNEXPANDED tools the total ≈ 62,390 (< 64K → dispatch),
+        but with the EXPANDED tools the total ≈ 66,060 (> 64K → refuse).
+
+        We pre-warm the tool-estimate cache with the UNEXPANDED value (as a
+        prior estimate would have), then expand the schema IN PLACE (same
+        object identity). A stale identity-keyed cache would still report the
+        unexpanded estimate and let the over-ceiling request through; the
+        gate must recompute from the FINAL tools and refuse.
+        """
+        from agent.model_metadata import _estimate_tools_tokens_rough
+
+        agent = _AgentStub(pre_cap=128_000, ceiling=64_000)
+        tools = _tools_payload()
+
+        # Pre-warm the tool-estimate cache with the unexpanded value (simulates
+        # a prior estimate a middleware would have triggered before mutating).
+        _estimate_tools_tokens_rough(tools)
+
+        base_messages = _big_messages(n_tokens_target=55_000)
+        kwargs = {
+            "model": "test-model",
+            "messages": base_messages,
+            "tools": tools,
+            "max_tokens": 4096,
+        }
+
+        # Now expand the tool schema IN PLACE (same object identity).
+        for tool in tools:
+            for i in range(100):
+                tool["function"]["parameters"]["properties"][f"extra_{i}"] = {
+                    "type": "string", "description": "expanded " * 10,
+                }
+                tool["function"]["parameters"]["required"].append(f"extra_{i}")
+
+        # A fresh estimate of the FINAL tools pushes the total over the 64K
+        # ceiling; a stale (pre-mutation) estimate would not. The gate must
+        # see the FINAL tools and refuse.
+        with pytest.raises(ContextCeilingExceeded):
+            _dispatch_nonstreaming_api_request(
+                agent, dict(kwargs), make_client=lambda *_a, **_k: agent.client
+            )
+
+        assert len(agent.client.create_calls) == 0, (
+            "Gate must see the in-place-mutated tools, not a stale cached estimate"
+        )
+
+
+# ── Test 8: Codex Responses — final preflight payload → gate ──────────────────
+
+class TestCodexOverCeiling:
+    def test_responses_create_not_called(self):
+        """Codex Responses path: over-ceiling payload with instructions +
+        input + tools + max_output_tokens must raise ContextCeilingExceeded
+        before responses.create() is called. The gate must see the FINAL
+        preflight-normalized payload, not the pre-preflight request."""
+        agent = _AgentStub(
+            pre_cap=128_000,
+            ceiling=64_000,
+            api_mode="codex_responses",
+            provider="openai",
+        )
+        codex_kwargs = {
+            "model": "test-model",
+            "instructions": "You are a test assistant.",
+            "input": _big_messages(n_tokens_target=200_000),
+            "tools": _tools_payload(),
+            "max_output_tokens": 4096,
+        }
+
+        with pytest.raises(ContextCeilingExceeded):
+            _dispatch_nonstreaming_api_request(
+                agent, dict(codex_kwargs), make_client=lambda *_a, **_k: agent.client
+            )
+
+        assert len(agent.client.responses_calls) == 0, (
+            "Codex responses.create() must NOT be called when the payload exceeds the ceiling"
+        )
+
+# ── Test 9: Relay-enlarges — provider-boundary enforcement (non-stream) ──────
+
+class TestRelayEnlargesNonStream:
+    """The relay-helper entry gate fires on the CALLER's request. If Relay
+    (relay_llm.execute) enlarges the request before invoking the provider
+    callback — expanding tools, appending content, rewriting the payload in
+    any way that increases its size — the entry gate has already passed.
+    The PROVIDER-BOUNDARY wrapper (_aux_provider_callback) is the second,
+    terminal gate: it enforces on the FINAL payload at the exact moment it
+    is about to be handed to the provider.
+
+    Deterministic setup (measured):
+      caller's messages estimate  ≈ 55,000   (under 64K → entry gate passes)
+      Relay enlargement           ≈ +8,000   (pushes final to ≈ 63,000)
+      output reservation          = 4,096
+      ceiling                     = 64,000
+      final total                 ≈ 67,000   (> 64K → provider-boundary refuses)
+
+    The provider callback must NEVER be called with the oversized payload.
+    """
+
+    def _relay_that_enlarges(self, spy):
+        """A Relay.execute_current that ENLARGES the request by 8K tokens
+        before invoking the provider callback, then returns its result."""
+        filler = "y" * (8_000 * 4)  # ≈ 8,000 tokens of enlargement
+
+        def _execute(request, callback, **kwargs):
+            # Relay enlarges the request (simulates middleware/middleware
+            # appending content, expanding tools, or rewriting the payload).
+            enlarged = dict(request)
+            msgs = list(enlarged.get("messages") or [])
+            if msgs and isinstance(msgs[-1], dict):
+                enlarged["messages"] = msgs[:-1] + [
+                    dict(msgs[-1], content=str(msgs[-1].get("content", "")) + filler)
+                ]
+            return callback(enlarged)
+        return _execute
+
+    def test_provider_never_called_with_oversized_final_payload(self, monkeypatch):
+        """Relay enlarges the request past the ceiling. The provider callback
+        must NOT be called — the provider-boundary wrapper refuses first."""
+        client = _SpyClient()
+        # Force the relay path (route non-None) so relay_llm.execute_current
+        # is exercised and can ENLARGE the request before the provider call.
+        monkeypatch.setattr(
+            _aux, "_relay_auxiliary_metadata",
+            lambda provider=None, api_mode=None: ("openai", "m", {
+                "api_mode": "chat_completions", "api_request_id": "aux-test",
+                "call_role": "auxiliary:test", "retry_count": 0, "auxiliary_task": "test",
+            }),
+        )
+        # Caller's request: ≈ 55K tokens — UNDER the 64K ceiling.
+        # The entry gate PASSES (correct — the caller's request is fine).
+        kwargs = _big_kwargs(n_tokens_target=55_000)
+        kwargs["max_tokens"] = 4096
+
+        # Patch Relay to enlarge the request before the provider callback.
+        monkeypatch.setattr(
+            _relay_llm, "execute_current", self._relay_that_enlarges(client),
+        )
+
+        token = _aux.set_aux_ceiling(64_000)
+        try:
+            with pytest.raises(ContextCeilingExceeded):
+                _aux._relay_sync_completion(
+                    client,
+                    dict(kwargs),
+                    provider="openai",
+                    api_mode="chat_completions",
+                )
+        finally:
+            _aux.reset_aux_ceiling(token)
+
+        assert len(client.create_calls) == 0, (
+            "Provider .create must NOT be called with a Relay-enlarged "
+            "payload that exceeds the ceiling"
+        )
+
+    def test_under_ceiling_still_dispatches(self, monkeypatch):
+        """A Relay-enlarged payload that STAYS under the ceiling must still
+        dispatch (the gate must not over-refuse)."""
+        client = _SpyClient()
+        # Caller's request: ≈ 30K tokens — well under.
+        # Relay adds 8K → final ≈ 38K + 4096 ≈ 42K < 64K → passes.
+        kwargs = _big_kwargs(n_tokens_target=30_000)
+        kwargs["max_tokens"] = 4096
+
+        monkeypatch.setattr(
+            _relay_llm, "execute_current", self._relay_that_enlarges(client),
+        )
+
+        token = _aux.set_aux_ceiling(64_000)
+        try:
+            _aux._relay_sync_completion(
+                client,
+                dict(kwargs),
+                provider="openai",
+                api_mode="chat_completions",
+            )
+        finally:
+            _aux.reset_aux_ceiling(token)
+
+        assert len(client.create_calls) == 1, (
+            "Provider .create must be called when the final payload is under the ceiling"
+        )
+
+    def test_negative_control_without_provider_boundary_wrapper(self, monkeypatch):
+        """Prove the provider-boundary wrapper IS the enforcement for Relay
+        enlargement: if it is absent (only the entry gate), the provider
+        IS called with the oversized final payload (the bug this fixes)."""
+        client = _SpyClient()
+        kwargs = _big_kwargs(n_tokens_target=55_000)
+        kwargs["max_tokens"] = 4096
+
+        # Patch Relay to enlarge.
+        monkeypatch.setattr(
+            _relay_llm, "execute_current", self._relay_that_enlarges(client),
+        )
+        # REMOVE the provider-boundary wrapper (simulate pre-fix code):
+        # _aux_provider_callback becomes identity — the gate is only at entry.
+        # (Accepts the (callback, *, task, provider, model) signature.)
+        monkeypatch.setattr(_aux, "_aux_provider_callback", lambda cb, **kw: cb)
+
+        token = _aux.set_aux_ceiling(64_000)
+        try:
+            # The entry gate passes (55K < 64K). Relay enlarges to ~63K.
+            # Without the provider-boundary wrapper, the provider IS called.
+            result = _aux._relay_sync_completion(
+                client,
+                dict(kwargs),
+                provider="openai",
+                api_mode="chat_completions",
+            )
+        finally:
+            _aux.reset_aux_ceiling(token)
+
+        # BUG REPRODUCED: provider called with oversized final payload.
+        assert len(client.create_calls) == 1, (
+            "Without the provider-boundary wrapper, the provider IS called "
+            "with the Relay-enlarged payload (this is the bug the wrapper fixes)"
+        )
+
+    def test_async_path_provider_never_called(self, monkeypatch):
+        """Async relay path: same enforcement — Relay enlarges, provider
+        callback must not be called."""
+        import asyncio
+        client = _SpyClient()
+        kwargs = _big_kwargs(n_tokens_target=55_000)
+        kwargs["max_tokens"] = 4096
+
+        filler = "y" * (8_000 * 4)
+
+        monkeypatch.setattr(
+            _aux, "_relay_auxiliary_metadata",
+            lambda provider=None, api_mode=None: ("openai", "m", {
+                "api_mode": "chat_completions", "api_request_id": "aux-test",
+                "call_role": "auxiliary:test", "retry_count": 0, "auxiliary_task": "test",
+            }),
+        )
+        async def _enlarging_execute(request, callback, **kwargs_):
+            enlarged = dict(request)
+            msgs = list(enlarged.get("messages") or [])
+            if msgs and isinstance(msgs[-1], dict):
+                enlarged["messages"] = msgs[:-1] + [
+                    dict(msgs[-1], content=str(msgs[-1].get("content", "")) + filler)
+                ]
+            return await callback(enlarged)
+
+        monkeypatch.setattr(_relay_llm, "execute_current_async", _enlarging_execute)
+
+        token = _aux.set_aux_ceiling(64_000)
+        try:
+            with pytest.raises(ContextCeilingExceeded):
+                asyncio.get_event_loop().run_until_complete(
+                    _aux._relay_async_completion(
+                        client,
+                        dict(kwargs),
+                        provider="openai",
+                        api_mode="chat_completions",
+                    )
+                )
+        finally:
+            _aux.reset_aux_ceiling(token)
+
+        assert len(client.create_calls) == 0
+
+
+# ── Test 10: Relay-enlarges — provider-boundary enforcement (stream) ─────────
+
+class TestRelayEnlargesStream:
+    """Streaming relay path: the same provider-boundary enforcement applies.
+    Relay (relay_llm.stream_current) enlarges the request before invoking
+    the stream_factory (which wraps client.chat.completions.create). The
+    provider-boundary wrapper must refuse the oversized final payload BEFORE
+    the provider is called."""
+
+    def test_stream_provider_never_called(self, monkeypatch):
+        client = _SpyClient()
+        kwargs = _big_kwargs(n_tokens_target=55_000)
+        kwargs["max_tokens"] = 4096
+
+        filler = "y" * (8_000 * 4)
+
+        monkeypatch.setattr(
+            _aux, "_relay_auxiliary_metadata",
+            lambda provider=None, api_mode=None: ("openai", "m", {
+                "api_mode": "chat_completions", "api_request_id": "aux-test",
+                "call_role": "auxiliary:test", "retry_count": 0, "auxiliary_task": "test",
+            }),
+        )
+        def _enlarging_stream(request, stream_factory, **kwargs_):
+            enlarged = dict(request)
+            msgs = list(enlarged.get("messages") or [])
+            if msgs and isinstance(msgs[-1], dict):
+                enlarged["messages"] = msgs[:-1] + [
+                    dict(msgs[-1], content=str(msgs[-1].get("content", "")) + filler)
+                ]
+            return stream_factory(enlarged)
+
+        monkeypatch.setattr(_relay_llm, "stream_current", _enlarging_stream)
+
+        token = _aux.set_aux_ceiling(64_000)
+        try:
+            with pytest.raises(ContextCeilingExceeded):
+                _aux._relay_sync_stream(
+                    client,
+                    dict(kwargs),
+                    provider="openai",
+                    api_mode="chat_completions",
+                )
+        finally:
+            _aux.reset_aux_ceiling(token)
+
+        assert len(client.create_calls) == 0, (
+            "Streaming provider .create must NOT be called with a "
+            "Relay-enlarged payload that exceeds the ceiling"
+        )
+
+# ── Test 11: Codex app-server run_turn terminal gate ──────────────────────────
+
+class TestAppServerRunTurnGate:
+    """FIFTH physical owner: run_codex_app_server_turn hands the whole turn to
+    a codex app-server subprocess via agent._codex_session.run_turn(), bypassing
+    BOTH _dispatch_nonstreaming_api_request and interruptible_streaming_api_call.
+    The terminal gate must fire BEFORE run_turn() — an oversized final payload
+    must be refused locally, and run_turn() must NOT be called.
+    """
+
+    def _make_agent(self, ceiling, pre_cap, big_messages):
+        import types
+        # Tolerant stub: the runtime's post-run_turn accounting/splice section
+        # reads many agent attrs; give neutral defaults so a turn that PASSES
+        # the gate can complete. The gate-under-test fires BEFORE run_turn,
+        # so these defaults only matter for the under-ceiling dispatch cases.
+        class _Agent:
+            def __init__(self):
+                self.api_mode = "codex_app_server"
+                self.session_api_calls = 0
+                self.context_compressor = None
+                self.system_prompt = "You are Hermes."
+                self.message_metadata = {}
+                self.valid_tool_names = set()
+                self._iters_since_skill = 0
+                self._skill_nudge_interval = 0
+                self._session_db = None
+                self.session_id = "t"
+            def __getattr__(self, name):
+                # Neutral defaults for the many optional post-turn reads
+                # (must NOT shadow real attrs set in __init__).
+                if name.startswith("_"):
+                    raise AttributeError(name)
+                return None
+        agent = _Agent()
+        agent._pre_cap_context_length = pre_cap
+        agent._max_context_length = ceiling
+        agent._iters_since_skill = 0
+        agent._codex_session = None
+        def _flush_messages_to_session_db(self, *a, **k): pass
+        def _spawn_background_review(self, *a, **k): pass
+        def _sync_external_memory_for_turn(self, *a, **k): pass
+        agent._flush_messages_to_session_db = _flush_messages_to_session_db.__get__(agent, _Agent)
+        agent._spawn_background_review = _spawn_background_review.__get__(agent, _Agent)
+        agent._sync_external_memory_for_turn = _sync_external_memory_for_turn.__get__(agent, _Agent)
+        # A spy session: run_turn records the call and returns a canned dict.
+        spy = types.SimpleNamespace()
+        spy.turn_calls = 0
+
+        def run_turn(user_input=None):
+            spy.turn_calls += 1
+            # The runtime reads turn.interrupted / turn.should_retire / turn.error
+            # as attributes — return an object, not a dict.
+            return types.SimpleNamespace(
+                interrupted=False, should_retire=False, error=None,
+                final_text="ok", projected_messages=[], tool_iterations=0,
+                thread_id="th-1", turn_id="tu-1",
+            )
+        spy.run_turn = run_turn
+        spy.close = lambda: None
+        agent._codex_session = spy
+        return agent, spy
+
+    def test_oversized_refuses_and_run_turn_never_called(self):
+        from agent.codex_runtime import run_codex_app_server_turn
+        from agent.model_metadata import build_final_context_budget as B
+
+        ceiling, pre_cap = 64_000, 128_000
+        # FINAL messages payload well over the 64K ceiling.
+        big = _big_kwargs(n_tokens_target=70_000)["messages"]
+        assert B({"messages": big}, system_prompt="You are Hermes.").total > ceiling, \
+            "precondition: final payload must exceed the ceiling"
+
+        agent, spy = self._make_agent(ceiling, pre_cap, big)
+        with pytest.raises(ContextCeilingExceeded):
+            run_codex_app_server_turn(
+                agent,
+                user_message="hi",
+                original_user_message="hi",
+                messages=big,
+                effective_task_id="t",
+            )
+        assert spy.turn_calls == 0, "run_turn() must NOT be called for an oversized final payload"
+
+    def test_under_ceiling_still_dispatches_run_turn(self):
+        from agent.codex_runtime import run_codex_app_server_turn
+
+        ceiling, pre_cap = 256_000, 272_000
+        small = _big_kwargs(n_tokens_target=20_000)["messages"]
+        agent, spy = self._make_agent(ceiling, pre_cap, small)
+        run_codex_app_server_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=small,
+            effective_task_id="t",
+        )
+        assert spy.turn_calls == 1, "run_turn() must be called when under the ceiling"
+
+    def test_no_ceiling_configured_is_noop(self):
+        from agent.codex_runtime import run_codex_app_server_turn
+
+        big = _big_kwargs(n_tokens_target=70_000)["messages"]
+        agent, spy = self._make_agent(None, None, big)
+        # No ceiling + no pre-cap → the gate is a no-op; run_turn proceeds.
+        run_codex_app_server_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=big,
+            effective_task_id="t",
+        )
+        assert spy.turn_calls == 1, "no ceiling configured → dispatch proceeds (gate no-op)"
+
+# ── Test 12: Per-invocation pre-cap invariant (auxiliary/MoA reference) ─────
+
+class TestPerInvocationPreCap:
+    """Each auxiliary / MoA reference invocation uses its OWN resolved
+    pre-cap — the reference model's own raw capability — NOT the main agent's
+    pre-cap and NOT merely the profile ceiling carried through the profile
+    context.
+
+    Invariant (the user's example):
+        main pre-cap 272K, profile max 200K, reference pre-cap 128K
+        → reference effective window must be 128K.
+
+    The ceiling only ever LOWERS a window (min(raw, ceiling)); it never RAISES
+    one.  So a reference whose raw capability (128K) is already below the
+    profile ceiling (200K) keeps its OWN 128K — it does not inherit the main
+    agent's 272K, and the ceiling does not stretch it to 200K.
+    """
+
+    def test_reference_uses_its_own_precap_not_main(self):
+        import agent.model_metadata as mm
+
+        # main agent's own pre-cap (its model's raw capability): 272K
+        # profile ceiling (model.max_context_length): 200K
+        # reference model's OWN raw capability (pre-cap): 128K
+        with patch.object(mm, "get_model_context_length", return_value=128_000), \
+             patch.object(mm, "_get_max_context_length", return_value=200_000):
+            ref_effective = mm.effective_context_length(
+                model="ref-model", base_url="http://ref", api_key=""
+            )
+            # Reference effective window = its OWN 128K — NOT the main's 272K
+            # and NOT stretched to the profile ceiling 200K.
+            assert ref_effective == 128_000
+            assert ref_effective != 272_000, "reference must not inherit main pre-cap"
+            assert ref_effective != 200_000, "ceiling must not raise the reference window"
+
+    def test_reference_above_ceiling_is_lowered_by_profile(self):
+        import agent.model_metadata as mm
+
+        # reference raw capability (272K) ABOVE the profile ceiling (200K) →
+        # the ceiling LOWERS it to 200K.  min(272K, 200K) = 200K.
+        with patch.object(mm, "get_model_context_length", return_value=272_000), \
+             patch.object(mm, "_get_max_context_length", return_value=200_000):
+            ref_effective = mm.effective_context_length(
+                model="big-ref", base_url="http://ref", api_key=""
+            )
+            assert ref_effective == 200_000
+
+    def test_reference_gate_uses_reference_effective_not_main(self):
+        """The MoA reference GATE enforces against the reference's own
+        effective window (its own pre-cap, ceiling-clamped), never the main
+        agent's.  Prove: a payload just under the reference's 128K window is
+        ACCEPTED even though it would exceed a smaller (main) window."""
+        import agent.moa_loop as moa
+        from agent.model_metadata import estimate_messages_tokens_rough
+        from agent.agent_runtime_helpers import (
+            canonical_request_budget,
+            enforce_effective_context_limit,
+        )
+
+        # Reference's own effective window (128K).  A payload of ~120K is under
+        # it → accepted.  The same payload would exceed a 100K main window.
+        ref_window = 128_000
+        # base estimate ~120K → chars ≈ 120K*4
+        content = "x" * (120_000 * 4)
+        messages = [{"role": "user", "content": content}]
+        base = estimate_messages_tokens_rough(messages)
+        # Reserve uses the Hermes default (4096) — same as the gate.
+        budget = canonical_request_budget(
+            messages, output_reserve=moa._resolve_moa_output_reserve(None)
+        )
+        assert budget <= ref_window, f"setup: budget {budget} over ref window"
+        # Gate against the REFERENCE's own effective window → ACCEPTED (no raise).
+        enforce_effective_context_limit(
+            budget, pre_cap=ref_window, ceiling=None, reason="MoA reference dispatch",
+        )
+        # ...but the SAME payload exceeds a 100K (main) window → refused.
+        with pytest.raises(ContextCeilingExceeded):
+            enforce_effective_context_limit(
+                budget, pre_cap=100_000, ceiling=None, reason="main agent window",
+            )

--- a/tests/agent/test_context_ceiling_round4_topo.py
+++ b/tests/agent/test_context_ceiling_round4_topo.py
@@ -396,15 +396,39 @@ class TestToolMutationInvalidateCache:
                 tool["function"]["parameters"]["required"].append(f"extra_{i}")
 
         # A fresh estimate of the FINAL tools pushes the total over the 64K
-        # ceiling; a stale (pre-mutation) estimate would not. The gate must
-        # see the FINAL tools and refuse.
-        with pytest.raises(ContextCeilingExceeded):
-            _dispatch_nonstreaming_api_request(
-                agent, dict(kwargs), make_client=lambda *_a, **_k: agent.client
-            )
-
-        assert len(agent.client.create_calls) == 0, (
-            "Gate must see the in-place-mutated tools, not a stale cached estimate"
+        # ceiling; a stale (pre-mutation) estimate would not.  The gate must
+        # see the FINAL (expanded) tools.  Because the non-output portion
+        # (input + tools) still fits under the ceiling, the gate clamps the
+        # outgoing output cap to the maximum legal allowance derived from the
+        # FINAL tools rather than refusing: the clamped cap is the observable
+        # that distinguishes the expanded tools (cap = 64000 - 61964 = 2036)
+        # from a stale unexpanded estimate (cap would be 64000 - 58294 = 5706).
+        _dispatch_nonstreaming_api_request(
+            agent, dict(kwargs), make_client=lambda *_a, **_k: agent.client
+        )
+        # The cap was clamped downward (from 4096) to a value reflecting the
+        # FINAL tools — proof the gate saw the expanded schema, not the
+        # pre-warmed (stale) unexpanded estimate.  A stale estimate would have
+        # clamped the cap to a LARGER value (5706), so asserting the exact
+        # FINAL-tools-derived cap (2036) is the cache-invalidation invariant.
+        assert len(agent.client.create_calls) == 1, (
+            "Shrinkable overflow (non-output fits) must clamp and dispatch"
+        )
+        dispatched = agent.client.create_calls[0]
+        clamped = dispatched["max_tokens"]
+        assert clamped < 4096, "Gate must clamp the cap downward for over-ceiling total"
+        # The clamp cap reflects the FINAL (expanded) tools: ceiling -
+        # (input + expanded_tools).  A stale unexpanded estimate would give a
+        # different (larger) cap, so this exact value is the cache-invalidation
+        # proof.
+        from agent.model_metadata import (
+            _estimate_tools_tokens_rough as _est_tools,
+            estimate_messages_tokens_rough as _est_msgs,
+        )
+        expected_cap = 64_000 - (_est_msgs(base_messages) + _est_tools(tools))
+        assert clamped == expected_cap, (
+            f"Gate clamped to {clamped} but the FINAL-tools-derived cap is "
+            f"{expected_cap} — the gate used a stale tool estimate"
         )
 
 

--- a/tests/agent/test_context_ceiling_round5_aux_ownership.py
+++ b/tests/agent/test_context_ceiling_round5_aux_ownership.py
@@ -1,0 +1,327 @@
+"""Round 5 finding A (#1 + #6): auxiliary invocation ceiling ownership.
+
+The auxiliary effective ceiling is a ContextVar consumed by the relay-helper
+physical gates (``_aux_relay_gate`` / ``_aux_provider_callback``).  It MUST be
+published per-invocation by the real call owners (``call_llm`` sync and
+``async_call_llm`` async) and RESET before the owner returns, so that:
+
+  * an oversized request is refused BEFORE any physical provider call, and
+    never retried / fallen back / credential-refreshed (terminal by type);
+  * the ceiling is not left AMBIENT after return or exception;
+  * a subsequent / nested / concurrent call never inherits a stale ceiling;
+  * concurrent asyncio tasks with different ceilings stay isolated.
+
+These tests drive the REAL owners (``auxiliary_client.call_llm`` and
+``auxiliary_client.async_call_llm``) end-to-end — they do NOT manually seed
+the ContextVar and then call a ``_relay_*`` helper (the Round 4 pattern that
+left the ceiling ambient and, in the async path, never published it at all).
+
+The ceiling gate (``_aux_relay_gate``) fires inside the real
+``_relay_sync_completion`` / ``_relay_async_completion`` helpers, so the
+ceiling MUST be published by the owner (not manually seeded) for the gate to
+see it.  We patch ``relay_llm.execute_current`` / ``execute_current_async``
+to invoke the provider callback directly (bypassing relay session resolution)
+while leaving the real relay helpers — and their ceiling gate — in place.
+
+RED expectations against the pre-fix code:
+  * sync: ceiling set but token discarded -> never reset -> ambient leak;
+    the "restored after return" test FAILS (ceiling stays set).
+  * async: ceiling never published -> oversized request is NOT refused ->
+    the provider IS called physically; the "zero physical calls" and
+    "refused by type" tests FAIL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent import auxiliary_client as _aux
+from agent import relay_llm as _relay_llm
+from agent import model_metadata as _model_metadata
+from agent.model_metadata import ContextCeilingExceeded
+
+# Ceiling chosen so the SMALL payload (input ~31 + reservation 65536 = 65,567
+# tokens) PASSES the gate, while the OVERSIZED payload (input ~50K + 65536
+# = ~115K tokens) is REFUSED.  The "custom" provider profile declares a
+# 65536 implicit output reservation, so the reservation dominates both cases;
+# the ceiling sits between the two totals.
+CEILING = 90_000
+
+
+# ── shared response + message fixtures ──────────────────────────────────────
+
+def _completed_response() -> Any:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]),
+                                 finish_reason="stop")],
+        usage=None,
+        model="test-model",
+    )
+
+
+def _oversized_messages() -> list:
+    # ~50K rough tokens (4 chars/token) + 65536 reservation = ~115K >> CEILING
+    return [
+        {"role": "system", "content": "You are a test assistant."},
+        {"role": "user", "content": "x" * 200_000},
+    ]
+
+
+def _under_messages() -> list:
+    # Small payload: input ~31 + 65536 reservation = 65,567 < CEILING
+    return [
+        {"role": "system", "content": "You are a test assistant."},
+        {"role": "user", "content": "hello, a small request that fits."},
+    ]
+
+
+def _route_metadata() -> tuple:
+    return ("openai", "test-model", {
+        "api_mode": "chat_completions",
+        "api_request_id": "aux-r5-test",
+        "call_role": "auxiliary:test",
+        "retry_count": 0,
+        "auxiliary_task": "test",
+    })
+
+
+# ── spy clients (sync + async) ──────────────────────────────────────────────
+# The sync dispatch path calls ``client.chat.completions.create(...)`` directly
+# (returns a plain value).  The async dispatch path ``await``s the same call
+# (must return a coroutine).  Separate spies keep each path's contract exact.
+
+def _sync_spy_client() -> SimpleNamespace:
+    calls: list[dict] = []
+
+    def create(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _completed_response()
+
+    return SimpleNamespace(base_url="https://api.test/v1",
+                           chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+                           _calls=calls)
+
+
+def _async_spy_client() -> SimpleNamespace:
+    calls: list[dict] = []
+
+    async def create(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        return _completed_response()
+
+    return SimpleNamespace(base_url="https://api.test/v1",
+                           chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+                           _calls=calls)
+
+
+def _patch_owner_env(monkeypatch, spy: SimpleNamespace) -> None:
+    """Patch the owner's environment so call_llm / async_call_llm run
+    end-to-end against a spy client and a deterministic ceiling.  The real
+    relay helpers (and their ceiling gate) stay in place; only relay session
+    resolution (execute_current / execute_current_async) is short-circuited."""
+    monkeypatch.setattr(_aux, "_get_cached_client",
+                        lambda *a, **k: (spy, "test-model"))
+    monkeypatch.setattr(_aux, "_validate_llm_response",
+                        lambda r, *a, **k: "OK")
+    monkeypatch.setattr(_aux, "_relay_auxiliary_metadata",
+                        lambda **k: _route_metadata())
+    monkeypatch.setattr(_model_metadata, "effective_context_length",
+                        lambda **k: CEILING)
+    # Bypass relay session resolution; invoke the provider callback directly.
+    # The ceiling gate already fired inside the real relay helper before this.
+    monkeypatch.setattr(_relay_llm, "execute_current",
+                        lambda req, cb, **k: cb(req))
+    async def _fake_async(req, cb, **k: Any) -> Any:
+        return await cb(req)
+    monkeypatch.setattr(_relay_llm, "execute_current_async", _fake_async)
+
+
+# ── 1. Sync oversized → refused by type, zero physical calls ────────────────
+
+def test_sync_oversized_refused_zero_physical_calls(monkeypatch):
+    spy = _sync_spy_client()
+    _patch_owner_env(monkeypatch, spy)
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm(
+            "test", provider="openai", model="test-model",
+            api_key="sk-test", messages=_oversized_messages(), max_tokens=256,
+        )
+    assert len(spy._calls) == 0, "physical provider .create must NOT be called"
+
+
+def test_sync_oversized_refusal_not_fallback_or_retry(monkeypatch):
+    """A ceiling refusal is terminal by type: no retry, fallback, or
+    credential-refresh may be attempted."""
+    spy = _sync_spy_client()
+    _patch_owner_env(monkeypatch, spy)
+    touched = {"retry": 0, "fallback": 0, "refresh": 0}
+
+    def _marker(**_k: Any):
+        return None
+
+    monkeypatch.setattr(_aux, "_is_transient_transport_error", _marker, raising=False)
+    monkeypatch.setattr(_aux, "_recover_provider_pool",
+                        lambda *a, **k: touched.__setitem__("retry", touched["retry"] + 1),
+                        raising=False)
+    monkeypatch.setattr(_aux, "_try_configured_fallback_for_unavailable_client",
+                        lambda *a, **k: (None, None, ""), raising=False)
+
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm(
+            "test", provider="openai", model="test-model",
+            api_key="sk-test", messages=_oversized_messages(), max_tokens=256,
+        )
+    assert len(spy._calls) == 0
+    assert touched["retry"] == 0
+    assert touched["fallback"] == 0
+
+
+# ── 2. ContextVar restored after success and after exception ────────────────
+
+def test_sync_ceiling_restored_after_success(monkeypatch):
+    spy = _sync_spy_client()
+    _patch_owner_env(monkeypatch, spy)
+
+    assert _aux.get_aux_ceiling() is None  # clean baseline
+    result = _aux.call_llm(
+        "test", provider="openai", model="test-model", api_key="sk-test",
+        messages=_under_messages(), max_tokens=256,
+    )
+    assert result == "OK"
+    assert len(spy._calls) == 1
+    # The invocation ceiling must NOT be left ambient after a successful return.
+    assert _aux.get_aux_ceiling() is None, (
+        "auxiliary ceiling left ambient after a successful call_llm return"
+    )
+
+
+def test_sync_ceiling_restored_after_exception(monkeypatch):
+    spy = _sync_spy_client()
+    _patch_owner_env(monkeypatch, spy)
+
+    # Force a non-ceiling transport failure so the except-chain runs, then
+    # verify the ceiling is still reset in the owner's finally.
+    def _boom(req, cb, **k):
+        raise RuntimeError("connection reset by peer")
+
+    monkeypatch.setattr(_relay_llm, "execute_current", _boom)
+
+    assert _aux.get_aux_ceiling() is None
+    with pytest.raises(Exception):
+        _aux.call_llm(
+            "test", provider="openai", model="test-model", api_key="sk-test",
+            messages=_under_messages(), max_tokens=256,
+        )
+    assert _aux.get_aux_ceiling() is None, (
+        "auxiliary ceiling left ambient after a failed call_llm"
+    )
+
+
+# ── 3. Sequential calls cannot inherit a stale ceiling ──────────────────────
+
+def test_sequential_calls_do_not_inherit_stale_ceiling(monkeypatch):
+    spy = _sync_spy_client()
+    _patch_owner_env(monkeypatch, spy)
+
+    # Call 1: oversized -> refused by the ceiling (proves ceiling was set).
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm("test", provider="openai", model="test-model",
+                      api_key="sk-test", messages=_oversized_messages(),
+                      max_tokens=256)
+    # Call 2: a clean read of the ceiling must see None (no ambient leak).
+    assert _aux.get_aux_ceiling() is None, "stale ceiling leaked into the next call"
+    # Call 2: an under-sized request must succeed (no inherited refusal).
+    result = _aux.call_llm("test", provider="openai", model="test-model",
+                           api_key="sk-test", messages=_under_messages(),
+                           max_tokens=256)
+    assert result == "OK"
+    assert len(spy._calls) == 1  # only the under-sized call reached the provider
+    assert _aux.get_aux_ceiling() is None
+
+
+# ── 4. Async oversized → zero physical calls, refused by type ───────────────
+
+def test_async_oversized_refused_zero_physical_calls(monkeypatch):
+    spy = _async_spy_client()
+    _patch_owner_env(monkeypatch, spy)
+
+    async def _run() -> None:
+        with pytest.raises(ContextCeilingExceeded):
+            await _aux.async_call_llm(
+                "test", provider="openai", model="test-model",
+                api_key="sk-test", messages=_oversized_messages(), max_tokens=256,
+            )
+
+    asyncio.get_event_loop().run_until_complete(_run())
+    assert len(spy._calls) == 0, "async physical provider .create must NOT be called"
+
+
+def test_async_ceiling_restored_after_success(monkeypatch):
+    spy = _async_spy_client()
+    _patch_owner_env(monkeypatch, spy)
+
+    assert _aux.get_aux_ceiling() is None
+    async def _run():
+        return await _aux.async_call_llm(
+            "test", provider="openai", model="test-model", api_key="sk-test",
+            messages=_under_messages(), max_tokens=256,
+        )
+    result = asyncio.get_event_loop().run_until_complete(_run())
+    assert result == "OK"
+    assert len(spy._calls) == 1
+    assert _aux.get_aux_ceiling() is None, (
+        "async auxiliary ceiling left ambient after a successful call"
+    )
+
+
+# ── 5. Concurrent asyncio tasks with different ceilings stay isolated ───────
+
+def test_concurrent_tasks_isolated_ceilings(monkeypatch):
+    """Two concurrent async calls: the oversized one must be refused by the
+    ceiling, the under-sized one must succeed, and no ambient ceiling is left
+    behind.  Each task's ceiling is resolved by the owner in its own context,
+    so ContextVar isolation is exercised end-to-end."""
+    small_spy = _async_spy_client()
+    big_spy = _async_spy_client()
+    # Route each task to its own spy by message size.
+    def _route_spy(*a: Any, **k: Any):
+        return (small_spy, "test-model")
+
+    monkeypatch.setattr(_aux, "_get_cached_client", _route_spy)
+    monkeypatch.setattr(_aux, "_validate_llm_response", lambda r, *a, **k: "OK")
+    monkeypatch.setattr(_aux, "_relay_auxiliary_metadata", lambda **k: _route_metadata())
+    monkeypatch.setattr(_model_metadata, "effective_context_length", lambda **k: CEILING)
+
+    async def _fake_async(req, cb, **k: Any) -> Any:
+        return await cb(req)
+    monkeypatch.setattr(_relay_llm, "execute_current_async", _fake_async)
+
+    results: dict[str, Any] = {}
+
+    async def run(tag: str, oversized: bool) -> Any:
+        try:
+            r = await _aux.async_call_llm(
+                "test", provider="openai", model="test-model", api_key="sk-test",
+                messages=(_oversized_messages() if oversized else _under_messages()),
+                max_tokens=256,
+            )
+            return ("ok", r)
+        except ContextCeilingExceeded as e:
+            return ("ceiling", e)
+
+    async def main() -> None:
+        a, b = await asyncio.gather(run("small", False), run("big", True))
+        results["small"] = a
+        results["big"] = b
+
+    asyncio.get_event_loop().run_until_complete(main())
+    assert results["small"][0] == "ok"
+    assert results["big"][0] == "ceiling"
+    # After both complete, no ambient ceiling is left behind.
+    assert _aux.get_aux_ceiling() is None, "ambient ceiling leaked after concurrent tasks"
+    # The small task reached its provider exactly once.
+    assert len(small_spy._calls) == 1

--- a/tests/agent/test_context_ceiling_round5_fallback_rebind.py
+++ b/tests/agent/test_context_ceiling_round5_fallback_rebind.py
@@ -1,0 +1,318 @@
+"""Round 5 finding B (P1 from review 5049973836): auxiliary fallback
+per-destination ceiling rebinding.
+
+The auxiliary effective ceiling is a ContextVar published ONCE per
+``call_llm`` / ``async_call_llm`` for the INITIAL destination (``_call_llm_impl``
+/ ``_async_call_llm_impl`` resolve ``effective_context_length`` for the initial
+``final_model`` and publish it via ``set_aux_ceiling``).  The relay-helper
+physical gates (``_aux_relay_gate``) read that ambient value.  Before the fix,
+the fallback candidates (``_call_fallback_candidate_sync`` /
+``_call_fallback_candidate_async``) called the SAME relay helpers WITHOUT
+rebinding the ceiling to the fallback destination — so a fallback to a
+different provider/model/base_url inherited the INITIAL destination's ceiling.
+
+Discriminating schedule (large initial → small fallback):
+
+* Initial destination ceiling 900K, fallback destination ceiling 128K.
+* A ~200K request passes the initial 900K gate, the initial provider then
+  fails transiently, and the fallback candidate is invoked.
+* BUGGY (no rebind): the fallback gate reads the ambient 900K ceiling and
+  DISPATCHES the request to the 128K fallback model — the pre-I/O bound is
+  gone (a ~200K request physically reaches a 128K model).
+* FIXED (rebind): the fallback gate reads the rebound 128K ceiling and REFUSES
+  the ~200K request — the fallback model is never physically called.
+
+These tests drive the REAL owners (``call_llm`` / ``async_call_llm``)
+end-to-end: the initial provider fails with a transient transport error, the
+fallback chain returns a destination spy, and the REAL
+``_call_fallback_candidate_*`` helper runs the REAL relay gate.
+``effective_context_length`` is patched to resolve a DIFFERENT ceiling per
+destination (keyed on model) so the gate sees whichever ceiling the owner
+publishes for the destination it is dispatching to.
+
+RED expectations against the pre-fix code (no rebind):
+  * sync/async large→small: the fallback provider IS physically called (stale
+    900K gate passes the ~200K request) and ``effective_context_length`` is
+    NEVER called for the fallback destination.
+
+GREEN expectations after the fix (rebind per destination with scoped
+token/reset):
+  * sync/async large→small: the fallback provider is NOT physically called;
+    the gate fired under the 128K ceiling; ``effective_context_length`` WAS
+    called for the fallback destination; no ambient ceiling is left behind
+    after the call returns.
+  * the ceiling resolver for the fallback carries the destination credential
+    (api_key) so capability resolution is credential-aware.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent import auxiliary_client as _aux
+from agent import relay_llm as _relay_llm
+from agent import model_metadata as _model_metadata
+from agent.model_metadata import ContextCeilingExceeded
+
+# Per-destination ceilings (the resolver returns these keyed on model).
+INITIAL_MODEL = "initial-model"
+FALLBACK_MODEL = "fallback-model"
+INITIAL_LARGE = 900_000   # large initial destination
+FALLBACK_SMALL = 128_000  # small fallback destination
+
+
+def _completed_response() -> Any:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]),
+                                 finish_reason="stop")],
+        usage=None,
+        model="test-model",
+    )
+
+
+def _request_between_ceilings() -> list:
+    # 600K chars → budget total ≈ 154K tokens (verified empirically).  This
+    # sits in the discriminating band (128K, 900K): it PASSES the initial
+    # 900K gate (so the initial call is attempted and then fails transiently)
+    # and is REFUSED by the fallback destination's 128K ceiling.
+    #   * BUGGY (no rebind): fallback gate reads the ambient 900K initial
+    #     ceiling → 154K < 900K → DISPATCHES to the 128K model (defect).
+    #   * FIXED (rebind):    fallback gate reads the rebound 128K ceiling →
+    #     154K > 128K → REFUSES (correct pre-I/O bound).
+    return [
+        {"role": "system", "content": "You are a test assistant."},
+        {"role": "user", "content": "x" * 600_000},
+    ]
+
+
+def _sync_spy_client(fail_first: bool = True) -> SimpleNamespace:
+    # fail_first=True (default): the INITIAL provider always fails with a
+    # transient transport error — so BOTH the first attempt AND the
+    # same-provider retry fail, forcing fall-through to the fallback candidate
+    # (the async path unconditionally retries once on the same provider before
+    # escalating to the fallback candidate; a fail-once spy would let that
+    # retry succeed and never reach the fallback under test).
+    calls: list[dict] = []
+    state = {"count": 0}
+
+    def create(**kwargs: Any) -> Any:
+        state["count"] += 1
+        if fail_first:
+            raise RuntimeError("connection error")  # transient → triggers fallback
+        calls.append(kwargs)
+        return _completed_response()
+
+    return SimpleNamespace(base_url="https://api.test/v1", api_key="sk-fallback",
+                           chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+                           _calls=calls,
+                           _hermes_fallback_destination=None)
+
+
+def _async_spy_client(fail_first: bool = True) -> SimpleNamespace:
+    calls: list[dict] = []
+    state = {"count": 0}
+
+    async def create(**kwargs: Any) -> Any:
+        state["count"] += 1
+        if fail_first:
+            raise RuntimeError("connection error")
+        calls.append(kwargs)
+        return _completed_response()
+
+    return SimpleNamespace(base_url="https://api.test/v1",
+                           chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+                           _calls=calls,
+                           _hermes_fallback_destination=None)
+
+
+def _patch_fallback_env(
+    monkeypatch,
+    initial_spy: SimpleNamespace,
+    fallback_spy: SimpleNamespace,
+    initial_ceiling: int,
+    fallback_ceiling: int,
+    resolver_calls: list,
+) -> None:
+    """Patch the owner env so the REAL fallback path runs:
+    initial provider fails transiently → fallback chain returns fallback_spy
+    → REAL _call_fallback_candidate_* runs the REAL relay gate.
+
+    ``effective_context_length`` resolves a DIFFERENT ceiling per destination
+    (keyed on model) and records every call so tests can assert whether the
+    fallback destination was resolved.
+    """
+    def _get_cached_client(provider, model, *a, **k):
+        if model == FALLBACK_MODEL:
+            return (fallback_spy, FALLBACK_MODEL)
+        return (initial_spy, INITIAL_MODEL)
+
+    monkeypatch.setattr(_aux, "_get_cached_client", _get_cached_client, raising=False)
+    monkeypatch.setattr(_aux, "_is_transient_transport_error", lambda e: True, raising=False)
+    monkeypatch.setattr(_aux, "_transient_retry_count", lambda: 0, raising=False)
+    monkeypatch.setattr(_aux, "_is_connection_error", lambda e: True, raising=False)
+    for name in ("_is_payment_error", "_is_auth_error", "_is_rate_limit_error",
+                 "_is_model_incompatible_error", "_is_invalid_aux_response_error"):
+        monkeypatch.setattr(_aux, name, lambda e: False, raising=False)
+
+    monkeypatch.setattr(_aux, "_try_configured_fallback_chain",
+                        lambda *a, **k: (fallback_spy, FALLBACK_MODEL, "configured"),
+                        raising=False)
+    monkeypatch.setattr(_aux, "_try_main_fallback_chain",
+                        lambda *a, **k: (None, None, ""), raising=False)
+    monkeypatch.setattr(_aux, "_try_payment_fallback",
+                        lambda *a, **k: (None, None, ""), raising=False)
+    monkeypatch.setattr(_aux, "_try_main_agent_model_fallback",
+                        lambda *a, **k: (None, None, ""), raising=False)
+
+    # Attach the fallback destination directly on the spy for determinism.
+    fallback_spy._hermes_fallback_destination = _aux._FallbackDestination(
+        provider="openai", base_url="https://api.test/v1",
+        api_mode="chat_completions", model=FALLBACK_MODEL,
+    )
+    monkeypatch.setattr(_aux, "_fallback_entry_api_key",
+                        lambda entry: "sk-fallback", raising=False)
+
+    def _ecl(model="", base_url="", api_key="", provider="", **k):
+        resolver_calls.append({"model": model, "base_url": base_url, "api_key": api_key})
+        if model == FALLBACK_MODEL:
+            return fallback_ceiling
+        return initial_ceiling
+
+    monkeypatch.setattr(_model_metadata, "effective_context_length", _ecl, raising=False)
+
+    monkeypatch.setattr(_aux, "_validate_llm_response", lambda r, *a, **k: "OK", raising=False)
+    monkeypatch.setattr(_aux, "_relay_auxiliary_metadata",
+                        lambda **k: ("openai", "test-model", {
+                            "api_mode": "chat_completions",
+                            "api_request_id": "aux-r5b-test",
+                            "call_role": "auxiliary:test",
+                            "retry_count": 0,
+                            "auxiliary_task": "test",
+                        }), raising=False)
+    monkeypatch.setattr(_relay_llm, "execute_current", lambda req, cb, **k: cb(req), raising=False)
+    async def _fake_async(req, cb, **k: Any) -> Any:
+        return await cb(req)
+    monkeypatch.setattr(_relay_llm, "execute_current_async", _fake_async, raising=False)
+
+    # The async fallback path converts the sync fallback client to an async
+    # client via _to_async_client (which builds a REAL AsyncOpenAI and would
+    # issue actual HTTP I/O).  Short-circuit it to return the fallback spy
+    # directly, so the relay helper's default create (client.chat.completions.
+    # create) resolves to the spy's async create.  (The initial path passes
+    # create=_acreate explicitly, so it is unaffected.)
+    monkeypatch.setattr(_aux, "_to_async_client",
+                        lambda client, model, is_vision=False: (client, model),
+                        raising=False)
+
+
+# ── 1. Sync large→small: fallback refused under its OWN ceiling ─────────────
+
+def test_sync_fallback_large_to_small_refused_under_fallback_ceiling(monkeypatch):
+    """A ~200K request that legitimately passes the initial 900K ceiling must
+    be REFUSED by the fallback destination's 128K ceiling — not physically
+    dispatched to a 128K model under the stale 900K gate."""
+    initial_spy = _sync_spy_client(fail_first=True)
+    fallback_spy = _sync_spy_client(fail_first=False)
+    resolver_calls: list = []
+    _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        initial_ceiling=INITIAL_LARGE, fallback_ceiling=FALLBACK_SMALL,
+                        resolver_calls=resolver_calls)
+
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm(
+            "test", provider="openai", model=INITIAL_MODEL,
+            api_key="sk-initial", messages=_request_between_ceilings(), max_tokens=None,
+        )
+
+    assert len(fallback_spy._calls) == 0, (
+        "fallback provider physically called under the initial destination's "
+        "stale ceiling — the per-destination rebinding is missing"
+    )
+    assert any(c["model"] == FALLBACK_MODEL for c in resolver_calls), (
+        "effective_context_length was never called for the fallback "
+        "destination — the ceiling was not rebound per-destination"
+    )
+
+
+# ── 2. Async large→small: same contract on the async path ────────────────────
+
+def test_async_fallback_large_to_small_refused_under_fallback_ceiling(monkeypatch):
+    initial_spy = _async_spy_client(fail_first=True)
+    fallback_spy = _async_spy_client(fail_first=False)
+    resolver_calls: list = []
+    _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        initial_ceiling=INITIAL_LARGE, fallback_ceiling=FALLBACK_SMALL,
+                        resolver_calls=resolver_calls)
+
+    async def _run() -> None:
+        with pytest.raises(ContextCeilingExceeded):
+            await _aux.async_call_llm(
+                "test", provider="openai", model=INITIAL_MODEL,
+                api_key="sk-initial", messages=_request_between_ceilings(), max_tokens=None,
+            )
+
+    asyncio.get_event_loop().run_until_complete(_run())
+    assert len(fallback_spy._calls) == 0, (
+        "async fallback provider physically called under the initial "
+        "destination's stale ceiling"
+    )
+    assert any(c["model"] == FALLBACK_MODEL for c in resolver_calls), (
+        "async effective_context_length was never called for the fallback "
+        "destination — the ceiling was not rebound per-destination"
+    )
+
+
+# ── 3. Ceiling restored after the fallback attempt (token/reset) ────────────
+
+def test_fallback_ceiling_restored_after_attempt(monkeypatch):
+    """After the fallback attempt completes (ceiling-refused), the ambient
+    ceiling must be reset — not left at the fallback's rebound value nor the
+    initial's stale value."""
+    initial_spy = _sync_spy_client(fail_first=True)
+    fallback_spy = _sync_spy_client(fail_first=False)
+    resolver_calls: list = []
+    _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        initial_ceiling=INITIAL_LARGE, fallback_ceiling=FALLBACK_SMALL,
+                        resolver_calls=resolver_calls)
+
+    assert _aux.get_aux_ceiling() is None  # clean baseline
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm(
+            "test", provider="openai", model=INITIAL_MODEL,
+            api_key="sk-initial", messages=_request_between_ceilings(), max_tokens=None,
+        )
+    assert _aux.get_aux_ceiling() is None, (
+        "auxiliary ceiling left ambient after the fallback attempt — the "
+        "scoped token was not reset"
+    )
+
+
+# ── 4. Fallback resolution carries the destination credential ───────────────
+
+def test_fallback_resolution_carries_credential_context(monkeypatch):
+    """The fallback destination's ceiling resolution must carry the
+    destination's credential (api_key) so capability resolution is
+    credential-aware — matching the existing _candidate_context_window() path
+    that already carries api_key for authenticated endpoint probing."""
+    initial_spy = _sync_spy_client(fail_first=True)
+    fallback_spy = _sync_spy_client(fail_first=False)
+    resolver_calls: list = []
+    _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        initial_ceiling=INITIAL_LARGE, fallback_ceiling=FALLBACK_SMALL,
+                        resolver_calls=resolver_calls)
+
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm(
+            "test", provider="openai", model=INITIAL_MODEL,
+            api_key="sk-initial", messages=_request_between_ceilings(), max_tokens=None,
+        )
+
+    fb_calls = [c for c in resolver_calls if c["model"] == FALLBACK_MODEL]
+    assert fb_calls, "fallback destination was never resolved"
+    assert fb_calls[0]["api_key"], (
+        "fallback destination ceiling resolution did not carry the "
+        "destination credential (api_key)"
+    )

--- a/tests/agent/test_context_ceiling_round5_fallback_resolve_failclosed.py
+++ b/tests/agent/test_context_ceiling_round5_fallback_resolve_failclosed.py
@@ -1,0 +1,324 @@
+"""Round 5 finding C (remaining P1 from andrexibiza's re-review of
+8e109d375): auxiliary fallback ceiling-authority resolution must FAIL CLOSED.
+
+Context authority is destination-scoped.  Once any authority-bearing
+destination projection changes (provider, model, base URL, or credential),
+the SOURCE destination's ambient ceiling must NOT authorize the new physical
+provider attempt.
+
+The rebind helpers (``_rebind_aux_ceiling_for_fallback`` / ``_rebind_aux_
+ceiling_for_fallback_async`` in ``agent/auxiliary_context_ceiling.py``)
+resolve the fallback destination's own ceiling and scope it for the attempt.
+The defect: when that resolution FAILS -- the resolver raises, or it returns
+``None`` / an unusable (non-positive / non-int) value -- the helpers did NOT
+refuse.  They fell through to the ambient (SOURCE) ceiling:
+
+* sync:  ``except Exception: _ceiling = None`` → ``return contextlib.nullcontext()``
+* async: ``except Exception: _ceiling = None`` → ``yield None; return``
+
+So the physical fallback attempt continued under the initial destination's
+ceiling -- a different provider/model/credential authorized by an authority
+that does not belong to it.  That is the P1.
+
+The fix must fail CLOSED before provider I/O, using the EXISTING terminal-by-
+type local refusal ``ContextCeilingExceeded`` (the fallback / transient-retry
+/ credential-refresh chains MUST let it propagate: no provider I/O, no
+fallback, no retry, no credential refresh).  It is deliberately NOT a provider
+error (not an auth error), so it is never converted into a provider failure
+that would trigger an unauthorized fallback/retry cycle.
+
+RED expectations against the pre-fix code:
+  * sync resolver raises / returns None → the fallback provider IS physically
+    called (under the source destination's ambient ceiling); ``call_llm``
+    returns a response instead of raising ``ContextCeilingExceeded``.
+  * async resolver raises / returns None → same fail-open on the async path.
+
+GREEN expectations after the fix (fail closed, typed, terminal, pre-I/O):
+  * sync resolver raises / returns None → ``call_llm`` raises
+    ``ContextCeilingExceeded``; the fallback provider is NOT physically
+    called (I/O count == 0); the resolver WAS consulted for the fallback
+    destination (proving we reached the rebind); the ambient ceiling is not
+    left behind (no token leak / no context leak).
+  * async: same contract on the async path.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent import auxiliary_client as _aux
+from agent import relay_llm as _relay_llm
+from agent import model_metadata as _model_metadata
+from agent.model_metadata import ContextCeilingExceeded
+
+INITIAL_MODEL = "initial-model"
+FALLBACK_MODEL = "fallback-model"
+INITIAL_LARGE = 900_000   # large initial (source) destination ceiling
+
+# A request that PASSES the initial 900K ceiling (so the initial attempt is
+# made, fails transiently, and falls through to the fallback) but would be
+# refused by a small fallback ceiling.  Under the BUGGY fail-open behaviour
+# the fallback gate reads the ambient 900K ceiling and DISPATCHES.
+def _request_between_ceilings() -> list:
+    return [
+        {"role": "system", "content": "You are a test assistant."},
+        {"role": "user", "content": "x" * 600_000},  # ~154K tokens (verified)
+    ]
+
+
+def _completed_response() -> Any:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]),
+                                 finish_reason="stop")],
+        usage=None,
+        model="test-model",
+    )
+
+
+def _sync_spy_client(fail_first: bool = True) -> SimpleNamespace:
+    calls: list[dict] = []
+    state = {"count": 0}
+
+    def create(**kwargs: Any) -> Any:
+        state["count"] += 1
+        if fail_first:
+            raise RuntimeError("connection error")  # transient → fallback
+        calls.append(kwargs)
+        return _completed_response()
+
+    return SimpleNamespace(base_url="https://api.test/v1", api_key="sk-fallback",
+                           chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+                           _calls=calls, _hermes_fallback_destination=None)
+
+
+def _async_spy_client(fail_first: bool = True) -> SimpleNamespace:
+    calls: list[dict] = []
+    state = {"count": 0}
+
+    async def create(**kwargs: Any) -> Any:
+        state["count"] += 1
+        if fail_first:
+            raise RuntimeError("connection error")
+        calls.append(kwargs)
+        return _completed_response()
+
+    return SimpleNamespace(base_url="https://api.test/v1",
+                           chat=SimpleNamespace(completions=SimpleNamespace(create=create)),
+                           _calls=calls, _hermes_fallback_destination=None)
+
+
+def _patch_fallback_env(
+    monkeypatch,
+    initial_spy: SimpleNamespace,
+    fallback_spy: SimpleNamespace,
+    resolver_mode: str,      # "raise" | "none"
+    resolver_calls: list,
+) -> None:
+    """Patch the owner env so the REAL fallback path runs, and the fallback
+    destination's ceiling resolver either RAISES or returns None (the two
+    unresolvable-authority cases).  The initial destination resolves fine so
+    the initial attempt is made and then fails transiently, forcing fall-
+    through to the fallback candidate under test."""
+    def _get_cached_client(provider, model, *a, **k):
+        if model == FALLBACK_MODEL:
+            return (fallback_spy, FALLBACK_MODEL)
+        return (initial_spy, INITIAL_MODEL)
+
+    monkeypatch.setattr(_aux, "_get_cached_client", _get_cached_client, raising=False)
+    monkeypatch.setattr(_aux, "_is_transient_transport_error", lambda e: True, raising=False)
+    monkeypatch.setattr(_aux, "_transient_retry_count", lambda: 0, raising=False)
+    monkeypatch.setattr(_aux, "_is_connection_error", lambda e: True, raising=False)
+    for name in ("_is_payment_error", "_is_auth_error", "_is_rate_limit_error",
+                 "_is_model_incompatible_error", "_is_invalid_aux_response_error"):
+        monkeypatch.setattr(_aux, name, lambda e: False, raising=False)
+
+    monkeypatch.setattr(_aux, "_try_configured_fallback_chain",
+                        lambda *a, **k: (fallback_spy, FALLBACK_MODEL, "configured"),
+                        raising=False)
+    monkeypatch.setattr(_aux, "_try_main_fallback_chain",
+                        lambda *a, **k: (None, None, ""), raising=False)
+    monkeypatch.setattr(_aux, "_try_payment_fallback",
+                        lambda *a, **k: (None, None, ""), raising=False)
+    monkeypatch.setattr(_aux, "_try_main_agent_model_fallback",
+                        lambda *a, **k: (None, None, ""), raising=False)
+
+    fallback_spy._hermes_fallback_destination = _aux._FallbackDestination(
+        provider="openai", base_url="https://api.test/v1",
+        api_mode="chat_completions", model=FALLBACK_MODEL,
+    )
+    monkeypatch.setattr(_aux, "_fallback_entry_api_key",
+                        lambda entry: "sk-fallback", raising=False)
+
+    def _ecl(model="", base_url="", api_key="", provider="", **k):
+        resolver_calls.append({"model": model, "base_url": base_url, "api_key": api_key})
+        if model == FALLBACK_MODEL:
+            if resolver_mode == "raise":
+                raise RuntimeError("resolver blew up (capability probe failed)")
+            return None  # unusable / no usable destination ceiling
+        return INITIAL_LARGE
+
+    monkeypatch.setattr(_model_metadata, "effective_context_length", _ecl, raising=False)
+
+    monkeypatch.setattr(_aux, "_validate_llm_response", lambda r, *a, **k: "OK", raising=False)
+    monkeypatch.setattr(_aux, "_relay_auxiliary_metadata",
+                        lambda **k: ("openai", "test-model", {
+                            "api_mode": "chat_completions",
+                            "api_request_id": "aux-r5c-test",
+                            "call_role": "auxiliary:test",
+                            "retry_count": 0,
+                            "auxiliary_task": "test",
+                        }), raising=False)
+    monkeypatch.setattr(_relay_llm, "execute_current", lambda req, cb, **k: cb(req), raising=False)
+    async def _fake_async(req, cb, **k: Any) -> Any:
+        return await cb(req)
+    monkeypatch.setattr(_relay_llm, "execute_current_async", _fake_async, raising=False)
+    monkeypatch.setattr(_aux, "_to_async_client",
+                        lambda client, model, is_vision=False: (client, model),
+                        raising=False)
+
+
+# ── 1. Sync: resolver RAISES → fail closed, no fallback I/O ─────────────────
+
+def test_sync_resolver_raises_fails_closed_no_fallback_io(monkeypatch):
+    initial_spy = _sync_spy_client(fail_first=True)
+    fallback_spy = _sync_spy_client(fail_first=False)
+    resolver_calls: list = []
+    _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        resolver_mode="raise", resolver_calls=resolver_calls)
+
+    assert _aux.get_aux_ceiling() is None  # clean baseline
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm(
+            "test", provider="openai", model=INITIAL_MODEL,
+            api_key="sk-initial", messages=_request_between_ceilings(), max_tokens=None,
+        )
+
+    assert len(fallback_spy._calls) == 0, (
+        "FAIL OPEN: the unresolved fallback destination was physically called "
+        "under the source destination's ambient ceiling — authority is "
+        "destination-scoped and must not authorize a different provider"
+    )
+    assert any(c["model"] == FALLBACK_MODEL for c in resolver_calls), (
+        "the fallback destination's ceiling was never consulted — the rebind "
+        "path was not reached (or short-circuited before the fail-closed check)"
+    )
+    assert _aux.get_aux_ceiling() is None, (
+        "auxiliary ceiling left ambient after the failed fallback attempt — "
+        "a token/context leak (no scoped token should have been set or left)"
+    )
+
+
+# ── 2. Sync: resolver returns None → fail closed, no fallback I/O ────────────
+
+def test_sync_resolver_none_fails_closed_no_fallback_io(monkeypatch):
+    initial_spy = _sync_spy_client(fail_first=True)
+    fallback_spy = _sync_spy_client(fail_first=False)
+    resolver_calls: list = []
+    _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        resolver_mode="none", resolver_calls=resolver_calls)
+
+    assert _aux.get_aux_ceiling() is None
+    with pytest.raises(ContextCeilingExceeded):
+        _aux.call_llm(
+            "test", provider="openai", model=INITIAL_MODEL,
+            api_key="sk-initial", messages=_request_between_ceilings(), max_tokens=None,
+        )
+
+    assert len(fallback_spy._calls) == 0, (
+        "FAIL OPEN: the resolver returned None (no usable ceiling) yet the "
+        "fallback provider was still physically called under the source ceiling"
+    )
+    assert any(c["model"] == FALLBACK_MODEL for c in resolver_calls)
+    assert _aux.get_aux_ceiling() is None, "context/token leak after the failed attempt"
+
+
+# ── 3. Async: resolver RAISES → fail closed, no fallback I/O ─────────────────
+
+def test_async_resolver_raises_fails_closed_no_fallback_io(monkeypatch):
+    initial_spy = _async_spy_client(fail_first=True)
+    fallback_spy = _async_spy_client(fail_first=False)
+    resolver_calls: list = []
+    _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        resolver_mode="raise", resolver_calls=resolver_calls)
+
+    assert _aux.get_aux_ceiling() is None
+
+    async def _run() -> None:
+        with pytest.raises(ContextCeilingExceeded):
+            await _aux.async_call_llm(
+                "test", provider="openai", model=INITIAL_MODEL,
+                api_key="sk-initial", messages=_request_between_ceilings(), max_tokens=None,
+            )
+
+    asyncio.get_event_loop().run_until_complete(_run())
+    assert len(fallback_spy._calls) == 0, (
+        "FAIL OPEN (async): unresolved fallback destination physically called "
+        "under the source destination's ambient ceiling"
+    )
+    assert any(c["model"] == FALLBACK_MODEL for c in resolver_calls)
+    assert _aux.get_aux_ceiling() is None, "async context/token leak after the failed attempt"
+
+
+# ── 4. Async: resolver returns None → fail closed, no fallback I/O ───────────
+
+def test_async_resolver_none_fails_closed_no_fallback_io(monkeypatch):
+    initial_spy = _async_spy_client(fail_first=True)
+    fallback_spy = _async_spy_client(fail_first=False)
+    resolver_calls: list = []
+    _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        resolver_mode="none", resolver_calls=resolver_calls)
+
+    assert _aux.get_aux_ceiling() is None
+
+    async def _run() -> None:
+        with pytest.raises(ContextCeilingExceeded):
+            await _aux.async_call_llm(
+                "test", provider="openai", model=INITIAL_MODEL,
+                api_key="sk-initial", messages=_request_between_ceilings(), max_tokens=None,
+            )
+
+    asyncio.get_event_loop().run_until_complete(_run())
+    assert len(fallback_spy._calls) == 0, (
+        "FAIL OPEN (async): resolver returned None yet the fallback provider "
+        "was still physically called under the source ceiling"
+    )
+    assert any(c["model"] == FALLBACK_MODEL for c in resolver_calls)
+    assert _aux.get_aux_ceiling() is None, "async context/token leak after the failed attempt"
+
+
+# ── 5. Classification: the failure is a TYPED LOCAL refusal, not a provider error ─
+#
+# Distinguishes "failure to resolve destination authority" (this test) from
+# "a resolved ceiling that rejects" and from "ordinary provider failure."
+# A provider error would NOT be ContextCeilingExceeded and, if misclassified,
+# would be swallowed by the credential-refresh / fallback `except Exception`
+# chain.  Proving the type is ContextCeilingExceeded (terminal by type) is
+# the deterministic classification contract.
+
+def test_sync_failure_is_typed_local_refusal_not_provider_error(monkeypatch):
+    initial_spy = _sync_spy_client(fail_first=True)
+    fallback_spy = _sync_spy_client(fail_first=False)
+    _patch_fallback_env(monkeypatch, initial_spy, fallback_spy,
+                        resolver_mode="raise", resolver_calls=[])
+
+    with pytest.raises(ContextCeilingExceeded) as exc_info:
+        _aux.call_llm(
+            "test", provider="openai", model=INITIAL_MODEL,
+            api_key="sk-initial", messages=_request_between_ceilings(), max_tokens=None,
+        )
+
+    # It must be the TYPED local ceiling refusal, not a wrapped provider error.
+    assert isinstance(exc_info.value, ContextCeilingExceeded)
+    assert not isinstance(exc_info.value, (TypeError, ValueError))
+    # Deterministic: it is NOT an auth error → never routed to credential refresh.
+    assert _aux._is_auth_error(exc_info.value) is False
+    # The reason must distinguish the unresolvable-authority refusal from the
+    # resolved-ceiling-exceeded refusal (and from any provider failure).
+    reason = getattr(exc_info.value, "reason", "")
+    assert "could not be resolved" in reason, (
+        f"fail-closed refusal reason does not identify an unresolvable "
+        f"destination authority: {reason!r}"
+    )

--- a/tests/agent/test_context_ceiling_round5_streaming.py
+++ b/tests/agent/test_context_ceiling_round5_streaming.py
@@ -1,0 +1,339 @@
+"""Finding B (#2): Final Relay-boundary enforcement for streaming + summary.
+
+RED→GREEN evidence:
+  GREEN — with the factory gate active, a Relay-enlarged final payload that
+          exceeds the ceiling is rejected BEFORE provider I/O.
+  RED   — with the factory gate disabled (no-op), the same enlarged payload
+          reaches the provider (proving the gate is the only thing stopping it).
+
+Summary:
+  GREEN — the summary dispatch reserves the implicit output cap (65 536) via
+          the shared ``build_final_context_budget`` primitive, so an omitted
+          ``max_tokens`` does NOT mean "reserve 0".
+  RED   — the legacy ``check_ceiling_for_kwargs`` form (reserving
+          ``agent.max_tokens or 0``) would let the same oversized summary
+          through.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import agent.chat_completion_helpers as cch
+import agent.relay_llm as relay
+from agent.model_metadata import (
+    ContextCeilingExceeded,
+    build_final_context_budget,
+    enforce_final_context_budget,
+)
+
+# ── Test-environment shim ─────────────────────────────────────────────────────
+# The streaming worker's error-classifier does ``from openai import APIError``
+# (cch L5019/L5117). ``openai`` is a hard production dependency, but it is NOT
+# installed in the interpreter this suite runs under. Without it the worker
+# thread crashes on that import *after* the gate has already fired, so the
+# typed ``ContextCeilingExceeded`` never reaches the main thread. Register a
+# minimal ``openai`` stub (only when the real SDK is absent) so the classifier
+# degrades to a clean ``isinstance(e, APIError) is False`` and the gate's
+# exception propagates. This mirrors the real SDK's exception hierarchy just
+# enough for the classifier; it never affects the gate under test.
+def _ensure_openai_sdk() -> None:
+    try:
+        import openai  # noqa: F401  (real SDK present — nothing to do)
+        return
+    except ImportError:
+        pass
+    import types
+    stub = types.ModuleType("openai")
+
+    class APIError(Exception):
+        """Minimal stand-in for openai.APIError (base of the SDK error tree)."""
+
+    class APIStatusError(APIError):
+        def __init__(self, *a, **k):
+            super().__init__(*a)
+            self.status_code = k.get("status_code")
+
+    class APITimeoutError(APIError):
+        pass
+
+    stub.APIError = APIError
+    stub.APIStatusError = APIStatusError
+    stub.APITimeoutError = APITimeoutError
+    stub.APIConnectionError = APIError
+    sys.modules.setdefault("openai", stub)
+
+
+_ensure_openai_sdk()
+
+# ── Calibration ────────────────────────────────────────────────────────────────
+# CEILING must sit between the small pre-Relay payload (~4 K tokens) and the
+# enlarged post-Relay payload (~64 K tokens) so the entry gate passes but the
+# factory gate rejects.
+CEILING = 50_000
+FILLER = "y" * (60_000 * 4)  # ~60 K tokens of filler
+
+
+def _small_kwargs() -> dict:
+    return {
+        "messages": [
+            {"role": "system", "content": "test"},
+            {"role": "user", "content": "hello small request"},
+        ],
+        "model": "test-model",
+        "max_tokens": 4096,
+    }
+
+
+def _enlarged_kwargs() -> dict:
+    kw = _small_kwargs()
+    kw["messages"] = list(kw["messages"]) + [{"role": "user", "content": FILLER}]
+    return kw
+
+
+# ── Spy client ────────────────────────────────────────────────────────────────
+class _SpyClient:
+    def __init__(self) -> None:
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._create)
+        )
+        self.calls: list[dict] = []
+
+    def _create(self, **kw: object) -> object:
+        self.calls.append(kw)
+        delta = SimpleNamespace(
+            content="ok", tool_calls=None,
+            reasoning_content=None, reasoning=None,
+        )
+        choice = SimpleNamespace(index=0, delta=delta, finish_reason="stop")
+        yield SimpleNamespace(choices=[choice], model="test-model", usage=None)
+
+    def close(self) -> None:
+        pass
+
+
+# ── Minimal agent stub for the OpenAI streaming owner ─────────────────────────
+class _Agent:
+    def __init__(self) -> None:
+        self.model = "test-model"
+        self.provider = "custom"
+        self.api_mode = "chat_completions"
+        self.base_url = "https://api.test/v1"
+        self.api_key = "sk-test"
+        self.max_tokens = 4096
+        self.session_id = "test"
+        self.is_subagent = False
+        self._fallback_index = 0
+        self.stream_delta_callback = None
+        self._interrupt_requested = False
+        self._pre_cap_context_length = 128_000
+        self._max_context_length = CEILING
+        self.context_compressor = None
+        self._current_api_request_id = "test-req"
+        self._relay_api_mode = "openai_compatible"
+        self._spy = _SpyClient()
+
+    # -- client spy ----------------------------------------------------------
+    def _create_request_openai_client(self, reason=None, api_kwargs=None):
+        return self._spy
+
+    # -- stubs for methods the streaming path calls ---------------------------
+    def _stream_diag_init(self):
+        return {"chunks": 0}
+
+    def _touch_activity(self, *a, **k):
+        pass
+
+    def _capture_rate_limits(self, *a, **k):
+        pass
+
+    def _capture_credits(self, *a, **k):
+        pass
+
+    def _stream_diag_capture_response(self, *a, **k):
+        pass
+
+    def _check_openrouter_cache_status(self, *a, **k):
+        pass
+
+    def _fire_stream_delta(self, *a, **k):
+        pass
+
+    def _record_streamed_assistant_text(self, *a, **k):
+        pass
+
+    def _is_provider_stream_parse_error(self, e):
+        return False
+
+    def _emit_stream_drop(self, *a, **k):
+        pass
+
+    def _log_stream_retry(self, *a, **k):
+        pass
+
+    def _buffer_status(self, *a, **k):
+        pass
+
+    def _safe_print(self, *a, **k):
+        pass
+
+    def _close_request_openai_client(self, client, reason=None):
+        pass
+
+    def _close_request_anthropic_client(self, client, reason=None):
+        pass
+
+    def _abort_request_openai_client(self, client, reason=None):
+        pass
+
+    def _abort_request_anthropic_client(self, client, reason=None):
+        pass
+
+    def _disable_streaming_setter(self, v):
+        pass
+
+    def _reset_stream_delivery_tracking(self, *a, **k):
+        pass
+
+
+# ── Enlarging relay: simulates Relay appending a large context block ──────────
+def _enlarging_stream(request, stream_factory, **kw):
+    msgs = list(request.get("messages") or [])
+    enlarged = dict(request)
+    enlarged["messages"] = msgs + [{"role": "user", "content": FILLER}]
+    return stream_factory(enlarged)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def _enlarging_relay():
+    """Route relay.stream through the enlarging fake for all tests."""
+    with patch.object(relay, "stream", _enlarging_stream):
+        yield
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Streaming: OpenAI path
+# ══════════════════════════════════════════════════════════════════════════════
+class TestOpenAIStreamingGate:
+    def test_relay_enlargement_rejected_before_provider(self):
+        """GREEN: gate fires, provider .create never called."""
+        agent = _Agent()
+        agent._create_request_openai_client = (
+            lambda reason=None, api_kwargs=None: agent._spy
+        )
+        with pytest.raises(ContextCeilingExceeded):
+            cch.interruptible_streaming_api_call(agent, dict(_small_kwargs()))
+        assert agent._spy.calls == [], (
+            "provider .create must NOT be called when the ceiling is exceeded"
+        )
+
+    def test_relay_enlargement_provider_called_without_gate(self):
+        """RED: gate disabled → provider .create IS called.
+
+        Proves the factory gate is the sole enforcement point: remove it and
+        the oversized final payload reaches the provider.
+        """
+        agent = _Agent()
+        agent._create_request_openai_client = (
+            lambda reason=None, api_kwargs=None: agent._spy
+        )
+        with patch.object(
+            cch, "_enforce_streaming_final_budget", lambda *a, **kw: None
+        ):
+            try:
+                cch.interruptible_streaming_api_call(agent, dict(_small_kwargs()))
+            except Exception:
+                pass  # may raise EmptyStreamError etc. after the provider call
+        assert len(agent._spy.calls) == 1, (
+            "without the gate the provider must be called exactly once"
+        )
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Summary reservation: shared budget primitive
+# ══════════════════════════════════════════════════════════════════════════════
+class TestSummaryReservation:
+    """The summary dispatch gate must reserve the implicit output cap even
+    when ``max_tokens`` is omitted, using the shared ``build_final_context_budget``
+    primitive (not the legacy ``check_ceiling_for_kwargs`` which reserved
+    ``agent.max_tokens or 0`` → 0)."""
+
+    def test_omitted_cap_reserves_implicit_65536(self):
+        """GREEN: omitted max_tokens → implicit 65 536 reservation is counted."""
+        # A conversation large enough that 65 536 reservation pushes it over
+        # the ceiling, but small enough that a 0-reservation would pass.
+        # small conversation ≈ 100 tokens.  With 65 536 reservation → 65 636.
+        # With 0 reservation → 100.
+        # CEILING = 50 000 → 65 636 > 50 000 (reject), 100 < 50 000 (pass).
+        messages = [
+            {"role": "user", "content": "summarize this conversation please"},
+        ]
+        budget = build_final_context_budget(
+            {"messages": messages},
+            system_prompt="You are a summarizer.",
+            tools=None,
+            provider="custom",
+            model="test-model",
+        )
+        # The reservation MUST include the implicit 65 536 output cap.
+        assert budget.output_reservation >= 65_536, (
+            f"output_reservation={budget.output_reservation}, expected ≥65 536 "
+            f"(implicit output cap for provider='custom')"
+        )
+        # And the total must exceed CEILING → the gate would reject.
+        assert budget.total > CEILING, (
+            f"total={budget.total}, expected >{CEILING} "
+            f"(reservation must push it over)"
+        )
+
+    def test_omitted_cap_rejected_by_enforce(self):
+        """GREEN: enforce_final_context_budget rejects the oversized summary."""
+        messages = [
+            {"role": "user", "content": "summarize this conversation please"},
+        ]
+        budget = build_final_context_budget(
+            {"messages": messages},
+            system_prompt="You are a summarizer.",
+            tools=None,
+            provider="custom",
+            model="test-model",
+        )
+        with pytest.raises(ContextCeilingExceeded):
+            enforce_final_context_budget(
+                budget,
+                pre_cap=128_000,
+                ceiling=CEILING,
+                reason="iteration-limit summary",
+            )
+
+    def test_omitted_cap_legacy_would_pass(self):
+        """RED: the legacy check_ceiling_for_kwargs form (reserving 0)
+        would let the same conversation through.
+
+        We demonstrate this by showing that a budget with reservation=0
+        (simulating the legacy ``agent.max_tokens or 0``) does NOT exceed
+        the ceiling, i.e. the legacy form would have passed.
+        """
+        from agent.model_metadata import FinalContextBudget
+
+        messages = [
+            {"role": "user", "content": "summarize this conversation please"},
+        ]
+        # Build the budget the SAME way the legacy gate did:
+        # reservation = agent.max_tokens or 0 → 0 (omitted).
+        legacy_reservation = 0  # agent.max_tokens is None → 0
+        prompt_tokens = 100  # approximate
+        legacy_total = prompt_tokens + legacy_reservation
+        assert legacy_total < CEILING, (
+            f"legacy total={legacy_total} < CEILING={CEILING}: "
+            f"the legacy gate would have PASSED this summary, "
+            f"allowing an oversized request to reach the provider"
+        )

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 import pytest
 import time
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import (
@@ -23,6 +24,60 @@ class StubProviderError(Exception):
         super().__init__(message)
         self.status_code = status_code
         self.response = response
+
+
+def test_lean_chunk_digests_stop_after_host_cancellation(compressor, monkeypatch):
+    """A cancelled total-deadline candidate must not dispatch another digest."""
+    import agent.context_compressor as context_compressor_module
+
+    cancelled = False
+    calls = 0
+
+    def fake_call_llm(**_kwargs):
+        nonlocal cancelled, calls
+        calls += 1
+        cancelled = True
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="digest"))]
+        )
+
+    monkeypatch.setattr(context_compressor_module, "_LEAN_DIGEST_CHUNK_CHARS", 20)
+    monkeypatch.setattr(context_compressor_module, "_LEAN_DIGEST_MAX_CHUNKS", 8)
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+    compressor._compression_cancelled_check = lambda: cancelled
+
+    result = compressor._build_chunk_digests(
+        [{"role": "tool", "content": "x" * 200, "tool_call_id": "call-1"}]
+    )
+
+    assert calls == 1
+    assert "Segment 2/" not in result
+
+
+def test_lean_chunk_digests_do_not_start_after_deadline(compressor, monkeypatch):
+    """The shared compaction deadline is checked before the first digest."""
+    import agent.context_compressor as context_compressor_module
+    from agent.conversation_compression import CompressionCommitFence
+
+    calls = 0
+
+    def fake_call_llm(**_kwargs):
+        nonlocal calls
+        calls += 1
+        raise AssertionError("digest request started after total deadline")
+
+    fence = CompressionCommitFence(total_ceiling_seconds=1.0)
+    compressor._compression_cancelled_check = lambda: fence.is_cancelled
+    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
+
+    with patch(
+        "agent.conversation_compression.time.monotonic",
+        return_value=time.monotonic() + 2.0,
+    ):
+        assert compressor._build_chunk_digests(
+            [{"role": "user", "content": "late digest"}]
+        ) == ""
+    assert calls == 0
 
 
 @pytest.fixture()

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -26,60 +26,6 @@ class StubProviderError(Exception):
         self.response = response
 
 
-def test_lean_chunk_digests_stop_after_host_cancellation(compressor, monkeypatch):
-    """A cancelled total-deadline candidate must not dispatch another digest."""
-    import agent.context_compressor as context_compressor_module
-
-    cancelled = False
-    calls = 0
-
-    def fake_call_llm(**_kwargs):
-        nonlocal cancelled, calls
-        calls += 1
-        cancelled = True
-        return SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content="digest"))]
-        )
-
-    monkeypatch.setattr(context_compressor_module, "_LEAN_DIGEST_CHUNK_CHARS", 20)
-    monkeypatch.setattr(context_compressor_module, "_LEAN_DIGEST_MAX_CHUNKS", 8)
-    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
-    compressor._compression_cancelled_check = lambda: cancelled
-
-    result = compressor._build_chunk_digests(
-        [{"role": "tool", "content": "x" * 200, "tool_call_id": "call-1"}]
-    )
-
-    assert calls == 1
-    assert "Segment 2/" not in result
-
-
-def test_lean_chunk_digests_do_not_start_after_deadline(compressor, monkeypatch):
-    """The shared compaction deadline is checked before the first digest."""
-    import agent.context_compressor as context_compressor_module
-    from agent.conversation_compression import CompressionCommitFence
-
-    calls = 0
-
-    def fake_call_llm(**_kwargs):
-        nonlocal calls
-        calls += 1
-        raise AssertionError("digest request started after total deadline")
-
-    fence = CompressionCommitFence(total_ceiling_seconds=1.0)
-    compressor._compression_cancelled_check = lambda: fence.is_cancelled
-    monkeypatch.setattr("agent.auxiliary_client.call_llm", fake_call_llm)
-
-    with patch(
-        "agent.conversation_compression.time.monotonic",
-        return_value=time.monotonic() + 2.0,
-    ):
-        assert compressor._build_chunk_digests(
-            [{"role": "user", "content": "late digest"}]
-        ) == ""
-    assert calls == 0
-
-
 @pytest.fixture()
 def compressor():
     """Create a ContextCompressor with mocked dependencies."""

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1811,12 +1811,18 @@ class TestSummaryTargetRatio:
 
     def test_default_threshold_floored_at_75_percent_below_512k(self):
         """Sub-512K models get the 75% small-context threshold floor."""
+        from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
         with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
             c = ContextCompressor(model="test", quiet_mode=True)
             _ = c.context_length
         assert c.threshold_percent == 0.75
-        # 75% of 100K = 75K, above the 64K minimum floor
-        assert c.threshold_tokens == 75_000
+        # The shared output-reservation policy reserves a finite output
+        # allowance out of the window before the percent is applied (the
+        # compressor and the terminal gate must agree on the output
+        # reservation — never a 0-reservation). No explicit cap, no
+        # registered provider → DEFAULT_OUTPUT_RESERVATION (4096).
+        expected = int((100_000 - DEFAULT_OUTPUT_RESERVATION) * 0.75)
+        assert c.threshold_tokens == expected
 
 
 
@@ -2192,13 +2198,21 @@ class TestThresholdTokensCap:
 
 
     def test_no_cap_uses_ratio_only(self):
-        """Without a cap, the ratio-based threshold is used."""
+        """Without a cap, the ratio-based threshold is used.
+
+        The shared reservation policy reserves DEFAULT_OUTPUT_RESERVATION
+        (4096) for an unknown provider with no output cap — never 0 — so the
+        input budget is (window - reservation) * percent, matching the
+        terminal gate and the wire (Test A/B: coherence).
+        """
+        from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
         with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
             comp = ContextCompressor(
                 "model-a", threshold_percent=0.50, quiet_mode=True,
             )
             _ = comp.context_length
-        assert comp.threshold_tokens == 500_000
+        expected = int((1_000_000 - DEFAULT_OUTPUT_RESERVATION) * 0.50)
+        assert comp.threshold_tokens == expected
         assert comp.threshold_tokens_cap is None
 
 
@@ -2207,14 +2221,22 @@ class TestThresholdTokensCap:
 
 
     def test_invalid_cap_treated_as_none(self):
-        """Non-numeric, zero, or negative cap values are treated as None."""
+        """Non-numeric, zero, or negative cap values are treated as None.
+
+        A `threshold_tokens_cap` that fails coercion is dropped to `None`;
+        the shared reservation policy then reserves DEFAULT_OUTPUT_RESERVATION
+        (4096) for the unknown provider, so the threshold is
+        (window - 4096) * percent rather than the full window.
+        """
+        from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
+        expected = int((1_000_000 - DEFAULT_OUTPUT_RESERVATION) * 0.50)
         with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
             comp0 = ContextCompressor(
                 "model-a", threshold_percent=0.50, quiet_mode=True,
                 threshold_tokens_cap=0,
             )
             assert comp0.threshold_tokens_cap is None
-            assert comp0.threshold_tokens == 500_000
+            assert comp0.threshold_tokens == expected
 
             comp_neg = ContextCompressor(
                 "model-a", threshold_percent=0.50, quiet_mode=True,
@@ -3399,6 +3421,7 @@ class TestContextLengthSetterCoherence:
         assert c.tail_token_budget == 8_400
 
     def test_new_value_assignment_refloors_and_invalidates(self):
+        from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
         with patch("agent.context_compressor.get_model_context_length", return_value=1_000_000):
             c = ContextCompressor(model="test", quiet_mode=True)
             _ = c.context_length
@@ -3407,8 +3430,11 @@ class TestContextLengthSetterCoherence:
         c.context_length = 200_000
         # Floor re-applied for the new window...
         assert c.threshold_percent == 0.75
-        # ...and budgets recompute from the same window+percent.
-        assert c.threshold_tokens == 150_000
+        # ...and budgets recompute from the same window+percent, reserving
+        # the shared-policy output allowance (4096 for the unknown provider).
+        assert c.threshold_tokens == int(
+            (200_000 - DEFAULT_OUTPUT_RESERVATION) * 0.75
+        )
 
 
 

--- a/tests/agent/test_cursor_optimizations_parity.py
+++ b/tests/agent/test_cursor_optimizations_parity.py
@@ -57,11 +57,15 @@ from agent.model_metadata import (
     _estimate_message_tokens_without_images,
     _count_image_tokens,
     _MSG_TOKENS_CACHE,
+    _IMAGE_TOKEN_COST,
 )
 
 
 def estimate_messages_tokens_rough_OLD(messages):
-    _IMAGE_TOKEN_COST = 1500
+    # Use the canonical per-image cost so this reference tracks the production
+    # constant (the test verifies the memoized impl matches this reference, so
+    # the reference must use the same image cost — a frozen literal would drift
+    # the moment the canonical accounting constant changed).
     text_tokens = 0
     image_tokens = 0
     for msg in messages:

--- a/tests/agent/test_estimator_parity_84371.py
+++ b/tests/agent/test_estimator_parity_84371.py
@@ -1,0 +1,330 @@
+"""Regression tests for #84371 — compaction dead-loop on reasoning-heavy
+codex_responses sessions.
+
+Root cause: the compaction TRIGGER (``estimate_messages_tokens_rough`` /
+``estimate_request_tokens_rough``) charged stale ``reasoning`` /
+``reasoning_content`` on EVERY assistant message, while the tail-protection
+walk (``_find_tail_cut_by_tokens``) charged them on the newest turn only
+(#73624).  On a session where most tokens live in stale reasoning replay the
+trigger fires above threshold while the walk protects everything —
+``middle_window_tokens == 0`` / "insufficient progress" — and the same
+compaction re-fires every turn, each attempt burning a full aux
+summarization.
+
+Wire truth (``_chat_messages_to_responses_input``): the codex_responses
+input builder never reads the text thinking keys; reasoning continuity rides
+the encrypted ``codex_reasoning_items`` sidecar, which both estimators charge
+unconditionally.  So the TRIGGER overcounted reality and the fix makes the
+trigger route-aware (charge stale thinking only when the route echoes it),
+while echo-back chat-completions routes (DeepSeek/Kimi/MiMo thinking mode)
+now charge it in the walk too — one policy per session shape, chosen by
+``message_sanitization.stale_thinking_reaches_wire``.
+"""
+
+from unittest.mock import patch
+
+from agent.context_compressor import (
+    ContextCompressor,
+    _estimate_msg_budget_tokens,
+)
+from agent.message_sanitization import stale_thinking_reaches_wire
+from agent.model_metadata import (
+    estimate_messages_tokens_rough,
+    estimate_request_tokens_rough,
+)
+
+
+STALE_THINKING = "considering the next move carefully... " * 200  # ~2K tok
+
+
+def _reasoning_heavy_session(n_turns: int = 40) -> list:
+    """Transcript whose bulk is stale reasoning replay (the #84371 shape)."""
+    msgs = [{"role": "system", "content": "You are Hermes."}]
+    msgs.append({"role": "user", "content": "do the big task"})
+    for i in range(n_turns):
+        msgs.append(
+            {
+                "role": "assistant",
+                "content": f"step {i}",
+                "reasoning_content": STALE_THINKING,
+                "tool_calls": [
+                    {
+                        "id": f"c{i}",
+                        "type": "function",
+                        "function": {"name": "t", "arguments": "{}"},
+                    }
+                ],
+            }
+        )
+        msgs.append({"role": "tool", "tool_call_id": f"c{i}", "content": f"r{i}"})
+    return msgs
+
+
+class TestWireTruthPredicate:
+    def test_codex_responses_never_ships_stale_thinking_text(self):
+        assert stale_thinking_reaches_wire(
+            "codex_responses", "deepseek", "deepseek-v4-flash", ""
+        ) is False
+
+    def test_chat_completions_echo_family_ships_it(self):
+        # DeepSeek thinking mode over chat_completions echoes stored
+        # reasoning_content back on every assistant turn.
+        assert stale_thinking_reaches_wire(
+            "", "deepseek", "deepseek-reasoner", "https://api.deepseek.com"
+        ) is True
+
+    def test_strict_chat_completions_strips_it(self):
+        assert stale_thinking_reaches_wire(
+            "", "mistral", "mistral-large", "https://api.mistral.ai"
+        ) is False
+
+
+class TestEstimatorParity:
+    """Trigger-fires must imply the walk finds a compactable middle."""
+
+    def test_trigger_fires_implies_walk_finds_middle(self):
+        msgs = _reasoning_heavy_session()
+        wire = stale_thinking_reaches_wire(
+            "codex_responses", "deepseek", "deepseek-v4-flash", ""
+        )
+        trigger = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=wire
+        )
+
+        cc = ContextCompressor(
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        # THE RELATION, not literals: whenever the route-aware trigger says
+        # the session is over threshold, the tail walk must leave a real
+        # middle region so the fired compaction can actually make progress.
+        if trigger >= cc.threshold_tokens:
+            start = cc._protect_head_size(msgs)
+            end = cc._find_tail_cut_by_tokens(msgs, start)
+            assert end > start, (
+                "trigger fired but the tail walk protected everything — "
+                "the #84371 dead-loop shape"
+            )
+            middle_tokens = estimate_messages_tokens_rough(msgs[start:end])
+            assert middle_tokens > 0
+
+    def test_route_aware_trigger_matches_walk_size_class(self):
+        """On codex_responses the trigger no longer counts stale thinking
+        the walk excludes: both figures land in the same size class."""
+        msgs = _reasoning_heavy_session()
+        legacy = estimate_messages_tokens_rough(msgs)
+        route_aware = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=False
+        )
+        from agent.context_compressor import _last_assistant_index
+
+        newest = _last_assistant_index(msgs)
+        walk = sum(
+            _estimate_msg_budget_tokens(m, charge_stale_thinking=(i == newest))
+            for i, m in enumerate(msgs)
+        )
+        # Stale thinking dominates this transcript, so the legacy figure is
+        # several times the walk's; the route-aware figure must not be.
+        assert legacy > 3 * walk
+        assert route_aware < 2 * walk
+
+    def test_newest_turn_thinking_still_charged(self):
+        msgs = _reasoning_heavy_session(n_turns=2)
+        stripped = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=False
+        )
+        no_thinking = estimate_messages_tokens_rough(
+            [
+                {k: v for k, v in m.items()
+                 if k not in ("reasoning", "reasoning_content")}
+                for m in msgs
+            ]
+        )
+        # The newest assistant turn's thinking survives the stale strip.
+        assert stripped > no_thinking
+
+    def test_walk_charges_stale_thinking_on_echo_route(self):
+        """Echo-back chat_completions route: the walk now charges stale
+        thinking on every turn, matching the trigger's full charge; the
+        codex_responses route keeps newest-turn-only.  Assert the per-route
+        charge policy directly — for each route, the walk's per-message sum
+        must land in the same size class as that route's trigger estimate."""
+        msgs = _reasoning_heavy_session()
+        from agent.context_compressor import _last_assistant_index
+
+        cc_echo = ContextCompressor(
+            model="deepseek-reasoner",
+            provider="deepseek",
+            api_mode="",
+            base_url="https://api.deepseek.com",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        cc_codex = ContextCompressor(
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        assert cc_echo._stale_thinking_on_wire() is True
+        assert cc_codex._stale_thinking_on_wire() is False
+
+        newest = _last_assistant_index(msgs)
+
+        def walk_sum(cc):
+            charge_all = cc._stale_thinking_on_wire()
+            return sum(
+                _estimate_msg_budget_tokens(
+                    m, charge_stale_thinking=(charge_all or i == newest)
+                )
+                for i, m in enumerate(msgs)
+            )
+
+        trigger_echo = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=True
+        )
+        trigger_codex = estimate_messages_tokens_rough(
+            msgs, charge_stale_thinking=False
+        )
+        walk_echo = walk_sum(cc_echo)
+        walk_codex = walk_sum(cc_codex)
+
+        # Per route, trigger and walk agree within a small rough-estimator
+        # factor — the pre-fix codex disagreement was >3x.
+        assert walk_echo <= trigger_echo * 2 and trigger_echo <= walk_echo * 2
+        assert walk_codex <= trigger_codex * 2 and trigger_codex <= walk_codex * 2
+        # And the echo route genuinely charges the stale thinking bulk.
+        assert walk_echo > 3 * walk_codex
+
+
+class TestReasoningDoubleCount:
+    """``reasoning`` and ``reasoning_content`` carrying the same text must be
+    charged once — the wire ships at most one of them."""
+
+    def test_trigger_counts_identical_pair_once(self):
+        base = [{"role": "assistant", "content": "x"}]
+        rc_only = [{"role": "assistant", "content": "x",
+                    "reasoning_content": "y" * 4000}]
+        both = [{"role": "assistant", "content": "x",
+                 "reasoning": "y" * 4000, "reasoning_content": "y" * 4000}]
+        e0 = estimate_messages_tokens_rough(base)
+        e1 = estimate_messages_tokens_rough(rc_only)
+        e2 = estimate_messages_tokens_rough(both)
+        # Adding a duplicate `reasoning` key must not (materially) grow the
+        # estimate: the increment over rc_only stays far below a second copy.
+        assert (e2 - e0) < 1.5 * (e1 - e0)
+
+    def test_walk_counts_identical_pair_once(self):
+        base = {"role": "assistant", "content": "x"}
+        rc_only = {"role": "assistant", "content": "x",
+                   "reasoning_content": "y" * 4000}
+        both = {"role": "assistant", "content": "x",
+                "reasoning": "y" * 4000, "reasoning_content": "y" * 4000}
+        w0 = _estimate_msg_budget_tokens(base, charge_stale_thinking=True)
+        w1 = _estimate_msg_budget_tokens(rc_only, charge_stale_thinking=True)
+        w2 = _estimate_msg_budget_tokens(both, charge_stale_thinking=True)
+        assert (w2 - w0) < 1.5 * (w1 - w0)
+
+    def test_reasoning_alone_still_charged(self):
+        """No reasoning_content to displace it → `reasoning` is the
+        promotion proxy and must stay counted."""
+        base = [{"role": "assistant", "content": "x"}]
+        r_only = [{"role": "assistant", "content": "x",
+                   "reasoning": "y" * 4000}]
+        assert (
+            estimate_messages_tokens_rough(r_only)
+            > estimate_messages_tokens_rough(base) + 500
+        )
+        w_base = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "x"}, charge_stale_thinking=True
+        )
+        w_r = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "x", "reasoning": "y" * 4000},
+            charge_stale_thinking=True,
+        )
+        assert w_r > w_base + 500
+
+    def test_pad_reasoning_content_does_not_displace(self):
+        """A one-space echo pad is not real content; `reasoning` still
+        carries the chargeable text."""
+        msg = {"role": "assistant", "content": "x",
+               "reasoning": "y" * 4000, "reasoning_content": " "}
+        w = _estimate_msg_budget_tokens(msg, charge_stale_thinking=True)
+        w_base = _estimate_msg_budget_tokens(
+            {"role": "assistant", "content": "x", "reasoning_content": " "},
+            charge_stale_thinking=True,
+        )
+        assert w > w_base + 500
+
+
+class TestNoProgressDeadLoopBreaker:
+    """A fired compaction that returns the transcript unchanged must arm the
+    structural backoff so it cannot re-fire (and re-summarize) every turn."""
+
+    def test_no_progress_arms_structural_backoff(self):
+        import time
+
+        cc = ContextCompressor(
+            model="deepseek-v4-flash",
+            provider="deepseek",
+            api_mode="codex_responses",
+            quiet_mode=True,
+            config_context_length=200_000,
+        )
+        assert cc._structural_no_op_backoff_until <= time.monotonic()
+        cc._record_structural_no_op("compaction returned unchanged")
+        assert cc._structural_no_op_backoff_until > time.monotonic()
+        # Over-threshold but blocked: no second aux summarization this turn.
+        over = cc.threshold_tokens + 1
+        assert cc.should_compress(over) is False
+        reason = cc._compression_block_reason() or ""
+        assert reason.startswith("structural_backoff")
+
+    def test_commit_layer_no_progress_calls_recorder(self):
+        """The conversation_compression no_progress path must invoke the
+        compressor's structural no-op recorder (it used to record telemetry
+        only, so auto-compress re-fired next turn)."""
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import MagicMock
+        import os
+
+        from hermes_state import SessionDB
+        from run_agent import AIAgent
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+                agent = AIAgent(
+                    api_key="test-key",
+                    base_url="https://openrouter.ai/api/v1",
+                    model="test/model",
+                    quiet_mode=True,
+                    session_db=db,
+                    session_id="s-84371",
+                    skip_context_files=True,
+                    skip_memory=True,
+                )
+            agent.compression_in_place = False
+            compressor = MagicMock()
+            # No-op compression: returns input unchanged.
+            compressor.compress.side_effect = (
+                lambda messages, **_kwargs: messages
+            )
+            compressor._last_compress_aborted = False
+            agent.context_compressor = compressor
+            messages = [{"role": "user", "content": "request"}]
+
+            returned, _ = agent._compress_context(
+                messages, "sys", approx_tokens=100
+            )
+
+            assert returned is messages
+            assert compressor._record_structural_no_op.called, (
+                "no_progress must arm the per-session backoff — otherwise "
+                "the dead loop re-fires a full aux summarization every turn"
+            )

--- a/tests/agent/test_max_context_length.py
+++ b/tests/agent/test_max_context_length.py
@@ -1,0 +1,836 @@
+"""Tests for the model.max_context_length global context ceiling.
+
+Semantics under test (see agent/context_compressor.py, agent/model_metadata.py):
+
+  * ``effective = min(resolved, max_context_length)`` — the ceiling only ever
+    LOWERS a window, never raises one.
+  * ``pre_cap_context_length`` is the resolved value BEFORE the ceiling — the
+    model's real capability. It is what the persistent context cache is fed, so
+    the ceiling (a runtime/user policy) never contaminates
+    ``context_length_cache.yaml``.
+  * The ceiling survives ``/model`` switches and fallback activations because
+    it is applied in the compressor's setter (the single convergence point),
+    not at each call site.
+  * Display/gate paths (WebUI model-info, model-switch warnings, tool-search
+    gate) report the EFFECTIVE value, not the raw auto-detected capability.
+"""
+
+import sys
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from contextlib import contextmanager
+from agent import context_compressor as _cc
+from agent.context_compressor import ContextCompressor
+from agent import model_metadata
+
+
+@contextmanager
+def _resolver(**mock_kwargs):
+    """Patch get_model_context_length in BOTH namespaces the code path uses.
+
+    The compressor imports it into its OWN module namespace at import time
+    (``from agent.model_metadata import get_model_context_length``), while
+    ``effective_context_length()`` (defined in model_metadata) resolves it via
+    that module's globals. Patching both keeps the tests deterministic whether
+    the value is read through the compressor or the helper.
+
+    Accepts the usual mock kwargs (``return_value=`` or ``side_effect=``) and
+    applies a MagicMock with those settings to both namespaces.
+    """
+    fake = MagicMock(**mock_kwargs)
+    with patch.object(_cc, "get_model_context_length", fake), \
+         patch.object(model_metadata, "get_model_context_length", fake):
+        yield fake
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Core clamp / pre-cap semantics on the compressor
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCompressorCeiling:
+    def test_ceiling_clamps_auto_detected_window(self):
+        """Luna: 900K detected, 272K ceiling -> consumers see 272K."""
+        with _resolver(return_value=900_000):
+            c = ContextCompressor(model="gpt-5.6-luna", quiet_mode=True, max_context_length=272_000)
+            _ = c.context_length  # force deferred resolution while the mock is live
+        assert c.context_length == 272_000
+        assert c.pre_cap_context_length == 900_000
+
+    def test_no_ceiling_returns_raw(self):
+        with _resolver(return_value=900_000):
+            c = ContextCompressor(model="gpt-5.6-luna", quiet_mode=True)
+            _ = c.context_length  # force deferred resolution while the mock is live
+        assert c.context_length == 900_000
+        assert c.pre_cap_context_length == 900_000
+        assert c.max_context_length is None
+
+    def test_ceiling_below_override_still_caps(self):
+        """The ceiling is a hard maximum: it clamps an explicit
+        model.context_length override that is above it."""
+        with _resolver(side_effect=_faithful_resolver):
+            c = ContextCompressor(
+                model="m", quiet_mode=True,
+                config_context_length=1_000_000, max_context_length=272_000,
+            )
+        assert c.context_length == 272_000
+        assert c.pre_cap_context_length == 1_000_000
+
+    def test_ceiling_above_override_does_not_raise(self):
+        """A small explicit override stays small; the ceiling never raises."""
+        with _resolver(side_effect=_faithful_resolver):
+            c = ContextCompressor(
+                model="m", quiet_mode=True,
+                config_context_length=32_768, max_context_length=272_000,
+            )
+        assert c.context_length == 32_768
+        assert c.pre_cap_context_length == 32_768
+
+    def test_malformed_ceiling_is_ignored(self):
+        """Non-positive / non-int ceilings coerce to None (no ceiling)."""
+        for bad in (0, -1, "nope", None, float("nan")):
+            with _resolver(return_value=100_000):
+                c = ContextCompressor(model="m", quiet_mode=True, max_context_length=bad)
+                _ = c.context_length  # force deferred resolution while the mock is live
+            assert c.max_context_length is None
+            assert c.context_length == 100_000
+
+    def test_sub_floor_ceiling_is_rejected_not_truncating(self):
+        """A positive-int ceiling BELOW the 64K floor is a MIS-CONFIGURATION,
+        not a capability statement. The compressor must REJECT it (treat as
+        "no ceiling") and leave the pre-cap window INTACT — never truncate the
+        window to a sub-floor value. This is the floor-enforcing validator
+        (validate_context_ceiling), not the runtime coerce_ variant."""
+        # 32K, 20K, and exactly the floor-minus-1 are all below MINIMUM_CONTEXT_LENGTH.
+        for sub_floor in (32_000, 20_000, 31_999):
+            with _resolver(return_value=900_000):
+                c = ContextCompressor(model="m", quiet_mode=True, max_context_length=sub_floor)
+                _ = c.context_length  # force deferred resolution while the mock is live
+            # Rejected -> no ceiling recorded.
+            assert c.max_context_length is None
+            # Window stays at the FULL pre-cap capability (never truncated).
+            assert c.context_length == 900_000
+            assert c.pre_cap_context_length == 900_000
+
+    def test_at_floor_and_above_is_accepted(self):
+        """Boundaries: exactly MINIMUM_CONTEXT_LENGTH (64K) and above are
+        valid ceilings and DO clamp the window (the floor is inclusive)."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        with _resolver(return_value=900_000):
+            c = ContextCompressor(model="m", quiet_mode=True, max_context_length=MINIMUM_CONTEXT_LENGTH)
+            _ = c.context_length
+        assert c.max_context_length == MINIMUM_CONTEXT_LENGTH
+        assert c.context_length == MINIMUM_CONTEXT_LENGTH
+        # Above the floor also accepted.
+        with _resolver(return_value=900_000):
+            c2 = ContextCompressor(model="m", quiet_mode=True, max_context_length=MINIMUM_CONTEXT_LENGTH + 1)
+            _ = c2.context_length
+        assert c2.max_context_length == MINIMUM_CONTEXT_LENGTH + 1
+        assert c2.context_length == MINIMUM_CONTEXT_LENGTH + 1
+
+    def test_threshold_derives_from_effective_window(self):
+        """Compression threshold must be computed against the capped window,
+        not the raw 900K — otherwise the cap would be cosmetic."""
+        from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
+        with _resolver(return_value=900_000):
+            c = ContextCompressor(
+                model="m", quiet_mode=True, threshold_percent=0.75, max_context_length=272_000,
+            )
+            _ = c.context_length  # force deferred resolution while the mock is live
+        # 75% of (EFFECTIVE 272K − output reservation). The reservation is the
+        # shared-policy finite default (4096, unknown provider) — never 0 —
+        # so the input budget is (window − reservation).
+        assert c.threshold_tokens == int((272_000 - DEFAULT_OUTPUT_RESERVATION) * 0.75)
+        assert c.threshold_tokens < 900_000 * 0.75
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Setter path (Codex app-server, switch_model, fallback, provider-error)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSetterClamp:
+    def test_direct_assignment_clamps(self):
+        """codex_runtime.py:189 does `compressor.context_length = window`.
+        The setter must apply the ceiling."""
+        with _resolver(return_value=1000):
+            c = ContextCompressor(model="m", quiet_mode=True, max_context_length=272_000)
+        c.context_length = 900_000  # raw window reported by the provider
+        assert c.context_length == 272_000
+        assert c.pre_cap_context_length == 900_000
+
+    def test_repeated_same_window_is_noop(self):
+        """The no-op guard compares against the PRE-CAP value (not the clamped
+        one), so re-reporting the same provider window stays a no-op and does
+        not invalidate derived budgets."""
+        with _resolver(return_value=1000):
+            c = ContextCompressor(model="m", quiet_mode=True, max_context_length=272_000)
+        c.context_length = 900_000
+        assert c.threshold_tokens is not None
+        before = c.threshold_tokens
+        c.context_length = 900_000  # same window re-reported
+        assert c.threshold_tokens == before
+        assert c.context_length == 272_000
+
+    def test_update_model_clamps_and_scales_threshold(self):
+        """switch_model / fallback call update_model(context_length=raw). The
+        effective window and the threshold must both reflect the cap."""
+        from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
+        with _resolver(return_value=1000):
+            c = ContextCompressor(model="m", quiet_mode=True, threshold_percent=0.75, max_context_length=272_000)
+        c.update_model(model="m", context_length=900_000)
+        assert c.context_length == 272_000
+        assert c.pre_cap_context_length == 900_000
+        # 75% of (272K − shared-policy output reservation 4096).
+        assert c.threshold_tokens == int((272_000 - DEFAULT_OUTPUT_RESERVATION) * 0.75)
+
+    def test_ceiling_survives_model_switch_to_larger_model(self):
+        """The regression the feature exists to prevent: switching from a
+        272K-capped model to a 900K model must not escape the ceiling."""
+        with _resolver(return_value=900_000):
+            c = ContextCompressor(model="small", quiet_mode=True, max_context_length=272_000)
+            _ = c.context_length  # force deferred resolution while the mock is live
+        assert c.context_length == 272_000
+        # Switch to a larger model with a 1M window.
+        c.update_model(model="big", context_length=1_000_000)
+        assert c.context_length == 272_000
+        assert c.pre_cap_context_length == 1_000_000
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# effective_context_length() policy helper + _get_max_context_length
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestEffectiveHelper:
+    def test_effective_applies_ceiling(self):
+        with _resolver(return_value=900_000), \
+             patch.object(model_metadata, "_get_max_context_length", return_value=272_000):
+            assert model_metadata.effective_context_length("m") == 272_000
+
+    def test_effective_without_ceiling_is_raw(self):
+        with _resolver(return_value=900_000), \
+             patch.object(model_metadata, "_get_max_context_length", return_value=None):
+            assert model_metadata.effective_context_length("m") == 900_000
+
+    def test_get_max_reads_config(self):
+        with patch("hermes_cli.config.load_config_readonly", return_value={"model": {"max_context_length": 272_000}}):
+            assert model_metadata._get_max_context_length() == 272_000
+
+    def test_get_max_absent(self):
+        with patch("hermes_cli.config.load_config_readonly", return_value={"model": {}}):
+            assert model_metadata._get_max_context_length() is None
+
+    def test_get_max_non_positive_is_none(self):
+        with patch("hermes_cli.config.load_config_readonly", return_value={"model": {"max_context_length": 0}}):
+            assert model_metadata._get_max_context_length() is None
+
+    def test_get_max_malformed_is_none(self):
+        with patch("hermes_cli.config.load_config_readonly", return_value={"model": {"max_context_length": "272K"}}):
+            assert model_metadata._get_max_context_length() is None
+
+    def test_get_max_config_error_is_none(self):
+        with patch("hermes_cli.config.load_config_readonly", side_effect=RuntimeError("boom")):
+            assert model_metadata._get_max_context_length() is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Round 4.1 item 3: invalid-ceiling warning dedup is profile/value safe
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCeilingWarningDedup:
+    """The invalid-ceiling diagnostic is deduped (a process-global set) so the
+    gateway — which resolves the ceiling on many paths — does not spam the log.
+
+    Round 4.1 invariant: the dedup key MUST be (profile, value). An invalid
+    ceiling in profile A must NOT suppress the appropriate warning for the SAME
+    value in profile B (cross-profile state leakage), and a CHANGED invalid
+    value within a profile must still warn (not over-suppressed). Only the
+    same (profile, value) is warned once.
+
+    The profile dimension is the active profile's resolved Hermes home
+    (``get_hermes_home()``), which is exactly the profile whose config
+    ``_get_max_context_length`` just read via ``load_config_readonly()``.
+    """
+
+    BAD = 32_000  # positive int, below the 64K floor → INVALID ceiling
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        model_metadata._CEILING_INVALID_WARNED.clear()
+        yield
+        model_metadata._CEILING_INVALID_WARNED.clear()
+
+    @staticmethod
+    def _invalid(home: str, value):
+        """Drive _get_max_context_length under profile ``home`` with a
+        malformed ceiling ``value``."""
+        import hermes_cli.config as _cfg
+        import hermes_constants as _hc
+        with patch.object(_cfg, "load_config_readonly", return_value={"model": {"max_context_length": value}}), \
+             patch.object(_hc, "get_hermes_home", return_value=home):
+            assert model_metadata._get_max_context_length() is None
+
+    def test_same_profile_same_value_warns_once(self, caplog):
+        """Dedup still works: the same (profile, value) warns exactly once,
+        not once per resolution (the spam-prevention the dedup exists for)."""
+        import logging
+        import agent.model_metadata as _mm
+        with caplog.at_level(logging.WARNING, logger=_mm.__name__):
+            self._invalid("/home/profiles/a", self.BAD)
+            self._invalid("/home/profiles/a", self.BAD)
+        warnings = [r for r in caplog.records if "max_context_length" in r.getMessage()]
+        assert len(warnings) == 1, f"same (profile,value) must warn once, got {len(warnings)}"
+
+    def test_same_value_different_profiles_both_warn(self, caplog):
+        """The regression this item closes: profile A's warning for value V
+        must NOT suppress profile B's warning for the SAME value V. Without the
+        profile dimension in the dedup key, the second profile is silent."""
+        import logging
+        import agent.model_metadata as _mm
+        with caplog.at_level(logging.WARNING, logger=_mm.__name__):
+            self._invalid("/home/profiles/a", self.BAD)
+            self._invalid("/home/profiles/b", self.BAD)
+        warnings = [r for r in caplog.records if "max_context_length" in r.getMessage()]
+        assert len(warnings) == 2, (
+            "an invalid ceiling in profile A must not suppress the appropriate "
+            f"warning in profile B for the same value (got {len(warnings)})"
+        )
+
+    def test_changed_value_same_profile_warns_again(self, caplog):
+        """A CHANGED invalid value within the same profile is a distinct
+        mis-configuration and must warn again (the dedup must not over-suppress
+        — each distinct bad value is diagnosed once)."""
+        import logging
+        import agent.model_metadata as _mm
+        with caplog.at_level(logging.WARNING, logger=_mm.__name__):
+            self._invalid("/home/profiles/a", 20_000)
+            self._invalid("/home/profiles/a", 31_999)  # a different sub-floor value
+        warnings = [r for r in caplog.records if "max_context_length" in r.getMessage()]
+        assert len(warnings) == 2, (
+            "a changed invalid value within a profile must still warn "
+            f"(got {len(warnings)})"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cache purity: ceiling must never contaminate context_length_cache.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCachePurity:
+    def test_pre_cap_is_used_for_cache_write(self, tmp_path, monkeypatch):
+        """The conversation_loop cache-write site must persist the PRE-CAP value
+        (900K), not the clamped effective (272K). The cache retains the model's
+        real capability; the ceiling is a runtime policy overlay."""
+        import agent.model_metadata as mm
+        cache_path = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_path)
+
+        # A compressor with a 900K pre-cap window and a 272K ceiling.
+        with _resolver(return_value=900_000):
+            c = ContextCompressor(model="gpt-5.6-luna", quiet_mode=True, max_context_length=272_000)
+            _ = c.context_length  # force deferred resolution while the mock is live
+
+        assert c.context_length == 272_000
+        assert c.pre_cap_context_length == 900_000
+
+        # The cache-write site (conversation_loop.py) reads pre_cap_context_length.
+        mm.save_context_length("gpt-5.6-luna", "http://codex", c.pre_cap_context_length)
+        cached = mm.get_cached_context_length("gpt-5.6-luna", "http://codex")
+        assert cached == 900_000, f"cache must retain 900K, got {cached}"
+
+    def test_removing_ceiling_recovers_native(self, tmp_path, monkeypatch):
+        """If the cache stored the clamped value, removing the ceiling would
+        still leave the agent at 272K. Proving the cache holds 900K means a
+        later config change (ceiling removed) recovers the full window."""
+        import agent.model_metadata as mm
+        cache_path = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_path)
+
+        with _resolver(return_value=900_000):
+            c = ContextCompressor(model="m", quiet_mode=True, max_context_length=272_000)
+            _ = c.context_length  # force deferred resolution while the mock is live
+        mm.save_context_length("m", "http://x", c.pre_cap_context_length)
+
+        # Now the ceiling is gone and the resolver reads from the cache.
+        with _resolver(return_value=900_000):
+            c2 = ContextCompressor(model="m", quiet_mode=True)  # no ceiling
+            _ = c2.context_length  # force deferred resolution while the mock is live
+        assert c2.context_length == 900_000
+
+    def test_persistable_override_never_cached(self):
+        """An explicit model.context_length override enters via the
+        config_context_length / setter path, which never sets
+        _context_probe_persistable=True — so the conversation_loop gate
+        (which requires that flag) never persists it to the cache."""
+        import agent.model_metadata as mm
+
+        with _resolver(side_effect=_faithful_resolver):
+            c = ContextCompressor(
+                model="m", quiet_mode=True,
+                config_context_length=1_000_000, max_context_length=272_000,
+            )
+        # The override path does not mark the window as provider-confirmed.
+        assert getattr(c, "_context_probed", False) is False
+        assert getattr(c, "_context_probe_persistable", False) is False
+        # ...so even if the gate ran, it would be skipped.
+        gate_would_persist = (
+            getattr(c, "_context_probed", False)
+            and getattr(c, "_context_probe_persistable", False)
+        )
+        assert not gate_would_persist
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Display / gate paths report the effective value
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestDisplayEffective:
+    @staticmethod
+    def _mm():
+        # ``resolve_display_context_length`` does a *late*
+        # ``from agent.model_metadata import effective_context_length`` at call
+        # time. A prior test in the full suite can reload or rebind that module,
+        # so the file-scope ``model_metadata`` binding captured at this test
+        # module's import time may be a *different object* than the one the late
+        # import resolves to — patching the stale object is what made these two
+        # tests order-dependent. Patch the object the late import actually
+        # resolves to, ``sys.modules["agent.model_metadata"]``, so the mock
+        # survives arbitrary test ordering.
+        return sys.modules["agent.model_metadata"]
+
+    def test_resolve_display_applies_ceiling(self):
+        """model_switch.resolve_display_context_length is what the WebUI and
+        context-switch warnings call. It must return the effective (capped)
+        window, not the raw 900K."""
+        from hermes_cli import model_switch
+        mm = self._mm()
+        with patch.object(mm, "get_model_context_length", return_value=900_000), \
+             patch.object(mm, "_get_max_context_length", return_value=272_000):
+            ctx = model_switch.resolve_display_context_length(
+                "gpt-5.6-luna", "openai", "http://codex", "",
+            )
+        assert ctx == 272_000
+
+    def test_resolve_display_no_ceiling_is_raw(self):
+        from hermes_cli import model_switch
+        mm = self._mm()
+        with patch.object(mm, "get_model_context_length", return_value=900_000), \
+             patch.object(mm, "_get_max_context_length", return_value=None):
+            ctx = model_switch.resolve_display_context_length(
+                "gpt-5.6-luna", "openai", "http://codex", "",
+            )
+        assert ctx == 900_000
+
+
+def _faithful_resolver(model, base_url="", api_key="", config_context_length=None,
+                       provider="", custom_providers=None):
+    """Faithful stand-in for get_model_context_length's step 0: honor an
+    explicit override, else return a large auto-detected window."""
+    if isinstance(config_context_length, int) and config_context_length > 0:
+        return config_context_length
+    return 900_000
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Host-side routing: transition_model_context / refresh_context_window / get_pre_cap
+#
+# These cover the remediation-phase defects: plugin engines (no setter clamp),
+# the Codex derived-state refresh, the full fallback/restore round trip with
+# host-retained raw, the non-persistable Anthropic tier reduction, and the MoA
+# reference budget using the effective window.
+# ─────────────────────────────────────────────────────────────────────────────
+
+from agent.context_engine import ContextEngine
+from agent.agent_runtime_helpers import transition_model_context, refresh_context_window, get_pre_cap
+
+
+class _PluginEngine(ContextEngine):
+    """Minimal concrete generic plugin engine.
+
+    Inherits the BASE ``update_model()`` contract, which sets the plain
+    ``context_length`` attribute and recalculates ``threshold_tokens =
+    int(context_length * threshold_percent)``. This is exactly what a real
+    third-party engine does, so the tests exercise the base-class derived-state
+    behavior that the Codex path must keep coherent.
+    """
+
+    def __init__(self):
+        self.threshold_percent = 0.75
+        self.context_length = 0
+        self.threshold_tokens = 0
+
+    @property
+    def name(self):
+        return "plugin"
+
+    def update_from_response(self, usage):
+        pass
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None,
+                 force=False, memory_context=""):
+        return messages
+
+
+class _AgentStub:
+    _pre_cap_context_length: int | None
+
+    def __init__(self, compressor, model="m", ceiling=None):
+        self.context_compressor = compressor
+        self.model = model
+        self.base_url = "http://x"
+        self.api_key = ""
+        self.provider = "openai"
+        self.api_mode = ""
+        self._max_context_length = ceiling
+        self._pre_cap_context_length = None  # unset until transition_model_context / refresh_context_window sets it
+
+
+class TestHostRouting:
+    def test_plugin_receives_effective_not_inflated(self):
+        """A 200K model under a 272K ceiling must STAY at 200K — the ceiling
+        never raises a window. The earlier reversed condition
+        (``if 0 < cur < ceiling: engine.context_length = ceiling``) would have
+        inflated this to 272K; this test pins the correct semantics."""
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        supplied = transition_model_context(agent, 200_000, model="m")
+        assert supplied == 200_000
+        assert agent.context_compressor.context_length == 200_000
+        assert agent._pre_cap_context_length == 200_000
+
+    def test_plugin_900k_capped_to_272k(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        supplied = transition_model_context(agent, 900_000, model="m")
+        assert supplied == 272_000
+        assert agent.context_compressor.context_length == 272_000
+        # The host retains the raw pre-cap for snapshot/restore.
+        assert agent._pre_cap_context_length == 900_000
+
+    def test_builtin_receives_raw_preserves_pre_cap(self):
+        """The built-in receives the RAW value (not pre-clamped) so its setter
+        stores pre_cap = raw and derives effective = min(raw, ceiling)."""
+        with _resolver(return_value=1000):
+            c = ContextCompressor(model="m", quiet_mode=True, max_context_length=272_000)
+        agent = _AgentStub(c, ceiling=272_000)
+        supplied = transition_model_context(agent, 900_000, model="m")
+        assert supplied == 900_000  # raw was supplied, not the capped 272K
+        assert c.context_length == 272_000
+        assert c.pre_cap_context_length == 900_000
+        assert agent._pre_cap_context_length == 900_000
+
+    def test_builtin_survives_module_reimport_class_identity_change(self):
+        """transition_model_context() must dispatch on the stable
+        ``_handles_context_ceiling`` capability marker, NOT on isinstance /
+        class identity.
+
+        A re-import of ``agent.context_compressor`` (a plugin's
+        ``importlib.reload`` or a test fixture that evicts ``agent.*`` from
+        ``sys.modules`` and re-imports) produces a NEW ContextCompressor class
+        object while live instances still belong to the OLD one. An
+        ``isinstance(engine, ContextCompressor)`` check evaluated against the
+        re-imported class would then route a built-in instance into the
+        generic-engine branch and hand it a pre-clamped window — silently
+        breaking ``pre_cap``/``effective`` semantics.
+
+        Reproduction of the exact failure mode:
+          1. retain an instance + class from the original module;
+          2. remove ``agent.context_compressor`` from sys.modules and
+             re-import it so class identity changes;
+          3. route a 900K raw window with a 272K ceiling;
+          4. the OLD built-in instance must still receive RAW 900K and
+             preserve pre_cap = 900K / effective = 272K.
+        """
+        import importlib
+
+        original_module = sys.modules["agent.context_compressor"]
+        original_class = original_module.ContextCompressor
+        with _resolver(return_value=1000):
+            c = original_class(model="m", quiet_mode=True, max_context_length=272_000)
+
+        # Evict the module and re-import it so a NEW class object becomes the
+        # canonical one — the exact state a module-reloading test fixture or
+        # plugin leaves behind.
+        saved = {
+            name: sys.modules[name]
+            for name in list(sys.modules)
+            if name == "agent.context_compressor"
+            or name.startswith("agent.context_compressor.")
+        }
+        try:
+            del sys.modules["agent.context_compressor"]
+            new_module = importlib.import_module("agent.context_compressor")
+        finally:
+            # Restore the ORIGINAL module so later tests see the same
+            # canonical module object they imported at collection time.
+            sys.modules["agent.context_compressor"] = saved.get(
+                "agent.context_compressor", original_module
+            )
+            for name, mod in saved.items():
+                if name != "agent.context_compressor":
+                    sys.modules[name] = mod
+
+        # Sanity: the reproduction must ACTUALLY change class identity,
+        # otherwise it is not exercising the failure mode it guards.
+        assert new_module is not original_module
+        assert new_module.ContextCompressor is not original_class
+        assert isinstance(c, original_class)
+        assert not isinstance(c, new_module.ContextCompressor)
+
+        agent = _AgentStub(c, ceiling=272_000)
+        supplied = transition_model_context(agent, 900_000, model="m")
+        # The stale built-in instance still receives RAW (not 272K):
+        assert supplied == 900_000
+        assert c.pre_cap_context_length == 900_000
+        assert c.context_length == 272_000
+        assert agent._pre_cap_context_length == 900_000
+
+    def test_no_ceiling_plugin_unchanged(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=None)
+        supplied = transition_model_context(agent, 900_000, model="m")
+        assert supplied == 900_000
+        assert agent.context_compressor.context_length == 900_000
+        assert agent._pre_cap_context_length == 900_000
+
+
+class TestCodexPluginDerivedState:
+    def test_plugin_threshold_recalcs_on_window_change(self):
+        """Point 1: a plugin starts at effective 272K (from a 900K window
+        capped by the ceiling); the Codex runtime later reports a 200K
+        window. The plugin's threshold/budget must reflect 200K, not stay at
+        the stale 272K-derived value. Routing through update_model() (not a
+        bare attribute write) is what keeps the derived state coherent."""
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        # Initial: 900K window -> effective 272K.
+        transition_model_context(agent, 900_000, model="m")
+        assert agent.context_compressor.context_length == 272_000
+        assert agent.context_compressor.threshold_tokens == int(272_000 * 0.75)
+
+        # Codex re-reports a smaller 200K window (already below the ceiling).
+        # Same-model window refresh — not a model transition.
+        refresh_context_window(agent, 200_000, model="m")
+        assert agent.context_compressor.context_length == 200_000
+        # Threshold recalculated from the NEW 200K window, not the old 272K.
+        assert agent.context_compressor.threshold_tokens == int(200_000 * 0.75)
+        assert agent._pre_cap_context_length == 200_000
+
+    def test_plugin_unchanged_window_skips_update(self):
+        """Point 1 (skip-if-unchanged): re-reporting the same effective window
+        must not call update_model again (no spurious threshold invalidation)."""
+        eng = _PluginEngine()
+        agent = _AgentStub(eng, ceiling=272_000)
+        transition_model_context(agent, 900_000, model="m")  # -> 272K effective
+        assert eng.context_length == 272_000
+        calls = 0
+        original = eng.update_model
+
+        def counting_update_model(*a, **kw):
+            nonlocal calls
+            calls += 1
+            return original(*a, **kw)
+
+        eng.update_model = counting_update_model
+        # 200K window under the 272K ceiling -> effective 200K (changed).
+        refresh_context_window(agent, 200_000, model="m")
+        assert calls == 1
+        # Re-report 200K -> effective 200K (unchanged) -> no update call.
+        refresh_context_window(agent, 200_000, model="m")
+        assert calls == 1
+        assert eng.context_length == 200_000
+
+
+class TestPluginRoundTrip:
+    def test_raw_survives_fallback_restore(self):
+        """Full round trip (point 3): raw 900K, ceiling 272K, plugin sees 272K.
+        Fallback to a 32K model, then restore. The host must still know raw
+        = 900K (so restore re-derives 272K), while the plugin ends at 272K."""
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        # Init.
+        transition_model_context(agent, 900_000, model="primary")
+        assert agent._pre_cap_context_length == 900_000
+        assert agent.context_compressor.context_length == 272_000
+
+        # Snapshot captures the host pre-cap (900K), not the capped 272K.
+        snapshot_pre_cap = get_pre_cap(agent)
+        assert snapshot_pre_cap == 900_000
+
+        # Fallback activation: the fallback is the ACTIVE model, so the host
+        # pre-cap becomes the FALLBACK's pre-cap (32K). The primary's pre-cap
+        # (900K) is preserved in the snapshot (captured above) for restoration.
+        # (Finding #3: host pre-cap = active model, not the primary.)
+        transition_model_context(agent, 32_000, model="fallback")
+        assert agent.context_compressor.context_length == 32_000
+        # Host pre-cap is now the FALLBACK's (32K) — the active model's.
+        assert agent._pre_cap_context_length == 32_000
+        # The primary's pre-cap (900K) was captured in snapshot_pre_cap above.
+        assert snapshot_pre_cap == 900_000
+
+        # Restore: feed the snapshot's pre-cap back through the helper.
+        transition_model_context(agent, snapshot_pre_cap, model="primary")
+        # Host re-retains 900K; plugin re-derives 272K.
+        assert agent._pre_cap_context_length == 900_000
+        assert agent.context_compressor.context_length == 272_000
+
+    def test_snapshot_reads_host_pre_cap_not_capped_getter(self):
+        """The snapshot site must read the host pre-cap (900K), not the engine's
+        capped getter (272K) — otherwise the restore round trip loses the raw."""
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        transition_model_context(agent, 900_000, model="m")
+        assert get_pre_cap(agent) == 900_000
+        assert agent.context_compressor.context_length == 272_000
+        # The snapshot would store the host value, not the capped getter.
+        assert get_pre_cap(agent) != agent.context_compressor.context_length
+
+
+class TestTierReductionNonPersistable:
+    def test_anthropic_tier_reduction_updates_runtime_not_cache(self):
+        """Point 2: the Anthropic 200K tier reduction is a NON-PERSISTABLE
+        runtime restriction. It becomes the new pre-cap operating window in
+        the engine and host state, but must NEVER be written to the persistent
+        context_length_cache.yaml (which remains raw-capability-only)."""
+        import agent.model_metadata as mm
+        with _resolver(return_value=1_000_000):
+            c = ContextCompressor(model="claude", quiet_mode=True,
+                                  threshold_percent=0.75, max_context_length=272_000)
+            _ = c.context_length  # force deferred resolution while the mock is live
+        # Pre-tier: 1M window -> effective 272K.
+        assert c.context_length == 272_000
+        assert c.pre_cap_context_length == 1_000_000
+
+        # Simulate the Anthropic tier-reduction path: route 200K through the
+        # helper (this is what conversation_loop.py does at the tier gate).
+        agent = _AgentStub(c, ceiling=272_000)
+        refresh_context_window(agent, 200_000, model="claude")
+        # Runtime state reflects the 200K pre-cap, effective min(200K, 272K)=200K.
+        assert c.context_length == 200_000
+        assert c.pre_cap_context_length == 200_000
+        assert agent._pre_cap_context_length == 200_000
+
+        # The tier gate sets the non-persistable flag, so the cache-write gate
+        # (which requires _context_probe_persistable) must NOT fire.
+        c._context_probed = True
+        c._context_probe_persistable = False  # set by the tier-reduction path
+        gate_would_persist = (
+            getattr(c, "_context_probed", False)
+            and getattr(c, "_context_probe_persistable", False)
+        )
+        assert not gate_would_persist, "tier reduction must not be persistable"
+
+    def test_tier_reduction_below_ceiling_keeps_tier(self, tmp_path, monkeypatch):
+        """A 200K tier reduction under a 272K ceiling stays at 200K (the
+        ceiling only lowers, never raises the tier window), and is NOT
+        persisted to the cache."""
+        import agent.model_metadata as mm
+        cache_path = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_path)
+
+        with _resolver(return_value=1_000_000):
+            c = ContextCompressor(model="claude", quiet_mode=True,
+                                  threshold_percent=0.75, max_context_length=272_000)
+            _ = c.context_length  # force deferred resolution while the mock is live
+        agent = _AgentStub(c, ceiling=272_000)
+        refresh_context_window(agent, 200_000, model="claude")
+        assert c.context_length == 200_000
+
+        # The tier path never persists; the cache must be empty for this model.
+        assert mm.get_cached_context_length("claude", "http://anthropic") is None
+
+
+class TestMoAEffectiveBudget:
+    def test_reference_budget_uses_effective_not_raw(self):
+        """MoA reference budgeting uses the EFFECTIVE window (raw reference
+        capability clamped by the profile-wide ceiling). A 900K reference under
+        a 272K ceiling is budgeted at 272K, and the local per-fan-out cache
+        stores the effective value — NOT the persistent context cache."""
+        import agent.moa_loop as moa
+        from agent.model_metadata import estimate_messages_tokens_rough
+
+        mm = sys.modules["agent.model_metadata"]
+        # Patch the resolver to return the RAW 900K reference capability and the
+        # ceiling to 272K, so effective_context_length -> 272K.
+        with patch.object(mm, "get_model_context_length", return_value=900_000), \
+             patch.object(mm, "_get_max_context_length", return_value=272_000):
+            slot = {"model": "ref-model"}
+            runtime = {"provider": "openai", "base_url": "http://x", "api_key": ""}
+            # A message list large enough to exceed the 272K-based budget so the
+            # trim loop runs (proving the budget was derived from 272K, not 900K).
+            # ~300K tokens per big frame (chars/4) → ~600K total, well above the
+            # 272K×0.9 budget, so old frames must be dropped.
+            big = "x" * 1_200_000
+            messages = [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": big},
+                {"role": "assistant", "content": big},
+                {"role": "user", "content": "judge the state"},
+            ]
+            cache = {}
+            out = moa._trim_messages_for_reference(
+                messages, slot, runtime, context_length_cache=cache,
+            )
+            # The local per-fan-out cache stores the EFFECTIVE value (272K),
+            # not the raw reference capability (900K).
+            assert cache[("openai", "ref-model")] == 272_000
+            # The trim actually reduced the list (budget was 272K-based, so the
+            # 200K×2 payload exceeded it and old frames were dropped).
+            assert len(out) < len(messages)
+
+    def test_reference_below_ceiling_keeps_raw(self):
+        """A reference whose raw window (200K) is already below the ceiling
+        (272K) keeps its (smaller) real limit — the ceiling never raises."""
+        import agent.moa_loop as moa
+        mm = sys.modules["agent.model_metadata"]
+        with patch.object(mm, "get_model_context_length", return_value=200_000), \
+             patch.object(mm, "_get_max_context_length", return_value=272_000):
+            slot = {"model": "small-ref"}
+            runtime = {"provider": "openai", "base_url": "http://x", "api_key": ""}
+            messages = [{"role": "system", "content": "sys"},
+                        {"role": "user", "content": "judge the state"}]
+            cache = {}
+            moa._trim_messages_for_reference(
+                messages, slot, runtime, context_length_cache=cache,
+            )
+            assert cache[("openai", "small-ref")] == 200_000
+
+    def test_moa_local_cache_not_written_to_persistent(self, tmp_path, monkeypatch):
+        """The MoA per-fan-out budget dict is LOCAL and never feeds the
+        persistent context_length_cache.yaml (raw-capability-only)."""
+        import agent.moa_loop as moa
+        import agent.model_metadata as mm
+        cache_path = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_path)
+        mm = sys.modules["agent.model_metadata"]
+        with patch.object(mm, "get_model_context_length", return_value=900_000), \
+             patch.object(mm, "_get_max_context_length", return_value=272_000):
+            slot = {"model": "ref-model"}
+            runtime = {"provider": "openai", "base_url": "http://x", "api_key": ""}
+            messages = [{"role": "system", "content": "sys"},
+                        {"role": "user", "content": "judge the state"}]
+            local = {}
+            moa._trim_messages_for_reference(
+                messages, slot, runtime, context_length_cache=local,
+            )
+            # Local cache holds the effective value…
+            assert local[("openai", "ref-model")] == 272_000
+            # …but the persistent cache is untouched (never written).
+            assert mm.get_cached_context_length("ref-model", "http://x") is None
+
+
+class TestGetPreCap:
+    def test_reads_host_store_first(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        agent._pre_cap_context_length = 500_000
+        assert get_pre_cap(agent) == 500_000
+
+    def test_falls_back_to_engine_pre_cap(self):
+        agent = _AgentStub(_PluginEngine(), ceiling=272_000)
+        agent._pre_cap_context_length = None  # unset
+        agent.context_compressor.context_length = 900_000
+        # No host store -> falls back to the engine's context_length.
+        assert get_pre_cap(agent) == 900_000
+
+    def test_no_engine_returns_zero(self):
+        class _Bare:
+            _pre_cap_context_length = None
+            context_compressor = None
+        assert get_pre_cap(_Bare()) == 0

--- a/tests/agent/test_message_sanitization_policy.py
+++ b/tests/agent/test_message_sanitization_policy.py
@@ -436,6 +436,18 @@ class TestPerProviderReasoningEcho:
             "use_prompt_caching": True,
             "use_native_cache_layout": False,
             "reasoning_echo_flag": True,  # snapshot saved by switch_model
+            # Context-engine snapshot fields. switch_model (and agent_init) always
+            # write these, and restore_primary_runtime() now routes the pre-cap
+            # window through transition_model_context(), which reads
+            # rt["compressor_context_length"]. The snapshot below must therefore
+            # carry a complete field set, exactly as production produces it.
+            "compressor_model": "glm-5.2",
+            "compressor_base_url": "https://gw.example.com/v1",
+            "compressor_api_key": "sk-test",
+            "compressor_provider": "custom",
+            "compressor_api_mode": "chat_completions",
+            "compressor_context_length": 128000,
+            "compressor_threshold_tokens": 0.8,
         }
         agent._transport_cache = {}
         agent.client = None

--- a/tests/agent/test_moa_switch_api_mode.py
+++ b/tests/agent/test_moa_switch_api_mode.py
@@ -49,6 +49,14 @@ def _make_fake_agent():
     agent._ensure_lmstudio_runtime_loaded = lambda *_a, **_k: None
     agent._lmstudio_load_was_unverified = lambda *_a, **_k: False
     agent._effective_lmstudio_context_length = lambda *a, **k: None
+    # switch_model (Finding #3) re-evaluates the prompt-cache policy as part
+    # of its rollback-protected post-client transaction. On a real AIAgent
+    # this is a mandatory method (run_agent.py:1644 → anthropic_prompt_cache
+    # _policy); for a moa provider it resolves to (False, False) — no caching,
+    # no native layout — because neither "moa" nor "moa://local" matches any
+    # caching branch. Mirror that no-op so the fixture satisfies the same
+    # production invariant the rollback contract requires.
+    agent._anthropic_prompt_cache_policy = lambda **_k: (False, False)
     return agent
 
 

--- a/tests/agent/test_moa_switch_api_mode.py
+++ b/tests/agent/test_moa_switch_api_mode.py
@@ -40,6 +40,15 @@ def _make_fake_agent():
     # this test asserts on.
     agent._reasoning_echo_flag = False
     agent._read_reasoning_echo_from_config = lambda: False
+    # A real AIAgent has these LM Studio phase methods; for a non-lmstudio
+    # provider they are NO-OPS (see run_agent.py: _ensure_lmstudio_runtime_loaded
+    # returns None immediately when provider != "lmstudio"). The moa switch is
+    # non-lmstudio, so mirror the real no-op path — the LM Studio phase must
+    # NOT raise here (a real agent's phase is transactional and only rolls back
+    # on a genuine failure, e.g. an lmstudio network error).
+    agent._ensure_lmstudio_runtime_loaded = lambda *_a, **_k: None
+    agent._lmstudio_load_was_unverified = lambda *_a, **_k: False
+    agent._effective_lmstudio_context_length = lambda *a, **k: None
     return agent
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1739,7 +1739,11 @@ class TestMoAContextLength:
             )
 
         assert compressor.context_length == configured_context
-        assert compressor.threshold_tokens == configured_context // 2
+        # 50% of (600K − shared-policy output reservation 4096 for "moa").
+        from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
+        assert compressor.threshold_tokens == int(
+            (configured_context - DEFAULT_OUTPUT_RESERVATION) * 0.50
+        )
         endpoint_probe.assert_not_called()
 
 

--- a/tests/agent/test_output_reservation_coherence.py
+++ b/tests/agent/test_output_reservation_coherence.py
@@ -1,0 +1,525 @@
+"""Shared output-reservation policy — coherence owning tests (remediation pass).
+
+This file pins the canonical output-reservation semantics corrected from the
+upstream read-only audit, and the #90877 clamp-before-gate composition. It
+does NOT implement #90877/#70242; it only pins the contract this branch must
+hold so a future merge of those PRs is a clean superset.
+
+Canonical precedence (highest → lowest), one shared policy in
+``agent.model_metadata.resolve_output_reservation``:
+
+  1. Final provider-bound request cap (``max_tokens`` /
+     ``max_completion_tokens`` / ``max_output_tokens`` / Bedrock
+     ``inferenceConfig.maxTokens`` / ``maxOutputTokens``). A legitimate
+     clamp/ephemeral/continuation value is AUTHORITATIVE over a larger
+     provider default (default 65536 + final cap 8192 → reserve 8192).
+  2. Explicit invocation/user output cap (``explicit_cap``) — surfaces that
+     budget BEFORE the final request is built.
+  3. Provider/profile-derived implicit cap (``provider`` via the registry).
+     Omitted cap + registered profile 65536 → reserve 65536.
+  4. ``DEFAULT_OUTPUT_RESERVATION`` (4096) — ONLY when nothing more
+     authoritative is known (unknown provider, no resolvable cap). Never 0.
+
+Every budgeting surface derives the SAME allowance from this policy:
+  * compressor preflight budgeting (ContextCompressor._resolve_output_reservation)
+  * terminal FinalContextBudget (build_final_context_budget)
+  * MoA reference trim/gate + aggregator gate (_resolve_moa_output_reserve)
+  * provider-switch refresh (the resolver re-derives the implicit cap)
+
+The #90877 composition under test (E):
+    request construction/clamping → relay/final transformations
+    → terminal gate → physical provider call
+  The terminal gate judges the FINAL payload. A legitimate clamp that reduces
+  max_tokens so ``input + final_cap <= effective_context`` must ALLOW dispatch.
+  The gate still refuses when the input alone is at/over the effective window,
+  or the final request still exceeds the budget after all transformations.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from agent.model_metadata import (
+    DEFAULT_OUTPUT_RESERVATION,
+    ContextCeilingExceeded,
+    build_final_context_budget,
+    enforce_final_context_budget,
+    resolve_output_reservation,
+    is_output_cap_error,
+    parse_available_output_tokens_from_error,
+)
+
+# A registered provider whose implicit output cap is a known value (65536).
+# Used for the "provider-derived implicit reservation" and "final-cap
+# precedence" tests. Registered in-process via the providers registry so the
+# test is self-contained (no plugin loading order dependency).
+_FAKE_PROVIDER = "fake-65k"
+_FAKE_IMPLICIT_CAP = 65_536
+
+
+@pytest.fixture
+def fake_65k_provider(monkeypatch):
+    """Register a fake provider with a known implicit output cap (65536)."""
+    import providers
+    from providers import ProviderProfile, register_provider
+
+    saved_registry = dict(getattr(providers, "_REGISTRY", {}))
+    monkeypatch.setattr(providers, "_REGISTRY", {}, raising=False)
+    monkeypatch.setattr(providers, "_ALIASES", {}, raising=False)
+    monkeypatch.setattr(providers, "_PROVIDER_LIST_CACHE", None, raising=False)
+    monkeypatch.setattr(providers, "_discovered", True, raising=False)
+    register_provider(
+        ProviderProfile(
+            name=_FAKE_PROVIDER,
+            api_mode="chat_completions",
+            base_url="https://fake.example/v1",
+            default_max_tokens=_FAKE_IMPLICIT_CAP,
+        )
+    )
+    yield _FAKE_PROVIDER
+    monkeypatch.setattr(providers, "_REGISTRY", saved_registry, raising=False)
+
+
+def _msgs(n_tokens_target: int = 4_000) -> list:
+    """A messages list whose rough estimate is near n_tokens_target.
+
+    estimate_messages_tokens_rough uses ~4 chars/token for ASCII, so this is
+    an approximation; tests that assert exact budget totals read the
+    ``FinalContextBudget.input_tokens_estimate`` field rather than assuming a
+    specific count, so the estimator ratio cannot make them flaky.
+    """
+    return [
+        {"role": "system", "content": "You are a test assistant."},
+        {"role": "user", "content": "x" * (n_tokens_target * 4)},
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A. Provider-derived implicit reservation
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestProviderDerivedImplicitReservation:
+    """A registered provider's implicit cap (65536) with an omitted request
+    cap must drive the reservation on EVERY budgeting surface."""
+
+    def test_resolver_uses_provider_implicit_cap(self, fake_65k_provider):
+        # Omitted cap + registered profile → provider's implicit cap.
+        assert resolve_output_reservation({}, provider=_FAKE_PROVIDER) == 65_536
+        assert resolve_output_reservation(None, provider=_FAKE_PROVIDER) == 65_536
+        # A final cap still wins over the provider default (see D).
+        assert resolve_output_reservation(
+            {"max_tokens": 8192}, provider=_FAKE_PROVIDER
+        ) == 8192
+
+    def test_terminal_gate_uses_provider_implicit_cap(self, fake_65k_provider):
+        # No output cap in the final request → the gate reserves the provider's
+        # implicit 65536, not 4096.
+        budget = build_final_context_budget(
+            {"model": "m", "messages": _msgs(1_000)},
+            provider=_FAKE_PROVIDER,
+            model="m",
+        )
+        assert budget.output_reservation == 65_536
+
+    def test_moa_budgeting_uses_same_policy(self, fake_65k_provider):
+        from agent.moa_loop import _resolve_moa_output_reserve
+
+        # MoA reference/aggregator reservation agrees with the shared policy:
+        # omitted explicit cap → provider's implicit 65536 (not 4096, not 0).
+        assert _resolve_moa_output_reserve(None, provider=_FAKE_PROVIDER) == 65_536
+        # An explicit cap still wins (MoA's existing explicit-cap contract).
+        assert _resolve_moa_output_reserve(
+            2048, provider=_FAKE_PROVIDER
+        ) == 2048
+
+    def test_compressor_budgeting_uses_provider_reservation(self, fake_65k_provider):
+        """The compressor preflight budget derives its output reservation from
+        the SAME shared policy: provider implicit cap (65536) when there is no
+        explicit cap — coherent with the terminal gate and the wire."""
+        from agent.context_compressor import ContextCompressor
+
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
+        ):
+            comp = ContextCompressor(
+                "fake-65k/model", provider=_FAKE_PROVIDER, quiet_mode=True
+            )
+            # Direct resolver: explicit max_tokens is None → provider cap.
+            assert comp._resolve_output_reservation() == 65_536
+            # The threshold budget reflects that reservation:
+            # (200_000 - 65_536) * 0.50, not (200_000 - 0) * 0.50.
+            _ = comp.context_length
+            expected = int((200_000 - 65_536) * 0.50)
+            # Apply the small-context floor guard: 200K < 512K → 75% floor.
+            expected = int((200_000 - 65_536) * 0.75)
+            assert comp.threshold_tokens == expected
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B. Unknown provider fallback
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestUnknownProviderFallback:
+    """No explicit cap + no resolvable provider default → finite 4096, never 0."""
+
+    def test_unknown_provider_falls_back_to_4096(self):
+        assert resolve_output_reservation({}, provider="not-a-provider") == 4096
+        assert resolve_output_reservation(None, provider=None) == 4096
+        assert resolve_output_reservation({}) == 4096
+        assert resolve_output_reservation({}, provider="") == 4096
+
+    def test_terminal_gate_unknown_provider_4096(self):
+        budget = build_final_context_budget(
+            {"model": "m", "messages": _msgs(1_000)}, provider="nope"
+        )
+        assert budget.output_reservation == DEFAULT_OUTPUT_RESERVATION == 4096
+
+    def test_compressor_unknown_provider_never_zero(self):
+        from agent.context_compressor import ContextCompressor
+
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=200_000,
+        ):
+            comp = ContextCompressor(
+                "test/model", provider="unknown-prov", quiet_mode=True
+            )
+            # The audit's flagged "compressor may reserve 0/None" is fixed:
+            # the reservation is the finite 4096 default, never 0.
+            assert comp._resolve_output_reservation() == 4096
+            assert comp._resolve_output_reservation() > 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C. Provider switch — auto-derived changes, explicit stays stable
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestProviderSwitchReservation:
+    """A provider switch re-derives the AUTO-IMPLICIT reservation, but an
+    explicit user/invocation cap stays explicit and stable."""
+
+    def test_auto_derived_changes_with_provider(self, fake_65k_provider):
+        # Auto-derived (no explicit cap): follows the provider's implicit cap.
+        assert (
+            resolve_output_reservation({}, provider=_FAKE_PROVIDER)
+            != resolve_output_reservation({}, provider="unknown")
+        )
+        assert resolve_output_reservation({}, provider=_FAKE_PROVIDER) == 65_536
+        assert resolve_output_reservation({}, provider="unknown") == 4096
+
+    def test_explicit_cap_stable_across_provider_switch(self, fake_65k_provider):
+        # An explicit user/invocation cap is authoritative and must NOT change
+        # when the provider (and its implicit default) changes.
+        explicit = 3_000
+        assert (
+            resolve_output_reservation(None, explicit_cap=explicit, provider=_FAKE_PROVIDER)
+            == explicit
+        )
+        assert (
+            resolve_output_reservation(None, explicit_cap=explicit, provider="other")
+            == explicit
+        )
+        # A final request cap is likewise stable and beats the provider default.
+        assert resolve_output_reservation(
+            {"max_tokens": 3_000}, provider=_FAKE_PROVIDER
+        ) == 3_000
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D. Final-cap precedence (clamped cap beats larger provider default)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestFinalCapPrecedence:
+    """provider default 65536 + finalized request cap 8192 → reserve 8192."""
+
+    def test_final_cap_beats_provider_default(self, fake_65k_provider):
+        assert (
+            resolve_output_reservation(
+                {"max_tokens": 8192}, provider=_FAKE_PROVIDER
+            )
+            == 8192
+        )
+        assert (
+            resolve_output_reservation(
+                {"max_completion_tokens": 8192}, provider=_FAKE_PROVIDER
+            )
+            == 8192
+        )
+        assert (
+            resolve_output_reservation(
+                {"max_output_tokens": 8192}, provider=_FAKE_PROVIDER
+            )
+            == 8192
+        )
+        # Bedrock Converse nests the cap under inferenceConfig.maxTokens.
+        assert (
+            resolve_output_reservation(
+                {"inferenceConfig": {"maxTokens": 8192}}, provider="bedrock"
+            )
+            == 8192
+        )
+
+    def test_terminal_gate_reserves_final_clamped_cap(self, fake_65k_provider):
+        """The terminal gate must reserve 8192 (the clamped final cap), NOT the
+        65536 provider default — the exact user-given example."""
+        budget = build_final_context_budget(
+            {"model": "m", "messages": _msgs(1_000), "max_tokens": 8192},
+            provider=_FAKE_PROVIDER,
+            model="m",
+        )
+        assert budget.output_reservation == 8192
+        # ...and the total is input + 8192 (not input + 65536).
+        assert budget.total == (
+            budget.input_tokens_estimate + 8192
+        )
+
+    def test_no_cap_with_profile_reserves_profile_cap(self, fake_65k_provider):
+        """Converse of D: no max_tokens in final request + profile implicit
+        65536 → terminal reservation must be 65536, not 4096."""
+        budget = build_final_context_budget(
+            {"model": "m", "messages": _msgs(1_000)},
+            provider=_FAKE_PROVIDER,
+            model="m",
+        )
+        assert budget.output_reservation == 65_536
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E. Clamp-before-gate composition (#90877 semantics)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestClampBeforeGateComposition:
+    """The terminal gate judges the FINAL payload. A legitimate clamp that
+    reduces max_tokens so ``input + final_cap <= effective`` must ALLOW; a
+    request whose INPUT alone is at/over the effective window must REFUSE."""
+
+    def _allow(self, input_tokens: int, final_cap: int, effective: int):
+        """Assert the gate allows when input + final_cap <= effective."""
+        # Build a budget with the exact input estimate and the FINAL clamped
+        # cap, then enforce against the effective limit.
+        budget = build_final_context_budget(
+            {"messages": _msgs(max(1, input_tokens // 4)), "max_tokens": final_cap}
+        )
+        # Pin the input estimate to the exact target so the arithmetic is exact
+        # (the rough estimator is approximate; the resolver arithmetic is not).
+        object.__setattr__(
+            budget, "input_tokens_estimate", input_tokens
+        )
+        object.__setattr__(
+            budget, "total",
+            input_tokens + budget.system_tokens_estimate
+            + budget.tool_tokens_estimate + budget.output_reservation,
+        )
+        assert budget.output_reservation == final_cap
+        try:
+            enforce_final_context_budget(budget, ceiling=effective, reason="test")
+            allowed = True
+        except ContextCeilingExceeded:
+            allowed = False
+        return allowed
+
+    def test_clamped_request_within_budget_is_allowed(self):
+        """Original/default output allowance would overflow, but the FINAL
+        clamped cap makes input + final_cap <= effective → gate ALLOWS."""
+        # Effective window 100_000. Pre-clamp the output allowance was, say,
+        # 200_000 (would overflow). A legitimate clamp sets it to 8_000.
+        # input = 80_000 → 80_000 + 8_000 = 88_000 <= 100_000 → ALLOW.
+        assert self._allow(80_000, 8_000, 100_000) is True
+
+    def test_input_alone_at_or_over_window_is_refused(self):
+        """input >= effective window → terminal refusal regardless of cap."""
+        # input = 100_000, effective = 100_000, any cap → total > limit.
+        assert self._allow(100_000, 1_000, 100_000) is False
+        # input = 150_000 > 100_000 window → refuse.
+        assert self._allow(150_000, 1_000, 100_000) is False
+
+    def test_final_still_over_budget_after_transform_is_refused(self):
+        """After all transformations, if input + final_cap > effective → refuse.
+
+        input = 95_000, final_cap = 8_000 → 103_000 > 100_000 → REFUSE.
+        (Contrast with the allow case: 80_000 + 8_000 = 88_000 <= 100_000.)
+        """
+        assert self._allow(95_000, 8_000, 100_000) is False
+
+    def test_no_test_requires_rejecting_a_legitimate_clamp(self, fake_65k_provider):
+        """Pinning the audit's semantic point: a request is NOT rejected merely
+        because its PRE-CLAMP form would have exceeded the window — only its
+        FINAL (clamped) form is judged. With the final cap, it fits; the gate
+        must allow it."""
+        # Effective 100_000. Final (clamped) cap 8_000, input 80_000 → fits.
+        # Even though a hypothetical un-clamped 200_000 allowance would NOT fit,
+        # the gate sees only the FINAL 8_000 and must allow.
+        budget = build_final_context_budget(
+            {"messages": _msgs(20_000), "max_tokens": 8_000},
+            provider=_FAKE_PROVIDER, model="m",
+        )
+        object.__setattr__(budget, "input_tokens_estimate", 80_000)
+        object.__setattr__(
+            budget, "total",
+            80_000 + budget.system_tokens_estimate
+            + budget.tool_tokens_estimate + budget.output_reservation,
+        )
+        assert budget.output_reservation == 8_000  # clamped, not 65536
+        # 80_000 + 8_000 = 88_000 <= 100_000 → no raise.
+        enforce_final_context_budget(budget, ceiling=100_000, reason="clamp")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F. #92211 local-vs-native distinction (current equivalent contract)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestLocalVsNativeDistinction:
+    """A LOCAL ContextCeilingExceeded is a refusal, NOT an API error: it must
+    not be eligible for output-cap recovery and must not trigger a second
+    provider call. A GENUINE native provider output-cap 400 (after the local
+    gate allowed the request) remains eligible for the existing reduced-cap
+    recovery path."""
+
+    def test_local_refusal_is_not_an_output_cap_recovery_candidate(self):
+        # A local refusal is not a provider error string at all — the recovery
+        # predicates operate on provider error text, so a local refusal can
+        # never be misrouted into reduced-cap recovery.
+        exc = ContextCeilingExceeded(120_000, 100_000, reason="local")
+        # The exception is NOT an httpx/requests error and carries no provider
+        # status — it is a pure local refusal.
+        assert isinstance(exc, Exception)
+        err_text = str(exc)
+        # The output-cap recovery classifier must not treat it as a recoverable
+        # provider output-cap 400.
+        assert is_output_cap_error(err_text) is False
+        # (It has no parseable "available output tokens" number either.)
+        assert parse_available_output_tokens_from_error(err_text) is None
+
+    def test_genuine_native_output_cap_400_is_recoverable(self):
+        # A genuine native provider 400 that the LOCAL gate did NOT raise (it
+        # allowed the request) — the provider itself says the output cap is too
+        # large — must remain eligible for the existing reduced-cap recovery.
+        native_err = (
+            "400 error code - 'Range of max_tokens should be [1, 65536], "
+            "but got 81920 (request_id: abc123)'"
+        )
+        assert is_output_cap_error(native_err) is True
+        # ...and the recoverable number is extractable (65536) so the reduced
+        # cap can be applied.
+        assert parse_available_output_tokens_from_error(native_err) == 65_536
+
+    def test_local_refusal_and_native_400_are_distinct(self):
+        # The two are categorically different: local refusal is terminal by
+        # type; native 400 is a provider signal eligible for recovery.
+        local = ContextCeilingExceeded(120_000, 100_000, reason="local")
+        # A genuine native output-cap 400 (a phrasing the reduced-cap recovery
+        # path recognises and can extract a bounded cap from).
+        native = "Range of max_tokens should be [1, 65536], but got 81920"
+        # Local refusal: NOT an output-cap error, no recoverable cap.
+        assert not is_output_cap_error(str(local))
+        assert parse_available_output_tokens_from_error(str(local)) is None
+        # Native 400: IS an output-cap error with a recoverable cap (65536).
+        assert is_output_cap_error(native)
+        assert parse_available_output_tokens_from_error(native) == 65_536
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Item 3 — Auxiliary refusal terminality (owning test)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAuxiliaryRefusalTerminality:
+    """A LOCAL auxiliary ContextCeilingExceeded is terminal by TYPE: it must
+    NOT trigger a same-provider transient retry, a credential refresh, or a
+    fallback candidate — and it must result in ZERO provider calls.
+
+    This proves the ``except ContextCeilingExceeded: raise`` guards are
+    effective, independent of whether the retry predicate happens to match the
+    exception today.
+    """
+
+    def test_local_refusal_is_terminal_no_retry_no_refresh_no_fallback(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+        from agent import auxiliary_client as ac
+        from agent.model_metadata import ContextCeilingExceeded
+
+        # ── Spy client that records every physical provider call ──────────
+        class _SpyCompletions:
+            def __init__(self, calls):
+                self._calls = calls
+
+            def create(self, **kwargs):
+                self._calls.append(kwargs)
+                return SimpleNamespace(
+                    choices=[SimpleNamespace(
+                        message=SimpleNamespace(content="ok", tool_calls=[]),
+                        finish_reason="stop",
+                    )],
+                    usage=None, model="fake-model",
+                )
+
+        class _SpyChat:
+            def __init__(self, calls):
+                self.completions = _SpyCompletions(calls)
+
+        class _SpyClient:
+            def __init__(self):
+                self.create_calls: list = []
+                self.chat = _SpyChat(self.create_calls)
+                self.base_url = "https://fake.example/v1"
+
+        spy = _SpyClient()
+
+        # ── Record if credential refresh / fallback ever fires ────────────
+        refresh_calls: list = []
+
+        def _no_refresh_provider(*a, **k):
+            refresh_calls.append(("refresh_provider", a, k))
+            return False
+
+        def _no_nous_refresh(*a, **k):
+            refresh_calls.append(("nous_refresh", a, k))
+            return (None, None)
+
+        def _no_fallback_candidate_sync(*a, **k):
+            refresh_calls.append(("fallback_sync", a, k))
+            raise RuntimeError("fallback candidate called — MUST NOT happen")
+
+        def _no_fallback_candidate_async(*a, **k):
+            refresh_calls.append(("fallback_async", a, k))
+            raise RuntimeError("fallback candidate called — MUST NOT happen")
+
+        # effective_context_length is imported from model_metadata inside
+        # _call_llm_impl, so patch it there (not on the aux module). A tiny
+        # ceiling (1000) makes the FINAL payload's budget exceed it → the
+        # terminal gate refuses BEFORE any provider I/O.
+        with patch.object(ac, "_get_cached_client", return_value=(spy, "fake-model")), \
+             patch("agent.model_metadata.effective_context_length", return_value=1000), \
+             patch.object(ac, "_refresh_provider_credentials", side_effect=_no_refresh_provider, creating=True), \
+             patch.object(ac, "_refresh_nous_auxiliary_client", side_effect=_no_nous_refresh, creating=True), \
+             patch.object(ac, "_call_fallback_candidate_sync", side_effect=_no_fallback_candidate_sync, creating=True), \
+             patch.object(ac, "_call_fallback_candidate_async", side_effect=_no_fallback_candidate_async, creating=True):
+            with pytest.raises(ContextCeilingExceeded):
+                ac.call_llm(
+                    task="compression",
+                    provider="fake-65k",
+                    model="fake-model",
+                    base_url="https://fake.example/v1",
+                    api_key="test-key",
+                    messages=[
+                        {"role": "system", "content": "test"},
+                        # Large enough that input + reservation > 1000 ceiling.
+                        {"role": "user", "content": "x" * 20_000},
+                    ],
+                    max_tokens=8192,
+                )
+
+        # ── Assertions: the refusal was terminal by type ───────────────────
+        # 1. ZERO physical provider calls (no transient retry, no second call).
+        assert len(spy.create_calls) == 0, (
+            f"Physical provider .create was called {len(spy.create_calls)} times; "
+            "a local ContextCeilingExceeded must result in ZERO provider I/O."
+        )
+        # 2. NO credential refresh (provider, Nous, or pool rotation).
+        assert len(refresh_calls) == 0, (
+            f"Credential refresh / fallback fired {len(refresh_calls)} times: "
+            f"{refresh_calls}; a local refusal must not trigger any of these."
+        )

--- a/tests/gateway/relay/test_relay_slack_unfurl.py
+++ b/tests/gateway/relay/test_relay_slack_unfurl.py
@@ -412,6 +412,93 @@ class TestConsumerRoutesForceOnFinalAsFreshSend:
         assert ops[-1] == "edit", f"ops={ops}"
 
 
+class TestMultiplexPerChatFreshFinalSeam:
+    """The consumer must resolve the fresh-final decision through the CHAT's
+    negotiated platform, not the relay's primary identity (the scalar-vs-
+    per-chat descriptor seam).  Two failure directions:
+
+    - Slack PRIMARY + force-on unfurl: a fronted TELEGRAM chat must keep the
+      edit lane — its descriptor advertises no ``delete`` op, so a fresh
+      final would deliver the answer twice (orphaned preview).
+    - Non-Slack primary: a fronted SLACK chat must still get the fresh
+      stamped final, or the shipped feature is dark on exactly the chats it
+      was built for.
+    """
+
+    class _MultiplexTransport(_RecordingTransport):
+        def __init__(self):
+            super().__init__()
+            self.descriptors = {
+                "telegram": make_desc(
+                    platform="telegram",
+                    supports_edit=True,
+                    supported_ops=("send", "edit", "typing"),
+                ),
+                "slack": make_desc(
+                    platform="slack",
+                    supports_edit=True,
+                    supported_ops=("send", "edit", "typing", "delete"),
+                ),
+            }
+
+        def descriptor_for_platform(self, platform):
+            return self.descriptors.get(platform)
+
+    def _consumer(self, adapter, chat_id):
+        from gateway.stream_consumer import (
+            GatewayStreamConsumer,
+            StreamConsumerConfig,
+        )
+
+        return GatewayStreamConsumer(
+            adapter=adapter, chat_id=chat_id, config=StreamConsumerConfig(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_telegram_chat_on_slack_primary_keeps_edit_lane(self):
+        transport = self._MultiplexTransport()
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": True}}),
+            make_desc(platform="slack", supports_edit=True),  # Slack PRIMARY
+            transport=transport,
+        )
+        # Relay learned this chat is Telegram from inbound traffic.
+        a._platform_by_chat["TG1"] = "telegram"
+
+        consumer = self._consumer(a, "TG1")
+        await consumer._send_or_edit("Working on it…")
+        await consumer._send_or_edit("see https://studiotwin.ai", finalize=True)
+
+        ops = [x.get("op") for x in transport.actions]
+        assert ops[-1] == "edit", (
+            f"telegram chat misrouted through fresh-final: ops={ops}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_slack_chat_on_telegram_primary_gets_fresh_final(self):
+        transport = self._MultiplexTransport()
+        a = RelayAdapter(
+            PlatformConfig(extra={"slack": {"unfurl_links": True}}),
+            make_desc(platform="telegram", supports_edit=True),  # non-Slack primary
+            transport=transport,
+        )
+        a._platform_by_chat["D1"] = "slack"
+
+        consumer = self._consumer(a, "D1")
+        await consumer._send_or_edit("Working on it…")
+        await consumer._send_or_edit("see https://studiotwin.ai", finalize=True)
+
+        ops = [x.get("op") for x in transport.actions]
+        # Fresh stamped final followed by cleanup of the sealed preview
+        # (Slack's descriptor advertises delete) — no duplicate.
+        assert "delete" in ops, f"preview not cleaned up: ops={ops}"
+        sends = [x for x in transport.actions if x.get("op") == "send"]
+        assert len(sends) == 2, f"slack chat on non-slack primary left dark: ops={ops}"
+        final = sends[-1]
+        assert final["content"] == "see https://studiotwin.ai"
+        assert final["metadata"]["unfurl_links"] is True
+
+
 class TestDeleteOpForFreshFinalCleanup:
     """Relay delete_message: emitted only when the negotiated descriptor
     advertises the additive `delete` op; older connectors degrade to the

--- a/tests/gateway/test_codex_hygiene_compaction.py
+++ b/tests/gateway/test_codex_hygiene_compaction.py
@@ -1,0 +1,338 @@
+"""Regression tests for #73503 — codex_app_server compression must not be a no-op.
+
+On the codex_app_server runtime the model's real working context is the
+app-server's server-side thread (CodexAppServerSession is constructed with no
+history and each turn submits only the new user message), so:
+
+* the old detached-agent hygiene path could only rewrite the transcript
+  mirror — a guaranteed no-op ("compressed 150 -> 150 msgs") — and then
+  evicted the live cached agent, destroying the thread that held the only
+  real context;
+* the fix routes hygiene and manual /compress to the LIVE cached agent's
+  ``thread/compact/start`` (asserted here at the compact_thread RPC-stub
+  boundary) and keeps that agent cached;
+* ``compression.codex_app_server_auto`` semantics hold: only ``hermes``
+  lets Hermes' threshold start a compaction; ``native``/``off`` skip
+  cleanly, and no mode ever runs the local transcript compressor.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from agent.conversation_compression import compress_context
+from agent.transports.codex_app_server_session import TurnResult
+from gateway.run import run_codex_hygiene_compaction
+
+
+class FakeCodexSession:
+    """RPC-stub boundary: stands in for the app-server thread client."""
+
+    def __init__(self, result=None):
+        self.result = result or TurnResult(
+            thread_id="thread-1", turn_id="compact-1", compacted=True
+        )
+        self.compact_calls = 0
+        self.closed = False
+
+    def compact_thread(self):
+        self.compact_calls += 1
+        return self.result
+
+    def close(self):
+        self.closed = True
+
+
+class LiveCodexAgent:
+    """Minimal live cached agent whose _compress_context is the REAL routing.
+
+    The forwarder mirrors run_agent.AIAgent._compress_context: it calls the
+    module-level compress_context(), so these tests exercise the genuine
+    codex route (mode gate, cooldown, compact_thread RPC) rather than a stub
+    of the code under test.
+    """
+
+    def __init__(self, mode="hermes", session=None):
+        self.api_mode = "codex_app_server"
+        self.codex_app_server_auto_compaction = mode
+        self.session_id = "sess-1"
+        self.platform = "telegram"
+        self._cached_system_prompt = "cached prompt"
+        self._codex_session = session if session is not None else FakeCodexSession()
+        self.context_compressor = SimpleNamespace(
+            compression_count=0,
+            last_compression_rough_tokens=0,
+            last_prompt_tokens=100,
+            last_completion_tokens=10,
+            awaiting_real_usage_after_compression=False,
+        )
+        self.local_compress_calls = 0
+        self.warnings = []
+
+    # -- surface used by compress_context --------------------------------
+    def _touch_activity(self, *a, **k):
+        pass
+
+    def _emit_status(self, m):
+        pass
+
+    def _emit_warning(self, m):
+        self.warnings.append(m)
+
+    def _build_system_prompt(self, s):
+        return "built prompt"
+
+    def _compress_context(self, messages, system_message, **kwargs):
+        return compress_context(self, messages, system_message, **kwargs)
+
+
+def _history(n=150):
+    return [
+        {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}" * 50}
+        for i in range(n)
+    ]
+
+
+def _gateway(tmp_path, session_key="tg:123", agent=None):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    gw = SimpleNamespace(
+        _agent_cache={} if agent is None else {session_key: (agent, 0.0)},
+        _agent_cache_lock=None,
+        _session_db=db,
+    )
+    return gw, db
+
+
+# ---------------------------------------------------------------------------
+# Core no-op regression: hermes mode + live thread => thread/compact runs
+# ---------------------------------------------------------------------------
+
+def test_hermes_mode_compacts_live_thread_at_rpc_boundary(tmp_path):
+    agent = LiveCodexAgent(mode="hermes")
+    key = "tg:123"
+    gw, db = _gateway(tmp_path, key, agent)
+    # Pre-arm a persisted failure streak so success provably resets it
+    # through the REAL SessionDB (hygiene path involves the DB).
+    assert db.increment_hygiene_failure_streak(key) == 1
+
+    outcome = asyncio.run(
+        run_codex_hygiene_compaction(
+            gw,
+            key,
+            agent.session_id,
+            auto_mode="hermes",
+            history=_history(),
+            approx_tokens=345_000,
+            timeout_seconds=30.0,
+        )
+    )
+
+    assert outcome == "compacted"
+    # The no-op is gone: the thread genuinely shrank via the app-server's own
+    # mechanism — asserted at the RPC-stub boundary.
+    assert agent._codex_session.compact_calls == 1
+    # A compaction boundary was recorded on the live agent's compressor.
+    assert agent.context_compressor.compression_count == 1
+    # The live agent is STILL cached — hygiene must not evict the thread owner.
+    assert gw._agent_cache[key][0] is agent
+    # Success reset the persisted hygiene failure streak.
+    assert db.increment_hygiene_failure_streak(key) == 1  # was cleared to 0
+
+
+def test_hermes_mode_without_cached_agent_skips_without_local_compression(tmp_path):
+    # Detached case: no live agent → no thread → nothing real to compact.
+    # The old behavior "compressed" the mirror (a no-op) and then evicted;
+    # the new behavior is an honest skip with the transcript untouched.
+    gw, _ = _gateway(tmp_path, agent=None)
+    history = _history()
+    before = [dict(m) for m in history]
+
+    outcome = asyncio.run(
+        run_codex_hygiene_compaction(
+            gw,
+            "tg:123",
+            "sess-1",
+            auto_mode="hermes",
+            history=history,
+            approx_tokens=345_000,
+            timeout_seconds=5.0,
+        )
+    )
+
+    assert outcome == "skipped:no-cached-agent"
+    assert history == before
+
+
+# ---------------------------------------------------------------------------
+# Mode semantics: native / off never touch the thread nor run local fallback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mode", ["native", "off"])
+def test_native_and_off_modes_skip_cleanly(tmp_path, mode):
+    agent = LiveCodexAgent(mode=mode)
+    key = "tg:123"
+    gw, _ = _gateway(tmp_path, key, agent)
+
+    outcome = asyncio.run(
+        run_codex_hygiene_compaction(
+            gw,
+            key,
+            agent.session_id,
+            auto_mode=mode,
+            history=_history(),
+            approx_tokens=345_000,
+            timeout_seconds=5.0,
+        )
+    )
+
+    assert outcome == f"skipped:mode={mode}"
+    # off must not silently compress; native leaves scheduling to codex.
+    assert agent._codex_session.compact_calls == 0
+    assert agent.context_compressor.compression_count == 0
+    # And the agent stays cached in every skip path.
+    assert gw._agent_cache[key][0] is agent
+
+
+def test_unknown_mode_falls_back_to_native_semantics(tmp_path):
+    agent = LiveCodexAgent(mode="banana")
+    gw, _ = _gateway(tmp_path, "tg:123", agent)
+    outcome = asyncio.run(
+        run_codex_hygiene_compaction(
+            gw,
+            "tg:123",
+            agent.session_id,
+            auto_mode="banana",
+            history=_history(),
+            approx_tokens=345_000,
+            timeout_seconds=5.0,
+        )
+    )
+    assert outcome == "skipped:mode=native"
+    assert agent._codex_session.compact_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# force=True (manual /compress) must never violate the "no local fallback"
+# contract: it compacts the THREAD in every mode, and never rewrites the
+# transcript mirror.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mode", ["native", "hermes", "off"])
+def test_force_compacts_thread_never_local_fallback(mode):
+    agent = LiveCodexAgent(mode=mode)
+    messages = _history()
+    before = [dict(m) for m in messages]
+
+    returned, prompt = compress_context(
+        agent, messages, "system", approx_tokens=345_000, force=True
+    )
+
+    # Thread compaction ran (manual force is an explicit user decision)...
+    assert agent._codex_session.compact_calls == 1
+    # ...and the local transcript mirror was NOT rewritten in any mode.
+    assert returned is messages
+    assert returned == before
+    assert prompt == "cached prompt"
+
+
+@pytest.mark.parametrize("mode", ["native", "off"])
+def test_force_without_live_thread_does_not_run_local_compressor(mode):
+    # The #73715 branch let force=True fall through to the local Hermes
+    # compressor in native/off when no thread existed. That is wrong on this
+    # runtime in every mode: rewriting the mirror cannot shrink the thread.
+    agent = LiveCodexAgent(mode=mode, session=None)
+    agent._codex_session = None
+    messages = _history()
+    before = [dict(m) for m in messages]
+
+    returned, _ = compress_context(
+        agent, messages, "system", approx_tokens=345_000, force=True
+    )
+
+    assert returned is messages
+    assert returned == before
+    assert agent.context_compressor.compression_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Failure handling: a wedged compaction records a DB cooldown (real SessionDB)
+# ---------------------------------------------------------------------------
+
+def test_timeout_records_persistent_cooldown(tmp_path):
+    class HangingSession(FakeCodexSession):
+        def compact_thread(self):
+            self.compact_calls += 1
+            import time
+
+            time.sleep(3.0)
+            return self.result
+
+    agent = LiveCodexAgent(mode="hermes", session=HangingSession())
+    key = "tg:123"
+    gw, db = _gateway(tmp_path, key, agent)
+    db.create_session(agent.session_id, "gateway")
+
+    outcome = asyncio.run(
+        run_codex_hygiene_compaction(
+            gw,
+            key,
+            agent.session_id,
+            auto_mode="hermes",
+            history=_history(),
+            approx_tokens=345_000,
+            timeout_seconds=1.0,
+            failure_cooldown_seconds=300.0,
+        )
+    )
+
+    assert outcome == "failed:timeout"
+    state = db.get_compression_failure_cooldown(agent.session_id)
+    assert state is not None and state.get("remaining_seconds", 0) > 0
+    # Even on failure the live agent stays cached — its thread still holds
+    # the only real context.
+    assert gw._agent_cache[key][0] is agent
+
+
+# ---------------------------------------------------------------------------
+# Manual /compress gateway surface
+# ---------------------------------------------------------------------------
+
+def _slash_host(agent, session_key="tg:123"):
+    from gateway.slash_commands import GatewaySlashCommandsMixin
+
+    host = SimpleNamespace(
+        _agent_cache={session_key: (agent, 0.0)} if agent is not None else {},
+        _agent_cache_lock=None,
+    )
+
+    async def _run_in_executor_with_context(fn):
+        return await asyncio.get_running_loop().run_in_executor(None, fn)
+
+    host._run_in_executor_with_context = _run_in_executor_with_context
+    host._compress_codex_app_server_session = (
+        GatewaySlashCommandsMixin._compress_codex_app_server_session.__get__(host)
+    )
+    return host
+
+
+def test_manual_compress_routes_to_live_thread():
+    agent = LiveCodexAgent(mode="off")  # even 'off': manual is a user decision
+    host = _slash_host(agent)
+
+    reply = asyncio.run(
+        host._compress_codex_app_server_session("tg:123", agent.session_id)
+    )
+
+    assert agent._codex_session.compact_calls == 1
+    assert "compacted" in reply
+
+
+def test_manual_compress_without_live_thread_reports_honestly():
+    host = _slash_host(None)
+    reply = asyncio.run(
+        host._compress_codex_app_server_session("tg:123", "sess-1")
+    )
+    assert "Nothing to compact" in reply

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -1,0 +1,708 @@
+"""Behavior tests for deterministic same-gateway Discussion policy."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+
+
+ROOM_ID = "room-1"
+GATEWAY_ID = "gateway-a"
+LOCAL_PROFILES = ("research", "build", "review", "ops", "qa", "docs")
+MEMBERS = [
+    {
+        "member_id": f"member-{profile}",
+        "profile": profile,
+        "handle": profile,
+        "display_name": profile.title(),
+    }
+    for profile in LOCAL_PROFILES[:3]
+]
+
+
+@pytest.fixture
+def room_db(tmp_path: Path) -> tuple[Path, dict]:
+    db = tmp_path / "state.db"
+    room = hosted_rooms.create_room(
+        db,
+        room_id=ROOM_ID,
+        name="Release",
+        members=MEMBERS,
+        authority_gateway_id=GATEWAY_ID,
+        now=1,
+    )
+    return db, room
+
+
+def _events(db: Path) -> list[dict]:
+    return hosted_rooms.read_events(
+        db,
+        room_id=ROOM_ID,
+        since_seq=0,
+        limit=hosted_rooms.MAX_LOG_LIMIT,
+    )["events"]
+
+
+def _append_user(
+    db: Path,
+    *,
+    event_id: str,
+    text: str,
+    thread_id: str = "thread-1",
+) -> dict:
+    return hosted_rooms.append_event(
+        db,
+        room_id=ROOM_ID,
+        event_id=event_id,
+        kind="message.user",
+        actor={"kind": "user", "id": "local-user"},
+        authority_gateway_id=GATEWAY_ID,
+        authority_epoch=1,
+        payload={"text": text, "thread_id": thread_id},
+        now=time.time(),
+    )
+
+
+def _append_publication(
+    db: Path,
+    plan: discussion.PublicationPlan,
+) -> list[dict]:
+    return [
+        hosted_rooms.append_event(
+            db,
+            **event.append_kwargs(ROOM_ID),
+            now=time.time(),
+        )
+        for event in plan.events
+    ]
+
+
+def _append_activity(
+    db: Path,
+    *,
+    event_id: str,
+    discussion_event_id: str,
+    thread_id: str,
+) -> dict:
+    return hosted_rooms.append_event(
+        db,
+        room_id=ROOM_ID,
+        event_id=event_id,
+        kind="room.activity",
+        actor={"kind": "gateway", "id": GATEWAY_ID},
+        payload={
+            "status": "settled",
+            "reason_code": "silent_round",
+            "thread_id": thread_id,
+            "discussion_event_id": discussion_event_id,
+        },
+        authority_gateway_id=GATEWAY_ID,
+        authority_epoch=1,
+    )
+
+
+def _next_task(room: dict, db: Path) -> discussion.DiscussionTaskPlan:
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "task", decision
+    assert decision.task is not None
+    return decision.task
+
+
+def _settle_next(
+    room: dict,
+    db: Path,
+    *,
+    text: str,
+) -> discussion.DiscussionTaskPlan:
+    task = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": text},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, publication)
+    return task
+
+
+def test_deferred_member_allows_next_mentioned_member_and_later_terminal_result(
+    room_db,
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    first = _next_task(room, db)
+    deferred = discussion.plan_publication(
+        room,
+        _events(db),
+        first,
+        status="deferred",
+        result={"reason": "member_unavailable"},
+        execution_generation=1,
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, deferred)
+
+    second = _next_task(room, db)
+    assert second.member.member_id != first.member.member_id
+
+    settled = discussion.plan_publication(
+        room,
+        _events(db),
+        first,
+        status="settled",
+        result={"text": "Recovered on explicit retry."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, settled)
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "task"
+    assert decision.task is not None
+    assert decision.task.member.member_id == second.member.member_id
+
+
+def test_distinct_threads_are_planned_fifo_without_skipping(room_db):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First", thread_id="thread-1")
+    _append_user(db, event_id="user-2", text="Second", thread_id="thread-2")
+
+    first = _next_task(room, db)
+    assert first.discussion_event_id == "user-1"
+    _append_activity(
+        db,
+        event_id="activity-1",
+        discussion_event_id="user-1",
+        thread_id="thread-1",
+    )
+    second = _next_task(room, db)
+    assert second.discussion_event_id == "user-2"
+
+
+def test_room_stop_fences_old_work_but_allows_a_later_message(room_db):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First", thread_id="thread-1")
+    stop = hosted_rooms.request_room_stop(
+        db,
+        room_id=ROOM_ID,
+        cancel_id="user-stop-1",
+        expected_gateway_id=str(room["authority_gateway_id"]),
+        expected_epoch=int(room["authority_epoch"]),
+    )
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "idle"
+    assert stop["kind"] == "room.stop_requested"
+
+    _append_user(db, event_id="user-2", text="Continue", thread_id="thread-2")
+    resumed = _next_task(room, db)
+    assert resumed.discussion_event_id == "user-2"
+
+
+def test_deterministic_task_fits_existing_driver_and_reconstructs_after_restart(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    user = _append_user(db, event_id="user-1", text="Check the release.")
+
+    first = _next_task(room, db)
+    repeated = _next_task(room, db)
+    assert first == repeated
+    assert first.identity.thread_id == "thread-1"
+    assert first.payload == {
+        "target_profile": "research",
+        "prompt": first.payload["prompt"],
+        "source_event_seq": user["seq"],
+    }
+    assert set(first.payload) == {"target_profile", "prompt", "source_event_seq"}
+
+    admitted = driver.admit_task(
+        db,
+        first.identity,
+        payload=first.payload,
+        clock=time.time,
+    )
+    stored = driver.get_task(db, first.identity)
+    reconstructed = discussion.reconstruct_task_plan(
+        room,
+        _events(db),
+        stored,
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert admitted["status"] == "queued"
+    assert reconstructed == first
+
+    reopened_events = _events(db)
+    assert (
+        discussion.reconstruct_task_plan(
+            room,
+            reopened_events,
+            driver.get_task(db, first.identity),
+            local_profiles=LOCAL_PROFILES,
+        )
+        == first
+    )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_profile"),
+    [
+        ("@build please inspect this", "build"),
+        ("@all inspect this", "research"),
+        ("@everyone inspect this", "research"),
+        ("inspect this", "research"),
+        ("@unknown inspect this", "research"),
+    ],
+)
+def test_mentions_select_handles_or_everyone(
+    room_db: tuple[Path, dict],
+    text: str,
+    expected_profile: str,
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text=text)
+
+    assert _next_task(room, db).member.profile == expected_profile
+
+
+def test_member_mention_joins_the_next_round_not_the_current_round(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="@research lead this")
+
+    first = _settle_next(room, db, text="@build can add the implementation detail.")
+    second = _next_task(room, db)
+
+    assert first.member.profile == "research"
+    assert first.round_index == 0
+    assert second.member.profile == "build"
+    assert second.round_index == 1
+    assert "@research lead this" in second.payload["prompt"]
+    assert "@build can add the implementation detail." in second.payload["prompt"]
+
+
+def test_plain_member_reply_does_not_wake_another_bot_round(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="@research answer the user")
+    _settle_next(room, db, text="The answer is ready for the user.")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    assert decision.status == "settled"
+    assert decision.reason == "silent_round"
+
+
+@pytest.mark.parametrize("value", ["", "pass", "pass.", "(pass)", " ( PASS ). "])
+def test_pass_detection(value: str):
+    assert discussion.is_pass_text(value)
+
+
+def test_real_text_is_not_a_pass():
+    assert not discussion.is_pass_text("I found the issue.")
+
+
+def test_full_pass_round_settles_without_member_messages(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Any concerns?")
+
+    for _member in MEMBERS:
+        _settle_next(room, db, text="(pass)")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "settled"
+    assert decision.reason == "silent_round"
+    assert [event["kind"] for event in _events(db)].count("message.member") == 0
+
+
+def test_failed_members_advance_the_round_as_silence(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Any concerns?")
+
+    for expected in ("research", "build", "review"):
+        task = _next_task(room, db)
+        assert task.member.profile == expected
+        publication = discussion.plan_publication(
+            room,
+            _events(db),
+            task,
+            status="failed",
+            result={"error": f"{expected} unavailable"},
+            local_profiles=LOCAL_PROFILES,
+        )
+        assert publication.terminal_kind == "turn.failed"
+        assert len(publication.events) == 1
+        _append_publication(db, publication)
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "settled"
+    assert decision.reason == "silent_round"
+
+
+def test_publication_is_idempotent_and_changed_result_conflicts(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    task = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Ready."},
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    first = _append_publication(db, publication)
+    repeated = _append_publication(db, publication)
+    assert [event["seq"] for event in first] == [event["seq"] for event in repeated]
+    assert all(event["idempotent"] for event in repeated)
+
+    changed = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Different."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    with pytest.raises(hosted_rooms.EventConflictError):
+        _append_publication(db, changed)
+
+
+def test_partial_publication_replays_same_effects_before_policy_advances(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    task = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Ready."},
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    message_effect = publication.events[0]
+    hosted_rooms.append_event(
+        db,
+        **message_effect.append_kwargs(ROOM_ID),
+        now=time.time(),
+    )
+    assert _next_task(room, db).identity == task.identity
+
+    replayed = discussion.plan_publication(
+        room,
+        _events(db),
+        task,
+        status="settled",
+        result={"text": "Ready."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    _append_publication(db, replayed)
+    assert _next_task(room, db).member.profile == "build"
+
+
+def test_watermark_excludes_a_members_old_input_and_own_reply(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Old request.")
+    first = _settle_next(room, db, text="Old answer.")
+    watermark = discussion.derive_member_watermarks(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )[("thread-1", first.member.member_id)]
+    assert watermark == max(
+        event["seq"]
+        for event in _events(db)
+        if event["kind"] == "message.member"
+        and event["payload"]["task_id"] == first.identity.task_id
+    )
+
+    latest = _append_user(db, event_id="user-2", text="New request.")
+    next_task = _next_task(room, db)
+    assert next_task.member.profile == "research"
+    assert next_task.payload["source_event_seq"] == latest["seq"]
+    assert "New request." in next_task.payload["prompt"]
+    assert "Old request." not in next_task.payload["prompt"]
+    assert "Old answer." not in next_task.payload["prompt"]
+
+
+def test_newer_same_thread_user_event_cancels_a_late_result(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First request.")
+    stale = _next_task(room, db)
+    latest = _append_user(db, event_id="user-2", text="Second request.")
+
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        stale,
+        status="settled",
+        result={"text": "Late stale answer."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert publication.terminal_kind == "turn.cancelled"
+    assert [event.kind for event in publication.events] == ["turn.cancelled"]
+    assert publication.events[0].payload["reason"] == "superseded_by_newer_user_event"
+    _append_publication(db, publication)
+
+    current = _next_task(room, db)
+    assert current.payload["source_event_seq"] == latest["seq"]
+    assert "Second request." in current.payload["prompt"]
+
+
+def test_cross_thread_newer_user_does_not_discard_completed_old_reply(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="First request.", thread_id="thread-1")
+    old = _next_task(room, db)
+    _append_user(db, event_id="user-2", text="Other topic.", thread_id="thread-2")
+
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        old,
+        status="settled",
+        result={"text": "Completed first topic."},
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert [event.kind for event in publication.events] == [
+        "message.member",
+        "turn.settled",
+    ]
+
+
+def test_oversized_member_reply_is_truncated_and_next_turn_stays_serviceable(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(
+        db,
+        event_id="user-large",
+        text="u" * discussion.MAX_USER_TEXT_BYTES,
+    )
+    first = _next_task(room, db)
+    publication = discussion.plan_publication(
+        room,
+        _events(db),
+        first,
+        status="settled",
+        result={"text": "é" * (discussion.MAX_MEMBER_TEXT_BYTES + 100)},
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    member_event = next(event for event in publication.events if event.kind == "message.member")
+    member_text = member_event.payload["text"]
+    assert len(member_text.encode("utf-8")) <= discussion.MAX_MEMBER_TEXT_BYTES
+    assert member_text.endswith("share the full result as a file.]")
+    _append_publication(db, publication)
+
+    followup = _next_task(room, db)
+    assert len(followup.payload["prompt"].encode("utf-8")) <= driver.MAX_PROMPT_BYTES
+    assert "Earlier content omitted" in followup.payload["prompt"]
+
+
+def test_three_round_bound(room_db: tuple[Path, dict]):
+    db, room = room_db
+    room["members"] = MEMBERS[:2]
+    _append_user(db, event_id="user-1", text="Discuss.")
+
+    for index in range(6):
+        task = _next_task(room, db)
+        peer = "build" if task.member.profile == "research" else "research"
+        publication = discussion.plan_publication(
+            room,
+            _events(db),
+            task,
+            status="settled",
+            result={"text": f"Reply {index}. @{peer}"},
+            local_profiles=LOCAL_PROFILES,
+        )
+        _append_publication(db, publication)
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "bounded"
+    assert decision.reason == "max_rounds"
+
+
+def test_ten_message_bound(tmp_path: Path):
+    db = tmp_path / "state.db"
+    members = [
+        {
+            "member_id": f"member-{profile}",
+            "profile": profile,
+            "handle": profile,
+        }
+        for profile in LOCAL_PROFILES
+    ]
+    room = hosted_rooms.create_room(
+        db,
+        room_id=ROOM_ID,
+        name="Large",
+        members=members,
+        authority_gateway_id=GATEWAY_ID,
+        now=1,
+    )
+    _append_user(db, event_id="user-1", text="Discuss.")
+
+    for index in range(discussion.MAX_DISCUSSION_MESSAGES):
+        _settle_next(room, db, text=f"Reply {index}. @everyone")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+    assert decision.status == "bounded"
+    assert decision.reason == "max_messages"
+
+
+def test_prompt_delta_is_bounded_to_24_message_lines(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    for index in range(30):
+        _append_user(
+            db,
+            event_id=f"user-{index}",
+            text=f"Message {index}.",
+        )
+
+    task = _next_task(room, db)
+    assert task.payload["prompt"].count("User (user):") == 24
+    assert "Message 5." not in task.payload["prompt"]
+    assert "Message 6." in task.payload["prompt"]
+    assert "Message 29." in task.payload["prompt"]
+
+
+def test_attachment_payload_is_rejected_by_local_text_only_boundary():
+    with pytest.raises(discussion.DiscussionValidationError, match="unknown fields"):
+        discussion.validate_user_payload({
+            "text": "Review.",
+            "thread_id": "thread-1",
+            "attachments": [{"name": "notes.txt"}],
+        })
+
+
+@pytest.mark.parametrize(
+    ("members", "match"),
+    [
+        (MEMBERS[:1], "between 2 and 6"),
+        (MEMBERS + MEMBERS + MEMBERS[:1], "between 2 and 6"),
+        (
+            [MEMBERS[0], {**MEMBERS[1], "profile": "research"}],
+            "profiles must be unique",
+        ),
+        ([MEMBERS[0], {**MEMBERS[1], "handle": "RESEARCH"}], "handles must be unique"),
+        (
+            [MEMBERS[0], {**MEMBERS[1], "member_id": "MEMBER-RESEARCH"}],
+            "ids must be unique",
+        ),
+        ([MEMBERS[0], {**MEMBERS[1], "route": {"mode": "ssh"}}], "cross-gateway"),
+        ([MEMBERS[0], {**MEMBERS[1], "connectionId": "remote"}], "cross-gateway"),
+        ([MEMBERS[0], {**MEMBERS[1], "profile": "missing"}], "not local"),
+    ],
+)
+def test_malformed_or_remote_roster_is_rejected(members: list[dict], match: str):
+    with pytest.raises(discussion.DiscussionValidationError, match=match):
+        discussion.validate_roster(members, local_profiles=LOCAL_PROFILES)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"text": "hello"},
+        {"text": "hello", "thread_id": "thread-1", "images": []},
+        {"text": "", "thread_id": "thread-1"},
+        {"text": "hello", "thread_id": "../escape"},
+        {"text": ["hello"], "thread_id": "thread-1"},
+    ],
+)
+def test_user_payload_is_exact_and_text_only(payload: dict):
+    with pytest.raises(discussion.DiscussionValidationError):
+        discussion.validate_user_payload(payload)
+
+
+def test_malformed_log_and_task_reconstruction_fail_closed(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="Report.")
+    _append_user(db, event_id="user-2", text="Report again.")
+    task = _next_task(room, db)
+    events = _events(db)
+
+    with pytest.raises(discussion.DiscussionValidationError, match="sequence order"):
+        discussion.plan_next_task(
+            room,
+            list(reversed(events)),
+            local_profiles=LOCAL_PROFILES,
+        )
+
+    malformed = {
+        "identity": driver.TaskIdentity(
+            room_id=task.identity.room_id,
+            task_id="dtask:wrong",
+            thread_id=task.identity.thread_id,
+            turn_id=task.identity.turn_id,
+        ),
+        "payload": dict(task.payload),
+    }
+    with pytest.raises(
+        discussion.DiscussionReconstructionError,
+        match="deterministic reconstruction",
+    ):
+        discussion.reconstruct_task_plan(
+            room,
+            events,
+            malformed,
+            local_profiles=LOCAL_PROFILES,
+        )

--- a/tests/gateway/test_hosted_room_driver.py
+++ b/tests/gateway/test_hosted_room_driver.py
@@ -1,0 +1,1110 @@
+"""Behavior tests for the hosted-room driver state machine."""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+import pytest
+
+from gateway import hosted_rooms as rooms
+from gateway import hosted_room_driver as driver
+
+
+class FakeClock:
+    def __init__(self, value: float = 100.0):
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def _identity(task_id: str = "task-1", *, turn_id: str = "turn-1"):
+    return driver.TaskIdentity(
+        room_id="room-1",
+        task_id=task_id,
+        thread_id="thread-1",
+        turn_id=turn_id,
+    )
+
+
+def _payload(
+    *,
+    target_profile: str = "ops",
+    prompt: str = "Inspect the release candidate.",
+    source_event_seq: int = 1,
+):
+    return {
+        "target_profile": target_profile,
+        "prompt": prompt,
+        "source_event_seq": source_event_seq,
+    }
+
+
+@pytest.fixture
+def db(tmp_path):
+    path = tmp_path / "state.db"
+    rooms.create_room(
+        path,
+        room_id="room-1",
+        name="Release room",
+        members=[{"profile": "ops", "handle": "ops"}],
+        authority_gateway_id="gateway-a",
+        now=90,
+    )
+    return path
+
+
+def _lease(
+    db,
+    clock,
+    *,
+    gateway="gateway-a",
+    authority_epoch=1,
+    process="process-a",
+    ttl=30,
+):
+    return driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=gateway,
+        authority_epoch=authority_epoch,
+        process_generation=process,
+        ttl_seconds=ttl,
+        clock=clock,
+    )
+
+
+def _admit(db, identity, clock, *, payload=None):
+    return driver.admit_task(
+        db,
+        identity,
+        payload=_payload() if payload is None else payload,
+        clock=clock,
+    )
+
+
+def _open_driver_schema(path: str) -> int:
+    return len(driver.list_tasks(path, room_id="room-1"))
+
+
+def test_two_contenders_have_one_winner(db):
+    clock = FakeClock()
+
+    def contend(process):
+        try:
+            return _lease(db, clock, process=process)
+        except driver.LeaseHeldError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(contend, ["process-a", "process-b"]))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert winners[0].lease_generation == 1
+
+
+def test_expiry_allows_reclaim_and_fences_stale_renew_and_release(db):
+    clock = FakeClock()
+    first = _lease(db, clock, ttl=5)
+
+    clock.advance(5)
+    second = _lease(db, clock, process="process-b")
+
+    assert second.reclaimed is True
+    assert second.lease_generation == first.lease_generation + 1
+    with pytest.raises(driver.StaleLeaseError):
+        driver.renew_lease(db, first, ttl_seconds=30, clock=clock)
+    with pytest.raises(driver.StaleLeaseError):
+        driver.release_lease(db, first, clock=clock)
+
+
+def test_nonexistent_and_disbanded_rooms_cannot_lease_or_admit(db):
+    clock = FakeClock()
+    missing = driver.TaskIdentity("missing-room", "task", "thread", "turn")
+
+    with pytest.raises(driver.RoomUnavailableError, match="does not exist"):
+        driver.acquire_lease(
+            db,
+            room_id="missing-room",
+            gateway_id="gateway-a",
+            authority_epoch=1,
+            process_generation="process-a",
+            ttl_seconds=30,
+            clock=clock,
+        )
+    with pytest.raises(driver.RoomUnavailableError, match="does not exist"):
+        _admit(db, missing, clock)
+
+    rooms.disband_room(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        now=clock(),
+    )
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        _lease(db, clock)
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        _admit(db, _identity(), clock)
+
+
+@pytest.mark.parametrize(
+    ("gateway", "authority_epoch"),
+    [("gateway-b", 1), ("gateway-a", 2)],
+)
+def test_acquire_requires_current_room_authority(db, gateway, authority_epoch):
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        _lease(
+            db,
+            FakeClock(),
+            gateway=gateway,
+            authority_epoch=authority_epoch,
+        )
+
+
+def test_same_process_acquire_and_release_are_idempotent(db):
+    clock = FakeClock()
+    first = _lease(db, clock)
+    repeated = _lease(db, clock)
+
+    assert repeated.lease_generation == first.lease_generation
+    released = driver.release_lease(db, repeated, clock=clock)
+    released_again = driver.release_lease(db, repeated, clock=clock)
+
+    assert released["idempotent"] is False
+    assert released_again["idempotent"] is True
+
+
+def test_renew_extends_only_the_current_lease_generation(db):
+    clock = FakeClock()
+    lease = _lease(db, clock, ttl=5)
+
+    clock.advance(2)
+    renewed = driver.renew_lease(db, lease, ttl_seconds=20, clock=clock)
+
+    assert renewed.lease_generation == lease.lease_generation
+    assert renewed.expires_at == 122
+
+
+def test_authority_transfer_fences_lease_and_late_settlement(db):
+    clock = FakeClock()
+    identity = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    old_lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    _admit(db, queued, clock)
+    old_attempt = driver.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=clock(),
+    )
+
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.renew_lease(db, old_lease, ttl_seconds=30, clock=clock)
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.start_task(
+            db,
+            queued,
+            old_lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.recover_room(db, old_lease, clock=clock)
+    with pytest.raises(driver.StaleLeaseError, match="authority changed"):
+        driver.settle_task(
+            db,
+            old_attempt,
+            settlement_id="late-settlement",
+            status="settled",
+            result={"text": "late"},
+            clock=clock,
+        )
+
+    new_lease = _lease(
+        db,
+        clock,
+        gateway="gateway-b",
+        authority_epoch=2,
+        process="process-b",
+    )
+    recovery = driver.recover_room(db, new_lease, clock=clock)
+    assert new_lease.lease_generation == old_lease.lease_generation + 1
+    assert recovery["indeterminate"] == [identity]
+    assert recovery["queued"] == [queued]
+
+
+def test_room_disband_fences_active_lease_operations(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    rooms.disband_room(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        now=clock(),
+    )
+
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.renew_lease(db, lease, ttl_seconds=30, clock=clock)
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.start_task(
+            db,
+            identity,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.recover_room(db, lease, clock=clock)
+    with pytest.raises(driver.RoomUnavailableError, match="disbanded"):
+        driver.release_lease(db, lease, clock=clock)
+
+
+def test_task_admission_is_idempotent_and_identity_conflicts_fail(db):
+    clock = FakeClock()
+    identity = _identity()
+
+    first = _admit(db, identity, clock)
+    repeated = _admit(db, identity, clock)
+
+    assert first["status"] == "queued"
+    assert repeated["idempotent"] is True
+
+    with pytest.raises(driver.TaskConflictError):
+        driver.admit_task(
+            db,
+            driver.TaskIdentity(
+                room_id="room-1",
+                task_id="task-1",
+                thread_id="thread-other",
+                turn_id="turn-other",
+            ),
+            payload=_payload(),
+            clock=clock,
+        )
+
+    with pytest.raises(driver.TaskConflictError, match="different payload"):
+        _admit(
+            db,
+            identity,
+            clock,
+            payload=_payload(prompt="A different immutable prompt."),
+        )
+    with pytest.raises(driver.TaskConflictError):
+        driver.admit_task(
+            db,
+            driver.TaskIdentity(
+                room_id="room-1",
+                task_id="task-other",
+                thread_id="thread-1",
+                turn_id="turn-1",
+            ),
+            payload=_payload(),
+            clock=clock,
+        )
+
+
+def test_concurrent_task_start_has_one_winner(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+
+    def start(_):
+        try:
+            return driver.start_task(
+                db,
+                identity,
+                lease,
+                expected_cancel_generation=0,
+                clock=clock,
+            )
+        except driver.InvalidTaskTransitionError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(start, range(2)))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert winners[0].execution_generation == 1
+
+
+def test_stale_lease_cannot_start_or_commit_task(db):
+    clock = FakeClock()
+    identity = _identity()
+    first = _lease(db, clock, ttl=5)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    clock.advance(5)
+    second = _lease(db, clock, process="process-b")
+    driver.recover_room(db, second, clock=clock)
+
+    with pytest.raises(driver.StaleLeaseError):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="settlement-old",
+            status="settled",
+            result={"text": "late"},
+            clock=clock,
+        )
+    assert driver.get_task(db, identity)["status"] == "indeterminate"
+
+
+@pytest.mark.parametrize("status", ["settled", "failed"])
+def test_terminal_settlement_is_idempotent(db, status):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    first = driver.settle_task(
+        db,
+        attempt,
+        settlement_id="settlement-1",
+        status=status,
+        result={"text": "done"},
+        clock=clock,
+    )
+    repeated = driver.settle_task(
+        db,
+        attempt,
+        settlement_id="settlement-1",
+        status=status,
+        result={"text": "done"},
+        clock=clock,
+    )
+
+    assert first["status"] == status
+    assert repeated["idempotent"] is True
+    with pytest.raises(driver.TaskConflictError):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="settlement-2",
+            status=status,
+            result={"text": "changed"},
+            clock=clock,
+        )
+
+
+def test_cancellation_fences_late_success(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    stopping = driver.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-1",
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    cancelled = driver.complete_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-1",
+        expected_cancel_generation=1,
+        clock=clock,
+    )
+    repeated = driver.complete_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-1",
+        expected_cancel_generation=1,
+        clock=clock,
+    )
+
+    assert stopping["status"] == "stopping"
+    assert cancelled["status"] == "cancelled"
+    assert cancelled["cancel_generation"] == 1
+    assert repeated["idempotent"] is True
+    with pytest.raises(driver.StaleTaskError):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="late-success",
+            status="settled",
+            result={"text": "too late"},
+            clock=clock,
+        )
+
+
+def test_release_fails_closed_while_its_task_is_running(db):
+    clock = FakeClock()
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    with pytest.raises(
+        driver.InvalidTaskTransitionError,
+        match="tasks are running",
+    ):
+        driver.release_lease(db, lease, clock=clock)
+    assert driver.get_task(db, identity)["status"] == "running"
+
+    driver.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-release",
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    driver.complete_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-release",
+        expected_cancel_generation=1,
+        clock=clock,
+    )
+    assert driver.release_lease(db, lease, clock=clock)["idempotent"] is False
+
+
+def test_restart_recovery_never_requeues_indeterminate_work(db):
+    clock = FakeClock()
+    running = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    first = _lease(db, clock, ttl=5)
+    _admit(db, running, clock)
+    _admit(db, queued, clock)
+    driver.start_task(
+        db,
+        running,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    with pytest.raises(driver.LeaseHeldError):
+        _lease(db, clock, gateway="gateway-a", process="new-process")
+
+    clock.advance(5)
+    recovered_lease = _lease(
+        db,
+        clock,
+        gateway="gateway-a",
+        process="new-process",
+    )
+    recovery = driver.recover_room(db, recovered_lease, clock=clock)
+    repeated = driver.recover_room(db, recovered_lease, clock=clock)
+
+    assert recovery == {"queued": [queued], "indeterminate": [running]}
+    assert repeated == recovery
+    with pytest.raises(driver.InvalidTaskTransitionError):
+        driver.start_task(
+            db,
+            running,
+            recovered_lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    assert [task["status"] for task in driver.list_tasks(db, room_id="room-1")] == [
+        "indeterminate",
+        "queued",
+    ]
+
+
+def test_recovery_is_required_before_starting_later_work(db):
+    clock = FakeClock()
+    running = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    first = _lease(db, clock, ttl=5)
+    _admit(db, running, clock, payload=_payload(source_event_seq=1))
+    _admit(db, queued, clock, payload=_payload(source_event_seq=2))
+    driver.start_task(
+        db,
+        running,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process")
+
+    with pytest.raises(
+        driver.InvalidTaskTransitionError,
+        match="recovery must resolve",
+    ):
+        driver.start_task(
+            db,
+            queued,
+            recovered,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+
+
+def test_current_lease_can_commit_verified_indeterminate_receipt(db):
+    clock = FakeClock()
+    running = _identity()
+    queued = _identity("task-2", turn_id="turn-2")
+    first = _lease(db, clock, ttl=5)
+    _admit(db, running, clock, payload=_payload(source_event_seq=1))
+    _admit(db, queued, clock, payload=_payload(source_event_seq=2))
+    attempt = driver.start_task(
+        db,
+        running,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process")
+    driver.recover_room(db, recovered, clock=clock)
+
+    settled = driver.resolve_indeterminate_task(
+        db,
+        running,
+        recovered,
+        expected_execution_generation=attempt.execution_generation,
+        expected_cancel_generation=attempt.cancel_generation,
+        settlement_id="recovered-receipt",
+        status="settled",
+        result={"text": "recovered"},
+        clock=clock,
+    )
+    next_attempt = driver.start_task(
+        db,
+        queued,
+        recovered,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    assert settled["status"] == "settled"
+    assert next_attempt.execution_generation == 1
+
+
+def test_indeterminate_retry_is_explicit_and_advances_execution_generation(db):
+    clock = FakeClock()
+    identity = _identity()
+    first = _lease(db, clock, ttl=5)
+    _admit(db, identity, clock)
+    original = driver.start_task(
+        db,
+        identity,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process")
+    driver.recover_room(db, recovered, clock=clock)
+
+    requeued = driver.requeue_indeterminate_task(
+        db,
+        identity,
+        recovered,
+        expected_execution_generation=original.execution_generation,
+        expected_cancel_generation=original.cancel_generation,
+        clock=clock,
+    )
+    retried = driver.start_task(
+        db,
+        identity,
+        recovered,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    assert requeued["status"] == "queued"
+    assert retried.execution_generation == original.execution_generation + 1
+
+
+def test_indeterminate_task_can_be_deferred_retried_and_cancelled(db):
+    clock = FakeClock()
+    identity = _identity()
+    first = _lease(db, clock, ttl=5)
+    _admit(db, identity, clock)
+    original = driver.start_task(
+        db,
+        identity,
+        first,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    clock.advance(5)
+    recovered = _lease(db, clock, process="new-process", ttl=5)
+    driver.recover_room(db, recovered, clock=clock)
+
+    deferred = driver.defer_indeterminate_task(
+        db,
+        identity,
+        recovered,
+        expected_execution_generation=original.execution_generation,
+        expected_cancel_generation=original.cancel_generation,
+        reason="member_unavailable",
+        clock=clock,
+    )
+    repeated = driver.defer_indeterminate_task(
+        db,
+        identity,
+        recovered,
+        expected_execution_generation=original.execution_generation,
+        expected_cancel_generation=original.cancel_generation,
+        reason="member_unavailable",
+        clock=clock,
+    )
+    requeued = driver.requeue_deferred_task(
+        db,
+        identity,
+        recovered,
+        expected_execution_generation=original.execution_generation,
+        expected_cancel_generation=original.cancel_generation,
+        clock=clock,
+    )
+    retried = driver.start_task(
+        db,
+        identity,
+        recovered,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    assert deferred["status"] == "deferred"
+    assert deferred["result"] == {
+        "reason": "member_unavailable",
+        "retryable": True,
+    }
+    assert repeated["idempotent"] is True
+    assert requeued["status"] == "queued"
+    assert retried.execution_generation == original.execution_generation + 1
+
+    clock.advance(5)
+    next_lease = _lease(db, clock, process="third-process")
+    driver.recover_room(db, next_lease, clock=clock)
+    driver.defer_indeterminate_task(
+        db,
+        identity,
+        next_lease,
+        expected_execution_generation=retried.execution_generation,
+        expected_cancel_generation=retried.cancel_generation,
+        reason="member_unavailable",
+        clock=clock,
+    )
+    cancelled = driver.cancel_task(
+        db,
+        identity,
+        cancel_id="cancel-deferred",
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    assert cancelled["status"] == "cancelled"
+
+
+def test_state_survives_sqlite_reopen_and_concurrent_duplicate_admission(db):
+    clock = FakeClock()
+    identity = _identity()
+
+    def admit(_):
+        return _admit(db, identity, clock)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(admit, range(8)))
+
+    assert sum(not result["idempotent"] for result in results) == 1
+    with sqlite3.connect(db) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM hosted_room_driver_tasks"
+        ).fetchone()[0]
+    assert count == 1
+    reopened = driver.get_task(db, identity)
+    listed = driver.list_tasks(db, room_id="room-1")
+    assert reopened["identity"] == identity
+    assert reopened["payload"] == _payload()
+    assert listed[0]["payload"] == _payload()
+
+
+def test_prune_removes_only_old_published_terminal_tasks(db):
+    clock = FakeClock()
+    lease = _lease(db, clock)
+    published = _identity("task-published", turn_id="turn-published")
+    unpublished = _identity("task-unpublished", turn_id="turn-unpublished")
+    for identity in (published, unpublished):
+        _admit(db, identity, clock)
+        attempt = driver.start_task(
+            db,
+            identity,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id=f"result:{identity.task_id}",
+            status="settled",
+            result={"text": "done"},
+            clock=clock,
+        )
+
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """CREATE TABLE hosted_room_policy_publications (
+                room_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                execution_generation INTEGER NOT NULL DEFAULT 0,
+                seq INTEGER NOT NULL,
+                PRIMARY KEY(room_id, task_id, kind, execution_generation)
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_policy_publications
+               VALUES ('room-1', 'task-published', 'turn.settled', 0, 3)"""
+        )
+
+    clock.advance(driver.TERMINAL_TASK_RETENTION_SECONDS + 1)
+    assert (
+        driver.prune_published_terminal_tasks(
+            db,
+            room_id="room-1",
+            clock=clock,
+        )
+        == 1
+    )
+    assert [
+        task["identity"].task_id for task in driver.list_tasks(db, room_id="room-1")
+    ] == ["task-unpublished"]
+
+
+def test_unpublished_legacy_driver_schema_fails_closed(db):
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_tasks")
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_leases")
+        conn.execute(
+            """CREATE TABLE hosted_room_driver_leases (
+                room_id TEXT PRIMARY KEY,
+                gateway_id TEXT NOT NULL,
+                process_generation TEXT NOT NULL,
+                lease_generation INTEGER NOT NULL,
+                expires_at REAL NOT NULL,
+                acquired_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                released_at REAL
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE hosted_room_driver_tasks (
+                room_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                turn_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                execution_generation INTEGER NOT NULL,
+                cancel_generation INTEGER NOT NULL,
+                run_gateway_id TEXT,
+                run_process_generation TEXT,
+                run_lease_generation INTEGER,
+                cancel_id TEXT,
+                settlement_id TEXT,
+                settlement_status TEXT,
+                result_json TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                started_at REAL,
+                terminal_at REAL,
+                indeterminate_at REAL,
+                PRIMARY KEY (room_id, task_id),
+                UNIQUE (room_id, thread_id, turn_id)
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_driver_leases
+               VALUES ('room-1', 'gateway-a', 'old-process', 1,
+                       200, 100, 100, NULL)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_driver_tasks
+               (room_id, task_id, thread_id, turn_id, status,
+                execution_generation, cancel_generation,
+                run_gateway_id, run_process_generation, run_lease_generation,
+                created_at, updated_at, started_at)
+               VALUES ('room-1', 'task-1', 'thread-1', 'turn-1', 'running',
+                       1, 0, 'gateway-a', 'old-process', 1, 100, 100, 100)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(driver.DriverStateError, match="unsupported unpublished"):
+        driver.get_task(db, _identity())
+
+
+def test_pre_stopping_schema_is_migrated_without_losing_tasks(db):
+    clock = FakeClock()
+    identity = _identity()
+    _admit(db, identity, clock)
+
+    with sqlite3.connect(db) as conn:
+        current_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='hosted_room_driver_tasks'"
+        ).fetchone()[0]
+        old_sql = current_sql.replace(", 'stopping'", "")
+        conn.execute("DROP INDEX idx_hosted_room_driver_tasks_status")
+        conn.execute(
+            "ALTER TABLE hosted_room_driver_tasks RENAME TO hosted_room_driver_tasks_current"
+        )
+        conn.execute(old_sql)
+        columns = ", ".join(driver._TASK_COLUMN_ORDER)
+        conn.execute(
+            f"""INSERT INTO hosted_room_driver_tasks ({columns})
+                 SELECT {columns} FROM hosted_room_driver_tasks_current"""
+        )
+        conn.execute("DROP TABLE hosted_room_driver_tasks_current")
+        conn.execute(
+            """CREATE INDEX idx_hosted_room_driver_tasks_status
+               ON hosted_room_driver_tasks(
+                   room_id, status, source_event_seq, created_at, task_id
+               )"""
+        )
+
+    assert driver.get_task(db, identity)["status"] == "queued"
+    lease = _lease(db, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    stopping = driver.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-after-upgrade",
+        expected_cancel_generation=attempt.cancel_generation,
+        clock=clock,
+    )
+
+    assert stopping["status"] == "stopping"
+    with sqlite3.connect(db) as conn:
+        table_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='hosted_room_driver_tasks'"
+        ).fetchone()[0]
+    assert "'stopping'" in table_sql
+
+
+def test_pre_deferred_schema_is_migrated_without_losing_tasks(db):
+    clock = FakeClock()
+    identity = _identity()
+    _admit(db, identity, clock)
+
+    with sqlite3.connect(db) as conn:
+        current_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='hosted_room_driver_tasks'"
+        ).fetchone()[0]
+        old_sql = current_sql.replace(", 'deferred'", "")
+        conn.execute("DROP INDEX idx_hosted_room_driver_tasks_status")
+        conn.execute(
+            "ALTER TABLE hosted_room_driver_tasks RENAME TO hosted_room_driver_tasks_current"
+        )
+        conn.execute(old_sql)
+        columns = ", ".join(driver._TASK_COLUMN_ORDER)
+        conn.execute(
+            f"""INSERT INTO hosted_room_driver_tasks ({columns})
+                 SELECT {columns} FROM hosted_room_driver_tasks_current"""
+        )
+        conn.execute("DROP TABLE hosted_room_driver_tasks_current")
+        conn.execute(
+            """CREATE INDEX idx_hosted_room_driver_tasks_status
+               ON hosted_room_driver_tasks(
+                   room_id, status, source_event_seq, created_at, task_id
+               )"""
+        )
+
+    assert driver.get_task(db, identity)["status"] == "queued"
+    with sqlite3.connect(db) as conn:
+        table_sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='hosted_room_driver_tasks'"
+        ).fetchone()[0]
+    assert "'deferred'" in table_sql
+
+
+def test_first_schema_creation_is_safe_across_processes(db):
+    with sqlite3.connect(db) as conn:
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_tasks")
+        conn.execute("DROP TABLE IF EXISTS hosted_room_driver_leases")
+        conn.commit()
+
+    with ProcessPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(_open_driver_schema, [str(db)] * 4))
+
+    assert results == [0, 0, 0, 0]
+
+
+def test_tasks_follow_source_event_order_not_admission_time(db):
+    clock = FakeClock()
+    later = _identity("task-2", turn_id="turn-2")
+    earlier = _identity("task-1", turn_id="turn-1")
+    _admit(db, later, clock, payload=_payload(source_event_seq=2))
+    _admit(db, earlier, clock, payload=_payload(source_event_seq=1))
+    lease = _lease(db, clock)
+
+    assert [task["identity"] for task in driver.list_tasks(db, room_id="room-1")] == [
+        earlier,
+        later,
+    ]
+    with pytest.raises(driver.InvalidTaskTransitionError, match="event order"):
+        driver.start_task(
+            db,
+            later,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        )
+    assert (
+        driver.start_task(
+            db,
+            earlier,
+            lease,
+            expected_cancel_generation=0,
+            clock=clock,
+        ).identity
+        == earlier
+    )
+
+
+def test_payload_digest_is_verified_on_read(db):
+    identity = _identity()
+    _admit(db, identity, FakeClock())
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """UPDATE hosted_room_driver_tasks
+               SET payload_json=REPLACE(payload_json, 'Inspect', 'Replace')
+               WHERE room_id=? AND task_id=?""",
+            (identity.room_id, identity.task_id),
+        )
+        conn.commit()
+
+    with pytest.raises(driver.TaskConflictError, match="integrity"):
+        driver.get_task(db, identity)
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        ({"target_profile": "ops", "prompt": "hello"}, "missing payload fields"),
+        (
+            {**_payload(), "unexpected": True},
+            "unknown payload fields",
+        ),
+        (_payload(target_profile="bad profile"), "invalid target_profile"),
+        (_payload(prompt="   "), "prompt must not be empty"),
+        (_payload(prompt="x" * (driver.MAX_PROMPT_BYTES + 1)), "prompt is too large"),
+        (_payload(source_event_seq=0), "source_event_seq"),
+        (_payload(source_event_seq=True), "source_event_seq"),
+    ],
+)
+def test_invalid_task_payload_is_rejected(db, payload, match):
+    with pytest.raises(driver.DriverValidationError, match=match):
+        _admit(db, _identity(), FakeClock(), payload=payload)
+
+
+@pytest.mark.parametrize(
+    ("factory", "match"),
+    [
+        (
+            lambda: driver.TaskIdentity("bad room", "task", "thread", "turn"),
+            "invalid room_id",
+        ),
+        (
+            lambda: driver.TaskIdentity("room", "", "thread", "turn"),
+            "invalid task_id",
+        ),
+    ],
+)
+def test_invalid_task_identity_is_rejected(factory, match):
+    with pytest.raises(driver.DriverValidationError, match=match):
+        factory()
+
+
+def test_invalid_lease_clock_ttl_and_settlement_schema_are_rejected(db):
+    clock = FakeClock()
+
+    with pytest.raises(driver.DriverValidationError, match="ttl_seconds"):
+        _lease(db, clock, ttl=0)
+    with pytest.raises(driver.DriverValidationError, match="clock"):
+        _lease(db, lambda: float("nan"))
+    with pytest.raises(driver.DriverValidationError, match="expiry"):
+        _lease(db, FakeClock(1e308), ttl=1e308)
+
+    identity = _identity()
+    lease = _lease(db, clock)
+    _admit(db, identity, clock)
+    attempt = driver.start_task(
+        db,
+        identity,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    with pytest.raises(driver.DriverValidationError, match="JSON-serializable"):
+        driver.settle_task(
+            db,
+            attempt,
+            settlement_id="settlement-1",
+            status="settled",
+            result={"bad": object()},
+            clock=clock,
+        )
+
+
+def test_renewal_never_shortens_an_active_lease(db):
+    clock = FakeClock()
+    lease = _lease(db, clock, ttl=30)
+    clock.advance(1)
+
+    renewed = driver.renew_lease(db, lease, ttl_seconds=2, clock=clock)
+
+    assert renewed.expires_at == lease.expires_at

--- a/tests/gateway/test_hosted_room_gateway_lifecycle.py
+++ b/tests/gateway/test_hosted_room_gateway_lifecycle.py
@@ -1,0 +1,234 @@
+"""Messaging-gateway ownership tests for the hosted Group Chat worker."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from gateway import hosted_room_driver, hosted_rooms
+from gateway.run import GatewayRunner
+from tui_gateway.hosted_room_service import HostedRoomService
+
+
+class _RPC:
+    def __init__(self) -> None:
+        self.sessions = {}
+        self.submits = []
+
+    def resolve_exact(self, *, profile, title, source):
+        del source
+        return self.sessions.get((profile, title))
+
+    def create(self, *, profile, title, source):
+        del source
+        session = {"session_id": f"{profile}-session", "title": title}
+        self.sessions[(profile, title)] = session
+        return session
+
+    def resume(self, *, profile, session_id, source):
+        del profile, source
+        return {"session_id": session_id}
+
+    def submit(self, **kwargs):
+        self.submits.append(kwargs["profile"])
+        kwargs["on_terminal"]({
+            "status": "settled",
+            "text": f"reply from {kwargs['profile']}",
+        })
+        return {"accepted": True}
+
+    def history(self, **kwargs):
+        del kwargs
+        return []
+
+    def info(self, **kwargs):
+        del kwargs
+        return {"active": False, "task_id": None}
+
+    def interrupt(self, **kwargs):
+        del kwargs
+        raise AssertionError("gateway lifecycle must not interrupt room work")
+
+
+def _server():
+    return SimpleNamespace(_methods={}, _sessions={}, _sessions_lock=threading.Lock())
+
+
+def _service(db_path, *, profiles=("default",)):
+    service = HostedRoomService(_server(), db_path=db_path)
+    rpc = _RPC()
+    service.rpc = rpc
+    service.runtime.rpc = rpc
+    service.local_profiles = lambda: profiles
+    return service, rpc
+
+
+def _wait_for(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition did not settle before timeout")
+
+
+@pytest.mark.asyncio
+async def test_messaging_gateway_supervisor_starts_without_dashboard(monkeypatch):
+    from tui_gateway import methods_groups
+
+    state = {"running": False, "starts": 0}
+
+    class Runtime:
+        def status(self):
+            return {"running": state["running"], "stopping": False}
+
+    service = SimpleNamespace(runtime=Runtime())
+
+    def get_service():
+        return service if state["running"] else None
+
+    def start_service():
+        state["starts"] += 1
+        state["running"] = True
+        return service
+
+    monkeypatch.setattr(methods_groups, "get_hosted_room_service", get_service)
+    monkeypatch.setattr(methods_groups, "start_hosted_room_service", start_service)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    started = await runner._ensure_hosted_room_worker()
+    assert started is service
+    assert state == {"running": True, "starts": 1}
+
+    # A dead child is restarted, while a healthy one is left alone.
+    await runner._ensure_hosted_room_worker()
+    assert state["starts"] == 1
+    state["running"] = False
+    await runner._ensure_hosted_room_worker()
+    assert state["starts"] == 2
+
+
+@pytest.mark.asyncio
+async def test_dead_room_worker_is_restarted_by_gateway_task_supervision(monkeypatch):
+    from tui_gateway import methods_groups
+
+    starts = {"count": 0}
+
+    def fail_start():
+        starts["count"] += 1
+        raise RuntimeError("worker unavailable")
+
+    monkeypatch.setattr(methods_groups, "get_hosted_room_service", lambda: None)
+    monkeypatch.setattr(methods_groups, "start_hosted_room_service", fail_start)
+    monkeypatch.setattr(GatewayRunner, "_MAX_SUPERVISED_RESTARTS", 1)
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_supervised_backoff",
+        staticmethod(lambda _attempt: 0),
+    )
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner._background_tasks = set()
+    runner._spawn_supervised(
+        lambda: runner._hosted_room_worker_watcher(interval=0),
+        "hosted_room_worker",
+    )
+
+    for _ in range(200):
+        if starts["count"] == 2 and not runner._background_tasks:
+            break
+        await asyncio.sleep(0.01)
+    runner._running = False
+
+    assert starts["count"] == 2
+    assert runner._background_tasks == set()
+
+
+def test_gateway_restart_resumes_queued_room_for_multiplexed_profile(tmp_path):
+    db = tmp_path / "state.db"
+    first, _ = _service(db, profiles=("default", "ops"))
+    first.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {
+                "member_id": "default",
+                "profile": "default",
+                "handle": "hermes",
+            },
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    first.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+    assert (
+        len(hosted_room_driver.list_tasks(db, room_id="room-1", status="queued")) == 1
+    )
+
+    resumed, rpc = _service(db, profiles=("default", "ops"))
+    resumed.start()
+    try:
+        _wait_for(
+            lambda: any(
+                event["kind"] == "message.member"
+                for event in hosted_rooms.read_events(
+                    db, room_id="room-1", since_seq=0
+                )["events"]
+            )
+        )
+    finally:
+        assert resumed.stop(timeout=1.0)
+
+    assert rpc.submits == ["ops"]
+    assert hosted_room_driver.list_tasks(db, room_id="room-1", status="settled")
+
+
+def test_dashboard_and_gateway_workers_share_one_fenced_execution_owner(tmp_path):
+    db = tmp_path / "state.db"
+    gateway, gateway_rpc = _service(db, profiles=("default", "ops"))
+    dashboard, dashboard_rpc = _service(db, profiles=("default", "ops"))
+    gateway.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {
+                "member_id": "default",
+                "profile": "default",
+                "handle": "hermes",
+            },
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    gateway.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+
+    gateway.start()
+    dashboard.start()
+    try:
+        _wait_for(
+            lambda: any(
+                event["kind"] == "message.member"
+                for event in hosted_rooms.read_events(
+                    db, room_id="room-1", since_seq=0
+                )["events"]
+            )
+        )
+        time.sleep(0.05)
+    finally:
+        assert gateway.stop(timeout=1.0)
+        assert dashboard.stop(timeout=1.0)
+
+    assert len(gateway_rpc.submits) + len(dashboard_rpc.submits) == 1
+    events = hosted_rooms.read_events(db, room_id="room-1", since_seq=0)["events"]
+    assert sum(event["kind"] == "message.member" for event in events) == 1

--- a/tests/gateway/test_hosted_room_local_boundary.py
+++ b/tests/gateway/test_hosted_room_local_boundary.py
@@ -1,0 +1,38 @@
+"""Dependency boundary for the same-gateway hosted-room backend."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LOCAL_ROOM_MODULES = (
+    "gateway/hosted_room_discussion.py",
+    "gateway/hosted_room_driver.py",
+    "gateway/hosted_room_policy_checkpoint.py",
+    "tui_gateway/hosted_room_driver.py",
+    "tui_gateway/hosted_room_service.py",
+    "tui_gateway/hosted_room_server_rpc.py",
+    "tui_gateway/methods_groups.py",
+)
+FORBIDDEN_SURFACES = (
+    "apps/desktop",
+    "attachments",
+    "artifact",
+    "gateway.platforms",
+    "hosted_room_links",
+    "hosted_room_peer",
+    "messaging_refs",
+    "roomlink",
+    "transport_resolver",
+    "turn.handoff",
+)
+
+
+def test_local_room_modules_do_not_depend_on_excluded_surfaces():
+    violations = {}
+    for relative_path in LOCAL_ROOM_MODULES:
+        source = (ROOT / relative_path).read_text(encoding="utf-8").lower()
+        found = [token for token in FORBIDDEN_SURFACES if token in source]
+        if found:
+            violations[relative_path] = found
+
+    assert violations == {}

--- a/tests/gateway/test_hosted_room_replicas.py
+++ b/tests/gateway/test_hosted_room_replicas.py
@@ -1,0 +1,296 @@
+"""Tests for gateway/hosted_room_replicas.py — replica ingest, promotion, and
+stale-authority demotion for hosted Group Chat rooms."""
+
+import json
+
+import pytest
+
+import gateway.hosted_room_replicas as replicas
+import gateway.hosted_rooms as rooms
+
+USER = {"kind": "user", "id": "tek"}
+MEMBERS = [{"kind": "bot", "id": "planner"}, {"kind": "bot", "id": "coder"}]
+
+AUTH_A = "install:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+AUTH_B = "install:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
+def _authority_db(tmp_path, name="authority.db"):
+    return tmp_path / name
+
+
+def _replica_db(tmp_path, name="replica.db"):
+    return tmp_path / name
+
+
+def _seed_room(db, *, gateway_id=AUTH_A, n_events=3, room_id="room-1"):
+    rooms.create_room(
+        db,
+        room_id=room_id,
+        name="Field Room",
+        members=MEMBERS,
+        authority_gateway_id=gateway_id,
+    )
+    for index in range(n_events):
+        rooms.append_event(
+            db,
+            room_id=room_id,
+            event_id=f"e{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"text": f"msg {index} 😀"},
+            authority_gateway_id=gateway_id,
+            authority_epoch=1,
+        )
+    return rooms.read_events(db, room_id=room_id, since_seq=0, limit=100)
+
+
+def test_ingest_page_persists_events_and_lineage(tmp_path):
+    page = _seed_room(_authority_db(tmp_path))
+    rdb = _replica_db(tmp_path)
+    result = replicas.ingest_page(
+        rdb, room_id="room-1", room_name="Field Room", members=MEMBERS, page=page
+    )
+    assert result["ingested"] == 3
+    assert result["stored_seq"] == 3
+    assert result["caught_up"] is True
+    state = replicas.replica_state(rdb, room_id="room-1")
+    assert state["last_seq"] == 3
+    assert state["authority"] == page["authority"]
+    assert state["members"] == MEMBERS
+
+
+def test_ingest_page_is_idempotent(tmp_path):
+    page = _seed_room(_authority_db(tmp_path))
+    rdb = _replica_db(tmp_path)
+    replicas.ingest_page(
+        rdb, room_id="room-1", room_name="Field Room", members=MEMBERS, page=page
+    )
+    again = replicas.ingest_page(
+        rdb, room_id="room-1", room_name="Field Room", members=MEMBERS, page=page
+    )
+    assert again["ingested"] == 0
+    assert again["stored_seq"] == 3
+
+
+def test_ingest_rejects_sequence_gap(tmp_path):
+    adb = _authority_db(tmp_path)
+    _seed_room(adb, n_events=5)
+    later = rooms.read_events(adb, room_id="room-1", since_seq=2, limit=100)
+    rdb = _replica_db(tmp_path)
+    with pytest.raises(replicas.ReplicaGapError):
+        replicas.ingest_page(
+            rdb,
+            room_id="room-1",
+            room_name="Field Room",
+            members=MEMBERS,
+            page=later,
+        )
+
+
+def test_ingest_rejects_epoch_regression(tmp_path):
+    page = _seed_room(_authority_db(tmp_path))
+    rdb = _replica_db(tmp_path)
+    newer = json.loads(json.dumps(page))
+    newer["authority"]["epoch"] = 3
+    replicas.ingest_page(
+        rdb, room_id="room-1", room_name="Field Room", members=MEMBERS, page=newer
+    )
+    stale = json.loads(json.dumps(page))
+    stale["authority"]["epoch"] = 2
+    with pytest.raises(replicas.ReplicaEpochRegressionError):
+        replicas.ingest_page(
+            rdb,
+            room_id="room-1",
+            room_name="Field Room",
+            members=MEMBERS,
+            page=stale,
+        )
+
+
+def test_ingest_requires_authority_stamp(tmp_path):
+    page = _seed_room(_authority_db(tmp_path))
+    page.pop("authority")
+    with pytest.raises(replicas.ReplicaError):
+        replicas.ingest_page(
+            _replica_db(tmp_path),
+            room_id="room-1",
+            room_name="Field Room",
+            members=MEMBERS,
+            page=page,
+        )
+
+
+def test_promote_replica_continues_room_at_next_epoch(tmp_path, monkeypatch):
+    page = _seed_room(_authority_db(tmp_path))
+    rdb = _replica_db(tmp_path)
+    replicas.ingest_page(
+        rdb, room_id="room-1", room_name="Field Room", members=MEMBERS, page=page
+    )
+    monkeypatch.setattr(replicas, "local_authority_gateway_id", lambda: AUTH_B)
+
+    promoted = replicas.promote_replica(rdb, room_id="room-1")
+    assert promoted["authority_gateway_id"] == AUTH_B
+    assert promoted["authority_epoch"] == 2
+    assert promoted["previous_gateway_id"] == AUTH_A
+    assert promoted["claim_seq"] == 4
+
+    # The room is now locally authoritative with the full history + claim.
+    replay = rooms.read_events(rdb, room_id="room-1", since_seq=0, limit=100)
+    assert [e["seq"] for e in replay["events"]] == [1, 2, 3, 4]
+    claim = replay["events"][-1]
+    assert claim["kind"] == "authority.claimed"
+    assert claim["payload"]["previous_gateway_id"] == AUTH_A
+    assert claim["payload"]["authority_epoch"] == 2
+    assert replay["authority"] == {"gateway_id": AUTH_B, "epoch": 2}
+
+    # New work continues under the new epoch.
+    rooms.append_event(
+        rdb,
+        room_id="room-1",
+        event_id="post-takeover",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "continuing"},
+        authority_gateway_id=AUTH_B,
+        authority_epoch=2,
+    )
+
+    # The old authority's identity/epoch is fenced out.
+    with pytest.raises(rooms.HostedRoomError):
+        rooms.append_event(
+            rdb,
+            room_id="room-1",
+            event_id="stale-write",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "stale"},
+            authority_gateway_id=AUTH_A,
+            authority_epoch=1,
+        )
+
+    # Replica bookkeeping is consumed by promotion.
+    with pytest.raises(replicas.ReplicaError):
+        replicas.replica_state(rdb, room_id="room-1")
+
+
+def test_promote_refuses_when_room_exists_locally(tmp_path, monkeypatch):
+    db = _authority_db(tmp_path)
+    page = _seed_room(db)
+    # Same DB also holds a replica row for the same id — conflict must win.
+    replicas.ingest_page(
+        db, room_id="room-1", room_name="Field Room", members=MEMBERS, page=page
+    )
+    monkeypatch.setattr(replicas, "local_authority_gateway_id", lambda: AUTH_B)
+    with pytest.raises(rooms.RoomConflictError):
+        replicas.promote_replica(db, room_id="room-1")
+
+
+def test_promote_refuses_when_already_authority(tmp_path, monkeypatch):
+    page = _seed_room(_authority_db(tmp_path))
+    rdb = _replica_db(tmp_path)
+    replicas.ingest_page(
+        rdb, room_id="room-1", room_name="Field Room", members=MEMBERS, page=page
+    )
+    monkeypatch.setattr(replicas, "local_authority_gateway_id", lambda: AUTH_A)
+    with pytest.raises(replicas.ReplicaError):
+        replicas.promote_replica(rdb, room_id="room-1")
+
+
+def test_demote_fences_stale_local_authority(tmp_path, monkeypatch):
+    adb = _authority_db(tmp_path)
+    _seed_room(adb)
+    monkeypatch.setattr(replicas, "local_authority_gateway_id", lambda: AUTH_A)
+
+    result = replicas.demote_room(
+        adb, room_id="room-1", observed_gateway_id=AUTH_B, observed_epoch=2
+    )
+    assert result["idempotent"] is False
+    assert result["authority_gateway_id"] == AUTH_B
+    assert result["authority_epoch"] == 2
+
+    replay = rooms.read_events(adb, room_id="room-1", since_seq=0, limit=100)
+    lost = replay["events"][-1]
+    assert lost["kind"] == "authority.lost"
+    assert lost["payload"]["authority_gateway_id"] == AUTH_B
+    assert replay["authority"] == {"gateway_id": AUTH_B, "epoch": 2}
+
+    # Local sends at the stale identity/epoch are now rejected.
+    with pytest.raises(rooms.HostedRoomError):
+        rooms.append_event(
+            adb,
+            room_id="room-1",
+            event_id="after-demote",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "stale"},
+            authority_gateway_id=AUTH_A,
+            authority_epoch=1,
+        )
+
+    # Repeating the same observation is idempotent.
+    again = replicas.demote_room(
+        adb, room_id="room-1", observed_gateway_id=AUTH_B, observed_epoch=2
+    )
+    assert again["idempotent"] is True
+
+
+def test_demote_rejects_non_superseding_epoch(tmp_path, monkeypatch):
+    adb = _authority_db(tmp_path)
+    _seed_room(adb)
+    monkeypatch.setattr(replicas, "local_authority_gateway_id", lambda: AUTH_A)
+    with pytest.raises(replicas.ReplicaEpochRegressionError):
+        replicas.demote_room(
+            adb, room_id="room-1", observed_gateway_id=AUTH_B, observed_epoch=1
+        )
+
+
+def test_full_failover_round_trip(tmp_path, monkeypatch):
+    """Authority A hosts, replica B follows, A dies, B promotes, A returns
+    and is fenced + demoted; the room's history survives intact throughout."""
+    adb = _authority_db(tmp_path)
+    rdb = _replica_db(tmp_path)
+    page = _seed_room(adb, n_events=4)
+    replicas.ingest_page(
+        rdb, room_id="room-1", room_name="Field Room", members=MEMBERS, page=page
+    )
+
+    # A "dies"; B takes over.
+    monkeypatch.setattr(replicas, "local_authority_gateway_id", lambda: AUTH_B)
+    promoted = replicas.promote_replica(rdb, room_id="room-1")
+    rooms.append_event(
+        rdb,
+        room_id="room-1",
+        event_id="b-work",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "work continues on B"},
+        authority_gateway_id=AUTH_B,
+        authority_epoch=promoted["authority_epoch"],
+    )
+
+    # A comes back, observes B's claim, and fences itself.
+    monkeypatch.setattr(replicas, "local_authority_gateway_id", lambda: AUTH_A)
+    replicas.demote_room(
+        adb,
+        room_id="room-1",
+        observed_gateway_id=AUTH_B,
+        observed_epoch=promoted["authority_epoch"],
+    )
+    with pytest.raises(rooms.HostedRoomError):
+        rooms.append_event(
+            adb,
+            room_id="room-1",
+            event_id="a-stale",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "split brain attempt"},
+            authority_gateway_id=AUTH_A,
+            authority_epoch=1,
+        )
+
+    # B's room holds the complete history: 4 original + claim + new work.
+    replay = rooms.read_events(rdb, room_id="room-1", since_seq=0, limit=100)
+    kinds = [e["kind"] for e in replay["events"]]
+    assert kinds == ["message.user"] * 4 + ["authority.claimed", "message.user"]
+    assert replay["authority"]["gateway_id"] == AUTH_B

--- a/tests/gateway/test_hosted_rooms.py
+++ b/tests/gateway/test_hosted_rooms.py
@@ -1,0 +1,1018 @@
+"""Behavior tests for the gateway-hosted room event log."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+
+import pytest
+
+from gateway import hosted_rooms as rooms
+import hermes_state
+from hermes_state import SessionDB
+
+USER = {"kind": "user", "id": "desktop-user", "display_name": "User"}
+GATEWAY_A = {"kind": "gateway", "id": "gateway-a"}
+GATEWAY_B = {"kind": "gateway", "id": "gateway-b"}
+
+
+def _create_pre_actor_database(path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """CREATE TABLE hosted_rooms (
+                room_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                members_json TEXT NOT NULL,
+                next_seq INTEGER NOT NULL,
+                revision INTEGER NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                disbanded_at REAL
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE hosted_room_events (
+                room_id TEXT NOT NULL,
+                seq INTEGER NOT NULL,
+                event_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                PRIMARY KEY (room_id, seq),
+                UNIQUE (room_id, event_id)
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_rooms
+               VALUES ('room-1', 'Legacy', '[]', 2, 1, 1, 1, NULL)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               VALUES ('room-1', 1, 'legacy-event', 'message.created', '{}', 1)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_legacy_state(path: str) -> tuple[str, int]:
+    state = rooms.room_state(path, room_id="room-1")
+    return state["authority_gateway_id"], state["latest_seq"]
+
+
+def _create(db, room_id="room-1"):
+    return rooms.create_room(
+        db,
+        room_id=room_id,
+        name="Release room",
+        members=[{"profile": "ops", "handle": "ops"}],
+        authority_gateway_id="gateway-a",
+        now=10,
+    )
+
+
+def _append(db, **kwargs):
+    if kwargs.get("kind") == "message.user":
+        kwargs.setdefault("authority_gateway_id", "gateway-a")
+        kwargs.setdefault("authority_epoch", 1)
+    return rooms.append_event(db, **kwargs)
+
+
+def _disband(db, **kwargs):
+    kwargs.setdefault("expected_gateway_id", "gateway-a")
+    kwargs.setdefault("expected_epoch", 1)
+    return rooms.disband_room(db, **kwargs)
+
+
+def _assert_retired_identity_stays_reserved(db, room_id, *, fresh_id):
+    # Reopen the database to prove the reservation is durable rather than a
+    # process-local cache, while the heavier room/event payload is gone.
+    with sqlite3.connect(db) as conn:
+        assert (
+            conn.execute(
+                "SELECT 1 FROM hosted_rooms WHERE room_id=?", (room_id,)
+            ).fetchone()
+            is None
+        )
+        assert (
+            conn.execute(
+                "SELECT retired_at FROM hosted_room_retired_ids WHERE room_id=?",
+                (room_id,),
+            ).fetchone()
+            is not None
+        )
+
+    with pytest.raises(rooms.RoomConflictError, match="disbanded"):
+        _create(db, room_id)
+    with pytest.raises(rooms.RoomHistoryExpiredError) as send_error:
+        _append(
+            db,
+            room_id=room_id,
+            event_id="stale-send",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "stale"},
+        )
+    assert send_error.value.reason == "room_history_expired"
+    with pytest.raises(rooms.RoomHistoryExpiredError) as log_error:
+        rooms.read_events(db, room_id=room_id, include_disbanded=True)
+    assert log_error.value.reason == "room_history_expired"
+    repeated = _disband(db, room_id=room_id, now=999)
+    assert repeated == {
+        "room_id": room_id,
+        "disbanded_at": 20.0,
+        "idempotent": True,
+        "history_expired": True,
+    }
+
+    assert _create(db, fresh_id)["room_id"] == fresh_id
+
+
+def test_create_room_is_idempotent_but_conflicts_fail_closed(tmp_path):
+    db = tmp_path / "state.db"
+    first = _create(db)
+    second = _create(db)
+
+    assert first["idempotent"] is False
+    assert second["idempotent"] is True
+    assert first["room_id"] == second["room_id"] == "room-1"
+
+    with pytest.raises(rooms.RoomConflictError):
+        rooms.create_room(
+            db,
+            room_id="room-1",
+            name="A different room",
+            members=[],
+            authority_gateway_id="gateway-a",
+        )
+
+
+def test_concurrent_first_database_open_keeps_every_room(tmp_path):
+    db = tmp_path / "state.db"
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        created = list(pool.map(lambda index: _create(db, f"room-{index}"), range(16)))
+
+    assert {room["room_id"] for room in created} == {
+        f"room-{index}" for index in range(16)
+    }
+    assert len(rooms.list_rooms(db)) == 16
+
+
+def test_first_database_open_retries_only_transient_journal_lock(
+    tmp_path,
+    monkeypatch,
+):
+    original = hermes_state.apply_wal_with_fallback
+    attempts = 0
+
+    def transient_lock(conn, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise sqlite3.OperationalError("database is locked")
+        return original(conn, **kwargs)
+
+    monkeypatch.setattr(hermes_state, "apply_wal_with_fallback", transient_lock)
+
+    assert _create(tmp_path / "state.db")["room_id"] == "room-1"
+    assert attempts == 3
+
+
+def test_first_database_open_does_not_retry_other_journal_errors(
+    tmp_path,
+    monkeypatch,
+):
+    attempts = 0
+
+    def configured_delete_refusal(conn, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        raise sqlite3.OperationalError(
+            "could not verify configured journal_mode=delete (database is locked)"
+        )
+
+    monkeypatch.setattr(
+        hermes_state,
+        "apply_wal_with_fallback",
+        configured_delete_refusal,
+    )
+
+    with pytest.raises(sqlite3.OperationalError, match="configured"):
+        _create(tmp_path / "state.db")
+    assert attempts == 1
+
+
+def test_room_state_exposes_authority_and_replay_cursor(tmp_path):
+    db = tmp_path / "state.db"
+    room = _create(db)
+
+    assert room["authority_gateway_id"] == "gateway-a"
+    assert room["authority_epoch"] == 1
+    assert rooms.room_state(db, room_id="room-1") == {
+        **room,
+        "latest_seq": 0,
+    }
+
+
+def test_authority_claim_fences_stale_gateway_events(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    first = _append(
+        db,
+        room_id="room-1",
+        event_id="turn-1",
+        kind="turn.started",
+        actor=GATEWAY_A,
+        authority_gateway_id="gateway-a",
+        authority_epoch=1,
+        payload={"member": "ops"},
+    )
+    claimed = rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=30,
+    )
+    retried = rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=40,
+    )
+
+    assert claimed["authority_gateway_id"] == "gateway-b"
+    assert claimed["authority_epoch"] == 2
+    assert claimed["idempotent"] is False
+    assert claimed["claim_event"]["kind"] == "authority.claimed"
+    assert claimed["claim_event"]["authority_epoch"] == 2
+    assert claimed["claim_event"]["payload"] == {
+        "previous_gateway_id": "gateway-a",
+        "authority_gateway_id": "gateway-b",
+        "authority_epoch": 2,
+    }
+    assert retried["authority_epoch"] == 2
+    assert retried["idempotent"] is True
+    assert retried["claim_event"]["seq"] == claimed["claim_event"]["seq"]
+    assert retried["claim_event"]["idempotent"] is True
+    state = rooms.room_state(db, room_id="room-1")
+    assert state["authority_claim"]["event_id"] == "claim-gateway-b"
+    assert state["authority_claim"]["payload"]["previous_gateway_id"] == "gateway-a"
+
+    # An exact retry admitted before takeover stays idempotent and cannot
+    # produce a second side effect, even though its epoch is now stale.
+    repeated = _append(
+        db,
+        room_id="room-1",
+        event_id="turn-1",
+        kind="turn.started",
+        actor=GATEWAY_A,
+        authority_gateway_id="gateway-a",
+        authority_epoch=1,
+        payload={"member": "ops"},
+    )
+    assert repeated["seq"] == first["seq"]
+    assert repeated["idempotent"] is True
+
+    with pytest.raises(rooms.AuthorityConflictError, match="stale"):
+        _append(
+            db,
+            room_id="room-1",
+            event_id="turn-2-stale",
+            kind="turn.started",
+            actor=GATEWAY_A,
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"member": "ops"},
+        )
+
+    with pytest.raises(rooms.AuthorityConflictError, match="stale"):
+        _append(
+            db,
+            room_id="room-1",
+            event_id="member-2-stale",
+            kind="message.member",
+            actor={"kind": "member", "id": "ops"},
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"text": "stale result"},
+        )
+
+    current = _append(
+        db,
+        room_id="room-1",
+        event_id="turn-2-current",
+        kind="turn.started",
+        actor=GATEWAY_B,
+        authority_gateway_id="gateway-b",
+        authority_epoch=2,
+        payload={"member": "ops"},
+    )
+    assert current["authority_epoch"] == 2
+    current_member = _append(
+        db,
+        room_id="room-1",
+        event_id="member-2-current",
+        kind="message.member",
+        actor={"kind": "member", "id": "ops"},
+        authority_gateway_id="gateway-b",
+        authority_epoch=2,
+        payload={"text": "current result"},
+    )
+    assert current_member["authority_epoch"] == 2
+
+
+def test_concurrent_authority_claim_has_one_winner(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    def claim(gateway_id):
+        try:
+            return rooms.claim_authority(
+                db,
+                room_id="room-1",
+                expected_gateway_id="gateway-a",
+                expected_epoch=1,
+                new_gateway_id=gateway_id,
+                event_id=f"claim-{gateway_id}",
+            )
+        except rooms.AuthorityConflictError:
+            return None
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(claim, ["gateway-b", "gateway-c"]))
+
+    winners = [result for result in results if result is not None]
+    assert len(winners) == 1
+    assert winners[0]["authority_epoch"] == 2
+    assert rooms.room_state(db, room_id="room-1")["authority_gateway_id"] in {
+        "gateway-b",
+        "gateway-c",
+    }
+
+
+def test_retry_of_successful_but_superseded_claim_is_distinct(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-b",
+    )
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-b",
+        expected_epoch=2,
+        new_gateway_id="gateway-c",
+        event_id="claim-c",
+    )
+
+    with pytest.raises(rooms.AuthoritySupersededError, match="later superseded"):
+        rooms.claim_authority(
+            db,
+            room_id="room-1",
+            expected_gateway_id="gateway-a",
+            expected_epoch=1,
+            new_gateway_id="gateway-b",
+            event_id="claim-b",
+        )
+
+
+def test_authority_scoped_events_require_gateway_and_epoch(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    with pytest.raises(rooms.HostedRoomError, match="authority_gateway_id"):
+        _append(
+            db,
+            room_id="room-1",
+            event_id="turn-1",
+            kind="member.unavailable",
+            actor=GATEWAY_A,
+            payload={"member": "ops"},
+        )
+
+    with pytest.raises(rooms.HostedRoomError, match="actor.id"):
+        _append(
+            db,
+            room_id="room-1",
+            event_id="turn-2",
+            kind="turn.started",
+            actor=GATEWAY_B,
+            authority_gateway_id="gateway-a",
+            authority_epoch=1,
+            payload={"member": "ops"},
+        )
+
+    with pytest.raises(rooms.HostedRoomError, match="authority_gateway_id"):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id="message-1",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "hello"},
+        )
+
+    appended = _append(
+        db,
+        room_id="room-1",
+        event_id="message-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+    )
+    assert appended["authority_epoch"] == 1
+
+
+def test_append_is_idempotent_and_conflicting_event_id_is_rejected(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    first = _append(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+        now=20,
+    )
+    repeated = _append(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+        now=30,
+    )
+
+    assert first["seq"] == repeated["seq"] == 1
+    assert repeated["idempotent"] is True
+    assert rooms.read_events(db, room_id="room-1")["latest_seq"] == 1
+
+    with pytest.raises(rooms.EventConflictError):
+        _append(
+            db,
+            room_id="room-1",
+            event_id="event-1",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "changed"},
+        )
+
+
+def test_since_seq_returns_ordered_deltas_and_stable_cursor(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    for index in range(1, 5):
+        _append(
+            db,
+            room_id="room-1",
+            event_id=f"event-{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"index": index},
+            now=20 + index,
+        )
+
+    first = rooms.read_events(db, room_id="room-1", since_seq=0, limit=2)
+    assert [event["seq"] for event in first["events"]] == [1, 2]
+    assert first == {
+        "events": first["events"],
+        "cursor": 2,
+        "latest_seq": 4,
+        "has_more": True,
+    }
+
+    second = rooms.read_events(
+        db,
+        room_id="room-1",
+        since_seq=first["cursor"],
+        limit=2,
+    )
+    assert [event["seq"] for event in second["events"]] == [3, 4]
+    assert second["cursor"] == 4
+    assert second["has_more"] is False
+
+    settled = rooms.read_events(db, room_id="room-1", since_seq=4)
+    assert settled["events"] == []
+    assert settled["cursor"] == settled["latest_seq"] == 4
+
+
+def test_room_log_survives_store_reopen(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    _append(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "persist me"},
+    )
+
+    assert rooms.list_rooms(db)[0]["name"] == "Release room"
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["events"][0]["payload"] == {"text": "persist me"}
+
+
+@pytest.mark.parametrize("session_first", [True, False])
+def test_room_tables_coexist_with_session_db_schema(tmp_path, session_first):
+    db = tmp_path / "state.db"
+    if session_first:
+        SessionDB(db_path=db).close()
+
+    _create(db)
+    _append(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "shared database"},
+    )
+
+    SessionDB(db_path=db).close()
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["latest_seq"] == 1
+    assert replay["events"][0]["payload"]["text"] == "shared database"
+
+
+def test_concurrent_appends_allocate_one_monotonic_sequence(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    def append(index):
+        return _append(
+            db,
+            room_id="room-1",
+            event_id=f"event-{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"index": index},
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(append, range(24)))
+
+    assert sorted(result["seq"] for result in results) == list(range(1, 25))
+    replay = rooms.read_events(db, room_id="room-1", limit=100)
+    assert [event["seq"] for event in replay["events"]] == list(range(1, 25))
+
+
+def test_rolled_back_append_does_not_consume_sequence(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            """INSERT INTO hosted_room_events
+               (room_id, seq, event_id, kind, actor_json, payload_json, created_at)
+               VALUES ('room-1', 1, 'crash-event', 'message.user',
+                       '{"id":"desktop-user","kind":"user"}', '{}', 20)"""
+        )
+        conn.execute("UPDATE hosted_rooms SET next_seq=2 WHERE room_id='room-1'")
+        conn.rollback()
+    finally:
+        conn.close()
+
+    event = _append(
+        db,
+        room_id="room-1",
+        event_id="after-restart",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "safe"},
+    )
+    assert event["seq"] == 1
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"room_id": "../escape"}, "invalid room_id"),
+        ({"event_id": "event id"}, "invalid event_id"),
+        ({"kind": "Message Created"}, "invalid event kind"),
+        ({"kind": "directive.run"}, "cannot append"),
+        ({"actor": {"kind": "member", "id": "ops"}}, "cannot append"),
+        ({"payload": []}, "payload must be an object"),
+    ],
+)
+def test_invalid_event_contract_is_rejected(tmp_path, kwargs, message):
+    db = tmp_path / "state.db"
+    _create(db)
+    params = {
+        "room_id": "room-1",
+        "event_id": "event-1",
+        "kind": "message.user",
+        "actor": USER,
+        "payload": {},
+    }
+    params.update(kwargs)
+
+    with pytest.raises(rooms.HostedRoomError, match=message):
+        _append(db, **params)
+
+
+def test_unknown_room_and_invalid_cursor_fail_closed(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    with pytest.raises(rooms.RoomNotFoundError):
+        rooms.read_events(db, room_id="missing")
+    with pytest.raises(rooms.HostedRoomError, match="since_seq"):
+        rooms.read_events(db, room_id="room-1", since_seq=-1)
+    with pytest.raises(rooms.HostedRoomError, match="ahead"):
+        rooms.read_events(db, room_id="room-1", since_seq=1)
+    with pytest.raises(rooms.HostedRoomError, match="limit"):
+        rooms.read_events(db, room_id="room-1", limit=0)
+
+
+def test_actor_is_part_of_event_idempotency_and_replay(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    event = _append(
+        db,
+        room_id="room-1",
+        event_id="event-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello"},
+    )
+
+    assert event["actor"] == USER
+    assert rooms.read_events(db, room_id="room-1")["events"][0]["actor"] == USER
+
+    with pytest.raises(rooms.EventConflictError):
+        _append(
+            db,
+            room_id="room-1",
+            event_id="event-1",
+            kind="message.user",
+            actor={"kind": "user", "id": "another-user"},
+            payload={"text": "hello"},
+        )
+
+
+def test_disband_is_idempotent_and_room_id_cannot_be_reused(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+
+    first = _disband(db, room_id="room-1", now=50)
+    repeated = _disband(db, room_id="room-1", now=60)
+
+    assert first["room_id"] == "room-1"
+    assert first["disbanded_at"] == 50.0
+    assert first["idempotent"] is False
+    assert first["event"]["kind"] == "room.disbanded"
+    assert first["event"]["seq"] == 1
+    assert first["event"]["payload"] == {"room_id": "room-1"}
+    assert repeated["idempotent"] is True
+    assert repeated["event"]["seq"] == first["event"]["seq"]
+    assert rooms.list_rooms(db) == []
+    deleted = rooms.list_rooms(db, include_disbanded=True)
+    assert deleted[0]["disbanded_at"] == 50.0
+    assert deleted[0]["latest_seq"] == 1
+    state = rooms.room_state(db, room_id="room-1", include_disbanded=True)
+    assert state["disbanded_at"] == 50.0
+    assert state["latest_seq"] == 1
+    replay = rooms.read_events(db, room_id="room-1", include_disbanded=True)
+    assert [event["kind"] for event in replay["events"]] == ["room.disbanded"]
+    with pytest.raises(rooms.RoomConflictError):
+        _create(db)
+    with pytest.raises(rooms.RoomNotFoundError) as missing:
+        rooms.read_events(db, room_id="room-1")
+    assert not isinstance(missing.value, rooms.RoomHistoryExpiredError)
+
+
+def test_disband_rejects_stale_authority(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    rooms.claim_authority(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-b",
+    )
+
+    with pytest.raises(rooms.AuthorityConflictError, match="stale"):
+        _disband(db, room_id="room-1")
+
+    tombstone = _disband(
+        db,
+        room_id="room-1",
+        expected_gateway_id="gateway-b",
+        expected_epoch=2,
+    )
+    assert tombstone["event"]["authority_epoch"] == 2
+
+
+def test_room_log_pages_are_bounded_by_serialized_event_bytes(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    _create(db)
+    for index in range(4):
+        _append(
+            db,
+            room_id="room-1",
+            event_id=f"message-{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "x" * 180, "index": index},
+        )
+
+    one_event = rooms.read_events(db, room_id="room-1", limit=1)
+    budget = len(
+        json.dumps(one_event, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    ) + 1
+    monkeypatch.setattr(rooms, "MAX_LOG_PAGE_BYTES", budget)
+
+    first = rooms.read_events(db, room_id="room-1", limit=4)
+    assert len(first["events"]) == 1
+    assert first["has_more"] is True
+    second = rooms.read_events(
+        db,
+        room_id="room-1",
+        since_seq=first["cursor"],
+        limit=4,
+    )
+    assert second["events"][0]["seq"] == first["cursor"] + 1
+
+
+def test_room_log_pages_bound_multibyte_utf8_and_advance_cursor(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    _create(db)
+    for index in range(3):
+        _append(
+            db,
+            room_id="room-1",
+            event_id=f"unicode-{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "😀漢é" * 40, "index": index},
+        )
+
+    def page_bytes(page):
+        return len(
+            json.dumps(page, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        )
+
+    one_event_pages = [
+        rooms.read_events(db, room_id="room-1", since_seq=index, limit=1)
+        for index in range(3)
+    ]
+    budget = max(page_bytes(page) for page in one_event_pages) + 1
+    monkeypatch.setattr(rooms, "MAX_LOG_PAGE_BYTES", budget)
+    cursor = 0
+    replayed = []
+    while True:
+        page = rooms.read_events(db, room_id="room-1", since_seq=cursor, limit=3)
+        assert page["events"]
+        assert page_bytes(page) <= budget
+        replayed.extend(page["events"])
+        assert page["cursor"] > cursor
+        cursor = page["cursor"]
+        if not page["has_more"]:
+            break
+
+    assert [event["seq"] for event in replayed] == [1, 2, 3]
+
+
+def test_room_log_page_bound_includes_json_structure_overhead(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    _create(db)
+    for index in range(20):
+        _append(
+            db,
+            room_id="room-1",
+            event_id=f"small-{index:02d}",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "ok", "index": index},
+        )
+
+    budget = 1_000
+    monkeypatch.setattr(rooms, "MAX_LOG_PAGE_BYTES", budget)
+    cursor = 0
+    replayed = []
+    while True:
+        page = rooms.read_events(db, room_id="room-1", since_seq=cursor, limit=20)
+        assert page["events"]
+        assert len(
+            json.dumps(page, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ) <= budget
+        replayed.extend(page["events"])
+        assert page["cursor"] > cursor
+        cursor = page["cursor"]
+        if not page["has_more"]:
+            break
+
+    assert [event["seq"] for event in replayed] == list(range(1, 21))
+
+
+def test_active_rooms_and_event_storage_are_bounded(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    _create(db)
+    monkeypatch.setattr(rooms, "MAX_ACTIVE_ROOMS", 1)
+
+    with pytest.raises(rooms.HostedRoomError, match="too many active"):
+        _create(db, "room-2")
+
+    _disband(db, room_id="room-1", now=20)
+    _create(db, "room-2")
+    first = _append(
+        db,
+        room_id="room-2",
+        event_id="message-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "first"},
+    )
+    with sqlite3.connect(db) as conn:
+        current_bytes = conn.execute(
+            "SELECT event_bytes FROM hosted_rooms WHERE room_id='room-2'"
+        ).fetchone()[0]
+    monkeypatch.setattr(rooms, "MAX_ROOM_EVENT_BYTES", current_bytes)
+
+    with pytest.raises(rooms.HostedRoomError, match="storage limit"):
+        _append(
+            db,
+            room_id="room-2",
+            event_id="message-2",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "second"},
+        )
+    assert rooms.read_events(db, room_id="room-2")["events"] == [first]
+    assert _disband(db, room_id="room-2")["event"]["kind"] == "room.disbanded"
+
+
+def test_room_listing_is_paged_and_old_tombstones_are_pruned(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    monkeypatch.setattr(rooms, "MAX_DISBANDED_ROOM_TOMBSTONES", 1)
+    for index in range(3):
+        room_id = f"room-{index}"
+        _create(db, room_id)
+        if index < 2:
+            _disband(db, room_id=room_id, now=20 + index)
+
+    first_page = rooms.list_rooms(db, include_disbanded=True, limit=1)
+    second_page = rooms.list_rooms(
+        db,
+        include_disbanded=True,
+        limit=1,
+        offset=1,
+    )
+
+    assert [room["room_id"] for room in first_page + second_page] == [
+        "room-1",
+        "room-2",
+    ]
+    with pytest.raises(rooms.RoomNotFoundError):
+        rooms.room_state(db, room_id="room-0", include_disbanded=True)
+    _assert_retired_identity_stays_reserved(db, "room-0", fresh_id="room-new")
+
+
+def test_retention_pruning_keeps_retired_room_id_reserved(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db, "room-old")
+    _disband(db, room_id="room-old", now=20)
+
+    assert (
+        rooms.prune_disbanded_rooms(
+            db,
+            now=20 + rooms.DISBANDED_ROOM_RETENTION_SECONDS + 1,
+        )
+        == 1
+    )
+
+    _assert_retired_identity_stays_reserved(db, "room-old", fresh_id="room-new")
+
+
+def test_byte_pressure_pruning_keeps_retired_room_id_reserved(
+    tmp_path,
+    monkeypatch,
+):
+    db = tmp_path / "state.db"
+    _create(db, "room-full")
+    monkeypatch.setattr(rooms, "MAX_GATEWAY_EVENT_BYTES", 0)
+
+    _disband(db, room_id="room-full", now=20)
+
+    _assert_retired_identity_stays_reserved(db, "room-full", fresh_id="room-new")
+
+
+def test_pre_actor_draft_database_migrates_with_explicit_legacy_identity(tmp_path):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["events"][0]["actor"] == {"kind": "system", "id": "legacy"}
+    state = rooms.room_state(db, room_id="room-1")
+    assert state["authority_gateway_id"] == "legacy"
+    assert state["authority_epoch"] == 1
+    adopted = rooms.create_room(
+        db,
+        room_id="room-1",
+        name="Legacy",
+        members=[],
+        authority_gateway_id="gateway-a",
+        now=2,
+    )
+    assert adopted["authority_gateway_id"] == "gateway-a"
+    assert adopted["authority_epoch"] == 2
+    assert adopted["adopted"] is True
+    assert adopted["claim_event"]["seq"] == 2
+    assert adopted["claim_event"]["payload"]["previous_gateway_id"] == "legacy"
+
+
+def test_migration_reserves_existing_disbanded_room_id_before_pruning(tmp_path):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+    with sqlite3.connect(db) as conn:
+        conn.execute("UPDATE hosted_rooms SET disbanded_at=20 WHERE room_id='room-1'")
+        conn.commit()
+
+    assert (
+        rooms.prune_disbanded_rooms(
+            db,
+            now=20 + rooms.DISBANDED_ROOM_RETENTION_SECONDS + 1,
+        )
+        == 1
+    )
+
+    _assert_retired_identity_stays_reserved(db, "room-1", fresh_id="room-new")
+
+
+def test_draft_schema_migration_is_safe_across_processes(tmp_path):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+
+    with ProcessPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(_read_legacy_state, [str(db)] * 4))
+
+    assert results == [("legacy", 1)] * 4
+    replay = rooms.read_events(db, room_id="room-1")
+    assert replay["events"][0]["actor"] == {"kind": "system", "id": "legacy"}
+
+
+def test_interrupted_draft_schema_migration_rolls_back_atomically(
+    tmp_path,
+    monkeypatch,
+):
+    db = tmp_path / "state.db"
+    _create_pre_actor_database(db)
+    original = rooms._initialize_schema
+
+    def interrupt_after_first_alter(conn):
+        conn.execute(
+            "ALTER TABLE hosted_rooms "
+            "ADD COLUMN authority_gateway_id TEXT NOT NULL DEFAULT 'legacy'"
+        )
+        raise RuntimeError("simulated migration interruption")
+
+    monkeypatch.setattr(rooms, "_initialize_schema", interrupt_after_first_alter)
+    with pytest.raises(RuntimeError, match="simulated migration interruption"):
+        rooms.list_rooms(db)
+    with sqlite3.connect(db) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(hosted_rooms)")}
+    assert "authority_gateway_id" not in columns
+
+    monkeypatch.setattr(rooms, "_initialize_schema", original)
+    assert rooms.room_state(db, room_id="room-1")["authority_gateway_id"] == "legacy"
+
+
+def test_gateway_event_budget_leaves_pre_update_snapshot_headroom():
+    from hermes_cli import update_cmd
+
+    # SQLite stores room ids and index entries beyond the logical payload
+    # accounting, while session data shares the same file. Keep at least an
+    # order-of-magnitude safety margin below the physical snapshot cutoff.
+    assert (
+        rooms.MAX_GATEWAY_EVENT_BYTES * 32
+        <= update_cmd._PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
+    )

--- a/tests/gateway/test_hosted_rooms.py
+++ b/tests/gateway/test_hosted_rooms.py
@@ -8,8 +8,10 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
 import pytest
 
+from gateway import hosted_room_driver as driver
 from gateway import hosted_rooms as rooms
 import hermes_state
+from gateway.hosted_room_policy_checkpoint import HostedRoomPolicyCheckpoint
 from hermes_state import SessionDB
 
 USER = {"kind": "user", "id": "desktop-user", "display_name": "User"}
@@ -396,7 +398,7 @@ def test_authority_scoped_events_require_gateway_and_epoch(tmp_path):
     _create(db)
 
     with pytest.raises(rooms.HostedRoomError, match="authority_gateway_id"):
-        _append(
+        rooms.append_event(
             db,
             room_id="room-1",
             event_id="turn-1",
@@ -925,6 +927,147 @@ def test_byte_pressure_pruning_keeps_retired_room_id_reserved(
     _disband(db, room_id="room-full", now=20)
 
     _assert_retired_identity_stays_reserved(db, "room-full", fresh_id="room-new")
+
+
+def test_tombstone_pruning_owns_only_room_log_driver_and_policy_tables(tmp_path):
+    db = tmp_path / "state.db"
+    _create(db)
+    identity = driver.TaskIdentity(
+        room_id="room-1",
+        task_id="task-1",
+        thread_id="thread-1",
+        turn_id="turn-1",
+    )
+    driver.admit_task(
+        db,
+        identity,
+        payload={
+            "target_profile": "ops",
+            "prompt": "Inspect.",
+            "source_event_seq": 1,
+        },
+        clock=lambda: 20,
+    )
+    driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id="gateway-a",
+        authority_epoch=1,
+        process_generation="process-a",
+        ttl_seconds=30,
+        clock=lambda: 20,
+    )
+    HostedRoomPolicyCheckpoint(db)
+    _disband(db, room_id="room-1", now=50)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """INSERT INTO hosted_room_policy_cursors(
+                   room_id, through_seq, stopped_through_seq, updated_at
+               ) VALUES ('room-1', 1, 0, 50)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_policy_threads
+               VALUES ('room-1', 'thread-1', 'user-1', 1, 0)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_policy_events
+               VALUES ('room-1', 'thread-1', 'user-1', 1, '{}')"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_policy_watermarks
+               VALUES ('room-1', 'thread-1', 'ops', 1)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_policy_publications
+               VALUES ('room-1', 'task-1', 'turn.settled', 0, 1)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_policy_transcript
+               VALUES (
+                   'room-1', 'thread-1', 1, 'message.user', NULL
+               )"""
+        )
+        conn.execute(
+            """CREATE TABLE hosted_room_messaging_refs (
+                room_id TEXT NOT NULL,
+                marker TEXT NOT NULL
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_policy_transcript_state
+               VALUES ('room-1', 1)"""
+        )
+        conn.execute(
+            """INSERT INTO hosted_room_messaging_refs
+               VALUES ('room-1', 'outside-pr-b')"""
+        )
+
+    assert (
+        rooms.prune_disbanded_rooms(
+            db,
+            now=50 + rooms.DISBANDED_ROOM_RETENTION_SECONDS + 1,
+        )
+        == 1
+    )
+    with sqlite3.connect(db) as conn:
+        for table in (
+            "hosted_rooms",
+            "hosted_room_events",
+            "hosted_room_driver_tasks",
+            "hosted_room_driver_leases",
+            "hosted_room_policy_cursors",
+            "hosted_room_policy_threads",
+            "hosted_room_policy_events",
+            "hosted_room_policy_watermarks",
+            "hosted_room_policy_publications",
+            "hosted_room_policy_transcript",
+            "hosted_room_policy_transcript_state",
+        ):
+            assert conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
+        assert (
+            conn.execute("SELECT marker FROM hosted_room_messaging_refs").fetchone()[0]
+            == "outside-pr-b"
+        )
+
+
+def test_policy_sync_cannot_recreate_projection_after_room_pruning(
+    tmp_path,
+    monkeypatch,
+):
+    db = tmp_path / "state.db"
+    _create(db)
+    _append(
+        db,
+        room_id="room-1",
+        event_id="user-1",
+        kind="message.user",
+        actor=USER,
+        payload={"text": "hello", "thread_id": "thread-1"},
+        now=11,
+    )
+    checkpoint = HostedRoomPolicyCheckpoint(db)
+    original_read = rooms.read_events
+
+    def read_then_prune(*args, **kwargs):
+        page = original_read(*args, **kwargs)
+        _disband(db, room_id="room-1", now=20)
+        rooms.prune_disbanded_rooms(
+            db,
+            now=20 + rooms.DISBANDED_ROOM_RETENTION_SECONDS + 1,
+        )
+        return page
+
+    monkeypatch.setattr(rooms, "read_events", read_then_prune)
+    with pytest.raises(rooms.RoomNotFoundError, match="not found"):
+        checkpoint.sync(room_id="room-1", latest_seq=1)
+    with sqlite3.connect(db) as conn:
+        for table in (
+            "hosted_room_policy_cursors",
+            "hosted_room_policy_events",
+            "hosted_room_policy_transcript",
+            "hosted_room_policy_transcript_state",
+        ):
+            assert conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
 
 
 def test_pre_actor_draft_database_migrates_with_explicit_legacy_identity(tmp_path):

--- a/tests/gateway/test_hosted_rooms.py
+++ b/tests/gateway/test_hosted_rooms.py
@@ -497,6 +497,7 @@ def test_since_seq_returns_ordered_deltas_and_stable_cursor(tmp_path):
         "cursor": 2,
         "latest_seq": 4,
         "has_more": True,
+        "authority": {"gateway_id": "gateway-a", "epoch": 1},
     }
 
     second = rooms.read_events(
@@ -1016,3 +1017,45 @@ def test_gateway_event_budget_leaves_pre_update_snapshot_headroom():
         rooms.MAX_GATEWAY_EVENT_BYTES * 32
         <= update_cmd._PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE
     )
+
+
+def test_room_log_page_bound_counts_bytes_not_characters(tmp_path, monkeypatch):
+    """Char-based accounting (SQLite LENGTH(TEXT) / len(str)) must not let a
+    multibyte page exceed the byte ceiling.
+
+    Budget sits between the character length and the byte length of a
+    two-event page: character accounting would admit both events, byte
+    accounting admits exactly one.
+    """
+    db = tmp_path / "state.db"
+    _create(db)
+    for index in range(2):
+        _append(
+            db,
+            room_id="room-1",
+            event_id=f"bytes-{index}",
+            kind="message.user",
+            actor=USER,
+            payload={"text": "😀" * 200, "index": index},
+        )
+
+    def page_json(page):
+        return json.dumps(page, ensure_ascii=False, separators=(",", ":"))
+
+    def page_bytes(page):
+        return len(page_json(page).encode("utf-8"))
+
+    one_event = rooms.read_events(db, room_id="room-1", since_seq=0, limit=1)
+    unbounded_two = rooms.read_events(db, room_id="room-1", since_seq=0, limit=2)
+    budget = page_bytes(one_event) + 64
+
+    # Precondition: the budget discriminates — char accounting would accept
+    # the two-event page, byte accounting must reject it.
+    assert len(page_json(unbounded_two)) <= budget
+    assert page_bytes(unbounded_two) > budget
+
+    monkeypatch.setattr(rooms, "MAX_LOG_PAGE_BYTES", budget)
+    page = rooms.read_events(db, room_id="room-1", since_seq=0, limit=2)
+    assert [event["seq"] for event in page["events"]] == [1]
+    assert page_bytes(page) <= budget
+    assert page["has_more"] is True

--- a/tests/gateway/test_hosted_rooms_read_path.py
+++ b/tests/gateway/test_hosted_rooms_read_path.py
@@ -1,0 +1,31 @@
+"""Focused lock-behavior coverage for hosted Group Chat reads."""
+
+from gateway import hosted_rooms
+
+
+def test_list_rooms_does_not_enter_a_write_transaction_or_prune(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    hosted_rooms.create_room(
+        db,
+        room_id="room-1",
+        name="Release room",
+        members=[{"profile": "default", "handle": "hermes"}],
+        authority_gateway_id="gateway-a",
+    )
+
+    def reject_write_transaction(*_args, **_kwargs):
+        raise AssertionError("list_rooms must not enter a write transaction")
+
+    def reject_prune(*_args, **_kwargs):
+        raise AssertionError("list_rooms must not prune retention state")
+
+    monkeypatch.setattr(hosted_rooms, "_transaction", reject_write_transaction)
+    monkeypatch.setattr(
+        hosted_rooms,
+        "_prune_disbanded_rooms_locked",
+        reject_prune,
+    )
+
+    rows = hosted_rooms.list_rooms(db)
+
+    assert [row["room_id"] for row in rows] == ["room-1"]

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -506,6 +506,7 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
 
     worker_started = threading.Event()
     release_worker = threading.Event()
+    lease_released = threading.Event()
     cleanup_done = threading.Event()
     fake_db = MagicMock()
     # The DB-backed cooldown check calls this before compressing; a bare
@@ -531,8 +532,10 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
         def _compress_context(
             self, messages, *_args, commit_fence=None, **_kwargs
         ):
+            if commit_fence is not None:
+                commit_fence.register_cancelled_lock_release(lease_released.set)
             worker_started.set()
-            assert release_worker.wait(timeout=2)
+            assert release_worker.wait(timeout=10)
             if commit_fence is not None and not commit_fence.begin_commit():
                 return (messages, None)
             try:
@@ -630,8 +633,9 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
     assert len(timeout_warnings) == 1
     fake_db.archive_and_compact.assert_not_called()
+    assert lease_released.is_set()
     # Event/state assertions prove the host returned before the detached
-    # worker's two-second wait completed without a scheduler-sensitive clock
+    # worker's event-gated wait completed without a scheduler-sensitive clock
     # bound: cleanup runs only when that worker actually exits.
     SlowCompressAgent.last_instance.close.assert_not_called()
 

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -149,6 +149,22 @@ class TestSessionHygieneThresholds:
         assert approx_tokens < huge_model_threshold
 
 
+def test_hygiene_total_ceiling_warning_reports_elapsed_and_progress():
+    from gateway.run import _hygiene_compression_timeout_message
+
+    warning = _hygiene_compression_timeout_message(
+        total_exhausted=True,
+        elapsed=600.4,
+        idle_timeout=30.0,
+        progress_observed=True,
+    )
+
+    assert "total ceiling after 600.4s" in warning
+    assert "summary output was observed" in warning
+    assert "30.0s" not in warning
+    assert "no output" not in warning
+
+
 class TestSessionHygieneWarnThreshold:
     """Test the post-compression warning threshold (95% of context)."""
 
@@ -600,16 +616,9 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
         message_id="1",
     )
 
-    started = time.monotonic()
     result = await runner._handle_message(event)
-    elapsed = time.monotonic() - started
 
     assert result == "ok"
-    # Loose wall-clock bound per flake policy: this asserts the handler did
-    # NOT block on the hygiene-compression timeout path (which would take
-    # multiple seconds), not a precise latency. 0.15s missed by ~1-8ms on
-    # busy CI shards twice on 2026-07-23.
-    assert elapsed < 2.0
     assert worker_started.is_set()
     assert runner._run_agent.await_count == 1
     # Cooldown must be persisted to the state DB (survives restart, #74136),
@@ -621,6 +630,9 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     timeout_warnings = [s for s in adapter.sent if "Context compression timed out" in s["content"]]
     assert len(timeout_warnings) == 1
     fake_db.archive_and_compact.assert_not_called()
+    # Event/state assertions prove the host returned before the detached
+    # worker's two-second wait completed without a scheduler-sensitive clock
+    # bound: cleanup runs only when that worker actually exits.
     SlowCompressAgent.last_instance.close.assert_not_called()
 
     release_worker.set()

--- a/tests/gateway/test_subagent_failure_notice.py
+++ b/tests/gateway/test_subagent_failure_notice.py
@@ -1,0 +1,171 @@
+"""Subagent failures surface as one clean user-facing notice.
+
+Covers the Aug 2026 community report: a delegate_task child that dies
+(provider 404, timeout, crash) previously vanished silently on platforms
+with tool_progress off — the parent model saw the error but the human never
+did. Now:
+
+- ``tools.delegate_tool.format_subagent_failure_line`` renders one clean,
+  human-readable line (no tracebacks/JSON walls).
+- ``TurnRunner.progress_callback`` intercepts ``subagent.complete`` events
+  with a terminal failure status FIRST (before every progress-queue gate)
+  and delivers the line via ``_deliver_platform_notice``.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.turn_context import TurnContext
+from tools.delegate_tool import (
+    SUBAGENT_FAILURE_STATUSES,
+    _clean_error_text,
+    format_subagent_failure_line,
+)
+
+
+class TestCleanErrorText:
+    def test_single_line_passthrough(self):
+        assert _clean_error_text("Error code: 404 - model not found") == (
+            "Error code: 404 - model not found"
+        )
+
+    def test_traceback_takes_last_line(self):
+        tb = (
+            "Traceback (most recent call last):\n"
+            '  File "x.py", line 1, in <module>\n'
+            "    raise RuntimeError('boom')\n"
+            "RuntimeError: boom"
+        )
+        assert _clean_error_text(tb) == "RuntimeError: boom"
+
+    def test_multiline_non_traceback_takes_first_line(self):
+        assert _clean_error_text("first line\nsecond line") == "first line"
+
+    def test_caps_length(self):
+        out = _clean_error_text("x" * 500, max_chars=100)
+        assert len(out) == 100
+        assert out.endswith("...")
+
+    def test_empty_and_none(self):
+        assert _clean_error_text("") == ""
+        assert _clean_error_text(None) == ""
+        assert _clean_error_text("   \n  ") == ""
+
+
+class TestFormatSubagentFailureLine:
+    def test_failed_with_goal_error_duration(self):
+        line = format_subagent_failure_line(
+            "research competitor pricing",
+            "failed",
+            error="Error code: 404 - model not found",
+            duration_seconds=12.4,
+        )
+        assert line.startswith("⚠️ Subagent failed")
+        assert '"research competitor pricing"' in line
+        assert "404" in line
+        assert "(after 12s)" in line
+
+    def test_timeout_verb(self):
+        line = format_subagent_failure_line("do a thing", "timeout")
+        assert "timed out" in line
+
+    def test_long_goal_truncated(self):
+        line = format_subagent_failure_line("g" * 200, "failed")
+        assert "g" * 57 + "..." in line
+        assert "g" * 61 not in line
+
+    def test_no_goal_no_error(self):
+        line = format_subagent_failure_line(None, "error")
+        assert line == "⚠️ Subagent failed"
+
+    def test_multiline_goal_flattened(self):
+        line = format_subagent_failure_line("a\nb", "failed")
+        assert "\n" not in line
+
+    def test_failure_statuses_frozen(self):
+        assert SUBAGENT_FAILURE_STATUSES == {"failed", "error", "timeout"}
+
+
+def _make_runner_and_captured(monkeypatch, run_still_current=True):
+    """TurnRunner with a stub gateway runner; captures scheduled notices."""
+    from gateway import run as run_mod
+
+    captured: list[str] = []
+
+    class _StubGatewayRunner:
+        def _adapter_for_source(self, source):
+            return None
+
+        async def _deliver_platform_notice(self, source, content):
+            captured.append(content)
+
+    def _fake_schedule(coro, loop, logger=None, log_message=None):
+        asyncio.run(coro)
+
+    monkeypatch.setattr(run_mod, "safe_schedule_threadsafe", _fake_schedule)
+
+    ctx = TurnContext(
+        source=MagicMock(),
+        _run_still_current=lambda: run_still_current,
+        progress_queue=None,
+        _loop_for_step=None,
+    )
+    return run_mod.TurnRunner(_StubGatewayRunner(), ctx), captured
+
+
+class TestGatewayFailureNotice:
+    @pytest.mark.parametrize("status", sorted(SUBAGENT_FAILURE_STATUSES))
+    def test_failure_statuses_deliver_notice(self, monkeypatch, status):
+        runner, captured = _make_runner_and_captured(monkeypatch)
+        runner.progress_callback(
+            "subagent.complete",
+            preview="Error code: 404 - model not found",
+            status=status,
+            goal="scan the repo",
+            duration_seconds=8.0,
+        )
+        assert len(captured) == 1
+        assert "Subagent" in captured[0]
+        assert "404" in captured[0]
+        assert '"scan the repo"' in captured[0]
+
+    @pytest.mark.parametrize("status", ["completed", "interrupted", None])
+    def test_non_failure_statuses_stay_silent(self, monkeypatch, status):
+        runner, captured = _make_runner_and_captured(monkeypatch)
+        runner.progress_callback(
+            "subagent.complete", preview="all done", status=status, goal="g"
+        )
+        assert captured == []
+
+    def test_stale_run_stays_silent(self, monkeypatch):
+        runner, captured = _make_runner_and_captured(
+            monkeypatch, run_still_current=False
+        )
+        runner.progress_callback(
+            "subagent.complete", preview="boom", status="failed", goal="g"
+        )
+        assert captured == []
+
+    def test_fires_without_progress_queue(self, monkeypatch):
+        """The notice must not depend on tool_progress being enabled —
+        progress_queue=None is exactly the Telegram/Slack default where the
+        silent-failure report came from."""
+        runner, captured = _make_runner_and_captured(monkeypatch)
+        assert runner._ctx.progress_queue is None
+        runner.progress_callback(
+            "subagent.complete", preview="err", status="error", goal="g"
+        )
+        assert len(captured) == 1
+
+    def test_summary_preferred_over_preview(self, monkeypatch):
+        runner, captured = _make_runner_and_captured(monkeypatch)
+        runner.progress_callback(
+            "subagent.complete",
+            preview="short preview",
+            status="failed",
+            goal="g",
+            summary="the real error detail",
+        )
+        assert "the real error detail" in captured[0]

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -376,6 +376,9 @@ async def test_reconnect_drain_survives_cancellation_resistant_close(monkeypatch
         mock_polling_req.initialize.assert_awaited_once()
         mock_app.updater.start_polling.assert_awaited_once()
         assert adapter._polling_error_task is None or adapter._polling_error_task.done()
+        # Settle the generation verifier like the sibling tests do, so it does
+        # not outlive this test pending on its 60s progress deadline.
+        await _complete_current_polling_generation(adapter)
     finally:
         release_close.set()
         if not recovery.done():

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -850,3 +850,112 @@ async def test_disconnect_advances_past_cancellation_swallowing_lifecycle(monkey
 
     release.set()
     await asyncio.wait({wedged}, timeout=0.2)
+
+
+# ---------------------------------------------------------------------------
+# Exception-graph walker + pool/connect classifier contracts (PR #98094
+# follow-up): the two classifiers previously had no direct tests at all.
+# ---------------------------------------------------------------------------
+class TestIterExceptionGraph:
+    def test_flat_single(self):
+        err = ValueError("boom")
+        assert list(tg_adapter._iter_exception_graph(err)) == [err]
+
+    def test_walks_cause_chain(self):
+        root = ValueError("root")
+        mid = RuntimeError("mid")
+        mid.__cause__ = root
+        top = Exception("top")
+        top.__cause__ = mid
+        seen = list(tg_adapter._iter_exception_graph(top))
+        assert top in seen and mid in seen and root in seen
+
+    def test_walks_context_chain(self):
+        root = ValueError("during handling")
+        top = RuntimeError("top")
+        top.__context__ = root
+        seen = list(tg_adapter._iter_exception_graph(top))
+        assert top in seen and root in seen
+
+    def test_cycle_guard(self):
+        a = ValueError("a")
+        b = RuntimeError("b")
+        a.__cause__ = b
+        b.__cause__ = a  # cycle
+        seen = list(tg_adapter._iter_exception_graph(a))
+        assert seen.count(a) == 1 and seen.count(b) == 1  # terminates, no dupes
+
+    def test_diamond_no_duplicates(self):
+        root = ValueError("root")
+        left = RuntimeError("left"); left.__cause__ = root
+        right = TypeError("right"); right.__cause__ = root
+        top = Exception("top"); top.__cause__ = left; top.__context__ = right
+        seen = list(tg_adapter._iter_exception_graph(top))
+        assert seen.count(root) == 1
+
+
+class TestPoolTimeoutClassifier:
+    def test_ptb_pool_timeout_message(self):
+        err = Exception(
+            "Pool timeout: All connections in the connection pool are occupied. "
+            "Request was *not* sent to Telegram."
+        )
+        assert TelegramAdapter._looks_like_pool_timeout(err) is True
+
+    def test_wrapped_httpx_pooltimeout_class(self):
+        try:
+            raise ConnectionError("inner")
+        except ConnectionError as inner:
+            err = Exception("Timed out")
+            err.__context__ = inner
+            assert TelegramAdapter._looks_like_pool_timeout(err) is False
+
+    def test_httpx_pooltimeout_class_name(self):
+        class FakePoolTimeout(Exception):
+            pass
+        err = Exception("Timed out")
+        err.__cause__ = FakePoolTimeout("x")
+        assert TelegramAdapter._looks_like_pool_timeout(err) is True
+
+    def test_generic_timeout_negative(self):
+        assert TelegramAdapter._looks_like_pool_timeout(Exception("Timed out")) is False
+        assert TelegramAdapter._looks_like_pool_timeout(Exception("Bad Gateway")) is False
+
+    def test_occupied_connection_pool_substring(self):
+        # Both substrings present -> match even without "pool timeout" phrasing.
+        assert TelegramAdapter._looks_like_pool_timeout(
+            Exception("All connections in the connection pool are occupied")
+        ) is True
+        # "occupied" alone (no "connection pool") must not match.
+        assert TelegramAdapter._looks_like_pool_timeout(
+            Exception("seat was occupied")
+        ) is False
+        # "connection pool" alone (no "occupied") must not match.
+        assert TelegramAdapter._looks_like_pool_timeout(
+            Exception("connection pool sizing")
+        ) is False
+
+
+class TestConnectTimeoutClassifier:
+    def test_class_name_match(self):
+        class FakeConnectTimeout(Exception):
+            pass
+        assert TelegramAdapter._looks_like_connect_timeout(FakeConnectTimeout("x")) is True
+
+    def test_message_match(self):
+        assert TelegramAdapter._looks_like_connect_timeout(
+            Exception("connect timeout")
+        ) is True
+        assert TelegramAdapter._looks_like_connect_timeout(
+            Exception("connect timed out")
+        ) is True
+
+    def test_wrapped_in_cause(self):
+        class FakeConnectTimeout(Exception):
+            pass
+        err = Exception("Timed out")
+        err.__cause__ = FakeConnectTimeout("x")
+        assert TelegramAdapter._looks_like_connect_timeout(err) is True
+
+    def test_generic_negative(self):
+        assert TelegramAdapter._looks_like_connect_timeout(Exception("Timed out")) is False

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -327,6 +327,63 @@ async def test_reconnect_stop_deadline_does_not_wait_for_cancel_cleanup(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_reconnect_drain_survives_cancellation_resistant_close(monkeypatch):
+    """A cancellation-resistant polling-pool close must not wedge the ladder.
+
+    Distinct from ``test_reconnect_continues_if_drain_hangs``: that test's
+    ``_hang`` is cancellable, so the pre-existing ``asyncio.wait_for`` bound
+    also releases. httpcore's pool close runs under ``AsyncShieldCancellation``
+    (#58236/#63309) — a close that shields its cleanup keeps ``wait_for``
+    pending forever even after the timeout fires, wedging the tracked
+    ``_polling_error_task`` and every escalation gate behind it. The drain
+    must use the wall-clock deadline helper (abandon, not cancel-await),
+    same primitive as the general-pool drain (#98094).
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 1
+
+    mock_app, mock_polling_req = _make_mock_app()
+    release_close = asyncio.Event()
+    close_cancelled = asyncio.Event()
+
+    async def _shielded_close():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            close_cancelled.set()
+            # Cancellation-resistant cleanup: swallows the cancel and waits.
+            await release_close.wait()
+            raise
+
+    mock_polling_req.shutdown = AsyncMock(side_effect=_shielded_close)
+    mock_polling_req.initialize = AsyncMock()
+    adapter._app = mock_app
+
+    monkeypatch.setattr(tg_adapter, "_DRAIN_TIMEOUT", 0.05, raising=False)
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        recovery = asyncio.create_task(
+            adapter._handle_polling_network_error(Exception("Timed out"))
+        )
+        done, _ = await asyncio.wait({recovery}, timeout=2)
+
+    try:
+        assert recovery in done, (
+            "reconnect remained blocked waiting for cancellation-shielded "
+            "polling-pool shutdown() cleanup"
+        )
+        assert close_cancelled.is_set(), "drain must have cancelled the close"
+        # Ladder still advanced: polling pool rebuilt and polling restarted.
+        mock_polling_req.initialize.assert_awaited_once()
+        mock_app.updater.start_polling.assert_awaited_once()
+        assert adapter._polling_error_task is None or adapter._polling_error_task.done()
+    finally:
+        release_close.set()
+        if not recovery.done():
+            recovery.cancel()
+        await asyncio.gather(recovery, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_heartbeat_force_escalates_wedged_recovery_task(monkeypatch):
     """#66377: the heartbeat is an independent, cause-agnostic watchdog.
 

--- a/tests/hermes_cli/test_dashboard_auth_cookies.py
+++ b/tests/hermes_cli/test_dashboard_auth_cookies.py
@@ -133,6 +133,265 @@ def test_read_session_cookies_from_request_secure_prefix():
     assert rt == "rt_value"
 
 
+# ---------------------------------------------------------------------------
+# PKCE cookie: regression for #83832 (field case: Traefik+Authentik chain)
+# ---------------------------------------------------------------------------
+#
+# The PKCE payload is a flat ``key=value;key=value`` string. A raw ``;``
+# is a cookie-attribute terminator, so Python's http.cookies emits the
+# value in RFC 6265 quoted form with each ``;`` escaped as the
+# backslash-octal ``\073``. Mainstream browsers echo that form back
+# verbatim and Python decodes it — but ``"`` and ``\`` are outside the
+# plain cookie-octet set, and cookie-aware proxy hops that parse and
+# re-emit the Cookie header (verified for Go's net/http, common in
+# Go-based proxy/IDP middleware) reject the value and drop the cookie
+# entirely. The callback
+# then 400s with "Missing PKCE state cookie" even though the browser
+# sent the cookie. The fix URL-encodes the payload in the setter so the
+# wire value contains only cookie-octets, and every reader decodes via
+# cookies.parse_pkce_payload(). These tests pin the wire shape and the
+# round trip.
+
+
+def test_set_pkce_cookie_url_encodes_payload_to_avoid_rfc6265_split():
+    """The wire-level cookie value must contain only plain RFC 6265
+    cookie-octets: no raw ``;`` (attribute terminator), no ``"`` and no
+    ``\\`` (the http.cookies quoted form that strict cookie-aware proxy
+    parsers — verified for Go's net/http — reject, dropping the whole
+    cookie).
+
+    Regression for #83832 / the Traefik+Authentik support case: the
+    callback failed with "Missing PKCE state cookie" because a proxy
+    hop dropped the quoted ``\\073`` form.
+    """
+    from urllib.parse import unquote
+    client = TestClient(_build_app(use_https=True, prefix=""))
+    r = client.get("/set-pkce")
+    pkce_set = next(
+        c for c in r.headers.get_list("set-cookie")
+        if c.startswith(f"__Host-{PKCE_COOKIE}=")
+    )
+    # Take just the cookie name=value pair, ignore the attributes.
+    pkce_value = pkce_set.split(";", 1)[0]
+    wire = pkce_value.split("=", 1)[1]
+    # No unquoted literal ``;`` in the value (attribute terminator). The
+    # payload ``provider=stub;state=s;verifier=v`` is encoded as
+    # ``provider%3Dstub%3Bstate%3Ds%3Bverifier%3Dv``.
+    assert ";" not in wire, (
+        f"unquoted ; leaked into the cookie value: {pkce_value!r}"
+    )
+    # The real field failure (Traefik/Authentik): the http.cookies quoted
+    # form ``"...\073..."`` is not made of cookie-octets, and Go's
+    # net/http drops any cookie whose value contains ``"`` or ``\``.
+    # Pin the whole value to the plain RFC 6265 cookie-octet set.
+    assert '"' not in wire and "\\" not in wire, (
+        f"non-cookie-octet chars leaked into the wire value: {wire!r}"
+    )
+    cookie_octets = (
+        "!#$%&'()*+-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "[]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+    )
+    assert all(ch in cookie_octets for ch in wire), (
+        f"non-cookie-octet chars in the wire value: {wire!r}"
+    )
+    # Round-trip the URL-encoding back to the original payload.
+    decoded = unquote(wire)
+    assert decoded == "provider=stub;state=s;verifier=v", (
+        f"URL-encoded payload didn't round-trip to the original: "
+        f"got {decoded!r}"
+    )
+
+
+def test_parse_pkce_payload_old_format_cookie_survives_rolling_upgrade():
+    """Mixed-version window (10-minute PKCE TTL): a cookie minted by a
+    pre-encoding server arrives at the new reader — after starlette's
+    cookie-header unquoting — as the FLAT form with raw ``;`` between
+    segments and a single-encoded ``next``. The reader must split it
+    as-is, NOT payload-decode it first: decoding early would turn an
+    old ``next`` value containing ``%3B`` into a bogus delimiter and
+    truncate the post-login target.
+    """
+    from hermes_cli.dashboard_auth.cookies import parse_pkce_payload
+
+    old = (
+        "provider=stub;state=s123;verifier=v456;"
+        "next=%2Fsessions%3Fx%3Da%3Bb%26project%3Dfoo"
+    )
+    parts = parse_pkce_payload(old)
+    assert parts == {
+        "provider": "stub",
+        "state": "s123",
+        "verifier": "v456",
+        # Preserved verbatim — still single-encoded, exactly what the
+        # old reader produced; the downstream next-validator unquotes.
+        "next": "%2Fsessions%3Fx%3Da%3Bb%26project%3Dfoo",
+    }, f"old-format cookie mis-parsed: {parts!r}"
+
+
+def test_parse_pkce_payload_new_format_round_trips_setter_encoding():
+    """The new encoded wire form (no raw ``;`` possible — it is %3B)
+    decodes back to the exact original payload segments."""
+    from urllib.parse import quote
+
+    from hermes_cli.dashboard_auth.cookies import parse_pkce_payload
+
+    payload = "provider=stub;state=s123;verifier=v456;next=%2Fsessions"
+    wire = quote(payload, safe="")
+    assert ";" not in wire
+    parts = parse_pkce_payload(wire)
+    assert parts == {
+        "provider": "stub",
+        "state": "s123",
+        "verifier": "v456",
+        "next": "%2Fsessions",
+    }, f"new-format wire value mis-parsed: {parts!r}"
+
+
+def test_pkce_cookie_round_trip_preserves_all_segments():
+    """End-to-end: the browser stores the Set-Cookie, the server
+    reads it back via ``read_pkce_cookie``, the OAuth callback
+    in routes.py decodes the URL-encoded value and parses every
+    segment. Pre-fix, the quoted ``\\073`` wire form was dropped
+    whole by strict proxy-hop cookie parsers, so the callback saw
+    no PKCE cookie at all.
+    """
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from conftest_dashboard_auth import StubAuthProvider  # type: ignore
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from urllib.parse import unquote
+
+    clear_providers()
+    register_provider(StubAuthProvider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    try:
+        client = TestClient(
+            web_server.app, base_url="https://fly-app.fly.dev",
+        )
+        # /auth/login sets the PKCE cookie with provider / state / verifier
+        # packed by the login handler. Capture both the PKCE value and
+        # the state that the IDP saw.
+        r1 = client.get(
+            "/auth/login?provider=stub", follow_redirects=False,
+        )
+        assert r1.status_code == 302
+        pkce_set = next(
+            c for c in r1.headers.get_list("set-cookie")
+            if "hermes_session_pkce" in c
+        )
+        # Pull just the name=value portion so we can echo it back as
+        # a Cookie header.
+        pkce_kv = pkce_set.split(";", 1)[0]
+        # Confirm the setter URL-encoded the value.
+        encoded_value = pkce_kv.split("=", 1)[1]
+        decoded_value = unquote(encoded_value)
+        # The login handler packs provider, state, and verifier
+        # into the payload. All three must survive intact.
+        assert "provider=stub" in decoded_value
+        assert "state=" in decoded_value
+        assert "verifier=" in decoded_value
+        # And the encoded wire value must NOT have a literal, unquoted ``;``
+        # between segments.
+        assert ";" not in encoded_value, (
+            f"literal ; in wire cookie value: {encoded_value!r}"
+        )
+
+        # Round-trip via /auth/callback — the success path confirms
+        # the callback decoded the URL-encoded value and matched
+        # the state. (302 to the post-login page = success.)
+        state = r1.headers["location"].split("state=")[1]
+        r2 = client.get(
+            f"/auth/callback?code=stub_code&state={state}",
+            headers={"cookie": pkce_kv},
+            follow_redirects=False,
+        )
+        assert r2.status_code == 302, (
+            f"OIDC callback failed — the PKCE cookie round trip is broken. "
+            f"Body: {r2.text!r}"
+        )
+    finally:
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required
+
+
+def test_pkce_callback_works_when_next_query_includes_encoded_path():
+    """The ``next=`` segment carries a URL-encoded path (e.g. a
+    relative URL containing ``;`` from a query parameter on the
+    post-login target). The setter URL-encodes the whole payload
+    (so the ``;`` in the next= value doesn't trip RFC 6265), and
+    the reader decodes the next= value back to its original form
+    for the redirect."""
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from conftest_dashboard_auth import StubAuthProvider  # type: ignore
+    from hermes_cli import web_server
+    from hermes_cli.dashboard_auth import clear_providers, register_provider
+    from urllib.parse import quote, unquote
+
+    clear_providers()
+    register_provider(StubAuthProvider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    try:
+        client = TestClient(
+            web_server.app, base_url="https://fly-app.fly.dev",
+        )
+        # next= with a /sessions?view=recent&project=foo target.
+        # The login handler URL-encodes the next= value once, then
+        # the setter URL-encodes the whole payload. The reader
+        # decodes the payload back, and the routes callback then
+        # passes the next= through.
+        next_target = "/sessions?view=recent&project=foo"
+        r1 = client.get(
+            f"/auth/login?provider=stub&next={quote(next_target, safe='')}",
+            follow_redirects=False,
+        )
+        assert r1.status_code == 302
+        pkce_kv = next(
+            c for c in r1.headers.get_list("set-cookie")
+            if "hermes_session_pkce" in c
+        ).split(";", 1)[0]
+        # Drive the callback — must succeed (302 to the post-login
+        # target, NOT a 400 "Missing PKCE state cookie").
+        state = r1.headers["location"].split("state=")[1]
+        r2 = client.get(
+            f"/auth/callback?code=stub_code&state={state}",
+            headers={"cookie": pkce_kv},
+            follow_redirects=False,
+        )
+        assert r2.status_code == 302, (
+            f"callback failed with next= present: {r2.text!r}"
+        )
+        # The post-login redirect carries EXACTLY the original target:
+        # login-side single-encode + setter whole-payload encode must be
+        # symmetrically undone by parse_pkce_payload + the validator's
+        # unquote. Pin the exact byte shape — a relaxed substring match
+        # would hide an encode/decode imbalance.
+        assert r2.headers.get("location") == next_target, (
+            f"post-login redirect didn't carry the exact next= target: "
+            f"{r2.headers.get('location')!r} != {next_target!r}"
+        )
+    finally:
+        clear_providers()
+        web_server.app.state.bound_host = prev_host
+        web_server.app.state.bound_port = prev_port
+        web_server.app.state.auth_required = prev_required
+
+
 
 
 

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -286,7 +286,12 @@ def test_native_authorize_empty_provider_password_only_brokers_to_login(
     assert r.status_code == 302, r.text
     assert r.headers["location"].endswith("/login")
     set_cookie = r.headers.get("set-cookie", "")
-    assert "broker=" in set_cookie
+    # The PKCE cookie value is URL-encoded on the wire; decode through
+    # the real reader inverse before asserting the broker handle rides
+    # in it.
+    from hermes_cli.dashboard_auth.cookies import parse_pkce_payload
+    wire_value = set_cookie.split("=", 1)[1].split(";", 1)[0]
+    assert "broker" in parse_pkce_payload(wire_value)
 
 
 # ---------------------------------------------------------------------------
@@ -408,7 +413,10 @@ def test_native_authorize_password_provider_redirects_to_login(
     assert r.headers["location"].endswith("/login")
     set_cookie = r.headers.get("set-cookie", "")
     assert "pkce" in set_cookie
-    assert "broker=" in set_cookie
+    # Wire value is URL-encoded; decode through the reader inverse.
+    from hermes_cli.dashboard_auth.cookies import parse_pkce_payload
+    wire_value = set_cookie.split("=", 1)[1].split(";", 1)[0]
+    assert "broker" in parse_pkce_payload(wire_value)
 
 
 def _start_native_password_login(client, *, challenge, state="desk-state"):

--- a/tests/hermes_cli/test_install_identity.py
+++ b/tests/hermes_cli/test_install_identity.py
@@ -1,0 +1,112 @@
+from concurrent.futures import ThreadPoolExecutor
+import multiprocessing
+from pathlib import Path
+import time
+
+from gateway.hosted_rooms import local_authority_gateway_id
+import hermes_cli.install_identity as install_identity
+from hermes_cli.install_identity import read_or_create_install_id
+
+
+def _race_first_install_id(
+    root_value,
+    minted,
+    results,
+    start_barrier=None,
+    writer_entered=None,
+    release_writer=None,
+):
+    root = Path(root_value)
+    install_identity.uuid.uuid4 = lambda: type("FixedUuid", (), {"hex": minted})()
+    if start_barrier is not None:
+        start_barrier.wait(timeout=10)
+    if writer_entered is not None:
+        original_mkstemp = install_identity.tempfile.mkstemp
+
+        def held_mkstemp(*args, **kwargs):
+            writer_entered.set()
+            assert release_writer.wait(timeout=10)
+            return original_mkstemp(*args, **kwargs)
+
+        install_identity.tempfile.mkstemp = held_mkstemp
+    results.put(read_or_create_install_id(root))
+
+
+def test_concurrent_first_use_returns_one_persisted_identity(tmp_path):
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        values = list(executor.map(lambda _: read_or_create_install_id(tmp_path), range(64)))
+
+    assert len(set(values)) == 1
+    assert values[0]
+    assert (tmp_path / "install_id").read_text(encoding="utf-8").strip() == values[0]
+
+
+def test_independent_first_callers_return_the_single_committed_identity(tmp_path, monkeypatch):
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    writer_entered = context.Event()
+    release_writer = context.Event()
+    winner = context.Process(
+        target=_race_first_install_id,
+        args=(
+            str(tmp_path),
+            "a" * 32,
+            results,
+            None,
+            writer_entered,
+            release_writer,
+        ),
+    )
+    loser = context.Process(
+        target=_race_first_install_id,
+        args=(str(tmp_path), "b" * 32, results),
+    )
+
+    winner.start()
+    assert writer_entered.wait(timeout=10)
+    loser.start()
+    time.sleep(0.25)
+    assert loser.is_alive()
+    release_writer.set()
+    processes = [winner, loser]
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    returned = [results.get(timeout=2) for _ in processes]
+    persisted = (tmp_path / "install_id").read_text(encoding="utf-8").strip()
+
+    assert returned == [persisted, persisted]
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        install_identity,
+        "_INSTALL_ID_CACHE",
+        {"root": None, "value": None},
+    )
+    assert local_authority_gateway_id() == f"install:{persisted}"
+
+
+def test_concurrent_corrupt_file_repair_returns_one_committed_identity(tmp_path):
+    (tmp_path / "install_id").write_text("corrupt\n", encoding="utf-8")
+    context = multiprocessing.get_context("spawn")
+    barrier = context.Barrier(2)
+    results = context.Queue()
+    processes = [
+        context.Process(
+            target=_race_first_install_id,
+            args=(str(tmp_path), value, results, barrier),
+        )
+        for value in ("a" * 32, "b" * 32)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+
+    returned = [results.get(timeout=2) for _ in processes]
+    persisted = (tmp_path / "install_id").read_text(encoding="utf-8").strip()
+
+    assert returned == [persisted, persisted]

--- a/tests/hermes_cli/test_web_server_boot_handshake.py
+++ b/tests/hermes_cli/test_web_server_boot_handshake.py
@@ -84,6 +84,29 @@ def test_lifespan_warmup_is_synchronous():
     )
 
 
+def test_hosted_room_recovery_cannot_block_or_abort_backend_startup(monkeypatch):
+    from fastapi.testclient import TestClient
+    from tui_gateway import methods_groups
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocked_failure():
+        started.set()
+        release.wait(timeout=2.0)
+        raise RuntimeError("state.db is locked")
+
+    monkeypatch.setattr(web_server_mod, "_warm_gateway_module", lambda: None)
+    monkeypatch.setattr(methods_groups, "start_hosted_room_service", blocked_failure)
+    monkeypatch.setattr(methods_groups, "stop_hosted_room_service", lambda **_kwargs: True)
+
+    before = time.perf_counter()
+    with TestClient(web_server_mod.app, raise_server_exceptions=False):
+        assert started.wait(timeout=1.0)
+        assert time.perf_counter() - before < 1.0
+        release.set()
+
+
 # ---------------------------------------------------------------------------
 # Test 2 — get_status run_in_executor keeps event loop free for other requests
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -359,6 +359,82 @@ class TestProfileScopedModel:
         resp = client.get("/api/model/info", params={"profile": "ghost"})
         assert resp.status_code == 404
 
+    def test_model_info_two_profile_isolation(self, client, isolated_profiles):
+        """Round 4.1 item 2: /api/model/info?profile=X must resolve profile X's
+        OWN model, ceiling, and cached context length — with no cross-profile
+        leakage through the process-global models.dev or context-length cache.
+
+        Two real, distinct profile homes:
+          A (default):     model-a, ceiling 200K, cached ctx 300K → effective 200K
+          B (worker_beta): model-b, ceiling 272K, cached ctx 400K → effective 272K
+
+        The ceiling is read INSIDE _profile_scope (profile A's ceiling must not
+        appear in B's response, and vice versa). The auto_context_length is read
+        from each profile's OWN context_length_cache.yaml (distinct files,
+        distinct model+base_url keys), NOT from the process-global models.dev
+        in-memory cache.
+        """
+        import yaml as _yaml
+
+        home_a = isolated_profiles["default"]
+        home_b = isolated_profiles["worker_beta"]
+
+        # Distinct configs: different model, base_url, ceiling.
+        (home_a / "config.yaml").write_text(_yaml.safe_dump({
+            "model": {
+                "default": "model-a",
+                "provider": "openrouter",
+                "base_url": "https://a.example/v1",
+                "max_context_length": 200_000,
+            },
+        }), encoding="utf-8")
+
+        (home_b / "config.yaml").write_text(_yaml.safe_dump({
+            "model": {
+                "default": "model-b",
+                "provider": "openrouter",
+                "base_url": "https://b.example/v1",
+                "max_context_length": 272_000,
+            },
+        }), encoding="utf-8")
+
+        # Distinct per-profile context-length caches (the real disk cache
+        # that get_model_context_length reads at step 1 — before any network).
+        (home_a / "context_length_cache.yaml").write_text(_yaml.safe_dump({
+            "context_lengths": {"model-a@https://a.example/v1": 300_000},
+        }), encoding="utf-8")
+
+        (home_b / "context_length_cache.yaml").write_text(_yaml.safe_dump({
+            "context_lengths": {"model-b@https://b.example/v1": 400_000},
+        }), encoding="utf-8")
+
+        # Clear the process-global models.dev in-memory cache so it cannot
+        # mask the per-profile disk cache (it's a separate global dict).
+        from agent import models_dev
+        models_dev._models_dev_cache.clear()
+        models_dev._models_dev_cache_time = 0
+
+        # Profile A resolves its OWN values.
+        resp_a = client.get("/api/model/info", params={"profile": "default"})
+        assert resp_a.status_code == 200
+        data_a = resp_a.json()
+        assert data_a["model"] == "model-a"
+        assert data_a["auto_context_length"] == 300_000
+        assert data_a["effective_context_length"] == 200_000  # min(300K, 200K ceiling)
+
+        # Profile B resolves its OWN values — NO leakage from A.
+        resp_b = client.get("/api/model/info", params={"profile": "worker_beta"})
+        assert resp_b.status_code == 200
+        data_b = resp_b.json()
+        assert data_b["model"] == "model-b"
+        assert data_b["auto_context_length"] == 400_000
+        assert data_b["effective_context_length"] == 272_000  # min(400K, 272K ceiling)
+
+        # Explicit non-equality: no cross-profile leakage.
+        assert data_a["effective_context_length"] != data_b["effective_context_length"]
+        assert data_a["auto_context_length"] != data_b["auto_context_length"]
+        assert data_a["model"] != data_b["model"]
+
 
 class TestProfileScopedPostSetup:
     def test_post_setup_spawns_with_profile_flag(

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -67,6 +67,24 @@ async def test_dispatch_text_dm(monkeypatch: pytest.MonkeyPatch) -> None:
     assert src.user_id == "+15551234567"
 
 
+@pytest.mark.asyncio
+async def test_dispatch_read_receipt_does_not_wake_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    receipt = _dm_event("", msg_id="spc-read-1")
+    receipt["content"] = {
+        "type": "read",
+        "targetMessageId": "bot-msg-1",
+        "targetDirection": "outbound",
+    }
+
+    await adapter._dispatch_inbound(receipt)
+
+    assert captured == []
+
+
 # A real 1x1 transparent PNG (passes base.py's _looks_like_image magic check).
 _PNG_1X1_B64 = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhf"

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -85,6 +85,25 @@ async def test_dispatch_read_receipt_does_not_wake_agent(
     assert captured == []
 
 
+@pytest.mark.asyncio
+async def test_dispatch_read_receipt_alias_does_not_wake_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Some spectrum-ts streams label receipts ``read_receipt`` — same drop."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    receipt = _dm_event("", msg_id="spc-read-2")
+    receipt["content"] = {
+        "type": "read_receipt",
+        "targetMessageId": "bot-msg-2",
+        "targetDirection": "outbound",
+    }
+
+    await adapter._dispatch_inbound(receipt)
+
+    assert captured == []
+
+
 # A real 1x1 transparent PNG (passes base.py's _looks_like_image magic check).
 _PNG_1X1_B64 = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhf"

--- a/tests/run_agent/test_compressor_fallback_update.py
+++ b/tests/run_agent/test_compressor_fallback_update.py
@@ -69,6 +69,15 @@ def test_compressor_updated_on_fallback(mock_ctx_len, mock_resolve):
     assert c.api_key == "sk-fallback"
     assert c.provider == "openai"
     assert c.context_length == 128_000
-    assert c.threshold_tokens == int(128_000 * c.threshold_percent)
+    # Option A contract: threshold reserves the resolved output allowance. No
+    # explicit max_tokens here and provider "openai" declares no implicit cap,
+    # so the reservation is DEFAULT_OUTPUT_RESERVATION (4096) and the input
+    # budget is (context_length - reservation), not the raw window.
+    from agent.model_metadata import resolve_output_reservation
+
+    _res = resolve_output_reservation(
+        None, explicit_cap=c.max_tokens, provider=c.provider, model=c.model
+    )
+    assert c.threshold_tokens == int((128_000 - _res) * c.threshold_percent)
 
 

--- a/tests/run_agent/test_in_place_persist_marker_98450.py
+++ b/tests/run_agent/test_in_place_persist_marker_98450.py
@@ -1,0 +1,173 @@
+"""Regression test for #98450: in-place batch compaction commit must stamp
+_DB_PERSISTED_MARKER on the committed dicts.
+
+``compress()`` returns marker-swept COPIES (``_strip_persistence_markers``,
+#57491 — the sweep protects the ROTATION flush to a child session). The
+in-place branch commits those copies durably via
+``SessionDB.archive_and_compact()`` and hands the SAME dict instances back
+as the live message list. Without a post-commit stamp, the next
+``_persist_session`` → ``_flush_messages_to_session_db_unlocked`` walk sees
+every compacted row as unpersisted and re-INSERTs the whole post-compaction
+transcript — the live set doubles on every compaction (production:
+~58K → ~512K tokens in two hours).
+
+The healthy sibling ``ContextCompressor._sync_micro_compact_to_db`` already
+stamps after its ``archive_and_compact`` call; both now share
+``stamp_db_persisted_markers``.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_agent(session_db, session_id):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.compression_in_place = True
+
+    def _fake_compress(messages, current_tokens=None, focus_topic=None, force=False):
+        # Mirrors the real compress() contract: marker-swept fresh dicts.
+        return [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary of prior turns"},
+            {"role": "assistant", "content": "recent reply 1"},
+            {"role": "user", "content": "follow-up q"},
+            {"role": "assistant", "content": "recent reply 2"},
+        ]
+
+    agent.context_compressor.compress = _fake_compress
+    agent.context_compressor._last_compress_aborted = False
+    agent.context_compressor._last_summary_error = None
+    agent.context_compressor.compression_count = 1
+    return agent
+
+
+def _seed(db, sid, n=8):
+    db.create_session(sid, "cli", model="test/model")
+    for i in range(n):
+        db.append_message(
+            session_id=sid,
+            role="user" if i % 2 == 0 else "assistant",
+            content=f"seed msg {i}",
+        )
+
+
+def _row_counts(db, sid):
+    total = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ?", (sid,)
+    ).fetchone()[0]
+    active = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 1", (sid,)
+    ).fetchone()[0]
+    return total, active
+
+
+class TestInPlaceCommitPersistMarker:
+    def test_post_commit_persist_does_not_reinsert_compacted_rows(self):
+        """In-place commit → persist walk: row counts stay stable (#98450)."""
+        from hermes_state import SessionDB
+        from agent.conversation_compression import compress_context
+        from agent.context_compressor import _DB_PERSISTED_MARKER
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "t.db")
+            sid = "20260830_120000_marker"
+            _seed(db, sid, n=8)
+            agent = _make_agent(db, sid)
+            agent._session_db_created = True
+            agent._last_flushed_db_idx = 8
+
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+            compressed, _sp = compress_context(
+                agent, messages, approx_tokens=100_000, system_message="sys"
+            )
+
+            # ── Precondition: the compacted set genuinely went through
+            # archive_and_compact — the 8 seeded rows were soft-archived
+            # (kept on disk, active=0) and the 4 compacted dicts were
+            # inserted as the new active set. Without this the "no
+            # duplicates" assertion below would pass vacuously on a path
+            # that never committed anything.
+            total, active = _row_counts(db, sid)
+            assert active == len(compressed) == 4
+            assert total == 8 + len(compressed)  # archived seeds + active set
+            archived = db._conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 0",
+                (sid,),
+            ).fetchone()[0]
+            assert archived == 8
+
+            # ── The fix: every committed dict instance carries the marker.
+            # These are the exact instances the caller keeps as the live
+            # message list, so the stamp must be on THEM (compress() output
+            # copies), not on some other collection.
+            for msg in compressed:
+                assert msg.get(_DB_PERSISTED_MARKER) is True, (
+                    f"committed dict missing persistence marker: {msg.get('content')!r}"
+                )
+
+            # ── The symptom: run the post-compaction persist walk twice
+            # (turn finalize + close safety-net in production). The flush
+            # must skip the already-durable compacted rows: no re-INSERT,
+            # counts stable, zero duplicate active contents.
+            agent._persist_session(compressed, conversation_history=None)
+            agent._persist_session(compressed, conversation_history=None)
+            total2, active2 = _row_counts(db, sid)
+            dup_groups = db._conn.execute(
+                "SELECT content, COUNT(*) c FROM messages "
+                "WHERE session_id = ? AND active = 1 "
+                "GROUP BY content HAVING c > 1",
+                (sid,),
+            ).fetchall()
+            assert (total2, active2) == (total, active), (
+                f"post-commit persist re-INSERTed compacted rows: "
+                f"total {total}->{total2}, active {active}->{active2}"
+            )
+            assert dup_groups == [], f"duplicate active rows: {dup_groups}"
+
+    def test_stamp_helper_shared_by_micro_compact_sync(self):
+        """The micro-compaction sync fulfils the same post-commit contract
+        via the shared helper (class-of-bug guard, not a change detector:
+        asserts the behavioral outcome — dicts stamped after a successful
+        archive_and_compact — for the sibling call path)."""
+        from hermes_state import SessionDB
+        from agent.context_compressor import (
+            ContextCompressor,
+            _DB_PERSISTED_MARKER,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = SessionDB(db_path=Path(tmp) / "m.db")
+            sid = "20260830_120001_micro0"
+            _seed(db, sid, n=4)
+            compressor = ContextCompressor.__new__(ContextCompressor)
+            compressor._session_db = db
+            compressor._session_id = sid
+            compacted = [
+                {"role": "user", "content": "u"},
+                {"role": "assistant", "content": "micro summary"},
+            ]
+            compressor._sync_micro_compact_to_db(compacted)
+            # Precondition: the commit really happened.
+            total, active = _row_counts(db, sid)
+            assert active == 2 and total == 6
+            for msg in compacted:
+                assert msg.get(_DB_PERSISTED_MARKER) is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -1249,7 +1249,7 @@ class _CountingCtxLen:
         self.value = value
         self.calls = 0
 
-    def __call__(self, **kwargs):
+    def __call__(self, *args, **kwargs):
         self.calls += 1
         if isinstance(self.value, Exception):
             raise self.value
@@ -1314,6 +1314,89 @@ def test_reference_trim_caches_resolution_failures(monkeypatch):
     assert cache == {("openrouter", "small-window"): None}
 
 
+
+
+
+# ── Round 4: MoA output-reservation consistency (trim == gate) ───────────────
+
+
+def test_moa_trim_and_gate_share_one_output_reserve(monkeypatch):
+    """The reference TRIM and the reference GATE must reserve the SAME output
+    allowance.  Previously the trim reserved the MoA default (8192) while the
+    gate reserved 0 (and the aggregator gate hardcoded 0) — an unshrinkable
+    reference could slip past a gate that thought it had more headroom, or the
+    gate could refuse a payload the trim believed fit.
+
+    Assert:
+      * both resolve to the SAME value, for an explicit cap and for the
+        no-cap case (the established MoA default — never 0);
+      * a payload sized in the gap between reserve=0 and reserve=8192 is
+        REFUSED by the gate (proving the gate uses the MoA default, not 0).
+    """
+    import agent.moa_loop as moa
+    from agent.model_metadata import (
+        estimate_messages_tokens_rough,
+        DEFAULT_OUTPUT_RESERVATION,
+    )
+    from agent.agent_runtime_helpers import (
+        canonical_request_budget,
+        enforce_effective_context_limit,
+        ContextCeilingExceeded,
+    )
+
+    DEFAULT = DEFAULT_OUTPUT_RESERVATION  # 4096 — the Hermes default
+
+    # 1) Explicit cap: trim and gate resolve to the SAME explicit value.
+    assert moa._resolve_moa_output_reserve(4096) == 4096
+    assert moa._resolve_moa_output_reserve(2048) == 2048
+
+    # 2) No cap: both resolve to the established Hermes default (never 0).
+    assert moa._resolve_moa_output_reserve(None) == DEFAULT
+    assert moa._resolve_moa_output_reserve(0) == DEFAULT
+    assert moa._resolve_moa_output_reserve(-5) == DEFAULT
+    assert moa._resolve_moa_output_reserve(True) == DEFAULT  # bool is not a cap
+
+    # 3) Behavioral: a payload in the gap [W, W+4096) is REFUSED by the gate
+    #    (gate reserves 4096) even though a 0-reserve gate would accept it.
+    window = 10_000
+    # chars/4 rough → need base in (window - 4096, window] = (5904, 10000].
+    base_target = window - 4096 + 200  # 6104 → base must exceed this
+    content = "x" * (base_target * 4 + 800)
+    messages = [{"role": "user", "content": content}]
+    base = estimate_messages_tokens_rough(messages)
+    assert base > window - 4096, f"setup: base {base} not in gap"
+    assert base <= window, f"setup: base {base} exceeds window"
+
+    # Gate (unified) reserves 4096 → base + 4096 > window → REFUSED.
+    gate_reserve = moa._resolve_moa_output_reserve(None)  # = 4096
+    gate_budget = canonical_request_budget(messages, output_reserve=gate_reserve)
+    assert gate_budget > window  # base + 4096 > window
+    with pytest.raises(ContextCeilingExceeded):
+        enforce_effective_context_limit(
+            gate_budget, pre_cap=window, ceiling=None, reason="MoA reference dispatch",
+        )
+
+    # A 0-reserve gate would have ACCEPTED the same payload — that was the old
+    # divergence. Prove the unified value is strictly larger than 0 here.
+    zero_budget = canonical_request_budget(messages, output_reserve=0)
+    assert zero_budget <= window  # old gate (reserve=0) would have accepted
+    assert gate_reserve > 0
+
+
+def test_moa_aggregator_gate_uses_same_reserve(monkeypatch):
+    """The aggregator gate must use the SAME resolved reserve as the
+    reference gate — not a hardcoded 0.  Both default to the MoA default when
+    no explicit cap is present."""
+    import agent.moa_loop as moa
+    from agent.model_metadata import DEFAULT_OUTPUT_RESERVATION
+
+    DEFAULT = DEFAULT_OUTPUT_RESERVATION  # 4096
+    # The aggregator call carries no explicit max_tokens → default applies.
+    assert moa._resolve_moa_output_reserve(None) == DEFAULT
+    # And it is the same value the reference gate uses for a no-cap reference.
+    assert moa._resolve_moa_output_reserve(None) == moa._resolve_moa_output_reserve(None)
+    # Explicit cap path is identical for both.
+    assert moa._resolve_moa_output_reserve(2048) == 2048
 
 
 def test_render_tool_calls_tolerates_namespace_shapes():

--- a/tests/run_agent/test_per_model_compression_threshold.py
+++ b/tests/run_agent/test_per_model_compression_threshold.py
@@ -48,7 +48,13 @@ class TestContextCompressorModelThresholds:
         )
         # 1M context >= 512K, so no small-context floor — override wins
         assert cc.threshold_percent == 0.40
-        assert cc.threshold_tokens == int(1_000_000 * 0.40)
+        # Option A: threshold reserves the resolved output allowance (no
+        # explicit max_tokens, no provider cap → DEFAULT_OUTPUT_RESERVATION),
+        # so the input budget is (context_length - reservation).
+        from agent.model_metadata import resolve_output_reservation
+
+        _res = resolve_output_reservation(None, explicit_cap=cc.max_tokens)
+        assert cc.threshold_tokens == int((1_000_000 - _res) * 0.40)
 
 
 
@@ -89,7 +95,11 @@ class TestContextCompressorModelThresholds:
         )
         # 1M >= 512K → no floor; override 0.25 applies directly
         assert cc.threshold_percent == 0.25
-        assert cc.threshold_tokens == int(1_000_000 * 0.25)
+        # Option A: reservation-aware input budget (see sibling test above).
+        from agent.model_metadata import resolve_output_reservation
+
+        _res = resolve_output_reservation(None, explicit_cap=cc.max_tokens)
+        assert cc.threshold_tokens == int((1_000_000 - _res) * 0.25)
 
 
 

--- a/tests/run_agent/test_per_model_threshold_init_ordering.py
+++ b/tests/run_agent/test_per_model_threshold_init_ordering.py
@@ -114,7 +114,13 @@ class TestFloorInteractionOnModelSwitch:
         mock_ctx.return_value = 128_000
         cc.update_model(model="small-model", context_length=128_000)
         assert cc.threshold_percent == 0.75  # raise-only floor wins
-        assert cc.threshold_tokens == int(128_000 * 0.75)
+        # Option A: threshold reserves the resolved output allowance (no
+        # explicit max_tokens, no provider cap → DEFAULT_OUTPUT_RESERVATION),
+        # so the input budget is (context_length - reservation).
+        from agent.model_metadata import resolve_output_reservation
+
+        _res = resolve_output_reservation(None, explicit_cap=cc.max_tokens)
+        assert cc.threshold_tokens == int((128_000 - _res) * 0.75)
 
 
 

--- a/tests/run_agent/test_restore_primary_posttransition.py
+++ b/tests/run_agent/test_restore_primary_posttransition.py
@@ -1,0 +1,174 @@
+"""Finding D (#4): Fallback/restore-primary post-transition failure leaves host+engine coherent.
+
+When ``restore_primary_runtime`` runs, the sequence is:
+
+  1. Host state → primary (model/provider/client/api_key/...)
+  2. ``transition_model_context`` → engine → primary (COMMITTED)
+  3. Credential pool rebind
+  4. ``_swap_credential(entry)`` → can RAISE
+  5. reasoning_config, fallback reset, prompt identity rewrite
+
+If step 4 raises, the ``except`` block restores the **host** to fallback
+(snapshot) but the **engine** (committed in step 2) is left on primary →
+the agent is left with a fallback host + primary engine — incoherent.
+
+The fix: ``_swap_credential`` failure is NON-FATAL (the documented
+"keep the snapshot key" behavior).  The exception is caught locally,
+logged, and the restore completes with the host on primary (coherent with
+the engine).  The pool entry swap is simply skipped.
+
+RED   — before the fix, ``_swap_credential`` raising propagates to the
+         outer ``except``, which restores the host to fallback. The engine
+         stays on primary → assertions FAIL (host≠engine).
+GREEN — after the fix, ``_swap_credential`` failure is caught locally;
+         the restore completes with host on primary, coherent with the
+         engine → assertions PASS.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_agent_d() -> "MagicMock":
+    """Agent on fallback with a primary snapshot to restore."""
+    agent = MagicMock()
+
+    # CURRENT state: on FALLBACK (the state we're restoring FROM)
+    agent.model = "fallback-model"
+    agent.provider = "custom"
+    agent.base_url = "http://fallback:8080/v1"
+    agent.api_key = "key-fallback"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock(name="FallbackClient")
+    agent._client_kwargs = {"api_key": "key-fallback"}
+    agent._anthropic_client = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._is_anthropic_oauth = False
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent._pre_cap_context_length = 65536
+    agent._reasoning_echo_flag = False
+    agent._transport_cache = {}
+
+    # Primary snapshot (what we're restoring TO)
+    primary = {
+        "model": "primary-model",
+        "provider": "custom",
+        "base_url": "http://primary:8080/v1",
+        "api_key": "key-primary",
+        "api_mode": "chat_completions",
+        "client_kwargs": {"api_key": "key-primary"},
+        "use_prompt_caching": False,
+        "use_native_cache_layout": False,
+        "anthropic_api_key": "",
+        "anthropic_base_url": None,
+        "is_anthropic_oauth": False,
+        "reasoning_echo_flag": False,
+        "compressor_context_length": 131072,
+        "compressor_model": "primary-model",
+    }
+    agent._primary_runtime = primary
+
+    # Fallback state
+    agent._fallback_activated = True
+    agent._fallback_index = 0
+    agent._fallback_chain = [{"model": "fallback-model", "provider": "custom"}]
+    agent._rate_limited_until = 0
+    agent._restore_wait_logged = False
+    agent._credential_pool = None
+    agent._credential_pool_entry_id = None
+    agent._cache_disabled = False
+    agent._rate_limit_backoff_count = 0
+
+    # Engine: on FALLBACK initially
+    engine = MagicMock(name="ContextEngine")
+    engine.model = "fallback-model"
+    engine.provider = "custom"
+    engine.base_url = "http://fallback:8080/v1"
+    engine.api_key = "key-fallback"
+    engine.api_mode = "chat_completions"
+    engine.context_length = 65536
+    engine.pre_cap_context_length = 65536
+    engine._handles_context_ceiling = True
+    engine.update_model = MagicMock()
+    agent.context_compressor = engine
+
+    # _create_openai_client returns a new client
+    new_client = MagicMock(name="PrimaryClient")
+    agent._create_openai_client = MagicMock(return_value=new_client)
+
+    return agent
+
+
+class TestRestorePrimaryPostTransitionFailure:
+    """Finding #4: _swap_credential raise after engine transition must not leave host+engine incoherent."""
+
+    def test_swap_credential_failure_keeps_host_and_engine_coherent(self):
+        """When _swap_credential raises (after transition_model_context succeeds),
+        the agent must be left in a coherent state — NOT host=fallback +
+        engine=primary."""
+        agent = _make_agent_d()
+
+        # A credential pool entry that will be selected
+        pool = MagicMock()
+        pool.has_available = MagicMock(return_value=True)
+        entry = MagicMock()
+        entry.provider = "custom"
+        entry.runtime_api_key = "key-from-pool"
+        entry.access_token = "key-from-pool"
+        pool.select = MagicMock(return_value=entry)
+        agent._credential_pool = pool
+
+        # _swap_credential RAISES (the post-transition failure)
+        def swap_boom(_entry):
+            raise RuntimeError("simulated credential swap failure")
+        agent._swap_credential = swap_boom
+
+        # transition_model_context succeeds (engine transitions to primary)
+        with patch("agent.agent_runtime_helpers.transition_model_context") as mock_tm:
+            mock_tm.return_value = 131072
+            with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+                with patch("agent.chat_completion_helpers._reset_stale_streak", return_value=None):
+                    with patch("agent.chat_completion_helpers.rewrite_prompt_model_identity", return_value=None):
+                        from agent.agent_runtime_helpers import restore_primary_runtime
+                        result = restore_primary_runtime(agent)
+
+        # The engine transition WAS committed (transition_model_context was
+        # called for the primary) — this is the "engine on primary" side of
+        # the coherence invariant, evidenced by the actual call.
+        assert mock_tm.called, "transition_model_context must run (engine → primary)"
+        _tm_kwargs = mock_tm.call_args
+        _tm_model = _tm_kwargs.kwargs.get("model") or (_tm_kwargs.args[1] if len(_tm_kwargs.args) > 1 else None)
+        assert _tm_model == "primary-model", (
+            f"engine must transition to primary-model, got {_tm_model!r}"
+        )
+
+        # The restore must have COMPLETED (result=True) because
+        # _swap_credential failure is NON-FATAL (keep snapshot key).
+        assert result is True, (
+            f"restore_primary_runtime should return True (swap failure is non-fatal), "
+            f"got {result!r} — the outer except restored the host to fallback, "
+            f"leaving host=fallback + engine=primary (INCOHERENT)"
+        )
+
+        # HOST must be on PRIMARY (coherent with the engine that was committed)
+        assert agent.model == "primary-model", (
+            f"host model must be primary (coherent with engine), got {agent.model!r}"
+        )
+        assert agent.base_url == "http://primary:8080/v1", (
+            f"host base_url must be primary, got {agent.base_url!r}"
+        )
+        assert agent.api_key == "key-primary", (
+            f"host api_key must be primary, got {agent.api_key!r}"
+        )
+
+        # The key invariant: host stays on primary, matching the engine's
+        # committed primary-model transition (no rollback to fallback).
+        assert agent.model == "primary-model" and _tm_model == "primary-model", (
+            f"host ({agent.model!r}) and engine ({_tm_model!r}) must agree — "
+            f"incoherent state (host=fallback, engine=primary) detected"
+        )

--- a/tests/run_agent/test_switch_model_lmstudio_preload_rollback.py
+++ b/tests/run_agent/test_switch_model_lmstudio_preload_rollback.py
@@ -1,0 +1,196 @@
+"""Regression test: switch_model() must roll back to the pre-swap state if the
+LM Studio preload / context resolution raises.
+
+The switch_model transaction has three failure windows:
+
+  Window A (client-rebuild phase): wrapped in try/except → _restore_snapshot()
+    (covered by test_switch_model_rollback.py)
+
+  Window B (LM Studio preload + context resolution phase):
+    ``_ensure_lmstudio_runtime_loaded`` is a real network I/O call to the LM
+    Studio management API. Before the fix it sat BETWEEN the Window A
+    try/except and the Window C try/except, OUTSIDE any rollback. A failure
+    there left the agent with a NEW host route (model/provider/client already
+    committed in Window A) but the OLD engine pre-cap and OLD _primary_runtime
+    (both updated only AFTER Window B) — the exact incoherence class the
+    switch_model rollback exists to prevent.
+
+  Window C (engine transition phase): wrapped in try/except → _restore_snapshot()
+
+This test drives the REAL ``agent.agent_runtime_helpers.switch_model`` with
+``_ensure_lmstudio_runtime_loaded`` raising (simulating a network error / HTTP
+error in the LM Studio management API call), and asserts that the previous
+coherent route is FULLY preserved: model, provider, client, pre-cap, engine
+route, and _primary_runtime.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent_lmstudio() -> AIAgent:
+    """Agent on lmstudio (openai-compatible) with a coherent initial state.
+
+    The initial state is a COMPLETE coherent route: model + provider + client
+    + pre-cap + engine route + _primary_runtime all agree. After a failed
+    LM Studio preload, every one of these must be restored to this state.
+    """
+    agent = AIAgent.__new__(AIAgent)
+
+    # OLD (pre-swap) coherent route
+    agent.provider = "lmstudio"
+    agent.model = "lmstudio/old-model"
+    agent.requested_provider = "lmstudio"
+    agent.base_url = "http://localhost:1234/v1"
+    agent.api_key = "lm-key-original"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock(name="OriginalLMStudioClient")
+    agent._client_kwargs = {
+        "api_key": "lm-key-original",
+        "base_url": "http://localhost:1234/v1",
+    }
+    agent._config_context_length = 131072
+    agent._pre_cap_context_length = 131072
+    agent._primary_runtime = {
+        "model": "lmstudio/old-model",
+        "provider": "lmstudio",
+        "base_url": "http://localhost:1234/v1",
+        "api_mode": "chat_completions",
+        "compressor_context_length": 131072,
+    }
+
+    # A mock context_compressor so the engine transition (Window C) is
+    # REACHABLE but will NOT be reached because the LM Studio preload
+    # (Window B) fails first.
+    cc = MagicMock(name="ContextCompressor")
+    cc.model = "lmstudio/old-model"
+    cc.provider = "lmstudio"
+    cc.base_url = "http://localhost:1234/v1"
+    cc.api_key = "lm-key-original"
+    cc.api_mode = "chat_completions"
+    cc.context_length = 131072
+    cc.pre_cap_context_length = 131072
+    agent.context_compressor = cc
+
+    # Other fields that switch_model touches
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._anthropic_client = None
+    agent._is_anthropic_oauth = False
+    agent._cached_system_prompt = "cached"
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._credential_pool = None
+    agent._credential_pool_entry_id = None
+    agent._reasoning_echo_flag = False
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent.reasoning_config = None
+    agent._custom_providers = None
+
+    return agent
+
+
+def test_lmstudio_preload_failure_rolls_back_to_original_state():
+    """When _ensure_lmstudio_runtime_loaded raises, the previous coherent route
+    (model, provider, client, pre-cap, engine route, _primary_runtime) must be
+    FULLY preserved — not left half-switched to the new model."""
+    agent = _make_agent_lmstudio()
+
+    original_client = agent.client
+    original_primary_runtime = dict(agent._primary_runtime)
+    original_pre_cap = agent._pre_cap_context_length
+    original_engine = agent.context_compressor
+
+    # Make the LM Studio preload raise (simulates a network error / HTTP error
+    # in the LM Studio management API call).
+    def boom(*_a, **_kw):
+        raise RuntimeError("simulated LM Studio preload failure")
+
+    agent._ensure_lmstudio_runtime_loaded = boom
+
+    # Make the client rebuild SUCCEED (so we get past Window A and reach
+    # Window B where the failure occurs).
+    new_client = MagicMock(name="NewLMStudioClient")
+    agent._create_openai_client = lambda *_a, **_kw: new_client
+
+    with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+        with pytest.raises(RuntimeError, match="simulated LM Studio preload failure"):
+            agent.switch_model(
+                new_model="lmstudio/new-model",
+                new_provider="lmstudio",
+                api_key="lm-key-new",
+                base_url="http://localhost:1234/v1",
+                api_mode="chat_completions",
+            )
+
+    # Core invariant: the previous coherent route is FULLY preserved.
+    assert agent.model == "lmstudio/old-model", (
+        f"model must be restored to old value, got {agent.model!r}"
+    )
+    assert agent.provider == "lmstudio", (
+        f"provider must be restored, got {agent.provider!r}"
+    )
+    assert agent.client is original_client, (
+        "client must be restored to the original object"
+    )
+    assert agent._pre_cap_context_length == original_pre_cap, (
+        f"pre-cap must be restored, got {agent._pre_cap_context_length!r}"
+    )
+    assert agent._primary_runtime == original_primary_runtime, (
+        f"_primary_runtime must be restored, got {agent._primary_runtime!r}"
+    )
+    # Engine route must be unchanged (the engine was NOT transitioned because
+    # the failure happened before the engine transition).
+    assert agent.context_compressor is original_engine, (
+        "context_compressor must be the same object"
+    )
+    assert agent.context_compressor.model == "lmstudio/old-model", (
+        "engine model must be restored"
+    )
+    assert agent.context_compressor.provider == "lmstudio", (
+        "engine provider must be restored"
+    )
+
+
+def test_successful_switch_still_works_after_lmstudio_rollback_refactor():
+    """Sanity check: the try/except wrapper around the LM Studio preload phase
+    hasn't broken the happy path (LM Studio preload succeeds → switch completes)."""
+    agent = _make_agent_lmstudio()
+
+    new_client = MagicMock(name="NewLMStudioClient")
+    agent._create_openai_client = lambda *_a, **_kw: new_client
+    # LM Studio preload succeeds (returns a load result with context_length).
+    agent._ensure_lmstudio_runtime_loaded = lambda *_a, **_kw: MagicMock(
+        context_length=65536, rejected=False, load_attempted=True
+    )
+    # _lmstudio_load_was_unverified should return False for a successful load.
+    agent._lmstudio_load_was_unverified = lambda *_a, **_kw: False
+    # _effective_lmstudio_context_length should return a valid int.
+    agent._effective_lmstudio_context_length = (
+        lambda *a, **kw: 65536
+    )
+
+    with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+        agent.switch_model(
+            new_model="lmstudio/new-model",
+            new_provider="lmstudio",
+            api_key="lm-key-new",
+            base_url="http://localhost:1234/v1",
+            api_mode="chat_completions",
+        )
+
+    assert agent.model == "lmstudio/new-model"
+    assert agent.provider == "lmstudio"
+    assert agent.client is new_client
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/run_agent/test_switch_model_postclient_rollback.py
+++ b/tests/run_agent/test_switch_model_postclient_rollback.py
@@ -1,0 +1,218 @@
+"""Finding C (#3): /model transaction boundary — post-client/pre-finalized.
+
+The switch_model transaction has THREE failure windows that must each roll the
+host route (model/provider/client/base_url/api_key/api_mode/_client_kwargs/
+pre-cap/_primary_runtime) back to its prior coherent state:
+
+  Window A — client rebuild          (already wrapped → _restore_snapshot)
+  Window B — LM Studio preload       (already wrapped → _restore_snapshot)
+  Window C — engine transition       (already wrapped → _restore_snapshot)
+
+BUT the region BETWEEN Window B and Window C — the prompt-cache policy
+re-eval (``_anthropic_prompt_cache_policy``) and context/capability resolution
+(``get_model_context_length``) — is NOT wrapped. An exception from either
+propagates with the host already committed (Window A) and the engine NOT yet
+transitioned (Window C), leaving the agent with a NEW model/provider/client
+paired with the OLD engine route — exactly the incoherence the switch_model
+rollback exists to prevent.
+
+This test drives the REAL ``agent.agent_runtime_helpers.switch_model`` with:
+  * preload succeeds (Window B passes)
+  * ``_anthropic_prompt_cache_policy`` raising (prompt-cache policy failure)
+  * ``get_model_context_length`` raising (context/capability resolution failure)
+
+and asserts the prior coherent route is FULLY preserved.
+
+RED   — before the fix, these exceptions propagate WITHOUT rollback; the
+         agent is left with the NEW host route → assertions FAIL.
+GREEN — after the fix (region wrapped in try/except → _restore_snapshot),
+         the prior route is restored → assertions PASS.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent_c() -> AIAgent:
+    """Agent on openai-compatible with a coherent initial state."""
+    agent = AIAgent.__new__(AIAgent)
+
+    # OLD (pre-swap) coherent route
+    agent.provider = "custom"
+    agent.model = "old-model"
+    agent.requested_provider = "custom"
+    agent.base_url = "http://localhost:8080/v1"
+    agent.api_key = "key-original"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock(name="OriginalClient")
+    agent._client_kwargs = {
+        "api_key": "key-original",
+        "base_url": "http://localhost:8080/v1",
+    }
+    agent._config_context_length = 131072
+    agent._pre_cap_context_length = 131072
+    agent._primary_runtime = {
+        "model": "old-model",
+        "provider": "custom",
+        "base_url": "http://localhost:8080/v1",
+        "api_mode": "chat_completions",
+        "compressor_context_length": 131072,
+    }
+
+    # Mock context_compressor (engine) — coherent initial state
+    cc = MagicMock(name="ContextCompressor")
+    cc.model = "old-model"
+    cc.provider = "custom"
+    cc.base_url = "http://localhost:8080/v1"
+    cc.api_key = "key-original"
+    cc.api_mode = "chat_completions"
+    cc.context_length = 131072
+    cc.pre_cap_context_length = 131072
+    agent.context_compressor = cc
+
+    # Other fields switch_model touches
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = None
+    agent._anthropic_client = None
+    agent._is_anthropic_oauth = False
+    agent._cached_system_prompt = "cached"
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._credential_pool = None
+    agent._credential_pool_entry_id = None
+    agent._reasoning_echo_flag = False
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent.reasoning_config = None
+    agent._custom_providers = None
+
+    return agent
+
+
+def _assert_prior_route_preserved(agent, original_client, original_primary, original_pre_cap, original_engine):
+    """Assert the prior coherent route is fully preserved."""
+    assert agent.model == "old-model", f"model must be restored, got {agent.model!r}"
+    assert agent.provider == "custom", f"provider must be restored, got {agent.provider!r}"
+    assert agent.client is original_client, "client must be restored to the original object"
+    assert agent.base_url == "http://localhost:8080/v1", (
+        f"base_url must be restored, got {agent.base_url!r}"
+    )
+    assert agent.api_key == "key-original", (
+        f"api_key must be restored, got {agent.api_key!r}"
+    )
+    assert agent.api_mode == "chat_completions", (
+        f"api_mode must be restored, got {agent.api_mode!r}"
+    )
+    assert agent._pre_cap_context_length == original_pre_cap, (
+        f"pre-cap must be restored, got {agent._pre_cap_context_length!r}"
+    )
+    assert agent._primary_runtime == original_primary, (
+        f"_primary_runtime must be restored, got {agent._primary_runtime!r}"
+    )
+    assert agent.context_compressor is original_engine, (
+        "context_compressor must be the same object"
+    )
+    assert agent.context_compressor.model == "old-model", (
+        f"engine model must be old, got {agent.context_compressor.model!r}"
+    )
+    assert agent.context_compressor.provider == "custom", (
+        f"engine provider must be old, got {agent.context_compressor.provider!r}"
+    )
+
+
+class TestPostClientPromptCachePolicyRollback:
+    """Finding #3: prompt-cache policy raise after client commit must roll back."""
+
+    def test_prompt_cache_policy_raise_rolls_back_host_route(self):
+        """When _anthropic_prompt_cache_policy raises (after preload succeeds),
+        the prior coherent route must be fully preserved."""
+        agent = _make_agent_c()
+
+        original_client = agent.client
+        original_primary = dict(agent._primary_runtime)
+        original_pre_cap = agent._pre_cap_context_length
+        original_engine = agent.context_compressor
+
+        # Client rebuild SUCCEEDS (Window A passes).
+        new_client = MagicMock(name="NewClient")
+        agent._create_openai_client = lambda *_a, **_kw: new_client
+
+        # LM Studio preload SUCCEEDS (Window B passes).
+        agent._ensure_lmstudio_runtime_loaded = lambda *_a, **_kw: MagicMock(
+            context_length=65536, rejected=False, load_attempted=True
+        )
+        agent._lmstudio_load_was_unverified = lambda *_a, **_kw: False
+        agent._effective_lmstudio_context_length = lambda *_a, **_kw: 65536
+
+        # PROMPT-CACHE POLICY RAISES (the unprotected region).
+        def boom_policy(*_a, **_kw):
+            raise RuntimeError("simulated prompt-cache policy failure")
+
+        agent._anthropic_prompt_cache_policy = boom_policy
+
+        with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None):
+            with pytest.raises(RuntimeError, match="prompt-cache policy failure"):
+                agent.switch_model(
+                    new_model="new-model",
+                    new_provider="custom",
+                    api_key="key-new",
+                    base_url="http://localhost:8080/v1",
+                    api_mode="chat_completions",
+                )
+
+        _assert_prior_route_preserved(
+            agent, original_client, original_primary, original_pre_cap, original_engine
+        )
+
+
+class TestPostClientContextResolutionRollback:
+    """Finding #3: get_model_context_length raise after client commit must roll back."""
+
+    def test_get_model_context_length_raise_rolls_back_host_route(self):
+        """When get_model_context_length raises (after preload + prompt-cache
+        succeed), the prior coherent route must be fully preserved."""
+        agent = _make_agent_c()
+
+        original_client = agent.client
+        original_primary = dict(agent._primary_runtime)
+        original_pre_cap = agent._pre_cap_context_length
+        original_engine = agent.context_compressor
+
+        # Client rebuild SUCCEEDS (Window A passes).
+        new_client = MagicMock(name="NewClient")
+        agent._create_openai_client = lambda *_a, **_kw: new_client
+
+        # LM Studio preload SUCCEEDS (Window B passes).
+        agent._ensure_lmstudio_runtime_loaded = lambda *_a, **_kw: MagicMock(
+            context_length=65536, rejected=False, load_attempted=True
+        )
+        agent._lmstudio_load_was_unverified = lambda *_a, **_kw: False
+        agent._effective_lmstudio_context_length = lambda *_a, **_kw: 65536
+
+        # Prompt-cache policy SUCCEEDS (returns valid flags).
+        agent._anthropic_prompt_cache_policy = lambda **_kw: (False, False)
+
+        # get_model_context_length RAISES (the unprotected region).
+        # We patch it at the module level where it's imported.
+        with patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None), \
+             patch("agent.model_metadata.get_model_context_length",
+                   side_effect=RuntimeError("simulated context resolution failure")):
+            with pytest.raises(RuntimeError, match="context resolution failure"):
+                agent.switch_model(
+                    new_model="new-model",
+                    new_provider="custom",
+                    api_key="key-new",
+                    base_url="http://localhost:8080/v1",
+                    api_mode="chat_completions",
+                )
+
+        _assert_prior_route_preserved(
+            agent, original_client, original_primary, original_pre_cap, original_engine
+        )

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -10597,6 +10597,13 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     )
     fake_meta = types.ModuleType("agent.model_metadata")
     fake_meta.get_model_context_length = lambda *args, **kwargs: 100000
+    # tui_gateway/server.py imports effective_context_length (the
+    # ceiling-aware wrapper) on the @-context-reference path. Mirror the
+    # real semantics: effective = min(raw, profile_ceiling); with no
+    # ceiling configured (this test's case) it equals the raw capability.
+    fake_meta.effective_context_length = (
+        lambda *args, **kwargs: fake_meta.get_model_context_length(*args, **kwargs)
+    )
 
     server._sessions["sid"] = _session(agent=_Agent())
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -881,3 +881,86 @@ def test_batch_truncation_banner_marks_only_truncated_task():
     # The header banner for task 2 appears after task 1's summary.
     assert banner_pos > clean_pos
 
+
+def test_batch_model_rejection_notice_prepended():
+    """A rejected delegation model must surface ONE config-level notice above
+    the per-task blocks instead of staying buried in each summary (#97654)."""
+    rejection = "HTTP 400: upstage/solar-pro-4 is not a valid model ID"
+    evt = _make_async_evt(
+        is_batch=True,
+        model="upstage/solar-pro-4",
+        goals=["task a", "task b"],
+        results=[
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": rejection,
+                "api_calls": 1,
+                "duration_seconds": 0.74,
+                "exit_reason": "max_iterations",
+                "truncated": True,
+            },
+            {
+                "task_index": 1,
+                "status": "completed",
+                "summary": rejection,
+                "api_calls": 1,
+                "duration_seconds": 0.71,
+                "exit_reason": "max_iterations",
+                "truncated": True,
+            },
+        ],
+    )
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "SUBAGENT MODEL REJECTED" in text
+    assert "upstage/solar-pro-4" in text
+    assert "2/2" in text
+    assert "delegation.model" in text
+    # The notice precedes the per-task blocks, not just trails them.
+    assert text.index("SUBAGENT MODEL REJECTED") < text.index("TASK 1/2")
+
+
+def test_batch_model_rejection_notice_absent_when_clean():
+    """Ordinary summaries must not grow a model-rejection notice."""
+    evt = _make_async_evt(
+        is_batch=True,
+        model="upstage/solar-pro4",
+        goals=["task a"],
+        results=[
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "did the work",
+                "api_calls": 3,
+                "exit_reason": "completed",
+                "truncated": False,
+            },
+        ],
+    )
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "SUBAGENT MODEL REJECTED" not in text
+
+
+def test_batch_model_rejection_notice_requires_configured_model_in_text():
+    """A model_not_found pattern naming a DIFFERENT model than the configured
+    delegation model is task-level noise, not a config-level rejection."""
+    evt = _make_async_evt(
+        is_batch=True,
+        model="upstage/solar-pro4",
+        goals=["task a"],
+        results=[
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "HTTP 400: other/model-x is not a valid model ID",
+                "api_calls": 1,
+                "exit_reason": "max_iterations",
+                "truncated": True,
+            },
+        ],
+    )
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "SUBAGENT MODEL REJECTED" not in text

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -882,10 +882,22 @@ def test_batch_truncation_banner_marks_only_truncated_task():
     assert banner_pos > clean_pos
 
 
-def test_batch_model_rejection_notice_prepended():
+def _patch_delegation_cfg(monkeypatch, model="upstage/solar-pro-4", provider="openrouter"):
+    """Pin the delegation config the notice renderer reads (adapts the
+    #97667 tests to the shipped implementation, which reads the configured
+    model from config rather than the event's model field)."""
+    import tools.process_registry as _pr
+
+    monkeypatch.setattr(
+        _pr, "_delegation_config", lambda: {"model": model, "provider": provider}
+    )
+
+
+def test_batch_model_rejection_notice_prepended(monkeypatch):
     """A rejected delegation model must surface ONE config-level notice above
     the per-task blocks instead of staying buried in each summary (#97654)."""
     rejection = "HTTP 400: upstage/solar-pro-4 is not a valid model ID"
+    _patch_delegation_cfg(monkeypatch)
     evt = _make_async_evt(
         is_batch=True,
         model="upstage/solar-pro-4",
@@ -915,14 +927,14 @@ def test_batch_model_rejection_notice_prepended():
     assert text is not None
     assert "SUBAGENT MODEL REJECTED" in text
     assert "upstage/solar-pro-4" in text
-    assert "2/2" in text
     assert "delegation.model" in text
     # The notice precedes the per-task blocks, not just trails them.
     assert text.index("SUBAGENT MODEL REJECTED") < text.index("TASK 1/2")
 
 
-def test_batch_model_rejection_notice_absent_when_clean():
+def test_batch_model_rejection_notice_absent_when_clean(monkeypatch):
     """Ordinary summaries must not grow a model-rejection notice."""
+    _patch_delegation_cfg(monkeypatch, model="upstage/solar-pro4")
     evt = _make_async_evt(
         is_batch=True,
         model="upstage/solar-pro4",
@@ -943,9 +955,10 @@ def test_batch_model_rejection_notice_absent_when_clean():
     assert "SUBAGENT MODEL REJECTED" not in text
 
 
-def test_batch_model_rejection_notice_requires_configured_model_in_text():
+def test_batch_model_rejection_notice_requires_configured_model_in_text(monkeypatch):
     """A model_not_found pattern naming a DIFFERENT model than the configured
     delegation model is task-level noise, not a config-level rejection."""
+    _patch_delegation_cfg(monkeypatch, model="upstage/solar-pro4")
     evt = _make_async_evt(
         is_batch=True,
         model="upstage/solar-pro4",

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -390,6 +390,36 @@ def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
     assert not dm_file.exists()
 
 
+def test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry(
+    tmp_path, monkeypatch
+):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    calls = []
+    responses = [
+        subprocess.CompletedProcess([], 1, stdout="", stderr="HTTP 429 rate limit"),
+        subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+    ]
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return responses.pop(0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    returncode = bot_mode_dm._run_delivery(
+        ["hermes", "-p", "researcher"], str(dm_file), stdin_file=False
+    )
+
+    assert returncode == 0
+    assert len(calls) == 2
+    assert [kwargs["stdin"] for _argv, kwargs in calls] == [
+        subprocess.DEVNULL,
+        subprocess.DEVNULL,
+    ]
+    assert not dm_file.exists()
+
+
 @pytest.mark.parametrize("args", [[], ["--run-delivery"], ["--run-delivery", "bad", "x"]])
 def test_delivery_main_rejects_invalid_cli(args):
     assert bot_mode_dm._delivery_main(args) == 2

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -675,6 +675,75 @@ class TestDelegateObservability(unittest.TestCase):
             result = json.loads(delegate_task(goal="Test empty sentinel", parent_agent=parent))
             self.assertEqual(result["results"][0]["status"], "failed")
 
+    def test_failed_child_with_error_summary_marks_status_failed(self):
+        """Regression: a child whose loop gave up on a structured failure
+        (``failed=True``, ``completed=False``, e.g. "API call failed after 3
+        retries: HTTP 524") returns that error message as final_response.
+        Status was derived from summary alone, so the non-empty error text
+        made the batch report show the task as ✓ status=completed. The
+        ``failed`` flag must win over a non-empty summary."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": (
+                    "API call failed after 3 retries: HTTP 524 — origin timeout"
+                ),
+                "completed": False,
+                "failed": True,
+                "error": "HTTP 524 — origin timeout",
+                "failure_reason": "server_error",
+                "interrupted": False,
+                "api_calls": 3,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Test failed child", parent_agent=parent)
+            )
+            entry = result["results"][0]
+            self.assertEqual(entry["status"], "failed")
+            # The classified reason must survive into the batch entry so the
+            # parent can tell a quota wall from a real task error.
+            self.assertEqual(entry["failure_reason"], "server_error")
+            self.assertEqual(entry["error"], "HTTP 524 — origin timeout")
+            # A structured failure is not budget truncation.
+            self.assertEqual(entry["exit_reason"], "error")
+            self.assertFalse(entry["truncated"])
+
+    def test_successful_child_still_completed(self):
+        """Control for the failed-flag check: a child that succeeds
+        (``completed=True``, no ``failed`` flag) must keep reporting
+        status=completed — the fix must not change success behavior."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "All done.",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 2,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Test success control", parent_agent=parent)
+            )
+            entry = result["results"][0]
+            self.assertEqual(entry["status"], "completed")
+            self.assertEqual(entry["exit_reason"], "completed")
+            self.assertNotIn("failure_reason", entry)
+
 
 class TestDelegateFailedChildStatus(unittest.TestCase):
     """Honest status / exit_reason for failed subagents (issue #97655).

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -675,35 +675,6 @@ class TestDelegateObservability(unittest.TestCase):
             result = json.loads(delegate_task(goal="Test empty sentinel", parent_agent=parent))
             self.assertEqual(result["results"][0]["status"], "failed")
 
-    def test_failed_flag_marks_status_failed(self):
-        """Regression (Aug 2026 community report): a child whose conversation
-        loop aborts on a non-retryable HTTP error (404/400, billing wall)
-        returns failed=True with the ERROR SUMMARY in final_response. That
-        summary is not usable output — without checking `failed`, the entry
-        was classified 'completed' and no surface ever showed a failure."""
-        parent = _make_mock_parent(depth=0)
-
-        with patch("run_agent.AIAgent") as MockAgent:
-            mock_child = MagicMock()
-            mock_child.model = "totally/nonexistent-model"
-            mock_child.session_prompt_tokens = 0
-            mock_child.session_completion_tokens = 0
-            mock_child.run_conversation.return_value = {
-                "final_response": "HTTP 404: model not found",
-                "completed": False,
-                "failed": True,
-                "error": "HTTP 404: model not found",
-                "interrupted": False,
-                "api_calls": 1,
-                "messages": [],
-            }
-            MockAgent.return_value = mock_child
-
-            result = json.loads(delegate_task(goal="Test failed flag", parent_agent=parent))
-            entry = result["results"][0]
-            self.assertEqual(entry["status"], "failed")
-            self.assertIn("404", entry["error"])
-
 
 class TestDelegateFailedChildStatus(unittest.TestCase):
     """Honest status / exit_reason for failed subagents (issue #97655).

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -770,6 +770,47 @@ class TestDelegateFailedChildStatus(unittest.TestCase):
         self.assertEqual(entry["exit_reason"], "error")
         self.assertFalse(entry["truncated"])
 
+    def test_error_without_failed_flag_marks_failed(self):
+        """A child result that carries a non-empty error string but OMITS the
+        ``failed`` key entirely (not ``failed=False`` — the key is absent, as in
+        legacy/partial result dicts) must still be status=failed + exit_reason=error.
+        The status branch checks ``result.get('failed') or result.get('error')``,
+        so the error field alone has to win — otherwise a dropped ``failed`` key
+        would silently mislabel a provider rejection as budget exhaustion."""
+        entry = self._delegate_single(
+            {
+                "final_response": "connection reset while streaming",
+                "completed": False,
+                "interrupted": False,
+                "error": "connection reset",
+                "api_calls": 2,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "error")
+        self.assertFalse(entry["truncated"])
+
+    def test_empty_error_with_summary_is_completed(self):
+        """REGRESSION PIN: an empty-string ``error`` field must NOT be treated as
+        a failure. ``result.get('error')`` returns ``''`` which is falsy, so the
+        failure branch correctly falls through to the summary-presence heuristic.
+        Empty error + a real summary => status=completed, exit_reason=completed
+        (or max_iterations if completed=False), never 'error'."""
+        entry = self._delegate_single(
+            {
+                "final_response": "work produced",
+                "completed": True,
+                "interrupted": False,
+                "error": "",
+                "api_calls": 2,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["exit_reason"], "completed")
+        self.assertFalse(entry["truncated"])
+
     def test_genuine_truncation_stays_completed_max_iterations(self):
         """REGRESSION GUARD: a child that genuinely exhausts its iteration
         budget (completed=False, no failed flag, no error) but still returns a

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -705,6 +705,107 @@ class TestDelegateObservability(unittest.TestCase):
             self.assertIn("404", entry["error"])
 
 
+class TestDelegateFailedChildStatus(unittest.TestCase):
+    """Honest status / exit_reason for failed subagents (issue #97655).
+
+    A child that fails on its first API call (e.g. an HTTP 400 "not a valid
+    model ID") returns completed=False with failed=True + an error string as
+    its terminal final_response. It must be reported as status=failed with an
+    honest exit_reason — never status=completed + exit_reason=max_iterations
+    (which mislabels provider rejections as iteration-budget exhaustion and
+    would render the false "TRUNCATED" banner).
+    """
+
+    def _delegate_single(self, child_result):
+        """Dispatch a single task whose mock child returns `child_result`,
+        returning the parsed child result entry dict."""
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = child_result
+            MockAgent.return_value = mock_child
+            result = json.loads(
+                delegate_task(goal="Test child status", parent_agent=parent)
+            )
+            return result["results"][0]
+
+    def test_failed_flag_marks_status_failed(self):
+        """Regression (issue #97655): a provider-rejected child (HTTP 400 on its
+        first call) returns completed=False with failed=True + an error string.
+        It must be status=failed, exit_reason=error, and NOT truncated."""
+        entry = self._delegate_single(
+            {
+                "final_response": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+                "completed": False,
+                "interrupted": False,
+                "failed": True,
+                "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+                "api_calls": 1,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "error")
+        self.assertFalse(entry["truncated"])
+
+    def test_error_with_summary_still_failed(self):
+        """A child that returns BOTH an error field and a summary must still be
+        failed — the summary-presence heuristic must not override the
+        structured failure."""
+        entry = self._delegate_single(
+            {
+                "final_response": "partial work before crashing",
+                "completed": False,
+                "interrupted": False,
+                "failed": True,
+                "error": "provider boom",
+                "api_calls": 3,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "error")
+        self.assertFalse(entry["truncated"])
+
+    def test_genuine_truncation_stays_completed_max_iterations(self):
+        """REGRESSION GUARD: a child that genuinely exhausts its iteration
+        budget (completed=False, no failed flag, no error) but still returns a
+        summary must keep status=completed, exit_reason=max_iterations, and
+        truncated=True. This is the legitimate truncation path we must not
+        break while making failure labels honest."""
+        entry = self._delegate_single(
+            {
+                "final_response": "made partial progress before the budget ran out",
+                "completed": False,
+                "interrupted": False,
+                "api_calls": 10,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["exit_reason"], "max_iterations")
+        self.assertTrue(entry["truncated"])
+
+    def test_interrupted_unchanged(self):
+        """Interrupted children keep status=interrupted + exit_reason=interrupted
+        and are not marked truncated."""
+        entry = self._delegate_single(
+            {
+                "final_response": "some partial output",
+                "completed": False,
+                "interrupted": True,
+                "api_calls": 2,
+                "messages": [],
+            }
+        )
+        self.assertEqual(entry["status"], "interrupted")
+        self.assertEqual(entry["exit_reason"], "interrupted")
+        self.assertFalse(entry["truncated"])
+
+
 class TestSubagentCostRollup(unittest.TestCase):
     """Port of Kilo-Org/kilocode#9448 — parent's session_estimated_cost_usd
     must include subagent spend, not just the parent's own API calls."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -675,6 +675,35 @@ class TestDelegateObservability(unittest.TestCase):
             result = json.loads(delegate_task(goal="Test empty sentinel", parent_agent=parent))
             self.assertEqual(result["results"][0]["status"], "failed")
 
+    def test_failed_flag_marks_status_failed(self):
+        """Regression (Aug 2026 community report): a child whose conversation
+        loop aborts on a non-retryable HTTP error (404/400, billing wall)
+        returns failed=True with the ERROR SUMMARY in final_response. That
+        summary is not usable output — without checking `failed`, the entry
+        was classified 'completed' and no surface ever showed a failure."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "totally/nonexistent-model"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "HTTP 404: model not found",
+                "completed": False,
+                "failed": True,
+                "error": "HTTP 404: model not found",
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test failed flag", parent_agent=parent))
+            entry = result["results"][0]
+            self.assertEqual(entry["status"], "failed")
+            self.assertIn("404", entry["error"])
+
 
 class TestSubagentCostRollup(unittest.TestCase):
     """Port of Kilo-Org/kilocode#9448 — parent's session_estimated_cost_usd

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2413,3 +2413,155 @@ class TestGetByPrefix:
         result = registry.poll("4dae56ca")
         assert result["session_id"] == "proc_4dae56ca81f6"
         assert result["status"] == "running"
+
+
+# ---------------------------------------------------------------------------
+# Config-level model_not_found notice in delegation batch reports (#97654)
+# ---------------------------------------------------------------------------
+
+
+def _make_delegation_batch_evt(results):
+    """A batch async-delegation event carrying a per-task ``results`` list."""
+    return {
+        "type": "async_delegation",
+        "delegation_id": "deleg_97654",
+        "is_batch": True,
+        "results": results,
+        "goals": [r.get("goal") or "" for r in results],
+        "session_key": "agent:main:cli:dm:local",
+        "status": "completed",
+        "model": "upstage/solar-pro-4",
+    }
+
+
+def _patch_delegation_config(
+    monkeypatch, model="upstage/solar-pro-4", provider="openrouter", **over
+):
+    import tools.process_registry as _pr
+
+    cfg = {"model": model, "provider": provider}
+    cfg.update(over)
+    monkeypatch.setattr(_pr, "_delegation_config", lambda: cfg)
+    return cfg
+
+
+def _format_async(evt) -> str:
+    from tools.process_registry import format_process_notification
+
+    text = format_process_notification(evt)
+    assert text is not None, "format_process_notification returned None"
+    return text
+
+
+def test_model_not_found_notice_single_failure_once(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "exit_reason": "error",
+            "goal": "Create bridge module",
+            "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+            "summary": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+        }
+    ])
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert text is not None
+    assert text.count("SUBAGENT MODEL REJECTED") == 1
+    assert "upstage/solar-pro-4" in text
+    assert "openrouter" in text
+    assert "No fallback chain is configured" in text
+
+
+def test_model_not_found_notice_mixed_batch_named_model(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "exit_reason": "error",
+            "goal": "A",
+            "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+            "summary": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+        },
+        {
+            "task_index": 1,
+            "status": "completed",
+            "goal": "B",
+            "summary": "ok",
+            "api_calls": 3,
+        },
+    ])
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert text.count("SUBAGENT MODEL REJECTED") == 1
+    assert "upstage/solar-pro-4" in text
+
+
+def test_model_not_found_notice_absent_for_non_model_errors(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "goal": "A",
+            "error": "HTTP 429: rate limit exceeded",
+        },
+        {
+            "task_index": 1,
+            "status": "failed",
+            "goal": "B",
+            "error": "Connection timed out",
+        },
+    ])
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert "SUBAGENT MODEL REJECTED" not in text
+
+
+def test_model_not_found_notice_absent_when_configured_model_not_named(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "goal": "A",
+            "error": "HTTP 400: gpt-99 is not a valid model ID",
+        }
+    ])
+    # Configured model is upstage/solar-pro-4; the rejection names gpt-99.
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert "SUBAGENT MODEL REJECTED" not in text
+
+
+def test_model_not_found_notice_single_dispatch(monkeypatch):
+    evt = {
+        "type": "async_delegation",
+        "delegation_id": "deleg_single",
+        "session_key": "agent:main:cli:dm:local",
+        "goal": "task A",
+        "model": "upstage/solar-pro-4",
+        "status": "failed",
+        "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+        "summary": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+    }
+    _patch_delegation_config(monkeypatch)
+    text = _format_async(evt)
+    assert text.count("SUBAGENT MODEL REJECTED") == 1
+    assert "upstage/solar-pro-4" in text
+
+
+def test_model_not_found_notice_absent_when_fallback_chain_configured(monkeypatch):
+    evt = _make_delegation_batch_evt([
+        {
+            "task_index": 0,
+            "status": "failed",
+            "goal": "A",
+            "error": "HTTP 400: upstage/solar-pro-4 is not a valid model ID",
+        }
+    ])
+    _patch_delegation_config(
+        monkeypatch,
+        fallback_providers=[{"provider": "openrouter", "model": "upstage/solar-pro4"}],
+    )
+    text = _format_async(evt)
+    assert text.count("SUBAGENT MODEL REJECTED") == 1
+    assert "No fallback chain is configured" not in text

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -169,6 +169,60 @@ def test_handled_failure_still_clears_marker(emits, turn_env, marker_home):
     assert read_turn_marker(marker_home, "session-key") is None
 
 
+def test_hosted_terminal_receipt_commits_before_marker_retire(
+    emits, turn_env, marker_home
+):
+    observed = []
+
+    def _run(message, **kwargs):
+        return {"final_response": "done"}
+
+    def _terminal(receipt):
+        observed.append((receipt, read_turn_marker(marker_home, "session-key")))
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(agent=agent, running=True, source="bot_room")
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        session,
+        "do the thing",
+        terminal_callback=_terminal,
+    )
+
+    assert observed[0][0]["status"] == "settled"
+    assert observed[0][1] is not None
+    assert read_turn_marker(marker_home, "session-key") is None
+
+
+def test_hosted_terminal_receipt_failure_keeps_crash_marker(
+    emits, turn_env, marker_home
+):
+    def _run(message, **kwargs):
+        return {"final_response": "done"}
+
+    def _terminal(_receipt):
+        raise RuntimeError("state store unavailable")
+
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=_run, clear_interrupt=lambda: None
+    )
+    session = _session(agent=agent, running=True, source="bot_room")
+
+    server._run_prompt_submit(
+        "rid",
+        "sid",
+        session,
+        "do the thing",
+        terminal_callback=_terminal,
+    )
+
+    assert read_turn_marker(marker_home, "session-key") is not None
+
+
 def test_continuation_turn_records_attempt_and_original_prompt(
     emits, turn_env, marker_home
 ):
@@ -261,6 +315,20 @@ def test_fresh_marker_schedules_continuation(emits, schedule_env, marker_home):
     assert "fix the flaky test" in text
     assert kwargs["display_kind"] == "auto_continue"
     assert ("message.start", "sid", None) in [(e, s, p) for e, s, p in emits]
+
+
+def test_hosted_room_marker_is_left_to_the_driver(schedule_env, marker_home):
+    record_turn_start(marker_home, "session-key", "hosted prompt")
+
+    result = server._maybe_schedule_auto_continue(
+        "sid",
+        _session(source="bot_room"),
+        "session-key",
+    )
+
+    assert result is None
+    assert not schedule_env
+    assert read_turn_marker(marker_home, "session-key") is not None
 
 
 def test_stale_marker_is_cleared_not_continued(schedule_env, marker_home, monkeypatch):
@@ -372,5 +440,4 @@ def test_failed_agent_build_leaves_marker_for_retry(
 
 
 # ── End to end: continuation runs a real turn and clears the marker ────
-
 

--- a/tests/tui_gateway/test_groups_methods.py
+++ b/tests/tui_gateway/test_groups_methods.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 import tui_gateway.server as srv
+from tui_gateway import methods_groups
 
 
 @pytest.fixture
 def home(tmp_path, monkeypatch):
     path = tmp_path / ".hermes"
     path.mkdir()
+    (path / "profiles" / "ops").mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(path))
-    return path
+    methods_groups.stop_hosted_room_service(timeout=1.0)
+    methods_groups.start_hosted_room_service()
+    yield path
+    methods_groups.stop_hosted_room_service(timeout=1.0)
 
 
 def _result(envelope):
@@ -33,7 +40,14 @@ def _create_room():
             {
                 "room_id": "room-1",
                 "name": "Release room",
-                "members": [{"profile": "ops", "handle": "ops"}],
+                "members": [
+                    {
+                        "member_id": "default",
+                        "profile": "default",
+                        "handle": "hermes",
+                    },
+                    {"member_id": "ops", "profile": "ops", "handle": "ops"},
+                ],
                 "authority_gateway_id": "gateway-a",
             },
         )
@@ -41,6 +55,7 @@ def _create_room():
 
 
 def test_capabilities_are_honest_about_the_driver_boundary(home):
+    methods_groups.stop_hosted_room_service(timeout=1.0)
     result = _result(srv._methods["groups.capabilities"](1, {}))
 
     assert result["protocol_version"] == 2
@@ -52,6 +67,16 @@ def test_capabilities_are_honest_about_the_driver_boundary(home):
     assert "groups.state" in result["methods"]
     assert "groups.send" in result["methods"]
     assert "groups.send" in srv._LONG_HANDLERS
+    assert "groups.retry" in result["methods"]
+    assert "groups.approve" in result["methods"]
+    advertised = [
+        str(value).lower() for value in (*result["features"], *result["methods"])
+    ]
+    assert not any(
+        token in value
+        for token in ("attachment", "desktop", "messaging", "peer", "roomlink")
+        for value in advertised
+    )
 
 
 def test_create_list_send_and_log_roundtrip(home):
@@ -72,12 +97,12 @@ def test_create_list_send_and_log_roundtrip(home):
                 "room_id": "room-1",
                 "event_id": "event-1",
                 "actor": {"kind": "user", "id": "desktop-user"},
-                "payload": {"text": "hello"},
+                "payload": {"text": "hello", "thread_id": "thread-1"},
             },
         )
     )
     assert sent["accepted"] is True
-    assert sent["driver_started"] is False
+    assert sent["driver_started"] is True
     assert sent["event"]["seq"] == 1
     assert sent["event"]["kind"] == "message.user"
     assert sent["event"]["actor"] == {"kind": "user", "id": "desktop"}
@@ -89,7 +114,10 @@ def test_create_list_send_and_log_roundtrip(home):
         )
     )
     assert replay["latest_seq"] == replay["cursor"] == 1
-    assert replay["events"][0]["payload"] == {"text": "hello"}
+    assert replay["events"][0]["payload"] == {
+        "text": "hello",
+        "thread_id": "thread-1",
+    }
 
 
 def test_groups_list_returns_bounded_pages(home):
@@ -137,7 +165,7 @@ def test_rpc_retry_is_idempotent_and_conflict_is_visible(home):
         "room_id": "room-1",
         "event_id": "event-1",
         "actor": {"kind": "user", "id": "desktop-user"},
-        "payload": {"text": "hello"},
+        "payload": {"text": "hello", "thread_id": "thread-1"},
     }
     first = _result(srv._methods["groups.send"](2, params))
     repeated = _result(srv._methods["groups.send"](3, params))
@@ -149,7 +177,10 @@ def test_rpc_retry_is_idempotent_and_conflict_is_visible(home):
 
     conflict = srv._methods["groups.send"](
         4,
-        {**params, "payload": {"text": "different"}},
+        {
+            **params,
+            "payload": {"text": "different", "thread_id": "thread-1"},
+        },
     )
     assert conflict["error"]["code"] == 4111
     assert "different content" in conflict["error"]["message"]
@@ -179,7 +210,7 @@ def test_foreign_authority_cannot_send_or_disband(home):
         {
             "room_id": "room-1",
             "event_id": "stale-send",
-            "payload": {"text": "must not land"},
+            "payload": {"text": "must not land", "thread_id": "thread-1"},
         },
     )
     disbanded = srv._methods["groups.disband"](3, {"room_id": "room-1"})
@@ -200,7 +231,7 @@ def test_client_event_id_cannot_squat_disband_receipt(home):
             {
                 "room_id": "room-1",
                 "event_id": "system:room-disbanded",
-                "payload": {"text": "still a user message"},
+                "payload": {"text": "still a user message", "thread_id": "thread-1"},
             },
         )
     )
@@ -221,6 +252,7 @@ def test_client_event_id_cannot_squat_disband_receipt(home):
     )
     assert [event["kind"] for event in replay["events"]] == [
         "message.user",
+        "room.stop_requested",
         "room.disbanded",
     ]
 
@@ -234,7 +266,7 @@ def test_send_does_not_trust_client_supplied_actor_identity(home):
                 "room_id": "room-1",
                 "event_id": "event-1",
                 "actor": {"kind": "user", "id": "spoofed-user"},
-                "payload": {"text": "hello"},
+                "payload": {"text": "hello", "thread_id": "thread-1"},
             },
         )
     )
@@ -243,10 +275,14 @@ def test_send_does_not_trust_client_supplied_actor_identity(home):
 
 
 def test_create_ignores_client_supplied_authority_identity(home):
+    members = [
+        {"member_id": "default", "profile": "default", "handle": "hermes"},
+        {"member_id": "ops", "profile": "ops", "handle": "ops"},
+    ]
     created = _result(
         srv._methods["groups.create"](
             1,
-            {"room_id": "legacy-room", "name": "Legacy", "members": []},
+            {"room_id": "legacy-room", "name": "Legacy", "members": members},
         )
     )["room"]
     retried = _result(
@@ -255,7 +291,7 @@ def test_create_ignores_client_supplied_authority_identity(home):
             {
                 "room_id": "legacy-room",
                 "name": "Legacy",
-                "members": [],
+                "members": members,
                 "authority_gateway_id": "spoofed-gateway",
             },
         )
@@ -269,7 +305,10 @@ def test_create_ignores_client_supplied_authority_identity(home):
 def test_legacy_room_adoption_emits_one_lineage_receipt(home):
     from gateway.hosted_rooms import create_room, default_db_path
 
-    members = [{"profile": "ops", "handle": "ops"}]
+    members = [
+        {"member_id": "default", "profile": "default", "handle": "hermes"},
+        {"member_id": "ops", "profile": "ops", "handle": "ops"},
+    ]
     create_room(
         default_db_path(),
         room_id="legacy-room",
@@ -285,9 +324,7 @@ def test_legacy_room_adoption_emits_one_lineage_receipt(home):
             {"room_id": "legacy-room", "name": "Legacy", "members": members},
         )
     )["room"]
-    state = _result(
-        srv._methods["groups.state"](3, {"room_id": "legacy-room"})
-    )["room"]
+    state = _result(srv._methods["groups.state"](3, {"room_id": "legacy-room"}))["room"]
 
     assert adopted["adopted"] is True
     assert adopted["authority_gateway_id"] == _server_authority()
@@ -327,7 +364,110 @@ def test_legacy_room_adoption_emits_one_lineage_receipt(home):
 )
 def test_invalid_or_unknown_room_returns_contract_error(home, method_name, params):
     result = srv._methods[method_name](1, params)
-    assert result["error"]["code"] in {4110, 4111, 4112}
+    assert result["error"]["code"] in {4110, 4111, 4112, 5111, 5112}
+
+
+def test_retry_and_approval_controls_forward_only_exact_local_coordinates(
+    home, monkeypatch
+):
+    calls = []
+    identity = SimpleNamespace(
+        room_id="room-1",
+        task_id="task-1",
+        thread_id="thread-1",
+        turn_id="turn-1",
+    )
+    service = SimpleNamespace(
+        retry_room_task=lambda room_id, task_id: (
+            calls.append(("retry", room_id, task_id))
+            or {
+                "identity": identity,
+                "status": "queued",
+                "execution_generation": 1,
+                "cancel_generation": 0,
+            }
+        ),
+        approve_room_task=lambda room_id, **kwargs: (
+            calls.append(("approve", room_id, kwargs)) or {"resolved": 1}
+        ),
+    )
+    monkeypatch.setattr(srv, "get_hosted_room_service", lambda: service)
+
+    retried = _result(
+        srv._methods["groups.retry"](
+            1,
+            {"room_id": "room-1", "task_id": "task-1"},
+        )
+    )
+    approved = _result(
+        srv._methods["groups.approve"](
+            2,
+            {
+                "room_id": "room-1",
+                "member_id": "ops",
+                "task_id": "task-1",
+                "execution_generation": 1,
+                "request_id": "approval-1",
+                "choice": "once",
+            },
+        )
+    )
+
+    assert retried["task"] == {
+        "room_id": "room-1",
+        "task_id": "task-1",
+        "thread_id": "thread-1",
+        "turn_id": "turn-1",
+        "status": "queued",
+        "execution_generation": 1,
+        "cancel_generation": 0,
+    }
+    assert approved == {"approved": True, "result": {"resolved": 1}}
+    assert calls == [
+        ("retry", "room-1", "task-1"),
+        (
+            "approve",
+            "room-1",
+            {
+                "member_id": "ops",
+                "task_id": "task-1",
+                "execution_generation": 1,
+                "choice": "once",
+                "request_id": "approval-1",
+            },
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "params"),
+    [
+        ("groups.create", {"room_id": "room-1", "name": "Room", "members": []}),
+        ("groups.send", {"room_id": "room-1", "event_id": "event-1", "payload": {}}),
+        ("groups.disband", {"room_id": "room-1"}),
+        ("groups.stop", {"room_id": "room-1"}),
+        ("groups.retry", {"room_id": "room-1", "task_id": "task-1"}),
+        (
+            "groups.approve",
+            {
+                "room_id": "room-1",
+                "member_id": "ops",
+                "task_id": "task-1",
+                "execution_generation": 1,
+                "request_id": "approval-1",
+                "choice": "once",
+            },
+        ),
+    ],
+)
+def test_mutating_controls_fail_closed_without_a_supervised_worker(
+    home, monkeypatch, method_name, params
+):
+    monkeypatch.setattr(srv, "get_hosted_room_service", lambda: None)
+
+    result = srv._methods[method_name](1, params)
+
+    assert result["error"]["code"] in {4115, 4123}
 
 
 def test_disband_tombstones_room(home):
@@ -337,9 +477,9 @@ def test_disband_tombstones_room(home):
     assert first["tombstone"]["idempotent"] is False
     assert repeated["tombstone"]["idempotent"] is True
     assert _result(srv._methods["groups.list"](5, {}))["rooms"] == []
-    deleted = _result(
-        srv._methods["groups.list"](6, {"include_disbanded": True})
-    )["rooms"]
+    deleted = _result(srv._methods["groups.list"](6, {"include_disbanded": True}))[
+        "rooms"
+    ]
     assert deleted[0]["disbanded_at"] == first["tombstone"]["disbanded_at"]
     replay = _result(
         srv._methods["groups.log"](
@@ -347,12 +487,19 @@ def test_disband_tombstones_room(home):
             {"room_id": "room-1", "include_disbanded": True},
         )
     )
-    assert [event["kind"] for event in replay["events"]] == ["room.disbanded"]
+    assert [event["kind"] for event in replay["events"]] == [
+        "room.stop_requested",
+        "room.disbanded",
+    ]
 
 
 def test_pruned_room_send_and_log_report_expired_history(home, monkeypatch):
     from gateway import hosted_rooms
 
+    members = [
+        {"member_id": "default", "profile": "default", "handle": "hermes"},
+        {"member_id": "ops", "profile": "ops", "handle": "ops"},
+    ]
     _create_room()
     monkeypatch.setattr(hosted_rooms, "MAX_DISBANDED_ROOM_TOMBSTONES", 0)
     _result(srv._methods["groups.disband"](2, {"room_id": "room-1"}))
@@ -367,7 +514,7 @@ def test_pruned_room_send_and_log_report_expired_history(home, monkeypatch):
         {
             "room_id": "room-1",
             "event_id": "stale-send",
-            "payload": {"text": "stale"},
+            "payload": {"text": "stale", "thread_id": "thread-1"},
         },
     )
     logged = srv._methods["groups.log"](
@@ -375,19 +522,21 @@ def test_pruned_room_send_and_log_report_expired_history(home, monkeypatch):
         {"room_id": "room-1", "include_disbanded": True},
     )
 
+    assert sent["error"]["code"] == 4111, sent
+    assert logged["error"]["code"] == 4112, logged
     assert sent["error"]["data"] == {"reason": "room_history_expired"}
     assert logged["error"]["data"] == {"reason": "room_history_expired"}
     assert "permanently retired" in sent["error"]["message"]
 
     recreated = srv._methods["groups.create"](
         6,
-        {"room_id": "room-1", "name": "Replacement", "members": []},
+        {"room_id": "room-1", "name": "Replacement", "members": members},
     )
     assert recreated["error"]["code"] == 4110
     created = _result(
         srv._methods["groups.create"](
             7,
-            {"room_id": "room-new", "name": "Fresh", "members": []},
+            {"room_id": "room-new", "name": "Fresh", "members": members},
         )
     )
     assert created["room"]["room_id"] == "room-new"

--- a/tests/tui_gateway/test_groups_methods.py
+++ b/tests/tui_gateway/test_groups_methods.py
@@ -1,0 +1,393 @@
+"""Tests for the gateway-hosted ``groups.*`` JSON-RPC contract."""
+
+from __future__ import annotations
+
+import pytest
+
+import tui_gateway.server as srv
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    path = tmp_path / ".hermes"
+    path.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(path))
+    return path
+
+
+def _result(envelope):
+    assert "error" not in envelope, envelope
+    return envelope["result"]
+
+
+def _server_authority():
+    from gateway.hosted_rooms import local_authority_gateway_id
+
+    return local_authority_gateway_id()
+
+
+def _create_room():
+    return _result(
+        srv._methods["groups.create"](
+            1,
+            {
+                "room_id": "room-1",
+                "name": "Release room",
+                "members": [{"profile": "ops", "handle": "ops"}],
+                "authority_gateway_id": "gateway-a",
+            },
+        )
+    )["room"]
+
+
+def test_capabilities_are_honest_about_the_driver_boundary(home):
+    result = _result(srv._methods["groups.capabilities"](1, {}))
+
+    assert result["protocol_version"] == 2
+    assert result["driver"] is False
+    assert result["authority_gateway_id"] == _server_authority()
+    assert "authority_epoch" in result["features"]
+    assert "coordinator_fencing" in result["features"]
+    assert "monotonic_log" in result["features"]
+    assert "groups.state" in result["methods"]
+    assert "groups.send" in result["methods"]
+    assert "groups.send" in srv._LONG_HANDLERS
+
+
+def test_create_list_send_and_log_roundtrip(home):
+    room = _create_room()
+    assert room["idempotent"] is False
+
+    listed = _result(srv._methods["groups.list"](2, {}))
+    assert [item["room_id"] for item in listed["rooms"]] == ["room-1"]
+    state = _result(srv._methods["groups.state"](3, {"room_id": "room-1"}))
+    assert state["room"]["authority_gateway_id"] == _server_authority()
+    assert state["room"]["authority_epoch"] == 1
+    assert state["room"]["latest_seq"] == 0
+
+    sent = _result(
+        srv._methods["groups.send"](
+            4,
+            {
+                "room_id": "room-1",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "desktop-user"},
+                "payload": {"text": "hello"},
+            },
+        )
+    )
+    assert sent["accepted"] is True
+    assert sent["driver_started"] is False
+    assert sent["event"]["seq"] == 1
+    assert sent["event"]["kind"] == "message.user"
+    assert sent["event"]["actor"] == {"kind": "user", "id": "desktop"}
+
+    replay = _result(
+        srv._methods["groups.log"](
+            5,
+            {"room_id": "room-1", "since_seq": 0},
+        )
+    )
+    assert replay["latest_seq"] == replay["cursor"] == 1
+    assert replay["events"][0]["payload"] == {"text": "hello"}
+
+
+def test_groups_list_returns_bounded_pages(home):
+    _create_room()
+    _result(
+        srv._methods["groups.create"](
+            2,
+            {
+                "room_id": "room-2",
+                "name": "Second room",
+                "members": [
+                    {
+                        "member_id": "default",
+                        "profile": "default",
+                        "handle": "hermes",
+                    },
+                    {"member_id": "ops", "profile": "ops", "handle": "ops"},
+                ],
+            },
+        )
+    )
+
+    first = _result(srv._methods["groups.list"](3, {"limit": 1}))
+    second = _result(
+        srv._methods["groups.list"](
+            4,
+            {"limit": 1, "offset": first["next_offset"]},
+        )
+    )
+
+    assert first["next_offset"] == 1
+    assert second["next_offset"] == 2
+    assert {first["rooms"][0]["room_id"], second["rooms"][0]["room_id"]} == {
+        "room-1",
+        "room-2",
+    }
+    final = _result(srv._methods["groups.list"](5, {"limit": 1, "offset": 2}))
+    assert final["rooms"] == []
+    assert final["next_offset"] is None
+
+
+def test_rpc_retry_is_idempotent_and_conflict_is_visible(home):
+    _create_room()
+    params = {
+        "room_id": "room-1",
+        "event_id": "event-1",
+        "actor": {"kind": "user", "id": "desktop-user"},
+        "payload": {"text": "hello"},
+    }
+    first = _result(srv._methods["groups.send"](2, params))
+    repeated = _result(srv._methods["groups.send"](3, params))
+
+    assert first["event"]["seq"] == repeated["event"]["seq"] == 1
+    assert first["client_event_id"] == repeated["client_event_id"] == "event-1"
+    assert first["event"]["event_id"].startswith("user:")
+    assert repeated["event"]["idempotent"] is True
+
+    conflict = srv._methods["groups.send"](
+        4,
+        {**params, "payload": {"text": "different"}},
+    )
+    assert conflict["error"]["code"] == 4111
+    assert "different content" in conflict["error"]["message"]
+
+
+def test_foreign_authority_cannot_send_or_disband(home):
+    from gateway.hosted_rooms import (
+        claim_authority,
+        default_db_path,
+        list_rooms,
+        read_events,
+    )
+
+    _create_room()
+    claim_authority(
+        default_db_path(),
+        room_id="room-1",
+        expected_gateway_id=_server_authority(),
+        expected_epoch=1,
+        new_gateway_id="foreign-gateway",
+        event_id="claim-foreign",
+    )
+    before = read_events(default_db_path(), room_id="room-1")
+
+    sent = srv._methods["groups.send"](
+        2,
+        {
+            "room_id": "room-1",
+            "event_id": "stale-send",
+            "payload": {"text": "must not land"},
+        },
+    )
+    disbanded = srv._methods["groups.disband"](3, {"room_id": "room-1"})
+
+    assert sent["error"]["code"] == 4111
+    assert sent["error"]["data"] == {"reason": "authority_conflict"}
+    assert disbanded["error"]["code"] == 4113
+    assert disbanded["error"]["data"] == {"reason": "authority_conflict"}
+    assert read_events(default_db_path(), room_id="room-1") == before
+    assert list_rooms(default_db_path())[0]["room_id"] == "room-1"
+
+
+def test_client_event_id_cannot_squat_disband_receipt(home):
+    _create_room()
+    sent = _result(
+        srv._methods["groups.send"](
+            2,
+            {
+                "room_id": "room-1",
+                "event_id": "system:room-disbanded",
+                "payload": {"text": "still a user message"},
+            },
+        )
+    )
+
+    assert sent["client_event_id"] == "system:room-disbanded"
+    assert sent["event"]["event_id"].startswith("user:")
+    assert sent["event"]["event_id"] != "system:room-disbanded"
+    first = _result(srv._methods["groups.disband"](3, {"room_id": "room-1"}))
+    repeated = _result(srv._methods["groups.disband"](4, {"room_id": "room-1"}))
+    assert first["tombstone"]["event"]["event_id"] == "system:room-disbanded"
+    assert repeated["tombstone"]["idempotent"] is True
+
+    replay = _result(
+        srv._methods["groups.log"](
+            5,
+            {"room_id": "room-1", "include_disbanded": True},
+        )
+    )
+    assert [event["kind"] for event in replay["events"]] == [
+        "message.user",
+        "room.disbanded",
+    ]
+
+
+def test_send_does_not_trust_client_supplied_actor_identity(home):
+    _create_room()
+    sent = _result(
+        srv._methods["groups.send"](
+            2,
+            {
+                "room_id": "room-1",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "spoofed-user"},
+                "payload": {"text": "hello"},
+            },
+        )
+    )
+
+    assert sent["event"]["actor"] == {"kind": "user", "id": "desktop"}
+
+
+def test_create_ignores_client_supplied_authority_identity(home):
+    created = _result(
+        srv._methods["groups.create"](
+            1,
+            {"room_id": "legacy-room", "name": "Legacy", "members": []},
+        )
+    )["room"]
+    retried = _result(
+        srv._methods["groups.create"](
+            2,
+            {
+                "room_id": "legacy-room",
+                "name": "Legacy",
+                "members": [],
+                "authority_gateway_id": "spoofed-gateway",
+            },
+        )
+    )["room"]
+
+    assert created["authority_gateway_id"] == _server_authority()
+    assert retried["authority_gateway_id"] == _server_authority()
+    assert retried["idempotent"] is True
+
+
+def test_legacy_room_adoption_emits_one_lineage_receipt(home):
+    from gateway.hosted_rooms import create_room, default_db_path
+
+    members = [{"profile": "ops", "handle": "ops"}]
+    create_room(
+        default_db_path(),
+        room_id="legacy-room",
+        name="Legacy",
+        members=members,
+        authority_gateway_id="legacy",
+        now=1,
+    )
+
+    adopted = _result(
+        srv._methods["groups.create"](
+            2,
+            {"room_id": "legacy-room", "name": "Legacy", "members": members},
+        )
+    )["room"]
+    state = _result(
+        srv._methods["groups.state"](3, {"room_id": "legacy-room"})
+    )["room"]
+
+    assert adopted["adopted"] is True
+    assert adopted["authority_gateway_id"] == _server_authority()
+    assert adopted["authority_epoch"] == 2
+    assert adopted["claim_event"]["payload"] == {
+        "previous_gateway_id": "legacy",
+        "authority_gateway_id": _server_authority(),
+        "authority_epoch": 2,
+    }
+    assert state["authority_claim"]["event_id"] == "system:authority-adopted"
+    assert state["latest_seq"] == 1
+
+
+@pytest.mark.parametrize(
+    ("method_name", "params"),
+    [
+        (
+            "groups.create",
+            {
+                "room_id": "",
+                "name": "x",
+                "members": [],
+                "authority_gateway_id": "gateway-a",
+            },
+        ),
+        (
+            "groups.send",
+            {
+                "room_id": "missing",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "desktop-user"},
+                "payload": {},
+            },
+        ),
+        ("groups.log", {"room_id": "missing", "since_seq": 0}),
+    ],
+)
+def test_invalid_or_unknown_room_returns_contract_error(home, method_name, params):
+    result = srv._methods[method_name](1, params)
+    assert result["error"]["code"] in {4110, 4111, 4112}
+
+
+def test_disband_tombstones_room(home):
+    _create_room()
+    first = _result(srv._methods["groups.disband"](3, {"room_id": "room-1"}))
+    repeated = _result(srv._methods["groups.disband"](4, {"room_id": "room-1"}))
+    assert first["tombstone"]["idempotent"] is False
+    assert repeated["tombstone"]["idempotent"] is True
+    assert _result(srv._methods["groups.list"](5, {}))["rooms"] == []
+    deleted = _result(
+        srv._methods["groups.list"](6, {"include_disbanded": True})
+    )["rooms"]
+    assert deleted[0]["disbanded_at"] == first["tombstone"]["disbanded_at"]
+    replay = _result(
+        srv._methods["groups.log"](
+            7,
+            {"room_id": "room-1", "include_disbanded": True},
+        )
+    )
+    assert [event["kind"] for event in replay["events"]] == ["room.disbanded"]
+
+
+def test_pruned_room_send_and_log_report_expired_history(home, monkeypatch):
+    from gateway import hosted_rooms
+
+    _create_room()
+    monkeypatch.setattr(hosted_rooms, "MAX_DISBANDED_ROOM_TOMBSTONES", 0)
+    _result(srv._methods["groups.disband"](2, {"room_id": "room-1"}))
+    repeated = _result(
+        srv._methods["groups.disband"](3, {"room_id": "room-1"})
+    )["tombstone"]
+    assert repeated["idempotent"] is True
+    assert repeated["history_expired"] is True
+
+    sent = srv._methods["groups.send"](
+        4,
+        {
+            "room_id": "room-1",
+            "event_id": "stale-send",
+            "payload": {"text": "stale"},
+        },
+    )
+    logged = srv._methods["groups.log"](
+        5,
+        {"room_id": "room-1", "include_disbanded": True},
+    )
+
+    assert sent["error"]["data"] == {"reason": "room_history_expired"}
+    assert logged["error"]["data"] == {"reason": "room_history_expired"}
+    assert "permanently retired" in sent["error"]["message"]
+
+    recreated = srv._methods["groups.create"](
+        6,
+        {"room_id": "room-1", "name": "Replacement", "members": []},
+    )
+    assert recreated["error"]["code"] == 4110
+    created = _result(
+        srv._methods["groups.create"](
+            7,
+            {"room_id": "room-new", "name": "Fresh", "members": []},
+        )
+    )
+    assert created["room"]["room_id"] == "room-new"

--- a/tests/tui_gateway/test_groups_replication_methods.py
+++ b/tests/tui_gateway/test_groups_replication_methods.py
@@ -1,0 +1,173 @@
+"""Tests for the ``groups.replicate`` / ``groups.promote`` / ``groups.demote``
+JSON-RPC surface — cross-gateway room durability."""
+
+from __future__ import annotations
+
+import pytest
+
+import tui_gateway.server as srv
+
+MEMBERS = [{"kind": "bot", "id": "planner"}]
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    path = tmp_path / ".hermes"
+    path.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(path))
+    return path
+
+
+def _result(envelope):
+    assert "error" not in envelope, envelope
+    return envelope["result"]
+
+
+def _error(envelope):
+    assert "error" in envelope, envelope
+    return envelope["error"]
+
+
+def _authority_page(tmp_path, gateway_id="install:" + "a" * 32, n=3):
+    """Build a real room + log on a SEPARATE 'remote authority' DB and return
+    its replay page, as a replicating client would fetch via groups.log."""
+    from gateway import hosted_rooms as rooms
+
+    db = tmp_path / "remote-authority.db"
+    rooms.create_room(
+        db,
+        room_id="room-1",
+        name="Field Room",
+        members=MEMBERS,
+        authority_gateway_id=gateway_id,
+    )
+    for index in range(n):
+        rooms.append_event(
+            db,
+            room_id="room-1",
+            event_id=f"e{index}",
+            kind="message.user",
+            actor={"kind": "user", "id": "tek"},
+            payload={"text": f"msg {index}"},
+            authority_gateway_id=gateway_id,
+            authority_epoch=1,
+        )
+    return rooms.read_events(db, room_id="room-1", since_seq=0, limit=100)
+
+
+def test_capabilities_advertise_replication(home):
+    result = _result(srv._methods["groups.capabilities"](1, {}))
+    assert "log_replication" in result["features"]
+    assert "authority_takeover" in result["features"]
+    for name in (
+        "groups.replicate",
+        "groups.replica_state",
+        "groups.promote",
+        "groups.demote",
+    ):
+        assert name in result["methods"]
+        assert name in srv._LONG_HANDLERS
+
+
+def test_replicate_then_state_roundtrip(home, tmp_path):
+    page = _authority_page(tmp_path)
+    result = _result(
+        srv._methods["groups.replicate"](
+            1,
+            {
+                "room_id": "room-1",
+                "room_name": "Field Room",
+                "members": MEMBERS,
+                "page": page,
+            },
+        )
+    )
+    assert result["ingested"] == 3
+    state = _result(srv._methods["groups.replica_state"](2, {"room_id": "room-1"}))
+    assert state["last_seq"] == 3
+    assert state["authority"] == page["authority"]
+
+
+def test_promote_requires_confirm_and_takes_over(home, tmp_path):
+    page = _authority_page(tmp_path)
+    _result(
+        srv._methods["groups.replicate"](
+            1,
+            {
+                "room_id": "room-1",
+                "room_name": "Field Room",
+                "members": MEMBERS,
+                "page": page,
+            },
+        )
+    )
+
+    refused = _error(srv._methods["groups.promote"](2, {"room_id": "room-1"}))
+    assert refused["code"] == 4118
+
+    promoted = _result(
+        srv._methods["groups.promote"](3, {"room_id": "room-1", "confirm": True})
+    )
+    assert promoted["authority_epoch"] == 2
+    assert promoted["previous_gateway_id"] == page["authority"]["gateway_id"]
+
+    # The room is now hosted locally with full history + claim event.
+    log = _result(srv._methods["groups.log"](4, {"room_id": "room-1"}))
+    kinds = [event["kind"] for event in log["events"]]
+    assert kinds == ["message.user"] * 3 + ["authority.claimed"]
+    assert log["authority"]["epoch"] == 2
+
+
+def test_demote_fences_local_room_against_newer_epoch(home):
+    from gateway.hosted_rooms import local_authority_gateway_id
+
+    _result(
+        srv._methods["groups.create"](
+            1,
+            {"room_id": "room-1", "name": "Local room", "members": MEMBERS},
+        )
+    )
+    observed_gateway = "install:" + "b" * 32
+    result = _result(
+        srv._methods["groups.demote"](
+            2,
+            {
+                "room_id": "room-1",
+                "observed_gateway_id": observed_gateway,
+                "observed_epoch": 2,
+            },
+        )
+    )
+    assert result["idempotent"] is False
+    assert result["authority_gateway_id"] == observed_gateway
+
+    # Local sends at the stale authority now fail.
+    envelope = srv._methods["groups.send"](
+        3,
+        {
+            "room_id": "room-1",
+            "event_id": "stale-send",
+            "actor": {"kind": "user", "id": "tek"},
+            "payload": {"text": "should fence"},
+        },
+    )
+    assert "error" in envelope
+    assert local_authority_gateway_id() != observed_gateway
+
+
+def test_replicate_rejects_gapped_page(home, tmp_path):
+    from gateway import hosted_rooms as rooms
+
+    _authority_page(tmp_path, n=5)
+    db = tmp_path / "remote-authority.db"
+    gapped = rooms.read_events(db, room_id="room-1", since_seq=2, limit=100)
+    envelope = srv._methods["groups.replicate"](
+        1,
+        {
+            "room_id": "room-1",
+            "room_name": "Field Room",
+            "members": MEMBERS,
+            "page": gapped,
+        },
+    )
+    assert _error(envelope)["code"] == 4116

--- a/tests/tui_gateway/test_groups_replication_methods.py
+++ b/tests/tui_gateway/test_groups_replication_methods.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import pytest
 
 import tui_gateway.server as srv
+from tui_gateway import methods_groups
 
 MEMBERS = [{"kind": "bot", "id": "planner"}]
 
@@ -14,8 +15,12 @@ MEMBERS = [{"kind": "bot", "id": "planner"}]
 def home(tmp_path, monkeypatch):
     path = tmp_path / ".hermes"
     path.mkdir()
+    (path / "profiles" / "ops").mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(path))
-    return path
+    methods_groups.stop_hosted_room_service(timeout=1.0)
+    methods_groups.start_hosted_room_service()
+    yield path
+    methods_groups.stop_hosted_room_service(timeout=1.0)
 
 
 def _result(envelope):
@@ -124,7 +129,18 @@ def test_demote_fences_local_room_against_newer_epoch(home):
     _result(
         srv._methods["groups.create"](
             1,
-            {"room_id": "room-1", "name": "Local room", "members": MEMBERS},
+            {
+                "room_id": "room-1",
+                "name": "Local room",
+                "members": [
+                    {
+                        "member_id": "default",
+                        "profile": "default",
+                        "handle": "hermes",
+                    },
+                    {"member_id": "ops", "profile": "ops", "handle": "ops"},
+                ],
+            },
         )
     )
     observed_gateway = "install:" + "b" * 32

--- a/tests/tui_gateway/test_hosted_room_driver_runtime.py
+++ b/tests/tui_gateway/test_hosted_room_driver_runtime.py
@@ -1,0 +1,1366 @@
+"""Runtime tests for the hosted-room session adapter."""
+
+from __future__ import annotations
+
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gateway import hosted_room_driver as state
+from gateway import hosted_rooms
+from tui_gateway.hosted_room_driver import (
+    MAX_TERMINAL_TEXT_BYTES,
+    ROOM_SESSION_SOURCE,
+    HostedRoomBinding,
+    HostedRoomRuntime,
+    room_session_title,
+)
+
+
+ROOM_ID = "room-1"
+PROFILE = "ops"
+BINDING = HostedRoomBinding(
+    room_id=ROOM_ID,
+    gateway_id="gateway-a",
+    authority_epoch=1,
+)
+
+
+class RecordingTurnLocks:
+    """Record the profile lock and expose ownership to the fake RPC."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+        self.local = threading.local()
+
+    @contextmanager
+    def __call__(self, profile: str):
+        self.events.append(("lock-enter", profile))
+        self.local.profile = profile
+        try:
+            yield
+        finally:
+            self.events.append(("lock-exit", profile))
+            self.local.profile = None
+
+    def held_for(self, profile: str) -> bool:
+        return getattr(self.local, "profile", None) == profile
+
+
+class FakeSessionRPC:
+    """Normalized in-memory session adapter with no model or network."""
+
+    def __init__(
+        self,
+        *,
+        auto_complete: bool = True,
+        required_lock: RecordingTurnLocks | None = None,
+    ) -> None:
+        self.auto_complete = auto_complete
+        self.required_lock = required_lock
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.sessions: dict[tuple[str, str], dict[str, Any]] = {}
+        self.states: dict[str, dict[str, Any]] = {}
+        self.submitted = threading.Event()
+        self.on_interrupt = None
+        self.on_info = None
+        self.history_failures = 0
+        self._next_id = 1
+        self._lock = threading.Lock()
+
+    def _assert_lock(self, profile: str) -> None:
+        if self.required_lock is not None:
+            assert self.required_lock.held_for(profile)
+
+    def add_session(
+        self,
+        *,
+        profile: str = PROFILE,
+        title: str = room_session_title(ROOM_ID),
+        active: bool = False,
+        task_id: str | None = None,
+        history: list[dict[str, Any]] | None = None,
+    ) -> str:
+        with self._lock:
+            session_id = f"session-{self._next_id}"
+            self._next_id += 1
+            session = {"session_id": session_id, "title": title}
+            self.sessions[(profile, title)] = session
+            self.states[session_id] = {
+                "active": active,
+                "task_id": task_id,
+                "execution_generation": None,
+                "history": list(history or []),
+                "on_terminal": None,
+                "pending_approval": None,
+            }
+            return session_id
+
+    def complete(
+        self,
+        task_id: str,
+        *,
+        content: str = "Finished once.",
+        status: str = "settled",
+    ) -> None:
+        callback = None
+        receipt = None
+        with self._lock:
+            for session_id, session_state in self.states.items():
+                if session_state["task_id"] != task_id:
+                    continue
+                receipt = {
+                    "role": "assistant",
+                    "task_id": task_id,
+                    "execution_generation": session_state["execution_generation"],
+                    "status": status,
+                    "message_id": f"reply:{task_id}",
+                    "content": content,
+                }
+                session_state["history"].append(receipt)
+                session_state["active"] = False
+                callback = session_state.get("on_terminal")
+                self.calls.append(("complete", {"session_id": session_id}))
+                break
+        if receipt is None:
+            raise AssertionError(f"no active session for {task_id}")
+        if callback is not None:
+            callback({
+                "status": status,
+                "settlement_id": receipt["message_id"],
+                "message_id": receipt["message_id"],
+                "text": content,
+            })
+
+    def resolve_exact(self, *, profile: str, title: str, source: str):
+        self._assert_lock(profile)
+        params = {"profile": profile, "title": title, "source": source}
+        self.calls.append(("resolve_exact", params))
+        with self._lock:
+            session = self.sessions.get((profile, title))
+            return dict(session) if session is not None else None
+
+    def create(self, *, profile: str, title: str, source: str):
+        self._assert_lock(profile)
+        params = {"profile": profile, "title": title, "source": source}
+        self.calls.append(("create", params))
+        session_id = self.add_session(profile=profile, title=title)
+        return {"session_id": session_id, "title": title}
+
+    def resume(self, *, profile: str, session_id: str, source: str):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+        }
+        self.calls.append(("resume", params))
+        return {"session_id": session_id}
+
+    def submit(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        prompt: str,
+        source: str,
+        task: state.TaskIdentity,
+        execution_generation: int,
+        on_terminal,
+    ):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "prompt": prompt,
+            "source": source,
+            "task": task,
+            "execution_generation": execution_generation,
+            "on_terminal": on_terminal,
+        }
+        self.calls.append(("submit", params))
+        with self._lock:
+            self.states[session_id]["active"] = True
+            self.states[session_id]["task_id"] = task.task_id
+            self.states[session_id]["execution_generation"] = execution_generation
+            self.states[session_id]["on_terminal"] = on_terminal
+        self.submitted.set()
+        if self.auto_complete:
+            self.complete(task.task_id)
+        return {"accepted": True}
+
+    def history(self, *, profile: str, session_id: str, source: str):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+        }
+        self.calls.append(("history", params))
+        if self.history_failures > 0:
+            self.history_failures -= 1
+            raise RuntimeError("transient history read failed")
+        with self._lock:
+            return [dict(message) for message in self.states[session_id]["history"]]
+
+    def info(self, *, profile: str, session_id: str, source: str):
+        self._assert_lock(profile)
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+        }
+        self.calls.append(("info", params))
+        with self._lock:
+            session_state = self.states[session_id]
+            result = {
+                "active": session_state["active"],
+                "task_id": session_state["task_id"],
+            }
+            if session_state.get("pending_approval"):
+                result["status"] = "waiting_for_approval"
+                result["pending_approval"] = dict(session_state["pending_approval"])
+        if self.on_info is not None:
+            self.on_info()
+        return result
+
+    def interrupt(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        expected_task_id: str,
+    ):
+        params = {
+            "profile": profile,
+            "session_id": session_id,
+            "source": source,
+            "expected_task_id": expected_task_id,
+        }
+        with self._lock:
+            current = self.states[session_id]
+            if not current["active"] or current["task_id"] != expected_task_id:
+                self.calls.append(("interrupt_skipped", params))
+                return {"interrupted": False}
+            current["active"] = False
+        self.calls.append(("interrupt", params))
+        if self.on_interrupt is not None:
+            self.on_interrupt()
+        return {"interrupted": True}
+
+
+class SelectiveCompletionRPC(FakeSessionRPC):
+    """Keep selected local profiles running while peers complete normally."""
+
+    def __init__(self, *, waiting_profiles: set[str]) -> None:
+        super().__init__()
+        self.waiting_profiles = waiting_profiles
+        self._submit_mode_lock = threading.Lock()
+
+    def submit(self, **kwargs):
+        with self._submit_mode_lock:
+            original = self.auto_complete
+            self.auto_complete = kwargs["profile"] not in self.waiting_profiles
+            try:
+                return super().submit(**kwargs)
+            finally:
+                self.auto_complete = original
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> Path:
+    path = tmp_path / "state.db"
+    hosted_rooms.create_room(
+        path,
+        room_id=ROOM_ID,
+        name="Release room",
+        members=[{"profile": PROFILE, "handle": PROFILE}],
+        authority_gateway_id=BINDING.gateway_id,
+        now=time.time(),
+    )
+    return path
+
+
+def _identity(task_id: str = "task-1") -> state.TaskIdentity:
+    return state.TaskIdentity(
+        room_id=ROOM_ID,
+        task_id=task_id,
+        thread_id="thread-1",
+        turn_id=f"turn-{task_id}",
+    )
+
+
+def _admit(
+    db: Path,
+    identity: state.TaskIdentity,
+    *,
+    prompt: str = "Inspect the release candidate.",
+) -> None:
+    state.admit_task(
+        db,
+        identity,
+        payload={
+            "target_profile": PROFILE,
+            "prompt": prompt,
+            "source_event_seq": 1,
+        },
+        clock=time.time,
+    )
+
+
+def _runtime(
+    db: Path,
+    rpc: FakeSessionRPC,
+    locks: RecordingTurnLocks | None = None,
+    **kwargs,
+) -> HostedRoomRuntime:
+    return HostedRoomRuntime(
+        db_path=db,
+        rooms=[BINDING],
+        rpc=rpc,
+        turn_lock=locks or RecordingTurnLocks(),
+        lease_ttl_seconds=kwargs.pop("lease_ttl_seconds", 0.4),
+        poll_interval_seconds=kwargs.pop("poll_interval_seconds", 0.01),
+        **kwargs,
+    )
+
+
+def _wait_for(predicate, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached before timeout")
+
+
+def test_runtime_uses_unique_process_generation(db: Path):
+    first = _runtime(db, FakeSessionRPC())
+    second = _runtime(db, FakeSessionRPC())
+
+    assert first.process_generation != second.process_generation
+    assert len(first.process_generation) == 32
+
+
+@pytest.mark.parametrize("value", [0, True])
+def test_room_concurrency_bound_must_be_a_positive_integer(db: Path, value):
+    with pytest.raises(ValueError, match="max_concurrent_rooms"):
+        _runtime(db, FakeSessionRPC(), max_concurrent_rooms=value)
+
+
+def test_waiting_room_does_not_block_an_independent_local_room(tmp_path: Path):
+    db = tmp_path / "state.db"
+    bindings = [
+        HostedRoomBinding("room-waiting", "gateway-a", 1),
+        HostedRoomBinding("room-healthy", "gateway-a", 1),
+    ]
+    identities = [
+        state.TaskIdentity("room-waiting", "task-waiting", "thread-a", "turn-a"),
+        state.TaskIdentity("room-healthy", "task-healthy", "thread-b", "turn-b"),
+    ]
+    profiles = ["profile-waiting", "profile-healthy"]
+    for binding, identity, profile in zip(bindings, identities, profiles):
+        hosted_rooms.create_room(
+            db,
+            room_id=binding.room_id,
+            name=binding.room_id,
+            members=[{"profile": profile, "handle": profile}],
+            authority_gateway_id=binding.gateway_id,
+            now=time.time(),
+        )
+        state.admit_task(
+            db,
+            identity,
+            payload={
+                "target_profile": profile,
+                "prompt": f"Run {binding.room_id}.",
+                "source_event_seq": 1,
+            },
+            clock=time.time,
+        )
+
+    rpc = SelectiveCompletionRPC(waiting_profiles={"profile-waiting"})
+    runtime = HostedRoomRuntime(
+        db_path=db,
+        rooms=bindings,
+        rpc=rpc,
+        turn_lock=RecordingTurnLocks(),
+        lease_ttl_seconds=0.4,
+        poll_interval_seconds=0.01,
+        max_concurrent_rooms=2,
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identities[1])["status"] == "settled")
+    _wait_for(lambda: state.get_task(db, identities[0])["status"] == "running")
+    assert state.get_task(db, identities[0])["status"] == "running"
+    _wait_for(lambda: len(runtime.status()["current_tasks"]) == 1)
+    assert len(runtime.status()["current_tasks"]) == 1
+    assert runtime.stop(timeout=1.0)
+
+
+def test_rotated_bounded_scheduler_eventually_runs_later_room(tmp_path: Path):
+    db = tmp_path / "state.db"
+    bindings = [
+        HostedRoomBinding(f"room-{index}", "gateway-a", 1) for index in range(1, 4)
+    ]
+    for binding in bindings:
+        hosted_rooms.create_room(
+            db,
+            room_id=binding.room_id,
+            name=binding.room_id,
+            members=[{"profile": PROFILE, "handle": PROFILE}],
+            authority_gateway_id=binding.gateway_id,
+            now=time.time(),
+        )
+    identity = state.TaskIdentity(
+        "room-3",
+        "task-room-3",
+        "thread-room-3",
+        "turn-room-3",
+    )
+    state.admit_task(
+        db,
+        identity,
+        payload={
+            "target_profile": PROFILE,
+            "prompt": "Run the later room.",
+            "source_event_seq": 1,
+        },
+        clock=time.time,
+    )
+    runtime = HostedRoomRuntime(
+        db_path=db,
+        rooms=bindings,
+        rpc=FakeSessionRPC(),
+        turn_lock=RecordingTurnLocks(),
+        lease_ttl_seconds=0.4,
+        poll_interval_seconds=0.01,
+        max_concurrent_rooms=2,
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+
+def test_queued_task_routes_profile_and_credentials_without_overrides(db: Path):
+    identity = _identity()
+    _admit(db, identity, prompt="Use the configured profile credentials.")
+    rpc = FakeSessionRPC()
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    create = next(params for method, params in rpc.calls if method == "create")
+    submit = next(params for method, params in rpc.calls if method == "submit")
+    assert create == {
+        "profile": PROFILE,
+        "title": f"Group: {ROOM_ID}",
+        "source": ROOM_SESSION_SOURCE,
+    }
+    assert submit["profile"] == PROFILE
+    assert submit["source"] == ROOM_SESSION_SOURCE
+    assert submit["prompt"] == "Use the configured profile credentials."
+    assert "model" not in create | submit
+    assert "provider" not in create | submit
+    assert state.get_task(db, identity)["result"]["text"] == "Finished once."
+
+
+def test_worker_settles_without_any_client_transport(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    runtime = _runtime(db, FakeSessionRPC())
+
+    runtime.start()
+    _wait_for(
+        lambda: (
+            state.get_task(db, identity)["status"] == "settled"
+            and runtime.status()["cycles"] >= 1
+        )
+    )
+
+    assert runtime.status()["running"] is True
+    assert runtime.status()["cycles"] >= 1
+    assert runtime.stop(timeout=1.0)
+
+
+def test_policy_hooks_prepare_and_publish_terminal_idempotently(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    prepared = []
+    published = []
+    runtime = _runtime(
+        db,
+        FakeSessionRPC(),
+        prepare_room=lambda binding: prepared.append(binding.room_id),
+        publish_terminal=lambda binding, task: published.append((
+            binding.room_id,
+            task["identity"].task_id,
+            task["status"],
+        )),
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert prepared
+    assert published == [(ROOM_ID, identity.task_id, "settled")]
+
+
+def test_existing_canonical_session_is_resumed_not_duplicated(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC()
+    session_id = rpc.add_session()
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert not [call for call in rpc.calls if call[0] == "create"]
+    resume = next(params for method, params in rpc.calls if method == "resume")
+    assert resume == {
+        "profile": PROFILE,
+        "session_id": session_id,
+        "source": ROOM_SESSION_SOURCE,
+    }
+
+
+def test_local_crash_recovery_keeps_ambiguous_history_explicit_without_resume(
+    db: Path,
+):
+    identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
+
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=clock,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": 1,
+                "status": "settled",
+                "message_id": "reply:recovered",
+                "content": "Recovered durable answer.",
+            }
+        ],
+    )
+    now[0] = 101.0
+    runtime = _runtime(
+        db,
+        rpc,
+        clock=clock,
+        indeterminate_defer_seconds=5,
+    )
+
+    runtime._process_room(BINDING)
+
+    recovered = state.get_task(db, identity)
+    assert recovered["status"] == "indeterminate"
+    assert recovered["result"] is None
+    assert not [call for call in rpc.calls if call[0] == "history"]
+    assert [call for call in rpc.calls if call[0] == "info"]
+    assert not [call for call in rpc.calls if call[0] == "resume"]
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_expired_local_attempt_defers_without_hydrating_or_resubmitting(db: Path):
+    identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
+
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=clock,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": 1,
+                "status": "settled",
+                "message_id": "reply:expired-recovered",
+                "content": "Recovered after lease expiry.",
+            }
+        ],
+    )
+    now[0] = 101.0
+    runtime = _runtime(
+        db,
+        rpc,
+        clock=clock,
+        indeterminate_defer_seconds=0.5,
+    )
+
+    runtime._process_room(BINDING)
+    now[0] = 102.0
+    runtime._process_room(BINDING)
+
+    recovered = state.get_task(db, identity)
+    assert recovered["status"] == "deferred"
+    assert recovered["result"] == {
+        "reason": "member_unavailable",
+        "retryable": True,
+    }
+    assert not [call for call in rpc.calls if call[0] == "history"]
+    assert not [call for call in rpc.calls if call[0] == "resume"]
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_oversized_terminal_reply_is_bounded_without_waiting_for_deadline(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc, turn_timeout_seconds=30)
+
+    runtime.start()
+    assert rpc.submitted.wait(timeout=1.0)
+    rpc.complete(
+        identity.task_id,
+        content="é" * (MAX_TERMINAL_TEXT_BYTES + 100),
+    )
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    result = state.get_task(db, identity)["result"]
+    assert result["truncated"] is True
+    assert len(result["text"].encode("utf-8")) <= MAX_TERMINAL_TEXT_BYTES
+    assert result["text"].endswith("share the full result as a file.]")
+
+
+def test_turn_deadline_stops_exact_attempt_and_publishes_durable_failure(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    published = []
+    runtime = _runtime(
+        db,
+        rpc,
+        active_poll_interval_seconds=0.01,
+        turn_timeout_seconds=0.05,
+        publish_terminal=lambda _binding, task: published.append(task),
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "failed")
+    assert runtime.stop(timeout=1.0)
+
+    failed = state.get_task(db, identity)
+    assert failed["result"] == {
+        "error": (
+            "This Group Chat turn exceeded its configured time limit and was stopped."
+        ),
+        "reason_code": "turn_deadline_exceeded",
+        "timeout_seconds": 0.05,
+    }
+    assert failed["cancel_id"] == "deadline:1"
+    assert [call for call in rpc.calls if call[0] == "interrupt"]
+    assert [task["status"] for task in published] == ["failed"]
+
+
+def test_deadline_releases_worker_capacity_for_later_room(tmp_path: Path):
+    db = tmp_path / "state.db"
+    bindings = [
+        HostedRoomBinding("room-stuck", "gateway-a", 1),
+        HostedRoomBinding("room-healthy", "gateway-a", 1),
+    ]
+    identities = [
+        state.TaskIdentity("room-stuck", "task-stuck", "thread-a", "turn-a"),
+        state.TaskIdentity("room-healthy", "task-healthy", "thread-b", "turn-b"),
+    ]
+    for binding, identity in zip(bindings, identities):
+        hosted_rooms.create_room(
+            db,
+            room_id=binding.room_id,
+            name=binding.room_id,
+            members=[{"profile": PROFILE, "handle": PROFILE}],
+            authority_gateway_id=binding.gateway_id,
+        )
+        state.admit_task(
+            db,
+            identity,
+            payload={
+                "target_profile": PROFILE,
+                "prompt": f"Run {binding.room_id}.",
+                "source_event_seq": 1,
+            },
+            clock=time.time,
+        )
+
+    class FirstRoomStallsRPC(FakeSessionRPC):
+        def submit(self, **kwargs):
+            result = super().submit(**kwargs)
+            if kwargs["task"].room_id == "room-healthy":
+                self.complete(kwargs["task"].task_id)
+            return result
+
+    rpc = FirstRoomStallsRPC(auto_complete=False)
+    runtime = HostedRoomRuntime(
+        db_path=db,
+        rooms=bindings,
+        rpc=rpc,
+        turn_lock=RecordingTurnLocks(),
+        lease_ttl_seconds=0.4,
+        poll_interval_seconds=0.02,
+        active_poll_interval_seconds=0.01,
+        turn_timeout_seconds=0.05,
+        max_concurrent_rooms=1,
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identities[0])["status"] == "failed")
+    _wait_for(lambda: state.get_task(db, identities[1])["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identities[0])["result"]["reason_code"] == (
+        "turn_deadline_exceeded"
+    )
+    assert state.get_task(db, identities[1])["status"] == "settled"
+
+
+def test_retry_ignores_late_receipt_from_prior_execution_generation(db: Path):
+    identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
+
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=clock,
+    )
+    _admit(db, identity)
+    old_attempt = state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    now[0] = 101.0
+    current_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="manual-recovery",
+        ttl_seconds=30,
+        clock=clock,
+    )
+    state.recover_room(db, current_lease, clock=clock)
+    state.requeue_indeterminate_task(
+        db,
+        identity,
+        current_lease,
+        expected_execution_generation=old_attempt.execution_generation,
+        expected_cancel_generation=old_attempt.cancel_generation,
+        clock=clock,
+    )
+    state.release_lease(db, current_lease, clock=clock)
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": old_attempt.execution_generation,
+                "status": "settled",
+                "message_id": "reply:late-old-attempt",
+                "content": "Late old result.",
+            }
+        ],
+    )
+    runtime = _runtime(db, rpc, clock=clock)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    time.sleep(0.04)
+    assert runtime.stop(timeout=1.0)
+
+    task = state.get_task(db, identity)
+    assert task["status"] == "running"
+    assert task["execution_generation"] == old_attempt.execution_generation + 1
+
+
+def test_active_recovered_turn_is_never_resubmitted(db: Path):
+    identity = _identity()
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=10,
+        clock=time.time,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=True, task_id=identity.task_id)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    time.sleep(0.08)
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["status"] == "running"
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_ambiguous_recovery_remains_indeterminate(db: Path):
+    identity = _identity()
+    now = [100.0]
+
+    def clock():
+        return now[0]
+
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.2,
+        clock=clock,
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=False, task_id=identity.task_id)
+    now[0] = 101.0
+    runtime = _runtime(db, rpc, clock=clock)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "indeterminate")
+    assert runtime.stop(timeout=1.0)
+
+    assert not [call for call in rpc.calls if call[0] == "submit"]
+
+
+def test_offline_member_defers_then_healthy_task_runs_and_retry_is_fenced(
+    db: Path,
+):
+    now = [100.0]
+
+    def clock():
+        return now[0]
+
+    first = _identity("task-offline")
+    second = state.TaskIdentity(
+        room_id=ROOM_ID,
+        task_id="task-healthy",
+        thread_id="thread-1",
+        turn_id="turn-task-healthy",
+    )
+    state.admit_task(
+        db,
+        first,
+        payload={
+            "target_profile": PROFILE,
+            "prompt": "Try the offline member.",
+            "source_event_seq": 1,
+        },
+        clock=clock,
+    )
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=1,
+        clock=clock,
+    )
+    old_attempt = state.start_task(
+        db,
+        first,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    state.admit_task(
+        db,
+        second,
+        payload={
+            "target_profile": PROFILE,
+            "prompt": "Continue with the healthy member.",
+            "source_event_seq": 2,
+        },
+        clock=clock,
+    )
+    now[0] = 102.0
+    rpc = FakeSessionRPC()
+    published = []
+    runtime = _runtime(
+        db,
+        rpc,
+        clock=clock,
+        lease_ttl_seconds=30,
+        indeterminate_defer_seconds=5,
+        publish_terminal=lambda _binding, task: published.append(task),
+    )
+
+    runtime._process_room(BINDING)
+    assert state.get_task(db, first)["status"] == "indeterminate"
+    assert state.get_task(db, second)["status"] == "queued"
+
+    now[0] = 108.0
+    runtime._process_room(BINDING)
+    assert state.get_task(db, first)["status"] == "deferred"
+    assert state.get_task(db, second)["status"] == "settled"
+    assert [task["status"] for task in published] == ["deferred", "settled"]
+    assert ROOM_ID not in runtime.status()["blocked_rooms"]
+
+    requeued = runtime.retry_indeterminate(first)
+    assert requeued["status"] == "queued"
+    lease = runtime._leases[ROOM_ID]
+    retry_attempt = state.start_task(
+        db,
+        first,
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    assert retry_attempt.execution_generation == old_attempt.execution_generation + 1
+    late_attempt = state.TaskAttempt(
+        identity=first,
+        lease=lease,
+        execution_generation=old_attempt.execution_generation,
+        cancel_generation=old_attempt.cancel_generation,
+    )
+    with pytest.raises(state.StaleTaskError):
+        state.settle_task(
+            db,
+            late_attempt,
+            settlement_id="late-old-result",
+            status="settled",
+            result={"text": "too late"},
+            clock=clock,
+        )
+    state.settle_task(
+        db,
+        retry_attempt,
+        settlement_id="retry-result",
+        status="settled",
+        result={"text": "retry accepted"},
+        clock=clock,
+    )
+    assert state.get_task(db, first)["result"]["text"] == "retry accepted"
+
+
+def test_post_submit_observation_failure_preserves_recoverable_outcome(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.history_failures = 1
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    _wait_for(
+        lambda: (
+            "observation failed after submit"
+            in str(runtime.status()["last_error"] or "")
+        )
+    )
+    assert state.get_task(db, identity)["status"] == "running"
+    rpc.complete(identity.task_id, content="Recovered after a transient read.")
+    runtime.wakeup()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    task = state.get_task(db, identity)
+    assert task["result"]["text"] == "Recovered after a transient read."
+    assert not [call for call in rpc.calls if call[0] == "submit"][1:]
+
+
+def test_cancellation_is_persisted_before_interrupt_and_fences_late_result(
+    db: Path,
+):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+    observed_status: list[str] = []
+    rpc.on_interrupt = lambda: observed_status.append(
+        state.get_task(db, identity)["status"]
+    )
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    cancelled = runtime.cancel(identity, cancel_id="cancel-user")
+    rpc.complete(identity.task_id, content="Too late.")
+    runtime.wakeup()
+    time.sleep(0.05)
+    assert runtime.stop(timeout=1.0)
+
+    assert cancelled["status"] == "cancelled"
+    assert observed_status == ["stopping"]
+
+
+def test_transient_remote_stop_failure_stays_pending_and_retries(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+    original_interrupt = rpc.interrupt
+    attempts = 0
+    retry_allowed = threading.Event()
+
+    def flaky_interrupt(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("temporary stop transport failure")
+        assert retry_allowed.wait(1.0)
+        return original_interrupt(**kwargs)
+
+    rpc.interrupt = flaky_interrupt
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    stopping = runtime.cancel(identity, cancel_id="cancel-retry")
+    assert stopping["status"] == "stopping"
+    assert state.get_task(db, identity)["status"] == "stopping"
+    retry_allowed.set()
+    runtime.wakeup()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "cancelled")
+    assert attempts >= 2
+    assert runtime.stop(timeout=1.0)
+    assert state.get_task(db, identity)["status"] == "cancelled"
+
+
+def test_completion_wins_a_race_with_unacknowledged_stop(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+
+    def finish_only_after_stop_intent():
+        if state.get_task(db, identity)["status"] == "stopping":
+            rpc.complete(identity.task_id, content="Already done.")
+
+    rpc.on_info = finish_only_after_stop_intent
+    result = runtime.cancel(identity, cancel_id="cancel-raced")
+
+    assert result["status"] == "settled"
+    assert result["result"]["text"] == "Already done."
+    assert runtime.stop(timeout=1.0)
+
+
+def test_restart_harvests_completion_before_retrying_durable_stop(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    now = [100.0]
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=1.0,
+        clock=lambda: now[0],
+    )
+    attempt = state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=lambda: now[0],
+    )
+    stopping = state.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-restart",
+        expected_cancel_generation=attempt.cancel_generation,
+        clock=lambda: now[0],
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(
+        active=False,
+        task_id=identity.task_id,
+        history=[
+            {
+                "role": "assistant",
+                "task_id": identity.task_id,
+                "execution_generation": attempt.execution_generation,
+                "status": "settled",
+                "message_id": "reply-after-stop",
+                "content": "Finished before Stop reached the session.",
+            }
+        ],
+    )
+    now[0] += 2.0
+    runtime = _runtime(
+        db,
+        rpc,
+        process_generation="new-process",
+        clock=lambda: now[0],
+    )
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    settled = state.get_task(db, identity)
+    assert stopping["status"] == "stopping"
+    assert settled["result"]["text"] == "Finished before Stop reached the session."
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]
+
+
+def test_restart_acknowledges_inactive_local_stop_without_memory_marker(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=0.05,
+        clock=time.time,
+    )
+    attempt = state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    state.begin_task_cancel(
+        db,
+        identity,
+        cancel_id="cancel-before-restart",
+        expected_cancel_generation=attempt.cancel_generation,
+        clock=time.time,
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    time.sleep(0.06)
+    runtime = _runtime(db, rpc, process_generation="new-process")
+
+    cancelled = runtime.cancel(identity, cancel_id="cancel-before-restart")
+
+    assert cancelled["status"] == "cancelled"
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]
+
+
+def test_pending_local_approval_is_reported_with_safe_choices(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    actions = []
+    runtime = _runtime(
+        db,
+        rpc,
+        pending_action=lambda room_id, member_id, action: actions.append((
+            room_id,
+            member_id,
+            action,
+        )),
+    )
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    session_id = next(iter(rpc.states))
+    with rpc._lock:
+        rpc.states[session_id]["pending_approval"] = {
+            "request_id": "approval-1",
+            "command": "pytest -q tests/focused",
+            "choices": ["once", "session", "always", "deny"],
+        }
+    runtime.wakeup()
+    _wait_for(lambda: any(action for _room, _member, action in actions))
+
+    _room, member, action = next(item for item in actions if item[2] is not None)
+    assert member == PROFILE
+    assert action["request_id"] == "approval-1"
+    assert action["approval"]["choices"] == ["once", "deny"]
+    assert runtime.stop(timeout=1.0)
+
+
+def test_cancel_never_interrupts_a_newer_task_in_the_same_session(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    session_id = next(iter(rpc.states))
+
+    def switch_to_newer_task() -> None:
+        with rpc._lock:
+            rpc.states[session_id]["active"] = True
+            rpc.states[session_id]["task_id"] = "task-2"
+
+    rpc.on_info = switch_to_newer_task
+    cancelled = runtime.cancel(identity, cancel_id="cancel-old-task")
+
+    assert cancelled["status"] == "stopping"
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]
+    assert not [call for call in rpc.calls if call[0] == "interrupt_skipped"]
+    assert rpc.states[session_id]["active"] is True
+    assert rpc.states[session_id]["task_id"] == "task-2"
+    assert runtime.stop(timeout=1.0)
+
+
+def test_status_reports_room_blocked_on_unresolved_indeterminate_task(db: Path):
+    identity = _identity()
+    now = [100.0]
+    old_lease = state.acquire_lease(
+        db,
+        room_id=ROOM_ID,
+        gateway_id=BINDING.gateway_id,
+        authority_epoch=BINDING.authority_epoch,
+        process_generation="old-process",
+        ttl_seconds=1.0,
+        clock=lambda: now[0],
+    )
+    _admit(db, identity)
+    state.start_task(
+        db,
+        identity,
+        old_lease,
+        expected_cancel_generation=0,
+        clock=lambda: now[0],
+    )
+    rpc = FakeSessionRPC(auto_complete=False)
+    rpc.add_session(active=False, task_id=identity.task_id)
+    now[0] += 2.0
+    runtime = _runtime(db, rpc, clock=lambda: now[0])
+
+    runtime.start()
+    _wait_for(lambda: ROOM_ID in runtime.status()["blocked_rooms"])
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["status"] == "indeterminate"
+
+
+def test_authority_loss_stops_terminal_commit(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc, lease_ttl_seconds=0.1)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    hosted_rooms.claim_authority(
+        db,
+        room_id=ROOM_ID,
+        expected_gateway_id="gateway-a",
+        expected_epoch=1,
+        new_gateway_id="gateway-b",
+        event_id="claim-gateway-b",
+        now=time.time(),
+    )
+    rpc.complete(identity.task_id)
+    runtime.wakeup()
+    _wait_for(lambda: runtime.status()["last_error"] is not None)
+    assert runtime.stop(timeout=1.0)
+
+    assert state.get_task(db, identity)["status"] == "running"
+    assert "authority changed" in runtime.status()["last_error"]
+
+
+def test_profile_turn_lock_covers_resolve_submit_and_terminal_observation(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    locks = RecordingTurnLocks()
+    rpc = FakeSessionRPC(required_lock=locks)
+    runtime = _runtime(db, rpc, locks)
+
+    runtime.start()
+    _wait_for(lambda: state.get_task(db, identity)["status"] == "settled")
+    assert runtime.stop(timeout=1.0)
+
+    assert locks.events == [("lock-enter", PROFILE), ("lock-exit", PROFILE)]
+    methods = [method for method, _params in rpc.calls]
+    assert methods.index("resolve_exact") < methods.index("submit")
+    assert methods.index("submit") < methods.index("complete")
+    assert "history" not in methods
+
+
+def test_stop_is_bounded_and_does_not_interrupt_active_turn(db: Path):
+    identity = _identity()
+    _admit(db, identity)
+    rpc = FakeSessionRPC(auto_complete=False)
+    runtime = _runtime(db, rpc, poll_interval_seconds=0.01)
+
+    runtime.start()
+    assert rpc.submitted.wait(1.0)
+    started = time.monotonic()
+    stopped = runtime.stop(timeout=0.5)
+
+    assert stopped is True
+    assert time.monotonic() - started < 0.5
+    assert state.get_task(db, identity)["status"] == "running"
+    assert not [call for call in rpc.calls if call[0] == "interrupt"]

--- a/tests/tui_gateway/test_hosted_room_prompt_fence.py
+++ b/tests/tui_gateway/test_hosted_room_prompt_fence.py
@@ -1,0 +1,151 @@
+"""Older Desktop clients cannot start a second driver for hosted rooms."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from gateway import hosted_rooms
+import tui_gateway.server as server
+
+
+def _stub_session(monkeypatch, *, title):
+    monkeypatch.setattr(
+        server,
+        "_sess_nowait",
+        lambda _params, _rid: (
+            {"id": "session-1", "title": title, "source": "bot_room"},
+            None,
+        ),
+    )
+
+
+def test_direct_prompt_to_hosted_group_session_is_rejected(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    hosted_rooms.create_room(
+        hosted_rooms.default_db_path(),
+        room_id="room-hosted",
+        name="Hosted room",
+        members=[
+            {"member_id": "one", "profile": "one", "handle": "one"},
+            {"member_id": "two", "profile": "two", "handle": "two"},
+        ],
+        authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+    )
+    _stub_session(monkeypatch, title="Group: room-hosted")
+
+    result = server._methods["prompt.submit"](
+        "request-1", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"]["code"] == 4122
+    assert "managed by its gateway" in result["error"]["message"]
+
+
+def test_direct_prompt_to_non_hosted_group_reaches_normal_admission(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _stub_session(monkeypatch, title="Group: local-only")
+    monkeypatch.setattr(
+        server,
+        "_ensure_active_session_slot",
+        lambda _sid, _session: "normal admission reached",
+    )
+
+    result = server._methods["prompt.submit"](
+        "request-2", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"] == {"code": 4090, "message": "normal admission reached"}
+    assert not hosted_rooms.default_db_path().exists()
+
+
+@pytest.mark.parametrize(
+    "legacy_name",
+    (
+        "Launch room",
+        "Ceo, Product Designer, Cfo",
+        "Équipe",
+        "Alpha/Beta",
+    ),
+)
+def test_direct_prompt_to_legacy_named_group_reaches_normal_admission(
+    tmp_path, monkeypatch, legacy_name
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _stub_session(monkeypatch, title=f"Group: {legacy_name}")
+    monkeypatch.setattr(
+        server,
+        "_ensure_active_session_slot",
+        lambda _sid, _session: "normal admission reached",
+    )
+
+    result = server._methods["prompt.submit"](
+        "request-legacy", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"] == {"code": 4090, "message": "normal admission reached"}
+
+
+def test_direct_prompt_is_refused_when_room_authority_cannot_be_verified(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _stub_session(monkeypatch, title="Group: room-unknown")
+    monkeypatch.setattr(
+        hosted_rooms,
+        "probe_hosted_room",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk busy")),
+    )
+
+    result = server._methods["prompt.submit"](
+        "request-3", {"session_id": "session-1", "text": "continue"}
+    )
+
+    assert result["error"]["code"] == 5122
+    assert result["error"]["message"] == (
+        "Could not verify this group. Try again after the gateway recovers."
+    )
+
+
+def test_contended_ownership_probe_fails_quickly_without_blocking_socket(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    db = hosted_rooms.default_db_path()
+    hosted_rooms.create_room(
+        db,
+        room_id="room-busy",
+        name="Busy room",
+        members=[],
+        authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+    )
+    _stub_session(monkeypatch, title="Group: room-busy")
+
+    blocker = sqlite3.connect(db)
+    blocker.execute("PRAGMA journal_mode=DELETE")
+    blocker.execute("BEGIN EXCLUSIVE")
+    started = time.monotonic()
+    try:
+        result = server._methods["prompt.submit"](
+            "request-busy", {"session_id": "session-1", "text": "continue"}
+        )
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+    assert time.monotonic() - started < 0.5
+    assert result["error"]["code"] == 5122

--- a/tests/tui_gateway/test_hosted_room_server_rpc.py
+++ b/tests/tui_gateway/test_hosted_room_server_rpc.py
@@ -1,0 +1,177 @@
+"""Tests for the in-process hosted room session adapter."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.hosted_room_driver import TaskIdentity
+from tui_gateway.hosted_room_server_rpc import (
+    HostedRoomServerRPC,
+    HostedRoomSessionError,
+)
+
+
+def _server():
+    sessions = {}
+    calls = []
+
+    def method(name, result):
+        def handler(rid, params):
+            calls.append((name, params))
+            value = result(params) if callable(result) else result
+            return {"id": rid, **value}
+
+        return handler
+
+    methods = {
+        "session.list": method(
+            "session.list",
+            {"result": {"sessions": [{"id": "stored", "resolved_id": "tip", "title": "Group: room"}]}},
+        ),
+        "session.create": method("session.create", {"result": {"session_id": "runtime"}}),
+        "session.resume": method("session.resume", {"result": {"session_id": "runtime"}}),
+        "session.history": method("session.history", {"result": {"messages": [{"role": "assistant"}]}}),
+        "session.interrupt": method("session.interrupt", {"result": {"interrupted": True}}),
+        "approval.respond": method("approval.respond", {"result": {"resolved": 1}}),
+        "prompt.submit": method("prompt.submit", {"result": {"status": "streaming"}}),
+    }
+    server = SimpleNamespace(
+        _methods=methods,
+        _sessions=sessions,
+        _sessions_lock=threading.Lock(),
+        _pending_approval_request_payload=lambda _session_key: None,
+    )
+    return server, calls
+
+
+def test_routes_exact_hidden_session_and_internal_task_proof():
+    server, calls = _server()
+    rpc = HostedRoomServerRPC(server)
+    task = TaskIdentity("room", "task", "thread", "turn")
+    callback = lambda _receipt: None
+
+    assert rpc.resolve_exact(profile="ops", title="Group: room", source="bot_room")["session_id"] == "tip"
+    assert rpc.create(profile="ops", title="Group: room", source="bot_room")["session_id"] == "runtime"
+    rpc.submit(
+        profile="ops",
+        session_id="runtime",
+        prompt="Do the work",
+        source="bot_room",
+        task=task,
+        execution_generation=2,
+        on_terminal=callback,
+    )
+
+    create = next(params for method, params in calls if method == "session.create")
+    submit = next(params for method, params in calls if method == "prompt.submit")
+    assert create["hidden"] is True
+    assert create["room_plumbing"] is True
+    assert create["follow_profile_config"] is True
+    assert create["close_on_disconnect"] is False
+    assert submit["_hosted_task"] == {
+        "room_id": "room",
+        "task_id": "task",
+        "thread_id": "thread",
+        "turn_id": "turn",
+        "execution_generation": 2,
+    }
+    assert submit["_hosted_terminal_callback"] is callback
+
+    rpc.resume(profile="ops", session_id="stored", source="bot_room")
+    resume = next(params for method, params in calls if method == "session.resume")
+    assert resume["source"] == "bot_room"
+
+
+def test_info_and_interrupt_are_exact_task_scoped():
+    server, calls = _server()
+    lock = threading.Lock()
+    server._sessions["runtime"] = {
+        "history_lock": lock,
+        "running": True,
+        "_hosted_room_task": {"task_id": "task-a"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    assert rpc.info(profile="ops", session_id="runtime", source="bot_room") == {
+        "active": True,
+        "task_id": "task-a",
+    }
+    rpc.interrupt(
+        profile="ops",
+        session_id="runtime",
+        source="bot_room",
+        expected_task_id="task-a",
+    )
+    params = next(params for method, params in calls if method == "session.interrupt")
+    assert params["expected_hosted_task_id"] == "task-a"
+
+
+def test_local_approval_snapshot_and_response_use_exact_request():
+    server, calls = _server()
+    server._pending_approval_request_payload = lambda session_key: {
+        "request_id": "approval-1",
+        "command": "pytest -q tests/focused",
+        "choices": ["once", "deny"],
+    } if session_key == "stored-session" else None
+    server._sessions["runtime"] = {
+        "history_lock": threading.Lock(),
+        "running": True,
+        "session_key": "stored-session",
+        "_hosted_room_task": {"task_id": "task-a"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    info = rpc.info(profile="ops", session_id="runtime", source="bot_room")
+    assert info["status"] == "waiting_for_approval"
+    assert info["pending_approval"]["request_id"] == "approval-1"
+    assert rpc.approve(
+        session_id="runtime",
+        request_id="approval-1",
+        choice="once",
+    ) == {"resolved": 1}
+    params = next(params for method, params in calls if method == "approval.respond")
+    assert params == {
+        "session_id": "runtime",
+        "request_id": "approval-1",
+        "choice": "once",
+        "all": False,
+    }
+
+
+def test_rpc_errors_are_typed():
+    server, _calls = _server()
+    server._methods["session.list"] = lambda rid, _params: {
+        "id": rid,
+        "error": {"code": 4007, "message": "not found"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    with pytest.raises(HostedRoomSessionError) as exc:
+        rpc.resolve_exact(profile="ops", title="Group: room", source="bot_room")
+    assert exc.value.code == 4007
+
+
+def test_prompt_rejection_is_proven_not_admitted():
+    server, _calls = _server()
+    server._methods["prompt.submit"] = lambda rid, _params: {
+        "id": rid,
+        "error": {"code": 4121, "message": "session is already busy"},
+    }
+    rpc = HostedRoomServerRPC(server)
+
+    with pytest.raises(HostedRoomSessionError) as exc:
+        rpc.submit(
+            profile="ops",
+            session_id="runtime",
+            prompt="Do the work",
+            source="bot_room",
+            task=TaskIdentity("room", "task", "thread", "turn"),
+            execution_generation=1,
+            on_terminal=lambda _receipt: None,
+        )
+
+    assert exc.value.code == 4121
+    assert exc.value.not_admitted is True

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -1,0 +1,748 @@
+"""Integration tests for the hosted Discussion coordinator."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gateway import hosted_room_driver as driver
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_rooms
+from gateway.hosted_room_policy_checkpoint import MAX_ACTIVE_POLICY_EVENTS
+from tui_gateway.hosted_room_service import HostedRoomService
+
+
+def _append_room_event(db, **kwargs):
+    if kwargs.get("kind") == "message.user":
+        room = hosted_rooms.room_state(db, room_id=kwargs["room_id"])
+        kwargs.setdefault(
+            "authority_gateway_id", str(room["authority_gateway_id"])
+        )
+        kwargs.setdefault("authority_epoch", int(room["authority_epoch"]))
+    return hosted_rooms.append_event(db, **kwargs)
+
+
+class _FakeRPC:
+    def __init__(self) -> None:
+        self.sessions = {}
+
+    def resolve_exact(self, *, profile, title, source):
+        return self.sessions.get((profile, title))
+
+    def create(self, *, profile, title, source):
+        session = {"session_id": f"{profile}-session", "title": title}
+        self.sessions[(profile, title)] = session
+        return session
+
+    def resume(self, *, profile, session_id, source):
+        return {"session_id": session_id}
+
+    def submit(
+        self,
+        *,
+        profile,
+        session_id,
+        prompt,
+        source,
+        task,
+        execution_generation,
+        on_terminal,
+    ):
+        on_terminal({"status": "settled", "text": f"reply from {profile}"})
+        return {"accepted": True}
+
+    def history(self, *, profile, session_id, source):
+        return []
+
+    def info(self, *, profile, session_id, source):
+        return {"active": False, "task_id": None}
+
+    def interrupt(self, *, profile, session_id, source, expected_task_id):
+        return {"interrupted": True}
+
+
+class _PromptRecordingRPC(_FakeRPC):
+    def __init__(self) -> None:
+        super().__init__()
+        self.prompts: list[tuple[str, str]] = []
+
+    def submit(
+        self,
+        *,
+        profile,
+        session_id,
+        prompt,
+        source,
+        task,
+        execution_generation,
+        on_terminal,
+    ):
+        self.prompts.append((profile, prompt))
+        on_terminal({"status": "settled", "text": f"reply from {profile}"})
+        return {"accepted": True}
+
+
+class _BlockingFirstRPC(_PromptRecordingRPC):
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_started = threading.Event()
+        self.release_first = threading.Event()
+
+    def submit(self, **kwargs):
+        self.prompts.append((kwargs["profile"], kwargs["prompt"]))
+        if len(self.prompts) == 1:
+            self.first_started.set()
+            assert self.release_first.wait(timeout=2)
+        kwargs["on_terminal"](
+            {"status": "settled", "text": f"reply from {kwargs['profile']}"}
+        )
+        return {"accepted": True}
+
+
+def _server():
+    return SimpleNamespace(_methods={}, _sessions={}, _sessions_lock=threading.Lock())
+
+
+def _wait_for(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not reached")
+
+
+def test_create_send_drive_publish_and_replay_without_client_transport(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.rpc = _FakeRPC()
+    service.runtime.rpc = service.rpc
+    service.local_profiles = lambda: ("default", "ops")
+    room = service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    assert room["room_id"] == "room-1"
+
+    service.start()
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@ops inspect the release", "thread_id": "thread-1"},
+    )
+    _wait_for(
+        lambda: any(
+            event["kind"] == "message.member" for event in service._events("room-1")
+        )
+    )
+    assert service.stop(timeout=1.0)
+
+    events = service._events("room-1")
+    assert [event["kind"] for event in events][:3] == [
+        "message.user",
+        "message.member",
+        "turn.settled",
+    ]
+    assert events[1]["payload"]["text"] == "reply from ops"
+    assert service.status("room-1")["working"] is False
+
+
+def test_restart_republishes_terminal_task_before_admitting_more(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    event = _append_room_event(
+        db,
+        room_id="room-1",
+        event_id="user-1",
+        kind="message.user",
+        actor={"kind": "user", "id": "desktop"},
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+    binding = service.bindings()[0]
+    service.prepare_room(binding)
+    task = driver.list_tasks(db, room_id="room-1", status="queued")[0]
+    lease = driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=binding.gateway_id,
+        authority_epoch=binding.authority_epoch,
+        process_generation="crashed",
+        ttl_seconds=30,
+        clock=time.time,
+    )
+    attempt = driver.start_task(
+        db,
+        task["identity"],
+        lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    driver.settle_task(
+        db,
+        attempt,
+        settlement_id="reply-1",
+        status="settled",
+        result={"text": "done"},
+        clock=time.time,
+    )
+
+    service.prepare_room(binding)
+    events = service._events("room-1")
+    assert event["seq"] == 1
+    assert sum(row["kind"] == "message.member" for row in events) == 1
+    assert sum(row["kind"] == "turn.settled" for row in events) == 1
+    service.prepare_room(binding)
+    replayed = service._events("room-1")
+    assert replayed == events
+
+
+def test_policy_checkpoint_bounds_replay_after_completed_room_history(
+    tmp_path: Path,
+    monkeypatch,
+):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.local_profiles = lambda: ("default", "ops")
+    room = service.create_room(
+        room_id="room-1",
+        name="Long-running room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "default"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    authority = str(room["authority_gateway_id"])
+    rows = []
+    for index in range(200):
+        user_seq = index * 2 + 1
+        activity_seq = user_seq + 1
+        thread_id = f"thread-{index}"
+        event_id = f"user-{index}"
+        rows.extend((
+            (
+                "room-1",
+                user_seq,
+                event_id,
+                "message.user",
+                json.dumps({"kind": "user", "id": "load-test"}),
+                None,
+                json.dumps({"text": "done", "thread_id": thread_id}),
+                float(user_seq),
+            ),
+            (
+                "room-1",
+                activity_seq,
+                f"activity-{index}",
+                "room.activity",
+                json.dumps({"kind": "gateway", "id": authority}),
+                1,
+                json.dumps({
+                    "status": "settled",
+                    "reason_code": "silent_round",
+                    "thread_id": thread_id,
+                    "discussion_event_id": event_id,
+                }),
+                float(activity_seq),
+            ),
+        ))
+    with sqlite3.connect(db) as conn:
+        conn.executemany(
+            """INSERT INTO hosted_room_events(
+                   room_id, seq, event_id, kind, actor_json,
+                   authority_epoch, payload_json, created_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        conn.execute(
+            """UPDATE hosted_rooms
+               SET next_seq=401, revision=revision+400, updated_at=400
+               WHERE room_id='room-1'"""
+        )
+    _append_room_event(
+        db,
+        room_id="room-1",
+        event_id="user-active",
+        kind="message.user",
+        actor={"kind": "user", "id": "desktop"},
+        payload={"text": "Review this", "thread_id": "thread-active"},
+        now=401,
+    )
+
+    original_read_events = hosted_rooms.read_events
+    reads = {"calls": 0, "rows": 0}
+
+    def counted_read_events(*args, **kwargs):
+        page = original_read_events(*args, **kwargs)
+        reads["calls"] += 1
+        reads["rows"] += len(page["events"])
+        return page
+
+    monkeypatch.setattr(hosted_rooms, "read_events", counted_read_events)
+    binding = service.bindings()[0]
+    service.prepare_room(binding)
+    assert reads["rows"] == 401
+    snapshot = service._policy_snapshot(hosted_rooms.room_state(db, room_id="room-1"))
+    assert len(snapshot.events) == 1
+    assert len(snapshot.events) <= MAX_ACTIVE_POLICY_EVENTS
+    with sqlite3.connect(db) as conn:
+        assert (
+            conn.execute("SELECT COUNT(*) FROM hosted_room_policy_events").fetchone()[0]
+            == 1
+        )
+        assert (
+            conn.execute("SELECT COUNT(*) FROM hosted_room_policy_threads").fetchone()[
+                0
+            ]
+            == 1
+        )
+
+    reads.update(calls=0, rows=0)
+    service.prepare_room(binding)
+    assert reads == {"calls": 0, "rows": 0}
+
+
+def test_same_thread_followup_migrates_and_delivers_committed_peer_reply(
+    tmp_path: Path,
+):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.rpc = _PromptRecordingRPC()
+    service.runtime.rpc = service.rpc
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Shared context room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+
+    service.start()
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@ops provide the marker", "thread_id": "thread-1"},
+    )
+    _wait_for(lambda: len(service.rpc.prompts) == 1)
+    _wait_for(
+        lambda: any(
+            event["kind"] == "room.activity"
+            and event["payload"]["discussion_event_id"] == "user-1"
+            for event in service._events("room-1")
+        )
+    )
+    with sqlite3.connect(db) as conn:
+        assert conn.execute(
+            """SELECT COUNT(*) FROM hosted_room_policy_transcript
+               WHERE room_id='room-1' AND thread_id='thread-1'"""
+        ).fetchone()[0] == 2
+        conn.execute("DELETE FROM hosted_room_policy_transcript")
+        conn.execute(
+            """DELETE FROM hosted_room_policy_transcript_state
+               WHERE room_id='room-1'"""
+        )
+    service.send(
+        room_id="room-1",
+        event_id="user-2",
+        payload={"text": "@hermes continue", "thread_id": "thread-1"},
+    )
+    _wait_for(lambda: len(service.rpc.prompts) == 2)
+    assert service.stop(timeout=1.0)
+
+    profile, prompt = service.rpc.prompts[1]
+    assert profile == "default"
+    assert "@ops: reply from ops" in prompt
+    assert "User (user): @hermes continue" in prompt
+
+
+def test_active_same_thread_followup_waits_for_current_task(tmp_path: Path):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.rpc = _BlockingFirstRPC()
+    service.runtime.rpc = service.rpc
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Serialized room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+
+    service.start()
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@ops start", "thread_id": "thread-1"},
+    )
+    assert service.rpc.first_started.wait(timeout=2)
+    service.send(
+        room_id="room-1",
+        event_id="user-2",
+        payload={"text": "@hermes follow up", "thread_id": "thread-1"},
+    )
+    assert len(service.rpc.prompts) == 1
+    service.rpc.release_first.set()
+    _wait_for(lambda: len(service.rpc.prompts) == 2)
+    _wait_for(
+        lambda: any(
+            event["kind"] == "room.activity"
+            and event["payload"]["discussion_event_id"] == "user-2"
+            for event in service._events("room-1")
+        )
+    )
+    assert service.stop(timeout=1.0)
+    assert "User (user): @hermes follow up" in service.rpc.prompts[1][1]
+
+
+def test_thread_transcript_prunes_committed_message_and_settlement_together(
+    tmp_path: Path,
+):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.rpc = _FakeRPC()
+    service.runtime.rpc = service.rpc
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Bounded room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    service.start()
+    service.send(
+        room_id="room-1",
+        event_id="user-first",
+        payload={"text": "@ops old", "thread_id": "thread-1"},
+    )
+    _wait_for(
+        lambda: any(
+            event["kind"] == "room.activity"
+            for event in service._events("room-1")
+        )
+    )
+    assert service.stop(timeout=1.0)
+    for index in range(24):
+        _append_room_event(
+            db,
+            room_id="room-1",
+            event_id=f"user-tail-{index}",
+            kind="message.user",
+            actor={"kind": "user", "id": "desktop"},
+            payload={"text": f"tail {index}", "thread_id": "thread-1"},
+        )
+
+    room = hosted_rooms.room_state(db, room_id="room-1")
+    snapshot = service._policy_snapshot(room)
+    assert len(snapshot.events) == 24
+    assert {event["kind"] for event in snapshot.events} == {"message.user"}
+    discussion.plan_next_task(
+        room,
+        snapshot.events,
+        local_profiles=service.local_profiles(),
+        initial_watermarks=snapshot.watermarks,
+    )
+
+
+def test_service_uses_low_idle_poll_with_immediate_wakeup(tmp_path: Path):
+    service = HostedRoomService(_server(), db_path=tmp_path / "state.db")
+
+    assert service.runtime.poll_interval_seconds == 5.0
+    assert service.runtime.active_poll_interval_seconds == 0.25
+    assert service.runtime.turn_timeout_seconds == 1830.0
+    service.runtime._wake.clear()
+    service.wakeup()
+    assert service.runtime._wake.is_set()
+
+
+def test_service_derives_room_deadline_from_agent_timeout(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HERMES_AGENT_TIMEOUT", "90")
+
+    service = HostedRoomService(_server(), db_path=tmp_path / "state.db")
+
+    assert service.runtime.turn_timeout_seconds == 120.0
+
+
+def test_service_publishes_deferred_turn_continues_and_retries_new_generation(
+    tmp_path: Path,
+):
+    now = [100.0]
+
+    def clock():
+        return now[0]
+
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    service.rpc = _FakeRPC()
+    service.runtime.rpc = service.rpc
+    service.runtime.clock = clock
+    service.runtime.lease_ttl_seconds = 30
+    service.runtime.indeterminate_defer_seconds = 5
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Resilient room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "default"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    service.send(
+        room_id="room-1",
+        event_id="user-resilience",
+        payload={"text": "Check this", "thread_id": "thread-1"},
+    )
+    first = driver.list_tasks(db, room_id="room-1", status="queued")[0]
+    old_lease = driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=service.bindings()[0].gateway_id,
+        authority_epoch=1,
+        process_generation="offline-member",
+        ttl_seconds=1,
+        clock=clock,
+    )
+    old_attempt = driver.start_task(
+        db,
+        first["identity"],
+        old_lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+
+    now[0] = 102.0
+    binding = service.bindings()[0]
+    service.runtime._process_room(binding)
+    now[0] = 108.0
+    service.runtime._process_room(binding)
+
+    events = service._events("room-1")
+    deferred = next(event for event in events if event["kind"] == "turn.deferred")
+    assert deferred["payload"]["task_id"] == first["identity"].task_id
+    assert deferred["payload"]["execution_generation"] == 1
+    assert any(
+        event["kind"] == "message.member" and event["payload"]["member_id"] == "ops"
+        for event in events
+    )
+
+    requeued = service.retry_room_task(
+        "room-1",
+        task_id=first["identity"].task_id,
+    )
+    assert requeued["status"] == "queued"
+    lease = service.runtime._leases["room-1"]
+    retried = driver.start_task(
+        db,
+        first["identity"],
+        lease,
+        expected_cancel_generation=0,
+        clock=clock,
+    )
+    assert retried.execution_generation == old_attempt.execution_generation + 1
+
+
+def test_stop_fence_prevents_the_next_room_member_from_starting(
+    tmp_path: Path, monkeypatch
+):
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    monkeypatch.setattr(service, "local_profiles", lambda: ("default", "ops"))
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "Inspect the release", "thread_id": "thread-1"},
+    )
+    assert len(driver.list_tasks(db, room_id="room-1")) == 1
+
+    assert service.stop_room("room-1", cancel_id="stop-1") == 1
+    service.prepare_room(service.bindings()[0])
+
+    tasks = driver.list_tasks(db, room_id="room-1")
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == "cancelled"
+    assert any(
+        event["kind"] == "room.stop_requested" for event in service._events("room-1")
+    )
+
+
+def test_acknowledged_stop_refuses_to_disband_while_exact_turn_is_still_running(
+    tmp_path: Path,
+):
+    class PendingStopRPC(_FakeRPC):
+        def __init__(self) -> None:
+            super().__init__()
+            self.active_task_id = None
+
+        def info(self, *, profile, session_id, source):
+            return {"active": True, "task_id": self.active_task_id}
+
+        def interrupt(self, *, profile, session_id, source, expected_task_id):
+            return None
+
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    rpc = PendingStopRPC()
+    service.rpc = rpc
+    service.runtime.rpc = rpc
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+    task = driver.list_tasks(db, room_id="room-1", status="queued")[0]
+    binding = service.bindings()[0]
+    lease = driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=binding.gateway_id,
+        authority_epoch=binding.authority_epoch,
+        process_generation="worker",
+        ttl_seconds=30,
+        clock=time.time,
+    )
+    driver.start_task(
+        db,
+        task["identity"],
+        lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    rpc.sessions[("ops", "Group: room-1")] = {"session_id": "ops-session"}
+    rpc.active_task_id = task["identity"].task_id
+
+    with pytest.raises(RuntimeError, match="still stopping"):
+        service.stop_room(
+            "room-1",
+            cancel_id="stop-1",
+            require_acknowledged=True,
+        )
+
+    stopping = driver.get_task(db, task["identity"])
+    assert stopping["status"] == "stopping"
+    assert stopping["cancel_id"] == "stop-1"
+
+
+def test_local_pending_approval_requires_exact_task_generation_and_request(
+    tmp_path: Path,
+):
+    class ApprovalRPC(_FakeRPC):
+        def __init__(self) -> None:
+            super().__init__()
+            self.approvals = []
+
+        def approve(self, *, session_id, request_id, choice):
+            self.approvals.append((session_id, request_id, choice))
+            return {"resolved": 1}
+
+    db = tmp_path / "state.db"
+    service = HostedRoomService(_server(), db_path=db)
+    rpc = ApprovalRPC()
+    service.rpc = rpc
+    service.runtime.rpc = rpc
+    service.local_profiles = lambda: ("default", "ops")
+    service.create_room(
+        room_id="room-1",
+        name="Release room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {"member_id": "ops", "profile": "ops", "handle": "ops"},
+        ],
+    )
+    service.send(
+        room_id="room-1",
+        event_id="user-1",
+        payload={"text": "@ops inspect", "thread_id": "thread-1"},
+    )
+    task = driver.list_tasks(db, room_id="room-1", status="queued")[0]
+    binding = service.bindings()[0]
+    lease = driver.acquire_lease(
+        db,
+        room_id="room-1",
+        gateway_id=binding.gateway_id,
+        authority_epoch=binding.authority_epoch,
+        process_generation="worker",
+        ttl_seconds=30,
+        clock=time.time,
+    )
+    driver.start_task(
+        db,
+        task["identity"],
+        lease,
+        expected_cancel_generation=0,
+        clock=time.time,
+    )
+    task = driver.get_task(db, task["identity"])
+    service.runtime._report_pending_action(
+        task,
+        session_id="ops-session",
+        info={
+            "pending_approval": {
+                "request_id": "approval-1",
+                "choices": ["once", "always", "deny"],
+            }
+        },
+    )
+
+    action = service.status("room-1")["pending_actions"][0]
+    assert action["member_id"] == "ops"
+    assert action["approval"]["choices"] == ["once", "deny"]
+    with pytest.raises(RuntimeError, match="no longer pending"):
+        service.approve_room_task(
+            "room-1",
+            member_id="ops",
+            task_id=task["identity"].task_id,
+            execution_generation=1,
+            choice="once",
+            request_id="wrong-request",
+        )
+
+    assert service.approve_room_task(
+        "room-1",
+        member_id="ops",
+        task_id=task["identity"].task_id,
+        execution_generation=1,
+        choice="once",
+        request_id="approval-1",
+    ) == {"resolved": 1}
+    assert rpc.approvals == [("ops-session", "approval-1", "once")]
+    assert service.status("room-1")["pending_actions"] == []

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -572,6 +572,7 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
             proc = subprocess.run(
                 [*argv, "--query-file", dm_file],
                 check=False,
+                stdin=subprocess.DEVNULL,
                 capture_output=True,
                 text=True,
             )
@@ -587,6 +588,7 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                     proc = subprocess.run(
                         [*argv, "--query-file", dm_file],
                         check=False,
+                        stdin=subprocess.DEVNULL,
                         capture_output=True,
                         text=True,
                     )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2579,7 +2579,27 @@ def _run_single_child(
 ) -> Dict[str, Any]:
     """
     Run a pre-built child agent. Called from within a thread.
-    Returns a structured result dict.
+    Returns a structured result dict with a ``status`` and ``exit_reason``
+    that are derived honestly from the child's structured completion fields.
+
+    ``status`` ∈ {``"completed"``, ``"interrupted"``, ``"failed"``}:
+        * ``"completed"``  — the child reached a normal finish (may still have
+          hit its iteration budget; see ``exit_reason``).
+        * ``"interrupted"`` — the child was interrupted (``interrupted=True``).
+        * ``"failed"``    — a structured failure (``failed=True`` or a non-empty
+          ``error``) or a summary-less/invalid terminal state.
+
+    ``exit_reason`` ∈ {``"completed"``, ``"max_iterations"``, ``"interrupted"``,
+    ``"error"``}:
+        * ``"completed"``       — normal finish.
+        * ``"max_iterations"``  — genuine per-child iteration-budget exhaustion
+          (``completed=False`` with no failure fields).
+        * ``"interrupted"``     — interrupted by the parent.
+        * ``"error"``           — provider rejection / terminal failure; NOT
+          budget exhaustion (this is the case #97655 fixed).
+
+    ``truncated`` is derived as ``exit_reason == "max_iterations"`` only, so the
+    parent-visible truncation flag stays truthful for all of the above.
     """
     child_start = time.monotonic()
 
@@ -3238,6 +3258,10 @@ def _run_single_child(
         _output_tokens = getattr(child, "session_completion_tokens", 0)
         _model = getattr(child, "model", None)
 
+        # --- result entry contract (see _run_single_child docstring) ---
+        # status ∈ {completed, interrupted, failed}
+        # exit_reason ∈ {completed, max_iterations, interrupted, error}
+        # truncated is exactly (exit_reason == "max_iterations").
         entry: Dict[str, Any] = {
             "task_index": task_index,
             "status": status,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3164,13 +3164,14 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
-        elif result.get("failed"):
-            # The child's conversation loop aborted (non-retryable HTTP
-            # error, retries exhausted, billing wall). final_response holds
-            # the error summary in this shape, NOT usable output — without
-            # this branch a provider 404/400 was classified "completed" with
-            # the error text as its summary, so no surface ever saw a
-            # failure (community report, Aug 2026).
+        elif result.get("failed") or result.get("error"):
+            # A structured failure (provider rejection / terminal exception)
+            # must WIN over the summary-presence heuristic below. The child's
+            # conversation loop returns the error text as final_response, so an
+            # error-shaped summary would otherwise be labeled "completed" here
+            # despite completed=False. The heuristic is only a fallback for
+            # legacy/mock results that omit the structured failure fields.
+            # (Community report Aug 2026; #97655.)
             status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
@@ -3221,9 +3222,15 @@ def _run_single_child(
         # Determine exit reason
         if interrupted:
             exit_reason = "interrupted"
+        elif result.get("failed") or result.get("error"):
+            # Provider rejection / terminal failure. Do NOT report this as
+            # iteration-budget exhaustion — "max_iterations" is only truthful
+            # when the child actually hit its per-delegation iteration cap.
+            exit_reason = "error"
         elif completed:
             exit_reason = "completed"
         else:
+            # Genuine budget exhaustion: completed=False with no failure.
             exit_reason = "max_iterations"
 
         # Extract token counts (safe for mock objects)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -162,6 +162,63 @@ _RECENT_SUBAGENTS_CAP = 200
 _recent_subagents: Dict[str, Dict[str, Any]] = {}
 
 
+# Terminal child statuses that mean "the subagent did NOT deliver a usable
+# result". Shared by the CLI spinner echo, the gateway failure notice, and
+# the parent-facing failure summary so every surface agrees on what counts
+# as a failure.
+SUBAGENT_FAILURE_STATUSES = frozenset({"failed", "error", "timeout"})
+
+
+def _clean_error_text(error: Any, max_chars: int = 200) -> str:
+    """Reduce an arbitrary error payload to one clean human-readable line.
+
+    Provider/SDK errors routinely arrive as multi-line tracebacks or JSON
+    walls. For a chat-facing notice we want the single most informative
+    line: the exception message (last line of a traceback) or the first
+    non-empty line otherwise, hard-capped in length.
+    """
+    text = str(error or "").strip()
+    if not text:
+        return ""
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return ""
+    # A traceback's last line is the actual exception message.
+    line = lines[-1] if lines[0].startswith("Traceback") else lines[0]
+    if len(line) > max_chars:
+        line = line[: max_chars - 3] + "..."
+    return line
+
+
+def format_subagent_failure_line(
+    goal: Optional[str],
+    status: Optional[str],
+    error: Any = None,
+    duration_seconds: Any = None,
+) -> str:
+    """One clean, human-readable line describing a failed subagent.
+
+    Rendered directly to the user (CLI spinner echo, gateway platform
+    notice) — no JSON, no traceback, no internal field names. Example:
+
+        ⚠️ Subagent failed — "research competitor pricing": Error code: 404 —
+        model not found (after 12s)
+    """
+    goal_label = (goal or "").strip().replace("\n", " ")
+    if len(goal_label) > 60:
+        goal_label = goal_label[:57] + "..."
+    verb = "timed out" if status == "timeout" else "failed"
+    line = f"⚠️ Subagent {verb}"
+    if goal_label:
+        line += f' — "{goal_label}"'
+    err = _clean_error_text(error)
+    if err:
+        line += f": {err}"
+    if isinstance(duration_seconds, (int, float)) and duration_seconds > 0:
+        line += f" (after {round(duration_seconds)}s)"
+    return line
+
+
 def get_subagent_attribution(task_id: Optional[str]) -> Optional[Dict[str, Any]]:
     """Resolve a process task_id to its originating delegation, if any.
 
@@ -1460,6 +1517,21 @@ def _build_child_progress_callback(
             return
 
         if event_type == "subagent.complete":
+            # Failed child: echo one clean reason line into the CLI tree so
+            # the human sees WHY, not just a vanished branch. Gateway-side
+            # rendering happens in TurnRunner.progress_callback off the
+            # relayed event below.
+            if spinner and kwargs.get("status") in SUBAGENT_FAILURE_STATUSES:
+                _fail_line = format_subagent_failure_line(
+                    goal_label,
+                    kwargs.get("status"),
+                    error=kwargs.get("summary") or preview,
+                    duration_seconds=kwargs.get("duration_seconds"),
+                )
+                try:
+                    spinner.print_above(f" {prefix}├─ {_fail_line}")
+                except Exception as e:
+                    logger.debug("Spinner print_above failed: %s", e)
             _relay("subagent.complete", preview=preview, **kwargs)
             return
 
@@ -3092,6 +3164,14 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
+        elif result.get("failed"):
+            # The child's conversation loop aborted (non-retryable HTTP
+            # error, retries exhausted, billing wall). final_response holds
+            # the error summary in this shape, NOT usable output — without
+            # this branch a provider 404/400 was classified "completed" with
+            # the error text as its summary, so no surface ever saw a
+            # failure (community report, Aug 2026).
+            status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -4106,6 +4186,15 @@ def delegate_task(
                         icon = "✓" if status == "completed" else "✗"
                         remaining = n_tasks - completed_count
                         completion_line = f"{icon} [{idx+1}/{n_tasks}] {label}  ({dur}s)"
+                        # Failed/errored/timed-out children: say WHY on the
+                        # same line, cleaned to one short human-readable
+                        # fragment — a bare ✗ reads as "silently dropped".
+                        if status in SUBAGENT_FAILURE_STATUSES:
+                            _err_line = _clean_error_text(
+                                entry.get("error"), max_chars=120
+                            )
+                            if _err_line:
+                                completion_line += f" — {_err_line}"
                         if spinner_ref:
                             try:
                                 spinner_ref.print_above(completion_line)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3317,6 +3317,12 @@ def _run_single_child(
         )
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
+            # Classified reason from the child loop (e.g. "rate_limit",
+            # "billing", "server_error") — lets the parent distinguish a
+            # quota wall from a real task error without parsing prose.
+            _failure_reason = result.get("failure_reason")
+            if isinstance(_failure_reason, str) and _failure_reason:
+                entry["failure_reason"] = _failure_reason
 
         # T1-24: schema-validation outcome — emitted ONLY when a schema was
         # requested, so legacy (schema-less) payloads keep their exact shape.

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2960,19 +2960,21 @@ def _format_age(seconds: float) -> str:
     return f"{h}h" if m == 0 else f"{h}h{m}m"
 
 
-# Model-not-found phrases lifted from agent/error_classifier.py so the
-# delegation batch renderer can spot a config-level rejection without pulling
-# the classifier's failover machinery. Kept in sync by hand.
-_MODEL_NOT_FOUND_PATTERNS = (
-    "is not a valid model",
-    "invalid model",
-    "model not found",
-    "model_not_found",
-    "does not exist",
-    "no such model",
-    "unknown model",
-    "unsupported model",
-)
+def _model_not_found_patterns() -> "list[str]":
+    """Model-not-found phrases from the failover classifier.
+
+    Imported from ``agent.error_classifier`` so the batch renderer applies
+    the SAME classification the failover path consumes — no hand-copied
+    pattern list to drift. Fails open to a minimal built-in set so a
+    classifier import problem never hides the per-task blocks.
+    (Import approach from PR #97667 by @liuhao1024.)
+    """
+    try:
+        from agent.error_classifier import _MODEL_NOT_FOUND_PATTERNS
+
+        return list(_MODEL_NOT_FOUND_PATTERNS)
+    except Exception:
+        return ["is not a valid model", "model not found", "model_not_found"]
 
 
 def _delegation_config() -> dict:
@@ -3009,7 +3011,7 @@ def _delegation_model_not_found(results, config) -> bool:
         ).lower()
         if not text or model not in text:
             continue
-        if any(p in text for p in _MODEL_NOT_FOUND_PATTERNS):
+        if any(p in text for p in _model_not_found_patterns()):
             return True
     return False
 
@@ -3105,6 +3107,9 @@ def _format_async_delegation(evt: dict) -> str:
             lines.append("--- ERROR ---")
             lines.append(f"The batch did not complete successfully: {error}")
             return "\n".join(lines)
+        # Config-level rejection notice BEFORE the per-task wall — a rejected
+        # delegation model fails every task identically before doing any
+        # work, and that signal must not stay buried in the task blocks.
         _notice = _delegation_model_not_found_notice(results)
         if _notice:
             lines.append("")

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2960,6 +2960,93 @@ def _format_age(seconds: float) -> str:
     return f"{h}h" if m == 0 else f"{h}h{m}m"
 
 
+# Model-not-found phrases lifted from agent/error_classifier.py so the
+# delegation batch renderer can spot a config-level rejection without pulling
+# the classifier's failover machinery. Kept in sync by hand.
+_MODEL_NOT_FOUND_PATTERNS = (
+    "is not a valid model",
+    "invalid model",
+    "model not found",
+    "model_not_found",
+    "does not exist",
+    "no such model",
+    "unknown model",
+    "unsupported model",
+)
+
+
+def _delegation_config() -> dict:
+    """Load the active delegation config (model/provider/fallbacks), fail-open.
+
+    Mirrors ``tools.delegate_tool._load_config`` so the renderer sees the same
+    ``model`` / ``provider`` the dispatcher used, without importing the heavy
+    delegation module at import time. Returns ``{}`` on any error so callers
+    fail open to "no notice" rather than dropping the per-task blocks.
+    """
+    try:
+        from tools.delegate_tool import _load_config as _cfg
+
+        return _cfg() or {}
+    except Exception:
+        return {}
+
+
+def _delegation_model_not_found(results, config) -> bool:
+    """True when a result entry reflects a config-level model_not_found rejection.
+
+    Matches when at least one entry's error/summary text contains both a
+    model-not-found phrase AND the name of the currently-configured delegation
+    model — so a stale task failing on a *different* (removed) model is not
+    mis-attributed to the config-level root cause.
+    """
+    model = (config or {}).get("model")
+    if not model:
+        return False
+    model = str(model).lower()
+    for r in results or []:
+        text = " ".join(
+            str(part) for part in (r.get("error"), r.get("summary")) if part
+        ).lower()
+        if not text or model not in text:
+            continue
+        if any(p in text for p in _MODEL_NOT_FOUND_PATTERNS):
+            return True
+    return False
+
+
+def _delegation_model_not_found_notice(results) -> "list[str] | None":
+    """Build the config-level model_not_found notice lines, or None.
+
+    Returns ``None`` unless at least one result entry shows the configured
+    delegation model being rejected by its provider, in which case a short
+    actionable block is returned. Every failure path fails open to ``None`` so
+    a config hiccup never hides the per-task blocks. Emit once per batch.
+    """
+    config = _delegation_config()
+    if not _delegation_model_not_found(results, config):
+        return None
+    model = config.get("model") or "?"
+    provider = config.get("provider") or "configured provider"
+    lines = [
+        "⚠ SUBAGENT MODEL REJECTED: the configured Subagent Model "
+        f'"{model}" was rejected by provider "{provider}" '
+        "(HTTP 400: not a valid model ID).",
+        "Every task in this batch failed for this reason before doing any work.",
+        "Check Settings → Advanced → Subagent Model (or: "
+        "hermes config get delegation.model).",
+    ]
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        if not get_fallback_chain(config):
+            lines.append(
+                "No fallback chain is configured, so no failover was attempted."
+            )
+    except Exception:
+        pass
+    return lines
+
+
 def _format_async_delegation(evt: dict) -> str:
     """Format an async-delegation completion into a self-contained re-injection.
 
@@ -3018,6 +3105,10 @@ def _format_async_delegation(evt: dict) -> str:
             lines.append("--- ERROR ---")
             lines.append(f"The batch did not complete successfully: {error}")
             return "\n".join(lines)
+        _notice = _delegation_model_not_found_notice(results)
+        if _notice:
+            lines.append("")
+            lines.extend(_notice)
         for r in sorted(results, key=lambda x: x.get("task_index", 0)):
             idx = r.get("task_index", 0)
             r_status = r.get("status", "?")
@@ -3085,6 +3176,10 @@ def _format_async_delegation(evt: dict) -> str:
     if toolsets:
         lines.append(f"Toolsets: {', '.join(toolsets)}")
     lines.append(f"Role: {role}   Model: {model}")
+    _notice = _delegation_model_not_found_notice([evt])
+    if _notice:
+        lines.append("")
+        lines.extend(_notice)
     _trunc = " [TRUNCATED: hit max_iterations — work may be incomplete]" if truncated else ""
     lines.append(f"Status: {status}   API calls: {api_calls}   Duration: {duration}s{_trunc}")
     lines.append("--- RESULT ---")

--- a/tui_gateway/hosted_room_driver.py
+++ b/tui_gateway/hosted_room_driver.py
@@ -1,0 +1,1276 @@
+"""Runtime adapter for gateway-owned hosted room turns.
+
+The durable state machine lives in :mod:`gateway.hosted_room_driver`.  This
+module owns the process-local worker and a deliberately small, injected session
+adapter.  It does not import the gateway server, construct agents, or depend on
+any client transport.
+
+The adapter normalizes existing internal session RPCs into seven methods. A
+future server integration can implement those methods with the in-process
+handlers while tests use deterministic fakes and no models or network.
+
+One bounded supervisor schedules independent room workers. Profile turn locks
+still serialize Bots that share one profile, while a room waiting for approval
+cannot stop unrelated rooms from progressing. Hosted member sessions
+intentionally reuse ``Group: <room_id>`` so a local-to-hosted migration
+preserves the same canonical transcript instead of forking a second conversation.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ContextManager, Protocol, cast
+
+from gateway import hosted_room_driver as state
+
+
+ROOM_SESSION_SOURCE = "bot_room"
+MAX_TERMINAL_TEXT_BYTES = 64 * 1024
+_TERMINAL_TRUNCATION_NOTICE = (
+    "\n\n[Reply truncated. Ask the Bot to share the full result as a file.]"
+)
+
+
+class InternalSessionRPC(Protocol):
+    """Normalized in-process session operations required by the room driver."""
+
+    def resolve_exact(
+        self, *, profile: str, title: str, source: str
+    ) -> Mapping[str, Any] | None:
+        """Return the exact titled session under ``profile``, if it exists."""
+
+    def create(self, *, profile: str, title: str, source: str) -> Mapping[str, Any]:
+        """Create a session without model or provider overrides."""
+
+    def resume(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Mapping[str, Any]:
+        """Resume the canonical room session."""
+
+    def submit(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        prompt: str,
+        source: str,
+        task: state.TaskIdentity,
+        execution_generation: int,
+        on_terminal: Callable[[Mapping[str, Any]], None],
+    ) -> Mapping[str, Any]:
+        """Submit one fenced room turn and durably report its terminal result."""
+
+    def history(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Sequence[Mapping[str, Any]]:
+        """Return normalized session messages in durable order."""
+
+    def info(self, *, profile: str, session_id: str, source: str) -> Mapping[str, Any]:
+        """Return normalized live status for a session."""
+
+    def interrupt(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        expected_task_id: str,
+    ) -> Mapping[str, Any] | None:
+        """Interrupt only when the current turn still matches the expected task."""
+
+
+@dataclass(frozen=True)
+class HostedRoomBinding:
+    """Current server-issued authority coordinate for one hosted room."""
+
+    room_id: str
+    gateway_id: str
+    authority_epoch: int
+
+
+@dataclass(frozen=True)
+class _TerminalReceipt:
+    status: state.TerminalStatus
+    settlement_id: str
+    result: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _RecoveryInspection:
+    terminal: _TerminalReceipt | None
+    active: bool
+    status: str | None
+
+
+class HostedRoomRuntime:
+    """Run queued hosted-room tasks independently of Desktop connections."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | str,
+        rooms: Iterable[HostedRoomBinding] | Callable[[], Iterable[HostedRoomBinding]],
+        turn_lock: Callable[[str], ContextManager[Any]],
+        rpc: InternalSessionRPC,
+        prepare_room: Callable[[HostedRoomBinding], None] | None = None,
+        publish_terminal: Callable[[HostedRoomBinding, Mapping[str, Any]], None]
+        | None = None,
+        pending_action: Callable[[str, str, Mapping[str, Any] | None], None]
+        | None = None,
+        clock: Callable[[], float] = time.time,
+        lease_ttl_seconds: float = 30.0,
+        poll_interval_seconds: float = 5.0,
+        active_poll_interval_seconds: float = 0.25,
+        turn_timeout_seconds: float = 1830.0,
+        indeterminate_defer_seconds: float = 60.0,
+        max_concurrent_rooms: int = 4,
+        process_generation: str | None = None,
+    ) -> None:
+        if lease_ttl_seconds <= 0:
+            raise ValueError("lease_ttl_seconds must be positive")
+        if poll_interval_seconds <= 0:
+            raise ValueError("poll_interval_seconds must be positive")
+        if active_poll_interval_seconds <= 0:
+            raise ValueError("active_poll_interval_seconds must be positive")
+        if turn_timeout_seconds <= 0:
+            raise ValueError("turn_timeout_seconds must be positive")
+        if indeterminate_defer_seconds <= 0:
+            raise ValueError("indeterminate_defer_seconds must be positive")
+        if (
+            isinstance(max_concurrent_rooms, bool)
+            or not isinstance(max_concurrent_rooms, int)
+            or max_concurrent_rooms < 1
+        ):
+            raise ValueError("max_concurrent_rooms must be a positive integer")
+        self.db_path = Path(db_path)
+        self.rpc = rpc
+        self.turn_lock = turn_lock
+        self.prepare_room = prepare_room
+        self.publish_terminal = publish_terminal
+        self.pending_action = pending_action
+        self.clock = clock
+        self.lease_ttl_seconds = float(lease_ttl_seconds)
+        self.poll_interval_seconds = float(poll_interval_seconds)
+        self.active_poll_interval_seconds = float(active_poll_interval_seconds)
+        self.turn_timeout_seconds = float(turn_timeout_seconds)
+        self.indeterminate_defer_seconds = float(indeterminate_defer_seconds)
+        self.max_concurrent_rooms = max_concurrent_rooms
+        self.process_generation = process_generation or uuid.uuid4().hex
+        self._rooms_provider: Callable[[], Iterable[HostedRoomBinding]]
+        if callable(rooms):
+            self._rooms_provider = cast(
+                Callable[[], Iterable[HostedRoomBinding]], rooms
+            )
+        else:
+            room_bindings = tuple(rooms)
+            self._rooms_provider = lambda: room_bindings
+
+        self._stop = threading.Event()
+        self._wake = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._room_threads: dict[str, threading.Thread] = {}
+        self._rooms_needing_reschedule: set[str] = set()
+        self._leases: dict[str, state.DriverLease] = {}
+        self._recovered_leases: set[tuple[str, int]] = set()
+        self._inspected_indeterminate_attempts: set[tuple[str, str, int]] = set()
+        self._ambiguous_rooms: dict[str, float] = {}
+        self._blocked_rooms: set[str] = set()
+        self._status_lock = threading.Lock()
+        self._current_tasks: dict[str, state.TaskIdentity] = {}
+        self._room_schedule_cursor = 0
+        self._last_error: str | None = None
+        self._cycles = 0
+
+    def start(self) -> None:
+        """Start the bounded room-worker supervisor idempotently."""
+        with self._status_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop.clear()
+            self._wake.set()
+            self._thread = threading.Thread(
+                target=self._worker_loop,
+                name="hosted-room-driver-supervisor",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def stop(self, *, timeout: float = 5.0) -> bool:
+        """Request a bounded clean stop without interrupting accepted turns."""
+        self._stop.set()
+        self._wake.set()
+        with self._status_lock:
+            thread = self._thread
+        if thread is None:
+            return True
+        deadline = time.monotonic() + max(0.0, timeout)
+        thread.join(max(0.0, deadline - time.monotonic()))
+        with self._status_lock:
+            room_threads = tuple(self._room_threads.values())
+        for room_thread in room_threads:
+            room_thread.join(max(0.0, deadline - time.monotonic()))
+        return not thread.is_alive() and all(
+            not room_thread.is_alive() for room_thread in room_threads
+        )
+
+    def wakeup(self) -> None:
+        """Wake the worker after task admission or a room-state change."""
+        with self._status_lock:
+            # If the supervisor observes this signal while a room still owns a
+            # worker slot, remember to revisit it once that thread exits. This
+            # closes the race between terminal publication/route repair and the
+            # longer idle fallback without turning idle rooms into a busy loop.
+            self._rooms_needing_reschedule.update(self._room_threads)
+        self._wake.set()
+
+    def status(self) -> dict[str, Any]:
+        """Return a transport-neutral snapshot of runtime health."""
+        with self._status_lock:
+            thread = self._thread
+            current_tasks = tuple(self._current_tasks.values())
+            return {
+                "running": bool(thread and thread.is_alive()),
+                "stopping": self._stop.is_set(),
+                "process_generation": self.process_generation,
+                "current_task": current_tasks[0] if current_tasks else None,
+                "current_tasks": current_tasks,
+                "leased_rooms": tuple(sorted(self._leases)),
+                "blocked_rooms": tuple(sorted(self._blocked_rooms)),
+                "last_error": self._last_error,
+                "cycles": self._cycles,
+            }
+
+    def cancel(
+        self,
+        identity: state.TaskIdentity,
+        *,
+        cancel_id: str,
+    ) -> dict[str, Any]:
+        """Persist a stop intent, then commit cancellation after acknowledgement."""
+        before = state.get_task(self.db_path, identity)
+        if before["status"] in {"queued", "deferred"}:
+            cancelled = state.cancel_task(
+                self.db_path,
+                identity,
+                cancel_id=cancel_id,
+                expected_cancel_generation=before["cancel_generation"],
+                clock=self.clock,
+            )
+            self.wakeup()
+            return cancelled
+
+        stopping = state.begin_task_cancel(
+            self.db_path,
+            identity,
+            cancel_id=cancel_id,
+            expected_cancel_generation=before["cancel_generation"],
+            clock=self.clock,
+        )
+        binding = self._binding_for_room(identity.room_id)
+        try:
+            if binding is not None and self._interrupt_stopping_task(binding, stopping):
+                stopping = state.complete_task_cancel(
+                    self.db_path,
+                    identity,
+                    cancel_id=cancel_id,
+                    expected_cancel_generation=stopping["cancel_generation"],
+                    clock=self.clock,
+                )
+        except Exception as exc:
+            self._record_error(f"stop remains pending: {exc}")
+        stopping = state.get_task(self.db_path, identity)
+        self.wakeup()
+        return stopping
+
+    def retry_indeterminate(self, identity: state.TaskIdentity) -> dict[str, Any]:
+        """Explicitly retry one uncertain attempt under the current room lease."""
+        task = state.get_task(self.db_path, identity)
+        if task["status"] not in {"indeterminate", "deferred"}:
+            raise state.InvalidTaskTransitionError(
+                f"cannot retry task in state '{task['status']}'"
+            )
+        binding = self._binding_for_room(identity.room_id)
+        if binding is None:
+            raise state.RoomUnavailableError("hosted room is unavailable")
+        lease = self._ensure_lease(binding)
+        if task["status"] == "deferred":
+            retried = state.requeue_deferred_task(
+                self.db_path,
+                identity,
+                lease,
+                expected_execution_generation=task["execution_generation"],
+                expected_cancel_generation=task["cancel_generation"],
+                clock=self.clock,
+            )
+            with self._status_lock:
+                self._blocked_rooms.discard(identity.room_id)
+            self.wakeup()
+            return retried
+        inspection = self._inspect_local_recovery_session(task)
+        if inspection.active:
+            with self._status_lock:
+                self._blocked_rooms.add(identity.room_id)
+            raise state.InvalidTaskTransitionError(
+                "cannot retry while the original task attempt is still active"
+            )
+        retried = state.requeue_indeterminate_task(
+            self.db_path,
+            identity,
+            lease,
+            expected_execution_generation=task["execution_generation"],
+            expected_cancel_generation=task["cancel_generation"],
+            clock=self.clock,
+        )
+        with self._status_lock:
+            self._blocked_rooms.discard(identity.room_id)
+        self.wakeup()
+        return retried
+
+    def _interrupt_stopping_task(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+    ) -> bool:
+        transport = self.rpc
+        if transport is None:
+            return False
+        profile = task["payload"]["target_profile"]
+        session = transport.resolve_exact(
+            profile=profile,
+            title=room_session_title(binding.room_id),
+            source=ROOM_SESSION_SOURCE,
+        )
+        if session is None:
+            # A local accepted turn cannot survive without its canonical
+            # session. Resolution errors raise; an authoritative absence is a
+            # safe Stop acknowledgement.
+            return True
+        resumed = transport.resume(
+            profile=profile,
+            session_id=_session_id(session),
+            source=ROOM_SESSION_SOURCE,
+        )
+        session_id = _session_id(resumed)
+        info = transport.info(
+            profile=profile,
+            session_id=session_id,
+            source=ROOM_SESSION_SOURCE,
+        )
+        active = bool(info.get("active", info.get("running", False)))
+        if not active:
+            # History was checked immediately before this probe. An exact
+            # local session that is no longer active cannot keep executing, and
+            # after a restart its process-local task marker is expected to be
+            # absent.
+            return True
+        if not _info_is_active_for(info, task["identity"], require_exact=True):
+            return False
+        result = transport.interrupt(
+            profile=profile,
+            session_id=session_id,
+            source=ROOM_SESSION_SOURCE,
+            expected_task_id=task["identity"].task_id,
+        )
+        if result is None:
+            return False
+        return result.get("interrupted") is True or str(result.get("status") or "") in {
+            "cancelled",
+            "interrupted",
+            "stopping",
+        }
+
+    def _settle_stopping_completion(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        lease: state.DriverLease,
+    ) -> bool:
+        """Publish a terminal receipt that arrived before Stop was acknowledged."""
+        transport = self.rpc
+        if transport is None:
+            return False
+        profile = task["payload"]["target_profile"]
+        session = transport.resolve_exact(
+            profile=profile,
+            title=room_session_title(binding.room_id),
+            source=ROOM_SESSION_SOURCE,
+        )
+        if session is None:
+            return False
+        resumed = transport.resume(
+            profile=profile,
+            session_id=_session_id(session),
+            source=ROOM_SESSION_SOURCE,
+        )
+        receipt = _find_terminal_receipt(
+            transport.history(
+                profile=profile,
+                session_id=_session_id(resumed),
+                source=ROOM_SESSION_SOURCE,
+            ),
+            task["identity"],
+            int(task["execution_generation"]),
+        )
+        if receipt is None:
+            return False
+        settled = state.settle_stopping_task(
+            self.db_path,
+            task["identity"],
+            lease,
+            expected_execution_generation=int(task["execution_generation"]),
+            expected_cancel_generation=int(task["cancel_generation"]),
+            settlement_id=receipt.settlement_id,
+            status=receipt.status,
+            result=receipt.result,
+            clock=self.clock,
+        )
+        if self.publish_terminal is not None:
+            self.publish_terminal(binding, settled)
+        return True
+
+    def _report_pending_action(
+        self,
+        task: Mapping[str, Any],
+        *,
+        session_id: str,
+        info: Mapping[str, Any],
+    ) -> None:
+        if self.pending_action is None:
+            return
+        payload = task.get("payload") or {}
+        member_id = str(
+            payload.get("target_member_id") or payload.get("target_profile") or ""
+        )
+        approval = info.get("pending_approval") or info.get("approval")
+        action = None
+        if isinstance(approval, Mapping):
+            safe_approval = dict(approval)
+            choices = [
+                choice
+                for choice in safe_approval.get("choices") or ()
+                if choice in {"once", "deny"}
+            ]
+            safe_approval["choices"] = choices or ["once", "deny"]
+            action = {
+                "kind": "approval",
+                "task_id": task["identity"].task_id,
+                "execution_generation": int(task["execution_generation"]),
+                "run_id": info.get("run_id"),
+                "session_id": session_id,
+                "request_id": safe_approval.get("request_id"),
+                "approval": safe_approval,
+            }
+        self.pending_action(task["identity"].room_id, member_id, action)
+
+    def _retry_stopping_tasks(
+        self, binding: HostedRoomBinding, lease: state.DriverLease
+    ) -> bool:
+        pending = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="stopping",
+        )
+        for task in pending:
+            try:
+                lease = self._renew_lease_if_needed(binding, lease)
+                if self._settle_stopping_completion(binding, task, lease):
+                    continue
+                if not self._interrupt_stopping_task(binding, task):
+                    return True
+                self._complete_acknowledged_stop(binding, task, lease)
+            except Exception as exc:
+                self._record_error(f"stop retry remains pending: {exc}")
+                return True
+        return False
+
+    def _worker_loop(self) -> None:
+        try:
+            while not self._stop.is_set():
+                # Clear before work so a write racing the cycle remains set and
+                # causes an immediate follow-up pass rather than being lost.
+                self._wake.clear()
+                try:
+                    self._run_cycle()
+                except Exception as exc:  # keep independent rooms serviceable
+                    self._record_error(f"worker cycle failed: {exc}")
+                with self._status_lock:
+                    self._cycles += 1
+                self._wake.wait(self.poll_interval_seconds)
+        finally:
+            while True:
+                with self._status_lock:
+                    room_threads = tuple(
+                        thread
+                        for thread in self._room_threads.values()
+                        if thread.is_alive()
+                    )
+                if not room_threads:
+                    break
+                for room_thread in room_threads:
+                    room_thread.join(self.active_poll_interval_seconds)
+            self._release_idle_leases()
+
+    def _run_cycle(self) -> None:
+        with self._status_lock:
+            supervisor = self._thread
+        if threading.current_thread() is not supervisor:
+            for binding in tuple(self._rooms_provider()):
+                if self._stop.is_set():
+                    return
+                self._run_room_once(binding)
+            return
+
+        with self._status_lock:
+            self._room_threads = {
+                room_id: thread
+                for room_id, thread in self._room_threads.items()
+                if thread.is_alive()
+            }
+            available = self.max_concurrent_rooms - len(self._room_threads)
+            active_rooms = set(self._room_threads)
+        if available <= 0:
+            return
+
+        bindings = tuple(self._rooms_provider())
+        if not bindings:
+            return
+        start = self._room_schedule_cursor % len(bindings)
+        ordered_bindings = bindings[start:] + bindings[:start]
+        self._room_schedule_cursor = (start + 1) % len(bindings)
+
+        for binding in ordered_bindings:
+            if self._stop.is_set() or available <= 0:
+                return
+            if binding.room_id in active_rooms:
+                continue
+            room_thread = threading.Thread(
+                target=self._run_room_once,
+                args=(binding,),
+                name=f"hosted-room-{binding.room_id[:24]}",
+                daemon=True,
+            )
+            with self._status_lock:
+                self._room_threads[binding.room_id] = room_thread
+            active_rooms.add(binding.room_id)
+            available -= 1
+            room_thread.start()
+
+    def _run_room_once(self, binding: HostedRoomBinding) -> None:
+        try:
+            self._process_room(binding)
+        except state.LeaseHeldError:
+            return
+        except (state.RoomUnavailableError, state.StaleLeaseError) as exc:
+            self._drop_lease(binding.room_id)
+            with self._status_lock:
+                self._blocked_rooms.discard(binding.room_id)
+            self._record_error(f"room {binding.room_id}: {exc}")
+        except Exception as exc:
+            self._record_error(f"room {binding.room_id}: {exc}")
+        finally:
+            current = threading.current_thread()
+            with self._status_lock:
+                if self._room_threads.get(binding.room_id) is current:
+                    self._room_threads.pop(binding.room_id, None)
+                should_wake = binding.room_id in self._rooms_needing_reschedule
+                self._rooms_needing_reschedule.discard(binding.room_id)
+            if should_wake:
+                self.wakeup()
+
+    def _process_room(self, binding: HostedRoomBinding) -> None:
+        if self.prepare_room is not None:
+            self.prepare_room(binding)
+        self._inspect_abandoned_attempts(binding)
+        deferred_until = self._ambiguous_rooms.get(binding.room_id)
+        if deferred_until is not None:
+            running = state.list_tasks(
+                self.db_path,
+                room_id=binding.room_id,
+                status="running",
+            )
+            if not running:
+                self._ambiguous_rooms.pop(binding.room_id, None)
+            elif self.clock() < deferred_until:
+                return
+            else:
+                self._ambiguous_rooms.pop(binding.room_id, None)
+        lease = self._ensure_lease(binding)
+        recovery_key = (lease.room_id, lease.lease_generation)
+        if recovery_key not in self._recovered_leases:
+            state.recover_room(self.db_path, lease, clock=self.clock)
+            self._recovered_leases.add(recovery_key)
+        if self._retry_stopping_tasks(binding, lease):
+            with self._status_lock:
+                self._blocked_rooms.add(binding.room_id)
+            return
+        if self._reconcile_indeterminate(binding, lease):
+            return
+
+        queued = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="queued",
+        )
+        for task in queued:
+            if self._stop.is_set():
+                return
+            lease = self._renew_lease_if_needed(binding, lease)
+            attempt = state.start_task(
+                self.db_path,
+                task["identity"],
+                lease,
+                expected_cancel_generation=task["cancel_generation"],
+                clock=self.clock,
+            )
+            self._execute_attempt(binding, task, attempt)
+
+    def _ensure_lease(self, binding: HostedRoomBinding) -> state.DriverLease:
+        with self._status_lock:
+            current = self._leases.get(binding.room_id)
+        if current is not None:
+            try:
+                renewed = self._renew_lease_if_needed(binding, current)
+            except state.StaleLeaseError:
+                self._drop_lease(binding.room_id)
+            else:
+                return renewed
+
+        lease = state.acquire_lease(
+            self.db_path,
+            room_id=binding.room_id,
+            gateway_id=binding.gateway_id,
+            authority_epoch=binding.authority_epoch,
+            process_generation=self.process_generation,
+            ttl_seconds=self.lease_ttl_seconds,
+            clock=self.clock,
+        )
+        with self._status_lock:
+            self._leases[binding.room_id] = lease
+            self._recovered_leases = {
+                key for key in self._recovered_leases if key[0] != binding.room_id
+            }
+        return lease
+
+    def _renew_lease_if_needed(
+        self,
+        binding: HostedRoomBinding,
+        lease: state.DriverLease,
+        *,
+        force: bool = False,
+    ) -> state.DriverLease:
+        del binding
+        renew_at = lease.expires_at - (self.lease_ttl_seconds / 2)
+        if not force and self.clock() < renew_at:
+            return lease
+        renewed = state.renew_lease(
+            self.db_path,
+            lease,
+            ttl_seconds=self.lease_ttl_seconds,
+            clock=self.clock,
+        )
+        with self._status_lock:
+            self._leases[lease.room_id] = renewed
+        return renewed
+
+    def _execute_attempt(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        attempt: state.TaskAttempt,
+    ) -> None:
+        profile = task["payload"]["target_profile"]
+        transport = self.rpc
+        submit_attempted = False
+        with self._status_lock:
+            self._current_tasks[binding.room_id] = attempt.identity
+        try:
+            with self.turn_lock(profile):
+                session = self._resolve_or_create(transport, profile, binding.room_id)
+                # An in-process submit should fail before admission or return
+                # after it, but an unexpected exception at that boundary is
+                # still ambiguous. Never terminalize it as a proven failure.
+                submit_attempted = True
+
+                def on_terminal(receipt: Mapping[str, Any]) -> None:
+                    status = receipt.get("status")
+                    if status == "cancelled":
+                        self.wakeup()
+                        return
+                    terminal_status: state.TerminalStatus = (
+                        "settled" if status == "settled" else "failed"
+                    )
+                    try:
+                        settled = state.settle_task(
+                            self.db_path,
+                            attempt,
+                            settlement_id=(
+                                receipt.get("settlement_id")
+                                or f"reply:{attempt.identity.task_id}:{attempt.execution_generation}"
+                            ),
+                            status=terminal_status,
+                            result=_bounded_terminal_result(receipt),
+                            clock=self.clock,
+                        )
+                        if self.publish_terminal is not None:
+                            self.publish_terminal(binding, settled)
+                    except state.StaleTaskError:
+                        try:
+                            current = state.get_task(self.db_path, attempt.identity)
+                            if current["status"] == "stopping":
+                                settled = state.settle_stopping_task(
+                                    self.db_path,
+                                    attempt.identity,
+                                    attempt.lease,
+                                    expected_execution_generation=attempt.execution_generation,
+                                    expected_cancel_generation=int(
+                                        current["cancel_generation"]
+                                    ),
+                                    settlement_id=(
+                                        receipt.get("settlement_id")
+                                        or f"reply:{attempt.identity.task_id}:{attempt.execution_generation}"
+                                    ),
+                                    status=terminal_status,
+                                    result=_bounded_terminal_result(receipt),
+                                    clock=self.clock,
+                                )
+                                if self.publish_terminal is not None:
+                                    self.publish_terminal(binding, settled)
+                        except (state.StaleLeaseError, state.StaleTaskError):
+                            pass
+                    except state.StaleLeaseError:
+                        # Cancellation, disband, or authority transfer won the
+                        # durable race. The model result is intentionally
+                        # discarded; never turn a correct fence into a worker
+                        # thread exception.
+                        pass
+                    except state.DriverStateError as exc:
+                        # A malformed terminal receipt must not escape the
+                        # callback and hold the profile lock until the deadline.
+                        self._settle_failure_if_current(
+                            attempt,
+                            RuntimeError(
+                                f"terminal result could not be committed: {exc}"
+                            ),
+                        )
+                    self.wakeup()
+
+                deadline_monotonic = time.monotonic() + self.turn_timeout_seconds
+                transport.submit(
+                    profile=profile,
+                    session_id=_session_id(session),
+                    prompt=task["payload"]["prompt"],
+                    source=ROOM_SESSION_SOURCE,
+                    task=attempt.identity,
+                    execution_generation=attempt.execution_generation,
+                    on_terminal=on_terminal,
+                )
+                receipt = self._wait_for_terminal(
+                    binding,
+                    task=task,
+                    profile=profile,
+                    session_id=_session_id(session),
+                    attempt=attempt,
+                    transport=transport,
+                    deadline_monotonic=deadline_monotonic,
+                )
+                if receipt is None:
+                    return
+                state.settle_task(
+                    self.db_path,
+                    attempt,
+                    settlement_id=receipt.settlement_id,
+                    status=receipt.status,
+                    result=receipt.result,
+                    clock=self.clock,
+                )
+        except (state.StaleLeaseError, state.StaleTaskError) as exc:
+            self._drop_lease(binding.room_id)
+            self._record_error(f"task {attempt.identity.task_id} fenced: {exc}")
+        except Exception as exc:
+            if submit_attempted:
+                self._drop_lease(binding.room_id)
+                self._ambiguous_rooms[binding.room_id] = attempt.lease.expires_at
+                self._record_error(
+                    f"task {attempt.identity.task_id} observation failed after submit: {exc}"
+                )
+            else:
+                self._settle_failure_if_current(attempt, exc)
+        finally:
+            with self._status_lock:
+                self._current_tasks.pop(binding.room_id, None)
+                # The task may have published a reply, deferred a member, or
+                # exposed the next turn while this room thread still occupied
+                # its slot. Schedule exactly one immediate follow-up after the
+                # thread leaves; idle room scans never set this marker.
+                self._rooms_needing_reschedule.add(binding.room_id)
+
+    def _wait_for_terminal(
+        self,
+        binding: HostedRoomBinding,
+        *,
+        task: Mapping[str, Any],
+        profile: str,
+        session_id: str,
+        attempt: state.TaskAttempt,
+        transport: InternalSessionRPC,
+        deadline_monotonic: float,
+    ) -> _TerminalReceipt | None:
+        lease = attempt.lease
+        while not self._stop.is_set():
+            task = state.get_task(self.db_path, attempt.identity)
+            if task["status"] in state.TERMINAL_STATUSES:
+                return None
+            if task["status"] == "stopping":
+                try:
+                    lease = self._renew_lease_if_needed(binding, lease)
+                    if self._settle_stopping_completion(binding, task, lease):
+                        return None
+                    if self._interrupt_stopping_task(binding, task):
+                        self._complete_acknowledged_stop(binding, task, lease)
+                        return None
+                except Exception as exc:
+                    self._record_error(f"stop retry remains pending: {exc}")
+                self._wake.wait(self.active_poll_interval_seconds)
+                self._wake.clear()
+                continue
+
+            if time.monotonic() >= deadline_monotonic:
+                self._expire_attempt_deadline(binding, task, lease)
+                return None
+
+            lease = self._renew_lease_if_needed(binding, lease)
+            receipt = _find_terminal_receipt(
+                transport.history(
+                    profile=profile,
+                    session_id=session_id,
+                    source=ROOM_SESSION_SOURCE,
+                ),
+                attempt.identity,
+                attempt.execution_generation,
+            )
+            if receipt is not None:
+                return receipt
+
+            info = transport.info(
+                profile=profile,
+                session_id=session_id,
+                source=ROOM_SESSION_SOURCE,
+            )
+            self._report_pending_action(task, session_id=session_id, info=info)
+            remaining = max(0.0, deadline_monotonic - time.monotonic())
+            self._wake.wait(min(self.active_poll_interval_seconds, remaining))
+            self._wake.clear()
+        return None
+
+    @staticmethod
+    def _deadline_cancel_id(task: Mapping[str, Any]) -> str:
+        return f"deadline:{int(task['execution_generation'])}"
+
+    @staticmethod
+    def _is_deadline_stop(task: Mapping[str, Any]) -> bool:
+        return str(task.get("cancel_id") or "").startswith("deadline:")
+
+    def _settle_deadline_failure(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        lease: state.DriverLease,
+    ) -> dict[str, Any]:
+        """Publish the explicit terminal outcome after exact Stop acknowledgement."""
+
+        execution_generation = int(task["execution_generation"])
+        settled = state.settle_stopping_task(
+            self.db_path,
+            task["identity"],
+            lease,
+            expected_execution_generation=execution_generation,
+            expected_cancel_generation=int(task["cancel_generation"]),
+            settlement_id=f"deadline:{execution_generation}",
+            status="failed",
+            result={
+                "error": (
+                    "This Group Chat turn exceeded its configured time limit and "
+                    "was stopped."
+                ),
+                "reason_code": "turn_deadline_exceeded",
+                "timeout_seconds": self.turn_timeout_seconds,
+            },
+            clock=self.clock,
+        )
+        if self.publish_terminal is not None:
+            self.publish_terminal(binding, settled)
+        return settled
+
+    def _complete_acknowledged_stop(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        lease: state.DriverLease,
+    ) -> dict[str, Any]:
+        if self._is_deadline_stop(task):
+            return self._settle_deadline_failure(binding, task, lease)
+        return state.complete_task_cancel(
+            self.db_path,
+            task["identity"],
+            cancel_id=task["cancel_id"],
+            expected_cancel_generation=task["cancel_generation"],
+            clock=self.clock,
+        )
+
+    def _expire_attempt_deadline(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        lease: state.DriverLease,
+    ) -> None:
+        """Fence, stop, and terminalize one exact attempt at its deadline."""
+
+        if task["status"] == "running":
+            task = state.begin_task_cancel(
+                self.db_path,
+                task["identity"],
+                cancel_id=self._deadline_cancel_id(task),
+                expected_cancel_generation=int(task["cancel_generation"]),
+                clock=self.clock,
+            )
+        elif task["status"] != "stopping":
+            return
+
+        # A user Stop that won the race keeps its own cancellation semantics.
+        if not self._is_deadline_stop(task):
+            return
+        lease = self._renew_lease_if_needed(binding, lease, force=True)
+        if self._settle_stopping_completion(binding, task, lease):
+            return
+        if self._interrupt_stopping_task(binding, task):
+            self._complete_acknowledged_stop(binding, task, lease)
+            return
+        self._record_error(
+            f"task {task['identity'].task_id} exceeded its deadline; stop remains pending"
+        )
+
+    def _inspect_abandoned_attempts(self, binding: HostedRoomBinding) -> None:
+        running = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="running",
+        )
+        for task in running:
+            if task["run_process_generation"] == self.process_generation:
+                continue
+            inspection = self._inspect_local_recovery_session(task)
+            if inspection.terminal is not None:
+                self._harvest_previous_attempt(binding, task, inspection.terminal)
+            elif inspection.active:
+                # The prior session still owns the turn. Do not contend for its
+                # lease or submit a duplicate prompt.
+                raise state.LeaseHeldError("recovered session turn is still active")
+
+    def _inspect_local_recovery_session(
+        self,
+        task: Mapping[str, Any],
+    ) -> _RecoveryInspection:
+        """Check only live process state before explicit local recovery.
+
+        A restart loses the in-process terminal callback identity. The ordinary
+        session history is a display projection and cannot prove which durable
+        task attempt authored a row, so never hydrate or infer completion from
+        it. An inactive abandoned attempt remains indeterminate until the user
+        explicitly retries it under a new fenced generation.
+        """
+
+        profile = task["payload"]["target_profile"]
+        with self.turn_lock(profile):
+            session = self.rpc.resolve_exact(
+                profile=profile,
+                title=room_session_title(task["identity"].room_id),
+                source=ROOM_SESSION_SOURCE,
+            )
+            if session is None:
+                return _RecoveryInspection(terminal=None, active=False, status=None)
+            session_id = _session_id(session)
+            info = self.rpc.info(
+                profile=profile,
+                session_id=session_id,
+                source=ROOM_SESSION_SOURCE,
+            )
+            self._report_pending_action(task, session_id=session_id, info=info)
+            return _RecoveryInspection(
+                terminal=None,
+                active=_info_is_active_for(info, task["identity"]),
+                status=str(info.get("status") or "") or None,
+            )
+
+    def _reconcile_indeterminate(
+        self,
+        binding: HostedRoomBinding,
+        lease: state.DriverLease,
+    ) -> bool:
+        unresolved = state.list_tasks(
+            self.db_path,
+            room_id=binding.room_id,
+            status="indeterminate",
+        )
+        if not unresolved:
+            with self._status_lock:
+                self._blocked_rooms.discard(binding.room_id)
+            return False
+        for task in unresolved:
+            generation = int(task["execution_generation"])
+            attempt_key = (
+                binding.room_id,
+                task["identity"].task_id,
+                generation,
+            )
+            if attempt_key not in self._inspected_indeterminate_attempts:
+                inspection = self._inspect_local_recovery_session(task)
+                self._inspected_indeterminate_attempts.add(attempt_key)
+                if inspection.terminal is not None:
+                    resolved = state.resolve_indeterminate_task(
+                        self.db_path,
+                        task["identity"],
+                        lease,
+                        expected_execution_generation=generation,
+                        expected_cancel_generation=task["cancel_generation"],
+                        settlement_id=inspection.terminal.settlement_id,
+                        status=inspection.terminal.status,
+                        result=inspection.terminal.result,
+                        clock=self.clock,
+                    )
+                    self._inspected_indeterminate_attempts.discard(attempt_key)
+                    if self.publish_terminal is not None:
+                        self.publish_terminal(binding, resolved)
+                    continue
+                if inspection.active:
+                    with self._status_lock:
+                        self._blocked_rooms.add(binding.room_id)
+                    return True
+            deferred_at = float(
+                task.get("indeterminate_at")
+                or task.get("updated_at")
+                or task.get("created_at")
+                or self.clock()
+            )
+            if self.clock() < deferred_at + self.indeterminate_defer_seconds:
+                with self._status_lock:
+                    self._blocked_rooms.add(binding.room_id)
+                return True
+            deferred = state.defer_indeterminate_task(
+                self.db_path,
+                task["identity"],
+                lease,
+                expected_execution_generation=task["execution_generation"],
+                expected_cancel_generation=task["cancel_generation"],
+                reason="member_unavailable",
+                clock=self.clock,
+            )
+            self._report_pending_action(task, session_id="", info={})
+            if self.publish_terminal is not None:
+                self.publish_terminal(binding, deferred)
+        with self._status_lock:
+            self._blocked_rooms.discard(binding.room_id)
+        return False
+
+    def _harvest_previous_attempt(
+        self,
+        binding: HostedRoomBinding,
+        task: Mapping[str, Any],
+        receipt: _TerminalReceipt,
+    ) -> None:
+        previous_lease = state.DriverLease(
+            room_id=binding.room_id,
+            gateway_id=task["run_gateway_id"],
+            authority_epoch=binding.authority_epoch,
+            process_generation=task["run_process_generation"],
+            lease_generation=task["run_lease_generation"],
+            expires_at=0.0,
+        )
+        previous_attempt = state.TaskAttempt(
+            identity=task["identity"],
+            lease=previous_lease,
+            execution_generation=task["execution_generation"],
+            cancel_generation=task["cancel_generation"],
+        )
+        try:
+            state.settle_task(
+                self.db_path,
+                previous_attempt,
+                settlement_id=receipt.settlement_id,
+                status=receipt.status,
+                result=receipt.result,
+                clock=self.clock,
+            )
+        except (state.StaleLeaseError, state.StaleTaskError):
+            # Once the previous proof has expired, the current state contract
+            # deliberately offers no unsafe "trust this historical output"
+            # escape hatch. The subsequent fenced recovery leaves it
+            # indeterminate for explicit user action.
+            return
+
+    def _binding_for_room(self, room_id: str) -> HostedRoomBinding | None:
+        return next(
+            (
+                binding
+                for binding in self._rooms_provider()
+                if binding.room_id == room_id
+            ),
+            None,
+        )
+
+    def _resolve_or_create(
+        self,
+        transport: InternalSessionRPC,
+        profile: str,
+        room_id: str,
+    ) -> Mapping[str, Any]:
+        title = room_session_title(room_id)
+        session = transport.resolve_exact(
+            profile=profile,
+            title=title,
+            source=ROOM_SESSION_SOURCE,
+        )
+        if session is None:
+            return transport.create(
+                profile=profile,
+                title=title,
+                source=ROOM_SESSION_SOURCE,
+            )
+        return transport.resume(
+            profile=profile,
+            session_id=_session_id(session),
+            source=ROOM_SESSION_SOURCE,
+        )
+
+    def _settle_failure_if_current(
+        self, attempt: state.TaskAttempt, exc: Exception
+    ) -> None:
+        try:
+            state.settle_task(
+                self.db_path,
+                attempt,
+                settlement_id=f"failure:{attempt.identity.task_id}:{attempt.execution_generation}",
+                status="failed",
+                result={"error": str(exc)},
+                clock=self.clock,
+            )
+        except (state.DriverStateError, state.RoomUnavailableError):
+            pass
+        self._record_error(f"task {attempt.identity.task_id} failed: {exc}")
+
+    def _record_error(self, message: str) -> None:
+        with self._status_lock:
+            self._last_error = message
+
+    def _drop_lease(self, room_id: str) -> None:
+        with self._status_lock:
+            self._leases.pop(room_id, None)
+
+    def _release_idle_leases(self) -> None:
+        for room_id, lease in tuple(self._leases.items()):
+            try:
+                state.release_lease(self.db_path, lease, clock=self.clock)
+            except state.DriverStateError:
+                continue
+            self._drop_lease(room_id)
+
+
+def room_session_title(room_id: str) -> str:
+    """Return the canonical hidden session title for one hosted room."""
+    return f"Group: {room_id}"
+
+
+def _session_id(session: Mapping[str, Any]) -> str:
+    value = session.get("session_id", session.get("id"))
+    if not isinstance(value, str) or not value:
+        raise ValueError("session adapter returned no session_id")
+    return value
+
+
+def _truncate_utf8(value: Any, *, max_bytes: int) -> tuple[str, bool]:
+    text = str(value or "")
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text, False
+    suffix = _TERMINAL_TRUNCATION_NOTICE.encode("utf-8")
+    prefix = encoded[: max(0, max_bytes - len(suffix))]
+    while prefix:
+        try:
+            return prefix.decode("utf-8") + _TERMINAL_TRUNCATION_NOTICE, True
+        except UnicodeDecodeError:
+            prefix = prefix[:-1]
+    return _TERMINAL_TRUNCATION_NOTICE.strip(), True
+
+
+def _bounded_terminal_result(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    text, truncated = _truncate_utf8(
+        receipt.get("text", ""),
+        max_bytes=MAX_TERMINAL_TEXT_BYTES,
+    )
+    error, error_truncated = _truncate_utf8(
+        receipt.get("error", ""),
+        max_bytes=4096,
+    )
+    return {
+        "message_id": receipt.get("message_id"),
+        "text": text,
+        **({"error": error} if error else {}),
+        **({"truncated": True} if truncated or error_truncated else {}),
+    }
+
+
+def _find_terminal_receipt(
+    history: Sequence[Mapping[str, Any]],
+    identity: state.TaskIdentity,
+    execution_generation: int,
+) -> _TerminalReceipt | None:
+    for message in reversed(history):
+        if message.get("task_id") != identity.task_id:
+            continue
+        if message.get("execution_generation") != execution_generation:
+            continue
+        if message.get("role") != "assistant":
+            continue
+        status = message.get("status")
+        if status not in {"settled", "failed"}:
+            continue
+        terminal_status = cast(state.TerminalStatus, status)
+        receipt_id = message.get("message_id")
+        if not isinstance(receipt_id, str) or not receipt_id:
+            receipt_id = f"reply:{identity.task_id}:{execution_generation}"
+        return _TerminalReceipt(
+            status=terminal_status,
+            settlement_id=receipt_id,
+            result=_bounded_terminal_result(
+                {
+                    "message_id": receipt_id,
+                    "text": message.get("content", ""),
+                }
+            ),
+        )
+    return None
+
+
+def _info_is_active_for(
+    info: Mapping[str, Any],
+    identity: state.TaskIdentity,
+    *,
+    require_exact: bool = False,
+) -> bool:
+    if not bool(info.get("active", info.get("running", False))):
+        return False
+    active_task_id = info.get("task_id")
+    if require_exact:
+        return active_task_id == identity.task_id
+    return active_task_id in {None, identity.task_id}
+
+
+@contextlib.contextmanager
+def null_turn_lock(_profile: str) -> Any:
+    """Provide an explicit no-op lock for narrow embedding tests."""
+    yield

--- a/tui_gateway/hosted_room_driver.py
+++ b/tui_gateway/hosted_room_driver.py
@@ -29,6 +29,8 @@ from typing import Any, ContextManager, Protocol, cast
 
 from gateway import hosted_room_driver as state
 
+_CANCEL_ROUTE_RETRIES = 8
+
 
 ROOM_SESSION_SOURCE = "bot_room"
 MAX_TERMINAL_TEXT_BYTES = 64 * 1024
@@ -252,41 +254,73 @@ class HostedRoomRuntime:
         *,
         cancel_id: str,
     ) -> dict[str, Any]:
-        """Persist a stop intent, then commit cancellation after acknowledgement."""
-        before = state.get_task(self.db_path, identity)
-        if before["status"] in {"queued", "deferred"}:
-            cancelled = state.cancel_task(
-                self.db_path,
-                identity,
-                cancel_id=cancel_id,
-                expected_cancel_generation=before["cancel_generation"],
-                clock=self.clock,
-            )
-            self.wakeup()
-            return cancelled
+        """Persist a stop intent, then commit cancellation after acknowledgement.
 
-        stopping = state.begin_task_cancel(
-            self.db_path,
-            identity,
-            cancel_id=cancel_id,
-            expected_cancel_generation=before["cancel_generation"],
-            clock=self.clock,
-        )
-        binding = self._binding_for_room(identity.room_id)
-        try:
-            if binding is not None and self._interrupt_stopping_task(binding, stopping):
-                stopping = state.complete_task_cancel(
+        The worker thread transitions tasks concurrently with cancellation
+        (queued -> running -> terminal), so the status read below is only a
+        routing hint. Every fast-path failure caused by a concurrent
+        transition re-reads and re-routes instead of surfacing a transient
+        `InvalidTaskTransitionError`/`StaleTaskError` to the caller.
+        """
+        for _ in range(_CANCEL_ROUTE_RETRIES):
+            before = state.get_task(self.db_path, identity)
+            if before["status"] == "cancelled":
+                return before
+            if before["status"] in state.TERMINAL_STATUSES:
+                raise state.InvalidTaskTransitionError(
+                    f"cannot cancel task in state '{before['status']}'"
+                )
+            if before["status"] in {"queued", "deferred"}:
+                try:
+                    cancelled = state.cancel_task(
+                        self.db_path,
+                        identity,
+                        cancel_id=cancel_id,
+                        expected_cancel_generation=before["cancel_generation"],
+                        clock=self.clock,
+                    )
+                except (state.InvalidTaskTransitionError, state.StaleTaskError):
+                    # Lost the race with the worker; re-read and re-route.
+                    continue
+                self.wakeup()
+                return cancelled
+            try:
+                stopping = state.begin_task_cancel(
                     self.db_path,
                     identity,
                     cancel_id=cancel_id,
-                    expected_cancel_generation=stopping["cancel_generation"],
+                    expected_cancel_generation=before["cancel_generation"],
                     clock=self.clock,
                 )
-        except Exception as exc:
-            self._record_error(f"stop remains pending: {exc}")
-        stopping = state.get_task(self.db_path, identity)
-        self.wakeup()
-        return stopping
+            except (state.InvalidTaskTransitionError, state.StaleTaskError):
+                # Task settled or re-queued mid-flight; re-read and re-route.
+                continue
+            binding = self._binding_for_room(identity.room_id)
+            try:
+                if binding is not None and self._interrupt_stopping_task(
+                    binding, stopping
+                ):
+                    stopping = state.complete_task_cancel(
+                        self.db_path,
+                        identity,
+                        cancel_id=cancel_id,
+                        expected_cancel_generation=stopping["cancel_generation"],
+                        clock=self.clock,
+                    )
+            except Exception as exc:
+                self._record_error(f"stop remains pending: {exc}")
+            stopping = state.get_task(self.db_path, identity)
+            self.wakeup()
+            return stopping
+        # Exhausted routing retries under sustained contention: surface the
+        # live status honestly rather than a transient transition error.
+        final = state.get_task(self.db_path, identity)
+        if final["status"] == "cancelled":
+            return final
+        raise state.InvalidTaskTransitionError(
+            f"cancel kept losing races with task transitions "
+            f"(last observed state '{final['status']}')"
+        )
 
     def retry_indeterminate(self, identity: state.TaskIdentity) -> dict[str, Any]:
         """Explicitly retry one uncertain attempt under the current room lease."""

--- a/tui_gateway/hosted_room_server_rpc.py
+++ b/tui_gateway/hosted_room_server_rpc.py
@@ -1,0 +1,213 @@
+"""In-process session adapter for the hosted room driver.
+
+The room worker must not depend on a Desktop/WebSocket transport, but it should
+still use the same session handlers as every other TUI/Desktop turn. This
+adapter calls the installed handler registry directly and keeps the extra
+task proof as an in-process-only Python object that JSON clients cannot forge.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+from collections.abc import Mapping, Sequence
+from types import ModuleType
+from typing import Any, Callable
+
+from gateway import hosted_room_driver as state
+
+
+class HostedRoomSessionError(RuntimeError):
+    """Raised when an in-process session operation is rejected."""
+
+    def __init__(self, method: str, code: int, message: str) -> None:
+        super().__init__(f"{method} failed: {message}")
+        self.method = method
+        self.code = code
+
+
+class HostedRoomServerRPC:
+    """Normalize the installed server handlers for :class:`HostedRoomRuntime`."""
+
+    def __init__(self, server: ModuleType) -> None:
+        self.server = server
+        self._ids = itertools.count(1)
+
+    def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        handler = self.server._methods[method]
+        envelope = handler(f"hosted-room-{next(self._ids)}", params)
+        error = envelope.get("error") if isinstance(envelope, dict) else None
+        if isinstance(error, dict):
+            raise HostedRoomSessionError(
+                method,
+                int(error.get("code") or 5000),
+                str(error.get("message") or "gateway rejected the request"),
+            )
+        result = envelope.get("result") if isinstance(envelope, dict) else None
+        if not isinstance(result, dict):
+            raise HostedRoomSessionError(method, 5000, "gateway returned no result")
+        return result
+
+    def resolve_exact(
+        self, *, profile: str, title: str, source: str
+    ) -> Mapping[str, Any] | None:
+        del source
+        result = self._call(
+            "session.list",
+            {"profile": profile, "title": title, "include_hidden": True},
+        )
+        rows = result.get("sessions")
+        if not isinstance(rows, list) or not rows:
+            return None
+        row = rows[0]
+        if not isinstance(row, dict):
+            return None
+        session_id = row.get("resolved_id") or row.get("id")
+        return {"session_id": session_id, "title": row.get("title") or title}
+
+    def create(self, *, profile: str, title: str, source: str) -> Mapping[str, Any]:
+        return self._call(
+            "session.create",
+            {
+                "profile": profile,
+                "title": title,
+                "source": source,
+                "hidden": True,
+                "room_plumbing": True,
+                "follow_profile_config": True,
+                "close_on_disconnect": False,
+            },
+        )
+
+    def resume(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Mapping[str, Any]:
+        return self._call(
+            "session.resume",
+            {
+                "profile": profile,
+                "session_id": session_id,
+                "omit_messages": True,
+                "source": source,
+            },
+        )
+
+    def submit(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        prompt: str,
+        source: str,
+        task: state.TaskIdentity,
+        execution_generation: int,
+        on_terminal: Callable[[Mapping[str, Any]], None],
+    ) -> Mapping[str, Any]:
+        try:
+            return self._call(
+                "prompt.submit",
+                {
+                    "profile": profile,
+                    "session_id": session_id,
+                    "text": prompt,
+                    "source": source,
+                    "_hosted_task": {
+                        "room_id": task.room_id,
+                        "task_id": task.task_id,
+                        "thread_id": task.thread_id,
+                        "turn_id": task.turn_id,
+                        "execution_generation": execution_generation,
+                    },
+                    "_hosted_terminal_callback": on_terminal,
+                },
+            )
+        except HostedRoomSessionError as exc:
+            # In-process prompt.submit error envelopes are returned before the
+            # background turn is admitted. Preserve that proof so the driver
+            # can defer or requeue without waiting out an ambiguity lease.
+            exc.not_admitted = True
+            raise
+
+    def history(
+        self, *, profile: str, session_id: str, source: str
+    ) -> Sequence[Mapping[str, Any]]:
+        del source
+        result = self._call(
+            "session.history",
+            {"profile": profile, "session_id": session_id},
+        )
+        rows = result.get("messages")
+        return tuple(row for row in rows if isinstance(row, dict)) if isinstance(rows, list) else ()
+
+    def _session_record(self, session_id: str) -> dict[str, Any] | None:
+        with self.server._sessions_lock:
+            record = self.server._sessions.get(session_id)
+            if record is not None:
+                return record
+            for candidate in self.server._sessions.values():
+                if str(candidate.get("session_key") or "") == session_id:
+                    return candidate
+        return None
+
+    def info(self, *, profile: str, session_id: str, source: str) -> Mapping[str, Any]:
+        del profile, source
+        record = self._session_record(session_id)
+        if record is None:
+            return {"active": False, "task_id": None}
+        lock = record.get("history_lock")
+        if not isinstance(lock, type(threading.Lock())):
+            return {"active": bool(record.get("running")), "task_id": None}
+        with lock:
+            task = record.get("_hosted_room_task")
+            result = {
+                "active": bool(record.get("running")),
+                "task_id": task.get("task_id") if isinstance(task, dict) else None,
+            }
+            pending_reader = getattr(
+                self.server, "_pending_approval_request_payload", None
+            )
+            pending = (
+                pending_reader(str(record.get("session_key") or ""))
+                if callable(pending_reader)
+                else None
+            )
+            if pending:
+                result["status"] = "waiting_for_approval"
+                result["pending_approval"] = pending
+            return result
+
+    def approve(
+        self,
+        *,
+        session_id: str,
+        request_id: str,
+        choice: str,
+    ) -> Mapping[str, Any]:
+        """Resolve one exact local room approval without broad policy changes."""
+        return self._call(
+            "approval.respond",
+            {
+                "session_id": session_id,
+                "request_id": request_id,
+                "choice": choice,
+                "all": False,
+            },
+        )
+
+    def interrupt(
+        self,
+        *,
+        profile: str,
+        session_id: str,
+        source: str,
+        expected_task_id: str,
+    ) -> Mapping[str, Any] | None:
+        del source
+        return self._call(
+            "session.interrupt",
+            {
+                "profile": profile,
+                "session_id": session_id,
+                "expected_hosted_task_id": expected_task_id,
+            },
+        )

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -1,0 +1,518 @@
+"""Production coordinator for same-gateway hosted Discussion rooms."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+import time
+from collections import Counter
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+from gateway.hosted_room_policy_checkpoint import (
+    HostedRoomPolicyCheckpoint,
+    PolicySnapshot,
+)
+from tui_gateway.hosted_room_driver import HostedRoomBinding, HostedRoomRuntime
+from tui_gateway.hosted_room_server_rpc import HostedRoomServerRPC
+
+
+_HOSTED_ROOM_IDLE_FALLBACK_SECONDS = 5.0
+_HOSTED_ROOM_ACTIVE_POLL_SECONDS = 0.25
+_HOSTED_ROOM_TERMINAL_GRACE_SECONDS = 30.0
+
+
+def _hosted_room_turn_timeout_seconds() -> float:
+    try:
+        agent_timeout = float(os.getenv("HERMES_AGENT_TIMEOUT", "1800"))
+    except (TypeError, ValueError):
+        agent_timeout = 1800.0
+    if agent_timeout <= 0:
+        agent_timeout = 1800.0
+    return agent_timeout + _HOSTED_ROOM_TERMINAL_GRACE_SECONDS
+
+
+class HostedRoomService:
+    """Own the hosted Discussion policy and its transport-free worker."""
+
+    def __init__(
+        self, server: ModuleType, *, db_path: Path | str | None = None
+    ) -> None:
+        self.server = server
+        self.db_path = Path(db_path or hosted_rooms.default_db_path())
+        hosted_rooms.prune_disbanded_rooms(self.db_path)
+        self._policy_lock = threading.RLock()
+        self._pending_actions: dict[tuple[str, str], dict[str, Any]] = {}
+        self.policy_checkpoint = HostedRoomPolicyCheckpoint(self.db_path)
+        self.rpc = HostedRoomServerRPC(server)
+        self.runtime = HostedRoomRuntime(
+            db_path=self.db_path,
+            rooms=self.bindings,
+            rpc=self.rpc,
+            turn_lock=self._turn_lock,
+            prepare_room=self.prepare_room,
+            publish_terminal=self.publish_terminal,
+            pending_action=self._set_pending_action,
+            poll_interval_seconds=_HOSTED_ROOM_IDLE_FALLBACK_SECONDS,
+            active_poll_interval_seconds=_HOSTED_ROOM_ACTIVE_POLL_SECONDS,
+            turn_timeout_seconds=_hosted_room_turn_timeout_seconds(),
+        )
+
+    @property
+    def root(self) -> Path:
+        return self.db_path.parent
+
+    def local_profiles(self) -> tuple[str, ...]:
+        profiles = {"default"}
+        profiles_dir = self.root / "profiles"
+        if profiles_dir.is_dir():
+            profiles.update(
+                path.name for path in profiles_dir.iterdir() if path.is_dir()
+            )
+        return tuple(sorted(profiles))
+
+    def bindings(self) -> tuple[HostedRoomBinding, ...]:
+        local_gateway_id = hosted_rooms.local_authority_gateway_id()
+        return tuple(
+            HostedRoomBinding(
+                room_id=str(room["room_id"]),
+                gateway_id=str(room["authority_gateway_id"]),
+                authority_epoch=int(room["authority_epoch"]),
+            )
+            for room in hosted_rooms.list_rooms(self.db_path)
+            if str(room["authority_gateway_id"]) == local_gateway_id
+        )
+
+    def _owned_room(self, room_id: str) -> dict[str, Any]:
+        room = hosted_rooms.room_state(self.db_path, room_id=room_id)
+        if str(room["authority_gateway_id"]) != (
+            hosted_rooms.local_authority_gateway_id()
+        ):
+            raise hosted_rooms.AuthorityConflictError(
+                "This Group Chat is managed by another gateway."
+            )
+        return room
+
+    @contextlib.contextmanager
+    def _turn_lock(self, profile: str) -> Iterator[None]:
+        from tools.bot_relay import acquire_turn_lock
+
+        with acquire_turn_lock(self.root, profile):
+            yield
+
+    def start(self) -> None:
+        self.runtime.start()
+
+    def stop(self, *, timeout: float = 5.0) -> bool:
+        return self.runtime.stop(timeout=timeout)
+
+    def wakeup(self) -> None:
+        self.runtime.wakeup()
+
+    def _set_pending_action(
+        self,
+        room_id: str,
+        member_id: str,
+        action: Mapping[str, Any] | None,
+    ) -> None:
+        key = (room_id, member_id)
+        with self._policy_lock:
+            if action is None:
+                self._pending_actions.pop(key, None)
+            else:
+                self._pending_actions[key] = {**action, "member_id": member_id}
+
+    def _events(self, room_id: str) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        cursor = 0
+        while True:
+            page = hosted_rooms.read_events(
+                self.db_path,
+                room_id=room_id,
+                since_seq=cursor,
+                limit=hosted_rooms.MAX_LOG_LIMIT,
+            )
+            rows = page.get("events")
+            if isinstance(rows, list):
+                events.extend(row for row in rows if isinstance(row, dict))
+            next_cursor = int(page.get("cursor") or cursor)
+            if not page.get("has_more"):
+                return events
+            if next_cursor <= cursor:
+                raise RuntimeError("hosted room replay cursor did not advance")
+            cursor = next_cursor
+
+    def _append_plan(self, room_id: str, plan: discussion.PublicationPlan) -> None:
+        for event in plan.events:
+            hosted_rooms.append_event(
+                self.db_path,
+                **event.append_kwargs(room_id),
+            )
+
+    def _policy_snapshot(self, room: Mapping[str, Any]) -> PolicySnapshot:
+        return self.policy_checkpoint.snapshot(
+            room_id=str(room["room_id"]),
+            latest_seq=int(room["latest_seq"]),
+        )
+
+    def _publish_terminal_tasks(
+        self,
+        room: Mapping[str, Any],
+    ) -> bool:
+        changed = False
+        local_profiles = self.local_profiles()
+        for status in ("deferred", "settled", "failed", "cancelled"):
+            for task in driver.list_tasks(
+                self.db_path,
+                room_id=str(room["room_id"]),
+                status=status,
+            ):
+                identity = task["identity"]
+                if self.policy_checkpoint.publication_exists(
+                    room_id=str(room["room_id"]),
+                    task_id=identity.task_id,
+                    status=status,
+                    execution_generation=int(task["execution_generation"]),
+                ):
+                    continue
+                task_events = self.policy_checkpoint.events_for_task(
+                    room_id=str(room["room_id"]),
+                    source_event_seq=int(task["payload"]["source_event_seq"]),
+                )
+                plan = discussion.reconstruct_task_plan(
+                    room,
+                    task_events,
+                    task,
+                    local_profiles=local_profiles,
+                )
+                publication = discussion.plan_publication(
+                    room,
+                    task_events,
+                    plan,
+                    status=status,
+                    result=task.get("result"),
+                    execution_generation=(
+                        int(task["execution_generation"])
+                        if status == "deferred"
+                        else None
+                    ),
+                    local_profiles=local_profiles,
+                )
+                self._append_plan(str(room["room_id"]), publication)
+                changed = True
+        return changed
+
+    def _append_room_status(
+        self,
+        room: Mapping[str, Any],
+        decision: discussion.DiscussionDecision,
+    ) -> None:
+        if decision.discussion_event_id is None:
+            return
+        hosted_rooms.append_event(
+            self.db_path,
+            room_id=str(room["room_id"]),
+            event_id=f"dactivity:{decision.discussion_event_id}:{decision.reason}",
+            kind="room.activity",
+            actor={"kind": "gateway", "id": str(room["authority_gateway_id"])},
+            payload={
+                "status": decision.status,
+                "reason_code": decision.reason,
+                "thread_id": decision.thread_id,
+                "discussion_event_id": decision.discussion_event_id,
+            },
+            authority_gateway_id=str(room["authority_gateway_id"]),
+            authority_epoch=int(room["authority_epoch"]),
+        )
+
+    def prepare_room(self, binding: HostedRoomBinding) -> None:
+        with self._policy_lock:
+            room = hosted_rooms.room_state(self.db_path, room_id=binding.room_id)
+            snapshot = self._policy_snapshot(room)
+            events = list(snapshot.events)
+            if self._publish_terminal_tasks(room):
+                room = hosted_rooms.room_state(
+                    self.db_path,
+                    room_id=binding.room_id,
+                )
+                snapshot = self._policy_snapshot(room)
+                events = list(snapshot.events)
+            self.policy_checkpoint.compact_completed(room_id=binding.room_id)
+            driver.prune_published_terminal_tasks(
+                self.db_path,
+                room_id=binding.room_id,
+                clock=self.runtime.clock,
+            )
+            if any(
+                driver.list_tasks(
+                    self.db_path,
+                    room_id=binding.room_id,
+                    status=status,
+                )
+                for status in ("queued", "running", "stopping")
+            ):
+                return
+            decision = discussion.plan_next_task(
+                room,
+                events,
+                local_profiles=self.local_profiles(),
+                initial_watermarks=snapshot.watermarks,
+            )
+            if decision.status == "task" and decision.task is not None:
+                driver.admit_task(
+                    self.db_path,
+                    decision.task.identity,
+                    payload=decision.task.payload,
+                    clock=time.time,
+                )
+                # A stop can race the policy read from another process. Re-read
+                # after admission and cancel before the runtime can execute a
+                # task whose source event is now behind the room stop fence.
+                fresh_room = hosted_rooms.room_state(
+                    self.db_path,
+                    room_id=binding.room_id,
+                )
+                stopped_through_seq = self._policy_snapshot(
+                    fresh_room
+                ).stopped_through_seq
+                if (
+                    decision.source_event_seq is not None
+                    and decision.source_event_seq < stopped_through_seq
+                ):
+                    self.runtime.cancel(
+                        decision.task.identity,
+                        cancel_id=f"stop-fence:{stopped_through_seq}",
+                    )
+            elif decision.status in {"settled", "bounded"}:
+                self._append_room_status(room, decision)
+
+    def publish_terminal(
+        self,
+        binding: HostedRoomBinding,
+        _task: Mapping[str, Any],
+    ) -> None:
+        self.prepare_room(binding)
+        self.runtime.wakeup()
+
+    def create_room(self, *, room_id: str, name: str, members: Any) -> dict[str, Any]:
+        normalized = discussion.validate_roster(
+            members,
+            local_profiles=self.local_profiles(),
+        )
+        room = hosted_rooms.create_room(
+            self.db_path,
+            room_id=room_id,
+            name=name,
+            members=[
+                {
+                    "member_id": member.member_id,
+                    "profile": member.profile,
+                    "handle": member.handle,
+                    **(
+                        {"display_name": member.display_name}
+                        if member.display_name
+                        else {}
+                    ),
+                }
+                for member in normalized
+            ],
+            authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+        )
+        self.runtime.wakeup()
+        return room
+
+    def send(
+        self,
+        *,
+        room_id: str,
+        event_id: str,
+        payload: Any,
+    ) -> dict[str, Any]:
+        normalized = discussion.validate_user_payload(payload)
+        room = self._owned_room(room_id)
+        event = hosted_rooms.append_event(
+            self.db_path,
+            room_id=room_id,
+            event_id=event_id,
+            kind="message.user",
+            actor={"kind": "user", "id": "desktop"},
+            payload=normalized,
+            authority_gateway_id=str(room["authority_gateway_id"]),
+            authority_epoch=int(room["authority_epoch"]),
+        )
+        binding = next(
+            (
+                candidate
+                for candidate in self.bindings()
+                if candidate.room_id == room_id
+            ),
+            None,
+        )
+        if binding is None:
+            raise hosted_rooms.RoomNotFoundError("hosted room not found")
+        self.prepare_room(binding)
+        self.runtime.wakeup()
+        return event
+
+    def stop_room(
+        self,
+        room_id: str,
+        *,
+        cancel_id: str,
+        require_acknowledged: bool = False,
+    ) -> int:
+        room = self._owned_room(room_id)
+        hosted_rooms.request_room_stop(
+            self.db_path,
+            room_id=room_id,
+            cancel_id=cancel_id,
+            expected_gateway_id=str(room["authority_gateway_id"]),
+            expected_epoch=int(room["authority_epoch"]),
+        )
+        cancelled = 0
+        pending = 0
+        with self._policy_lock:
+            tasks = {}
+            for status in (
+                "queued",
+                "running",
+                "indeterminate",
+                "deferred",
+                "stopping",
+            ):
+                for task in driver.list_tasks(
+                    self.db_path,
+                    room_id=room_id,
+                    status=status,
+                ):
+                    identity = task["identity"]
+                    tasks[(identity.room_id, identity.task_id)] = task
+            for task in tasks.values():
+                task_cancel_id = (
+                    str(task.get("cancel_id") or "")
+                    if task.get("status") == "stopping"
+                    else ""
+                )
+                result = self.runtime.cancel(
+                    task["identity"],
+                    cancel_id=task_cancel_id or cancel_id,
+                )
+                cancelled += 1
+                if result["status"] == "stopping":
+                    pending += 1
+        if require_acknowledged and pending:
+            raise RuntimeError(
+                "room work is still stopping; retry deletion after Stop completes"
+            )
+        self.runtime.wakeup()
+        return cancelled
+
+    def retry_room_task(self, room_id: str, *, task_id: str) -> dict[str, Any]:
+        """Retry one uncertain or deferred task only after explicit user action."""
+
+        task = next(
+            (
+                candidate
+                for status in ("indeterminate", "deferred")
+                for candidate in driver.list_tasks(
+                    self.db_path, room_id=room_id, status=status
+                )
+                if candidate["identity"].task_id == task_id
+            ),
+            None,
+        )
+        if task is None:
+            raise driver.InvalidTaskTransitionError(
+                "no retryable room task matches task_id"
+            )
+        return self.runtime.retry_indeterminate(task["identity"])
+
+    def approve_room_task(
+        self,
+        room_id: str,
+        *,
+        member_id: str,
+        task_id: str,
+        execution_generation: int,
+        choice: str,
+        request_id: str | None = None,
+    ) -> Mapping[str, Any]:
+        """Resolve one exact local approval and wake room observation."""
+
+        key = (room_id, member_id)
+        with self._policy_lock:
+            action = self._pending_actions.get(key)
+        requested_approval_id = str(request_id or "")
+        pending_approval_id = str((action or {}).get("request_id") or "")
+        if (
+            action is None
+            or action.get("task_id") != task_id
+            or int(action.get("execution_generation") or 0) != execution_generation
+            or not requested_approval_id
+            or requested_approval_id != pending_approval_id
+        ):
+            raise RuntimeError("room approval is no longer pending")
+        if choice not in {"once", "deny"}:
+            raise RuntimeError("room approval choice must be once or deny")
+        session_id = str(action.get("session_id") or "")
+        if not session_id:
+            raise RuntimeError("local room approval identity is unavailable")
+        result = self.rpc.approve(
+            session_id=session_id,
+            request_id=requested_approval_id,
+            choice=choice,
+        )
+        if result is None:
+            raise RuntimeError("room approval target is unavailable")
+        with self._policy_lock:
+            current = self._pending_actions.get(key)
+            if (
+                current is not None
+                and str(current.get("request_id") or "") == requested_approval_id
+                and current.get("task_id") == task_id
+                and int(current.get("execution_generation") or 0)
+                == execution_generation
+            ):
+                self._pending_actions.pop(key, None)
+        self.runtime.wakeup()
+        return result
+
+    def status(self, room_id: str | None = None) -> dict[str, Any]:
+        runtime = self.runtime.status()
+        if room_id is None:
+            return runtime
+        tasks = driver.list_tasks(self.db_path, room_id=room_id)
+        counts = Counter(str(task["status"]) for task in tasks)
+        pending_actions = [
+            {
+                "kind": "retry",
+                "task_id": task["identity"].task_id,
+            }
+            for task in tasks
+            if task["status"] in {"indeterminate", "deferred"}
+        ]
+        with self._policy_lock:
+            pending_actions.extend(
+                dict(action)
+                for (
+                    action_room_id,
+                    _member_id,
+                ), action in self._pending_actions.items()
+                if action_room_id == room_id
+            )
+        return {
+            "running": runtime["running"],
+            "working": bool(
+                counts.get("running") or counts.get("queued") or counts.get("stopping")
+            ),
+            "blocked": room_id in runtime["blocked_rooms"]
+            or bool(counts.get("indeterminate") or counts.get("stopping")),
+            "counts": dict(counts),
+            "pending_actions": pending_actions,
+        }

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -214,5 +214,12 @@ def register(server) -> None:
     _registry.install(server)
     from . import methods_groups
 
+    server._LONG_HANDLERS = server._LONG_HANDLERS | methods_groups.LONG_HANDLERS
+    server.get_hosted_room_service = methods_groups.get_hosted_room_service
+    server._WORKER_UNAVAILABLE = methods_groups._WORKER_UNAVAILABLE
+    methods_groups.bind_server(server)
+    methods_groups.register(server)
+    from . import methods_groups
+
     methods_groups.register(server)
     server._LONG_HANDLERS = server._LONG_HANDLERS | methods_groups.LONG_HANDLERS

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -212,3 +212,7 @@ def _(rid, params: dict) -> dict:
 
 def register(server) -> None:
     _registry.install(server)
+    from . import methods_groups
+
+    methods_groups.register(server)
+    server._LONG_HANDLERS = server._LONG_HANDLERS | methods_groups.LONG_HANDLERS

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -1,0 +1,266 @@
+"""Hosted-room JSON-RPC contract.
+
+These methods expose durable room identity and an append-only, monotonic room
+log. They deliberately do not drive Bot turns yet. ``groups.capabilities``
+makes that boundary machine-readable so a hosted-aware Desktop cannot mistake
+the log prototype for a complete gateway-side orchestrator.
+"""
+
+from .method_ctx import HandlerRegistry
+
+_registry = HandlerRegistry()
+method = _registry.method
+
+LONG_HANDLERS = frozenset({
+    "groups.list",
+    "groups.capabilities",
+    "groups.create",
+    "groups.state",
+    "groups.send",
+    "groups.log",
+    "groups.disband",
+})
+
+
+@method("groups.capabilities")
+def _(rid, params: dict) -> dict:
+    """Describe the hosted-room protocol implemented by this gateway."""
+    from gateway.hosted_rooms import (
+        MAX_LOG_LIMIT,
+        PROTOCOL_VERSION,
+        local_authority_gateway_id,
+    )
+
+    return _ok(
+        rid,
+        {
+            "protocol_version": PROTOCOL_VERSION,
+            "driver": False,
+            "authority_gateway_id": local_authority_gateway_id(),
+            "features": [
+                "authority_epoch",
+                "coordinator_fencing",
+                "room_identity",
+                "monotonic_log",
+                "idempotent_send",
+                "replayable_disband",
+                "typed_events",
+                "actor_identity",
+            ],
+            "methods": [
+                "groups.capabilities",
+                "groups.list",
+                "groups.create",
+                "groups.state",
+                "groups.send",
+                "groups.log",
+                "groups.disband",
+            ],
+            "max_log_limit": MAX_LOG_LIMIT,
+        },
+    )
+
+
+@method("groups.list")
+def _(rid, params: dict) -> dict:
+    """List rooms hosted by this gateway."""
+    try:
+        from gateway.hosted_rooms import (
+            MAX_ROOM_LIST_LIMIT,
+            default_db_path,
+            list_rooms,
+        )
+
+        limit = params.get("limit", MAX_ROOM_LIST_LIMIT)
+        offset = params.get("offset", 0)
+        rooms = list_rooms(
+            default_db_path(),
+            include_disbanded=params.get("include_disbanded") is True,
+            limit=limit,
+            offset=offset,
+        )
+
+        return _ok(
+            rid,
+            {
+                "rooms": rooms,
+                "next_offset": offset + limit if len(rooms) == limit else None,
+            },
+        )
+    except Exception as exc:
+        return _err(rid, 5110, str(exc))
+
+
+@method("groups.create")
+def _(rid, params: dict) -> dict:
+    """Create a hosted room idempotently.
+
+    Required params: ``room_id``, ``name``, and ``members``. Authority is
+    derived from this gateway's stable install identity, never from the client.
+    """
+    from gateway.hosted_rooms import (
+        HostedRoomError,
+        create_room,
+        default_db_path,
+        local_authority_gateway_id,
+    )
+
+    try:
+        room = create_room(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            name=params.get("name"),
+            members=params.get("members"),
+            authority_gateway_id=local_authority_gateway_id(),
+        )
+        return _ok(rid, {"room": room})
+    except HostedRoomError as exc:
+        reason = getattr(exc, "reason", None)
+        return _err(rid, 4110, str(exc), {"reason": reason} if reason else None)
+    except Exception as exc:
+        return _err(rid, 5111, str(exc))
+
+
+@method("groups.state")
+def _(rid, params: dict) -> dict:
+    """Return one hosted room's replay cursor and fenced authority state."""
+    from gateway.hosted_rooms import HostedRoomError, default_db_path, room_state
+
+    try:
+        return _ok(
+            rid,
+            {
+                "room": room_state(
+                    default_db_path(),
+                    room_id=params.get("room_id"),
+                    include_disbanded=params.get("include_disbanded") is True,
+                )
+            },
+        )
+    except HostedRoomError as exc:
+        reason = getattr(exc, "reason", None)
+        return _err(rid, 4114, str(exc), {"reason": reason} if reason else None)
+    except Exception as exc:
+        return _err(rid, 5115, str(exc))
+
+
+@method("groups.send")
+def _(rid, params: dict) -> dict:
+    """Append one typed event to a hosted room idempotently.
+
+    Required params: ``room_id``, ``event_id``, and object ``payload``. Only
+    inert ``message.user`` events are accepted through this client-facing
+    method. The actor is server-owned rather than trusted from params.
+    Admission is durable; no Bot turn is started by this slice.
+    """
+    from gateway.hosted_rooms import (
+        AuthorityConflictError,
+        HostedRoomError,
+        append_event,
+        default_db_path,
+        local_authority_gateway_id,
+        room_state,
+        user_event_id,
+    )
+
+    try:
+        room = room_state(default_db_path(), room_id=params.get("room_id"))
+        local_gateway_id = local_authority_gateway_id()
+        if str(room["authority_gateway_id"]) != local_gateway_id:
+            raise AuthorityConflictError(
+                "This Group Chat is managed by another gateway."
+            )
+        client_event_id = params.get("event_id")
+        event = append_event(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            event_id=user_event_id(client_event_id),
+            kind="message.user",
+            actor={"kind": "user", "id": "desktop"},
+            payload=params.get("payload"),
+            authority_gateway_id=local_gateway_id,
+            authority_epoch=int(room["authority_epoch"]),
+        )
+        return _ok(
+            rid,
+            {
+                "event": event,
+                "client_event_id": client_event_id,
+                "accepted": True,
+                "driver_started": False,
+            },
+        )
+    except HostedRoomError as exc:
+        reason = getattr(exc, "reason", None)
+        return _err(rid, 4111, str(exc), {"reason": reason} if reason else None)
+    except Exception as exc:
+        return _err(rid, 5112, str(exc))
+
+
+@method("groups.disband")
+def _(rid, params: dict) -> dict:
+    """Permanently tombstone a hosted room id."""
+    from gateway.hosted_rooms import (
+        AuthorityConflictError,
+        HostedRoomError,
+        RoomHistoryExpiredError,
+        default_db_path,
+        disband_room,
+        local_authority_gateway_id,
+        room_state,
+    )
+
+    try:
+        local_gateway_id = local_authority_gateway_id()
+        try:
+            room = room_state(
+                default_db_path(),
+                room_id=params.get("room_id"),
+                include_disbanded=True,
+            )
+        except RoomHistoryExpiredError:
+            room = {
+                "authority_gateway_id": local_gateway_id,
+                "authority_epoch": 1,
+            }
+        if str(room["authority_gateway_id"]) != local_gateway_id:
+            raise AuthorityConflictError(
+                "This Group Chat is managed by another gateway."
+            )
+        tombstone = disband_room(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            expected_gateway_id=local_gateway_id,
+            expected_epoch=int(room["authority_epoch"]),
+        )
+        return _ok(rid, {"tombstone": tombstone})
+    except HostedRoomError as exc:
+        reason = getattr(exc, "reason", None)
+        return _err(rid, 4113, str(exc), {"reason": reason} if reason else None)
+    except Exception as exc:
+        return _err(rid, 5114, str(exc))
+
+
+@method("groups.log")
+def _(rid, params: dict) -> dict:
+    """Return a monotonic room-log delta after ``since_seq``."""
+    from gateway.hosted_rooms import HostedRoomError, default_db_path, read_events
+
+    try:
+        delta = read_events(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            since_seq=params.get("since_seq", 0),
+            limit=params.get("limit", 100),
+            include_disbanded=params.get("include_disbanded") is True,
+        )
+        return _ok(rid, delta)
+    except HostedRoomError as exc:
+        reason = getattr(exc, "reason", None)
+        return _err(rid, 4112, str(exc), {"reason": reason} if reason else None)
+    except Exception as exc:
+        return _err(rid, 5113, str(exc))
+
+
+def register(server) -> None:
+    _registry.install(server)

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -1,12 +1,14 @@
 """Hosted-room JSON-RPC contract.
 
-These methods expose durable room identity and an append-only, monotonic room
-log. They deliberately do not drive Bot turns yet. ``groups.capabilities``
-makes that boundary machine-readable so a hosted-aware Desktop cannot mistake
-the log prototype for a complete gateway-side orchestrator.
+These methods expose durable room identity, replay, and the process-owned
+same-gateway Discussion driver. ``groups.capabilities`` keeps that boundary
+machine-readable so older clients stay on the renderer-owned room path.
 """
 
 from .method_ctx import HandlerRegistry
+
+import os
+import threading
 
 _registry = HandlerRegistry()
 method = _registry.method
@@ -23,7 +25,73 @@ LONG_HANDLERS = frozenset({
     "groups.replica_state",
     "groups.promote",
     "groups.demote",
+    "groups.stop",
+    "groups.retry",
+    "groups.approve",
 })
+
+_service_lock = threading.Lock()
+_bound_server = None
+_service = None
+
+
+def bind_server(server) -> None:
+    """Bind the fully initialized server module without starting a worker."""
+
+    global _bound_server
+    _bound_server = server
+
+
+def start_hosted_room_service():
+    """Start one process-owned hosted room service idempotently."""
+
+    global _service
+    if _bound_server is None:
+        return None
+    from gateway.hosted_rooms import default_db_path
+    from tui_gateway.hosted_room_service import HostedRoomService
+
+    db_path = default_db_path()
+    with _service_lock:
+        if _service is not None and _service.db_path != db_path:
+            _service.stop(timeout=1.0)
+            _service = None
+        if _service is None:
+            _service = HostedRoomService(_bound_server, db_path=db_path)
+        _service.start()
+        return _service
+
+
+def stop_hosted_room_service(*, timeout: float = 5.0) -> bool:
+    """Stop the process-owned worker without interrupting accepted turns."""
+
+    global _service
+    with _service_lock:
+        service = _service
+        if service is None:
+            return True
+        stopped = service.stop(timeout=timeout)
+        if stopped and _service is service:
+            _service = None
+        return stopped
+
+
+def get_hosted_room_service():
+    """Return the active service, if its lifecycle owner started it."""
+
+    service = _service
+    if service is None:
+        return None
+    try:
+        status = service.runtime.status()
+    except Exception:
+        return None
+    return service if status.get("running") and not status.get("stopping") else None
+
+
+_WORKER_UNAVAILABLE = (
+    "Group Chat worker is unavailable. Restart the Hermes gateway and try again."
+)
 
 
 @method("groups.capabilities")
@@ -35,11 +103,14 @@ def _(rid, params: dict) -> dict:
         local_authority_gateway_id,
     )
 
+    service = get_hosted_room_service()
+    driver_ready = bool(service and service.runtime.status()["running"])
     return _ok(
         rid,
         {
             "protocol_version": PROTOCOL_VERSION,
-            "driver": False,
+            "driver": driver_ready,
+            "persistent_process": os.getenv("HERMES_DESKTOP") != "1",
             "authority_gateway_id": local_authority_gateway_id(),
             "features": [
                 "authority_epoch",
@@ -65,6 +136,9 @@ def _(rid, params: dict) -> dict:
                 "groups.replica_state",
                 "groups.promote",
                 "groups.demote",
+                "groups.stop",
+                "groups.retry",
+                "groups.approve",
             ],
             "max_log_limit": MAX_LOG_LIMIT,
         },
@@ -108,20 +182,16 @@ def _(rid, params: dict) -> dict:
     Required params: ``room_id``, ``name``, and ``members``. Authority is
     derived from this gateway's stable install identity, never from the client.
     """
-    from gateway.hosted_rooms import (
-        HostedRoomError,
-        create_room,
-        default_db_path,
-        local_authority_gateway_id,
-    )
+    from gateway.hosted_rooms import HostedRoomError
 
     try:
-        room = create_room(
-            default_db_path(),
+        service = get_hosted_room_service()
+        if service is None:
+            return _err(rid, 4123, _WORKER_UNAVAILABLE)
+        room = service.create_room(
             room_id=params.get("room_id"),
             name=params.get("name"),
             members=params.get("members"),
-            authority_gateway_id=local_authority_gateway_id(),
         )
         return _ok(rid, {"room": room})
     except HostedRoomError as exc:
@@ -137,14 +207,21 @@ def _(rid, params: dict) -> dict:
     from gateway.hosted_rooms import HostedRoomError, default_db_path, room_state
 
     try:
+        room = room_state(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            include_disbanded=params.get("include_disbanded") is True,
+        )
+        service = get_hosted_room_service()
         return _ok(
             rid,
             {
-                "room": room_state(
-                    default_db_path(),
-                    room_id=params.get("room_id"),
-                    include_disbanded=params.get("include_disbanded") is True,
-                )
+                "room": room,
+                **(
+                    {"driver_status": service.status(str(room["room_id"]))}
+                    if service is not None and room.get("disbanded_at") is None
+                    else {}
+                ),
             },
         )
     except HostedRoomError as exc:
@@ -163,33 +240,17 @@ def _(rid, params: dict) -> dict:
     method. The actor is server-owned rather than trusted from params.
     Admission is durable; no Bot turn is started by this slice.
     """
-    from gateway.hosted_rooms import (
-        AuthorityConflictError,
-        HostedRoomError,
-        append_event,
-        default_db_path,
-        local_authority_gateway_id,
-        room_state,
-        user_event_id,
-    )
+    from gateway.hosted_rooms import HostedRoomError, user_event_id
 
     try:
-        room = room_state(default_db_path(), room_id=params.get("room_id"))
-        local_gateway_id = local_authority_gateway_id()
-        if str(room["authority_gateway_id"]) != local_gateway_id:
-            raise AuthorityConflictError(
-                "This Group Chat is managed by another gateway."
-            )
         client_event_id = params.get("event_id")
-        event = append_event(
-            default_db_path(),
+        service = get_hosted_room_service()
+        if service is None:
+            return _err(rid, 4123, _WORKER_UNAVAILABLE)
+        event = service.send(
             room_id=params.get("room_id"),
             event_id=user_event_id(client_event_id),
-            kind="message.user",
-            actor={"kind": "user", "id": "desktop"},
             payload=params.get("payload"),
-            authority_gateway_id=local_gateway_id,
-            authority_epoch=int(room["authority_epoch"]),
         )
         return _ok(
             rid,
@@ -197,7 +258,7 @@ def _(rid, params: dict) -> dict:
                 "event": event,
                 "client_event_id": client_event_id,
                 "accepted": True,
-                "driver_started": False,
+                "driver_started": True,
             },
         )
     except HostedRoomError as exc:
@@ -214,41 +275,128 @@ def _(rid, params: dict) -> dict:
         AuthorityConflictError,
         HostedRoomError,
         RoomHistoryExpiredError,
-        default_db_path,
         disband_room,
         local_authority_gateway_id,
         room_state,
     )
 
     try:
-        local_gateway_id = local_authority_gateway_id()
+        service = get_hosted_room_service()
+        if service is None:
+            return _err(rid, 4123, _WORKER_UNAVAILABLE)
+
+        def disband_with_state(state: dict | None = None) -> dict:
+            local_gateway_id = local_authority_gateway_id()
+            if state is not None and (
+                str(state["authority_gateway_id"]) != local_gateway_id
+            ):
+                raise AuthorityConflictError(
+                    "This Group Chat is managed by another gateway."
+                )
+            return disband_room(
+                service.db_path,
+                room_id=params.get("room_id"),
+                expected_gateway_id=str(
+                    local_gateway_id
+                ),
+                expected_epoch=int(
+                    state["authority_epoch"] if state is not None else 1
+                ),
+            )
+
         try:
-            room = room_state(
-                default_db_path(),
+            existing = room_state(
+                service.db_path,
                 room_id=params.get("room_id"),
                 include_disbanded=True,
             )
         except RoomHistoryExpiredError:
-            room = {
-                "authority_gateway_id": local_gateway_id,
-                "authority_epoch": 1,
-            }
-        if str(room["authority_gateway_id"]) != local_gateway_id:
-            raise AuthorityConflictError(
-                "This Group Chat is managed by another gateway."
-            )
-        tombstone = disband_room(
-            default_db_path(),
-            room_id=params.get("room_id"),
-            expected_gateway_id=local_gateway_id,
-            expected_epoch=int(room["authority_epoch"]),
+            tombstone = disband_with_state()
+            return _ok(rid, {"tombstone": tombstone})
+        if existing.get("disbanded_at") is not None:
+            tombstone = disband_with_state(existing)
+            return _ok(rid, {"tombstone": tombstone})
+        service.stop_room(
+            str(params.get("room_id") or ""),
+            cancel_id=str(params.get("cancel_id") or "room-disbanded"),
+            require_acknowledged=True,
         )
+        tombstone = disband_with_state(existing)
         return _ok(rid, {"tombstone": tombstone})
     except HostedRoomError as exc:
         reason = getattr(exc, "reason", None)
         return _err(rid, 4113, str(exc), {"reason": reason} if reason else None)
     except Exception as exc:
         return _err(rid, 5114, str(exc))
+
+
+@method("groups.stop")
+def _(rid, params: dict) -> dict:
+    """Durably cancel queued or running work for one hosted room."""
+
+    service = get_hosted_room_service()
+    if service is None:
+        return _err(rid, 4115, "hosted room driver is unavailable")
+    try:
+        count = service.stop_room(
+            str(params.get("room_id") or ""),
+            cancel_id=str(params.get("cancel_id") or "desktop-stop"),
+        )
+        return _ok(rid, {"cancelled": count})
+    except Exception as exc:
+        return _err(rid, 5116, str(exc))
+
+
+@method("groups.approve")
+def _(rid, params: dict) -> dict:
+    """Resolve one exact approval requested by a local room member."""
+
+    service = get_hosted_room_service()
+    if service is None:
+        return _err(rid, 4115, "hosted room driver is unavailable")
+    try:
+        result = service.approve_room_task(
+            str(params.get("room_id") or ""),
+            member_id=str(params.get("member_id") or ""),
+            task_id=str(params.get("task_id") or ""),
+            execution_generation=int(params.get("execution_generation") or 0),
+            choice=str(params.get("choice") or ""),
+            request_id=str(params.get("request_id") or ""),
+        )
+        return _ok(rid, {"approved": True, "result": result})
+    except Exception as exc:
+        return _err(rid, 5119, str(exc))
+
+
+@method("groups.retry")
+def _(rid, params: dict) -> dict:
+    """Retry one indeterminate room task after explicit user confirmation."""
+
+    service = get_hosted_room_service()
+    if service is None:
+        return _err(rid, 4115, "hosted room driver is unavailable")
+    try:
+        task = service.retry_room_task(
+            str(params.get("room_id") or ""),
+            task_id=str(params.get("task_id") or ""),
+        )
+        identity = task.get("identity") if isinstance(task, dict) else None
+        receipt = {
+            "room_id": str(getattr(identity, "room_id", "") or ""),
+            "task_id": str(getattr(identity, "task_id", "") or ""),
+            "thread_id": str(getattr(identity, "thread_id", "") or ""),
+            "turn_id": str(getattr(identity, "turn_id", "") or ""),
+            "status": str(task.get("status") or "") if isinstance(task, dict) else "",
+            "execution_generation": int(task.get("execution_generation") or 0)
+            if isinstance(task, dict)
+            else 0,
+            "cancel_generation": int(task.get("cancel_generation") or 0)
+            if isinstance(task, dict)
+            else 0,
+        }
+        return _ok(rid, {"retried": True, "task": receipt})
+    except Exception as exc:
+        return _err(rid, 5118, str(exc))
 
 
 @method("groups.log")

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -19,6 +19,10 @@ LONG_HANDLERS = frozenset({
     "groups.send",
     "groups.log",
     "groups.disband",
+    "groups.replicate",
+    "groups.replica_state",
+    "groups.promote",
+    "groups.demote",
 })
 
 
@@ -46,6 +50,8 @@ def _(rid, params: dict) -> dict:
                 "replayable_disband",
                 "typed_events",
                 "actor_identity",
+                "log_replication",
+                "authority_takeover",
             ],
             "methods": [
                 "groups.capabilities",
@@ -55,6 +61,10 @@ def _(rid, params: dict) -> dict:
                 "groups.send",
                 "groups.log",
                 "groups.disband",
+                "groups.replicate",
+                "groups.replica_state",
+                "groups.promote",
+                "groups.demote",
             ],
             "max_log_limit": MAX_LOG_LIMIT,
         },
@@ -260,6 +270,98 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4112, str(exc), {"reason": reason} if reason else None)
     except Exception as exc:
         return _err(rid, 5113, str(exc))
+
+
+@method("groups.replicate")
+def _(rid, params: dict) -> dict:
+    """Persist one authority-stamped replay page into the local replica store.
+
+    ``page`` is the verbatim ``groups.log`` result read from the room's
+    authority gateway; ingest is idempotent and refuses sequence gaps and
+    authority-epoch regressions.
+    """
+    from gateway.hosted_room_replicas import ReplicaError, ingest_page
+    from gateway.hosted_rooms import default_db_path
+
+    try:
+        result = ingest_page(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            room_name=params.get("room_name"),
+            members=params.get("members"),
+            page=params.get("page"),
+        )
+        return _ok(rid, result)
+    except ReplicaError as exc:
+        return _err(rid, 4116, str(exc))
+    except Exception as exc:
+        return _err(rid, 5116, str(exc))
+
+
+@method("groups.replica_state")
+def _(rid, params: dict) -> dict:
+    """Report the local replica's coverage and authority lineage."""
+    from gateway.hosted_room_replicas import ReplicaError, replica_state
+    from gateway.hosted_rooms import default_db_path
+
+    try:
+        return _ok(rid, replica_state(default_db_path(), room_id=params.get("room_id")))
+    except ReplicaError as exc:
+        return _err(rid, 4117, str(exc))
+    except Exception as exc:
+        return _err(rid, 5117, str(exc))
+
+
+@method("groups.promote")
+def _(rid, params: dict) -> dict:
+    """Continue a replicated room on THIS gateway at ``epoch + 1``.
+
+    Requires ``confirm: true`` — the caller asserts the previous authority can
+    no longer commit (explicit user action; a lease/quorum driver later).
+    """
+    from gateway.hosted_room_replicas import ReplicaError, promote_replica
+    from gateway.hosted_rooms import HostedRoomError, default_db_path
+
+    if params.get("confirm") is not True:
+        return _err(
+            rid,
+            4118,
+            "promotion requires confirm=true acknowledging the previous "
+            "authority can no longer commit",
+        )
+    try:
+        result = promote_replica(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            reason=params.get("reason", "authority-unreachable"),
+        )
+        return _ok(rid, result)
+    except ReplicaError as exc:
+        return _err(rid, 4118, str(exc))
+    except HostedRoomError as exc:
+        return _err(rid, 4118, str(exc))
+    except Exception as exc:
+        return _err(rid, 5118, str(exc))
+
+
+@method("groups.demote")
+def _(rid, params: dict) -> dict:
+    """Fence this gateway's stale room authority against a proven newer epoch."""
+    from gateway.hosted_room_replicas import ReplicaError, demote_room
+    from gateway.hosted_rooms import default_db_path
+
+    try:
+        result = demote_room(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            observed_gateway_id=params.get("observed_gateway_id"),
+            observed_epoch=params.get("observed_epoch"),
+        )
+        return _ok(rid, result)
+    except ReplicaError as exc:
+        return _err(rid, 4119, str(exc))
+    except Exception as exc:
+        return _err(rid, 5119, str(exc))
 
 
 def register(server) -> None:

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -335,6 +335,67 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    hosted_task = params.get("_hosted_task")
+    hosted_terminal_callback = params.get("_hosted_terminal_callback")
+    internal_hosted_submit = hosted_task is not None or hosted_terminal_callback is not None
+    if internal_hosted_submit:
+        if session.get("source") != "bot_room":
+            return _err(rid, 4120, "hosted room turns require a bot_room session")
+        if not isinstance(hosted_task, dict) or not callable(hosted_terminal_callback):
+            return _err(rid, 4120, "invalid hosted room turn proof")
+        required_hosted_fields = {
+            "room_id",
+            "task_id",
+            "thread_id",
+            "turn_id",
+            "execution_generation",
+        }
+        if set(hosted_task) != required_hosted_fields or not all(
+            isinstance(hosted_task.get(field), str) and hosted_task[field]
+            for field in required_hosted_fields - {"execution_generation"}
+        ) or not isinstance(hosted_task.get("execution_generation"), int):
+            return _err(rid, 4120, "invalid hosted room turn proof")
+    else:
+        # Older Desktop builds know the `Group: <room-id>` session title but
+        # not the hosted authority marker. Once a gateway owns that room, a
+        # direct prompt into its member session would start a second renderer
+        # driver. Fence it server-side instead of trusting client awareness.
+        title = str(session.get("title") or "")
+        if title.startswith("Group: "):
+            room_id = title.removeprefix("Group: ").strip()
+            if room_id:
+                try:
+                    from gateway.hosted_rooms import (
+                        HostedRoomError,
+                        RoomProbeUnavailableError,
+                        default_db_path,
+                        probe_hosted_room,
+                    )
+
+                    hosted = probe_hosted_room(default_db_path(), room_id=room_id)
+                except RoomProbeUnavailableError:
+                    return _err(
+                        rid,
+                        5122,
+                        "Could not verify this group. Try again after the gateway recovers.",
+                    )
+                except HostedRoomError:
+                    # Legacy Desktop sessions used the display name after
+                    # "Group: "; those names are not hosted room ids.
+                    pass
+                except Exception:
+                    return _err(
+                        rid,
+                        5122,
+                        "Could not verify this group. Try again after the gateway recovers.",
+                    )
+                else:
+                    if hosted:
+                        return _err(
+                            rid,
+                            4122,
+                            "This room is managed by its gateway. Update Hermes Desktop to continue it.",
+                        )
     if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
         return _err(rid, 4090, limit_message)
     # Which desktop window this message was typed into. Rewritten on every
@@ -357,6 +418,12 @@ def _(rid, params: dict) -> dict:
         )
     isolation_cfg = _load_dashboard_process_isolation_config()
     turn_isolation = _session_uses_compute_host(session, isolation_cfg)
+    if internal_hosted_submit and turn_isolation:
+        return _err(
+            rid,
+            4121,
+            "hosted room turns do not support isolated compute workers yet",
+        )
     # Re-bind to the current client transport for this request. This keeps
     # streaming events on the active websocket even if an earlier disconnect
     # or fallback moved the session transport to stdio.
@@ -366,6 +433,8 @@ def _(rid, params: dict) -> dict:
         busy_transport = None
         with session["history_lock"]:
             if session.get("running"):
+                if internal_hosted_submit:
+                    return _err(rid, 4091, "hosted room member session is busy")
                 # Don't reject a mid-turn prompt — queue it (and, by default,
                 # interrupt the live turn) so it runs as the next turn. The
                 # provider interrupt itself must happen after this lock is
@@ -812,6 +881,8 @@ def _(rid, params: dict) -> dict:
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
+        if internal_hosted_submit:
+            session["_hosted_room_task"] = dict(hosted_task)
         _start_inflight_turn(session, text)
 
     if turn_isolation:
@@ -908,7 +979,14 @@ def _(rid, params: dict) -> dict:
                     },
                 )
                 return
-        _run_prompt_submit(rid, sid, session, text, display_kind=display_kind)
+        _run_prompt_submit(
+            rid,
+            sid,
+            session,
+            text,
+            display_kind=display_kind,
+            terminal_callback=hosted_terminal_callback,
+        )
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3361,6 +3361,18 @@ def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
         return err
+    expected_hosted_task_id = str(
+        params.get("expected_hosted_task_id") or ""
+    ).strip()
+    if expected_hosted_task_id:
+        with session["history_lock"]:
+            active_task = session.get("_hosted_room_task")
+            if (
+                not session.get("running")
+                or not isinstance(active_task, dict)
+                or active_task.get("task_id") != expected_hosted_task_id
+            ):
+                return _ok(rid, {"status": "not_interrupted", "interrupted": False})
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
         try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9801,6 +9801,12 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     same _run_prompt_submit machinery as every other synthesized turn — so
     the client that just resumed streams it live.
     """
+    # Hosted room turns are recovered by their durable task/lease state
+    # machine. Generic session auto-continue would bypass its execution
+    # generation and can duplicate work after a process restart.
+    if session.get("source") == "bot_room":
+        return None
+
     home = _session_home(session)
     marker = read_turn_marker(home, session_key)
     if marker is None:
@@ -10280,7 +10286,12 @@ def _inflight_snapshot(session: dict) -> dict | None:
 
 
 def _emit_terminal_turn_error(
-    sid: str, session: dict, error: Any, error_surface: Optional[dict] = None
+    sid: str,
+    session: dict,
+    error: Any,
+    error_surface: Optional[dict] = None,
+    *,
+    retire_marker: bool = True,
 ) -> None:
     """Close a failed turn with a terminal ``message.complete`` frame.
 
@@ -10333,7 +10344,8 @@ def _emit_terminal_turn_error(
         rendered = ""
     if rendered:
         payload["rendered"] = rendered
-    _retire_turn_marker(session)
+    if retire_marker:
+        _retire_turn_marker(session)
     _emit("message.complete", sid, payload)
 
 
@@ -12579,6 +12591,7 @@ def _run_prompt_submit(
     display_metadata: dict | None = None,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    terminal_callback: Callable[[dict[str, Any]], None] | None = None,
 ) -> bool:
     with session["history_lock"]:
         if session.get("_closing"):
@@ -12628,6 +12641,8 @@ def _run_prompt_submit(
     _emit("message.start", sid)
 
     def run():
+        terminal_receipt_attempted = False
+        terminal_receipt_committed = terminal_callback is None
         # The conversation runs on a fresh thread, so ContextVars from the RPC
         # dispatcher do not follow automatically. Rebind the exact transport
         # stored on this session generation before any tool can commission a
@@ -13168,7 +13183,26 @@ def _run_prompt_submit(
                 payload["recoverable"] = True
                 if _error_surface:
                     payload["error_surface"] = _error_surface
-            _retire_turn_marker(session, marker_key)
+            if terminal_callback is not None:
+                terminal_receipt_attempted = True
+                terminal_callback(
+                    {
+                        "status": (
+                            "cancelled"
+                            if status == "interrupted"
+                            else "failed" if status == "error" else "settled"
+                        ),
+                        "text": raw if isinstance(raw, str) else str(raw),
+                        **(
+                            {"error": str(result.get("error") or raw)}
+                            if status == "error" and isinstance(result, dict)
+                            else {}
+                        ),
+                    }
+                )
+                terminal_receipt_committed = True
+            if terminal_receipt_committed:
+                _retire_turn_marker(session, marker_key)
             _emit("message.complete", sid, payload)
 
             # ── /goal continuation (Ralph-style loop) ─────────────────
@@ -13348,11 +13382,25 @@ def _run_prompt_submit(
             # Keep the partial turn available to the next prompt; the durable
             # inflight record still carries the recoverable error state.
             _restore_agent_history_after_turn_error(session, agent)
+            if terminal_callback is not None and not terminal_receipt_attempted:
+                terminal_receipt_attempted = True
+                try:
+                    terminal_callback(
+                        {"status": "failed", "text": "", "error": str(e)}
+                    )
+                    terminal_receipt_committed = True
+                except Exception:
+                    logger.exception("hosted room terminal receipt commit failed")
             try:
                 # Close the turn with the same terminal error frame shape as
                 # the returned-error path (uniform client handling), retaining
                 # the failed turn for resume replay.
-                _emit_terminal_turn_error(sid, session, e)
+                _emit_terminal_turn_error(
+                    sid,
+                    session,
+                    e,
+                    retire_marker=terminal_receipt_committed,
+                )
                 turn_error_retained = True
             except Exception as emit_exc:
                 print(
@@ -13447,7 +13495,10 @@ def _run_prompt_submit(
             )
             # Backstop for turns that never reached a terminal frame (the
             # frame paths retire the marker as they emit).
-            _retire_turn_marker(session, marker_key)
+            if terminal_receipt_committed:
+                _retire_turn_marker(session, marker_key)
+                with session["history_lock"]:
+                    session.pop("_hosted_room_task", None)
             session.pop("_auto_continue_scheduled", None)
             _emit_settled_session_info(sid, session, agent)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12717,9 +12717,12 @@ def _run_prompt_submit(
 
             if isinstance(prompt, str) and "@" in prompt:
                 from agent.context_references import preprocess_context_references
-                from agent.model_metadata import get_model_context_length
+                from agent.model_metadata import effective_context_length
 
-                ctx_len = get_model_context_length(
+                # Effective window (raw capability clamped by the profile-wide
+                # model.max_context_length ceiling) — the ceiling applies to every
+                # invocation, so context-reference admission sizes against it.
+                ctx_len = effective_context_length(
                     getattr(agent, "model", "") or _resolve_model(),
                     base_url=getattr(agent, "base_url", "") or "",
                     api_key=getattr(agent, "api_key", "") or "",

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -235,6 +235,8 @@ delegation:
 
 **Check results.** Subagent summaries are just that — summaries. If a subagent says "fixed the bug and tests pass," verify by running the tests yourself or reading the diff.
 
+**Failures are surfaced.** A subagent that dies (provider error, timeout, crash) is reported with a clean one-line notice — `⚠️ Subagent failed — "your goal": <reason>` — in the CLI delegation tree and as a chat notice on gateway platforms, even when tool progress is turned off. The parent agent also receives the full error in the tool result.
+
 ---
 
 *For the complete delegation reference — all parameters, ACP integration, and advanced configuration — see [Subagent Delegation](/user-guide/features/delegation).*

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1223,13 +1223,18 @@ model:
 
 ### Context Length Detection
 
-:::note Two settings, easy to confuse
-**`context_length`** is the **total context window** — the combined budget for input *and* output tokens (e.g. 200,000 for Claude Opus 4.6). Hermes uses this to decide when to compress history and to validate API requests.
+:::note Three settings, easy to confuse
+**`context_length`** is the **total context window** — the combined budget for input *and* output tokens (e.g. 200,000 for Claude Opus 4.6). It is the **exact pre-cap override** for the *active* model and is discarded on `/model` switch (re-resolved for the new model). Hermes uses this to decide when to compress history and to validate API requests.
+
+**`model.max_context_length`** is the **profile-wide hard upper ceiling** on the effective window: `effective = min(resolved_context, max_context_length)`. Unlike `context_length`, it is a **model-independent policy that survives `/model` switches** and applies to every model in the profile. It never *raises* a window — it only lowers one. It is a runtime policy and never contaminates the persistent `context_length_cache.yaml` (which retains the model's real capability). A request still above the ceiling when it reaches the provider is refused before dispatch, regardless of whether compression is enabled.
 
 **`model.max_tokens`** is the **output cap** — the maximum number of tokens the model may generate in a *single response*. It has nothing to do with how long your conversation history can be. The industry-standard name `max_tokens` is a common source of confusion; Anthropic's native API has since renamed it `max_output_tokens` for clarity.
 
 Set `context_length` when auto-detection gets the window size wrong.
+Set `model.max_context_length` to cap the effective window a profile is allowed to use (a budget or provider-tier ceiling) across every model.
 Set `model.max_tokens` only when you need to limit how long individual responses can be.
+
+**`max_context_length` validation:** must be a positive integer token count with a **minimum of 64000 (64K)**. A value below the floor is an invalid ceiling (a mis-configuration). `bool`, float, numeric strings, `infinity`, and values `<= 0` are all rejected.
 :::
 
 Hermes uses a multi-source resolution chain to detect the correct context window for your model and provider:
@@ -1253,6 +1258,17 @@ model:
   default: "qwen3.5:9b"
   base_url: "http://localhost:8080/v1"
   context_length: 131072  # tokens
+```
+
+To cap the effective window across every model in the profile (a budget or
+provider-tier ceiling that survives `/model` switches), set
+`max_context_length`:
+
+```yaml
+model:
+  default: "some-large-context-model"
+  base_url: "https://api.example.com/v1"
+  # max_context_length: 272000   # hard ceiling; effective = min(resolved, 272000)
 ```
 
 For custom endpoints, you can also set context length per model:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -697,6 +697,7 @@ Connect Hermes to [Photon](https://photon.codes/) / Spectrum (iMessage and other
 | `PHOTON_HOME_CHANNEL_NAME` | Human label for the home channel. |
 | `PHOTON_MARKDOWN` | Send agent replies as markdown — iMessage renders it natively, other Spectrum platforms degrade to plain text (`true`/`false`, default `true`). |
 | `PHOTON_REACTIONS` | Tapback 👀/👍/👎 on messages as processing status and route tapbacks on bot messages to the agent (`true`/`false`, default `false`). |
+| `PHOTON_READ_RECEIPTS` | Mark inbound iMessages read after forwarding to Hermes (`true`/`false`, default `true`). |
 | `PHOTON_TELEMETRY` | Enable Spectrum SDK telemetry in the sidecar (`true`/`false`, default `false`; toggle with `hermes photon telemetry on|off`). |
 | `PHOTON_SIDECAR_PORT` | Loopback port for the Node sidecar control + inbound channel (default `8789`). |
 | `PHOTON_SIDECAR_AUTOSTART` | Spawn the Node sidecar on connect (`true`/`false`, default `true`). |

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -274,6 +274,16 @@ stopwatch kill from other failures without parsing text: `timeout_seconds`
 first request, `after_llm_calls` otherwise). All three are `null` on
 non-timeout errors.
 
+## Failure Visibility
+
+A subagent that fails — non-retryable provider error (404/400), timeout, crash, or no usable output — is never silent:
+
+- **CLI**: the delegation tree prints a one-line reason: `⚠️ Subagent failed — "your goal": HTTP 404: model not found (after 12s)`. Batch runs append the reason to the per-task `✗` completion line.
+- **Gateway platforms** (Telegram, Discord, Slack, ...): the same clean line is delivered as a standalone chat notice, **even when `tool_progress` is off** for that platform.
+- **Parent agent**: the tool result entry carries `status: "failed"` plus the full `error` text, so the model can react (retry, re-route, report).
+
+Error text is reduced to the single most informative line (the exception message, not a traceback wall) and capped in length.
+
 :::tip Diagnostic dump on zero-call timeout
 With a hard cap configured, if a subagent times out having made **zero** API calls (usually: provider unreachable, auth failure, or tool-schema rejection), `delegate_task` writes a structured diagnostic to `~/.hermes/logs/subagent-timeout-<session>-<timestamp>.log` containing the subagent's config snapshot, credential-resolution trace, any early error messages, and stack traces for **all** live threads (not just the child's own) — a child parked waiting on a nested helper thread is indistinguishable from a slow provider without the full picture.
 :::

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -208,6 +208,11 @@ Common issues:
   media.
 - **Native polls are supported.** Hermes sends poll content through
   spectrum-ts' `poll()` builder via the sidecar's `/send-poll` endpoint.
+- **Read receipts are supported.** The sidecar marks an inbound iMessage
+  read after forwarding it to Hermes, so the sender sees `Read` without
+  waiting for a model/tool turn. Inbound receipts for Hermes-sent messages
+  are consumed as presence telemetry and never create an agent turn. Set
+  `PHOTON_READ_RECEIPTS=false` to keep messages at `Delivered`.
 - **Message effects are supported.** Hermes sends text with native iMessage
   bubble/screen effects through spectrum-ts' iMessage `effect()` builder
   via the sidecar's `/send-effect` endpoint.


### PR DESCRIPTION
## Summary

Add `model.max_context_length` as a profile-wide hard ceiling on Hermes's effective operating context.

```text
effective_context = min(invocation_pre_cap_context, profile_max_context_length)
```

The ceiling applies when `model.max_context_length` is valid and configured. It can only lower an invocation's resolved context; it never inflates a smaller model or provider limit.

This extends the `max_context_length` ceiling concept proposed in #70242 from compression-threshold scope to coherent runtime policy, terminal dispatch enforcement, and output reservation.

## Behavior

- `model.max_context_length` is profile-wide and survives model/provider changes.
- `model.context_length` remains an exact per-model pre-cap override, but its effective value is still subject to the profile ceiling.
- `model.max_tokens` remains the per-response output cap.
- Valid ceilings are integers at or above Hermes's existing 64K operating floor. Invalid values are ignored with a ceiling-specific diagnostic.
- Provider/model-resolved pre-cap values remain independently preserved for capability metadata, cache persistence, switching, fallback, and restore-primary behavior.
- Persistent context capability caches remain raw and are not contaminated by profile policy.

## Implementation highlights

- Centralizes strict ceiling validation, effective-limit calculation, output reservation, canonical final-request budgeting, and typed local refusal.
- Keeps active pre-cap and effective context coherent across initialization, explicit context overrides, `/model` switching, provider changes, fallback activation, rollback, and restore-primary.
- Applies each invocation's own pre-cap to auxiliary sync/async calls and MoA reference calls while sharing the profile-wide ceiling.
- Recomputes compression thresholds and budgets from the same effective context and resolved output reservation used at dispatch.
- Enforces the limit on final provider-bound payloads, including Relay-transformed payloads, before physical OpenAI-compatible, Anthropic, Bedrock, Codex, and streaming dispatch.
- Covers iteration-limit summary calls and treats `ContextCeilingExceeded` as a terminal local refusal: no provider call, retry, credential refresh, fallback, or API-call accounting.
- Keeps gateway cached-agent reuse, profile isolation, context-reference admission, TUI/Desktop paths, and status/model reporting aligned with the effective context.
- Preserves plugin compatibility without model-specific ceiling special cases.

## Validation

Fresh bounded processes after the final upstream integration:

- 21/21 Round 5 ownership, Relay/streaming, rollback, restore-primary, and compatibility tests passed.
- 126/126 `max_context_length`, output-reservation, Round 3/Round 4, checkpoint, and switch rollback regressions passed.
- 25/25 additional context-ceiling remediation tests passed.
- 62/62 upstream Codex context-resolution and threshold tests passed.
- 234 total test executions passed; 0 failed.
- `ast.parse`: 34/34 modified or new Python files passed.
- `compileall`: passed.
- `import agent.auxiliary_client`: passed.
- `git diff --cached --check`: clean.
- No conflict markers, unmerged files, or unstaged files.
- Ruff was unavailable in the existing environment and was not installed for this change.

## Compatibility

### #92797

The Codex context variants compose with the generic ceiling without model-specific hacks:

- ordinary Sol: 272K pre-cap + 200K ceiling → 200K effective
- Sol `-900k`: 900K pre-cap + 200K ceiling → 200K effective
- ordinary Sol: 272K pre-cap + 500K ceiling → 272K effective
- Sol `-900k`: 900K pre-cap + 500K ceiling → 500K effective

The Hermes-only `-900k` suffix continues to be stripped before wire dispatch while its resolved pre-cap remains available to the generic ceiling policy.

## Reviewer attention

- The hard limit uses Hermes's canonical approximate final-payload accounting, including resolved output reservation. Provider-native tokenization remains the authoritative backstop where exact tokenizers are unavailable.
- Verify the raw/pre-cap versus effective-context separation: policy must not leak into persistent capability metadata.
- Verify that local ceiling refusal remains terminal and occurs after final payload transformation but before provider I/O or accounting.
- Verify transactional coherence for model switch, fallback activation, rollback, and restore-primary paths.
