### PR TITLE
feat(desktop): per-job reasoning effort picker in the cron editor

### DIFF
--- a/apps/desktop/src/app/cron/cron-job-model.test.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.test.ts
@@ -1,12 +1,38 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  CRON_REASONING_VALUES,
   cronEditorUpdates,
+  cronReasoningEffortToWire,
   jobIsScriptOnly,
+  normalizeCronReasoningEffort,
   parseCronDeliveryTargets,
   toggleCronDeliveryTarget,
   validateCronEditor
 } from './cron-job-model'
+
+describe('cron reasoning effort normalization', () => {
+  it('normalizes valid strings and the YAML false spelling', () => {
+    expect(normalizeCronReasoningEffort('  XHIGH ')).toBe('xhigh')
+    expect(normalizeCronReasoningEffort(false)).toBe('none')
+    expect(CRON_REASONING_VALUES).toContain('ultra')
+  })
+
+  it('clamps unknown, empty, and boolean true values to inherit', () => {
+    expect(normalizeCronReasoningEffort('turbo')).toBe('inherit')
+    expect(normalizeCronReasoningEffort('')).toBe('inherit')
+    expect(normalizeCronReasoningEffort(true)).toBe('inherit')
+    expect(normalizeCronReasoningEffort(null)).toBe('inherit')
+  })
+
+  it('uses one nullable wire mapping for create and edit payloads', () => {
+    expect(cronReasoningEffortToWire('inherit')).toBe(null)
+    expect(cronReasoningEffortToWire('bogus')).toBe(null)
+    expect(cronReasoningEffortToWire(true)).toBe(null)
+    expect(cronReasoningEffortToWire(false)).toBe('none')
+    expect(cronReasoningEffortToWire('high')).toBe('high')
+  })
+})
 
 describe('jobIsScriptOnly', () => {
   it('is true when no_agent is set and a script is present', () => {
@@ -63,7 +89,15 @@ describe('cronEditorUpdates', () => {
   it('omits prompt when saving a script-only job with an empty prompt', () => {
     expect(
       cronEditorUpdates(
-        { deliver: 'local', model: '', name: 'Weekly', prompt: '', provider: '', schedule: '0 9 * * 1' },
+        {
+          deliver: 'local',
+          model: '',
+          name: 'Weekly',
+          prompt: '',
+          provider: '',
+          reasoningEffort: 'inherit',
+          schedule: '0 9 * * 1'
+        },
         { scriptOnlyJob: true }
       )
     ).toEqual({
@@ -76,7 +110,15 @@ describe('cronEditorUpdates', () => {
   it('includes prompt when the user typed one on a script-only job', () => {
     expect(
       cronEditorUpdates(
-        { deliver: 'email', model: '', name: 'Weekly', prompt: 'note', provider: '', schedule: '0 9 * * 1' },
+        {
+          deliver: 'email',
+          model: '',
+          name: 'Weekly',
+          prompt: 'note',
+          provider: '',
+          reasoningEffort: 'inherit',
+          schedule: '0 9 * * 1'
+        },
         { scriptOnlyJob: true }
       ).prompt
     ).toBe('note')
@@ -90,6 +132,7 @@ describe('cronEditorUpdates', () => {
         name: 'Daily',
         prompt: 'go',
         provider: 'anthropic',
+        reasoningEffort: 'high',
         schedule: '0 9 * * *'
       },
       { scriptOnlyJob: false }
@@ -101,7 +144,15 @@ describe('cronEditorUpdates', () => {
 
   it('clears a previous pin when the override is reset to default', () => {
     const updates = cronEditorUpdates(
-      { deliver: 'local', model: '', name: 'Daily', prompt: 'go', provider: '', schedule: '0 9 * * *' },
+      {
+        deliver: 'local',
+        model: '',
+        name: 'Daily',
+        prompt: 'go',
+        provider: '',
+        reasoningEffort: 'inherit',
+        schedule: '0 9 * * *'
+      },
       { scriptOnlyJob: false }
     )
 
@@ -111,11 +162,69 @@ describe('cronEditorUpdates', () => {
 
   it('never touches model fields on script-only jobs', () => {
     const updates = cronEditorUpdates(
-      { deliver: 'local', model: 'x', name: 'Weekly', prompt: '', provider: 'y', schedule: '0 9 * * 1' },
+      {
+        deliver: 'local',
+        model: 'x',
+        name: 'Weekly',
+        prompt: '',
+        provider: 'y',
+        reasoningEffort: 'max',
+        schedule: '0 9 * * 1'
+      },
       { scriptOnlyJob: true }
     )
 
     expect('model' in updates).toBe(false)
     expect('provider' in updates).toBe(false)
+    expect('reasoning_effort' in updates).toBe(false)
+  })
+
+  it('sets and clears a per-job reasoning override explicitly', () => {
+    const pinned = cronEditorUpdates(
+      {
+        deliver: 'local',
+        model: '',
+        name: 'Daily',
+        prompt: 'go',
+        provider: '',
+        reasoningEffort: 'xhigh',
+        schedule: '0 9 * * *'
+      },
+      { scriptOnlyJob: false }
+    )
+
+    expect(pinned.reasoning_effort).toBe('xhigh')
+
+    const cleared = cronEditorUpdates(
+      {
+        deliver: 'local',
+        model: '',
+        name: 'Daily',
+        prompt: 'go',
+        provider: '',
+        reasoningEffort: 'inherit',
+        schedule: '0 9 * * *'
+      },
+      { scriptOnlyJob: false }
+    )
+
+    expect(cleared.reasoning_effort).toBe(null)
+  })
+
+  it('does not persist an invalid runtime picker value', () => {
+    const updates = cronEditorUpdates(
+      {
+        deliver: 'local',
+        model: '',
+        name: 'Daily',
+        prompt: 'go',
+        provider: '',
+        reasoningEffort: 'turbo' as never,
+        schedule: '0 9 * * *'
+      },
+      { scriptOnlyJob: false }
+    )
+
+    expect(updates.reasoning_effort).toBe(null)
   })
 })

--- a/apps/desktop/src/app/cron/cron-job-model.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.ts
@@ -1,6 +1,47 @@
-import type { CronJob, CronJobUpdates } from '@/types/hermes'
+import type { CronJob, CronJobUpdates, CronReasoningEffortOption } from '@/types/hermes'
 
 const asText = (value: unknown): string => (typeof value === 'string' ? value : '')
+
+// The backend remains the final validator. This tuple is the renderer's
+// closed picker grammar, including its two UI sentinels.
+export const CRON_REASONING_VALUES = [
+  'inherit',
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra'
+] as const satisfies readonly CronReasoningEffortOption[]
+
+export type CronReasoningValue = CronReasoningEffortOption
+
+const CRON_REASONING_VALUE_SET: ReadonlySet<string> = new Set(CRON_REASONING_VALUES)
+
+/** Clamp stored or UI input to the closed picker grammar. */
+export function normalizeCronReasoningEffort(value: unknown): CronReasoningValue {
+  // YAML/JSON boolean false is the backend's explicit disable spelling.
+  if (value === false) {
+    return 'none'
+  }
+
+  if (typeof value !== 'string') {
+    return 'inherit'
+  }
+
+  const normalized = value.trim().toLowerCase()
+
+  return CRON_REASONING_VALUE_SET.has(normalized) ? (normalized as CronReasoningValue) : 'inherit'
+}
+
+/** Map the picker grammar onto the backend's nullable override field. */
+export function cronReasoningEffortToWire(value: unknown): null | string {
+  const normalized = normalizeCronReasoningEffort(value)
+
+  return normalized === 'inherit' ? null : normalized
+}
 
 /** Script-only cron jobs run a shell script on schedule with no LLM prompt. */
 export function jobIsScriptOnly(job: Pick<CronJob, 'no_agent' | 'script'>): boolean {
@@ -40,6 +81,8 @@ export interface CronEditorSaveValues {
   model: string
   name: string
   prompt: string
+  /** Per-job reasoning effort ('inherit' = follow config resolution at fire time). */
+  reasoningEffort: CronReasoningValue
   /** Provider for the model override ('' = none). Always paired with model. */
   provider: string
   schedule: string
@@ -82,13 +125,14 @@ export function cronEditorUpdates(values: CronEditorSaveValues, options: { scrip
     updates.prompt = trimmedPrompt
   }
 
-  // Script-only jobs never run an agent, so the scheduler ignores model
-  // overrides — leave whatever is stored untouched. For agent jobs, always
-  // write both axes so resetting to "default" clears a previous pin (the
-  // backend normalizes null/'' to "no override").
+  // Script-only jobs never run an agent, so the scheduler ignores model and
+  // reasoning overrides — leave whatever is stored untouched. For agent
+  // jobs, always write all three axes so resetting to "default" clears a
+  // previous pin (the backend normalizes null/'' to "no override").
   if (!options.scriptOnlyJob) {
     updates.model = values.model.trim() || null
     updates.provider = values.provider.trim() || null
+    updates.reasoning_effort = cronReasoningEffortToWire(values.reasoningEffort)
   }
 
   return updates

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -76,8 +76,12 @@ import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 import { BlueprintSlotControl, blueprintSlotHelp, cleanBlueprintFieldError, initialBlueprintValues } from './blueprints'
 import { mutateAndRefreshCronJobs, refreshCronJobs, triggerAndRefreshCronJobs } from './cron-actions'
 import {
+  CRON_REASONING_VALUES,
   cronEditorUpdates,
+  cronReasoningEffortToWire,
+  type CronReasoningValue,
   jobIsScriptOnly,
+  normalizeCronReasoningEffort,
   parseCronDeliveryTargets,
   toggleCronDeliveryTarget,
   validateCronEditor
@@ -146,6 +150,10 @@ function jobModel(job: CronJob): string {
 
 function jobProvider(job: CronJob): string {
   return asText(job.provider).trim()
+}
+
+function jobReasoningEffort(job: CronJob): CronReasoningValue {
+  return normalizeCronReasoningEffort(job.reasoning_effort)
 }
 
 function cronParts(expr: string): null | string[] {
@@ -564,7 +572,8 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
           schedule: values.schedule,
           name: values.name || undefined,
           deliver: values.deliver || DEFAULT_DELIVER,
-          ...(values.model.trim() ? { model: values.model.trim(), provider: values.provider.trim() || undefined } : {})
+          ...(values.model.trim() ? { model: values.model.trim(), provider: values.provider.trim() || undefined } : {}),
+          reasoning_effort: cronReasoningEffortToWire(values.reasoningEffort)
         })
       )
 
@@ -797,6 +806,7 @@ function CronJobDetail({
   const deliver = jobDeliver(job)
   const prompt = jobPrompt(job)
   const modelOverride = jobModel(job)
+  const reasoningOverride = jobReasoningEffort(job)
 
   return (
     <PanelDetail>
@@ -822,7 +832,10 @@ function CronJobDetail({
             { label: c.last.replace(/:$/, ''), value: formatTime(job.last_run_at) },
             { label: c.next.replace(/:$/, ''), value: formatTime(job.next_run_at) },
             { label: c.deliverLabel, value: c.deliveryLabels[deliver] ?? deliver },
-            ...(modelOverride ? [{ label: c.modelLabel, value: modelOverride }] : [])
+            ...(modelOverride ? [{ label: c.modelLabel, value: modelOverride }] : []),
+            ...(reasoningOverride !== 'inherit'
+              ? [{ label: c.reasoningLabel, value: c.reasoningLabels[reasoningOverride] ?? reasoningOverride }]
+              : [])
           ]}
         />
 
@@ -1040,6 +1053,9 @@ function CronEditorDialog({
   // Per-job model override, encoded as `${providerSlug}:${model}` (split on the
   // first ':' when saving). MODEL_DEFAULT_VALUE = follow the global default.
   const [modelChoice, setModelChoice] = useState(MODEL_DEFAULT_VALUE)
+  // Per-job reasoning effort. 'inherit' = follow config resolution at fire
+  // time; see CRON_REASONING_VALUES in cron-job-model.ts.
+  const [reasoningEffort, setReasoningEffort] = useState<CronReasoningValue>('inherit')
   // Blueprint fills typed slots (time/enum/weekdays/text) instead of the raw
   // cron fields; the backend renders the prompt + schedule from them.
   const [slotValues, setSlotValues] = useState<Record<string, string>>({})
@@ -1094,6 +1110,7 @@ function CronEditorDialog({
     setSchedulePreset(initial ? scheduleOptionForExpr(jobScheduleExpr(initial)).value : 'daily')
     setDeliver(initial ? jobDeliver(initial) : DEFAULT_DELIVER)
     setModelChoice(initial && jobModel(initial) ? `${jobProvider(initial)}:${jobModel(initial)}` : MODEL_DEFAULT_VALUE)
+    setReasoningEffort(initial ? jobReasoningEffort(initial) : 'inherit')
     setSlotValues({})
     setTemplateChoice(editor.mode === 'create' ? (editor.blueprintKey ?? CUSTOM_TEMPLATE) : CUSTOM_TEMPLATE)
     setError(null)
@@ -1175,6 +1192,7 @@ function CronEditorDialog({
         name: name.trim(),
         prompt: prompt.trim(),
         provider: overrideProvider,
+        reasoningEffort,
         schedule: schedule.trim()
       })
     } catch (err) {
@@ -1366,6 +1384,26 @@ function CronEditorDialog({
               </Field>
             )}
 
+            {!scriptOnlyJob && (
+              <Field htmlFor="cron-reasoning" label={c.reasoningLabel} optional optionalLabel={c.optional}>
+                <Select
+                  onValueChange={value => setReasoningEffort(normalizeCronReasoningEffort(value))}
+                  value={reasoningEffort}
+                >
+                  <SelectTrigger className="h-9 rounded-md" id="cron-reasoning">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CRON_REASONING_VALUES.map(value => (
+                      <SelectItem key={value} value={value}>
+                        {c.reasoningLabels[value] ?? value}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+            )}
+
             {schedulePreset === 'custom' ? (
               <Field htmlFor="cron-schedule" label={c.customScheduleLabel}>
                 <Input
@@ -1423,6 +1461,8 @@ interface EditorValues {
   prompt: string
   /** Provider slug for the model override ('' = none). */
   provider: string
+  /** Per-job reasoning effort ('inherit' = follow config resolution). */
+  reasoningEffort: CronReasoningValue
   schedule: string
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2075,6 +2075,18 @@ export const en: Translations = {
     deliverNeedsHomeChannel: 'set a home channel first',
     modelLabel: 'Model',
     modelDefault: 'Default (global model)',
+    reasoningLabel: 'Reasoning effort',
+    reasoningLabels: {
+      inherit: 'Inherit model/global setting',
+      none: 'Off',
+      minimal: 'Minimal',
+      low: 'Low',
+      medium: 'Medium',
+      high: 'High',
+      xhigh: 'Extra High',
+      max: 'Max',
+      ultra: 'Ultra'
+    },
     customScheduleLabel: 'Custom schedule',
     customPlaceholder: '0 9 * * * or weekdays at 9am',
     customHint: 'Cron expression, or phrases like "every hour" or "weekdays at 9am".',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1761,6 +1761,18 @@ export const ja = defineLocale({
     deliverNeedsHomeChannel: '先にホームチャンネルを設定してください',
     modelLabel: 'モデル',
     modelDefault: 'デフォルト（グローバルモデル）',
+    reasoningLabel: '推論強度',
+    reasoningLabels: {
+      inherit: 'モデル/グローバル設定を継承',
+      none: 'オフ',
+      minimal: '最小',
+      low: '低',
+      medium: '中',
+      high: '高',
+      xhigh: '特高',
+      max: '最大',
+      ultra: 'ウルトラ'
+    },
     customScheduleLabel: 'カスタムスケジュール',
     customPlaceholder: '0 9 * * * または weekdays at 9am',
     customHint: 'Cron 式、または「every hour」「weekdays at 9am」のようなフレーズ。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -6,6 +6,7 @@
 // fall back to English while new keys remain type-checked.
 
 import type { TipId } from '@/lib/tips/catalog'
+import type { CronReasoningEffortOption } from '@/types/hermes'
 
 export type Locale = 'en' | 'zh' | 'zh-hant' | 'ja' | 'ar'
 
@@ -1747,6 +1748,8 @@ export interface Translations {
     deliverNeedsHomeChannel: string
     modelLabel: string
     modelDefault: string
+    reasoningLabel: string
+    reasoningLabels: Record<CronReasoningEffortOption, string>
     customScheduleLabel: string
     customPlaceholder: string
     customHint: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1697,6 +1697,18 @@ export const zhHant = defineLocale({
     deliverNeedsHomeChannel: '請先設定主頻道',
     modelLabel: '模型',
     modelDefault: '預設（全域模型）',
+    reasoningLabel: '推理強度',
+    reasoningLabels: {
+      inherit: '繼承模型/全域設定',
+      none: '關閉',
+      minimal: '最小',
+      low: '低',
+      medium: '中',
+      high: '高',
+      xhigh: '超高',
+      max: '最大',
+      ultra: '極致'
+    },
     customScheduleLabel: '自訂排程',
     customPlaceholder: '0 9 * * * 或 weekdays at 9am',
     customHint: 'Cron 表達式，或類似「每小時」「工作日上午 9 點」的短語。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2256,6 +2256,18 @@ export const zh: Translations = {
     deliverNeedsHomeChannel: '请先设置主频道',
     modelLabel: '模型',
     modelDefault: '默认（全局模型）',
+    reasoningLabel: '推理强度',
+    reasoningLabels: {
+      inherit: '继承模型/全局设置',
+      none: '关闭',
+      minimal: '最小',
+      low: '低',
+      medium: '中',
+      high: '高',
+      xhigh: '超高',
+      max: '最大',
+      ultra: '极致'
+    },
     customScheduleLabel: '自定义排程',
     customPlaceholder: '0 9 * * * 或 weekdays at 9am',
     customHint: 'Cron 表达式，或类似"每小时""工作日上午 9 点"的短语。',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -844,6 +844,9 @@ export interface AnalyticsTotals {
   total_sessions: number
 }
 
+export type CronReasoningEffortOption =
+  'inherit' | 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'ultra'
+
 export interface CronJob {
   deliver?: null | string
   enabled: boolean
@@ -856,6 +859,7 @@ export interface CronJob {
   no_agent?: boolean
   prompt?: null | string
   provider?: null | string
+  reasoning_effort?: false | null | string
   schedule?: CronJobSchedule
   schedule_display?: null | string
   script?: null | string
@@ -868,6 +872,7 @@ export interface CronJobCreatePayload {
   name?: string
   prompt: string
   provider?: string
+  reasoning_effort?: false | null | string
   schedule: string
 }
 
@@ -884,6 +889,7 @@ export interface CronJobUpdates {
   name?: string
   prompt?: string
   provider?: null | string
+  reasoning_effort?: false | null | string
   schedule?: string
 }
 


### PR DESCRIPTION
## Summary

Adds a per-job reasoning-effort picker to the Desktop cron editor.

- `inherit` follows runtime config resolution;
- `none` explicitly disables reasoning;
- supported effort levels pin the job value;
- agent-backed create/edit writes the nullable backend override;
- script-only jobs leave model/provider/reasoning fields untouched;
- the selected override appears in cron job details;
- English, Simplified Chinese, Traditional Chinese, and Japanese copy are included.

## Input and wire invariants

One pure boundary in `cron-job-model.ts` owns the picker grammar and wire normalization:

- stored `false` maps to `none`;
- stored boolean `true`, empty values, and unknown/legacy strings clamp to `inherit`;
- create and edit both call the same `cronReasoningEffortToWire` helper;
- `inherit` and invalid runtime values serialize as `null`, never as junk;
- the API type accepts literal `false` rather than arbitrary booleans;
- locale `reasoningLabels` must cover every `CronReasoningEffortOption` at compile time.

The Python storage layer remains the final validator through `cron/jobs.py::_normalize_reasoning_effort`; the Desktop does not duplicate it with a source-snapshot/change-detector test.

## Verification

- Desktop renderer, Electron, and E2E TypeScript projects: typecheck passed;
- targeted ESLint: passed with zero warnings;
- complete cron UI unit set: **37 passed**;
- focused normalization/editor test: **20 passed**;
- `git diff --check`: passed;
- current base: `cced6fa36`.