### PR TITLE
fix(agent): strip OpenRouter-only reasoning_details for strict proxies

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -63,6 +63,7 @@ from agent.message_sanitization import (
     _strip_images_from_messages,
     _strip_non_ascii,
     serialized_messages_bytes,
+    strip_reasoning_details_for_non_openrouter,
 )
 # Must mirror _STALE_TOOL_CALL_MARKER_RE in hermes_state.py — kept local
 # to avoid importing hermes_state at module load time (its module-level
@@ -2381,6 +2382,21 @@ def run_conversation(
             # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
             # The signature field helps maintain reasoning continuity
             api_messages.append(api_msg)
+
+        # Reconcile OpenRouter-only 'reasoning_details' against the active
+        # provider. OpenRouter emits it on reasoning turns and consumes it
+        # back for continuity (kept verbatim above, line ~2317); it is NOT
+        # standard Chat Completions schema, so strict proxies reject it. The
+        # observed failure is the Palantir Foundry LLM proxy 400-ing with
+        # 'unrecognizedProperty=reasoning_details' after a session mixes an
+        # OpenRouter reasoning turn into history and then routes to Palantir —
+        # the session then loops on the 400 until /new. Strip from the
+        # outgoing API copy for every non-OpenRouter provider (history keeps
+        # the field, so a switch back to OpenRouter still has it).
+        _is_or_provider = (agent.provider or "").strip().lower() == "openrouter" or (
+            agent._is_openrouter_url()
+        )
+        strip_reasoning_details_for_non_openrouter(api_messages, _is_or_provider)
 
         # Build the final system message: cached prompt + ephemeral system prompt.
         # Ephemeral additions are API-call-time only (not persisted to session DB).

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2383,20 +2383,19 @@ def run_conversation(
             # The signature field helps maintain reasoning continuity
             api_messages.append(api_msg)
 
-        # Reconcile OpenRouter-only 'reasoning_details' against the active
-        # provider. OpenRouter emits it on reasoning turns and consumes it
-        # back for continuity (kept verbatim above, line ~2317); it is NOT
-        # standard Chat Completions schema, so strict proxies reject it. The
-        # observed failure is the Palantir Foundry LLM proxy 400-ing with
-        # 'unrecognizedProperty=reasoning_details' after a session mixes an
-        # OpenRouter reasoning turn into history and then routes to Palantir —
-        # the session then loops on the 400 until /new. Strip from the
-        # outgoing API copy for every non-OpenRouter provider (history keeps
-        # the field, so a switch back to OpenRouter still has it).
-        _is_or_provider = (agent.provider or "").strip().lower() == "openrouter" or (
-            agent._is_openrouter_url()
-        )
-        strip_reasoning_details_for_non_openrouter(api_messages, _is_or_provider)
+        # NOTE: OpenRouter-only 'reasoning_details' is deliberately NOT
+        # reconciled here. OpenRouter emits it on reasoning turns and consumes
+        # it back for continuity (kept verbatim in the assistant branch
+        # above); it is NOT standard Chat Completions schema, so strict
+        # proxies reject it with 400 unrecognizedProperty (observed on the
+        # Palantir Foundry LLM proxy — session loops on the 400 until /new).
+        # Which side wins depends on the provider that actually serves each
+        # request, and mid-retry fallback can switch that provider AFTER this
+        # point — so the reconcile runs per attempt inside the retry loop,
+        # right next to _reapply_reasoning_echo_for_provider (same
+        # built-once-vs-current-provider staleness class as that pad and the
+        # #72626 prompt-cache redecoration). History keeps the field, so a
+        # later switch back to OpenRouter still finds it.
 
         # Build the final system message: cached prompt + ephemeral system prompt.
         # Ephemeral additions are API-call-time only (not persisted to session DB).
@@ -2996,6 +2995,16 @@ def run_conversation(
                 # unless the active provider needs it) so the fallback request
                 # isn't sent with stale, primary-shaped reasoning fields.
                 agent._reapply_reasoning_echo_for_provider(api_messages)
+                # Same staleness class: OpenRouter-only 'reasoning_details'
+                # must be reconciled against the provider serving THIS attempt
+                # (mid-retry fallback can have just switched it). Recompute the
+                # OpenRouter flag from the live agent state each iteration;
+                # idempotent, O(n), history keeps the field for a switch back.
+                strip_reasoning_details_for_non_openrouter(
+                    api_messages,
+                    (agent.provider or "").strip().lower() == "openrouter"
+                    or agent._is_openrouter_url(),
+                )
                 # Same story for prompt-cache decoration (#72626): try_activate_
                 # fallback refreshes the policy flags, but the decorated list
                 # still carries the primary's breakpoints (or none). Strip and

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -1033,6 +1033,49 @@ def reapply_reasoning_echo(api_messages: list, needs_thinking_pad: bool) -> int:
     return changed
 
 
+def strip_reasoning_details_for_non_openrouter(
+    api_messages: list, is_openrouter: bool
+) -> int:
+    """Strip ``reasoning_details`` from assistant turns for non-OpenRouter APIs.
+
+    ``reasoning_details`` is an OpenRouter-specific field: OpenRouter emits it
+    on reasoning-model turns and consumes it back on the next turn to maintain
+    reasoning continuity (``chat_completion_helpers`` preserves it verbatim for
+    exactly this).  It is NOT part of the standard Chat Completions schema.
+
+    Strict OpenAI-compatible endpoints validate the schema and reject the
+    unknown field.  The one observed in the wild is the Palantir Foundry LLM
+    proxy (``LanguageModelService``), whose GPT/Gemini endpoints 400 with
+    ``INVALID_ARGUMENT ... unrecognizedProperty=reasoning_details`` when a
+    session mixes an OpenRouter reasoning turn into history and then routes a
+    request to Palantir — the session then loops on the 400 until ``/new``.
+    Mistral, Fireworks, and other strict Chat Completions proxies are the same
+    field-rejection class.
+
+    ``api_messages`` is built once before the retry loop while the *primary*
+    provider is active; a mid-conversation fallback can switch providers, so
+    the field baked in for a prior OpenRouter turn must be reconciled against
+    the *current* provider.  Only OpenRouter should carry it on the wire; every
+    other provider gets it stripped from the outgoing API copy (the internal
+    history keeps it, so a later switch back to OpenRouter still has it).
+
+    Idempotent and safe to call every iteration.  Returns the number of
+    assistant turns whose ``reasoning_details`` was removed.
+    """
+    if is_openrouter:
+        return 0
+    removed = 0
+    for api_msg in api_messages:
+        if not isinstance(api_msg, dict):
+            continue
+        if api_msg.get("role") != "assistant":
+            continue
+        if "reasoning_details" in api_msg:
+            api_msg.pop("reasoning_details", None)
+            removed += 1
+    return removed
+
+
 # ---------------------------------------------------------------------------
 # Image / multimodal parts — evaluated, NOT consolidated (verdict: syntax)
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_message_sanitization_policy.py
+++ b/tests/agent/test_message_sanitization_policy.py
@@ -478,3 +478,68 @@ class TestPerProviderReasoningEcho:
         api_msg = {"role": "assistant", "content": "hi"}
         apply_reasoning_content_policy(source, api_msg, needs_thinking_pad=False)
         assert "reasoning_content" not in api_msg
+
+
+# ---------------------------------------------------------------------------
+# strip_reasoning_details_for_non_openrouter — OpenRouter-only field guard
+# ---------------------------------------------------------------------------
+
+class TestStripReasoningDetails:
+    """reasoning_details is OpenRouter-specific; strict proxies (Palantir
+    Foundry LLM, Mistral, Fireworks) 400 on it. Keep it only for OpenRouter,
+    strip it from the outgoing copy for every other provider."""
+
+    def _history(self):
+        # An OpenRouter reasoning turn mixed into history, then a plain turn.
+        return [
+            {"role": "user", "content": "ahoj"},
+            {
+                "role": "assistant",
+                "content": "Zdravim.",
+                "reasoning_details": [
+                    {"type": "reasoning.text", "text": "user pozdravil", "format": "unknown"}
+                ],
+            },
+            {"role": "user", "content": "co je 2+2?"},
+        ]
+
+    def test_strips_for_non_openrouter(self):
+        """Palantir/strict provider: the field must be gone from the wire copy."""
+        from agent.message_sanitization import strip_reasoning_details_for_non_openrouter
+        msgs = self._history()
+        removed = strip_reasoning_details_for_non_openrouter(msgs, is_openrouter=False)
+        assert removed == 1
+        assert all("reasoning_details" not in m for m in msgs)
+
+    def test_preserves_for_openrouter(self):
+        """OpenRouter consumes the field back for reasoning continuity — keep it."""
+        from agent.message_sanitization import strip_reasoning_details_for_non_openrouter
+        msgs = self._history()
+        removed = strip_reasoning_details_for_non_openrouter(msgs, is_openrouter=True)
+        assert removed == 0
+        assert msgs[1]["reasoning_details"]  # untouched
+
+    def test_idempotent_and_noop_when_absent(self):
+        """Safe to call every iteration; no-op when no assistant turn carries it."""
+        from agent.message_sanitization import strip_reasoning_details_for_non_openrouter
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        assert strip_reasoning_details_for_non_openrouter(msgs, is_openrouter=False) == 0
+        # Second pass after a real strip stays a no-op.
+        hist = self._history()
+        strip_reasoning_details_for_non_openrouter(hist, is_openrouter=False)
+        assert strip_reasoning_details_for_non_openrouter(hist, is_openrouter=False) == 0
+
+    def test_only_touches_assistant_turns(self):
+        """A stray reasoning_details on a non-assistant row is left alone."""
+        from agent.message_sanitization import strip_reasoning_details_for_non_openrouter
+        msgs = [
+            {"role": "user", "content": "hi", "reasoning_details": [{"x": 1}]},
+            {"role": "assistant", "content": "yo", "reasoning_details": [{"y": 2}]},
+        ]
+        removed = strip_reasoning_details_for_non_openrouter(msgs, is_openrouter=False)
+        assert removed == 1
+        assert "reasoning_details" in msgs[0]  # user row untouched
+        assert "reasoning_details" not in msgs[1]  # assistant row stripped


### PR DESCRIPTION
## Problem

A session that mixes an **OpenRouter reasoning-model turn** into history and then routes a request to a **strict OpenAI-compatible proxy** loops on HTTP 400 until the user runs `/new`.

Observed in the field against the Palantir Foundry LLM proxy (`LanguageModelService`), whose GPT/Gemini (`chat_completions`) endpoints reject the request:

```
400 INVALID_ARGUMENT
"unsafeParams": {"unrecognizedProperty=reasoning_details"}
"message": "Request contained an unrecognized field"
```

Repro shape:
1. A reasoning model via OpenRouter (e.g. a stealth/reasoning model) answers a turn → its response carries `reasoning_details`, which Hermes stores and keeps in history.
2. The user switches the session to a strict proxy (Palantir GPT/Gemini here; Mistral / Fireworks / other strict Chat Completions proxies are the same class).
3. Every subsequent request 400s on the stale `reasoning_details` field, and the session is stuck until `/new`.

## Root cause

`conversation_loop` **intentionally keeps** `reasoning_details` on the outgoing `chat_completions` copy for OpenRouter multi-turn reasoning continuity:

```python
# Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
api_messages.append(api_msg)
```

`reasoning_details` is an **OpenRouter extension** — emitted by OpenRouter and consumed back by OpenRouter — not part of the standard Chat Completions schema. Strict proxies validate the schema and reject the unknown field.

Note: the **Anthropic adapter already drops it** when building its wire payload (`build_anthropic_kwargs` rebuilds assistant messages into clean content blocks), so *only the chat_completions path leaks*. Verified by reproducing both paths: Anthropic output never contains the field; the chat_completions `api_messages` does.

## Fix

Allowlist the field to OpenRouter. New helper `strip_reasoning_details_for_non_openrouter` in `agent/message_sanitization.py` reconciles the already-built `api_messages` against the **active** provider and removes `reasoning_details` from the outgoing copy for every non-OpenRouter provider. The internal history keeps the field, so a mid-conversation switch **back** to OpenRouter still carries it.

Wired in `conversation_loop` right after `api_messages` is assembled, gated on `provider == "openrouter" or _is_openrouter_url()`.

This mirrors the existing `reapply_reasoning_echo` reconciler for `reasoning_content` (same "reconcile a reasoning field against the current provider before the retry loop" shape). Idempotent, no-op when the field is absent, touches only assistant turns.

## Testing

4 cases in `tests/agent/test_message_sanitization_policy.py`:
- strips for a non-OpenRouter (strict) provider,
- preserves for OpenRouter,
- idempotent + no-op when the field is absent,
- only touches assistant turns (a stray field on a user row is left alone).

Also verified: `agent.conversation_loop` imports cleanly with the helper wired, and a repro of the full build path shows the field gone from the chat_completions copy for a Palantir base_url while OpenRouter keeps it.

## Invariants

- Renderer/wire-copy only — internal message history is untouched (`reasoning_details` stays in stored history for OpenRouter round-trips).
- No prompt-cache prefix change, no role-alternation change.
- No new deps.
