### PR TITLE
fix(desktop): stop Bot responsibilities from drifting from SOUL

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -2192,8 +2192,7 @@ async function duplicateBot(bot, roster) {
 
   await requestForBot(bot, 'profiles.create', {
     name,
-    clone_from: base,
-    description: bot.description || ''
+    clone_from: base
   })
 
   // Same look: avatar shape/color/image and a "(copy)" title so the two
@@ -7206,6 +7205,27 @@ function composeSoul({ name, title, description, roster, customSoul }) {
   return serverInjectsProtocol ? identity : identity + '\n\n' + messagingProtocolSection(name, roster)
 }
 
+/** A Bot mission belongs only in SOUL.md. Generic profile descriptions are
+ * kanban routing metadata, not a second copy of the Bot's responsibilities. */
+function buildBotProfileCreateParams({ name, cloneFrom, noSkills, shareAuth, soul, model = '', provider = '' }) {
+  const payload = {
+    name,
+    clone_from: cloneFrom,
+    no_skills: Boolean(noSkills),
+    share_auth: Boolean(shareAuth),
+    soul
+  }
+  const normalizedModel = model.trim()
+  const normalizedProvider = provider.trim()
+
+  if (normalizedModel && normalizedProvider) {
+    payload.model = normalizedModel
+    payload.provider = normalizedProvider
+  }
+
+  return payload
+}
+
 // ── human-readable row helpers ───────────────────────────────────────────────
 
 /** Bot-to-bot delivery prefix (see messagingProtocolSection): either the
@@ -8526,7 +8546,6 @@ function EditProfileDialog({ bot, open, onClose }) {
   const [color, setColor] = useState(appearance.color)
   const [image, setImage] = useState(appearance.image)
   const [title, setTitle] = useState(meta?.title || '')
-  const [description, setDescription] = useState(bot?.description || '')
   const [busy, setBusy] = useState(false)
   const [advanced, setAdvanced] = useState(false)
   const [adv, setAdv] = useState(emptyAdvancedState())
@@ -8541,7 +8560,6 @@ function EditProfileDialog({ bot, open, onClose }) {
       setColor(appearance.color)
       setImage(appearance.image)
       setTitle(meta?.title || '')
-      setDescription(bot.description || '')
       setBusy(false)
       setAdvanced(false)
       setAdv(emptyAdvancedState())
@@ -8579,18 +8597,6 @@ function EditProfileDialog({ bot, open, onClose }) {
       queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
     }
 
-    const desc = description.trim()
-    if (desc !== (bot.description || '').trim()) {
-      try {
-        await requestForBot(bot, 'cli.exec', {
-          argv: ['profile', 'describe', bot.name, '--text', desc]
-        })
-        queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
-      } catch (err) {
-        host.notifyError(err, 'Saved look locally; description update failed')
-      }
-    }
-
     if (adv.loaded && (adv.dirtyModel || adv.dirtySoul || adv.dirtySkills || adv.dirtyToolsets || adv.dirtyMcp)) {
       try {
         const res = await applyAdvancedConfig(bot, adv)
@@ -8626,7 +8632,7 @@ function EditProfileDialog({ bot, open, onClose }) {
         jsxs(DialogHeader, {
           children: [
             jsx(DialogTitle, { children: 'Edit Profile' }),
-            jsx(DialogDescription, { children: `Appearance and role for ${displayName(bot, null)} (${bot.name}).` })
+            jsx(DialogDescription, { children: `Appearance and identity for ${displayName(bot, null)} (${bot.name}).` })
           ]
         }),
         jsxs('div', {
@@ -8643,7 +8649,7 @@ function EditProfileDialog({ bot, open, onClose }) {
               onShape: setShape,
               onColor: setColor,
               onImage: setImage,
-              generateSeed: { name: bot.name, title, description }
+              generateSeed: { name: bot.name, title }
             }),
             labeled(
               'Title',
@@ -8651,15 +8657,6 @@ function EditProfileDialog({ bot, open, onClose }) {
                 placeholder: displayName(bot, null),
                 value: title,
                 onChange: event => setTitle(event.target.value)
-              })
-            ),
-            labeled(
-              'Description',
-              jsx(Textarea, {
-                className: 'min-h-16',
-                placeholder: 'What should this agent help with?',
-                value: description,
-                onChange: event => setDescription(event.target.value)
               })
             ),
             jsxs('button', {
@@ -8705,7 +8702,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
   // createdRef must stay a slug string for its sibling consumers.
   const flightRef = useRef(null)
   const [title, setTitle] = useState('')
-  const [description, setDescription] = useState('')
+  const [mission, setMission] = useState('')
   // Default shapes mode: deterministic blob face drawn from the agent's name
   // (falls back to the legacy shape vocabulary on older SDKs).
   const [shape, setShape] = useState(blobatarSvg ? 'blobatar' : 'circle')
@@ -8807,7 +8804,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
   const reset = () => {
     setName('')
     setTitle('')
-    setDescription('')
+    setMission('')
     setShape(blobatarSvg ? 'blobatar' : 'circle')
     setColor(AVATAR_COLORS[3])
     setImage(null)
@@ -8906,24 +8903,22 @@ function CreateAgentDialog({ open, onClose, roster }) {
         return null
       }
 
-      const descriptionText = [title, description].filter(Boolean).join(' — ')
-
-      await requestForTarget('profiles.create', {
+      await requestForTarget('profiles.create', buildBotProfileCreateParams({
         name: slug,
-        description: descriptionText,
         // Clone sources are profiles of the TARGET backend. The picker's
         // roster is the local one, so a remote create always starts from the
         // remote machine's default (or fresh) — never a local profile name
         // the remote box doesn't have.
-        clone_from: cloneFrom === '__none__' ? null : remoteTarget ? 'default' : cloneFrom,
-        no_skills: noSkills,
+        cloneFrom: cloneFrom === '__none__' ? null : remoteTarget ? 'default' : cloneFrom,
+        noSkills,
         // Shared (not copied) auth keeps ONE OAuth/token pool with the main
         // profile, so refreshes can't invalidate each other. Older gateways
         // ignore the param and copy — still functional, just forked.
-        share_auth: shareAuth,
-        soul: composeSoul({ name: slug, title, description, roster, customSoul: soul }),
-        ...(model.trim() && provider.trim() ? { model: model.trim(), provider: provider.trim() } : {})
-      })
+        shareAuth,
+        soul: composeSoul({ name: slug, title, description: mission, roster, customSoul: soul }),
+        model,
+        provider
+      }))
 
       createdRef.current = slug
 
@@ -9082,7 +9077,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
               onShape: setShape,
               onColor: setColor,
               onImage: setImage,
-              generateSeed: { name: slug || 'agent', title, description }
+              generateSeed: { name: slug || 'agent', title, description: mission }
             }),
             labeled(
               'Name',
@@ -9158,12 +9153,12 @@ function CreateAgentDialog({ open, onClose, roster }) {
               })
             ),
             labeled(
-              'Description',
+              'Mission',
               jsx(Textarea, {
                 className: 'min-h-16',
-                placeholder: 'What should this Bot help with?',
-                value: description,
-                onChange: event => setDescription(event.target.value)
+                placeholder: 'What should this Bot help with? This seeds SOUL.md.',
+                value: mission,
+                onChange: event => setMission(event.target.value)
               })
             ),
             jsxs('button', {

--- a/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
@@ -204,7 +204,7 @@ test('source contract: New Agent has a Create on picker that routes creation to 
   assert.match(pluginSource, /'Create on'/)
   assert.match(pluginSource, /const \[targetConnection, setTargetConnection\] = useState\(''\)/)
   // Creation and configuration go through the target door, not bare host.request.
-  assert.match(pluginSource, /await requestForTarget\('profiles\.create', \{/)
+  assert.match(pluginSource, /await requestForTarget\('profiles\.create', buildBotProfileCreateParams\(\{/)
   assert.match(pluginSource, /await requestForTarget\('profiles\.configure', \{ name: slug/)
   // The picker only renders on multi-connection registries.
   assert.match(pluginSource, /connections\.length > 1/)

--- a/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs
@@ -12,7 +12,7 @@ function loadSoulHelpers({ serverInjects = false } = {}) {
   assert.notEqual(end, -1, 'soul-helper section delimiter is missing')
   const context = { serverInjectsProtocol: serverInjects }
   vm.runInNewContext(
-    `${source.slice(start, end)}\nObject.assign(globalThis, { botHandle, hasMessagingProtocol, ensureMessagingProtocol, composeSoul, messagingProtocolSection })`,
+    `${source.slice(start, end)}\nObject.assign(globalThis, { botHandle, hasMessagingProtocol, ensureMessagingProtocol, composeSoul, buildBotProfileCreateParams, messagingProtocolSection })`,
     context
   )
   return context
@@ -66,12 +66,37 @@ test('composeSoul does not double-append when custom SOUL already has the protoc
     roster,
     customSoul: ''
   })
+  assert.match(withProtocol, /\*\*Mission:\*\* literature review/)
   const cloned = composeSoul({
     name: 'researcher',
     roster,
     customSoul: withProtocol
   })
   assert.equal(cloned.split('## Messaging other agents').length, 2)
+})
+
+test('bot creation keeps its mission in SOUL without duplicating profile description', () => {
+  const { buildBotProfileCreateParams } = loadSoulHelpers()
+  const params = buildBotProfileCreateParams({
+    name: 'researcher',
+    cloneFrom: 'default',
+    noSkills: false,
+    shareAuth: true,
+    soul: '# Researcher\n\n**Mission:** Review papers',
+    model: '  model-id  ',
+    provider: '  provider-id  '
+  })
+
+  assert.deepEqual({ ...params }, {
+    name: 'researcher',
+    clone_from: 'default',
+    no_skills: false,
+    share_auth: true,
+    soul: '# Researcher\n\n**Mission:** Review papers',
+    model: 'model-id',
+    provider: 'provider-id'
+  })
+  assert.equal('description' in params, false)
 })
 
 test('backfill is one-shot: describe-only when protocol exists, configure when missing', async () => {


### PR DESCRIPTION
## What does this PR do?

Bot Mode no longer presents a second editable Description as the bot's responsibilities. New bots now use a clearly named Mission field only to seed SOUL.md, and creation or duplication no longer copies that mission into generic profile routing metadata. This keeps SOUL.md as the bot identity authority while preserving profile descriptions for their separate kanban-routing purpose.

### Symptom

Editing a bot's SOUL.md could leave the Bot detail editor showing an older Description that contradicted the bot's current responsibilities.

### Impact

Users could not tell which of two responsibility fields controlled bot behavior, and the desktop could display stale role text after SOUL.md changed.

### Bug Cause

**Trigger:** `apps/desktop/src/plugins/hermes-bots/plugin.js:8903` / `CreateAgentDialog.ensureAgentCreated`

**Causal chain:**
1. New Bot accepted a Description and passed it both to `composeSoul()` and `profiles.create`.
2. `composeSoul()` stored the text as the SOUL Mission while `profiles.create` persisted a separate profile description.
3. Later SOUL edits updated only the identity file, so Edit Profile continued loading stale profile metadata as another responsibility field.

**Why it is wrong:** Bot identity and behavior come from SOUL.md, while profile descriptions were introduced as kanban routing summaries. Reusing one input for both created two independently editable authorities.

**Working sibling / contrast:** Custom SOUL text already bypasses generated identity fields and remains authoritative; the fix makes the normal creation path follow the same ownership rule.

**Ruled out:** This is not a stale React Query cache. The conflicting values are persisted in separate files and remain different across fresh profile listings.

### Fix

- Rename the creation field to Mission and document that it seeds SOUL.md.
- Stop sending Bot missions through the generic profile `description` field on creation and duplication.
- Remove the Bot Edit Profile Description control; identity changes remain available through the SOUL.md editor.
- Keep the create payload pure and covered so model, credential-sharing, clone, and cross-connection routing fields remain unchanged.

## Related Issue

N/A



## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` - make Mission a SOUL-only creation seed and remove the duplicate editor.
- `apps/desktop/src/plugins/hermes-bots/tests/soul-protocol-backfill.test.mjs` - verify the Mission stays in SOUL and is absent from profile metadata.
- `apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs` - retain the target-backend creation contract after payload extraction.

## How to Test

1. Open New Bot and confirm the identity field is named Mission and explains that it seeds SOUL.md.
2. Create a bot, edit SOUL.md, and confirm Edit Profile exposes SOUL.md rather than a second Description responsibility field.
3. Run the bundled desktop plugin suite:

```bash
cd apps/desktop
npm run check:test:plugins
```

Result: 476 tests passed. `npm run check:lint` reaches TypeScript but is currently blocked by the checkout's unresolved pre-existing `blobatar/blob` and `blobatar/react` modules.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant desktop plugin tests and all 476 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant inline copy and comments are updated; standalone docs are N/A
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Cross-platform impact considered; the change is renderer-only JavaScript
- [x] Tool descriptions and schemas are N/A because no tool behavior changed
