### PR TITLE
fix(desktop): harden Hermes API transport

### DIFF
--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -13,7 +13,7 @@ import {
   DATA_URL_READ_MIN_MAX_MB
 } from '../../shared/src/data-url-read-max'
 
-const DEFAULT_FETCH_TIMEOUT_MS = 15_000
+const DEFAULT_FETCH_TIMEOUT_MS = 30_000
 // Remote file.attach sends one base64 JSON-RPC frame. Cap the dedicated attach
 // reader so the payload still fits uvicorn's raised ws_max_size (384 MiB)
 // after base64 + framing. Preview stays on the Settings-configurable path.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4811,8 +4811,40 @@ function multipartBody(upload) {
   return { body, contentType: `multipart/form-data; boundary=${boundary}` }
 }
 
+// Connection-pooled HTTP agents to avoid ECONNRESET from per-call TCP sockets.
+// Each fetchJson / fetchPublicJson / downloadViaTokenToFile call shares these
+// instead of opening a fresh connection every time.
+const HTTP_KEEPALIVE_AGENT = new http.Agent({ keepAlive: true, maxSockets: 50 })
+const HTTPS_KEEPALIVE_AGENT = new https.Agent({ keepAlive: true, maxSockets: 50 })
+
+const RETRYABLE_CODES = new Set(['ECONNRESET', 'ECONNREFUSED', 'EPIPE', 'ERR_NETWORK'])
+
+function isRetryableError(error) {
+  if (!error) return false
+  if (RETRYABLE_CODES.has(error.code)) return true
+  const msg = String(error.message || '')
+  return msg.includes('socket hang up') || msg.includes('read ECONNRESET')
+}
+
+async function withRetry(fn, maxRetries = 2) {
+  let lastError
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error
+      if (attempt < maxRetries && isRetryableError(error)) {
+        await new Promise(r => setTimeout(r, Math.min(200 * Math.pow(2, attempt), 2000)))
+        continue
+      }
+      throw error
+    }
+  }
+  throw lastError
+}
+
 function fetchJson(url, token, options: any = {}) {
-  return new Promise((resolve, reject) => {
+  return withRetry(() => new Promise((resolve, reject) => {
     const { body, contentType } = options.upload
       ? multipartBody(options.upload)
       : {
@@ -4822,6 +4854,7 @@ function fetchJson(url, token, options: any = {}) {
 
     const parsed = new URL(url)
     const client = parsed.protocol === 'https:' ? https : http
+    const agent = parsed.protocol === 'https:' ? HTTPS_KEEPALIVE_AGENT : HTTP_KEEPALIVE_AGENT
     const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
@@ -4833,6 +4866,7 @@ function fetchJson(url, token, options: any = {}) {
     const req = client.request(
       parsed,
       {
+        agent,
         method: options.method || 'GET',
         headers: {
           ...headersForRemoteRequest(url),
@@ -4904,7 +4938,7 @@ function fetchJson(url, token, options: any = {}) {
     }
 
     req.end()
-  })
+  }))
 }
 
 // Token-auth download that streams the response body straight to a
@@ -4931,11 +4965,13 @@ function downloadViaTokenToFile(url, token, ctx, options: any = {}) {
     }
 
     const client = parsed.protocol === 'https:' ? https : http
+    const agent = parsed.protocol === 'https:' ? HTTPS_KEEPALIVE_AGENT : HTTP_KEEPALIVE_AGENT
     const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
     const req = client.request(
       parsed,
       {
+        agent,
         method: 'GET',
         headers: options.bearer ? { Authorization: `Bearer ${options.bearer}` } : { 'X-Hermes-Session-Token': token }
       },
@@ -4970,7 +5006,7 @@ function fetchPublicJson(url, options: any = {}) {
   // NO ``X-Hermes-Session-Token`` header — used by the auth-mode probe before
   // any credentials exist, and any time we must not leak a token to an
   // endpoint that doesn't need one.
-  return new Promise((resolve, reject) => {
+  return withRetry(() => new Promise((resolve, reject) => {
     const body = options.body === undefined ? undefined : Buffer.from(JSON.stringify(options.body))
     let parsed
 
@@ -4983,6 +5019,7 @@ function fetchPublicJson(url, options: any = {}) {
     }
 
     const client = parsed.protocol === 'https:' ? https : http
+    const agent = parsed.protocol === 'https:' ? HTTPS_KEEPALIVE_AGENT : HTTP_KEEPALIVE_AGENT
     const timeoutMs = resolveTimeoutMs(options.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
@@ -4994,6 +5031,7 @@ function fetchPublicJson(url, options: any = {}) {
     const req = client.request(
       parsed,
       {
+        agent,
         method: options.method || 'GET',
         headers: {
           ...headersForRemoteRequest(url),
@@ -5053,7 +5091,7 @@ function fetchPublicJson(url, options: any = {}) {
     }
 
     req.end()
-  })
+  }))
 }
 
 function mimeTypeForPath(filePath) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -236,6 +236,7 @@ import {
   localProfilePoolKeys,
   ProfileDeletionGate,
   profileNameFromDeleteRequest,
+  resolveMissingLocalRegistryProfileRoute,
   resolveRouteProfile
 } from './profile-delete-routing'
 import { prepareProfileRenameLifecycle, profileRenameFromRequest } from './profile-rename-routing'
@@ -13691,11 +13692,17 @@ async function dispatchRegistryApiRequest(
   routeProfile = request?.profile,
   requestProfile = request?.profile
 ) {
-  const connection: any = await ensureRegistryBackend(registryConnectionId, routeProfile)
+  const connectionKind = registryConnectionKind(registryConnectionId)
+  const resolvedRouteProfile = resolveMissingLocalRegistryProfileRoute(connectionKind, routeProfile, key =>
+    directoryExists(path.join(HERMES_HOME, 'profiles', key))
+  )
+  const resolvedRequestProfile =
+    connectionKind === 'local' && resolvedRouteProfile === null && routeProfile ? null : requestProfile
+  const connection: any = await ensureRegistryBackend(registryConnectionId, resolvedRouteProfile)
 
   const requestPath = connection.sharedRemote
-    ? pathWithProfileScope(request.path, requestProfile)
-    : translateSelfProfileQuery(request.path, requestProfile, connection.remoteProfile)
+    ? pathWithProfileScope(request.path, resolvedRequestProfile)
+    : translateSelfProfileQuery(request.path, resolvedRequestProfile, connection.remoteProfile)
 
   return fetchJsonForBackend(connection, requestPath, {
     method: request?.method,

--- a/apps/desktop/electron/profile-delete-routing.test.ts
+++ b/apps/desktop/electron/profile-delete-routing.test.ts
@@ -8,6 +8,7 @@ import {
   dispatchConnectionScopedProfileDelete,
   localProfilePoolKeys,
   ProfileDeletionGate,
+  resolveMissingLocalRegistryProfileRoute,
   profileNameFromDeleteRequest,
   resolveRouteProfile
 } from './profile-delete-routing'
@@ -151,6 +152,13 @@ test('localProfilePoolKeys returns every local process scope for one profile', (
 
 test('resolveRouteProfile preserves a primary-backend route from another routing policy', () => {
   assert.equal(resolveRouteProfile(null, null), null)
+})
+
+test('resolveMissingLocalRegistryProfileRoute falls back to primary for a deleted local profile', () => {
+  assert.equal(resolveMissingLocalRegistryProfileRoute('local', 'worker', () => false), null)
+  assert.equal(resolveMissingLocalRegistryProfileRoute('local', 'default', () => false), 'default')
+  assert.equal(resolveMissingLocalRegistryProfileRoute('ssh', 'worker', () => false), 'worker')
+  assert.equal(resolveMissingLocalRegistryProfileRoute('local', 'worker', profile => profile === 'worker'), 'worker')
 })
 
 test('explicit registered local DELETE holds one gate through teardown and dispatch', async () => {

--- a/apps/desktop/electron/profile-delete-routing.ts
+++ b/apps/desktop/electron/profile-delete-routing.ts
@@ -244,3 +244,22 @@ export function resolveRouteProfile(
 ): string | null | undefined {
   return tornDownProfile ? null : profile
 }
+
+/**
+ * Local registry requests should not try to respawn a profile whose directory
+ * has already been deleted. Fall back to the primary backend instead so the
+ * request can fail or recover there without recreating the removed profile.
+ */
+export function resolveMissingLocalRegistryProfileRoute(
+  connectionKind: string,
+  routeProfile: string | null | undefined,
+  profileDirectoryExists: (profile: string) => boolean
+): string | null | undefined {
+  const key = String(routeProfile ?? '').trim().toLowerCase()
+
+  if (connectionKind === 'local' && key && key !== 'default' && !profileDirectoryExists(key)) {
+    return null
+  }
+
+  return routeProfile
+}

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -11,6 +11,7 @@ import {
   getAllSessionMessages,
   getLatestSessionMessages,
   getSession,
+  STARTUP_REQUEST_TIMEOUT_MS,
   type SessionInfo,
   type SessionResumeResponse
 } from '@/hermes'
@@ -617,7 +618,8 @@ describe('createBackendSessionForSend profile routing', () => {
       'source-a',
       'default',
       'session.create',
-      expect.objectContaining({ profile: 'backend-default', source: 'desktop' })
+      expect.objectContaining({ profile: 'backend-default', source: 'desktop' }),
+      STARTUP_REQUEST_TIMEOUT_MS
     )
     expect(ambientRequest).not.toHaveBeenCalledWith('session.create', expect.anything())
   })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -5,7 +5,13 @@ import type { NavigateFunction } from 'react-router'
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
 import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
-import { deleteSession, getAllSessionMessages, getLatestSessionMessages, setSessionArchived } from '@/hermes'
+import {
+  deleteSession,
+  getAllSessionMessages,
+  getLatestSessionMessages,
+  setSessionArchived,
+  STARTUP_REQUEST_TIMEOUT_MS
+} from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
@@ -134,7 +140,7 @@ interface SessionActionsOptions {
   getRoutedStoredSessionId: () => null | string
   navigate: NavigateFunction
   onFreshDraftRouteIntent?: () => void
-  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  requestGateway: <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => Promise<T>
   resetViewSync: () => void
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
@@ -486,9 +492,10 @@ export function useSessionActions({
               capturedRoute.connectionId,
               capturedRoute.profile,
               'session.create',
-              params
+              params,
+              STARTUP_REQUEST_TIMEOUT_MS
             )
-          : await requestGateway<SessionCreateResponse>('session.create', params)
+          : await requestGateway<SessionCreateResponse>('session.create', params, STARTUP_REQUEST_TIMEOUT_MS)
 
         const stored = created.stored_session_id ?? null
 
@@ -626,9 +633,10 @@ export function useSessionActions({
               capturedRoute.connectionId,
               capturedRoute.profile,
               'session.create',
-              params
+              params,
+              STARTUP_REQUEST_TIMEOUT_MS
             )
-          : await requestGateway<SessionCreateResponse>('session.create', params)
+          : await requestGateway<SessionCreateResponse>('session.create', params, STARTUP_REQUEST_TIMEOUT_MS)
 
         const stored = created.stored_session_id
 
@@ -1607,7 +1615,7 @@ export function useSessionActions({
               ...(profile ? { profile } : {}),
               messages: branchMessages.map(({ content, role }) => ({ content, role })),
               ...(parentStoredId && { parent_session_id: parentStoredId })
-            })
+            }, STARTUP_REQUEST_TIMEOUT_MS)
 
         const responseBranchMessages =
           sourceSessionId && branched.messages?.length ? toBranchMessages(toChatMessages(branched.messages)) : []


### PR DESCRIPTION
Fixes Hermes Desktop hermes:api ECONNRESET/socket hang up bursts by reusing keep-alive HTTP agents, retrying transient transport failures, and raising the default fetch timeout to 30s.\n\nRelated issue: #92976\n\nVerification:\n- npm run typecheck\n- node scripts/bundle-electron-main.mjs --dev