### PR TITLE
fix(approvals): fail fast on rejected event delivery

### DIFF
--- a/tests/gateway/test_tui_approval_redaction.py
+++ b/tests/gateway/test_tui_approval_redaction.py
@@ -65,3 +65,13 @@ class TestTuiApprovalEmitRedaction:
 
         assert emitted["payload"]["choices"] == expected
 
+    def test_emit_approval_request_propagates_transport_rejection(self, monkeypatch):
+        from tui_gateway import server as tui_server
+
+        monkeypatch.setattr(tui_server, "_emit", lambda *_args, **_kwargs: False)
+
+        delivered = tui_server._emit_approval_request(
+            "sess-1", {"command": "echo ok", "description": "x"}
+        )
+
+        assert delivered is False

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1341,6 +1341,40 @@ class TestApprovalTimeoutIsNotConsent:
         ]
         assert hook_calls[-1][1]["choice"] == "notify_failed"
 
+    def test_rejected_transport_write_fails_fast_and_cleans_up(self, monkeypatch):
+        """A closed transport reports False instead of raising."""
+        from tools import approval as mod
+
+        hook_calls = []
+        monkeypatch.setattr(
+            mod,
+            "_fire_approval_hook",
+            lambda event_name, **kwargs: hook_calls.append((event_name, kwargs)),
+        )
+
+        decision = mod._await_gateway_decision(
+            self.SESSION_KEY,
+            lambda _data: False,
+            {
+                "command": "redacted-command",
+                "description": "redacted-description",
+                "pattern_key": "dangerous",
+                "pattern_keys": ["dangerous"],
+            },
+        )
+
+        assert decision == {
+            "resolved": False,
+            "choice": None,
+            "notify_failed": True,
+        }
+        assert self.SESSION_KEY not in mod._gateway_queues
+        assert [name for name, _ in hook_calls] == [
+            "pre_approval_request",
+            "post_approval_response",
+        ]
+        assert hook_calls[-1][1]["choice"] == "notify_failed"
+
     def test_pending_approval_is_replayable_and_acknowledged(self, monkeypatch):
         from tools import approval as mod
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2647,10 +2647,12 @@ _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval
 def register_gateway_notify(session_key: str, cb) -> None:
     """Register a per-session callback for sending approval requests to the user.
 
-    The callback signature is ``cb(approval_data: dict) -> None`` where
+    The callback signature is ``cb(approval_data: dict) -> object`` where
     *approval_data* contains ``command``, ``description``, and
     ``pattern_keys``.  The callback bridges sync→async (runs in the agent
-    thread, must schedule the actual send on the event loop).
+    thread, must schedule the actual send on the event loop). Returning exactly
+    ``False`` reports that the transport rejected the write; legacy callbacks
+    that return ``None`` remain fire-and-forget.
     """
     with _lock:
         _gateway_notify_cbs[session_key] = cb
@@ -4308,7 +4310,9 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     # Notify the user (bridges sync agent thread → async gateway)
     try:
-        notify_cb(dict(entry.data))
+        delivered = notify_cb(dict(entry.data))
+        if delivered is False:
+            raise RuntimeError("approval transport rejected the event write")
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
         _drop_entry()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4241,8 +4241,11 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
 
     Returns ``{"resolved": bool, "choice": str|None}`` on completion, or
     ``{"resolved": False, "choice": None, "notify_failed": True}`` if the
-    notify callback raised.  Persistence of an approved choice and building
-    the final tool-facing result dict remain the caller's responsibility.
+    notify callback raised or explicitly rejected the event write.  A truthy
+    write result confirms transport acceptance, not client receipt; a client
+    that accepts but never answers still follows the normal approval timeout.
+    Persistence of an approved choice and building the final tool-facing
+    result dict remain the caller's responsibility.
     """
     command = approval_data.get("command", "")
     description = approval_data.get("description", "")
@@ -4308,13 +4311,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         surface=surface,
     )
 
-    # Notify the user (bridges sync agent thread → async gateway)
-    try:
-        delivered = notify_cb(dict(entry.data))
-        if delivered is False:
-            raise RuntimeError("approval transport rejected the event write")
-    except Exception as exc:
-        logger.warning("Gateway approval notify failed: %s", exc)
+    def _notify_failed(reason) -> dict:
+        logger.warning("Gateway approval notify failed: %s", reason)
         _drop_entry()
         _fire_approval_hook(
             "post_approval_response",
@@ -4327,6 +4325,16 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
             choice="notify_failed",
         )
         return {"resolved": False, "choice": None, "notify_failed": True}
+
+    # Notify the user (bridges sync agent thread → async gateway)
+    try:
+        delivered = notify_cb(dict(entry.data))
+    except Exception as exc:
+        return _notify_failed(exc)
+    if delivered is False:
+        return _notify_failed(
+            "approval transport rejected the event write"
+        )
 
     # Block until the user responds or the canonical approval timeout elapses
     # (default 300s). Poll in short slices so we can fire activity heartbeats

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1690,8 +1690,8 @@ def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
     return {"jsonrpc": "2.0", "method": "event", "params": params}
 
 
-def _emit(event: str, sid: str, payload: dict | None = None):
-    write_json(_event_frame(event, sid, payload))
+def _emit(event: str, sid: str, payload: dict | None = None) -> bool:
+    return write_json(_event_frame(event, sid, payload))
 
 
 # Live client transports, one per connected WS peer (maintained by tui_gateway.ws).
@@ -2007,7 +2007,7 @@ def _pending_approval_request_payload(session_key: str) -> dict | None:
     return _approval_request_payload(approval) if approval else None
 
 
-def _emit_approval_request(sid: str, data: dict | None) -> None:
+def _emit_approval_request(sid: str, data: dict | None) -> bool:
     """Emit an ``approval.request`` event to the TUI client with the command
     redacted. The approval payload is built from the RAW command string, so a
     credential-shaped value Tirith flagged would otherwise be echoed verbatim
@@ -2015,7 +2015,16 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
     platforms and the SSE/API stream fixed in #50767). Reuse the shared gateway
     seam so all approval transports redact consistently."""
     payload = _approval_request_payload(data)
-    _emit("approval.request", sid, payload)
+    request_id = str(payload.get("request_id") or "")
+    delivered = _emit("approval.request", sid, payload)
+    if delivered is False:
+        logger.warning(
+            "Approval request transport rejected delivery for session %s "
+            "(request_id=%s)",
+            sid,
+            request_id or "unknown",
+        )
+    return delivered
 
 
 def _status_update(sid: str, kind: str, text: str | None = None):


### PR DESCRIPTION
Refs #91980

## Summary

- propagate a rejected Desktop/TUI event write back to the blocking approval gate
- resolve the request as `notify_failed` immediately and remove its pending entry instead of waiting for the full 300-second timeout
- keep legacy notify callbacks that return `None` compatible
- share cleanup between callback exceptions and explicit write rejection without synthetic exceptions
- log the rejected delivery without including the command payload

The fail-fast guarantee covers an immediate transport write rejection. A transport that accepts the frame but receives no client response still follows the normal approval timeout.

## Testing

- `scripts/run_tests.sh tests/tools/test_approval.py tests/gateway/test_tui_approval_redaction.py tests/tui_gateway/test_protocol.py -q` (176 passed)
- broader approval transport suite (204 passed)
- `ruff check` on changed Python files
