### PR TITLE
feat(doctor): add Windows managed binary launcher check and auto-repair

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2056,6 +2056,78 @@ def run_doctor(args):
                         manual_issues.append(f"Add {_cmd_link_display} to your PATH")
                 else:
                     issues.append(f"Missing {_cmd_link_display}/hermes symlink — run 'hermes doctor --fix'")
+    else:
+        _section("Command Installation")
+        # On Windows, canonical launchers live in the managed binary dir (HERMES_HOME\bin)
+        from hermes_constants import get_default_hermes_root, project_venv_dir, venv_bin_dir
+        from hermes_cli import _install_repair as _ir_mod
+
+        try:
+            _default_root = Path(get_default_hermes_root())
+        except Exception:
+            _default_root = Path.home() / ".hermes"
+
+        _managed_bin = _default_root / "bin"
+        _launcher_names = getattr(_ir_mod, "_WINDOWS_BIN_LAUNCHERS", ("hermes", "hermes-acp"))
+
+        _venv_dir = project_venv_dir(PROJECT_ROOT)
+        _venv_scripts = venv_bin_dir(_venv_dir, windows=True) if _venv_dir else None
+        _venv_hermes_exe = (_venv_scripts / "hermes.exe") if _venv_scripts else None
+
+        if _venv_hermes_exe is None or not _venv_hermes_exe.is_file():
+            check_warn(
+                "Venv entry point not found",
+                f"(hermes.exe not found in venv Scripts directory — reinstall with pip install -e '.[all]')"
+            )
+            manual_issues.append(
+                f"Reinstall entry point: cd {PROJECT_ROOT} && venv\\Scripts\\activate && pip install -e '.[all]'"
+            )
+        else:
+            try:
+                _rel = _venv_hermes_exe.relative_to(PROJECT_ROOT)
+            except ValueError:
+                _rel = _venv_hermes_exe
+            check_ok(f"Venv entry point exists ({_rel})")
+
+            _missing_launchers = [
+                name for name in _launcher_names
+                if not ((_managed_bin / f"{name}.exe").is_file() or (_managed_bin / f"{name}.cmd").is_file())
+            ]
+
+            if not _missing_launchers:
+                check_ok(f"Managed launchers exist in {_managed_bin}")
+            else:
+                _missing_str = ", ".join(_missing_launchers)
+                check_fail(
+                    f"Managed launcher(s) missing: {_missing_str}",
+                    f"(expected in {_managed_bin})"
+                )
+                if should_fix:
+                    try:
+                        _restored = _ir_mod.ensure_windows_bin_launchers(PROJECT_ROOT, windows=True)
+                        if _restored:
+                            check_ok(f"Restored managed launcher(s): {', '.join(_restored)}")
+                            fixed_count += 1
+                        else:
+                            check_warn(f"Could not automatically restore launchers into {_managed_bin}")
+                    except Exception as _e:
+                        check_warn(f"Failed to restore launchers: {_e}")
+                else:
+                    issues.append(f"Missing managed launcher(s) in {_managed_bin} — run 'hermes doctor --fix'")
+
+            # Check if managed bin dir is in user/process PATH
+            _norm_bin = _ir_mod._normalize_windows_path(_managed_bin)
+            _user_entries = _ir_mod._windows_user_path_entries()
+            _norm_entries = {_ir_mod._normalize_windows_path(e) for e in _user_entries}
+
+            if _norm_bin in _norm_entries:
+                check_ok(f"{_managed_bin} is on PATH")
+            else:
+                check_warn(
+                    f"{_managed_bin} is not on your PATH",
+                    f"(run in PowerShell: [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';{_managed_bin}', 'User'))"
+                )
+                manual_issues.append(f"Add {_managed_bin} to your User PATH")
 
     _section("External Tools")
     # Git

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2061,6 +2061,7 @@ def run_doctor(args):
         # On Windows, canonical launchers live in the managed binary dir (HERMES_HOME\bin)
         from hermes_constants import get_default_hermes_root, project_venv_dir, venv_bin_dir
         from hermes_cli import _install_repair as _ir_mod
+        from hermes_cli._install_repair import _WINDOWS_BIN_LAUNCHERS
 
         try:
             _default_root = Path(get_default_hermes_root())
@@ -2068,7 +2069,7 @@ def run_doctor(args):
             _default_root = Path.home() / ".hermes"
 
         _managed_bin = _default_root / "bin"
-        _launcher_names = getattr(_ir_mod, "_WINDOWS_BIN_LAUNCHERS", ("hermes", "hermes-acp"))
+        _launcher_names = _WINDOWS_BIN_LAUNCHERS
 
         _venv_dir = project_venv_dir(PROJECT_ROOT)
         _venv_scripts = venv_bin_dir(_venv_dir, windows=True) if _venv_dir else None
@@ -2123,9 +2124,10 @@ def run_doctor(args):
             if _norm_bin in _norm_entries:
                 check_ok(f"{_managed_bin} is on PATH")
             else:
+                _escaped_bin = str(_managed_bin).replace("'", "''")
                 check_warn(
                     f"{_managed_bin} is not on your PATH",
-                    f"(run in PowerShell: [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';{_managed_bin}', 'User'))"
+                    f"(run in PowerShell: [Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + '{_escaped_bin}', 'User'))"
                 )
                 manual_issues.append(f"Add {_managed_bin} to your User PATH")
 

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -149,3 +149,49 @@ class TestDoctorCommandInstallation:
         assert "Command Installation" in out
         assert "$PREFIX/bin" in out
 
+    @pytest.mark.windows_only
+    def test_windows_managed_launchers_doctor_check_and_fix(self, monkeypatch, tmp_path):
+        """On Windows, doctor checks %LOCALAPPDATA%\\hermes\\bin and repairs missing launchers."""
+        home = tmp_path / "hermes"
+        project = home / "hermes-agent"
+        scripts = project / "venv" / "Scripts"
+        scripts.mkdir(parents=True)
+        (scripts / "hermes.exe").write_bytes(b"MZ launcher hermes")
+        (scripts / "hermes-acp.exe").write_bytes(b"MZ launcher acp")
+        (project / "venv" / "pyvenv.cfg").write_text("home = X\n", encoding="utf-8")
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        import hermes_constants
+        monkeypatch.setattr(hermes_constants, "get_default_hermes_root", lambda: str(home))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        from hermes_cli import _install_repair as ir_mod
+        # Simulate managed bin on user PATH
+        managed_bin = home / "bin"
+        monkeypatch.setattr(ir_mod, "_windows_user_path_entries", lambda: [str(managed_bin)])
+
+        # 1. First run without fix — detects missing launchers
+        out_no_fix = _run_doctor(fix=False)
+        assert "Command Installation" in out_no_fix
+        assert "Venv entry point exists" in out_no_fix
+        assert "Managed launcher(s) missing" in out_no_fix
+
+        # 2. Run with fix — repairs launchers into home/bin
+        out_fix = _run_doctor(fix=True)
+        assert "Restored managed launcher(s)" in out_fix
+        assert (managed_bin / "hermes.exe").is_file()
+        assert (managed_bin / "hermes-acp.exe").is_file()
+
+        # 3. Subsequent run without fix — all ok
+        out_after_fix = _run_doctor(fix=False)
+        assert "Managed launchers exist" in out_after_fix
+        assert "is on PATH" in out_after_fix
+


### PR DESCRIPTION
## What does this PR do?

Follow-up to #91812 per maintainer feedback and tracking in #91277.

Following PR #92636, Windows binary launchers now reside in the managed directory (`%LOCALAPPDATA%\hermes\bin`) outside the git working tree to prevent autostash sweeps during updates.

This PR adds full Windows parity to `hermes doctor` for the new layout:
- Verifies that `hermes.exe` exists in the project venv Scripts directory.
- Checks whether canonical launchers (`hermes` / `hermes-acp` as `.exe` or `.cmd`) are present in `get_default_hermes_root() / "bin"`.
- Invokes `hermes_cli._install_repair.ensure_windows_bin_launchers` when running with `--fix`.
- Verifies whether the managed binary directory is present in the User PATH environment variable, providing an accurate PowerShell command hint if missing.
- Adds comprehensive unit tests in `tests/hermes_cli/test_doctor_command_install.py` with the `@pytest.mark.windows_only` marker.

## Type of Change

- [x] Cross-platform improvement / feature (non-breaking change adding diagnostics parity)

## How to Test

1. Run unit test suite:
```bash
pytest tests/hermes_cli/test_doctor_command_install.py -v
```
Result: `1 passed, 3 skipped` (on Windows).

2. Run full doctor test suite:
```bash
pytest tests/hermes_cli/test_doctor.py -v
```
Result: `56 passed`.

## Checklist

- [x] Commit follows Conventional Commits (`feat(doctor):`)
- [x] Follows the managed binary layout merged in #92636
- [x] Unit test added and verified passing locally