### PR TITLE
fix(bot-mode): avoid false bot unread markers

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-open-focus-identity.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-open-focus-identity.test.ts
@@ -22,9 +22,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { RosterRow } from './types'
 
-const { ackStoredSessionId, openBotCanonicalChat } = vi.hoisted(() => ({
+const { ackStoredSessionId, openBotCanonicalChat, prepareBotSource } = vi.hoisted(() => ({
   ackStoredSessionId: vi.fn(),
-  openBotCanonicalChat: vi.fn()
+  openBotCanonicalChat: vi.fn(),
+  prepareBotSource: vi.fn()
 }))
 
 vi.mock('@hermes/plugin-sdk', async importOriginal => {
@@ -38,26 +39,92 @@ vi.mock('./canonical-chat', () => ({
   ensureBotMetadata: vi.fn(async () => ({})),
   notifyBotOpenFailure: vi.fn(),
   openBotCanonicalChat,
-  prepareBotSource: vi.fn(async () => undefined),
+  prepareBotSource,
   PROFILE_SESSION_LIST_LIMIT: 200
 }))
 
+const { host } = await import('@hermes/plugin-sdk')
 const { $openBotChat } = await import('./bot-state')
 const { openRosterBot } = await import('./roster-actions')
 const { releaseStaleOpenBotChat } = await import('./roster-pane')
 
+const bot = {
+  canonical_session: { id: 'reg-1', last_active: 100 },
+  connectionId: 'local',
+  name: 'ops'
+} as RosterRow
+
+function withFocusApi(impl: () => null | string) {
+  const original = host.focusOpenWorkspaceSession
+
+  host.focusOpenWorkspaceSession = impl
+
+  return () => {
+    host.focusOpenWorkspaceSession = original
+  }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   $openBotChat.set(null)
+  prepareBotSource.mockResolvedValue(undefined)
+  openBotCanonicalChat.mockResolvedValue({ openedId: 'tip-9', registryId: 'reg-1' })
 })
 
 describe('an open claims both identities of the chat it opened', () => {
   it('records the registry row and the lineage tip it actually navigated to', async () => {
     openBotCanonicalChat.mockResolvedValue({ openedId: 'tip-9', registryId: 'reg-1' })
 
-    await openRosterBot({ connectionId: 'local', name: 'ops' } as RosterRow)
+    await openRosterBot(bot)
 
     expect($openBotChat.get()).toMatchObject({ openedRegistryId: 'reg-1', openedSessionId: 'tip-9' })
+  })
+})
+
+describe('unread acknowledgement follows a successful foreground transition', () => {
+  it('acknowledges only after the canonical chat opens', async () => {
+    openBotCanonicalChat.mockImplementation(async () => {
+      expect(ackStoredSessionId).not.toHaveBeenCalled()
+
+      return { openedId: 'tip-9', registryId: 'reg-1' }
+    })
+
+    await expect(openRosterBot(bot)).resolves.toBe(true)
+
+    expect(ackStoredSessionId).toHaveBeenCalledWith('reg-1', 'ops')
+  })
+
+  it('acknowledges after an existing bot tab successfully fronts', async () => {
+    const restore = withFocusApi(() => {
+      expect(ackStoredSessionId).not.toHaveBeenCalled()
+
+      return 'reg-1'
+    })
+
+    try {
+      await expect(openRosterBot(bot)).resolves.toBe(true)
+
+      expect(openBotCanonicalChat).not.toHaveBeenCalled()
+      expect(ackStoredSessionId).toHaveBeenCalledWith('reg-1', 'ops')
+    } finally {
+      restore()
+    }
+  })
+
+  it('preserves unread activity when source preparation fails', async () => {
+    prepareBotSource.mockRejectedValue(new Error('gateway unavailable'))
+
+    await expect(openRosterBot(bot)).resolves.toBe(false)
+
+    expect(ackStoredSessionId).not.toHaveBeenCalled()
+  })
+
+  it('preserves unread activity when the canonical chat fails to open', async () => {
+    openBotCanonicalChat.mockRejectedValue(new Error('open failed'))
+
+    await expect(openRosterBot(bot)).resolves.toBe(false)
+
+    expect(ackStoredSessionId).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/bot-state.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-state.ts
@@ -14,8 +14,9 @@ import { botRosterKey, botSelectionKey } from './data'
 import { getPluginCtx } from './shared'
 import type { RosterRow } from './types'
 
-// last_active watermark per source-qualified bot, seeded on first poll so a
-// fresh mount doesn't mark ancient history unread.
+// last_active watermark per source-qualified bot. Each key seeds on its first
+// sighting, and entries intentionally survive a temporary roster absence so a
+// returning bot only badges activity newer than its own last-seen watermark.
 export const rosterWatermarks = new Map<string, number>()
 
 // Bot Mode sessions are ALWAYS hidden from the global Sessions sidebar:

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.test.ts
@@ -72,6 +72,15 @@ vi.mock('./group-panes', () => ({ closeGroupChatMainTab: vi.fn() }))
 const chatting = (name: string, lastActive: number, preview = 'hello'): RosterRow =>
   ({ canonical_session: { id: `${name}-chat`, last_active: lastActive, preview }, name }) as RosterRow
 
+const scopedChatting = (connectionId: string, lastActive: number, preview = 'hello'): RosterRow =>
+  ({
+    canonical_session: { id: `${connectionId}-chat`, last_active: lastActive, preview },
+    connectionId,
+    name: 'default',
+    route: { connectionId, mode: 'remote', profile: 'default', targetProfile: 'default' },
+    sourceScoped: true
+  }) as RosterRow
+
 async function loadActions() {
   vi.resetModules()
 
@@ -96,6 +105,17 @@ describe('the first poll only seeds watermarks', () => {
 
     expect(markUnreadMock).not.toHaveBeenCalled()
     expect(hostMock.notify).not.toHaveBeenCalled()
+  })
+
+  it('seeds a source discovered after the first poll without badging its history', async () => {
+    const { trackInboundActivity } = await loadActions()
+
+    trackInboundActivity([scopedChatting('local', 5000)])
+    trackInboundActivity([scopedChatting('local', 5000), scopedChatting('remote', 9000)])
+    expect(markUnreadMock).not.toHaveBeenCalled()
+
+    trackInboundActivity([scopedChatting('local', 5000), scopedChatting('remote', 10_000)])
+    expect(markUnreadMock.mock.calls).toEqual([['remote-chat', 'default']])
   })
 })
 
@@ -180,19 +200,23 @@ describe('new activity after the seed', () => {
   it('tracks two same-named bots on different connections independently', async () => {
     const { trackInboundActivity } = await loadActions()
 
-    const scoped = (connectionId: string, lastActive: number) =>
-      ({
-        canonical_session: { id: `${connectionId}-chat`, last_active: lastActive },
-        connectionId,
-        name: 'default',
-        route: { connectionId, mode: 'remote', profile: 'default', targetProfile: 'default' },
-        sourceScoped: true
-      }) as RosterRow
-
-    trackInboundActivity([scoped('a', 5000), scoped('b', 5000)])
-    trackInboundActivity([scoped('a', 6000), scoped('b', 5000)])
+    trackInboundActivity([scopedChatting('a', 5000), scopedChatting('b', 5000)])
+    trackInboundActivity([scopedChatting('a', 6000), scopedChatting('b', 5000)])
 
     expect(markUnreadMock.mock.calls).toEqual([['a-chat', 'default']])
+  })
+
+  it('keeps a source watermark while the bot is temporarily absent', async () => {
+    const { trackInboundActivity } = await loadActions()
+
+    trackInboundActivity([scopedChatting('remote', 5000)])
+    trackInboundActivity([])
+    trackInboundActivity([scopedChatting('remote', 5000)])
+    trackInboundActivity([scopedChatting('remote', 4000)])
+    expect(markUnreadMock).not.toHaveBeenCalled()
+
+    trackInboundActivity([scopedChatting('remote', 6000)])
+    expect(markUnreadMock.mock.calls).toEqual([['remote-chat', 'default']])
   })
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -23,10 +23,6 @@ import { botCanonicalSessionId } from './row-helpers'
 import { bumpBotOpenGeneration, getBotOpenGeneration, getPluginCtx } from './shared'
 import type { RosterRow } from './types'
 
-// last_active watermark per source-qualified bot, seeded on first poll so a
-// fresh mount doesn't mark ancient history unread.
-let watermarksSeeded = false
-
 /** User pref: toast on every new bot activity. Default OFF — a busy roster
  *  (cron runs, bot-to-bot chatter) turns the toasts into a firehose, and the
  *  unread badge already carries the signal. Persisted via ctx.storage. */
@@ -54,17 +50,15 @@ export function setActivityToasts(enabled: boolean) {
  *  own unread watermark iterates, and deliveries from the CLI, cron, another
  *  bot, or another machine never touch this window's live turn edge either. */
 export function trackInboundActivity(roster: RosterRow[]) {
-  const seeding = !watermarksSeeded
-  watermarksSeeded = true
-
   for (const bot of roster) {
     const key = botSelectionKey(bot)
     const activity = botActivitySession(bot)
     const ts = activity?.last_active || 0
+    const seeded = rosterWatermarks.has(key)
     const prev = rosterWatermarks.get(key) || 0
     rosterWatermarks.set(key, Math.max(prev, ts))
 
-    if (seeding || ts <= prev) {
+    if (!seeded || ts <= prev) {
       continue
     }
 

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -226,12 +226,6 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
     openGroupChat(currentGroup)
   }
 
-  // The persisted half of clear-on-open. The transient dot is retired by
-  // core's own selection path once the chat lands; this retires the marker,
-  // which the selection listener alone would file against the wrong profile —
-  // a bot open deliberately leaves the gateway on the launch profile.
-  ackStoredSessionId(botCanonicalSessionId(bot), bot.name)
-
   const fronted = focusExistingBotTab(bot)
 
   if (fronted) {
@@ -239,6 +233,7 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
     // round-trip. Both identities are recorded so the reclaim listener and
     // the roster-activity refresh treat it exactly like a registry open.
     $openBotChat.set({ key, openedRegistryId: fronted.registryId, openedSessionId: fronted.storedSessionId })
+    ackStoredSessionId(botCanonicalSessionId(bot), bot.name)
 
     return true
   }
@@ -281,6 +276,11 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
         openedRegistryId: opened.registryId,
         openedSessionId: opened.openedId
       })
+      // Reading acknowledgement follows a successful foreground transition.
+      // A failed source lookup/open leaves the persisted marker intact so
+      // Retry still tells the truth. The owner hint is required because a bot
+      // open deliberately leaves the gateway on the launch profile.
+      ackStoredSessionId(botCanonicalSessionId(bot), bot.name)
 
       return true
     }


### PR DESCRIPTION
## What does this PR do?

Connecting another gateway can make old Bot activity look unread. A failed attempt to open a Bot Chat can also clear its unread marker before the user sees the conversation. This fixes both cases.

Each Bot is initialized independently when its source first appears. Its activity watermark survives a temporary roster absence. Read acknowledgement happens only after the exact canonical Bot Chat successfully opens or comes to the foreground; a failed source lookup or open leaves the marker intact.

The current-main recut preserves the newer canonical-tab fast path and focused-chat transcript refresh. It does not restore the older arbitrary side-tab shortcut.

## Related Work

- #94726 tracks the wider Bot Mode bug classes. This is limited to first-seen activity and successful-open acknowledgement.
- Open #100571 changes persistent/headless unread behavior in the same area. Its inspected head retains the global first-poll latch and acknowledges before open, so these two fixes remain relevant; whichever lands second needs composition.
- #92989 is broader activity UI, not a dependency. Merged #93292 owns runtime rebinding after gateway restart.
- #93993 handles Group Chat attention markers; this PR is about canonical Bot Chats.

## Validation

Current candidate: `2db14d4b1d3b331f9609f5c8f2b076f6b0e8f6ec`, based on `main@593aa74c6182ce2e5e23bc102daaaae71710c05d`.

- The focused behavior cases produce **5 failures / 15 passes** on the unchanged main implementation, then **20 passes** with this fix.
- Complete typed Bot Mode suite: **61 files / 576 tests passed**.
- Desktop renderer, Electron and E2E typechecks passed; changed-file ESLint and diff checks passed.
- Two independent bounded reviews found no blocking issues on this exact candidate. Their 54-test and 90-test selections overlap and are not added together.
- All four changed files are below 2,000 physical lines.
- Exact-head [CI](https://github.com/NousResearch/hermes-agent/actions/runs/33705585946), [Docker amd64/arm64](https://github.com/NousResearch/hermes-agent/actions/runs/33705585350), and [Nix](https://github.com/NousResearch/hermes-agent/actions/runs/33705585258) pass. Hosted Desktop E2E was skipped; packaged-app UAT for this exact recut is not yet claimed.

The two original authored changes remain separate cherry-pickable commits, with source trailers. No Python source changed, so the Python suite is not selected.

## Type of Change

- [x] Bug fix
- [x] Tests
