### PR TITLE
fix(cron): normalize id-keyed jobs stores on load

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1313,6 +1313,8 @@ def load_jobs() -> List[Dict[str, Any]]:
     # down the whole cron subsystem.
     if isinstance(data, dict):
         jobs = data.get("jobs", [])
+        if isinstance(jobs, dict):
+            jobs = list(jobs.values())
         if _strict_retry and jobs:
             # Hit control-character corruption — rewrite with proper escaping.
             save_jobs(jobs)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1189,6 +1189,50 @@ class TestLateEnvRepointScopesStore:
 # UTF-8 BOM on jobs.json (Windows Notepad / PowerShell 5.1)
 # =========================================================================
 
+class TestJobsJsonShapes:
+    def test_load_jobs_normalizes_id_keyed_jobs_mapping(self, tmp_cron_dir):
+        import json
+        from cron.jobs import JOBS_FILE
+
+        job_a = {
+            "id": "cron1234abcd",
+            "name": "daily briefing",
+            "enabled": True,
+            "prompt": "Summarize overnight incidents",
+            "schedule": {"kind": "interval", "minutes": 1440, "display": "every 24h"},
+        }
+        job_b = {
+            "id": "cron5678efgh",
+            "name": "disabled cleanup",
+            "enabled": False,
+            "prompt": "Clean stale scratch files",
+            "schedule": {"kind": "once", "run_at": "2030-01-15T14:00:00+00:00"},
+        }
+        payload = {
+            "jobs": {
+                job_a["id"]: job_a,
+                job_b["id"]: job_b,
+            },
+            "updated_at": "2026-08-23T00:00:00+00:00",
+        }
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(payload), encoding="utf-8")
+
+        loaded = load_jobs()
+        assert isinstance(loaded, list)
+        assert {job["id"] for job in loaded} == {job_a["id"], job_b["id"]}
+
+        listed = {job["id"]: job for job in list_jobs(include_disabled=True)}
+        assert set(listed) == {job_a["id"], job_b["id"]}
+        for expected in (job_a, job_b):
+            actual = listed[expected["id"]]
+            assert actual["id"] == expected["id"]
+            assert actual["name"] == expected["name"]
+            assert actual["prompt"] == expected["prompt"]
+            assert actual["schedule"] == expected["schedule"]
+            assert actual["enabled"] is expected["enabled"]
+
+
 class TestJobsJsonUtf8Bom:
     """jobs.json readers must accept a leading UTF-8 BOM.
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

- Normalize `{"jobs": {job_id: job}}` cron stores in `load_jobs()` so the public API always returns a list.
- Keep the compatibility fix at the load boundary without changing downstream cron CRUD or scheduler paths.
- Add regression coverage for ID-keyed `jobs.json` stores and `list_jobs(include_disabled=True)`.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #92935

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Updated `cron/jobs.py` so `load_jobs()` normalizes ID-keyed cron stores shaped as `{"jobs": {job_id: job_record}}` into the documented `List[Dict[str, Any]]` return type.
- Added a regression test in `tests/cron/test_jobs.py` covering ID-keyed `jobs.json` stores and verifying `list_jobs(include_disabled=True)` preserves job fields without raising.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Write a cron store shaped as `{"jobs": {"cron1234abcd": {...}, "cron5678efgh": {...}}, "updated_at": "..."}` to `cron/jobs.json`.
2. Run `load_jobs()` and verify it returns a list whose job IDs match the mapped records.
3. Run `list_jobs(include_disabled=True)` and verify it does not raise and preserves fields like `id`, `name`, `prompt`, `schedule`, and `enabled`.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

