### PR TITLE
fix(cron): use venv Python from macOS app gateways

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3798,6 +3798,38 @@ def _windows_cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str
     return str(interpreter), env_overlay
 
 
+def _cron_python_invocation(python_exe: str) -> tuple[str, dict[str, str]]:
+    """Resolve a real Python interpreter for cron script subprocesses.
+
+    App-bundled macOS gateways expose the signed app launcher as
+    ``sys.executable``.  Reusing that binary as ``python script.py`` starts the
+    bundle bootstrap without its packaged Python home.  The gateway already
+    publishes its backing virtual environment, so use that interpreter when
+    it exists.  Normal POSIX and all Windows behavior remains unchanged.
+    """
+    if sys.platform == "win32":
+        return _windows_cron_python_invocation(python_exe)
+    if sys.platform != "darwin":
+        return python_exe, {}
+
+    executable_parts = Path(python_exe).parts
+    app_bundle_executable = any(
+        part.endswith(".app")
+        and executable_parts[index + 1 : index + 3] == ("Contents", "MacOS")
+        for index, part in enumerate(executable_parts[:-2])
+    )
+    if not app_bundle_executable:
+        return python_exe, {}
+
+    virtual_environment = os.environ.get("VIRTUAL_ENV", "").strip()
+    if virtual_environment:
+        for interpreter_name in ("python", "python3"):
+            interpreter = Path(virtual_environment) / "bin" / interpreter_name
+            if interpreter.is_file():
+                return str(interpreter), {}
+    return python_exe, {}
+
+
 def _terminate_cron_script_process(proc: subprocess.Popen) -> None:
     """Best-effort hard stop of a cron script and every child it spawned."""
     if proc.poll() is not None:
@@ -4037,7 +4069,7 @@ def _run_job_script(
         argv = [_bash, str(path)]
         env_overlay: dict[str, str] = {}
     else:
-        python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)
+        python_exe, env_overlay = _cron_python_invocation(sys.executable)
         if env_overlay:
             # Overlay mode (Windows uv venv): PYTHONPATH alone cannot make
             # editable installs importable — .pth processing needs

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -275,6 +275,50 @@ class TestRunJobScript:
         assert argv == [sys.executable, str(script)]
 
 
+    def test_macos_app_bundle_uses_virtualenv_python_for_script(
+        self, cron_env, tmp_path, monkeypatch
+    ):
+        from cron import scheduler as sched_mod
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "probe.py"
+        script.write_text('print("ok")\n', encoding="utf-8")
+
+        app_python = tmp_path / "Jarvis.app" / "Contents" / "MacOS" / "Jarvis"
+        app_python.parent.mkdir(parents=True)
+        app_python.write_text("", encoding="utf-8")
+        venv_python = tmp_path / "venv" / "bin" / "python"
+        venv_python.parent.mkdir(parents=True)
+        venv_python.write_text("", encoding="utf-8")
+
+        captured = {}
+
+        class FakeProc:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["kwargs"] = kwargs
+                self.returncode = 0
+
+            def poll(self):
+                return self.returncode
+
+            def communicate(self, timeout=None):
+                return ("ok\n", "")
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+        monkeypatch.setattr(sched_mod.sys, "platform", "darwin")
+        monkeypatch.setattr(sched_mod.sys, "executable", str(app_python))
+        monkeypatch.setenv("VIRTUAL_ENV", str(venv_python.parent.parent))
+        monkeypatch.setattr(sched_mod.subprocess, "Popen", FakeProc)
+
+        success, output = _run_job_script("probe.py")
+
+        assert success is True
+        assert output == "ok"
+        assert captured["argv"] == [str(venv_python), str(script.resolve())]
+
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="Windows always takes the overlay/creationflags branch",


### PR DESCRIPTION
## Outcome

Script-only cron jobs run correctly when the gateway is packaged as a signed macOS app. The scheduler now uses the gateway virtual environment Python instead of treating the `.app/Contents/MacOS/*` launcher as a child interpreter.

This fixes jobs such as Jarvis's Hy-MT2 canary, which currently fail because the app launcher cannot resolve `/install/lib/python3.12` when invoked as `python script.py`.

## Scope

- macOS only
- activates only when `sys.executable` is inside `.app/Contents/MacOS`
- uses `<VIRTUAL_ENV>/bin/python` or `python3` only when that file exists
- preserves existing POSIX and Windows behavior otherwise

## Verification

- focused script suite: `28 passed, 1 skipped`
- full cron suite: `873 passed, 1 skipped`
- one unrelated heartbeat timing test remains red on both this branch and a clean detached `origin/main`: `test_repeated_heartbeat_errors_cancel_after_bounded_grace`, expected at least 3 calls, observed 2

## Risk

Low. The fallback is conditional and returns the original app launcher unchanged when no backing virtual environment interpreter can be proven.