### PR TITLE
fix(kanban): enforce principal-aware task creation policy

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2597,6 +2597,16 @@ DEFAULT_CONFIG = {
     # each claimable ready task. One dispatcher per profile is sufficient;
     # running more than one on the same kanban.db will race for claims.
     "kanban": {
+        # Profiles may create/link tasks unless explicitly restricted. Agent,
+        # CLI, swarm, and decomposer fan-out paths all enforce this centrally
+        # before opening a write transaction. Set false on analysis-only
+        # expert profiles that should propose work but never create it.
+        "can_create": True,
+        # Separate human-dashboard policy. "authenticated" lets a human who
+        # passed the dashboard auth middleware create/link cards regardless of
+        # the backend profile's can_create value; "disabled" turns those two
+        # dashboard writes off. Unknown values fail closed.
+        "dashboard_create_policy": "authenticated",
         # Auto-subscribe the originating gateway/TUI session to task
         # completion + block events when ``kanban_create`` is called from
         # inside a session that has a persistent delivery channel. The

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -26,6 +26,11 @@ from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
+from hermes_cli.kanban_policy import (
+    KanbanCreationDenied,
+    current_profile_principal,
+    require_creation_allowed,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -1541,6 +1546,13 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
 
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
+        require_creation_allowed(
+            current_profile_principal(), operation="kanban create"
+        )
+    except KanbanCreationDenied as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 1
+    try:
         ws_kind, ws_path = _parse_workspace_flag(args.workspace)
         branch_name = _parse_branch_flag(getattr(args, "branch", None))
     except argparse.ArgumentTypeError as exc:
@@ -1608,6 +1620,13 @@ def _cmd_create(args: argparse.Namespace) -> int:
 
 
 def _cmd_swarm(args: argparse.Namespace) -> int:
+    try:
+        require_creation_allowed(
+            current_profile_principal(), operation="kanban swarm"
+        )
+    except KanbanCreationDenied as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 1
     try:
         workers = [ks.parse_worker_arg(raw) for raw in (args.worker or [])]
     except ValueError as exc:
@@ -2067,6 +2086,13 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
 
 
 def _cmd_link(args: argparse.Namespace) -> int:
+    try:
+        require_creation_allowed(
+            current_profile_principal(), operation="kanban link"
+        )
+    except KanbanCreationDenied as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 1
     with kb.connect_closing() as conn:
         kb.link_tasks(conn, args.parent_id, args.child_id)
     print(f"Linked {args.parent_id} -> {args.child_id}")

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -45,6 +45,11 @@ from typing import Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import profiles as profiles_mod
+from hermes_cli.kanban_policy import (
+    KanbanCreationDenied,
+    current_profile_principal,
+    require_creation_allowed,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -384,6 +389,13 @@ def decompose_task(
         return DecomposeOutcome(
             task_id, False, "decomposer returned fanout=true with empty tasks list",
         )
+
+    try:
+        require_creation_allowed(
+            current_profile_principal(), operation="kanban decompose fan-out"
+        )
+    except KanbanCreationDenied as exc:
+        return DecomposeOutcome(task_id, False, str(exc))
 
     # Rewrite invalid assignees to the default fallback. Never leave a
     # task with assignee=None — the user explicitly does not want that.

--- a/hermes_cli/kanban_policy.py
+++ b/hermes_cli/kanban_policy.py
@@ -1,0 +1,157 @@
+"""Principal-aware policy for creating and linking Kanban tasks.
+
+The database layer deliberately stays policy-free: fixtures, migrations, and
+trusted recovery code need to build task graphs without impersonating an
+interactive caller.  Every user-facing creation surface calls this module
+before opening a write transaction instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Any, Mapping, Optional
+
+
+PROFILE_PRINCIPAL = "profile"
+DASHBOARD_HUMAN_PRINCIPAL = "dashboard-human"
+
+
+@dataclass(frozen=True)
+class KanbanPrincipal:
+    """Identity class used by the Kanban creation policy."""
+
+    kind: str
+    name: str
+    authenticated: bool = True
+
+
+@dataclass(frozen=True)
+class KanbanCreationDecision:
+    """Policy verdict with a stable, user-facing denial reason."""
+
+    allowed: bool
+    reason: str
+
+
+class KanbanCreationDenied(PermissionError):
+    """Raised before a creation/link surface reaches the database."""
+
+
+def current_profile_principal() -> KanbanPrincipal:
+    """Return the profile that owns the current CLI/worker process."""
+
+    name = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if not name:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            name = (get_active_profile_name() or "default").strip()
+        except Exception:
+            name = "default"
+    return KanbanPrincipal(PROFILE_PRINCIPAL, name or "default")
+
+
+def dashboard_human_principal(name: Optional[str] = None) -> KanbanPrincipal:
+    """Return an authenticated interactive-dashboard principal.
+
+    HTTP authentication remains owned by the dashboard middleware.  The
+    plugin route calls this only after that middleware has admitted the
+    request (cookie/native bearer in gated mode, ephemeral session token in
+    loopback mode).
+    """
+
+    return KanbanPrincipal(
+        DASHBOARD_HUMAN_PRINCIPAL,
+        (name or "dashboard-session").strip() or "dashboard-session",
+        authenticated=True,
+    )
+
+
+def _load_policy_config() -> Mapping[str, Any]:
+    from hermes_cli.config import load_config
+
+    config = load_config()
+    if not isinstance(config, Mapping):
+        raise TypeError("Kanban policy config must be a mapping")
+    return config
+
+
+def creation_decision(
+    principal: KanbanPrincipal,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+) -> KanbanCreationDecision:
+    """Evaluate task creation/link permission for ``principal``.
+
+    Profile callers use ``kanban.can_create`` (backward-compatible default:
+    true).  Interactive dashboard humans use the independent
+    ``kanban.dashboard_create_policy`` setting.  Unknown principals, invalid
+    policy values, and unreadable configuration all fail closed.
+    """
+
+    if config is None:
+        try:
+            config = _load_policy_config()
+        except Exception:
+            return KanbanCreationDecision(
+                False,
+                "Kanban creation policy is unavailable; refusing fail-closed.",
+            )
+    if not isinstance(config, Mapping):
+        return KanbanCreationDecision(
+            False,
+            "Kanban creation policy is invalid; refusing fail-closed.",
+        )
+    raw_kanban = config.get("kanban") or {}
+    if not isinstance(raw_kanban, Mapping):
+        return KanbanCreationDecision(
+            False,
+            "Kanban creation policy is invalid; refusing fail-closed.",
+        )
+
+    if principal.kind == PROFILE_PRINCIPAL:
+        if bool(raw_kanban.get("can_create", True)):
+            return KanbanCreationDecision(True, "")
+        return KanbanCreationDecision(
+            False,
+            f"profile {principal.name!r} has kanban.can_create=false",
+        )
+
+    if principal.kind == DASHBOARD_HUMAN_PRINCIPAL:
+        policy = str(
+            raw_kanban.get("dashboard_create_policy", "authenticated")
+        ).strip().lower()
+        if policy == "authenticated" and principal.authenticated:
+            return KanbanCreationDecision(True, "")
+        if policy == "disabled":
+            return KanbanCreationDecision(
+                False,
+                "kanban.dashboard_create_policy is disabled",
+            )
+        return KanbanCreationDecision(
+            False,
+            "kanban.dashboard_create_policy must be 'authenticated' or "
+            "'disabled'; refusing fail-closed",
+        )
+
+    return KanbanCreationDecision(
+        False,
+        f"unknown Kanban principal kind {principal.kind!r}; refusing fail-closed",
+    )
+
+
+def require_creation_allowed(
+    principal: KanbanPrincipal,
+    *,
+    operation: str,
+    config: Optional[Mapping[str, Any]] = None,
+) -> None:
+    """Raise :class:`KanbanCreationDenied` when policy denies ``operation``."""
+
+    decision = creation_decision(principal, config=config)
+    if not decision.allowed:
+        raise KanbanCreationDenied(
+            f"{operation} refused for {principal.kind} {principal.name!r}: "
+            f"{decision.reason}"
+        )

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -22,6 +22,10 @@ import sqlite3
 from typing import Any, Iterable, Optional
 
 from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_policy import (
+    current_profile_principal,
+    require_creation_allowed,
+)
 
 BLACKBOARD_PREFIX = "[swarm:blackboard] "
 
@@ -143,6 +147,9 @@ def create_swarm(
     idempotency_key: Optional[str] = None,
 ) -> SwarmCreated:
     """Atomically create a durable, immediately dispatchable Kanban swarm."""
+    require_creation_allowed(
+        current_profile_principal(), operation="kanban swarm"
+    )
     activation_summary = (
         "Swarm topology planned; root remains the shared blackboard."
     )

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -44,12 +44,17 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile, WebSocket, WebSocketDisconnect, status as http_status
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from hermes_cli import kanban_db
 from hermes_cli import kanban_diagnostics as kd
+from hermes_cli.kanban_policy import (
+    KanbanCreationDenied,
+    dashboard_human_principal,
+    require_creation_allowed,
+)
 
 log = logging.getLogger(__name__)
 
@@ -621,7 +626,20 @@ class CreateTaskBody(BaseModel):
 
 
 @router.post("/tasks")
-def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
+def create_task(
+    payload: CreateTaskBody,
+    request: Request,
+    board: Optional[str] = Query(None),
+):
+    session = getattr(request.state, "session", None)
+    principal_name = getattr(session, "user_id", None) or "dashboard-session"
+    try:
+        require_creation_allowed(
+            dashboard_human_principal(principal_name),
+            operation="dashboard kanban create",
+        )
+    except KanbanCreationDenied as exc:
+        raise HTTPException(status_code=403, detail=str(exc))
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -1263,7 +1281,20 @@ class LinkBody(BaseModel):
 
 
 @router.post("/links")
-def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
+def add_link(
+    payload: LinkBody,
+    request: Request,
+    board: Optional[str] = Query(None),
+):
+    session = getattr(request.state, "session", None)
+    principal_name = getattr(session, "user_id", None) or "dashboard-session"
+    try:
+        require_creation_allowed(
+            dashboard_human_principal(principal_name),
+            operation="dashboard kanban link",
+        )
+    except KanbanCreationDenied as exc:
+        raise HTTPException(status_code=403, detail=str(exc))
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:

--- a/tests/hermes_cli/test_kanban_creation_policy.py
+++ b/tests/hermes_cli/test_kanban_creation_policy.py
@@ -1,0 +1,296 @@
+"""Behavior tests for the principal-aware Kanban creation gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_decompose as decompose
+from hermes_cli import kanban_policy as policy
+from hermes_cli import kanban_swarm
+from tools import kanban_tools
+
+
+RESTRICTED_PROFILES = ("colbert", "julien", "ruth")
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _set_policy(
+    monkeypatch,
+    *,
+    profile: str,
+    can_create: bool,
+    dashboard_policy: str = "authenticated",
+) -> None:
+    monkeypatch.setenv("HERMES_PROFILE", profile)
+    monkeypatch.setattr(
+        policy,
+        "_load_policy_config",
+        lambda: {
+            "kanban": {
+                "can_create": can_create,
+                "dashboard_create_policy": dashboard_policy,
+            }
+        },
+    )
+
+
+@pytest.mark.parametrize("profile", RESTRICTED_PROFILES)
+def test_profile_policy_denies_restricted_experts(profile):
+    decision = policy.creation_decision(
+        policy.KanbanPrincipal(policy.PROFILE_PRINCIPAL, profile),
+        config={"kanban": {"can_create": False}},
+    )
+    assert decision.allowed is False
+    assert profile in decision.reason
+
+
+@pytest.mark.parametrize("profile", ("amber", "architect"))
+def test_profile_policy_allows_orchestrators_and_root_workers(profile):
+    decision = policy.creation_decision(
+        policy.KanbanPrincipal(policy.PROFILE_PRINCIPAL, profile),
+        config={"kanban": {"can_create": True}},
+    )
+    assert decision.allowed is True
+
+
+def test_policy_load_error_fails_closed(monkeypatch):
+    def broken_config():
+        raise OSError("unreadable")
+
+    monkeypatch.setattr(policy, "_load_policy_config", broken_config)
+    decision = policy.creation_decision(
+        policy.KanbanPrincipal(policy.PROFILE_PRINCIPAL, "amber")
+    )
+    assert decision.allowed is False
+    assert "fail-closed" in decision.reason
+
+
+def test_authenticated_dashboard_policy_is_independent_of_profile_gate():
+    principal = policy.dashboard_human_principal("human-1")
+    allowed = policy.creation_decision(
+        principal,
+        config={
+            "kanban": {
+                "can_create": False,
+                "dashboard_create_policy": "authenticated",
+            }
+        },
+    )
+    disabled = policy.creation_decision(
+        principal,
+        config={"kanban": {"dashboard_create_policy": "disabled"}},
+    )
+    assert allowed.allowed is True
+    assert disabled.allowed is False
+
+
+@pytest.mark.parametrize("profile", RESTRICTED_PROFILES)
+def test_cli_create_link_and_swarm_deny_before_database_calls(
+    monkeypatch, profile, capsys
+):
+    _set_policy(monkeypatch, profile=profile, can_create=False)
+    connect = MagicMock(side_effect=AssertionError("database must not open"))
+    monkeypatch.setattr(kb, "connect_closing", connect)
+
+    assert kanban_cli._cmd_create(SimpleNamespace()) == 1
+    assert kanban_cli._cmd_link(SimpleNamespace()) == 1
+    assert kanban_cli._cmd_swarm(SimpleNamespace()) == 1
+    connect.assert_not_called()
+
+    err = capsys.readouterr().err
+    assert err.count("kanban.can_create=false") == 3
+
+
+@pytest.mark.parametrize("profile", RESTRICTED_PROFILES)
+def test_swarm_programmatic_entry_denies_before_write(monkeypatch, profile):
+    _set_policy(monkeypatch, profile=profile, can_create=False)
+    conn = MagicMock()
+
+    with pytest.raises(policy.KanbanCreationDenied):
+        kanban_swarm.create_swarm(
+            conn,
+            goal="deny this graph",
+            workers=[],
+            verifier_assignee="architect",
+            synthesizer_assignee="amber",
+        )
+
+    conn.execute.assert_not_called()
+
+
+@pytest.mark.parametrize("profile", RESTRICTED_PROFILES)
+def test_agent_tool_create_and_link_deny_before_database_calls(
+    monkeypatch, profile
+):
+    _set_policy(monkeypatch, profile=profile, can_create=False)
+    monkeypatch.setattr(kanban_tools, "_check_kanban_mode", lambda: True)
+    connect = MagicMock(side_effect=AssertionError("database must not open"))
+    monkeypatch.setattr(kb, "connect_closing", connect)
+
+    create_result = kanban_tools._handle_create(
+        {"title": "must not exist", "assignee": "worker"}
+    )
+    link_result = kanban_tools._handle_link(
+        {"parent_id": "t_parent", "child_id": "t_child"}
+    )
+
+    assert "refused" in create_result
+    assert "refused" in link_result
+    connect.assert_not_called()
+
+
+def _fake_aux_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = json.dumps(payload)
+    return response
+
+
+@pytest.mark.parametrize("profile", RESTRICTED_PROFILES)
+def test_decompose_fanout_denies_without_creating_children(
+    kanban_home, monkeypatch, profile
+):
+    _set_policy(monkeypatch, profile=profile, can_create=False)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="restricted fanout", triage=True)
+
+    roster = [
+        SimpleNamespace(
+            name="amber",
+            is_default=True,
+            description="orchestrator",
+            description_auto=False,
+            model="m",
+            provider="p",
+            skill_count=1,
+        )
+    ]
+    monkeypatch.setattr(decompose.profiles_mod, "list_profiles", lambda: roster)
+    monkeypatch.setattr(decompose.profiles_mod, "profile_exists", lambda name: name == "amber")
+    monkeypatch.setattr(decompose.profiles_mod, "get_active_profile_name", lambda: "amber")
+    monkeypatch.setattr(
+        "agent.auxiliary_client.call_llm",
+        lambda **kwargs: _fake_aux_response(
+            {
+                "fanout": True,
+                "rationale": "parallel work",
+                "tasks": [
+                    {
+                        "title": "child",
+                        "body": "must not be persisted",
+                        "assignee": "amber",
+                        "parents": [],
+                    }
+                ],
+            }
+        ),
+    )
+
+    outcome = decompose.decompose_task(task_id, author=profile)
+
+    assert outcome.ok is False
+    assert "kanban.can_create=false" in outcome.reason
+    with kb.connect_closing() as conn:
+        rows = kb.list_tasks(conn, include_archived=True, limit=20)
+        root = kb.get_task(conn, task_id)
+    assert [task.id for task in rows] == [task_id]
+    assert root is not None and root.status == "triage"
+
+
+def _dashboard_client() -> TestClient:
+    plugin_file = (
+        Path(__file__).resolve().parents[2]
+        / "plugins"
+        / "kanban"
+        / "dashboard"
+        / "plugin_api.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_creation_policy_test",
+        plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    app = FastAPI()
+    app.include_router(module.router, prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("profile", RESTRICTED_PROFILES)
+def test_dashboard_human_can_create_and_link_independently(
+    kanban_home, monkeypatch, profile
+):
+    _set_policy(monkeypatch, profile=profile, can_create=False)
+    client = _dashboard_client()
+
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent"}
+    )
+    child = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "child"}
+    )
+    assert parent.status_code == 200
+    assert child.status_code == 200
+    link = client.post(
+        "/api/plugins/kanban/links",
+        json={
+            "parent_id": parent.json()["task"]["id"],
+            "child_id": child.json()["task"]["id"],
+        },
+    )
+    assert link.status_code == 200
+
+
+def test_dashboard_disabled_policy_denies_before_database_write(
+    kanban_home, monkeypatch
+):
+    _set_policy(
+        monkeypatch,
+        profile="amber",
+        can_create=True,
+        dashboard_policy="disabled",
+    )
+    client = _dashboard_client()
+
+    response = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "must not exist"}
+    )
+    assert response.status_code == 403
+    with kb.connect_closing() as conn:
+        assert kb.list_tasks(conn, include_archived=True, limit=20) == []
+
+
+def test_root_worker_tool_create_is_allowed(kanban_home, monkeypatch):
+    _set_policy(monkeypatch, profile="architect", can_create=True)
+    monkeypatch.setattr(kanban_tools, "_check_kanban_mode", lambda: True)
+
+    result = kanban_tools._handle_create(
+        {"title": "root-created", "assignee": "worker"}
+    )
+
+    assert json.loads(result)["ok"] is True
+    with kb.connect_closing() as conn:
+        tasks = kb.list_tasks(conn, limit=20)
+    assert [task.title for task in tasks] == ["root-created"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -35,7 +35,12 @@ from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
 from hermes_cli.goals import judge_goal
-from tools.registry import registry, tool_error
+from hermes_cli.kanban_policy import (
+    KanbanCreationDenied,
+    current_profile_principal,
+    require_creation_allowed,
+)
+from tools.registry import no_cache_check_fn, registry, tool_error
 from hermes_cli.config import cfg_get, load_config
 
 logger = logging.getLogger(__name__)
@@ -117,6 +122,39 @@ def _check_kanban_mode() -> bool:
     if os.environ.get("HERMES_KANBAN_TASK") and _is_dispatcher_owned_worker():
         return True
     return _profile_has_kanban_toolset()
+
+
+@no_cache_check_fn
+def _check_kanban_creator_mode() -> bool:
+    """Surface de CREATION de taches (kanban_create, kanban_link).
+
+    Iron Rod, 2026-08-15, reporte sur 0.20.5 le 2026-08-23 : la creation
+    de taches est reservee aux profils dont la config porte
+    ``kanban.can_create: true`` (defaut True pour ne rien casser
+    ailleurs).  Les experts (colbert, julien, ruth) analysent et
+    PROPOSENT ; Amber seule cree.  Le lifecycle des cartes qui leur sont
+    assignees (show, comment, heartbeat, block, complete) reste ouvert :
+    il passe par ``_check_kanban_mode``, pas par ici.
+
+    FAIL-CLOSED : si la configuration ne peut pas etre lue, la creation
+    est REFUSEE.  Une erreur de chargement ne doit jamais ouvrir la
+    surface de creation ; c est le defaut du correctif d origine, corrige
+    ici sur demande de la revue Architect du 2026-08-22.
+    """
+    if not _check_kanban_mode():
+        return False
+    try:
+        require_creation_allowed(
+            current_profile_principal(),
+            operation="kanban tool discovery",
+        )
+    except KanbanCreationDenied:
+        logger.warning(
+            "kanban.can_create: task creation unavailable for this profile "
+            "(fail-closed)"
+        )
+        return False
+    return True
 
 
 def _check_kanban_orchestrator_mode() -> bool:
@@ -1340,6 +1378,32 @@ def _handle_attachments(args: dict, **kw) -> str:
         return tool_error(f"kanban_attachments: {e}")
 
 
+def _reject_uncreatable_profile(tool_name: str) -> Optional[str]:
+    """Refuse la CREATION de taches aux profils sans ``kanban.can_create``.
+
+    Second verrou, indispensable : ``registry.dispatch()`` appelle le
+    handler SANS reevaluer le ``check_fn``, et le registre met les
+    resultats de ``check_fn`` en cache (30 s, plus une grace pouvant
+    aller a 60 s apres un False ou une exception).  Un ``check_fn`` seul
+    n est donc qu indicatif : il masque l outil dans le schema, il ne
+    l interdit pas.  Ajoute le 2026-08-23 sur constat de la revue
+    Architect, qui a montre que le fail-closed annonce ne tenait pas.
+    """
+    if not _check_kanban_mode():
+        return tool_error(
+            f"{tool_name} refused: the current principal is not an active "
+            "Kanban worker or configured orchestrator profile."
+        )
+    try:
+        require_creation_allowed(
+            current_profile_principal(),
+            operation=tool_name,
+        )
+    except KanbanCreationDenied as exc:
+        return tool_error(str(exc))
+    return None
+
+
 def _handle_create(args: dict, **kw) -> str:
     """Create a child task. Orchestrator workers use this to fan out.
 
@@ -1349,6 +1413,9 @@ def _handle_create(args: dict, **kw) -> str:
     delegated_err = _reject_delegated_child_mutation("kanban_create")
     if delegated_err:
         return delegated_err
+    creator_err = _reject_uncreatable_profile("kanban_create")
+    if creator_err:
+        return creator_err
     title = args.get("title")
     if not title or not str(title).strip():
         return tool_error("title is required")
@@ -1646,6 +1713,9 @@ def _handle_link(args: dict, **kw) -> str:
     delegated_err = _reject_delegated_child_mutation("kanban_link")
     if delegated_err:
         return delegated_err
+    creator_err = _reject_uncreatable_profile("kanban_link")
+    if creator_err:
+        return creator_err
     parent_id = args.get("parent_id")
     child_id = args.get("child_id")
     if not parent_id or not child_id:
@@ -2457,7 +2527,7 @@ registry.register(
     toolset="kanban",
     schema=KANBAN_CREATE_SCHEMA,
     handler=_handle_create,
-    check_fn=_check_kanban_mode,
+    check_fn=_check_kanban_creator_mode,
     emoji="➕",
 )
 
@@ -2475,6 +2545,6 @@ registry.register(
     toolset="kanban",
     schema=KANBAN_LINK_SCHEMA,
     handler=_handle_link,
-    check_fn=_check_kanban_mode,
+    check_fn=_check_kanban_creator_mode,
     emoji="🔗",
 )

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -609,12 +609,20 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 
 | Key | Default | Purpose |
 |---|---|---|
+| `can_create` | `true` | Profile-level permission shared by agent tools, direct CLI create/link, swarm creation, and decomposer fan-out. Set `false` on analysis-only experts. Configuration errors fail closed. |
+| `dashboard_create_policy` | `"authenticated"` | Independent human policy for dashboard create/link. `authenticated` allows a human admitted by dashboard auth; `disabled` rejects these writes. An expert profile cannot use the dashboard surface to reinterpret its own permission. |
 | `auto_decompose` | `true` | Dispatcher auto-runs the built-in decomposer for Triage tasks every tick. It does not gate profile-driven `kanban_create` calls or creator wake turns. |
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, terminal events resume that originating agent with a synthetic status turn. Set to `false` for passive completion or to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |
 | `done_sub_retention_days` | `30` | Notify subscriptions survive `done` (reopen-safe) and are removed on `archived`. The notifier GC purges subscriptions whose task has been `done` with no new events for this many days, bounding sub-table growth on boards that never archive. `0` disables the sweep. |
+
+Tool definitions are byte-stable for a conversation to preserve prompt
+caching. If `can_create` changes during an existing session, the cached schema
+may still display `kanban_create`/`kanban_link`; their handlers nevertheless
+re-evaluate the central policy and refuse the write. Start a new session to
+refresh visibility.
 
 And the two auxiliary LLM slots:
 


### PR DESCRIPTION
## Summary

- centralize the principal-aware `kanban.can_create` gate across CLI create/link/swarm, programmatic swarm, decomposer fanout, and agent tool handlers
- keep dashboard human creation under the separate explicit `kanban.dashboard_create_policy`
- add negative coverage for restricted profiles (`colbert`, `julien`, `ruth`) and positive coverage for orchestrator/root-worker and authenticated-dashboard paths
- document cached tool-schema visibility and handler-time enforcement

Iron Rod task: `t_a7f8d96a`.

## Test plan

- [ ] `CI / Python tests`
- [ ] `CI / Python lints`
- [ ] `CI / OS-specific tests`
- [ ] `CI / All required checks pass`

Targeted Pi run before publication reached 23 passing assertions and one test-contract mismatch; the mismatch was corrected from the nonexistent `success` response key to the historical `ok` key. The corrected candidate is intentionally left for GitHub CI validation.