### PR TITLE
fix(desktop): route unmentioned group-room turns to the default owner

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4569,16 +4569,64 @@ function parseGroupChatMentions(text, members) {
   return { everyone, mentioned }
 }
 
-/** Members that should take a turn this round: everyone when no member is
- *  @-mentioned in messages since the last user entry (or @everyone appears),
- *  otherwise only the mentioned members. Recomputed every round so a member
- *  pulled in mid-conversation joins the next round. */
-function resolveGroupResponders(log, members) {
+/** Room default-owner registry. Exact names only — a rename is a new room. */
+const GROUP_ROOM_OWNERS = Object.freeze({
+  'Sherman Personal Office': { owner: 'company-pa', status: 'company-cos' },
+  'Bellyfed Products & Technology': { owner: 'company-cpo', status: 'company-cos' },
+  'Bellyfed Studios & Growth': { owner: 'company-cos', status: 'company-cos' },
+  'Bellyfed Group — Executive Office': { owner: 'company-cos', status: 'company-cos' }
+})
+
+function findGroupMemberByProfile(members, profileName) {
+  const wanted = String(profileName || '').trim().toLowerCase()
+  if (!wanted) return null
+  return members.find(member => String(member.name || '').trim().toLowerCase() === wanted) || null
+}
+
+/** Named role, then company-cos, then the old everyone wake so the room never goes silent. */
+function pickGroupRoomSpeaker(members, groupName, role) {
+  const spec = GROUP_ROOM_OWNERS[groupName]
+  const candidates = []
+  if (spec?.[role]) candidates.push(spec[role])
+  if (!candidates.includes('company-cos')) candidates.push('company-cos')
+  for (const name of candidates) {
+    const member = findGroupMemberByProfile(members, name)
+    if (member) return [member]
+  }
+  return members
+}
+
+/** Status questions go to the status speaker. Planning questions are work. */
+function isGroupStatusIntent(text) {
+  const raw = String(text || '').toLowerCase()
+  if (/\bwhat(?:['’]s|s| is) the plan\b/.test(raw)) return false
+  return (
+    /\bstatus\s*\?/.test(raw) ||
+    /\bwhat(?:['’]s|s| is) the status\b/.test(raw) ||
+    /\bwhat(?:['’]s|s| is) happening\b/.test(raw) ||
+    /\bi(?:['’]?m| am) lost\b/.test(raw) ||
+    /\bwhere did we stop\b/.test(raw) ||
+    /\bwhere are we\b/.test(raw)
+  )
+}
+
+/** Members that should take a turn this round.
+ *  Inspect only messages since the last user line:
+ *  1. @everyone/@all → every member
+ *  2. any other member @mention → those members only
+ *  3. no mention + status intent → status speaker
+ *  4. no mention + anything else → default owner
+ *  Unregistered rooms, or a missing named profile, fall back to company-cos
+ *  then the legacy everyone wake. Recomputed every round so a member pulled
+ *  in mid-conversation joins the next round. */
+function resolveGroupResponders(log, members, groupName) {
   let sinceLastUser = []
+  let lastUserText = ''
 
   for (let i = log.length - 1; i >= 0; i--) {
     if (log[i].from.kind === 'user') {
       sinceLastUser = log.slice(i)
+      lastUserText = log[i].text
       break
     }
   }
@@ -4598,11 +4646,15 @@ function resolveGroupResponders(log, members) {
     }
   }
 
-  if (everyone || mentioned.size === 0) {
+  if (everyone) {
     return members
   }
 
-  return members.filter(member => mentioned.has(groupMemberKey(member)))
+  if (mentioned.size > 0) {
+    return members.filter(member => mentioned.has(groupMemberKey(member)))
+  }
+
+  return pickGroupRoomSpeaker(members, groupName, isGroupStatusIntent(lastUserText) ? 'status' : 'owner')
 }
 
 /** Rotate the roster so a different member leads each round. */
@@ -4671,7 +4723,12 @@ function buildGroupChatTurnPrompt({ groupName, members, viewer, deltaLines }) {
     'Rules for this room:',
     '- Reply with ONE conversational message ONLY if you have something new worth adding: build on what was just said, claim or hand off work, answer a question aimed at you, or report a real result. Keep chatter short (1-3 sentences) — but when you are delivering a result, an answer the user asked for, or substantive work, give it at full quality and length; never thin out real content to fit the room.',
     '- If you have nothing new to add, reply with exactly "(pass)". Passing is good — it lets the conversation settle.',
-    '- Mention a teammate as @name to pull them in; mention @user only for a judgment call or a result the user needs. Do not repeat points already made.',
+    '- Mention a teammate as @name to pull them in. Do not repeat points already made.',
+    '- Never ask the user to type start, continue, or tag a Bot already in the room.',
+    '- You are not waiting for the user to tag you.',
+    '- If you are the default owner and this is work: create/resume a Kanban card on the matching board and start. The @mention is optional visibility after the card exists.',
+    '- If you are CoS and this is status: answer from the board with BF-/PO-/ST- IDs; if owned work should be running and is not, dispatch the owner then @mention them.',
+    '- Mention @user only for Auth Handoff, spend, public-send, or explicit yes/no.',
     '- Never reveal content from your private 1:1 chats. Your reply text goes to the room verbatim — no preamble, no meta-commentary.'
   ].join('\n')
 }
@@ -5476,7 +5533,7 @@ async function runGroupChatRounds(group, members, thread) {
       // value shape, since markers are a bare number pre-thread or
       // {before, thread} post-thread.
       const strandedNow = ($groupChats.get()[group] || {}).stranded || {}
-      const responders = rotateGroupSpeakers(resolveGroupResponders(roomLog, members), round)
+      const responders = rotateGroupSpeakers(resolveGroupResponders(roomLog, members, group), round)
         .filter(member => !Object.prototype.hasOwnProperty.call(strandedNow, groupMemberKey(member)))
       let spokeThisRound = 0
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
@@ -124,6 +124,24 @@ test('mentions: @name-device handle resolves the remote member; same-named agent
   assert.equal(responders[0].remoteSource, true)
 })
 
+test('design A: unmentioned work in Sherman Personal Office does not wake a remote qwen', () => {
+  const ctx = runtime()
+  const { resolveGroupResponders } = ctx.__x
+  const members = [
+    { name: 'company-pa', title: 'Personal Administration' },
+    { name: 'company-cos', title: 'Chief of Staff' },
+    { name: 'qwen', handle: 'qwen-mac-mini', connectionId: 'mac-mini', remoteSource: true }
+  ]
+  const officeResponders = resolveGroupResponders(
+    [{ from: { kind: 'user', name: 'You' }, text: 'file the missing MyCTOS months', at: 1 }],
+    members,
+    'Sherman Personal Office'
+  )
+  assert.equal(officeResponders.map(member => member.name).join(','), 'company-pa')
+  assert.equal(officeResponders.length, 1)
+  assert.equal(officeResponders[0].remoteSource, undefined)
+})
+
 test('room lines and turn prompts badge cross-connection speakers with their device', () => {
   const ctx = runtime()
   const { formatGroupChatLine, buildGroupChatTurnPrompt } = ctx.__x

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -209,6 +209,23 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
 
+const PERSONAL_OFFICE = [
+  { name: 'company-cos', title: 'Chief of Staff' },
+  { name: 'company-pa', title: 'Personal Administration' },
+  { name: 'company-installer', title: 'Installer' },
+  { name: 'qwen', title: 'Qwen' }
+]
+
+const STUDIOS = [
+  { name: 'company-cos', title: 'Chief of Staff' },
+  { name: 'company-social', title: 'Social' },
+  { name: 'company-yuna', title: 'Yuna' }
+]
+
+function responderNames(members) {
+  return members.map(member => member.name).join(',')
+}
+
 function roomLog(gc, group) {
   return (gc.$groupChats.get()[group] || { log: [] }).log
 }
@@ -222,7 +239,7 @@ test('pass detection: (pass), pass, pass., empty are silence; real text is not',
   assert.equal(gc.isGroupPassText('I will pass this to ops'), false)
 })
 
-test('mention routing: only @-mentioned members respond; @everyone or none = all', () => {
+test('mention routing: only @-mentioned members respond; @everyone or none in an unregistered room = all', () => {
   const gc = load(() => '(pass)')
   const log = [{ from: { kind: 'user', name: 'You' }, text: '@builder take this one', at: 1 }]
   const one = gc.resolveGroupResponders(log, MEMBERS)
@@ -243,6 +260,84 @@ test('mention routing: display titles resolve to the member and @user never matc
   const parsed = gc.parseGroupChatMentions('@theops please check, then ping @user', MEMBERS)
   assert.equal(parsed.mentioned.has('ops'), true)
   assert.equal(parsed.mentioned.size, 1)
+})
+
+test('design A: unmentioned status in Sherman Personal Office wakes only company-cos', () => {
+  const gc = load(() => '(pass)')
+  const responders = gc.resolveGroupResponders(
+    [{ from: { kind: 'user', name: 'You' }, text: 'so what is the status', at: 1 }],
+    PERSONAL_OFFICE,
+    'Sherman Personal Office'
+  )
+  assert.equal(responderNames(responders), 'company-cos')
+})
+
+test('design A: unmentioned work in Sherman Personal Office wakes only company-pa', () => {
+  const gc = load(() => '(pass)')
+  const responders = gc.resolveGroupResponders(
+    [{ from: { kind: 'user', name: 'You' }, text: 'file the missing MyCTOS months', at: 1 }],
+    PERSONAL_OFFICE,
+    'Sherman Personal Office'
+  )
+  assert.equal(responderNames(responders), 'company-pa')
+})
+
+test('design A: @personal-administration status? still wakes only PA', () => {
+  const gc = load(() => '(pass)')
+  const responders = gc.resolveGroupResponders(
+    [{ from: { kind: 'user', name: 'You' }, text: '@personal-administration status?', at: 1 }],
+    PERSONAL_OFFICE,
+    'Sherman Personal Office'
+  )
+  assert.equal(responderNames(responders), 'company-pa')
+})
+
+test('design A: @everyone in Sherman Personal Office still wakes all members', () => {
+  const gc = load(() => '(pass)')
+  const responders = gc.resolveGroupResponders(
+    [{ from: { kind: 'user', name: 'You' }, text: '@everyone standup', at: 1 }],
+    PERSONAL_OFFICE,
+    'Sherman Personal Office'
+  )
+  assert.equal(responderNames(responders), 'company-cos,company-pa,company-installer,qwen')
+})
+
+test('design A: unmentioned plan question in Studios & Growth is work for company-cos', () => {
+  const gc = load(() => '(pass)')
+  const responders = gc.resolveGroupResponders(
+    [{ from: { kind: 'user', name: 'You' }, text: "what's the plan for today's sherman x.com", at: 1 }],
+    STUDIOS,
+    'Bellyfed Studios & Growth'
+  )
+  assert.equal(responderNames(responders), 'company-cos')
+})
+
+test('design A: missing owner falls back to company-cos, then everyone', () => {
+  const gc = load(() => '(pass)')
+  const withoutPa = PERSONAL_OFFICE.filter(member => member.name !== 'company-pa')
+  const cosOnly = gc.resolveGroupResponders(
+    [{ from: { kind: 'user', name: 'You' }, text: 'file the missing MyCTOS months', at: 1 }],
+    withoutPa,
+    'Sherman Personal Office'
+  )
+  assert.equal(responderNames(cosOnly), 'company-cos')
+
+  const strangers = [{ name: 'research', title: '' }, { name: 'builder', title: '' }]
+  const everyone = gc.resolveGroupResponders(
+    [{ from: { kind: 'user', name: 'You' }, text: 'file the missing MyCTOS months', at: 1 }],
+    strangers,
+    'Sherman Personal Office'
+  )
+  assert.equal(responderNames(everyone), 'research,builder')
+})
+
+test('design A: runGroupChatRounds only prompts the default owner on unmentioned work', async () => {
+  const gc = load(() => '(pass)')
+  gc.sendToGroupChat('Sherman Personal Office', PERSONAL_OFFICE, 'file the missing MyCTOS months')
+  for (let i = 0; i < 200 && (gc.$groupChats.get()['Sherman Personal Office'] || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  assert.equal([...new Set(gc.calls.map(call => call.profile))].join(','), 'company-pa')
 })
 
 test('a member @-mentioned by another bot joins the NEXT round', async () => {
@@ -1486,6 +1581,30 @@ test('turn prompt: results are full quality — only chatter is asked to stay sh
   })
   assert.match(prompt, /never thin out real content/i)
   assert.match(prompt, /Keep chatter short/i)
+})
+
+test('turn prompt: default owner cards work; CoS answers status; never ask the user to type start', () => {
+  const gc = load(() => '(pass)')
+  const prompt = gc.buildGroupChatTurnPrompt({
+    groupName: 'Sherman Personal Office',
+    members: [
+      { name: 'company-cos', title: 'Chief of Staff' },
+      { name: 'company-pa', title: 'Personal Administration' }
+    ],
+    viewer: { name: 'company-cos', title: 'Chief of Staff' },
+    deltaLines: ['You (user): resume the parked sitting']
+  })
+
+  assert.match(prompt, /If you have nothing new to add, reply with exactly "\(pass\)"/)
+  assert.match(prompt, /Reply with ONE conversational message ONLY/)
+  assert.match(prompt, /Never ask the user to type start, continue, or tag a Bot already in the room/)
+  assert.match(prompt, /If you are the default owner and this is work: create\/resume a Kanban card on the matching board and start/)
+  assert.match(prompt, /The @mention is optional visibility after the card exists/)
+  assert.match(prompt, /If you are CoS and this is status: answer from the board with BF-\/PO-\/ST- IDs/)
+  assert.match(prompt, /if owned work should be running and is not, dispatch the owner then @mention them/)
+  assert.match(prompt, /Mention @user only for Auth Handoff, spend, public-send, or explicit yes\/no/)
+  assert.doesNotMatch(prompt, /mention @user only for a judgment call or a result the user needs/)
+  assert.doesNotMatch(prompt, /If you are orchestrating, @mention exactly one owner/)
 })
 
 test('threads: room composer mints a new thread; replies land in it', async () => {


### PR DESCRIPTION
## Summary
Mechanical Design A for Desktop Bot Mode group rooms. Unmentioned status wakes the room status speaker; other unmentioned lines wake only the default owner. `@everyone`/`@all` and member `@mentions` keep their current behavior. Room prompts tell the owner to card work and tell CoS to answer status from BF-/PO-/ST- IDs instead of asking Sherman to type start or tag a Bot already in the room.

## Before Evidence
- Live packaged renderer before install (`~/Applications/Hermes.app`, `index-O5UTVjzL.js` offset 230980): `mention @user only for a judgment call or a result the user needs`. No default-owner registry. Unmentioned lines woke every member.
- Reproduction against unfixed code: unmentioned `so what is the status` in Sherman Personal Office returned company-cos + company-pa + installer + qwen.

## After Evidence
- Tests (RED then GREEN) in `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs` and `cross-connection-bots.test.mjs`.
- Installed packaged renderer `~/Applications/Hermes.app/Contents/Resources/app.asar.unpacked/dist/assets/index-B7vaHbX2.js`:
  - Registry: `"Sherman Personal Office":{owner:company-pa,status:company-cos}`
  - Prompt: `create/resume a Kanban card on the matching board and start`
  - Prompt: `Never ask the user to type start, continue, or tag a Bot already in the room`
- Commit: `82a5f87f97`

## Evidence Comparison
- Changed: mechanical `resolveGroupResponders(log, members, groupName)` plus room turn-prompt rules.
- Unchanged: `@everyone`/`@all`, explicit member mentions, `@user` never matching a bot, title mentions, unregistered-room fallback to everyone.
- Unchecked: a live room send after relaunch. Install waited for an in-flight CoS turn to finish; no test prompt was sent into Sherman's rooms.

## Shipped State
DEPLOYED_NOT_LIVE_VERIFIED — `~/Applications/Hermes.app` replaced and relaunched (pid 5478). Renderer string readback is from the installed unpacked asar payload, not only the worktree candidate.
