### PR TITLE
fix(bot-mode): group rooms name renamed bots — "Lucy is thinking…", never a stale "Hermes"

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5960,11 +5960,43 @@ function rotateGroupSpeakers(members, round) {
   return [...members.slice(shift), ...members.slice(0, shift)]
 }
 
-/** Transcript form of a room speaker's profile name. The primary profile is
- *  literally named "default" — render it as Hermes (matching displayName and
- *  the @hermes handle) so the main agent never loses its name in rooms. */
+/** Transcript form of a room speaker's profile name. Friendly identity wins:
+ *  a Bot Mode title or a core profile display_name (e.g. default renamed to
+ *  "Lucy") labels the speaker everywhere this helper feeds — the "X is
+ *  thinking…" working line, the activity feed, and transcript lines — so a
+ *  renamed bot never shows up as its raw profile id or a stale "Hermes"
+ *  (community report, Aug 21 2026: renamed default still read "Hermes is
+ *  thinking…" in group rooms). The untitled primary profile is literally
+ *  named "default" — render it as Hermes (matching displayName and the
+ *  @hermes handle) so the main agent never loses its name in rooms. */
 function groupSpeakerLabel(name) {
-  return (name || '').trim().toLowerCase() === 'default' ? 'Hermes' : name
+  const trimmed = (name || '').trim()
+
+  if (!trimmed) {
+    return trimmed
+  }
+
+  // Bot Mode title (edit dialog) — same first rung as displayName().
+  const title = String($botMeta.get()?.[trimmed]?.title || '').trim()
+
+  if (title) {
+    return title
+  }
+
+  // Core profile display_name (`hermes profile rename …` / dashboard) from
+  // the ACTIVE gateway's roster row. Source-scoped remote speakers carry
+  // their device suffix separately and keep their raw name here.
+  const roster = $lastRoster.get()
+  const row = Array.isArray(roster)
+    ? roster.find(bot => bot?.name === trimmed && !bot?.remoteSource && !bot?.sourceScoped)
+    : null
+  const renamed = typeof row?.display_name === 'string' ? row.display_name.trim() : ''
+
+  if (renamed) {
+    return renamed
+  }
+
+  return trimmed.toLowerCase() === 'default' ? 'Hermes' : trimmed
 }
 
 /** Room-log line as a member sees it: `Name (user): …` / `Name: …` /

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -196,7 +196,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -1278,6 +1278,43 @@ test('default profile speaks as Hermes in room transcripts, not @default', () =>
   assert.equal(you, 'Hermes (you): hi')
   const plain = gc.formatGroupChatLine({ from: { kind: 'member', name: 'builder' }, text: 'yo' }, 'research')
   assert.equal(plain, 'builder: yo')
+})
+
+test('speaker labels honor friendly identity: Bot Mode title, then display_name, never a stale Hermes', () => {
+  const gc = load(() => '(pass)')
+
+  // A renamed default (core display_name via `hermes profile rename`) must
+  // read as its new name — the community report was "Lucy" still showing
+  // "Hermes is thinking…" in group rooms.
+  gc.$lastRoster.set([{ name: 'default', display_name: 'Lucy' }])
+  assert.equal(gc.groupSpeakerLabel('default'), 'Lucy')
+  assert.equal(
+    gc.formatGroupChatLine({ from: { kind: 'member', name: 'default' }, text: 'hi' }, 'builder'),
+    'Lucy: hi'
+  )
+
+  // A Bot Mode title outranks display_name (same precedence as displayName).
+  gc.$botMeta.set({ default: { title: 'Moxie' } })
+  assert.equal(gc.groupSpeakerLabel('default'), 'Moxie')
+
+  // Secondary profiles get their title too — the thinking line names the
+  // renamed bot, not the raw profile slug.
+  gc.$botMeta.set({ research: { title: 'Radar' } })
+  gc.$lastRoster.set([])
+  assert.equal(gc.groupSpeakerLabel('research'), 'Radar')
+
+  // Untitled rows keep today's behavior: default → Hermes, others verbatim.
+  gc.$botMeta.set({})
+  assert.equal(gc.groupSpeakerLabel('default'), 'Hermes')
+  assert.equal(gc.groupSpeakerLabel('builder'), 'builder')
+})
+
+test('speaker labels never borrow a remote row\u2019s display_name for a local speaker', () => {
+  const gc = load(() => '(pass)')
+  // Only a remote/thin row named default exists — its display_name belongs
+  // to that connection, not to the active gateway's default.
+  gc.$lastRoster.set([{ name: 'default', display_name: 'HomelabBot', remoteSource: true }])
+  assert.equal(gc.groupSpeakerLabel('default'), 'Hermes')
 })
 
 test('turn prompt addresses the default profile as @hermes', () => {


### PR DESCRIPTION
# fix(bot-mode): group rooms name renamed bots — "Lucy is thinking…", never a stale "Hermes"

## Summary
A renamed bot now keeps its name in group-chat rooms: the working line reads "Lucy is thinking…", the activity feed says "Lucy replied", and transcript lines are prefixed "Lucy:" — instead of falling back to "Hermes" (renamed default) or the raw profile slug (retitled secondary bots).

Root cause: `groupSpeakerLabel()` resolved friendly identity for exactly one case — the literal profile name `default` → "Hermes". A core `display_name` (from `hermes profile rename`) or a Bot Mode title never reached it. Community report (flep, Discord, Aug 21): a default profile renamed "Lucy" still showed "hermes thinking" in group chat.

## Changes
- `apps/desktop/src/plugins/hermes-bots/plugin.js`: `groupSpeakerLabel` now walks the same rungs as `displayName()` — Bot Mode title first, then the ACTIVE gateway roster row's `display_name` (remote/thin rows skipped so another connection's `default` can't lend its name), then the existing default→Hermes fallback. This single helper feeds the "is thinking…" line, the activity feed, and transcript speaker prefixes.
- `tests/group-chat.test.mjs`: exports `groupSpeakerLabel` + `$lastRoster` from the vm harness; adds precedence tests (title > display_name > default→Hermes) and a negative test that a remote row's `display_name` is never borrowed for a local speaker.

## Validation
| | Before | After |
|---|---|---|
| Renamed default ("Lucy") in group room | "Hermes is thinking…" | "Lucy is thinking…" |
| Titled secondary bot ("Radar") | raw slug in activity feed | "Radar" |
| Untitled default / untitled bots | "Hermes" / slug | unchanged |
| group-chat.test.mjs | 85/85 | 87/87 |
| full hermes-bots suite | — | 474/474 |

## Infographic

![mission patch — group chat identity fix](https://v3b.fal.media/files/b/0aa77cc7/ZDIQ-3hle-B0yeefAs_nl_myQy4HLj.png)
