### PR TITLE
fix(fallback): honor destination context overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2617,6 +2617,22 @@ def init_agent(
                                     )
                     break
 
+    # A runtime selected from ``fallback_providers`` has already replaced the
+    # configured default before initialization.  Its override belongs to that
+    # destination runtime and must not be discarded with model.context_length.
+    if _config_context_length is None:
+        try:
+            from hermes_cli.config import get_fallback_provider_context_length
+
+            _config_context_length = get_fallback_provider_context_length(
+                agent.model,
+                agent.provider,
+                agent.base_url,
+                fallback_model,
+            )
+        except Exception:
+            _config_context_length = None
+
     # Persist for reuse on switch_model / fallback activation. Must come
     # AFTER the custom_providers branch so per-model overrides aren't lost.
     agent._config_context_length = _config_context_length

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2631,6 +2631,10 @@ def init_agent(
                 fallback_model,
             )
         except Exception:
+            logger.debug(
+                "Could not resolve the active fallback context override",
+                exc_info=True,
+            )
             _config_context_length = None
 
     # Persist for reuse on switch_model / fallback activation. Must come
@@ -3062,6 +3066,7 @@ def init_agent(
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_echo_flag": getattr(agent, "_reasoning_echo_flag", False),
+        "config_context_length": agent._config_context_length,
         # Context engine state that _try_activate_fallback() overwrites.
         # Use getattr for model/base_url/api_key/provider since plugin
         # engines may not have these (they're ContextCompressor-specific).

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1350,6 +1350,7 @@ def try_recover_primary_transport(
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
+        agent._config_context_length = rt.get("config_context_length")
 
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -1581,6 +1582,7 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
+        agent._config_context_length = rt.get("config_context_length")
         agent._client_kwargs = dict(rt["client_kwargs"])
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
@@ -2991,6 +2993,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_config": dict(agent.reasoning_config) if getattr(agent, "reasoning_config", None) else None,
         "reasoning_echo_flag": getattr(agent, "_reasoning_echo_flag", False),
+        "config_context_length": agent._config_context_length,
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2643,10 +2643,18 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         old_model = agent.model
         old_provider = agent.provider
 
-        # Clear the per-config context_length override so the fallback
-        # model's actual context window is resolved instead of inheriting
-        # the stale value from the previous model.  See #22387.
-        agent._config_context_length = None
+        # Replace the primary model's override with the fallback entry's own
+        # intent.  Clearing unconditionally made fallback_providers[].
+        # context_length ineffective and could reject an otherwise valid local
+        # model at the 64K floor.  See #22387 and #92732.
+        from hermes_cli.config import get_fallback_provider_context_length
+
+        agent._config_context_length = get_fallback_provider_context_length(
+            fb_model,
+            fb_provider,
+            fb_base_url,
+            fb,
+        )
         agent.model = fb_model
         agent.provider = fb_provider
         agent.requested_provider = fb_provider

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -128,6 +128,10 @@ model:
   #   my-proxy:
   #     base_url: "https://llm.internal.example.com/v1"
   #     key_env: "MY_PROXY_API_KEY"
+  #     context_length: 131072  # Provider-wide default for this route.
+  #     models:
+  #       large-model:
+  #         context_length: 262144  # Per-model value takes precedence.
   #     extra_headers:
   #       CF-Access-Client-Id: "xxxx.access"
   #       CF-Access-Client-Secret: "${CF_ACCESS_SECRET}"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1891,24 +1891,30 @@ def get_fallback_provider_context_length(
     if not active_provider or not active_model:
         return None
 
-    for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        entry_provider = str(entry.get("provider") or "").strip().lower()
-        entry_model = str(entry.get("model") or "").strip()
-        if entry_provider != active_provider or entry_model != active_model:
-            continue
-        entry_url = normalize_route_base_url(entry.get("base_url"))
-        if entry_url and entry_url != active_url:
-            continue
-        raw_ctx = entry.get("context_length")
-        try:
-            context_length = int(raw_ctx)
-        except (TypeError, ValueError):
-            continue
-        if isinstance(raw_ctx, bool) or context_length <= 0:
-            continue
-        return context_length
+    # Prefer an entry pinned to the active route over an otherwise identical
+    # provider/model entry.  Config order remains the tiebreaker within each
+    # specificity tier.
+    for require_route in (True, False):
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            entry_provider = str(entry.get("provider") or "").strip().lower()
+            entry_model = str(entry.get("model") or "").strip()
+            if entry_provider != active_provider or entry_model != active_model:
+                continue
+            entry_url = normalize_route_base_url(entry.get("base_url"))
+            if bool(entry_url) != require_route:
+                continue
+            if entry_url and entry_url != active_url:
+                continue
+            raw_ctx = entry.get("context_length")
+            try:
+                context_length = int(raw_ctx)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(raw_ctx, bool) or context_length <= 0:
+                continue
+            return context_length
     return None
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1809,7 +1809,8 @@ def get_custom_provider_context_length(
 
     Matches any entry whose normalized route identity equals ``base_url`` and
     returns ``custom_providers[i].models.<model>.context_length`` if present and
-    valid.  Returns ``None`` when no override applies.
+    valid.  An entry-level ``context_length`` is the provider-wide fallback.
+    Returns ``None`` when no override applies.
 
     This is the single source of truth for custom-provider context overrides,
     used by:
@@ -1846,13 +1847,14 @@ def get_custom_provider_context_length(
         entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue
+        raw_ctx = None
         models = entry.get("models")
-        if not isinstance(models, dict):
-            continue
-        model_cfg = models.get(model)
-        if not isinstance(model_cfg, dict):
-            continue
-        raw_ctx = model_cfg.get("context_length")
+        if isinstance(models, dict):
+            model_cfg = models.get(model)
+            if isinstance(model_cfg, dict):
+                raw_ctx = model_cfg.get("context_length")
+        if raw_ctx is None:
+            raw_ctx = entry.get("context_length")
         if raw_ctx is None:
             continue
         try:
@@ -1861,6 +1863,52 @@ def get_custom_provider_context_length(
             continue
         if ctx > 0:
             return ctx
+    return None
+
+
+def get_fallback_provider_context_length(
+    model: str,
+    provider: str,
+    base_url: str,
+    fallback_providers: Any,
+) -> Optional[int]:
+    """Return the context override for the active fallback runtime.
+
+    Provider/model identity is required.  When an inline fallback also pins a
+    route, that route must match too; this prevents an override for one custom
+    endpoint leaking onto another endpoint that happens to reuse its model id.
+    """
+    entries = (
+        fallback_providers
+        if isinstance(fallback_providers, list)
+        else [fallback_providers]
+        if isinstance(fallback_providers, dict)
+        else []
+    )
+    active_provider = str(provider or "").strip().lower()
+    active_model = str(model or "").strip()
+    active_url = normalize_route_base_url(base_url)
+    if not active_provider or not active_model:
+        return None
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_provider = str(entry.get("provider") or "").strip().lower()
+        entry_model = str(entry.get("model") or "").strip()
+        if entry_provider != active_provider or entry_model != active_model:
+            continue
+        entry_url = normalize_route_base_url(entry.get("base_url"))
+        if entry_url and entry_url != active_url:
+            continue
+        raw_ctx = entry.get("context_length")
+        try:
+            context_length = int(raw_ctx)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(raw_ctx, bool) or context_length <= 0:
+            continue
+        return context_length
     return None
 
 

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -10,11 +10,44 @@ from unittest.mock import patch
 
 from hermes_cli.config import (
     get_custom_provider_context_length,
+    get_fallback_provider_context_length,
     get_custom_provider_model_capability,
 )
 
 
 class TestGetCustomProviderContextLength:
+
+    def test_provider_level_override_applies_when_model_has_no_override(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "context_length": 65_536,
+                "models": {"m": {}},
+            }
+        ]
+
+        assert (
+            get_custom_provider_context_length(
+                "m", "https://example.invalid/v1", custom
+            )
+            == 65_536
+        )
+
+    def test_model_override_wins_over_provider_level_default(self):
+        custom = [
+            {
+                "base_url": "https://example.invalid/v1",
+                "context_length": 65_536,
+                "models": {"m": {"context_length": 131_072}},
+            }
+        ]
+
+        assert (
+            get_custom_provider_context_length(
+                "m", "https://example.invalid/v1", custom
+            )
+            == 131_072
+        )
 
     def test_trailing_slash_insensitive(self):
         custom = [
@@ -50,6 +83,43 @@ class TestGetCustomProviderContextLength:
         assert get_custom_provider_context_length("m", "", [{"base_url": "", "models": {"m": {"context_length": 1}}}]) is None
         assert get_custom_provider_context_length("m", "http://x", None) is None
         assert get_custom_provider_context_length("m", "http://x", []) is None
+
+
+class TestGetFallbackProviderContextLength:
+    def test_matches_the_active_runtime(self):
+        fallbacks = [
+            {
+                "provider": "custom",
+                "model": "qwen3:32b",
+                "base_url": "http://localhost:11434/v1",
+                "context_length": 65_536,
+            }
+        ]
+
+        assert get_fallback_provider_context_length(
+            "qwen3:32b",
+            "custom",
+            "http://localhost:11434/v1/",
+            fallbacks,
+        ) == 65_536
+
+    def test_route_mismatch_does_not_leak_the_override(self):
+        fallback = {
+            "provider": "custom",
+            "model": "shared-model",
+            "base_url": "https://first.invalid/v1",
+            "context_length": 65_536,
+        }
+
+        assert (
+            get_fallback_provider_context_length(
+                "shared-model",
+                "custom",
+                "https://second.invalid/v1",
+                fallback,
+            )
+            is None
+        )
 
 
 class TestGetCustomProviderModelCapability:

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -121,6 +121,50 @@ class TestGetFallbackProviderContextLength:
             is None
         )
 
+    def test_route_pinned_match_outranks_earlier_unpinned_match(self):
+        fallbacks = [
+            {
+                "provider": "custom",
+                "model": "shared-model",
+                "context_length": 32_768,
+            },
+            {
+                "provider": "custom",
+                "model": "shared-model",
+                "base_url": "https://exact.invalid/v1",
+                "context_length": 65_536,
+            },
+        ]
+
+        assert get_fallback_provider_context_length(
+            "shared-model",
+            "custom",
+            "https://exact.invalid/v1/",
+            fallbacks,
+        ) == 65_536
+
+    def test_unpinned_match_applies_when_pinned_route_does_not_match(self):
+        fallbacks = [
+            {
+                "provider": "custom",
+                "model": "shared-model",
+                "base_url": "https://other.invalid/v1",
+                "context_length": 65_536,
+            },
+            {
+                "provider": "custom",
+                "model": "shared-model",
+                "context_length": 32_768,
+            },
+        ]
+
+        assert get_fallback_provider_context_length(
+            "shared-model",
+            "custom",
+            "https://active.invalid/v1",
+            fallbacks,
+        ) == 32_768
+
 
 class TestGetCustomProviderModelCapability:
     def test_matches_exact_model_on_normalized_route(self):

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -82,6 +82,7 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["api_mode"] == agent.api_mode
         assert "client_kwargs" in rt
         assert "compressor_context_length" in rt
+        assert rt["config_context_length"] == agent._config_context_length
 
     def test_snapshot_includes_compressor_state(self):
         agent = _make_agent()
@@ -196,6 +197,39 @@ class TestRestorePrimaryRuntime:
 
         assert agent.context_compressor.context_length == original_ctx_len
         assert agent.context_compressor.threshold_tokens == original_threshold
+
+    def test_restores_primary_context_override_after_fallback(self):
+        fallback = {
+            "provider": "custom",
+            "model": "fallback-model",
+            "base_url": "https://fallback.example/v1",
+            "context_length": 65_536,
+        }
+        agent = _make_agent(fallback_model=[fallback])
+        agent._config_context_length = 200_000
+        agent._primary_runtime["config_context_length"] = 200_000
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_resolve(
+                        base_url="https://fallback.example/v1",
+                        api_key="fallback-key-1234",
+                    ),
+                    "fallback-model",
+                ),
+            ),
+            patch("agent.model_metadata.get_model_context_length", return_value=65_536),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent._config_context_length == 65_536
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent._config_context_length == 200_000
 
     def test_restores_prompt_caching_flag(self):
         agent = _make_agent()

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -145,6 +145,37 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
 
+    def test_applies_inline_context_length_to_fallback_runtime(self):
+        fallback = {
+            "provider": "custom",
+            "model": "fallback-model",
+            "base_url": "https://fallback.example/v1",
+            "api_key": "test-key",
+            "context_length": 65_536,
+        }
+        agent = _make_agent(fallback_model=[fallback])
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(
+                        base_url="https://fallback.example/v1",
+                        api_key="test-key",
+                    ),
+                    "fallback-model",
+                ),
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=65_536,
+            ) as resolve_context,
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent._config_context_length == 65_536
+        assert resolve_context.call_args.kwargs["config_context_length"] == 65_536
+
 
     def test_nous_anthropic_fallback_uses_the_messages_wire(self):
         """Portal Claude fallbacks must not stay on chat_completions.

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -283,4 +283,5 @@ def test_lmstudio_switch_uses_destination_context_and_verified_runtime(monkeypat
     call_kwargs = mock_ctx_len.call_args.kwargs
     assert call_kwargs.get("config_context_length") == 100_000
     assert agent._config_context_length == 120_000
+    assert agent._primary_runtime["config_context_length"] == 120_000
     assert agent.context_compressor.context_length == 100_000


### PR DESCRIPTION
Refs #92732

## Summary

- honor `fallback_providers[].context_length` when that fallback becomes active
- restore the primary context override after fallback use or transport recovery
- persist the selected override when `switch_model` replaces the primary runtime
- treat `providers.<name>.context_length` as a provider-wide default while preserving per-model precedence
- prefer route-pinned fallback entries over unpinned provider/model matches
- prevent context overrides from leaking across endpoints or between primary and fallback models

This addresses the context-window half of #92732; #92741 covers the separate credential carry-through defect.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_custom_provider_context_length.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_invalid_context_length_warning.py tests/run_agent/test_switch_model_context.py tests/agent/test_model_metadata_local_ctx.py -q` (86 passed)
- `ruff check` on changed Python files
