### PR TITLE
fix(cron): load id-keyed job stores

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1313,6 +1313,9 @@ def load_jobs() -> List[Dict[str, Any]]:
     # down the whole cron subsystem.
     if isinstance(data, dict):
         jobs = data.get("jobs", [])
+        # Some legacy/external writers key records by ID; callers expect a list.
+        if isinstance(jobs, dict):
+            jobs = list(jobs.values())
         if _strict_retry and jobs:
             # Hit control-character corruption — rewrite with proper escaping.
             save_jobs(jobs)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -231,6 +231,40 @@ class TestJobCRUD:
         jobs = list_jobs()
         assert len(jobs) == 2
 
+    def test_loads_id_keyed_jobs_store_as_records(self, tmp_cron_dir):
+        import json
+        from cron.jobs import JOBS_FILE
+
+        job = {
+            "id": "cron1234abcd",
+            "name": "Example job",
+            "prompt": "Check server status",
+            "schedule": {
+                "kind": "interval",
+                "minutes": 30,
+                "display": "every 30m",
+            },
+            "enabled": True,
+        }
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(
+            json.dumps(
+                {
+                    "jobs": {job["id"]: job},
+                    "updated_at": "2026-08-23T10:10:12+08:00",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        listed = list_jobs(include_disabled=True)
+
+        assert load_jobs() == [job]
+        assert len(listed) == 1
+        assert listed[0]["name"] == job["name"]
+        assert listed[0]["prompt"] == job["prompt"]
+        assert listed[0]["schedule"] == job["schedule"]
+
 
     def test_remove_job(self, tmp_cron_dir):
         job = create_job(prompt="Temp job", schedule="30m")


### PR DESCRIPTION
## Summary
- normalize ID-keyed `jobs` maps to the list contract at the `load_jobs()` boundary
- preserve each stored job record and all existing list-shaped stores
- cover both `load_jobs()` and the user-facing `list_jobs()` path

Fixes #92935

## Testing
- `python -m pytest tests/cron/test_jobs.py -q` (71 passed, 2 skipped)
- `python -m pytest tests/cron/test_jobs.py::TestJobCRUD::test_loads_id_keyed_jobs_store_as_records tests/tools/test_cronjob_tools.py -q` (69 passed)
- `python -m ruff check cron/jobs.py tests/cron/test_jobs.py`