### PR TITLE
fix(curator): say what pin actually does on an unmanaged skill

### DIFF
--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -296,6 +296,18 @@ def _cmd_pin(args) -> int:
         )
         return 1
     skill_usage.set_pinned(args.skill, True)
+    if not skill_usage.is_curator_managed(args.skill):
+        # Unmanaged (pre-marker) skills never appear in curated_report(), so
+        # auto-transitions cannot touch them — the pin is recorded but inert
+        # until the skill is adopted (#92993). Say so instead of claiming the
+        # pin bypasses transitions that were never going to run.
+        print(
+            f"curator: pinned '{args.skill}' (recorded; this skill is unmanaged "
+            "— auto-transitions never consider it. Run "
+            f"`hermes curator adopt {args.skill}` to put it under curator "
+            "management)"
+        )
+        return 0
     print(f"curator: pinned '{args.skill}' (will bypass auto-transitions)")
     return 0
 
@@ -309,6 +321,12 @@ def _cmd_unpin(args) -> int:
         )
         return 1
     skill_usage.set_pinned(args.skill, False)
+    if not skill_usage.is_curator_managed(args.skill):
+        print(
+            f"curator: unpinned '{args.skill}' (recorded; this skill is "
+            "unmanaged — it was never under auto-transitions to begin with)"
+        )
+        return 0
     print(f"curator: unpinned '{args.skill}'")
     return 0
 

--- a/tests/hermes_cli/test_curator_pin_unmanaged.py
+++ b/tests/hermes_cli/test_curator_pin_unmanaged.py
@@ -1,0 +1,100 @@
+"""Pin/unpin messaging on unmanaged skills (#92993).
+
+`hermes curator pin <name>` on an unmanaged skill (curation-eligible but no
+`created_by` marker — the pre-marker population `list-unmanaged` shows) used
+to print "will bypass auto-transitions" and exit 0. But `curated_report()`
+only walks marker-carrying skills, so auto-transitions never consider an
+unmanaged skill at all: the pin is recorded yet inert, and the message
+claimed an effect that does not exist. The fix keeps the write (the flag
+becomes meaningful after `hermes curator adopt`) and makes the message say
+what actually happened.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _ns(skill: str) -> SimpleNamespace:
+    return SimpleNamespace(skill=skill)
+
+
+def _stub(monkeypatch, *, managed: bool):
+    """Point the CLI at stubbed skill_usage surfaces.
+
+    ``managed`` drives ``is_curator_managed`` — the policy flag the new
+    branch reads. ``is_agent_created`` stays True so the existing bundled/
+    hub refusal guard passes and the code reaches the managed check.
+    """
+    import tools.skill_usage as skill_usage
+
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(skill_usage, "is_agent_created", lambda name: True)
+    monkeypatch.setattr(skill_usage, "is_curator_managed", lambda name: managed)
+    monkeypatch.setattr(
+        skill_usage,
+        "set_pinned",
+        lambda name, pinned: calls.append((name, pinned)),
+    )
+    return calls
+
+
+def test_pin_unmanaged_records_flag_and_prints_adopt_hint(monkeypatch, capsys):
+    import hermes_cli.curator as curator_cli
+
+    calls = _stub(monkeypatch, managed=False)
+
+    rc = curator_cli._cmd_pin(_ns("legacy-skill"))
+
+    # The write still happens — the flag becomes meaningful after adopt.
+    assert calls == [("legacy-skill", True)]
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "unmanaged" in out
+    assert "hermes curator adopt legacy-skill" in out
+    # The old lie must be gone: the pin does NOT bypass anything here.
+    assert "will bypass auto-transitions" not in out
+
+
+def test_pin_managed_keeps_bypass_message(monkeypatch, capsys):
+    import hermes_cli.curator as curator_cli
+
+    calls = _stub(monkeypatch, managed=True)
+
+    rc = curator_cli._cmd_pin(_ns("agent-skill"))
+
+    assert calls == [("agent-skill", True)]
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "will bypass auto-transitions" in out
+    assert "unmanaged" not in out
+
+
+def test_unpin_unmanaged_says_it_was_never_managed(monkeypatch, capsys):
+    import hermes_cli.curator as curator_cli
+
+    calls = _stub(monkeypatch, managed=False)
+
+    rc = curator_cli._cmd_unpin(_ns("legacy-skill"))
+
+    assert calls == [("legacy-skill", False)]
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "unmanaged" in out
+    assert "never under auto-transitions" in out
+
+
+def test_pin_still_refuses_bundled_skills(monkeypatch, capsys):
+    import hermes_cli.curator as curator_cli
+    import tools.skill_usage as skill_usage
+
+    calls = _stub(monkeypatch, managed=True)
+    # _stub leaves is_agent_created True; override AFTER so the refusal
+    # guard fires before the managed check.
+    monkeypatch.setattr(skill_usage, "is_agent_created", lambda name: False)
+
+    rc = curator_cli._cmd_pin(_ns("bundled-skill"))
+
+    assert rc == 1
+    assert calls == []
+    assert "cannot pin" in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

Makes `hermes curator pin` / `unpin` say what actually happens on an **unmanaged** skill (curation-eligible but no `created_by` marker — the pre-marker population `hermes curator list-unmanaged` shows). The command guarded on `is_agent_created` (a filesystem-shape check: not bundled, not hub, not external), but the flag only matters when the skill carries the curator-management marker: `curated_report()` walks marker-carrying skills only, so `apply_automatic_transitions` never considers an unmanaged skill at all. Pinning one recorded the flag and then printed "will bypass auto-transitions" — claiming an effect that does not exist and hiding the remedy (`hermes curator adopt`).

The fix keeps the write (the pin becomes meaningful the moment the skill is adopted, which matches the "belt-and-braces insurance" framing in the issue) and branches the message on `is_curator_managed`: an unmanaged pin now says the skill is unmanaged, that auto-transitions never consider it, and names the `adopt` command. Unpin gets the symmetric wording.

## Related Issue

Fixes #92993

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/curator.py`
  - `_cmd_pin`: after `set_pinned`, branch on `skill_usage.is_curator_managed`; the unmanaged branch prints the recorded-but-inert wording plus the exact `hermes curator adopt <name>` invocation, with a comment naming the mechanism (`curated_report()` only walks marker-carrying skills)
  - `_cmd_unpin`: symmetric branch ("never under auto-transitions to begin with")
- `tests/hermes_cli/test_curator_pin_unmanaged.py` (new)
  - pin on unmanaged: flag IS written, message names `unmanaged` + the adopt command, and the old "will bypass auto-transitions" claim is asserted absent
  - pin on managed keeps the existing bypass message unchanged
  - unpin on unmanaged gets the symmetric wording
  - bundled skills are still refused before any write (guard-order regression pin)

## How to Test

1. `.venv/bin/python -m pytest tests/hermes_cli/test_curator_pin_unmanaged.py tests/hermes_cli/test_curator_archive_prune.py tests/hermes_cli/test_curator_status.py tests/hermes_cli/test_curator_usage.py tests/hermes_cli/test_curator_recent_run_notice.py -q`
2. Observed result: 13 passed. Reverting only `hermes_cli/curator.py` to main makes the two unmanaged-message tests fail (`2 failed, 2 passed`), confirming they pin the new wording.
3. Manual check on a long-lived install: `hermes curator pin <name>` for a skill from `hermes curator list-unmanaged` now prints `curator: pinned '<name>' (recorded; this skill is unmanaged — auto-transitions never consider it. Run \`hermes curator adopt <name>\` ...)` instead of the false bypass claim.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (all curator CLI suites green: 13/13)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the curated_report mechanism)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure CLI string changes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
