### PR TITLE
fix(desktop): submit focused clarify choices with Enter

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -390,7 +390,8 @@ describe('ClarifyTool recommended option', () => {
     expect(recommended.querySelector('.text-\\(--ui-text-tertiary\\)')?.textContent).toBe('(Recommended)')
 
     fireEvent.click(recommended)
-    fireEvent.keyDown(window, { key: 'Enter' })
+    recommended.focus()
+    fireEvent.keyDown(recommended, { key: 'Enter' })
 
     // The decorated string goes back verbatim; the tool strips the label before
     // the agent ever sees the answer.

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -233,6 +233,7 @@ function ChoiceButton({
   disabled,
   keyShortcuts,
   onClick,
+  onKeyDown,
   selected,
   title
 }: {
@@ -242,6 +243,7 @@ function ChoiceButton({
   disabled?: boolean
   keyShortcuts?: string
   onClick: () => void
+  onKeyDown?: (event: KeyboardEvent<HTMLButtonElement>) => void
   selected?: boolean
   title?: string
 }) {
@@ -269,6 +271,7 @@ function ChoiceButton({
         data-highlighted={active || undefined}
         disabled={disabled}
         onClick={onClick}
+        onKeyDown={onKeyDown}
         type="button"
       >
         <KeyBadge char={char} preview={active} selected={Boolean(selected)} />
@@ -574,6 +577,18 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
     [submitAnswer]
   )
 
+  const handleChoiceKey = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.nativeEvent.isComposing || event.key !== 'Enter') {
+        return
+      }
+
+      event.preventDefault()
+      submitAnswer()
+    },
+    [submitAnswer]
+  )
+
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
@@ -712,6 +727,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
                 key={`${index}-${choice}`}
                 keyShortcuts={`${letterFor(index)} ${index + 1}`}
                 onClick={() => selectChoice(choice, index)}
+                onKeyDown={handleChoiceKey}
                 selected={selectedChoices.includes(choice)}
               />
             ))}


### PR DESCRIPTION
## Summary
- let a focused clarify choice submit the staged answer with Enter
- keep the global focus guard intact so unrelated focused controls retain keyboard ownership
- update the regression test to dispatch Enter through the focused choice, matching browser event targeting

Fixes #92816

## Testing
- `npm run test:ui -- src/components/assistant-ui/clarify-tool.test.tsx` (27 passed)
- `npm run typecheck`
- `npx eslint src/components/assistant-ui/clarify-tool.tsx src/components/assistant-ui/clarify-tool.test.tsx` (0 errors)
- `npx prettier --check src/components/assistant-ui/clarify-tool.tsx src/components/assistant-ui/clarify-tool.test.tsx`