### PR TITLE
feat(skills): config escape hatch for background-review read-before-write guard

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -940,6 +940,14 @@ skills:
   # Set to 0 to disable.
   creation_nudge_interval: 15
 
+  # Background-review (autonomous skill curation) write safety.
+  # Default true: the review fork must load the exact target via skill_view()
+  # in the same turn it patches. Some models split read/write across turns or
+  # lose the turn-scoped marker (see issue #73965), refusing every patch.
+  # Set false to let the fork patch without re-reading.
+  background_review:
+    require_read_before_write: true
+
   # External skill directories — share skills across tools/agents without
   # copying them into ~/.hermes/skills/.  Each path is expanded (~ and ${VAR})
   # and resolved to an absolute path.  External dirs are read-only: skill

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2084,6 +2084,17 @@ DEFAULT_CONFIG = {
         "inline_shell": False,
         # Timeout (seconds) for each !`cmd` snippet when inline_shell is on.
         "inline_shell_timeout": 10,
+        # Background-review (autonomous skill curation) write safety.
+        # The read-before-write guard requires the review fork to load the
+        # exact target via skill_view() in the same turn it patches. Models
+        # that split read/write across turns (or lose the turn-scoped marker
+        # across worker threads — see issue #73965) can never satisfy it, so
+        # every autonomous skill patch is refused. Set false to let the fork
+        # patch without re-reading (trusts the model not to blind-edit stale
+        # content). Default true = shipped-safe.
+        "background_review": {
+            "require_read_before_write": True,
+        },
         # Run the keyword/pattern security scanner on skills the agent
         # writes via skill_manage (create/edit/patch).  Off by default
         # because the agent can already execute the same code paths via

--- a/tests/agent/test_read_before_write_guard.py
+++ b/tests/agent/test_read_before_write_guard.py
@@ -1,11 +1,13 @@
 """Tests for the background-review read-before-write guard config escape hatch.
 
 Mirrors test_curator.py's env-isolation pattern (tmp_path + monkeypatch of
-Path.home / HERMES_HOME, reload of the module under test). No LLM is spawned.
+Path.home / HERMES_HOME). No LLM is spawned. Fixtures use monkeypatch's
+auto-restoring setitem so no global module state leaks across tests.
 """
 from __future__ import annotations
 
-import importlib
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -15,21 +17,26 @@ from hermes_cli.config import load_config
 
 @pytest.fixture
 def guard_env(tmp_path, monkeypatch):
-    """Isolate HERMES_HOME and reload the skill_manager_tool module."""
+    """Isolate HERMES_HOME for the skill_manager_tool module under test."""
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(home))
     import tools.skill_manager_tool as smt
-    importlib.reload(smt)
     return smt
 
 
-def test_guard_default_on_when_config_absent(guard_env):
+def _patch_is_background_review(monkeypatch, value):
+    """Auto-restoring override of tools.skill_provenance.is_background_review."""
+    fake_mod = types.ModuleType("tools.skill_provenance")
+    fake_mod.is_background_review = lambda: value  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tools.skill_provenance", fake_mod)
+
+
+def test_guard_default_on_when_config_absent(guard_env, monkeypatch):
     """Shipped-default behaviour: guard active even with no config key set."""
     smt = guard_env
-    # Patch is_background_review to True and simulate an unread target.
-    monkeypatch_is_bg(smt, True)
+    _patch_is_background_review(monkeypatch, True)
     result = smt._background_review_read_before_write_guard(
         name="demo-skill", target=Path("/x/SKILL.md"),
         action="patch", file_label="SKILL.md",
@@ -42,18 +49,17 @@ def test_guard_off_when_config_false(guard_env, monkeypatch):
     """Escape hatch: skills.background_review.require_read_before_write: false
     lets the fork patch without re-reading."""
     smt = guard_env
-    monkeypatch_is_bg(smt, True)
-    # Force the config key to False regardless of on-disk config.
-    import hermes_cli.config as cfg_mod
-    orig = cfg_mod.cfg_get
+    _patch_is_background_review(monkeypatch, True)
+    # Patch the name bound inside the module (cfg_get is imported at module
+    # top, so patching the source module attribute would not reach it).
+    orig = smt.cfg_get
 
     def fake_cfg(cfg, *keys, default=None):
         if keys == ("skills", "background_review", "require_read_before_write"):
             return False
         return orig(cfg, *keys, default=default)
 
-    monkeypatch.setattr(cfg_mod, "cfg_get", fake_cfg)
-    importlib.reload(smt)
+    monkeypatch.setattr(smt, "cfg_get", fake_cfg)
     result = smt._background_review_read_before_write_guard(
         name="demo-skill", target=Path("/x/SKILL.md"),
         action="patch", file_label="SKILL.md",
@@ -64,7 +70,7 @@ def test_guard_off_when_config_false(guard_env, monkeypatch):
 def test_guard_skipped_for_foreground(guard_env, monkeypatch):
     """Foreground turns (not background review) are never gated."""
     smt = guard_env
-    monkeypatch_is_bg(smt, False)
+    _patch_is_background_review(monkeypatch, False)
     result = smt._background_review_read_before_write_guard(
         name="demo-skill", target=Path("/x/SKILL.md"),
         action="patch", file_label="SKILL.md",
@@ -72,17 +78,39 @@ def test_guard_skipped_for_foreground(guard_env, monkeypatch):
     assert result is None
 
 
+def test_guard_fail_closed_when_config_unreadable(guard_env, monkeypatch):
+    """Fail-closed: a config-read error must KEEP the guard on, not bypass it.
+
+    Regression test for the review finding that the original `except: return
+    None` silently disabled the safety guard whenever load_config() raised.
+    """
+    smt = guard_env
+    _patch_is_background_review(monkeypatch, True)
+    import hermes_cli.config as cfg_mod
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated broken config / plugin hook")
+
+    monkeypatch.setattr(cfg_mod, "load_config", boom)
+    result = smt._background_review_read_before_write_guard(
+        name="demo-skill", target=Path("/x/SKILL.md"),
+        action="patch", file_label="SKILL.md",
+    )
+    # Guard stays enforced despite the config error.
+    assert result is not None
+    assert result.get("_read_before_write_required") is True
+
+
+def test_no_module_state_leak():
+    """The fake provenance module must not survive a test that patched it."""
+    assert "tools.skill_provenance" not in sys.modules or (
+        hasattr(sys.modules.get("tools.skill_provenance"), "is_background_review")
+        and sys.modules["tools.skill_provenance"].__name__ == "tools.skill_provenance"
+    )
+
+
 def test_config_default_present():
     """DEFAULT_CONFIG carries the new key defaulting to True."""
     from hermes_cli import config_defaults
     assert config_defaults.DEFAULT_CONFIG["skills"]["background_review"][
         "require_read_before_write"] is True
-
-
-def monkeypatch_is_bg(smt, value):
-    """Override is_background_review() import used inside the guard."""
-    import sys
-    import types
-    fake_mod = types.ModuleType("tools.skill_provenance")
-    fake_mod.is_background_review = lambda: value  # type: ignore[attr-defined]
-    sys.modules["tools.skill_provenance"] = fake_mod

--- a/tests/agent/test_read_before_write_guard.py
+++ b/tests/agent/test_read_before_write_guard.py
@@ -1,0 +1,88 @@
+"""Tests for the background-review read-before-write guard config escape hatch.
+
+Mirrors test_curator.py's env-isolation pattern (tmp_path + monkeypatch of
+Path.home / HERMES_HOME, reload of the module under test). No LLM is spawned.
+"""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.config import load_config
+
+
+@pytest.fixture
+def guard_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME and reload the skill_manager_tool module."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import tools.skill_manager_tool as smt
+    importlib.reload(smt)
+    return smt
+
+
+def test_guard_default_on_when_config_absent(guard_env):
+    """Shipped-default behaviour: guard active even with no config key set."""
+    smt = guard_env
+    # Patch is_background_review to True and simulate an unread target.
+    monkeypatch_is_bg(smt, True)
+    result = smt._background_review_read_before_write_guard(
+        name="demo-skill", target=Path("/x/SKILL.md"),
+        action="patch", file_label="SKILL.md",
+    )
+    assert result is not None
+    assert result.get("_read_before_write_required") is True
+
+
+def test_guard_off_when_config_false(guard_env, monkeypatch):
+    """Escape hatch: skills.background_review.require_read_before_write: false
+    lets the fork patch without re-reading."""
+    smt = guard_env
+    monkeypatch_is_bg(smt, True)
+    # Force the config key to False regardless of on-disk config.
+    import hermes_cli.config as cfg_mod
+    orig = cfg_mod.cfg_get
+
+    def fake_cfg(cfg, *keys, default=None):
+        if keys == ("skills", "background_review", "require_read_before_write"):
+            return False
+        return orig(cfg, *keys, default=default)
+
+    monkeypatch.setattr(cfg_mod, "cfg_get", fake_cfg)
+    importlib.reload(smt)
+    result = smt._background_review_read_before_write_guard(
+        name="demo-skill", target=Path("/x/SKILL.md"),
+        action="patch", file_label="SKILL.md",
+    )
+    assert result is None  # guard bypassed
+
+
+def test_guard_skipped_for_foreground(guard_env, monkeypatch):
+    """Foreground turns (not background review) are never gated."""
+    smt = guard_env
+    monkeypatch_is_bg(smt, False)
+    result = smt._background_review_read_before_write_guard(
+        name="demo-skill", target=Path("/x/SKILL.md"),
+        action="patch", file_label="SKILL.md",
+    )
+    assert result is None
+
+
+def test_config_default_present():
+    """DEFAULT_CONFIG carries the new key defaulting to True."""
+    from hermes_cli import config_defaults
+    assert config_defaults.DEFAULT_CONFIG["skills"]["background_review"][
+        "require_read_before_write"] is True
+
+
+def monkeypatch_is_bg(smt, value):
+    """Override is_background_review() import used inside the guard."""
+    import sys
+    import types
+    fake_mod = types.ModuleType("tools.skill_provenance")
+    fake_mod.is_background_review = lambda: value  # type: ignore[attr-defined]
+    sys.modules["tools.skill_provenance"] = fake_mod

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -439,13 +439,18 @@ def _background_review_read_before_write_guard(
     # (default True). When False, the autonomous fork may patch without first
     # loading the target — see issue #73965 for why the turn-scoped marker is
     # otherwise unreachable for multi-turn / worker-thread review passes.
+    # Fail CLOSED: any config-read error keeps the guard enforced (logs and
+    # falls through to the read check below) rather than silently disabling it.
     try:
         from hermes_cli.config import load_config
         if not cfg_get(load_config(), "skills", "background_review",
                        "require_read_before_write", default=True):
             return None
     except Exception:
-        return None
+        logger.warning(
+            "read-before-write guard: config unreadable, keeping guard ON",
+            exc_info=True,
+        )
 
     if _background_review_has_read(target):
         return None

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -435,6 +435,18 @@ def _background_review_read_before_write_guard(
     except Exception:
         return None
 
+    # Config escape hatch: skills.background_review.require_read_before_write
+    # (default True). When False, the autonomous fork may patch without first
+    # loading the target — see issue #73965 for why the turn-scoped marker is
+    # otherwise unreachable for multi-turn / worker-thread review passes.
+    try:
+        from hermes_cli.config import load_config
+        if not cfg_get(load_config(), "skills", "background_review",
+                       "require_read_before_write", default=True):
+            return None
+    except Exception:
+        return None
+
     if _background_review_has_read(target):
         return None
 


### PR DESCRIPTION
## What does this PR do?

Adds a config toggle `skills.background_review.require_read_before_write` (default `True` = shipped-safe) that lets users disable the autonomous background-review read-before-write guard.

The `_background_review_read_before_write_guard` requires the review fork to load the exact target via `skill_view()` in the **same turn** it patches. Models that split the read and write across turns — or lose the turn-scoped marker across worker threads (root cause tracked in #73965) — can never satisfy it, so **every** autonomous skill patch is refused. The exact symptom is reported in #62397.

This is a distinct proposal from the root-cause fix in #73965: it is an opt-out escape hatch, not a rewrite of the guard.

## Related Issue

Relates-to #73965 (root cause — turn-scoped ContextVar lost across worker threads) and #62397 (symptom — all bg-review skill writes refused). Not a duplicate: this adds a user-facing config escape hatch; #73965 is the in-process marker fix.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config_defaults.py`: add `skills.background_review.require_read_before_write: True` default.
- `cli-config.yaml.example`: document the new key (PR template housekeeping checklist).
- `tools/skill_manager_tool.py`: gate `_background_review_read_before_write_guard` on the config flag (read via `cfg_get(load_config(), ...)`, default `True`). Guard still skipped for foreground turns and non-review forks.
- `tests/agent/test_read_before_write_guard.py`: 4 tests — default-on, off-when-config-false, foreground-skipped, default-present-in-DEFAULT_CONFIG.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_read_before_write_guard.py -q` → 4 passed.
2. Set `skills.background_review.require_read_before_write: false` in `~/.hermes/config.yaml`; the autonomous fork patches without re-reading.
3. Default (key absent) → guard active, behavior unchanged from current main.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see #73965 / #62397)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass (ran the affected suite via `scripts/run_tests.sh`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (aarch64)
- [x] I've updated `cli-config.yaml.example` (added the new config key)
- [x] Considered cross-platform impact: change is pure Python config read, no OS-specific paths