### PR TITLE
fix(desktop): make unread session counts actionable

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -5,6 +5,7 @@ import type { CSSProperties, ReactElement, PointerEvent as ReactPointerEvent } f
 import { SessionDraftTitle } from '@/app/chat/session-draft-title'
 import { SessionStatusDot } from '@/app/chat/session-status-dot'
 import { PALETTE_AREA, type PaletteContribution, paletteToggle } from '@/app/command-palette/contrib'
+import { SessionsTabTitle } from '@/app/shell/sessions-tab-title'
 import { type StatusbarItem } from '@/app/shell/statusbar-controls'
 import { InlinePreviewDirective } from '@/components/assistant-ui/inline-preview-directive'
 import { IdleMount } from '@/components/idle-mount'
@@ -70,8 +71,10 @@ import {
   REVIEW_PANE_ID
 } from '@/store/review'
 import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionMatchesStoredId } from '@/store/session'
+import { $unreadSessionCount } from '@/store/session-dot-state'
 import { watchSessionPins } from '@/store/session-pin-sync'
 import { $botChatScopes } from '@/store/session-states'
+import { requestOpenNextUnread } from '@/store/session-unread-navigation'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
 import { isBrowserWindow, isHudWindow } from '@/store/windows'
@@ -122,6 +125,14 @@ const renderWorkspacePane = () => <WiredPane part="chatRoutes" />
 // Boot-hidden panes mount behind display:none (instant-toggle contract) — defer
 // them to idle so they're off the first-paint path, warm before reveal.
 const idle = (node: ReactElement) => <IdleMount>{node}</IdleMount>
+
+/** Subscribes the unread count so the presentational SessionsTabTitle stays
+ *  pure (render tests drive it via props). Keep the hook in a real component:
+ *  pane-shell invokes `tabTitle()` as a callback, not as a component. */
+function SessionsPaneTabTitle() {
+  return <SessionsTabTitle onOpenNextUnread={requestOpenNextUnread} unread={useStore($unreadSessionCount)} />
+}
+
 // The main tab carries the same session context menu as tile tabs (targets
 // the loaded primary session; no menu on a fresh draft).
 const wrapWorkspaceTab = (tab: ReactElement) => <WorkspaceTabMenu>{tab}</WorkspaceTabMenu>
@@ -171,6 +182,7 @@ registry.registerMany([
       // Standing chrome: no close gestures at all — the tab is shown/hidden
       // (zone menu Show/Hide rows + the auto-registered ⌘K toggle below).
       hideOnly: true,
+      tabTitle: () => <SessionsPaneTabTitle />,
       width: `${SIDEBAR_DEFAULT_WIDTH}px`,
       minWidth: `${SIDEBAR_DEFAULT_WIDTH}px`,
       maxWidth: `${SIDEBAR_MAX_WIDTH}px`

--- a/apps/desktop/src/app/contrib/hooks/use-unread-navigation.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-unread-navigation.test.tsx
@@ -1,0 +1,385 @@
+import { useStore } from '@nanostores/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { StrictMode, useEffect } from 'react'
+import { MemoryRouter, useLocation, useNavigate } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as Hermes from '@/hermes'
+
+const h = vi.hoisted(() => ({ getSession: vi.fn(), rowOpen: vi.fn(), noop: () => undefined }))
+vi.mock('@/hermes', async original => ({ ...(await original<typeof Hermes>()), getSession: h.getSession }))
+
+import { SidebarSessionsSection } from '@/app/chat/sidebar/sessions-section'
+import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
+import { SessionsTabTitle } from '@/app/shell/sessions-tab-title'
+import { TitlebarControls } from '@/app/shell/titlebar-controls'
+import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
+import { findGroup, group, setSplitWeights, split } from '@/components/pane-shell/tree/model'
+import { $narrowOverlayChrome } from '@/components/pane-shell/tree/renderer/narrow-overlay-state'
+import { NarrowOverlays } from '@/components/pane-shell/tree/renderer/narrow-overlays'
+import {
+  $activeTreeGroup,
+  $hiddenStripTabs,
+  $hiddenTreePanes,
+  $layoutTree,
+  $narrowViewport,
+  activateTreePane,
+  noteActiveTreeGroup,
+  trackActiveTreeGroup
+} from '@/components/pane-shell/tree/store'
+import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
+import { registry } from '@/contrib/registry'
+import { $panesFlipped, $sidebarOpen, setFileBrowserOpen, setSidebarOpen } from '@/store/layout'
+import { $notifications } from '@/store/notifications'
+import { $activeGatewayProfile, $showAllProfiles } from '@/store/profile'
+import {
+  $connection,
+  $cronSessions,
+  $lastReadAtBySessionId,
+  $messagingSessions,
+  $selectedStoredSessionId,
+  $sessionResumeRequest,
+  $sessions,
+  $unreadFinishedSessionIds,
+  _resetSessionOwnerHintsForTests,
+  getSessionOwnerHints,
+  setSessionOwnerHint
+} from '@/store/session'
+import { $unreadSessionCount } from '@/store/session-dot-state'
+import { $focusedStoredSessionId, $sessionTiles, clearAllSessionStates } from '@/store/session-states'
+import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
+import { $openNextUnreadRequest, requestOpenNextUnread } from '@/store/session-unread-navigation'
+import { $unreadWriteGuard } from '@/store/session-unread-remote'
+import { stubResizeObserver } from '@/test/jsdom'
+import type { SessionInfo } from '@/types/hermes'
+
+import { useUnreadNavigation } from './use-unread-navigation'
+
+// Composition regressions from independent A RA1/RA2 and B B5. Real router,
+// pane actions, count, sidebar rows and stores; only backend I/O is stubbed.
+const target: SessionInfo = {
+  id: 'unread',
+  connection_id: 'source-a',
+  profile: 'ops',
+  source: 'desktop',
+  title: 'Unread conversation',
+  ended_at: null,
+  input_tokens: 0,
+  output_tokens: 0,
+  is_active: false,
+  model: null,
+  preview: null,
+  tool_call_count: 0,
+  started_at: 1,
+  last_active: 100,
+  message_count: 2,
+  unread: true
+}
+
+const disposers: (() => void)[] = []
+
+function Rows() {
+  return (
+    <SidebarSessionsSection
+      activeSessionId={useStore($selectedStoredSessionId)}
+      emptyState={null}
+      label="Recent conversations"
+      onArchiveSession={h.noop}
+      onDeleteSession={h.noop}
+      onResumeSession={h.rowOpen}
+      onToggle={h.noop}
+      onTogglePin={h.noop}
+      onToggleUnread={h.noop}
+      open
+      pinned={false}
+      sessions={useStore($sessions)}
+    />
+  )
+}
+
+function LiveTitle() {
+  return <SessionsTabTitle onOpenNextUnread={requestOpenNextUnread} unread={useStore($unreadSessionCount)} />
+}
+
+function Host() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const narrow = useStore($narrowViewport)
+  useUnreadNavigation(navigate, `${location.key}:${location.pathname}:${location.search}:${location.hash}`)
+  useEffect(() => trackActiveTreeGroup(), [])
+
+  return (
+    <>
+      <output data-testid="route">{location.pathname}</output>
+      {!narrow && (
+        <div data-tree-group="side">
+          <LiveTitle />
+          <button onPointerDown={() => activateTreePane('side', 'terminal')}>Terminal tab</button>
+          <button onPointerDown={() => activateTreePane('side', 'sessions')}>Sessions tab</button>
+        </div>
+      )}
+      <TitlebarControls onOpenSettings={h.noop} />
+      <NarrowOverlays />
+    </>
+  )
+}
+
+const mount = () =>
+  render(
+    <StrictMode>
+      <MemoryRouter initialEntries={['/initial']}>
+        <Host />
+      </MemoryRouter>
+    </StrictMode>
+  )
+
+const path = () => screen.getByTestId('route').textContent
+
+const reveal = (id: string) =>
+  act(() => {
+    window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id, mode: 'open' } }))
+  })
+
+const clickCount = async () =>
+  act(async () => {
+    const count = screen.getByRole('button', { name: '1 unread session' })
+    fireEvent.pointerDown(count, { button: 0, pointerType: 'touch' })
+    fireEvent.click(count)
+  })
+
+function deferPreflight() {
+  let resolve!: () => void
+  h.getSession.mockReturnValue(
+    new Promise(done => {
+      resolve = () => done({ session: target })
+    })
+  )
+
+  return () => act(async () => resolve())
+}
+
+const snapshot = () => ({
+  route: path(),
+  focused: $focusedStoredSessionId.get(),
+  activeGroup: $activeTreeGroup.get(),
+  tiles: $sessionTiles.get(),
+  hints: getSessionOwnerHints('unread'),
+  resume: $sessionResumeRequest.get(),
+  unread: $unreadFinishedSessionIds.get(),
+  markers: $unreadFinishedMarkers.get(),
+  seen: $sessionSeenCounts.get(),
+  readAt: $lastReadAtBySessionId.get(),
+  notifications: $notifications.get()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getSession.mockReset().mockResolvedValue({ session: target })
+  window.hermesDesktop = { getProfileRoutes: vi.fn(async () => []) } as unknown as typeof window.hermesDesktop
+  stubResizeObserver()
+  vi.stubGlobal('matchMedia', (media: string) => ({
+    matches: media === SIDEBAR_COLLAPSE_MEDIA_QUERY && $narrowViewport.get(),
+    media,
+    addEventListener: h.noop,
+    removeEventListener: h.noop,
+    addListener: h.noop,
+    removeListener: h.noop,
+    dispatchEvent: h.noop
+  }))
+  clearAllSessionStates()
+  _resetSessionOwnerHintsForTests()
+  $sessionTiles.set([])
+  $openNextUnreadRequest.set(0)
+  $connection.set({
+    connectionId: 'primary',
+    baseUrl: 'http://unused.invalid',
+    wsUrl: 'ws://unused.invalid',
+    token: '',
+    isFullscreen: false,
+    nativeOverlayWidth: 0,
+    logs: [],
+    windowButtonPosition: null
+  })
+  $activeGatewayProfile.set('default')
+  $showAllProfiles.set(true)
+  setWorkspaceScope('sessions')
+  $selectedStoredSessionId.set('initial')
+  $sessionResumeRequest.set(null)
+  $sessions.set([target])
+  $messagingSessions.set([])
+  $cronSessions.set([])
+  $unreadFinishedSessionIds.set(['unread'])
+  $unreadFinishedMarkers.set({ ops: ['unread'] })
+  $sessionSeenCounts.set({ ops: { unread: 1 } })
+  $lastReadAtBySessionId.set({})
+  $unreadWriteGuard.set(new Map())
+  $notifications.set([])
+  $panesFlipped.set(false)
+  $hiddenStripTabs.set(new Set())
+  $hiddenTreePanes.set(new Set())
+  $narrowViewport.set(false)
+  setSidebarOpen(true)
+  setFileBrowserOpen(true)
+
+  for (const id of ['sessions', 'bots', 'terminal', 'workspace', 'session-tile:unread']) {
+    const sidebar = ['sessions', 'bots', 'terminal'].includes(id)
+    disposers.push(
+      registry.register({
+        area: 'panes',
+        id,
+        title: id,
+        data: {
+          placement: sidebar ? 'left' : 'main',
+          collapsible: sidebar,
+          width: '237px',
+          ...(id === 'sessions'
+            ? { hideOnly: true, revealAliases: ['chat-sidebar'], tabTitle: () => <LiveTitle /> }
+            : {})
+        },
+        render: id === 'sessions' ? () => <Rows /> : () => <div data-testid={`${id}-body`}>{id}</div>
+      })
+    )
+  }
+
+  $layoutTree.set(
+    split('row', [
+      group(['sessions', 'bots', 'terminal'], { id: 'side' }),
+      group(['workspace', 'session-tile:unread'], { id: 'main' })
+    ])
+  )
+  noteActiveTreeGroup('side')
+})
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+  $narrowViewport.set(false)
+  vi.unstubAllGlobals()
+})
+
+describe('unread navigation pane intent', () => {
+  it.each([false, true])(
+    'cancels a same-group Terminal selection, including a round trip (%s)',
+    async returnToSessions => {
+      const finish = deferPreflight()
+      mount()
+      await clickCount()
+      expect(h.getSession).toHaveBeenCalledOnce()
+      fireEvent.pointerDown(screen.getByText('Terminal tab'), { button: 0 })
+      expect(findGroup($layoutTree.get()!, 'side')?.active).toBe('terminal')
+      expect($activeTreeGroup.get()).toBe('side')
+      expect($focusedStoredSessionId.get()).toBe('initial')
+
+      if (returnToSessions) {
+        fireEvent.pointerDown(screen.getByText('Sessions tab'), { button: 0 })
+      }
+
+      const before = snapshot()
+      await finish()
+      expect(snapshot()).toEqual(before)
+    }
+  )
+
+  it('does not self-cancel its docked reveal or cancel on a layout resize', async () => {
+    activateTreePane('side', 'terminal')
+    const finish = deferPreflight()
+    mount()
+    await clickCount()
+    expect(findGroup($layoutTree.get()!, 'side')?.active).toBe('sessions')
+    act(() => {
+      const tree = $layoutTree.get()!
+      $layoutTree.set(setSplitWeights(tree, tree.id, [2, 3]))
+    })
+    await finish()
+    expect(path()).toBe('/unread')
+    expect($sessionResumeRequest.get()?.ownerRoute).toEqual({ connectionId: 'source-a', profile: 'ops' })
+  })
+
+  it.each(['bots', 'terminal'])(
+    'reveals Sessions from %s without self-cancelling a successful preflight',
+    async sibling => {
+      setSidebarOpen(false)
+      $narrowViewport.set(true)
+      const finish = deferPreflight()
+      mount()
+      reveal(sibling)
+      await clickCount()
+      expect(screen.getByText('Unread conversation')).toBeDefined()
+      expect($narrowOverlayChrome.get()?.paneId).toBe('sessions')
+      expect($sidebarOpen.get()).toBe(false)
+      await clickCount()
+      act(() => {
+        const tree = $layoutTree.get()!
+        $layoutTree.set(setSplitWeights(tree, tree.id, [2, 3]))
+      })
+      expect(h.getSession).toHaveBeenCalledOnce()
+      await finish()
+      expect(path()).toBe('/unread')
+    }
+  )
+
+  it.each(['tab', 'reveal-event', 'close'])('cancels later narrow pane intent (%s)', async intent => {
+    $narrowViewport.set(true)
+    const finish = deferPreflight()
+    const view = mount()
+    reveal('sessions')
+    await clickCount()
+
+    if (intent === 'tab') {
+      const tab = view.container.querySelector<HTMLElement>('[data-narrow-overlay-tab="terminal"]')!
+      fireEvent.pointerDown(tab, { button: 0 })
+    } else if (intent === 'reveal-event') {
+      reveal('terminal')
+    } else {
+      fireEvent.keyDown(window, { key: 'Escape' })
+    }
+
+    expect($narrowOverlayChrome.get()?.paneId ?? null).toBe(intent === 'close' ? null : 'terminal')
+    const before = snapshot()
+    await finish()
+    expect(snapshot()).toEqual(before)
+  })
+
+  it('observes later Terminal intent even if the request started before narrow collapse', async () => {
+    const finish = deferPreflight()
+    mount()
+    await clickCount()
+    act(() => $narrowViewport.set(true))
+    reveal('terminal')
+    expect($narrowOverlayChrome.get()?.paneId).toBe('terminal')
+    const before = snapshot()
+    await finish()
+    expect(snapshot()).toEqual(before)
+  })
+})
+
+describe('unread navigation recovery reveal', () => {
+  it.each([
+    ['bots', 'ambiguous'],
+    ['bots', 'offline'],
+    ['terminal', 'ambiguous'],
+    ['terminal', 'offline']
+  ])('reveals usable Sessions rows from %s after %s refusal', async (sibling, failure) => {
+    if (failure === 'ambiguous') {
+      const ownerRoute = { connectionId: 'source-b', profile: 'ops' }
+      $sessionTiles.set([{ storedSessionId: 'unread', ownerRoute, workspaceMode: 'sessions' }])
+      setSessionOwnerHint('unread', ownerRoute)
+    } else {
+      h.getSession.mockRejectedValue(new Error('offline'))
+    }
+
+    $narrowViewport.set(true)
+    noteActiveTreeGroup('main')
+    mount()
+    reveal(sibling)
+    expect(screen.getByTestId(`${sibling}-body`)).toBeDefined()
+    const before = snapshot()
+    await clickCount()
+    expect(snapshot()).toEqual(before)
+    expect($sessionTiles.get()).toBe(before.tiles)
+    expect(h.getSession).toHaveBeenCalledOnce()
+    expect($narrowOverlayChrome.get()?.paneId).toBe('sessions')
+    expect(screen.queryByTestId(`${sibling}-body`)).toBeNull()
+    fireEvent.click(screen.getByText('Unread conversation'))
+    expect(h.rowOpen).toHaveBeenCalledWith('unread', target)
+  })
+})

--- a/apps/desktop/src/app/contrib/hooks/use-unread-navigation.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-unread-navigation.ts
@@ -2,7 +2,10 @@ import { useStore } from '@nanostores/react'
 import { useEffect, useRef } from 'react'
 
 import { openSession, type OpenSessionNavigate } from '@/app/open-session'
-import { $activeTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
+import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
+import { findGroup, findGroupOfPane } from '@/components/pane-shell/tree/model'
+import { $narrowOverlayChrome } from '@/components/pane-shell/tree/renderer/narrow-overlay-state'
+import { $activeTreeGroup, $layoutTree, $narrowViewport, revealTreePane } from '@/components/pane-shell/tree/store'
 import { $workspaceMode, $workspaceOwnerKey } from '@/components/pane-shell/workspace-scope'
 import { getSession } from '@/hermes'
 import { $activeConnectionId } from '@/store/connections'
@@ -35,6 +38,13 @@ function isStillUnread(target: UnreadSessionTarget): boolean {
         current.connectionId === target.connectionId &&
         current.profile === target.profile
     )
+}
+
+function activePaneId(): string | undefined {
+  const tree = $layoutTree.get()
+  const groupId = $activeTreeGroup.get()
+
+  return tree ? (groupId ? findGroup(tree, groupId) : findGroupOfPane(tree, 'workspace'))?.active : undefined
 }
 
 /** openSession's focus fast path is ID/lineage-only. Until that shared store
@@ -78,6 +88,13 @@ export function useUnreadNavigation(navigate: OpenSessionNavigate, routeToken: s
 
     seen.current = request
     revealTreePane('sessions')
+    const narrow = $narrowViewport.get()
+
+    if (narrow) {
+      // Use the narrow reveal protocol without changing positional dock flags
+      // (the left rail can belong to another pane in a flipped wide layout).
+      window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id: 'sessions', mode: 'open' } }))
+    }
 
     if (pending.current) {
       return
@@ -97,6 +114,37 @@ export function useUnreadNavigation(navigate: OpenSessionNavigate, routeToken: s
 
     pending.current = cancel
     const isCurrent = () => pending.current === cancel && currentRoute.current === capturedRoute
+
+    // Capture AFTER our own reveal. A same-group Terminal tab changes neither
+    // group nor focused session, whereas resizing the group changes neither
+    // its active pane nor the user's intent.
+    const capturedPaneId = activePaneId()
+    cleanups.push(
+      $layoutTree.listen(() => {
+        if (activePaneId() !== capturedPaneId) {
+          cancel()
+        }
+      })
+    )
+
+    cleanups.push(
+      $narrowOverlayChrome.listen(chrome => {
+        if (chrome) {
+          if (chrome.paneId !== 'sessions') {
+            cancel()
+          }
+        } else {
+          // Overlay effects clear then republish chrome, including our own
+          // Sessions reveal and cosmetic updates. Only a settled close wins;
+          // leaving narrow mode alone is not a different pane selection.
+          queueMicrotask(() => {
+            if (isCurrent() && $narrowViewport.get() && $narrowOverlayChrome.get()?.paneId !== 'sessions') {
+              cancel()
+            }
+          })
+        }
+      })
+    )
 
     // Subscribe only during this operation. Synchronous invalidation catches
     // switch-away-and-back and focus-only changes even before React renders.

--- a/apps/desktop/src/app/contrib/hooks/use-unread-navigation.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-unread-navigation.ts
@@ -1,0 +1,166 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useRef } from 'react'
+
+import { openSession, type OpenSessionNavigate } from '@/app/open-session'
+import { $activeTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
+import { $workspaceMode, $workspaceOwnerKey } from '@/components/pane-shell/workspace-scope'
+import { getSession } from '@/hermes'
+import { $activeConnectionId } from '@/store/connections'
+import { $activeGatewayProfile, $freshSessionRequest, $profileScope } from '@/store/profile'
+import {
+  $selectedStoredSessionId,
+  $sessionResumeRequest,
+  $sessions,
+  forgetSessionOwnerHintsForSession,
+  lineageAliases,
+  requestSessionResume
+} from '@/store/session'
+import { $unreadSessionTargets, type UnreadSessionTarget } from '@/store/session-dot-state'
+import type { SessionProfileRoute } from '@/store/session-request-router'
+import { $focusedStoredSessionId, $sessionTiles } from '@/store/session-states'
+import {
+  $openNextUnreadRequest,
+  openNextValidUnread,
+  ownerRouteForUnreadTarget,
+  preflightCandidatesForUnreadTarget
+} from '@/store/session-unread-navigation'
+
+function isStillUnread(target: UnreadSessionTarget): boolean {
+  return $unreadSessionTargets
+    .get()
+    .some(
+      current =>
+        current.id === target.id &&
+        current.kind === target.kind &&
+        current.connectionId === target.connectionId &&
+        current.profile === target.profile
+    )
+}
+
+/** openSession's focus fast path is ID/lineage-only. Until that shared store
+ * can represent source twins, skip an open surface whose owner is unproven.
+ * Do this BEFORE publishing resume intent or acknowledging any unread state. */
+function canOpenUnread(target: UnreadSessionTarget, owner: SessionProfileRoute | null): boolean {
+  const aliases = lineageAliases(target.id, $sessions.get())
+  const tiles = $sessionTiles.get().filter(tile => aliases.includes(tile.storedSessionId))
+
+  if (tiles.length) {
+    return tiles.every(
+      ({ ownerRoute }) =>
+        owner &&
+        ownerRoute &&
+        owner.connectionId === ownerRoute.connectionId &&
+        owner.profile === ownerRoute.profile &&
+        (owner.targetProfile || owner.profile) === (ownerRoute.targetProfile || ownerRoute.profile)
+    )
+  }
+
+  // Main's selected ID alone cannot prove which source is already hydrated.
+  return !aliases.includes($selectedStoredSessionId.get() ?? '')
+}
+
+export function useUnreadNavigation(navigate: OpenSessionNavigate, routeToken: string): void {
+  const request = useStore($openNextUnreadRequest)
+  // A genuine remount consumes no historical intent; StrictMode can re-run
+  // effects without replaying an already seen counter.
+  const seen = useRef($openNextUnreadRequest.get())
+  const pending = useRef<null | (() => void)>(null)
+  const currentRoute = useRef(routeToken)
+  currentRoute.current = routeToken
+
+  useEffect(() => () => pending.current?.(), [routeToken])
+
+  // eslint-disable-next-line no-restricted-syntax -- consume one-shot navigation intent, not an atom mirror
+  useEffect(() => {
+    if (request === seen.current) {
+      return
+    }
+
+    seen.current = request
+    revealTreePane('sessions')
+
+    if (pending.current) {
+      return
+    }
+
+    const capturedRoute = currentRoute.current
+    const activeConnectionId = $activeConnectionId.get()
+    const cleanups: (() => void)[] = []
+
+    const cancel = () => {
+      if (pending.current === cancel) {
+        pending.current = null
+      }
+
+      cleanups.splice(0).forEach(cleanup => cleanup())
+    }
+
+    pending.current = cancel
+    const isCurrent = () => pending.current === cancel && currentRoute.current === capturedRoute
+
+    // Subscribe only during this operation. Synchronous invalidation catches
+    // switch-away-and-back and focus-only changes even before React renders.
+    for (const store of [
+      $activeConnectionId,
+      $activeGatewayProfile,
+      $profileScope,
+      $workspaceMode,
+      $workspaceOwnerKey,
+      $activeTreeGroup,
+      $focusedStoredSessionId,
+      $selectedStoredSessionId,
+      $sessionResumeRequest,
+      $freshSessionRequest
+    ]) {
+      cleanups.push(store.listen(cancel))
+    }
+
+    void openNextValidUnread(
+      $unreadSessionTargets.get(),
+      async target => {
+        if (!isStillUnread(target)) {
+          throw new Error('Unread target no longer eligible')
+        }
+
+        const baseOwner = ownerRouteForUnreadTarget(target, activeConnectionId)
+
+        const routes = baseOwner ? await window.hermesDesktop.getProfileRoutes([baseOwner.profile]).catch(() => []) : []
+
+        let lastError: unknown
+
+        for (const candidate of preflightCandidatesForUnreadTarget(target, activeConnectionId, routes)) {
+          if (!isCurrent() || !isStillUnread(target)) {
+            throw new Error('Unread navigation superseded')
+          }
+
+          try {
+            await getSession(target.id, candidate.scope)
+
+            return candidate.ownerRoute
+          } catch (error) {
+            lastError = error
+          }
+        }
+
+        throw lastError
+      },
+      (target, ownerRoute) => {
+        if (!isStillUnread(target) || !canOpenUnread(target, ownerRoute)) {
+          return false
+        }
+
+        cancel()
+
+        // Preserve the ordinary row's ownerless recovery, including a fresh
+        // request replacing a previously captured explicit owner.
+        if (!ownerRoute) {
+          forgetSessionOwnerHintsForSession(target.id)
+        }
+
+        requestSessionResume(target.id, ownerRoute ?? undefined)
+        openSession(target.id, navigate)
+      },
+      isCurrent
+    ).finally(cancel)
+  }, [navigate, request])
+}

--- a/apps/desktop/src/app/contrib/wiring-unread.test.tsx
+++ b/apps/desktop/src/app/contrib/wiring-unread.test.tsx
@@ -1,0 +1,494 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { type ReactElement, StrictMode, useContext } from 'react'
+import { MemoryRouter, useLocation, useNavigate } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Adapted from independent review A/B's mounted repros for #93007. Keep the
+// router, unread/owner stores, layout and openSession real; stub backend I/O
+// and unrelated feature hooks/surfaces, not the consumer under test.
+const h = vi.hoisted(() => {
+  const noop = () => undefined
+
+  return { api: new Proxy({}, { get: () => noop }), getSession: vi.fn(), noop, routes: vi.fn() }
+})
+
+vi.mock('@/hermes', async original => ({ ...(await original<typeof Hermes>()), getSession: h.getSession }))
+vi.mock('@/store/profile', async original => ({ ...(await original<typeof Profile>()), refreshActiveProfile: h.noop }))
+vi.mock('@/app/gateway/hooks/use-gateway-boot', () => ({ useGatewayBoot: h.noop }))
+vi.mock('@/app/contrib/hooks/use-background-sync', () => ({ useBackgroundSync: h.noop }))
+vi.mock('@/app/contrib/hooks/use-desktop-integrations', () => ({ useDesktopIntegrations: h.noop }))
+vi.mock('@/app/contrib/hooks/use-pet-bridge', () => ({ usePetBridge: h.noop }))
+vi.mock('@/app/contrib/hooks/use-quick-entry-bridge', () => ({ useQuickEntryBridge: h.noop }))
+vi.mock('@/app/contrib/hooks/use-session-tile-delegate', () => ({ useSessionTileDelegate: h.noop }))
+vi.mock('@/app/session/hooks/use-context-suggestions', () => ({ useContextSuggestions: h.noop }))
+vi.mock('@/app/session/hooks/use-background-queue-drain', () => ({ useBackgroundQueueDrain: h.noop }))
+vi.mock('@/app/session/hooks/use-route-resume', () => ({ useRouteResume: h.noop }))
+vi.mock('@/app/session/hooks/use-session-actions', () => ({ useSessionActions: () => h.api }))
+vi.mock('@/app/session/hooks/use-session-list-actions', () => ({ useSessionListActions: () => h.api }))
+vi.mock('@/app/session/hooks/use-hermes-config', () => ({ useHermesConfig: () => h.api }))
+vi.mock('@/app/session/hooks/use-model-controls', () => ({ useModelControls: () => h.api }))
+vi.mock('@/app/session/hooks/use-message-stream', () => ({ useMessageStream: () => h.api }))
+vi.mock('@/app/session/hooks/use-preview-routing', () => ({ usePreviewRouting: () => h.api }))
+vi.mock('@/app/session/hooks/use-prompt-actions', () => ({ usePromptActions: () => h.api }))
+vi.mock('@/app/chat/hooks/use-composer-actions', () => ({ useComposerActions: () => h.api }))
+vi.mock('@/app/hooks/use-config-record', () => ({ useHermesConfigRecord: () => ({ isPending: true }) }))
+vi.mock('@/app/hooks/use-keybinds', () => ({ useKeybinds: h.noop }))
+vi.mock('@/app/hud/handoff', () => ({ useHudHandoff: h.noop }))
+vi.mock('@/app/contrib/dev/credits-notice-demo', () => ({ installCreditsNoticeDemo: h.noop }))
+vi.mock('@/components/boot-failure-overlay', () => ({ BootFailureOverlay: () => null }))
+vi.mock('@/components/confirm-host', () => ({ ConfirmHost: () => null }))
+vi.mock('@/components/desktop-install-overlay', () => ({ DesktopInstallOverlay: () => null }))
+vi.mock('@/components/find-bar', () => ({ FindBar: () => null }))
+vi.mock('@/components/gateway-connecting-overlay', () => ({ GatewayConnectingOverlay: () => null }))
+vi.mock('@/components/notifications', () => ({ NotificationStack: () => null }))
+vi.mock('@/components/onboarding', () => ({ DesktopOnboardingOverlay: () => null }))
+vi.mock('@/components/pet/floating-pet', () => ({ FloatingPet: () => null }))
+vi.mock('@/components/remote-display-banner', () => ({ RemoteDisplayBanner: () => null }))
+vi.mock('@/components/send-diagnostics-dialog', () => ({ SendDiagnosticsHost: () => null }))
+vi.mock('@/components/tips', () => ({ TipHost: () => null }))
+vi.mock('@/app/command-palette', () => ({ CommandPalette: () => null }))
+vi.mock('@/app/model-picker-overlay', () => ({ ModelPickerOverlay: () => null }))
+vi.mock('@/app/model-visibility-overlay', () => ({ ModelVisibilityOverlay: () => null }))
+vi.mock('@/app/pet-generate/pet-generate-overlay', () => ({ PetGenerateOverlay: () => null }))
+vi.mock('@/app/right-sidebar/file-actions', () => ({ FileActionDialogs: () => null }))
+vi.mock('@/app/right-sidebar/files/remote-picker', () => ({ RemoteFolderPicker: () => null }))
+vi.mock('@/app/right-sidebar/terminal/persistent', () => ({ PersistentTerminal: () => null }))
+vi.mock('@/app/session-picker-overlay', () => ({ SessionPickerOverlay: () => null }))
+vi.mock('@/app/session-switcher', () => ({ SessionSwitcher: () => null }))
+vi.mock('@/app/settings/plugin-install-modal', () => ({ PluginInstallModal: () => null }))
+vi.mock('@/app/shell/titlebar-controls', () => ({ TitlebarControls: () => null }))
+vi.mock('@/app/updates-overlay', () => ({ UpdatesOverlay: () => null }))
+vi.mock('@/app/contrib/mcp-install-deeplink-dialog', () => ({ McpInstallDeepLinkDialog: () => null }))
+vi.mock('@/app/contrib/surfaces', () => ({
+  ChatRoutesSurface: () => null,
+  SidebarSurface: () => null,
+  StatusbarSurface: () => null,
+  TerminalSurface: () => null
+}))
+
+import { group, split } from '@/components/pane-shell/tree/model'
+import {
+  $activeTreeGroup,
+  $hiddenTreePanes,
+  $layoutTree,
+  noteActiveTreeGroup
+} from '@/components/pane-shell/tree/store'
+import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
+import { registry } from '@/contrib/registry'
+import type * as Hermes from '@/hermes'
+import type * as Profile from '@/store/profile'
+import { $activeGatewayProfile, $showAllProfiles } from '@/store/profile'
+import {
+  $connection,
+  $messagingSessions,
+  $selectedStoredSessionId,
+  $sessionResumeRequest,
+  $sessions,
+  $unreadFinishedSessionIds,
+  _resetSessionOwnerHintsForTests,
+  getSessionOwnerHint,
+  requestSessionResume,
+  setSessionOwnerHint
+} from '@/store/session'
+import { $unreadSessionTargets } from '@/store/session-dot-state'
+import { $focusedStoredSessionId, $sessionTiles, clearAllSessionStates } from '@/store/session-states'
+import { $openNextUnreadRequest, requestOpenNextUnread } from '@/store/session-unread-navigation'
+import { $unreadWriteGuard } from '@/store/session-unread-remote'
+import type { SessionInfo } from '@/types/hermes'
+
+import { sessionRoute } from '../routes'
+
+import { ContribWiringContext } from './context'
+import type { SidebarActions } from './types'
+import { ContribWiring } from './wiring'
+
+const row = (id = 'unread', extra: Partial<SessionInfo> = {}): SessionInfo => ({
+  id,
+  profile: 'ops',
+  connection_id: 'source-a',
+  source: 'desktop',
+  title: id,
+  ended_at: null,
+  input_tokens: 0,
+  output_tokens: 0,
+  is_active: false,
+  model: null,
+  preview: null,
+  tool_call_count: 0,
+  started_at: 1,
+  last_active: 100,
+  message_count: 2,
+  unread: true,
+  ...extra
+})
+
+function Controls() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const api = useContext(ContribWiringContext)!
+  const actions = (api.sidebar as ReactElement<{ actions: SidebarActions }>).props.actions
+
+  return (
+    <>
+      <output data-testid="route">{location.pathname}</output>
+      <button onClick={requestOpenNextUnread}>Next unread</button>
+      <button onClick={() => navigate(sessionRoute('manual'))}>Manual selection</button>
+      <button onClick={() => navigate(sessionRoute('initial'))}>Return</button>
+      <button onClick={() => actions.onResumeSession('unread', row('unread', { connection_id: undefined }))}>
+        Ordinary row
+      </button>
+    </>
+  )
+}
+
+const mount = () =>
+  render(
+    <StrictMode>
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter initialEntries={[sessionRoute('initial')]}>
+          <ContribWiring>
+            <Controls />
+          </ContribWiring>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </StrictMode>
+  )
+
+const clickCount = () => fireEvent.click(screen.getByText('Next unread'))
+
+const flush = async () =>
+  act(async () => {
+    await Promise.resolve()
+  })
+
+const path = () => screen.getByTestId('route').textContent
+
+const setConnectionId = (connectionId: string) =>
+  $connection.set({
+    connectionId,
+    baseUrl: 'http://unused.invalid',
+    wsUrl: 'ws://unused.invalid',
+    token: '',
+    isFullscreen: false,
+    nativeOverlayWidth: 0,
+    logs: [],
+    windowButtonPosition: null
+  })
+
+function deferred() {
+  let resolve!: (value?: unknown) => void
+
+  const promise = new Promise(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+const disposers: (() => void)[] = []
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getSession.mockReset()
+  h.routes.mockReset()
+  window.hermesDesktop = { getProfileRoutes: h.routes } as unknown as typeof window.hermesDesktop
+  clearAllSessionStates()
+  $sessionTiles.set([])
+  _resetSessionOwnerHintsForTests()
+  $openNextUnreadRequest.set(0)
+  setConnectionId('primary')
+  $activeGatewayProfile.set('default')
+  $showAllProfiles.set(true)
+  setWorkspaceScope('sessions')
+  $selectedStoredSessionId.set('initial')
+  $sessionResumeRequest.set(null)
+  $sessions.set([row()])
+  $messagingSessions.set([])
+  $unreadFinishedSessionIds.set(['unread'])
+  $unreadWriteGuard.set(new Map())
+  $hiddenTreePanes.set(new Set())
+
+  for (const id of ['sessions', 'workspace', 'session-tile:unread', 'session-tile:root']) {
+    disposers.push(registry.register({ area: 'panes', id, data: { placement: 'main' }, render: () => null }))
+  }
+
+  $layoutTree.set(split('row', [group(['sessions']), group(['workspace'])]))
+  $activeTreeGroup.set(null)
+  h.routes.mockResolvedValue([])
+  h.getSession.mockResolvedValue({ session: row(), messages: [] })
+})
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+describe('mounted unread intent and routing', () => {
+  it.each([
+    'route',
+    'roundtrip',
+    'selection',
+    'resume',
+    'focus',
+    'workspace',
+    'workspace-owner',
+    'connection',
+    'profile',
+    'filter'
+  ])('does not publish a delayed preflight after newer %s intent', async change => {
+    const pending = deferred()
+    h.getSession.mockReturnValue(pending.promise)
+
+    if (change === 'workspace-owner') {
+      setWorkspaceScope('bots', 'source-a::ops')
+    }
+
+    mount()
+    clickCount()
+    await flush()
+    expect(h.getSession).toHaveBeenCalledOnce()
+    act(() => {
+      if (change === 'route' || change === 'roundtrip') {
+        fireEvent.click(screen.getByText('Manual selection'))
+      }
+
+      if (change === 'selection') {
+        $selectedStoredSessionId.set('manual')
+      }
+
+      if (change === 'resume') {
+        requestSessionResume('manual')
+      }
+
+      if (change === 'focus') {
+        const tileGroup = group(['session-tile:manual'])
+        $layoutTree.set(split('row', [group(['workspace']), tileGroup]))
+        noteActiveTreeGroup(tileGroup.id)
+        expect($focusedStoredSessionId.get()).toBe('manual')
+      }
+
+      if (change === 'workspace' || change === 'workspace-owner') {
+        setWorkspaceScope('bots', 'source-b::ops')
+      }
+
+      if (change === 'connection') {
+        setConnectionId('other')
+      }
+
+      if (change === 'profile') {
+        $activeGatewayProfile.set('other')
+      }
+
+      if (change === 'filter') {
+        $showAllProfiles.set(false)
+      }
+    })
+
+    if (change === 'roundtrip') {
+      fireEvent.click(screen.getByText('Return'))
+    }
+
+    const resume = $sessionResumeRequest.get()
+    await act(async () => pending.resolve({ session: row() }))
+    expect(path()).toBe(sessionRoute(change === 'route' ? 'manual' : 'initial'))
+    expect($sessionResumeRequest.get()).toBe(resume)
+    expect($unreadFinishedSessionIds.get()).toContain('unread')
+    expect(getSessionOwnerHint('unread')).toBeUndefined()
+  })
+
+  it('stops the probe ladder if a connection changes during registry lookup', async () => {
+    const pending = deferred()
+    h.routes.mockReturnValue(pending.promise)
+    mount()
+    clickCount()
+    act(() => setConnectionId('other'))
+    await act(async () => pending.resolve([]))
+    expect(h.getSession).not.toHaveBeenCalled()
+    expect(path()).toBe('/initial')
+  })
+
+  it('can accept a fresh intent while an invalidated request is still pending', async () => {
+    const old = deferred()
+    const fresh = deferred()
+    h.getSession.mockReturnValueOnce(old.promise).mockReturnValueOnce(fresh.promise)
+    mount()
+    clickCount()
+    await flush()
+    fireEvent.click(screen.getByText('Manual selection'))
+    clickCount()
+    await flush()
+    expect(h.getSession).toHaveBeenCalledTimes(2)
+    await act(async () => old.resolve())
+    clickCount()
+    await flush()
+    expect(h.getSession).toHaveBeenCalledTimes(2)
+    await act(async () => fresh.resolve())
+    expect(path()).toBe('/unread')
+  })
+
+  it.each(['read', 'archive', 'remove'])('revalidates live target membership after %s', async change => {
+    const pending = deferred()
+    h.getSession.mockReturnValue(pending.promise)
+    mount()
+    clickCount()
+    await flush()
+    act(() => {
+      $sessions.set(
+        change === 'remove' ? [] : [row('unread', change === 'read' ? { unread: false } : { archived: true })]
+      )
+      $unreadFinishedSessionIds.set([])
+    })
+    expect($unreadSessionTargets.get()).toEqual([])
+    await act(async () => pending.resolve())
+    expect(path()).toBe('/initial')
+    expect($sessionResumeRequest.get()).toBeNull()
+  })
+
+  it.each(['Next unread', 'Ordinary row'])(
+    '%s clears a migrated owner hint and replaces the old resume intent',
+    async button => {
+      $sessions.set([row('unread', { connection_id: undefined })])
+      requestSessionResume('unread', { connectionId: 'stale-local', profile: 'ops' })
+      const previous = $sessionResumeRequest.get()
+      mount()
+      await act(async () => fireEvent.click(screen.getByText(button)))
+      expect(path()).toBe('/unread')
+      expect(getSessionOwnerHint('unread')).toBeUndefined()
+      expect($sessionResumeRequest.get()).toMatchObject({ sessionId: 'unread' })
+      expect($sessionResumeRequest.get()?.ownerRoute).toBeUndefined()
+      expect($sessionResumeRequest.get()).not.toBe(previous)
+    }
+  )
+
+  it('coalesces pending count clicks and preserves exact alias routing', async () => {
+    const pending = deferred()
+    h.getSession.mockReturnValue(pending.promise)
+    h.routes.mockResolvedValue([{ connectionId: 'source-a', profile: 'ops', targetProfile: 'backend-ops' }])
+    mount()
+    clickCount()
+    await flush()
+    clickCount()
+    expect(h.getSession).toHaveBeenCalledOnce()
+    expect(h.getSession).toHaveBeenCalledWith('unread', { connectionId: 'source-a', profile: 'backend-ops' })
+    await act(async () => pending.resolve())
+    expect($sessionResumeRequest.get()?.ownerRoute).toEqual({
+      connectionId: 'source-a',
+      profile: 'ops',
+      targetProfile: 'backend-ops'
+    })
+    expect(path()).toBe('/unread')
+  })
+
+  it('does not replay or accept late completion across a real remount', async () => {
+    const pending = deferred()
+    h.getSession.mockReturnValue(pending.promise)
+    const first = mount()
+    clickCount()
+    await flush()
+    first.unmount()
+    mount()
+    await act(async () => pending.resolve())
+    expect(h.getSession).toHaveBeenCalledOnce()
+    expect(path()).toBe('/initial')
+    expect($unreadFinishedSessionIds.get()).toContain('unread')
+  })
+
+  it('retains the primary profile-first ladder and exact registry fallback', async () => {
+    $sessions.set([row('unread', { connection_id: undefined })])
+    h.routes.mockResolvedValue([{ connectionId: 'primary', profile: 'ops', targetProfile: 'backend-ops' }])
+    h.getSession.mockRejectedValueOnce(new Error('profile route unavailable'))
+    mount()
+    await act(async () => clickCount())
+    expect(h.getSession.mock.calls).toEqual([
+      ['unread', 'ops'],
+      ['unread', { connectionId: 'primary', profile: 'backend-ops' }]
+    ])
+    expect($sessionResumeRequest.get()?.ownerRoute).toEqual({
+      connectionId: 'primary',
+      profile: 'ops',
+      targetProfile: 'backend-ops'
+    })
+    expect(path()).toBe('/unread')
+  })
+
+  it('does not acknowledge an already-selected main ID whose hydrated owner is unproven', async () => {
+    $selectedStoredSessionId.set('unread')
+    $unreadFinishedSessionIds.set(['unread'])
+    mount()
+    await act(async () => clickCount())
+    expect(path()).toBe('/initial')
+    expect($sessionResumeRequest.get()).toBeNull()
+    expect($unreadFinishedSessionIds.get()).toContain('unread')
+  })
+
+  it('selects the unread source, not its newer read twin', async () => {
+    $sessions.set([row(), row('unread', { connection_id: 'source-b', last_active: 200, unread: false })])
+    $unreadFinishedSessionIds.set([])
+    mount()
+    await act(async () => clickCount())
+    expect(h.getSession.mock.calls).toEqual([['unread', { connectionId: 'source-a', profile: 'ops' }]])
+    expect($sessionResumeRequest.get()?.ownerRoute?.connectionId).toBe('source-a')
+  })
+
+  it.each(['wrong-owner', 'unknown-owner', 'ownerless-probe', 'lineage'])(
+    'skips an ambiguous open tile (%s) without focus, ack, or owner mutation',
+    async kind => {
+      const tileId = kind === 'lineage' ? 'root' : 'unread'
+      const ownerRoute = kind === 'unknown-owner' ? undefined : { connectionId: 'source-b', profile: 'ops' }
+      $sessionTiles.set([{ storedSessionId: tileId, ownerRoute, workspaceMode: 'sessions' }])
+
+      if (kind === 'ownerless-probe') {
+        $sessions.set([row('unread', { connection_id: undefined })])
+      }
+
+      if (kind === 'lineage') {
+        $sessions.set([row('unread', { _lineage_root_id: 'root' })])
+      }
+
+      $layoutTree.set(split('row', [group(['sessions']), group(['workspace', `session-tile:${tileId}`])]))
+      $unreadFinishedSessionIds.set(['unread'])
+      const tiles = $sessionTiles.get()
+      const currentHint = { connectionId: 'source-b', profile: 'ops' }
+      setSessionOwnerHint('unread', currentHint)
+      mount()
+      expect($unreadFinishedSessionIds.get()).toContain('unread')
+      await act(async () => clickCount())
+      expect(path()).toBe('/initial')
+      expect($activeTreeGroup.get()).toBeNull()
+      expect($focusedStoredSessionId.get()).toBe('initial')
+      expect($unreadFinishedSessionIds.get()).toContain('unread')
+      expect($sessionResumeRequest.get()).toBeNull()
+      expect($sessionTiles.get()).toBe(tiles)
+      expect(getSessionOwnerHint('unread')).toEqual(currentHint)
+    }
+  )
+
+  it('still focuses a tile whose exact owner matches the preflight', async () => {
+    $sessionTiles.set([
+      { storedSessionId: 'unread', ownerRoute: { connectionId: 'source-a', profile: 'ops' }, workspaceMode: 'sessions' }
+    ])
+    $layoutTree.set(split('row', [group(['sessions']), group(['workspace', 'session-tile:unread'])]))
+    mount()
+    await act(async () => clickCount())
+    expect(path()).toBe('/initial')
+    expect($focusedStoredSessionId.get()).toBe('unread')
+    expect($unreadFinishedSessionIds.get()).not.toContain('unread')
+  })
+
+  it('falls through an ambiguous tile and a failed owner without acknowledging either', async () => {
+    $sessionTiles.set([{ storedSessionId: 'unread', ownerRoute: { connectionId: 'source-b', profile: 'ops' } }])
+    $sessions.set([row(), row('offline', { last_active: 50 }), row('available', { last_active: 10 })])
+    $unreadFinishedSessionIds.set(['unread', 'offline', 'available'])
+    h.getSession.mockImplementation(async id => {
+      if (id === 'offline') {
+        throw new Error('offline')
+      }
+
+      return { session: row(id) }
+    })
+    mount()
+    await act(async () => clickCount())
+    expect(path()).toBe('/available')
+    expect($unreadFinishedSessionIds.get()).toEqual(['unread', 'offline'])
+  })
+})

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -22,7 +22,7 @@ import { FindBar } from '@/components/find-bar'
 import { GatewayConnectingOverlay } from '@/components/gateway-connecting-overlay'
 import { NotificationStack } from '@/components/notifications'
 import { DesktopOnboardingOverlay } from '@/components/onboarding'
-import { $newSessionTabAction, registerPaneCloser, revealTreePane } from '@/components/pane-shell/tree/store'
+import { $newSessionTabAction, registerPaneCloser } from '@/components/pane-shell/tree/store'
 import {
   $workspaceMode,
   $workspaceNewSessionTarget,
@@ -34,7 +34,7 @@ import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { SendDiagnosticsHost } from '@/components/send-diagnostics-dialog'
 import { TipHost } from '@/components/tips'
 import { emitGatewayEvent } from '@/contrib/events'
-import { getLatestSessionMessages, getSession } from '@/hermes'
+import { getLatestSessionMessages } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
@@ -81,13 +81,6 @@ import {
   setBusy,
   setMessages
 } from '@/store/session'
-import { $unreadSessionTargets } from '@/store/session-dot-state'
-import {
-  $openNextUnreadRequest,
-  openNextValidUnread,
-  ownerRouteForUnreadTarget,
-  preflightCandidatesForUnreadTarget
-} from '@/store/session-unread-navigation'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
@@ -157,6 +150,7 @@ import { useDesktopIntegrations } from './hooks/use-desktop-integrations'
 import { usePetBridge } from './hooks/use-pet-bridge'
 import { useQuickEntryBridge } from './hooks/use-quick-entry-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
+import { useUnreadNavigation } from './hooks/use-unread-navigation'
 import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { createSessionRpcDispatcher } from './session-rpc-dispatcher'
@@ -184,83 +178,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const location = useLocation()
   const navigate = useNavigate()
 
-  const openNextUnreadPendingRef = useRef(false)
-  const openNextUnreadActiveRef = useRef(true)
-  const openNextUnreadRequest = useStore($openNextUnreadRequest)
-  // Start at the current counter so a genuine wiring remount cannot replay an
-  // intent that the previous mount already consumed.
-  const openNextUnreadSeenRef = useRef($openNextUnreadRequest.get())
-
-  // eslint-disable-next-line no-restricted-syntax -- mounted-lifetime sentinel for async completion, not an atom mirror
-  useEffect(() => {
-    openNextUnreadActiveRef.current = true
-
-    return () => {
-      openNextUnreadActiveRef.current = false
-      openNextUnreadPendingRef.current = false
-    }
-  }, [])
-
-  const openNextUnread = useCallback(() => {
-    // The count is first a reveal control: even if every target is stale or
-    // offline, leave the user looking at the Sessions list rather than a no-op.
-    revealTreePane('sessions')
-
-    if (openNextUnreadPendingRef.current) {
-      return
-    }
-
-    openNextUnreadPendingRef.current = true
-    const activeConnectionId = $activeConnectionId.get()
-    void openNextValidUnread(
-      $unreadSessionTargets.get(),
-      async target => {
-        const baseOwner = ownerRouteForUnreadTarget(target, activeConnectionId)
-
-        const registeredRoutes = baseOwner
-          ? await window.hermesDesktop.getProfileRoutes([baseOwner.profile]).catch(() => [])
-          : []
-
-        let lastError: unknown
-
-        for (const candidate of preflightCandidatesForUnreadTarget(target, activeConnectionId, registeredRoutes)) {
-          try {
-            await getSession(target.id, candidate.scope)
-
-            return candidate.ownerRoute
-          } catch (error) {
-            lastError = error
-          }
-        }
-
-        throw lastError
-      },
-      (target, ownerRoute) => {
-        if (!openNextUnreadActiveRef.current) {
-          return
-        }
-
-        if (ownerRoute) {
-          // Stamp the exact connection before navigation can trigger resume.
-          requestSessionResume(target.id, ownerRoute)
-        }
-
-        openSession(target.id, navigate)
-      }
-    ).finally(() => {
-      openNextUnreadPendingRef.current = false
-    })
-  }, [navigate])
-
-  // eslint-disable-next-line no-restricted-syntax -- one-shot request-seen sentinel, not an atom mirror
-  useEffect(() => {
-    if (openNextUnreadRequest === openNextUnreadSeenRef.current) {
-      return
-    }
-
-    openNextUnreadSeenRef.current = openNextUnreadRequest
-    openNextUnread()
-  }, [openNextUnread, openNextUnreadRequest])
+  useUnreadNavigation(navigate, `${location.key}:${location.pathname}:${location.search}:${location.hash}`)
 
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -22,7 +22,7 @@ import { FindBar } from '@/components/find-bar'
 import { GatewayConnectingOverlay } from '@/components/gateway-connecting-overlay'
 import { NotificationStack } from '@/components/notifications'
 import { DesktopOnboardingOverlay } from '@/components/onboarding'
-import { $newSessionTabAction, registerPaneCloser } from '@/components/pane-shell/tree/store'
+import { $newSessionTabAction, registerPaneCloser, revealTreePane } from '@/components/pane-shell/tree/store'
 import {
   $workspaceMode,
   $workspaceNewSessionTarget,
@@ -34,7 +34,7 @@ import { RemoteDisplayBanner } from '@/components/remote-display-banner'
 import { SendDiagnosticsHost } from '@/components/send-diagnostics-dialog'
 import { TipHost } from '@/components/tips'
 import { emitGatewayEvent } from '@/contrib/events'
-import { getLatestSessionMessages } from '@/hermes'
+import { getLatestSessionMessages, getSession } from '@/hermes'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMessagingSource } from '@/lib/session-source'
 import { latestSessionTodos } from '@/lib/todos'
@@ -81,6 +81,13 @@ import {
   setBusy,
   setMessages
 } from '@/store/session'
+import { $unreadSessionTargets } from '@/store/session-dot-state'
+import {
+  $openNextUnreadRequest,
+  openNextValidUnread,
+  ownerRouteForUnreadTarget,
+  preflightCandidatesForUnreadTarget
+} from '@/store/session-unread-navigation'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
@@ -176,6 +183,84 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient()
   const location = useLocation()
   const navigate = useNavigate()
+
+  const openNextUnreadPendingRef = useRef(false)
+  const openNextUnreadActiveRef = useRef(true)
+  const openNextUnreadRequest = useStore($openNextUnreadRequest)
+  // Start at the current counter so a genuine wiring remount cannot replay an
+  // intent that the previous mount already consumed.
+  const openNextUnreadSeenRef = useRef($openNextUnreadRequest.get())
+
+  // eslint-disable-next-line no-restricted-syntax -- mounted-lifetime sentinel for async completion, not an atom mirror
+  useEffect(() => {
+    openNextUnreadActiveRef.current = true
+
+    return () => {
+      openNextUnreadActiveRef.current = false
+      openNextUnreadPendingRef.current = false
+    }
+  }, [])
+
+  const openNextUnread = useCallback(() => {
+    // The count is first a reveal control: even if every target is stale or
+    // offline, leave the user looking at the Sessions list rather than a no-op.
+    revealTreePane('sessions')
+
+    if (openNextUnreadPendingRef.current) {
+      return
+    }
+
+    openNextUnreadPendingRef.current = true
+    const activeConnectionId = $activeConnectionId.get()
+    void openNextValidUnread(
+      $unreadSessionTargets.get(),
+      async target => {
+        const baseOwner = ownerRouteForUnreadTarget(target, activeConnectionId)
+
+        const registeredRoutes = baseOwner
+          ? await window.hermesDesktop.getProfileRoutes([baseOwner.profile]).catch(() => [])
+          : []
+
+        let lastError: unknown
+
+        for (const candidate of preflightCandidatesForUnreadTarget(target, activeConnectionId, registeredRoutes)) {
+          try {
+            await getSession(target.id, candidate.scope)
+
+            return candidate.ownerRoute
+          } catch (error) {
+            lastError = error
+          }
+        }
+
+        throw lastError
+      },
+      (target, ownerRoute) => {
+        if (!openNextUnreadActiveRef.current) {
+          return
+        }
+
+        if (ownerRoute) {
+          // Stamp the exact connection before navigation can trigger resume.
+          requestSessionResume(target.id, ownerRoute)
+        }
+
+        openSession(target.id, navigate)
+      }
+    ).finally(() => {
+      openNextUnreadPendingRef.current = false
+    })
+  }, [navigate])
+
+  // eslint-disable-next-line no-restricted-syntax -- one-shot request-seen sentinel, not an atom mirror
+  useEffect(() => {
+    if (openNextUnreadRequest === openNextUnreadSeenRef.current) {
+      return
+    }
+
+    openNextUnreadSeenRef.current = openNextUnreadRequest
+    openNextUnread()
+  }, [openNextUnread, openNextUnreadRequest])
 
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)

--- a/apps/desktop/src/app/shell/narrow-unread-owner.test.tsx
+++ b/apps/desktop/src/app/shell/narrow-unread-owner.test.tsx
@@ -1,0 +1,146 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
+import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
+import { group, split } from '@/components/pane-shell/tree/model'
+import { NarrowOverlays } from '@/components/pane-shell/tree/renderer/narrow-overlays'
+import { $hiddenStripTabs, $hiddenTreePanes, $layoutTree, $narrowViewport } from '@/components/pane-shell/tree/store'
+import { $workspaceMode } from '@/components/pane-shell/workspace-scope'
+import { registry } from '@/contrib/registry'
+import { $panesFlipped, setFileBrowserOpen, setSidebarOpen } from '@/store/layout'
+import { stubResizeObserver } from '@/test/jsdom'
+
+import { SessionsTabTitle } from './sessions-tab-title'
+import { TitlebarControls } from './titlebar-controls'
+
+vi.mock('@/store/session-dot-state', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $unreadSessionCount: atom(3) }
+})
+
+// Review B's rendered narrow repro, extended to require exactly one owner
+// across reveal, close and breakpoint transitions, including flipped layouts.
+const open = vi.fn()
+const disposers: (() => void)[] = []
+
+const register = (id: string, placement: string, collapsible = true) => {
+  disposers.push(
+    registry.register({
+      area: 'panes',
+      id,
+      title: id,
+      data: {
+        placement,
+        collapsible,
+        width: '237px',
+        ...(id === 'sessions'
+          ? {
+              hideOnly: true,
+              revealAliases: ['chat-sidebar'],
+              tabTitle: () => <SessionsTabTitle onOpenNextUnread={open} unread={3} />
+            }
+          : {})
+      },
+      render: () => <div data-testid={`${id}-body`}>{id}</div>
+    })
+  )
+}
+
+const reveal = (id = 'sessions') =>
+  act(() => {
+    window.dispatchEvent(new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id, mode: 'open' } }))
+  })
+
+const count = () => screen.getAllByRole('button', { name: /3 unread sessions/ })
+
+const mount = () =>
+  render(
+    <MemoryRouter>
+      <TitlebarControls onOpenSettings={vi.fn()} />
+      <NarrowOverlays />
+    </MemoryRouter>
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  stubResizeObserver()
+  vi.stubGlobal('matchMedia', (media: string) => ({
+    matches: media === SIDEBAR_COLLAPSE_MEDIA_QUERY && $narrowViewport.get(),
+    media,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn()
+  }))
+  $workspaceMode.set('sessions')
+  $panesFlipped.set(false)
+  $hiddenTreePanes.set(new Set())
+  $hiddenStripTabs.set(new Set())
+  setSidebarOpen(true)
+  setFileBrowserOpen(true)
+  $narrowViewport.set(true)
+})
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+  $narrowViewport.set(false)
+  $layoutTree.set(null)
+  vi.unstubAllGlobals()
+})
+
+describe('narrow unread affordance', () => {
+  it.each([false, true])('hands off one count between titlebar and single-pane overlay (flipped=%s)', flipped => {
+    $panesFlipped.set(flipped)
+    register('sessions', 'left')
+    register('workspace', 'main', false)
+    $layoutTree.set(split('row', [group(['sessions']), group(['workspace'])]))
+    mount()
+    expect(screen.queryByTestId('sessions-body')).toBeNull()
+    expect(count()).toHaveLength(1)
+    expect(count()[0].getAttribute('aria-label')).toMatch(/show/i)
+    fireEvent.click(count()[0])
+    expect(screen.getByTestId('sessions-body')).toBeDefined()
+    expect(count()).toHaveLength(1)
+    fireEvent.click(count()[0])
+    expect(open).toHaveBeenCalledOnce()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByTestId('sessions-body')).toBeNull()
+    expect(count()).toHaveLength(1)
+    act(() => $narrowViewport.set(false))
+    expect(screen.queryByRole('button', { name: /3 unread sessions/ })).toBeNull()
+    act(() => $narrowViewport.set(true))
+    expect(count()).toHaveLength(1)
+  })
+
+  it('keeps one live count in a shared overlay without activating Bots on count clicks', () => {
+    register('sessions', 'left')
+    register('bots', 'left')
+    register('workspace', 'main', false)
+    $layoutTree.set(split('row', [group(['sessions', 'bots']), group(['workspace'])]))
+    mount()
+    reveal('bots')
+    expect(count()).toHaveLength(1)
+    fireEvent.pointerDown(count()[0], { button: 0, pointerType: 'touch' })
+    fireEvent.click(count()[0], { detail: 0 })
+    expect(open).toHaveBeenCalledOnce()
+    expect(screen.getByTestId('bots-body')).toBeDefined()
+  })
+
+  it.each(['bots', 'terminal'])('does not put a Sessions count on a narrow %s toggle', active => {
+    register('sessions', 'left')
+    register(active, 'left')
+    register('workspace', 'main', false)
+    $layoutTree.set(split('row', [group(['sessions', active], { active }), group(['workspace'])]))
+
+    if (active === 'bots') {
+      $workspaceMode.set('bots')
+    }
+
+    mount()
+    expect(screen.queryByRole('button', { name: /3 unread sessions/ })).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/sessions-tab-title.test.tsx
+++ b/apps/desktop/src/app/shell/sessions-tab-title.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SessionsTabTitle } from './sessions-tab-title'
+
+// The Sessions pane tab carries the unread count as a visible node plus an
+// accessible label. Zero must render no count node at all (not "0" — the tab
+// is just "sessions"); any nonzero count renders the number with both
+// an aria-label so assistive tech names the count action.
+
+const renderTitle = (unread: number, onOpenNextUnread = vi.fn()) =>
+  render(<SessionsTabTitle onOpenNextUnread={onOpenNextUnread} unread={unread} />)
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('SessionsTabTitle', () => {
+  it('renders only the sessions label when nothing is unread', () => {
+    const { container } = renderTitle(0)
+
+    expect(screen.getByText('sessions')).toBeDefined()
+    expect(container.querySelector('[aria-label]')).toBeNull()
+    expect(container.textContent).not.toContain('0')
+  })
+
+  it('exposes the visible count with an accessible label when sessions are unread', () => {
+    renderTitle(12)
+
+    const count = screen.getByRole('button', { name: '12 unread sessions' })
+    expect(count.textContent).toBe('12')
+    expect(screen.getByText('sessions')).toBeDefined()
+  })
+
+  it('labels a single unread session in singular', () => {
+    renderTitle(1)
+
+    expect(screen.getByLabelText('1 unread session').textContent).toBe('1')
+  })
+
+  it('reserves two digit slots so crossing 9 → 10 does not reflow the tab', () => {
+    // The count span keeps its box through the 1-to-2 digit transition; the
+    // reserved width is asserted on the class contract rather than layout.
+    const single = renderTitle(9)
+    const singleCount = screen.getByLabelText('9 unread sessions') as HTMLElement
+    expect(singleCount.className).toContain('min-w-[2ch]')
+    single.unmount()
+    cleanup()
+
+    renderTitle(10)
+    const doubleCount = screen.getByLabelText('10 unread sessions') as HTMLElement
+    expect(doubleCount.className).toBe(singleCount.className)
+  })
+
+  it('opens the newest unread without turning the count into a pane drag or tab select', () => {
+    const onOpenNextUnread = vi.fn()
+    const onParentClick = vi.fn()
+    const onParentPointerDown = vi.fn()
+
+    render(
+      <div onClick={onParentClick} onPointerDown={onParentPointerDown}>
+        <SessionsTabTitle onOpenNextUnread={onOpenNextUnread} unread={3} />
+      </div>
+    )
+
+    const count = screen.getByRole('button', { name: '3 unread sessions' })
+    fireEvent.pointerDown(count)
+    fireEvent.click(count)
+
+    expect(onOpenNextUnread).toHaveBeenCalledOnce()
+    expect(onParentPointerDown).not.toHaveBeenCalled()
+    expect(onParentClick).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/shell/sessions-tab-title.tsx
+++ b/apps/desktop/src/app/shell/sessions-tab-title.tsx
@@ -1,0 +1,38 @@
+import { translateNow } from '@/i18n'
+import { compactNumber } from '@/lib/format'
+
+interface SessionsTabTitleProps {
+  /** Live unread count — subscribed by the caller, so this stays a pure
+   *  presentational component that render tests can drive directly. */
+  unread: number
+  onOpenNextUnread: () => void
+}
+
+/** An unread count is navigation, not layout state. Keep it on the Sessions
+ *  tab while the sidebar is visible; the titlebar reveal control takes over
+ *  only while the whole sidebar is hidden. */
+export function SessionsTabTitle({ onOpenNextUnread, unread }: SessionsTabTitleProps) {
+  const unreadLabel = unread > 0 ? translateNow('titlebar.unreadSessions', unread) : ''
+
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1.5">
+      <span>sessions</span>
+      {unread > 0 ? (
+        // Reserve two digit slots (tabular-nums equalizes digit widths, not
+        // the node's own box) so 9 → 10 doesn't re-flow the tab label.
+        <button
+          aria-label={unreadLabel}
+          className="inline-block min-w-[2ch] shrink-0 text-center text-(--ui-accent) tabular-nums outline-none hover:bg-(--chrome-action-hover) focus-visible:ring-1 focus-visible:ring-(--ui-accent)"
+          onClick={event => {
+            event.stopPropagation()
+            onOpenNextUnread()
+          }}
+          onPointerDown={event => event.stopPropagation()}
+          type="button"
+        >
+          {compactNumber(unread)}
+        </button>
+      ) : null}
+    </span>
+  )
+}

--- a/apps/desktop/src/app/shell/titlebar-controls.test.ts
+++ b/apps/desktop/src/app/shell/titlebar-controls.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { unreadBadgeForEdge } from './titlebar-controls'
+
+describe('unreadBadgeForEdge', () => {
+  it('does not put an unread badge on a visible sidebar hide control', () => {
+    expect(unreadBadgeForEdge('left', false, true, 3, true, true)).toBeUndefined()
+  })
+
+  it('puts the count on the control that reveals a hidden Sessions sidebar', () => {
+    expect(unreadBadgeForEdge('left', false, false, 3, true, true)).toBe(3)
+    expect(unreadBadgeForEdge('right', false, false, 3, true, true)).toBeUndefined()
+  })
+
+  it('follows the Sessions sidebar when pane sides are flipped', () => {
+    expect(unreadBadgeForEdge('left', true, false, 3, true, true)).toBeUndefined()
+    expect(unreadBadgeForEdge('right', true, false, 3, true, true)).toBe(3)
+  })
+
+  it('hides empty counts', () => {
+    expect(unreadBadgeForEdge('left', false, false, 0, true, true)).toBeUndefined()
+  })
+
+  it.each([
+    { edgeOpen: true, flipped: false },
+    { edgeOpen: false, flipped: false },
+    { edgeOpen: false, flipped: true }
+  ])('never badges a sidebar control in the Bots workspace', ({ edgeOpen, flipped }) => {
+    expect(unreadBadgeForEdge(flipped ? 'right' : 'left', flipped, edgeOpen, 3, false, false)).toBeUndefined()
+  })
+
+  it.each([
+    { edgeOpen: true, flipped: false },
+    { edgeOpen: false, flipped: false },
+    { edgeOpen: false, flipped: true }
+  ])('never badges while Bots or Terminal owns the shared sidebar group', ({ edgeOpen, flipped }) => {
+    expect(unreadBadgeForEdge(flipped ? 'right' : 'left', flipped, edgeOpen, 3, true, false)).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -5,11 +5,8 @@ import { useLocation, useNavigate } from 'react-router'
 import { hudTargetSessionId } from '@/app/hud/handoff'
 import { toggleLayoutEditMode } from '@/components/pane-shell/edit-mode'
 import { isPaneActiveInLayoutGroup } from '@/components/pane-shell/tree/model'
-import {
-  $hiddenStripTabs,
-  $layoutTree,
-  resetLayoutTree
-} from '@/components/pane-shell/tree/store'
+import { $narrowOverlayChrome } from '@/components/pane-shell/tree/renderer/narrow-overlay-state'
+import { $hiddenStripTabs, $layoutTree, $narrowViewport, resetLayoutTree } from '@/components/pane-shell/tree/store'
 import { $workspaceMode } from '@/components/pane-shell/workspace-scope'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -163,6 +160,8 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const fileBrowserOpen = useStore($fileBrowserOpen)
   const hiddenStripTabs = useStore($hiddenStripTabs)
   const layoutTree = useStore($layoutTree)
+  const narrow = useStore($narrowViewport)
+  const narrowOverlay = useStore($narrowOverlayChrome)
   const panesFlipped = useStore($panesFlipped)
   const sidebarOpen = useStore($sidebarOpen)
   const unreadCount = useStore($unreadSessionCount)
@@ -188,13 +187,17 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   // show/hide affordances.
   const leftEdge = { open: sidebarOpen, toggle: toggleSidebarOpen }
   const rightEdge = { open: fileBrowserOpen, toggle: toggleFileBrowserOpen }
-  const leftLabel = leftEdge.open ? t.titlebar.hideSidebar : t.titlebar.showSidebar
-  const rightLabel = rightEdge.open ? t.titlebar.hideRightSidebar : t.titlebar.showRightSidebar
+  // Narrow toggles use fixed reveal aliases (chat-sidebar / file-browser),
+  // independent of the wide tree's physical flip and docked-open flags.
+  const leftVisible = narrow ? narrowOverlay?.paneId === 'sessions' : leftEdge.open
+  const rightVisible = narrow ? narrowOverlay?.paneId === 'files' : rightEdge.open
+  const leftLabel = leftVisible ? t.titlebar.hideSidebar : t.titlebar.showSidebar
+  const rightLabel = rightVisible ? t.titlebar.hideRightSidebar : t.titlebar.showRightSidebar
 
   const leftUnreadBadge = unreadBadgeForEdge(
     'left',
-    panesFlipped,
-    leftEdge.open,
+    narrow ? false : panesFlipped,
+    narrow ? !!narrowOverlay?.tabIds.includes('sessions') : leftEdge.open,
     unreadCount,
     workspaceMode === 'sessions',
     sessionsPaneActive
@@ -202,8 +205,8 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   const rightUnreadBadge = unreadBadgeForEdge(
     'right',
-    panesFlipped,
-    rightEdge.open,
+    narrow ? false : panesFlipped,
+    narrow ? !!narrowOverlay?.tabIds.includes('sessions') : rightEdge.open,
     unreadCount,
     workspaceMode === 'sessions',
     sessionsPaneActive

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -4,7 +4,13 @@ import { useLocation, useNavigate } from 'react-router'
 
 import { hudTargetSessionId } from '@/app/hud/handoff'
 import { toggleLayoutEditMode } from '@/components/pane-shell/edit-mode'
-import { resetLayoutTree } from '@/components/pane-shell/tree/store'
+import { isPaneActiveInLayoutGroup } from '@/components/pane-shell/tree/model'
+import {
+  $hiddenStripTabs,
+  $layoutTree,
+  resetLayoutTree
+} from '@/components/pane-shell/tree/store'
+import { $workspaceMode } from '@/components/pane-shell/workspace-scope'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
@@ -58,6 +64,25 @@ export interface TitlebarTool {
 
 export type TitlebarToolSide = 'left' | 'right'
 export type SetTitlebarToolGroup = (id: string, tools: readonly TitlebarTool[], side?: TitlebarToolSide) => void
+
+/** The unread count belongs only on a control proven to reveal Sessions.
+ *  Bots and Terminal can share the same sidebar group, so edge position and
+ *  visibility are not enough: Sessions must also own the active tab in the
+ *  Sessions workspace. */
+export function unreadBadgeForEdge(
+  edge: TitlebarToolSide,
+  panesFlipped: boolean,
+  edgeOpen: boolean,
+  unreadCount: number,
+  workspaceIsSessions: boolean,
+  sessionsPaneActive: boolean
+): number | undefined {
+  const sessionsEdge: TitlebarToolSide = panesFlipped ? 'right' : 'left'
+
+  return edge === sessionsEdge && !edgeOpen && workspaceIsSessions && sessionsPaneActive && unreadCount > 0
+    ? unreadCount
+    : undefined
+}
 
 interface TitlebarControlsProps extends ComponentProps<'div'> {
   leftTools?: readonly TitlebarTool[]
@@ -136,11 +161,13 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const modHeld = useModifierHeld()
   const hapticsMuted = useStore($hapticsMuted)
   const fileBrowserOpen = useStore($fileBrowserOpen)
+  const hiddenStripTabs = useStore($hiddenStripTabs)
+  const layoutTree = useStore($layoutTree)
   const panesFlipped = useStore($panesFlipped)
   const sidebarOpen = useStore($sidebarOpen)
   const unreadCount = useStore($unreadSessionCount)
-  const unreadBadge = unreadCount > 0 ? unreadCount : undefined
-  const unreadHint = unreadBadge ? ` · ${t.titlebar.unreadSessions(unreadBadge)}` : ''
+  const workspaceMode = useStore($workspaceMode)
+  const sessionsPaneActive = isPaneActiveInLayoutGroup(layoutTree, hiddenStripTabs, 'sessions')
 
   const toggleHaptics = () => {
     if (!hapticsMuted) {
@@ -164,13 +191,33 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
   const leftLabel = leftEdge.open ? t.titlebar.hideSidebar : t.titlebar.showSidebar
   const rightLabel = rightEdge.open ? t.titlebar.hideRightSidebar : t.titlebar.showRightSidebar
 
+  const leftUnreadBadge = unreadBadgeForEdge(
+    'left',
+    panesFlipped,
+    leftEdge.open,
+    unreadCount,
+    workspaceMode === 'sessions',
+    sessionsPaneActive
+  )
+
+  const rightUnreadBadge = unreadBadgeForEdge(
+    'right',
+    panesFlipped,
+    rightEdge.open,
+    unreadCount,
+    workspaceMode === 'sessions',
+    sessionsPaneActive
+  )
+
+  const unreadHint = (count: number | undefined) => (count ? ` · ${t.titlebar.unreadSessions(count)}` : '')
+
   const leftToolbarTools: TitlebarTool[] = [
     {
       actionId: 'view.toggleSidebar',
-      badge: panesFlipped ? undefined : unreadBadge,
+      badge: leftUnreadBadge,
       icon: <TitlebarIcon name="layout-sidebar-left" />,
       id: 'sidebar',
-      label: `${leftLabel}${panesFlipped ? '' : unreadHint}`,
+      label: `${leftLabel}${unreadHint(leftUnreadBadge)}`,
       onSelect: () => {
         triggerHaptic('tap')
         leftEdge.toggle()
@@ -191,10 +238,10 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   const rightSidebarTool: TitlebarTool = {
     actionId: 'view.toggleRightSidebar',
-    badge: panesFlipped ? unreadBadge : undefined,
+    badge: rightUnreadBadge,
     icon: <TitlebarIcon name="layout-sidebar-right" />,
     id: 'right-sidebar',
-    label: `${rightLabel}${panesFlipped ? unreadHint : ''}`,
+    label: `${rightLabel}${unreadHint(rightUnreadBadge)}`,
     onSelect: () => {
       triggerHaptic('tap')
       rightEdge.toggle()

--- a/apps/desktop/src/app/shell/titlebar-unread-owner.test.tsx
+++ b/apps/desktop/src/app/shell/titlebar-unread-owner.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { group, split } from '@/components/pane-shell/tree/model'
+import { $hiddenStripTabs, $layoutTree } from '@/components/pane-shell/tree/store'
+import { $workspaceMode } from '@/components/pane-shell/workspace-scope'
+import { $panesFlipped, setFileBrowserOpen, setSidebarOpen } from '@/store/layout'
+
+import { TitlebarControls } from './titlebar-controls'
+
+vi.mock('@/store/session-dot-state', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $unreadSessionCount: atom(3) }
+})
+
+const renderControls = () =>
+  render(
+    <MemoryRouter>
+      <TitlebarControls onOpenSettings={vi.fn()} />
+    </MemoryRouter>
+  )
+
+beforeEach(() => {
+  $workspaceMode.set('sessions')
+  $panesFlipped.set(false)
+  setSidebarOpen(true)
+  setFileBrowserOpen(true)
+  $hiddenStripTabs.set(new Set())
+  $layoutTree.set(split('row', [group(['sessions', 'bots', 'terminal']), group(['workspace'])]))
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('rendered unread badge ownership', () => {
+  it('does not attach a count to the visible sidebar hide button', () => {
+    renderControls()
+
+    expect(screen.queryByRole('button', { name: /3 unread sessions/ })).toBeNull()
+  })
+
+  it('does not label a Bots workspace toggle with a Sessions count', () => {
+    $workspaceMode.set('bots')
+    setSidebarOpen(false)
+    renderControls()
+
+    expect(screen.queryByRole('button', { name: /3 unread sessions/ })).toBeNull()
+  })
+
+  it('does not label a Terminal reveal control with a Sessions count', () => {
+    $layoutTree.set(split('row', [group(['sessions', 'terminal'], { active: 'terminal' }), group(['workspace'])]))
+    setSidebarOpen(false)
+    renderControls()
+
+    expect(screen.queryByRole('button', { name: /3 unread sessions/ })).toBeNull()
+  })
+
+  it.each([false, true])('puts one count on the hidden Sessions reveal control (flipped=%s)', flipped => {
+    $panesFlipped.set(flipped)
+    setSidebarOpen(flipped)
+    setFileBrowserOpen(!flipped)
+    renderControls()
+
+    const controls = screen.getAllByRole('button', { name: /3 unread sessions/ })
+
+    expect(controls).toHaveLength(1)
+    expect(controls[0].textContent).toContain('3')
+    expect(controls[0].getAttribute('aria-label')).toMatch(/show/i)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/hide-only-strip-tabs.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/hide-only-strip-tabs.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { registry } from '@/contrib/registry'
 
-import { allPaneIds, group, split } from './model'
+import { allPaneIds, group, isPaneActiveInLayoutGroup, split } from './model'
 import {
   $hiddenStripTabs,
   $hiddenTreePanes,
@@ -52,6 +52,22 @@ afterEach(() => {
 })
 
 describe('hide-only strip tabs', () => {
+  it('identifies which shared sidebar tab a reveal control would expose', () => {
+    sessionsBotsTree()
+    const sessionsActive = $layoutTree.get()!
+
+    expect(isPaneActiveInLayoutGroup(sessionsActive, new Set(), 'sessions')).toBe(true)
+    expect(isPaneActiveInLayoutGroup(sessionsActive, new Set(['sessions']), 'sessions')).toBe(false)
+
+    $layoutTree.set(
+      split('row', [
+        group(['sessions', 'hermes-bots:pane'], { active: 'hermes-bots:pane', id: 'g-side' }),
+        group(['workspace'], { active: 'workspace', id: 'g-main' })
+      ])
+    )
+    expect(isPaneActiveInLayoutGroup($layoutTree.get(), new Set(), 'sessions')).toBe(false)
+  })
+
   it('hides and shows a chrome tab, keeping the pane in the tree', () => {
     sessionsBotsTree()
 

--- a/apps/desktop/src/components/pane-shell/tree/model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/model.ts
@@ -121,6 +121,17 @@ export function findGroupOfPane(node: LayoutNode, paneId: string): GroupNode | n
   return null
 }
 
+/** Whether a pane owns its group's active tab and is available in the strip. */
+export function isPaneActiveInLayoutGroup(
+  tree: LayoutNode | null,
+  hiddenStripTabs: ReadonlySet<string>,
+  paneId: string
+): boolean {
+  const group = tree ? findGroupOfPane(tree, paneId) : null
+
+  return group?.active === paneId && !hiddenStripTabs.has(paneId)
+}
+
 export function allPaneIds(node: LayoutNode): string[] {
   return node.type === 'group' ? [...node.panes] : node.children.flatMap(allPaneIds)
 }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlay-state.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlay-state.ts
@@ -1,0 +1,10 @@
+import { atom } from 'nanostores'
+
+interface NarrowOverlayChrome {
+  paneId: string
+  tabIds: readonly string[]
+}
+
+/** Actual mounted overlay chrome, not the persisted docked-open flags.
+ * Lets titlebar affordances yield to their visible pane title on narrow. */
+export const $narrowOverlayChrome = atom<NarrowOverlayChrome | null>(null)

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
@@ -1,4 +1,6 @@
+import { useStore } from '@nanostores/react'
 import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { atom } from 'nanostores'
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
@@ -21,6 +23,13 @@ beforeAll(() => {
 })
 
 const disposers: (() => void)[] = []
+const $sessionsUnread = atom(0)
+
+const LiveSessionsTitle = () => {
+  const unread = useStore($sessionsUnread)
+
+  return <span data-testid="sessions-live-title">sessions {unread}</span>
+}
 
 const registerPane = (id: string, title: string, data: Record<string, unknown>, body: string) => {
   disposers.push(
@@ -37,8 +46,14 @@ const registerPane = (id: string, title: string, data: Record<string, unknown>, 
 beforeEach(() => {
   window.localStorage.clear()
   $hiddenTreePanes.set(new Set())
+  $sessionsUnread.set(2)
 
-  registerPane('sessions', 'sessions', { collapsible: true, placement: 'left', width: '237px' }, 'session rows')
+  registerPane(
+    'sessions',
+    'sessions',
+    { collapsible: true, placement: 'left', tabTitle: () => <LiveSessionsTitle />, width: '237px' },
+    'session rows'
+  )
   registerPane('bots', 'Bots', { collapsible: true, placement: 'left', width: '260px' }, 'bot roster')
   registerPane('workspace', 'workspace', { placement: 'main', uncloseable: true }, 'chat')
 
@@ -90,5 +105,15 @@ describe('narrow overlay of a stacked zone', () => {
 
     expect(getByTestId('sessions-body')).toBeTruthy()
     expect(overlayTab('sessions')).toBeNull()
+  })
+
+  it('renders the pane live tab title and updates its unread count', () => {
+    const { getByTestId } = render(<NarrowOverlays />)
+
+    revealPane('sessions')
+    expect(getByTestId('sessions-live-title').textContent).toBe('sessions 2')
+
+    act(() => $sessionsUnread.set(4))
+    expect(getByTestId('sessions-live-title').textContent).toBe('sessions 4')
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx
@@ -94,7 +94,7 @@ describe('narrow overlay of a stacked zone', () => {
     expect(queryByTestId('sessions-body')).toBeNull()
   })
 
-  it('keeps the stripless form for a zone with a single collapsible', () => {
+  it('keeps live title controls for a zone with a single collapsible', () => {
     // Direct set: declareDefaultTree only ADOPTS into an existing tree — it
     // would keep the beforeEach zone (with bots) instead of replacing it.
     $layoutTree.set(split('row', [group(['sessions']), group(['workspace'])]))
@@ -104,7 +104,18 @@ describe('narrow overlay of a stacked zone', () => {
     revealPane('sessions')
 
     expect(getByTestId('sessions-body')).toBeTruthy()
-    expect(overlayTab('sessions')).toBeNull()
+    expect(overlayTab('sessions')).toBeTruthy()
+    expect(getByTestId('sessions-live-title').textContent).toBe('sessions 2')
+  })
+
+  it('keeps an ordinary single pane stripless', () => {
+    $layoutTree.set(split('row', [group(['bots']), group(['workspace'])]))
+    const { getByTestId } = render(<NarrowOverlays />)
+
+    revealPane('bots')
+
+    expect(getByTestId('bots-body')).toBeTruthy()
+    expect(overlayTab('bots')).toBeNull()
   })
 
   it('renders the pane live tab title and updates its unread count', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
@@ -176,7 +176,7 @@ export function NarrowOverlays() {
                     }
                   }}
                 >
-                  <PaneTabLabel>{pane.title ?? pane.id}</PaneTabLabel>
+                  <PaneTabLabel>{paneChrome(pane).tabTitle?.() ?? pane.title ?? pane.id}</PaneTabLabel>
                 </PaneTab>
               ))}
             </PaneTabStrip>

--- a/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/narrow-overlays.tsx
@@ -20,6 +20,7 @@ import { PANE_TOGGLE_REVEAL_EVENT } from '../..'
 import { allPaneIds, findGroupOfPane } from '../model'
 import { $hiddenTreePanes, $layoutTree, $narrowViewport } from '../store'
 
+import { $narrowOverlayChrome } from './narrow-overlay-state'
 import { paneChrome } from './track-model'
 
 export function NarrowOverlays() {
@@ -101,10 +102,6 @@ export function NarrowOverlays() {
     }
   }, [narrow])
 
-  if (!narrow || collapsibles.length === 0) {
-    return null
-  }
-
   const sideOf = (c: Contribution) => (paneChrome(c).placement === 'left' ? 'left' : 'right')
   const revealed = reveal ? collapsibles.find(p => p.id === reveal.id) : undefined
   const sides = [...new Set(collapsibles.map(sideOf))]
@@ -113,7 +110,7 @@ export function NarrowOverlays() {
   // stacks SESSIONS | BOTS): the overlay mirrors the zone's tab strip so a
   // pane docked into a collapsed zone stays reachable on narrow viewports —
   // without this, only the zone's first pane ever surfaces again.
-  const zonePanes = (() => {
+  const zonePanes = useMemo(() => {
     if (!revealed || !tree) {
       return [revealed].filter((p): p is Contribution => Boolean(p))
     }
@@ -123,7 +120,27 @@ export function NarrowOverlays() {
     const shown = mates.filter((p): p is Contribution => Boolean(p))
 
     return shown.length > 0 ? shown : [revealed]
-  })()
+  }, [revealed, tree, collapsibles])
+
+  const tabIds = useMemo(
+    () =>
+      narrow && revealed && (zonePanes.length > 1 || paneChrome(revealed).tabTitle)
+        ? zonePanes.map(pane => pane.id)
+        : [],
+    [narrow, revealed, zonePanes]
+  )
+
+  // Publish mounted chrome so a collapsed docked-open pane cannot hide the
+  // titlebar count. Cleanup hands ownership back on close or unmount.
+  useEffect(() => {
+    $narrowOverlayChrome.set(narrow && revealed ? { paneId: revealed.id, tabIds } : null)
+
+    return () => $narrowOverlayChrome.set(null)
+  }, [narrow, revealed, tabIds])
+
+  if (!narrow || collapsibles.length === 0) {
+    return null
+  }
 
   return (
     <>
@@ -160,8 +177,9 @@ export function NarrowOverlays() {
           style={{ width: `min(${(revealed.data as { width?: string } | undefined)?.width ?? '18rem'}, 85vw)` }}
         >
           {/* Zone-mates share the overlay through the zone's own tab strip
-              (SESSIONS | BOTS) — a lone pane keeps the stripless form. */}
-          {zonePanes.length > 1 && (
+              (SESSIONS | BOTS). A lone pane with live title controls keeps
+              that chrome too; ordinary single panes stay stripless. */}
+          {tabIds.length > 0 && (
             <PaneTabStrip>
               {zonePanes.map(pane => (
                 <PaneTab

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -17,9 +17,12 @@ import {
   $delegatingSessionIds,
   $sessionDotStateById,
   $unreadSessionCount,
+  $unreadSessionIds,
   hasLiveTurn,
   showsRunningArc,
-  unreadSessionCount
+  unreadSessionCount,
+  unreadSessionIds,
+  unreadSessionTargets
 } from './session-dot-state'
 import { clearAllSessionStates, publishSessionState } from './session-states'
 import { $unreadWriteGuard } from './session-unread-remote'
@@ -238,5 +241,93 @@ describe('$unreadSessionCount (titlebar badge)', () => {
 
     expect($unreadSessionCount.get()).toBe(0)
     expect($sessionDotStateById.get()['cron-1']).not.toBe('unread')
+  })
+})
+
+describe('unreadSessionIds', () => {
+  it('globally orders listed rows by effective recency', () => {
+    expect(
+      unreadSessionIds(
+        { cron: 'unread', message: 'unread', normal: 'unread' },
+        [{ id: 'normal', last_active: 10 }],
+        [{ id: 'cron', last_active: 30 }],
+        [{ id: 'message', last_active: 20 }]
+      )
+    ).toEqual(['cron', 'message', 'normal'])
+  })
+
+  it('uses started_at as the fallback and excludes archived or non-unread rows', () => {
+    expect(
+      unreadSessionIds(
+        { archived: 'unread', idle: 'idle', newer: 'unread', older: 'unread' },
+        [
+          { id: 'older', last_active: 0, started_at: 4 },
+          { archived: true, id: 'archived', last_active: 99 },
+          { id: 'idle', last_active: 100 }
+        ],
+        [{ id: 'newer', last_active: 0, started_at: 8 }]
+      )
+    ).toEqual(['newer', 'older'])
+  })
+})
+
+describe('$unreadSessionIds (titlebar navigation)', () => {
+  beforeEach(() => {
+    clearAllSessionStates()
+    $sessions.set([])
+    $cronSessions.set([])
+    $messagingSessions.set([])
+    $unreadFinishedSessionIds.set([])
+    $unreadWriteGuard.set(new Map())
+  })
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $sessions.set([])
+    $cronSessions.set([])
+    $messagingSessions.set([])
+    $unreadFinishedSessionIds.set([])
+    $unreadWriteGuard.set(new Map())
+  })
+
+  it('orders regular and messaging targets while excluding cron', () => {
+    setSessions([storedRow('regular', { last_active: 10, unread: true })])
+    setMessagingSessions([storedRow('message', { last_active: 20 })])
+    setCronSessions([storedRow('cron', { last_active: 30, source: 'cron' })])
+    $unreadFinishedSessionIds.set(['message', 'cron'])
+
+    expect($unreadSessionIds.get()).toEqual(['message', 'regular'])
+  })
+})
+
+describe('unreadSessionTargets', () => {
+  it('preserves source kind through the global recency ordering', () => {
+    expect(
+      unreadSessionTargets(
+        { cron: 'unread', message: 'unread', normal: 'unread' },
+        [{ id: 'normal', last_active: 10 }],
+        [{ id: 'cron', last_active: 30 }],
+        [{ id: 'message', last_active: 20 }]
+      )
+    ).toEqual([
+      { id: 'cron', kind: 'cron' },
+      { id: 'message', kind: 'messaging' },
+      { id: 'normal', kind: 'session' }
+    ])
+  })
+
+  it('carries a trimmed profile and registry connection owner', () => {
+    expect(
+      unreadSessionTargets(
+        { local: 'unread', remote: 'unread' },
+        [
+          { connection_id: ' conn-a ', id: 'remote', last_active: 20, profile: ' research ' },
+          { id: 'local', last_active: 10 }
+        ]
+      )
+    ).toEqual([
+      { connectionId: 'conn-a', id: 'remote', kind: 'session', profile: 'research' },
+      { id: 'local', kind: 'session' }
+    ])
   })
 })

--- a/apps/desktop/src/store/session-dot-state.test.ts
+++ b/apps/desktop/src/store/session-dot-state.test.ts
@@ -18,6 +18,7 @@ import {
   $sessionDotStateById,
   $unreadSessionCount,
   $unreadSessionIds,
+  $unreadSessionTargets,
   hasLiveTurn,
   showsRunningArc,
   unreadSessionCount,
@@ -298,6 +299,64 @@ describe('$unreadSessionIds (titlebar navigation)', () => {
 
     expect($unreadSessionIds.get()).toEqual(['message', 'regular'])
   })
+
+  it.each([
+    [
+      { connection_id: 'source-a', profile: 'ops' },
+      { connection_id: 'source-b', profile: 'ops' }
+    ],
+    [
+      { connection_id: 'source-a', profile: 'ops' },
+      { connection_id: 'source-a', profile: 'other' }
+    ],
+    [{ profile: 'ops' }, { connection_id: 'source-b', profile: 'ops' }]
+  ])('qualifies eligibility before ranking duplicate IDs (%j / %j)', (unreadOwner, readOwner) => {
+    $sessions.set([
+      storedRow('twin', { ...unreadOwner, last_active: 100, unread: true }),
+      storedRow('twin', { ...readOwner, last_active: 200, unread: false })
+    ])
+
+    expect($unreadSessionTargets.get()).toEqual([
+      {
+        id: 'twin',
+        kind: 'session',
+        profile: unreadOwner.profile,
+        ...('connection_id' in unreadOwner ? { connectionId: unreadOwner.connection_id } : {})
+      }
+    ])
+    expect($unreadSessionCount.get()).toBe(1)
+  })
+
+  it('does not assign an ID-only runtime unread marker to either source twin', () => {
+    $sessions.set([
+      storedRow('twin', { connection_id: 'a', unread: false }),
+      storedRow('twin', { connection_id: 'b', unread: false })
+    ])
+    $unreadFinishedSessionIds.set(['twin'])
+
+    expect($sessionDotStateById.get().twin).toBe('unread')
+    expect($unreadSessionTargets.get()).toEqual([])
+  })
+
+  it.each([true, false])('does not attribute an unscoped optimistic write (%s) to a source twin', value => {
+    $sessions.set([
+      storedRow('twin', { connection_id: 'a', unread: true }),
+      storedRow('twin', { connection_id: 'b', unread: false })
+    ])
+    $unreadFinishedSessionIds.set(['twin'])
+    $unreadWriteGuard.set(new Map([['twin', { at: Date.now(), value }]]))
+
+    expect($unreadSessionTargets.get()).toEqual([])
+    $unreadWriteGuard.set(new Map())
+    expect($unreadSessionTargets.get()).toMatchObject([{ id: 'twin', connectionId: 'a' }])
+  })
+
+  it('qualifies a messaging twin as well as regular sessions', () => {
+    $sessions.set([storedRow('twin', { connection_id: 'a', unread: true })])
+    $messagingSessions.set([storedRow('twin', { connection_id: 'b', unread: false, last_active: 200 })])
+
+    expect($unreadSessionTargets.get()).toMatchObject([{ id: 'twin', kind: 'session', connectionId: 'a' }])
+  })
 })
 
 describe('unreadSessionTargets', () => {
@@ -318,13 +377,10 @@ describe('unreadSessionTargets', () => {
 
   it('carries a trimmed profile and registry connection owner', () => {
     expect(
-      unreadSessionTargets(
-        { local: 'unread', remote: 'unread' },
-        [
-          { connection_id: ' conn-a ', id: 'remote', last_active: 20, profile: ' research ' },
-          { id: 'local', last_active: 10 }
-        ]
-      )
+      unreadSessionTargets({ local: 'unread', remote: 'unread' }, [
+        { connection_id: ' conn-a ', id: 'remote', last_active: 20, profile: ' research ' },
+        { id: 'local', last_active: 10 }
+      ])
     ).toEqual([
       { connectionId: 'conn-a', id: 'remote', kind: 'session', profile: 'research' },
       { id: 'local', kind: 'session' }

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -202,12 +202,75 @@ export function unreadSessionCount(
   return n
 }
 
+/** Where an unread row came from. Keep this explicit rather than inferring it
+ * from an id when a source needs different navigation in the future. */
+export type UnreadSessionKind = 'cron' | 'messaging' | 'session'
+
+interface UnreadSessionRow {
+  archived?: boolean
+  connection_id?: string
+  id: string
+  last_active?: number
+  profile?: string
+  started_at?: number
+}
+
+export interface UnreadSessionTarget {
+  connectionId?: string
+  id: string
+  kind: UnreadSessionKind
+  profile?: string
+}
+
+/** Listed unread rows across every sidebar source, globally newest first,
+ * carrying the owner scope needed to validate a cross-gateway open. */
+export function unreadSessionTargets(
+  byId: Readonly<Record<string, SessionDotState>>,
+  sessions: readonly UnreadSessionRow[] = [],
+  cron: readonly UnreadSessionRow[] = [],
+  messaging: readonly UnreadSessionRow[] = []
+): UnreadSessionTarget[] {
+  return [
+    ...sessions.map(row => ({ kind: 'session' as const, row })),
+    ...cron.map(row => ({ kind: 'cron' as const, row })),
+    ...messaging.map(row => ({ kind: 'messaging' as const, row }))
+  ]
+    .filter(({ row }) => !row.archived && byId[row.id] === 'unread')
+    .sort((a, b) => {
+      const byRecency =
+        Math.max(b.row.last_active || 0, b.row.started_at || 0) -
+        Math.max(a.row.last_active || 0, a.row.started_at || 0)
+
+      return byRecency || a.row.id.localeCompare(b.row.id)
+    })
+    .map(({ kind, row }) => ({
+      ...(row.connection_id?.trim() ? { connectionId: row.connection_id.trim() } : {}),
+      id: row.id,
+      kind,
+      ...(row.profile?.trim() ? { profile: row.profile.trim() } : {})
+    }))
+}
+
+/** Compatibility mapper over {@link unreadSessionTargets}. */
+export function unreadSessionIds(
+  byId: Readonly<Record<string, SessionDotState>>,
+  sessions: readonly UnreadSessionRow[] = [],
+  cron: readonly UnreadSessionRow[] = [],
+  messaging: readonly UnreadSessionRow[] = []
+): string[] {
+  return unreadSessionTargets(byId, sessions, cron, messaging).map(target => target.id)
+}
+
+export const $unreadSessionTargets = computed(
+  [$sessionDotStateById, $sessions, $messagingSessions],
+  (byId, sessions, messaging) => unreadSessionTargets(byId, sessions, [], messaging)
+)
+
+export const $unreadSessionIds = computed($unreadSessionTargets, targets => targets.map(target => target.id))
+
 /** The titlebar badge. Cron sessions are deliberately EXCLUDED: cron runs
  *  finish unwatched by design, so counting them turns the badge into a cron
  *  run counter that is permanently lit (#93552). Their unread state stays
  *  visible where it belongs — the sidebar's cron section rows — and
  *  "mark all as read" still acks them (ackAllSessionsRead iterates cron rows). */
-export const $unreadSessionCount = computed(
-  [$sessionDotStateById, $sessions, $messagingSessions],
-  (byId, sessions, messaging) => unreadSessionCount(byId, sessions, messaging)
-)
+export const $unreadSessionCount = computed($unreadSessionIds, ids => ids.length)

--- a/apps/desktop/src/store/session-dot-state.ts
+++ b/apps/desktop/src/store/session-dot-state.ts
@@ -213,6 +213,7 @@ interface UnreadSessionRow {
   last_active?: number
   profile?: string
   started_at?: number
+  unread?: boolean
 }
 
 export interface UnreadSessionTarget {
@@ -228,14 +229,40 @@ export function unreadSessionTargets(
   byId: Readonly<Record<string, SessionDotState>>,
   sessions: readonly UnreadSessionRow[] = [],
   cron: readonly UnreadSessionRow[] = [],
-  messaging: readonly UnreadSessionRow[] = []
+  messaging: readonly UnreadSessionRow[] = [],
+  unreadWriteGuard: ReadonlyMap<string, { at: number; value: boolean }> = new Map()
 ): UnreadSessionTarget[] {
-  return [
+  const rows = [
     ...sessions.map(row => ({ kind: 'session' as const, row })),
     ...cron.map(row => ({ kind: 'cron' as const, row })),
     ...messaging.map(row => ({ kind: 'messaging' as const, row }))
   ]
-    .filter(({ row }) => !row.archived && byId[row.id] === 'unread')
+
+  const ownersById = new Map<string, Set<string>>()
+
+  for (const { row } of rows) {
+    const owners = ownersById.get(row.id) ?? new Set<string>()
+    owners.add(JSON.stringify([row.connection_id?.trim() || '', row.profile?.trim() || 'default']))
+    ownersById.set(row.id, owners)
+  }
+
+  return rows
+    .filter(({ row }) => {
+      if (row.archived || byId[row.id] !== 'unread') {
+        return false
+      }
+
+      if ((ownersById.get(row.id)?.size ?? 0) > 1) {
+        // The shared dot, runtime marker and optimistic guard are ID-only.
+        // With source twins, only the row's own persisted unread flag proves
+        // eligibility; a pending unscoped write makes even that ambiguous.
+        const guard = unreadWriteGuard.get(row.id)
+
+        return row.unread === true && !(guard && Date.now() - guard.at < UNREAD_WRITE_GUARD_MS)
+      }
+
+      return true
+    })
     .sort((a, b) => {
       const byRecency =
         Math.max(b.row.last_active || 0, b.row.started_at || 0) -
@@ -262,8 +289,8 @@ export function unreadSessionIds(
 }
 
 export const $unreadSessionTargets = computed(
-  [$sessionDotStateById, $sessions, $messagingSessions],
-  (byId, sessions, messaging) => unreadSessionTargets(byId, sessions, [], messaging)
+  [$sessionDotStateById, $sessions, $messagingSessions, $unreadWriteGuard],
+  (byId, sessions, messaging, guard) => unreadSessionTargets(byId, sessions, [], messaging, guard)
 )
 
 export const $unreadSessionIds = computed($unreadSessionTargets, targets => targets.map(target => target.id))

--- a/apps/desktop/src/store/session-unread-navigation.test.ts
+++ b/apps/desktop/src/store/session-unread-navigation.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { UnreadSessionTarget } from './session-dot-state'
+import {
+  $openNextUnreadRequest,
+  openNextValidUnread,
+  ownerRouteForUnreadTarget,
+  preflightCandidatesForUnreadTarget,
+  profileScopeForUnreadTarget,
+  requestOpenNextUnread
+} from './session-unread-navigation'
+
+beforeEach(() => {
+  $openNextUnreadRequest.set(0)
+})
+
+afterEach(() => {
+  $openNextUnreadRequest.set(0)
+})
+
+describe('unread session navigation requests', () => {
+  it('starts inert and increments once per request', () => {
+    expect($openNextUnreadRequest.get()).toBe(0)
+
+    requestOpenNextUnread()
+    requestOpenNextUnread()
+
+    expect($openNextUnreadRequest.get()).toBe(2)
+  })
+})
+
+const target = (id: string, extra: Partial<UnreadSessionTarget> = {}): UnreadSessionTarget => ({
+  id,
+  kind: 'session',
+  ...extra
+})
+
+describe('unread target navigation', () => {
+  it.each(['session', 'cron', 'messaging'] as const)('opens a valid %s target', async kind => {
+    const open = vi.fn()
+    const item = target(kind, { kind })
+
+    await expect(openNextValidUnread([item], async () => null, open)).resolves.toEqual(item)
+    expect(open).toHaveBeenCalledWith(item, null)
+  })
+
+  it('uses the exact connection and profile for preflight and resume', async () => {
+    const item = target('remote', { connectionId: ' conn-a ', profile: ' research ' })
+    const route = { connectionId: 'conn-a', profile: 'research' }
+    const open = vi.fn()
+
+    expect(profileScopeForUnreadTarget(item)).toEqual(route)
+    expect(ownerRouteForUnreadTarget(item)).toEqual(route)
+    await openNextValidUnread([item], async candidate => ownerRouteForUnreadTarget(candidate), open)
+    expect(open).toHaveBeenCalledWith(item, route)
+  })
+
+  it('pins an untagged primary row to the active registered gateway', () => {
+    const item = target('primary', { profile: 'default' })
+    const route = { connectionId: 'work-vps', profile: 'default' }
+
+    expect(profileScopeForUnreadTarget(item, 'work-vps')).toEqual(route)
+    expect(ownerRouteForUnreadTarget(item, 'work-vps')).toEqual(route)
+  })
+
+  it('uses the backend target profile from the exact registered route', () => {
+    const item = target('primary', { profile: 'claude-martin' })
+
+    const routes = [
+      {
+        connectionId: 'work-vps',
+        mode: 'remote' as const,
+        profile: 'claude-martin',
+        targetProfile: 'default'
+      }
+    ]
+
+    expect(profileScopeForUnreadTarget(item, 'work-vps', routes)).toEqual({
+      connectionId: 'work-vps',
+      profile: 'default'
+    })
+    expect(ownerRouteForUnreadTarget(item, 'work-vps', routes)).toEqual({
+      connectionId: 'work-vps',
+      mode: 'remote',
+      profile: 'claude-martin',
+      targetProfile: 'default'
+    })
+  })
+
+  it('ignores a same-named profile route from another connection', () => {
+    const item = target('primary', { profile: 'work' })
+    const routes = [{ connectionId: 'other', profile: 'work', targetProfile: 'default' }]
+
+    expect(profileScopeForUnreadTarget(item, 'work-vps', routes)).toEqual({
+      connectionId: 'work-vps',
+      profile: 'work'
+    })
+  })
+
+  it('tries profile routing before the active registry fallback for a primary row', () => {
+    const item = target('primary', { profile: 'claude-martin' })
+
+    const routes = [
+      {
+        connectionId: 'work-vps',
+        mode: 'remote' as const,
+        profile: 'claude-martin',
+        targetProfile: 'default'
+      }
+    ]
+
+    expect(preflightCandidatesForUnreadTarget(item, 'work-vps', routes)).toEqual([
+      { ownerRoute: null, scope: 'claude-martin' },
+      {
+        ownerRoute: {
+          connectionId: 'work-vps',
+          mode: 'remote',
+          profile: 'claude-martin',
+          targetProfile: 'default'
+        },
+        scope: { connectionId: 'work-vps', profile: 'default' }
+      }
+    ])
+  })
+
+  it('uses only the exact owner for a tagged secondary row', () => {
+    const item = target('secondary', { connectionId: 'homelab', profile: 'research' })
+
+    expect(preflightCandidatesForUnreadTarget(item, 'work-vps')).toEqual([
+      {
+        ownerRoute: { connectionId: 'homelab', profile: 'research' },
+        scope: { connectionId: 'homelab', profile: 'research' }
+      }
+    ])
+  })
+
+  it('prefers a row-owned connection over the active gateway fallback', () => {
+    const item = target('secondary', { connectionId: 'homelab', profile: 'research' })
+    const route = { connectionId: 'homelab', profile: 'research' }
+
+    expect(profileScopeForUnreadTarget(item, 'work-vps')).toEqual(route)
+    expect(ownerRouteForUnreadTarget(item, 'work-vps')).toEqual(route)
+  })
+
+  it('keeps a stale newest target unread and falls through to the next', async () => {
+    const stale = target('stale', { kind: 'cron' })
+    const next = target('next', { kind: 'messaging' })
+    const open = vi.fn()
+
+    const opened = await openNextValidUnread(
+      [stale, next],
+      async candidate => {
+        if (candidate === stale) {
+          throw new Error('not found')
+        }
+
+        return null
+      },
+      open
+    )
+
+    expect(opened).toEqual(next)
+    expect(open).toHaveBeenCalledOnce()
+    expect(open).toHaveBeenCalledWith(next, null)
+  })
+
+  it('does not open or mutate anything when every target is unavailable', async () => {
+    const open = vi.fn()
+
+    await expect(
+      openNextValidUnread([target('a'), target('b')], async () => {
+        throw new Error('offline')
+      }, open)
+    ).resolves.toBeNull()
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  it('does not swallow an opening failure and continue to a second target', async () => {
+    const open = vi.fn(() => {
+      throw new Error('open failed')
+    })
+
+    await expect(openNextValidUnread([target('first'), target('second')], async () => null, open)).rejects.toThrow(
+      'open failed'
+    )
+    expect(open).toHaveBeenCalledOnce()
+  })
+
+  it('keeps profile-only and ambient preflight scopes distinct', () => {
+    expect(profileScopeForUnreadTarget(target('profile', { profile: 'writer' }))).toBe('writer')
+    expect(profileScopeForUnreadTarget(target('ambient'))).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/store/session-unread-navigation.test.ts
+++ b/apps/desktop/src/store/session-unread-navigation.test.ts
@@ -168,9 +168,13 @@ describe('unread target navigation', () => {
     const open = vi.fn()
 
     await expect(
-      openNextValidUnread([target('a'), target('b')], async () => {
-        throw new Error('offline')
-      }, open)
+      openNextValidUnread(
+        [target('a'), target('b')],
+        async () => {
+          throw new Error('offline')
+        },
+        open
+      )
     ).resolves.toBeNull()
     expect(open).not.toHaveBeenCalled()
   })
@@ -184,6 +188,32 @@ describe('unread target navigation', () => {
       'open failed'
     )
     expect(open).toHaveBeenCalledOnce()
+  })
+
+  it('leaves a declined ambiguous target untouched and advances to the next', async () => {
+    const open = vi.fn(candidate => candidate.id !== 'ambiguous')
+
+    await expect(openNextValidUnread([target('ambiguous'), target('next')], async () => null, open)).resolves.toEqual(
+      target('next')
+    )
+    expect(open).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops a cancelled ladder before opening or probing another target', async () => {
+    let current = true
+    const open = vi.fn()
+
+    const preflight = vi.fn(async () => {
+      current = false
+
+      return null
+    })
+
+    await expect(
+      openNextValidUnread([target('first'), target('second')], preflight, open, () => current)
+    ).resolves.toBeNull()
+    expect(preflight).toHaveBeenCalledOnce()
+    expect(open).not.toHaveBeenCalled()
   })
 
   it('keeps profile-only and ambient preflight scopes distinct', () => {

--- a/apps/desktop/src/store/session-unread-navigation.test.ts
+++ b/apps/desktop/src/store/session-unread-navigation.test.ts
@@ -57,32 +57,32 @@ describe('unread target navigation', () => {
 
   it('pins an untagged primary row to the active registered gateway', () => {
     const item = target('primary', { profile: 'default' })
-    const route = { connectionId: 'work-vps', profile: 'default' }
+    const route = { connectionId: 'remote-primary', profile: 'default' }
 
-    expect(profileScopeForUnreadTarget(item, 'work-vps')).toEqual(route)
-    expect(ownerRouteForUnreadTarget(item, 'work-vps')).toEqual(route)
+    expect(profileScopeForUnreadTarget(item, 'remote-primary')).toEqual(route)
+    expect(ownerRouteForUnreadTarget(item, 'remote-primary')).toEqual(route)
   })
 
   it('uses the backend target profile from the exact registered route', () => {
-    const item = target('primary', { profile: 'claude-martin' })
+    const item = target('primary', { profile: 'remote-alias' })
 
     const routes = [
       {
-        connectionId: 'work-vps',
+        connectionId: 'remote-primary',
         mode: 'remote' as const,
-        profile: 'claude-martin',
+        profile: 'remote-alias',
         targetProfile: 'default'
       }
     ]
 
-    expect(profileScopeForUnreadTarget(item, 'work-vps', routes)).toEqual({
-      connectionId: 'work-vps',
+    expect(profileScopeForUnreadTarget(item, 'remote-primary', routes)).toEqual({
+      connectionId: 'remote-primary',
       profile: 'default'
     })
-    expect(ownerRouteForUnreadTarget(item, 'work-vps', routes)).toEqual({
-      connectionId: 'work-vps',
+    expect(ownerRouteForUnreadTarget(item, 'remote-primary', routes)).toEqual({
+      connectionId: 'remote-primary',
       mode: 'remote',
-      profile: 'claude-martin',
+      profile: 'remote-alias',
       targetProfile: 'default'
     })
   })
@@ -91,34 +91,34 @@ describe('unread target navigation', () => {
     const item = target('primary', { profile: 'work' })
     const routes = [{ connectionId: 'other', profile: 'work', targetProfile: 'default' }]
 
-    expect(profileScopeForUnreadTarget(item, 'work-vps', routes)).toEqual({
-      connectionId: 'work-vps',
+    expect(profileScopeForUnreadTarget(item, 'remote-primary', routes)).toEqual({
+      connectionId: 'remote-primary',
       profile: 'work'
     })
   })
 
   it('tries profile routing before the active registry fallback for a primary row', () => {
-    const item = target('primary', { profile: 'claude-martin' })
+    const item = target('primary', { profile: 'remote-alias' })
 
     const routes = [
       {
-        connectionId: 'work-vps',
+        connectionId: 'remote-primary',
         mode: 'remote' as const,
-        profile: 'claude-martin',
+        profile: 'remote-alias',
         targetProfile: 'default'
       }
     ]
 
-    expect(preflightCandidatesForUnreadTarget(item, 'work-vps', routes)).toEqual([
-      { ownerRoute: null, scope: 'claude-martin' },
+    expect(preflightCandidatesForUnreadTarget(item, 'remote-primary', routes)).toEqual([
+      { ownerRoute: null, scope: 'remote-alias' },
       {
         ownerRoute: {
-          connectionId: 'work-vps',
+          connectionId: 'remote-primary',
           mode: 'remote',
-          profile: 'claude-martin',
+          profile: 'remote-alias',
           targetProfile: 'default'
         },
-        scope: { connectionId: 'work-vps', profile: 'default' }
+        scope: { connectionId: 'remote-primary', profile: 'default' }
       }
     ])
   })
@@ -126,7 +126,7 @@ describe('unread target navigation', () => {
   it('uses only the exact owner for a tagged secondary row', () => {
     const item = target('secondary', { connectionId: 'homelab', profile: 'research' })
 
-    expect(preflightCandidatesForUnreadTarget(item, 'work-vps')).toEqual([
+    expect(preflightCandidatesForUnreadTarget(item, 'remote-primary')).toEqual([
       {
         ownerRoute: { connectionId: 'homelab', profile: 'research' },
         scope: { connectionId: 'homelab', profile: 'research' }
@@ -138,8 +138,8 @@ describe('unread target navigation', () => {
     const item = target('secondary', { connectionId: 'homelab', profile: 'research' })
     const route = { connectionId: 'homelab', profile: 'research' }
 
-    expect(profileScopeForUnreadTarget(item, 'work-vps')).toEqual(route)
-    expect(ownerRouteForUnreadTarget(item, 'work-vps')).toEqual(route)
+    expect(profileScopeForUnreadTarget(item, 'remote-primary')).toEqual(route)
+    expect(ownerRouteForUnreadTarget(item, 'remote-primary')).toEqual(route)
   })
 
   it('keeps a stale newest target unread and falls through to the next', async () => {

--- a/apps/desktop/src/store/session-unread-navigation.ts
+++ b/apps/desktop/src/store/session-unread-navigation.ts
@@ -1,0 +1,123 @@
+import { atom } from 'nanostores'
+
+import type { UnreadSessionTarget } from './session-dot-state'
+import type { SessionProfileRoute } from './session-request-router'
+
+/** Navigation intent emitted by pane chrome and consumed by the mounted
+ * Sessions wiring. State survives StrictMode effect teardown/re-setup, unlike
+ * an imperative handler stored in a module variable. */
+export const $openNextUnreadRequest = atom(0)
+
+export function requestOpenNextUnread(): void {
+  $openNextUnreadRequest.set($openNextUnreadRequest.get() + 1)
+}
+
+export type UnreadTargetProfileScope = SessionProfileRoute | string | undefined
+
+export interface UnreadTargetPreflightCandidate {
+  ownerRoute: null | SessionProfileRoute
+  scope: UnreadTargetProfileScope
+}
+
+/** Route to persist before opening a connection-owned target. */
+export function ownerRouteForUnreadTarget(
+  target: UnreadSessionTarget,
+  activeConnectionId?: null | string,
+  registeredRoutes: readonly SessionProfileRoute[] = []
+): SessionProfileRoute | null {
+  // Unified-list rows from secondary gateways carry connectionId. Rows served
+  // by the currently-primary registered gateway do not, so freeze the active
+  // source as their owner before navigation can move presentation elsewhere.
+  const connectionId = target.connectionId?.trim() || activeConnectionId?.trim()
+  const profile = target.profile?.trim() || 'default'
+
+  if (!connectionId) {
+    return null
+  }
+
+  const route = registeredRoutes.find(
+    candidate => candidate.connectionId.trim() === connectionId && candidate.profile.trim() === profile
+  )
+
+  return route
+    ? {
+        connectionId,
+        ...(route.mode ? { mode: route.mode } : {}),
+        profile,
+        ...(route.targetProfile?.trim() ? { targetProfile: route.targetProfile.trim() } : {})
+      }
+    : { connectionId, profile }
+}
+
+/** Exact REST scope for a target. A registered Desktop profile can map to a
+ * differently named backend profile, so use targetProfile when the registry
+ * route provides one. */
+export function profileScopeForUnreadTarget(
+  target: UnreadSessionTarget,
+  activeConnectionId?: null | string,
+  registeredRoutes: readonly SessionProfileRoute[] = []
+): UnreadTargetProfileScope {
+  const ownerRoute = ownerRouteForUnreadTarget(target, activeConnectionId, registeredRoutes)
+
+  if (ownerRoute) {
+    return { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile || ownerRoute.profile }
+  }
+
+  return target.profile?.trim() || undefined
+}
+
+/** Ordered owner probes for an unread row. Primary rows intentionally omit a
+ * connection id: profile-only routing must get the first chance so Electron can
+ * honor per-profile remote overrides. Registry scoping is the fallback for a
+ * global-remote primary and the only path for explicitly tagged secondary rows. */
+export function preflightCandidatesForUnreadTarget(
+  target: UnreadSessionTarget,
+  activeConnectionId?: null | string,
+  registeredRoutes: readonly SessionProfileRoute[] = []
+): UnreadTargetPreflightCandidate[] {
+  const candidates: UnreadTargetPreflightCandidate[] = []
+
+  if (!target.connectionId?.trim()) {
+    candidates.push({ ownerRoute: null, scope: target.profile?.trim() || undefined })
+  }
+
+  const ownerRoute = ownerRouteForUnreadTarget(target, activeConnectionId, registeredRoutes)
+
+  if (ownerRoute) {
+    candidates.push({
+      ownerRoute,
+      scope: { connectionId: ownerRoute.connectionId, profile: ownerRoute.targetProfile || ownerRoute.profile }
+    })
+  }
+
+  return candidates.length ? candidates : [{ ownerRoute: null, scope: undefined }]
+}
+
+export type PreflightUnreadTarget = (
+  target: UnreadSessionTarget
+) => Promise<null | SessionProfileRoute>
+
+/** Open the first target whose row still resolves on its owning backend. A
+ * rejected preflight leaves that candidate unread and advances to the next. */
+export async function openNextValidUnread(
+  targets: readonly UnreadSessionTarget[],
+  preflight: PreflightUnreadTarget,
+  open: (target: UnreadSessionTarget, ownerRoute: null | SessionProfileRoute) => void
+): Promise<UnreadSessionTarget | null> {
+  for (const target of targets) {
+    let ownerRoute: null | SessionProfileRoute
+
+    try {
+      ownerRoute = await preflight(target)
+    } catch {
+      // Stale or unavailable rows remain unread; try the next candidate.
+      continue
+    }
+
+    open(target, ownerRoute)
+
+    return target
+  }
+
+  return null
+}

--- a/apps/desktop/src/store/session-unread-navigation.ts
+++ b/apps/desktop/src/store/session-unread-navigation.ts
@@ -93,18 +93,21 @@ export function preflightCandidatesForUnreadTarget(
   return candidates.length ? candidates : [{ ownerRoute: null, scope: undefined }]
 }
 
-export type PreflightUnreadTarget = (
-  target: UnreadSessionTarget
-) => Promise<null | SessionProfileRoute>
+export type PreflightUnreadTarget = (target: UnreadSessionTarget) => Promise<null | SessionProfileRoute>
 
 /** Open the first target whose row still resolves on its owning backend. A
  * rejected preflight leaves that candidate unread and advances to the next. */
 export async function openNextValidUnread(
   targets: readonly UnreadSessionTarget[],
   preflight: PreflightUnreadTarget,
-  open: (target: UnreadSessionTarget, ownerRoute: null | SessionProfileRoute) => void
+  open: (target: UnreadSessionTarget, ownerRoute: null | SessionProfileRoute) => boolean | void,
+  isCurrent: () => boolean = () => true
 ): Promise<UnreadSessionTarget | null> {
   for (const target of targets) {
+    if (!isCurrent()) {
+      return null
+    }
+
     let ownerRoute: null | SessionProfileRoute
 
     try {
@@ -114,7 +117,15 @@ export async function openNextValidUnread(
       continue
     }
 
-    open(target, ownerRoute)
+    if (!isCurrent()) {
+      return null
+    }
+
+    // A caller can decline an eligible row when its open surface is ambiguous
+    // or its live read state changed during preflight. Leave it untouched.
+    if (open(target, ownerRoute) === false) {
+      continue
+    }
 
     return target
   }


### PR DESCRIPTION
## Summary

Clicking the Sessions unread count opens the newest reachable conversation that needs attention. It no longer toggles an unrelated sidebar, spends the count on the wrong connection, or pulls you back after you have deliberately moved to another pane.

The count stays with Sessions: on its tab when visible, and on its reveal control when hidden. Bots and Terminal never inherit it. Narrow layouts retain the same actionable count.

## Changes

- Use the same typed list for the count and navigation order. Stale or unavailable rows remain unread while navigation tries the next candidate; cron rows retain their own unread state without keeping the global badge lit, consistent with #93552.
- Preserve exact connection/profile ownership, including Desktop profile aliases and cross-connection duplicate session IDs. Ambiguous targets stay unread and the Sessions list remains available for manual selection.
- Coalesce rapid clicks and fence stale asynchronous results after navigation, profile changes, or a later pane selection. The shortcut's own Sessions reveal does not cancel its navigation.
- Keep the count visible and the actual Sessions rows accessible in narrow overlays, including recovery from an unavailable or ambiguous target.

The shared session opener and successful-open acknowledgement semantics are unchanged. This is not a redesign of transcript hydration or all-source unread persistence.

## Validation

Head `d232586bad`, based on main `593aa74c61`. The two original authored changes are preserved, followed by focused test and repair commits; no unrelated composer cleanup is included.

| Check | Result |
| --- | --- |
| Focused mounted routing, unread, titlebar and narrow-overlay tests | 15 files / 209 passed |
| Renderer, Electron and E2E typechecks | All three passed |
| Targeted lint and diff checks | Passed |
| Modified-file size | All 20 files below 2,000 lines |
| Two independent adversarial reviews | Both cleared the final bounded repair after rerunning their failure cases |

Exact-head [CI](https://github.com/NousResearch/hermes-agent/actions/runs/33712480629), [Docker amd64/arm64](https://github.com/NousResearch/hermes-agent/actions/runs/33712479788), and [Nix](https://github.com/NousResearch/hermes-agent/actions/runs/33712479822) pass; GitHub reports mergeable. The tests exercise real Desktop stores, router, pane actions and mounted components with backend I/O stubbed. Historical packaged UAT is not presented as validation of this recut; fresh packaged, live-gateway and touch/keyboard UAT remain unverified for this head.

<details>
<summary>Failure cases exercised</summary>

Unavailable/stale candidates; profile-first and exact-connection fallback; alias versus target-profile routing; duplicate IDs; wrong-owner and ownerless open tiles; pending navigation during manual session or pane changes; rapid clicks; remounts; flipped and narrow layouts; overlay close/reopen; resize; and recovery through visible Sessions rows. The final independent reviews reran the original reproduction harnesses. Overlapping runs are not added to the 209-test count above.

Already-dispatched reads are fenced, not aborted. Conservative skips preserve unread state rather than guessing an owner or deleting/relabeling a tile. A successful preflight is not a guarantee that subsequent transcript hydration succeeds.

</details>

## Related

- Complements #93006's Bot unread-marker fix; this PR owns Sessions navigation and chrome.
- Retains #93552's cron-badge policy without clearing cron-row unread state.
- #92829 addresses separate no-row acknowledgement behavior.
- #92946 concerns the neighboring Files/sidebar control, not a dependency. Later composition must preserve Sessions ownership of this count.
