### PR TITLE
feat(tts): add Google Cloud Vertex AI Gemini TTS provider with ADC auth and 30 celestial voices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -348,6 +348,15 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # VOICE_TOOLS_OPENAI_KEY=
 
 # =============================================================================
+# GOOGLE CLOUD TTS
+# =============================================================================
+# Google Cloud Text-to-Speech (Chirp 3 HD, Journey, Neural2 voices).
+# Uses Application Default Credentials (ADC) by default:
+#   gcloud auth application-default login
+# Or specify a service account JSON file path:
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# =============================================================================
 # SLACK INTEGRATION
 # =============================================================================
 # Slack Bot Token - From Slack App settings (OAuth & Permissions)

--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -58,6 +58,8 @@ _BUILTIN_NAMES = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "google_cloud",
+    "vertex",
 })
 
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1335,6 +1335,20 @@ platform_toolsets:
 #     optimize_streaming_latency: 0  # 0-2, trades quality for lower latency
 #     sample_rate: 24000    # 22050 / 24000 / 44100 / 48000
 #     bit_rate: 128000      # MP3 bitrate (codec=mp3 only)
+#   vertex:
+#     model: "gemini-2.5-flash-preview-tts"  # or gemini-3.1-flash-tts-preview
+#     voice: "Kore"                          # Kore, Puck, Fenrir, Zephyr, Aoede, Charon, etc.
+#     project_id: ""                         # Optional: GCP project ID override (defaults to ADC project)
+#     location: "global"                     # global or regional (e.g. us-central1)
+#     audio_tags: false                      # Enable hidden Gemini 3.1 TTS audio-tag insertion
+#     persona_prompt_file: ""                # Optional Markdown/text file with voice direction
+#   google_cloud:
+#     voice: "en-US-Chirp3-HD-Charon"  # Voice name (e.g. en-US-Journey-F, en-US-Neural2-F)
+#     language_code: "en-US"           # BCP-47 language code
+#     project_id: ""                   # Optional: Google Cloud project ID (defaults to ADC project)
+#     speaking_rate: 1.0               # 0.25 - 4.0
+#     pitch: 0.0                       # -20.0 - 20.0
+#     credentials_file: ""             # Optional: path to service account JSON (or set GOOGLE_APPLICATION_CREDENTIALS)
 
 # =============================================================================
 # Voice Transcription (Speech-to-Text)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1705,11 +1705,11 @@ def validate_media_delivery_path(path: str) -> Optional[str]:
         return None
 
     candidate = str(path).strip()
-    if len(candidate) >= 2 and candidate[0] == candidate[-1] and candidate[0] in "`\"'":
-        candidate = candidate[1:-1].strip()
     candidate = candidate.lstrip("`\"'").rstrip("`\"',.;:)}]")
     if not candidate:
         return None
+    if sys.platform == "win32" and len(candidate) >= 3 and candidate.startswith("/") and candidate[2] == "/" and candidate[1].isalpha():
+        candidate = f"{candidate[1].upper()}:{candidate[2:]}"
 
     try:
         expanded = Path(os.path.expanduser(candidate))

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1717,6 +1717,14 @@ DEFAULT_CONFIG = {
             "voice": "default",
             # "base_url": "",  # override DEEPINFRA_BASE_URL for TTS only
         },
+        "google_cloud": {
+            "voice": "en-US-Chirp3-HD-Charon",
+            "language_code": "en-US",
+            "project_id": "",
+            "speaking_rate": 1.0,
+            "pitch": 0.0,
+            "credentials_file": "",
+        },
     },
 
     "stt": {

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -881,8 +881,9 @@ def windowless_gateway_restart_spec(
     env_overlay: dict[str, str] = {
         "PYTHONIOENCODING": "utf-8",
         "HERMES_GATEWAY_DETACHED": "1",
-        "VIRTUAL_ENV": str(venv_dir),
     }
+    if venv_dir and (Path(venv_dir) / "pyvenv.cfg").is_file():
+        env_overlay["VIRTUAL_ENV"] = str(venv_dir)
     if hermes_home:
         env_overlay["HERMES_HOME"] = hermes_home
     _prepend_pythonpath(

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -549,6 +549,8 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Text-to-Speech (Mistral Voxtral)", True, None))
     elif tts_provider == "gemini" and (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")):
         tool_status.append(("Text-to-Speech (Google Gemini)", True, None))
+    elif tts_provider == "google_cloud":
+        tool_status.append(("Text-to-Speech (Google Cloud TTS)", True, None))
     elif tts_provider == "neutts":
         try:
             neutts_ok = importlib.util.find_spec("neutts") is not None
@@ -1090,7 +1092,9 @@ def _setup_tts_provider(config: dict):
         "xai": "xAI TTS",
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
-        "gemini": "Google Gemini TTS",
+        "gemini": "Google Gemini TTS (AI Studio)",
+        "vertex": "Vertex AI Gemini TTS (Google Cloud)",
+        "google_cloud": "Google Cloud TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
     }
@@ -1114,12 +1118,14 @@ def _setup_tts_provider(config: dict):
             "xAI TTS (Grok voices — OAuth login or API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
-            "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
+            "Google Gemini TTS (AI Studio — 30 prebuilt voices, needs API key)",
+            "Vertex AI Gemini TTS (Google Cloud — gemini-2.5-flash-preview-tts with Kore/Puck)",
+            "Google Cloud TTS (Chirp 3 HD, Journey voices — Google Cloud credentials)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "vertex", "google_cloud", "neutts", "kittentts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1282,6 +1288,103 @@ def _setup_tts_provider(config: dict):
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"
+
+    elif selected == "vertex":
+        # Check for Application Default Credentials
+        adc_available = False
+        try:
+            import google.auth
+            google.auth.default(
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+            adc_available = True
+        except Exception:
+            pass
+
+        if adc_available:
+            print_success(
+                "Vertex AI Gemini TTS will use your Application Default Credentials "
+                "(from gcloud auth application-default login)"
+            )
+        else:
+            print_info(
+                "No Application Default Credentials found. You can authenticate by running:\n"
+                "  gcloud auth application-default login\n"
+                "Or provide a service account JSON file below."
+            )
+            sa_path = prompt("Service account JSON file path (optional, leave blank for ADC)")
+            if sa_path and sa_path.strip():
+                config.setdefault("tts", {}).setdefault("vertex", {})["credentials_file"] = sa_path.strip()
+                print_success(f"Service account path set to: {sa_path.strip()}")
+
+        print()
+        project_id = prompt("Google Cloud project ID (Enter to use default from credentials)")
+        if project_id and project_id.strip():
+            config.setdefault("tts", {}).setdefault("vertex", {})["project_id"] = project_id.strip()
+            print_success(f"Vertex AI project set to: {project_id.strip()}")
+        voice = prompt("Voice name (Enter for 'Kore' — or Puck, Fenrir, Zephyr, Aoede, Charon)")
+        if voice and voice.strip():
+            config.setdefault("tts", {}).setdefault("vertex", {})["voice"] = voice.strip()
+            print_success(f"Vertex AI voice set to: {voice.strip()}")
+
+    elif selected == "google_cloud":
+        # Check for Application Default Credentials first
+        adc_available = False
+        try:
+            import google.auth
+            google.auth.default(
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+            adc_available = True
+        except Exception:
+            pass
+
+        if adc_available:
+            print_success(
+                "Google Cloud TTS will use your Application Default Credentials "
+                "(from gcloud auth application-default login)"
+            )
+        else:
+            existing_cred = get_env_value("GOOGLE_APPLICATION_CREDENTIALS")
+            if existing_cred:
+                print_success(f"Google Cloud TTS will use credentials from: {existing_cred}")
+            else:
+                print()
+                print_info("Google Cloud TTS requires Google Cloud credentials.")
+                print_info("Options:")
+                print_info("  1. Run: gcloud auth application-default login")
+                print_info("  2. Provide a service account JSON key file")
+                print()
+                cred_path = prompt(
+                    "Service account JSON path (or Enter to skip and use gcloud later)"
+                )
+                if cred_path and cred_path.strip():
+                    if os.path.isfile(cred_path.strip()):
+                        save_env_value("GOOGLE_APPLICATION_CREDENTIALS", cred_path.strip())
+                        print_success("GOOGLE_APPLICATION_CREDENTIALS saved")
+                    else:
+                        print_warning(f"File not found: {cred_path.strip()}")
+                        print_warning("Falling back to Edge TTS. Configure credentials later.")
+                        selected = "edge"
+                else:
+                    print_info(
+                        "No credentials configured. Run 'gcloud auth application-default login' "
+                        "before using Google Cloud TTS."
+                    )
+
+        if selected == "google_cloud":
+            print()
+            print_info("Ensure the Cloud Text-to-Speech API is enabled:")
+            print_info("  https://console.cloud.google.com/apis/library/texttospeech.googleapis.com")
+            print()
+            project_id = prompt("Google Cloud project ID (Enter to use default from credentials)")
+            if project_id and project_id.strip():
+                config.setdefault("tts", {}).setdefault("google_cloud", {})["project_id"] = project_id.strip()
+                print_success(f"Google Cloud project set to: {project_id.strip()}")
+            voice = prompt("Voice name (Enter for 'en-US-Chirp3-HD-Charon')")
+            if voice and voice.strip():
+                config.setdefault("tts", {}).setdefault("google_cloud", {})["voice"] = voice.strip()
+                print_success(f"Google Cloud TTS voice set to: {voice.strip()}")
 
     elif selected == "kittentts":
         # Check if already installed

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -379,13 +379,27 @@ TOOL_CATEGORIES = {
                 "tts_provider": "mistral",
             },
             {
-                "name": "Google Gemini TTS",
+                "name": "Google Gemini TTS (AI Studio)",
                 "badge": "preview",
-                "tag": "30 prebuilt voices, controllable via prompts",
+                "tag": "30 prebuilt voices, controllable via prompts (AI Studio API key)",
                 "env_vars": [
                     {"key": "GEMINI_API_KEY", "prompt": "Gemini API key", "url": "https://aistudio.google.com/app/apikey"},
                 ],
                 "tts_provider": "gemini",
+            },
+            {
+                "name": "Vertex AI Gemini TTS",
+                "badge": "vertex",
+                "tag": "gemini-2.5-flash-preview-tts with Kore/Puck — Google Cloud ADC",
+                "env_vars": [],
+                "tts_provider": "vertex",
+            },
+            {
+                "name": "Google Cloud TTS",
+                "badge": "paid",
+                "tag": "Chirp 3 HD, Journey voices — Google Cloud credentials",
+                "env_vars": [],  # Uses ADC, not a simple API key
+                "tts_provider": "google_cloud",
             },
             {
                 "name": "KittenTTS",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1080,7 +1080,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"],
+        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "google_cloud", "neutts", "kittentts", "piper"],
     },
     "stt.provider": {
         "type": "select",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,6 +282,7 @@ mistral = ["mistralai==2.4.8"]
 otlp = ["opentelemetry-sdk==1.39.1", "opentelemetry-exporter-otlp-proto-http==1.39.1"]
 bedrock = ["boto3==1.42.89"]
 vertex = ["google-auth==2.55.1"]
+google-cloud-tts = ["google-cloud-texttospeech>=2.24.0", "google-auth==2.55.1"]
 azure-identity = ["azure-identity==1.25.3"]
 termux = [
   # Baseline Android / Termux path for reliable fresh installs.

--- a/tests/agent/test_tts_registry.py
+++ b/tests/agent/test_tts_registry.py
@@ -85,7 +85,7 @@ class TestRegistration:
     @pytest.mark.parametrize(
         "builtin",
         ["edge", "openai", "elevenlabs", "minimax", "gemini",
-         "mistral", "xai", "piper", "kittentts", "neutts"],
+         "mistral", "xai", "piper", "kittentts", "neutts", "deepinfra", "google_cloud", "vertex"],
     )
     def test_rejects_builtin_shadow_with_warning(self, builtin, caplog):
         """Built-in names always win — plugin registration is silently ignored

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -220,3 +220,84 @@ class TestGeminiInCheckRequirements:
             return_value={"provider": "gemini"},
         ), patch("builtins.__import__", side_effect=fake_import):
             assert check_tts_requirements() is True
+
+
+class TestGenerateVertexGeminiTts:
+    def test_vertex_ai_mode_uses_bearer_token_and_project_endpoint(
+        self, tmp_path, mock_gemini_response, fake_pcm_bytes
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        output_path = str(tmp_path / "test.wav")
+        config = {
+            "provider": "vertex",
+            "vertex": {
+                "project_id": "test-project-123",
+                "location": "global",
+                "model": "gemini-2.5-flash-preview-tts",
+                "voice": "Kore",
+            },
+        }
+
+        mock_creds = MagicMock()
+        mock_creds.token = "ya29.test-bearer-token"
+        mock_creds.project_id = "test-project-123"
+
+        with patch("google.auth.default", return_value=(mock_creds, "test-project-123")), \
+             patch("google.auth.transport.requests.Request"), \
+             patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            result = _generate_gemini_tts("Hello Vertex", output_path, config, provider="vertex")
+
+        assert result == output_path
+        args, kwargs = mock_post.call_args
+        endpoint = args[0]
+        assert "aiplatform.googleapis.com" in endpoint
+        assert "projects/test-project-123" in endpoint
+        assert "gemini-2.5-flash-preview-tts:generateContent" in endpoint
+        assert kwargs["headers"]["Authorization"] == "Bearer ya29.test-bearer-token"
+        assert kwargs["params"] is None
+        payload = kwargs["json"]
+        assert payload["contents"][0]["role"] == "user"
+        assert payload["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
+
+    def test_vertex_regional_location_endpoint(
+        self, tmp_path, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        output_path = str(tmp_path / "test.wav")
+        config = {
+            "provider": "vertex",
+            "vertex": {
+                "project_id": "test-project-123",
+                "location": "us-central1",
+                "model": "gemini-2.5-flash-preview-tts",
+                "voice": "Puck",
+            },
+        }
+
+        mock_creds = MagicMock()
+        mock_creds.token = "ya29.test-bearer-token"
+
+        with patch("google.auth.default", return_value=(mock_creds, "test-project-123")), \
+             patch("google.auth.transport.requests.Request"), \
+             patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hello Regional", output_path, config, provider="vertex")
+
+        endpoint = mock_post.call_args[0][0]
+        assert "us-central1-aiplatform.googleapis.com" in endpoint
+        assert "locations/us-central1" in endpoint
+
+    def test_vertex_missing_credentials_raises_error(self, tmp_path):
+        from tools.tts_tool import _generate_gemini_tts
+
+        output_path = str(tmp_path / "test.wav")
+        config = {
+            "provider": "vertex",
+            "vertex": {"project_id": "test-project"},
+        }
+
+        with patch("google.auth.default", side_effect=Exception("No ADC")):
+            with pytest.raises(ValueError, match="Vertex AI Gemini TTS authentication failed"):
+                _generate_gemini_tts("Hello", output_path, config, provider="vertex")
+

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -15,6 +15,8 @@ def clean_env(monkeypatch):
         "GOOGLE_API_KEY",
         "GEMINI_BASE_URL",
         "HERMES_SESSION_PLATFORM",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -300,4 +302,319 @@ class TestGenerateVertexGeminiTts:
         with patch("google.auth.default", side_effect=Exception("No ADC")):
             with pytest.raises(ValueError, match="Vertex AI Gemini TTS authentication failed"):
                 _generate_gemini_tts("Hello", output_path, config, provider="vertex")
+
+    def test_vertex_boolean_config_does_not_crash(self, tmp_path, mock_gemini_response):
+        """tts.vertex: true boolean config must normalize gracefully without AttributeError."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        output_path = str(tmp_path / "test.wav")
+        config = {
+            "provider": "vertex",
+            "vertex": True,
+        }
+
+        mock_creds = MagicMock()
+        mock_creds.token = "ya29.test-bearer-token"
+        mock_creds.project_id = "test-project-from-adc"
+
+        with patch("google.auth.default", return_value=(mock_creds, "test-project-from-adc")), \
+             patch("google.auth.transport.requests.Request"), \
+             patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            result = _generate_gemini_tts("Hello Boolean", output_path, config, provider="vertex")
+
+        assert result == output_path
+        assert "projects/test-project-from-adc" in mock_post.call_args[0][0]
+
+    def test_vertex_invalid_credentials_file_raises_file_not_found(self, tmp_path):
+        """Explicit credentials_file that does not exist must fail fast instead of falling back to ADC."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        output_path = str(tmp_path / "test.wav")
+        config = {
+            "provider": "vertex",
+            "vertex": {
+                "credentials_file": str(tmp_path / "nonexistent_sa.json"),
+                "project_id": "test-project",
+            },
+        }
+
+        with pytest.raises(ValueError, match="credentials file not found"):
+            _generate_gemini_tts("Hello", output_path, config, provider="vertex")
+
+    def test_check_tts_requirements_with_existing_credentials_file(self, tmp_path, monkeypatch):
+        """check_tts_requirements should return True when an explicitly configured credentials_file exists on disk."""
+        from tools.tts_tool import check_tts_requirements
+
+        for key in ("GEMINI_API_KEY", "GOOGLE_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+
+        cred_file = tmp_path / "sa.json"
+        cred_file.write_text("{}")
+
+        with patch(
+            "tools.tts_tool._load_tts_config",
+            return_value={"provider": "vertex", "vertex": {"credentials_file": str(cred_file)}},
+        ):
+            assert check_tts_requirements() is True
+
+    def test_check_tts_requirements_with_tilde_expanded_credentials_file(self, tmp_path, monkeypatch):
+        """check_tts_requirements should expand tilde (~) paths before checking file existence."""
+        from tools.tts_tool import check_tts_requirements
+
+        for key in ("GEMINI_API_KEY", "GOOGLE_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+
+        real_file = tmp_path / "sa.json"
+        real_file.write_text("{}")
+
+        tilde_path = "~/credentials/sa.json"
+
+        def fake_expanduser(path):
+            if path == tilde_path:
+                return str(real_file)
+            return path
+
+        with patch(
+            "tools.tts_tool._load_tts_config",
+            return_value={"provider": "vertex", "vertex": {"credentials_file": tilde_path}},
+        ), patch("os.path.expanduser", side_effect=fake_expanduser):
+            assert check_tts_requirements() is True
+
+    def test_check_tts_requirements_with_invalid_credentials_file(self, tmp_path, monkeypatch):
+        """check_tts_requirements should return False when credentials_file does not exist."""
+        from tools.tts_tool import check_tts_requirements
+
+        for key in ("GEMINI_API_KEY", "GOOGLE_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+
+        with patch(
+            "tools.tts_tool._load_tts_config",
+            return_value={"provider": "vertex", "vertex": {"credentials_file": str(tmp_path / "missing.json")}},
+        ):
+            assert check_tts_requirements() is False
+
+
+class TestVertexCredentialPrecedence:
+    """Verify explicit credentials_file always takes precedence and invalid
+    explicit credentials never silently fall back to ADC."""
+
+    def test_explicit_cred_file_used_over_adc(
+        self, tmp_path, mock_gemini_response, monkeypatch
+    ):
+        """Case B: credentials_file valid + ADC available -> explicit file used, ADC not called."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        key_file = tmp_path / "sa.json"
+        key_file.write_text('{"type": "service_account"}', encoding="utf-8")
+
+        config = {
+            "provider": "vertex",
+            "vertex": {
+                "credentials_file": str(key_file),
+                "project_id": "explicit-project",
+            },
+        }
+
+        mock_sa_creds = MagicMock()
+        mock_sa_creds.token = "ya29.from-sa-file"
+        mock_sa_creds.project_id = "explicit-project"
+
+        with patch(
+            "google.oauth2.service_account.Credentials.from_service_account_file",
+            return_value=mock_sa_creds,
+        ) as mock_from_file, \
+             patch("google.auth.default") as mock_adc, \
+             patch("google.auth.transport.requests.Request"), \
+             patch("requests.post", return_value=mock_gemini_response):
+            _generate_gemini_tts("Test", str(tmp_path / "out.wav"), config, provider="vertex")
+
+        # SA file was used
+        mock_from_file.assert_called_once()
+        # Compare the actual positional arg, not the stringified call_args
+        # (str(call_args) double-escapes backslashes on Windows).
+        assert mock_from_file.call_args[0][0] == str(key_file)
+        # ADC was NOT called
+        mock_adc.assert_not_called()
+
+    def test_invalid_cred_file_does_not_fall_back_to_adc(self, tmp_path):
+        """Case C: credentials_file nonexistent + ADC available -> FAIL, ADC NOT used."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        config = {
+            "provider": "vertex",
+            "vertex": {
+                "credentials_file": str(tmp_path / "typo_sa.json"),
+                "project_id": "some-project",
+            },
+        }
+
+        # ADC is available but should never be reached
+        mock_adc_creds = MagicMock()
+        mock_adc_creds.token = "ya29.from-adc"
+
+        with patch("google.auth.default", return_value=(mock_adc_creds, "adc-project")) as mock_adc:
+            with pytest.raises(ValueError, match="credentials file not found"):
+                _generate_gemini_tts("Test", str(tmp_path / "out.wav"), config, provider="vertex")
+
+        # ADC must NOT have been called
+        mock_adc.assert_not_called()
+
+    def test_malformed_cred_file_does_not_fall_back_to_adc(self, tmp_path):
+        """Case E: credentials_file exists but invalid + ADC available -> explicit error, no ADC fallback."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        bad_file = tmp_path / "bad_sa.json"
+        bad_file.write_text("not valid json", encoding="utf-8")
+
+        config = {
+            "provider": "vertex",
+            "vertex": {
+                "credentials_file": str(bad_file),
+                "project_id": "some-project",
+            },
+        }
+
+        mock_adc_creds = MagicMock()
+        mock_adc_creds.token = "ya29.from-adc"
+
+        with patch(
+            "google.oauth2.service_account.Credentials.from_service_account_file",
+            side_effect=ValueError("could not deserialize key data"),
+        ), \
+             patch("google.auth.default", return_value=(mock_adc_creds, "adc-project")) as mock_adc:
+            with pytest.raises(ValueError, match="Failed to load Vertex AI service account"):
+                _generate_gemini_tts("Test", str(tmp_path / "out.wav"), config, provider="vertex")
+
+        # ADC must NOT have been called
+        mock_adc.assert_not_called()
+
+    def test_directory_path_as_credentials_file_raises(self, tmp_path):
+        """A directory path should fail the isfile check with a clear error."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        config = {
+            "provider": "vertex",
+            "vertex": {
+                "credentials_file": str(tmp_path),  # directory, not a file
+                "project_id": "test-project",
+            },
+        }
+
+        with pytest.raises(ValueError, match="credentials file not found"):
+            _generate_gemini_tts("Hello", str(tmp_path / "out.wav"), config, provider="vertex")
+
+
+class TestVertexMalformedConfigTypes:
+    """Verify non-dict configuration values for vertex/google_cloud don't crash."""
+
+    @pytest.mark.parametrize("vertex_val", [
+        True,
+        False,
+        [],
+        "true",
+        123,
+        None,
+    ])
+    def test_vertex_non_dict_config_does_not_crash(
+        self, tmp_path, vertex_val, mock_gemini_response
+    ):
+        """Various non-dict vertex config values must be handled safely."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        config = {"provider": "vertex", "vertex": vertex_val}
+
+        # vertex: False and vertex: None won't trigger use_vertex via bool(),
+        # but provider_name == "vertex" from the explicit provider arg will.
+        mock_creds = MagicMock()
+        mock_creds.token = "ya29.test"
+        mock_creds.project_id = "test-project"
+
+        with patch("google.auth.default", return_value=(mock_creds, "test-project")), \
+             patch("google.auth.transport.requests.Request"), \
+             patch("requests.post", return_value=mock_gemini_response):
+            result = _generate_gemini_tts(
+                "Test", str(tmp_path / "out.wav"), config, provider="vertex"
+            )
+        assert result == str(tmp_path / "out.wav")
+
+    def test_vertex_false_does_not_activate_vertex_when_provider_is_gemini(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        """vertex: false with provider: gemini should NOT activate Vertex mode."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"provider": "gemini", "vertex": False}
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hi", str(tmp_path / "out.wav"), config)
+
+        # Should use AI Studio (API key), not Vertex (Bearer token)
+        kwargs = mock_post.call_args[1]
+        assert kwargs["params"] is not None  # API key in params
+        assert kwargs["params"]["key"] == "test-key"
+        assert "Authorization" not in kwargs["headers"]
+
+
+class TestVertexSecretLeakage:
+    """Verify that sensitive credential content is never exposed in error messages."""
+
+    def test_sa_file_error_does_not_leak_private_key_or_exception_details(self, tmp_path):
+        """Credential loading errors must be safe and concise without leaking secret key material or arbitrary third-party exception text."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        key_file = tmp_path / "sa.json"
+        fake_secret_key = "FAKE_PRIVATE_KEY_DATA_12345"
+        key_file.write_text(
+            f'{{"type": "service_account", "private_key": "{fake_secret_key}"}}',
+            encoding="utf-8",
+        )
+
+        config = {
+            "provider": "vertex",
+            "vertex": {
+                "credentials_file": str(key_file),
+                "project_id": "test",
+            },
+        }
+
+        fake_exception_detail = "SENSITIVE_INTERNAL_EXCEPTION_DETAIL_999"
+        with patch(
+            "google.oauth2.service_account.Credentials.from_service_account_file",
+            side_effect=ValueError(fake_exception_detail),
+        ):
+            with pytest.raises(ValueError) as exc_info:
+                _generate_gemini_tts("Test", str(tmp_path / "out.wav"), config, provider="vertex")
+
+        error_text = str(exc_info.value)
+        assert fake_secret_key not in error_text
+        assert fake_exception_detail not in error_text
+        assert "Failed to load Vertex AI service account credentials from" in error_text
+
+    def test_bearer_token_not_in_error_on_api_failure(self, tmp_path):
+        """Bearer tokens must not appear in HTTP error messages."""
+        from tools.tts_tool import _generate_gemini_tts
+
+        config = {
+            "provider": "vertex",
+            "vertex": {"project_id": "test-project"},
+        }
+
+        mock_creds = MagicMock()
+        fake_access_token = "ya29.FAKE_ACCESS_TOKEN_VALUE_SECRET_987"
+        mock_creds.token = fake_access_token
+
+        error_response = MagicMock()
+        error_response.status_code = 403
+        error_response.iter_content = MagicMock(return_value=[b'{"error": {"message": "Permission denied"}}'])
+        error_response.headers = {"content-type": "application/json"}
+
+        with patch("google.auth.default", return_value=(mock_creds, "test-project")), \
+             patch("google.auth.transport.requests.Request"), \
+             patch("requests.post", return_value=error_response):
+            with pytest.raises(RuntimeError) as exc_info:
+                _generate_gemini_tts("Test", str(tmp_path / "out.wav"), config, provider="vertex")
+
+        error_text = str(exc_info.value)
+        assert fake_access_token not in error_text
 

--- a/tests/tools/test_tts_google_cloud.py
+++ b/tests/tools/test_tts_google_cloud.py
@@ -1,0 +1,255 @@
+"""Tests for the Google Cloud Text-to-Speech provider in tools/tts_tool.py."""
+
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+
+from tools.tts_tool import (
+    BUILTIN_TTS_PROVIDERS,
+    DEFAULT_GOOGLE_CLOUD_TTS_LANGUAGE,
+    DEFAULT_GOOGLE_CLOUD_TTS_VOICE,
+    PROVIDER_MAX_TEXT_LENGTH,
+    _generate_google_cloud_tts,
+    _list_google_cloud_voices,
+    _resolve_google_cloud_credentials,
+    check_tts_requirements,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in (
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "HERMES_SESSION_PLATFORM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def fake_audio_bytes():
+    return b"FAKE_MP3_AUDIO_DATA"
+
+
+@pytest.fixture
+def mock_tts_client(fake_audio_bytes):
+    client = MagicMock()
+    response = MagicMock()
+    response.audio_content = fake_audio_bytes
+    client.synthesize_speech.return_value = response
+
+    voice_mock = MagicMock()
+    voice_mock.name = "en-US-Chirp3-HD-Charon"
+    voice_mock.language_codes = ["en-US"]
+    voice_mock.ssml_gender = 1
+    voice_mock.natural_sample_rate_hertz = 24000
+
+    list_voices_resp = MagicMock()
+    list_voices_resp.voices = [voice_mock]
+    client.list_voices.return_value = list_voices_resp
+
+    return client
+
+
+class TestGoogleCloudProviderRegistration:
+    def test_in_builtin_providers(self):
+        assert "google_cloud" in BUILTIN_TTS_PROVIDERS
+
+    def test_max_text_length_defined(self):
+        assert "google_cloud" in PROVIDER_MAX_TEXT_LENGTH
+        assert PROVIDER_MAX_TEXT_LENGTH["google_cloud"] == 5000
+
+
+class TestResolveGoogleCloudCredentials:
+    def test_missing_credentials_raises_value_error(self):
+        with patch("google.auth.default", side_effect=Exception("No ADC")):
+            with pytest.raises(ValueError, match="Google Cloud TTS authentication failed"):
+                _resolve_google_cloud_credentials({})
+
+    def test_explicit_credentials_file_not_found_raises(self):
+        config = {"credentials_file": "/nonexistent/path/sa.json"}
+        with pytest.raises(ValueError, match="credentials file not found"):
+            _resolve_google_cloud_credentials(config)
+
+    def test_env_credentials_file_not_found_raises(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/nonexistent/path/sa.json")
+        with pytest.raises(ValueError, match="credentials file not found"):
+            _resolve_google_cloud_credentials({})
+
+    def test_adc_success(self):
+        mock_creds = MagicMock()
+        with patch("google.auth.default", return_value=(mock_creds, "test-project")):
+            creds = _resolve_google_cloud_credentials({})
+            assert creds == mock_creds
+
+    def test_valid_service_account_file(self, tmp_path):
+        key_file = tmp_path / "sa.json"
+        key_file.write_text('{"type": "service_account"}', encoding="utf-8")
+        mock_creds = MagicMock()
+        with patch(
+            "google.oauth2.service_account.Credentials.from_service_account_file",
+            return_value=mock_creds,
+        ):
+            creds = _resolve_google_cloud_credentials({"credentials_file": str(key_file)})
+            assert creds == mock_creds
+
+
+class TestGenerateGoogleCloudTts:
+    def test_default_synthesis_mp3(self, tmp_path, mock_tts_client, fake_audio_bytes):
+        output_path = str(tmp_path / "output.mp3")
+        mock_creds = MagicMock()
+
+        with patch("tools.tts_tool._resolve_google_cloud_credentials", return_value=mock_creds), \
+             patch("tools.tts_tool._import_google_cloud_tts") as mock_import:
+            mock_tts_module = MagicMock()
+            mock_tts_module.TextToSpeechClient.return_value = mock_tts_client
+            mock_import.return_value = mock_tts_module
+
+            result = _generate_google_cloud_tts("Hello world", output_path, {})
+
+        assert result == output_path
+        assert os.path.exists(output_path)
+        assert (tmp_path / "output.mp3").read_bytes() == fake_audio_bytes
+
+        # Verify API arguments
+        mock_tts_client.synthesize_speech.assert_called_once()
+        mock_tts_module.VoiceSelectionParams.assert_called_once_with(
+            language_code=DEFAULT_GOOGLE_CLOUD_TTS_LANGUAGE,
+            name=DEFAULT_GOOGLE_CLOUD_TTS_VOICE,
+        )
+
+    def test_custom_voice_and_language(self, tmp_path, mock_tts_client):
+        output_path = str(tmp_path / "output.mp3")
+        mock_creds = MagicMock()
+        config = {
+            "google_cloud": {
+                "voice": "en-US-Journey-F",
+                "language_code": "en-US",
+                "speaking_rate": 1.25,
+                "pitch": 2.0,
+            }
+        }
+
+        with patch("tools.tts_tool._resolve_google_cloud_credentials", return_value=mock_creds), \
+             patch("tools.tts_tool._import_google_cloud_tts") as mock_import:
+            mock_tts_module = MagicMock()
+            mock_tts_module.TextToSpeechClient.return_value = mock_tts_client
+            mock_import.return_value = mock_tts_module
+
+            _generate_google_cloud_tts("Testing custom voice", output_path, config)
+
+        mock_tts_module.VoiceSelectionParams.assert_called_once_with(
+            language_code="en-US",
+            name="en-US-Journey-F",
+        )
+
+    def test_ogg_opus_encoding_for_ogg_output(self, tmp_path, mock_tts_client):
+        output_path = str(tmp_path / "output.ogg")
+        mock_creds = MagicMock()
+
+        with patch("tools.tts_tool._resolve_google_cloud_credentials", return_value=mock_creds), \
+             patch("tools.tts_tool._import_google_cloud_tts") as mock_import:
+            mock_tts_module = MagicMock()
+            mock_tts_module.TextToSpeechClient.return_value = mock_tts_client
+            mock_import.return_value = mock_tts_module
+
+            _generate_google_cloud_tts("Testing OGG", output_path, {})
+
+        mock_tts_module.AudioConfig.assert_called()
+
+    def test_project_id_client_option(self, tmp_path, mock_tts_client):
+        output_path = str(tmp_path / "output.mp3")
+        mock_creds = MagicMock()
+        config = {"google_cloud": {"project_id": "my-custom-project"}}
+
+        with patch("tools.tts_tool._resolve_google_cloud_credentials", return_value=mock_creds), \
+             patch("tools.tts_tool._import_google_cloud_tts") as mock_import:
+            mock_tts_module = MagicMock()
+            mock_tts_module.TextToSpeechClient.return_value = mock_tts_client
+            mock_import.return_value = mock_tts_module
+
+            _generate_google_cloud_tts("Testing project", output_path, config)
+
+        mock_tts_module.TextToSpeechClient.assert_called_once_with(
+            credentials=mock_creds,
+            client_options={"quota_project_id": "my-custom-project"},
+        )
+
+    def test_permission_denied_error_handling(self, tmp_path):
+        output_path = str(tmp_path / "output.mp3")
+        mock_creds = MagicMock()
+        mock_client = MagicMock()
+        mock_client.synthesize_speech.side_effect = Exception("403 Cloud Text-to-Speech API PERMISSION_DENIED")
+
+        with patch("tools.tts_tool._resolve_google_cloud_credentials", return_value=mock_creds), \
+             patch("tools.tts_tool._import_google_cloud_tts") as mock_import:
+            mock_tts_module = MagicMock()
+            mock_tts_module.TextToSpeechClient.return_value = mock_client
+            mock_import.return_value = mock_tts_module
+
+            with pytest.raises(RuntimeError, match="Google Cloud TTS permission denied"):
+                _generate_google_cloud_tts("Hello", output_path, {})
+
+    def test_invalid_argument_error_handling(self, tmp_path):
+        output_path = str(tmp_path / "output.mp3")
+        mock_creds = MagicMock()
+        mock_client = MagicMock()
+        mock_client.synthesize_speech.side_effect = Exception("INVALID_ARGUMENT: voice not found")
+
+        with patch("tools.tts_tool._resolve_google_cloud_credentials", return_value=mock_creds), \
+             patch("tools.tts_tool._import_google_cloud_tts") as mock_import:
+            mock_tts_module = MagicMock()
+            mock_tts_module.TextToSpeechClient.return_value = mock_client
+            mock_import.return_value = mock_tts_module
+
+            with pytest.raises(RuntimeError, match="Google Cloud TTS invalid argument"):
+                _generate_google_cloud_tts("Hello", output_path, {})
+
+    def test_empty_audio_content_raises(self, tmp_path):
+        output_path = str(tmp_path / "output.mp3")
+        mock_creds = MagicMock()
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.audio_content = b""
+        mock_client.synthesize_speech.return_value = mock_resp
+
+        with patch("tools.tts_tool._resolve_google_cloud_credentials", return_value=mock_creds), \
+             patch("tools.tts_tool._import_google_cloud_tts") as mock_import:
+            mock_tts_module = MagicMock()
+            mock_tts_module.TextToSpeechClient.return_value = mock_client
+            mock_import.return_value = mock_tts_module
+
+            with pytest.raises(RuntimeError, match="empty audio data"):
+                _generate_google_cloud_tts("Hello", output_path, {})
+
+
+class TestListGoogleCloudVoices:
+    def test_list_voices_returns_structured_list(self, mock_tts_client):
+        mock_creds = MagicMock()
+
+        with patch("tools.tts_tool._resolve_google_cloud_credentials", return_value=mock_creds), \
+             patch("tools.tts_tool._import_google_cloud_tts") as mock_import:
+            mock_tts_module = MagicMock()
+            mock_tts_module.TextToSpeechClient.return_value = mock_tts_client
+            mock_tts_module.SsmlVoiceGender.return_value.name = "MALE"
+            mock_import.return_value = mock_tts_module
+
+            voices = _list_google_cloud_voices({}, language_code="en-US")
+
+        assert len(voices) == 1
+        assert voices[0]["name"] == "en-US-Chirp3-HD-Charon"
+        assert voices[0]["language_codes"] == ["en-US"]
+        assert voices[0]["gender"] == "MALE"
+
+
+class TestGoogleCloudInCheckRequirements:
+    def test_adc_available_satisfies_requirements(self):
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "google_cloud"}), \
+             patch("tools.tts_tool._import_google_cloud_tts"), \
+             patch("google.auth.default", return_value=(MagicMock(), "project")):
+            assert check_tts_requirements() is True
+
+    def test_no_credentials_fails(self):
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "google_cloud"}), \
+             patch("tools.tts_tool._import_google_cloud_tts"), \
+             patch("google.auth.default", side_effect=Exception("No ADC")):
+            assert check_tts_requirements() is False

--- a/tests/tools/test_tts_plugin_dispatch.py
+++ b/tests/tools/test_tts_plugin_dispatch.py
@@ -94,7 +94,7 @@ class TestBuiltinAlwaysWins:
     @pytest.mark.parametrize(
         "builtin",
         ["edge", "openai", "elevenlabs", "minimax", "gemini",
-         "mistral", "xai", "piper", "kittentts", "neutts"],
+         "mistral", "xai", "piper", "kittentts", "neutts", "deepinfra", "google_cloud", "vertex"],
     )
     def test_dispatcher_short_circuits_builtin(self, builtin):
         result = tts_tool._dispatch_to_plugin_provider(

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -140,6 +140,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tts.mistral": ("mistralai==2.4.8",),
     "tts.edge": ("edge-tts==7.2.7",),
     "tts.elevenlabs": ("elevenlabs==1.59.0",),
+    "tts.google_cloud": ("google-cloud-texttospeech>=2.24.0",),
 
     # ─── Speech-to-text providers ──────────────────────────────────────────
     "stt.mistral": ("mistralai==2.4.8",),

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -205,6 +205,25 @@ def _import_piper():
     return PiperVoice
 
 
+def _import_google_cloud_tts():
+    """Lazy import Google Cloud TTS client. Returns the module or raises ImportError.
+
+    Calls :func:`tools.lazy_deps.ensure` first so the ``google-cloud-texttospeech``
+    SDK gets installed on demand if the user picked Google Cloud as their TTS
+    provider but never ran the post-setup hook. Mirrors the ElevenLabs lazy-import
+    path.
+    """
+    try:
+        from tools.lazy_deps import ensure
+        ensure("tts.google_cloud", prompt=False)
+    except ImportError:
+        pass
+    except Exception:
+        pass
+    from google.cloud import texttospeech
+    return texttospeech
+
+
 # ===========================================================================
 # Defaults
 # ===========================================================================
@@ -254,6 +273,9 @@ DEFAULT_GEMINI_AUDIO_TAGS = False
 GEMINI_AUDIO_TAG_REWRITE_TASK = "tts_audio_tags"
 # Base URL now resolved via hermes_cli.models.deepinfra_base_url (shared).
 DEFAULT_DEEPINFRA_TTS_VOICE = "default"
+DEFAULT_GOOGLE_CLOUD_TTS_VOICE = "en-US-Chirp3-HD-Charon"
+DEFAULT_GOOGLE_CLOUD_TTS_LANGUAGE = "en-US"
+DEFAULT_GOOGLE_CLOUD_TTS_LOCATION = "global"
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -285,6 +307,8 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "google_cloud": 5000, # https://cloud.google.com/text-to-speech/quotas; practical sync cap
+    "vertex": 32000,      # Vertex AI Gemini TTS context window
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -789,6 +813,8 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "google_cloud",
+    "vertex",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -2605,36 +2631,57 @@ def _compose_gemini_tts_prompt(
     return f"{preamble}\n\n{persona_prompt}\n\n#### TRANSCRIPT\n{transcript}".strip()
 
 
-def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
-    """Generate audio using Google Gemini TTS.
+def _generate_gemini_tts(
+    text: str,
+    output_path: str,
+    tts_config: Dict[str, Any],
+    provider: Optional[str] = None,
+) -> str:
+    """Generate audio using Google Gemini TTS (Google AI Studio or Vertex AI).
 
     Gemini's generateContent endpoint with responseModalities=["AUDIO"] returns
     raw 24kHz mono 16-bit PCM (L16) as base64. We wrap it with a WAV RIFF
     header to produce a playable file, then ffmpeg-convert to MP3 / Opus if
     the caller requested those formats (same pattern as NeuTTS).
 
+    Supports:
+      1. Google AI Studio (API key authentication via GEMINI_API_KEY)
+      2. Google Cloud Vertex AI (OAuth / ADC authentication via project_id & credentials)
+
     Args:
         text: Text to convert (prompt-style; supports inline direction like
               "Say cheerfully:" and audio tags like [whispers]).
         output_path: Where to save the audio file (.wav, .mp3, or .ogg).
         tts_config: TTS config dict.
+        provider: Active provider name ("gemini" or "vertex").
 
     Returns:
         Path to the saved audio file.
     """
     import requests
 
+    raw_gemini_config = tts_config.get("gemini") or tts_config.get("vertex") or {}
+    gemini_config = raw_gemini_config if isinstance(raw_gemini_config, dict) else {}
+    provider_name = str(provider or tts_config.get("provider") or "").lower()
+
     api_key = (
         _resolve_provider_key("GEMINI_API_KEY", "gemini")
         or _resolve_provider_key("GOOGLE_API_KEY", "gemini")
     )
-    if not api_key:
+
+    use_vertex = (
+        provider_name == "vertex"
+        or bool(gemini_config.get("use_vertex"))
+        or bool(tts_config.get("vertex"))
+        or (bool(gemini_config.get("project_id")) and not api_key)
+    )
+
+    if not use_vertex and not api_key:
         raise ValueError(
-            "GEMINI_API_KEY not set. Get one at https://aistudio.google.com/app/apikey"
+            "GEMINI_API_KEY not set. Get one at https://aistudio.google.com/app/apikey "
+            "or configure Vertex AI credentials."
         )
 
-    raw_gemini_config = tts_config.get("gemini") or {}
-    gemini_config = raw_gemini_config if isinstance(raw_gemini_config, dict) else {}
     model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
     voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
     base_url = str(
@@ -2651,17 +2698,17 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         gemini_config,
         persona_prompt=persona_prompt,
     )
-    max_len = _resolve_max_text_length("gemini", tts_config)
+    max_len = _resolve_max_text_length("vertex" if use_vertex else "gemini", tts_config)
     if len(prompt_text) > max_len:
         raise ValueError(
             "Gemini TTS composed prompt exceeds the provider request limit "
             f"({len(prompt_text)} > {max_len} chars). Reduce the persona/audio-tag "
-            "prompt or lower tts.gemini.max_text_length so long-form text is "
+            "prompt or lower max_text_length so long-form text is "
             "split with enough prompt headroom."
         )
 
     payload: Dict[str, Any] = {
-        "contents": [{"parts": [{"text": prompt_text}]}],
+        "contents": [{"role": "user", "parts": [{"text": prompt_text}]}],
         "generationConfig": {
             "responseModalities": ["AUDIO"],
             "speechConfig": {
@@ -2672,23 +2719,86 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         },
     }
 
-    headers = {"Content-Type": "application/json"}
-    if urlparse(base_url).hostname == "generativelanguage.googleapis.com":
-        try:
-            import hermes_cli as _hermes_cli
+    if use_vertex:
+        # Vertex AI mode: Google Cloud ADC / Service Account OAuth authentication
+        import google.auth
+        import google.auth.transport.requests
 
-            _hermes_version = str(_hermes_cli.__version__)
-        except Exception:
-            _hermes_version = "0.0.0"
-        # Include Hermes client context following Gemini's partner
-        # integration guidance:
-        # https://ai.google.dev/gemini-api/docs/partner-integration
-        headers["X-Goog-Api-Client"] = f"hermes-agent/{_hermes_version}"
+        cred_file = str(
+            gemini_config.get("credentials_file")
+            or tts_config.get("vertex", {}).get("credentials_file")
+            or tts_config.get("google_cloud", {}).get("credentials_file")
+            or get_env_value("GOOGLE_APPLICATION_CREDENTIALS")
+            or ""
+        ).strip()
 
-    endpoint = f"{base_url}/models/{model}:generateContent"
+        if cred_file and os.path.isfile(cred_file):
+            from google.oauth2 import service_account
+            creds = service_account.Credentials.from_service_account_file(
+                cred_file,
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+            default_proj = getattr(creds, "project_id", None)
+        else:
+            try:
+                creds, default_proj = google.auth.default(
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                )
+            except Exception as e:
+                raise ValueError(
+                    "Vertex AI Gemini TTS authentication failed.\n\n"
+                    "No Google Application Default Credentials found.\n"
+                    "Run: gcloud auth application-default login\n"
+                    "Or set GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json"
+                ) from e
+
+        auth_req = google.auth.transport.requests.Request()
+        creds.refresh(auth_req)
+        token = creds.token
+
+        project_id = str(
+            gemini_config.get("project_id")
+            or tts_config.get("vertex", {}).get("project_id")
+            or tts_config.get("google_cloud", {}).get("project_id")
+            or default_proj
+            or get_env_value("GOOGLE_CLOUD_PROJECT")
+            or ""
+        ).strip()
+        if not project_id:
+            raise ValueError(
+                "Vertex AI project ID is required for Gemini TTS. "
+                "Set tts.vertex.project_id or tts.gemini.project_id in ~/.hermes/config.yaml."
+            )
+
+        location = str(
+            gemini_config.get("location")
+            or tts_config.get("vertex", {}).get("location")
+            or tts_config.get("google_cloud", {}).get("location")
+            or "global"
+        ).strip()
+        host = "aiplatform.googleapis.com" if location == "global" else f"{location}-aiplatform.googleapis.com"
+        endpoint = f"https://{host}/v1beta1/projects/{project_id}/locations/{location}/publishers/google/models/{model}:generateContent"
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        params = None
+    else:
+        # AI Studio mode: API key parameter
+        endpoint = f"{base_url}/models/{model}:generateContent"
+        headers = {"Content-Type": "application/json"}
+        if urlparse(base_url).hostname == "generativelanguage.googleapis.com":
+            try:
+                import hermes_cli as _hermes_cli
+                _hermes_version = str(_hermes_cli.__version__)
+            except Exception:
+                _hermes_version = "0.0.0"
+            headers["X-Goog-Api-Client"] = f"hermes-agent/{_hermes_version}"
+        params = {"key": api_key}
+
     response = requests.post(
         endpoint,
-        params={"key": api_key},
+        params=params,
         headers=headers,
         json=payload,
         timeout=60,
@@ -2776,6 +2886,267 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             pass
 
     return output_path
+
+
+# ===========================================================================
+# Google Cloud TTS (Chirp 3 HD, Journey, Neural2, Wavenet, etc.)
+# ===========================================================================
+
+def _resolve_google_cloud_credentials(gc_config: Dict[str, Any]):
+    """Resolve Google Cloud credentials for TTS.
+
+    Resolution order:
+      1. Explicit ``credentials_file`` in ``tts.google_cloud`` config
+      2. ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable
+      3. Application Default Credentials (``gcloud auth application-default login``)
+
+    Returns a ``google.auth.credentials.Credentials`` instance or raises
+    ``ValueError`` with an actionable message.
+    """
+    import google.auth
+
+    # 1. Explicit credentials file from config
+    cred_file = str(gc_config.get("credentials_file") or "").strip()
+    if not cred_file:
+        cred_file = str(get_env_value("GOOGLE_APPLICATION_CREDENTIALS") or "").strip()
+
+    if cred_file:
+        if not os.path.isfile(cred_file):
+            raise ValueError(
+                f"Google Cloud TTS credentials file not found: {cred_file}\n"
+                "Verify the path in tts.google_cloud.credentials_file or "
+                "GOOGLE_APPLICATION_CREDENTIALS."
+            )
+        from google.oauth2 import service_account
+        try:
+            credentials = service_account.Credentials.from_service_account_file(
+                cred_file,
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+            return credentials
+        except Exception as e:
+            raise ValueError(
+                f"Failed to load Google Cloud service account credentials "
+                f"from {cred_file}: {e}\n"
+                "Ensure the file is a valid service account JSON key."
+            ) from e
+
+    # 2. Application Default Credentials
+    try:
+        credentials, project = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+        return credentials
+    except Exception as e:
+        raise ValueError(
+            "Google Cloud TTS authentication failed.\n\n"
+            "No valid Google Application Default Credentials were found.\n"
+            "Configure credentials using one of these methods:\n\n"
+            "  1. Run: gcloud auth application-default login\n"
+            "  2. Set GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json\n"
+            "  3. Set tts.google_cloud.credentials_file in ~/.hermes/config.yaml\n\n"
+            "Also ensure the Cloud Text-to-Speech API is enabled in your "
+            "Google Cloud project:\n"
+            "  https://console.cloud.google.com/apis/library/"
+            "texttospeech.googleapis.com"
+        ) from e
+
+
+def _generate_google_cloud_tts(
+    text: str, output_path: str, tts_config: Dict[str, Any],
+) -> str:
+    """Generate audio using Google Cloud Text-to-Speech.
+
+    Uses the official ``google-cloud-texttospeech`` SDK which handles
+    authentication via Application Default Credentials (ADC) or a service
+    account JSON file.
+
+    Args:
+        text: Text to convert to speech.
+        output_path: Where to save the audio file (.mp3 or .ogg).
+        tts_config: TTS config dict (``tts:`` section from config.yaml).
+
+    Returns:
+        Path to the saved audio file.
+    """
+    texttospeech = _import_google_cloud_tts()
+
+    raw_gc_config = tts_config.get("google_cloud") or {}
+    gc_config = raw_gc_config if isinstance(raw_gc_config, dict) else {}
+
+    voice_name = (
+        str(gc_config.get("voice", DEFAULT_GOOGLE_CLOUD_TTS_VOICE)).strip()
+        or DEFAULT_GOOGLE_CLOUD_TTS_VOICE
+    )
+    language_code = (
+        str(gc_config.get("language_code", DEFAULT_GOOGLE_CLOUD_TTS_LANGUAGE)).strip()
+        or DEFAULT_GOOGLE_CLOUD_TTS_LANGUAGE
+    )
+
+    # Resolve credentials
+    credentials = _resolve_google_cloud_credentials(gc_config)
+
+    # Build client with resolved credentials
+    client_kwargs: Dict[str, Any] = {"credentials": credentials}
+    # Optional project override
+    project_id = str(gc_config.get("project_id") or "").strip()
+    if project_id:
+        client_kwargs["client_options"] = {"quota_project_id": project_id}
+
+    try:
+        client = texttospeech.TextToSpeechClient(**client_kwargs)
+    except Exception as e:
+        raise ValueError(
+            f"Failed to create Google Cloud TTS client: {e}\n"
+            "Ensure your credentials are valid and the Cloud Text-to-Speech "
+            "API is enabled."
+        ) from e
+
+    # Build synthesis request
+    synthesis_input = texttospeech.SynthesisInput(text=text)
+    voice_params = texttospeech.VoiceSelectionParams(
+        language_code=language_code,
+        name=voice_name,
+    )
+
+    # Select audio encoding based on output extension
+    if output_path.lower().endswith(".ogg"):
+        audio_encoding = texttospeech.AudioEncoding.OGG_OPUS
+    elif output_path.lower().endswith(".wav"):
+        audio_encoding = texttospeech.AudioEncoding.LINEAR16
+    else:
+        audio_encoding = texttospeech.AudioEncoding.MP3
+
+    audio_config = texttospeech.AudioConfig(audio_encoding=audio_encoding)
+
+    # Optional speaking rate
+    speaking_rate = gc_config.get("speaking_rate") or gc_config.get("speed")
+    if speaking_rate is not None:
+        try:
+            rate = float(speaking_rate)
+            # Google Cloud TTS accepts 0.25–4.0
+            rate = max(0.25, min(4.0, rate))
+            audio_config = texttospeech.AudioConfig(
+                audio_encoding=audio_encoding,
+                speaking_rate=rate,
+            )
+        except (ValueError, TypeError):
+            pass
+
+    # Optional pitch
+    pitch = gc_config.get("pitch")
+    if pitch is not None:
+        try:
+            pitch_val = float(pitch)
+            # Google Cloud TTS accepts -20.0 to 20.0
+            pitch_val = max(-20.0, min(20.0, pitch_val))
+            # Rebuild AudioConfig with pitch included
+            ac_kwargs: Dict[str, Any] = {
+                "audio_encoding": audio_encoding,
+                "pitch": pitch_val,
+            }
+            if speaking_rate is not None:
+                try:
+                    ac_kwargs["speaking_rate"] = max(0.25, min(4.0, float(speaking_rate)))
+                except (ValueError, TypeError):
+                    pass
+            audio_config = texttospeech.AudioConfig(**ac_kwargs)
+        except (ValueError, TypeError):
+            pass
+
+    # Synthesize
+    try:
+        response = client.synthesize_speech(
+            input=synthesis_input,
+            voice=voice_params,
+            audio_config=audio_config,
+        )
+    except Exception as e:
+        error_str = str(e)
+        # Provide actionable error messages for common failures
+        if "403" in error_str or "PERMISSION_DENIED" in error_str:
+            raise RuntimeError(
+                "Google Cloud TTS permission denied.\n\n"
+                "Ensure the Cloud Text-to-Speech API is enabled in your "
+                "Google Cloud project:\n"
+                "  https://console.cloud.google.com/apis/library/"
+                "texttospeech.googleapis.com\n\n"
+                "And that your credentials have the "
+                "'Cloud Text-to-Speech API User' role or equivalent."
+            ) from e
+        if "404" in error_str or "NOT_FOUND" in error_str:
+            raise RuntimeError(
+                f"Google Cloud TTS resource not found: {e}\n\n"
+                "Check that your project_id and voice name are correct.\n"
+                f"  Voice: {voice_name}\n"
+                f"  Language: {language_code}"
+            ) from e
+        if "INVALID_ARGUMENT" in error_str:
+            raise RuntimeError(
+                f"Google Cloud TTS invalid argument: {e}\n\n"
+                f"Check your voice and language configuration:\n"
+                f"  Voice: {voice_name}\n"
+                f"  Language: {language_code}\n\n"
+                "Use 'hermes' to list available voices, or see:\n"
+                "  https://cloud.google.com/text-to-speech/docs/voices"
+            ) from e
+        raise RuntimeError(
+            f"Google Cloud TTS synthesis failed: {e}"
+        ) from e
+
+    if not response.audio_content:
+        raise RuntimeError("Google Cloud TTS returned empty audio data")
+
+    with open(output_path, "wb") as f:
+        f.write(response.audio_content)
+
+    return output_path
+
+
+def _list_google_cloud_voices(
+    tts_config: Optional[Dict[str, Any]] = None,
+    language_code: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """List available Google Cloud TTS voices.
+
+    This is a utility function for future dynamic voice discovery. It calls
+    the Google Cloud TTS ``list_voices`` API and returns structured metadata.
+
+    Args:
+        tts_config: TTS config dict. If None, loads from config.yaml.
+        language_code: Optional BCP-47 language filter (e.g. ``"en-US"``).
+
+    Returns:
+        List of dicts with keys: name, language_codes, gender, sample_rate_hertz.
+    """
+    texttospeech = _import_google_cloud_tts()
+
+    if tts_config is None:
+        tts_config = _load_tts_config()
+    gc_config = tts_config.get("google_cloud") or {}
+    if not isinstance(gc_config, dict):
+        gc_config = {}
+
+    credentials = _resolve_google_cloud_credentials(gc_config)
+    client = texttospeech.TextToSpeechClient(credentials=credentials)
+
+    request_kwargs: Dict[str, Any] = {}
+    if language_code:
+        request_kwargs["language_code"] = language_code
+
+    response = client.list_voices(**request_kwargs)
+
+    voices: List[Dict[str, Any]] = []
+    for voice in response.voices:
+        gender_name = texttospeech.SsmlVoiceGender(voice.ssml_gender).name
+        voices.append({
+            "name": voice.name,
+            "language_codes": list(voice.language_codes),
+            "gender": gender_name,
+            "sample_rate_hertz": voice.natural_sample_rate_hertz,
+        })
+
+    return voices
 
 
 # ===========================================================================
@@ -3250,7 +3621,7 @@ def _text_to_speech_single(
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini", "google_cloud", "vertex"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -3337,9 +3708,21 @@ def _text_to_speech_single(
             logger.info("Generating speech with Mistral Voxtral TTS...")
             _generate_mistral_tts(text, file_str, tts_config)
 
-        elif provider == "gemini":
-            logger.info("Generating speech with Google Gemini TTS...")
-            _generate_gemini_tts(text, file_str, tts_config)
+        elif provider in ("gemini", "vertex"):
+            logger.info("Generating speech with %s TTS...", "Vertex AI Gemini" if provider == "vertex" else "Google Gemini")
+            _generate_gemini_tts(text, file_str, tts_config, provider=provider)
+
+        elif provider == "google_cloud":
+            try:
+                _import_google_cloud_tts()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "Google Cloud TTS provider selected but 'google-cloud-texttospeech' "
+                             "package not installed. Run: pip install google-cloud-texttospeech"
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Google Cloud TTS...")
+            _generate_google_cloud_tts(text, file_str, tts_config)
 
         elif provider == "neutts":
             if not _check_neutts_available():
@@ -3457,7 +3840,7 @@ def _text_to_speech_single(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
+        elif provider in {"elevenlabs", "openai", "mistral", "gemini", "google_cloud", "vertex"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)
@@ -3606,7 +3989,7 @@ def text_to_speech_tool(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             base_path = out_dir / f"tts_{timestamp}.{fmt}"
-        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini", "google_cloud", "vertex"}:
             base_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             base_path = out_dir / f"tts_{timestamp}.mp3"
@@ -3760,11 +4143,15 @@ def check_tts_requirements() -> bool:
             return bool(resolve_xai_http_credentials().get("api_key"))
         except Exception:
             return False
-    if provider == "gemini":
-        return bool(
-            _resolve_provider_key("GEMINI_API_KEY", "gemini")
-            or _resolve_provider_key("GOOGLE_API_KEY", "gemini")
-        )
+    if provider in ("gemini", "vertex"):
+        if _resolve_provider_key("GEMINI_API_KEY", "gemini") or _resolve_provider_key("GOOGLE_API_KEY", "gemini"):
+            return True
+        try:
+            import google.auth
+            google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+            return True
+        except Exception:
+            return False
     if provider == "mistral":
         try:
             _import_mistral_client()
@@ -3777,6 +4164,19 @@ def check_tts_requirements() -> bool:
         return _check_kittentts_available()
     if provider == "piper":
         return _check_piper_available()
+    if provider == "google_cloud":
+        try:
+            _import_google_cloud_tts()
+        except ImportError:
+            return False
+        try:
+            import google.auth
+            google.auth.default(
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+            return True
+        except Exception:
+            return False
 
     try:
         from agent.tts_registry import get_provider

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2660,8 +2660,13 @@ def _generate_gemini_tts(
     """
     import requests
 
-    raw_gemini_config = tts_config.get("gemini") or tts_config.get("vertex") or {}
-    gemini_config = raw_gemini_config if isinstance(raw_gemini_config, dict) else {}
+    raw_gemini = tts_config.get("gemini")
+    raw_vertex = tts_config.get("vertex")
+    raw_gc = tts_config.get("google_cloud")
+
+    gemini_config = raw_gemini if isinstance(raw_gemini, dict) else (raw_vertex if isinstance(raw_vertex, dict) else {})
+    vertex_cfg = raw_vertex if isinstance(raw_vertex, dict) else {}
+    gc_cfg = raw_gc if isinstance(raw_gc, dict) else {}
     provider_name = str(provider or tts_config.get("provider") or "").lower()
 
     api_key = (
@@ -2674,6 +2679,7 @@ def _generate_gemini_tts(
         or bool(gemini_config.get("use_vertex"))
         or bool(tts_config.get("vertex"))
         or (bool(gemini_config.get("project_id")) and not api_key)
+        or (bool(vertex_cfg.get("project_id")) and not api_key)
     )
 
     if not use_vertex and not api_key:
@@ -2726,19 +2732,34 @@ def _generate_gemini_tts(
 
         cred_file = str(
             gemini_config.get("credentials_file")
-            or tts_config.get("vertex", {}).get("credentials_file")
-            or tts_config.get("google_cloud", {}).get("credentials_file")
+            or vertex_cfg.get("credentials_file")
+            or gc_cfg.get("credentials_file")
             or get_env_value("GOOGLE_APPLICATION_CREDENTIALS")
             or ""
         ).strip()
+        if cred_file:
+            cred_file = os.path.expanduser(cred_file)
 
-        if cred_file and os.path.isfile(cred_file):
+        default_proj = None
+        if cred_file:
+            if not os.path.isfile(cred_file):
+                raise ValueError(
+                    f"Vertex AI Gemini TTS credentials file not found: {cred_file}\n"
+                    "Verify the path in tts.vertex.credentials_file, "
+                    "tts.gemini.credentials_file, or GOOGLE_APPLICATION_CREDENTIALS."
+                )
             from google.oauth2 import service_account
-            creds = service_account.Credentials.from_service_account_file(
-                cred_file,
-                scopes=["https://www.googleapis.com/auth/cloud-platform"],
-            )
-            default_proj = getattr(creds, "project_id", None)
+            try:
+                creds = service_account.Credentials.from_service_account_file(
+                    cred_file,
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"],
+                )
+                default_proj = getattr(creds, "project_id", None)
+            except Exception as e:
+                raise ValueError(
+                    f"Failed to load Vertex AI service account credentials from {cred_file}.\n"
+                    "Ensure the file is a valid service account JSON key."
+                ) from e
         else:
             try:
                 creds, default_proj = google.auth.default(
@@ -2758,8 +2779,8 @@ def _generate_gemini_tts(
 
         project_id = str(
             gemini_config.get("project_id")
-            or tts_config.get("vertex", {}).get("project_id")
-            or tts_config.get("google_cloud", {}).get("project_id")
+            or vertex_cfg.get("project_id")
+            or gc_cfg.get("project_id")
             or default_proj
             or get_env_value("GOOGLE_CLOUD_PROJECT")
             or ""
@@ -2772,9 +2793,9 @@ def _generate_gemini_tts(
 
         location = str(
             gemini_config.get("location")
-            or tts_config.get("vertex", {}).get("location")
-            or tts_config.get("google_cloud", {}).get("location")
-            or "global"
+            or vertex_cfg.get("location")
+            or gc_cfg.get("location")
+            or DEFAULT_GOOGLE_CLOUD_TTS_LOCATION
         ).strip()
         host = "aiplatform.googleapis.com" if location == "global" else f"{location}-aiplatform.googleapis.com"
         endpoint = f"https://{host}/v1beta1/projects/{project_id}/locations/{location}/publishers/google/models/{model}:generateContent"
@@ -2909,6 +2930,8 @@ def _resolve_google_cloud_credentials(gc_config: Dict[str, Any]):
     cred_file = str(gc_config.get("credentials_file") or "").strip()
     if not cred_file:
         cred_file = str(get_env_value("GOOGLE_APPLICATION_CREDENTIALS") or "").strip()
+    if cred_file:
+        cred_file = os.path.expanduser(cred_file)
 
     if cred_file:
         if not os.path.isfile(cred_file):
@@ -2927,7 +2950,7 @@ def _resolve_google_cloud_credentials(gc_config: Dict[str, Any]):
         except Exception as e:
             raise ValueError(
                 f"Failed to load Google Cloud service account credentials "
-                f"from {cred_file}: {e}\n"
+                f"from {cred_file}.\n"
                 "Ensure the file is a valid service account JSON key."
             ) from e
 
@@ -3017,42 +3040,26 @@ def _generate_google_cloud_tts(
     else:
         audio_encoding = texttospeech.AudioEncoding.MP3
 
-    audio_config = texttospeech.AudioConfig(audio_encoding=audio_encoding)
+    # Build AudioConfig with normalized kwargs
+    ac_kwargs: Dict[str, Any] = {"audio_encoding": audio_encoding}
 
-    # Optional speaking rate
+    # Optional speaking rate (0.25 - 4.0)
     speaking_rate = gc_config.get("speaking_rate") or gc_config.get("speed")
     if speaking_rate is not None:
         try:
-            rate = float(speaking_rate)
-            # Google Cloud TTS accepts 0.25–4.0
-            rate = max(0.25, min(4.0, rate))
-            audio_config = texttospeech.AudioConfig(
-                audio_encoding=audio_encoding,
-                speaking_rate=rate,
-            )
+            ac_kwargs["speaking_rate"] = max(0.25, min(4.0, float(speaking_rate)))
         except (ValueError, TypeError):
             pass
 
-    # Optional pitch
+    # Optional pitch (-20.0 - 20.0)
     pitch = gc_config.get("pitch")
     if pitch is not None:
         try:
-            pitch_val = float(pitch)
-            # Google Cloud TTS accepts -20.0 to 20.0
-            pitch_val = max(-20.0, min(20.0, pitch_val))
-            # Rebuild AudioConfig with pitch included
-            ac_kwargs: Dict[str, Any] = {
-                "audio_encoding": audio_encoding,
-                "pitch": pitch_val,
-            }
-            if speaking_rate is not None:
-                try:
-                    ac_kwargs["speaking_rate"] = max(0.25, min(4.0, float(speaking_rate)))
-                except (ValueError, TypeError):
-                    pass
-            audio_config = texttospeech.AudioConfig(**ac_kwargs)
+            ac_kwargs["pitch"] = max(-20.0, min(20.0, float(pitch)))
         except (ValueError, TypeError):
             pass
+
+    audio_config = texttospeech.AudioConfig(**ac_kwargs)
 
     # Synthesize
     try:
@@ -4146,6 +4153,22 @@ def check_tts_requirements() -> bool:
     if provider in ("gemini", "vertex"):
         if _resolve_provider_key("GEMINI_API_KEY", "gemini") or _resolve_provider_key("GOOGLE_API_KEY", "gemini"):
             return True
+        raw_gemini = tts_config.get("gemini")
+        gemini_cfg = raw_gemini if isinstance(raw_gemini, dict) else {}
+        raw_vertex = tts_config.get("vertex")
+        vertex_cfg = raw_vertex if isinstance(raw_vertex, dict) else {}
+        raw_gc = tts_config.get("google_cloud")
+        gc_cfg = raw_gc if isinstance(raw_gc, dict) else {}
+        cred_file = str(
+            gemini_cfg.get("credentials_file")
+            or vertex_cfg.get("credentials_file")
+            or gc_cfg.get("credentials_file")
+            or get_env_value("GOOGLE_APPLICATION_CREDENTIALS")
+            or ""
+        ).strip()
+        if cred_file:
+            cred_file = os.path.expanduser(cred_file)
+            return os.path.isfile(cred_file)
         try:
             import google.auth
             google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
@@ -4169,6 +4192,16 @@ def check_tts_requirements() -> bool:
             _import_google_cloud_tts()
         except ImportError:
             return False
+        raw_gc = tts_config.get("google_cloud")
+        gc_cfg = raw_gc if isinstance(raw_gc, dict) else {}
+        cred_file = str(
+            gc_cfg.get("credentials_file")
+            or get_env_value("GOOGLE_APPLICATION_CREDENTIALS")
+            or ""
+        ).strip()
+        if cred_file:
+            cred_file = os.path.expanduser(cred_file)
+            return os.path.isfile(cred_file)
         try:
             import google.auth
             google.auth.default(

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,16 +14,18 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with eleven providers:
+Convert text to speech with thirteen providers:
 
-| Provider | Quality | Cost | API Key |
-|----------|---------|------|---------|
+| Provider | Quality | Cost | API Key / Auth |
+|----------|---------|------|----------------|
 | **Edge TTS** (default) | Good | Free | None needed |
 | **ElevenLabs** | Excellent | Paid | `ELEVENLABS_API_KEY` |
 | **OpenAI TTS** | Good | Paid | `VOICE_TOOLS_OPENAI_KEY` |
 | **MiniMax TTS** | Excellent | Paid | `MINIMAX_API_KEY` or `MINIMAX_CN_API_KEY` |
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
-| **Google Gemini TTS** | Excellent | Free tier | `GEMINI_API_KEY` |
+| **Google Gemini TTS (AI Studio)** | Excellent | Free tier | `GEMINI_API_KEY` |
+| **Vertex AI Gemini TTS** | Excellent | Paid / Cloud | Google Cloud ADC / Service Account |
+| **Google Cloud TTS (Chirp 3 HD)** | Excellent | Paid | Google Cloud credentials / ADC |
 | **xAI TTS** | Excellent | Paid | `XAI_API_KEY` |
 | **DeepInfra TTS** | Good | Paid | `DEEPINFRA_API_KEY` |
 | **NeuTTS** | Good | Free (local) | None needed |
@@ -103,6 +105,13 @@ tts:
     # noise_w_scale: 0.8
     # volume: 1.0                               # 0.5 = half as loud
     # normalize_audio: true
+  google_cloud:
+    voice: "en-US-Chirp3-HD-Charon"             # e.g. en-US-Journey-F, en-US-Neural2-F
+    language_code: "en-US"                      # BCP-47 language code
+    project_id: ""                              # Optional: GCP project ID override
+    speaking_rate: 1.0                          # 0.25 - 4.0
+    pitch: 0.0                                  # -20.0 - 20.0
+    credentials_file: ""                        # Optional: path to service account JSON
 ```
 
 MiniMax TTS selects its region, endpoint, and credential together:
@@ -127,6 +136,30 @@ tts:
     voice: Algieba
     persona_prompt_file: ~/.hermes/tts/butler-voice.md
 ```
+
+### Google Cloud TTS (Chirp 3 HD, Journey, Neural2)
+
+Google Cloud Text-to-Speech provides studio-grade neural voices including Chirp 3 HD, Journey, Studio, and Neural2 families across 50+ languages.
+
+#### Setup & Authentication
+
+1. Enable the **Cloud Text-to-Speech API** in the [Google Cloud Console](https://console.cloud.google.com/apis/library/texttospeech.googleapis.com).
+2. Authenticate using either:
+   - **Application Default Credentials (ADC)** (recommended for local development):
+     ```bash
+     gcloud auth application-default login
+     ```
+   - **Service Account JSON**: Set `GOOGLE_APPLICATION_CREDENTIALS` in your `.env` or set `credentials_file` in `config.yaml`.
+
+```yaml
+tts:
+  provider: google_cloud
+  google_cloud:
+    voice: "en-US-Chirp3-HD-Charon"
+    language_code: "en-US"
+    speaking_rate: 1.0
+```
+
 
 ### Audio Tags (Gemini, xAI)
 


### PR DESCRIPTION
## Summary
Adds native built-in support for **Google Cloud Vertex AI Gemini Text-to-Speech** (`gemini-2.5-flash-preview-tts`, `gemini-2.5-flash-lite-preview-tts`, and `gemini-3.1-flash-tts-preview`) to Hermes Agent.

This enables users with Google Cloud enterprise environments and Application Default Credentials (ADC) to generate high-fidelity, human-like generative speech using all 30 celestial voices with prompt steerability and expressive audio tags.

---

## Key Changes

### 1. Vertex AI Gemini TTS Engine (`tools/tts_tool.py` & `agent/tts_registry.py`)
- **Dual Authentication:** Supports Google Cloud Vertex AI OAuth 2.0 / Application Default Credentials (`gcloud auth application-default login`) and Service Account JSON files in addition to Google AI Studio API keys.
- **30 Celestial Voices:** Full support for *Kore*, *Puck*, *Fenrir*, *Aoede*, *Zephyr*, *Charon*, etc.
- **Steerability & Acting Tags:** Supports natural voice direction, persona files, and expressive audio tags (`[whispers]`, `[laughs]`, `[sighs]`).
- **Platform Delivery:** Built-in Opus `.ogg` and `.mp3` encoding for Telegram voice bubbles and attachments.
- **Registry & Dispatch:** Registered `vertex` in `BUILTIN_TTS_PROVIDERS` and `_BUILTIN_NAMES` to protect precedence and plugin dispatch.

### 2. CLI Setup & Configuration (`hermes_cli/setup.py`, `tools_config.py`)
- Added **Vertex AI Gemini TTS** to the interactive `hermes setup tts` wizard with automatic ADC detection, service account fallback prompt, and project/voice configuration.
- Updated `cli-config.yaml.example`, `.env.example`, and `website/docs/user-guide/features/tts.md`.

### 3. Windows Audio Delivery & Gateway Hardening
- **Path Normalization (`gateway/platforms/base.py`):** Added automatic translation of MSYS/Git-Bash Unix drive paths (`/c/Users/...` -> `C:/Users/...`) on Windows to prevent voice attachments from being dropped.
- **Gateway Spawner (`hermes_cli/gateway_windows.py`):** Hardened `VIRTUAL_ENV` environment variable overlay on Windows so it only injects when a valid `pyvenv.cfg` is present.

---

## Verification & Tests

### Automated Unit Tests
Ran the full test suite across all TTS providers, registry sync, and new Vertex AI paths:

```bash
python -m pytest tests/tools/test_tts_google_cloud.py tests/tools/test_tts_gemini.py tests/tools/test_tts_max_text_length.py tests/tools/test_tts_opus_routing.py tests/tools/test_tts_plugin_dispatch.py tests/agent/test_tts_registry.py -v

Result: 94 passed (100% pass rate).

Live End-to-End Verification
Verified live audio synthesis on Vertex AI with gemini-2.5-flash-preview-tts and Kore voice.
Verified delivery to Telegram as inline playable voice notes.