### PR TITLE
feat(mcp): make the stateless client path production-authoritative

### DIFF
--- a/.github/workflows/mcp-dual-era-conformance.yml
+++ b/.github/workflows/mcp-dual-era-conformance.yml
@@ -15,6 +15,8 @@ on:
       - "tests/test_mcp_serve.py"
       - "tests/agent/transports/test_hermes_tools_mcp_server.py"
       - "tests/hermes_cli/test_mcp_dashboard_oauth.py"
+      - "tests/website/test_mcp_config_reference.py"
+      - "website/docs/reference/mcp-config-reference.md"
       - ".github/workflows/mcp-dual-era-conformance.yml"
   push:
     branches:
@@ -32,6 +34,8 @@ on:
       - "tests/test_mcp_serve.py"
       - "tests/agent/transports/test_hermes_tools_mcp_server.py"
       - "tests/hermes_cli/test_mcp_dashboard_oauth.py"
+      - "tests/website/test_mcp_config_reference.py"
+      - "website/docs/reference/mcp-config-reference.md"
       - ".github/workflows/mcp-dual-era-conformance.yml"
   workflow_dispatch:
 
@@ -91,6 +95,7 @@ jobs:
             tests/tools/test_mcp_stateless_liveness.py \
             tests/test_mcp_serve.py \
             tests/agent/transports/test_hermes_tools_mcp_server.py \
+            tests/website/test_mcp_config_reference.py \
             tests/tools/test_computer_use.py::TestCuaEnvironmentScrubbing::test_cua_session_sanitizes_provider_env_vars \
             -o addopts= \
             -q

--- a/.github/workflows/mcp-dual-era-conformance.yml
+++ b/.github/workflows/mcp-dual-era-conformance.yml
@@ -90,6 +90,7 @@ jobs:
             tests/tools/test_mcp_mrtr.py \
             tests/tools/test_mcp_subscriptions.py \
             tests/tools/test_mcp_schema_cache.py \
+            tests/tools/test_mcp_list_pagination.py \
             tests/tools/test_mcp_lifecycle.py \
             tests/tools/test_mcp_oauth_issuer.py \
             tests/tools/test_mcp_stateless_liveness.py \

--- a/.github/workflows/mcp-dual-era-conformance.yml
+++ b/.github/workflows/mcp-dual-era-conformance.yml
@@ -1,0 +1,115 @@
+name: MCP Dual-Era Conformance
+
+on:
+  pull_request:
+    paths:
+      - "tools/mcp_*.py"
+      - "tools/mcp_tool.py"
+      - "tools/computer_use/cua_backend.py"
+      - "mcp_serve.py"
+      - "agent/transports/hermes_tools_mcp_server.py"
+      - "hermes_cli/web_routers/mcp.py"
+      - "tui_gateway/mcp_oauth_sessions.py"
+      - "tests/tools/test_mcp_*.py"
+      - "tests/fixtures/mcp_*.py"
+      - "tests/test_mcp_serve.py"
+      - "tests/agent/transports/test_hermes_tools_mcp_server.py"
+      - "tests/hermes_cli/test_mcp_dashboard_oauth.py"
+      - ".github/workflows/mcp-dual-era-conformance.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/mcp_*.py"
+      - "tools/mcp_tool.py"
+      - "tools/computer_use/cua_backend.py"
+      - "mcp_serve.py"
+      - "agent/transports/hermes_tools_mcp_server.py"
+      - "hermes_cli/web_routers/mcp.py"
+      - "tui_gateway/mcp_oauth_sessions.py"
+      - "tests/tools/test_mcp_*.py"
+      - "tests/fixtures/mcp_*.py"
+      - "tests/test_mcp_serve.py"
+      - "tests/agent/transports/test_hermes_tools_mcp_server.py"
+      - "tests/hermes_cli/test_mcp_dashboard_oauth.py"
+      - ".github/workflows/mcp-dual-era-conformance.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-dual-era-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conformance:
+    name: Modern and legacy wire conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          version: "0.9.28"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install locked repository environment
+        run: uv sync --locked --python 3.11 --extra dev --extra mcp
+
+      - name: Create isolated legacy MCP environment
+        run: |
+          uv venv --python 3.11 .mcp-legacy
+          uv pip install --python .mcp-legacy/bin/python "mcp==1.28.1"
+
+      - name: Run dual-era lifecycle conformance
+        env:
+          MCP_LEGACY_PYTHON: ${{ github.workspace }}/.mcp-legacy/bin/python
+          OPENAI_API_KEY: ""
+          OPENROUTER_API_KEY: ""
+          NOUS_API_KEY: ""
+        run: |
+          source .venv/bin/activate
+          python -m pytest \
+            tests/tools/test_mcp_protocol_negotiation.py \
+            tests/tools/test_mcp_preflight_content_type.py \
+            tests/tools/test_mcp_dual_era_wire.py \
+            tests/tools/test_mcp_mrtr.py \
+            tests/tools/test_mcp_subscriptions.py \
+            tests/tools/test_mcp_schema_cache.py \
+            tests/tools/test_mcp_lifecycle.py \
+            tests/tools/test_mcp_oauth_issuer.py \
+            tests/tools/test_mcp_stateless_liveness.py \
+            tests/test_mcp_serve.py \
+            tests/agent/transports/test_hermes_tools_mcp_server.py \
+            tests/tools/test_computer_use.py::TestCuaEnvironmentScrubbing::test_cua_session_sanitizes_provider_env_vars \
+            -o addopts= \
+            -q
+
+      - name: Run static conformance checks
+        run: |
+          source .venv/bin/activate
+          python -m ruff check \
+            tools/mcp_protocol.py \
+            tools/mcp_tool.py \
+            tools/mcp_schema_cache.py \
+            tools/mcp_oauth.py \
+            tools/mcp_oauth_manager.py \
+            tests/tools
+          python -m py_compile \
+            tools/mcp_protocol.py \
+            tools/mcp_tool.py \
+            tools/mcp_schema_cache.py \
+            tools/mcp_oauth.py \
+            tools/mcp_oauth_manager.py
+          uv lock --check
+          git diff --check

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -338,6 +338,7 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    iss: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -360,7 +361,7 @@ async def mcp_oauth_callback(
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
     try:
-        flow.deliver_callback(code=code, state=state, error=error)
+        flow.deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         reason = str(exc)
         status_code = 409 if "already received" in reason else 400

--- a/tests/fixtures/mcp_legacy_client.py
+++ b/tests/fixtures/mcp_legacy_client.py
@@ -1,0 +1,76 @@
+import asyncio
+import json
+import sys
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+
+
+def _is_error(result) -> bool:
+    return bool(
+        getattr(result, "is_error", False)
+        or getattr(result, "isError", False)
+    )
+
+
+def _text(result) -> str:
+    return "".join(
+        getattr(block, "text", "") or ""
+        for block in (getattr(result, "content", None) or [])
+    )
+
+
+async def _run(tool_name: str, arguments: dict, server_argv: list[str]) -> dict:
+    params = StdioServerParameters(
+        command=server_argv[0],
+        args=server_argv[1:],
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            initialized = await session.initialize()
+            tools = await session.list_tools()
+            call = await session.call_tool(tool_name, arguments=arguments)
+            missing_error = None
+            try:
+                missing = await session.call_tool(
+                    "__missing_protocol_probe__",
+                    arguments={},
+                )
+                missing_error = _is_error(missing)
+            except Exception as exc:
+                missing_error = type(exc).__name__
+            return {
+                "protocol_version": (
+                    getattr(initialized, "protocol_version", None)
+                    or getattr(initialized, "protocolVersion", None)
+                    or getattr(session, "protocol_version", None)
+                ),
+                "tools": sorted(tool.name for tool in tools.tools),
+                "call_error": _is_error(call),
+                "call_text": _text(call),
+                "missing_error": missing_error,
+            }
+
+
+def main() -> int:
+    if len(sys.argv) < 4:
+        sys.stderr.write(
+            "usage: mcp_legacy_client.py <tool_name> <arguments-json> <server-command...>\n"
+        )
+        return 2
+    try:
+        result = asyncio.run(
+            _run(
+                sys.argv[1],
+                json.loads(sys.argv[2]),
+                sys.argv[3:],
+            )
+        )
+    except Exception as exc:
+        sys.stderr.write(f"{type(exc).__name__}: {exc}\n")
+        return 1
+    sys.stdout.write(json.dumps(result, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/mcp_legacy_server.py
+++ b/tests/fixtures/mcp_legacy_server.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+
+server = FastMCP("legacy-fixture")
+
+
+@server.tool(name="ping_echo", description="Return a deterministic pong response.")
+def ping_echo() -> str:
+    return "pong"
+
+
+@server.tool(name="application_error", description="Raise a deterministic application error.")
+def application_error() -> str:
+    raise RuntimeError("fixture application error")
+
+
+@server.tool(name="slow_echo", description="Return after a bounded delay.")
+async def slow_echo(delay_ms: int = 5_000) -> str:
+    await asyncio.sleep(delay_ms / 1_000)
+    return "slow-pong"
+
+
+@server.tool(name="crash_transport", description="Terminate the fixture transport.")
+def crash_transport() -> str:
+    os._exit(17)
+
+
+if __name__ == "__main__":
+    server.run()

--- a/tests/fixtures/mcp_modern_server.py
+++ b/tests/fixtures/mcp_modern_server.py
@@ -1,0 +1,109 @@
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+import threading
+
+from mcp.server import MCPServer
+
+
+server = MCPServer("modern-fixture")
+
+
+@server.tool(name="ping_echo", description="Return a deterministic pong response.")
+def ping_echo() -> str:
+    return "pong"
+
+
+@server.tool(name="application_error", description="Raise a deterministic application error.")
+def application_error() -> str:
+    raise RuntimeError("fixture application error")
+
+
+@server.tool(name="slow_echo", description="Return after a bounded delay.")
+async def slow_echo(delay_ms: int = 5_000) -> str:
+    await asyncio.sleep(delay_ms / 1_000)
+    return "slow-pong"
+
+
+@server.tool(name="crash_transport", description="Terminate the fixture transport.")
+def crash_transport() -> str:
+    os._exit(17)
+
+
+class CaptureMiddleware:
+    def __init__(self, app, path: Path) -> None:
+        self.app = app
+        self.path = path
+        self.lock = threading.Lock()
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        messages = []
+        body = bytearray()
+        while True:
+            message = await receive()
+            messages.append(message)
+            body.extend(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+
+        headers = {
+            key.decode("latin-1").lower(): value.decode("latin-1")
+            for key, value in scope.get("headers", [])
+        }
+        try:
+            payload = json.loads(bytes(body) or b"{}")
+        except (TypeError, ValueError):
+            payload = {}
+        record = {
+            "method": payload.get("method"),
+            "session_id": headers.get("mcp-session-id"),
+        }
+        with self.lock:
+            with self.path.open("a", encoding="utf-8", newline="\n") as handle:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+        index = 0
+
+        async def replay():
+            nonlocal index
+            if index < len(messages):
+                message = messages[index]
+                index += 1
+                return message
+            return {"type": "http.disconnect"}
+
+        await self.app(scope, replay, send)
+
+
+def main() -> int:
+    if "--http" not in sys.argv:
+        server.run()
+        return 0
+
+    import uvicorn
+
+    port = int(sys.argv[sys.argv.index("--http") + 1])
+    capture = Path(sys.argv[sys.argv.index("--capture") + 1])
+    app = server.streamable_http_app(
+        streamable_http_path="/mcp",
+        json_response=True,
+        stateless_http=True,
+        host="127.0.0.1",
+    )
+    uvicorn.run(
+        CaptureMiddleware(app, capture),
+        host="127.0.0.1",
+        port=port,
+        log_level="critical",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -83,7 +83,7 @@ def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert flow._callback == ("abc", "expected")
+    assert flow._callback == ("abc", "expected", None)
 
 
 def test_hosted_auth_allows_same_server_name_in_different_profiles(tmp_path, monkeypatch):
@@ -130,7 +130,7 @@ def test_flow_status_does_not_expose_authorization_code():
     )
     flow.authorization_url = "https://idp.example/authorize"
     flow.status = "approved"
-    flow._callback = ("secret-code", "secret-state")
+    flow._callback = ("secret-code", "secret-state", "https://issuer.example")
     web_server._mcp_oauth_flows[flow.flow_id] = flow
 
     response = _client().get("/api/mcp/oauth/flows/flow-status")

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1571,6 +1571,14 @@ class TestCuaEnvironmentScrubbing:
         session = _CuaDriverSession(bridge)
 
         captured_env: Dict[str, str] = {}
+        captured_session = {}
+        captured_negotiation = {}
+
+        from tools.mcp_protocol import negotiate_protocol as negotiate_protocol_impl
+
+        async def capture_negotiation(*args, **kwargs):
+            captured_negotiation["session"] = args[0]
+            return await negotiate_protocol_impl(*args, **kwargs)
 
         async def drive_lifecycle():
             test_env = {
@@ -1578,6 +1586,8 @@ class TestCuaEnvironmentScrubbing:
                 "ANTHROPIC_API_KEY": "sk-ant-secret",  # blocked
                 "PATH": "/usr/bin:/bin",               # safe
                 "HOME": "/home/user",                  # safe
+                "USERPROFILE": r"C:\Users\test",
+                "LOCALAPPDATA": r"C:\Users\test\AppData\Local",
                 "SAFE_VAR": "allowed",                 # safe
             }
 
@@ -1594,7 +1604,9 @@ class TestCuaEnvironmentScrubbing:
                        return_value=("cua-driver", ["mcp"])), \
                  patch("mcp.StdioServerParameters", side_effect=capture_env), \
                  patch("mcp.client.stdio.stdio_client") as mock_stdio, \
-                 patch("mcp.ClientSession") as mock_session_class:
+                 patch("mcp.ClientSession") as mock_session_class, \
+                 patch("tools.mcp_protocol.negotiate_protocol",
+                       side_effect=capture_negotiation):
 
                 # stdio_client(params) is used as `async with`.
                 mock_stdio.return_value.__aenter__ = AsyncMock(
@@ -1604,6 +1616,9 @@ class TestCuaEnvironmentScrubbing:
                 # ClientSession(read, write) is used as `async with`.
                 fake_session = MagicMock()
                 fake_session.initialize = AsyncMock()
+                fake_session.discover = AsyncMock()
+                fake_session.protocol_version = "2026-07-28"
+                captured_session["value"] = fake_session
                 # tools/list yields nothing — keeps _populate_capabilities
                 # quiet without us needing to fully mock the response shape.
                 fake_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
@@ -1626,8 +1641,6 @@ class TestCuaEnvironmentScrubbing:
                 signal_task = asyncio.create_task(_signal_shutdown_when_ready())
                 try:
                     await session._lifecycle_coro()
-                except BaseException:
-                    pass  # mocks may raise; the env capture still landed
                 finally:
                     signal_task.cancel()
                     try:
@@ -1642,6 +1655,11 @@ class TestCuaEnvironmentScrubbing:
             "OPENAI_API_KEY should be stripped from cua-driver subprocess"
         assert "ANTHROPIC_API_KEY" not in captured_env, \
             "ANTHROPIC_API_KEY should be stripped from cua-driver subprocess"
+        assert session._setup_error is None, repr(session._setup_error)
+        assert captured_negotiation
+        assert captured_negotiation["session"] is captured_session["value"]
+        assert captured_session["value"].discover.await_count == 1
+        assert captured_session["value"].initialize.await_count == 0
         # At least one safe var must survive the scrub.
         assert "PATH" in captured_env or "SAFE_VAR" in captured_env, \
             "At least one safe environment variable should be preserved"
@@ -2317,7 +2335,7 @@ class TestStartupTimeoutPhaseDetail:
         session._ready_event = threading.Event()  # never set → timeout path
         session._setup_error = None
         session._shutdown_event = None
-        session._startup_phase = "mcp-initialize"
+        session._startup_phase = "mcp-negotiate"
         session._signal_shutdown_locked = lambda: None
 
         fake_bridge = MagicMock()
@@ -2346,7 +2364,7 @@ class TestStartupTimeoutPhaseDetail:
                 assert False, "expected RuntimeError"
             except RuntimeError as e:
                 msg = str(e)
-                assert "stuck in phase: mcp-initialize" in msg
+                assert "stuck in phase: mcp-negotiate" in msg
                 assert "computer-use doctor" in msg
 
 

--- a/tests/tools/test_mcp_client_cert.py
+++ b/tests/tools/test_mcp_client_cert.py
@@ -131,6 +131,9 @@ class TestHTTPClientCert:
             async def initialize(self):
                 return None
 
+            async def discover(self):
+                return None
+
         async def _discover_tools(self):
             self._shutdown_event.set()
 
@@ -206,6 +209,7 @@ def patch_sse_client():
         async def __aenter__(self):
             mock_session = MagicMock()
             mock_session.initialize = AsyncMock()
+            mock_session.discover = AsyncMock()
             return mock_session
 
         async def __aexit__(self, *a):

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -26,8 +26,8 @@ def test_dashboard_flow_exposes_authorization_url_and_accepts_callback():
         "error": None,
     }
 
-    flow.deliver_callback(code="code-1", state="s1", error=None)
-    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1")
+    flow.deliver_callback(code="code-1", state="s1", error=None, iss=None)
+    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1", None)
 
 
 def test_dashboard_flow_accepts_only_one_concurrent_callback():
@@ -91,11 +91,20 @@ def test_mcp_oauth_helpers_use_dashboard_flow_without_loopback_port():
                 "https://idp.example/authorize?state=state-4"
             )
         )
-        flow.deliver_callback(code="code-4", state="state-4", error=None)
+        flow.deliver_callback(
+            code="code-4",
+            state="state-4",
+            error=None,
+            iss="https://idp.example",
+        )
         # mcp 2.0's callback_handler contract returns an
         # AuthorizationCodeResult, not the legacy (code, state) tuple.
         result = asyncio.run(_make_callback_waiter(0)())
-        assert (result.code, result.state) == ("code-4", "state-4")
+        assert (result.code, result.state, result.iss) == (
+            "code-4",
+            "state-4",
+            "https://idp.example",
+        )
 
     assert flow.authorization_url == "https://idp.example/authorize?state=state-4"
 

--- a/tests/tools/test_mcp_dual_era_wire.py
+++ b/tests/tools/test_mcp_dual_era_wire.py
@@ -1,0 +1,589 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+from typing import Any
+
+import psutil
+import pytest
+
+import tools.mcp_tool as mcp_tool
+from tools.mcp_tool import MCPServerTask
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEGACY_SERVER = REPO_ROOT / "tests" / "fixtures" / "mcp_legacy_server.py"
+LEGACY_CLIENT = REPO_ROOT / "tests" / "fixtures" / "mcp_legacy_client.py"
+MODERN_SERVER = REPO_ROOT / "tests" / "fixtures" / "mcp_modern_server.py"
+
+
+class _CountingSession:
+    def __init__(self, session: Any) -> None:
+        self._session = session
+        self.calls: list[str] = []
+
+    @property
+    def protocol_version(self) -> str | None:
+        return self._session.protocol_version
+
+    async def discover(self):
+        self.calls.append("server/discover")
+        return await self._session.discover()
+
+    async def initialize(self):
+        self.calls.append("initialize")
+        return await self._session.initialize()
+
+
+def _legacy_python() -> str:
+    path = os.environ.get("MCP_LEGACY_PYTHON")
+    if not path or not Path(path).is_file():
+        pytest.skip("MCP_LEGACY_PYTHON must point to the isolated mcp==1.28.1 interpreter")
+    return path
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _result_text(result: Any) -> str:
+    return "".join(
+        getattr(block, "text", "") or ""
+        for block in (getattr(result, "content", None) or [])
+    )
+
+
+async def _wait_until(predicate, timeout: float = 30.0) -> None:
+    async with asyncio.timeout(timeout):
+        while not predicate():
+            await asyncio.sleep(0.02)
+
+
+async def _shutdown_without_leaks(
+    task: MCPServerTask,
+    baseline_tasks: set[asyncio.Task],
+    baseline_children: set[int],
+) -> None:
+    await task.shutdown()
+    await asyncio.sleep(0)
+    assert task._task is not None and task._task.done()
+    assert task.session is None
+    assert not task._pending_refresh_tasks
+    assert not task._pending_mrtr_tasks
+    assert task._listen_task is None or task._listen_task.done()
+    current = asyncio.current_task()
+    leaked_tasks = {
+        pending
+        for pending in asyncio.all_tasks()
+        if pending not in baseline_tasks
+        and pending is not current
+        and not pending.done()
+    }
+    assert leaked_tasks == set()
+    live_children = {
+        child.pid
+        for child in psutil.Process().children(recursive=True)
+        if child.is_running()
+    }
+    assert live_children - baseline_children == set()
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _wait_for_port(port: int, process: subprocess.Popen, timeout: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"stateless fixture exited with {process.returncode}")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.settimeout(0.1)
+            if probe.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(0.05)
+    raise TimeoutError(f"stateless fixture did not listen on port {port}")
+
+
+def _legacy_client_report(tool_name: str, arguments: dict, server_argv: list[str]) -> dict:
+    completed = subprocess.run(
+        [
+            _legacy_python(),
+            str(LEGACY_CLIENT),
+            tool_name,
+            json.dumps(arguments),
+            *server_argv,
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, "HERMES_QUIET": "1"},
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return json.loads(completed.stdout)
+
+
+def test_auto_modern_wire_sends_discover_without_initialize():
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-c", "import mcp_serve; mcp_serve.run_mcp_server()"],
+        env={**os.environ, "HERMES_QUIET": "1"},
+    )
+
+    async def drive() -> None:
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                counted = _CountingSession(session)
+                task = MCPServerTask("modern-wire")
+                task._config = {"protocol": "auto", "command": sys.executable}
+                result = await task._negotiate_session(counted, 30)
+                assert result is not None
+                tools = await session.list_tools()
+                assert any(tool.name == "conversations_list" for tool in tools.tools)
+                call = await session.call_tool("conversations_list", arguments={})
+                assert not call.is_error
+                assert counted.calls == ["server/discover"]
+                assert task.negotiated_era == "modern"
+
+    _run(drive())
+
+
+def test_auto_legacy_wire_attempts_modern_then_proves_legacy_once():
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(
+        command=_legacy_python(),
+        args=[str(LEGACY_SERVER)],
+    )
+
+    async def drive() -> None:
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                counted = _CountingSession(session)
+                task = MCPServerTask("legacy-wire")
+                task._config = {"protocol": "auto", "command": _legacy_python()}
+                result = await task._negotiate_session(counted, 30)
+                assert result is not None
+                tools = await session.list_tools()
+                assert "ping_echo" in {tool.name for tool in tools.tools}
+                call = await session.call_tool("ping_echo", arguments={})
+                text = "".join(
+                    getattr(block, "text", "") or "" for block in call.content
+                )
+                assert text.strip() == "pong"
+                assert counted.calls == ["server/discover", "initialize"]
+                assert task.negotiated_era == "legacy"
+                assert task._protocol_state is not None
+                assert task._protocol_state.legacy_proof_attempted is True
+
+    _run(drive())
+
+
+def test_strict_modern_legacy_wire_never_initializes():
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    from mcp.shared.exceptions import MCPError
+
+    params = StdioServerParameters(
+        command=_legacy_python(),
+        args=[str(LEGACY_SERVER)],
+    )
+
+    async def drive() -> None:
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                counted = _CountingSession(session)
+                task = MCPServerTask("strict-modern-wire")
+                task._config = {"protocol": "2026-07-28", "command": _legacy_python()}
+                with pytest.raises(MCPError):
+                    await task._negotiate_session(counted, 30)
+                assert counted.calls == ["server/discover"]
+                assert task.negotiated_era is None
+
+    _run(drive())
+
+
+def test_explicit_legacy_wire_sends_initialize_without_discover():
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(
+        command=_legacy_python(),
+        args=[str(LEGACY_SERVER)],
+    )
+
+    async def drive() -> None:
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                counted = _CountingSession(session)
+                task = MCPServerTask("strict-legacy-wire")
+                task._config = {"protocol": "legacy", "command": _legacy_python()}
+                result = await task._negotiate_session(counted, 30)
+                assert result is not None
+                tools = await session.list_tools()
+                assert "ping_echo" in {tool.name for tool in tools.tools}
+                call = await session.call_tool("ping_echo", arguments={})
+                assert _result_text(call).strip() == "pong"
+                assert counted.calls == ["initialize"]
+                assert task.negotiated_era == "legacy"
+
+    _run(drive())
+
+
+@pytest.mark.parametrize(
+    ("server_args", "success_tool", "success_args", "error_tool", "error_args", "error_text"),
+    [
+        (
+            ["-c", "import mcp_serve; mcp_serve.run_mcp_server()"],
+            "conversations_list",
+            {},
+            "conversation_get",
+            {"session_key": "missing-wire-session"},
+            "Conversation not found",
+        ),
+        (
+            ["-m", "agent.transports.hermes_tools_mcp_server"],
+            "skills_list",
+            {},
+            "skill_view",
+            {"name": "missing-wire-skill"},
+            "not found",
+        ),
+    ],
+    ids=["mcp-serve", "hermes-tools"],
+)
+def test_production_lifecycle_runs_both_first_party_server_surfaces(
+    server_args,
+    success_tool,
+    success_args,
+    error_tool,
+    error_args,
+    error_text,
+    tmp_path,
+    monkeypatch,
+):
+    async def drive() -> None:
+        mcp_tool._ensure_mcp_sdk()
+        real_session = mcp_tool.ClientSession
+        calls: list[str] = []
+
+        class RecordingSession(real_session):
+            async def discover(self):
+                calls.append("server/discover")
+                return await super().discover()
+
+            async def initialize(self):
+                calls.append("initialize")
+                return await super().initialize()
+
+        monkeypatch.setattr(mcp_tool, "ClientSession", RecordingSession)
+        baseline_tasks = set(asyncio.all_tasks())
+        baseline_children = {
+            child.pid for child in psutil.Process().children(recursive=True)
+        }
+        task = MCPServerTask(f"first-party-{success_tool}")
+        try:
+            await asyncio.wait_for(
+                task.start(
+                    {
+                        "protocol": "auto",
+                        "command": sys.executable,
+                        "args": server_args,
+                        "env": {
+                            "HERMES_HOME": str(tmp_path),
+                            "HERMES_QUIET": "1",
+                        },
+                        "connect_timeout": 45,
+                    }
+                ),
+                timeout=60,
+            )
+            initial_generation = task._connection_generation
+            initial_session = task.session
+            assert initial_session is not None
+            assert task.negotiated_era == "modern"
+            assert success_tool in {tool.name for tool in task._tools}
+            initial_discovery_count = calls.count("server/discover")
+            assert initial_discovery_count >= 1
+
+            async with task._rpc_lock:
+                success = await initial_session.call_tool(
+                    success_tool,
+                    arguments=success_args,
+                )
+                application_error = await initial_session.call_tool(
+                    error_tool,
+                    arguments=error_args,
+                )
+                protocol_error = await initial_session.call_tool(
+                    "__missing_protocol_probe__",
+                    arguments={},
+                )
+            assert not getattr(success, "is_error", False)
+            assert error_text.lower() in _result_text(application_error).lower()
+            assert getattr(protocol_error, "is_error", False)
+
+            task._reconnect_event.set()
+            await _wait_until(
+                lambda: task._connection_generation > initial_generation
+                and task.session is not None
+                and task.session is not initial_session,
+                timeout=45,
+            )
+            async with task._rpc_lock:
+                reconnected = await task.session.call_tool(
+                    success_tool,
+                    arguments=success_args,
+            )
+            assert not getattr(reconnected, "is_error", False)
+            assert "initialize" not in calls
+            assert calls.count("server/discover") > initial_discovery_count
+        finally:
+            await _shutdown_without_leaks(
+                task,
+                baseline_tasks,
+                baseline_children,
+            )
+
+    _run(drive())
+
+
+@pytest.mark.parametrize(
+    ("protocol", "command", "server_path", "expected_calls", "expected_era"),
+    [
+        (
+            "2026-07-28",
+            sys.executable,
+            MODERN_SERVER,
+            ["server/discover", "server/discover"],
+            "modern",
+        ),
+        (
+            "auto",
+            None,
+            LEGACY_SERVER,
+            ["server/discover", "initialize", "server/discover", "initialize"],
+            "legacy",
+        ),
+    ],
+    ids=["modern", "legacy"],
+)
+def test_production_lifecycle_cancellation_interruption_reconnect_and_cleanup(
+    protocol,
+    command,
+    server_path,
+    expected_calls,
+    expected_era,
+    tmp_path,
+    monkeypatch,
+):
+    async def drive() -> None:
+        mcp_tool._ensure_mcp_sdk()
+        real_session = mcp_tool.ClientSession
+        calls: list[str] = []
+
+        class RecordingSession(real_session):
+            async def discover(self):
+                calls.append("server/discover")
+                return await super().discover()
+
+            async def initialize(self):
+                calls.append("initialize")
+                return await super().initialize()
+
+        monkeypatch.setattr(mcp_tool, "ClientSession", RecordingSession)
+        baseline_tasks = set(asyncio.all_tasks())
+        baseline_children = {
+            child.pid for child in psutil.Process().children(recursive=True)
+        }
+        task = MCPServerTask(f"lifecycle-{expected_era}")
+        executable = command or _legacy_python()
+        try:
+            await asyncio.wait_for(
+                task.start(
+                    {
+                        "protocol": protocol,
+                        "command": executable,
+                        "args": [str(server_path)],
+                        "env": {
+                            "HERMES_HOME": str(tmp_path),
+                            "HERMES_QUIET": "1",
+                        },
+                        "connect_timeout": 30,
+                        "keepalive_interval": 5,
+                    }
+                ),
+                timeout=45,
+            )
+            assert task.negotiated_era == expected_era
+            assert {"ping_echo", "application_error", "slow_echo", "crash_transport"} <= {
+                tool.name for tool in task._tools
+            }
+            current_session = task.session
+            assert current_session is not None
+
+            application_error = await current_session.call_tool(
+                "application_error",
+                arguments={},
+            )
+            assert getattr(application_error, "is_error", False)
+            assert "fixture application error" in _result_text(application_error)
+
+            pending_call = asyncio.create_task(
+                current_session.call_tool(
+                    "slow_echo",
+                    arguments={"delay_ms": 10_000},
+                )
+            )
+            await asyncio.sleep(0.1)
+            pending_call.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await pending_call
+
+            healthy = await current_session.call_tool("ping_echo", arguments={})
+            assert _result_text(healthy).strip() == "pong"
+            generation = task._connection_generation
+            with pytest.raises(Exception):
+                await current_session.call_tool("crash_transport", arguments={})
+            await _wait_until(
+                lambda: task._connection_generation > generation
+                and task.session is not None
+                and task.session is not current_session,
+                timeout=45,
+            )
+            recovered = await task.session.call_tool("ping_echo", arguments={})
+            assert _result_text(recovered).strip() == "pong"
+            assert calls == expected_calls
+        finally:
+            await _shutdown_without_leaks(
+                task,
+                baseline_tasks,
+                baseline_children,
+            )
+
+    _run(drive())
+
+
+def test_stateless_http_wire_has_no_initialize_or_session_id(tmp_path):
+    port = _free_port()
+    capture = tmp_path / "wire.jsonl"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            str(MODERN_SERVER),
+            "--http",
+            str(port),
+            "--capture",
+            str(capture),
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, "HERMES_HOME": str(tmp_path), "HERMES_QUIET": "1"},
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        _wait_for_port(port, process)
+
+        async def drive() -> None:
+            task = MCPServerTask("stateless-http-wire")
+            baseline_tasks = set(asyncio.all_tasks())
+            baseline_children = {
+                child.pid for child in psutil.Process().children(recursive=True)
+            }
+            try:
+                await asyncio.wait_for(
+                    task.start(
+                        {
+                            "protocol": "2026-07-28",
+                            "url": f"http://127.0.0.1:{port}/mcp",
+                            "skip_preflight": True,
+                            "connect_timeout": 30,
+                        }
+                    ),
+                    timeout=45,
+                )
+                assert task.negotiated_era == "modern"
+                assert task.liveness_strategy == "stateless-discover"
+                result = await task.session.call_tool("ping_echo", arguments={})
+                assert _result_text(result).strip() == "pong"
+            finally:
+                await _shutdown_without_leaks(
+                    task,
+                    baseline_tasks,
+                    baseline_children,
+                )
+
+        _run(drive())
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+
+    records = [json.loads(line) for line in capture.read_text(encoding="utf-8").splitlines()]
+    methods = [record["method"] for record in records if record["method"]]
+    assert methods[0] == "server/discover"
+    assert "initialize" not in methods
+    assert "tools/list" in methods
+    assert "tools/call" in methods
+    assert all(record["session_id"] is None for record in records)
+
+
+@pytest.mark.parametrize(
+    ("server_argv", "tool_name", "arguments", "expected_text"),
+    [
+        (
+            [sys.executable, "-c", "import mcp_serve; mcp_serve.run_mcp_server()"],
+            "conversations_list",
+            {},
+            "conversations",
+        ),
+        (
+            [sys.executable, "-m", "agent.transports.hermes_tools_mcp_server"],
+            "skills_list",
+            {},
+            "skills",
+        ),
+        (
+            [None, str(LEGACY_SERVER)],
+            "ping_echo",
+            {},
+            "pong",
+        ),
+    ],
+    ids=["mcp-serve", "hermes-tools", "legacy-fixture"],
+)
+def test_legacy_sdk_client_real_wire_matrix(
+    server_argv,
+    tool_name,
+    arguments,
+    expected_text,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    argv = [(_legacy_python() if part is None else part) for part in server_argv]
+    report = _legacy_client_report(tool_name, arguments, argv)
+    assert report["protocol_version"] == "2025-11-25"
+    assert tool_name in report["tools"]
+    assert report["call_error"] is False
+    assert expected_text in report["call_text"]
+    assert report["missing_error"]

--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -107,15 +107,29 @@ class TestMessageHandler:
             mock_schedule.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_ignores_exceptions_and_other_messages(self):
+    async def test_transport_exception_requests_reconnect_and_ignores_other_messages(self):
         server = MCPServerTask("notif_srv")
         with patch.object(MCPServerTask, "_schedule_tools_refresh") as mock_schedule:
             handler = server._make_message_handler()
-            # Exceptions should not trigger refresh
             await handler(RuntimeError("connection dead"))
-            # Unknown message types should not trigger refresh
+            assert server._reconnect_event.is_set()
+            server._reconnect_event.clear()
             await handler({"jsonrpc": "2.0", "result": "ok"})
+            assert not server._reconnect_event.is_set()
             mock_schedule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stale_generation_handler_cannot_request_reconnect(self):
+        server = MCPServerTask("notif_srv")
+        server._connection_generation = 1
+        handler = server._make_message_handler(1)
+        server._connection_generation = 2
+        server.catalogue_state = "current"
+
+        await handler(RuntimeError("stale connection dead"))
+
+        assert not server._reconnect_event.is_set()
+        assert server.catalogue_state == "current"
 
 
 class TestDeregister:

--- a/tests/tools/test_mcp_identity_header.py
+++ b/tests/tools/test_mcp_identity_header.py
@@ -172,6 +172,9 @@ def _drive_http(server, config):
         async def initialize(self):
             return None
 
+        async def discover(self):
+            return None
+
     async def _discover_tools(self):
         self._shutdown_event.set()
 

--- a/tests/tools/test_mcp_initial_connect_shutdown.py
+++ b/tests/tools/test_mcp_initial_connect_shutdown.py
@@ -118,7 +118,7 @@ def test_initial_connect_failure_revives_same_registered_server(monkeypatch, tmp
     mock_registry = ToolRegistry()
 
     class _Session:
-        async def call_tool(self, name, arguments):
+        async def call_tool(self, name, arguments, **_kwargs):
             state["tool_calls"] += 1
             return SimpleNamespace(
                 isError=False,

--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -92,6 +92,97 @@ class TestLazyMcpRegistration:
 
         mock_run.assert_called_once()
 
+    def test_auto_lazy_expired_legacy_receipt_forces_live_connect(
+        self, monkeypatch, tmp_path
+    ):
+        import tools.mcp_schema_cache as schema_cache
+
+        config = _lazy_config()
+        server_config = config["playwright"]
+        monkeypatch.setattr(
+            schema_cache, "_cache_path", lambda: tmp_path / "cache.json"
+        )
+        now = 10_000.0
+        monkeypatch.setattr(schema_cache.time, "time", lambda: now)
+        fingerprint = schema_cache.config_fingerprint(
+            server_config, server_name="playwright"
+        )
+        schema_cache.write_cache_entry(
+            "playwright",
+            fingerprint,
+            config_digest=schema_cache.config_digest(server_config),
+            protocol_era="legacy",
+            tools=[{"name": "old_tool"}],
+        )
+        now += schema_cache.AUTO_LEGACY_RECEIPT_MAX_AGE_MS / 1000.0 + 1.0
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._register_from_cache_sync") as mock_register, \
+             patch("tools.mcp_tool._ensure_mcp_loop"), \
+             patch("tools.mcp_tool._run_on_mcp_loop") as mock_run:
+            mcp.register_mcp_servers(config)
+
+        mock_register.assert_not_called()
+        mock_run.assert_called_once()
+
+    def test_auto_lazy_registration_uses_newest_era_receipt(
+        self, monkeypatch, tmp_path
+    ):
+        import tools.mcp_schema_cache as schema_cache
+        from tools.registry import registry
+
+        server_name = "cache_freshness"
+        server_config = {
+            "command": "npx",
+            "args": [],
+            "lazy": True,
+        }
+        monkeypatch.setattr(
+            schema_cache, "_cache_path", lambda: tmp_path / "cache.json"
+        )
+        now = 20_000.0
+        monkeypatch.setattr(schema_cache.time, "time", lambda: now)
+        fingerprint = schema_cache.config_fingerprint(
+            server_config, server_name=server_name
+        )
+        config_digest = schema_cache.config_digest(server_config)
+        schema_cache.write_cache_entry(
+            server_name,
+            fingerprint,
+            config_digest=config_digest,
+            protocol_era="legacy",
+            tools=[{"name": "old_tool"}],
+        )
+        now += 1.0
+        schema_cache.write_cache_entry(
+            server_name,
+            fingerprint,
+            config_digest=config_digest,
+            protocol_era="modern",
+            tools=[{"name": "new_tool"}],
+            ttl_ms=60_000,
+        )
+        entry = schema_cache.get_cached_entry(server_name, fingerprint)
+        assert entry is not None
+        assert entry["tools"][0]["name"] == "new_tool"
+
+        registered_names = mcp._register_from_cache_sync(
+            server_name, server_config, entry
+        )
+        model_visible_name = mcp.mcp_prefixed_tool_name(server_name, "new_tool")
+        stale_name = mcp.mcp_prefixed_tool_name(server_name, "old_tool")
+        try:
+            assert model_visible_name in registered_names
+            assert model_visible_name in mcp._existing_tool_names()
+            assert stale_name not in registered_names
+            assert registry.get_toolset_for_tool(model_visible_name) == (
+                f"mcp-{server_name}"
+            )
+        finally:
+            for name in registered_names:
+                registry.deregister(name)
+                mcp._forget_mcp_tool_server(name)
+
     def test_non_lazy_server_never_touches_cache(self):
         config = {"playwright": {"command": "npx", "args": []}}
         with patch("tools.mcp_tool._MCP_AVAILABLE", True), \

--- a/tests/tools/test_mcp_lifecycle.py
+++ b/tests/tools/test_mcp_lifecycle.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+from tools.mcp_protocol import StaleConnectionGenerationError
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_stale_generation_refresh_cannot_replace_catalogue(monkeypatch):
+    fetched = asyncio.Event()
+    release = asyncio.Event()
+    registrations: list[list[str]] = []
+
+    class Session:
+        async def list_tools(self):
+            fetched.set()
+            await release.wait()
+            return SimpleNamespace(
+                tools=[SimpleNamespace(name="stale", description="", inputSchema={})],
+                next_cursor=None,
+            )
+
+    async def drive() -> None:
+        task = mcp_tool.MCPServerTask("stale-refresh")
+        task._connection_generation = 1
+        task.negotiated_era = "modern"
+        task.session = Session()
+        monkeypatch.setattr(mcp_tool.MCPServerTask, "_advertises_tools", lambda _self: True)
+        monkeypatch.setattr(
+            mcp_tool,
+            "_register_server_tools",
+            lambda _name, server, _config: registrations.append(
+                [tool.name for tool in server._tools]
+            )
+            or [],
+        )
+        refresh = asyncio.create_task(task._refresh_tools(generation=1))
+        await fetched.wait()
+        task._connection_generation = 2
+        task.session = SimpleNamespace()
+        release.set()
+        with pytest.raises(StaleConnectionGenerationError):
+            await refresh
+        assert task._tools == []
+        assert registrations == []
+
+    _run(drive())
+
+
+def test_stale_initial_discovery_cannot_replace_catalogue(monkeypatch):
+    fetched = asyncio.Event()
+    release = asyncio.Event()
+
+    class Session:
+        async def list_tools(self):
+            fetched.set()
+            await release.wait()
+            return SimpleNamespace(
+                tools=[SimpleNamespace(name="stale", description="", inputSchema={})],
+                next_cursor=None,
+            )
+
+    async def drive() -> None:
+        task = mcp_tool.MCPServerTask("stale-discovery")
+        task._connection_generation = 1
+        task.negotiated_era = "modern"
+        task.session = Session()
+        monkeypatch.setattr(mcp_tool.MCPServerTask, "_advertises_tools", lambda _self: True)
+        monkeypatch.setattr(
+            mcp_tool.MCPServerTask,
+            "_register_discovered_tools_if_needed",
+            lambda _self: None,
+        )
+        discovery = asyncio.create_task(task._discover_tools(generation=1))
+        await fetched.wait()
+        task._connection_generation = 2
+        task.session = SimpleNamespace()
+        task._tools = [SimpleNamespace(name="fresh")]
+        task._list_cache_meta = {"ttl_ms": 5_000}
+        release.set()
+        with pytest.raises(StaleConnectionGenerationError):
+            await discovery
+        assert [tool.name for tool in task._tools] == ["fresh"]
+        assert task._list_cache_meta == {"ttl_ms": 5_000}
+
+    _run(drive())
+
+
+def test_new_generation_cancels_owned_background_tasks():
+    async def drive() -> None:
+        task = mcp_tool.MCPServerTask("owned-tasks")
+        blocker = asyncio.Event()
+
+        async def wait_forever():
+            await blocker.wait()
+
+        refresh = asyncio.create_task(wait_forever())
+        mrtr = asyncio.create_task(wait_forever())
+        listener = asyncio.create_task(wait_forever())
+        task._pending_refresh_tasks.add(refresh)
+        task._pending_mrtr_tasks.add(mrtr)
+        task._listen_task = listener
+        generation = await task._begin_connection_generation()
+        assert generation == 1
+        assert refresh.cancelled()
+        assert mrtr.cancelled()
+        assert listener.cancelled()
+        assert task._pending_refresh_tasks == set()
+        assert task._pending_mrtr_tasks == set()
+        assert task._listen_task is None
+
+    _run(drive())
+
+
+def test_dynamic_refresh_replaces_payload_and_cache_metadata(monkeypatch):
+    async def drive() -> None:
+        server = mcp_tool.MCPServerTask("dynamic-metadata")
+        server._connection_generation = 1
+        server.negotiated_era = "modern"
+        server.session = SimpleNamespace(list_tools=object())
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [SimpleNamespace(name="old")]
+
+        async def paginate(
+            _method,
+            _items_attr,
+            _server_name,
+            cache_meta_out=None,
+            protocol_era=None,
+        ):
+            cache_meta_out.update(
+                {
+                    "protocol_era": protocol_era,
+                    "ttl_ms": 20.0,
+                    "cache_scope": "private",
+                    "metadata_complete": True,
+                }
+            )
+            return [SimpleNamespace(name="new", description="", inputSchema={})]
+
+        monkeypatch.setattr(mcp_tool, "_paginate_full_list", paginate)
+        monkeypatch.setattr(mcp_tool, "_register_server_tools", lambda *_args: [])
+        await server._refresh_tools(generation=1)
+        assert [tool.name for tool in server._tools] == ["new"]
+        assert server._list_cache_meta == {
+            "protocol_era": "modern",
+            "ttl_ms": 20.0,
+            "cache_scope": "private",
+            "metadata_complete": True,
+        }
+
+    _run(drive())

--- a/tests/tools/test_mcp_list_pagination.py
+++ b/tests/tools/test_mcp_list_pagination.py
@@ -10,6 +10,8 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from tools.mcp_tool import _MCP_LIST_MAX_PAGES, _paginate_full_list
 
 
@@ -153,6 +155,97 @@ class TestPaginateFullList:
             "protocol_era": "legacy",
             "metadata_complete": False,
         }
+
+    def test_real_legacy_result_without_ttl_hint_remains_hintless(self):
+        mcp_types = pytest.importorskip("mcp.types")
+        result = mcp_types.ListToolsResult.model_validate(
+            {"tools": [], "cacheScope": "private"}
+        )
+        metadata = {}
+
+        asyncio.run(
+            _paginate_full_list(
+                AsyncMock(return_value=result),
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="legacy",
+            )
+        )
+
+        assert "ttl_ms" not in metadata
+        assert metadata["cache_scope"] == "private"
+
+    def test_real_modern_result_without_ttl_hint_fails_closed(self):
+        mcp_types = pytest.importorskip("mcp.types")
+        result = mcp_types.ListToolsResult.model_validate(
+            {"tools": [], "cacheScope": "private"}
+        )
+        metadata = {}
+
+        asyncio.run(
+            _paginate_full_list(
+                AsyncMock(return_value=result),
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="modern",
+            )
+        )
+
+        assert metadata["ttl_ms"] == 0.0
+        assert metadata["cache_scope"] == "private"
+        assert metadata["metadata_complete"] is False
+
+    def test_real_legacy_result_preserves_explicit_zero_ttl(self):
+        mcp_types = pytest.importorskip("mcp.types")
+        result = mcp_types.ListToolsResult.model_validate(
+            {"tools": [], "ttlMs": 0}
+        )
+        metadata = {}
+
+        asyncio.run(
+            _paginate_full_list(
+                AsyncMock(return_value=result),
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="legacy",
+            )
+        )
+
+        assert metadata["ttl_ms"] == 0.0
+
+    def test_real_legacy_page_without_ttl_keeps_aggregate_hintless(self):
+        mcp_types = pytest.importorskip("mcp.types")
+        pages = [
+            mcp_types.ListToolsResult.model_validate(
+                {
+                    "tools": [],
+                    "nextCursor": "next",
+                    "ttlMs": 500,
+                    "cacheScope": "private",
+                }
+            ),
+            mcp_types.ListToolsResult.model_validate(
+                {"tools": [], "cacheScope": "private"}
+            ),
+        ]
+        metadata = {}
+
+        asyncio.run(
+            _paginate_full_list(
+                AsyncMock(side_effect=pages),
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="legacy",
+            )
+        )
+
+        assert "ttl_ms" not in metadata
+        assert metadata["cache_scope"] == "private"
+        assert metadata["metadata_complete"] is False
 
 
 class TestDiscoveryUsesPagination:

--- a/tests/tools/test_mcp_list_pagination.py
+++ b/tests/tools/test_mcp_list_pagination.py
@@ -44,6 +44,116 @@ class TestPaginateFullList:
         assert calls["n"] == _MCP_LIST_MAX_PAGES
         assert len(items) == _MCP_LIST_MAX_PAGES
 
+    def test_same_ttl_on_every_modern_page(self):
+        metadata = {}
+        pages = [
+            SimpleNamespace(tools=[_tool("a")], nextCursor="next", ttlMs=100, cacheScope="private"),
+            SimpleNamespace(tools=[_tool("b")], ttlMs=100, cacheScope="private"),
+        ]
+        method = AsyncMock(side_effect=pages)
+        asyncio.run(
+            _paginate_full_list(
+                method,
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="modern",
+            )
+        )
+        assert metadata == {
+            "protocol_era": "modern",
+            "ttl_ms": 100.0,
+            "cache_scope": "private",
+            "metadata_complete": True,
+        }
+
+    def test_shortest_ttl_wins_across_pages(self):
+        metadata = {}
+        pages = [
+            SimpleNamespace(tools=[], nextCursor="next", ttlMs=500, cacheScope="private"),
+            SimpleNamespace(tools=[], ttlMs=25, cacheScope="private"),
+        ]
+        asyncio.run(
+            _paginate_full_list(
+                AsyncMock(side_effect=pages),
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="modern",
+            )
+        )
+        assert metadata["ttl_ms"] == 25.0
+
+    def test_zero_ttl_on_one_page_wins(self):
+        metadata = {}
+        pages = [
+            SimpleNamespace(tools=[], nextCursor="next", ttlMs=100, cacheScope="private"),
+            SimpleNamespace(tools=[], ttlMs=0, cacheScope="private"),
+        ]
+        asyncio.run(
+            _paginate_full_list(
+                AsyncMock(side_effect=pages),
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="modern",
+            )
+        )
+        assert metadata["ttl_ms"] == 0.0
+
+    def test_scope_disagreement_fails_closed_to_private(self):
+        metadata = {}
+        pages = [
+            SimpleNamespace(tools=[], nextCursor="next", ttlMs=100, cacheScope="public"),
+            SimpleNamespace(tools=[], ttlMs=100, cacheScope="private"),
+        ]
+        asyncio.run(
+            _paginate_full_list(
+                AsyncMock(side_effect=pages),
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="modern",
+            )
+        )
+        assert metadata["cache_scope"] == "private"
+        assert metadata["scope_conflict"] is True
+
+    def test_missing_modern_metadata_is_immediately_stale(self):
+        metadata = {}
+        pages = [
+            SimpleNamespace(tools=[], nextCursor="next", ttlMs=100, cacheScope="private"),
+            SimpleNamespace(tools=[]),
+        ]
+        asyncio.run(
+            _paginate_full_list(
+                AsyncMock(side_effect=pages),
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="modern",
+            )
+        )
+        assert metadata["ttl_ms"] == 0.0
+        assert metadata["cache_scope"] == "private"
+        assert metadata["metadata_complete"] is False
+
+    def test_legacy_missing_metadata_remains_hintless(self):
+        metadata = {}
+        asyncio.run(
+            _paginate_full_list(
+                AsyncMock(return_value=SimpleNamespace(tools=[])),
+                "tools",
+                "srv",
+                cache_meta_out=metadata,
+                protocol_era="legacy",
+            )
+        )
+        assert metadata == {
+            "protocol_era": "legacy",
+            "metadata_complete": False,
+        }
+
 
 class TestDiscoveryUsesPagination:
     def test_discover_tools_drains_all_pages(self):

--- a/tests/tools/test_mcp_mrtr.py
+++ b/tests/tools/test_mcp_mrtr.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import asyncio
+import contextvars
+from types import SimpleNamespace
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+from mcp.shared.exceptions import MCPError
+from mcp.types import (
+    ElicitRequest,
+    ElicitRequestFormParams,
+    ElicitResult,
+    ErrorData,
+    InputRequiredResult,
+    ListRootsRequest,
+    ListRootsResult,
+)
+from tools.mcp_protocol import StaleConnectionGenerationError
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _roots_request():
+    return ListRootsRequest(params=None)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args", "kwargs"),
+    [
+        ("call_tool", ("echo",), {"arguments": {"value": "ok"}}),
+        ("get_prompt", ("welcome",), {"arguments": {"name": "Ada"}}),
+        ("read_resource", ("memory://item",), {}),
+    ],
+)
+def test_mrtr_success_is_sequential_for_all_result_methods(method_name, args, kwargs):
+    async def drive() -> None:
+        calls = []
+        dispatch_order = []
+        active = 0
+        max_active = 0
+
+        class Session:
+            async def _invoke(self, *method_args, **method_kwargs):
+                calls.append((method_args, method_kwargs))
+                if len(calls) == 1:
+                    return InputRequiredResult(
+                        inputRequests={"first": _roots_request(), "second": _roots_request()},
+                        requestState="opaque-state",
+                    )
+                return SimpleNamespace(method=method_name)
+
+            call_tool = _invoke
+            get_prompt = _invoke
+            read_resource = _invoke
+
+            async def dispatch_input_request(self, _ctx, request):
+                nonlocal active, max_active
+                key = "first" if not dispatch_order else "second"
+                dispatch_order.append(key)
+                active += 1
+                max_active = max(max_active, active)
+                await asyncio.sleep(0)
+                active -= 1
+                assert isinstance(request, ListRootsRequest)
+                return ListRootsResult(roots=[])
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-success")
+        server.session = session
+        server._connection_generation = 1
+        result = await mcp_tool._call_with_input_required(
+            server,
+            getattr(session, method_name),
+            *args,
+            timeout=1.0,
+            **kwargs,
+        )
+        assert result.method == method_name
+        assert dispatch_order == ["first", "second"]
+        assert max_active == 1
+        assert calls[1][1]["request_state"] == "opaque-state"
+        assert list(calls[1][1]["input_responses"]) == ["first", "second"]
+        assert server._pending_mrtr_tasks == set()
+
+    _run(drive())
+
+
+def test_mrtr_approval_continues_with_accepted_response():
+    async def drive() -> None:
+        calls = []
+
+        class Session:
+            async def call_tool(self, *args, **kwargs):
+                calls.append(kwargs)
+                if len(calls) == 1:
+                    return InputRequiredResult(
+                        inputRequests={
+                            "approval": ElicitRequest(
+                                params=ElicitRequestFormParams(
+                                    message="Approve operation",
+                                    requestedSchema={"type": "object"},
+                                )
+                            )
+                        },
+                        requestState="approval-state",
+                    )
+                return SimpleNamespace(done=True)
+
+            async def dispatch_input_request(self, _ctx, _request):
+                return ElicitResult(action="accept", content={})
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-approval")
+        server.session = session
+        server._connection_generation = 1
+        result = await mcp_tool._call_with_input_required(
+            server,
+            session.call_tool,
+            "approve",
+            timeout=1.0,
+        )
+        assert result.done is True
+        assert calls[1]["input_responses"]["approval"].action == "accept"
+
+    _run(drive())
+
+
+def test_mrtr_denial_fails_closed_without_retry():
+    async def drive() -> None:
+        calls = 0
+
+        class Session:
+            async def call_tool(self, *_args, **_kwargs):
+                nonlocal calls
+                calls += 1
+                return InputRequiredResult(
+                    inputRequests={"approval": _roots_request()},
+                    requestState="state",
+                )
+
+            async def dispatch_input_request(self, _ctx, _request):
+                return ErrorData(code=-32000, message="denied")
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-denial")
+        server.session = session
+        server._connection_generation = 1
+        with pytest.raises(MCPError, match="denied"):
+            await mcp_tool._call_with_input_required(
+                server,
+                session.call_tool,
+                "deny",
+                timeout=1.0,
+            )
+        assert calls == 1
+
+    _run(drive())
+
+
+def test_mrtr_whole_operation_timeout_cleans_task_registry():
+    async def drive() -> None:
+        class Session:
+            async def call_tool(self, *_args, **_kwargs):
+                return InputRequiredResult(
+                    inputRequests={"blocked": _roots_request()},
+                    requestState="state",
+                )
+
+            async def dispatch_input_request(self, _ctx, _request):
+                await asyncio.Event().wait()
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-timeout")
+        server.session = session
+        server._connection_generation = 1
+        with pytest.raises(TimeoutError):
+            await mcp_tool._call_with_input_required(
+                server,
+                session.call_tool,
+                "timeout",
+                timeout=0.01,
+            )
+        assert server._pending_mrtr_tasks == set()
+
+    _run(drive())
+
+
+def test_mrtr_caller_cancellation_propagates_and_cleans_task_registry():
+    async def drive() -> None:
+        entered = asyncio.Event()
+
+        class Session:
+            async def call_tool(self, *_args, **_kwargs):
+                return InputRequiredResult(
+                    inputRequests={"blocked": _roots_request()},
+                    requestState="state",
+                )
+
+            async def dispatch_input_request(self, _ctx, _request):
+                entered.set()
+                await asyncio.Event().wait()
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-cancel")
+        server.session = session
+        server._connection_generation = 1
+        operation = asyncio.create_task(
+            mcp_tool._call_with_input_required(
+                server,
+                session.call_tool,
+                "cancel",
+                timeout=5.0,
+            )
+        )
+        await entered.wait()
+        operation.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+        assert server._pending_mrtr_tasks == set()
+
+    _run(drive())
+
+
+def test_mrtr_rejects_malformed_empty_continuation():
+    async def drive() -> None:
+        class Session:
+            async def call_tool(self, *_args, **_kwargs):
+                return InputRequiredResult.model_construct(
+                    input_requests=None,
+                    request_state=None,
+                )
+
+            async def dispatch_input_request(self, _ctx, _request):
+                raise AssertionError("malformed continuation must not dispatch")
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-malformed")
+        server.session = session
+        server._connection_generation = 1
+        with pytest.raises(RuntimeError, match="malformed"):
+            await mcp_tool._call_with_input_required(
+                server,
+                session.call_tool,
+                "malformed",
+                timeout=1.0,
+            )
+
+    _run(drive())
+
+
+def test_mrtr_transport_disconnect_propagates():
+    async def drive() -> None:
+        calls = 0
+
+        class Session:
+            async def call_tool(self, *_args, **_kwargs):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    return InputRequiredResult(requestState="resume")
+                raise ConnectionError("transport lost")
+
+            async def dispatch_input_request(self, _ctx, _request):
+                raise AssertionError("state-only continuation must not dispatch")
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-disconnect")
+        server.session = session
+        server._connection_generation = 1
+        with pytest.raises(ConnectionError, match="transport lost"):
+            await mcp_tool._call_with_input_required(
+                server,
+                session.call_tool,
+                "disconnect",
+                timeout=1.0,
+            )
+
+    _run(drive())
+
+
+def test_mrtr_round_limit_exhaustion_is_bounded():
+    async def drive() -> None:
+        class Session:
+            async def call_tool(self, *_args, **_kwargs):
+                return InputRequiredResult(requestState="again")
+
+            async def dispatch_input_request(self, _ctx, _request):
+                raise AssertionError("state-only continuation must not dispatch")
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-round-limit")
+        server.session = session
+        server._config = {"input_required_max_rounds": 2}
+        server._connection_generation = 1
+        with pytest.raises(RuntimeError, match="more than 2 rounds"):
+            await mcp_tool._call_with_input_required(
+                server,
+                session.call_tool,
+                "loop",
+                timeout=1.0,
+            )
+
+    _run(drive())
+
+
+def test_mrtr_generation_replacement_rejects_stale_continuation():
+    async def drive() -> None:
+        entered = asyncio.Event()
+
+        class Session:
+            async def call_tool(self, *_args, **_kwargs):
+                return InputRequiredResult(
+                    inputRequests={"blocked": _roots_request()},
+                    requestState="old-generation",
+                )
+
+            async def dispatch_input_request(self, _ctx, _request):
+                entered.set()
+                await asyncio.Event().wait()
+                return ListRootsResult(roots=[])
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-generation")
+        server.session = session
+        server._connection_generation = 1
+        operation = asyncio.create_task(
+            mcp_tool._call_with_input_required(
+                server,
+                session.call_tool,
+                "generation",
+                timeout=1.0,
+            )
+        )
+        await entered.wait()
+        assert await server._begin_connection_generation() == 2
+        server.session = SimpleNamespace()
+        with pytest.raises(StaleConnectionGenerationError):
+            await operation
+        assert server._pending_mrtr_tasks == set()
+
+    _run(drive())
+
+
+def test_stale_mrtr_finalizer_cannot_clear_new_request_context():
+    async def drive() -> None:
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        class Session:
+            async def call_tool(self, *_args, **_kwargs):
+                return InputRequiredResult(
+                    inputRequests={"blocked": _roots_request()},
+                    requestState="old",
+                )
+
+            async def dispatch_input_request(self, _ctx, _request):
+                entered.set()
+                await release.wait()
+                return ListRootsResult(roots=[])
+
+        session = Session()
+        server = mcp_tool.MCPServerTask("mrtr-correlation")
+        server.session = session
+        server._connection_generation = 1
+        operation = asyncio.create_task(
+            mcp_tool._call_with_input_required(
+                server,
+                session.call_tool,
+                "correlation",
+                timeout=1.0,
+            )
+        )
+        await entered.wait()
+        new_context = contextvars.copy_context()
+        server._connection_generation = 2
+        server.session = SimpleNamespace()
+        server._pending_call_context = new_context
+        server._pending_call_generation = 2
+        release.set()
+        with pytest.raises(StaleConnectionGenerationError):
+            await operation
+        assert server._pending_call_context is new_context
+        assert server._pending_call_generation == 2
+
+    _run(drive())

--- a/tests/tools/test_mcp_oauth_issuer.py
+++ b/tests/tools/test_mcp_oauth_issuer.py
@@ -1,0 +1,222 @@
+import asyncio
+from urllib.parse import quote
+from urllib.request import urlopen
+
+import pytest
+
+from mcp.client.auth.oauth2 import OAuthFlowError
+from mcp.client.auth.utils import (
+    credentials_match_issuer,
+    validate_authorization_response_iss,
+)
+from mcp.shared.auth import (
+    OAuthClientInformationFull,
+    OAuthMetadata,
+    OAuthToken,
+)
+
+
+def _metadata(issuer: str, *, response_iss: bool = True) -> OAuthMetadata:
+    return OAuthMetadata.model_validate(
+        {
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+            "response_types_supported": ["code"],
+            "authorization_response_iss_parameter_supported": response_iss,
+        }
+    )
+
+
+def _client_info(issuer: str, client_id: str) -> OAuthClientInformationFull:
+    return OAuthClientInformationFull.model_validate(
+        {
+            "client_id": client_id,
+            "redirect_uris": ["https://agent.example/oauth/callback"],
+            "issuer": issuer,
+        }
+    )
+
+
+def _flow(*, flow_id: str = "issuer-flow"):
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    return DashboardOAuthFlow(
+        flow_id=flow_id,
+        server_name="reports",
+        profile=None,
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://agent.example/api/mcp/oauth/callback/reports",
+    )
+
+
+def test_dashboard_callback_preserves_expected_issuer_for_sdk_validation():
+    from tools.mcp_dashboard_oauth import dashboard_oauth_flow
+    from tools.mcp_oauth import _make_callback_waiter
+
+    issuer = "https://auth.example/tenant-a"
+    flow = _flow()
+    asyncio.run(flow.publish_authorization_url("https://auth.example/authorize?state=expected"))
+
+    with dashboard_oauth_flow(flow):
+        flow.deliver_callback(
+            code="code",
+            state="expected",
+            error=None,
+            iss=issuer,
+        )
+        result = asyncio.run(_make_callback_waiter(0)())
+
+    assert result.iss == issuer
+    validate_authorization_response_iss(result.iss, _metadata(issuer))
+
+
+def test_sdk_rejects_missing_issuer_when_metadata_requires_it():
+    from tools.mcp_oauth import _authorization_code_result
+
+    result = _authorization_code_result("code", "state")
+
+    with pytest.raises(OAuthFlowError, match="missing iss"):
+        validate_authorization_response_iss(
+            result.iss,
+            _metadata("https://auth.example/tenant-a"),
+        )
+
+
+def test_sdk_rejects_wrong_or_normalised_issuer():
+    from tools.mcp_oauth import _authorization_code_result
+
+    expected = "https://auth.example/tenant-a"
+    result = _authorization_code_result("code", "state", f"{expected}/")
+
+    with pytest.raises(OAuthFlowError, match="iss mismatch"):
+        validate_authorization_response_iss(result.iss, _metadata(expected))
+
+
+@pytest.mark.asyncio
+async def test_two_issuers_on_same_resource_origin_keep_distinct_credentials(
+    tmp_path,
+    monkeypatch,
+):
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    resource_url = "https://resource.example/mcp"
+    issuer_a = "https://auth.example/tenant-a"
+    issuer_b = "https://auth.example/tenant-b"
+
+    for name, issuer, token in (
+        ("tenant-a", issuer_a, "token-a"),
+        ("tenant-b", issuer_b, "token-b"),
+    ):
+        storage = HermesTokenStorage(name)
+        await storage.set_client_info(_client_info(issuer, f"client-{name}"))
+        await storage.set_tokens(
+            OAuthToken(
+                access_token=token,
+                token_type="Bearer",
+                refresh_token=f"refresh-{name}",
+                expires_in=3600,
+            )
+        )
+        storage.save_oauth_metadata(_metadata(issuer))
+
+    manager = MCPOAuthManager()
+    provider_a = manager.get_or_build_provider("tenant-a", resource_url, {})
+    provider_b = manager.get_or_build_provider("tenant-b", resource_url, {})
+    await provider_a._initialize()
+    await provider_b._initialize()
+
+    assert provider_a is not provider_b
+    assert provider_a.context.current_tokens.access_token == "token-a"
+    assert provider_b.context.current_tokens.access_token == "token-b"
+    assert provider_a.context.client_info.issuer == issuer_a
+    assert provider_b.context.client_info.issuer == issuer_b
+    assert credentials_match_issuer(provider_a.context.client_info, issuer_a, None)
+    assert not credentials_match_issuer(provider_a.context.client_info, issuer_b, None)
+
+
+@pytest.mark.asyncio
+async def test_issuer_binding_survives_provider_reconnect(tmp_path, monkeypatch):
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    issuer = "https://auth.example/tenant-a"
+    storage = HermesTokenStorage("reports")
+    await storage.set_client_info(_client_info(issuer, "client-reports"))
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="token",
+            token_type="Bearer",
+            refresh_token="refresh",
+            expires_in=3600,
+        )
+    )
+    storage.save_oauth_metadata(_metadata(issuer))
+
+    manager = MCPOAuthManager()
+    first = manager.get_or_build_provider(
+        "reports",
+        "https://resource.example/mcp",
+        {},
+    )
+    await first._initialize()
+    manager.evict("reports")
+    reconnected = manager.get_or_build_provider(
+        "reports",
+        "https://resource.example/mcp",
+        {},
+    )
+    await reconnected._initialize()
+
+    assert reconnected is not first
+    assert reconnected.context.client_info.issuer == issuer
+    assert str(reconnected.context.oauth_metadata.issuer) == issuer
+    assert reconnected.context.current_tokens.access_token == "token"
+
+
+def test_dashboard_http_relay_preserves_issuer():
+    from starlette.testclient import TestClient
+
+    from hermes_cli import web_server
+
+    issuer = "https://auth.example/tenant-a"
+    flow = _flow(flow_id="dashboard-route")
+    asyncio.run(flow.publish_authorization_url("https://auth.example/authorize?state=expected"))
+    web_server._mcp_oauth_flows[flow.flow_id] = flow
+    try:
+        response = TestClient(web_server.app).get(
+            "/api/mcp/oauth/callback/reports"
+            f"?code=code&state=expected&iss={quote(issuer, safe='')}"
+        )
+        callback = asyncio.run(flow.wait_for_callback())
+    finally:
+        web_server._mcp_oauth_flows.pop(flow.flow_id, None)
+
+    assert response.status_code == 200
+    assert callback == ("code", "expected", issuer)
+
+
+def test_tui_loopback_relay_preserves_issuer():
+    from tui_gateway.mcp_oauth_sessions import _start_loopback_listener
+
+    issuer = "https://auth.example/tenant-a"
+    flow = _flow(flow_id="tui-route")
+    asyncio.run(flow.publish_authorization_url("https://auth.example/authorize?state=expected"))
+    server = _start_loopback_listener(flow)
+    port = server.server_address[1]
+    try:
+        with urlopen(
+            "http://127.0.0.1:"
+            f"{port}/callback?code=code&state=expected&iss={quote(issuer, safe='')}",
+            timeout=5,
+        ) as response:
+            assert response.status == 200
+        callback = asyncio.run(flow.wait_for_callback())
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert callback == ("code", "expected", issuer)

--- a/tests/tools/test_mcp_preflight_content_type.py
+++ b/tests/tools/test_mcp_preflight_content_type.py
@@ -5,8 +5,8 @@ HTTP server (via httpx's ASGI/transport plumbing through a stdlib server),
 rather than reimplementing the probe inline. That distinction matters: the
 production probe must run on its own httpx client outside the MCP SDK's anyio
 task group, and a faithful test must exercise that actual method so the
-content-type allow-list, HEAD->GET fallback, POST probe fallback, and
-best-effort pass-through are all covered as shipped.
+content-type allow-list, HEAD->GET fallback, protocol-free ambiguity handling,
+and best-effort pass-through are all covered as shipped.
 
 OAuth note
 ----------
@@ -57,18 +57,14 @@ def _serve(handler_cls):
 def _handler(status: int = 200,
              content_type: "str | None" = "text/html; charset=utf-8",
              body: bytes = b"<html>x</html>", head_status=None, record=None,
-             post_content_type: "str | None" = None,
-             post_body: bytes = b"",
-             post_status: "int | None" = None):
+             allow_methods: "str | None" = None):
     """Build a BaseHTTPRequestHandler that replies with the given shape.
 
     ``head_status`` lets HEAD return a different status than GET (to exercise
     the HEAD->GET fallback). ``record`` is an optional list that captures the
     HTTP methods the server actually saw.
 
-    ``post_content_type`` / ``post_body`` / ``post_status`` let POST return a
-    different response than HEAD/GET (to exercise the POST probe fallback for
-    servers that serve HTML on GET but speak MCP via POST).
+    ``allow_methods`` models an endpoint that explicitly rules POST in or out.
     """
 
     class _H(http.server.BaseHTTPRequestHandler):
@@ -76,6 +72,8 @@ def _handler(status: int = 200,
             self.send_response(sc)
             if ct is not None:
                 self.send_header("Content-Type", ct)
+            if allow_methods is not None:
+                self.send_header("Allow", allow_methods)
             self.send_header("Content-Length", str(len(payload)))
             self.end_headers()
             if payload:
@@ -95,14 +93,10 @@ def _handler(status: int = 200,
         def do_POST(self):
             if record is not None:
                 record.append("POST")
-            # Read and discard request body to avoid broken pipe.
             length = int(self.headers.get("Content-Length", 0))
             if length:
                 self.rfile.read(length)
-            sc = post_status if post_status is not None else status
-            ct = post_content_type if post_content_type is not None else content_type
-            pb = post_body if post_body else body
-            self._write(sc, ct, pb)
+            self._write(status, content_type, body)
 
         def log_message(self, format, *args):  # noqa: A002
             pass
@@ -123,7 +117,11 @@ def _handler(status: int = 200,
 ])
 def test_non_mcp_content_type_raises(content_type):
     task = _make_task("bad_srv")
-    with _serve(_handler(status=200, content_type=content_type)) as base:
+    with _serve(_handler(
+        status=200,
+        content_type=content_type,
+        allow_methods="GET, HEAD",
+    )) as base:
         with pytest.raises(NonMcpEndpointError) as exc_info:
             asyncio.run(task._preflight_content_type(f"{base}/", timeout=5.0))
     msg = str(exc_info.value)
@@ -185,7 +183,11 @@ def test_oauth_server_html_response_raises_without_skip():
     """
     task = _make_task("hospitable")
     # HEAD returns 200 text/html — what Hospitable sends without a token.
-    with _serve(_handler(status=200, content_type="text/html; charset=UTF-8")) as base:
+    with _serve(_handler(
+        status=200,
+        content_type="text/html; charset=UTF-8",
+        allow_methods="GET, HEAD",
+    )) as base:
         with pytest.raises(NonMcpEndpointError) as exc_info:
             asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
     assert "hospitable" in str(exc_info.value)
@@ -266,21 +268,26 @@ def test_run_skips_preflight_when_skip_preflight_set(monkeypatch):
     )
 
 
-# ---------------------------------------------------------------------------
-# POST probe fallback for POST-only MCP servers
-# ---------------------------------------------------------------------------
-
-
-def test_post_probe_not_attempted_for_valid_head():
-    """When HEAD already returns application/json, no POST probe is needed."""
+def test_preflight_does_not_send_protocol_request_for_valid_head():
     task = _make_task()
     record: list[str] = []
     with _serve(_handler(
         status=200, content_type="application/json", body=b"{}",
-        post_content_type="application/json",
-        post_body=b'{}',
         record=record,
     )) as base:
         asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
     assert record == ["HEAD"]
     assert "POST" not in record
+
+
+def test_html_preflight_defers_without_sending_json_rpc():
+    task = _make_task()
+    record: list[str] = []
+    with _serve(_handler(
+        status=200,
+        content_type="text/html",
+        record=record,
+    )) as base:
+        asyncio.run(task._preflight_content_type(f"{base}/mcp", timeout=5.0))
+
+    assert record == ["HEAD"]

--- a/tests/tools/test_mcp_protocol_negotiation.py
+++ b/tests/tools/test_mcp_protocol_negotiation.py
@@ -1,144 +1,240 @@
-"""MCP 2026-07-28 protocol-era negotiation (_negotiate_session).
-
-The negotiation helper decides between the legacy ``initialize`` handshake
-and the stateless ``server/discover`` probe (SEP-2575) per the per-server
-``protocol`` config key. These tests drive it with duck-typed sessions —
-the live-path integration is covered by the real-server E2E in the PR.
-"""
+from __future__ import annotations
 
 import asyncio
 
 import pytest
 
-from tools.mcp_tool import (
-    MCPServerTask,
-    _handshake_rejected_as_modern,
-    _JSONRPC_UNSUPPORTED_PROTOCOL_VERSION,
+from tools.mcp_protocol import (
+    LegacyProofError,
+    ProtocolNegotiationState,
+    ProtocolPolicy,
+    StaleConnectionGenerationError,
+    is_candidate_legacy_discovery_rejection,
+    negotiate_protocol,
+    normalize_protocol_policy,
 )
+from tools.mcp_tool import MCPServerTask
 
 
 class _Err(Exception):
-    def __init__(self, code, msg="err"):
-        super().__init__(msg)
-        self.error = type("E", (), {"code": code})()
+    def __init__(
+        self,
+        code: int,
+        message: str = "Invalid request parameters",
+        data: object = "",
+    ) -> None:
+        super().__init__(message)
+        self.error = type(
+            "ErrorData",
+            (),
+            {"code": code, "message": message, "data": data},
+        )()
 
 
 class _Session:
-    def __init__(self, init=None, disc=None):
-        self._init = init
-        self._disc = disc
-        self.calls = []
+    def __init__(self, *, discover: object = "DISCOVER", initialize: object = "INITIALIZE") -> None:
+        self._discover = discover
+        self._initialize = initialize
+        self.calls: list[str] = []
+        self.protocol_version: str | None = None
 
-    async def initialize(self):
+    async def discover(self) -> object:
+        self.calls.append("server/discover")
+        if isinstance(self._discover, BaseException):
+            raise self._discover
+        self.protocol_version = "2026-07-28"
+        return self._discover
+
+    async def initialize(self) -> object:
         self.calls.append("initialize")
-        if isinstance(self._init, Exception):
-            raise self._init
-        return self._init
-
-    async def discover(self):
-        self.calls.append("discover")
-        if isinstance(self._disc, Exception):
-            raise self._disc
-        return self._disc
+        if isinstance(self._initialize, BaseException):
+            raise self._initialize
+        self.protocol_version = "2025-11-25"
+        return self._initialize
 
 
-class _LegacySession:
-    """mcp 1.x sessions have no discover() attribute at all."""
-
-    def __init__(self, init=None):
-        self._init = init
-        self.calls = []
-
-    async def initialize(self):
-        self.calls.append("initialize")
-        if isinstance(self._init, Exception):
-            raise self._init
-        return self._init
-
-
-def _task(protocol=None):
-    t = MCPServerTask("negotest")
-    t._config = {} if protocol is None else {"protocol": protocol}
-    return t
+def _state(policy: ProtocolPolicy, generation: int = 1) -> ProtocolNegotiationState:
+    return ProtocolNegotiationState(generation=generation, policy=policy)
 
 
 def _run(coro):
-    return asyncio.new_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
-class TestAutoMode:
-    def test_handshake_first_no_discover_on_success(self):
-        s = _Session(init="INIT_RESULT")
-        out = _run(_task()._negotiate_session(s, 5))
-        assert out == "INIT_RESULT"
-        assert s.calls == ["initialize"]
+class TestProtocolPolicy:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("auto", ProtocolPolicy.AUTO),
+            ("legacy", ProtocolPolicy.LEGACY),
+            ("stateless", ProtocolPolicy.MODERN),
+            ("2026-07-28", ProtocolPolicy.MODERN),
+            ("  AUTO  ", ProtocolPolicy.AUTO),
+        ],
+    )
+    def test_public_values_normalize_once(self, raw, expected):
+        assert normalize_protocol_policy(raw) is expected
 
-    def test_falls_back_to_discover_on_unsupported_protocol_version(self):
-        s = _Session(init=_Err(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION), disc="DISC_RESULT")
-        out = _run(_task()._negotiate_session(s, 5))
-        assert out == "DISC_RESULT"
-        assert s.calls == ["initialize", "discover"]
+    def test_omitted_protocol_is_auto(self):
+        assert normalize_protocol_policy() is ProtocolPolicy.AUTO
 
-    def test_falls_back_on_method_not_found(self):
-        s = _Session(init=_Err(-32601, "Method not found: initialize"), disc="DISC_RESULT")
-        out = _run(_task()._negotiate_session(s, 5))
-        assert out == "DISC_RESULT"
+    @pytest.mark.parametrize("raw", [None, "", "modern", "handshake", "bogus", 42])
+    def test_unknown_or_non_string_values_fail(self, raw):
+        with pytest.raises((TypeError, ValueError), match="protocol"):
+            normalize_protocol_policy(raw)
 
-    def test_unrelated_error_propagates_without_discover(self):
-        s = _Session(init=_Err(-32000, "borked"))
+    def test_unknown_value_fails_before_http_preflight(self, monkeypatch):
+        network_called = False
+
+        async def fail_if_called(*_args, **_kwargs):
+            nonlocal network_called
+            network_called = True
+            raise AssertionError("network preflight must not run")
+
+        monkeypatch.setattr(MCPServerTask, "_preflight_content_type", fail_if_called)
+        task = MCPServerTask("invalid-policy")
+        with pytest.raises(ValueError, match="protocol"):
+            _run(
+                task.run(
+                    {
+                        "protocol": "bogus",
+                        "url": "https://mcp.example.invalid/mcp",
+                    }
+                )
+            )
+        assert network_called is False
+
+
+class TestModernFirstAuto:
+    def test_auto_sends_discover_first_and_never_initializes_on_success(self):
+        session = _Session()
+        outcome = _run(negotiate_protocol(session, _state(ProtocolPolicy.AUTO), timeout=5))
+        assert outcome.era == "modern"
+        assert outcome.protocol_version == "2026-07-28"
+        assert session.calls == ["server/discover"]
+
+    def test_strict_modern_propagates_discover_failure_without_initialize(self):
+        rejection = _Err(-32602)
+        session = _Session(discover=rejection)
+        with pytest.raises(_Err) as raised:
+            _run(
+                negotiate_protocol(
+                    session,
+                    _state(ProtocolPolicy.MODERN),
+                    timeout=5,
+                )
+            )
+        assert raised.value is rejection
+        assert session.calls == ["server/discover"]
+
+    def test_explicit_legacy_never_sends_discover(self):
+        session = _Session()
+        outcome = _run(
+            negotiate_protocol(session, _state(ProtocolPolicy.LEGACY), timeout=5)
+        )
+        assert outcome.era == "legacy"
+        assert session.calls == ["initialize"]
+
+
+class TestBoundedLegacyProof:
+    def test_canonical_legacy_shape_permits_one_initialize_proof(self):
+        session = _Session(discover=_Err(-32602))
+        state = _state(ProtocolPolicy.AUTO)
+        outcome = _run(negotiate_protocol(session, state, timeout=5))
+        assert outcome.era == "legacy"
+        assert outcome.fallback_reason == "canonical-legacy-discover-rejection"
+        assert state.legacy_proof_attempted is True
+        assert session.calls == ["server/discover", "initialize"]
+
+    def test_proof_failure_surfaces_discovery_and_initialize_errors(self):
+        discovery = _Err(-32602)
+        proof = _Err(-32000, "initialize failed", {"detail": "proof"})
+        session = _Session(discover=discovery, initialize=proof)
+        state = _state(ProtocolPolicy.AUTO)
+        with pytest.raises(LegacyProofError) as raised:
+            _run(negotiate_protocol(session, state, timeout=5))
+        assert raised.value.discovery_error is discovery
+        assert raised.value.proof_error is proof
+        assert "Invalid request parameters" in str(raised.value)
+        assert "initialize failed" in str(raised.value)
+        assert state.negotiated_era is None
+        assert session.calls == ["server/discover", "initialize"]
+
+    def test_second_discover_failure_does_not_trigger_second_proof(self):
+        session = _Session(
+            discover=_Err(-32602),
+            initialize=_Err(-32000, "proof failed"),
+        )
+        state = _state(ProtocolPolicy.AUTO)
+        with pytest.raises(LegacyProofError):
+            _run(negotiate_protocol(session, state, timeout=5))
         with pytest.raises(_Err):
-            _run(_task()._negotiate_session(s, 5))
-        assert s.calls == ["initialize"]
+            _run(negotiate_protocol(session, state, timeout=5))
+        assert session.calls == ["server/discover", "initialize", "server/discover"]
 
-    def test_timeout_propagates_not_swallowed(self):
-        class _Hang(_Session):
-            async def initialize(self):
-                await asyncio.sleep(30)
+    @pytest.mark.parametrize(
+        "error",
+        [
+            _Err(-32602, "different message", ""),
+            _Err(-32602, "Invalid request parameters", {"unexpected": True}),
+            _Err(-32601, "Method not found", None),
+            _Err(-32000, "server error", None),
+        ],
+    )
+    def test_noncanonical_discover_errors_never_probe_initialize(self, error):
+        session = _Session(discover=error)
+        with pytest.raises(type(error)):
+            _run(negotiate_protocol(session, _state(ProtocolPolicy.AUTO), timeout=5))
+        assert session.calls == ["server/discover"]
 
-        with pytest.raises(asyncio.TimeoutError):
-            _run(_task()._negotiate_session(_Hang(), 0.05))
+    @pytest.mark.parametrize("method", ["tools/list", "tools/call", "prompts/get"])
+    def test_invalid_params_from_other_methods_is_not_a_legacy_fingerprint(self, method):
+        state = _state(ProtocolPolicy.AUTO)
+        assert not is_candidate_legacy_discovery_rejection(
+            _Err(-32602),
+            state=state,
+            request_method=method,
+        )
 
-
-class TestExplicitModes:
-    def test_stateless_probes_discover_first(self):
-        s = _Session(init="INIT_RESULT", disc="DISC_RESULT")
-        out = _run(_task("stateless")._negotiate_session(s, 5))
-        assert out == "DISC_RESULT"
-        assert s.calls == ["discover"]
-
-    def test_stateless_falls_back_to_handshake(self):
-        s = _Session(init="INIT_RESULT", disc=_Err(-32601))
-        out = _run(_task("stateless")._negotiate_session(s, 5))
-        assert out == "INIT_RESULT"
-        assert s.calls == ["discover", "initialize"]
-
-    def test_legacy_never_discovers(self):
-        s = _Session(init=_Err(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION), disc="DISC_RESULT")
-        with pytest.raises(_Err):
-            _run(_task("legacy")._negotiate_session(s, 5))
-        assert s.calls == ["initialize"]
-
-    def test_unknown_mode_treated_as_auto(self):
-        s = _Session(init="INIT_RESULT")
-        out = _run(_task("bogus")._negotiate_session(s, 5))
-        assert out == "INIT_RESULT"
-
-    def test_legacy_sdk_session_without_discover_reraises(self):
-        # mcp 1.x ClientSession has no .discover(): the auto fallback must
-        # re-raise the original handshake error, not AttributeError.
-        s = _LegacySession(init=_Err(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION))
-        with pytest.raises(_Err):
-            _run(_task()._negotiate_session(s, 5))
-        assert s.calls == ["initialize"]
+    def test_invalid_params_after_negotiation_is_not_a_legacy_fingerprint(self):
+        state = _state(ProtocolPolicy.AUTO)
+        state.negotiated_era = "modern"
+        assert not is_candidate_legacy_discovery_rejection(
+            _Err(-32602),
+            state=state,
+            request_method="server/discover",
+        )
 
 
-class TestModernRejectionClassifier:
-    def test_structural_codes(self):
-        assert _handshake_rejected_as_modern(_Err(-32022))
-        assert _handshake_rejected_as_modern(_Err(-32601))
-        assert not _handshake_rejected_as_modern(_Err(-32000))
+class TestConnectionGeneration:
+    def test_old_generation_cannot_mutate_current_state(self):
+        task = MCPServerTask("generation-test")
+        task._connection_generation = 2
+        with pytest.raises(StaleConnectionGenerationError, match="generation 1"):
+            task._assert_connection_generation(1)
 
-    def test_substring_fallbacks(self):
-        assert _handshake_rejected_as_modern(Exception("Unsupported protocol version"))
-        assert _handshake_rejected_as_modern(Exception("Unknown method: initialize"))
-        assert not _handshake_rejected_as_modern(Exception("connection reset by peer"))
+    def test_generation_replacement_rejects_inflight_negotiation(self):
+        session = _Session()
+        current_generation = 1
+
+        def assert_current(expected: int) -> None:
+            if current_generation != expected:
+                raise StaleConnectionGenerationError(expected, current_generation)
+
+        async def replace_during_discover() -> object:
+            nonlocal current_generation
+            session.calls.append("server/discover")
+            current_generation = 2
+            return "DISCOVER"
+
+        setattr(session, "discover", replace_during_discover)
+        with pytest.raises(StaleConnectionGenerationError):
+            _run(
+                negotiate_protocol(
+                    session,
+                    _state(ProtocolPolicy.AUTO),
+                    timeout=5,
+                    assert_generation=assert_current,
+                )
+            )
+        assert session.calls == ["server/discover"]

--- a/tests/tools/test_mcp_schema_cache.py
+++ b/tests/tools/test_mcp_schema_cache.py
@@ -90,8 +90,8 @@ class TestCacheFileLocation:
         assert (path.stat().st_mode & 0o777) == 0o600
 
 
-class TestWriteSkip:
-    def test_identical_payload_skips_rewrite(self, monkeypatch, tmp_path):
+class TestWriteReceipt:
+    def test_identical_payload_rewrites_validation_receipt(self, monkeypatch, tmp_path):
         monkeypatch.setattr(msc, "_cache_path", lambda: tmp_path / "cache.json")
         saves = []
         real_save = msc._save_all
@@ -104,12 +104,11 @@ class TestWriteSkip:
         tools = [{"name": "t1", "description": "d", "inputSchema": {}}]
         msc.write_cache_entry("srv", "fp1", tools=tools, utility_tools=[])
         assert len(saves) == 1
-        # Identical payload (reconnect / list_changed refresh) → no rewrite.
         msc.write_cache_entry("srv", "fp1", tools=list(tools), utility_tools=[])
-        assert len(saves) == 1
+        assert len(saves) == 2
         # Changed payload → rewrite.
         msc.write_cache_entry("srv", "fp2", tools=tools, utility_tools=[])
-        assert len(saves) == 2
+        assert len(saves) == 3
 
 
 class TestSecurityContextIdentity:
@@ -264,6 +263,8 @@ class TestProtocolEraFreshness:
         )
         modern = msc.get_cached_entry("srv", "fp", protocol_era="modern")
         legacy = msc.get_cached_entry("srv", "fp", protocol_era="legacy")
+        assert modern is not None
+        assert legacy is not None
         assert modern["tools"][0]["name"] == "modern"
         assert legacy["tools"][0]["name"] == "legacy"
         assert len(msc._load_all()) == 2
@@ -286,3 +287,58 @@ class TestProtocolEraFreshness:
             )
             is None
         )
+
+    def test_auto_hintless_legacy_receipt_expires(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        now = 1000.0
+        monkeypatch.setattr(msc.time, "time", lambda: now)
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            protocol_era="legacy",
+            tools=[{"name": "legacy"}],
+        )
+        assert msc.get_cached_entry("srv", "fp") is not None
+
+        now += msc.MAX_TTL_MS / 1000.0 + 0.001
+        assert msc.get_cached_entry("srv", "fp") is None
+
+    def test_auto_selects_the_newest_valid_era_receipt(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        now = 2000.0
+        monkeypatch.setattr(msc.time, "time", lambda: now)
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            protocol_era="modern",
+            tools=[{"name": "modern"}],
+            ttl_ms=60_000,
+        )
+        now += 1.0
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            protocol_era="legacy",
+            tools=[{"name": "legacy"}],
+        )
+
+        entry = msc.get_cached_entry("srv", "fp")
+        assert entry is not None
+        assert entry["protocol_era"] == "legacy"
+
+    def test_explicit_legacy_hintlessness_survives_the_auto_bound(
+        self, monkeypatch, tmp_path
+    ):
+        self._isolate(monkeypatch, tmp_path)
+        now = 3000.0
+        monkeypatch.setattr(msc.time, "time", lambda: now)
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            protocol_era="legacy",
+            tools=[{"name": "legacy"}],
+        )
+
+        now += msc.MAX_TTL_MS / 1000.0 + 10.0
+        entry = msc.get_cached_entry("srv", "fp", protocol_era="legacy")
+        assert entry is not None

--- a/tests/tools/test_mcp_schema_cache.py
+++ b/tests/tools/test_mcp_schema_cache.py
@@ -110,3 +110,179 @@ class TestWriteSkip:
         # Changed payload → rewrite.
         msc.write_cache_entry("srv", "fp2", tools=tools, utility_tools=[])
         assert len(saves) == 2
+
+
+class TestSecurityContextIdentity:
+    def test_partitions_protocol_headers_environment_auth_and_tls(self):
+        base = {"url": "https://mcp.example.test/rpc"}
+        variants = [
+            {"protocol": "legacy"},
+            {"headers": {"Authorization": "Bearer one"}},
+            {"env": {"MCP_TENANT": "one"}},
+            {"auth": "oauth", "oauth": {"issuer": "https://issuer-one.test"}},
+            {"ssl_verify": False},
+            {"client_cert": "cert-one.pem", "client_key": "key-one.pem"},
+        ]
+        baseline = msc.config_fingerprint(base)
+        assert all(
+            msc.config_fingerprint({**base, **variant}) != baseline
+            for variant in variants
+        )
+
+    def test_profile_identity_header_partitions_active_principal(self, monkeypatch):
+        import hermes_cli.profiles as profiles
+
+        config = {
+            "url": "https://mcp.example.test/rpc",
+            "identity_header": {
+                "name": "X-User-Id",
+                "value_from": "profile",
+            },
+        }
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "alice")
+        alice = msc.config_fingerprint(config)
+        monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "bob")
+        assert msc.config_fingerprint(config) != alice
+
+    def test_epoch_partitions_all_entries(self, monkeypatch):
+        config = {"command": "mcp-server"}
+        current = msc.config_fingerprint(config)
+        monkeypatch.setattr(msc, "CACHE_SCHEMA_EPOCH", 999)
+        assert msc.config_fingerprint(config) != current
+
+    def test_oauth_credential_rotation_changes_partition(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config = {
+            "url": "https://mcp.example.test/rpc",
+            "auth": "oauth",
+        }
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        token_path = token_dir / "srv.json"
+
+        missing = msc.config_fingerprint(config, server_name="srv")
+        token_path.write_text('{"access_token":"principal-a"}', encoding="utf-8")
+        principal_a = msc.config_fingerprint(config, server_name="srv")
+        token_path.write_text('{"access_token":"principal-b"}', encoding="utf-8")
+        principal_b = msc.config_fingerprint(config, server_name="srv")
+
+        assert len({missing, principal_a, principal_b}) == 3
+
+    def test_tls_file_rotation_changes_partition(self, tmp_path):
+        ca_bundle = tmp_path / "ca.pem"
+        ca_bundle.write_text("first trust anchor", encoding="utf-8")
+        config = {
+            "url": "https://mcp.example.test/rpc",
+            "ssl_verify": str(ca_bundle),
+        }
+        first = msc.config_fingerprint(config)
+        ca_bundle.write_text("replacement trust anchor material", encoding="utf-8")
+        assert msc.config_fingerprint(config) != first
+
+    def test_cache_file_never_contains_plaintext_identity_values(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(msc, "_cache_path", lambda: tmp_path / "cache.json")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        secret = "cache-identity-secret"
+        oauth_secret = "oauth-cache-identity-secret"
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        (token_dir / "srv.json").write_text(
+            f'{{"access_token":"{oauth_secret}"}}',
+            encoding="utf-8",
+        )
+        config = {
+            "url": "https://mcp.example.test/rpc",
+            "auth": "oauth",
+            "headers": {"Authorization": f"Bearer {secret}"},
+            "env": {"MCP_SECRET": secret},
+        }
+        fingerprint = msc.config_fingerprint(config, server_name="srv")
+        msc.write_cache_entry(
+            "srv",
+            fingerprint,
+            config_digest=msc.config_digest(config),
+            protocol_era="legacy",
+            tools=[],
+        )
+        payload = (tmp_path / "cache.json").read_text(encoding="utf-8")
+        assert secret not in payload
+        assert oauth_secret not in payload
+        assert f"Bearer {secret}" not in payload
+
+
+class TestProtocolEraFreshness:
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(msc, "_cache_path", lambda: tmp_path / "cache.json")
+
+    def test_modern_zero_ttl_is_immediately_stale(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            protocol_era="modern",
+            tools=[{"name": "modern"}],
+            ttl_ms=0,
+        )
+        assert msc.get_cached_entry("srv", "fp", protocol_era="modern") is None
+
+    def test_modern_missing_ttl_fails_closed(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            protocol_era="modern",
+            tools=[{"name": "modern"}],
+        )
+        assert msc.get_cached_entry("srv", "fp", protocol_era="modern") is None
+
+    def test_legacy_hintlessness_remains_usable(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            protocol_era="legacy",
+            tools=[{"name": "legacy"}],
+        )
+        entry = msc.get_cached_entry("srv", "fp", protocol_era="legacy")
+        assert entry is not None
+        assert "ttl_ms" not in entry
+
+    def test_era_is_a_destructive_partition_boundary(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            protocol_era="modern",
+            tools=[{"name": "modern"}],
+            ttl_ms=60_000,
+        )
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            protocol_era="legacy",
+            tools=[{"name": "legacy"}],
+        )
+        modern = msc.get_cached_entry("srv", "fp", protocol_era="modern")
+        legacy = msc.get_cached_entry("srv", "fp", protocol_era="legacy")
+        assert modern["tools"][0]["name"] == "modern"
+        assert legacy["tools"][0]["name"] == "legacy"
+        assert len(msc._load_all()) == 2
+
+    def test_config_digest_mismatch_is_a_miss(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        msc.write_cache_entry(
+            "srv",
+            "fp",
+            config_digest="digest-a",
+            protocol_era="legacy",
+            tools=[],
+        )
+        assert (
+            msc.get_cached_entry(
+                "srv",
+                "fp",
+                config_digest="digest-b",
+                protocol_era="legacy",
+            )
+            is None
+        )

--- a/tests/tools/test_mcp_schema_cache_ttl.py
+++ b/tests/tools/test_mcp_schema_cache_ttl.py
@@ -13,9 +13,11 @@ def _isolated_cache(tmp_path, monkeypatch):
     yield
 
 
-def test_entry_without_ttl_never_expires():
-    sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}])
-    assert sc.get_cached_entry("srv", "fp") is not None
+def test_entry_without_ttl_never_expires_when_legacy_is_explicit():
+    sc.write_cache_entry(
+        "srv", "fp", protocol_era="legacy", tools=[{"name": "t"}]
+    )
+    assert sc.get_cached_entry("srv", "fp", protocol_era="legacy") is not None
 
 
 def test_entry_within_ttl_served():
@@ -41,6 +43,21 @@ def test_ttl_rewrite_advances_written_at():
     # rewrite so written_at advances on every live reconfirmation.
     sc.write_cache_entry("srv", "fp", tools=[{"name": "t"}], ttl_ms=60_000)
     second = sc.get_cached_entry("srv", "fp")["written_at"]
+    assert second > first
+
+
+def test_hintless_legacy_rewrite_advances_validation_receipt(monkeypatch):
+    now = 1000.0
+    monkeypatch.setattr(sc.time, "time", lambda: now)
+    sc.write_cache_entry(
+        "srv", "fp", protocol_era="legacy", tools=[{"name": "t"}]
+    )
+    first = sc.get_cached_entry("srv", "fp", protocol_era="legacy")["validated_at"]
+    now += 1.0
+    sc.write_cache_entry(
+        "srv", "fp", protocol_era="legacy", tools=[{"name": "t"}]
+    )
+    second = sc.get_cached_entry("srv", "fp", protocol_era="legacy")["validated_at"]
     assert second > first
 
 

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -107,8 +107,7 @@ class TestStdioPidTracking:
         with _lock:
             _orphan_stdio_pids.add(fake_pid)
 
-        server = MCPServerTask.__new__(MCPServerTask)
-        server.name = "test-zombie-reap"
+        server = MCPServerTask("test-zombie-reap")
         server._ready = MagicMock()
         server._shutdown_event = MagicMock()
         server._shutdown_event.is_set.return_value = True

--- a/tests/tools/test_mcp_stateless_liveness.py
+++ b/tests/tools/test_mcp_stateless_liveness.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+from tools.mcp_protocol import ProtocolPolicy, StaleConnectionGenerationError
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_modern_liveness_uses_stateless_discover_only():
+    async def drive():
+        session = SimpleNamespace(
+            send_discover=AsyncMock(return_value={"supportedVersions": ["2026-07-28"]}),
+            send_ping=AsyncMock(),
+            initialize=AsyncMock(),
+            session_id=None,
+        )
+        server = mcp_tool.MCPServerTask("modern-reachability")
+        server._connection_generation = 7
+        server.negotiated_era = "modern"
+        server.negotiated_protocol_version = "2026-07-28"
+        server.session = session
+        await server._keepalive_probe()
+        session.send_discover.assert_awaited_once_with("2026-07-28")
+        session.send_ping.assert_not_called()
+        session.initialize.assert_not_called()
+        assert session.session_id is None
+        assert server.liveness_strategy == "stateless-discover"
+
+    _run(drive())
+
+
+def test_modern_liveness_rejects_stale_generation_result():
+    async def drive():
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def discover(_version):
+            started.set()
+            await release.wait()
+            return {}
+
+        session = SimpleNamespace(send_discover=discover, send_ping=AsyncMock())
+        server = mcp_tool.MCPServerTask("stale-reachability")
+        server._connection_generation = 1
+        server.negotiated_era = "modern"
+        server.negotiated_protocol_version = "2026-07-28"
+        server.session = session
+        probe = asyncio.create_task(server._keepalive_probe())
+        await asyncio.wait_for(started.wait(), timeout=0.2)
+        server._connection_generation = 2
+        server.session = SimpleNamespace()
+        release.set()
+        with pytest.raises(StaleConnectionGenerationError):
+            await probe
+        session.send_ping.assert_not_called()
+
+    _run(drive())
+
+
+def test_legacy_liveness_keeps_session_ping_semantics():
+    async def drive():
+        session = SimpleNamespace(send_ping=AsyncMock(), list_tools=AsyncMock())
+        server = mcp_tool.MCPServerTask("legacy-session")
+        server._connection_generation = 1
+        server.negotiated_era = "legacy"
+        server.session = session
+        await server._keepalive_probe()
+        session.send_ping.assert_awaited_once()
+        session.list_tools.assert_not_called()
+        assert server.liveness_strategy == "legacy-session-ping"
+
+    _run(drive())
+
+
+def test_status_exposes_protocol_lifecycle_without_secrets(monkeypatch):
+    secret = "status-secret-token"
+    config = {
+        "remote": {
+            "url": "https://mcp.example.test/rpc",
+            "protocol": "2026-07-28",
+            "headers": {"Authorization": f"Bearer {secret}"},
+            "env": {"MCP_SECRET": secret},
+        }
+    }
+    server = mcp_tool.MCPServerTask("remote")
+    server._config = config["remote"]
+    server.session = SimpleNamespace()
+    server._protocol_policy = ProtocolPolicy.MODERN
+    server._connection_generation = 4
+    server.negotiated_era = "modern"
+    server.negotiated_protocol_version = "2026-07-28"
+    server.fallback_reason = None
+    server.liveness_strategy = "stateless-discover"
+    server.subscription_state = "active"
+    server.catalogue_state = "current"
+    server.cache_state = "fresh"
+
+    monkeypatch.setattr(mcp_tool, "_load_mcp_config", lambda: config)
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        mcp_tool._servers.clear()
+        mcp_tool._servers["remote"] = server
+    try:
+        status = mcp_tool.get_mcp_status()
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+
+    protocol = status[0]["protocol"]
+    assert protocol["configured_policy"] == "modern"
+    assert protocol["negotiated_era"] == "modern"
+    assert protocol["negotiated_protocol_version"] == "2026-07-28"
+    assert protocol["connection_generation"] == 4
+    assert protocol["fallback_reason"] is None
+    assert protocol["legacy_proof_attempted"] is False
+    assert protocol["liveness_strategy"] == "stateless-discover"
+    assert protocol["subscription_state"] == "active"
+    assert protocol["catalogue_state"] == "current"
+    assert protocol["cache_state"] == "fresh"
+    assert protocol["mcp_sdk_version"]
+    encoded = json.dumps(status)
+    assert secret not in encoded
+    assert "Authorization" not in encoded
+    assert "MCP_SECRET" not in encoded
+
+
+def test_status_exposes_policy_before_connection_without_secrets(monkeypatch):
+    secret = "configured-status-secret"
+    config = {
+        "pending": {
+            "command": "pending-server",
+            "protocol": "stateless",
+            "env": {"MCP_SECRET": secret},
+        }
+    }
+    monkeypatch.setattr(mcp_tool, "_load_mcp_config", lambda: config)
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        mcp_tool._servers.clear()
+    try:
+        status = mcp_tool.get_mcp_status()
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+
+    assert status[0]["status"] == "configured"
+    assert status[0]["protocol"]["configured_policy"] == "modern"
+    assert status[0]["protocol"]["negotiated_era"] is None
+    assert secret not in json.dumps(status)

--- a/tests/tools/test_mcp_stdio_encoding_handler.py
+++ b/tests/tools/test_mcp_stdio_encoding_handler.py
@@ -29,6 +29,7 @@ class TestStdioEncodingErrorHandler:
         """
         mock_session = MagicMock()
         mock_session.initialize = AsyncMock()
+        mock_session.discover = AsyncMock()
         mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
 
         mock_stdio_cm = MagicMock()
@@ -68,6 +69,7 @@ class TestStdioEncodingErrorHandler:
         """Verify that the default encoding (utf-8) is not overridden."""
         mock_session = MagicMock()
         mock_session.initialize = AsyncMock()
+        mock_session.discover = AsyncMock()
         mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
 
         mock_stdio_cm = MagicMock()

--- a/tests/tools/test_mcp_stdio_init_timeout.py
+++ b/tests/tools/test_mcp_stdio_init_timeout.py
@@ -1,6 +1,6 @@
 """Regression test for the stdio-MCP subprocess/FD leak (#59349).
 
-A stdio MCP server that never completes ``initialize`` (e.g. emits a
+A stdio MCP server that never completes modern ``server/discover`` (e.g. emits a
 non-JSON-RPC frame and then blocks on stdin) used to hang ``_run_stdio``
 forever on the background event loop: ``connect_timeout`` bounded only the
 *caller's* ``.result()`` wait, not the coroutine itself. Because the connect
@@ -8,12 +8,12 @@ never unwound, the cleanup ``finally`` in ``_run_stdio`` never ran, so the
 spawned child process and its stdio pipes / pidfd leaked on *every* discovery
 retry — unbounded, until the gateway hit EMFILE.
 
-The fix wraps ``session.initialize()`` in
-``asyncio.wait_for(..., timeout=connect_timeout)`` so a stalled handshake fails
+The fix bounds canonical protocol negotiation by ``connect_timeout`` so a
+stalled first flight fails
 instead of hanging, which lets the existing ``finally`` reap the child.
 
 This test drives the *real* ``_run_stdio`` with a fake transport whose
-``initialize()`` hangs, and asserts the connect is bounded by
+``discover()`` hangs, and asserts the connect is bounded by
 ``connect_timeout`` rather than blocking forever. It is fully hermetic — no real
 subprocess, no network (the drain-to-zero behaviour was additionally verified
 manually against the reporter's live repro).
@@ -31,9 +31,7 @@ pytest.importorskip("mcp")
 
 
 class _HangingSession:
-    """Stand-in ClientSession whose handshake never completes."""
-
-    async def initialize(self):
+    async def discover(self):
         await asyncio.sleep(3600)
 
 
@@ -56,14 +54,11 @@ def _fake_stdio_client(*_args, **_kwargs):
 
 
 def _fake_client_session(*_args, **_kwargs):
-    # `async with ClientSession(...) as session` -> a session that hangs.
     return _FakeAsyncCM(_HangingSession())
 
 
-class TestStdioInitializeTimeout:
-    def test_hanging_initialize_is_bounded_not_leaked(self):
-        """A stdio server that hangs at ``initialize`` must fail within
-        ``connect_timeout`` — not block ``_run_stdio`` forever (#59349)."""
+class TestStdioNegotiationTimeout:
+    def test_hanging_discover_is_bounded_not_leaked(self):
         from tools import mcp_tool
 
         server = mcp_tool.MCPServerTask("leak-guard")
@@ -88,7 +83,7 @@ class TestStdioInitializeTimeout:
 
         elapsed = asyncio.run(drive())
         assert elapsed < 2.0, (
-            f"_run_stdio blocked {elapsed:.1f}s on a hanging initialize() — the "
+            f"_run_stdio blocked {elapsed:.1f}s on a hanging discover() — the "
             f"connect_timeout ({config['connect_timeout']}s) bound was not applied; "
             f"the #59349 subprocess/FD leak has regressed."
         )

--- a/tests/tools/test_mcp_streamable_http_arity.py
+++ b/tests/tools/test_mcp_streamable_http_arity.py
@@ -52,6 +52,9 @@ class _DummySession:
     async def initialize(self):
         return None
 
+    async def discover(self):
+        return None
+
 
 def _transport_yielding(*values):
     class _Ctx:
@@ -125,16 +128,7 @@ def test_the_session_streams_are_the_first_two_yielded():
     assert passed["args"][:2] == (read, write)
 
 
-def test_the_seeded_protocol_header_matches_the_handshake_the_client_sends():
-    """Header and body must agree about which revision this connection speaks.
-
-    `ClientSession.initialize()` sends `LATEST_HANDSHAKE_VERSION`; from
-    2026-07-28 onward `LATEST_PROTOCOL_VERSION` names a revision that replaced
-    the handshake with a per-request envelope. Seeding the header from the
-    latter advertised a revision the body does not speak, and a conforming
-    server answered `params._meta is missing the required envelope key(s)` --
-    observed against a live MCP endpoint, not hypothesised.
-    """
+def test_seeded_legacy_proof_header_matches_initialize_revision():
     from tools import mcp_tool
 
     try:
@@ -145,8 +139,7 @@ def test_the_seeded_protocol_header_matches_the_handshake_the_client_sends():
     assert mcp_tool.LATEST_HANDSHAKE_VERSION == sdk_handshake
 
 
-def test_the_seeded_header_is_the_handshake_version_on_the_wire():
-    """Asserted through the header dict `_run_http` actually builds."""
+def test_http_client_default_is_handshake_version_for_legacy_proof():
     from unittest.mock import patch as _patch
 
     from tools.mcp_tool import MCPServerTask, LATEST_HANDSHAKE_VERSION

--- a/tests/tools/test_mcp_subscriptions.py
+++ b/tests/tools/test_mcp_subscriptions.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+from mcp.client.subscriptions import (
+    PromptsListChanged,
+    ResourcesListChanged,
+    SubscriptionLost,
+    ToolsListChanged,
+)
+from mcp.shared.exceptions import MCPError
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _FakeSubscription:
+    def __init__(self, events=(), *, error=None, blocker=None, honored=None):
+        self._events = deque(events)
+        self._error = error
+        self._blocker = blocker
+        if honored is not None:
+            self.honored = honored
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._events:
+            return self._events.popleft()
+        if self._error is not None:
+            error = self._error
+            self._error = None
+            raise error
+        if self._blocker is not None:
+            await self._blocker.wait()
+        raise StopAsyncIteration
+
+
+class _CatalogueSession:
+    protocol_version = "2026-07-28"
+
+    def __init__(self):
+        self.catalogue_calls = []
+        self.catalogue_event = asyncio.Event()
+
+    async def list_prompts(self, **_kwargs):
+        self.catalogue_calls.append("prompts")
+        self.catalogue_event.set()
+        return SimpleNamespace(prompts=[], nextCursor=None)
+
+    async def list_resources(self, **_kwargs):
+        self.catalogue_calls.append("resources")
+        self.catalogue_event.set()
+        return SimpleNamespace(resources=[], nextCursor=None)
+
+
+def _modern_server(name="subscription-test"):
+    server = mcp_tool.MCPServerTask(name)
+    server._connection_generation = 1
+    server.negotiated_era = "modern"
+    server.negotiated_protocol_version = "2026-07-28"
+    server.session = _CatalogueSession()
+    server.initialize_result = SimpleNamespace(
+        capabilities=SimpleNamespace(
+            tools=SimpleNamespace(),
+            prompts=SimpleNamespace(),
+            resources=SimpleNamespace(),
+        )
+    )
+    return server
+
+
+def _install_listen(monkeypatch, subscriptions, calls, entered=None):
+    queue = deque(subscriptions)
+
+    @asynccontextmanager
+    async def fake_listen(_session, **kwargs):
+        calls.append(kwargs)
+        if entered is not None:
+            entered.set()
+        yield queue.popleft()
+
+    monkeypatch.setattr("mcp.client.subscriptions.listen", fake_listen)
+
+
+def test_subscription_has_one_owner_per_generation(monkeypatch):
+    async def drive():
+        blocker = asyncio.Event()
+        calls = []
+        _install_listen(
+            monkeypatch,
+            [_FakeSubscription(blocker=blocker)],
+            calls,
+        )
+        server = _modern_server()
+        first = server._start_subscription_supervisor(1)
+        second = server._start_subscription_supervisor(1)
+        await asyncio.sleep(0)
+        assert first is second
+        assert len(calls) == 1
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+    _run(drive())
+
+
+def test_subscription_event_refreshes_tools_and_delivers_sequentially(monkeypatch):
+    async def drive():
+        blocker = asyncio.Event()
+        calls = []
+        refreshed = asyncio.Event()
+        _install_listen(
+            monkeypatch,
+            [_FakeSubscription([ToolsListChanged()], blocker=blocker)],
+            calls,
+        )
+        server = _modern_server()
+        refresh_generations = []
+
+        async def refresh(_server, *, generation):
+            refresh_generations.append(generation)
+            refreshed.set()
+
+        monkeypatch.setattr(mcp_tool.MCPServerTask, "_refresh_tools", refresh)
+        listener = server._start_subscription_supervisor(1)
+        await asyncio.wait_for(refreshed.wait(), timeout=1)
+        assert refresh_generations == [1]
+        assert server.subscription_state == "active"
+        assert server.catalogue_state == "current"
+        listener.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await listener
+
+    _run(drive())
+
+
+@pytest.mark.parametrize(
+    ("event", "expected_family"),
+    [
+        (PromptsListChanged(), "prompts"),
+        (ResourcesListChanged(), "resources"),
+    ],
+)
+def test_subscription_event_reconciles_non_tool_catalogue(
+    monkeypatch, event, expected_family
+):
+    async def drive():
+        blocker = asyncio.Event()
+        calls = []
+        _install_listen(
+            monkeypatch,
+            [_FakeSubscription([event], blocker=blocker)],
+            calls,
+        )
+        server = _modern_server()
+        listener = server._start_subscription_supervisor(1)
+        await asyncio.wait_for(server.session.catalogue_event.wait(), timeout=1)
+        assert server.session.catalogue_calls == [expected_family]
+        assert server.catalogue_state == "current"
+        listener.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await listener
+
+    _run(drive())
+
+
+@pytest.mark.parametrize("first_error", [None, SubscriptionLost("dropped")])
+def test_subscription_gap_relists_and_reconciles_catalogue(monkeypatch, first_error):
+    async def drive():
+        blocker = asyncio.Event()
+        calls = []
+        refreshed = asyncio.Event()
+        first = _FakeSubscription(error=first_error)
+        second = _FakeSubscription(blocker=blocker)
+        _install_listen(monkeypatch, [first, second], calls)
+        server = _modern_server()
+        observed_states = []
+
+        async def refresh(_server, *, generation):
+            observed_states.append((generation, server.catalogue_state))
+            refreshed.set()
+
+        monkeypatch.setattr(mcp_tool.MCPServerTask, "_refresh_tools", refresh)
+        monkeypatch.setattr(mcp_tool, "_SUBSCRIPTION_RELISTEN_DELAY", 0)
+        listener = server._start_subscription_supervisor(1)
+        await asyncio.wait_for(refreshed.wait(), timeout=1)
+        assert len(calls) == 2
+        assert observed_states == [(1, "stale")]
+        assert server.session.catalogue_calls == ["prompts", "resources"]
+        assert server.catalogue_state == "current"
+        assert server.subscription_state == "active"
+        listener.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await listener
+
+    _run(drive())
+
+
+def test_subscription_relisten_exhaustion_escalates_to_reconnect(monkeypatch):
+    async def drive():
+        calls = []
+        _install_listen(
+            monkeypatch,
+            [_FakeSubscription(), _FakeSubscription(), _FakeSubscription()],
+            calls,
+        )
+        server = _modern_server()
+
+        async def refresh(_server, *, generation):
+            assert generation == 1
+
+        monkeypatch.setattr(mcp_tool.MCPServerTask, "_refresh_tools", refresh)
+        monkeypatch.setattr(mcp_tool, "_MAX_SUBSCRIPTION_RELISTENS", 2)
+        monkeypatch.setattr(mcp_tool, "_SUBSCRIPTION_RELISTEN_DELAY", 0)
+        listener = server._start_subscription_supervisor(1)
+        await asyncio.wait_for(listener, timeout=1)
+        assert len(calls) == 3
+        assert server.subscription_state == "exhausted"
+        assert server.catalogue_state == "stale"
+        assert server._reconnect_event.is_set()
+
+    _run(drive())
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        mcp_tool._JSONRPC_METHOD_NOT_FOUND,
+        "version",
+    ],
+)
+def test_subscription_not_supported_is_bounded(monkeypatch, failure):
+    async def drive():
+        calls = []
+
+        @asynccontextmanager
+        async def rejected(_session, **kwargs):
+            calls.append(kwargs)
+            if failure == "version":
+                from mcp.client.subscriptions import ListenNotSupportedError
+
+                raise ListenNotSupportedError("2025-11-25")
+            raise MCPError(code=failure, message="Method not found")
+            yield
+
+        monkeypatch.setattr("mcp.client.subscriptions.listen", rejected)
+        server = _modern_server()
+        listener = server._start_subscription_supervisor(1)
+        await asyncio.wait_for(listener, timeout=1)
+        assert len(calls) == 1
+        assert server.subscription_state == "unsupported"
+        assert not server._reconnect_event.is_set()
+
+    _run(drive())
+
+
+def test_subscription_empty_ack_is_unsupported_without_reconnect(monkeypatch):
+    async def drive():
+        calls = []
+        honored = SimpleNamespace(
+            tools_list_changed=None,
+            prompts_list_changed=None,
+            resources_list_changed=None,
+        )
+        _install_listen(
+            monkeypatch,
+            [_FakeSubscription(honored=honored)],
+            calls,
+        )
+        server = _modern_server()
+        monkeypatch.setattr(mcp_tool, "_MAX_SUBSCRIPTION_RELISTENS", 0)
+        listener = server._start_subscription_supervisor(1)
+        await asyncio.wait_for(listener, timeout=1)
+        assert len(calls) == 1
+        assert server.subscription_state == "unsupported"
+        assert not server._reconnect_event.is_set()
+
+    _run(drive())
+
+
+def test_subscription_caller_cancellation_cleans_owner(monkeypatch):
+    async def drive():
+        blocker = asyncio.Event()
+        entered = asyncio.Event()
+        calls = []
+        _install_listen(
+            monkeypatch,
+            [_FakeSubscription(blocker=blocker)],
+            calls,
+            entered,
+        )
+        server = _modern_server()
+        listener = server._start_subscription_supervisor(1)
+        await entered.wait()
+        listener.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await listener
+        await asyncio.sleep(0)
+        assert server._listen_task is None
+        assert server._listen_generation is None
+        assert server.subscription_state == "stopped"
+
+    _run(drive())
+
+
+def test_generation_replacement_cancels_listener_and_resets_state(monkeypatch):
+    async def drive():
+        blocker = asyncio.Event()
+        entered = asyncio.Event()
+        calls = []
+        _install_listen(
+            monkeypatch,
+            [_FakeSubscription(blocker=blocker)],
+            calls,
+            entered,
+        )
+        server = _modern_server()
+        listener = server._start_subscription_supervisor(1)
+        await entered.wait()
+        generation = await server._begin_connection_generation()
+        assert generation == 2
+        assert listener.cancelled()
+        assert server._listen_task is None
+        assert server._listen_generation is None
+        assert server.subscription_state == "idle"
+        assert server.catalogue_state == "stale"
+
+    _run(drive())
+
+
+def test_old_generation_listener_cannot_refresh_current_catalogue(monkeypatch):
+    async def drive():
+        release = asyncio.Event()
+        calls = []
+        _install_listen(
+            monkeypatch,
+            [_FakeSubscription([ToolsListChanged()], blocker=release)],
+            calls,
+        )
+        server = _modern_server()
+        refreshed = []
+
+        async def refresh(_server, *, generation):
+            refreshed.append(generation)
+
+        monkeypatch.setattr(mcp_tool.MCPServerTask, "_refresh_tools", refresh)
+        server._connection_generation = 2
+        server.subscription_state = "idle"
+        server.catalogue_state = "current"
+        await server._subscription_supervisor(1, server.session)
+        assert refreshed == []
+        assert server.subscription_state == "idle"
+        assert server.catalogue_state == "current"
+
+    _run(drive())

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -572,7 +572,11 @@ class TestToolHandler:
             with self._patch_mcp_loop():
                 result = json.loads(handler({"name": "world"}))
             assert result["result"] == "hello world"
-            mock_session.call_tool.assert_called_once_with("greet", arguments={"name": "world"})
+            mock_session.call_tool.assert_called_once_with(
+                "greet",
+                arguments={"name": "world"},
+                allow_input_required=True,
+            )
         finally:
             _servers.pop("test_srv", None)
 
@@ -603,7 +607,11 @@ class TestToolHandler:
                 result = json.loads(handler({"name": "world"}))
             assert result["result"] == "reconnected"
             reconnect.assert_called_once()
-            mock_session.call_tool.assert_called_once_with("greet", arguments={"name": "world"})
+            mock_session.call_tool.assert_called_once_with(
+                "greet",
+                arguments={"name": "world"},
+                allow_input_required=True,
+            )
         finally:
             _servers.pop("test_srv", None)
 
@@ -864,6 +872,10 @@ class TestMCPServerTask:
         mock_tools = [_make_mcp_tool("echo")]
         mock_session = MagicMock()
         mock_session.initialize = AsyncMock()
+        mock_session.discover = AsyncMock(
+            return_value=SimpleNamespace(capabilities=None)
+        )
+        mock_session.protocol_version = "2026-07-28"
         mock_session.list_tools = AsyncMock(
             return_value=SimpleNamespace(tools=mock_tools)
         )
@@ -880,7 +892,8 @@ class TestMCPServerTask:
                 assert server.session is mock_session
                 assert len(server._tools) == 1
                 assert server._tools[0].name == "echo"
-                mock_session.initialize.assert_called_once()
+                mock_session.discover.assert_awaited_once()
+                mock_session.initialize.assert_not_awaited()
                 assert params.call_args.kwargs["cwd"] == "/plugin"
 
                 await server.shutdown()
@@ -893,6 +906,10 @@ class TestMCPServerTask:
 
         mock_session = MagicMock()
         mock_session.initialize = AsyncMock()
+        mock_session.discover = AsyncMock(
+            return_value=SimpleNamespace(capabilities=None)
+        )
+        mock_session.protocol_version = "2026-07-28"
         mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
         p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
 
@@ -1625,7 +1642,9 @@ class TestUtilityHandlers:
             assert result["messages"][0]["role"] == "assistant"
             assert "summary" in result["messages"][0]["content"].lower()
             mock_session.get_prompt.assert_called_once_with(
-                "summarize", arguments={"text": "hello"}
+                "summarize",
+                arguments={"text": "hello"},
+                allow_input_required=True,
             )
         finally:
             _servers.pop("srv", None)

--- a/tests/tools/test_mcp_tool_issue_948.py
+++ b/tests/tools/test_mcp_tool_issue_948.py
@@ -75,6 +75,7 @@ def test_resolve_stdio_command_falls_back_to_usr_local_bin():
 def _stdio_mocks():
     mock_session = MagicMock()
     mock_session.initialize = AsyncMock()
+    mock_session.discover = AsyncMock()
     mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
     mock_stdio_cm = MagicMock()
     mock_stdio_cm.__aenter__ = AsyncMock(return_value=(object(), object()))

--- a/tests/tools/test_mcp_transport_group_reconnect.py
+++ b/tests/tools/test_mcp_transport_group_reconnect.py
@@ -64,6 +64,9 @@ class _FakeSession:
     async def initialize(self):
         return object()
 
+    async def discover(self):
+        return object()
+
 
 class _FakeSessionCM:
     async def __aenter__(self):

--- a/tests/website/test_mcp_config_reference.py
+++ b/tests/website/test_mcp_config_reference.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+
+DOC_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "website"
+    / "docs"
+    / "reference"
+    / "mcp-config-reference.md"
+)
+
+
+def _document() -> str:
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+def _table_row(document: str, key: str) -> str:
+    prefix = f"| `{key}` |"
+    return next(line for line in document.splitlines() if line.startswith(prefix))
+
+
+def test_protocol_reference_matches_runtime_authority():
+    document = _document()
+    assert "### Protocol authority" in document
+    assert "| omitted or `auto` | `server/discover` |" in document
+    assert "One same-generation `initialize` proof" in document
+    assert "canonical MCP 1.28.1 `-32602`" in document
+    assert "`stateless` or `2026-07-28` | `server/discover` |" in document
+    assert "strict modern mode and never sends `initialize`" in document
+    assert "| `legacy` | `initialize` |" in document
+    assert "rejected before transport creation or network I/O" in document
+
+    protocol_row = _table_row(document, "protocol")
+    assert "omitted/`auto` is modern-first" in protocol_row
+    assert "`stateless` and `2026-07-28` are strict-modern aliases" in protocol_row
+    assert "`legacy` is initialise-only" in protocol_row
+    assert "Unknown values fail before transport creation" in protocol_row
+    assert "legacy `initialize` handshake first" not in document
+    assert "falling back to the 2026-07-28 `server/discover` stateless probe" not in document
+
+
+def test_keepalive_reference_distinguishes_protocol_eras():
+    document = _document()
+    keepalive_row = _table_row(document, "keepalive_interval")
+    assert "Modern stateless peers" in keepalive_row
+    assert "stateless discovery" in keepalive_row
+    assert "Mcp-Session-Id" in keepalive_row
+    assert "Legacy peers use `ping`" in keepalive_row
+    assert "`tools/list`" in keepalive_row

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1623,9 +1623,31 @@ class _CuaDriverSession:
             )
 
             async with stdio_client(params) as (read, write):
-                self._startup_phase = "mcp-initialize"
+                self._startup_phase = "mcp-negotiate"
                 async with ClientSession(read, write) as session:
-                    await session.initialize()
+                    from tools.mcp_protocol import (
+                        ProtocolNegotiationState,
+                        ProtocolPolicy,
+                        StaleConnectionGenerationError,
+                        negotiate_protocol,
+                    )
+
+                    generation = self._transport_generation + 1
+
+                    def assert_generation(expected: int) -> None:
+                        current = self._transport_generation + 1
+                        if current != expected:
+                            raise StaleConnectionGenerationError(expected, current)
+
+                    await negotiate_protocol(
+                        session,
+                        ProtocolNegotiationState(
+                            generation=generation,
+                            policy=ProtocolPolicy.AUTO,
+                        ),
+                        timeout=30.0,
+                        assert_generation=assert_generation,
+                    )
                     _t_init = _time.monotonic()
                     # Populate capabilities + capability_version BEFORE
                     # exposing the session to callers, so the first

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -32,7 +32,11 @@ class DashboardOAuthFlow:
     error: str | None = None
     tools: list[dict] = field(default_factory=list)
     expected_state: str | None = field(default=None, init=False)
-    _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    _callback: tuple[str, str | None, str | None] | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
     _callback_error: str | None = field(default=None, init=False, repr=False)
     _authorization_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
     _callback_ready: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
@@ -65,6 +69,7 @@ class DashboardOAuthFlow:
         code: str | None,
         state: str | None,
         error: str | None,
+        iss: str | None = None,
     ) -> None:
         with self._lock:
             if self._callback_ready.is_set():
@@ -78,12 +83,15 @@ class DashboardOAuthFlow:
             if error:
                 self._callback_error = error
             elif code:
-                self._callback = (code, state)
+                self._callback = (code, state, iss)
             else:
                 self._callback_error = "OAuth callback did not include code or error"
             self._callback_ready.set()
 
-    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None]:
+    async def wait_for_callback(
+        self,
+        timeout: float = 300.0,
+    ) -> tuple[str, str | None, str | None]:
         ready = await asyncio.to_thread(self._callback_ready.wait, timeout)
         if not ready:
             raise TimeoutError("Timed out waiting for MCP OAuth callback")

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -951,10 +951,8 @@ def _make_callback_waiter(
 
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
-            # The dashboard flow still speaks the legacy tuple; normalize it
-            # here so both callback sources hand the SDK one shape.
-            dash_code, dash_state = await dashboard_flow.wait_for_callback()
-            return _authorization_code_result(dash_code, dash_state)
+            dash_code, dash_state, dash_iss = await dashboard_flow.wait_for_callback()
+            return _authorization_code_result(dash_code, dash_state, dash_iss)
 
         # Reject before binding the callback listener in non-interactive
         # contexts. Reaching here means the SDK entered the authorization-code

--- a/tools/mcp_protocol.py
+++ b/tools/mcp_protocol.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Literal
+
+
+class ProtocolPolicy(str, Enum):
+    AUTO = "auto"
+    LEGACY = "legacy"
+    MODERN = "modern"
+
+
+class StaleConnectionGenerationError(RuntimeError):
+    def __init__(self, expected: int, current: int) -> None:
+        super().__init__(
+            f"MCP connection generation {expected} is stale; current generation is {current}"
+        )
+        self.expected = expected
+        self.current = current
+
+
+class LegacyProofError(RuntimeError):
+    def __init__(self, discovery_error: BaseException, proof_error: BaseException) -> None:
+        super().__init__(
+            "Modern server/discover received the canonical candidate legacy rejection "
+            f"({discovery_error}); the one permitted legacy initialize proof failed "
+            f"({proof_error})"
+        )
+        self.discovery_error = discovery_error
+        self.proof_error = proof_error
+
+
+@dataclass
+class ProtocolNegotiationState:
+    generation: int
+    policy: ProtocolPolicy
+    negotiated_era: Literal["modern", "legacy"] | None = None
+    negotiated_protocol_version: str | None = None
+    legacy_proof_attempted: bool = False
+    fallback_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ProtocolNegotiationOutcome:
+    result: Any
+    era: Literal["modern", "legacy"]
+    protocol_version: str | None
+    fallback_reason: str | None
+
+
+_OMITTED = object()
+
+
+def normalize_protocol_policy(raw: object = _OMITTED) -> ProtocolPolicy:
+    if raw is _OMITTED:
+        return ProtocolPolicy.AUTO
+    if not isinstance(raw, str):
+        raise TypeError(
+            f"MCP protocol must be a string when configured, got {type(raw).__name__}"
+        )
+    value = raw.strip().lower()
+    if value == "auto":
+        return ProtocolPolicy.AUTO
+    if value == "legacy":
+        return ProtocolPolicy.LEGACY
+    if value in {"stateless", "2026-07-28"}:
+        return ProtocolPolicy.MODERN
+    raise ValueError(
+        f"Unknown MCP protocol {raw!r}; expected auto, legacy, stateless, or 2026-07-28"
+    )
+
+
+def _leaf_exceptions(exc: BaseException) -> list[BaseException]:
+    if isinstance(exc, BaseExceptionGroup):
+        leaves: list[BaseException] = []
+        for child in exc.exceptions:
+            leaves.extend(_leaf_exceptions(child))
+        return leaves
+    return [exc]
+
+
+def is_candidate_legacy_discovery_rejection(
+    exc: BaseException,
+    *,
+    state: ProtocolNegotiationState,
+    request_method: str,
+) -> bool:
+    if state.policy is not ProtocolPolicy.AUTO:
+        return False
+    if state.negotiated_era is not None or state.legacy_proof_attempted:
+        return False
+    if request_method != "server/discover":
+        return False
+    leaves = _leaf_exceptions(exc)
+    if len(leaves) != 1:
+        return False
+    error = getattr(leaves[0], "error", None)
+    return bool(
+        error is not None
+        and getattr(error, "code", None) == -32602
+        and getattr(error, "message", None) == "Invalid request parameters"
+        and getattr(error, "data", None) == ""
+    )
+
+
+def _protocol_version(session: Any, result: Any, era: str) -> str | None:
+    version = getattr(session, "protocol_version", None)
+    if isinstance(version, str) and version:
+        return version
+    if era == "legacy":
+        version = getattr(result, "protocol_version", None)
+        if isinstance(version, str) and version:
+            return version
+    return "2026-07-28" if era == "modern" else None
+
+
+async def negotiate_protocol(
+    session: Any,
+    state: ProtocolNegotiationState,
+    *,
+    timeout: float,
+    assert_generation: Callable[[int], None] | None = None,
+) -> ProtocolNegotiationOutcome:
+    def assert_current() -> None:
+        if assert_generation is not None:
+            assert_generation(state.generation)
+
+    async def bounded(call) -> Any:
+        assert_current()
+        result = await asyncio.wait_for(call(), timeout=timeout)
+        assert_current()
+        return result
+
+    if state.negotiated_era is not None:
+        raise RuntimeError(
+            f"MCP generation {state.generation} already negotiated {state.negotiated_era}"
+        )
+
+    if state.policy is ProtocolPolicy.LEGACY:
+        result = await bounded(session.initialize)
+        state.negotiated_era = "legacy"
+        state.negotiated_protocol_version = _protocol_version(session, result, "legacy")
+        return ProtocolNegotiationOutcome(
+            result,
+            "legacy",
+            state.negotiated_protocol_version,
+            None,
+        )
+
+    try:
+        result = await bounded(session.discover)
+    except asyncio.CancelledError:
+        raise
+    except Exception as discovery_error:
+        assert_current()
+        if not is_candidate_legacy_discovery_rejection(
+            discovery_error,
+            state=state,
+            request_method="server/discover",
+        ):
+            raise
+        state.legacy_proof_attempted = True
+        state.fallback_reason = "canonical-legacy-discover-rejection"
+        try:
+            result = await bounded(session.initialize)
+        except asyncio.CancelledError:
+            raise
+        except Exception as proof_error:
+            assert_current()
+            raise LegacyProofError(discovery_error, proof_error) from proof_error
+        state.negotiated_era = "legacy"
+        state.negotiated_protocol_version = _protocol_version(session, result, "legacy")
+        return ProtocolNegotiationOutcome(
+            result,
+            "legacy",
+            state.negotiated_protocol_version,
+            state.fallback_reason,
+        )
+
+    state.negotiated_era = "modern"
+    state.negotiated_protocol_version = _protocol_version(session, result, "modern")
+    return ProtocolNegotiationOutcome(
+        result,
+        "modern",
+        state.negotiated_protocol_version,
+        None,
+    )

--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -22,6 +22,7 @@ _CACHE_FILENAME = "mcp_schema_cache.json"
 _cache_lock = threading.Lock()
 CACHE_SCHEMA_EPOCH = 2
 MAX_TTL_MS = 24 * 60 * 60 * 1000
+AUTO_LEGACY_RECEIPT_MAX_AGE_MS = MAX_TTL_MS
 
 
 def _cache_path() -> Path:
@@ -152,6 +153,56 @@ def _entry_key(server_name: str, fingerprint: str, protocol_era: str) -> str:
     return f"{server_name}::{fingerprint}::{protocol_era}"
 
 
+def _numeric_timestamp(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    return number if number >= 0 else None
+
+
+def _validation_timestamp(entry: dict) -> Optional[float]:
+    validated_at = _numeric_timestamp(entry.get("validated_at"))
+    if validated_at is not None:
+        return validated_at
+    return _numeric_timestamp(entry.get("written_at"))
+
+
+def _entry_is_fresh(
+    entry: dict,
+    era: str,
+    now: float,
+    *,
+    auto: bool,
+) -> bool:
+    ttl_ms = entry.get("ttl_ms")
+    if isinstance(ttl_ms, bool) or (
+        ttl_ms is not None and not isinstance(ttl_ms, (int, float))
+    ):
+        return False
+    if era == "modern":
+        if ttl_ms is None:
+            return False
+        validated_at = _validation_timestamp(entry)
+        if validated_at is None:
+            return False
+        effective_ttl = min(max(float(ttl_ms), 0.0), float(MAX_TTL_MS))
+        return (now - validated_at) * 1000.0 < effective_ttl
+    if ttl_ms is not None:
+        written_at = _numeric_timestamp(entry.get("written_at"))
+        if written_at is None:
+            return False
+        effective_ttl = min(max(float(ttl_ms), 0.0), float(MAX_TTL_MS))
+        return (now - written_at) * 1000.0 < effective_ttl
+    if not auto:
+        return True
+    validated_at = _validation_timestamp(entry)
+    if validated_at is None:
+        return False
+    return (
+        now - validated_at
+    ) * 1000.0 < float(AUTO_LEGACY_RECEIPT_MAX_AGE_MS)
+
+
 def _load_all() -> Dict[str, Any]:
     path = _cache_path()
     if not path.exists():
@@ -188,11 +239,15 @@ def get_cached_entry(
     the server instead of serving a stale manifest forever. Entries without
     a recorded TTL (pre-2026 servers) keep the old never-expires behavior.
     ``cacheScope`` is irrelevant here: this cache is per-user local disk,
-    which satisfies even ``private``.
+    which satisfies even ``private``. Auto lookup requires a recent validation
+    receipt for hintless legacy entries; explicit legacy lookup retains their
+    compatibility semantics.
     """
     eras = (protocol_era,) if protocol_era is not None else ("modern", "legacy")
+    now = time.time()
     with _cache_lock:
         data = _load_all()
+    candidates = []
     for era in eras:
         entry = data.get(_entry_key(server_name, fingerprint, era))
         if not isinstance(entry, dict):
@@ -208,22 +263,23 @@ def get_cached_entry(
         cache_scope = entry.get("cache_scope")
         if cache_scope is not None and cache_scope not in {"public", "private"}:
             continue
-        ttl_ms = entry.get("ttl_ms")
-        written_at = entry.get("written_at")
-        if era == "modern" and not (
-            isinstance(ttl_ms, (int, float))
-            and not isinstance(ttl_ms, bool)
-            and isinstance(written_at, (int, float))
+        if not _entry_is_fresh(
+            entry,
+            era,
+            now,
+            auto=protocol_era is None,
         ):
             continue
-        if isinstance(ttl_ms, (int, float)) and not isinstance(ttl_ms, bool):
-            effective_ttl = min(max(float(ttl_ms), 0.0), float(MAX_TTL_MS))
-            if not isinstance(written_at, (int, float)):
+        if protocol_era is None:
+            validated_at = _validation_timestamp(entry)
+            if validated_at is None:
                 continue
-            if (time.time() - written_at) * 1000.0 >= effective_ttl:
-                continue
-        return entry
-    return None
+            candidates.append((validated_at, era == "modern", entry))
+        else:
+            return entry
+    if not candidates:
+        return None
+    return max(candidates, key=lambda candidate: (candidate[0], candidate[1]))[2]
 
 
 def has_cached_entry(
@@ -263,6 +319,7 @@ def write_cache_entry(
     """
     if protocol_era not in {"modern", "legacy"}:
         raise ValueError(f"Unsupported MCP cache protocol era: {protocol_era!r}")
+    validated_at = time.time()
     entry = {
         "epoch": CACHE_SCHEMA_EPOCH,
         "fingerprint": fingerprint,
@@ -270,6 +327,7 @@ def write_cache_entry(
         "protocol_era": protocol_era,
         "tools": tools,
         "utility_tools": utility_tools or [],
+        "validated_at": validated_at,
     }
     valid_ttl = (
         isinstance(ttl_ms, (int, float))
@@ -280,7 +338,7 @@ def write_cache_entry(
         valid_ttl = True
     if valid_ttl:
         entry["ttl_ms"] = min(max(float(ttl_ms), 0.0), float(MAX_TTL_MS))
-        entry["written_at"] = time.time()
+        entry["written_at"] = validated_at
     if protocol_era == "modern" and cache_scope not in {"public", "private"}:
         cache_scope = "private"
     if cache_scope in {"public", "private"}:
@@ -288,14 +346,6 @@ def write_cache_entry(
     key = _entry_key(server_name, fingerprint, protocol_era)
     with _cache_lock:
         data = _load_all()
-        # Write-through fires on every registration (reconnects,
-        # list_changed refreshes); skip the load-all+rewrite churn when the
-        # entry is byte-identical to what is already on disk. TTL'd entries
-        # always rewrite: written_at must advance or the entry would expire
-        # at its ORIGINAL write time no matter how many live reconnects
-        # confirmed it since.
-        if "written_at" not in entry and data.get(key) == entry:
-            return
         data[key] = entry
         _save_all(data)
 

--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -2,8 +2,8 @@
 
 Stores per-server tool manifests on disk so Hermes can register MCP tools
 into the agent snapshot without spawning the stdio child process at idle
-dashboard startup. Cache entries are keyed by server name + a fingerprint
-of the connection config (command/args/url/tools filters).
+dashboard startup. Cache entries are partitioned by server, protocol era,
+connection configuration, authentication identity, and TLS context.
 """
 
 from __future__ import annotations
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 _CACHE_FILENAME = "mcp_schema_cache.json"
 _cache_lock = threading.Lock()
+CACHE_SCHEMA_EPOCH = 2
+MAX_TTL_MS = 24 * 60 * 60 * 1000
 
 
 def _cache_path() -> Path:
@@ -28,19 +30,126 @@ def _cache_path() -> Path:
     return get_hermes_home() / "cache" / _CACHE_FILENAME
 
 
-def config_fingerprint(config: dict) -> str:
-    """Stable hash of the connection-defining parts of an MCP server config."""
-    tools_filter = config.get("tools") or {}
+def _digest(value: Any) -> str:
+    raw = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _resolved_identity_header(config: dict) -> Any:
+    identity = config.get("identity_header")
+    if not isinstance(identity, dict):
+        return identity
+    resolved = dict(identity)
+    if str(identity.get("value_from") or "static").strip().lower() == "profile":
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            resolved["resolved_value"] = get_active_profile_name()
+        except Exception:
+            resolved["resolved_value"] = None
+    return resolved
+
+
+def _file_context(value: Any) -> Any:
+    if isinstance(value, (list, tuple)):
+        return [_file_context(item) for item in value]
+    if not isinstance(value, str) or not value:
+        return value
+    path = Path(value).expanduser()
+    try:
+        stat = path.stat()
+    except OSError:
+        return {"path": str(path), "present": False}
+    return {
+        "path": str(path),
+        "present": True,
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
+def _oauth_credential_context(server_name: Optional[str], config: dict) -> Any:
+    if not server_name or str(config.get("auth") or "").strip().lower() != "oauth":
+        return None
+    try:
+        from tools.mcp_oauth import _get_token_dir, _safe_filename
+
+        token_dir = _get_token_dir()
+        stem = _safe_filename(server_name)
+        paths = {
+            "tokens": token_dir / f"{stem}.json",
+            "client": token_dir / f"{stem}.client.json",
+            "metadata": token_dir / f"{stem}.meta.json",
+        }
+    except Exception:
+        return None
+    identity = {}
+    for label, path in paths.items():
+        try:
+            identity[label] = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            identity[label] = None
+    return identity
+
+
+def _configured_policy(config: dict) -> str:
+    from tools.mcp_protocol import normalize_protocol_policy
+
+    if "protocol" in config:
+        return normalize_protocol_policy(config["protocol"]).value
+    return normalize_protocol_policy().value
+
+
+def expected_protocol_era(config: dict) -> Optional[str]:
+    policy = _configured_policy(config)
+    if policy == "modern":
+        return "modern"
+    if policy == "legacy":
+        return "legacy"
+    return None
+
+
+def config_digest(config: dict) -> str:
     payload = {
+        "config": config,
+        "resolved_identity_header": _resolved_identity_header(config),
+    }
+    return _digest(payload)[:16]
+
+
+def config_fingerprint(config: dict, *, server_name: Optional[str] = None) -> str:
+    tools_filter = config.get("tools") or {}
+    ssl_verify = config.get("ssl_verify", True)
+    payload = {
+        "cache_schema_epoch": CACHE_SCHEMA_EPOCH,
         "command": config.get("command"),
         "args": config.get("args") or [],
         "url": config.get("url"),
         "transport": config.get("transport"),
         "tools_include": sorted(tools_filter.get("include") or []),
         "tools_exclude": sorted(tools_filter.get("exclude") or []),
+        "protocol_policy": _configured_policy(config),
+        "headers": config.get("headers") or {},
+        "environment": config.get("env") or {},
+        "auth": config.get("auth"),
+        "oauth": config.get("oauth") or {},
+        "oauth_credentials": _oauth_credential_context(server_name, config),
+        "identity_header": _resolved_identity_header(config),
+        "ssl_verify": _file_context(ssl_verify),
+        "client_cert": _file_context(config.get("client_cert")),
+        "client_key": _file_context(config.get("client_key")),
+        "strict_redirect_headers": bool(config.get("strict_redirect_headers")),
     }
-    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    return _digest(payload)[:16]
+
+
+def _entry_key(server_name: str, fingerprint: str, protocol_era: str) -> str:
+    return f"{server_name}::{fingerprint}::{protocol_era}"
 
 
 def _load_all() -> Dict[str, Any]:
@@ -64,7 +173,13 @@ def _save_all(data: Dict[str, Any]) -> None:
     atomic_json_write(_cache_path(), data, mode=0o600)
 
 
-def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
+def get_cached_entry(
+    server_name: str,
+    fingerprint: str,
+    *,
+    config_digest: Optional[str] = None,
+    protocol_era: Optional[str] = None,
+) -> Optional[dict]:
     """Return cached entry when fingerprint matches (and TTL holds), else None.
 
     MCP 2026-07-28 (SEP-2549): ``tools/list`` results carry ``ttlMs`` as a
@@ -75,28 +190,66 @@ def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
     ``cacheScope`` is irrelevant here: this cache is per-user local disk,
     which satisfies even ``private``.
     """
+    eras = (protocol_era,) if protocol_era is not None else ("modern", "legacy")
     with _cache_lock:
-        entry = _load_all().get(server_name)
-    if not isinstance(entry, dict):
-        return None
-    if entry.get("fingerprint") != fingerprint:
-        return None
-    ttl_ms = entry.get("ttl_ms")
-    written_at = entry.get("written_at")
-    if isinstance(ttl_ms, (int, float)) and isinstance(written_at, (int, float)):
-        if (time.time() - written_at) * 1000.0 >= float(ttl_ms):
-            return None
-    return entry
+        data = _load_all()
+    for era in eras:
+        entry = data.get(_entry_key(server_name, fingerprint, era))
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("epoch") != CACHE_SCHEMA_EPOCH:
+            continue
+        if entry.get("fingerprint") != fingerprint:
+            continue
+        if entry.get("protocol_era") != era:
+            continue
+        if config_digest is not None and entry.get("config_digest") != config_digest:
+            continue
+        cache_scope = entry.get("cache_scope")
+        if cache_scope is not None and cache_scope not in {"public", "private"}:
+            continue
+        ttl_ms = entry.get("ttl_ms")
+        written_at = entry.get("written_at")
+        if era == "modern" and not (
+            isinstance(ttl_ms, (int, float))
+            and not isinstance(ttl_ms, bool)
+            and isinstance(written_at, (int, float))
+        ):
+            continue
+        if isinstance(ttl_ms, (int, float)) and not isinstance(ttl_ms, bool):
+            effective_ttl = min(max(float(ttl_ms), 0.0), float(MAX_TTL_MS))
+            if not isinstance(written_at, (int, float)):
+                continue
+            if (time.time() - written_at) * 1000.0 >= effective_ttl:
+                continue
+        return entry
+    return None
 
 
-def has_cached_entry(server_name: str, fingerprint: str) -> bool:
-    return get_cached_entry(server_name, fingerprint) is not None
+def has_cached_entry(
+    server_name: str,
+    fingerprint: str,
+    *,
+    config_digest: Optional[str] = None,
+    protocol_era: Optional[str] = None,
+) -> bool:
+    return (
+        get_cached_entry(
+            server_name,
+            fingerprint,
+            config_digest=config_digest,
+            protocol_era=protocol_era,
+        )
+        is not None
+    )
 
 
 def write_cache_entry(
     server_name: str,
     fingerprint: str,
     *,
+    config_digest: Optional[str] = None,
+    protocol_era: str = "legacy",
     tools: List[dict],
     utility_tools: Optional[List[dict]] = None,
     ttl_ms: Optional[float] = None,
@@ -108,16 +261,31 @@ def write_cache_entry(
     ``tools/list`` result (2026-07-28 servers). ``written_at`` anchors TTL
     expiry in :func:`get_cached_entry`.
     """
+    if protocol_era not in {"modern", "legacy"}:
+        raise ValueError(f"Unsupported MCP cache protocol era: {protocol_era!r}")
     entry = {
+        "epoch": CACHE_SCHEMA_EPOCH,
         "fingerprint": fingerprint,
+        "config_digest": config_digest,
+        "protocol_era": protocol_era,
         "tools": tools,
         "utility_tools": utility_tools or [],
     }
-    if isinstance(ttl_ms, (int, float)):
-        entry["ttl_ms"] = ttl_ms
+    valid_ttl = (
+        isinstance(ttl_ms, (int, float))
+        and not isinstance(ttl_ms, bool)
+    )
+    if protocol_era == "modern" and not valid_ttl:
+        ttl_ms = 0.0
+        valid_ttl = True
+    if valid_ttl:
+        entry["ttl_ms"] = min(max(float(ttl_ms), 0.0), float(MAX_TTL_MS))
         entry["written_at"] = time.time()
-    if cache_scope:
+    if protocol_era == "modern" and cache_scope not in {"public", "private"}:
+        cache_scope = "private"
+    if cache_scope in {"public", "private"}:
         entry["cache_scope"] = cache_scope
+    key = _entry_key(server_name, fingerprint, protocol_era)
     with _cache_lock:
         data = _load_all()
         # Write-through fires on every registration (reconnects,
@@ -126,18 +294,26 @@ def write_cache_entry(
         # always rewrite: written_at must advance or the entry would expire
         # at its ORIGINAL write time no matter how many live reconnects
         # confirmed it since.
-        if "written_at" not in entry and data.get(server_name) == entry:
+        if "written_at" not in entry and data.get(key) == entry:
             return
-        data[server_name] = entry
+        data[key] = entry
         _save_all(data)
 
 
 def clear_cache_entry(server_name: str) -> None:
+    prefix = f"{server_name}::"
     with _cache_lock:
         data = _load_all()
-        if server_name in data:
-            del data[server_name]
-            _save_all(data)
+        stale = [
+            key
+            for key in data
+            if key == server_name or key.startswith(prefix)
+        ]
+        if not stale:
+            return
+        for key in stale:
+            del data[key]
+        _save_all(data)
 
 
 def tools_from_cache_entry(entry: dict) -> List[dict]:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -100,6 +100,7 @@ import concurrent.futures
 import errno
 import fnmatch
 import inspect
+from importlib import metadata as importlib_metadata
 import json
 import logging
 import math
@@ -118,6 +119,13 @@ from urllib.parse import urlparse
 
 from tools.registry import tool_error
 from tools.ansi_strip import strip_unicode_tags
+from tools.mcp_protocol import (
+    ProtocolNegotiationState,
+    ProtocolPolicy,
+    StaleConnectionGenerationError,
+    negotiate_protocol,
+    normalize_protocol_policy,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -556,6 +564,8 @@ _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
+_MAX_SUBSCRIPTION_RELISTENS = 3
+_SUBSCRIPTION_RELISTEN_DELAY = 0.25
 # While parked (reconnect budget exhausted, tools deregistered) the run task
 # wakes on this cadence and attempts one revival probe. Without it a parked
 # server is unrevivable: its tools are out of the registry, so no tool call
@@ -767,35 +777,6 @@ def _exc_str(exc: BaseException) -> str:
 # lazy so this module never triggers the ~260ms `mcp` import at import time).
 _JSONRPC_METHOD_NOT_FOUND = -32601
 
-# 2026-07-28 stateless servers answering a legacy ``initialize`` reject it
-# with one of these: UnsupportedProtocolVersion (-32022, spec-reserved range)
-# or plain method-not-found when the handshake methods are gone entirely.
-# Structural codes only — checked via _handshake_rejected_as_modern().
-_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION = -32022
-
-
-def _handshake_rejected_as_modern(exc: BaseException) -> bool:
-    """True when a failed ``initialize`` signals a 2026-07-28-only server.
-
-    Mirrors :func:`_is_method_not_found_error`'s structural-then-substring
-    shape (never ``isinstance`` on SDK exception types — the SDK wraps
-    task-group errors in ``ExceptionGroup`` and symbols drift across
-    generations; see references/sdk-exceptiongroup-wrapping.md).
-    """
-    err = getattr(exc, "error", None)
-    code = getattr(err, "code", None) or getattr(exc, "code", None)
-    if code in (_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION, _JSONRPC_METHOD_NOT_FOUND):
-        return True
-    msg = str(exc).lower()
-    if not msg:
-        return False
-    return (
-        "unsupported protocol version" in msg
-        or str(_JSONRPC_UNSUPPORTED_PROTOCOL_VERSION) in msg
-        or _is_method_not_found_error(exc)
-    )
-
-
 def _is_method_not_found_error(exc: BaseException) -> bool:
     """Return True if *exc* is a JSON-RPC ``method not found`` (-32601).
 
@@ -900,8 +881,26 @@ def _prepend_path(env: dict, directory: str) -> dict:
 _MCP_LIST_MAX_PAGES = 50
 
 
+def _coerce_cache_ttl(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+    elif isinstance(value, str):
+        try:
+            number = float(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if not math.isfinite(number) or number < 0:
+        return None
+    return number
+
+
 async def _paginate_full_list(list_method, items_attr: str, server_name: str,
-                              cache_meta_out: Optional[dict] = None):
+                              cache_meta_out: Optional[dict] = None,
+                              protocol_era: Optional[str] = None):
     """Drain a paginated MCP ``list_*`` call by following ``nextCursor``.
 
     The MCP spec allows servers to paginate ``tools/list``,
@@ -917,10 +916,10 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
         items_attr: Result attribute holding the page's items
             (``"tools"``, ``"resources"``, or ``"prompts"``).
         server_name: For log messages.
-        cache_meta_out: Optional dict that receives the first page's
-            SEP-2549 cache hints (``ttl_ms``, ``cache_scope``) when the
-            server provides them (2026-07-28 servers MUST; earlier ones
-            won't). Callers use ``ttl_ms`` to bound the schema cache.
+        cache_meta_out: Optional dict that receives conservative SEP-2549
+            cache metadata aggregated across every page.
+        protocol_era: Negotiated era used to distinguish modern missing or
+            zero TTL metadata from legacy hintlessness.
 
     Returns:
         Combined list of items across all pages. Callers must hold the
@@ -929,6 +928,12 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
     """
     items: list = []
     cursor = None
+    era = protocol_era or "legacy"
+    missing_ttl = False
+    missing_scope = False
+    if cache_meta_out is not None:
+        cache_meta_out["protocol_era"] = era
+        cache_meta_out["metadata_complete"] = True
     for _ in range(_MCP_LIST_MAX_PAGES):
         if not cursor:
             result = await list_method()
@@ -944,13 +949,36 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
                     result = await list_method(cursor=cursor)
             except TypeError:
                 result = await list_method(cursor=cursor)
-        if cache_meta_out is not None and not items:
-            _ttl = mcp_field(result, "ttl_ms", "ttlMs")
-            _scope = mcp_field(result, "cache_scope", "cacheScope")
-            if _ttl is not None:
-                cache_meta_out["ttl_ms"] = _ttl
-            if _scope is not None:
-                cache_meta_out["cache_scope"] = _scope
+        if cache_meta_out is not None:
+            ttl = _coerce_cache_ttl(mcp_field(result, "ttl_ms", "ttlMs"))
+            scope = mcp_field(result, "cache_scope", "cacheScope")
+            if ttl is None:
+                missing_ttl = True
+                cache_meta_out["metadata_complete"] = False
+                if era == "modern" or "ttl_ms" in cache_meta_out:
+                    cache_meta_out["ttl_ms"] = 0.0
+            else:
+                previous_ttl = cache_meta_out.get("ttl_ms")
+                cache_meta_out["ttl_ms"] = (
+                    ttl if previous_ttl is None else min(float(previous_ttl), ttl)
+                )
+                if missing_ttl:
+                    cache_meta_out["ttl_ms"] = 0.0
+            if scope not in {"public", "private"}:
+                missing_scope = True
+                cache_meta_out["metadata_complete"] = False
+                if era == "modern" or "cache_scope" in cache_meta_out:
+                    cache_meta_out["cache_scope"] = "private"
+            else:
+                previous_scope = cache_meta_out.get("cache_scope")
+                if previous_scope is not None and previous_scope != scope:
+                    cache_meta_out["cache_scope"] = "private"
+                    cache_meta_out["scope_conflict"] = True
+                elif missing_scope:
+                    cache_meta_out["cache_scope"] = "private"
+                    cache_meta_out["scope_conflict"] = True
+                else:
+                    cache_meta_out["cache_scope"] = scope
         items.extend(getattr(result, items_attr, None) or [])
         cursor = mcp_field(result, "next_cursor", "nextCursor")
         # Per the MCP spec the cursor is an opaque string; anything else
@@ -2292,7 +2320,12 @@ class ElicitationHandler:
         # owner._pending_call_context we replay it here via
         # contextvars.Context.run so the gateway-platform detection in
         # request_elicitation_consent picks up the right session.
-        captured = getattr(self.owner, "_pending_call_context", None) if self.owner else None
+        captured = None
+        if self.owner is not None and (
+            getattr(self.owner, "_pending_call_generation", None)
+            == getattr(self.owner, "_connection_generation", None)
+        ):
+            captured = getattr(self.owner, "_pending_call_context", None)
 
         def _invoke_consent() -> str:
             if captured is None:
@@ -2363,11 +2396,15 @@ class MCPServerTask:
         "_sampling", "_elicitation",
         "_registered_tool_names", "_auth_type", "_refresh_lock",
         "_rpc_lock", "_pending_refresh_tasks",
-        "_pending_call_context",
+        "_pending_mrtr_tasks", "_listen_task", "_listen_generation",
+        "_pending_call_context", "_pending_call_generation",
         "_lifecycle_started_at", "_last_tool_call_at",
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported", "_list_cache_meta",
         "_reconnect_retries", "_session_proven", "_was_parked",
+        "_protocol_policy", "_protocol_state", "_connection_generation",
+        "negotiated_era", "negotiated_protocol_version", "fallback_reason",
+        "subscription_state", "catalogue_state", "liveness_strategy", "cache_state",
     )
 
     def __init__(self, name: str):
@@ -2394,7 +2431,7 @@ class MCPServerTask:
         # UNPROVEN until it demonstrates real health — it survived at least
         # one full keepalive interval (keepalive success path) or served at
         # least one successful tool call. Only a proven session clears the
-        # reconnect budget; a transport that flaps right after the handshake
+        # reconnect budget; a transport that flaps right after negotiation
         # keeps getting charged and still reaches the park instead of
         # hot-cycling respawns forever.
         self._session_proven: bool = False
@@ -2412,6 +2449,9 @@ class MCPServerTask:
         # transports for conservative per-server ordering.
         self._rpc_lock = asyncio.Lock()
         self._pending_refresh_tasks: set[asyncio.Task] = set()
+        self._pending_mrtr_tasks: set[asyncio.Task] = set()
+        self._listen_task: Optional[asyncio.Task] = None
+        self._listen_generation: Optional[int] = None
         # contextvars snapshot of the agent task that's currently in
         # session.call_tool(). The MCP recv loop dispatches incoming
         # elicitation/create requests on a SEPARATE asyncio task whose
@@ -2422,17 +2462,16 @@ class MCPServerTask:
         # gateway-platform attribution and routes the approval prompt
         # to the right surface (Telegram, Slack, etc.).
         self._pending_call_context: Optional[contextvars.Context] = None
+        self._pending_call_generation: Optional[int] = None
         now = time.monotonic()
         self._lifecycle_started_at: float = now
         self._last_tool_call_at: float = now
         self._idle_timeout_seconds: Optional[float] = None
         self._max_lifetime_seconds: Optional[float] = None
         self._recycled_reason: Optional[str] = None
-        # Captures the ``InitializeResult`` returned by
-        # ``await session.initialize()`` so downstream code can inspect the
-        # server's real advertised capabilities (``.capabilities.resources``,
-        # ``.capabilities.prompts``) instead of assuming every ``ClientSession``
-        # method attribute corresponds to a supported server method. See #18051.
+        # Captures the negotiated discover or initialize result so downstream
+        # code can inspect the server's advertised capabilities instead of
+        # treating every ClientSession method as supported. See #18051.
         self.initialize_result: Optional[Any] = None
         # SEP-2549 cache hints from the last tools/list (ttl_ms, cache_scope).
         self._list_cache_meta: dict = {}
@@ -2442,6 +2481,16 @@ class MCPServerTask:
         # back to ``list_tools`` (the pre-ping probe) so we neither spam pings
         # nor reconnect-loop. Reset on each fresh transport connection.
         self._ping_unsupported: bool = False
+        self._protocol_policy: Optional[ProtocolPolicy] = None
+        self._protocol_state: Optional[ProtocolNegotiationState] = None
+        self._connection_generation: int = 0
+        self.negotiated_era: Optional[str] = None
+        self.negotiated_protocol_version: Optional[str] = None
+        self.fallback_reason: Optional[str] = None
+        self.subscription_state: str = "idle"
+        self.catalogue_state: str = "stale"
+        self.liveness_strategy: str = "none"
+        self.cache_state: str = "uninitialised"
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -2467,86 +2516,91 @@ class MCPServerTask:
             return True
         return getattr(caps, "tools", None) is not None
 
+    def _assert_connection_generation(self, generation: int) -> None:
+        if generation != self._connection_generation:
+            raise StaleConnectionGenerationError(
+                generation,
+                self._connection_generation,
+            )
+
+    async def _cancel_generation_tasks(self) -> None:
+        current = asyncio.current_task()
+        tasks = {
+            task
+            for task in (
+                *self._pending_refresh_tasks,
+                *self._pending_mrtr_tasks,
+                self._listen_task,
+            )
+            if task is not None and task is not current
+        }
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._pending_refresh_tasks.clear()
+        self._pending_mrtr_tasks.clear()
+        self._listen_task = None
+        self._listen_generation = None
+
+    async def _begin_connection_generation(self) -> int:
+        self._connection_generation += 1
+        generation = self._connection_generation
+        self._pending_call_context = None
+        self._pending_call_generation = None
+        await self._cancel_generation_tasks()
+        self._protocol_state = None
+        self.negotiated_era = None
+        self.negotiated_protocol_version = None
+        self.fallback_reason = None
+        self._list_cache_meta = {}
+        self._ping_unsupported = False
+        self.subscription_state = "idle"
+        self.catalogue_state = "stale"
+        self.liveness_strategy = "none"
+        self.cache_state = "stale"
+        return generation
+
     async def _negotiate_session(self, session, connect_timeout: float):
-        """Negotiate the protocol era with the server and return its result.
-
-        MCP 2026-07-28 replaced the ``initialize``/``initialized`` handshake
-        with a stateless core: every request is self-describing and clients
-        MAY probe ``server/discover`` up front (SEP-2575). The SDK exposes
-        both paths on ``ClientSession`` (``initialize()`` / ``discover()``)
-        and ``adopt()``s whichever result installs the outbound stamp, so
-        the rest of this file is era-agnostic.
-
-        Per-server ``protocol`` config key:
-
-        - ``auto`` (default): try the legacy handshake FIRST, and fall back
-          to ``server/discover`` when the server signals it is modern-only
-          (``UnsupportedProtocolVersion`` -32022, or ``initialize`` missing
-          -32601). This is the reverse of the SDK's own discover-first auto
-          mode, on purpose: nearly every configured/catalog server today
-          speaks the handshake era, and initialize-first means ZERO extra
-          round-trips and zero behavior change for all of them, while
-          stateless-only servers still connect via the fallback.
-        - ``stateless``: probe ``server/discover`` first (one legacy retry
-          on MCPError, so a handshake-only server still connects).
-        - ``legacy``: handshake only, no fallback (escape hatch for servers
-          that misbehave on unknown methods).
-
-        Both result types expose ``.capabilities``, so downstream gates
-        (``_advertises_tools``, ``_select_utility_schemas``, the config
-        probe) work unchanged on either.
-        """
-        mode = str((self._config or {}).get("protocol", "auto")).lower().strip()
-        if mode in ("stateless", "modern", "2026-07-28"):
-            try:
-                return await asyncio.wait_for(
-                    session.discover(), timeout=connect_timeout
-                )
-            except asyncio.TimeoutError:
-                raise
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                logger.info(
-                    "MCP server '%s': server/discover rejected (%s) despite "
-                    "protocol=%s — falling back to the legacy handshake",
-                    self.name, exc, mode,
-                )
-                return await asyncio.wait_for(
-                    session.initialize(), timeout=connect_timeout
-                )
-        if mode in ("legacy", "handshake"):
-            return await asyncio.wait_for(
-                session.initialize(), timeout=connect_timeout
-            )
-        if mode != "auto":
-            logger.warning(
-                "MCP server '%s': unknown protocol=%r — treating as 'auto' "
-                "(valid: auto, stateless, legacy)", self.name, mode,
-            )
+        policy = self._protocol_policy
+        if policy is None:
+            if "protocol" in (self._config or {}):
+                policy = normalize_protocol_policy(self._config["protocol"])
+            else:
+                policy = normalize_protocol_policy()
+        self._protocol_policy = policy
+        generation = await self._begin_connection_generation()
+        state = ProtocolNegotiationState(generation=generation, policy=policy)
+        self._protocol_state = state
         try:
-            return await asyncio.wait_for(
-                session.initialize(), timeout=connect_timeout
+            outcome = await negotiate_protocol(
+                session,
+                state,
+                timeout=connect_timeout,
+                assert_generation=self._assert_connection_generation,
             )
-        except asyncio.TimeoutError:
+        except BaseException:
+            self._assert_connection_generation(generation)
+            self.fallback_reason = state.fallback_reason
             raise
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            if not _handshake_rejected_as_modern(exc):
-                raise
-            if not hasattr(session, "discover"):
-                # Legacy SDK generation (mcp 1.x) has no server/discover
-                # client — nothing to fall back to.
-                raise
-            logger.info(
-                "MCP server '%s': legacy handshake rejected (%s) — "
-                "retrying via server/discover (2026-07-28 stateless server)",
-                self.name, exc,
-            )
-            return await asyncio.wait_for(
-                session.discover(), timeout=connect_timeout
-            )
+        self._assert_connection_generation(generation)
+        self.negotiated_era = outcome.era
+        self.negotiated_protocol_version = outcome.protocol_version
+        self.fallback_reason = outcome.fallback_reason
+        self.liveness_strategy = (
+            "stateless-discover" if outcome.era == "modern" else "legacy-session-ping"
+        )
+        logger.info(
+            "MCP server '%s': protocol policy=%s negotiated era=%s version=%s "
+            "generation=%d",
+            self.name,
+            policy.value,
+            outcome.era,
+            outcome.protocol_version or "unknown",
+            generation,
+        )
+        return outcome.result
 
     def _is_recycled_stdio(self) -> bool:
         """Return True when a stdio server was intentionally recycled."""
@@ -2597,10 +2651,10 @@ class MCPServerTask:
 
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
 
-    async def _refresh_tools_task(self):
+    async def _refresh_tools_task(self, generation: int):
         """Run a dynamic tool refresh and log failures from background tasks."""
         try:
-            await self._refresh_tools()
+            await self._refresh_tools(generation=generation)
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -2608,10 +2662,202 @@ class MCPServerTask:
 
     def _schedule_tools_refresh(self) -> asyncio.Task:
         """Schedule a background tool refresh and keep it strongly referenced."""
-        task = asyncio.create_task(self._refresh_tools_task())
+        generation = self._connection_generation
+        task = asyncio.create_task(self._refresh_tools_task(generation))
         self._pending_refresh_tasks.add(task)
         task.add_done_callback(self._pending_refresh_tasks.discard)
         return task
+
+    def _subscription_filters(self) -> dict[str, bool]:
+        caps = getattr(self.initialize_result, "capabilities", None)
+        return {
+            "tools_list_changed": caps is None or getattr(caps, "tools", None) is not None,
+            "prompts_list_changed": caps is None or getattr(caps, "prompts", None) is not None,
+            "resources_list_changed": caps is None or getattr(caps, "resources", None) is not None,
+        }
+
+    async def _reconcile_subscription_catalogue(
+        self,
+        generation: int,
+        session: Any,
+        families: set[str],
+    ) -> None:
+        self._assert_connection_generation(generation)
+        if self.session is not session:
+            raise StaleConnectionGenerationError(
+                generation,
+                self._connection_generation,
+            )
+        self.catalogue_state = "stale"
+        filters = self._subscription_filters()
+        if "tools" in families and filters["tools_list_changed"]:
+            await self._refresh_tools(generation=generation)
+            self.catalogue_state = "stale"
+        for family, method_name in (
+            ("prompts", "list_prompts"),
+            ("resources", "list_resources"),
+        ):
+            if family not in families or not filters[f"{family}_list_changed"]:
+                continue
+            async with self._rpc_lock:
+                await _paginate_full_list(
+                    getattr(session, method_name),
+                    family,
+                    self.name,
+                    protocol_era=self.negotiated_era,
+                )
+            self._assert_connection_generation(generation)
+            if self.session is not session:
+                raise StaleConnectionGenerationError(
+                    generation,
+                    self._connection_generation,
+                )
+        self._assert_connection_generation(generation)
+        if self.session is not session:
+            raise StaleConnectionGenerationError(
+                generation,
+                self._connection_generation,
+            )
+        self.catalogue_state = "current"
+
+    async def _subscription_supervisor(self, generation: int, session: Any) -> None:
+        from mcp.client.subscriptions import (
+            ListenNotSupportedError,
+            PromptsListChanged,
+            ResourcesListChanged,
+            ToolsListChanged,
+            listen,
+        )
+
+        if generation != self._connection_generation or self.session is not session:
+            return
+
+        filters = self._subscription_filters()
+        relistens = 0
+        gap = False
+        try:
+            while generation == self._connection_generation and self.session is session:
+                self.subscription_state = "relistening" if gap else "establishing"
+                try:
+                    async with listen(session, **filters) as subscription:
+                        self._assert_connection_generation(generation)
+                        if self.session is not session:
+                            return
+                        honored = getattr(subscription, "honored", None)
+                        if honored is not None and not any(
+                            bool(getattr(honored, name, None))
+                            for name, requested in filters.items()
+                            if requested
+                        ):
+                            self.subscription_state = "unsupported"
+                            return
+                        self.subscription_state = "active"
+                        if gap:
+                            await self._reconcile_subscription_catalogue(
+                                generation,
+                                session,
+                                {
+                                    family
+                                    for family in ("tools", "prompts", "resources")
+                                    if filters[f"{family}_list_changed"]
+                                },
+                            )
+                        async for event in subscription:
+                            self._assert_connection_generation(generation)
+                            if self.session is not session:
+                                return
+                            if isinstance(event, ToolsListChanged):
+                                families = {"tools"}
+                            elif isinstance(event, PromptsListChanged):
+                                families = {"prompts"}
+                            elif isinstance(event, ResourcesListChanged):
+                                families = {"resources"}
+                            else:
+                                relistens = 0
+                                continue
+                            await self._reconcile_subscription_catalogue(
+                                generation,
+                                session,
+                                families,
+                            )
+                            relistens = 0
+                    gap_reason = "clean EOF"
+                except asyncio.CancelledError:
+                    raise
+                except ListenNotSupportedError:
+                    self._assert_connection_generation(generation)
+                    self.subscription_state = "unsupported"
+                    return
+                except StaleConnectionGenerationError:
+                    return
+                except Exception as exc:
+                    if _is_method_not_found_error(exc):
+                        self._assert_connection_generation(generation)
+                        self.subscription_state = "unsupported"
+                        return
+                    gap_reason = _exc_str(exc)
+
+                self._assert_connection_generation(generation)
+                if self.session is not session:
+                    return
+                self.catalogue_state = "stale"
+                if relistens >= _MAX_SUBSCRIPTION_RELISTENS:
+                    self.subscription_state = "exhausted"
+                    logger.warning(
+                        "MCP server '%s': subscription relisten exhausted after %d "
+                        "attempts (%s); reconnecting",
+                        self.name,
+                        relistens,
+                        gap_reason,
+                    )
+                    self._reconnect_event.set()
+                    return
+                relistens += 1
+                gap = True
+                self.subscription_state = "relistening"
+                logger.info(
+                    "MCP server '%s': subscription gap (%s); relisten %d/%d",
+                    self.name,
+                    gap_reason,
+                    relistens,
+                    _MAX_SUBSCRIPTION_RELISTENS,
+                )
+                await asyncio.sleep(_SUBSCRIPTION_RELISTEN_DELAY)
+        finally:
+            if generation == self._connection_generation and self.session is session:
+                if self.subscription_state not in {"unsupported", "exhausted"}:
+                    self.subscription_state = "stopped"
+
+    def _start_subscription_supervisor(self, generation: int) -> Optional[asyncio.Task]:
+        if self.negotiated_era != "modern":
+            self.subscription_state = "legacy-not-applicable"
+            return None
+        self._assert_connection_generation(generation)
+        session = self.session
+        if session is None:
+            return None
+        listener = self._listen_task
+        if listener is not None and not listener.done():
+            if self._listen_generation == generation:
+                return listener
+            raise RuntimeError(
+                f"MCP server '{self.name}' already owns a listener for generation "
+                f"{self._listen_generation}"
+            )
+        listener = asyncio.create_task(
+            self._subscription_supervisor(generation, session),
+            name=f"mcp-subscription-{self.name}-{generation}",
+        )
+        self._listen_task = listener
+        self._listen_generation = generation
+
+        def clear_owner(done: asyncio.Task) -> None:
+            if self._listen_task is done and self._listen_generation == generation:
+                self._listen_task = None
+                self._listen_generation = None
+
+        listener.add_done_callback(clear_owner)
+        return listener
 
     def _make_logging_callback(self):
         """Build a ``logging_callback`` for ``ClientSession``.
@@ -2647,17 +2893,26 @@ class MCPServerTask:
                 )
         return _on_log
 
-    def _make_message_handler(self):
+    def _make_message_handler(self, generation: Optional[int] = None):
         """Build a ``message_handler`` callback for ``ClientSession``.
 
         Dispatches on notification type.  Only ``ToolListChangedNotification``
         triggers a refresh; prompt and resource change notifications are
         logged as stubs for future work.
         """
+        handler_generation = (
+            self._connection_generation if generation is None else generation
+        )
+
         async def _handler(message):
             try:
+                if handler_generation != self._connection_generation:
+                    return
                 if isinstance(message, Exception):
                     logger.debug("MCP message handler (%s): exception: %s", self.name, message)
+                    self.catalogue_state = "stale"
+                    if not self._shutdown_event.is_set():
+                        self._reconnect_event.set()
                     return
                 if _MCP_NOTIFICATION_TYPES and isinstance(message, ServerNotification):
                     # mcp 2.0 turned ServerNotification from a RootModel into
@@ -2675,7 +2930,7 @@ class MCPServerTask:
                                 self.name,
                             )
                             # Some servers (notably mongodb-mcp-server) emit
-                            # tools/list_changed immediately after initialize,
+                            # tools/list_changed immediately after negotiation,
                             # while the client may already be executing another
                             # request. Refreshing synchronously inside the SDK
                             # notification handler can race with that request
@@ -2698,7 +2953,7 @@ class MCPServerTask:
                 logger.exception("Error in MCP message handler for '%s'", self.name)
         return _handler
 
-    async def _refresh_tools(self):
+    async def _refresh_tools(self, generation: Optional[int] = None):
         """Re-fetch tools from the server and update the registry.
 
         Called when the server sends ``notifications/tools/list_changed``.
@@ -2708,20 +2963,36 @@ class MCPServerTask:
         """
         from tools.registry import registry
 
-        if not self._advertises_tools():
+        generation = self._connection_generation if generation is None else generation
+        self._assert_connection_generation(generation)
+        session = self.session
+        if session is None or not self._advertises_tools():
             # A server that doesn't implement tools/* should never send
             # tools/list_changed, but guard anyway — calling tools/list
             # would raise MCPError(-32601).
             return
 
         async with self._refresh_lock:
+            self._assert_connection_generation(generation)
+            self.catalogue_state = "stale"
             # Capture old tool names for change diff
             old_tool_names = set(self._registered_tool_names)
 
             # 1. Fetch current tool list from server (follow nextCursor)
             async with self._rpc_lock:
+                cache_meta: dict = {}
                 new_mcp_tools = await _paginate_full_list(
-                    self.session.list_tools, "tools", self.name
+                    session.list_tools,
+                    "tools",
+                    self.name,
+                    cache_meta_out=cache_meta,
+                    protocol_era=self.negotiated_era,
+                )
+            self._assert_connection_generation(generation)
+            if self.session is not session:
+                raise StaleConnectionGenerationError(
+                    generation,
+                    self._connection_generation,
                 )
 
             # 2. Re-register with fresh tool list. Avoid nuke-and-repave for
@@ -2746,6 +3017,7 @@ class MCPServerTask:
 
             # 3. Re-register with the fresh list. The helper may skip names that
             # are ambiguous after normalization.
+            self._list_cache_meta = cache_meta
             self._tools = new_mcp_tools
             registered_names = _register_server_tools(
                 self.name, self, self._config
@@ -2783,6 +3055,8 @@ class MCPServerTask:
                     "MCP server '%s': dynamically refreshed %d tool(s) (no changes)",
                     self.name, len(self._registered_tool_names),
                 )
+            self.catalogue_state = "current"
+            self.cache_state = "live"
 
     async def _keepalive_probe(self) -> None:
         """Exercise the session to detect a stale/expired connection.
@@ -2800,9 +3074,25 @@ class MCPServerTask:
         Raises on a genuine connection failure so the caller triggers a
         reconnect; returns normally when the session is alive.
         """
+        generation = self._connection_generation
+        session = self.session
+        if self.negotiated_era == "modern":
+            version = self.negotiated_protocol_version or "2026-07-28"
+            self.liveness_strategy = "stateless-discover"
+            async with self._rpc_lock:
+                await asyncio.wait_for(session.send_discover(version), timeout=30.0)
+            self._assert_connection_generation(generation)
+            if self.session is not session:
+                raise StaleConnectionGenerationError(
+                    generation,
+                    self._connection_generation,
+                )
+            return
+
+        self.liveness_strategy = "legacy-session-ping"
         if not self._ping_unsupported:
             try:
-                await asyncio.wait_for(self.session.send_ping(), timeout=30.0)
+                await asyncio.wait_for(session.send_ping(), timeout=30.0)
                 return
             except Exception as exc:
                 # Only a "method not found" means ping is unsupported. Any
@@ -2814,6 +3104,7 @@ class MCPServerTask:
                     # No ping, no tools → no cheaper probe to fall back to.
                     raise
                 self._ping_unsupported = True
+                self.liveness_strategy = "legacy-tools-list"
                 logger.info(
                     "MCP server '%s': does not implement the optional 'ping' "
                     "utility (-32601); using 'list_tools' for keepalive on "
@@ -2822,14 +3113,15 @@ class MCPServerTask:
                 )
 
         # Fallback probe for servers without ping support.
-        await asyncio.wait_for(self.session.list_tools(), timeout=30.0)
+        self.liveness_strategy = "legacy-tools-list"
+        await asyncio.wait_for(session.list_tools(), timeout=30.0)
 
     def _mark_session_proven(self) -> None:
         """Record that the current session demonstrated real health.
 
         Called from the keepalive success path (session survived at least one
         full keepalive interval) and the tool-call success path. Only then is
-        the reconnect budget cleared: a handshake that completes but drops
+        the reconnect budget cleared: negotiation that completes but drops
         moments later must keep consuming ``_reconnect_retries`` so a flapping
         transport still reaches the park instead of respawning forever
         (#62212 — 6212 spawns in 63h).
@@ -2949,6 +3241,12 @@ class MCPServerTask:
             return "shutdown"
         self._reconnect_event.clear()
         return "reconnect"
+
+    async def _wait_for_lifecycle_and_stop_generation(self) -> str:
+        try:
+            return await self._wait_for_lifecycle_event()
+        finally:
+            await self._cancel_generation_tasks()
 
     async def _wait_for_reconnect_or_shutdown(
         self, timeout: Optional[float] = None
@@ -3074,7 +3372,9 @@ class MCPServerTask:
         if self._elicitation:
             sampling_kwargs.update(self._elicitation.session_kwargs())
         if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
-            sampling_kwargs["message_handler"] = self._make_message_handler()
+            sampling_kwargs["message_handler"] = self._make_message_handler(
+                self._connection_generation + 1
+            )
         if _MCP_LOGGING_CALLBACK_SUPPORTED:
             sampling_kwargs["logging_callback"] = self._make_logging_callback()
 
@@ -3134,8 +3434,8 @@ class MCPServerTask:
                 async with ClientSession(
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
-                    # Bound the MCP handshake. A stdio server that never
-                    # completes ``initialize`` (e.g. emits a non-JSON-RPC frame
+                    # Bound MCP negotiation. A stdio server that never answers
+                    # the first flight (e.g. emits a non-JSON-RPC frame
                     # and then blocks on stdin) otherwise hangs this coroutine
                     # forever on the background loop: ``connect_timeout`` only
                     # bounds the caller's ``.result()`` wait, not the coroutine
@@ -3154,13 +3454,14 @@ class MCPServerTask:
                     self.session = session
                     self._mark_lifecycle_started()
                     await self._discover_tools()
+                    self._start_subscription_supervisor(self._connection_generation)
                     self._ready.set()
                     # Session is live again: clear any breaker state from a
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
-                    # A completed handshake alone is NOT proof of health: a
-                    # flapping transport can handshake fine and drop moments
+                    # Completed negotiation alone is NOT proof of health: a
+                    # flapping transport can negotiate and drop moments
                     # later, forever (#62212). The session must prove itself
                     # (keepalive success or a successful tool call) before the
                     # reconnect budget is cleared — see _mark_session_proven.
@@ -3168,7 +3469,7 @@ class MCPServerTask:
                     # stdio transport does not use OAuth, but we still honor
                     # _reconnect_event (e.g. future manual /mcp refresh) for
                     # consistency with _run_http.
-                    return await self._wait_for_lifecycle_event()
+                    return await self._wait_for_lifecycle_and_stop_generation()
         finally:
             # Runs on clean exit, exceptions, AND asyncio cancellation.
             # If any of the spawned PIDs are still alive, the SDK's
@@ -3228,19 +3529,16 @@ class MCPServerTask:
         here catches that in ≤ ``timeout`` seconds and raises
         :class:`NonMcpEndpointError` with an actionable message.
 
-        Detection is allow-list based: a 2xx response is rejected only when it
-        carries a definite content type that is NOT one an MCP endpoint uses
-        (``application/json`` / ``text/event-stream``).  When HEAD/GET returns
-        a non-MCP content type (e.g. ``text/html``), a lightweight JSON-RPC
-        ``initialize`` POST is attempted before giving up — some servers
-        (e.g. DocuSeal) serve a web UI on GET but speak Streamable HTTP only
-        via POST.
+        Detection is allow-list based. A 2xx response with a non-MCP content
+        type is rejected only when the endpoint explicitly advertises an
+        ``Allow`` set without POST. Otherwise it is ambiguous because some
+        servers expose HTML on HEAD/GET and MCP only on POST, so the response
+        is left to the authoritative protocol negotiation.
 
         A missing or empty content type, non-2xx status, or any
         network/transport error passes through silently — the probe is
-        strictly best-effort, and the real handshake remains the source of
-        truth for everything except the unambiguous "this is a web page,
-        not MCP" case.
+        strictly best-effort. It never sends JSON-RPC, ensuring the actual
+        ``server/discover`` request remains the protocol first flight.
 
         Runs on its own httpx client OUTSIDE the SDK's anyio task group, so the
         raised error propagates as itself rather than being wrapped in an
@@ -3269,51 +3567,11 @@ class MCPServerTask:
                 if resp.status_code in (405, 501):
                     resp = await client.get(url, headers=probe_headers)
 
-                # Some MCP servers (e.g. DocuSeal) serve their web UI on
-                # HEAD/GET but speak Streamable HTTP only via POST.  Before
-                # rejecting the endpoint, try a lightweight JSON-RPC POST
-                # probe so we don't false-positive on POST-only servers.
-                ct = (
-                    resp.headers.get("content-type", "")
-                    .split(";")[0]
-                    .strip()
-                    .lower()
-                )
-                if (
-                    ct
-                    and ct not in self._MCP_CONTENT_TYPES
-                    and 200 <= resp.status_code < 300
-                ):
-                    post_resp = await client.post(
-                        url,
-                        headers={
-                            **probe_headers,
-                            "Content-Type": "application/json",
-                            "Accept": "application/json, text/event-stream",
-                        },
-                        content=(
-                            '{"jsonrpc":"2.0","id":"_probe",'
-                            '"method":"initialize",'
-                            '"params":{"protocolVersion":"2025-03-26",'
-                            '"capabilities":{},'
-                            '"clientInfo":{"name":"hermes-probe",'
-                            '"version":"0.1"}}}'
-                        ),
-                    )
-                    if 200 <= post_resp.status_code < 300:
-                        post_ct = (
-                            post_resp.headers.get("content-type", "")
-                            .split(";")[0]
-                            .strip()
-                            .lower()
-                        )
-                        if post_ct in self._MCP_CONTENT_TYPES:
-                            resp = post_resp
         except _httpx.HTTPError:
             return  # DNS/connect/timeout/transport error — let the SDK try.
 
         # Only judge successful responses. A 4xx/5xx may be an auth challenge
-        # or a transient error the real handshake handles correctly.
+        # or a transient error the real negotiation handles correctly.
         if not (200 <= resp.status_code < 300):
             return
 
@@ -3322,6 +3580,17 @@ class MCPServerTask:
             return  # No content type advertised — don't second-guess the SDK.
         if ct_base in self._MCP_CONTENT_TYPES:
             return  # Looks like a real MCP endpoint.
+
+        allow_header = resp.headers.get("allow", "")
+        if not allow_header:
+            return
+        allowed_methods = {
+            method.strip().upper()
+            for method in allow_header.split(",")
+            if method.strip()
+        }
+        if "POST" in allowed_methods:
+            return
 
         raise NonMcpEndpointError(
             f"MCP server '{self.name}' at {url} returned Content-Type "
@@ -3356,7 +3625,7 @@ class MCPServerTask:
         - the group carries a real ``CancelledError`` (task cancellation must
           propagate to asyncio, mirroring the ``run()`` guard for #9930);
         - we never reached a live session this attempt (``_ready`` unset) — a
-          connect/handshake failure SHOULD fall through to ``run()``'s backoff
+          connect/negotiation failure SHOULD fall through to ``run()``'s backoff
           rather than hot-loop reconnects against a broken endpoint.
         """
         if self._shutdown_event.is_set():
@@ -3398,18 +3667,10 @@ class MCPServerTask:
         # Optional per-user identity header (config-gated; static or
         # profile-derived). Explicit headers of the same name win.
         headers = _apply_identity_header(self.name, config, headers)
-        # Some MCP servers require MCP-Protocol-Version on the initial
-        # initialize request and reject session-less POSTs otherwise.
-        # Seed it as a client-level default, but treat user overrides as
-        # case-insensitive so conventional casing is preserved.
-        #
-        # Seeded from the HANDSHAKE version, not the latest one: this transport
-        # connects via `ClientSession.initialize()`, which sends
-        # LATEST_HANDSHAKE_VERSION (2025-11-25) in the body. Advertising
-        # 2026-07-28 in the header routes the request onto the server's
-        # per-request-envelope ladder, which then rejects the legacy body for
-        # missing its required `params._meta` envelope keys. The header has to
-        # agree with what the body actually speaks.
+        # Keep a handshake-compatible client default for the one bounded
+        # discover-to-initialize legacy proof. Modern discover requests carry
+        # a per-message 2026-07-28 header from ClientSession and override this
+        # default; the SDK clears that modern stamp before initialize.
         if not any(key.lower() == "mcp-protocol-version" for key in headers):
             headers["mcp-protocol-version"] = LATEST_HANDSHAKE_VERSION
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
@@ -3437,7 +3698,9 @@ class MCPServerTask:
         if self._elicitation:
             sampling_kwargs.update(self._elicitation.session_kwargs())
         if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
-            sampling_kwargs["message_handler"] = self._make_message_handler()
+            sampling_kwargs["message_handler"] = self._make_message_handler(
+                self._connection_generation + 1
+            )
         if _MCP_LOGGING_CALLBACK_SUPPORTED:
             sampling_kwargs["logging_callback"] = self._make_logging_callback()
 
@@ -3516,15 +3779,16 @@ class MCPServerTask:
                     async with ClientSession(
                         read_stream, write_stream, **sampling_kwargs
                     ) as session:
-                        # Bound the handshake — same orphaned-task hang as the
+                        # Bound negotiation — same orphaned-task hang as the
                         # stdio path (#59349): an endpoint that accepts the
-                        # connection but never answers ``initialize`` parks this
+                        # connection but never answers the first flight parks this
                         # coroutine forever on the background loop.
                         self.initialize_result = await self._negotiate_session(
                             session, float(connect_timeout)
                         )
                         self.session = session
                         await self._discover_tools()
+                        self._start_subscription_supervisor(self._connection_generation)
                         self._ready.set()
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
@@ -3532,7 +3796,7 @@ class MCPServerTask:
                         _reset_server_error(self.name)
                         # Unproven until keepalive/tool-call success (#62212).
                         self._session_proven = False
-                        reason = await self._wait_for_lifecycle_event()
+                        reason = await self._wait_for_lifecycle_and_stop_generation()
                         if reason == "reconnect":
                             logger.info(
                                 "MCP server '%s': reconnect requested — "
@@ -3584,12 +3848,13 @@ class MCPServerTask:
                     async with streamable_http_client(url, http_client=http_client) as _streams:
                         read_stream, write_stream = _streams[0], _streams[1]
                         async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
-                            # Bound the handshake (#59349) — see stdio path.
+                            # Bound negotiation (#59349) — see stdio path.
                             self.initialize_result = await self._negotiate_session(
                                 session, float(connect_timeout)
                             )
                             self.session = session
                             await self._discover_tools()
+                            self._start_subscription_supervisor(self._connection_generation)
                             self._ready.set()
                             # Session is live again: clear any breaker state from
                             # a prior outage so the first call after recovery
@@ -3597,7 +3862,7 @@ class MCPServerTask:
                             _reset_server_error(self.name)
                             # Unproven until keepalive/tool-call success (#62212).
                             self._session_proven = False
-                            reason = await self._wait_for_lifecycle_event()
+                            reason = await self._wait_for_lifecycle_and_stop_generation()
                             if reason == "reconnect":
                                 logger.info(
                                     "MCP server '%s': reconnect requested — "
@@ -3631,12 +3896,13 @@ class MCPServerTask:
                     read_stream, write_stream, _get_session_id,
                 ):
                     async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
-                        # Bound the handshake (#59349) — see stdio path.
+                        # Bound negotiation (#59349) — see stdio path.
                         self.initialize_result = await self._negotiate_session(
                             session, float(connect_timeout)
                         )
                         self.session = session
                         await self._discover_tools()
+                        self._start_subscription_supervisor(self._connection_generation)
                         self._ready.set()
                         # Session is live again: clear any breaker state from a
                         # prior outage so the first call after recovery isn't
@@ -3644,7 +3910,7 @@ class MCPServerTask:
                         _reset_server_error(self.name)
                         # Unproven until keepalive/tool-call success (#62212).
                         self._session_proven = False
-                        reason = await self._wait_for_lifecycle_event()
+                        reason = await self._wait_for_lifecycle_and_stop_generation()
                         if reason == "reconnect":
                             logger.info(
                                 "MCP server '%s': reconnect requested — "
@@ -3656,7 +3922,7 @@ class MCPServerTask:
                 reason = self._reconnect_or_reraise_group(_eg)
             return reason
 
-    async def _discover_tools(self):
+    async def _discover_tools(self, generation: Optional[int] = None):
         """Discover tools from the connected session.
 
         Capability-gated: prompt-only / resource-only MCP servers don't
@@ -3666,13 +3932,23 @@ class MCPServerTask:
         server doesn't advertise the ``tools`` capability.
         (Ported from anomalyco/opencode#31271.)
         """
+        generation = self._connection_generation if generation is None else generation
+        self._assert_connection_generation(generation)
+        session = self.session
+
         # Fresh transport connection → re-probe with the cheap ``ping`` path.
         # Clears any latch from a prior connection in case the server gained
         # ping support across the reconnect.
         self._ping_unsupported = False
-        if self.session is None:
+        if session is None:
             return
         if not self._advertises_tools():
+            self._assert_connection_generation(generation)
+            if self.session is not session:
+                raise StaleConnectionGenerationError(
+                    generation,
+                    self._connection_generation,
+                )
             logger.info(
                 "MCP server '%s': does not advertise 'tools' capability — "
                 "skipping tools/list (prompts/resources remain available)",
@@ -3680,14 +3956,27 @@ class MCPServerTask:
             )
             self._tools = []
             self._register_discovered_tools_if_needed()
+            self.catalogue_state = "current"
+            self.cache_state = "live"
             return
         async with self._rpc_lock:
-            self._list_cache_meta = {}
-            self._tools = await _paginate_full_list(
-                self.session.list_tools, "tools", self.name,
-                cache_meta_out=self._list_cache_meta,
+            cache_meta: dict = {}
+            tools = await _paginate_full_list(
+                session.list_tools, "tools", self.name,
+                cache_meta_out=cache_meta,
+                protocol_era=self.negotiated_era,
             )
+        self._assert_connection_generation(generation)
+        if self.session is not session:
+            raise StaleConnectionGenerationError(
+                generation,
+                self._connection_generation,
+            )
+        self._list_cache_meta = cache_meta
+        self._tools = tools
         self._register_discovered_tools_if_needed()
+        self.catalogue_state = "current"
+        self.cache_state = "live"
 
     def _register_discovered_tools_if_needed(self) -> None:
         """Re-register tools after an owned server reconnects if needed.
@@ -3725,6 +4014,10 @@ class MCPServerTask:
         connection drops unexpectedly (unless shutdown was requested).
         """
         self._config = config
+        if "protocol" in config:
+            self._protocol_policy = normalize_protocol_policy(config["protocol"])
+        else:
+            self._protocol_policy = normalize_protocol_policy()
         self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
         self._auth_type = (config.get("auth") or "").lower().strip()
         self._idle_timeout_seconds = _get_lifecycle_seconds(config, "idle_timeout_seconds")
@@ -3842,7 +4135,7 @@ class MCPServerTask:
                 # A clean transport return means a session was established and
                 # then asked to rebuild (auth recovery / manual refresh /
                 # keepalive failure / transport TaskGroup drop). That alone is
-                # NOT proof of health: a flapping transport handshakes fine and
+                # NOT proof of health: a flapping transport negotiates and
                 # drops moments later, and resetting the budget here let such
                 # servers respawn forever (#62212 — 6212 spawns in 63h).
                 # Only clear the consecutive-failure budget once the session
@@ -4122,6 +4415,7 @@ class MCPServerTask:
                 if self._shutdown_event.is_set():
                     return
             finally:
+                await self._cancel_generation_tasks()
                 self.session = None
 
     async def start(self, config: dict):
@@ -4165,11 +4459,7 @@ class MCPServerTask:
                     await self._task
                 except asyncio.CancelledError:
                     pass
-        if self._pending_refresh_tasks:
-            for task in list(self._pending_refresh_tasks):
-                task.cancel()
-            await asyncio.gather(*self._pending_refresh_tasks, return_exceptions=True)
-            self._pending_refresh_tasks.clear()
+        await self._cancel_generation_tasks()
         self._deregister_tools()
         self.session = None
 
@@ -5743,6 +6033,155 @@ def _mark_server_call_started(server: Any) -> None:
         mark_tool_call()
 
 
+async def _call_with_input_required(
+    server: MCPServerTask,
+    session_method,
+    *args,
+    timeout: Optional[float] = None,
+    **kwargs,
+):
+    from mcp.client import InputRequiredRoundsExceededError
+    from mcp.client.session import ClientRequestContext
+    from mcp.shared.exceptions import MCPError
+    from mcp.types import ErrorData, InputRequiredResult
+
+    session = server.session
+    if session is None:
+        raise RuntimeError(f"MCP server '{server.name}' is not connected")
+    generation = getattr(server, "_connection_generation", None)
+    raw_max_rounds = (getattr(server, "_config", None) or {}).get(
+        "input_required_max_rounds", 10
+    )
+    try:
+        max_rounds = int(raw_max_rounds)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("input_required_max_rounds must be a positive integer") from exc
+    if max_rounds < 1:
+        raise ValueError("input_required_max_rounds must be a positive integer")
+
+    supports_read_timeout = "read_timeout_seconds" in _method_params(session_method)
+    captured_context = contextvars.copy_context()
+    operation = asyncio.current_task()
+    pending_tasks = getattr(server, "_pending_mrtr_tasks", None)
+    if operation is not None and pending_tasks is not None:
+        pending_tasks.add(operation)
+    server._pending_call_context = captured_context
+    server._pending_call_generation = generation
+
+    def assert_current() -> None:
+        current_generation = getattr(server, "_connection_generation", None)
+        if generation is not None and current_generation != generation:
+            raise StaleConnectionGenerationError(generation, current_generation)
+        if server.session is not session:
+            raise RuntimeError(
+                f"MCP server '{server.name}' replaced its session without advancing "
+                "the connection generation"
+            )
+
+    async def invoke(
+        *,
+        input_responses=None,
+        request_state=None,
+        continuation: bool = False,
+    ):
+        assert_current()
+        call_kwargs = dict(kwargs)
+        call_kwargs["allow_input_required"] = True
+        if continuation:
+            call_kwargs["input_responses"] = input_responses
+            call_kwargs["request_state"] = request_state
+        if supports_read_timeout and timeout is not None:
+            call_kwargs["read_timeout_seconds"] = float(timeout)
+        result = await session_method(*args, **call_kwargs)
+        assert_current()
+        return result
+
+    async def dispatch(key: str, request):
+        assert_current()
+        context = ClientRequestContext(
+            session=session,
+            request_id=key,
+            meta=getattr(getattr(request, "params", None), "meta", None),
+        )
+        task = asyncio.create_task(
+            session.dispatch_input_request(context, request),
+            context=captured_context.copy(),
+        )
+        response = await task
+        assert_current()
+        return response
+
+    async def drive():
+        result = await invoke()
+        rounds = 0
+        state_only_delay = 0.05
+        while isinstance(result, InputRequiredResult):
+            rounds += 1
+            if rounds > max_rounds:
+                raise InputRequiredRoundsExceededError(max_rounds)
+            input_requests = getattr(result, "input_requests", None)
+            request_state = getattr(result, "request_state", None)
+            if input_requests is not None and not isinstance(input_requests, dict):
+                raise RuntimeError("malformed MCP continuation input_requests")
+            if request_state is not None and not isinstance(request_state, str):
+                raise RuntimeError("malformed MCP continuation request_state")
+            if not input_requests and request_state is None:
+                raise RuntimeError(
+                    "malformed MCP continuation has neither input requests nor request state"
+                )
+
+            responses = None
+            if input_requests:
+                state_only_delay = 0.05
+                responses = {}
+                for key, request in input_requests.items():
+                    if not isinstance(key, str):
+                        raise RuntimeError("malformed MCP continuation request key")
+                    response = await dispatch(key, request)
+                    if isinstance(response, ErrorData):
+                        raise MCPError.from_error_data(response)
+                    responses[key] = response
+            else:
+                await asyncio.sleep(state_only_delay)
+                assert_current()
+                state_only_delay = min(state_only_delay * 2, 0.25)
+
+            result = await invoke(
+                input_responses=responses,
+                request_state=request_state,
+                continuation=True,
+            )
+        return result
+
+    try:
+        async with asyncio.timeout(timeout):
+            return await drive()
+    except asyncio.CancelledError:
+        current_generation = getattr(server, "_connection_generation", None)
+        if generation is not None and current_generation != generation:
+            raise StaleConnectionGenerationError(
+                generation,
+                current_generation,
+            ) from None
+        raise
+    finally:
+        if operation is not None and pending_tasks is not None:
+            pending_tasks.discard(operation)
+        if (
+            getattr(server, "_pending_call_generation", None) == generation
+            and getattr(server, "_pending_call_context", None) is captured_context
+        ):
+            server._pending_call_context = None
+            server._pending_call_generation = None
+
+
+def _method_params(session_method) -> set[str]:
+    try:
+        return set(inspect.signature(session_method).parameters)
+    except (TypeError, ValueError):
+        return set()
+
+
 def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """Return a sync handler that calls an MCP tool via the background loop.
 
@@ -5807,7 +6246,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # transport — which respawns a dead stdio subprocess — and
                 # return a clean "reconnecting" error so the model backs off
                 # without burning iterations. The breaker resets once the
-                # fresh session initializes (_run_stdio/_run_http call
+                # fresh session negotiates (_run_stdio/_run_http call
                 # _reset_server_error).
                 _bump_server_error(server_name)
                 if _signal_reconnect(server):
@@ -5821,15 +6260,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                # Snapshot the agent's context so an elicitation callback
-                # triggered during this call (fired on the MCP recv loop
-                # task, which doesn't inherit our contextvars) can replay
-                # it and detect the gateway platform / session for routing.
-                server._pending_call_context = contextvars.copy_context()
-                try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
-                finally:
-                    server._pending_call_context = None
+                result = await _call_with_input_required(
+                    server,
+                    server.session.call_tool,
+                    tool_name,
+                    arguments=args,
+                    timeout=tool_timeout,
+                )
             # The RPC round-trip completed — the session is demonstrably
             # healthy at the transport level (even if the tool itself
             # returned isError). Clear the rapid-drop budget (#62212).
@@ -6084,7 +6521,12 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                result = await server.session.read_resource(uri)
+                result = await _call_with_input_required(
+                    server,
+                    server.session.read_resource,
+                    uri,
+                    timeout=tool_timeout,
+                )
             # read_resource returns ReadResourceResult with .contents list
             parts: List[str] = []
             contents = result.contents if hasattr(result, "contents") else []
@@ -6207,7 +6649,13 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock:
-                result = await server.session.get_prompt(name, arguments=arguments)
+                result = await _call_with_input_required(
+                    server,
+                    server.session.get_prompt,
+                    name,
+                    arguments=arguments,
+                    timeout=tool_timeout,
+                )
             # GetPromptResult has .messages list
             messages = []
             for msg in (result.messages if hasattr(result, "messages") else []):
@@ -6639,7 +7087,7 @@ _UTILITY_CAPABILITY_METHODS = {
 }
 
 # Maps each utility handler to the MCP capability key that must be non-None
-# on the server's ``initialize`` response for the handler to be registered.
+# on the negotiated capabilities for the handler to be registered.
 # Source of truth: MCP spec — capabilities.resources / capabilities.prompts
 # are present on the response only when the server actually implements
 # those request families. Without this gate, tools-only servers (e.g.
@@ -6709,7 +7157,7 @@ def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dic
                 continue
         else:
             # Legacy fallback for test fixtures or older code paths where
-            # initialize_result wasn't captured. Preserves the old behavior
+            # Negotiation result wasn't captured. Preserves the old behavior
             # of registering every stub in that case rather than regressing
             # any server that was working before this fix.
             required_method = _UTILITY_CAPABILITY_METHODS[handler_key]
@@ -6974,7 +7422,11 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         # live connect so the next startup can lazily register this server
         # without spawning it. Cache failures never break registration.
         try:
-            from tools.mcp_schema_cache import config_fingerprint, write_cache_entry
+            from tools.mcp_schema_cache import (
+                config_digest,
+                config_fingerprint,
+                write_cache_entry,
+            )
 
             tools_payload: List[dict] = []
             for mcp_tool in server._tools:
@@ -6998,7 +7450,9 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             ]
             write_cache_entry(
                 name,
-                config_fingerprint(config),
+                config_fingerprint(config, server_name=name),
+                config_digest=config_digest(config),
+                protocol_era=server.negotiated_era or "legacy",
                 tools=tools_payload,
                 utility_tools=utility_payload,
                 ttl_ms=(getattr(server, "_list_cache_meta", None) or {}).get("ttl_ms"),
@@ -7037,7 +7491,7 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
 
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
-    fingerprint = config_fingerprint(config)
+    fingerprint = config_fingerprint(config, server_name=name)
     tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
     tools_filter = config.get("tools") or {}
     include_set = _normalize_name_filter(
@@ -7299,16 +7753,38 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     eager_servers: Dict[str, dict] = dict(new_servers)
     lazy_registered = 0
     lazy_server_count = 0
+    cache_helpers = None
     try:
-        from tools.mcp_schema_cache import config_fingerprint, get_cached_entry
+        from tools.mcp_schema_cache import (
+            config_digest,
+            config_fingerprint,
+            expected_protocol_era,
+            get_cached_entry,
+        )
+        cache_helpers = (
+            config_digest,
+            config_fingerprint,
+            expected_protocol_era,
+            get_cached_entry,
+        )
     except Exception:  # pragma: no cover - cache module missing
-        config_fingerprint = None  # type: ignore[assignment]
-        get_cached_entry = None  # type: ignore[assignment]
-    if config_fingerprint is not None and get_cached_entry is not None:
+        pass
+    if cache_helpers is not None:
+        (
+            config_digest,
+            config_fingerprint,
+            expected_protocol_era,
+            get_cached_entry,
+        ) = cache_helpers
         for name, cfg in new_servers.items():
             if not _resolve_server_lazy(name, cfg):
                 continue
-            entry = get_cached_entry(name, config_fingerprint(cfg))
+            entry = get_cached_entry(
+                name,
+                config_fingerprint(cfg, server_name=name),
+                config_digest=config_digest(cfg),
+                protocol_era=expected_protocol_era(cfg),
+            )
             if not entry:
                 continue
             with _lock:
@@ -7539,6 +8015,46 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return bool(server_name and server_name in _parallel_safe_servers)
 
 
+def _mcp_sdk_version() -> Optional[str]:
+    try:
+        return importlib_metadata.version("mcp")
+    except importlib_metadata.PackageNotFoundError:
+        return None
+
+
+def _mcp_protocol_status(server: Optional[MCPServerTask], config: dict) -> dict:
+    policy = getattr(server, "_protocol_policy", None)
+    if isinstance(policy, ProtocolPolicy):
+        configured_policy = policy.value
+    else:
+        try:
+            configured_policy = normalize_protocol_policy(
+                config["protocol"] if "protocol" in config else "auto"
+            ).value
+        except (TypeError, ValueError):
+            configured_policy = "invalid"
+    protocol_state = getattr(server, "_protocol_state", None)
+    return {
+        "configured_policy": configured_policy,
+        "negotiated_era": getattr(server, "negotiated_era", None),
+        "negotiated_protocol_version": getattr(
+            server,
+            "negotiated_protocol_version",
+            None,
+        ),
+        "connection_generation": getattr(server, "_connection_generation", 0),
+        "fallback_reason": getattr(server, "fallback_reason", None),
+        "legacy_proof_attempted": bool(
+            getattr(protocol_state, "legacy_proof_attempted", False)
+        ),
+        "liveness_strategy": getattr(server, "liveness_strategy", "none"),
+        "subscription_state": getattr(server, "subscription_state", "idle"),
+        "catalogue_state": getattr(server, "catalogue_state", "stale"),
+        "cache_state": getattr(server, "cache_state", "uninitialised"),
+        "mcp_sdk_version": _mcp_sdk_version(),
+    }
+
+
 def get_mcp_status() -> List[dict]:
     """Return status of all configured MCP servers for banner display.
 
@@ -7574,30 +8090,29 @@ def get_mcp_status() -> List[dict]:
             }
             if server._sampling:
                 entry["sampling"] = dict(server._sampling.metrics)
-            result.append(entry)
         elif not enabled:
             # A server with enabled: false is intentionally not connected — it is
             # disabled, not failed. Surface that distinction so consumers (banner,
             # TUI) can render "disabled" rather than an alarming "failed".
-            result.append({
+            entry = {
                 "name": name,
                 "transport": transport,
                 "tools": 0,
                 "connected": False,
                 "disabled": True,
                 "status": "disabled",
-            })
+            }
         elif name in connecting:
-            result.append({
+            entry = {
                 "name": name,
                 "transport": transport,
                 "tools": 0,
                 "connected": False,
                 "disabled": False,
                 "status": "connecting",
-            })
+            }
         elif name in connect_errors:
-            result.append({
+            entry = {
                 "name": name,
                 "transport": transport,
                 "tools": 0,
@@ -7605,16 +8120,18 @@ def get_mcp_status() -> List[dict]:
                 "disabled": False,
                 "status": "failed",
                 "error": connect_errors[name],
-            })
+            }
         else:
-            result.append({
+            entry = {
                 "name": name,
                 "transport": transport,
                 "tools": 0,
                 "connected": False,
                 "disabled": False,
                 "status": "configured",
-            })
+            }
+        entry["protocol"] = _mcp_protocol_status(server, cfg)
+        result.append(entry)
 
     return result
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -898,6 +898,13 @@ def _coerce_cache_ttl(value: Any) -> Optional[float]:
     return number
 
 
+def _ttl_hint_was_sent(result: Any) -> bool:
+    fields_set = getattr(result, "model_fields_set", None)
+    if fields_set is None:
+        return True
+    return "ttl_ms" in fields_set or "ttlMs" in fields_set
+
+
 async def _paginate_full_list(list_method, items_attr: str, server_name: str,
                               cache_meta_out: Optional[dict] = None,
                               protocol_era: Optional[str] = None):
@@ -930,6 +937,7 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
     cursor = None
     era = protocol_era or "legacy"
     missing_ttl = False
+    explicit_zero_ttl = False
     missing_scope = False
     if cache_meta_out is not None:
         cache_meta_out["protocol_era"] = era
@@ -950,19 +958,32 @@ async def _paginate_full_list(list_method, items_attr: str, server_name: str,
             except TypeError:
                 result = await list_method(cursor=cursor)
         if cache_meta_out is not None:
-            ttl = _coerce_cache_ttl(mcp_field(result, "ttl_ms", "ttlMs"))
+            ttl = (
+                _coerce_cache_ttl(mcp_field(result, "ttl_ms", "ttlMs"))
+                if _ttl_hint_was_sent(result)
+                else None
+            )
             scope = mcp_field(result, "cache_scope", "cacheScope")
             if ttl is None:
                 missing_ttl = True
                 cache_meta_out["metadata_complete"] = False
-                if era == "modern" or "ttl_ms" in cache_meta_out:
+                if era == "modern":
                     cache_meta_out["ttl_ms"] = 0.0
+                elif not explicit_zero_ttl:
+                    cache_meta_out.pop("ttl_ms", None)
+            elif ttl == 0.0:
+                explicit_zero_ttl = True
+                cache_meta_out["ttl_ms"] = 0.0
+            elif explicit_zero_ttl:
+                cache_meta_out["ttl_ms"] = 0.0
+            elif missing_ttl and era == "legacy":
+                cache_meta_out.pop("ttl_ms", None)
             else:
                 previous_ttl = cache_meta_out.get("ttl_ms")
                 cache_meta_out["ttl_ms"] = (
                     ttl if previous_ttl is None else min(float(previous_ttl), ttl)
                 )
-                if missing_ttl:
+                if missing_ttl and era == "modern":
                     cache_meta_out["ttl_ms"] = 0.0
             if scope not in {"public", "private"}:
                 missing_scope = True

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -95,10 +95,11 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
             code = (qs.get("code") or [None])[0]
             state = (qs.get("state") or [None])[0]
             error = (qs.get("error") or [None])[0]
+            iss = (qs.get("iss") or [None])[0]
             body = b"<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>"
             status = 200
             try:
-                flow.deliver_callback(code=code, state=state, error=error)
+                flow.deliver_callback(code=code, state=state, error=error, iss=iss)
             except Exception:
                 body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
                 status = 400

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -56,11 +56,11 @@ mcp_servers:
 | `enabled` | bool | both | Skip the server entirely when false |
 | `timeout` | number | both | Tool call timeout in seconds (default: `300`) |
 | `connect_timeout` | number | both | Initial connection timeout in seconds (default: `60`) |
-| `protocol` | string | both | Protocol-era negotiation: `auto` (default — legacy `initialize` handshake first, falling back to the 2026-07-28 `server/discover` stateless probe when the server rejects the handshake as modern-only), `stateless` (probe `server/discover` first; one legacy retry), or `legacy` (handshake only, no fallback) |
+| `protocol` | string | both | Protocol authority: omitted/`auto` is modern-first; `stateless` and `2026-07-28` are strict-modern aliases; `legacy` is initialise-only. Unknown values fail before transport creation. See [Protocol authority](#protocol-authority). |
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
 | `skip_preflight` | bool | HTTP | Bypass the fail-fast content-type probe for valid Streamable HTTP endpoints whose HEAD/GET answers a non-MCP content type (default: `false`) |
 | `transport` | string | HTTP | Set to `sse` to use the SSE transport instead of Streamable HTTP |
-| `keepalive_interval` | number | both | Liveness ping cadence in seconds (default: `180`, floored at 5s). Set below the server's session TTL for servers that GC idle sessions quickly |
+| `keepalive_interval` | number | both | Liveness-check cadence in seconds (default: `180`, floored at 5s). Modern stateless peers are checked with stateless discovery and do not depend on `Mcp-Session-Id` or a legacy session lease. Legacy peers use `ping`, with `tools/list` as the unsupported-ping fallback; only legacy sessionful peers need the interval set below a server session TTL. |
 | `idle_timeout_seconds` | number | stdio | Optional stdio server recycle after idle time (`0` disables). May also live under a `lifecycle:` mapping |
 | `max_lifetime_seconds` | number | stdio | Optional stdio server recycle after age (`0` disables). May also live under a `lifecycle:` mapping |
 | `tools` | mapping | both | Filtering and utility-tool policy |
@@ -68,6 +68,16 @@ mcp_servers:
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
 | `elicitation` | mapping | both | Server-initiated user-input requests. `enabled` (default `true`) and `timeout` in seconds (default `300`). Form-mode requests route through the approval surface; URL-mode is declined (see MCP guide) |
 | `trust` | string | both | Trust tier: `full` (default) or `untrusted`. On an `untrusted` server, every write-capable tool call (any tool without a `readOnlyHint: true` annotation) requires user approval through the standard approval surface before it runs. `readOnlyHint` is a server-supplied *hint* — a lying server can at most skip approval for tools it claims are read-only, never gain extra access — so mark any server you don't fully control as `untrusted`. Unrecognized values are treated as `untrusted` (fail-closed) |
+
+### Protocol authority
+
+| Configured value | First request | Legacy fallback |
+|---|---|---|
+| omitted or `auto` | `server/discover` | One same-generation `initialize` proof only after the exact canonical MCP 1.28.1 `-32602` `Invalid request parameters` discovery rejection; the peer is classified as legacy only if that proof succeeds |
+| `stateless` or `2026-07-28` | `server/discover` | None; this is strict modern mode and never sends `initialize` |
+| `legacy` | `initialize` | None; modern discovery is not attempted |
+
+Any other value is rejected before transport creation or network I/O.
 
 ## Environment variable references
 


### PR DESCRIPTION
## Summary

This change makes the MCP 2026-07-28 stateless client lifecycle the production-authoritative path for modern peers. The MCP 2.x SDK migration in #88180 supplied the required SDK surface, and #88299 supplied protocol support, but the production client still required lifecycle closure: modern discovery had to become the normal first flight, while MCP 1.28.1 interoperability needed an explicit and bounded compatibility proof.

The public protocol contract now has one normaliser and three internal policies. Omitted protocol and `auto` send `server/discover` first; `stateless` aliases strict `2026-07-28` modern mode; and `legacy` performs the strict initialise path. Unknown values fail before transport creation or network I/O.

In `auto`, the canonical MCP 1.28.1 `server/discover` `-32602` response is only a candidate fingerprint. Hermes permits one initialise proof on that connection generation, records legacy only after successful proof, and reports both failures if the proof is rejected. Other `-32602` responses, post-negotiation failures, malformed discovery errors, and strict-modern failures cannot switch protocol era.

## Lifecycle and security boundaries

Protocol state is fenced by an explicit connection generation. Negotiation, fallback evidence, request ownership, MRTR continuations, subscription ownership, catalogue freshness, liveness and reconnect state reject stale-generation mutation.

MRTR handling is sequential and bounded across tools, prompts and resources, with whole-operation timeouts, round limits and fail-closed cancellation. Modern subscriptions have one supervised listener per generation, bounded relisten, catalogue reconciliation after a gap, and reconnect escalation after exhaustion.

Modern stateless reachability uses discovery and does not depend on `Mcp-Session-Id`, initialise state or legacy session renewal. Diagnostics expose the configured policy, negotiated era and revision, generation, proof reason, liveness strategy, subscription state, cache state and SDK version without exposing credentials.

Cache identity partitions by server, protocol era, authentication identity, relevant headers, environment identity, TLS context and schema epoch using deterministic digests. Modern `ttlMs == 0` remains immediately stale, while legacy hintlessness remains an explicit compatibility state. Pagination chooses the shortest valid TTL and fails closed on incompatible scopes. The client now also distinguishes an absent `ttlMs` field from MCP SDK 2.0's defaulted `ttl_ms == 0`: explicit zero remains immediately stale, a missing modern hint fails closed, and a missing legacy hint remains hintless. This field-presence regression uses real `mcp.types.ListToolsResult` instances, including a multi-page aggregate, and runs in the permanent dual-era workflow.

OAuth `iss` continuity is preserved across browser, dashboard, gateway and TUI relays, callback results, credential partitioning and reconnect.

Pre-negotiation `auto` cache reuse is bounded as well as era-partitioned. Every live catalogue write records a validation receipt; a hintless legacy receipt remains indefinitely usable only under explicit `protocol: legacy`, whilst `auto` limits it to the repository's global cache-authority maximum. When both era receipts exist, `auto` selects the newest valid receipt, with modern winning an exact timestamp tie.

The checked-in operator contract matches the lifecycle: omitted or `auto` is discover-first with one same-generation proof only for the canonical MCP 1.28.1 discovery rejection; `stateless` and `2026-07-28` are strict modern aliases that never initialise; `legacy` is initialise-only; and modern liveness uses stateless discovery rather than a legacy session ping.

## Verification

The conformance harness creates an isolated `mcp==1.28.1` environment without changing production dependencies. Real-wire coverage exercises a current Hermes client against modern and legacy peers, and a legacy client against both first-party Hermes MCP server surfaces where supported. It covers negotiation, listing, calls, application and protocol errors, cancellation, interruption, reconnect, shutdown and resource ownership. Wire assertions prove modern discovery without initialise or a session-ID requirement, and prove the one-shot legacy compatibility path.

At rebased local head `bd75b403eab5c0bd9bffa5d6ec5645be877ba792`, tree `2a6daa6ce2fbab435e94896e300102e93a9d0921`, the blocker cache/lazy/docs selection passed 45 tests with the known Windows POSIX-mode assertion deselected. The permanent focused selection passed 252 tests with two existing Windows/full-process assertions deselected: the POSIX cache-mode assertion and the same-tick `mcp_serve` EventBridge delivery test. The broader MCP/OAuth selection passed 745 tests and skipped 9 after deselecting three existing Windows-only cases concerning POSIX mode bits, inherited Windows location variables and locale-default source decoding. The dedicated leak selection passed 17 tests. The real-model pagination file passed 13 tests, and a local sabotage bypass of the new field-presence guard made the intended regression fail before the production condition was restored.

Website `npm ci` and `build:fast` pass. Local `lint:diagrams` cannot run because the checked-in Website package does not provide its `ascii-guard` executable; the hosted Docs Site check passes. Ruff, `py_compile`, `uv lock --check` and `git diff --check` pass.

`pyproject.toml` and `uv.lock` are unchanged.

## Current gate

Hosted evidence is complete for head `bd75b403eab5c0bd9bffa5d6ec5645be877ba792` on base `f293e7206b4ddd66042329442c6afebc19a8808d`:

- MCP Dual-Era Conformance run `32649207852` (job `97218070575`) passed 235 tests in 40.31 seconds, including the real MCP SDK field-presence regression. Its static conformance checks passed Ruff, `py_compile`, `uv lock --check` and `git diff --check`.
- Ordinary CI run `32649208110` passed every implementation check, including Python tests and e2e, Windows and macOS tests, Docs Site checks, Ruff and ty, lock validation, OSV and supply-chain scans, package and installer checks, Rust, JavaScript/TypeScript and Docker-script checks.
- Docker run `32649207859` passed.
- Nix run `32649207860` passed.

The only hosted failure is the policy-owned Review label gate (job `97218191669`), which reports that the maintainer-controlled `ci-reviewed` label is absent; the aggregate `All required checks pass` job `97218406761` therefore also reports failure. No implementation check failed, and no merge has been attempted.

## Provenance

The protocol-policy and lifecycle direction materially develops the architectural work from #88875. Relevant commits retain Axl Ibiza's authorship through `Co-authored-by` trailers; unrelated changes from that branch were not imported.

The SDK field-presence repair incorporates the relevant idea from #92621 into this PR's page-level metadata aggregation and retains lepetitprince716-prog's authorship through a `Co-authored-by` trailer. No commits carrying earlier provenance were amended or rewritten.

Refs #88698

Successor to #88875

Builds on #88180 and #88299
