### PR TITLE
fix(gateway): tell the user which provider package is missing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21074,6 +21074,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Failed to persist inbound user message after agent exception", exc_info=True)
             # Log full details server-side only; never expose raw exception
             # types or messages to end users (info-leakage risk).
+            #
+            # A missing optional provider SDK is handled first and separately.
+            # Providers whose client library lives in an extra (anthropic,
+            # boto3 for Bedrock, azure-identity, ...) raise ImportError from
+            # their adapter during agent CONSTRUCTION, before any request is
+            # sent, so there is no status_code and every branch below is
+            # inapplicable — the error fell through to the bare "unexpected
+            # error" catch-all. That reply is actively misleading here: the
+            # failure is deterministic, so "try again" never works, and
+            # /reset destroys the conversation without touching the cause.
+            # Point at the real fix instead.
+            if isinstance(e, ImportError):
+                # Name the package, but never echo str(e) — an arbitrary
+                # ImportError's text is not vetted for info-leakage the way
+                # this branch's own copy is. `.name` is set by the import
+                # machinery, but is None for a hand-raised ImportError, which
+                # is exactly the case the provider adapters produce; fall back
+                # to their shared phrasing, anchored so only that house format
+                # can match ("The 'x' package is required for ...").
+                _missing = getattr(e, "name", None) or ""
+                if not _missing:
+                    _m = re.match(
+                        r"The '([A-Za-z0-9_.\-]{1,40})' (?:Python )?package is required",
+                        str(e),
+                    )
+                    _missing = _m.group(1) if _m else ""
+                _pkg = f" (`{_missing}`)" if _missing else ""
+                return (
+                    f"⚠️ This model's provider needs an optional Python package"
+                    f"{_pkg} that isn't installed.\n"
+                    "Switch to another model with /model, or install the "
+                    "package and restart — retrying and /reset won't help."
+                )
             status_hint = ""
             status_code = getattr(e, "status_code", None)
             _hist_len = len(history) if 'history' in locals() else 0


### PR DESCRIPTION
## What

Providers whose client library ships in an optional extra — `anthropic`, `boto3` for Bedrock, `azure-identity` — raise `ImportError` from their adapter inside `AIAgent.__init__`, during agent **construction**, before any API request is sent. `ImportError` carries no `status_code`, so it fell through every branch of the status-hint chain in the agent-error handler in `gateway/run.py` and reached the user as:

```
Sorry, I encountered an unexpected error.
Try again or use /reset to start a fresh session.
```

This change handles `ImportError` ahead of that chain and names the missing package:

```
⚠️ This model's provider needs an optional Python package (`anthropic`) that isn't installed.
Switch to another model with /model, or install the package and restart — retrying and /reset won't help.
```

## Why

Both suggestions in the old message are wrong for this failure:

- **"Try again"** can never succeed. The error is deterministic — every turn on that model fails identically until the package is installed.
- **"/reset"** destroys the user's conversation and does nothing about the cause.

And the message gives no hint that a missing dependency is involved, so the natural next step is to go looking at API keys and model ids. Hit this in practice: a `provider: anthropic` model alias against an install without the `[anthropic]` extra. Every message came back as "unexpected error", and finding the real cause meant reading the server-side traceback.

This is the same reasoning the handler already applies to session-persistence failures a few lines up, which get their own message specifically because suggesting `/reset` there would be harmful.

## Implementation notes

- The package name comes from `e.name` when the import machinery raised the error. The provider adapters raise `ImportError` by hand, so `.name` is `None` there — exactly the case that matters — and it falls back to a regex anchored to the phrasing those adapters already share: `The 'x' package is required for ...` (`agent/anthropic_adapter.py`, `agent/bedrock_adapter.py`, `agent/azure_identity_adapter.py`, `tools/browser_cdp_tool.py`).
- **`str(e)` is never echoed.** That respects the info-leakage rule stated at the top of the handler ("never expose raw exception types or messages to end users"). An unrecognized `ImportError` degrades to the unnamed form rather than pasting arbitrary exception text into a chat message.
- Placed before the `status_code` chain rather than added as another `elif`, because the correct advice here contradicts the shared "Try again or use /reset" tail.

## How to test

Configure a model with `provider: anthropic` in an environment where the `anthropic` package is not installed (i.e. installed without the `[anthropic]` extra), then send any message.

- **Before:** `Sorry, I encountered an unexpected error. / Try again or use /reset to start a fresh session.`
- **After:** the message above, naming `anthropic`.

The same path is reachable with `provider: bedrock` without `boto3`.

## What I verified

- The branch body was exercised directly against five inputs: the hand-raised `ImportError`s from `anthropic_adapter` (`anthropic`), `bedrock_adapter` (`boto3`), and `browser_cdp_tool` (the `'x' Python package` variant); a real machinery-raised `ImportError` (`.name` populated, regex not used); and an unrecognized message, asserting the output contains no fragment of `str(e)`. All five render as intended.
- Original reproduction was on Linux (Debian slim, Python 3.11) in a container; the fix path itself is platform-independent — no file I/O, process management, or terminal handling involved.

**Not run:** the full `scripts/run_tests.sh` suite. I don't have the project venv provisioned. The change is additive — a new `isinstance` branch at the top of an `except` block — and touches no existing control flow, but a CI run is the real check.

## Related

I searched open and merged PRs and issues for this symptom before writing it and found nothing covering it, though `gh search` was failing in my environment so that search was not exhaustive. Happy to close as a duplicate if one exists.
