### PR TITLE
fix(honcho): honour contextTokens cap on summary/peer context calls

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1016,7 +1016,9 @@ class HonchoSessionManager:
             if session.honcho_session_id in self._sessions_cache:
                 ctx = self._authed_call(
                     "session summary fetch",
-                    lambda: self._sdk_session(session.honcho_session_id).context(summary=True),
+                    lambda: self._sdk_session(session.honcho_session_id).context(
+                        summary=True, tokens=self._context_tokens
+                    ),
                 )
                 if ctx.summary and getattr(ctx.summary, "content", None):
                     result["summary"] = ctx.summary.content
@@ -1368,6 +1370,7 @@ class HonchoSessionManager:
                 "session context fetch",
                 lambda: self._sdk_session(session.honcho_session_id).context(
                     summary=True,
+                    tokens=self._context_tokens,
                     peer_target=target_peer_id or observer_peer_id,
                     peer_perspective=observer_peer_id,
                 ),

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1315,3 +1315,62 @@ class TestGetSessionContextFallback:
         assert peer_id == "user-peer"
         assert target == "user-peer"
 
+
+# ---------------------------------------------------------------------------
+# contextTokens must reach session.context() (salvage of #70951)
+# ---------------------------------------------------------------------------
+
+
+class TestContextTokensForwarded:
+    """Honcho picks short vs long summary from the tokens= budget.
+
+    Regression: get_prefetch_context and get_session_context called
+    context(summary=True) without tokens=, so a configured contextTokens
+    cap was ignored and every turn got honcho_chat_summary_long.
+    """
+
+    def _manager(self, context_tokens=4000):
+        mgr = HonchoSessionManager(context_tokens=context_tokens)
+        session = HonchoSession(
+            key="cli:test",
+            user_peer_id="robert",
+            assistant_peer_id="hermes",
+            honcho_session_id="sess-1",
+        )
+        mgr._cache[session.key] = session
+        honcho_session = MagicMock()
+        honcho_session.context.return_value = SimpleNamespace(
+            summary=SimpleNamespace(content="short summary"),
+            peer_representation="rep",
+            peer_card=["fact"],
+            messages=[],
+        )
+        mgr._sessions_cache[session.honcho_session_id] = honcho_session
+        mgr._fetch_peer_context = MagicMock(
+            return_value={"representation": "", "card": []}
+        )
+        return mgr, session, honcho_session
+
+    def test_get_prefetch_context_passes_context_tokens_to_summary_call(self):
+        mgr, session, honcho_session = self._manager()
+
+        result = mgr.get_prefetch_context(session.key)
+
+        assert result["summary"] == "short summary"
+        honcho_session.context.assert_called_once_with(summary=True, tokens=4000)
+
+    def test_get_session_context_passes_context_tokens_to_cached_session_call(self):
+        """Sweeper gap on #70951: the cached session-level context() path
+        must forward tokens= alongside its peer arguments."""
+        mgr, session, honcho_session = self._manager()
+
+        result = mgr.get_session_context(session.key, peer="user")
+
+        assert result["summary"] == "short summary"
+        honcho_session.context.assert_called_once_with(
+            summary=True,
+            tokens=4000,
+            peer_target=session.user_peer_id,
+            peer_perspective=session.assistant_peer_id,
+        )
+


### PR DESCRIPTION
## What does this PR do?

Salvage of #70951 by @Willkons / @Alice-Willk-bot, with required regression tests added. 

`contextTokens` is documented as a per-turn cap on the auto-injected Honcho context block, but two of the three `session.context()` call sites never forwarded it:

- `get_prefetch_context()` called `context(summary=True)` with no `tokens=`
- `get_session_context()` likewise omitted it on the cached-session path

Honcho selects `honcho_chat_summary_short` vs `honcho_chat_summary_long` from the token budget, so an uncapped call always returns the **long** summary. On a long-running conversation that is a measured ~12 KB instead of ~2 KB — roughly 10 KB of avoidable prefix on every turn, while the cap appears to do nothing.

The third site (session init) already forwarded `tokens=self._context_tokens`. This PR does the same at the remaining two, rebased onto current `main` (`_authed_call` + `_sdk_session`).

## Related Issue

Supersedes #70951 (credit @Willkons). Same two-line production change; adds the missing cached-session test.

## Type of Change

- [x] Bug fix (non-breaking change that fixes a bug)

## Changes Made

- `plugins/memory/honcho/session.py` — pass `tokens=self._context_tokens` from `get_prefetch_context()` and `get_session_context()`.
- `tests/honcho_plugin/test_session.py` — two call-signature regressions: prefetch summary fetch, and cached `get_session_context()` including peer arguments.

## How to Test

```bash
uv run --with pytest pytest tests/honcho_plugin/test_session.py -o 'addopts=' -q
# 56 passed

uvx ruff check plugins/memory/honcho/session.py tests/honcho_plugin/test_session.py
# All checks passed
```

The new tests fail on unmodified `main` (`assert_called_once_with` sees `tokens=` missing) and pass on this head.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — this salvages #70951 rather than competing with it
- [x] My PR contains only changes related to this fix
- [x] Focused honcho session tests pass (56)
- [x] I've added tests for both changed production paths
- [x] Tested on macOS