### PR TITLE
Bring the old Nous palette back as Nous Alt

### DIFF
--- a/apps/desktop/src/themes/presets.test.ts
+++ b/apps/desktop/src/themes/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BUILTIN_THEME_LIST, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK } from './presets'
+import { BUILTIN_THEMES, BUILTIN_THEME_LIST, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK, nousAltTheme } from './presets'
 
 // #40364: none of the UI text/mono fonts carry emoji glyphs, so every font
 // stack must end with a color-emoji fallback or emoji render as tofu on
@@ -29,5 +29,17 @@ describe('theme typography emoji fallback (#40364)', () => {
     expect(EMOJI_FALLBACK).toContain('Apple Color Emoji')
     expect(EMOJI_FALLBACK).toContain('Segoe UI Emoji')
     expect(EMOJI_FALLBACK).toContain('Noto Color Emoji')
+  })
+})
+
+// The pre-GitHub Nous palette stays available as nous-alt; the default name
+// still means GitHub chrome + brand blue.
+describe('nous-alt is the retired Nous, not the default', () => {
+  it('is registered under its own name and leaves nous as the default', () => {
+    expect(DEFAULT_SKIN_NAME).toBe('nous')
+    expect(BUILTIN_THEMES['nous-alt']).toBe(nousAltTheme)
+    expect(BUILTIN_THEMES.nous).not.toBe(nousAltTheme)
+    expect(nousAltTheme.darkColors?.background).toBe('#0D2F86')
+    expect(BUILTIN_THEMES.nous.darkColors?.background).not.toBe(nousAltTheme.darkColors?.background)
   })
 })

--- a/apps/desktop/src/themes/presets.test.ts
+++ b/apps/desktop/src/themes/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { BUILTIN_THEMES, BUILTIN_THEME_LIST, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK, nousAltTheme } from './presets'
+import { BUILTIN_THEME_LIST, BUILTIN_THEMES, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAPHY, EMOJI_FALLBACK, nousAltTheme } from './presets'
 
 // #40364: none of the UI text/mono fonts carry emoji glyphs, so every font
 // stack must end with a color-emoji fallback or emoji render as tofu on

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -15,6 +15,9 @@
  *
  * Re-convert from the upstream extension rather than hand-editing hexes; hand
  * edits drift from upstream silently and can't be re-derived.
+ *
+ * `nous-alt` is the hand-authored Nous from before that fork: glass-tinted
+ * light and cream-on-navy dark. Not a marketplace theme, and not the default.
  */
 
 import type { DesktopTheme, DesktopThemeTypography } from './types'
@@ -586,7 +589,82 @@ export const solarizedTheme: DesktopTheme = {
   }
 }
 
-/** Warm crimson and bronze — forge vibes. Matches the CLI ares skin. */
+const NOUS_ALT_BLUE = '#0053FD'
+const NOUS_ALT_NAVY = '#1540B1'
+const NOUS_ALT_CREAM = '#FFE6CB'
+
+const nousAltTint = (pct: number) => `color-mix(in srgb, ${NOUS_ALT_BLUE} ${pct}%, #FFFFFF)`
+const nousAltTintTransparent = (pct: number) => `color-mix(in srgb, ${NOUS_ALT_BLUE} ${pct}%, transparent)`
+
+/**
+ * Nous Alt — the hand-authored Nous from before the GitHub fork. Light is
+ * glass neutrals with brand blue; dark is cream on mission-blue.
+ */
+export const nousAltTheme: DesktopTheme = {
+  name: 'nous-alt',
+  label: 'Nous Alt',
+  description: 'Glass neutrals, cream on mission-blue',
+  colors: {
+    background: '#F8FAFF',
+    foreground: '#17171A',
+    card: '#FFFFFF',
+    cardForeground: '#17171A',
+    muted: nousAltTint(5),
+    mutedForeground: '#666678',
+    popover: '#FFFFFF',
+    popoverForeground: '#17171A',
+    primary: NOUS_ALT_BLUE,
+    primaryForeground: '#FCFCFC',
+    secondary: nousAltTint(7),
+    secondaryForeground: '#242432',
+    accent: nousAltTint(10),
+    accentForeground: '#202030',
+    border: nousAltTintTransparent(22),
+    input: nousAltTintTransparent(30),
+    ring: NOUS_ALT_BLUE,
+    midground: NOUS_ALT_BLUE,
+    composerRing: NOUS_ALT_BLUE,
+    destructive: '#C72E4D',
+    destructiveForeground: '#FFFFFF',
+    sidebarBackground: '#F3F7FF',
+    sidebarBorder: nousAltTintTransparent(18),
+    userBubble: nousAltTint(6),
+    userBubbleBorder: nousAltTintTransparent(24)
+  },
+  darkColors: {
+    background: '#0D2F86',
+    foreground: NOUS_ALT_CREAM,
+    card: '#12378F',
+    cardForeground: NOUS_ALT_CREAM,
+    muted: '#183F9A',
+    mutedForeground: '#B5C7F3',
+    popover: '#123A96',
+    popoverForeground: NOUS_ALT_CREAM,
+    primary: NOUS_ALT_CREAM,
+    primaryForeground: '#0D2F86',
+    secondary: '#1B45A4',
+    secondaryForeground: '#E0E8FF',
+    accent: NOUS_ALT_NAVY,
+    accentForeground: '#F0F4FF',
+    border: '#3158AD',
+    input: '#0B2566',
+    ring: NOUS_ALT_CREAM,
+    midground: NOUS_ALT_BLUE,
+    composerRing: NOUS_ALT_CREAM,
+    destructive: '#C0473A',
+    destructiveForeground: '#FEF2F2',
+    sidebarBackground: '#09286F',
+    sidebarBorder: '#234A9C',
+    userBubble: '#143B91',
+    userBubbleBorder: '#3A63BD'
+  },
+  typography: {
+    fontSans: SYSTEM_SANS,
+    fontMono: SYSTEM_MONO,
+    fontUrl: 'https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap'
+  }
+}
+
 /**
  * Midnight — deep blue-violet, near-monotone. Dark only: it has no light
  * palette because the whole idea is the dark end of the spectrum.
@@ -775,6 +853,7 @@ export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   catppuccin: catppuccinTheme,
   everforest: everforestTheme,
   solarized: solarizedTheme,
+  'nous-alt': nousAltTheme,
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -13,11 +13,9 @@
  *   everforest ← sainnhe.everforest
  *   solarized  ← ryanolsonx.solarized
  *
- * Re-convert from the upstream extension rather than hand-editing hexes; hand
- * edits drift from upstream silently and can't be re-derived.
- *
- * `nous-alt` is the hand-authored Nous from before that fork: glass-tinted
- * light and cream-on-navy dark. Not a marketplace theme, and not the default.
+ * Re-convert marketplace forks from the upstream extension rather than
+ * hand-editing hexes; hand edits drift from upstream silently and can't be
+ * re-derived. `nous-alt` is first-party — do not re-derive it from GitHub.
  */
 
 import type { DesktopTheme, DesktopThemeTypography } from './types'


### PR DESCRIPTION
## What does this PR do?

[#90587](https://github.com/NousResearch/hermes-agent/pull/90587) replaced the bundled Nous skin with a GitHub Light/Dark fork plus brand blue. The earlier palette (glass-tinted light, cream on navy dark) is back as **Nous Alt**. Default stays `nous`.

## Related Issue

Follow-up to [#90587](https://github.com/NousResearch/hermes-agent/pull/90587).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How to Test

1. Open Appearance or run `/skin list` and confirm Nous Alt is there.
2. Switch to it. Dark mode should be cream text on `#0D2F86`; light should be icy glass with `#0053FD`.
3. Confirm a fresh profile still lands on Nous (GitHub chrome).