### PR TITLE
fix(desktop): route hidden Bot Chat RPCs to the owning profile backend (4001 session-not-found)

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -755,6 +755,18 @@ export const host = {
 
     if (ownerRoute) {
       setSessionOwnerHint(storedSessionId, ownerRoute)
+    } else if (profile) {
+      // Local plugin-owned opens (Bot Mode without a cross-connection route)
+      // still carry an explicit owning profile. Record it: hidden sessions
+      // (canonical Bot Chats) have no sidebar row, so this hint is the only
+      // durable owner record the session-RPC router can consult — without it
+      // a later prompt.submit resolves to the ACTIVE profile's backend and
+      // 4001s while the bot's own backend is healthy.
+      const connectionId = activeGatewayConnectionId()
+
+      if (connectionId) {
+        setSessionOwnerHint(storedSessionId, { connectionId, mode: 'local', profile: targetProfile })
+      }
     }
 
     // Bounded to 2 attempts (never more): a cold profile backend can lose the

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -82,6 +82,7 @@ vi.mock('@/store/gateway', async () => {
 
   return {
     $gateway: atom(null),
+    activeGatewayConnectionId: vi.fn(() => 'local'),
     ensureGatewayForAgent: vi.fn(),
     openGatewayForAgent: vi.fn(),
     openGatewayForProfile: vi.fn(),

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -918,6 +918,32 @@ describe('rememberedSessionProfile', () => {
     expect(rememberedSessionProfile([], 'uncached', 'research')).toBe('research')
   })
 
+  it('consults the owner hint for a hidden session absent from the list (Bot Chat 4001 class)', () => {
+    // Bot Mode's canonical chats are born hidden: no sidebar row ever exists,
+    // so without the hint the router would fall back to the ACTIVE profile and
+    // land prompt.submit on a backend that never owned the session.
+    setSessionOwnerHint('hidden-bot-chat', { connectionId: 'local', mode: 'local', profile: 'developer' })
+
+    expect(rememberedSessionProfile([], 'hidden-bot-chat', 'default')).toBe('developer')
+  })
+
+  it('prefers the routed targetProfile over the route profile in the hint fallback', () => {
+    setSessionOwnerHint('hidden-remote-chat', {
+      connectionId: 'ssh-1',
+      profile: 'default',
+      targetProfile: 'clippy'
+    })
+
+    expect(rememberedSessionProfile([], 'hidden-remote-chat', 'default')).toBe('clippy')
+  })
+
+  it('still prefers a real session row over the hint', () => {
+    setSessionOwnerHint('rowed-session', { connectionId: 'local', profile: 'wrong-hint' })
+    const sessions = [session({ id: 'rowed-session', profile: 'right-owner' })]
+
+    expect(rememberedSessionProfile(sessions, 'rowed-session', 'default')).toBe('right-owner')
+  })
+
   it('normalizes a blank active profile to default', () => {
     expect(rememberedSessionProfile([], null, '')).toBe('default')
     expect(rememberedSessionProfile([], null, null)).toBe('default')

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -135,6 +135,21 @@ export function rememberedSessionProfile(
     if (owner) {
       return owner
     }
+
+    // Hidden / plugin-owned sessions (Bot Mode's canonical "Bot Chat" rows are
+    // born hidden) never appear in the sidebar list, so the row lookup above
+    // misses for them whenever the aggregator page replaced the in-memory row.
+    // Falling straight through to the ACTIVE profile routed their session RPCs
+    // at a backend that never owned the session — prompt.submit answered 4001
+    // "session not found" while the bot's own backend sat healthy. The open
+    // path records an owner hint for exactly this; honor it before falling
+    // back to the active profile.
+    const hint = getSessionOwnerHint(sessionId)
+    const hinted = (hint?.targetProfile ?? hint?.profile)?.trim()
+
+    if (hinted) {
+      return hinted
+    }
   }
 
   return (activeProfile ?? '').trim() || 'default'


### PR DESCRIPTION
## Symptom
Bot Mode: chatting with ANY bot except the launch profile fails — first as **Turn failed / session not found** (4001), then as an endless hang on retry. Live repro on Windows v0.20.5 with healthy per-profile backends.

## Root cause (verified in logs + source)
An identity blind spot in the session-RPC router for **hidden** sessions:

1. `wiring.tsx`'s `requestGateway` resolves the owning profile via `rememberedSessionProfile($sessions, selectedStoredSessionId, activeProfile)`.
2. Canonical Bot Chats are **born hidden** (#86797), so the sidebar aggregator never lists them — whenever the in-memory row is absent (list page swap, restart), the lookup misses and the resolver **silently falls back to the ACTIVE profile**.
3. `prompt.submit` lands on the launch backend, which never owned the session → **4001**. `withSessionNotFoundResume`'s `session.resume` resolves the profile through the **same blind spot**, so recovery re-registers the wrong backend too — the ladder dies without ever reaching the bot's own healthy gateway.

**Log fingerprint** (matches the user's machine + an independent gateway repro): bot backend shows `ws accepted … ws closed messages=0` with **no** `tui prompt accepted` after the disconnect-reap, while the launch backend answers the 4001.

## Fix (at the resolver, covering the whole RPC class)
- `rememberedSessionProfile`: when no session row matches, consult the **session owner hint** (`targetProfile` over `profile`) before falling back to the active profile. One resolver, one policy — submit, resume, attach, interrupt, compress all inherit it.
- `sdk/index.ts` `openSession`: record an owner hint for **local** plugin opens that carry an explicit `profile` (remote `ownerRoute` opens already did). Hidden sessions have no sidebar row; the hint is the only durable owner record the router can consult.

## Verification
- 3 focused tests in `session.test.ts`: hidden-session hint fallback, `targetProfile` preference, row-over-hint precedence.
- `tsc --noEmit`: 0 errors (baseline-equal).
- CI runs the vitest suite (isolated worktree here is production-deps-only per repo convention).