### PR TITLE
feat(fallback): model-pinned entries — require_same_model + match_model

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2536,6 +2536,35 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         )
         return agent._try_activate_fallback(reason)
 
+    # ``require_same_model`` — model-pinned fallback entry.  The entry only
+    # applies when its model matches the model that just failed, so the chain
+    # can express "switch PROVIDERS serving this exact model, never switch to
+    # a different model".  A different-model primary (e.g. claude-opus-5 on a
+    # relay) never activates it and falls through to normal error handling.
+    #
+    # ``match_model`` (optional, list) — alternate wire names the same model is
+    # published under on this provider (e.g. stealth/ox-alpha on Nous/OpenRouter
+    # is x-preview-f-free on opencode-free).  The entry activates when the
+    # failed model equals ``model`` OR any ``match_model`` name.
+    if fb.get("require_same_model"):
+        failed_model = str(getattr(agent, "model", "") or "").strip().lower()
+        accepted = [fb_model.lower()]
+        accepted += [
+            str(n).strip().lower()
+            for n in (fb.get("match_model") or [])
+            if str(n).strip()
+        ]
+        if failed_model not in accepted:
+            logger.info(
+                "Fallback skip: %s/%s has require_same_model but primary model "
+                "is %r — this fallback only serves %s",
+                fb_provider,
+                fb_model,
+                failed_model,
+                ", ".join(accepted),
+            )
+            return agent._try_activate_fallback(reason)
+
     # Skip entries that resolve to the same backend that just failed —
     # falling back to it loops the failure. Identity semantics (which axes
     # distinguish two backends, shim aliases, first-class credential

--- a/tests/run_agent/test_fallback_model_pinned.py
+++ b/tests/run_agent/test_fallback_model_pinned.py
@@ -1,0 +1,155 @@
+"""Model-pinned fallback entries (require_same_model / match_model).
+
+Signal technique: stub resolve_provider_client via guarded __import__ so it
+records args then raises RuntimeError(sentinel). try_activate_fallback wraps
+client construction in a broad `except Exception` that logs
+"Failed to activate fallback <model>: <sentinel>" — a captured-log hit proves
+the entry passed every gate. The boolean return is NOT usable (False both when
+skipped and when construction raised).
+"""
+import logging
+import sys
+
+import pytest
+
+
+CHAIN = [{
+    "provider": "openrouter",
+    "model": "stealth/ox-alpha",
+    "match_model": ["x-preview-f-free"],
+    "require_same_model": True,
+}]
+
+SENTINEL = "pinned-sentinel"
+
+
+class _Agent:
+    def __init__(self, model, provider="nous",
+                 base_url="https://inference-api.nousresearch.com/v1"):
+        import hermes_constants  # noqa: F401  (ensure repo on path)
+
+        self.model = model
+        self.provider = provider
+        self.base_url = base_url
+        self.quiet_mode = True
+        self._fallback_chain = CHAIN
+        self._fallback_index = 0
+        self._fallback_activated = False
+        self._unavailable_fallback_keys = set()
+        self._rate_limited_until = 0
+        self._rate_limit_backoff_count = 0
+        self._primary_runtime = {"provider": provider}
+        self._config_context_length = None
+
+    @staticmethod
+    def _is_azure_openai_url(url):
+        return False
+
+    @staticmethod
+    def _is_direct_openai_url(url):
+        return False
+
+    def _provider_model_requires_responses_api(self, model, provider=None):
+        return False
+
+    def _anthropic_prompt_cache_policy(self, **kw):
+        return (False, False)
+
+    def _ensure_lmstudio_runtime_loaded(self):
+        pass
+
+    def _buffer_status(self, message):
+        pass
+
+    def _try_activate_fallback(self, reason=None):
+        from agent.chat_completion_helpers import try_activate_fallback
+        return try_activate_fallback(self, reason)
+
+
+@pytest.fixture()
+def captured_resolution(monkeypatch):
+    import builtins
+
+    recorded = {}
+    real_import = builtins.__import__
+
+    def fake_resolve(provider, model=None, **kw):
+        recorded["provider"] = provider
+        recorded["model"] = model
+        raise RuntimeError(SENTINEL)
+
+    def guarded(name, *a, **kw):
+        mod = real_import(name, *a, **kw)
+        if name == "agent.auxiliary_client":
+            mod.resolve_provider_client = fake_resolve
+        return mod
+
+    class Cap(logging.Handler):
+        def __init__(self):
+            super().__init__()
+            self.lines = []
+
+        def emit(self, record):
+            self.lines.append(record.getMessage())
+
+    cap = Cap()
+    lg = logging.getLogger("agent.chat_completion_helpers")
+    lg.addHandler(cap)
+    lg.setLevel(logging.DEBUG)
+    builtins.__import__ = guarded
+    try:
+        yield recorded, cap.lines
+    finally:
+        builtins.__import__ = real_import
+        lg.removeHandler(cap)
+
+
+def _hit(lines):
+    return [ln for ln in lines if SENTINEL in ln]
+
+
+def test_pinned_entry_fires_for_primary_model(captured_resolution, monkeypatch):
+    recorded, lines = captured_resolution
+    monkeypatch.setattr(sys, "path", sys.path)
+    agent = _Agent("stealth/ox-alpha")
+    agent._try_activate_fallback()
+    assert _hit(lines), "same-model primary should reach client construction"
+    assert recorded["provider"] == "openrouter"
+    assert recorded["model"] == "stealth/ox-alpha"
+
+
+def test_pinned_entry_fires_for_match_model(captured_resolution):
+    recorded, lines = captured_resolution
+    agent = _Agent(
+        "x-preview-f-free",
+        provider="opencode-free",
+        base_url="https://opencode.ai/zen/v1",
+    )
+    agent._try_activate_fallback()
+    assert _hit(lines), "match_model name should be accepted"
+    assert recorded["provider"] == "openrouter"
+
+
+def test_pinned_entry_skips_other_models(captured_resolution):
+    _, lines = captured_resolution
+    agent = _Agent(
+        "claude-opus-5",
+        provider="custom",
+        base_url="https://agentrouter.example/v1",
+    )
+    activated = agent._try_activate_fallback()
+    assert activated is False
+    assert not _hit(lines), "different-model primary must never reach resolution"
+    assert agent.provider == "custom", "provider must be untouched"
+    assert agent._fallback_index >= len(agent._fallback_chain)
+
+
+def test_unpinned_chain_unaffected(captured_resolution):
+    """Regression: chains without require_same_model behave as before."""
+    recorded, lines = captured_resolution
+    agent = _Agent("claude-opus-5", provider="custom",
+                   base_url="https://x.example/v1")
+    agent._fallback_chain = [{"provider": "openrouter", "model": "some/other"}]
+    agent._try_activate_fallback()
+    assert _hit(lines), "unpinned entry must still fire for any model"
+    assert recorded["model"] == "some/other"

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -430,3 +430,22 @@ See [Scheduled Tasks (Cron)](/user-guide/features/cron) for full configuration d
 | Triage specifier | Layered (see above) | `auxiliary.triage_specifier` |
 | Delegation | Inherits the parent's `fallback_providers` chain; optional provider/model override | `delegation.provider` / `delegation.model` |
 | Cron jobs | Inherit the configured `fallback_providers` chain; optional per-job provider override | Per-job `provider` / `model` |
+
+## Model-Pinned Entries
+
+By default every entry in the chain is tried no matter which model failed.
+Add `require_same_model: true` to pin an entry to its own model — it then only
+fires when the failing primary serves that exact model, letting you express
+"switch providers serving this model, never switch models":
+
+```yaml
+fallback_providers:
+  - provider: opencode-free
+    model: x-preview-f-free
+    match_model: [stealth/ox-alpha]   # alternate wire names of the same model
+    require_same_model: true
+```
+
+`match_model` lists additional wire names of the same model on other providers.
+Entries with `require_same_model` are skipped (without error) when the failing
+primary serves a different model — unpinned entries keep today's behavior.


### PR DESCRIPTION
# Model-pinned fallback entries (require_same_model / match_model)

Closes #47781.

## What

Adds two optional keys to `fallback_providers` entries:

```yaml
fallback_providers:
  - provider: opencode-free
    model: x-preview-f-free
    match_model: [stealth/ox-alpha]   # alternate wire names, same model
    require_same_model: true
```

- `require_same_model: true` — the entry fires **only** when the failing
  primary serves the entry's own model (or one of `match_model`). This lets a
  chain express "switch providers serving this exact model, never switch to a
  different model".
- `match_model: [names]` — additional wire names of the same model on other
  providers (e.g. `x-preview-f-free` on opencode-free is the same Ox Alpha
  model published as `stealth/ox-alpha` on OpenRouter/Nous).

Entries without these flags behave exactly as today — zero behavior change for
existing chains. Unknown keys were already tolerated by
`_iter_fallback_entries`, so old configs are untouched.

## Why

Failover today always switches to whatever `provider:model` the next entry
names. For models served by multiple providers under different slugs, users
want provider redundancy **for the same model** — e.g. keep answering with Ox
Alpha via opencode-free when Nous drops it, instead of silently degrading to a
different model. #47781 reports the mirror-image bug (cron failover sending the
primary's model name to the fallback provider), which shows the demand:
model identity should survive failover when the user asks for it.

## Implementation

~30 lines in `try_activate_fallback` (agent/chat_completion_helpers.py),
inserted after the local-availability gate and before the same-backend
identity gate:

- computes accepted names = entry model + match_model entries (lowercased)
- if the failing primary's model is not in that set → log an info line and
  advance to the next chain entry
- otherwise fall through to existing client construction unchanged

Skipped entries do not error and do not mark anything unavailable — they are
simply not applicable to this failure.

## Tests

`tests/run_agent/test_fallback_model_pinned.py` (4 cases):
1. pinned entry fires for its own primary model
2. fires for each `match_model` wire name
3. skips cleanly for a different-model primary (no resolution attempted,
   provider untouched, chain advances)
4. regression: unpinned chains unaffected

Technique: stubs `resolve_provider_client` via guarded `__import__` to record
arguments then raise; asserts on the captured
"Failed to activate fallback <model>: <sentinel>" log line, since the boolean
return is ambiguous (False both on skip and on construction failure).

```
scripts/run_tests.sh tests/run_agent/test_fallback_model_pinned.py
→ 4 passed

Regression: tests/run_agent/test_fallback_credential_isolation.py +
tests/run_agent/test_32646_fallback_429_after_timeout.py → 13 passed.
(test_nous_fallback_unavailable.py has one pre-existing failure on main,
unrelated to this change — anthropic package missing in the test env.)
```

## Docs

New "Model-Pinned Entries" section appended to
`website/docs/user-guide/features/fallback-providers.md`.
