### PR TITLE
fix(cron): support {"jobs": {id: job}} stores in load_jobs()

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1313,6 +1313,10 @@ def load_jobs() -> List[Dict[str, Any]]:
     # down the whole cron subsystem.
     if isinstance(data, dict):
         jobs = data.get("jobs", [])
+        # Support ID-keyed jobs maps: the public load_jobs() contract and
+        # every CRUD/scheduler caller expect a list of job records.
+        if isinstance(jobs, dict):
+            jobs = list(jobs.values())
         if _strict_retry and jobs:
             # Hit control-character corruption — rewrite with proper escaping.
             save_jobs(jobs)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1247,6 +1247,74 @@ class TestJobsJsonUtf8Bom:
 
 
 
+class TestIdKeyedJobsStore:
+    """load_jobs()/list_jobs() must accept an ID-keyed jobs map, not just a
+    list — some stores are written as {"jobs": {"<id>": {...}, ...}}.
+
+    Regression for the ValueError from dict(job) treating a bare string key
+    as a two-item pair (see issue #92935).
+    """
+
+    def test_load_jobs_accepts_id_keyed_map(self, tmp_cron_dir):
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        payload = {
+            "jobs": {
+                "cron1234abcd": {
+                    "id": "cron1234abcd",
+                    "name": "Example job",
+                    "enabled": True,
+                    "prompt": "do the thing",
+                    "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+                },
+                "cron5678efgh": {
+                    "id": "cron5678efgh",
+                    "name": "Second job",
+                    "enabled": True,
+                    "prompt": "do another thing",
+                    "schedule": {"kind": "interval", "minutes": 15, "display": "every 15m"},
+                },
+            },
+            "updated_at": "2026-08-23T10:10:12+08:00",
+        }
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(payload), encoding="utf-8")
+
+        loaded = load_jobs()
+        assert isinstance(loaded, list)
+        assert {j["id"] for j in loaded} == {"cron1234abcd", "cron5678efgh"}
+        by_id = {j["id"]: j for j in loaded}
+        assert by_id["cron1234abcd"]["name"] == "Example job"
+        assert by_id["cron1234abcd"]["prompt"] == "do the thing"
+        assert by_id["cron5678efgh"]["schedule"]["minutes"] == 15
+
+    def test_list_jobs_accepts_id_keyed_map(self, tmp_cron_dir):
+        """The cronjob(action="list") / `hermes cron list` path, not just
+        load_jobs() directly — this is what actually raised in the report."""
+        import json
+        from cron.jobs import JOBS_FILE, list_jobs
+
+        payload = {
+            "jobs": {
+                "cronaaaa1111": {
+                    "id": "cronaaaa1111",
+                    "name": "Listable job",
+                    "enabled": True,
+                    "prompt": "list me",
+                    "schedule": {"kind": "interval", "minutes": 5, "display": "every 5m"},
+                }
+            },
+            "updated_at": "2026-08-23T10:10:12+08:00",
+        }
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(payload), encoding="utf-8")
+
+        jobs = list_jobs(include_disabled=True)
+        assert [j["id"] for j in jobs] == ["cronaaaa1111"]
+        assert jobs[0]["name"] == "Listable job"
+
+
 class TestAdvanceNextRuns:
     """Tests for advance_next_runs() — the batched due-set advance.
 


### PR DESCRIPTION
Fixes #92935

## Description
`load_jobs()` assumed the `"jobs"` key is always a list, but some stores are written as an ID-keyed map (`{"jobs": {"<id>": {...}, ...}}`). Iterating that dict yielded string keys, and `_normalize_job_record → _apply_skill_fields → dict(job)` raised `ValueError: dictionary update sequence element #0 has length 1; 2 is required`.

This affects the `cronjob(action="list")` tool, `hermes cron list`, and the Dashboard cron view.

## Fix
At the `load_jobs()` boundary: if `jobs` is a dict, convert it to `list(jobs.values())` before returning. This covers every consumer (`update_job`, `remove_job`, the scheduler) since they all read through `load_jobs()`.

## Tests
Added `TestIdKeyedJobsStore` in `tests/cron/test_jobs.py`:
- `test_load_jobs_accepts_id_keyed_map`: verifies `load_jobs()` returns a list with all fields intact for a multi-entry ID-keyed store.
- `test_list_jobs_accepts_id_keyed_map`: verifies the actual `list_jobs()` path that raised in the report.

Full `tests/cron/test_jobs.py` suite passes locally (74 passed).

Thanks to @orangercat for the clear repro and root-cause analysis in the issue — this PR is essentially their proposed patch plus regression coverage.