### PR TITLE
fix(cli): let empty custom endpoints open setup from /model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11256,6 +11256,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 asyncio.run_coroutine_threadsafe(_run_setup(), app_loop).result()
             else:
                 _setup()
+        except KeyboardInterrupt:
+            _cprint("  Custom endpoint setup cancelled.")
+            self._invalidate(min_interval=0.0)
+            return
         except Exception as exc:
             _cprint(f"  ✗ Custom endpoint setup failed: {exc}")
             self._invalidate(min_interval=0.0)
@@ -11264,10 +11268,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         config = load_config()
         model_cfg = config.get("model")
         if not isinstance(model_cfg, dict):
+            _cprint("  No custom endpoint configured.")
+            self._invalidate(min_interval=0.0)
             return
         model = str(model_cfg.get("default") or "").strip()
         base_url = str(model_cfg.get("base_url") or "").strip()
         if model_cfg.get("provider") != "custom" or not model or not base_url:
+            _cprint("  No custom endpoint configured.")
+            self._invalidate(min_interval=0.0)
             return
 
         from hermes_cli.model_switch import switch_model

--- a/cli.py
+++ b/cli.py
@@ -11149,6 +11149,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         model_list = live
                 except Exception:
                     pass
+            if (
+                not model_list
+                and provider_data.get("slug") == "custom"
+                and provider_data.get("is_user_defined") is True
+            ):
+                custom_providers = state.get("custom_provs")
+                self._close_model_picker()
+                threading.Thread(
+                    target=self._configure_custom_endpoint_from_picker,
+                    args=(provider_data, custom_providers),
+                    daemon=True,
+                ).start()
+                return
             state["stage"] = "model"
             state["provider_data"] = provider_data
             state["model_list"] = model_list
@@ -11209,6 +11222,73 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     )
                 return
             self._close_model_picker()
+
+    def _configure_custom_endpoint_from_picker(
+        self,
+        provider_data: dict,
+        custom_providers=None,
+    ) -> None:
+        """Configure an empty custom row without fighting TUI stdin ownership."""
+        import asyncio
+
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+        from hermes_cli.main import _model_flow_custom
+
+        def _setup() -> None:
+            setup_config = load_config()
+            model_cfg = setup_config.get("model")
+            if not isinstance(model_cfg, dict):
+                model_cfg = {}
+                setup_config["model"] = model_cfg
+            if not model_cfg.get("base_url") and provider_data.get("api_url"):
+                model_cfg["base_url"] = provider_data["api_url"]
+            _model_flow_custom(setup_config)
+
+        app = getattr(self, "_app", None)
+        app_loop = getattr(app, "loop", None) if app is not None else None
+        try:
+            if app_loop is not None:
+                from prompt_toolkit.application import run_in_terminal
+
+                async def _run_setup() -> None:
+                    await run_in_terminal(_setup)
+
+                asyncio.run_coroutine_threadsafe(_run_setup(), app_loop).result()
+            else:
+                _setup()
+        except Exception as exc:
+            _cprint(f"  ✗ Custom endpoint setup failed: {exc}")
+            self._invalidate(min_interval=0.0)
+            return
+
+        config = load_config()
+        model_cfg = config.get("model")
+        if not isinstance(model_cfg, dict):
+            return
+        model = str(model_cfg.get("default") or "").strip()
+        base_url = str(model_cfg.get("base_url") or "").strip()
+        if model_cfg.get("provider") != "custom" or not model or not base_url:
+            return
+
+        from hermes_cli.model_switch import switch_model
+
+        fresh_custom_providers = get_compatible_custom_providers(config)
+        result = switch_model(
+            raw_input=model,
+            current_provider=self.provider or "",
+            current_model=self.model or "",
+            current_base_url=base_url,
+            current_api_key=str(model_cfg.get("api_key") or ""),
+            is_global=True,
+            explicit_provider="custom",
+            user_providers=config.get("providers"),
+            custom_providers=fresh_custom_providers or custom_providers,
+        )
+        self._confirm_and_apply_model_switch_result(
+            result,
+            True,
+            custom_providers=fresh_custom_providers or custom_providers,
+        )
 
     def _handle_model_switch(self, cmd_original: str):
         """Handle /model command — switch model.

--- a/cli.py
+++ b/cli.py
@@ -11251,7 +11251,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 from prompt_toolkit.application import run_in_terminal
 
                 async def _run_setup() -> None:
-                    await run_in_terminal(_setup)
+                    await run_in_terminal(_setup, in_executor=True)
 
                 asyncio.run_coroutine_threadsafe(_run_setup(), app_loop).result()
             else:

--- a/cli.py
+++ b/cli.py
@@ -11256,47 +11256,45 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 asyncio.run_coroutine_threadsafe(_run_setup(), app_loop).result()
             else:
                 _setup()
+
+            config = load_config()
+            model_cfg = config.get("model")
+            if not isinstance(model_cfg, dict):
+                _cprint("  No custom endpoint configured.")
+                self._invalidate(min_interval=0.0)
+                return
+            model = str(model_cfg.get("default") or "").strip()
+            base_url = str(model_cfg.get("base_url") or "").strip()
+            if model_cfg.get("provider") != "custom" or not model or not base_url:
+                _cprint("  No custom endpoint configured.")
+                self._invalidate(min_interval=0.0)
+                return
+
+            from hermes_cli.model_switch import switch_model
+
+            fresh_custom_providers = get_compatible_custom_providers(config)
+            result = switch_model(
+                raw_input=model,
+                current_provider=self.provider or "",
+                current_model=self.model or "",
+                current_base_url=base_url,
+                current_api_key=str(model_cfg.get("api_key") or ""),
+                is_global=True,
+                explicit_provider="custom",
+                user_providers=config.get("providers"),
+                custom_providers=fresh_custom_providers or custom_providers,
+            )
+            self._confirm_and_apply_model_switch_result(
+                result,
+                True,
+                custom_providers=fresh_custom_providers or custom_providers,
+            )
         except KeyboardInterrupt:
             _cprint("  Custom endpoint setup cancelled.")
             self._invalidate(min_interval=0.0)
-            return
         except Exception as exc:
             _cprint(f"  ✗ Custom endpoint setup failed: {exc}")
             self._invalidate(min_interval=0.0)
-            return
-
-        config = load_config()
-        model_cfg = config.get("model")
-        if not isinstance(model_cfg, dict):
-            _cprint("  No custom endpoint configured.")
-            self._invalidate(min_interval=0.0)
-            return
-        model = str(model_cfg.get("default") or "").strip()
-        base_url = str(model_cfg.get("base_url") or "").strip()
-        if model_cfg.get("provider") != "custom" or not model or not base_url:
-            _cprint("  No custom endpoint configured.")
-            self._invalidate(min_interval=0.0)
-            return
-
-        from hermes_cli.model_switch import switch_model
-
-        fresh_custom_providers = get_compatible_custom_providers(config)
-        result = switch_model(
-            raw_input=model,
-            current_provider=self.provider or "",
-            current_model=self.model or "",
-            current_base_url=base_url,
-            current_api_key=str(model_cfg.get("api_key") or ""),
-            is_global=True,
-            explicit_provider="custom",
-            user_providers=config.get("providers"),
-            custom_providers=fresh_custom_providers or custom_providers,
-        )
-        self._confirm_and_apply_model_switch_result(
-            result,
-            True,
-            custom_providers=fresh_custom_providers or custom_providers,
-        )
 
     def _handle_model_switch(self, cmd_original: str):
         """Handle /model command — switch model.

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -909,8 +909,17 @@ def _model_flow_custom(config):
     )
     from hermes_cli.secret_prompt import masked_secret_prompt
 
-    current_url = get_env_value("OPENAI_BASE_URL") or ""
-    current_key = get_env_value("OPENAI_API_KEY") or ""
+    current_model_cfg = config.get("model")
+    if not isinstance(current_model_cfg, dict):
+        current_model_cfg = {}
+    current_url = (
+        get_env_value("OPENAI_BASE_URL")
+        or str(current_model_cfg.get("base_url") or "").strip()
+    )
+    current_key = (
+        get_env_value("OPENAI_API_KEY")
+        or str(current_model_cfg.get("api_key") or "").strip()
+    )
 
     print("Custom OpenAI-compatible endpoint configuration:")
     if current_url:
@@ -998,7 +1007,6 @@ def _model_flow_custom(config):
 
     # Prompt for API compatibility mode explicitly so codex-compatible custom
     # providers don't silently fall back to chat_completions.
-    current_model_cfg = config.get("model")
     current_api_mode = ""
     if isinstance(current_model_cfg, dict):
         current_api_mode = str(current_model_cfg.get("api_mode") or "").strip()

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -481,6 +481,28 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     assert saved_env["MODEL"] == "llm"
 
 
+def test_model_flow_custom_prefills_endpoint_from_model_config(monkeypatch):
+    prompts = []
+    config = {
+        "model": {
+            "provider": "custom",
+            "base_url": "http://truenas.local:11434/v1",
+            "api_key": "configured-key",
+        }
+    }
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda _key: "")
+
+    def _cancel_after_url(prompt=""):
+        prompts.append(prompt)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("builtins.input", _cancel_after_url)
+
+    hermes_main._model_flow_custom(config)
+
+    assert "http://truenas.local:11434/v1" in prompts[0]
+
+
 def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
     saved_cfg = {"model": {"default": "", "provider": "custom", "base_url": ""}}
     captured_provider = {}

--- a/tests/hermes_cli/test_model_picker_expensive_confirm.py
+++ b/tests/hermes_cli/test_model_picker_expensive_confirm.py
@@ -1,3 +1,5 @@
+import asyncio
+import threading
 from types import SimpleNamespace
 
 from hermes_cli.model_switch import ModelSwitchResult
@@ -177,3 +179,71 @@ def test_custom_endpoint_picker_setup_applies_saved_route(monkeypatch):
     assert calls["switch"]["current_api_key"] == "local-key"
     assert calls["apply"][0] == (result, True)
     assert calls["apply"][1]["custom_providers"] == [{"name": "TrueNAS local"}]
+
+
+def test_custom_endpoint_picker_setup_leaves_prompt_toolkit_loop(monkeypatch):
+    """The blocking setup flow must not run on prompt_toolkit's event loop."""
+    import cli as cli_mod
+
+    configured = {
+        "model": {
+            "provider": "custom",
+            "default": "local-model",
+            "base_url": "http://truenas.local:11434/v1",
+        }
+    }
+    loop = asyncio.new_event_loop()
+    loop_ready = threading.Event()
+    calls = {}
+
+    def _run_loop():
+        asyncio.set_event_loop(loop)
+        calls["loop_thread"] = threading.get_ident()
+        loop_ready.set()
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=_run_loop)
+    loop_thread.start()
+    loop_ready.wait(timeout=2)
+
+    async def _run_in_terminal(func, *, in_executor=False):
+        calls["in_executor"] = in_executor
+        if in_executor:
+            return await asyncio.get_running_loop().run_in_executor(None, func)
+        return func()
+
+    def _setup(_config):
+        calls["setup_thread"] = threading.get_ident()
+
+    monkeypatch.setattr("prompt_toolkit.application.run_in_terminal", _run_in_terminal)
+    monkeypatch.setattr("hermes_cli.main._model_flow_custom", _setup)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: configured)
+    monkeypatch.setattr(
+        "hermes_cli.config.get_compatible_custom_providers", lambda _config: []
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **_kwargs: ModelSwitchResult(
+            success=False, error_message="stop after setup"
+        ),
+    )
+
+    self_ = SimpleNamespace(
+        _app=SimpleNamespace(loop=loop),
+        provider="openrouter",
+        model="old-model",
+        _confirm_and_apply_model_switch_result=lambda *_args, **_kwargs: None,
+        _invalidate=lambda **_kwargs: None,
+    )
+
+    try:
+        _bound(cli_mod.HermesCLI._configure_custom_endpoint_from_picker, self_)(
+            {"slug": "custom"}, []
+        )
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2)
+        loop.close()
+
+    assert calls["in_executor"] is True
+    assert calls["setup_thread"] != calls["loop_thread"]

--- a/tests/hermes_cli/test_model_picker_expensive_confirm.py
+++ b/tests/hermes_cli/test_model_picker_expensive_confirm.py
@@ -206,6 +206,37 @@ def test_custom_endpoint_picker_setup_handles_keyboard_interrupt(monkeypatch):
     assert invalidations == [{"min_interval": 0.0}]
 
 
+def test_custom_endpoint_picker_setup_handles_interrupt_while_reloading(monkeypatch):
+    import cli as cli_mod
+
+    output = []
+    invalidations = []
+    load_count = 0
+
+    def _load_config():
+        nonlocal load_count
+        load_count += 1
+        if load_count == 2:
+            raise KeyboardInterrupt
+        return {"model": {}}
+
+    monkeypatch.setattr("hermes_cli.main._model_flow_custom", lambda _config: None)
+    monkeypatch.setattr("hermes_cli.config.load_config", _load_config)
+    monkeypatch.setattr(cli_mod, "_cprint", output.append)
+
+    self_ = SimpleNamespace(
+        _app=None,
+        _invalidate=lambda **kwargs: invalidations.append(kwargs),
+    )
+
+    _bound(cli_mod.HermesCLI._configure_custom_endpoint_from_picker, self_)(
+        {"slug": "custom"}, []
+    )
+
+    assert output == ["  Custom endpoint setup cancelled."]
+    assert invalidations == [{"min_interval": 0.0}]
+
+
 def test_custom_endpoint_picker_setup_reports_missing_route(monkeypatch):
     import cli as cli_mod
 

--- a/tests/hermes_cli/test_model_picker_expensive_confirm.py
+++ b/tests/hermes_cli/test_model_picker_expensive_confirm.py
@@ -65,3 +65,115 @@ def test_prompt_toolkit_model_picker_defers_confirmation_off_key_handler(monkeyp
     # Third arg is the fresh picker custom_providers snapshot (None here).
     assert captured["args"] == (result, True, None)
     assert "ran_inline" not in captured
+
+
+def test_empty_custom_endpoint_row_defers_setup_off_key_handler(monkeypatch):
+    """Selecting a bare custom row with no models starts endpoint setup.
+
+    The provider picker cannot descend into an empty model list: that leaves
+    only Back/Cancel and makes the highlighted custom row appear inert.  The
+    setup flow is interactive, so it must run off the prompt_toolkit key
+    handler just like expensive-model confirmation.
+    """
+    import cli as cli_mod
+
+    captured = {}
+
+    class _Thread:
+        def __init__(self, *, target, args, daemon):
+            captured["target"] = target
+            captured["args"] = args
+            captured["daemon"] = daemon
+
+        def start(self):
+            captured["started"] = True
+
+    monkeypatch.setattr(cli_mod.threading, "Thread", _Thread)
+
+    provider = {
+        "slug": "custom",
+        "name": "Custom endpoint",
+        "models": [],
+        "is_user_defined": True,
+        "source": "model-config",
+    }
+    self_ = SimpleNamespace(
+        _app=object(),
+        _model_picker_state={
+            "stage": "provider",
+            "providers": [provider],
+            "selected": 0,
+            "custom_provs": [],
+        },
+        _restore_modal_input_snapshot=lambda: None,
+        _invalidate=lambda **_kwargs: None,
+    )
+    self_._close_model_picker = _bound(cli_mod.HermesCLI._close_model_picker, self_)
+    self_._configure_custom_endpoint_from_picker = lambda *_args: None
+
+    _bound(cli_mod.HermesCLI._handle_model_picker_selection, self_)()
+
+    assert self_._model_picker_state is None
+    assert captured["started"] is True
+    assert captured["daemon"] is True
+    assert captured["target"] is self_._configure_custom_endpoint_from_picker
+    assert captured["args"] == (provider, [])
+
+
+def test_custom_endpoint_picker_setup_applies_saved_route(monkeypatch):
+    import cli as cli_mod
+
+    configured = {
+        "model": {
+            "provider": "custom",
+            "default": "local-model",
+            "base_url": "http://truenas.local:11434/v1",
+            "api_key": "local-key",
+        },
+        "providers": {},
+    }
+    calls = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.main._model_flow_custom",
+        lambda config: calls.setdefault("setup_config", config),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: configured)
+    monkeypatch.setattr(
+        "hermes_cli.config.get_compatible_custom_providers",
+        lambda _config: [{"name": "TrueNAS local"}],
+    )
+    result = ModelSwitchResult(
+        success=True,
+        new_model="local-model",
+        target_provider="custom",
+        base_url="http://truenas.local:11434/v1",
+    )
+
+    def _switch_model(**kwargs):
+        calls["switch"] = kwargs
+        return result
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _switch_model)
+
+    self_ = SimpleNamespace(
+        _app=None,
+        provider="openrouter",
+        model="old-model",
+        _confirm_and_apply_model_switch_result=lambda *args, **kwargs: calls.setdefault(
+            "apply", (args, kwargs)
+        ),
+        _invalidate=lambda **_kwargs: None,
+    )
+
+    _bound(cli_mod.HermesCLI._configure_custom_endpoint_from_picker, self_)(
+        {"slug": "custom"}, []
+    )
+
+    assert calls["setup_config"] is configured
+    assert calls["switch"]["explicit_provider"] == "custom"
+    assert calls["switch"]["raw_input"] == "local-model"
+    assert calls["switch"]["current_base_url"] == "http://truenas.local:11434/v1"
+    assert calls["switch"]["current_api_key"] == "local-key"
+    assert calls["apply"][0] == (result, True)
+    assert calls["apply"][1]["custom_providers"] == [{"name": "TrueNAS local"}]

--- a/tests/hermes_cli/test_model_picker_expensive_confirm.py
+++ b/tests/hermes_cli/test_model_picker_expensive_confirm.py
@@ -169,7 +169,7 @@ def test_custom_endpoint_picker_setup_applies_saved_route(monkeypatch):
     )
 
     _bound(cli_mod.HermesCLI._configure_custom_endpoint_from_picker, self_)(
-        {"slug": "custom"}, []
+        {"slug": "custom"}, [{"name": "Stale endpoint"}]
     )
 
     assert calls["setup_config"] is configured
@@ -179,6 +179,53 @@ def test_custom_endpoint_picker_setup_applies_saved_route(monkeypatch):
     assert calls["switch"]["current_api_key"] == "local-key"
     assert calls["apply"][0] == (result, True)
     assert calls["apply"][1]["custom_providers"] == [{"name": "TrueNAS local"}]
+
+
+def test_custom_endpoint_picker_setup_handles_keyboard_interrupt(monkeypatch):
+    import cli as cli_mod
+
+    output = []
+    invalidations = []
+    monkeypatch.setattr(
+        "hermes_cli.main._model_flow_custom",
+        lambda _config: (_ for _ in ()).throw(KeyboardInterrupt),
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {}})
+    monkeypatch.setattr(cli_mod, "_cprint", output.append)
+
+    self_ = SimpleNamespace(
+        _app=None,
+        _invalidate=lambda **kwargs: invalidations.append(kwargs),
+    )
+
+    _bound(cli_mod.HermesCLI._configure_custom_endpoint_from_picker, self_)(
+        {"slug": "custom"}, []
+    )
+
+    assert output == ["  Custom endpoint setup cancelled."]
+    assert invalidations == [{"min_interval": 0.0}]
+
+
+def test_custom_endpoint_picker_setup_reports_missing_route(monkeypatch):
+    import cli as cli_mod
+
+    output = []
+    invalidations = []
+    monkeypatch.setattr("hermes_cli.main._model_flow_custom", lambda _config: None)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {}})
+    monkeypatch.setattr(cli_mod, "_cprint", output.append)
+
+    self_ = SimpleNamespace(
+        _app=None,
+        _invalidate=lambda **kwargs: invalidations.append(kwargs),
+    )
+
+    _bound(cli_mod.HermesCLI._configure_custom_endpoint_from_picker, self_)(
+        {"slug": "custom"}, []
+    )
+
+    assert output == ["  No custom endpoint configured."]
+    assert invalidations == [{"min_interval": 0.0}]
 
 
 def test_custom_endpoint_picker_setup_leaves_prompt_toolkit_loop(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Selecting an empty Custom endpoint row in the classic CLI `/model` provider picker now opens the existing URL, API key, and model setup flow instead of descending into a model screen that only offers Back and Cancel. The setup runs through prompt_toolkit's terminal handoff, then applies the saved custom route to the live session.

### Symptom

On a first-run custom endpoint with no discovered or configured models, highlighting Custom endpoint and pressing Enter does not reach endpoint or credential setup.

### Impact

Users running Hermes through terminals such as the TrueNAS app console cannot finish custom endpoint selection from the in-session `/model` picker. Other providers with populated model lists remain selectable.

### Bug Cause

**Trigger:** `cli.py:11138` / `_handle_model_picker_selection` when the selected user-defined `custom` row has an empty model list.

**Causal chain:**
1. The provider inventory surfaces the active bare custom endpoint even when it has no discovered or configured models.
2. The picker treats every provider row as a model-list row and advances the custom row to the model stage.
3. The model stage has no selectable models, so the user can only go Back or Cancel and cannot reach URL or API key setup.

**Why it is wrong:** An empty bare custom row represents an incomplete endpoint setup, not a provider with a usable empty catalog.

**Working sibling / contrast:** Providers with populated model lists correctly advance to model selection, and standalone `hermes model` already has the complete custom endpoint setup flow.

**Ruled out:** Enter key handling is not generally broken because the same key handler advances normal provider rows and the failing regression test observes the custom row entering the empty model stage.

### Fix

- Detect an empty user-defined bare custom row before entering model selection.
- Close the picker and run the established custom setup flow off the prompt_toolkit key handler, using `run_in_terminal` to transfer terminal ownership safely.
- Reuse configured endpoint and key values as setup defaults, then apply the saved custom route to the running session.
- Add behavioral tests for dispatch, saved-route activation, and config-backed endpoint defaults.

## Related Issue

Closes #92915

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` - route empty bare custom rows into terminal-safe endpoint setup and activate the saved route.
- `hermes_cli/model_setup_flows.py` - prefill custom setup from the active model configuration when legacy environment values are absent.
- `tests/hermes_cli/test_model_picker_expensive_confirm.py` - cover deferred setup and live route application.
- `tests/cli/test_cli_provider_resolution.py` - cover config-backed endpoint prefill.

## How to Test

1. Start Hermes with a bare custom provider whose endpoint has no discovered models.
2. Run `/model`, highlight Custom endpoint, and press Enter.
3. Confirm the URL, API key, and model prompts appear and the completed route is applied.
4. Automated tests already run locally: 34 passed.

```bash
scripts/run_tests.sh tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_model_switch_confirm_thread.py tests/hermes_cli/test_model_picker_expensive_confirm.py tests/cli/test_cli_provider_resolution.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing command or configuration schema changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Automated regression coverage is included. TrueNAS console verification is delegated to the review environment.
