### PR TITLE
fix(plugins): reject prefix-correct placeholder Langfuse keys

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -96,6 +96,16 @@ _LANGFUSE_KEY_PREFIXES: Dict[str, str] = {
     "HERMES_LANGFUSE_SECRET_KEY": "sk-lf-",
 }
 
+# Filler tokens pasted behind a correct-looking prefix. The prefix check
+# above passes `pk-lf-...` (the documented stub) and `pk-lf-your-key-here`
+# (copy-paste guides often keep the prefix), yet a real Langfuse key is
+# opaque base62 after the prefix — never dots or one of these words. Both
+# forms would otherwise fall back to the #23823 silent-failure mode (#92984).
+_LANGFUSE_PLACEHOLDER_TOKENS = frozenset({
+    "your-key", "your-key-here", "your-langfuse-key",
+    "test-key", "placeholder", "changeme",
+})
+
 
 def _env(name: str, default: str = "") -> str:
     return os.environ.get(name, default).strip()
@@ -241,12 +251,15 @@ def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
     expected = _LANGFUSE_KEY_PREFIXES.get(env_name, "")
     if not expected:
         return None
-    if value.startswith(expected):
-        return None
-    return (
-        f"{env_name}={_redact_key_preview(value)} "
-        f"(expected {expected!r} prefix)"
-    )
+    if not value.startswith(expected):
+        return (
+            f"{env_name}={_redact_key_preview(value)} "
+            f"(expected {expected!r} prefix)"
+        )
+    remainder = value[len(expected):].strip().lower()
+    if not remainder.strip(".") or remainder in _LANGFUSE_PLACEHOLDER_TOKENS:
+        return f"{env_name}={_redact_key_preview(value)} (placeholder value)"
+    return None
 
 
 def _get_langfuse() -> Optional[Langfuse]:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -503,6 +503,47 @@ class TestPlaceholderKeyDetection:
             "HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz"
         ) is None
 
+    # -- prefix-correct literal stubs (#92984) ------------------------------
+    # The documented stub `pk-lf-...` and guide leftovers like
+    # `pk-lf-your-key-here` carry the RIGHT prefix, so the prefix check
+    # above lets them through and the SDK drops every trace at flush time
+    # — the same silent failure #23823 fixed for wrong-prefix values.
+
+    def test_validate_langfuse_key_rejects_documented_stub_suffix(self, monkeypatch):
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin()
+        message = plugin._validate_langfuse_key(
+            "HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-..."
+        )
+        assert message is not None
+        assert "HERMES_LANGFUSE_PUBLIC_KEY" in message
+        assert "placeholder value" in message
+
+    def test_validate_langfuse_key_rejects_filler_after_correct_prefix(self, monkeypatch):
+        self._clear_env(monkeypatch)
+        plugin = self._fresh_plugin()
+        assert plugin._validate_langfuse_key(
+            "HERMES_LANGFUSE_SECRET_KEY", "sk-lf-your-key-here"
+        ) is not None
+        # A real opaque key with the same prefix stays accepted.
+        assert plugin._validate_langfuse_key(
+            "HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz"
+        ) is None
+
+    def test_stub_public_key_warns_and_skips_end_to_end(self, monkeypatch, caplog):
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-...")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_langfuse() is None
+        assert "HERMES_LANGFUSE_PUBLIC_KEY" in caplog.text
+        assert "placeholder value" in caplog.text
+        # The valid secret value must NOT appear in the log.
+        assert "'sk-lf-" not in caplog.text
+        # Never constructed the SDK client — short-circuited before that.
+        assert _FakeLangfuse.instances == []
+
 
     # -- end-to-end _get_langfuse() behaviour --------------------------------
     # These tests pass `monkeypatch` to _fresh_plugin() so the helper can


### PR DESCRIPTION
## What does this PR do?

Rejects Langfuse credentials that carry the *correct* `pk-lf-` / `sk-lf-` prefix but are literal placeholder stubs. The existing #23823 guard only validates the prefix, so the documented stub `pk-lf-...` (from the config description "Langfuse project public key (pk-lf-...)") and copy-paste leftovers like `pk-lf-your-key-here` pass validation, construct a client, register hooks, and then silently drop every trace at flush time — the exact silent-failure mode #23823 fixed for wrong-prefix values. `_validate_langfuse_key` now also flags values whose remainder after the correct prefix is only dots or a known filler token (`your-key`, `your-key-here`, `your-langfuse-key`, `test-key`, `placeholder`, `changeme`). A real Langfuse key is opaque base62 after the prefix, so these forms can never be legitimate. The one-shot warning, safe key preview/redaction, and `_INIT_FAILED` short-circuit reuse the existing #23823 machinery unchanged; no network probe is added (detection stays deterministic and offline).

## Related Issue

Fixes #51399
Refs #92984 (later duplicate report of the same behavior; the fix was scoped from its repro)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/observability/langfuse/__init__.py`
  - add `_LANGFUSE_PLACEHOLDER_TOKENS` (six literal filler tokens) next to the existing `_LANGFUSE_KEY_PREFIXES` table, with a comment documenting why prefix-correct stubs slip past the #23823 guard
  - `_validate_langfuse_key`: after the prefix check passes, flag values whose post-prefix remainder strips to only dots (the `pk-lf-...` stub form) or matches a filler token; returns a `... (placeholder value)` message in the same single-log-line format
- `tests/plugins/test_langfuse_plugin.py`
  - three regression tests in the existing `TestPlaceholderKeyDetection` class: `pk-lf-...` helper-level rejection, `sk-lf-your-key-here` rejection with a same-prefix real key still accepted, and an end-to-end `_get_langfuse()` test asserting the warning names the env var, never echoes the valid secret, and never constructs the SDK client

## How to Test

1. `.venv/bin/python -m pytest tests/plugins/test_langfuse_plugin.py -q`
2. Observed result: 92 passed (92), including the three new tests; reverting only the plugin file to main makes exactly those three fail (`3 failed, 89 passed`), confirming they pin the new guard.
3. Manual check: with `HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-...` set and the plugin enabled, startup logs `Langfuse plugin: credentials look like placeholders, traces will NOT be emitted (HERMES_LANGFUSE_PUBLIC_KEY='pk-lf...' (placeholder value))` once instead of silently shipping no traces.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full plugin suite green: 92/92 in `tests/plugins/test_langfuse_plugin.py`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (comment on the new constant documents the failure mode)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python string checks, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
