### PR TITLE
fix(webhook): accept Pocket (heypocketai.com) X-HeyPocket-Signature

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -991,6 +991,31 @@ class WebhookAdapter(BasePlatformAdapter):
             ).hexdigest()
             return _hmac_str_equal(gh_sig, expected)
 
+        # Pocket (heypocketai.com): X-HeyPocket-Signature = <hex HMAC-SHA256 of
+        # "{timestamp}.{raw_body}">, X-HeyPocket-Timestamp = unix ms.
+        # Pocket's documented scheme (docs.heypocketai.com/docs/api/webhooks);
+        # ms-resolution timestamp, 300s replay window (same as generic V2).
+        hp_sig = request.headers.get("X-HeyPocket-Signature", "")
+        if hp_sig:
+            hp_timestamp = request.headers.get("X-HeyPocket-Timestamp", "")
+            if not hp_timestamp:
+                return False
+            try:
+                hp_ts = int(hp_timestamp)
+            except (TypeError, ValueError):
+                return False
+            if abs(int(time.time() * 1000) - hp_ts) > 300_000:
+                logger.warning(
+                    "[webhook] Route '%s' Pocket timestamp outside replay window",
+                    request.match_info.get("route_name", ""),
+                )
+                return False
+            signed_content = hp_timestamp.encode() + b"." + body
+            expected_hp = hmac.new(
+                secret.encode(), signed_content, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(hp_sig, expected_hp)
+
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")
         if gl_token:


### PR DESCRIPTION
## Problem

The Hermes webhook adapter's `_validate_signature()` has no branch for Pocket's `X-HeyPocket-Signature` header, so Pocket webhook deliveries cannot be authenticated via HMAC. Pocket signs the raw request body with HMAC-SHA256 of `{timestamp}.{body}` using a per-webhook signing secret and sends the result in `X-HeyPocket-Signature`, with the millisecond-resolution timestamp in `X-HeyPocket-Timestamp`.

Because the adapter's `_validate_signature()` has no branch for that header name, any Pocket route with a real secret configured is rejected as "no recognized signature header" — forcing users to run Pocket webhooks with `INSECURE_NO_AUTH` (unauthenticated) or not use Pocket webhooks at all.

The algorithm Pocket uses is already implemented in the adapter (generic HMAC-SHA256, hex-encoded); the gap is the missing header-name branch plus the ms-resolution timestamp (the existing generic V2 scheme uses second-resolution).

## Fix

Adds a Pocket branch between the GitHub and GitLab branches in `_validate_signature()`:
- Reads `X-HeyPocket-Signature` + `X-HeyPocket-Timestamp`
- Enforces a 300s replay window on the millisecond timestamp (same window as generic V2)
- Rejects on missing/malformed/stale timestamp rather than falling through to a less-protected scheme (mirrors the V2 downgrade-guard reasoning)
- Compares with `_hmac_str_equal` for timing-safe comparison

## Testing

- All 95 existing webhook adapter tests pass (`pytest tests/gateway/test_webhook_adapter.py`)
- Verified live end-to-end with a real Pocket account: signed POST → 202, unsigned/wrong-signature → 401, stale timestamp → 401

## References

- Pocket webhook docs: https://docs.heypocketai.com/docs/api/webhooks
- Same pattern as the Linear branch added in #87348
- Similar vendor-signature PRs: #71968 (Redmine), #77569 (Juniper Mist), #66895 (Gitea)