### PR TITLE
fix(agent): strip nulls from Gemini functionResponse payloads (strict google-proxies 422)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -341,6 +341,13 @@ def _translate_tool_call_to_gemini(
     part: Dict[str, Any] = {
         "functionCall": {
             "name": str(fn.get("name") or ""),
+            # NB: args are deliberately NOT run through _strip_nulls (unlike
+            # functionResponse.response). functionCall.args are model-generated
+            # and replayed verbatim from history; Gemini 3 thinking models
+            # validate a replayed functionCall against its thoughtSignature, so
+            # mutating args (dropping a null the model emitted) risks trading a
+            # hypothetical 422 for a real 400 INVALID_ARGUMENT signature
+            # mismatch. The observed 422 is only on response payloads, never args.
             "args": args,
         }
     }
@@ -387,6 +394,27 @@ def _looks_like_json_schema(node: Any) -> bool:
     return False
 
 
+def _strip_nulls(value):
+    """Recursively drop ``None`` values from parsed tool-result payloads.
+
+    The Foundry google-proxy rejects any ``null`` inside
+    ``functionResponse.response`` with an opaque HTTP 422 (native Google AI
+    Studio tolerates it) — e.g. terminal's ``"error": null``. Verified live
+    against the proxy (session 20260613_214056_c75da3).
+
+    Scope note: only the ``null`` values are removed, not the containers that
+    held them. A dict that becomes empty (``{"e": None}`` -> ``{}``) is kept as
+    ``{}`` rather than dropped, because the 422 is triggered by the ``null``
+    literal, not by empty objects — and recursively pruning now-empty
+    dicts/lists would risk deleting keys a downstream schema still expects.
+    """
+    if isinstance(value, dict):
+        return {k: _strip_nulls(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [_strip_nulls(v) for v in value if v is not None]
+    return value
+
+
 def _translate_tool_result_to_gemini(
     message: Dict[str, Any],
     tool_name_by_call_id: Optional[Dict[str, str]] = None,
@@ -421,6 +449,7 @@ def _translate_tool_result_to_gemini(
     if isinstance(parsed, dict) and _looks_like_json_schema(parsed):
         parsed = None
     response = parsed if isinstance(parsed, dict) else {"output": content}
+    response = _strip_nulls(response)
     function_response: Dict[str, Any] = {
         "name": name,
         "response": response,

--- a/tests/agent/test_gemini_palantir_null_and_merge.py
+++ b/tests/agent/test_gemini_palantir_null_and_merge.py
@@ -1,0 +1,118 @@
+"""Regression tests for Palantir/Vertex google-proxy Gemini fixes (2026-06-13).
+
+Two independent bugs that made gemini-3-5-flash 422/400 opaquely on the
+Foundry google proxy once a real multi-turn tool history was present:
+
+1. NULL values inside functionResponse.response -> HTTP 422 (empty params).
+   The proxy rejects any ``null`` (e.g. terminal's ``"error": null``). Native
+   Google AI Studio tolerates it; only the Foundry proxy bites.
+
+2. Parallel tool calls split into N separate user turns -> HTTP 400
+   "the number of function response parts is equal to the number of function
+   call parts of the function call turn". Gemini-native requires a model turn
+   with N functionCalls to be answered by ONE user turn with N
+   functionResponses.
+
+Both verified empirically against the live proxy by replaying the exact
+22-message / 37-tool request that failed in session 20260613_214056_c75da3.
+"""
+from agent.gemini_native_adapter import build_gemini_request, _strip_nulls
+
+
+def test_strip_nulls_drops_none_values():
+    assert _strip_nulls({"output": "x", "error": None, "exit_code": 0}) == {
+        "output": "x",
+        "exit_code": 0,
+    }
+
+
+def test_strip_nulls_recurses_into_nested():
+    assert _strip_nulls({"a": {"b": None, "c": 1}, "d": [None, 2, {"e": None}]}) == {
+        "a": {"c": 1},
+        "d": [2, {}],
+    }
+
+
+def test_function_response_has_no_null_values():
+    msgs = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "1", "type": "function",
+                 "function": {"name": "terminal", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "1", "name": "terminal",
+         "content": '{"output": "ok", "exit_code": 0, "error": null}'},
+    ]
+    req = build_gemini_request(messages=msgs, tools=None)
+    # Assert the invariant structurally, not via the serialized string: a
+    # separators change (e.g. json.dumps(..., separators=(",", ":")) emitting
+    # ``:null`` without a space) would silently defeat a ``": null"`` substring
+    # count. Walk the parsed request and assert no ``None`` survives anywhere.
+    def _assert_no_none(node, path="req"):
+        if node is None:
+            raise AssertionError(f"null leaked into request at {path}")
+        if isinstance(node, dict):
+            for k, v in node.items():
+                _assert_no_none(v, f"{path}.{k}")
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                _assert_no_none(v, f"{path}[{i}]")
+
+    _assert_no_none(req)
+    fr = req["contents"][2]["parts"][0]["functionResponse"]["response"]
+    assert "error" not in fr
+    assert fr["output"] == "ok"
+
+
+def test_parallel_tool_results_merge_into_single_user_turn():
+    msgs = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"id": "1", "type": "function", "function": {"name": "a", "arguments": "{}"}},
+                {"id": "2", "type": "function", "function": {"name": "b", "arguments": "{}"}},
+                {"id": "3", "type": "function", "function": {"name": "c", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "1", "name": "a", "content": '{"r": 1}'},
+        {"role": "tool", "tool_call_id": "2", "name": "b", "content": '{"r": 2}'},
+        {"role": "tool", "tool_call_id": "3", "name": "c", "content": '{"r": 3}'},
+    ]
+    req = build_gemini_request(messages=msgs, tools=None)
+    roles = [c["role"] for c in req["contents"]]
+    assert roles == ["user", "model", "user"], roles
+    model_turn = req["contents"][1]
+    user_turn = req["contents"][2]
+    fc = [p for p in model_turn["parts"] if "functionCall" in p]
+    fr = [p for p in user_turn["parts"] if "functionResponse" in p]
+    assert len(fc) == 3
+    assert len(fr) == 3  # balanced: N functionCalls -> N functionResponses in one turn
+
+
+def test_separate_text_user_turn_not_merged_into_tool_results():
+    """A normal text user message must NOT be merged into a functionResponse turn.
+
+    Upstream (gemini-cli#28700 + #55125) now interposes a placeholder model
+    turn between the functionResponse content and the human text content —
+    two adjacent user contents are HTTP 400-unsafe, and folding the text in
+    makes Gemini "continue the tool result" instead of answering.
+    """
+    msgs = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "1", "type": "function", "function": {"name": "a", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "1", "name": "a", "content": '{"r": 1}'},
+        {"role": "user", "content": "now answer"},
+    ]
+    req = build_gemini_request(messages=msgs, tools=None)
+    roles = [c["role"] for c in req["contents"]]
+    # placeholder model turn keeps alternation valid; text stays its own user turn
+    assert roles == ["user", "model", "user", "model", "user"], roles
+    # last user turn is the text, not merged with the functionResponse turn
+    assert any("text" in p for p in req["contents"][4]["parts"])


### PR DESCRIPTION
## Problem

A session that runs Gemini through a strict google-proxy (Palantir Foundry
`LanguageModelService` / Vertex-style gateways) fails opaquely with HTTP 422
once real multi-turn tool history is present:

```
HTTP 422 — empty params
```

Root cause: tool results are commonly serialized with optional fields set to
`null` (e.g. the built-in terminal emits `"error": null`). Native Google AI
Studio tolerates `null` inside `functionResponse.response`, but the Foundry
google-proxy rejects **any** null with an opaque 422. The chat_completions →
Gemini-native translation passes the parsed payload through verbatim.

Verified empirically against the live proxy by replaying the exact
22-message / 37-tool request that failed in production (session
20260613_214056_c75da3); removing the nulls from that same replay returned
HTTP 200.

## Fix

Small, local, mirrors the existing sibling-helper style of this module:

- New `_strip_nulls(value)` — recursive drop of `None` values from dicts,
  lists and nested structures.
- Wired in `_translate_tool_result_to_gemini()` right after parsing, so only
  the outgoing `functionResponse.response` payload is affected. Message
  history is untouched; idempotent; no-op for payloads without nulls.
- Native Google AI Studio behavior is unchanged (it accepted both shapes).

## Tests

New regression file `tests/agent/test_gemini_palantir_null_and_merge.py`
(5 cases): direct dict/list/nested null-dropping contract, end-to-end
`build_gemini_request` assertion that no `: null` survives into the wire
payload, plus two pre-existing-behavior pins (parallel tool-result merging;
text user turn kept separate from functionResponse turns) so the surrounding
merge logic is guarded while we're here.

All 5 pass against the Hermes venv:

```
PASS: test_function_response_has_no_null_values
PASS: test_parallel_tool_results_merge_into_single_user_turn
PASS: test_separate_text_user_turn_not_merged_into_tool_results
PASS: test_strip_nulls_drops_none_values
PASS: test_strip_nulls_recurses_into_nested
--- 5/5 GREEN
```
