### PR TITLE
fix(email): send IMAP ID only when the server advertises the capability

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -141,7 +141,19 @@ def _open_smtp(host: str, port: int, security: str, ctx: ssl.SSLContext, smtp_cl
 
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID: 163/NetEase require it after LOGIN (else every UID command
-    returns ``BYE Unsafe Login``); other servers may reject it, so failures are swallowed."""
+    returns ``BYE Unsafe Login``); other servers may reject it, so failures are swallowed.
+
+    Sent only when the server advertises ``ID`` (RFC 2971 requires advertising it): a server
+    without the extension can answer an untagged ``* BYE Unknown command.`` and close the
+    connection, which imaplib cannot surface here — the failure appears one command later
+    as a misleading SELECT error and the adapter retries forever (Purelymail, #39856).
+    ``imap.capabilities`` is populated by imaplib at connect, so the check is free."""
+    caps = getattr(imap, "capabilities", ()) or ()
+    if "ID" not in caps:
+        logger.debug(
+            "[Email] Server does not advertise IMAP ID capability; skipping ID"
+        )
+        return
     try:
         try:
             from hermes_cli import __version__ as _hermes_version

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -939,6 +939,7 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
+        mock_imap.capabilities = ("IMAP4REV1", "ID", "UIDPLUS")
         mock_imap.uid.return_value = ("OK", [b""])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
@@ -961,6 +962,56 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         names = [c[0] for c in mock_imap.method_calls]
         self.assertIn("login", names)
         self.assertLess(names.index("login"), names.index("xatom"))
+
+    def test_send_imap_id_sent_when_capability_advertised(self):
+        """ID goes out when the server lists it in CAPABILITY."""
+        from plugins.platforms.email.adapter import _send_imap_id
+
+        mock_imap = MagicMock()
+        mock_imap.capabilities = ("IMAP4REV1", "ID", "UIDPLUS")
+
+        _send_imap_id(mock_imap)
+
+        mock_imap.xatom.assert_called_once()
+        self.assertEqual(mock_imap.xatom.call_args.args[0], "ID")
+
+    def test_send_imap_id_skipped_when_capability_absent(self):
+        """Servers that do not advertise ID must not receive it: Purelymail
+        answers the unknown command with an untagged ``* BYE Unknown
+        command.`` and drops the connection, which imaplib surfaces one
+        command later as a misleading SELECT failure."""
+        from plugins.platforms.email.adapter import _send_imap_id
+
+        mock_imap = MagicMock()
+        mock_imap.capabilities = ("IMAP4REV1", "UIDPLUS")
+
+        _send_imap_id(mock_imap)
+
+        mock_imap.xatom.assert_not_called()
+
+    def test_send_imap_id_skipped_when_capabilities_attribute_missing(self):
+        """A connection object without a capabilities attribute must not
+        crash the helper; fail toward not sending optional commands."""
+        from plugins.platforms.email.adapter import _send_imap_id
+
+        mock_imap = MagicMock(spec=["xatom"])
+
+        _send_imap_id(mock_imap)
+
+        mock_imap.xatom.assert_not_called()
+
+    def test_send_imap_id_rejection_still_swallowed(self):
+        """A server that advertises ID but rejects it with a tagged error
+        keeps the existing best-effort handling: no exception escapes."""
+        from plugins.platforms.email.adapter import _send_imap_id
+
+        mock_imap = MagicMock()
+        mock_imap.capabilities = ("IMAP4REV1", "ID")
+        mock_imap.xatom.side_effect = Exception("BAD ID rejected")
+
+        _send_imap_id(mock_imap)  # must not raise
+
+        mock_imap.xatom.assert_called_once()
 
 
 class TestConnectSmtp(unittest.TestCase):

--- a/tests/gateway/test_email_imap_id_protocol.py
+++ b/tests/gateway/test_email_imap_id_protocol.py
@@ -1,0 +1,124 @@
+"""Exercise IMAP ID negotiation with real imaplib and a local protocol peer.
+
+No external mail service or credentials are used. Unsupported ID gets BAD
+followed by BYE: swallowing the ID error still leaves SELECT unable to proceed.
+"""
+
+import asyncio
+import imaplib
+import socketserver
+import threading
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@contextmanager
+def imap_peer(id_mode):
+    commands = []
+
+    class Handler(socketserver.StreamRequestHandler):
+        def handle(self):
+            self.connection.settimeout(5)
+            try:
+                self.exchange()
+            except (TimeoutError, ConnectionError):
+                # Bound cleanup even if the client fails before LOGOUT.
+                return
+
+        def exchange(self):
+            self.wfile.write(b"* OK test IMAP ready\r\n")
+            while raw := self.rfile.readline():
+                tag, command, *_ = raw.decode("ascii").strip().split()
+                command = command.upper()
+                commands.append(command)
+                prefix = tag.encode("ascii")
+                if command == "CAPABILITY":
+                    caps = b"IMAP4rev1" + (b" ID" if id_mode != "absent" else b"")
+                    self.wfile.write(b"* CAPABILITY " + caps + b"\r\n")
+                elif command == "ID":
+                    if id_mode == "absent":
+                        self.wfile.write(
+                            prefix
+                            + b" BAD ID unsupported\r\n* BYE Unknown command.\r\n"
+                        )
+                        return
+                    if id_mode == "reject":
+                        self.wfile.write(prefix + b" BAD ID rejected\r\n")
+                        continue
+                    self.wfile.write(b"* ID NIL\r\n")
+                elif command == "SELECT":
+                    self.wfile.write(b"* 0 EXISTS\r\n")
+                elif command == "UID":
+                    self.wfile.write(b"* SEARCH\r\n")
+                elif command == "LOGOUT":
+                    self.wfile.write(
+                        b"* BYE logging out\r\n" + prefix + b" OK LOGOUT\r\n"
+                    )
+                    return
+                elif command != "LOGIN":
+                    self.wfile.write(prefix + b" BAD unexpected command\r\n")
+                    continue
+                self.wfile.write(prefix + b" OK completed\r\n")
+
+    # Non-daemon handler threads are joined by server_close on context exit;
+    # socket timeouts also bound teardown when the client fails prematurely.
+    with socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler) as server:
+        thread = threading.Thread(
+            target=server.serve_forever,
+            kwargs={"poll_interval": 0.05},
+            daemon=True,
+        )
+        thread.start()
+        try:
+            yield ("127.0.0.1", int(server.server_address[1])), commands
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+
+@pytest.mark.parametrize("id_mode", ["absent", "accept", "reject"])
+@pytest.mark.parametrize("phase", ["startup", "poll"])
+def test_id_negotiation_preserves_inbox_connection(monkeypatch, id_mode, phase):
+    from gateway.config import PlatformConfig
+    from plugins.platforms.email.adapter import EmailAdapter
+
+    for key, value in {
+        "EMAIL_ADDRESS": "agent@example.test",
+        "EMAIL_PASSWORD": "test-only",
+        "EMAIL_IMAP_HOST": "imap.example.test",
+        "EMAIL_SMTP_HOST": "smtp.example.test",
+    }.items():
+        monkeypatch.setenv(key, value)
+    adapter = EmailAdapter(PlatformConfig(enabled=True))
+    monkeypatch.setattr(adapter, "_connect_smtp", MagicMock(return_value=MagicMock()))
+
+    with imap_peer(id_mode) as (address, commands):
+        # TLS is out of scope: replace only the transport with real imaplib on
+        # loopback, keeping the actual IMAP parser and command API under test.
+        monkeypatch.setattr(
+            imaplib,
+            "IMAP4_SSL",
+            lambda *args, **kwargs: imaplib.IMAP4(*address, timeout=5),
+        )
+
+        if phase == "startup":
+
+            async def connect_and_stop():
+                try:
+                    return await adapter.connect()
+                finally:
+                    await adapter.disconnect()
+
+            assert asyncio.run(connect_and_stop()) is True
+        else:
+            assert adapter._fetch_new_messages() == []
+            assert adapter._last_fetch_failed is False
+
+    assert commands.count("ID") == (0 if id_mode == "absent" else 1)
+    assert commands.index("LOGIN") < commands.index("SELECT") < commands.index("UID")
+    if id_mode != "absent":
+        assert commands.index("LOGIN") < commands.index("ID") < commands.index("SELECT")
+    assert commands[-1] == "LOGOUT"


### PR DESCRIPTION
**What does this PR do?**

`_send_imap_id()` sends RFC 2971 `ID` unconditionally after login (a 163/NetEase requirement). Servers that do not support `ID` can react badly: Purelymail answers with an untagged `* BYE Unknown command.` and closes the connection, which `imaplib` cannot surface at the call site — the failure appears one command later as `IMAP connection failed: command: SELECT => Unknown command.` and the adapter retries forever. This PR gates the `ID` send on the server's advertised capabilities (`imap.capabilities`, populated by `imaplib` at connect), keeping the existing exception handler for servers that advertise `ID` but reject it. Ports open PR #39861 to the current plugin layout, as requested by the hermes-sweeper review there.

Credential-free reproduction of the server behavior:

```
$ printf 'a1 ID ("name" "test")\r\na2 CAPABILITY\r\na3 LOGOUT\r\n' | \
    openssl s_client -connect imap.purelymail.com:993 -quiet
* OK PM IMAP ready
* BYE Unknown command.
```

Verified on a live Purelymail session that `LOGIN` → `CAPABILITY` → `SELECT` succeeds, and that `ID` is absent from both the pre- and post-auth capability lists. Residual: a server that requires `ID` without advertising it (none known; RFC 2971 requires advertising) would regress to its pre-workaround behavior.

**Related Issue:** Fixes #39856. Supersedes #39861 (same fix, file since moved; credited with `Co-authored-by`).

**Type of Change:** 🐛 Bug fix

**Changes Made:**

- `plugins/platforms/email/adapter.py`: capability guard at the top of `_send_imap_id()`; debug log when skipping.
- `tests/gateway/test_email.py`: existing ID test's mock now advertises `ID`; four new tests (send / skip / missing-attribute / rejecting-server).

**How to Test:**

1. `scripts/run_tests.sh tests/gateway/test_email.py` — 43 tests, includes the four new ones.
2. Gateway against a Purelymail account: connects instead of failing with `SELECT => Unknown command`.
3. Gateway against a 163.com account: `ID` still sent after login.

Tested on: macOS (full `scripts/run_tests.sh` run; the 96 failures reproduce identically on pristine `main` — all pre-existing platform/environment issues, zero from this change), Linux (live gateway against a production Purelymail account: three profiles connect and process mail through the gated path).

Confirmed 163/NetEase advertises `ID`:
```
❯ printf 'a1 CAPABILITY\r\na2 LOGOUT\r\n' | openssl s_client -connect imap.163.com:993 -quiet
Connecting to 111.124.203.50
depth=2 C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G2
verify return:1
depth=1 C=US, O=DigiCert, Inc., CN=GeoTrust G2 TLS CN RSA4096 SHA256 2022 CA1
verify return:1
depth=0 C=CN, ST=Zhejiang, L=Hangzhou, O=NetEase (Hangzhou) Network Co., Ltd, CN=*.163.com
verify return:1
* OK Coremail System IMap Server Ready(163com[10774b260cc7a37d26d71b52404dcf5c])
* CAPABILITY IMAP4rev1 XLIST SPECIAL-USE ID LITERAL+ STARTTLS APPENDLIMIT=71680000 XAPPLEPUSHSERVICE UIDPLUS X-CM-EXT-1 SASL-IR AUTH=XOAUTH2
a1 OK CAPABILITY completed
* BYE IMAP4rev1 Server logging out
a2 OK LOGOUT completed
806148F501000000:error:0A000126:SSL routines::unexpected eof while reading:ssl/record/rec_layer_s3.c:703:
806148F501000000:error:0A000197:SSL routines:SSL_shutdown:shutdown while in init:ssl/ssl_lib.c:2804:
```
The same probe against imap.126.com and imap.yeah.net (the other NetEase mail domains) returns the identical Coremail capability list, ID included.


**Update: rebased, plus protocol tests from @mechkw**

The branch has been rebased onto current `main`. The only conflict was the `_send_imap_id()` docstring, which `main` had condensed in the platform-adapter refactor; the resolution keeps `main`'s wording and appends the capability-gating rationale under it. The guard itself is unchanged.

Ken Watts (@mechkw) wrote `tests/gateway/test_email_imap_id_protocol.py` and offered it on the fork. It is cherry-picked here as their own commit, unmodified.

The test stands up a throwaway IMAP server on loopback and drives the adapter at it through real `imaplib`, so the actual protocol exchange is asserted rather than a mock's call list. Six cases: three server behaviours (does not advertise `ID`; advertises and accepts it; advertises it and answers a tagged `BAD`) across both code paths that log in (startup connect, and the message poll). Each case asserts the command order on the wire and that the session ends with a clean `LOGOUT`.

The two cases where the server does not advertise `ID` are the ones this PR exists for, and they fail on the unguarded adapter. Removing the guard locally turns exactly those two red, with the misleading `[Email] IMAP fetch error: command: SELECT => Unknown command.` from the issue.

Run them with `pytest tests/gateway/test_email.py tests/gateway/test_email_imap_id_protocol.py`: 49 passed (43 existing plus the 6 new).
