### PR TITLE
feat(providers): support model-aware API mode resolution

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2034,7 +2034,7 @@ def switch_model(
     if _mandated_mode is not None:
         api_mode = _mandated_mode
     elif not api_mode:
-        api_mode = determine_api_mode(target_provider, base_url)
+        api_mode = determine_api_mode(target_provider, base_url, model=new_model)
 
     # --- Normalize model name for target provider ---
     new_model = _resolve_named_custom_model_id(

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -744,6 +744,52 @@ def determine_api_mode(provider: str, base_url: str = "", model: str = "") -> st
     if provider_norm in {"nous", "nous-portal", "nousresearch"}:
         return nous_api_mode(model)
 
+    # Provider plugins may be multi-wire even when every model shares one
+    # endpoint. Delegate only when the concrete profile class overrides the
+    # base hook: ordinary/static profiles must retain the existing catalog
+    # transport precedence (some intentionally differ from profile.api_mode on
+    # custom endpoints). Try both the raw identity and canonical core alias.
+    try:
+        from providers import get_provider_profile
+        from providers.base import ProviderProfile
+    except Exception:
+        get_provider_profile = None
+        ProviderProfile = None
+    if get_provider_profile is not None and ProviderProfile is not None:
+        canonical = normalize_provider(provider_norm)
+        for identity in dict.fromkeys((provider_norm, canonical)):
+            try:
+                profile = get_provider_profile(identity)
+            except Exception as exc:
+                logger.warning(
+                    "Provider profile lookup failed for %s: %s", identity, exc
+                )
+                continue
+            if profile is None:
+                continue
+            if type(profile).resolve_api_mode is ProviderProfile.resolve_api_mode:
+                break
+            try:
+                resolved_mode = profile.resolve_api_mode(model, base_url)
+            except Exception as exc:
+                logger.warning(
+                    "Provider %s resolve_api_mode failed; using catalog transport: %s",
+                    identity,
+                    exc,
+                )
+                break
+            if (
+                isinstance(resolved_mode, str)
+                and resolved_mode in set(TRANSPORT_TO_API_MODE.values())
+            ):
+                return resolved_mode
+            logger.warning(
+                "Provider %s returned unsupported api_mode %r; using catalog transport",
+                identity,
+                resolved_mode,
+            )
+            break
+
     pdef = get_provider(provider)
     if pdef is not None:
         return TRANSPORT_TO_API_MODE.get(pdef.transport, "chat_completions")

--- a/providers/base.py
+++ b/providers/base.py
@@ -101,6 +101,21 @@ class ProviderProfile:
 
     # ── Hooks (override in subclass for complex providers) ───
 
+    def resolve_api_mode(
+        self,
+        model: str | None,
+        base_url: str | None = None,
+    ) -> str:
+        """Return the wire protocol for *model*.
+
+        The default preserves the provider-wide :attr:`api_mode`. Multi-wire
+        provider plugins can override this hook to choose a supported mode per
+        concrete model without requiring a provider-name branch in core.
+        ``base_url`` is supplied for providers whose route policy also depends
+        on the configured endpoint.
+        """
+        return self.api_mode
+
     def resolve_aux_model(self, *, vision: bool = False) -> str:
         """Return a LIVE cheap-model id for auxiliary tasks, or "".
 

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -122,3 +122,22 @@ def test_xai_oauth_soft_accept_preserved_when_no_match():
     )
     assert result.success is True, result.error_message
     assert result.target_provider == "xai-oauth"
+
+
+def test_model_switch_passes_target_model_to_api_mode_resolution():
+    seen_models = []
+
+    def determine(provider, base_url, model=""):
+        seen_models.append(model)
+        return "codex_responses" if model.startswith("gpt-") else "chat_completions"
+
+    with patch("hermes_cli.model_switch.determine_api_mode", side_effect=determine):
+        result = _run_switch(
+            raw_input="gpt-7",
+            current_provider="dynamic-test",
+            current_base_url="https://relay.test/v1",
+        )
+
+    assert result.success is True, result.error_message
+    assert result.api_mode == "codex_responses"
+    assert "gpt-7" in seen_models

--- a/tests/hermes_cli/test_provider_profile_api_mode.py
+++ b/tests/hermes_cli/test_provider_profile_api_mode.py
@@ -1,0 +1,149 @@
+from types import SimpleNamespace
+
+from providers.base import ProviderProfile
+
+from hermes_cli import providers as provider_catalog
+from hermes_cli import runtime_provider
+
+
+class _DynamicProfile(ProviderProfile):
+    def resolve_api_mode(self, model, base_url=None):
+        return (
+            "codex_responses"
+            if str(model or "").startswith("gpt-")
+            else "chat_completions"
+        )
+
+
+def test_determine_api_mode_delegates_to_profile_with_target_model(monkeypatch):
+    profile = _DynamicProfile(
+        name="dynamic-test",
+        api_mode="chat_completions",
+        base_url="https://relay.test/v1",
+    )
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: profile if name == "dynamic-test" else None,
+    )
+
+    assert provider_catalog.determine_api_mode(
+        "dynamic-test", "https://relay.test/v1", "gpt-7"
+    ) == "codex_responses"
+    assert provider_catalog.determine_api_mode(
+        "dynamic-test", "https://relay.test/v1", "kimi-k4"
+    ) == "chat_completions"
+
+
+def test_runtime_fallback_passes_model_to_profile_hook(monkeypatch):
+    profile = _DynamicProfile(
+        name="dynamic-test",
+        api_mode="chat_completions",
+        base_url="https://relay.test/v1",
+    )
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: profile if name == "dynamic-test" else None,
+    )
+
+    assert runtime_provider._fallback_api_mode(
+        "dynamic-test", "https://relay.test/v1", "gpt-7"
+    ) == "codex_responses"
+    assert runtime_provider._fallback_api_mode(
+        "dynamic-test", "https://relay.test/v1", "kimi-k4"
+    ) == "chat_completions"
+
+
+def test_host_mandated_mode_still_wins_over_profile_hook(monkeypatch):
+    profile = _DynamicProfile(name="dynamic-test", api_mode="chat_completions")
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+
+    assert provider_catalog.determine_api_mode(
+        "dynamic-test", "https://api.anthropic.com", "gpt-7"
+    ) == "anthropic_messages"
+
+
+def test_static_profile_does_not_override_existing_catalog_transport(monkeypatch):
+    profile = ProviderProfile(name="static-test", api_mode="codex_responses")
+    monkeypatch.setattr("providers.get_provider_profile", lambda name: profile)
+    monkeypatch.setattr(
+        provider_catalog,
+        "get_provider",
+        lambda name: SimpleNamespace(transport="openai_chat"),
+    )
+
+    assert provider_catalog.determine_api_mode(
+        "static-test", "https://proxy.test/v1", "gpt-7"
+    ) == "chat_completions"
+
+
+def test_raising_profile_hook_falls_back_to_existing_transport(monkeypatch):
+    class RaisingProfile(ProviderProfile):
+        def resolve_api_mode(self, model, base_url=None):
+            raise RuntimeError("plugin boom")
+
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: RaisingProfile(name="raising-test"),
+    )
+    monkeypatch.setattr(
+        provider_catalog,
+        "get_provider",
+        lambda name: SimpleNamespace(transport="openai_chat"),
+    )
+
+    assert provider_catalog.determine_api_mode(
+        "raising-test", "https://relay.test/v1", "gpt-7"
+    ) == "chat_completions"
+
+
+def test_invalid_profile_hook_result_falls_back_to_existing_transport(monkeypatch):
+    class InvalidProfile(ProviderProfile):
+        def resolve_api_mode(self, model, base_url=None):
+            return "shell_exec"
+
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: InvalidProfile(name="invalid-test"),
+    )
+    monkeypatch.setattr(
+        provider_catalog,
+        "get_provider",
+        lambda name: SimpleNamespace(transport="anthropic_messages"),
+    )
+
+    assert provider_catalog.determine_api_mode(
+        "invalid-test", "https://relay.test/v1", "gpt-7"
+    ) == "anthropic_messages"
+
+
+def test_unhashable_profile_hook_result_falls_back_to_existing_transport(monkeypatch):
+    class InvalidProfile(ProviderProfile):
+        def resolve_api_mode(self, model, base_url=None):  # type: ignore[override]
+            return []
+
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: InvalidProfile(name="invalid-unhashable-test"),
+    )
+    monkeypatch.setattr(
+        provider_catalog,
+        "get_provider",
+        lambda name: SimpleNamespace(transport="openai_chat"),
+    )
+
+    assert provider_catalog.determine_api_mode(
+        "invalid-unhashable-test", "https://relay.test/v1", "gpt-7"
+    ) == "chat_completions"
+
+
+def test_core_alias_resolves_same_dynamic_profile_hook(monkeypatch):
+    profile = _DynamicProfile(name="canonical-test", api_mode="chat_completions")
+    monkeypatch.setitem(provider_catalog.ALIASES, "short-test", "canonical-test")
+    monkeypatch.setattr(
+        "providers.get_provider_profile",
+        lambda name: profile if name == "canonical-test" else None,
+    )
+
+    assert provider_catalog.determine_api_mode(
+        "short-test", "https://relay.test/v1", "gpt-7"
+    ) == "codex_responses"

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -4,6 +4,33 @@ from providers import get_provider_profile, _REGISTRY
 from providers.base import ProviderProfile, OMIT_TEMPERATURE
 
 
+def test_provider_profile_resolve_api_mode_defaults_to_static_mode():
+    profile = ProviderProfile(name="static", api_mode="anthropic_messages")
+
+    assert profile.resolve_api_mode("any-model", "https://relay.test/v1") == (
+        "anthropic_messages"
+    )
+
+
+def test_provider_profile_resolve_api_mode_can_be_overridden_per_model():
+    class DynamicProfile(ProviderProfile):
+        def resolve_api_mode(self, model, base_url=None):
+            return (
+                "codex_responses"
+                if str(model or "").startswith("gpt-")
+                else "chat_completions"
+            )
+
+    profile = DynamicProfile(name="dynamic", api_mode="chat_completions")
+
+    assert profile.resolve_api_mode("gpt-7", "https://relay.test/v1") == (
+        "codex_responses"
+    )
+    assert profile.resolve_api_mode("kimi-k4", "https://relay.test/v1") == (
+        "chat_completions"
+    )
+
+
 class TestRegistry:
     def test_discovery_populates_registry(self):
         p = get_provider_profile("nvidia")


### PR DESCRIPTION
## Summary

- add a backward-compatible `ProviderProfile.resolve_api_mode(model, base_url)` hook for providers whose wire protocol varies by model
- invoke the hook only when a concrete profile class overrides the base implementation, preserving existing static-provider/catalog precedence
- keep host-mandated and existing Nous routing precedence intact
- resolve both raw and canonical provider aliases
- catch profile lookup/hook failures and reject unsupported or malformed return values before falling back to the existing catalog transport
- pass the target model through the direct `/model` switch fallback path

## Why

A provider can expose one endpoint and one credential set while requiring different Hermes wire protocols for different model families. Today that requires provider-specific core special cases or splitting one logical provider into multiple UI entries. This hook provides a generic plugin extension point without changing behavior for ordinary profiles.

## Compatibility

The base implementation returns the existing static `api_mode`. Runtime delegation only occurs for classes that actually override the hook, so current provider profiles retain their existing transport behavior.

No private provider identifiers, endpoints, credentials, or model names are added to Hermes core.

## Test plan

Executed through the repository wrapper:

```text
scripts/run_tests.sh \
  tests/providers/test_provider_profiles.py \
  tests/hermes_cli/test_provider_profile_api_mode.py \
  tests/hermes_cli/test_runtime_provider_resolution.py \
  tests/hermes_cli/test_runtime_transport_precedence.py \
  tests/hermes_cli/test_model_switch_configured_provider_routing.py \
  tests/hermes_cli/test_provider_catalog.py \
  tests/hermes_cli/test_provider_parity.py -q
```

Result:

```text
7 files
106 tests passed
0 failed
```

Also passed Ruff on every modified Python file.
