### PR TITLE
fix(desktop): preserve preview actions across session recovery

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -452,6 +452,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const { handleGatewayEvent } = useMessageStream({
     activeGatewayProfile,
     activeSessionIdRef,
+    selectedStoredSessionIdRef,
     hydrateFromStoredSession,
     queryClient,
     refreshHermesConfig,

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -225,6 +225,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
   const messagingSessions = useStore($messagingSessions)
   const sessions = useStore($sessions)
+  const storedIdsShareLineage = useCallback(
+    (leftStoredId: string, rightStoredId: string) =>
+      leftStoredId === rightStoredId ||
+      sessions.some(
+        session => sessionMatchesStoredId(session, leftStoredId) && sessionMatchesStoredId(session, rightStoredId)
+      ),
+    [sessions]
+  )
   const activeConnectionId = useStore($activeConnectionId)
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const profileScope = useStore($profileScope)
@@ -453,6 +461,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     activeGatewayProfile,
     activeSessionIdRef,
     selectedStoredSessionIdRef,
+    storedIdsShareLineage,
     hydrateFromStoredSession,
     queryClient,
     refreshHermesConfig,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
@@ -262,6 +262,7 @@ describe('useMessageStream composed with the real useSessionStateCache', () => {
     const stream = useMessageStream({
       activeSessionIdRef: sessionCache.activeSessionIdRef,
       selectedStoredSessionIdRef: sessionCache.selectedStoredSessionIdRef,
+      storedIdsShareLineage: (left, right) => left === right,
       hydrateFromStoredSession: vi.fn(async () => undefined),
       queryClient: queryClientRef.current,
       refreshHermesConfig: vi.fn(async () => undefined),

--- a/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
@@ -261,6 +261,7 @@ describe('useMessageStream composed with the real useSessionStateCache', () => {
 
     const stream = useMessageStream({
       activeSessionIdRef: sessionCache.activeSessionIdRef,
+      selectedStoredSessionIdRef: sessionCache.selectedStoredSessionIdRef,
       hydrateFromStoredSession: vi.fn(async () => undefined),
       queryClient: queryClientRef.current,
       refreshHermesConfig: vi.fn(async () => undefined),

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import type { GatewayEventPayload } from '@/lib/chat-messages'
 import {
   approvalReplaySessionId,
+  gatewayEventIsActive,
   resolveGatewayEventSessionId,
   UNSCOPED_STREAM_EVENT_TYPES
 } from '@/lib/gateway-events'
@@ -193,7 +194,20 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
       }
 
-      const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
+      const payloadStoredSessionId =
+        typeof payload?.stored_session_id === 'string' ? payload.stored_session_id.trim() || null : null
+
+      const eventStoredSessionId =
+        payloadStoredSessionId ??
+        (sessionId ? (sessionStateByRuntimeIdRef.current.get(sessionId)?.storedSessionId ?? null) : null)
+
+      const isActiveEvent = gatewayEventIsActive({
+        activeRuntimeSessionId: activeSessionIdRef.current,
+        eventRuntimeSessionId: sessionId,
+        eventStoredSessionId,
+        fromActiveSource: fromActiveSource(),
+        selectedStoredSessionId: deps.selectedStoredSessionIdRef.current
+      })
 
       const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)
 
@@ -243,6 +257,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       deps.appendAssistantDelta,
       deps.appendReasoningDelta,
       deps.activeSessionIdRef,
+      deps.selectedStoredSessionIdRef,
       deps.activeGatewayProfile,
       deps.compactedTurnRef,
       deps.completeAssistantMessage,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -206,7 +206,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         eventRuntimeSessionId: sessionId,
         eventStoredSessionId,
         fromActiveSource: fromActiveSource(),
-        selectedStoredSessionId: deps.selectedStoredSessionIdRef.current
+        selectedStoredSessionId: deps.selectedStoredSessionIdRef.current,
+        storedIdsShareLineage: deps.storedIdsShareLineage
       })
 
       const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)
@@ -258,6 +259,7 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       deps.appendReasoningDelta,
       deps.activeSessionIdRef,
       deps.selectedStoredSessionIdRef,
+      deps.storedIdsShareLineage,
       deps.activeGatewayProfile,
       deps.compactedTurnRef,
       deps.completeAssistantMessage,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -9,6 +9,7 @@ import type { ClientSessionState } from '../../../../types'
 export interface GatewayEventDeps {
   activeGatewayProfile: string
   activeSessionIdRef: MutableRefObject<string | null>
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
   compactedTurnRef: MutableRefObject<Set<string>>
   lastCwdInfoSessionRef: MutableRefObject<string | null>
   nativeSubagentSessionsRef: MutableRefObject<Set<string>>

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/types.ts
@@ -10,6 +10,7 @@ export interface GatewayEventDeps {
   activeGatewayProfile: string
   activeSessionIdRef: MutableRefObject<string | null>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
+  storedIdsShareLineage: (leftStoredId: string, rightStoredId: string) => boolean
   compactedTurnRef: MutableRefObject<Set<string>>
   lastCwdInfoSessionRef: MutableRefObject<string | null>
   nativeSubagentSessionsRef: MutableRefObject<Set<string>>

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -39,6 +39,7 @@ interface MessageStreamOptions {
   activeGatewayProfile?: string
   activeSessionIdRef: MutableRefObject<string | null>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
+  storedIdsShareLineage: (leftStoredId: string, rightStoredId: string) => boolean
   hydrateFromStoredSession: (
     attempts?: number,
     storedSessionId?: string | null,
@@ -72,6 +73,7 @@ export function useMessageStream({
   activeGatewayProfile = 'default',
   activeSessionIdRef,
   selectedStoredSessionIdRef,
+  storedIdsShareLineage,
   hydrateFromStoredSession,
   queryClient,
   refreshHermesConfig,
@@ -848,6 +850,7 @@ export function useMessageStream({
     appendReasoningDelta,
     activeSessionIdRef,
     selectedStoredSessionIdRef,
+    storedIdsShareLineage,
     compactedTurnRef,
     lastCwdInfoSessionRef,
     nativeSubagentSessionsRef,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -38,6 +38,7 @@ import { completionErrorText, delegateTaskPayloads, MAX_STREAM_FLUSH_GAP_MS, STR
 interface MessageStreamOptions {
   activeGatewayProfile?: string
   activeSessionIdRef: MutableRefObject<string | null>
+  selectedStoredSessionIdRef: MutableRefObject<string | null>
   hydrateFromStoredSession: (
     attempts?: number,
     storedSessionId?: string | null,
@@ -70,6 +71,7 @@ const nextStreamMessageId = (prefix: string) => `${prefix}-${Date.now()}-${++str
 export function useMessageStream({
   activeGatewayProfile = 'default',
   activeSessionIdRef,
+  selectedStoredSessionIdRef,
   hydrateFromStoredSession,
   queryClient,
   refreshHermesConfig,
@@ -845,6 +847,7 @@ export function useMessageStream({
     appendAssistantDelta,
     appendReasoningDelta,
     activeSessionIdRef,
+    selectedStoredSessionIdRef,
     compactedTurnRef,
     lastCwdInfoSessionRef,
     nativeSubagentSessionsRef,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/steer-arrival-order.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/steer-arrival-order.test.tsx
@@ -64,6 +64,7 @@ function Harness() {
 
   const stream = useMessageStream({
     activeSessionIdRef,
+    selectedStoredSessionIdRef,
     hydrateFromStoredSession: vi.fn(async () => undefined),
     queryClient: queryClientRef.current,
     refreshHermesConfig: vi.fn(async () => undefined),

--- a/apps/desktop/src/app/session/hooks/use-message-stream/steer-arrival-order.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/steer-arrival-order.test.tsx
@@ -65,6 +65,7 @@ function Harness() {
   const stream = useMessageStream({
     activeSessionIdRef,
     selectedStoredSessionIdRef,
+    storedIdsShareLineage: (left, right) => left === right,
     hydrateFromStoredSession: vi.fn(async () => undefined),
     queryClient: queryClientRef.current,
     refreshHermesConfig: vi.fn(async () => undefined),

--- a/apps/desktop/src/app/session/hooks/use-message-stream/test-harness.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/test-harness.tsx
@@ -53,11 +53,13 @@ export function renderMessageStream(
 
   function Harness() {
     const activeSessionIdRef = useRef<string | null>(sessionId)
+    const selectedStoredSessionIdRef = useRef<string | null>(sessionId)
     const sessionStateByRuntimeIdRef = useRef(states)
     const queryClientRef = useRef(new QueryClient())
 
     const stream = useMessageStream({
       activeSessionIdRef,
+      selectedStoredSessionIdRef,
       hydrateFromStoredSession: vi.fn(async () => undefined),
       queryClient: queryClientRef.current,
       refreshHermesConfig: vi.fn(async () => undefined),

--- a/apps/desktop/src/app/session/hooks/use-message-stream/test-harness.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/test-harness.tsx
@@ -60,6 +60,7 @@ export function renderMessageStream(
     const stream = useMessageStream({
       activeSessionIdRef,
       selectedStoredSessionIdRef,
+      storedIdsShareLineage: (left, right) => left === right,
       hydrateFromStoredSession: vi.fn(async () => undefined),
       queryClient: queryClientRef.current,
       refreshHermesConfig: vi.fn(async () => undefined),

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { approvalReplaySessionId, gatewayEventRequiresSessionId, resolveGatewayEventSessionId } from './gateway-events'
+import {
+  approvalReplaySessionId,
+  gatewayEventIsActive,
+  gatewayEventRequiresSessionId,
+  resolveGatewayEventSessionId
+} from './gateway-events'
 
 describe('gateway event routing', () => {
   it('rehydrates pending approvals on reconnect ready and resumed session info', () => {
@@ -126,5 +131,53 @@ describe('gateway event routing', () => {
       pinned: true,
       sessionId: 'session-a'
     })
+  })
+
+  it('accepts a recovered runtime for the selected conversation from the active source', () => {
+    expect(
+      gatewayEventIsActive({
+        activeRuntimeSessionId: 'runtime-stale',
+        eventRuntimeSessionId: 'runtime-current',
+        eventStoredSessionId: 'stored-visible',
+        fromActiveSource: true,
+        selectedStoredSessionId: 'stored-visible'
+      })
+    ).toBe(true)
+  })
+
+  it('rejects a stored-session-id collision from an inactive source', () => {
+    expect(
+      gatewayEventIsActive({
+        activeRuntimeSessionId: 'runtime-visible',
+        eventRuntimeSessionId: 'runtime-background',
+        eventStoredSessionId: 'stored-visible',
+        fromActiveSource: false,
+        selectedStoredSessionId: 'stored-visible'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects an exact runtime-id collision from an inactive source', () => {
+    expect(
+      gatewayEventIsActive({
+        activeRuntimeSessionId: 'runtime-visible',
+        eventRuntimeSessionId: 'runtime-visible',
+        eventStoredSessionId: 'stored-visible',
+        fromActiveSource: false,
+        selectedStoredSessionId: 'stored-visible'
+      })
+    ).toBe(false)
+  })
+
+  it('rejects a runtime mismatch without a durable conversation mapping', () => {
+    expect(
+      gatewayEventIsActive({
+        activeRuntimeSessionId: 'runtime-visible',
+        eventRuntimeSessionId: 'runtime-recovered',
+        eventStoredSessionId: null,
+        fromActiveSource: true,
+        selectedStoredSessionId: 'stored-visible'
+      })
+    ).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { sessionMatchesStoredId } from '@/store/session'
+
 import {
   approvalReplaySessionId,
   gatewayEventIsActive,
@@ -8,6 +10,10 @@ import {
 } from './gateway-events'
 
 describe('gateway event routing', () => {
+  const lineageSessions = [{ id: 'stored-tip', _lineage_root_id: 'stored-root' }]
+  const storedIdsShareLineage = (left: string, right: string) =>
+    lineageSessions.some(session => sessionMatchesStoredId(session, left) && sessionMatchesStoredId(session, right))
+
   it('rehydrates pending approvals on reconnect ready and resumed session info', () => {
     expect(approvalReplaySessionId('gateway.ready', 'active-1', null)).toBe('active-1')
     expect(approvalReplaySessionId('session.info', 'active-1', 'routed-1')).toBe('routed-1')
@@ -140,7 +146,8 @@ describe('gateway event routing', () => {
         eventRuntimeSessionId: 'runtime-current',
         eventStoredSessionId: 'stored-visible',
         fromActiveSource: true,
-        selectedStoredSessionId: 'stored-visible'
+        selectedStoredSessionId: 'stored-visible',
+        storedIdsShareLineage: (left, right) => left === right
       })
     ).toBe(true)
   })
@@ -152,7 +159,8 @@ describe('gateway event routing', () => {
         eventRuntimeSessionId: 'runtime-background',
         eventStoredSessionId: 'stored-visible',
         fromActiveSource: false,
-        selectedStoredSessionId: 'stored-visible'
+        selectedStoredSessionId: 'stored-visible',
+        storedIdsShareLineage: (left, right) => left === right
       })
     ).toBe(false)
   })
@@ -164,7 +172,8 @@ describe('gateway event routing', () => {
         eventRuntimeSessionId: 'runtime-visible',
         eventStoredSessionId: 'stored-visible',
         fromActiveSource: false,
-        selectedStoredSessionId: 'stored-visible'
+        selectedStoredSessionId: 'stored-visible',
+        storedIdsShareLineage: (left, right) => left === right
       })
     ).toBe(false)
   })
@@ -176,7 +185,34 @@ describe('gateway event routing', () => {
         eventRuntimeSessionId: 'runtime-recovered',
         eventStoredSessionId: null,
         fromActiveSource: true,
-        selectedStoredSessionId: 'stored-visible'
+        selectedStoredSessionId: 'stored-visible',
+        storedIdsShareLineage: (left, right) => left === right
+      })
+    ).toBe(false)
+  })
+
+  it('accepts a durable event id at the lineage tip when the selected id is the root', () => {
+    expect(
+      gatewayEventIsActive({
+        activeRuntimeSessionId: 'runtime-stale',
+        eventRuntimeSessionId: 'runtime-current',
+        eventStoredSessionId: 'stored-tip',
+        fromActiveSource: true,
+        selectedStoredSessionId: 'stored-root',
+        storedIdsShareLineage
+      })
+    ).toBe(true)
+  })
+
+  it('rejects a durable event id from an unrelated lineage', () => {
+    expect(
+      gatewayEventIsActive({
+        activeRuntimeSessionId: 'runtime-visible',
+        eventRuntimeSessionId: 'runtime-background',
+        eventStoredSessionId: 'stored-unrelated',
+        fromActiveSource: true,
+        selectedStoredSessionId: 'stored-root',
+        storedIdsShareLineage
       })
     ).toBe(false)
   })

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -86,6 +86,7 @@ interface GatewayEventActiveInput {
   eventStoredSessionId: null | string
   fromActiveSource: boolean
   selectedStoredSessionId: null | string
+  storedIdsShareLineage: (leftStoredId: string, rightStoredId: string) => boolean
 }
 
 /** Runtime ids can be replaced while resuming/reclaiming a conversation. The
@@ -97,13 +98,16 @@ export function gatewayEventIsActive({
   eventRuntimeSessionId,
   eventStoredSessionId,
   fromActiveSource,
-  selectedStoredSessionId
+  selectedStoredSessionId,
+  storedIdsShareLineage
 }: GatewayEventActiveInput): boolean {
   return Boolean(
     fromActiveSource &&
       eventRuntimeSessionId &&
       (eventRuntimeSessionId === activeRuntimeSessionId ||
-        (eventStoredSessionId && eventStoredSessionId === selectedStoredSessionId))
+        (eventStoredSessionId &&
+          selectedStoredSessionId &&
+          storedIdsShareLineage(eventStoredSessionId, selectedStoredSessionId)))
   )
 }
 

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -80,6 +80,33 @@ export interface GatewayEventSessionRoute {
   sessionId: null | string
 }
 
+interface GatewayEventActiveInput {
+  activeRuntimeSessionId: null | string
+  eventRuntimeSessionId: null | string
+  eventStoredSessionId: null | string
+  fromActiveSource: boolean
+  selectedStoredSessionId: null | string
+}
+
+/** Runtime ids can be replaced while resuming/reclaiming a conversation. The
+ * stored id remains the durable statement of which transcript is on screen, so
+ * use it as the second leg of the foreground guard instead of falsely treating
+ * the newly recovered runtime as background. */
+export function gatewayEventIsActive({
+  activeRuntimeSessionId,
+  eventRuntimeSessionId,
+  eventStoredSessionId,
+  fromActiveSource,
+  selectedStoredSessionId
+}: GatewayEventActiveInput): boolean {
+  return Boolean(
+    fromActiveSource &&
+      eventRuntimeSessionId &&
+      (eventRuntimeSessionId === activeRuntimeSessionId ||
+        (eventStoredSessionId && eventStoredSessionId === selectedStoredSessionId))
+  )
+}
+
 export function approvalReplaySessionId(
   eventType: string | undefined,
   activeSessionId: null | string,


### PR DESCRIPTION
## Summary

- keep desktop preview actions available when the visible conversation has recovered onto a new runtime session ID
- use the selected durable stored-session identity as a guarded fallback
- require the active gateway source for both runtime and durable identity paths
- preserve foreground isolation so background profiles/conversations cannot control the visible preview
- make the durable selected-session ref explicit at every message-stream caller
- add regression coverage for recovered-runtime and background-collision cases

## Reproduction

1. Open a page in Hermes Desktop's preview pane.
2. Continue or recover the visible conversation such that its live runtime session identity differs from the durable selected conversation identity.
3. Call `drive_preview({ action: "elements" })`.
4. Before this fix, Desktop replies: `The in-app browser only takes actions in the session the user is looking at.` even though that conversation is visibly selected.

## Verification

- 25 tests passing across the gateway event, delta flush, and steer arrival suites
- full desktop TypeScript typecheck
- full desktop ESLint
- production desktop build
- live end-to-end validation against Gemini and ChatGPT in the in-app preview

## Risk

Both the exact runtime-ID path and durable-ID fallback require the active gateway source. The durable path accepts an explicit `stored_session_id` from the event, otherwise a known runtime-to-stored mapping, and must match the visibly selected stored conversation.
