### PR TITLE
fix: preserve MCP OAuth state on failed reauth

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -825,12 +825,32 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         return False
 
     # Wipe both disk and in-memory cache so the next probe forces a fresh
-    # OAuth flow.
+    # OAuth flow, but make the operation transactional: if the replacement
+    # OAuth attempt fails, restore the exact prior on-disk state so a failed
+    # reauth cannot destroy a still-useful refresh token/client/meta set.
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import get_manager
+
+    storage = HermesTokenStorage(name)
+    oauth_snapshot = storage.snapshot()
+    removed_entry = None
+    manager = get_manager()
     try:
-        from tools.mcp_oauth_manager import get_manager
-        get_manager().remove(name)
+        removed_entry = manager.remove(name)
     except Exception as exc:
         _warning(f"Could not clear existing OAuth state: {exc}")
+
+    def _rollback_oauth_state() -> None:
+        try:
+            if oauth_snapshot:
+                storage.restore(oauth_snapshot)
+                manager.restore_entry(name, removed_entry)
+            else:
+                # Brand-new failed logins must not leave partially written
+                # token/client/meta artifacts behind.
+                storage.remove()
+        except Exception as rollback_exc:
+            _warning(f"Could not restore previous OAuth state: {rollback_exc}")
 
     print()
     _info(f"Starting OAuth flow for '{name}'...")
@@ -868,6 +888,7 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         # real tool call later hangs until timeout because there's no token.
         # Verify a token actually landed on disk before claiming success.
         if not _oauth_tokens_present(name):
+            _rollback_oauth_state()
             _warning(
                 "Server responded, but no OAuth token was obtained — "
                 "authentication did not complete."
@@ -895,6 +916,7 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
             _success("Authenticated (server reported no tools)")
         return True
     except Exception as exc:
+        _rollback_oauth_state()
         try:
             from tools.mcp_oauth import humanize_oauth_registration_error
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -835,6 +835,10 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
     oauth_snapshot = storage.snapshot()
     removed_entry = None
     manager = get_manager()
+    # Snapshot/restore is intentionally scoped to the normal single interactive
+    # CLI login/reauth flow. A concurrent reauth for the same server could race
+    # between snapshot, manager.remove(), and replacement writes; this is not a
+    # cross-process transaction primitive.
     try:
         removed_entry = manager.remove(name)
     except Exception as exc:
@@ -888,11 +892,11 @@ def _reauth_oauth_server(name: str, server_config: dict) -> bool:
         # real tool call later hangs until timeout because there's no token.
         # Verify a token actually landed on disk before claiming success.
         if not _oauth_tokens_present(name):
-            _rollback_oauth_state()
             _warning(
                 "Server responded, but no OAuth token was obtained — "
                 "authentication did not complete."
             )
+            _rollback_oauth_state()
             print()
             _info(
                 "Some providers (e.g. Google Drive, Atlassian) do not support "

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -748,6 +748,7 @@ class TestMcpLogin:
         out = capsys.readouterr().out
 
         assert "no OAuth token was obtained" in out
+        assert "Could not restore previous OAuth state" not in out
         assert "Authenticated" not in out
         assert "client_id" in out
 
@@ -812,12 +813,26 @@ class TestMcpLogin:
             "hermes_cli.mcp_config._probe_single_server", mock_probe
         )
 
+        from tools.mcp_oauth_manager import get_manager, reset_manager_for_tests
+
+        reset_manager_for_tests()
+        _set_interactive_stdin(monkeypatch)
+        manager = get_manager()
+        provider = manager.get_or_build_provider(
+            "linear", "https://mcp.linear.app/mcp", None
+        )
+        assert manager._key("linear") in manager._entries
+
         from hermes_cli.mcp_config import cmd_mcp_login
 
         cmd_mcp_login(_make_args(name="linear"))
         out = capsys.readouterr().out
 
         assert "Authentication failed" in out
+        assert "Could not restore previous OAuth state" not in out
+        assert manager.get_or_build_provider(
+            "linear", "https://mcp.linear.app/mcp", None
+        ) is provider
         for name, data in original.items():
             path = token_dir / name
             assert path.read_bytes() == data

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -784,6 +784,142 @@ class TestMcpLogin:
         # OAuth round-trip — far longer than the 30s probe default.
         assert seen["connect_timeout"] >= 180
 
+    def test_login_failure_restores_existing_oauth_state(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """A failed replacement OAuth flow must not destroy prior state."""
+        _seed_config(tmp_path, {
+            "linear": {"url": "https://mcp.linear.app/mcp", "auth": "oauth"},
+        })
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        original = {
+            "linear.json": b'{"access_token":"old","refresh_token":"old-r"}',
+            "linear.client.json": b'{"client_id":"old-client"}',
+            "linear.meta.json": b'{"token_endpoint":"https://old/token"}',
+        }
+        for name, data in original.items():
+            path = token_dir / name
+            path.write_bytes(data)
+            path.chmod(0o600)
+
+        def mock_probe(*_args, **_kwargs):
+            # Simulate a failed flow after destructive remove has already run.
+            (token_dir / "linear.json").write_bytes(b'{"access_token":"partial"}')
+            raise RuntimeError("simulated callback failure")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="linear"))
+        out = capsys.readouterr().out
+
+        assert "Authentication failed" in out
+        for name, data in original.items():
+            path = token_dir / name
+            assert path.read_bytes() == data
+            assert path.stat().st_mode & 0o777 == 0o600
+
+    def test_login_success_replaces_existing_oauth_state(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """A successful replacement keeps the freshly written OAuth state."""
+        _seed_config(tmp_path, {
+            "linear": {"url": "https://mcp.linear.app/mcp", "auth": "oauth"},
+        })
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        for name in ("linear.json", "linear.client.json", "linear.meta.json"):
+            (token_dir / name).write_text("old")
+
+        new_state = {
+            "linear.json": b'{"access_token":"new","refresh_token":"new-r"}',
+            "linear.client.json": b'{"client_id":"new-client"}',
+            "linear.meta.json": b'{"token_endpoint":"https://new/token"}',
+        }
+
+        def mock_probe(*_args, **_kwargs):
+            token_dir.mkdir(exist_ok=True)
+            for name, data in new_state.items():
+                path = token_dir / name
+                path.write_bytes(data)
+                path.chmod(0o600)
+            return [("get_issue", "d")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="linear"))
+        out = capsys.readouterr().out
+
+        assert "Authenticated" in out
+        for name, data in new_state.items():
+            assert (token_dir / name).read_bytes() == data
+
+    def test_brand_new_failed_login_leaves_no_partial_oauth_state(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """No prior state: failed login cleans any partial token artifacts."""
+        _seed_config(tmp_path, {
+            "linear": {"url": "https://mcp.linear.app/mcp", "auth": "oauth"},
+        })
+        token_dir = tmp_path / "mcp-tokens"
+
+        def mock_probe(*_args, **_kwargs):
+            token_dir.mkdir(exist_ok=True)
+            (token_dir / "linear.client.json").write_text("partial-client")
+            raise RuntimeError("simulated timeout")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="linear"))
+        out = capsys.readouterr().out
+
+        assert "Authentication failed" in out
+        assert list(token_dir.glob("linear*.json")) == []
+
+    def test_login_failure_restores_partial_prior_oauth_state(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Rollback restores exactly the prior subset when only some files existed."""
+        _seed_config(tmp_path, {
+            "linear": {"url": "https://mcp.linear.app/mcp", "auth": "oauth"},
+        })
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir()
+        (token_dir / "linear.client.json").write_bytes(b'{"client_id":"old-client"}')
+
+        def mock_probe(*_args, **_kwargs):
+            token_dir.mkdir(exist_ok=True)
+            (token_dir / "linear.json").write_text("partial-token")
+            (token_dir / "linear.meta.json").write_text("partial-meta")
+            raise RuntimeError("simulated provider error")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_login
+
+        cmd_mcp_login(_make_args(name="linear"))
+        out = capsys.readouterr().out
+
+        assert "Authentication failed" in out
+        assert sorted(p.name for p in token_dir.glob("linear*.json")) == [
+            "linear.client.json"
+        ]
+        assert (token_dir / "linear.client.json").read_bytes() == b'{"client_id":"old-client"}'
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_reauth (GH#36767)

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -4,6 +4,7 @@ import json
 import stat
 import sys
 from io import BytesIO
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -159,6 +160,39 @@ class TestHermesTokenStorage:
 
         import asyncio
         assert asyncio.run(storage.get_tokens()) is None
+
+    def test_snapshot_warns_without_exposing_unreadable_file_contents(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        import logging
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("warn-server")
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        token_path = token_dir / "warn-server.json"
+        token_path.write_text("access-secret refresh-secret")
+        client_path = token_dir / "warn-server.client.json"
+        client_path.write_text('{"client_id":"safe"}')
+
+        original_read_bytes = Path.read_bytes
+
+        def fail_token_read(path):
+            if path == token_path:
+                raise OSError("permission denied")
+            return original_read_bytes(path)
+
+        monkeypatch.setattr(Path, "read_bytes", fail_token_read)
+
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_oauth"):
+            snapshot = storage.snapshot()
+
+        assert "warn-server.json" not in snapshot
+        assert "warn-server.client.json" in snapshot
+        assert "Incomplete OAuth state snapshot" in caplog.text
+        assert "warn-server.json" in caplog.text
+        assert "access-secret" not in caplog.text
+        assert "refresh-secret" not in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -55,6 +55,12 @@ def test_manager_restore_entry_preserves_newer_concurrent_entry(tmp_path, monkey
     manager = MCPOAuthManager()
     old_provider = manager.get_or_build_provider("shared", "https://old.example", {})
     old_entry = manager.remove("shared")
+    assert old_entry is not None
+
+    manager.restore_entry("shared", old_entry)
+    assert manager.get_or_build_provider("shared", "https://old.example", {}) is old_provider
+
+    old_entry = manager.remove("shared")
     new_provider = manager.get_or_build_provider("shared", "https://new.example", {})
 
     manager.restore_entry("shared", old_entry)

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -593,12 +593,30 @@ class HermesTokenStorage:
         for p in (self._tokens_path(), self._client_info_path(), self._meta_path()):
             try:
                 st = p.stat()
-                snap[p.name] = {
-                    "data": p.read_bytes(),
-                    "mode": stat.S_IMODE(st.st_mode),
-                }
-            except OSError:
-                pass
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                logger.warning(
+                    "Incomplete OAuth state snapshot for %s: could not stat %s: %s",
+                    self._server_name,
+                    p.name,
+                    exc,
+                )
+                continue
+            try:
+                data = p.read_bytes()
+            except OSError as exc:
+                logger.warning(
+                    "Incomplete OAuth state snapshot for %s: could not read %s: %s",
+                    self._server_name,
+                    p.name,
+                    exc,
+                )
+                continue
+            snap[p.name] = {
+                "data": data,
+                "mode": stat.S_IMODE(st.st_mode),
+            }
         return snap
 
     def restore(self, snapshot: dict[str, dict[str, Any]], *, only_if_absent: bool = False) -> None:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -580,22 +580,28 @@ class HermesTokenStorage:
         for p in (self._tokens_path(), self._client_info_path(), self._meta_path()):
             p.unlink(missing_ok=True)
 
-    def snapshot(self) -> dict[str, bytes]:
+    def snapshot(self) -> dict[str, dict[str, Any]]:
         """Capture on-disk OAuth state so a failed re-auth can restore it.
 
-        Maps filename -> bytes for whichever of the three state files exist.
-        Feed back to ``restore()`` to undo an intervening ``remove()`` when a
-        re-authentication attempt fails, so a still-valid token isn't destroyed.
+        Maps filename -> ``{"data": bytes, "mode": int}`` for whichever of
+        the three state files exist. Feed back to ``restore()`` to undo an
+        intervening ``remove()`` when a re-authentication attempt fails, so a
+        still-useful token/client/meta set is not destroyed. File modes are
+        captured with the bytes so rollback preserves secure permissions.
         """
-        snap: dict[str, bytes] = {}
+        snap: dict[str, dict[str, Any]] = {}
         for p in (self._tokens_path(), self._client_info_path(), self._meta_path()):
             try:
-                snap[p.name] = p.read_bytes()
+                st = p.stat()
+                snap[p.name] = {
+                    "data": p.read_bytes(),
+                    "mode": stat.S_IMODE(st.st_mode),
+                }
             except OSError:
                 pass
         return snap
 
-    def restore(self, snapshot: dict[str, bytes], *, only_if_absent: bool = False) -> None:
+    def restore(self, snapshot: dict[str, dict[str, Any]], *, only_if_absent: bool = False) -> None:
         """Revert to a snapshot without overwriting a concurrent successful write."""
         if only_if_absent and any(
             path.exists()
@@ -611,16 +617,19 @@ class HermesTokenStorage:
             return
         token_dir = _get_token_dir(self._hermes_home)
         token_dir.mkdir(parents=True, exist_ok=True)
-        for fname, data in snapshot.items():
+        for fname, entry in snapshot.items():
             path = token_dir / fname
             try:
+                data = entry["data"]
+                mode = int(entry.get("mode") or (stat.S_IRUSR | stat.S_IWUSR))
                 fd = os.open(
                     str(path),
                     os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                    stat.S_IRUSR | stat.S_IWUSR,
+                    mode,
                 )
                 with os.fdopen(fd, "wb") as fh:
                     fh.write(data)
+                os.chmod(path, mode)
             except OSError as exc:
                 logger.warning("Failed to restore OAuth state %s: %s", fname, exc)
 


### PR DESCRIPTION
## Summary
- Make MCP OAuth login/reauth transactional by snapshotting existing token/client/meta state before clearing it
- Restore prior OAuth state on callback, timeout, provider, or other reauth failures
- Preserve file permissions and clean partial state for brand-new failed logins

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth_manager.py`
- `ruff check hermes_cli/mcp_config.py tools/mcp_oauth.py tests/hermes_cli/test_mcp_config.py`
- Safe fake-home reproduction confirmed failed reauth preserves existing Linear token/client/meta files

## Security
- No real credentials used in tests
- No token values logged
