### PR TITLE
feat(kanban): add typed pre-completion policy hook

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2298,6 +2298,7 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 summary=summary,
                 metadata=metadata,
                 expected_run_id=_worker_run_id_for(tid),
+                actor=_profile_author(),
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -210,6 +210,76 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
         _log.debug("kanban lifecycle hook %s failed: %s", event, exc)
 
 
+def _completion_actor(actor: Optional[str]) -> str:
+    """Resolve the profile identity that is attempting a task completion."""
+    candidate = actor
+    if candidate is None:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            candidate = get_active_profile_name()
+        except Exception:
+            candidate = None
+    return _canonical_assignee(candidate) or "unknown"
+
+
+def _completion_veto_reason(results: Iterable[Any]) -> Optional[str]:
+    """Normalize typed ``before_kanban_task_complete`` policy decisions."""
+    for result in results:
+        if result is None or result is True:
+            continue
+        if result is False:
+            return "completion blocked by before_kanban_task_complete policy"
+        if isinstance(result, str):
+            return result.strip() or "completion blocked by policy"
+        if isinstance(result, Mapping):
+            allowed = result.get("allow")
+            if allowed is True:
+                continue
+            reason = result.get("reason")
+            if isinstance(reason, str) and reason.strip():
+                return reason.strip()
+            if allowed is False:
+                return "completion blocked by policy"
+            return "completion policy returned malformed decision"
+        return "completion policy returned unsupported decision"
+    return None
+
+
+def _before_kanban_task_complete(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: str,
+    summary: Optional[str],
+    result: Optional[str],
+    metadata: Optional[dict],
+) -> Optional[str]:
+    """Return a veto reason before the authoritative completion write."""
+    try:
+        from hermes_cli.lifecycle import has_hook, invoke_hook
+
+        if not has_hook("before_kanban_task_complete"):
+            return None
+        task = get_task(conn, task_id)
+        if task is None:
+            return "task not found"
+        decisions = invoke_hook(
+            "before_kanban_task_complete",
+            task_id=task_id,
+            task=task,
+            actor=actor,
+            summary=summary,
+            result=result,
+            metadata=metadata,
+            board=get_current_board(),
+        )
+        return _completion_veto_reason(decisions)
+    except Exception as exc:
+        # A configured policy that cannot run must not become an allow.
+        return f"before_kanban_task_complete hook failed: {type(exc).__name__}"
+
+
 def _kanban_observer_consumed(event: str) -> bool:
     """Return whether any first-party observer or plugin consumes *event*.
 
@@ -5359,6 +5429,7 @@ def complete_task(
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
     fire_lifecycle_hook: bool = True,
+    actor: Optional[str] = None,
 ) -> bool:
     """Transition ``running|ready|blocked|review -> done`` and record ``result``.
 
@@ -5393,6 +5464,7 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+    completion_actor = _completion_actor(actor)
     # Fail before validating cards or staging artifacts; re-check inside the
     # final write transaction below to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):
@@ -5424,6 +5496,24 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    veto_reason = _before_kanban_task_complete(
+        conn,
+        task_id,
+        actor=completion_actor,
+        summary=summary,
+        result=result,
+        metadata=metadata,
+    )
+    if veto_reason is not None:
+        with write_txn(conn):
+            _append_event(
+                conn,
+                task_id,
+                "completion_blocked_policy",
+                {"actor": completion_actor, "reason": veto_reason[:400]},
+            )
+        return False
 
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -257,6 +257,13 @@ def _before_kanban_task_complete(
 ) -> Optional[str]:
     """Return a veto reason before the authoritative completion write."""
     try:
+        # Completion may be invoked by a worker-side Kanban tool, which does
+        # not otherwise need the plugin registry.  Discover configured plugins
+        # here so a typed completion policy is never silently bypassed merely
+        # because this is the first plugin-aware operation in that process.
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
         from hermes_cli.lifecycle import has_hook, invoke_hook
 
         if not has_hook("before_kanban_task_complete"):

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -280,6 +280,13 @@ VALID_HOOKS: Set[str] = {
     #   run_id: int | None, profile_name: str.
     # kanban_task_completed adds: summary: str | None.
     # kanban_task_blocked adds:   reason: str | None.
+    # ``before_kanban_task_complete`` is the sole synchronous policy hook in
+    # this family. It runs before ``complete_task`` writes ``done`` and may
+    # return ``True``/``None`` to allow, or ``False``, a reason string, or
+    # ``{"allow": false, "reason": "..."}`` to veto. It receives the
+    # typed task snapshot, actor and completion metadata; it is intentionally
+    # not a terminal-command parser.
+    "before_kanban_task_complete",
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",

--- a/tests/hermes_cli/test_kanban_pre_completion_hook.py
+++ b/tests/hermes_cli/test_kanban_pre_completion_hook.py
@@ -1,0 +1,130 @@
+"""Authoritative, typed Kanban completion-veto tests.
+
+The hook is deliberately exercised through ``kanban_db.complete_task`` rather
+than a shell command.  A caller that can reach the core transition must not be
+able to bypass an enrolled completion policy by choosing a different surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.plugins import get_plugin_manager
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_before_kanban_task_complete_veto_blocks_core_api(kanban_home):
+    """A typed hook veto must preserve the task's pre-completion state."""
+    manager = get_plugin_manager()
+    saved = {key: list(value) for key, value in manager._hooks.items()}
+    observed = []
+
+    def veto(**payload):
+        observed.append(payload)
+        return {"allow": False, "reason": "production receipt missing"}
+
+    manager._hooks.setdefault("before_kanban_task_complete", []).append(veto)
+    try:
+        conn = kb.connect()
+        try:
+            task_id = kb.create_task(conn, title="delivery-v2 canary", assignee="implementer")
+            assert kb.complete_task(
+                conn,
+                task_id,
+                summary="attempt without receipt",
+                metadata={"delivery_v2": {"task_class": "PRODUCTION_CHANGE"}},
+                actor="implementer",
+            ) is False
+            assert kb.get_task(conn, task_id).status == "ready"
+        finally:
+            conn.close()
+    finally:
+        manager._hooks = saved
+
+    assert len(observed) == 1
+    payload = observed[0]
+    assert payload["task_id"] == task_id
+    assert payload["actor"] == "implementer"
+    assert payload["task"].id == task_id
+    assert payload["metadata"] == {"delivery_v2": {"task_class": "PRODUCTION_CHANGE"}}
+
+
+def test_before_kanban_task_complete_veto_blocks_cli(kanban_home, monkeypatch, capsys):
+    """The direct CLI reaches the same typed policy boundary as the API."""
+    monkeypatch.setenv("HERMES_PROFILE", "  CLI-VERIFIER ")
+    manager = get_plugin_manager()
+    saved = {key: list(value) for key, value in manager._hooks.items()}
+    observed = []
+
+    def veto(**payload):
+        observed.append(payload)
+        return "independent receipt required"
+
+    manager._hooks.setdefault("before_kanban_task_complete", []).append(veto)
+    try:
+        conn = kb.connect()
+        try:
+            task_id = kb.create_task(conn, title="cli canary", assignee="implementer")
+        finally:
+            conn.close()
+
+        from hermes_cli.kanban import _cmd_complete
+
+        args = argparse.Namespace(
+            task_ids=[task_id],
+            result=None,
+            summary="CLI bypass attempt",
+            metadata=json.dumps({"delivery_v2": {"task_class": "PRODUCTION_CHANGE"}}),
+        )
+        assert _cmd_complete(args) == 1
+        assert "cannot complete" in capsys.readouterr().err
+
+        conn = kb.connect()
+        try:
+            assert kb.get_task(conn, task_id).status == "ready"
+        finally:
+            conn.close()
+    finally:
+        manager._hooks = saved
+
+    assert observed[0]["actor"] == "cli-verifier"
+
+
+def test_malformed_pre_completion_decision_fails_closed(kanban_home):
+    """A plugin cannot accidentally allow completion with an ambiguous reply."""
+    manager = get_plugin_manager()
+    saved = {key: list(value) for key, value in manager._hooks.items()}
+    manager._hooks.setdefault("before_kanban_task_complete", []).append(
+        lambda **_: {"allow": "yes"}
+    )
+    try:
+        conn = kb.connect()
+        try:
+            task_id = kb.create_task(conn, title="malformed policy", assignee="implementer")
+            assert kb.complete_task(conn, task_id, summary="attempt") is False
+            assert kb.get_task(conn, task_id).status == "ready"
+            events = conn.execute(
+                "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+                (task_id,),
+            ).fetchall()
+        finally:
+            conn.close()
+    finally:
+        manager._hooks = saved
+
+    assert events[-1]["kind"] == "completion_blocked_policy"
+    assert "malformed" in json.loads(events[-1]["payload"])["reason"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -771,6 +771,7 @@ def _handle_complete(args: dict, **kw) -> str:
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
                     expected_run_id=_worker_run_id(tid),
+                    actor=os.environ.get("HERMES_PROFILE") or None,
                 )
             except kb.ArtifactPreservationError as artifact_err:
                 return tool_error(


### PR DESCRIPTION
## Summary

Adds the smallest typed, synchronous policy boundary before the authoritative `hermes_cli.kanban_db.complete_task` transition writes `done`.

- `before_kanban_task_complete` receives `task_id`, typed `Task` snapshot, normalized `actor`, `summary`, `result`, structured `metadata`, and board.
- Policy callbacks return allow/veto decisions; malformed non-null decisions fail closed.
- A veto leaves the task non-terminal and writes `completion_blocked_policy`.
- API, CLI and worker-tool completion all reach the same kernel boundary.
- Existing boards without a registered policy retain their current behaviour; post-completion observers remain unchanged.

## Tests

`python -m pytest tests/hermes_cli/test_kanban_pre_completion_hook.py tests/tools/test_kanban_tools.py -q`

35 passed.