### PR TITLE
fix(cron): deliver scheduled results as notifications, not silently

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3236,10 +3236,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
+                    "notify": True,
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
-                media_metadata = {"direct_messages_topic_id": str(thread_id)}
+                media_metadata = {"direct_messages_topic_id": str(thread_id), "notify": True}
             else:
                 # Forum-style topic (private chat / supergroup) or non-topic
                 # target: route via message_thread_id (#52060).  Put thread_id in
@@ -3250,10 +3251,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # anchor, so the metadata key bypasses that check and lets the
                 # adapter route via a plain message_thread_id.
                 route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
+                route_metadata = {"job_id": job["id"], "notify": True}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
-                media_metadata = {"thread_id": thread_id} if thread_id else None
+                media_metadata = {"thread_id": thread_id, "notify": True} if thread_id else {"notify": True}
 
             # Relay egress needs a tenant discriminator on the frame: the
             # connector's fail-closed guard resolves the workspace/guild from

--- a/tests/cron/test_delivery_notification.py
+++ b/tests/cron/test_delivery_notification.py
@@ -1,0 +1,112 @@
+"""Cron results must arrive as notifications, not silently.
+
+Field report: with the default ``notifications_mode: important`` the Telegram
+adapter sends every message with ``disable_notification=True`` unless the
+caller opts in via ``metadata["notify"]`` (see
+``TelegramAdapter._notification_kwargs``). The gateway sets that flag on its
+FINAL reply — the adapter's own comments at the streaming call sites read
+"the FINAL reply (metadata['notify'])".
+
+``_deliver_result`` never set it. A cron job's delivered result IS a final,
+user-facing delivery, so scheduled reports (order alerts, monitoring digests,
+morning briefs) landed on the phone with no notification at all — the exact
+messages the "important" mode exists to surface. The user only saw them by
+opening the chat manually.
+
+Both routing lanes are pinned: the ambiguous-topic Direct-Messages lane and
+the ordinary thread / non-thread lane.
+"""
+
+import asyncio
+from concurrent.futures import Future
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cron.scheduler import _deliver_result
+from gateway.config import Platform
+
+
+def _telegram_adapter():
+    adapter = AsyncMock()
+    adapter.fronts_platform = lambda p: False
+    return adapter
+
+
+def _gateway_config():
+    """Telegram natively configured — the live-adapter lane is gated on it."""
+    from gateway.config import PlatformConfig
+
+    config = MagicMock()
+    config.platforms = {Platform.TELEGRAM: PlatformConfig(enabled=True)}
+    config.get_home_channel = lambda p: None
+    return config
+
+
+def _run_delivery(job, *, dm_topic: bool):
+    """Drive ``_deliver_result`` through the live-adapter lane and capture the
+    routing metadata handed to the DeliveryRouter."""
+    captured = {}
+    loop = MagicMock()
+    loop.is_running.return_value = True
+
+    def fake_run_coro(coro, _loop):
+        future = Future()
+        try:
+            future.set_result(asyncio.run(coro))
+        except BaseException as e:  # noqa: BLE001
+            future.set_exception(e)
+        return future
+
+    router = MagicMock()
+
+    async def _deliver_to_platform(target, content, metadata):
+        captured["metadata"] = metadata
+        return {"success": True, "raw_response": None}
+
+    router._deliver_to_platform = _deliver_to_platform
+
+    with patch("gateway.config.load_gateway_config", return_value=_gateway_config()), \
+         patch("cron.scheduler.load_config",
+               return_value={"cron": {"wrap_response": False}}), \
+         patch("cron.scheduler._is_channel_dm_topic", return_value=dm_topic), \
+         patch("gateway.delivery.DeliveryRouter", return_value=router), \
+         patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+        _deliver_result(job, "Nightly report.",
+                        adapters={Platform.TELEGRAM: _telegram_adapter()},
+                        loop=loop)
+    return captured
+
+
+def _job(chat_id="8654275023", thread_id=None):
+    deliver = f"telegram:{chat_id}"
+    if thread_id is not None:
+        deliver = f"{deliver}:{thread_id}"
+    return {
+        "id": "notify-job",
+        "name": "Monitoring",
+        "deliver": deliver,
+        "origin": {"platform": "telegram", "chat_id": chat_id},
+    }
+
+
+@pytest.mark.parametrize("thread_id", [None, "42"])
+def test_plain_and_threaded_delivery_requests_a_notification(thread_id):
+    """The ordinary lane (no topic, or a forum-style thread) must opt in."""
+    captured = _run_delivery(_job(thread_id=thread_id), dm_topic=False)
+    metadata = captured.get("metadata") or {}
+    assert metadata.get("notify") is True, (
+        "cron result delivered without metadata['notify'] — under the default "
+        "notifications_mode=important the Telegram adapter stamps "
+        "disable_notification=True and the report arrives silently"
+    )
+
+
+def test_channel_dm_topic_delivery_requests_a_notification():
+    """The Bot API Direct-Messages topic lane (#22773) must opt in too."""
+    captured = _run_delivery(_job(thread_id="99"), dm_topic=True)
+    metadata = captured.get("metadata") or {}
+    assert metadata.get("notify") is True, (
+        "DM-topic cron result delivered silently — the topic lane builds its "
+        "own metadata dict and must carry notify like the ordinary lane"
+    )


### PR DESCRIPTION
## What does this PR do?

Cron results are delivered to chat **silently** under the default `notifications_mode: important`, so scheduled reports never raise a notification on the user's device.

`TelegramAdapter._notification_kwargs` stamps `disable_notification=True` on every send while in `important` mode, unless the caller opts in with `metadata["notify"]`:

```python
if getattr(self, "_notifications_mode", "important") != "important":
    return {}
if (metadata or {}).get("notify"):
    return {}
return {"disable_notification": True}
```

The gateway sets that flag on its final reply — the adapter's own comments at the streaming call sites read *"the FINAL reply (metadata['notify'])"* (`plugins/platforms/telegram/adapter.py:5237`, `:5500`). `cron/scheduler.py::_deliver_result` builds its routing metadata by hand and never sets it.

The result is that a cron job's delivered output — order alerts, monitoring digests, morning briefs — arrives with no notification at all. Those are precisely the messages `important` mode exists to surface; the user only sees them by opening the chat. Field-reported on a store-monitoring job running every 30 minutes: new-order alerts were delivered correctly and never noticed.

**Why this approach:** a cron delivery *is* a final, user-facing delivery, so it should follow the same convention as the gateway's final reply rather than introduce a parallel mechanism. The flag is honoured by the telegram, discord, mattermost and a2a adapters, so the fix is not Telegram-specific and needs no per-adapter work.

**Alternative considered:** a config knob (e.g. `cron.notify: true|false`). Not taken, because it would make cron the only final delivery whose notification behaviour is separately configurable, duplicating what `notifications_mode` already expresses. Happy to switch to a knob if maintainers prefer that — the change is small and self-contained either way.

## Related Issue

No existing issue — searched open/closed issues and PRs for `cron notification silent`, `disable_notification`, `notifications_mode important` and found no duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — `_deliver_result` sets `"notify": True` on the routing and media metadata in **both** live-adapter lanes, so they stay consistent:
  - the ambiguous Bot API Direct-Messages topic lane (#22773), which builds its own `direct_messages_topic_id` metadata dict;
  - the ordinary forum-thread / non-thread lane, including the previously-`None` media metadata when no thread is present.
- `tests/cron/test_delivery_notification.py` *(new)* — pins both lanes by capturing the metadata handed to `DeliveryRouter._deliver_to_platform`.

## How to Test

1. **Reproduce:** with `notifications_mode: important` (the default) and a Telegram cron target, let a job deliver. The message arrives in the chat with no notification — `disable_notification=True` on the send.
2. **Automated proof:**
   ```bash
   pytest tests/cron/test_delivery_notification.py -q     # 3 passed
   git stash push -- cron/scheduler.py
   pytest tests/cron/test_delivery_notification.py -q     # 3 failed
   git stash pop
   ```
   All three cases fail without the one-line-per-lane change and pass with it.
3. **No regressions:** `pytest tests/cron/ -q` → 876 passed, 1 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note below**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.8), Python 3.11.15, Hermes 0.20.5

> **Note on the full-suite checkbox.** `pytest tests/cron/ -q` passes completely — **876 passed, 1 skipped** — and that is the package this change lives in. I could not get a full `pytest tests/ -q` to finish on this machine: it dies at ~53% of collection progress on two independent runs, at the same point both times, with the interpreter terminating rather than any test reporting a failure (no `FAILED` lines, no summary). That is not something a four-line metadata change can cause, and it reproduces identically, so I have left the box unticked rather than claim a green run I did not get. Happy to dig into the crash separately if it is not already known — I did not want to bundle an unrelated investigation into this PR.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(no user-facing surface changes; the behaviour now matches what `notifications_mode: important` already documents)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(no new config keys)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(pure metadata change, no platform-specific code paths)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Metadata reaching `DeliveryRouter._deliver_to_platform` for an ordinary Telegram cron delivery:

```diff
- {'job_id': 'notify-job'}
+ {'job_id': 'notify-job', 'notify': True}
```

and for the Direct-Messages topic lane:

```diff
- {'direct_messages_topic_id': '99', 'job_id': 'notify-job'}
+ {'direct_messages_topic_id': '99', 'job_id': 'notify-job', 'notify': True}
```
