### PR TITLE
feat(cli): deterministic quiet-mode session binding via --session-id-file

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5478,7 +5478,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             short_uuid = uuid.uuid4().hex[:6]
             self.session_id = f"{timestamp_str}_{short_uuid}"
         getattr(self, "_write_terminal_breadcrumb", lambda: None)()
-        
+        self._bind_session_id_file()
+
         # History file for persistent input recall across sessions
         self._history_file = _hermes_home / ".hermes_history"
         self._last_invalidate: float = 0.0  # throttle UI repaints
@@ -9836,6 +9837,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return None
         return history_snapshot
 
+    def _bind_session_id_file(self):
+        """Write the live session id to the --session-id-file binding path.
+
+        No-op unless HERMES_SESSION_ID_FILE is set (via ``chat
+        --session-id-file``). Best-effort; see hermes_cli/session_binding.py.
+        """
+        try:
+            from hermes_cli.session_binding import (
+                resolve_session_id_file,
+                write_session_id_file,
+            )
+
+            write_session_id_file(
+                resolve_session_id_file(), getattr(self, "session_id", None)
+            )
+        except Exception:
+            pass
+
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
         old_session_id = self.session_id
@@ -9881,6 +9900,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         short_uuid = uuid.uuid4().hex[:6]
         self.session_id = f"{timestamp_str}_{short_uuid}"
         getattr(self, "_write_terminal_breadcrumb", lambda: None)()
+        self._bind_session_id_file()
         self.conversation_history = []
         self._pending_title = None
         self._resumed = False
@@ -21392,6 +21412,7 @@ def main(
                             and cli.agent.session_id != cli.session_id
                         ):
                             cli.session_id = cli.agent.session_id
+                            cli._bind_session_id_file()
                         response = result.get("final_response", "") if isinstance(result, dict) else str(result)
                         # Surface backend errors that produced no visible output
                         # (e.g. invalid model slug → provider 4xx). Mirrors the

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -510,6 +510,20 @@ def build_top_level_parser():
         help="Troubleshooting mode: disable ALL customizations — user config, AGENTS.md/memory injection, plugins, and MCP servers (implies --ignore-user-config and --ignore-rules). Use to isolate whether a problem comes from your setup or from Hermes itself.",
     )
     chat_parser.add_argument(
+        "--session-id-file",
+        dest="session_id_file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Write the live session id to PATH atomically (temp file + rename) "
+            "the moment it exists — at startup for new AND resumed sessions, on "
+            "/new rotation, and when a continuation session takes over. Path must "
+            "be unique per run; concurrent runs each bind only their own session. "
+            "For programmatic supervisors (Mission Control) that need the binding "
+            "before exit, including under -Q."
+        ),
+    )
+    chat_parser.add_argument(
         "--source",
         default=None,
         help="Session source tag for filtering (default: cli). Use 'tool' for third-party integrations that should not appear in user session lists.",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3209,6 +3209,13 @@ def cmd_chat(args):
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
+    # --session-id-file: deterministic native-session binding path for
+    # programmatic supervisors (Mission Control). The runtime (cli.py) reads
+    # HERMES_SESSION_ID_FILE and writes the live session id there at startup
+    # and whenever the session id changes.
+    if getattr(args, "session_id_file", None):
+        os.environ["HERMES_SESSION_ID_FILE"] = args.session_id_file
+
     _pin_kanban_board_env()
     _confirm_startup_expensive_model_override(args)
 

--- a/hermes_cli/session_binding.py
+++ b/hermes_cli/session_binding.py
@@ -1,0 +1,73 @@
+"""Deterministic native-session binding for supervised child runs.
+
+Mission Control (and any other programmatic supervisor) needs to know which
+native Hermes session a child run created or resumed, early and unambiguously
+— even under ``chat -Q --source mission-control``, where stdout chatter is
+suppressed and the ``session_id:`` line only appears at exit.
+
+The mechanism: the supervisor passes ``chat --session-id-file <path>`` (or
+sets ``HERMES_SESSION_ID_FILE``), with a path unique to that run. The runtime
+atomically writes the live session id to that file the moment the id exists
+— at startup for both fresh and resumed sessions, again on ``/new``
+rotation, and whenever a mid-run continuation session takes over. The file
+therefore ALWAYS names the currently-live session; supervisors never have
+to guess from "latest session".
+
+Profile-safe by construction: paths come from the caller, and session ids
+are read from the live CLI object — nothing global is consulted.
+"""
+
+import logging
+import os
+import tempfile
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def write_session_id_file(path: Optional[str], session_id: Optional[str]) -> bool:
+    """Atomically write *session_id* to *path* (temp file + rename).
+
+    Concurrency-safe: each run gets its own binding path (supplied by the
+    supervisor), and ``os.replace`` makes each individual write atomic so a
+    reader never observes a torn value. Best-effort: failures are logged and
+    return False rather than breaking the chat run — the binding file is a
+    correlation aid, not a correctness dependency of the session itself.
+
+    Returns True when the file was written.
+    """
+    if not path or not session_id:
+        return False
+    try:
+        directory = os.path.dirname(os.path.abspath(path)) or "."
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".session-id-", suffix=".tmp", dir=directory
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(str(session_id))
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        return True
+    except Exception as exc:
+        logger.warning("Failed to write session-id file %r: %s", path, exc)
+        return False
+
+
+def resolve_session_id_file(env=None) -> Optional[str]:
+    """Return the configured binding path, or None.
+
+    Reads ``HERMES_SESSION_ID_FILE`` (set by ``chat --session-id-file`` in
+    hermes_cli/main.py, mirroring the ``--source`` bridge). An empty value
+    disables the binding.
+    """
+    value = (env if env is not None else os.environ).get("HERMES_SESSION_ID_FILE")
+    return value.strip() or None if value else None

--- a/tests/cli/test_session_id_binding.py
+++ b/tests/cli/test_session_id_binding.py
@@ -1,0 +1,158 @@
+"""Deterministic quiet-mode native-session binding (--session-id-file).
+
+Behavior contracts:
+- atomic write of the live session id (new AND resumed) at startup
+- rebinding on /new rotation and continuation-session sync
+- concurrency-safe: distinct paths never cross-bind; last write wins on a
+  shared path and is always a complete value (never torn)
+- no-op when HERMES_SESSION_ID_FILE is unset (non-Mission-Control unchanged)
+"""
+
+import os
+
+import pytest
+
+from hermes_cli.session_binding import (
+    resolve_session_id_file,
+    write_session_id_file,
+)
+
+
+class TestWriteSessionIdFile:
+    def test_writes_exact_id(self, tmp_path):
+        path = str(tmp_path / "run1" / "binding")
+        assert write_session_id_file(path, "20260823_061808_ac9b1a") is True
+        with open(path) as fh:
+            assert fh.read() == "20260823_061808_ac9b1a"
+
+    def test_replaces_previous_value_atomically(self, tmp_path):
+        path = str(tmp_path / "binding")
+        write_session_id_file(path, "first_id")
+        write_session_id_file(path, "second_id")
+        with open(path) as fh:
+            assert fh.read() == "second_id"
+        # temp artifacts are cleaned up
+        leftovers = [
+            p for p in os.listdir(tmp_path)
+            if p != "binding" and not p.startswith("hermes_test")
+        ]
+        assert leftovers == []
+
+    def test_noop_on_missing_args(self, tmp_path):
+        path = str(tmp_path / "binding")
+        assert write_session_id_file(None, "sid") is False
+        assert write_session_id_file(path, None) is False
+        assert write_session_id_file("", "") is False
+        assert not os.path.exists(path)
+
+    def test_failure_returns_false_not_raises(self, tmp_path):
+        # A directory in place of the target makes os.replace fail.
+        target_dir = tmp_path / "blocking"
+        target_dir.mkdir()
+        assert write_session_id_file(str(target_dir), "sid") is False
+
+
+class TestResolveSessionIdFile:
+    def test_reads_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_SESSION_ID_FILE", str(tmp_path / "b"))
+        assert resolve_session_id_file() == str(tmp_path / "b")
+
+    def test_unset_is_none(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SESSION_ID_FILE", raising=False)
+        assert resolve_session_id_file() is None
+
+    def test_blank_is_none(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SESSION_ID_FILE", "   ")
+        assert resolve_session_id_file() is None
+
+
+class TestConcurrentRuns:
+    def test_distinct_paths_never_cross_bind(self, tmp_path):
+        run_a = str(tmp_path / "run-a")
+        run_b = str(tmp_path / "run-b")
+        write_session_id_file(run_a, "session_aaa")
+        write_session_id_file(run_b, "session_bbb")
+        assert open(run_a).read() == "session_aaa"
+        assert open(run_b).read() == "session_bbb"
+
+    def test_interleaved_writes_leave_complete_values(self, tmp_path):
+        import threading
+
+        path = str(tmp_path / "shared")
+        threads = [
+            threading.Thread(target=write_session_id_file, args=(path, f"sess_{i}"))
+            for i in range(8)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        value = open(path).read()
+        assert value.startswith("sess_")  # complete, never torn
+
+
+class TestCliBindingHooks:
+    """HermesCLI._bind_session_id_file writes at startup / rotation / sync."""
+
+    @pytest.fixture
+    def cli_stub(self):
+        import types
+        from types import SimpleNamespace
+
+        from cli import HermesCLI
+
+        stub = SimpleNamespace(session_id=None)
+        # Bind the real method so the test exercises HermesCLI's code as-is.
+        stub._bind_session_id_file = types.MethodType(
+            HermesCLI._bind_session_id_file, stub
+        )
+        return stub
+
+    def test_binds_fresh_session(self, monkeypatch, tmp_path, cli_stub):
+        binding = str(tmp_path / "mc-run-1")
+        monkeypatch.setenv("HERMES_SESSION_ID_FILE", binding)
+        cli_stub.session_id = "20260823_new00001"
+        cli_stub._bind_session_id_file()
+        assert open(binding).read() == "20260823_new00001"
+
+    def test_binds_resumed_session_at_startup(self, monkeypatch, tmp_path, cli_stub):
+        binding = str(tmp_path / "mc-run-2")
+        monkeypatch.setenv("HERMES_SESSION_ID_FILE", binding)
+        # Resumed runs set self.session_id to the known resumed id before any
+        # message is processed; startup binding must carry that exact id.
+        cli_stub.session_id = "20260822_resumed01"
+        cli_stub._bind_session_id_file()
+        assert open(binding).read() == "20260822_resumed01"
+
+    def test_rotation_rebinds(self, monkeypatch, tmp_path, cli_stub):
+        binding = str(tmp_path / "mc-run-3")
+        monkeypatch.setenv("HERMES_SESSION_ID_FILE", binding)
+        cli_stub.session_id = "old_session_id"
+        cli_stub._bind_session_id_file()
+        cli_stub.session_id = "rotated_new_id"  # /new generated this
+        cli_stub._bind_session_id_file()
+        assert open(binding).read() == "rotated_new_id"
+
+    def test_unset_env_is_full_noop(self, monkeypatch, tmp_path, cli_stub):
+        monkeypatch.delenv("HERMES_SESSION_ID_FILE", raising=False)
+        cli_stub.session_id = "some_session"
+        cli_stub._bind_session_id_file()  # must not raise or create anything
+        created = [p.name for p in tmp_path.iterdir() if p.name != "hermes_test"]
+        assert created == []
+
+
+class TestArgparseFlag:
+    def test_chat_subparser_accepts_flag(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _, chat_parser = build_top_level_parser()
+        args = parser.parse_args(["chat", "--session-id-file", "/tmp/bind-xyz"])
+        assert args.session_id_file == "/tmp/bind-xyz"
+        assert getattr(chat_parser, "_option_string_actions")  # sanity
+
+    def test_default_is_none(self):
+        from hermes_cli._parser import build_top_level_parser
+
+        parser, _, _ = build_top_level_parser()
+        args = parser.parse_args(["chat"])
+        assert args.session_id_file is None


### PR DESCRIPTION
## What

Adds `chat --session-id-file <path>` (bridged to `HERMES_SESSION_ID_FILE`, same pattern as `--source` → `HERMES_SESSION_SOURCE`). The runtime atomically writes the live native session id (temp file + `os.replace`) the moment it exists:

- **New sessions** — written at startup, well within ~1s of construction
- **Resumed sessions** — the known resumed id is bound at startup before any message is processed
- **/new rotation** — rebinding on session rotation
- **Mid-run continuation sessions** (compression) — rebound when `cli.session_id` syncs from `agent.session_id`

## Why

Supervised children under `chat -Q --source mission-control` previously exposed their session id only on the exit-time `session_id:` stderr line. A supervisor that must correlate a run with its live session mid-flight had nothing deterministic to read.

## Guarantees

- **Atomic**: temp file + fsync + rename; readers never see a torn value
- **Concurrency-safe**: path is unique per run (supervisor-supplied); two simultaneous children each bind only their own session
- **Profile-safe**: paths come from the caller; ids come from the live CLI object; no global 'latest session' guessing
- **Non-Mission-Control unchanged**: env unset ⇒ full no-op

## Tests

15 new tests in `tests/cli/test_session_id_binding.py`: exact-id writes, atomic replacement + temp cleanup, failure returns False (no raise), distinct-path concurrency, threaded shared-path interleaving (never torn), fresh/resumed/rotation binding through the real `HermesCLI._bind_session_id_file`, unset-env no-op, argparse flag parsing. All pass; `test_argparse_flag_propagation.py` + `test_cli_init.py` regression green.