### PR TITLE
feat(desktop): route CLI prompts through running sessions

### DIFF
--- a/apps/desktop/electron/chat-z.test.ts
+++ b/apps/desktop/electron/chat-z.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { ChatZRequestError, parseChatZRequest } from './chat-z'
+
+const ID = '123e4567-e89b-42d3-a456-426614174000'
+const NOW = 1_000
+
+function base() {
+  return {
+    version: 1,
+    requestId: ID,
+    profile: 'default',
+    text: 'Run this',
+    createdAt: NOW,
+    expiresAt: NOW + 30_000
+  }
+}
+
+describe('parseChatZRequest', () => {
+  it('accepts a fixed title on a project-scoped new session', () => {
+    expect(
+      parseChatZRequest({ ...base(), newSession: true, cwd: 'C:\\project', newTitle: 'Knowledge receiver' }, ID, NOW)
+    ).toMatchObject({ newSession: true, cwd: 'C:\\project', newTitle: 'Knowledge receiver' })
+  })
+
+  it('rejects a new title on an existing-session target', () => {
+    expect(() =>
+      parseChatZRequest({ ...base(), sessionId: 'stored-1', newTitle: 'Wrong target' }, ID, NOW)
+    ).toThrowError(ChatZRequestError)
+  })
+
+  it('requires exactly one target', () => {
+    expect(() => parseChatZRequest({ ...base(), sessionId: 'stored-1', title: 'Receiver' }, ID, NOW)).toThrowError(
+      /exactly one target/i
+    )
+  })
+
+  it('rejects expired requests before routing them to the renderer', () => {
+    expect(() => parseChatZRequest({ ...base(), sessionId: 'stored-1' }, ID, NOW + 30_001)).toThrowError(/expired/i)
+  })
+})

--- a/apps/desktop/electron/chat-z.test.ts
+++ b/apps/desktop/electron/chat-z.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { ChatZRequestError, parseChatZRequest } from './chat-z'
+import { type ChatZRequest, ChatZRequestError, ChatZRequestState, parseChatZRequest } from './chat-z'
 
 const ID = '123e4567-e89b-42d3-a456-426614174000'
 const NOW = 1_000
@@ -37,5 +37,33 @@ describe('parseChatZRequest', () => {
 
   it('rejects expired requests before routing them to the renderer', () => {
     expect(() => parseChatZRequest({ ...base(), sessionId: 'stored-1' }, ID, NOW + 30_001)).toThrowError(/expired/i)
+  })
+})
+
+describe('ChatZRequestState', () => {
+  it('fails inflight requests but preserves requests not yet sent across a renderer reload', () => {
+    const state = new ChatZRequestState()
+    const pending = { ...base(), requestId: 'pending', sessionId: 'stored-1' } as ChatZRequest
+    const inflight = { ...base(), requestId: 'inflight', sessionId: 'stored-2' } as ChatZRequest
+
+    state.queue(pending)
+    state.begin(inflight)
+
+    expect(state.rendererLost()).toEqual(['inflight'])
+    expect(state.isInflight('inflight')).toBe(false)
+    expect(state.pendingRequests()).toEqual([pending])
+  })
+
+  it('fails both pending and inflight requests when the Desktop window closes', () => {
+    const state = new ChatZRequestState()
+    const pending = { ...base(), requestId: 'pending', sessionId: 'stored-1' } as ChatZRequest
+    const inflight = { ...base(), requestId: 'inflight', sessionId: 'stored-2' } as ChatZRequest
+
+    state.queue(pending)
+    state.begin(inflight)
+
+    expect(new Set(state.rendererLost({ dropPending: true }))).toEqual(new Set(['pending', 'inflight']))
+    expect(state.pendingRequests()).toEqual([])
+    expect(state.isInflight('inflight')).toBe(false)
   })
 })

--- a/apps/desktop/electron/chat-z.ts
+++ b/apps/desktop/electron/chat-z.ts
@@ -1,0 +1,197 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const CHAT_Z_VERSION = 1
+export const CHAT_Z_MAX_REQUEST_BYTES = 1_100_000
+export const CHAT_Z_MAX_PROMPT_CHARS = 1_000_000
+
+const REQUEST_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export interface ChatZRequest {
+  version: 1
+  requestId: string
+  profile: string
+  text: string
+  title?: string
+  sessionId?: string
+  newSession?: true
+  newTitle?: string
+  cwd?: string
+  createdAt: number
+  expiresAt: number
+}
+
+export interface ChatZReceipt {
+  requestId: string
+  status: 'accepted' | 'error'
+  code?: string
+  message?: string
+  profile?: string
+  queued?: boolean
+  storedSessionId?: string
+  title?: string
+  created?: boolean
+  cwd?: string
+}
+
+export class ChatZRequestError extends Error {
+  constructor(
+    readonly code: string,
+    message: string
+  ) {
+    super(message)
+    this.name = 'ChatZRequestError'
+  }
+}
+
+export function isChatZRequestId(value: unknown): value is string {
+  return typeof value === 'string' && REQUEST_ID_RE.test(value)
+}
+
+export function chatZPaths(userData: string, requestId: string): { receipt: string; request: string } {
+  if (!isChatZRequestId(requestId)) {
+    throw new ChatZRequestError('invalid-request-id', 'Invalid chat-z request ID')
+  }
+
+  const root = path.join(userData, 'chat-z')
+
+  return {
+    request: path.join(root, 'requests', `${requestId}.json`),
+    receipt: path.join(root, 'receipts', `${requestId}.json`)
+  }
+}
+
+function requiredString(value: unknown, field: string, max: number): string {
+  const result = typeof value === 'string' ? value.trim() : ''
+
+  if (!result) {
+    throw new ChatZRequestError('invalid-request', `${field} is required`)
+  }
+
+  if (result.length > max) {
+    throw new ChatZRequestError('request-too-large', `${field} is too long`)
+  }
+
+  return result
+}
+
+export function parseChatZRequest(raw: unknown, expectedRequestId: string, now = Date.now()): ChatZRequest {
+  if (!raw || typeof raw !== 'object') {
+    throw new ChatZRequestError('invalid-request', 'Request must be a JSON object')
+  }
+  const input = raw as Record<string, unknown>
+
+  if (input.version !== CHAT_Z_VERSION) {
+    throw new ChatZRequestError('unsupported-version', `Unsupported chat-z request version: ${String(input.version)}`)
+  }
+
+  if (input.requestId !== expectedRequestId || !isChatZRequestId(input.requestId)) {
+    throw new ChatZRequestError('request-id-mismatch', 'Request ID does not match the deep link')
+  }
+
+  const title = typeof input.title === 'string' ? input.title.trim() : ''
+  const sessionId = typeof input.sessionId === 'string' ? input.sessionId.trim() : ''
+  const newSession = input.newSession === true
+  const newTitle = typeof input.newTitle === 'string' ? input.newTitle.trim() : ''
+  const cwd = typeof input.cwd === 'string' ? input.cwd.trim() : ''
+
+  if ([Boolean(title), Boolean(sessionId), newSession].filter(Boolean).length !== 1) {
+    throw new ChatZRequestError('invalid-target', 'Choose exactly one target: title, sessionId, or newSession')
+  }
+
+  if (title.length > 500 || sessionId.length > 500) {
+    throw new ChatZRequestError('invalid-target', 'Target is too long')
+  }
+
+  if (newSession !== Boolean(cwd)) {
+    throw new ChatZRequestError('invalid-workspace', 'newSession requires cwd, and cwd is only valid for newSession')
+  }
+
+  if (cwd.length > 4_096) {
+    throw new ChatZRequestError('invalid-workspace', 'cwd is too long')
+  }
+
+  if (newTitle && !newSession) {
+    throw new ChatZRequestError('invalid-title', 'newTitle is only valid for a new session')
+  }
+
+  if (newTitle.length > 500) {
+    throw new ChatZRequestError('invalid-title', 'newTitle is too long')
+  }
+
+  const createdAt = Number(input.createdAt)
+  const expiresAt = Number(input.expiresAt)
+
+  if (!Number.isFinite(createdAt) || !Number.isFinite(expiresAt) || expiresAt <= createdAt) {
+    throw new ChatZRequestError('invalid-request', 'Request timestamps are invalid')
+  }
+
+  if (expiresAt < now) {
+    throw new ChatZRequestError('request-expired', 'The chat-z request expired before Desktop could accept it')
+  }
+
+  return {
+    version: CHAT_Z_VERSION,
+    requestId: input.requestId,
+    profile: requiredString(input.profile, 'profile', 128),
+    text: requiredString(input.text, 'text', CHAT_Z_MAX_PROMPT_CHARS),
+    createdAt,
+    expiresAt,
+    ...(newSession ? { newSession: true, cwd, ...(newTitle ? { newTitle } : {}) } : title ? { title } : { sessionId })
+  }
+}
+
+export function readChatZRequest(userData: string, requestId: string, now = Date.now()): ChatZRequest {
+  const requestPath = chatZPaths(userData, requestId).request
+  let stat: fs.Stats
+
+  try {
+    stat = fs.statSync(requestPath)
+  } catch (error) {
+    throw new ChatZRequestError('request-not-found', `Request file is unavailable: ${(error as Error).message}`)
+  }
+
+  if (!stat.isFile() || stat.size > CHAT_Z_MAX_REQUEST_BYTES) {
+    throw new ChatZRequestError('request-too-large', 'Request file is invalid or too large')
+  }
+
+  try {
+    return parseChatZRequest(JSON.parse(fs.readFileSync(requestPath, 'utf8')), requestId, now)
+  } catch (error) {
+    if (error instanceof ChatZRequestError) {
+      throw error
+    }
+    throw new ChatZRequestError('invalid-json', `Request JSON is invalid: ${(error as Error).message}`)
+  }
+}
+
+export function writeChatZReceipt(userData: string, receipt: ChatZReceipt): void {
+  const receiptPath = chatZPaths(userData, receipt.requestId).receipt
+  fs.mkdirSync(path.dirname(receiptPath), { recursive: true })
+
+  const temporary = path.join(
+    path.dirname(receiptPath),
+    `.${path.basename(receiptPath)}.${process.pid}.${Date.now()}.tmp`
+  )
+
+  try {
+    fs.writeFileSync(temporary, JSON.stringify(receipt), { encoding: 'utf8', mode: 0o600, flag: 'wx' })
+    fs.renameSync(temporary, receiptPath)
+  } finally {
+    try {
+      fs.unlinkSync(temporary)
+    } catch {
+      /* renamed or never created */
+    }
+  }
+}
+
+export function removeChatZRequest(userData: string, requestId: string): void {
+  try {
+    fs.unlinkSync(chatZPaths(userData, requestId).request)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+}

--- a/apps/desktop/electron/chat-z.ts
+++ b/apps/desktop/electron/chat-z.ts
@@ -1,6 +1,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+// Chat-Z is a local same-user transport, not a remote authentication boundary.
+// UUIDs correlate a bounded request with its deep link; they are not bearer
+// credentials. Spool directories/files are restricted to the current OS user,
+// but another process already running as that user is intentionally inside the
+// trust boundary and can ask the user's running Desktop agent to submit work.
 export const CHAT_Z_VERSION = 1
 export const CHAT_Z_MAX_REQUEST_BYTES = 1_100_000
 export const CHAT_Z_MAX_PROMPT_CHARS = 1_000_000
@@ -27,7 +32,6 @@ export interface ChatZReceipt {
   code?: string
   message?: string
   profile?: string
-  queued?: boolean
   storedSessionId?: string
   title?: string
   created?: boolean
@@ -41,6 +45,57 @@ export class ChatZRequestError extends Error {
   ) {
     super(message)
     this.name = 'ChatZRequestError'
+  }
+}
+
+export class ChatZRequestState {
+  private readonly pendingById = new Map<string, ChatZRequest>()
+  private readonly inflightIds = new Set<string>()
+
+  has(requestId: string): boolean {
+    return this.pendingById.has(requestId) || this.inflightIds.has(requestId)
+  }
+
+  queue(request: ChatZRequest): void {
+    this.pendingById.set(request.requestId, request)
+  }
+
+  begin(request: ChatZRequest): boolean {
+    if (this.inflightIds.has(request.requestId)) {
+      return false
+    }
+
+    this.inflightIds.add(request.requestId)
+    this.pendingById.delete(request.requestId)
+
+    return true
+  }
+
+  pendingRequests(): ChatZRequest[] {
+    return [...this.pendingById.values()]
+  }
+
+  isInflight(requestId: string): boolean {
+    return this.inflightIds.has(requestId)
+  }
+
+  complete(requestId: string): void {
+    this.inflightIds.delete(requestId)
+  }
+
+  rendererLost({ dropPending = false }: { dropPending?: boolean } = {}): string[] {
+    const failed = new Set(this.inflightIds)
+    this.inflightIds.clear()
+
+    if (dropPending) {
+      for (const requestId of this.pendingById.keys()) {
+        failed.add(requestId)
+      }
+
+      this.pendingById.clear()
+    }
+
+    return [...failed]
   }
 }
 
@@ -79,6 +134,7 @@ export function parseChatZRequest(raw: unknown, expectedRequestId: string, now =
   if (!raw || typeof raw !== 'object') {
     throw new ChatZRequestError('invalid-request', 'Request must be a JSON object')
   }
+
   const input = raw as Record<string, unknown>
 
   if (input.version !== CHAT_Z_VERSION) {
@@ -161,18 +217,22 @@ export function readChatZRequest(userData: string, requestId: string, now = Date
     if (error instanceof ChatZRequestError) {
       throw error
     }
+
     throw new ChatZRequestError('invalid-json', `Request JSON is invalid: ${(error as Error).message}`)
   }
 }
 
 export function writeChatZReceipt(userData: string, receipt: ChatZReceipt): void {
   const receiptPath = chatZPaths(userData, receipt.requestId).receipt
-  fs.mkdirSync(path.dirname(receiptPath), { recursive: true })
+  const receiptDirectory = path.dirname(receiptPath)
 
-  const temporary = path.join(
-    path.dirname(receiptPath),
-    `.${path.basename(receiptPath)}.${process.pid}.${Date.now()}.tmp`
-  )
+  fs.mkdirSync(receiptDirectory, { recursive: true, mode: 0o700 })
+
+  if (process.platform !== 'win32') {
+    fs.chmodSync(receiptDirectory, 0o700)
+  }
+
+  const temporary = path.join(receiptDirectory, `.${path.basename(receiptPath)}.${process.pid}.${Date.now()}.tmp`)
 
   try {
     fs.writeFileSync(temporary, JSON.stringify(receipt), { encoding: 'utf8', mode: 0o600, flag: 'wx' })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -92,6 +92,7 @@ import {
   type ChatZReceipt,
   type ChatZRequest,
   ChatZRequestError,
+  ChatZRequestState,
   isChatZRequestId,
   readChatZRequest,
   removeChatZRequest,
@@ -14155,10 +14156,14 @@ function createWindow() {
     wakeIndicatorController.close()
 
     if (mainWindow === createdMainWindow) {
+      _failChatZRendererRequests(
+        'renderer-window-closed',
+        'Hermes Desktop closed before it could confirm the request',
+        true
+      )
       mainWindow = null
       // the replacement renderer must register before queued links can be delivered.
       _rendererReadyForDeepLink = false
-      _rendererReadyForChatZ = false
     }
   })
 
@@ -14237,6 +14242,14 @@ function createWindow() {
     reloadMax: RENDERER_RELOAD_MAX,
     recentReloadTimesRef: rendererReloadTimesRef,
     reloadOnFailedLoad: true
+  })
+  createdMainWindow.webContents.on('render-process-gone', () => {
+    if (mainWindow === createdMainWindow) {
+      _failChatZRendererRequests(
+        'renderer-process-gone',
+        'Hermes Desktop renderer stopped before it could confirm the request'
+      )
+    }
   })
 
   // Electron always passes the event first. The canonical (Electron 36+) shape
@@ -17327,8 +17340,7 @@ const HERMES_PROTOCOL = DEV_SERVER ? 'hermes-dev' : 'hermes'
 const DEEPLINK_SCHEMES = DEV_SERVER ? ['hermes-dev', 'hermes'] : ['hermes']
 let _pendingDeepLink = null
 let _rendererReadyForDeepLink = false
-const _pendingChatZ = new Map<string, ChatZRequest>()
-const _inflightChatZ = new Set<string>()
+const _chatZRequests = new ChatZRequestState()
 let _rendererReadyForChatZ = false
 
 function _chatZErrorReceipt(requestId: string, error: unknown): ChatZReceipt {
@@ -17338,27 +17350,50 @@ function _chatZErrorReceipt(requestId: string, error: unknown): ChatZReceipt {
   return { requestId, status: 'error', code, message }
 }
 
-function _writeChatZError(requestId: string, error: unknown): void {
+function _writeChatZError(requestId: string, error: unknown): boolean {
   try {
     writeChatZReceipt(app.getPath('userData'), _chatZErrorReceipt(requestId, error))
+
+    return true
   } catch (receiptError) {
     rememberLog(`[chat-z] failed to write error receipt for ${requestId}: ${(receiptError as Error).message}`)
+
+    return false
+  }
+}
+
+function _finishChatZError(requestId: string, error: unknown): void {
+  if (!_writeChatZError(requestId, error)) {
+    return
+  }
+
+  try {
+    removeChatZRequest(app.getPath('userData'), requestId)
+  } catch (removeError) {
+    rememberLog(`[chat-z] failed to remove rejected request ${requestId}: ${(removeError as Error).message}`)
+  }
+}
+
+function _failChatZRendererRequests(code: string, message: string, dropPending = false): void {
+  _rendererReadyForChatZ = false
+
+  for (const requestId of _chatZRequests.rendererLost({ dropPending })) {
+    _finishChatZError(requestId, new ChatZRequestError(code, message))
+    rememberLog(`[chat-z] renderer unavailable for ${requestId}: ${code}`)
   }
 }
 
 function _deliverChatZ(request: ChatZRequest): void {
   if (!_rendererReadyForChatZ || !mainWindow || mainWindow.isDestroyed()) {
-    _pendingChatZ.set(request.requestId, request)
+    _chatZRequests.queue(request)
 
     return
   }
 
-  if (_inflightChatZ.has(request.requestId)) {
+  if (!_chatZRequests.begin(request)) {
     return
   }
 
-  _inflightChatZ.add(request.requestId)
-  _pendingChatZ.delete(request.requestId)
   mainWindow.webContents.send('hermes:chat-z:submit', request)
   rememberLog(`[chat-z] routed ${request.requestId} to primary renderer`)
 }
@@ -17370,7 +17405,7 @@ function _handleChatZLink(requestId: string): void {
     return
   }
 
-  if (_pendingChatZ.has(requestId) || _inflightChatZ.has(requestId)) {
+  if (_chatZRequests.has(requestId)) {
     return
   }
 
@@ -17378,7 +17413,7 @@ function _handleChatZLink(requestId: string): void {
     _deliverChatZ(readChatZRequest(app.getPath('userData'), requestId))
   } catch (error) {
     rememberLog(`[chat-z] rejected ${requestId}: ${(error as Error).message}`)
-    _writeChatZError(requestId, error)
+    _finishChatZError(requestId, error)
   }
 }
 
@@ -17389,7 +17424,7 @@ ipcMain.handle('hermes:chat-z:ready', event => {
 
   _rendererReadyForChatZ = true
 
-  for (const request of [..._pendingChatZ.values()]) {
+  for (const request of _chatZRequests.pendingRequests()) {
     _deliverChatZ(request)
   }
 
@@ -17403,7 +17438,7 @@ ipcMain.on('hermes:chat-z:complete', (event, payload) => {
 
   const requestId = payload?.requestId
 
-  if (!isChatZRequestId(requestId) || !_inflightChatZ.has(requestId)) {
+  if (!isChatZRequestId(requestId) || !_chatZRequests.isInflight(requestId)) {
     return
   }
 
@@ -17431,7 +17466,7 @@ ipcMain.on('hermes:chat-z:complete', (event, payload) => {
     rememberLog(`[chat-z] completion failed for ${requestId}: ${(error as Error).message}`)
     _writeChatZError(requestId, error)
   } finally {
-    _inflightChatZ.delete(requestId)
+    _chatZRequests.complete(requestId)
   }
 })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -88,6 +88,15 @@ import {
   buildBrowserWindowUrl
 } from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
+import {
+  type ChatZReceipt,
+  type ChatZRequest,
+  ChatZRequestError,
+  isChatZRequestId,
+  readChatZRequest,
+  removeChatZRequest,
+  writeChatZReceipt
+} from './chat-z'
 import { applyConnectionChange, sshQuitShouldBlock, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
@@ -14149,6 +14158,7 @@ function createWindow() {
       mainWindow = null
       // the replacement renderer must register before queued links can be delivered.
       _rendererReadyForDeepLink = false
+      _rendererReadyForChatZ = false
     }
   })
 
@@ -17317,6 +17327,113 @@ const HERMES_PROTOCOL = DEV_SERVER ? 'hermes-dev' : 'hermes'
 const DEEPLINK_SCHEMES = DEV_SERVER ? ['hermes-dev', 'hermes'] : ['hermes']
 let _pendingDeepLink = null
 let _rendererReadyForDeepLink = false
+const _pendingChatZ = new Map<string, ChatZRequest>()
+const _inflightChatZ = new Set<string>()
+let _rendererReadyForChatZ = false
+
+function _chatZErrorReceipt(requestId: string, error: unknown): ChatZReceipt {
+  const code = error instanceof ChatZRequestError ? error.code : 'desktop-error'
+  const message = error instanceof Error ? error.message : String(error)
+
+  return { requestId, status: 'error', code, message }
+}
+
+function _writeChatZError(requestId: string, error: unknown): void {
+  try {
+    writeChatZReceipt(app.getPath('userData'), _chatZErrorReceipt(requestId, error))
+  } catch (receiptError) {
+    rememberLog(`[chat-z] failed to write error receipt for ${requestId}: ${(receiptError as Error).message}`)
+  }
+}
+
+function _deliverChatZ(request: ChatZRequest): void {
+  if (!_rendererReadyForChatZ || !mainWindow || mainWindow.isDestroyed()) {
+    _pendingChatZ.set(request.requestId, request)
+
+    return
+  }
+
+  if (_inflightChatZ.has(request.requestId)) {
+    return
+  }
+
+  _inflightChatZ.add(request.requestId)
+  _pendingChatZ.delete(request.requestId)
+  mainWindow.webContents.send('hermes:chat-z:submit', request)
+  rememberLog(`[chat-z] routed ${request.requestId} to primary renderer`)
+}
+
+function _handleChatZLink(requestId: string): void {
+  if (!isChatZRequestId(requestId)) {
+    rememberLog(`[chat-z] ignoring invalid request id: ${requestId}`)
+
+    return
+  }
+
+  if (_pendingChatZ.has(requestId) || _inflightChatZ.has(requestId)) {
+    return
+  }
+
+  try {
+    _deliverChatZ(readChatZRequest(app.getPath('userData'), requestId))
+  } catch (error) {
+    rememberLog(`[chat-z] rejected ${requestId}: ${(error as Error).message}`)
+    _writeChatZError(requestId, error)
+  }
+}
+
+ipcMain.handle('hermes:chat-z:ready', event => {
+  if (!mainWindow || event.sender !== mainWindow.webContents) {
+    return { ok: false }
+  }
+
+  _rendererReadyForChatZ = true
+
+  for (const request of [..._pendingChatZ.values()]) {
+    _deliverChatZ(request)
+  }
+
+  return { ok: true }
+})
+
+ipcMain.on('hermes:chat-z:complete', (event, payload) => {
+  if (!mainWindow || event.sender !== mainWindow.webContents) {
+    return
+  }
+
+  const requestId = payload?.requestId
+
+  if (!isChatZRequestId(requestId) || !_inflightChatZ.has(requestId)) {
+    return
+  }
+
+  try {
+    const status = payload?.status === 'accepted' ? 'accepted' : 'error'
+
+    const receipt: ChatZReceipt = {
+      requestId,
+      status,
+      ...(typeof payload?.code === 'string' ? { code: payload.code.slice(0, 128) } : {}),
+      ...(typeof payload?.message === 'string' ? { message: payload.message.slice(0, 2_000) } : {}),
+      ...(typeof payload?.profile === 'string' ? { profile: payload.profile.slice(0, 128) } : {}),
+      ...(typeof payload?.storedSessionId === 'string'
+        ? { storedSessionId: payload.storedSessionId.slice(0, 500) }
+        : {}),
+      ...(typeof payload?.title === 'string' ? { title: payload.title.slice(0, 500) } : {}),
+      ...(payload?.created === true ? { created: true } : {}),
+      ...(typeof payload?.cwd === 'string' ? { cwd: payload.cwd.slice(0, 4_096) } : {})
+    }
+
+    writeChatZReceipt(app.getPath('userData'), receipt)
+    removeChatZRequest(app.getPath('userData'), requestId)
+    rememberLog(`[chat-z] renderer ${status} ${requestId}`)
+  } catch (error) {
+    rememberLog(`[chat-z] completion failed for ${requestId}: ${(error as Error).message}`)
+    _writeChatZError(requestId, error)
+  } finally {
+    _inflightChatZ.delete(requestId)
+  }
+})
 
 function _extractDeepLink(argv) {
   if (!Array.isArray(argv)) {
@@ -17352,6 +17469,13 @@ function handleDeepLink(url) {
   // hermes://blueprint/<key>?slot=val  -> host="blueprint", path="/<key>"
   const kind = parsed.hostname || ''
   const name = decodeURIComponent((parsed.pathname || '').replace(/^\//, ''))
+
+  if (kind === 'chat-z') {
+    _handleChatZLink(name)
+
+    return
+  }
+
   const params = {}
   parsed.searchParams.forEach((v, k) => {
     params[k] = v

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -170,6 +170,16 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
       return () => ipcRenderer.removeListener('hermes:quick-entry:shown', listener)
     }
   },
+  chatZ: {
+    onSubmit: callback => {
+      const listener = (_event, payload) => callback(payload)
+      ipcRenderer.on('hermes:chat-z:submit', listener)
+
+      return () => ipcRenderer.removeListener('hermes:chat-z:submit', listener)
+    },
+    complete: payload => ipcRenderer.send('hermes:chat-z:complete', payload),
+    ready: () => ipcRenderer.invoke('hermes:chat-z:ready')
+  },
   getBootProgress: () => ipcRenderer.invoke('hermes:boot-progress:get'),
   getConnectionConfig: profile => ipcRenderer.invoke('hermes:connection-config:get', profile),
   saveConnectionConfig: payload => ipcRenderer.invoke('hermes:connection-config:save', payload),

--- a/apps/desktop/src/app/contrib/hooks/use-chat-z-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-chat-z-bridge.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react'
+
+import { submitChatZRequest } from '@/store/chat-z'
+import { isAuxiliaryWindow } from '@/store/windows'
+
+import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
+import type { GatewayRequester } from '../types'
+
+interface ChatZBridgeParams {
+  activeProfile: string
+  createDesktopSession: (cwd: string) => Promise<{ runtimeSessionId: string; storedSessionId: string } | null>
+  getSelectedStoredSessionId: () => null | string
+  requestGateway: GatewayRequester
+  submitText: ReturnType<typeof usePromptActions>['submitText']
+}
+
+export function useChatZBridge({
+  activeProfile,
+  createDesktopSession,
+  getSelectedStoredSessionId,
+  requestGateway,
+  submitText
+}: ChatZBridgeParams): void {
+  const activeProfileRef = useRef(activeProfile)
+  activeProfileRef.current = activeProfile
+  const createDesktopSessionRef = useRef(createDesktopSession)
+  createDesktopSessionRef.current = createDesktopSession
+  const requestGatewayRef = useRef(requestGateway)
+  requestGatewayRef.current = requestGateway
+  const getSelectedStoredSessionIdRef = useRef(getSelectedStoredSessionId)
+  getSelectedStoredSessionIdRef.current = getSelectedStoredSessionId
+  const submitTextRef = useRef(submitText)
+  submitTextRef.current = submitText
+  const submissionTailRef = useRef<Promise<void>>(Promise.resolve())
+
+  // eslint-disable-next-line no-restricted-syntax -- promise tail serializes external submissions, not reactive state.
+  useEffect(() => {
+    if (isAuxiliaryWindow()) {
+      return
+    }
+
+    const unsubscribe = window.hermesDesktop?.chatZ?.onSubmit(request => {
+      submissionTailRef.current = submissionTailRef.current
+        .catch(() => undefined)
+        .then(async () => {
+          try {
+            const receipt = await submitChatZRequest(request, {
+              activeProfile: activeProfileRef.current,
+              createDesktopSession: createDesktopSessionRef.current,
+              getSelectedStoredSessionId: getSelectedStoredSessionIdRef.current,
+              requestGateway: requestGatewayRef.current,
+              submitText: submitTextRef.current
+            })
+
+            window.hermesDesktop.chatZ.complete(receipt)
+          } catch (error) {
+            window.hermesDesktop.chatZ.complete({
+              requestId: request?.requestId ?? '',
+              status: 'error',
+              code: 'renderer-error',
+              message: (error as Error).message
+            })
+          }
+        })
+    })
+
+    void window.hermesDesktop?.chatZ?.ready()
+
+    return () => unsubscribe?.()
+  }, [])
+}

--- a/apps/desktop/src/app/contrib/hooks/use-chat-z-bridge.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-chat-z-bridge.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 
 import { submitChatZRequest } from '@/store/chat-z'
+import { sessionTileDelegate } from '@/store/session-states'
 import { isAuxiliaryWindow } from '@/store/windows'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
@@ -48,6 +49,15 @@ export function useChatZBridge({
               activeProfile: activeProfileRef.current,
               createDesktopSession: createDesktopSessionRef.current,
               getSelectedStoredSessionId: getSelectedStoredSessionIdRef.current,
+              prepareExistingDesktopSession: async storedSessionId => {
+                const delegate = sessionTileDelegate()
+
+                if (!delegate) {
+                  throw new Error('Desktop session bridge is not ready')
+                }
+
+                return delegate.resumeTile(storedSessionId, { refreshTranscript: true })
+              },
               requestGateway: requestGatewayRef.current,
               submitText: submitTextRef.current
             })

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -145,6 +145,7 @@ import {
   resolveActiveTranscriptSession,
   useBackgroundSync
 } from './hooks/use-background-sync'
+import { useChatZBridge } from './hooks/use-chat-z-bridge'
 import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
 import { usePetBridge } from './hooks/use-pet-bridge'
 import { useQuickEntryBridge } from './hooks/use-quick-entry-bridge'
@@ -676,6 +677,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // SAME submit machinery the normal composer uses (current chat / picked
   // session / new session), and it hears gateway truth from this window.
   useQuickEntryBridge({ startFreshSessionDraft, submitText })
+
+  useChatZBridge({
+    activeProfile: normalizeProfileKey(activeGatewayProfile),
+    createDesktopSession: async cwd => (await openNewSessionTile('center', { cwd, listed: true })) ?? null,
+    getSelectedStoredSessionId: () => $selectedStoredSessionId.get(),
+    requestGateway,
+    submitText
+  })
 
   // Leaving HUD mode hands this window the session back (see hud/handoff).
   useHudHandoff({ navigate, resumeSession })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -760,7 +760,7 @@ export function useSessionActions({
           await closeCreated.catch(() => undefined)
           notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
 
-          return
+          return null
         }
 
         createdThisRun.add(stored)
@@ -795,8 +795,12 @@ export function useSessionActions({
         if (listed) {
           broadcastSessionsChanged()
         }
+
+        return { runtimeSessionId: created.session_id, storedSessionId: stored }
       } catch (error) {
         notifyError(error, copy.createSessionFailed)
+
+        return null
       }
     },
     [copy, requestGateway, updateSessionState]

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -2,6 +2,7 @@ import type { GatewayWsUrlResult } from '@hermes/shared'
 import type { TranslucencyState } from '@hermes/shared/translucency'
 
 import type { WakeIndicatorState } from './lib/wake-indicator'
+import type { ChatZSubmitReceipt, ChatZSubmitRequest } from './store/chat-z'
 import type {
   PetOverlayBounds,
   PetOverlayControl,
@@ -147,6 +148,11 @@ declare global {
         // Quick window subscribes to "you were just summoned" so it can reset
         // its draft and re-focus the input on every open.
         onShown: (callback: () => void) => () => void
+      }
+      chatZ: {
+        onSubmit: (callback: (payload: ChatZSubmitRequest) => void) => () => void
+        complete: (payload: ChatZSubmitReceipt) => void
+        ready: () => Promise<{ ok: boolean }>
       }
       getBootProgress: () => Promise<DesktopBootProgress>
       getConnectionConfig: (profile?: null | string) => Promise<DesktopConnectionConfig>

--- a/apps/desktop/src/store/chat-z.test.ts
+++ b/apps/desktop/src/store/chat-z.test.ts
@@ -16,6 +16,7 @@ function deps() {
     activeProfile: 'default',
     createDesktopSession: vi.fn(async () => ({ runtimeSessionId: 'runtime-1', storedSessionId: 'stored-1' })),
     getSelectedStoredSessionId: vi.fn(() => null),
+    prepareExistingDesktopSession: vi.fn(async () => 'runtime-existing'),
     requestGateway: vi.fn(async () => ({})),
     submitText: vi.fn(async () => true)
   }
@@ -59,6 +60,7 @@ describe('submitChatZRequest', () => {
     expect(d.submitText).toHaveBeenCalledWith('Do the work', {
       attachments: [],
       fromQueue: true,
+      sessionId: 'runtime-existing',
       storedSessionId: 'stored-2'
     })
     expect(receipt).toMatchObject({ status: 'accepted', storedSessionId: 'stored-2', title: 'Receiver' })

--- a/apps/desktop/src/store/chat-z.test.ts
+++ b/apps/desktop/src/store/chat-z.test.ts
@@ -24,6 +24,7 @@ function deps() {
 describe('submitChatZRequest', () => {
   it('creates, titles, then submits a project-scoped Desktop session', async () => {
     const d = deps()
+
     const receipt = await submitChatZRequest(
       { ...base, newSession: true, cwd: 'C:\\project', newTitle: 'Knowledge receiver' },
       d
@@ -70,6 +71,17 @@ describe('submitChatZRequest', () => {
     const receipt = await submitChatZRequest({ ...base, title: 'Missing' }, d)
 
     expect(receipt).toMatchObject({ status: 'error', code: 'session-not-found' })
+    expect(d.submitText).not.toHaveBeenCalled()
+  })
+
+  it('rejects a request for a different Desktop profile before lookup or submission', async () => {
+    const d = deps()
+    d.activeProfile = 'research'
+
+    const receipt = await submitChatZRequest({ ...base, sessionId: 'stored-2' }, d)
+
+    expect(receipt).toMatchObject({ status: 'error', code: 'profile-mismatch' })
+    expect(d.requestGateway).not.toHaveBeenCalled()
     expect(d.submitText).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/chat-z.test.ts
+++ b/apps/desktop/src/store/chat-z.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { type ChatZSubmitRequest, submitChatZRequest } from './chat-z'
+
+const base: Omit<ChatZSubmitRequest, 'cwd' | 'newSession' | 'newTitle' | 'sessionId' | 'title'> = {
+  version: 1,
+  requestId: 'request-1',
+  profile: 'default',
+  text: 'Do the work',
+  createdAt: Date.now(),
+  expiresAt: Date.now() + 30_000
+}
+
+function deps() {
+  return {
+    activeProfile: 'default',
+    createDesktopSession: vi.fn(async () => ({ runtimeSessionId: 'runtime-1', storedSessionId: 'stored-1' })),
+    getSelectedStoredSessionId: vi.fn(() => null),
+    requestGateway: vi.fn(async () => ({})),
+    submitText: vi.fn(async () => true)
+  }
+}
+
+describe('submitChatZRequest', () => {
+  it('creates, titles, then submits a project-scoped Desktop session', async () => {
+    const d = deps()
+    const receipt = await submitChatZRequest(
+      { ...base, newSession: true, cwd: 'C:\\project', newTitle: 'Knowledge receiver' },
+      d
+    )
+
+    expect(d.createDesktopSession).toHaveBeenCalledWith('C:\\project')
+    expect(d.requestGateway).toHaveBeenCalledWith('session.title', {
+      session_id: 'runtime-1',
+      title: 'Knowledge receiver'
+    })
+    expect(d.submitText).toHaveBeenCalledWith('Do the work', {
+      attachments: [],
+      fromQueue: true,
+      sessionId: 'runtime-1',
+      storedSessionId: 'stored-1'
+    })
+    expect(receipt).toMatchObject({
+      status: 'accepted',
+      storedSessionId: 'stored-1',
+      title: 'Knowledge receiver',
+      created: true
+    })
+  })
+
+  it('resolves an exact title and submits without creating a session', async () => {
+    const d = deps()
+    d.requestGateway.mockResolvedValue({ sessions: [{ id: 'stored-2', title: 'Receiver' }] })
+
+    const receipt = await submitChatZRequest({ ...base, title: 'Receiver' }, d)
+
+    expect(d.createDesktopSession).not.toHaveBeenCalled()
+    expect(d.submitText).toHaveBeenCalledWith('Do the work', {
+      attachments: [],
+      fromQueue: true,
+      storedSessionId: 'stored-2'
+    })
+    expect(receipt).toMatchObject({ status: 'accepted', storedSessionId: 'stored-2', title: 'Receiver' })
+  })
+
+  it('fails clearly when an exact title does not exist', async () => {
+    const d = deps()
+    d.requestGateway.mockResolvedValue({ sessions: [] })
+
+    const receipt = await submitChatZRequest({ ...base, title: 'Missing' }, d)
+
+    expect(receipt).toMatchObject({ status: 'error', code: 'session-not-found' })
+    expect(d.submitText).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/store/chat-z.ts
+++ b/apps/desktop/src/store/chat-z.ts
@@ -1,0 +1,168 @@
+import { normalizeProfileKey } from './profile'
+
+export interface ChatZSubmitRequest {
+  version: 1
+  requestId: string
+  profile: string
+  text: string
+  title?: string
+  sessionId?: string
+  newSession?: true
+  newTitle?: string
+  cwd?: string
+  createdAt: number
+  expiresAt: number
+}
+
+export interface ChatZSubmitReceipt {
+  requestId: string
+  status: 'accepted' | 'error'
+  code?: string
+  message?: string
+  profile?: string
+  storedSessionId?: string
+  title?: string
+  created?: boolean
+  cwd?: string
+}
+
+interface SessionListRow {
+  id: string
+  resolved_id?: string
+  title?: string
+}
+interface ChatZSubmitDeps {
+  activeProfile: string
+  createDesktopSession: (cwd: string) => Promise<{ runtimeSessionId: string; storedSessionId: string } | null>
+  getSelectedStoredSessionId: () => null | string
+  requestGateway: (method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<unknown>
+  submitText: (
+    text: string,
+    options: { attachments: []; fromQueue?: true; sessionId?: string; storedSessionId?: string }
+  ) => Promise<boolean>
+}
+
+function errorReceipt(requestId: string, code: string, message: string): ChatZSubmitReceipt {
+  return { requestId, status: 'error', code, message }
+}
+
+export async function submitChatZRequest(
+  request: ChatZSubmitRequest,
+  deps: ChatZSubmitDeps
+): Promise<ChatZSubmitReceipt> {
+  const { activeProfile, createDesktopSession, getSelectedStoredSessionId, requestGateway, submitText } = deps
+  const requestId = typeof request?.requestId === 'string' ? request.requestId : ''
+  const text = typeof request?.text === 'string' ? request.text.trim() : ''
+  const profile = normalizeProfileKey(request?.profile)
+  const desktopProfile = normalizeProfileKey(activeProfile)
+
+  if (!requestId || !text) {
+    return errorReceipt(requestId, 'invalid-request', 'The chat-z request is missing text or an ID')
+  }
+
+  if (Number(request.expiresAt) < Date.now()) {
+    return errorReceipt(requestId, 'request-expired', 'The chat-z request expired before the renderer accepted it')
+  }
+
+  if (profile !== desktopProfile) {
+    return errorReceipt(
+      requestId,
+      'profile-mismatch',
+      `Desktop is on profile "${desktopProfile}", but chat-z targeted "${profile}"`
+    )
+  }
+
+  const title = typeof request.title === 'string' ? request.title.trim() : ''
+  const requestedSessionId = typeof request.sessionId === 'string' ? request.sessionId.trim() : ''
+  const newSession = request.newSession === true
+  const newTitle = typeof request.newTitle === 'string' ? request.newTitle.trim() : ''
+  const cwd = typeof request.cwd === 'string' ? request.cwd.trim() : ''
+
+  if ([Boolean(title), Boolean(requestedSessionId), newSession].filter(Boolean).length !== 1) {
+    return errorReceipt(requestId, 'invalid-target', 'Choose exactly one target: title, sessionId, or newSession')
+  }
+
+  if (newSession !== Boolean(cwd)) {
+    return errorReceipt(requestId, 'invalid-workspace', 'newSession requires cwd, and cwd is only valid for newSession')
+  }
+
+  if (newTitle && !newSession) {
+    return errorReceipt(requestId, 'invalid-title', 'newTitle is only valid for a new session')
+  }
+
+  if (newSession) {
+    try {
+      const created = await createDesktopSession(cwd)
+
+      if (!created) {
+        return errorReceipt(requestId, 'session-create-failed', 'Desktop could not create the requested session')
+      }
+
+      if (newTitle) {
+        await requestGateway('session.title', { session_id: created.runtimeSessionId, title: newTitle })
+      }
+
+      if (
+        !(await submitText(text, {
+          attachments: [],
+          fromQueue: true,
+          sessionId: created.runtimeSessionId,
+          storedSessionId: created.storedSessionId
+        }))
+      ) {
+        return errorReceipt(requestId, 'submit-rejected', 'Desktop did not accept the prompt')
+      }
+
+      return {
+        requestId,
+        status: 'accepted',
+        profile: desktopProfile,
+        storedSessionId: created.storedSessionId,
+        ...(newTitle ? { title: newTitle } : {}),
+        created: true,
+        cwd
+      }
+    } catch (error) {
+      return errorReceipt(
+        requestId,
+        'submit-failed',
+        `Desktop new-session submission failed: ${(error as Error).message}`
+      )
+    }
+  }
+
+  let storedSessionId = requestedSessionId
+
+  if (title) {
+    let result: { sessions?: SessionListRow[] }
+
+    try {
+      result = (await requestGateway('session.list', { title, include_hidden: true, profile: desktopProfile })) as {
+        sessions?: SessionListRow[]
+      }
+    } catch (error) {
+      return errorReceipt(
+        requestId,
+        'lookup-failed',
+        `Could not look up the Desktop session: ${(error as Error).message}`
+      )
+    }
+
+    const match = (result?.sessions ?? []).find(row => row.title === title)
+    storedSessionId = (match?.resolved_id || match?.id || '').trim()
+
+    if (!storedSessionId) {
+      return errorReceipt(requestId, 'session-not-found', `No existing session has the exact title "${title}"`)
+    }
+  }
+
+  try {
+    if (!(await submitText(text, { attachments: [], fromQueue: true, storedSessionId }))) {
+      return errorReceipt(requestId, 'submit-rejected', 'Desktop did not accept the prompt')
+    }
+  } catch (error) {
+    return errorReceipt(requestId, 'submit-failed', `Desktop prompt submission failed: ${(error as Error).message}`)
+  }
+
+  return { requestId, status: 'accepted', profile: desktopProfile, storedSessionId, ...(title ? { title } : {}) }
+}

--- a/apps/desktop/src/store/chat-z.ts
+++ b/apps/desktop/src/store/chat-z.ts
@@ -35,6 +35,7 @@ interface ChatZSubmitDeps {
   activeProfile: string
   createDesktopSession: (cwd: string) => Promise<{ runtimeSessionId: string; storedSessionId: string } | null>
   getSelectedStoredSessionId: () => null | string
+  prepareExistingDesktopSession: (storedSessionId: string) => Promise<string>
   requestGateway: (method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<unknown>
   submitText: (
     text: string,
@@ -50,7 +51,15 @@ export async function submitChatZRequest(
   request: ChatZSubmitRequest,
   deps: ChatZSubmitDeps
 ): Promise<ChatZSubmitReceipt> {
-  const { activeProfile, createDesktopSession, getSelectedStoredSessionId, requestGateway, submitText } = deps
+  const {
+    activeProfile,
+    createDesktopSession,
+    getSelectedStoredSessionId,
+    prepareExistingDesktopSession,
+    requestGateway,
+    submitText
+  } = deps
+
   const requestId = typeof request?.requestId === 'string' ? request.requestId : ''
   const text = typeof request?.text === 'string' ? request.text.trim() : ''
   const profile = normalizeProfileKey(request?.profile)
@@ -157,7 +166,9 @@ export async function submitChatZRequest(
   }
 
   try {
-    if (!(await submitText(text, { attachments: [], fromQueue: true, storedSessionId }))) {
+    const runtimeSessionId = await prepareExistingDesktopSession(storedSessionId)
+
+    if (!(await submitText(text, { attachments: [], fromQueue: true, sessionId: runtimeSessionId, storedSessionId }))) {
       return errorReceipt(requestId, 'submit-rejected', 'Desktop did not accept the prompt')
     }
   } catch (error) {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -500,6 +500,7 @@ from hermes_cli.subcommands.console import build_console_parser
 from hermes_cli.subcommands.update import build_update_parser
 from hermes_cli.subcommands.uninstall import build_uninstall_parser
 from hermes_cli.subcommands.dashboard import build_dashboard_parser
+from hermes_cli.subcommands.chat_z import build_chat_z_parser
 from hermes_cli.subcommands.gui import build_gui_parser
 from hermes_cli.subcommands.logs import build_logs_parser
 from hermes_cli.subcommands.prompt_size import build_prompt_size_parser
@@ -13356,6 +13357,7 @@ def main():
 
     parser, subparsers, chat_parser = build_top_level_parser()
     chat_parser.set_defaults(func=cmd_chat)
+    build_chat_z_parser(subparsers)
 
     # =========================================================================
     # model command  (parser built in hermes_cli/subcommands/model.py)

--- a/hermes_cli/subcommands/chat_z.py
+++ b/hermes_cli/subcommands/chat_z.py
@@ -1,0 +1,236 @@
+"""Submit prompts through the running Hermes Desktop renderer.
+
+The command spools a bounded request into Electron's user-data directory and
+opens a ``hermes://chat-z/<id>`` deep link.  The primary Desktop renderer uses
+its existing gateway connection and returns a receipt as soon as submission is
+accepted; the agent response is never awaited.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+import uuid
+
+
+CHAT_Z_VERSION = 1
+DEFAULT_TIMEOUT_SECONDS = 30.0
+MAX_PROMPT_CHARS = 1_000_000
+
+
+def desktop_user_data_dir() -> Path:
+    override = os.environ.get("HERMES_DESKTOP_USER_DATA_DIR", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", "").strip()
+        return (Path(appdata) if appdata else Path.home() / "AppData" / "Roaming") / "Hermes"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Hermes"
+    config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    return (Path(config_home) if config_home else Path.home() / ".config") / "Hermes"
+
+
+def _spool_paths(user_data: Path, request_id: str) -> tuple[Path, Path]:
+    root = user_data / "chat-z"
+    return root / "requests" / f"{request_id}.json", root / "receipts" / f"{request_id}.json"
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            temporary.chmod(0o600)
+        except OSError:
+            pass
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _read_prompt(args) -> str:
+    if args.query is not None:
+        text = args.query
+    elif args.query_file:
+        try:
+            text = Path(args.query_file).expanduser().read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ValueError(f"cannot read --query-file: {exc}") from exc
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        raise ValueError("provide -q/--query, --query-file, or pipe prompt text on stdin")
+
+    text = text.strip()
+    if not text:
+        raise ValueError("prompt is empty")
+    if len(text) > MAX_PROMPT_CHARS:
+        raise ValueError(f"prompt exceeds the {MAX_PROMPT_CHARS:,}-character limit")
+    return text
+
+
+def _launch_deep_link(uri: str) -> None:
+    if sys.platform == "win32":
+        os.startfile(uri)  # type: ignore[attr-defined]
+        return
+    command = ["open", uri] if sys.platform == "darwin" else ["xdg-open", uri]
+    subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+
+
+def _wait_for_receipt(path: Path, timeout_seconds: float) -> dict:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            time.sleep(0.05)
+        except (OSError, json.JSONDecodeError):
+            time.sleep(0.05)
+    raise TimeoutError(
+        f"Hermes Desktop did not acknowledge the request within {timeout_seconds:g}s. "
+        "The running Desktop may not include the chat-z bridge or may not have finished loading; "
+        "this timeout occurs before target-session lookup and is not caused by the session source."
+    )
+
+
+def send_to_desktop(args, *, launch=_launch_deep_link, user_data: Path | None = None) -> dict:
+    text = _read_prompt(args)
+    title = (getattr(args, "conversation", None) or "").strip()
+    session_id = (getattr(args, "session_id", None) or "").strip()
+    new_session = bool(getattr(args, "new_session", False))
+    new_title = (getattr(args, "title", None) or "").strip()
+    if sum((bool(title), bool(session_id), new_session)) != 1:
+        raise ValueError("choose exactly one target: -c/--conversation, --session-id, or --new")
+
+    cwd_input = (getattr(args, "cwd", None) or "").strip()
+    cwd = ""
+    if new_session:
+        if not cwd_input:
+            raise ValueError("--new requires --cwd with an existing project directory")
+        try:
+            cwd_path = Path(cwd_input).expanduser().resolve(strict=True)
+        except OSError as exc:
+            raise ValueError(f"cannot resolve --cwd: {exc}") from exc
+        if not cwd_path.is_dir():
+            raise ValueError("--cwd must identify an existing directory")
+        cwd = str(cwd_path)
+    elif cwd_input:
+        raise ValueError("--cwd can only be used with --new")
+
+    if new_title and not new_session:
+        raise ValueError("--title can only be used with --new")
+    if len(new_title) > 500:
+        raise ValueError("--title must be at most 500 characters")
+
+    timeout_seconds = float(getattr(args, "timeout", DEFAULT_TIMEOUT_SECONDS))
+    if timeout_seconds <= 0 or timeout_seconds > 300:
+        raise ValueError("--timeout must be greater than 0 and at most 300 seconds")
+
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile = get_active_profile_name()
+    except Exception:
+        profile = "default"
+
+    request_id = str(uuid.uuid4())
+    request_path, receipt_path = _spool_paths(user_data or desktop_user_data_dir(), request_id)
+    now_ms = int(time.time() * 1000)
+    request = {
+        "version": CHAT_Z_VERSION,
+        "requestId": request_id,
+        "profile": profile,
+        "text": text,
+        "createdAt": now_ms,
+        "expiresAt": now_ms + int(timeout_seconds * 1000),
+        **(
+            {"newSession": True, "cwd": cwd, **({"newTitle": new_title} if new_title else {})}
+            if new_session
+            else ({"title": title} if title else {"sessionId": session_id})
+        ),
+    }
+
+    _atomic_write_json(request_path, request)
+    try:
+        launch(f"hermes://chat-z/{request_id}")
+        receipt = _wait_for_receipt(receipt_path, timeout_seconds)
+        if receipt.get("requestId") != request_id:
+            raise RuntimeError("Desktop returned a receipt for a different request")
+        return receipt
+    finally:
+        for path in (request_path, receipt_path):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def cmd_chat_z(args) -> int:
+    try:
+        receipt = send_to_desktop(args)
+    except (OSError, RuntimeError, TimeoutError, ValueError) as exc:
+        print(f"chat-z: {exc}", file=sys.stderr)
+        return 1
+
+    if receipt.get("status") != "accepted":
+        message = receipt.get("message") or receipt.get("code") or "Desktop rejected the request"
+        print(f"chat-z: {message}", file=sys.stderr)
+        return 1
+
+    if not getattr(args, "quiet", False):
+        target = receipt.get("title") or receipt.get("storedSessionId") or "session"
+        queued = " (queued behind the current turn)" if receipt.get("queued") else ""
+        if receipt.get("created"):
+            workspace = f" in {receipt['cwd']}" if receipt.get("cwd") else ""
+            stored_session_id = receipt.get("storedSessionId")
+            created_target = (
+                f"{target} (ID: {stored_session_id})"
+                if receipt.get("title") and stored_session_id
+                else target
+            )
+            print(f"Created by Hermes Desktop: {created_target}{workspace}")
+        else:
+            print(f"Accepted by Hermes Desktop: {target}{queued}")
+    return 0
+
+
+def build_chat_z_parser(subparsers):
+    parser = subparsers.add_parser(
+        "chat-z",
+        help="Send a prompt through the running Hermes Desktop session",
+        description=(
+            "Submit through Hermes Desktop, targeting an existing conversation "
+            "or creating a new one in a project directory. Return as soon as "
+            "Desktop accepts the prompt; the agent response is not awaited."
+        ),
+    )
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("-c", "--conversation", help="Exact Desktop conversation title")
+    target.add_argument("--session-id", help="Stored Desktop session ID")
+    target.add_argument("--new", dest="new_session", action="store_true", help="Create a new Desktop conversation")
+    parser.add_argument("--cwd", help="Existing project directory for --new")
+    parser.add_argument("--title", help="Fixed session title for --new")
+    prompt = parser.add_mutually_exclusive_group()
+    prompt.add_argument("-q", "--query", help="Prompt text")
+    prompt.add_argument("--query-file", help="UTF-8 file containing the prompt")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"Seconds to wait for Desktop acceptance (default: {DEFAULT_TIMEOUT_SECONDS:g})",
+    )
+    parser.add_argument("-Q", "--quiet", action="store_true", help="Print nothing when accepted")
+    parser.set_defaults(func=cmd_chat_z)
+    return parser

--- a/hermes_cli/subcommands/chat_z.py
+++ b/hermes_cli/subcommands/chat_z.py
@@ -4,6 +4,10 @@ The command spools a bounded request into Electron's user-data directory and
 opens a ``hermes://chat-z/<id>`` deep link.  The primary Desktop renderer uses
 its existing gateway connection and returns a receipt as soon as submission is
 accepted; the agent response is never awaited.
+
+This is intentionally a same-OS-user channel, not a remote authentication
+boundary.  UUIDs correlate files and links rather than authorize callers; any
+process already running as the Desktop user is inside the trust boundary.
 """
 
 from __future__ import annotations
@@ -20,15 +24,20 @@ import uuid
 CHAT_Z_VERSION = 1
 DEFAULT_TIMEOUT_SECONDS = 30.0
 MAX_PROMPT_CHARS = 1_000_000
+MAX_REQUEST_BYTES = 1_100_000
 
 
 def desktop_user_data_dir() -> Path:
     override = os.environ.get("HERMES_DESKTOP_USER_DATA_DIR", "").strip()
     if override:
         return Path(override).expanduser().resolve()
+    # Electron sets the packaged app name to "Hermes" before resolving
+    # app.getPath("userData"), whose platform defaults match these locations.
     if sys.platform == "win32":
         appdata = os.environ.get("APPDATA", "").strip()
-        return (Path(appdata) if appdata else Path.home() / "AppData" / "Roaming") / "Hermes"
+        return (
+            Path(appdata) if appdata else Path.home() / "AppData" / "Roaming"
+        ) / "Hermes"
     if sys.platform == "darwin":
         return Path.home() / "Library" / "Application Support" / "Hermes"
     config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
@@ -37,15 +46,28 @@ def desktop_user_data_dir() -> Path:
 
 def _spool_paths(user_data: Path, request_id: str) -> tuple[Path, Path]:
     root = user_data / "chat-z"
-    return root / "requests" / f"{request_id}.json", root / "receipts" / f"{request_id}.json"
+    return (
+        root / "requests" / f"{request_id}.json",
+        root / "receipts" / f"{request_id}.json",
+    )
 
 
 def _atomic_write_json(path: Path, payload: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    if len(encoded) > MAX_REQUEST_BYTES:
+        raise ValueError(
+            f"serialized request exceeds the {MAX_REQUEST_BYTES:,}-byte limit"
+        )
+
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        path.parent.chmod(0o700)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
     try:
-        with temporary.open("x", encoding="utf-8") as handle:
-            json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
+        with temporary.open("xb") as handle:
+            handle.write(encoded)
             handle.flush()
             os.fsync(handle.fileno())
         try:
@@ -71,7 +93,9 @@ def _read_prompt(args) -> str:
     elif not sys.stdin.isatty():
         text = sys.stdin.read()
     else:
-        raise ValueError("provide -q/--query, --query-file, or pipe prompt text on stdin")
+        raise ValueError(
+            "provide -q/--query, --query-file, or pipe prompt text on stdin"
+        )
 
     text = text.strip()
     if not text:
@@ -86,7 +110,12 @@ def _launch_deep_link(uri: str) -> None:
         os.startfile(uri)  # type: ignore[attr-defined]
         return
     command = ["open", uri] if sys.platform == "darwin" else ["xdg-open", uri]
-    subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
+    subprocess.Popen(
+        command,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
 
 
 def _wait_for_receipt(path: Path, timeout_seconds: float) -> dict:
@@ -105,14 +134,18 @@ def _wait_for_receipt(path: Path, timeout_seconds: float) -> dict:
     )
 
 
-def send_to_desktop(args, *, launch=_launch_deep_link, user_data: Path | None = None) -> dict:
+def send_to_desktop(
+    args, *, launch=_launch_deep_link, user_data: Path | None = None
+) -> dict:
     text = _read_prompt(args)
     title = (getattr(args, "conversation", None) or "").strip()
     session_id = (getattr(args, "session_id", None) or "").strip()
     new_session = bool(getattr(args, "new_session", False))
     new_title = (getattr(args, "title", None) or "").strip()
     if sum((bool(title), bool(session_id), new_session)) != 1:
-        raise ValueError("choose exactly one target: -c/--conversation, --session-id, or --new")
+        raise ValueError(
+            "choose exactly one target: -c/--conversation, --session-id, or --new"
+        )
 
     cwd_input = (getattr(args, "cwd", None) or "").strip()
     cwd = ""
@@ -146,7 +179,9 @@ def send_to_desktop(args, *, launch=_launch_deep_link, user_data: Path | None = 
         profile = "default"
 
     request_id = str(uuid.uuid4())
-    request_path, receipt_path = _spool_paths(user_data or desktop_user_data_dir(), request_id)
+    request_path, receipt_path = _spool_paths(
+        user_data or desktop_user_data_dir(), request_id
+    )
     now_ms = int(time.time() * 1000)
     request = {
         "version": CHAT_Z_VERSION,
@@ -156,7 +191,11 @@ def send_to_desktop(args, *, launch=_launch_deep_link, user_data: Path | None = 
         "createdAt": now_ms,
         "expiresAt": now_ms + int(timeout_seconds * 1000),
         **(
-            {"newSession": True, "cwd": cwd, **({"newTitle": new_title} if new_title else {})}
+            {
+                "newSession": True,
+                "cwd": cwd,
+                **({"newTitle": new_title} if new_title else {}),
+            }
             if new_session
             else ({"title": title} if title else {"sessionId": session_id})
         ),
@@ -185,13 +224,16 @@ def cmd_chat_z(args) -> int:
         return 1
 
     if receipt.get("status") != "accepted":
-        message = receipt.get("message") or receipt.get("code") or "Desktop rejected the request"
+        message = (
+            receipt.get("message")
+            or receipt.get("code")
+            or "Desktop rejected the request"
+        )
         print(f"chat-z: {message}", file=sys.stderr)
         return 1
 
     if not getattr(args, "quiet", False):
         target = receipt.get("title") or receipt.get("storedSessionId") or "session"
-        queued = " (queued behind the current turn)" if receipt.get("queued") else ""
         if receipt.get("created"):
             workspace = f" in {receipt['cwd']}" if receipt.get("cwd") else ""
             stored_session_id = receipt.get("storedSessionId")
@@ -202,7 +244,7 @@ def cmd_chat_z(args) -> int:
             )
             print(f"Created by Hermes Desktop: {created_target}{workspace}")
         else:
-            print(f"Accepted by Hermes Desktop: {target}{queued}")
+            print(f"Accepted by Hermes Desktop: {target}")
     return 0
 
 
@@ -219,7 +261,12 @@ def build_chat_z_parser(subparsers):
     target = parser.add_mutually_exclusive_group(required=True)
     target.add_argument("-c", "--conversation", help="Exact Desktop conversation title")
     target.add_argument("--session-id", help="Stored Desktop session ID")
-    target.add_argument("--new", dest="new_session", action="store_true", help="Create a new Desktop conversation")
+    target.add_argument(
+        "--new",
+        dest="new_session",
+        action="store_true",
+        help="Create a new Desktop conversation",
+    )
     parser.add_argument("--cwd", help="Existing project directory for --new")
     parser.add_argument("--title", help="Fixed session title for --new")
     prompt = parser.add_mutually_exclusive_group()
@@ -231,6 +278,8 @@ def build_chat_z_parser(subparsers):
         default=DEFAULT_TIMEOUT_SECONDS,
         help=f"Seconds to wait for Desktop acceptance (default: {DEFAULT_TIMEOUT_SECONDS:g})",
     )
-    parser.add_argument("-Q", "--quiet", action="store_true", help="Print nothing when accepted")
+    parser.add_argument(
+        "-Q", "--quiet", action="store_true", help="Print nothing when accepted"
+    )
     parser.set_defaults(func=cmd_chat_z)
     return parser

--- a/skills/productivity/chat-z/SKILL.md
+++ b/skills/productivity/chat-z/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: chat-z
+description: Send prompts through running Hermes Desktop sessions.
+version: 1.0.0
+author: xxbwx888-cell (GitHub), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Desktop, Sessions, Messaging, Delegation, Productivity]
+    category: productivity
+    related_skills: [session-librarian]
+---
+
+# Chat-Z Skill
+
+Send a prompt through the running Hermes Desktop app to an existing Desktop
+session, or create a new Desktop session in a chosen project directory. This
+is a fire-and-confirm handoff: it confirms Desktop accepted the prompt but
+does not wait for the receiving agent to finish.
+
+## When to Use
+
+- The user asks to send or hand off work to another Hermes Desktop session.
+- A workflow needs to create a visible Desktop session in a specific project.
+- The receiving session must show the same native running state as a prompt
+  entered manually in Desktop.
+- The caller should continue immediately after Desktop accepts the prompt.
+
+Do not use this for subagent delegation that must return a result to the
+current turn. Use the normal delegation capability for that workflow.
+
+## Prerequisites
+
+- Hermes Desktop is already running and has finished loading.
+- The CLI and Desktop are using the same active Hermes profile.
+- New sessions require an existing project directory.
+- The caller is running as the same OS user as Desktop. Chat-Z is a local
+  same-user transport, not a remote authenticated messaging API.
+
+## How to Run
+
+Use `terminal` to invoke `hermes chat-z`. Choose exactly one target:
+
+```text
+hermes chat-z --session-id "<stored-session-id>" -q "<prompt>"
+hermes chat-z -c "<exact-desktop-title>" -q "<prompt>"
+hermes chat-z --new --cwd "<project-directory>" --title "<fixed-title>" -q "<prompt>"
+```
+
+For long, multiline, or shell-sensitive prompts, place the prompt in a UTF-8
+file and use `--query-file <path>` instead of `-q`.
+
+## Quick Reference
+
+| Option | Purpose |
+|---|---|
+| `--session-id ID` | Target an existing session by durable stored ID. |
+| `-c TITLE` | Target an existing session by its exact Desktop title. |
+| `--new` | Create a new Desktop session. |
+| `--cwd DIR` | Bind a new session to an existing project directory. |
+| `--title TITLE` | Give a new session a stable title. |
+| `-q TEXT` | Send prompt text directly. |
+| `--query-file PATH` | Read the prompt from a UTF-8 file. |
+| `--timeout SECONDS` | Limit the wait for Desktop acceptance, up to 300 seconds. |
+| `-Q` | Print nothing after successful acceptance. |
+
+## Procedure
+
+1. Determine whether the target already exists or a new session is required.
+2. For an existing session, prefer `--session-id` when an ID is known. Use
+   `-c` only with the complete, exact Desktop title.
+3. For a new session, resolve the intended existing project directory and
+   provide both `--cwd` and `--title`. Do not rely on the first prompt to
+   become the title.
+4. Send a self-contained prompt. The receiver does not automatically inherit
+   the current session's context, files, decisions, or authorization.
+5. Inspect the command result:
+   - `Accepted by Hermes Desktop` means an existing session accepted it.
+   - `Created by Hermes Desktop` means Desktop created and accepted a new
+     session. Preserve the printed session ID for future sends.
+6. Return control immediately after acceptance unless the user separately
+   requested a workflow that collects the receiver's result.
+
+## Pitfalls
+
+- Do not substitute `hermes chat -c`. That path can create or run a CLI
+  session without going through Desktop's native submit path.
+- Acceptance is not completion. Never report that the receiving agent
+  finished merely because Chat-Z returned exit code 0.
+- Titles are exact-match targets and can be ambiguous or change. Prefer the
+  stored session ID for durable automation.
+- `--new` without `--title` lets Desktop derive a title from the prompt, which
+  makes later title-based sends fragile.
+- A timeout occurs before target lookup. Check that Desktop is running,
+  loaded, includes the Chat-Z bridge, and uses the same profile; do not assume
+  the target session's source field caused the timeout.
+- Do not repeatedly retry an uncertain delivery. One retry after verifying
+  Desktop readiness is enough unless the user asks otherwise.
+
+## Verification
+
+Treat the handoff as successful only when the command exits with code 0 and
+prints an accepted or created receipt, or exits silently with code 0 under
+`-Q`. For a new session, retain the returned session ID and use it for the
+next message. If Desktop rejects the request or no receipt arrives, report the
+error without claiming delivery.

--- a/tests/hermes_cli/test_chat_z.py
+++ b/tests/hermes_cli/test_chat_z.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.subcommands.chat_z import build_chat_z_parser, send_to_desktop
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    build_chat_z_parser(parser.add_subparsers(dest="command", required=True))
+    return parser
+
+
+def _accepting_launcher(user_data: Path, seen: list[dict]):
+    def launch(_uri: str) -> None:
+        request_path = next((user_data / "chat-z" / "requests").glob("*.json"))
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+        seen.append(request)
+        receipt_path = user_data / "chat-z" / "receipts" / request_path.name
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text(
+            json.dumps(
+                {
+                    "requestId": request["requestId"],
+                    "status": "accepted",
+                    "storedSessionId": "stored-1",
+                    "title": request.get("newTitle") or request.get("title"),
+                    "created": bool(request.get("newSession")),
+                    "cwd": request.get("cwd"),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    return launch
+
+
+def test_new_session_spools_fixed_title_and_workspace(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    args = _parser().parse_args(
+        ["chat-z", "--new", "--cwd", str(project), "--title", "Knowledge receiver", "-q", "Wait"]
+    )
+    seen: list[dict] = []
+
+    receipt = send_to_desktop(args, launch=_accepting_launcher(tmp_path, seen), user_data=tmp_path)
+
+    assert receipt["storedSessionId"] == "stored-1"
+    assert seen[0]["newSession"] is True
+    assert seen[0]["newTitle"] == "Knowledge receiver"
+    assert seen[0]["cwd"] == str(project.resolve())
+    assert seen[0]["text"] == "Wait"
+
+
+def test_existing_session_by_id_spools_durable_target(tmp_path: Path) -> None:
+    args = _parser().parse_args(["chat-z", "--session-id", "stored-7", "-q", "Do work"])
+    seen: list[dict] = []
+
+    send_to_desktop(args, launch=_accepting_launcher(tmp_path, seen), user_data=tmp_path)
+
+    assert seen[0]["sessionId"] == "stored-7"
+    assert "title" not in seen[0]
+    assert "newSession" not in seen[0]
+
+
+def test_title_is_rejected_without_new(tmp_path: Path) -> None:
+    args = _parser().parse_args(["chat-z", "-c", "Receiver", "--title", "Wrong", "-q", "Message"])
+
+    with pytest.raises(ValueError, match="--title can only be used with --new"):
+        send_to_desktop(args, launch=lambda _uri: None, user_data=tmp_path)
+
+
+def test_new_requires_existing_directory(tmp_path: Path) -> None:
+    args = _parser().parse_args(["chat-z", "--new", "--cwd", str(tmp_path / "missing"), "-q", "Message"])
+
+    with pytest.raises(ValueError, match="cannot resolve --cwd"):
+        send_to_desktop(args, launch=lambda _uri: None, user_data=tmp_path)

--- a/tests/hermes_cli/test_chat_z.py
+++ b/tests/hermes_cli/test_chat_z.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from hermes_cli.subcommands.chat_z import build_chat_z_parser, send_to_desktop
+from hermes_cli.subcommands.chat_z import (
+    MAX_REQUEST_BYTES,
+    build_chat_z_parser,
+    desktop_user_data_dir,
+    send_to_desktop,
+)
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -23,16 +28,14 @@ def _accepting_launcher(user_data: Path, seen: list[dict]):
         receipt_path = user_data / "chat-z" / "receipts" / request_path.name
         receipt_path.parent.mkdir(parents=True, exist_ok=True)
         receipt_path.write_text(
-            json.dumps(
-                {
-                    "requestId": request["requestId"],
-                    "status": "accepted",
-                    "storedSessionId": "stored-1",
-                    "title": request.get("newTitle") or request.get("title"),
-                    "created": bool(request.get("newSession")),
-                    "cwd": request.get("cwd"),
-                }
-            ),
+            json.dumps({
+                "requestId": request["requestId"],
+                "status": "accepted",
+                "storedSessionId": "stored-1",
+                "title": request.get("newTitle") or request.get("title"),
+                "created": bool(request.get("newSession")),
+                "cwd": request.get("cwd"),
+            }),
             encoding="utf-8",
         )
 
@@ -42,12 +45,21 @@ def _accepting_launcher(user_data: Path, seen: list[dict]):
 def test_new_session_spools_fixed_title_and_workspace(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()
-    args = _parser().parse_args(
-        ["chat-z", "--new", "--cwd", str(project), "--title", "Knowledge receiver", "-q", "Wait"]
-    )
+    args = _parser().parse_args([
+        "chat-z",
+        "--new",
+        "--cwd",
+        str(project),
+        "--title",
+        "Knowledge receiver",
+        "-q",
+        "Wait",
+    ])
     seen: list[dict] = []
 
-    receipt = send_to_desktop(args, launch=_accepting_launcher(tmp_path, seen), user_data=tmp_path)
+    receipt = send_to_desktop(
+        args, launch=_accepting_launcher(tmp_path, seen), user_data=tmp_path
+    )
 
     assert receipt["storedSessionId"] == "stored-1"
     assert seen[0]["newSession"] is True
@@ -60,7 +72,9 @@ def test_existing_session_by_id_spools_durable_target(tmp_path: Path) -> None:
     args = _parser().parse_args(["chat-z", "--session-id", "stored-7", "-q", "Do work"])
     seen: list[dict] = []
 
-    send_to_desktop(args, launch=_accepting_launcher(tmp_path, seen), user_data=tmp_path)
+    send_to_desktop(
+        args, launch=_accepting_launcher(tmp_path, seen), user_data=tmp_path
+    )
 
     assert seen[0]["sessionId"] == "stored-7"
     assert "title" not in seen[0]
@@ -68,14 +82,62 @@ def test_existing_session_by_id_spools_durable_target(tmp_path: Path) -> None:
 
 
 def test_title_is_rejected_without_new(tmp_path: Path) -> None:
-    args = _parser().parse_args(["chat-z", "-c", "Receiver", "--title", "Wrong", "-q", "Message"])
+    args = _parser().parse_args([
+        "chat-z",
+        "-c",
+        "Receiver",
+        "--title",
+        "Wrong",
+        "-q",
+        "Message",
+    ])
 
     with pytest.raises(ValueError, match="--title can only be used with --new"):
         send_to_desktop(args, launch=lambda _uri: None, user_data=tmp_path)
 
 
 def test_new_requires_existing_directory(tmp_path: Path) -> None:
-    args = _parser().parse_args(["chat-z", "--new", "--cwd", str(tmp_path / "missing"), "-q", "Message"])
+    args = _parser().parse_args([
+        "chat-z",
+        "--new",
+        "--cwd",
+        str(tmp_path / "missing"),
+        "-q",
+        "Message",
+    ])
 
     with pytest.raises(ValueError, match="cannot resolve --cwd"):
         send_to_desktop(args, launch=lambda _uri: None, user_data=tmp_path)
+
+
+def test_serialized_request_rejects_multibyte_prompt_over_byte_limit(
+    tmp_path: Path,
+) -> None:
+    args = _parser().parse_args([
+        "chat-z",
+        "--session-id",
+        "stored-7",
+        "-q",
+        "界" * 400_000,
+    ])
+    launched = False
+
+    def launch(_uri: str) -> None:
+        nonlocal launched
+        launched = True
+
+    with pytest.raises(ValueError, match=rf"{MAX_REQUEST_BYTES:,}-byte limit"):
+        send_to_desktop(args, launch=launch, user_data=tmp_path)
+
+    assert launched is False
+    assert not (tmp_path / "chat-z" / "requests").exists()
+
+
+@pytest.mark.windows_only
+def test_windows_packaged_user_data_path_matches_hermes_app_name(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.delenv("HERMES_DESKTOP_USER_DATA_DIR", raising=False)
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    assert desktop_user_data_dir() == tmp_path / "Hermes"

--- a/tests/skills/test_chat_z_skill.py
+++ b/tests/skills/test_chat_z_skill.py
@@ -1,0 +1,53 @@
+"""Integration contracts for the bundled Chat-Z skill."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from hermes_cli.subcommands.chat_z import build_chat_z_parser
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = REPO_ROOT / "skills" / "productivity" / "chat-z" / "SKILL.md"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    build_chat_z_parser(parser.add_subparsers(dest="command", required=True))
+    return parser
+
+
+def test_chat_z_is_a_bundled_skill() -> None:
+    assert SKILL_PATH.is_file()
+
+
+def test_cli_supports_the_skill_existing_session_target() -> None:
+    args = _parser().parse_args([
+        "chat-z",
+        "--session-id",
+        "stored-session",
+        "-q",
+        "Run the task",
+    ])
+
+    assert args.session_id == "stored-session"
+    assert args.query == "Run the task"
+    assert args.new_session is False
+
+
+def test_cli_supports_the_skill_new_project_session_target(tmp_path: Path) -> None:
+    args = _parser().parse_args([
+        "chat-z",
+        "--new",
+        "--cwd",
+        str(tmp_path),
+        "--title",
+        "Receiver",
+        "-q",
+        "Wait for work",
+    ])
+
+    assert args.new_session is True
+    assert args.cwd == str(tmp_path)
+    assert args.title == "Receiver"

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -171,6 +171,8 @@ hermes chat-z --new --cwd "/path/to/project" --title "Knowledge receiver" -q "Wa
 
 Creation prints the stored session ID. Prefer that ID for later sends because titles can be renamed and must otherwise match exactly. Desktop must already be running, and the target must belong to its active profile.
 
+`chat-z` is a local same-OS-user transport, not a remotely authenticated API. Its private, expiring spool directories restrict ordinary access to the current OS account, while processes already running as the Desktop user are inside the trust boundary and can submit work to that user's agent.
+
 ### `hermes -z <prompt>` — scripted one-shot
 
 For programmatic callers (shell scripts, CI, cron, parent processes piping in a prompt), `hermes -z` is the purest one-shot entry point: **single prompt in, final response text out, nothing else on stdout or stderr.** No banner, no spinner, no tool previews, no `Session:` line — just the agent's final reply as plain text.

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -39,6 +39,7 @@ hermes [global-options] <command> [subcommand/options]
 | Command | Purpose |
 |---------|---------|
 | `hermes chat` | Interactive or one-shot chat with the agent. |
+| `hermes chat-z` | Submit a prompt through the running Desktop app and return after Desktop accepts it. |
 | `hermes model` | Interactively choose the default provider and model. |
 | `hermes moa` | Configure named Mixture of Agents presets selectable from the model picker. |
 | `hermes fallback` | Manage fallback providers tried when the primary model errors. |
@@ -145,6 +146,30 @@ hermes chat --worktree -q "Review this repo and open a PR"
 hermes chat --ignore-user-config --ignore-rules -q "Repro without my personal setup"
 hermes chat --safe-mode -q "Is this bug mine or Hermes'?"
 ```
+
+### `hermes chat-z` — submit through the running Desktop
+
+`chat-z` reuses the Desktop renderer's normal submit path, so the target session has the same running state and status indicator as a prompt entered in the app. The command returns as soon as Desktop accepts the prompt; it does not wait for the agent's answer.
+
+Send to an existing session by its durable ID (preferred):
+
+```bash
+hermes chat-z --session-id "20260823_221854_82325e" -q "Run the next task"
+```
+
+An exact visible title is also accepted:
+
+```bash
+hermes chat-z -c "Knowledge receiver" -q "Run the next task"
+```
+
+Create a Desktop session in a specific project directory and give it a stable title:
+
+```bash
+hermes chat-z --new --cwd "/path/to/project" --title "Knowledge receiver" -q "Wait for work"
+```
+
+Creation prints the stored session ID. Prefer that ID for later sends because titles can be renamed and must otherwise match exactly. Desktop must already be running, and the target must belong to its active profile.
 
 ### `hermes -z <prompt>` — scripted one-shot
 


### PR DESCRIPTION
# PR: feat(desktop): route CLI prompts through running sessions

## What does this PR do?

Adds `hermes chat-z`, a fire-and-accept CLI path that submits prompts through the running Hermes Desktop renderer instead of starting an independent CLI agent loop. It also bundles a `chat-z` skill so the agent knows when and how to use the command.

This fixes the observable mismatch where commands sent with `hermes chat -c` execute in the target conversation but Desktop never enters its native running state. The new path deliberately reuses Desktop's existing prompt submission machinery, so session state, streaming, status indicators, profile routing, and workspace behavior remain owned by the Desktop and gateway.

It can target an existing session by exact title or durable stored ID. It can also create a Desktop session in an explicit project directory with a stable title. The CLI returns after Desktop accepts or rejects the request and never waits for the agent response.

## Related Issue

Fixes #92980

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Tests

## Changes Made

- Add a bounded, expiring request/receipt spool and `hermes://chat-z/<request-id>` route in Electron.
- Add a narrow typed preload bridge between Electron and the primary renderer.
- Reuse the renderer's existing session lookup, creation, title, and prompt submission paths.
- Support existing targets by exact title or stored ID.
- Support `--new --cwd PATH --title TITLE`, returning the stored session ID.
- Add Python and Vitest behavior coverage plus CLI reference documentation.
- Add the bundled `skills/productivity/chat-z` agent skill and its CLI contract tests.

## How to Test

1. Start Hermes Desktop and open any session.
2. Run `hermes chat-z --session-id "<stored-id>" -q "test"`; verify the CLI returns after acceptance and Desktop shows the native running indicator.
3. Run `hermes chat-z --new --cwd "<existing-project>" --title "Receiver" -q "wait"`; verify the returned ID, workspace, stable title, and running state.
4. Run the targeted test suites:
   - `scripts/run_tests.sh tests/hermes_cli/test_chat_z.py tests/skills/test_chat_z_skill.py tests/skills/test_authoring_standards.py -q`
   - `cd apps/desktop && npx vitest run electron/chat-z.test.ts src/store/chat-z.test.ts`
   - `cd apps/desktop && npm run typecheck`

## Verification performed

- Python Chat-Z behavior tests: 6 passed.
- Chat-Z skill and bundled-skill authoring tests: 1,205 passed.
- Desktop behavior tests: 10 passed.
- Desktop TypeScript typecheck: passed.
- Desktop ESLint on touched files: passed.
- Ruff check and format on touched Python files: passed.
- Windows 11 live E2E:
  - existing session accepted through Desktop;
  - new project-scoped Desktop session created;
  - fixed title persisted after the first prompt;
  - subsequent exact-title delivery accepted;
  - Desktop log recorded `renderer accepted`.

## Notes

- Desktop must already be running.
- Requests are UUID-addressed, size-bounded, expiry-bounded, and removed after completion.
- A title lookup is exact; stored IDs are recommended for durable automation.
- No model tool is added, so this does not increase the prompt/tool-schema footprint.
## Receiver transcript hydration

A live Chat-Z test exposed a renderer-only gap: the resumed agent received its full model history, but `omit_messages: true` could leave the Desktop cache showing only the new background turn. Existing-session delivery now refreshes the persisted display transcript through the background session delegate before submit and reconciles optimistic/streaming rows without switching the foreground session.

Validated after rebasing onto current `main`: focused UI tests 12/12, Desktop TypeScript typecheck, and targeted ESLint.