### PR TITLE
fix(editor): wait for delayed prompt saves

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -42,6 +42,7 @@ from hermes_cli.browser_connect import (
 
 _EDITOR_SAVE_POLL_SECONDS = 0.05
 _EDITOR_SAVE_STABLE_SECONDS = 0.2
+_EDITOR_SAVE_UNCHANGED_GRACE_SECONDS = 0.3
 _EDITOR_SAVE_TIMEOUT_SECONDS = 2.0
 
 
@@ -65,7 +66,10 @@ def _read_editor_file_when_settled(path: str, initial: str) -> str:
                 latest = current
                 stable_since = now
                 observed_change = True
-            elif observed_change and now - stable_since >= _EDITOR_SAVE_STABLE_SECONDS:
+            elif observed_change:
+                if now - stable_since >= _EDITOR_SAVE_STABLE_SECONDS:
+                    return latest
+            elif now - started_at >= _EDITOR_SAVE_UNCHANGED_GRACE_SECONDS:
                 return latest
 
         time.sleep(_EDITOR_SAVE_POLL_SECONDS)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -40,6 +40,39 @@ from hermes_cli.browser_connect import (
 )
 
 
+_EDITOR_SAVE_POLL_SECONDS = 0.05
+_EDITOR_SAVE_STABLE_SECONDS = 0.2
+_EDITOR_SAVE_TIMEOUT_SECONDS = 2.0
+
+
+def _read_editor_file_when_settled(path: str, initial: str) -> str:
+    """Read an editor file after delayed or atomic saves have settled."""
+    started_at = time.monotonic()
+    latest = initial
+    stable_since = started_at
+    observed_change = False
+
+    while time.monotonic() - started_at < _EDITOR_SAVE_TIMEOUT_SECONDS:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                current = fh.read()
+        except OSError:
+            # Atomic-save editors can briefly replace or rename the target.
+            pass
+        else:
+            now = time.monotonic()
+            if current != latest:
+                latest = current
+                stable_since = now
+                observed_change = True
+            elif observed_change and now - stable_since >= _EDITOR_SAVE_STABLE_SECONDS:
+                return latest
+
+        time.sleep(_EDITOR_SAVE_POLL_SECONDS)
+
+    return latest
+
+
 class CLICommandsMixin:
     """Mixin holding the interactive-CLI slash-command handlers.
 
@@ -3184,20 +3217,18 @@ class CLICommandsMixin:
             "#! Compose your prompt below. Lines starting with '#!' are ignored.\n"
             "#! Save and quit to send; leave empty to cancel.\n\n"
         )
+        initial_buffer = header + initial_text
         fd, path = tempfile.mkstemp(suffix=".md", prefix="hermes_prompt_")
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                fh.write(header)
-                if initial_text:
-                    fh.write(initial_text)
+                fh.write(initial_buffer)
             try:
                 subprocess.call([*shlex.split(editor), path])
             except Exception:
                 # Fall back to a bare invocation (editor value may not be a
                 # simple argv-splittable string on some platforms).
                 subprocess.call(f"{editor} {shlex.quote(path)}", shell=True)
-            with open(path, "r", encoding="utf-8") as fh:
-                raw = fh.read()
+            raw = _read_editor_file_when_settled(path, initial_buffer)
         finally:
             try:
                 os.unlink(path)

--- a/tests/hermes_cli/test_prompt_compose_command.py
+++ b/tests/hermes_cli/test_prompt_compose_command.py
@@ -9,7 +9,10 @@ stripping, seeding, and the empty-buffer cancel path.
 
 import os
 import stat
+import subprocess
 import tempfile
+import threading
+import time
 
 import pytest
 
@@ -29,7 +32,7 @@ def _fake_editor(body: str, mode: str = "append") -> str:
         f.write("#!/usr/bin/env bash\n")
         f.write(f"cat >> \"$1\" <<'EOF'\n{body}\nEOF\n")
     else:  # clear
-        f.write("#!/usr/bin/env bash\n: > \"$1\"\n")
+        f.write('#!/usr/bin/env bash\n: > "$1"\n')
     f.close()
     os.chmod(f.name, os.stat(f.name).st_mode | stat.S_IEXEC)
     return f.name
@@ -59,3 +62,34 @@ def test_empty_buffer_does_not_seed(monkeypatch):
     s = _Stub()
     s._handle_prompt_compose_command("/prompt")
     assert s._pending_agent_seed is None
+
+
+def test_compose_waits_for_save_visible_after_editor_exit(monkeypatch, tmp_path):
+    prompt_path = tmp_path / "prompt.md"
+    writer = None
+
+    def fake_mkstemp(*_args, **_kwargs):
+        fd = os.open(prompt_path, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o600)
+        return fd, str(prompt_path)
+
+    def fake_editor_call(*_args, **_kwargs):
+        nonlocal writer
+
+        def delayed_save():
+            time.sleep(0.1)
+            prompt_path.write_text("edited prompt", encoding="utf-8")
+
+        writer = threading.Thread(target=delayed_save)
+        writer.start()
+        return 0
+
+    monkeypatch.setattr(tempfile, "mkstemp", fake_mkstemp)
+    monkeypatch.setattr(subprocess, "call", fake_editor_call)
+    monkeypatch.setenv("EDITOR", "fake-editor")
+    try:
+        out = _Stub()._compose_in_editor("initial draft")
+    finally:
+        if writer is not None:
+            writer.join()
+
+    assert out == "edited prompt"

--- a/tests/hermes_cli/test_prompt_compose_command.py
+++ b/tests/hermes_cli/test_prompt_compose_command.py
@@ -16,7 +16,7 @@ import time
 
 import pytest
 
-from hermes_cli.cli_commands_mixin import CLICommandsMixin
+from hermes_cli.cli_commands_mixin import CLICommandsMixin, _read_editor_file_when_settled
 from hermes_cli.commands import resolve_command
 
 
@@ -93,3 +93,15 @@ def test_compose_waits_for_save_visible_after_editor_exit(monkeypatch, tmp_path)
             writer.join()
 
     assert out == "edited prompt"
+
+
+def test_unchanged_editor_file_returns_without_full_timeout(tmp_path):
+    prompt_path = tmp_path / "prompt.md"
+    prompt_path.write_text("initial draft", encoding="utf-8")
+
+    started_at = time.monotonic()
+    out = _read_editor_file_when_settled(str(prompt_path), "initial draft")
+    elapsed = time.monotonic() - started_at
+
+    assert out == "initial draft"
+    assert elapsed < 1.0

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -1,9 +1,4 @@
-import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-
-import { useStdin, withInkSuspended } from '@hermes/ink'
+import { useStdin } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 
@@ -14,7 +9,7 @@ import { useCompletion } from '../hooks/useCompletion.js'
 import { useInputHistory } from '../hooks/useInputHistory.js'
 import { useQueue } from '../hooks/useQueue.js'
 import { isUsableClipboardText, readClipboardText } from '../lib/clipboard.js'
-import { resolveEditor } from '../lib/editor.js'
+import { openInEditor } from '../lib/editor.js'
 import { readOsc52Clipboard } from '../lib/osc52.js'
 import { isRemoteShellSession } from '../lib/terminalSetup.js'
 import { pasteTokenLabel, stripTrailingPasteNewlines } from '../lib/text.js'
@@ -389,35 +384,21 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
   )
 
   const openEditor = useCallback(async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'hermes-'))
-    const file = join(dir, 'prompt.md')
-    const [cmd, ...args] = resolveEditor()
+    const edited = await openInEditor([...inputBuf, input].join('\n'), '.md', 'prompt')
 
-    writeFileSync(file, [...inputBuf, input].join('\n'))
-
-    let exitCode: null | number = null
-
-    await withInkSuspended(async () => {
-      exitCode = spawnSync(cmd!, [...args, file], { stdio: 'inherit' }).status
-    })
-
-    try {
-      if (exitCode !== 0) {
-        return
-      }
-
-      const text = readFileSync(file, 'utf8').trimEnd()
-
-      if (!text) {
-        return
-      }
-
-      setInput('')
-      setInputBuf([])
-      submitRef.current(text)
-    } finally {
-      rmSync(dir, { force: true, recursive: true })
+    if (edited === null) {
+      return
     }
+
+    const text = edited.trimEnd()
+
+    if (!text) {
+      return
+    }
+
+    setInput('')
+    setInputBuf([])
+    submitRef.current(text)
   }, [input, inputBuf, setInput, submitRef])
 
   const actions = useMemo(

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -2,9 +2,9 @@ import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { resolveEditor } from './editor.js'
+import { openInEditor, resolveEditor } from './editor.js'
 
 const exe = (dir: string, name: string): string => {
   const path = join(dir, name)
@@ -70,5 +70,76 @@ describe('resolveEditor', () => {
 
   it('uses notepad.exe on Windows when no env override', () => {
     expect(resolveEditor({ PATH: dir }, 'win32')).toEqual(['notepad.exe'])
+  })
+})
+
+describe('openInEditor', () => {
+  const originalVisual = process.env.VISUAL
+
+  afterEach(() => {
+    if (originalVisual === undefined) {
+      delete process.env.VISUAL
+    } else {
+      process.env.VISUAL = originalVisual
+    }
+  })
+
+  it('returns an editor save that becomes visible shortly after the editor exits', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'editor-delayed-save-test-'))
+    const editor = join(dir, 'delayed-editor.mjs')
+
+    writeFileSync(
+      editor,
+      [
+        '#!/usr/bin/env node',
+        "import { spawn } from 'node:child_process'",
+        'const target = process.argv[2]',
+        'const writer = spawn(process.execPath, [',
+        "  '-e',",
+        "  `setTimeout(() => require('node:fs').writeFileSync(process.argv[1], 'edited prompt'), 100)`,",
+        '  target',
+        "], { detached: true, stdio: 'ignore' })",
+        'writer.unref()'
+      ].join('\n')
+    )
+    chmodSync(editor, 0o755)
+    process.env.VISUAL = `${process.execPath} ${editor}`
+
+    await expect(openInEditor('initial draft', '.md')).resolves.toBe('edited prompt')
+  })
+
+  it('returns the last stable value when an editor flushes multiple saves', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'editor-multiple-save-test-'))
+    const editor = join(dir, 'multi-save-editor.mjs')
+
+    writeFileSync(
+      editor,
+      [
+        '#!/usr/bin/env node',
+        "import { spawn } from 'node:child_process'",
+        'const target = process.argv[2]',
+        'const writer = spawn(process.execPath, [',
+        "  '-e',",
+        "  `const fs = require('node:fs'); setTimeout(() => fs.writeFileSync(process.argv[1], 'intermediate'), 50); setTimeout(() => fs.writeFileSync(process.argv[1], 'final prompt'), 150)`,",
+        '  target',
+        "], { detached: true, stdio: 'ignore' })",
+        'writer.unref()'
+      ].join('\n')
+    )
+    chmodSync(editor, 0o755)
+    process.env.VISUAL = `${process.execPath} ${editor}`
+
+    await expect(openInEditor('initial draft', '.md')).resolves.toBe('final prompt')
+  })
+
+  it('returns null when the editor exits unsuccessfully', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'editor-failure-test-'))
+    const editor = join(dir, 'failing-editor.mjs')
+
+    writeFileSync(editor, '#!/usr/bin/env node\nprocess.exit(1)\n')
+    chmodSync(editor, 0o755)
+    process.env.VISUAL = `${process.execPath} ${editor}`
+
+    await expect(openInEditor('initial draft', '.md')).resolves.toBeNull()
   })
 })

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -132,6 +132,19 @@ describe('openInEditor', () => {
     await expect(openInEditor('initial draft', '.md')).resolves.toBe('final prompt')
   })
 
+  it('returns an unchanged buffer without waiting for the full save timeout', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'editor-unchanged-test-'))
+    const editor = join(dir, 'unchanged-editor.mjs')
+
+    writeFileSync(editor, '#!/usr/bin/env node\nprocess.exit(0)\n')
+    chmodSync(editor, 0o755)
+    process.env.VISUAL = `${process.execPath} ${editor}`
+
+    const startedAt = Date.now()
+    await expect(openInEditor('initial draft', '.md')).resolves.toBe('initial draft')
+    expect(Date.now() - startedAt).toBeLessThan(1_000)
+  })
+
   it('returns null when the editor exits unsuccessfully', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'editor-failure-test-'))
     const editor = join(dir, 'failing-editor.mjs')

--- a/ui-tui/src/lib/editor.ts
+++ b/ui-tui/src/lib/editor.ts
@@ -13,6 +13,7 @@ import { withInkSuspended } from '@hermes/ink'
 const FALLBACKS = ['editor', 'nano', 'pico', 'vi', 'emacs']
 const EDITOR_SAVE_POLL_MS = 50
 const EDITOR_SAVE_STABLE_MS = 200
+const EDITOR_SAVE_UNCHANGED_GRACE_MS = 300
 const EDITOR_SAVE_TIMEOUT_MS = 2_000
 
 const delay = async (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
@@ -32,7 +33,11 @@ const readEditorFileWhenSettled = async (file: string, initial: string): Promise
         latest = current
         stableSince = now
         observedChange = true
-      } else if (observedChange && now - stableSince >= EDITOR_SAVE_STABLE_MS) {
+      } else if (observedChange) {
+        if (now - stableSince >= EDITOR_SAVE_STABLE_MS) {
+          return latest
+        }
+      } else if (now - startedAt >= EDITOR_SAVE_UNCHANGED_GRACE_MS) {
         return latest
       }
     } catch {

--- a/ui-tui/src/lib/editor.ts
+++ b/ui-tui/src/lib/editor.ts
@@ -11,6 +11,40 @@ import { withInkSuspended } from '@hermes/ink'
  * the TUI launch the same editor on a given box.
  */
 const FALLBACKS = ['editor', 'nano', 'pico', 'vi', 'emacs']
+const EDITOR_SAVE_POLL_MS = 50
+const EDITOR_SAVE_STABLE_MS = 200
+const EDITOR_SAVE_TIMEOUT_MS = 2_000
+
+const delay = async (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+const readEditorFileWhenSettled = async (file: string, initial: string): Promise<string> => {
+  const startedAt = Date.now()
+  let latest = initial
+  let stableSince = startedAt
+  let observedChange = false
+
+  while (Date.now() - startedAt < EDITOR_SAVE_TIMEOUT_MS) {
+    try {
+      const current = readFileSync(file, 'utf8')
+      const now = Date.now()
+
+      if (current !== latest) {
+        latest = current
+        stableSince = now
+        observedChange = true
+      } else if (observedChange && now - stableSince >= EDITOR_SAVE_STABLE_MS) {
+        return latest
+      }
+    } catch {
+      // Atomic-save editors can briefly replace or rename the target. Retry
+      // within the same bounded handoff instead of submitting stale contents.
+    }
+
+    await delay(EDITOR_SAVE_POLL_MS)
+  }
+
+  return latest
+}
 
 const isExecutable = (path: string): boolean => {
   try {
@@ -51,19 +85,24 @@ export const resolveEditor = (
 }
 
 /** Suspend Ink, open ``initial`` in $EDITOR, return the edited text (null if aborted). */
-export async function openInEditor(initial: string, suffix = '.txt'): Promise<null | string> {
+export async function openInEditor(initial: string, suffix = '.txt', basename = 'edit'): Promise<null | string> {
   const dir = mkdtempSync(join(tmpdir(), 'hermes-edit-'))
-  const file = join(dir, `edit${suffix}`)
+  const file = join(dir, `${basename}${suffix}`)
   writeFileSync(file, initial)
   const [cmd, ...args] = resolveEditor()
   let status: null | number = null
+  let edited: null | string = null
 
   await withInkSuspended(async () => {
     status = spawnSync(cmd!, [...args, file], { stdio: 'inherit' }).status
+
+    if (status === 0) {
+      edited = await readEditorFileWhenSettled(file, initial)
+    }
   })
 
   try {
-    return status === 0 ? readFileSync(file, 'utf8') : null
+    return status === 0 ? edited : null
   } finally {
     rmSync(dir, { force: true, recursive: true })
   }


### PR DESCRIPTION
## Summary

Fixes #92900.

Hermes could submit the initial external-editor draft even after the user saved different text. Both the TUI and classic CLI read and deleted the temporary file immediately after the editor process exited, which did not allow for delayed or atomic saves from graphical editors.

This PR:

- adds a bounded post-editor settling window before reading the temporary file;
- polls every 50 ms, requires changed content to remain stable for 200 ms, returns unchanged content after a 300 ms post-exit grace period, and caps changed/unstable waits at 2 seconds;
- retries transient read failures caused by atomic rename/replace saves;
- makes the TUI composer reuse the shared editor handoff while preserving its existing `prompt.md` filename;
- applies the equivalent protection to the classic CLI `/prompt` sibling path;
- preserves non-zero editor-exit cancellation behavior in the TUI;
- adds delayed-save, multiple-save, unchanged-exit latency, and editor-failure regression coverage.

No editor-specific branch, environment variable, or user-facing setting is introduced.

## Reproduction and regression proof

Before the fix, both delayed-save regression tests returned the initial draft instead of the later saved contents.

The TypeScript regression failed with:

```text
Expected: "edited prompt"
Received: "initial draft"
```

The Python regression failed with the same result.

As a sabotage check, immediate post-exit reads were temporarily restored after implementation; both delayed-save tests failed again, then passed after restoring the fix.

## Tests

Passed on macOS 26.5.2:

- `npm test --workspace ui-tui -- src/lib/editor.test.ts src/__tests__/createSlashHandler.test.ts` — 94 passed
- `npm run typecheck --workspace ui-tui`
- focused ESLint and Prettier checks for the three changed TUI files
- `uv run pytest -q tests/hermes_cli/test_prompt_compose_command.py` — 5 passed
- Ruff checks for the two changed Python files
- `npm run build --workspace ui-tui`

The full TUI suite completed with 1706 passed, 1 skipped, and 4 failures in two unrelated theme/syntax test files. Stashing every file in this PR and rerunning those exact files on the same upstream commit produced the same four failures, confirming they are baseline failures rather than regressions from this change:

- `src/__tests__/syntax.test.ts` — 3 failures
- `src/__tests__/createGatewayEventHandler.test.ts` — 1 failure

## Risk and behavior notes

- A changed prompt normally incurs about the 200 ms stability window after the final observed write.
- A truly unchanged prompt waits for a 300 ms post-exit grace period, rather than the full 2-second timeout.
- Saves that become visible after the timeout remain outside the guarantees of the generic `$EDITOR` protocol; editor-specific IPC is intentionally out of scope.
