### PR TITLE
fix(opencode-go): downgrade vision tool results

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -215,6 +215,7 @@ opencode_go = OpenCodeGoProfile(
     base_url="https://opencode.ai/zen/go/v1",
     default_headers=dict(_ATTRIBUTION_HEADERS),
     default_aux_model="glm-5",
+    supports_vision_tool_messages=False,
 )
 
 register_provider(opencode_zen)

--- a/tests/run_agent/test_vision_tool_messages.py
+++ b/tests/run_agent/test_vision_tool_messages.py
@@ -90,6 +90,19 @@ class TestToolResultContentProactiveDowngrade:
         assert isinstance(content, str)
         assert "screenshot captured" in content
 
+    def test_opencode_go_downgrades_to_text_summary(self):
+        """OpenCode Go accepts images in user messages, but not tool messages."""
+        agent = _make_agent("opencode-go", "mimo-v2.5")
+        result = _multimodal_result(text="screenshot captured")
+
+        with patch.object(agent, "_model_supports_vision", return_value=True):
+            content = agent._tool_result_content_for_active_model(
+                "browser_screenshot", result
+            )
+
+        assert isinstance(content, str)
+        assert "screenshot captured" in content
+
     def test_xiaomi_non_multimodal_passes_through(self):
         """Non-multimodal results should pass through unchanged."""
         agent = _make_agent("xiaomi", "mimo-v2.5")
@@ -149,5 +162,4 @@ class TestProviderProfileField:
         profile = get_provider_profile("xiaomi")
         assert profile is not None
         assert profile.supports_vision_tool_messages is False
-
 


### PR DESCRIPTION
## Summary
- mark OpenCode Go as unable to accept image parts in tool-result messages
- preserve vision support through the existing text-summary fallback
- add a regression test for multimodal tool-result downgrade

Fixes #89057

## Testing
- `python -m pytest tests/run_agent/test_vision_tool_messages.py tests/plugins/model_providers/test_opencode_go_profile.py -q` (35 passed)
- `python -m ruff check plugins/model-providers/opencode-zen/__init__.py tests/run_agent/test_vision_tool_messages.py`