### PR TITLE
fix(desktop): announce the ready port on the real stdout

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18944,6 +18944,39 @@ def _read_bound_port(server: "uvicorn.Server", fallback: int) -> int:
     return fallback
 
 
+def _announce_ready_port(token: str, port: int) -> None:
+    """Print the port-discovery sentinel on the process's real stdout.
+
+    The desktop spawns this backend and reads the sentinel off the child's
+    **stdout** to learn the ephemeral port
+    (``apps/desktop/electron/backend-ready.ts``), so delivery on stdout is
+    this line's contract.
+
+    A plain ``print`` cannot honour that contract, because whether
+    ``sys.stdout`` is still stdout by the time we get here depends on import
+    order. ``tui_gateway.server`` runs ``sys.stdout = sys.stderr`` at module
+    scope so a stray library ``print`` cannot corrupt the JSON-RPC stream it
+    owns — a sound guard for the gateway, but a process-wide one. Any import
+    of that module before ``start_server`` therefore silently moves the
+    sentinel to stderr. ``discover_plugins()`` runs first, so a single plugin
+    importing the gateway from its ``register()`` is enough.
+
+    The resulting failure is severe and self-concealing: the desktop's port
+    waiter watches stdout only and times out after 90s with a healthy backend
+    listening, while its log tap — attached to both streams — puts the
+    announcement in ``desktop.log`` for the whole window the waiter spends
+    starving.
+
+    ``sys.__stdout__`` is the interpreter's own reference to the real stream,
+    which no rebind touches, so the sentinel lands on stdout regardless of
+    what imported what. It is ``None`` under pythonw.exe, which has no
+    console at all; fall back to ``sys.stdout`` there to keep the previous
+    behavior on the one platform where this value cannot be read from stdout
+    anyway.
+    """
+    print(f"{token} port={port}", flush=True, file=sys.__stdout__ or sys.stdout)
+
+
 def _write_dashboard_ready_file(actual_port: int) -> None:
     """Optionally publish the dashboard port through an atomic ready file.
 
@@ -19373,7 +19406,7 @@ def start_server(
             # plain backend, not a dashboard, so it announces a neutral token;
             # `dashboard` keeps the legacy one. The desktop matches either.
             ready_token = "HERMES_BACKEND_READY" if headless else "HERMES_DASHBOARD_READY"
-            print(f"{ready_token} port={actual_port}", flush=True)
+            _announce_ready_port(ready_token, actual_port)
             if headless:
                 # No SPA, and the JSON-RPC/WS endpoints are auth-gated — don't
                 # advertise a paste-and-connect URL, just announce the bind.

--- a/tests/hermes_cli/test_ready_port_sentinel.py
+++ b/tests/hermes_cli/test_ready_port_sentinel.py
@@ -1,0 +1,72 @@
+"""The port-discovery sentinel must reach the process's real stdout.
+
+The desktop learns the backend's ephemeral port by matching
+``HERMES_(BACKEND|DASHBOARD)_READY port=<n>`` on the spawned child's stdout
+(``apps/desktop/electron/backend-ready.ts``). ``tui_gateway.server`` rebinds
+``sys.stdout = sys.stderr`` at import time to protect its JSON-RPC stream, and
+that rebind is process-wide, so a plain ``print`` sends the sentinel to stderr
+and desktop boot fails on the 90s port-announcement timeout with a healthy
+backend running.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+import textwrap
+
+
+class TestAnnounceReadyPort:
+    def test_writes_to_real_stdout_when_sys_stdout_is_rebound(self, monkeypatch):
+        """A rebound ``sys.stdout`` must not capture the sentinel."""
+        from hermes_cli.web_server import _announce_ready_port
+
+        rebound = io.StringIO()
+        real = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", rebound)
+        monkeypatch.setattr(sys, "__stdout__", real)
+
+        _announce_ready_port("HERMES_BACKEND_READY", 43210)
+
+        assert real.getvalue() == "HERMES_BACKEND_READY port=43210\n"
+        assert rebound.getvalue() == ""
+
+    def test_falls_back_to_sys_stdout_without_a_real_stream(self, monkeypatch):
+        """pythonw.exe has ``sys.__stdout__ is None`` — don't crash on it."""
+        from hermes_cli.web_server import _announce_ready_port
+
+        fallback = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", fallback)
+        monkeypatch.setattr(sys, "__stdout__", None)
+
+        _announce_ready_port("HERMES_DASHBOARD_READY", 1)
+
+        assert fallback.getvalue() == "HERMES_DASHBOARD_READY port=1\n"
+
+
+def test_sentinel_reaches_stdout_after_the_gateway_import():
+    """End-to-end over a pipe, the way the desktop actually reads it.
+
+    Importing ``tui_gateway.server`` is what rebinds ``sys.stdout``; doing it
+    before the announcement reproduces the real backend's import order. Both
+    streams are captured separately so a sentinel that lands on stderr fails
+    here instead of looking fine in a merged log.
+    """
+    script = textwrap.dedent(
+        """
+        import tui_gateway.server  # rebinds sys.stdout to sys.stderr
+        from hermes_cli.web_server import _announce_ready_port
+        _announce_ready_port("HERMES_BACKEND_READY", 43210)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=110,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "HERMES_BACKEND_READY port=43210" in proc.stdout
+    assert "HERMES_BACKEND_READY" not in proc.stderr


### PR DESCRIPTION
Desktop boot hangs for 90 seconds and dies with

```
[boot] Desktop boot failed: Timed out waiting for Hermes backend port announcement (90000ms)
```

while the backend is up, listening, and announcing — and the announcement is
sitting in `desktop.log` the entire time the waiter spends starving:

```
13:35:28.355 [boot] Waiting for Hermes backend to launch
13:35:33.779   Hermes backend listening on 127.0.0.1:49908
13:35:34.283 HERMES_BACKEND_READY port=49908      <- and every 0.5s after
...
13:36:58.490 [boot] Desktop boot failed: Timed out waiting ...
```

## Why

`apps/desktop/electron/backend-ready.ts` matches the sentinel on the child's
**stdout**, so stdout is that line's contract:

```js
child.stdout.on('data', onData)
```

Whether `sys.stdout` is still stdout when `web_server.py` prints it depends on
import order. `tui_gateway/server.py` runs

```python
sys.stdout = sys.stderr
```

at module scope, so a stray library `print` cannot corrupt the JSON-RPC stream
it owns. Sound for the gateway, but process-wide: **any** import of that module
before `start_server` moves the sentinel to stderr. `discover_plugins()`
(`hermes_cli/main.py:11744`) runs before `start_server`
(`hermes_cli/main.py:11783`), so one plugin importing the gateway from its
`register()` is enough to break desktop boot.

That is how it reached me — a local plugin whose `register()` does
`from tui_gateway import server`. **On a clean install with no such plugin the
sentinel still goes to stdout**, so this reproduces only where something
imports the gateway early. What it costs is worth fixing anyway: a supported
extension point can make the desktop unbootable, through a line whose delivery
looks unrelated to it.

The log misleads because the two listeners disagree: `rememberLog` is attached
to **both** streams (`apps/desktop/electron/main.ts`), the port waiter to stdout
only. The announcement is therefore plainly visible in the log the waiter cannot
see it in — I chased the packaged app, the code signature and the ready-file
path before capturing the two streams separately.

Measured on macOS by running the backend with the streams captured separately:

| | `HERMES_BACKEND_READY` on stdout | on stderr |
|---|---|---|
| before | 0 | 67 |
| after | 61 | 0 |

(Counts are high because that install re-announces; upstream prints once, which
makes the single delivery all the more load-bearing.)

## The change

Send the sentinel to `sys.__stdout__` — the interpreter's own reference to the
real stream, which no rebind touches — so it lands on stdout regardless of what
imported what.

It falls back to `sys.stdout` when `sys.__stdout__` is `None`: pythonw.exe,
which has no console, so the value cannot be read off stdout there in any case.

Only the sentinel moves. Every other `print` in that function is human-facing
log output and stays where it is.

## Alternatives considered

**Make the desktop waiter read stderr too.** Clears the symptom, but leaves a
protocol sentinel on the stream the process treats as the safe place for
garbage, and every other consumer of the sentinel keeps the bug.

**Make the gateway's rebind conditional.** Bigger blast radius, and the guard is
correct for the gateway itself — the sentinel is what is in the wrong place.

## Tests

`tests/hermes_cli/test_ready_port_sentinel.py`:

- a rebound `sys.stdout` does not capture the sentinel
- `sys.__stdout__ is None` falls back instead of crashing
- end-to-end over a real pipe: import `tui_gateway.server` first (reproducing
  the triggering import order), announce, and assert the line lands on stdout
  and **not** on stderr — the streams are captured separately so a regression
  cannot hide in a merged log

On `main` the first two fail on the missing helper; the third is the behavioural
one, and reverting just the `file=` argument on this branch fails tests 1 and 3.

Also ran the 40 test files touching `web_server` / `tui_gateway`: 1426 passed.
`tests/tools/test_local_env_blocklist.py` has 2 failures, identical with and
without this change on the same checkout.

## Known gap

If fd 1 is closed after interpreter start, `sys.__stdout__` is a live wrapper
over a dead fd, the `or` does not trigger, and the print raises. No spawn path
in the tree does that — the desktop holds both pipes open for the child's
lifetime (`stdio: ['ignore', 'pipe', 'pipe']`) — and `main` has the same
exposure whenever no rebind happened. Flagging it rather than guarding a case
that cannot currently occur; happy to add the guard if you would rather have it.
