### PR TITLE
fix(desktop): Send Diagnostics dialog no longer clips the link behind a horizontal scrollbar

### DIFF
--- a/apps/desktop/src/components/send-diagnostics-dialog.tsx
+++ b/apps/desktop/src/components/send-diagnostics-dialog.tsx
@@ -21,7 +21,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { useI18n } from '@/i18n'
-import { openExternalLink } from '@/lib/external-link'
+import { ExternalLink as ExternalLinkAnchor, openExternalLink } from '@/lib/external-link'
 import { ExternalLink, Loader2Icon, Lock } from '@/lib/icons'
 import { $sendDiagnostics, confirmSendDiagnostics, dismissSendDiagnostics } from '@/store/send-diagnostics'
 
@@ -97,12 +97,34 @@ export function SendDiagnosticsHost() {
               <DialogDescription className="text-left">{copy.doneDescription}</DialogDescription>
             </DialogHeader>
             {(state.result?.viewUrl || state.result?.uploadId) && (
-              <div className="flex items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) px-3 py-2">
-                <code className="min-w-0 flex-1 truncate text-[0.78rem] text-(--ui-text-secondary)">
-                  {state.result.viewUrl ?? copy.uploadIdFallback(state.result.uploadId ?? '')}
-                </code>
+              <div
+                className="flex items-center gap-2 rounded-md border border-(--ui-stroke-tertiary) px-3 py-2"
+                data-selectable-text="true"
+              >
+                {state.result.viewUrl ? (
+                  // A real anchor, not a <code> span: right-click resolves the
+                  // link context menu (open / copy URL), left-click opens it,
+                  // and the row's data-selectable-text keeps drag-to-select
+                  // working. `truncate` only clips the paint — selection and
+                  // copy still carry the full URL. `native` because the in-app
+                  // preview pane would open BEHIND this modal dialog; the
+                  // support buttons below already go to the system browser.
+                  <ExternalLinkAnchor
+                    className="min-w-0 flex-1 truncate font-mono text-[0.78rem] text-(--ui-text-secondary)"
+                    href={state.result.viewUrl}
+                    native
+                    title={state.result.viewUrl}
+                  >
+                    {state.result.viewUrl}
+                  </ExternalLinkAnchor>
+                ) : (
+                  <code className="min-w-0 flex-1 truncate text-[0.78rem] text-(--ui-text-secondary)">
+                    {copy.uploadIdFallback(state.result.uploadId ?? '')}
+                  </code>
+                )}
                 <CopyButton
                   appearance="inline"
+                  className="shrink-0"
                   label={copy.copyLink}
                   text={state.result.viewUrl ?? state.result.uploadId ?? ''}
                 />

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -148,7 +148,12 @@ function DialogContent({
           <DialogPortalContainerContext.Provider value={contentNode}>
             {/* Scroll lives on an inner box so this shell keeps a painted bottom radius. */}
             <div className="relative z-10 overflow-hidden rounded-xl border border-b-0 border-(--stroke-nous) bg-(--ui-chat-bubble-background)">
-              <div className={cn('grid max-h-[calc(85vh-5rem)] min-h-0 gap-3 overflow-y-auto p-4', bodyClassName)}>
+              <div
+                className={cn(
+                  'grid max-h-[calc(85vh-5rem)] min-h-0 grid-cols-[minmax(0,1fr)] gap-3 overflow-y-auto p-4',
+                  bodyClassName
+                )}
+              >
                 {children}
               </div>
             </div>
@@ -194,8 +199,17 @@ function DialogContent({
         <DialogPortalContainerContext.Provider value={contentNode}>
           {/* The BODY: layout and scroll. `min-h-0` lets this box shrink inside
               the max-height of the shell. The overflow then scrolls here
-              instead of pushing the shell past the viewport. */}
-          <div className={cn('grid min-h-0 gap-3 overflow-y-auto rounded-[inherit] p-4', bodyClassName)}>
+              instead of pushing the shell past the viewport. The explicit
+              `minmax(0,1fr)` column keeps the implicit grid track from sizing
+              to unbreakable content (a long URL in a nowrap <code>), which
+              otherwise widens the track past the dialog and grows a horizontal
+              scrollbar that clips the content instead of truncating it. */}
+          <div
+            className={cn(
+              'grid min-h-0 grid-cols-[minmax(0,1fr)] gap-3 overflow-y-auto rounded-[inherit] p-4',
+              bodyClassName
+            )}
+          >
             {children}
           </div>
           {closeButton}


### PR DESCRIPTION
## Summary
The Send Diagnostics "Diagnostics sent" dialog no longer clips its content behind a horizontal scrollbar, and the view link is now clickable, right-clickable, and selectable.

Root cause: `DialogContent`'s body box is a CSS grid with an implicit column, and an implicit track sizes to unbreakable content — the nowrap view-link `<code>` forced the track wider than the dialog. `min-w-0`/`truncate` on the code element never engaged because the *track* grew instead, so the description was cut off mid-sentence, the URL was clipped mid-UUID, and the Copy button sat off-screen behind a horizontal scrollbar. Selection/right-click were dead because the app ships `user-select: none` globally and the URL was a plain `<code>` span with no opt-in.

## Changes
- `components/ui/dialog.tsx`: both DialogContent body boxes (plain + banner variants) pin the grid column to `grid-template-columns: minmax(0,1fr)` — hardens every dialog against long unbreakable content, not just this one.
- `components/send-diagnostics-dialog.tsx`: view link is a real `ExternalLink` anchor (`native` → system browser, matching the support buttons; right-click resolves the app's link context menu with open/copy URL) inside a `data-selectable-text` row so drag-to-select works; Copy button gets `shrink-0`. Truncation clips paint only — selection still carries the full URL.

## Validation
| | Before | After |
|---|---|---|
| Body scrollWidth vs clientWidth (real browser repro, 30rem dialog) | 718 vs 480 → h-scrollbar | 480 vs 480 |
| Copy button | outside dialog, reachable only by scrolling | visible in the row |
| URL select/right-click | dead (`user-select:none`, `<code>` span) | full URL selectable, link context menu |

`tsc --noEmit` clean · eslint + prettier clean · `vitest run src/components` 122 files / 878 tests pass (includes dialog + copy-button suites).

## Infographic

![Send Diagnostics dialog overflow fix](https://v3b.fal.media/files/b/0aa77cb5/nr5LbR3fNQFWZTzxsfHsF_RsBGHuuq.png)
