### PR TITLE
test(cron): cover windowless Windows shell spawns

### DIFF
--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -202,6 +202,45 @@ class TestRunJobScript:
         assert env["VIRTUAL_ENV"] == str(venv)
         assert str(site_packages) in env["PYTHONPATH"]
 
+    @pytest.mark.windows_only
+    def test_windows_shell_script_runs_without_a_console(self, cron_env, monkeypatch):
+        """Shell-backed cron scripts use the same hidden process contract."""
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.sh"
+        script.write_text("printf 'ok\\n'\n", encoding="utf-8")
+        captured = {}
+
+        class FakeProc:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["kwargs"] = kwargs
+                self.returncode = 0
+
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout=None):
+                return ("ok\n", "")
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        monkeypatch.setattr(sched_mod.shutil, "which", lambda name: "bash.exe")
+        monkeypatch.setattr(sched_mod, "windows_hide_flags", lambda: 0x08000000)
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", FakeProc)
+
+        success, output = _run_job_script("probe.sh")
+
+        assert success is True
+        assert output == "ok"
+        assert captured["argv"] == ["bash.exe", str(script.resolve())]
+        expected_flags = sched_mod.windows_hide_flags() | getattr(
+            sched_mod.subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
+        assert captured["kwargs"]["creationflags"] == expected_flags
+
     def test_bootstrap_argv_makes_pth_editable_installs_importable(self, cron_env, tmp_path):
         """The bootstrap must process .pth files — the whole reason the
         overlay mode exists is that PYTHONPATH alone cannot (editable

--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -29,6 +29,7 @@ Hermes calls this **no-agent mode**. It's the cron system minus the LLM.
 - **No LLM call.** Zero tokens, zero agent loop, zero model spend.
 - **Script is the job.** The script decides whether to alert. Emit output → message gets sent. Emit nothing → silent tick.
 - **Bash or Python.** `.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash`; any other extension runs under the current Python interpreter. Paths must resolve inside `~/.hermes/scripts/` (relative, absolute, or `~` forms are OK if they stay in that directory). Cron scripts do **not** inherit provider credentials from the Hermes process environment.
+- **Windowless on native Windows.** Cron script processes are created without a visible console window. Python scripts also bypass the uv virtual-environment launcher when needed; `.sh` / `.bash` scripts still require `bash` from Git for Windows or another available Bash installation.
 - **Same scheduler.** Lives in `cronjob` alongside LLM jobs — pausing, resuming, listing, logs, and delivery targeting all work the same way.
 
 ## When to Use It


### PR DESCRIPTION
## Summary

- add native-Windows regression coverage for Bash-backed cron scripts
- assert the hidden-window and process-group creation flags
- document the windowless contract and Bash requirement

## Why

The production spawn path already applies the hidden-window flags. This change makes the remaining shell-script behavior an explicit Windows-tested contract and documents the runtime requirement.

## Testing

- `python -m pytest tests/cron/test_cron_script.py -q` (27 passed, 2 skipped)
- `python -m py_compile cron/scheduler.py tests/cron/test_cron_script.py`
- `git diff --check origin/main...HEAD`

Refs #79827