### PR TITLE
fix(cron): flatten id-keyed jobs maps in load_jobs() (#92935)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1313,10 +1313,28 @@ def load_jobs() -> List[Dict[str, Any]]:
     # down the whole cron subsystem.
     if isinstance(data, dict):
         jobs = data.get("jobs", [])
-        if _strict_retry and jobs:
-            # Hit control-character corruption — rewrite with proper escaping.
+        needs_shape_repair = False
+        if isinstance(jobs, dict):
+            # ID-keyed map ({"jobs": {"<job_id>": {...}, ...}}) — written by
+            # external tools or hand edits, never by save_jobs(). The public
+            # load_jobs() contract and every CRUD/scheduler consumer expect a
+            # list; iterating the dict would yield bare id strings and blow up
+            # downstream (e.g. _normalize_job_record -> dict(<str>)). The map
+            # values already carry their own "id", so list(values) is
+            # lossless. Mirror _peek_jobs_unlocked(), which already tolerates
+            # this shape.
+            jobs = list(jobs.values())
+            needs_shape_repair = True
+        if jobs and (_strict_retry or needs_shape_repair):
+            # Rewrite into the canonical {"jobs": [...]} form: either the parse
+            # hit control-character corruption (_strict_retry) or the store was
+            # an id-keyed map. save_jobs() re-emits the list shape every reader
+            # expects.
             save_jobs(jobs)
-            logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+            if needs_shape_repair:
+                logger.warning("Auto-repaired jobs.json (id-keyed jobs map flattened to list)")
+            else:
+                logger.warning("Auto-repaired jobs.json (had invalid control characters)")
         _record_load_stamp(pre_read_stamp)
         return jobs
     if isinstance(data, list):

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1247,6 +1247,99 @@ class TestJobsJsonUtf8Bom:
 
 
 
+# =========================================================================
+# ID-keyed jobs map on jobs.json (external tools / hand edits) — #92935
+# =========================================================================
+
+class TestJobsJsonIdKeyedMap:
+    """load_jobs() must flatten an ID-keyed ``jobs`` map to the list contract.
+
+    A store written as ``{"jobs": {"<job_id>": {...}, ...}}`` (external tool
+    or hand edit — Hermes' own save_jobs() only ever writes a list) made
+    load_jobs() return a dict. Every consumer iterates it as a list, so
+    ``list_jobs()`` → ``_normalize_job_record`` → ``dict(<id-string>)`` raised
+    ``ValueError: dictionary update sequence element #0 has length 1; 2 is
+    required`` and took down ``hermes cron list``, the ``cronjob(action=
+    "list")`` tool, and the Dashboard cron view. The values already carry
+    their own ``id`` matching the map key, so flattening is lossless.
+    """
+
+    _ID_KEYED = {
+        "jobs": {
+            "cron1234abcd": {
+                "id": "cron1234abcd",
+                "name": "Example job",
+                "enabled": True,
+                "prompt": "do a thing",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+            },
+            "cron5678efgh": {
+                "id": "cron5678efgh",
+                "name": "Second job",
+                "enabled": True,
+                "prompt": "do another",
+                "schedule": {"kind": "interval", "minutes": 30, "display": "every 30m"},
+            },
+        },
+        "updated_at": "2026-08-23T10:10:12+08:00",
+    }
+
+    def test_load_jobs_flattens_id_keyed_map(self, tmp_cron_dir):
+        """The pre-fix repro: load_jobs() returns a list, not the raw dict."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(self._ID_KEYED), encoding="utf-8")
+
+        loaded = load_jobs()
+        assert isinstance(loaded, list)
+        assert {j["id"] for j in loaded} == {"cron1234abcd", "cron5678efgh"}
+        assert all(isinstance(j, dict) for j in loaded)
+
+    def test_list_jobs_survives_id_keyed_map(self, tmp_cron_dir):
+        """The reported traceback path (hermes cron list / cronjob list tool)."""
+        import json
+        from cron.jobs import JOBS_FILE, list_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(self._ID_KEYED), encoding="utf-8")
+
+        # Pre-fix this raised ValueError from _normalize_job_record(dict(<str>)).
+        jobs = list_jobs(include_disabled=True)
+        assert {j["id"] for j in jobs} == {"cron1234abcd", "cron5678efgh"}
+
+    def test_id_keyed_map_repaired_to_list_on_disk(self, tmp_cron_dir):
+        """Loading rewrites the store into the canonical {"jobs": [...]} form."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(self._ID_KEYED), encoding="utf-8")
+
+        load_jobs()
+
+        on_disk = json.loads(JOBS_FILE.read_text(encoding="utf-8"))
+        assert isinstance(on_disk["jobs"], list)
+        assert {j["id"] for j in on_disk["jobs"]} == {"cron1234abcd", "cron5678efgh"}
+
+        # A second load reads the repaired list unchanged (idempotent).
+        reloaded = load_jobs()
+        assert {j["id"] for j in reloaded} == {"cron1234abcd", "cron5678efgh"}
+
+    def test_empty_id_keyed_map_returns_empty_list(self, tmp_cron_dir):
+        """An empty ``jobs`` map must not crash and yields no jobs."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps({"jobs": {}}), encoding="utf-8")
+
+        assert load_jobs() == []
+
+
+
+
 class TestAdvanceNextRuns:
     """Tests for advance_next_runs() — the batched due-set advance.
 


### PR DESCRIPTION
## What does this PR do?

`load_jobs()` (`cron/jobs.py`) is declared `List[Dict[str, Any]]`, but when a `jobs.json` stores an **ID-keyed map** — `{"jobs": {"<job_id>": {...}, ...}}` — it returned the raw `dict`. Every consumer iterates the result as a list, so iterating yielded bare id strings and crashed downstream.

### Symptom

`hermes cron list`, the `cronjob(action="list")` tool, and the Dashboard cron view all fail with:

```
dictionary update sequence element #0 has length 1; 2 is required
```

Traceback (from #92935):

```
cron/jobs.py in list_jobs -> jobs = [_normalize_job_record(j) for j in load_jobs()]
cron/jobs.py in _normalize_job_record -> normalized = _apply_skill_fields(job)
cron/jobs.py in _apply_skill_fields -> normalized = dict(job)   # dict(<id-string>)
ValueError: dictionary update sequence element #0 has length 1; 2 is required
```

An ID-keyed store is produced by external tools / hand edits — Hermes' own `save_jobs()` only ever writes the list form.

## Root cause

```python
if isinstance(data, dict):
    jobs = data.get("jobs", [])   # jobs may be a dict → returned as-is
```

The declared contract and all ~20 `load_jobs()` consumers (`list_jobs`, `update_job`, `remove_job`, `scheduler_provider`, …) expect a list.

## Fix

Normalize once at the **load boundary** so every consumer is covered, rather than patching a single caller. The map values already carry their own `id` matching the map key, so `list(jobs.values())` is lossless. This mirrors the sibling `_peek_jobs_unlocked()`, which already tolerates this shape, and reuses the existing auto-repair pattern (bare-list wrapping / control-char rewrite) to persist the canonical `{"jobs": [...]}` form back to disk.

## Tests

`tests/cron/test_jobs.py::TestJobsJsonIdKeyedMap` — 4 cases, all **fail on current `main` and pass with the fix**:

- `test_load_jobs_flattens_id_keyed_map` — returns a list, not the raw dict
- `test_list_jobs_survives_id_keyed_map` — the exact reported `ValueError` traceback path
- `test_id_keyed_map_repaired_to_list_on_disk` — store is rewritten to canonical list form; reload is idempotent
- `test_empty_id_keyed_map_returns_empty_list` — empty-map edge case

```
tests/cron/test_jobs.py — 74 passed, 2 skipped
```
(The 2 skips are unrelated; two env-only failures require the optional `croniter` package and also fail on unmodified `main`.)

## Related Issue

Fixes #92935

## Type of Change

- [x] Bug fix