### PR TITLE
feat(config): preserve explicit string values

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5381,7 +5381,13 @@ def _coerce_float(value: str):
     return f
 
 
-def set_config_value(key: str, value: str, force: bool = False):
+def set_config_value(
+    key: str,
+    value: str,
+    force: bool = False,
+    *,
+    string: bool = False,
+):
     """Set a configuration value.
 
     Args:
@@ -5394,6 +5400,9 @@ def set_config_value(key: str, value: str, force: bool = False):
             mapping). Without --force, scalar writes over mapping sections are
             refused (bare ``model`` is redirected to ``model.default``). The
             CLI exposes this via ``hermes config set --force``.
+        string: Store ``value`` exactly as a string without bool, number, null,
+            list, or mapping coercion. The CLI exposes this via
+            ``hermes config set --string``.
     """
     if is_managed():
         managed_error("set configuration values")
@@ -5477,7 +5486,7 @@ def set_config_value(key: str, value: str, force: bool = False):
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
     coerced_value: Any = value
-    if not isinstance(_default_value_for_key(key), str):
+    if not string and not isinstance(_default_value_for_key(key), str):
         _stripped = value.strip()
         _lower = _stripped.lower()
         if _lower in {'true', 'yes', 'on'}:
@@ -5773,8 +5782,9 @@ def config_command(args):
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
         force = bool(getattr(args, 'force', False))
+        string = bool(getattr(args, 'string', False))
         if not key or value is None:
-            print("Usage: hermes config set [--force] <key> <value>")
+            print("Usage: hermes config set [--force] [--string] <key> <value>")
             print()
             print("Examples:")
             print("  hermes config set model anthropic/claude-sonnet-4")
@@ -5783,8 +5793,9 @@ def config_command(args):
             print()
             print("  --force: skip the unknown-key notice for unrecognized keys,")
             print("           and allow a scalar to replace a whole mapping section")
+            print("  --string: store the value exactly without type coercion")
             sys.exit(1)
-        set_config_value(key, value, force=force)
+        set_config_value(key, value, force=force, string=string)
 
     elif subcmd == "unset":
         key = getattr(args, 'key', None)

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -46,6 +46,11 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
         help="Skip the unknown-key notice printed after writing a key the "
         "running version doesn't recognize (the value is saved either way).",
     )
+    config_set.add_argument(
+        "--string",
+        action="store_true",
+        help="Store the value exactly as a string without type coercion.",
+    )
 
     # config unset
     config_unset = config_subparsers.add_parser(

--- a/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
@@ -1,6 +1,6 @@
 # Configuration, Toolsets & Voice
 
-Edit with `hermes config edit` or `hermes config set section.key value`.
+Edit with `hermes config edit` or `hermes config set section.key value`. Use `hermes config set --string section.key value` when scalar-looking syntax such as `{message}`, `true`, or `42` must remain literal text.
 Full reference: https://hermes-agent.nousresearch.com/docs/user-guide/configuration
 
 ### Config Sections (most-used keys)

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -7,6 +7,8 @@ stored the value as a raw STRING. Every reader that gates on
 so the setting looked saved but never took effect (observed in the wild as a
 platform running on the wrong toolset bundle for weeks).
 """
+import argparse
+
 import pytest
 
 
@@ -39,6 +41,30 @@ def test_mapping_literal_is_parsed_to_dict(user_home):
     set_config_value("display.tool_progress_overrides", '{"terminal": "off"}')
     raw = read_raw_config()
     assert raw["display"]["tool_progress_overrides"] == {"terminal": "off"}
+
+
+@pytest.mark.parametrize("value", ["{message}", "[literal]", "true", "42", "null"])
+def test_explicit_string_preserves_scalar_syntax(user_home, value):
+    from hermes_cli.config import set_config_value, read_raw_config
+
+    set_config_value("webhooks.routes.example.prompt", value, string=True)
+    raw = read_raw_config()
+    stored = raw["webhooks"]["routes"]["example"]["prompt"]
+    assert stored == value
+    assert isinstance(stored, str)
+
+
+def test_config_set_parser_accepts_explicit_string_flag():
+    from hermes_cli.subcommands.config import build_config_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_config_parser(subparsers, cmd_config=lambda _args: None)
+
+    args = parser.parse_args(
+        ["config", "set", "--string", "webhooks.routes.example.prompt", "{message}"]
+    )
+    assert args.string is True
 
 
 def test_yaml_flow_list_is_parsed(user_home):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -42,12 +42,13 @@ hermes config migrate      # Interactively add missing options
 hermes config get model
 hermes config set model anthropic/claude-opus-4
 hermes config set terminal.backend docker
+hermes config set --string hooks.routes.example.prompt '{message}'  # Preserve scalar syntax exactly
 hermes config unset terminal.backend
 hermes config set OPENROUTER_API_KEY sk-or-...  # Saves to .env
 ```
 
 :::tip
-The `hermes config set` command automatically routes values to the right file — API keys are saved to `.env`, everything else to `config.yaml`.
+The `hermes config set` command automatically routes values to the right file — API keys are saved to `.env`, everything else to `config.yaml`. Values that look like lists, mappings, numbers, or booleans are parsed to their corresponding type; use `--string` when the value must remain literal text.
 :::
 
 ## Configuration Precedence


### PR DESCRIPTION
## Summary
- add `hermes config set --string KEY VALUE` for literal scalar text
- bypass YAML/number/boolean coercion only when explicitly requested
- document the flag and cover scalar-looking values plus parser wiring

## Motivation
Configuration prompts and templates can legitimately begin with YAML flow syntax, for example `{message}`. Without an explicit string mode, `config set` parses that value as a mapping; shell quoting either disappears before parsing or becomes part of the stored value.

## Verification
- `uv run --with pyyaml --with pytest python -m pytest -q tests/hermes_cli/test_config*.py` — 135 passed
- live temporary-profile CLI round trip stores `{message}` as an exact string