### PR TITLE
fix(terminal): isolate foreground gateway commands

### DIFF
--- a/tests/tools/test_local_systemd_scope.py
+++ b/tests/tools/test_local_systemd_scope.py
@@ -1,0 +1,237 @@
+import os
+import signal
+import subprocess
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+
+
+pytestmark = pytest.mark.linux_only
+
+
+def _environment(tmp_path):
+    with patch.object(LocalEnvironment, "init_session", return_value=None):
+        return LocalEnvironment(cwd=str(tmp_path), timeout=10)
+
+
+def _fake_process(pid=4321):
+    proc = MagicMock()
+    proc.pid = pid
+    proc.stdout = MagicMock()
+    proc.stdin = MagicMock()
+    proc.poll.return_value = None
+    return proc
+
+
+def test_foreground_gateway_command_runs_in_transient_scope(tmp_path, monkeypatch):
+    env = _environment(tmp_path)
+    monkeypatch.setattr("tools.environments.local._find_bash", lambda: "/bin/bash")
+    proc = _fake_process()
+    captured = {}
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr(
+        "tools.environments.local._is_supervised_gateway_process", lambda: True
+    )
+    monkeypatch.setattr(
+        "tools.environments.local._systemd_run_user_scope_available", lambda: True
+    )
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr("tools.environments.local.os.getpgid", lambda pid: pid)
+
+    with patch("tools.environments.local.subprocess.Popen", side_effect=fake_popen):
+        result = env._run_bash("printf scoped")
+
+    assert result is proc
+    argv = captured["argv"]
+    assert argv[0] == "/usr/bin/systemd-run"
+    assert argv[1:4] == ["--user", "--scope", "--quiet"]
+    unit_index = argv.index("--unit")
+    unit_name = argv[unit_index + 1]
+    assert unit_name.startswith("hermes-worker-foreground-")
+    assert getattr(proc, "_hermes_systemd_unit") == f"{unit_name}.scope"
+    properties = [
+        argv[index + 1]
+        for index, value in enumerate(argv[:-1])
+        if value == "--property"
+    ]
+    assert "MemoryAccounting=yes" in properties
+    assert "OOMPolicy=kill" in properties
+    assert "TimeoutStopSec=3s" in properties
+    memory_max = next(value for value in properties if value.startswith("MemoryMax="))
+    assert int(memory_max.partition("=")[2]) > 0
+    separator = argv.index("--")
+    assert argv[separator + 1 : separator + 3] == ["/bin/bash", "-c"]
+    assert argv[separator + 3] == "printf scoped"
+    assert captured["kwargs"]["start_new_session"] is True
+    assert captured["kwargs"]["cwd"] == str(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("gateway", "scope_available"),
+    [(False, True), (True, False)],
+)
+def test_foreground_non_gateway_or_unavailable_scope_keeps_direct_spawn(
+    tmp_path, monkeypatch, gateway, scope_available
+):
+    env = _environment(tmp_path)
+    monkeypatch.setattr("tools.environments.local._find_bash", lambda: "/bin/bash")
+    proc = _fake_process()
+    captured = {}
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = list(argv)
+        captured["kwargs"] = kwargs
+        return proc
+
+    monkeypatch.setattr(
+        "tools.environments.local._is_supervised_gateway_process", lambda: gateway
+    )
+    monkeypatch.setattr(
+        "tools.environments.local._systemd_run_user_scope_available",
+        lambda: scope_available,
+    )
+    monkeypatch.setattr("tools.environments.local.os.getpgid", lambda pid: pid)
+
+    with patch("tools.environments.local.subprocess.Popen", side_effect=fake_popen):
+        env._run_bash("printf direct")
+
+    assert captured["argv"] == ["/bin/bash", "-c", "printf direct"]
+    assert captured["kwargs"]["start_new_session"] is True
+    assert "_hermes_systemd_unit" not in proc.__dict__
+
+
+def test_foreground_timeout_cleanup_stops_entire_scope_before_pid_group(
+    tmp_path, monkeypatch
+):
+    env = _environment(tmp_path)
+    proc = _fake_process()
+    proc._hermes_systemd_unit = "hermes-worker-foreground-test.scope"
+    stopped = []
+
+    monkeypatch.setattr(
+        "tools.environments.local._stop_systemd_unit",
+        lambda unit: stopped.append(unit) or True,
+    )
+    getpgid = MagicMock(return_value=proc.pid)
+    killpg = MagicMock()
+    monkeypatch.setattr("tools.environments.local.os.getpgid", getpgid)
+    monkeypatch.setattr("tools.environments.local.os.killpg", killpg)
+
+    env._kill_process(proc)
+
+    assert stopped == ["hermes-worker-foreground-test.scope"]
+    proc.wait.assert_called_once_with(timeout=2.0)
+    getpgid.assert_not_called()
+    killpg.assert_not_called()
+
+
+def test_foreground_scope_stop_failure_falls_back_to_process_group(
+    tmp_path, monkeypatch
+):
+    env = _environment(tmp_path)
+    proc = _fake_process()
+    proc._hermes_systemd_unit = "hermes-worker-foreground-test.scope"
+    proc.poll.return_value = 0
+    calls = []
+
+    monkeypatch.setattr("tools.environments.local._stop_systemd_unit", lambda unit: False)
+    monkeypatch.setattr("tools.environments.local.os.getpgid", lambda pid: proc.pid)
+
+    def fake_killpg(pgid, sig):
+        calls.append((pgid, sig))
+        if sig == 0:
+            raise ProcessLookupError
+
+    monkeypatch.setattr("tools.environments.local.os.killpg", fake_killpg)
+
+    env._kill_process(proc)
+
+    assert calls[0] == (proc.pid, signal.SIGTERM)
+
+
+def test_cached_probe_with_missing_binary_does_not_record_false_scope(
+    tmp_path, monkeypatch
+):
+    env = _environment(tmp_path)
+    proc = _fake_process()
+    captured = {}
+
+    monkeypatch.setattr("tools.environments.local._find_bash", lambda: "/bin/bash")
+    monkeypatch.setattr(
+        "tools.environments.local._is_supervised_gateway_process", lambda: True
+    )
+    monkeypatch.setattr(
+        "tools.environments.local._systemd_run_user_scope_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "tools.systemd_scope.shutil.which",
+        lambda name: None if name == "systemd-run" else f"/usr/bin/{name}",
+    )
+    monkeypatch.setattr("tools.environments.local.os.getpgid", lambda pid: pid)
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = list(argv)
+        return proc
+
+    with patch("tools.environments.local.subprocess.Popen", side_effect=fake_popen):
+        env._run_bash("sleep 300")
+
+    assert captured["argv"] == ["/bin/bash", "-c", "sleep 300"]
+    assert "_hermes_systemd_unit" not in proc.__dict__
+
+
+def test_real_scope_timeout_reaps_setsid_sigterm_ignoring_descendant(
+    tmp_path, monkeypatch
+):
+    import tools.systemd_scope as scope
+
+    monkeypatch.setattr(scope, "_SYSTEMD_SCOPE_AVAILABLE", None)
+    if not scope._systemd_run_user_scope_available():
+        pytest.skip("systemd-run --user --scope unavailable")
+
+    child = tmp_path / "child.py"
+    pid_file = tmp_path / "child.pid"
+    child.write_text(
+        "import os, signal, time\n"
+        "os.setsid()\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        f"open({str(pid_file)!r}, 'w').write(str(os.getpid()))\n"
+        "time.sleep(300)\n"
+    )
+    parent = tmp_path / "parent.py"
+    parent.write_text(
+        "import subprocess, sys, time\n"
+        f"subprocess.Popen([sys.executable, {str(child)!r}])\n"
+        "from pathlib import Path\n"
+        "deadline = time.monotonic() + 5\n"
+        f"while not Path({str(pid_file)!r}).exists():\n"
+        "    assert time.monotonic() < deadline\n"
+        "    time.sleep(0.01)\n"
+        "time.sleep(300)\n"
+    )
+
+    env = _environment(tmp_path)
+    monkeypatch.setattr(
+        "tools.environments.local._is_supervised_gateway_process", lambda: True
+    )
+    started = time.monotonic()
+    result = env.execute(f"{sys.executable} {parent}", timeout=1)
+    elapsed = time.monotonic() - started
+
+    assert result["returncode"] == 124, result
+    child_pid = int(pid_file.read_text())
+    for _ in range(40):
+        if not os.path.exists(f"/proc/{child_pid}"):
+            break
+        time.sleep(0.05)
+    assert not os.path.exists(f"/proc/{child_pid}")
+    assert elapsed < 10

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -33,12 +33,12 @@ def _reset_systemd_scope_cache():
     ``INVOCATION_ID`` is set) doesn't leak into tests that mock
     ``subprocess.Popen``. Tests that exercise the probe directly reset the
     cache themselves."""
-    import tools.process_registry as _pr
+    import tools.systemd_scope as _scope
 
-    original = _pr._SYSTEMD_SCOPE_AVAILABLE
-    _pr._SYSTEMD_SCOPE_AVAILABLE = False
+    original = _scope._SYSTEMD_SCOPE_AVAILABLE
+    _scope._SYSTEMD_SCOPE_AVAILABLE = False
     yield
-    _pr._SYSTEMD_SCOPE_AVAILABLE = original
+    _scope._SYSTEMD_SCOPE_AVAILABLE = original
 
 
 def _make_session(
@@ -1835,6 +1835,30 @@ class TestSystemdCgroupIsolation:
         assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
         assert captured["start_new_session"] is True
 
+    def test_cached_probe_with_missing_binary_does_not_record_false_scope(
+        self, registry, monkeypatch, _gateway_identity
+    ):
+        fake_popen, captured = self._fake_popen_capture()
+
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr("shutil.which", lambda name: None)
+
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            session = registry.spawn_local("sleep 300", cwd="/tmp")
+
+        assert captured["argv"] == [
+            "/bin/bash", "-lic", "set +m; sleep 300",
+        ]
+        assert session.systemd_unit == ""
+
     def test_falls_back_when_not_under_supervisor(self, registry, monkeypatch):
         """CLI mode (no supervisor) must NOT wrap in a systemd scope even if
         systemd-run is available — isolation is a gateway concern."""
@@ -2109,13 +2133,13 @@ class TestSystemdCgroupIsolation:
         pipe_spawn.assert_not_called()
 
     def test_worker_memory_limit_honors_local_guard_mb_override(self, monkeypatch):
-        import tools.process_registry as pr
+        import tools.systemd_scope as scope
 
         monkeypatch.setenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "123")
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
 
-        with patch("tools.process_registry.logger.warning") as warning:
-            argv = pr._build_systemd_scope_argv(
+        with patch("tools.systemd_scope.logger.warning") as warning:
+            argv = scope._build_systemd_scope_argv(
                 ["/bin/bash", "-lc", "true"],
                 unit_suffix="test",
             )
@@ -2126,21 +2150,24 @@ class TestSystemdCgroupIsolation:
     def test_worker_memory_limit_caps_oversized_local_guard_override(
         self, monkeypatch
     ):
-        import tools.process_registry as pr
+        import tools.systemd_scope as scope
 
         monkeypatch.setenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "999999")
         monkeypatch.setattr(
-            pr.Path,
+            scope.Path,
             "read_text",
             lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("no cgroup")),
         )
         monkeypatch.setattr(
-            pr.os,
+            scope.os,
             "sysconf",
             lambda *_args: (_ for _ in ()).throw(OSError("no sysconf")),
         )
 
-        assert pr._worker_memory_max_bytes() == pr._DEFAULT_WORKER_MEMORY_MAX_BYTES
+        assert (
+            scope._worker_memory_max_bytes()
+            == scope._DEFAULT_WORKER_MEMORY_MAX_BYTES
+        )
 
     def test_kill_recovered_detached_already_exited_stops_persisted_scope(
         self, registry, monkeypatch
@@ -2177,10 +2204,10 @@ class TestSystemdCgroupIsolation:
     ):
         """The availability check probes once and caches — a second call must
         not re-probe (and must return the same value)."""
-        import tools.process_registry as pr
+        import tools.systemd_scope as scope
 
         # Reset the cache.
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(scope, "_SYSTEMD_SCOPE_AVAILABLE", None)
         probe_calls = []
 
         def fake_run(*args, **kwargs):
@@ -2190,8 +2217,8 @@ class TestSystemdCgroupIsolation:
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
         monkeypatch.setattr("subprocess.run", fake_run)
 
-        first = pr._systemd_run_user_scope_available()
-        second = pr._systemd_run_user_scope_available()
+        first = scope._systemd_run_user_scope_available()
+        second = scope._systemd_run_user_scope_available()
         assert first is True
         assert second is True
         assert len(probe_calls) == 1, "probe must run only once (cached)"
@@ -2202,9 +2229,9 @@ class TestSystemdCgroupIsolation:
         A temporary cached ``False`` would let a racing worker spawn inside the
         gateway cgroup, defeating the OOM isolation guarantee.
         """
-        import tools.process_registry as pr
+        import tools.systemd_scope as scope
 
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(scope, "_SYSTEMD_SCOPE_AVAILABLE", None)
         probe_started = threading.Event()
         release_probe = threading.Event()
         probe_calls = []
@@ -2220,10 +2247,10 @@ class TestSystemdCgroupIsolation:
         monkeypatch.setattr("subprocess.run", fake_run)
 
         first = threading.Thread(
-            target=lambda: results.append(pr._systemd_run_user_scope_available())
+            target=lambda: results.append(scope._systemd_run_user_scope_available())
         )
         second = threading.Thread(
-            target=lambda: results.append(pr._systemd_run_user_scope_available())
+            target=lambda: results.append(scope._systemd_run_user_scope_available())
         )
         first.start()
         assert probe_started.wait(timeout=2)
@@ -2244,10 +2271,10 @@ class TestSystemdCgroupIsolation:
         assert len(probe_calls) == 1
 
     def test_failed_systemd_probe_retries_after_cache_ttl(self, monkeypatch):
-        import tools.process_registry as pr
+        import tools.systemd_scope as scope
 
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
-        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 0.0, raising=False)
+        monkeypatch.setattr(scope, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(scope, "_SYSTEMD_SCOPE_PROBED_AT", 0.0)
         clock = [100.0]
         probe_results = [1, 0]
         probe_calls = []
@@ -2259,19 +2286,19 @@ class TestSystemdCgroupIsolation:
             )
 
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
-        monkeypatch.setattr("tools.process_registry.time.monotonic", lambda: clock[0])
+        monkeypatch.setattr("tools.systemd_scope.time.monotonic", lambda: clock[0])
         monkeypatch.setattr("subprocess.run", fake_run)
 
-        assert pr._systemd_run_user_scope_available() is False
-        assert pr._systemd_run_user_scope_available() is False
+        assert scope._systemd_run_user_scope_available() is False
+        assert scope._systemd_run_user_scope_available() is False
         assert len(probe_calls) == 1
 
         clock[0] += 61
-        assert pr._systemd_run_user_scope_available() is True
+        assert scope._systemd_run_user_scope_available() is True
         assert len(probe_calls) == 2
 
     def test_stop_systemd_unit_treats_absent_unit_as_clean(self, monkeypatch):
-        import tools.process_registry as pr
+        import tools.systemd_scope as scope
 
         monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemctl")
         monkeypatch.setattr(
@@ -2283,7 +2310,50 @@ class TestSystemdCgroupIsolation:
             ),
         )
 
-        assert pr._stop_systemd_unit("hermes-worker-gone.scope") is True
+        assert scope._stop_systemd_unit("hermes-worker-gone.scope") is True
+
+    def test_stop_timeout_force_kills_scope_and_verifies_inactive(self, monkeypatch):
+        import tools.systemd_scope as scope
+
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(list(argv))
+            if argv[2] == "stop":
+                raise subprocess.TimeoutExpired(argv, kwargs["timeout"])
+            if argv[2] == "kill":
+                return subprocess.CompletedProcess(argv, 0)
+            assert argv[2] == "is-active"
+            return subprocess.CompletedProcess(argv, 3, stdout=b"inactive\n")
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemctl")
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        assert scope._stop_systemd_unit("hermes-worker-stuck.scope") is True
+        assert [call[2] for call in calls] == ["stop", "kill", "is-active"]
+        assert "--kill-whom=all" in calls[1]
+        assert "--signal=SIGKILL" in calls[1]
+
+    def test_stop_timeout_does_not_accept_generic_is_active_error(self, monkeypatch):
+        import tools.systemd_scope as scope
+
+        def fake_run(argv, **kwargs):
+            if argv[2] == "stop":
+                raise subprocess.TimeoutExpired(argv, kwargs["timeout"])
+            if argv[2] == "kill":
+                return subprocess.CompletedProcess(argv, 0)
+            assert argv[2] == "is-active"
+            return subprocess.CompletedProcess(
+                argv,
+                1,
+                stdout=b"",
+                stderr=b"Failed to connect to bus\n",
+            )
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemctl")
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        assert scope._stop_systemd_unit("hermes-worker-unverified.scope") is False
 
 
 class TestNotificationRedaction:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -11,11 +11,18 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from collections.abc import Mapping
 from pathlib import Path
 
 from hermes_constants import get_process_hermes_home
 from tools.environments.base import BaseEnvironment, _pipe_stdin
+from tools.systemd_scope import (
+    _is_supervised_gateway_process,
+    _prepare_systemd_scope_argv,
+    _stop_systemd_unit,
+    _systemd_run_user_scope_available,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -1823,6 +1830,17 @@ class LocalEnvironment(BaseEnvironment):
 
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
+        scope_unit = ""
+        if (
+            not _IS_WINDOWS
+            and _is_supervised_gateway_process()
+            and _systemd_run_user_scope_available()
+        ):
+            unit_suffix = f"foreground-{uuid.uuid4().hex[:12]}"
+            args, scope_unit = _prepare_systemd_scope_argv(
+                args, unit_suffix=unit_suffix
+            )
+
         proc = subprocess.Popen(
             args,
             text=True,
@@ -1836,6 +1854,9 @@ class LocalEnvironment(BaseEnvironment):
             cwd=_popen_cwd,
             **_popen_kwargs,
         )
+        if scope_unit:
+            proc._hermes_systemd_unit = scope_unit
+
         if not _IS_WINDOWS:
             try:
                 proc._hermes_pgid = os.getpgid(proc.pid)
@@ -1893,6 +1914,14 @@ class LocalEnvironment(BaseEnvironment):
                     pass
             else:
                 try:
+                    scope_unit = getattr(proc, "_hermes_systemd_unit", "")
+                    if scope_unit and _stop_systemd_unit(scope_unit):
+                        try:
+                            proc.wait(timeout=2.0)
+                        except (subprocess.TimeoutExpired, OSError):
+                            pass
+                        return
+
                     pgid = os.getpgid(proc.pid)
                 except ProcessLookupError:
                     pgid = getattr(proc, "_hermes_pgid", None)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -40,7 +40,6 @@ import subprocess
 import threading
 import time
 import uuid
-from pathlib import Path
 
 _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
@@ -49,6 +48,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
+from tools import systemd_scope as _systemd_scope
 
 from agent.redact import redact_sensitive_text
 
@@ -80,276 +80,36 @@ WATCH_GLOBAL_WINDOW_SECONDS = 10
 WATCH_GLOBAL_COOLDOWN_SECONDS = 30
 
 
-# ---------------------------------------------------------------------------
-# systemd cgroup isolation for gateway-spawned local executors (#70716)
-# ---------------------------------------------------------------------------
-# When Hermes runs as a systemd gateway with MemoryHigh/MemoryMax limits,
-# local background terminal commands inherit the gateway's cgroup.  A
-# memory-heavy executor (Codex, tests, Node) can push the whole cgroup past
-# MemoryMax and trigger systemd-oomd to kill the ENTIRE gateway — taking down
-# the messaging control plane and silently losing the active turn.
-#
-# Wrapping the spawn in ``systemd-run --user --scope --unit=hermes-worker-<pid>``
-# places the worker in its own transient cgroup so an OOM in the worker kills
-# only the worker, not the gateway.  We probe *once* whether
-# ``systemd-run --user --scope`` is actually usable (the binary can exist on
-# the PATH while the user D-Bus session is unavailable — common for system
-# services and containers), and cache the result for the process lifetime.
-
-_SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
-_SYSTEMD_SCOPE_PROBE_LOCK = threading.Lock()
-_SYSTEMD_SCOPE_PROBED_AT = 0.0
-_SYSTEMD_SCOPE_FAILURE_TTL_SECONDS = 60.0
-_MIN_WORKER_MEMORY_MAX_BYTES = 64 * 1024 * 1024
-_DEFAULT_WORKER_MEMORY_MAX_BYTES = 1024 * 1024 * 1024
-_WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
-
-
 def _worker_memory_max_bytes() -> int:
-    """Return a finite per-worker cgroup limit without widening host risk.
-
-    The proposed local-memory-guard environment override is honored when it
-    tightens the safe bound, so this isolation composes with PR #57121 instead
-    of inventing a second knob.  An oversized override cannot widen host risk.
-    Otherwise retain the tighter of the gateway's current cgroup-v2
-    ``memory.max`` and half of physical RAM, capped at 4 GiB.  This keeps the
-    sibling worker outside the gateway cgroup while ensuring the worker cannot
-    consume memory up to the enclosing user slice or host limit.
-    """
-    override_bound: Optional[int] = None
-    override = os.getenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
-    if override:
-        override_valid = False
-        try:
-            parsed = int(override) * 1024 * 1024
-            if parsed >= _MIN_WORKER_MEMORY_MAX_BYTES:
-                override_bound = parsed
-                override_valid = True
-        except ValueError:
-            pass
-        if not override_valid:
-            logger.warning(
-                "Ignoring invalid TERMINAL_LOCAL_MEMORY_MAX_MB=%r; "
-                "expected an integer representing at least %d MiB",
-                override,
-                _MIN_WORKER_MEMORY_MAX_BYTES // (1024 * 1024),
-            )
-
-    candidates: List[int] = []
-    try:
-        for line in Path("/proc/self/cgroup").read_text(encoding="utf-8").splitlines():
-            if line.startswith("0::"):
-                relative = line.partition("::")[2].lstrip("/")
-                raw_limit = (
-                    Path("/sys/fs/cgroup") / relative / "memory.max"
-                ).read_text(encoding="utf-8").strip()
-                if raw_limit.isdigit():
-                    cgroup_limit = int(raw_limit)
-                    if cgroup_limit >= _MIN_WORKER_MEMORY_MAX_BYTES:
-                        candidates.append(cgroup_limit)
-                break
-    except (OSError, ValueError):
-        pass
-
-    try:
-        physical_bytes = int(os.sysconf("SC_PHYS_PAGES")) * int(
-            os.sysconf("SC_PAGE_SIZE")
-        )
-        physical_bound = min(
-            _WORKER_MEMORY_MAX_CAP_BYTES,
-            max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2),
-        )
-        candidates.append(physical_bound)
-    except (OSError, ValueError, TypeError):
-        pass
-
-    safe_bound = min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES
-    return min(override_bound, safe_bound) if override_bound else safe_bound
+    return _systemd_scope._worker_memory_max_bytes()
 
 
 def _systemd_run_user_scope_available() -> bool:
-    """Return True if ``systemd-run --user --scope`` can create a cgroup.
-
-    Cached after the first probe.  ``shutil.which`` alone is insufficient:
-    in system-service deployments (and containers) the user D-Bus session
-    bus that ``systemd-run --user`` needs may be absent even though the
-    binary is on PATH, causing every spawn to fail with
-    ``Failed to connect to user bus``.  We do a cheap no-op probe
-    (``systemd-run --user --scope --unit=… -- /bin/true``) and remember the
-    outcome.
-    """
-    global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
-    cached = _SYSTEMD_SCOPE_AVAILABLE
-    now = time.monotonic()
-    if cached is True:
-        return True
-    if (
-        cached is False
-        and now - _SYSTEMD_SCOPE_PROBED_AT < _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
-    ):
-        return False
-
-    # Double-checked locking keeps concurrent first-use spawns from observing
-    # a temporary False while the definitive probe is still in flight.  Such a
-    # race would launch the losing workload back inside the gateway cgroup.
-    with _SYSTEMD_SCOPE_PROBE_LOCK:
-        cached = _SYSTEMD_SCOPE_AVAILABLE
-        now = time.monotonic()
-        if cached is True:
-            return True
-        if (
-            cached is False
-            and now - _SYSTEMD_SCOPE_PROBED_AT
-            < _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
-        ):
-            return False
-
-        available = False
-        if not _IS_WINDOWS:
-            try:
-                import shutil
-
-                binary = shutil.which("systemd-run")
-                if binary:
-                    # Probe: create a transient scope that immediately exits.
-                    # A unique unit avoids collisions; timeout bounds D-Bus.
-                    probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
-                    result = subprocess.run(
-                        [
-                            binary, "--user", "--scope", "--quiet",
-                            "--unit", probe_unit,
-                            "--collect",
-                            "--property", "MemoryAccounting=yes",
-                            "--property", f"MemoryMax={_worker_memory_max_bytes()}",
-                            "--property", "OOMPolicy=kill",
-                            "--",
-                            "/bin/true",
-                        ],
-                        capture_output=True,
-                        timeout=3,
-                    )
-                    available = result.returncode == 0
-                    if not available:
-                        logger.debug(
-                            "systemd-run --user --scope probe failed (rc=%s): %s",
-                            result.returncode,
-                            (result.stderr or b"").decode(
-                                "utf-8", "replace"
-                            ).strip(),
-                        )
-            except Exception as exc:
-                logger.debug("systemd-run --user --scope probe error: %s", exc)
-
-        _SYSTEMD_SCOPE_AVAILABLE = available
-        _SYSTEMD_SCOPE_PROBED_AT = time.monotonic()
-        return available
+    return _systemd_scope._systemd_run_user_scope_available()
 
 
 def _is_supervised_gateway_process() -> bool:
-    """Return whether this process is in a supervised Hermes gateway runtime.
-
-    Both supervisor markers and ``_HERMES_GATEWAY`` are inherited by every
-    descendant, and importing ``gateway.run`` also sets the latter. Require
-    this process to own the live gateway PID file as well. That keeps transient
-    systemd scopes limited to the gateway itself instead of terminal children
-    or unrelated interactive CLIs in the same supervised process tree.
-    """
-    if os.environ.get("_HERMES_GATEWAY") != "1":
-        return False
-
-    try:
-        from gateway.restart import is_gateway_supervisor_process
-        from gateway.status import get_running_pid
-
-        return (
-            is_gateway_supervisor_process()
-            and get_running_pid(cleanup_stale=False) == os.getpid()
-        )
-    except Exception as exc:
-        logger.debug("Could not verify supervised gateway process identity: %s", exc)
-        return False
+    return _systemd_scope._is_supervised_gateway_process()
 
 
 def _build_systemd_scope_argv(
     shell_argv: List[str],
     unit_suffix: str,
 ) -> List[str]:
-    """Wrap *shell_argv* in a ``systemd-run --user --scope`` invocation.
+    return _systemd_scope._build_systemd_scope_argv(shell_argv, unit_suffix=unit_suffix)
 
-    The resulting cgroup gets its own memory accounting so an OOM in the
-    worker does not kill the gateway cgroup (#70716).  ``--collect`` makes
-    the transient scope self-clean after exit; ``--unit`` gives it a
-    recognisable name for ``systemctl --user status`` / journalctl.
-    """
-    import shutil
 
-    binary = shutil.which("systemd-run")
-    if binary is None:
-        # Caller should have checked _systemd_run_user_scope_available();
-        # guard anyway so we never pass None into Popen.
-        return shell_argv
-    unit_name = f"hermes-worker-{unit_suffix}"
-    memory_max = _worker_memory_max_bytes()
-    return [
-        binary,
-        "--user",
-        "--scope",
-        "--quiet",
-        "--unit",
-        unit_name,
-        "--collect",
-        "--property",
-        "MemoryAccounting=yes",
-        "--property",
-        f"MemoryMax={memory_max}",
-        "--property",
-        "OOMPolicy=kill",
-        "--",
-        *shell_argv,
-    ]
+def _prepare_systemd_scope_argv(
+    shell_argv: List[str],
+    unit_suffix: str,
+) -> tuple[List[str], str]:
+    return _systemd_scope._prepare_systemd_scope_argv(
+        shell_argv, unit_suffix=unit_suffix
+    )
 
 
 def _stop_systemd_unit(unit_name: str) -> bool:
-    """Stop a transient systemd user scope by unit name.
-
-    This reaps the *entire* cgroup — catching double-forked descendants that
-    survive a plain PID signal because they were reparented to init inside the
-    scope (issue #70716, reviewer gap #2).  ``systemctl --user stop`` sends
-    SIGTERM to every process in the unit's cgroup and escalates to SIGKILL
-    after the unit's ``TimeoutStopSec``.
-
-    Returns True if the unit was successfully stopped (or was already gone),
-    False if ``systemctl`` is unavailable or the stop command failed.
-    """
-    import shutil
-
-    binary = shutil.which("systemctl")
-    if binary is None:
-        return False
-    try:
-        result = subprocess.run(
-            [binary, "--user", "stop", unit_name],
-            capture_output=True,
-            timeout=15,
-        )
-        if result.returncode != 0:
-            stderr = (result.stderr or b"").decode(errors="replace").strip()
-            stderr_lower = stderr.lower()
-            if any(
-                marker in stderr_lower
-                for marker in ("not loaded", "not found", "does not exist")
-            ):
-                return True
-            logger.debug(
-                "systemctl --user stop %s exited %d: %s",
-                unit_name, result.returncode,
-                stderr,
-            )
-            return False
-        return True
-    except Exception as exc:
-        logger.debug("systemctl --user stop %s failed: %s", unit_name, exc)
-        return False
+    return _systemd_scope._stop_systemd_unit(unit_name)
 
 
 def format_uptime_short(seconds: int) -> str:
@@ -1032,12 +792,12 @@ class ProcessRegistry:
                 )
 
                 if pty_use_systemd_scope:
-                    pty_argv = _build_systemd_scope_argv(
+                    pty_argv, pty_unit = _prepare_systemd_scope_argv(
                         pty_argv,
                         unit_suffix=session.id,
                     )
-                    session.systemd_unit = f"hermes-worker-{session.id}.scope"
-                    pty_scope_attempted = True
+                    session.systemd_unit = pty_unit
+                    pty_scope_attempted = bool(pty_unit)
                 elif pty_in_supervised_gateway:
                     logger.debug(
                         "PTY background executor not isolated in a "
@@ -1112,11 +872,11 @@ class ProcessRegistry:
             unit_suffix = (
                 f"{session.id}-pipe-fallback" if pty_scope_attempted else session.id
             )
-            spawn_argv = _build_systemd_scope_argv(
+            spawn_argv, systemd_unit = _prepare_systemd_scope_argv(
                 shell_argv,
                 unit_suffix=unit_suffix,
             )
-            session.systemd_unit = f"hermes-worker-{unit_suffix}.scope"
+            session.systemd_unit = systemd_unit
             # CRITICAL (#70716 regression): systemd-run --scope does NOT give
             # the worker a new session — the invoked process keeps the
             # parent's session and inherits its controlling terminal.  From an

--- a/tools/systemd_scope.py
+++ b/tools/systemd_scope.py
@@ -1,0 +1,315 @@
+"""Shared helpers for launching Hermes subprocesses in user systemd scopes.
+
+This module centralizes the scoped-launch policy used by terminal execution
+paths. Both foreground and background command launchers should call through
+these helpers so user-visible behavior is identical across execution modes.
+"""
+
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import List, Optional
+
+_IS_WINDOWS = platform.system() == "Windows"
+logger = logging.getLogger(__name__)
+
+_SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
+_SYSTEMD_SCOPE_PROBE_LOCK = threading.Lock()
+_SYSTEMD_SCOPE_PROBED_AT = 0.0
+_SYSTEMD_SCOPE_FAILURE_TTL_SECONDS = 60.0
+_MIN_WORKER_MEMORY_MAX_BYTES = 64 * 1024 * 1024
+_DEFAULT_WORKER_MEMORY_MAX_BYTES = 1024 * 1024 * 1024
+_WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
+_WORKER_TIMEOUT_STOP_SECONDS = 3
+
+
+def _worker_memory_max_bytes() -> int:
+    """Return a finite per-worker cgroup limit without widening host risk.
+
+    ``TERMINAL_LOCAL_MEMORY_MAX_MB`` may tighten the calculated bound, but an
+    oversized value cannot widen it. Otherwise use the tightest known bound
+    from the current cgroup and half of physical RAM, capped at 4 GiB.
+    """
+    override_bound: Optional[int] = None
+    override = os.getenv("TERMINAL_LOCAL_MEMORY_MAX_MB", "").strip()
+    if override:
+        override_valid = False
+        try:
+            parsed = int(override) * 1024 * 1024
+            if parsed >= _MIN_WORKER_MEMORY_MAX_BYTES:
+                override_bound = parsed
+                override_valid = True
+        except ValueError:
+            pass
+        if not override_valid:
+            logger.warning(
+                "Ignoring invalid TERMINAL_LOCAL_MEMORY_MAX_MB=%r; "
+                "expected an integer representing at least %d MiB",
+                override,
+                _MIN_WORKER_MEMORY_MAX_BYTES // (1024 * 1024),
+            )
+
+    candidates: List[int] = []
+    try:
+        for line in Path("/proc/self/cgroup").read_text(encoding="utf-8").splitlines():
+            if line.startswith("0::"):
+                relative = line.partition("::")[2].lstrip("/")
+                raw_limit = (Path("/sys/fs/cgroup") / relative / "memory.max").read_text(
+                    encoding="utf-8"
+                ).strip()
+                if raw_limit.isdigit():
+                    cgroup_limit = int(raw_limit)
+                    if cgroup_limit >= _MIN_WORKER_MEMORY_MAX_BYTES:
+                        candidates.append(cgroup_limit)
+                break
+    except (OSError, ValueError):
+        pass
+
+    try:
+        physical_bytes = int(os.sysconf("SC_PHYS_PAGES")) * int(
+            os.sysconf("SC_PAGE_SIZE")
+        )
+        physical_bound = min(
+            _WORKER_MEMORY_MAX_CAP_BYTES,
+            max(_MIN_WORKER_MEMORY_MAX_BYTES, physical_bytes // 2),
+        )
+        candidates.append(physical_bound)
+    except (OSError, ValueError, TypeError):
+        pass
+
+    safe_bound = min(candidates) if candidates else _DEFAULT_WORKER_MEMORY_MAX_BYTES
+    return min(override_bound, safe_bound) if override_bound else safe_bound
+
+
+def _systemd_run_user_scope_available() -> bool:
+    """Return True when ``systemd-run --user --scope`` is usable.
+
+    ``shutil.which`` is intentionally not sufficient: some environments ship the
+    binary on PATH without a usable user bus. This function performs a short,
+    cached probe command so callers do not repeatedly hit the failure path.
+    """
+    global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
+    cached = _SYSTEMD_SCOPE_AVAILABLE
+    now = time.monotonic()
+    if cached is True:
+        return True
+    if (
+        cached is False
+        and now - _SYSTEMD_SCOPE_PROBED_AT < _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
+    ):
+        return False
+
+    with _SYSTEMD_SCOPE_PROBE_LOCK:
+        cached = _SYSTEMD_SCOPE_AVAILABLE
+        now = time.monotonic()
+        if cached is True:
+            return True
+        if (
+            cached is False
+            and now - _SYSTEMD_SCOPE_PROBED_AT < _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS
+        ):
+            return False
+
+        available = False
+        if not _IS_WINDOWS:
+            try:
+                binary = shutil.which("systemd-run")
+                if binary:
+                    probe_unit = (
+                        f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+                    )
+                    result = subprocess.run(
+                        [
+                            binary,
+                            "--user",
+                            "--scope",
+                            "--quiet",
+                            "--unit",
+                            probe_unit,
+                            "--collect",
+                            "--property",
+                            "MemoryAccounting=yes",
+                            "--property",
+                            f"MemoryMax={_worker_memory_max_bytes()}",
+                            "--property",
+                            "OOMPolicy=kill",
+                            "--",
+                            "/bin/true",
+                        ],
+                        capture_output=True,
+                        timeout=3,
+                    )
+                    available = result.returncode == 0
+                    if not available:
+                        logger.debug(
+                            "systemd-run --user --scope probe failed (rc=%s): %s",
+                            result.returncode,
+                            (result.stderr or b"").decode(
+                                "utf-8", "replace"
+                            ).strip(),
+                        )
+            except Exception as exc:
+                logger.debug("systemd-run --user --scope probe error: %s", exc)
+                available = False
+
+        _SYSTEMD_SCOPE_AVAILABLE = available
+        _SYSTEMD_SCOPE_PROBED_AT = time.monotonic()
+        return available
+
+
+def _is_supervised_gateway_process() -> bool:
+    """Return whether this process is the live supervised gateway process."""
+    if os.environ.get("_HERMES_GATEWAY") != "1":
+        return False
+
+    try:
+        from gateway.restart import is_gateway_supervisor_process
+        from gateway.status import get_running_pid
+
+        return (
+            is_gateway_supervisor_process()
+            and get_running_pid(cleanup_stale=False) == os.getpid()
+        )
+    except Exception as exc:
+        logger.debug("Could not verify supervised gateway process identity: %s", exc)
+        return False
+
+
+def _prepare_systemd_scope_argv(
+    shell_argv: List[str], unit_suffix: str
+) -> tuple[List[str], str]:
+    """Return ``(argv, unit_name)`` for a scoped launch.
+
+    ``unit_name`` is empty when the systemd-run binary disappeared after a
+    successful capability probe. Callers must only record scope metadata when
+    this function returns a non-empty unit name.
+    """
+    binary = shutil.which("systemd-run")
+    if binary is None:
+        return shell_argv, ""
+
+    unit_name = f"hermes-worker-{unit_suffix}"
+    memory_max = _worker_memory_max_bytes()
+    argv = [
+        binary,
+        "--user",
+        "--scope",
+        "--quiet",
+        "--unit",
+        unit_name,
+        "--collect",
+        "--property",
+        "MemoryAccounting=yes",
+        "--property",
+        f"MemoryMax={memory_max}",
+        "--property",
+        "OOMPolicy=kill",
+        "--property",
+        f"TimeoutStopSec={_WORKER_TIMEOUT_STOP_SECONDS}s",
+        "--",
+        *shell_argv,
+    ]
+    return argv, f"{unit_name}.scope"
+
+
+def _build_systemd_scope_argv(shell_argv: List[str], unit_suffix: str) -> List[str]:
+    """Compatibility wrapper returning only the scoped command argv."""
+    argv, _unit_name = _prepare_systemd_scope_argv(shell_argv, unit_suffix)
+    return argv
+
+
+def _stop_systemd_unit(unit_name: str) -> bool:
+    """Stop a transient scope and do not return while descendants can run.
+
+    Worker scopes carry a short ``TimeoutStopSec``. If the synchronous stop
+    still exceeds our outer bound, force-kill every process in the cgroup and
+    verify that systemd no longer reports the unit active before returning.
+    """
+    binary = shutil.which("systemctl")
+    if binary is None:
+        return False
+
+    try:
+        result = subprocess.run(
+            [binary, "--user", "stop", unit_name],
+            capture_output=True,
+            timeout=_WORKER_TIMEOUT_STOP_SECONDS + 5,
+        )
+        if result.returncode != 0:
+            stderr = (result.stderr or b"").decode(errors="replace").strip()
+            stderr_lower = stderr.lower()
+            if any(
+                marker in stderr_lower
+                for marker in ("not loaded", "not found", "does not exist")
+            ):
+                return True
+            logger.debug(
+                "systemctl --user stop %s exited %d: %s",
+                unit_name,
+                result.returncode,
+                stderr,
+            )
+            return False
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Timed out stopping %s gracefully; forcing SIGKILL for the scope",
+            unit_name,
+        )
+        try:
+            kill_result = subprocess.run(
+                [
+                    binary,
+                    "--user",
+                    "kill",
+                    "--kill-whom=all",
+                    "--signal=SIGKILL",
+                    unit_name,
+                ],
+                capture_output=True,
+                timeout=3,
+            )
+            if kill_result.returncode != 0:
+                logger.debug(
+                    "systemctl --user kill %s exited %d: %s",
+                    unit_name,
+                    kill_result.returncode,
+                    (kill_result.stderr or b"").decode(
+                        "utf-8", "replace"
+                    ).strip(),
+                )
+                return False
+            state = subprocess.run(
+                [binary, "--user", "is-active", unit_name],
+                capture_output=True,
+                timeout=3,
+            )
+            state_name = (state.stdout or b"").decode(
+                "utf-8", "replace"
+            ).strip().lower()
+            if state.returncode in {3, 4} and state_name in {
+                "inactive",
+                "failed",
+                "unknown",
+            }:
+                return True
+            logger.debug(
+                "Could not verify %s inactive after SIGKILL (rc=%d, state=%r): %s",
+                unit_name,
+                state.returncode,
+                state_name,
+                (state.stderr or b"").decode("utf-8", "replace").strip(),
+            )
+            return False
+        except Exception as exc:
+            logger.debug("Forced cleanup for %s failed: %s", unit_name, exc)
+            return False
+    except Exception as exc:
+        logger.debug("systemctl --user stop %s failed: %s", unit_name, exc)
+        return False


### PR DESCRIPTION
## Summary

Foreground `terminal` commands executed by the gateway run directly inside the gateway's systemd cgroup. Heavy terminal workloads (Node/Vitest/Rolldown workers, builds, language servers) can accumulate there, exhaust the cgroup's memory ceiling, and trigger an OOM kill that stalls the gateway's threads/timers/heartbeats — producing an apparent "gateway freeze."

This change isolates foreground gateway commands into their own transient `systemd-run --user --scope` units (`hermes-worker-foreground-<id>.scope`) with a bounded per-worker `MemoryMax`, so heavy terminal workloads can no longer OOM the gateway cgroup.

## Changes

- New `tools/systemd_scope.py`: shared scoped-launch policy (probe for `systemd-run --user --scope`, per-worker memory bound derivation, scope argv building, unit teardown).
- `tools/environments/local.py`: wrap foreground `Popen` in a scope when running as a supervised gateway process on a systemd host; stop the scope on teardown.
- `tools/process_registry.py`: delegate scope-launch / stale-unit cleanup to the shared helper (removes duplicated logic).
- Tests: `tests/tools/test_local_systemd_scope.py` (new) + extended `tests/tools/test_process_registry.py`.

## Behavior / portability

- Only activates when: not Windows, running as a supervised gateway process, and `systemd-run --user --scope` is actually usable (probed with a 60s failure TTL).
- Everywhere else (macOS, non-systemd Linux, standalone CLI runs) falls back to the existing plain `subprocess.Popen` path — no behavior change.
- Per-worker memory bound is the tightest of: current cgroup limit, half of physical RAM, capped at 4 GiB; optionally tightened (never widened) via `TERMINAL_LOCAL_MEMORY_MAX_MB`.

## Test plan

- `python -m pytest tests/tools/test_local_systemd_scope.py tests/tools/test_process_registry.py -q` → 96 passed, 4 skipped.
