### PR TITLE
fix(termux): uv platform tag, bionic PATH, and node shebang repair

### DIFF
--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -110,6 +110,11 @@ def _is_termux_env(env: dict | None = None) -> bool:
 
     Matches ``hermes_cli.main._is_termux_startup_environment`` without
     importing main (this module stays stdlib-only).
+
+    Intentionally tighter than the old ``_install_repair`` probe (any
+    PREFIX containing ``com.termux``): require ``com.termux/files/usr`` in
+    PREFIX, a ``/data/data/com.termux/`` prefix, or ``TERMUX_VERSION``.
+    Relocated / exotic PREFIX layouts without those markers are untreated.
     """
     check = env if env is not None else os.environ
     try:
@@ -131,6 +136,9 @@ def termux_uv_python_platform(env: dict | None = None) -> str:
     ``No module named 'pydantic_core._pydantic_core'``). Use an arch-specific
     GNU/Linux tag so locally built ``linux_aarch64`` wheels are accepted.
 
+    Unknown architectures return ``""`` so callers skip injection and keep
+    today's uv default instead of forcing the broken bare ``linux`` tag.
+
     Override with ``HERMES_UV_PYTHON_PLATFORM`` when needed.
     """
     base = env if env is not None else os.environ
@@ -143,7 +151,7 @@ def termux_uv_python_platform(env: dict | None = None) -> str:
         return "aarch64-unknown-linux-gnu"
     if machine in ("x86_64", "amd64"):
         return "x86_64-unknown-linux-gnu"
-    return "linux"
+    return ""
 
 
 def with_uv_termux_python_platform(
@@ -155,8 +163,9 @@ def with_uv_termux_python_platform(
     as incompatible with "Python on Android aarch64". Passing an arch-specific
     ``--python-platform`` (see :func:`termux_uv_python_platform`) makes uv
     accept those local builds so ``hermes update`` / interrupted-install
-    recovery can finish. No-op when not Termux, not an ``uv pip install``, or
-    when the flag is already present.
+    recovery can finish. No-op when not Termux, not an ``uv pip install``,
+    when the flag is already present, or when the arch is unknown (empty
+    platform — avoid injecting bare ``linux``).
     """
     if not _is_termux_env(env):
         return cmd
@@ -167,6 +176,9 @@ def with_uv_termux_python_platform(
         return cmd
     if "--python-platform" in cmd:
         return cmd
+    py_platform = termux_uv_python_platform(env)
+    if not py_platform:
+        return cmd
     try:
         install_idx = cmd.index("install")
     except ValueError:
@@ -174,7 +186,7 @@ def with_uv_termux_python_platform(
     out = list(cmd)
     out[install_idx + 1 : install_idx + 1] = [
         "--python-platform",
-        termux_uv_python_platform(env),
+        py_platform,
     ]
     return out
 
@@ -221,11 +233,19 @@ def fix_termux_node_shebangs(project_root: Path) -> None:
     node_modules = Path(project_root) / "node_modules"
     if not node_modules.is_dir():
         return
+    # npm CLI wrappers live under ``*/bin/`` / ``.bin/``. Scoping there (and
+    # skipping files >4 KiB) avoids reading every package asset on large trees.
+    _shebang_max_bytes = 4096
     targets: list[str] = []
     for path in node_modules.rglob("*"):
         if not path.is_file():
             continue
+        parts = path.parts
+        if "bin" not in parts and ".bin" not in parts:
+            continue
         try:
+            if path.stat().st_size > _shebang_max_bytes:
+                continue
             with path.open("rb") as handle:
                 head = handle.read(24)
         except OSError:

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -102,6 +103,145 @@ def _should_skip_external_secret_sources() -> bool:
 
 def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
+
+
+def _is_termux_env(env: dict | None = None) -> bool:
+    """Stdlib Termux probe — shared with ``_install_repair``.
+
+    Matches ``hermes_cli.main._is_termux_startup_environment`` without
+    importing main (this module stays stdlib-only).
+    """
+    check = env if env is not None else os.environ
+    try:
+        prefix = str(check.get("PREFIX", ""))
+        return bool(
+            check.get("TERMUX_VERSION")
+            or "com.termux/files/usr" in prefix
+            or prefix.startswith("/data/data/com.termux/")
+        )
+    except Exception:
+        return False
+
+
+def termux_uv_python_platform(env: dict | None = None) -> str:
+    """Return a uv ``--python-platform`` value for this Termux host.
+
+    Bare ``linux`` is wrong on uv 0.12+: it resolves to **x86_64** manylinux
+    even on aarch64 Android, which installs unloadable native wheels (symptom:
+    ``No module named 'pydantic_core._pydantic_core'``). Use an arch-specific
+    GNU/Linux tag so locally built ``linux_aarch64`` wheels are accepted.
+
+    Override with ``HERMES_UV_PYTHON_PLATFORM`` when needed.
+    """
+    base = env if env is not None else os.environ
+    override = (base.get("HERMES_UV_PYTHON_PLATFORM") or "").strip()
+    if override:
+        return override
+    machine = (base.get("HOSTTYPE") or platform.machine() or "").lower()
+    machine = machine.replace("arm64", "aarch64")
+    if machine == "aarch64":
+        return "aarch64-unknown-linux-gnu"
+    if machine in ("x86_64", "amd64"):
+        return "x86_64-unknown-linux-gnu"
+    return "linux"
+
+
+def with_uv_termux_python_platform(
+    cmd: list[str], env: dict | None = None
+) -> list[str]:
+    """On Termux, inject arch-aware ``uv pip install --python-platform …``.
+
+    uv builds wheels tagged ``linux_*`` on Android/Termux, then rejects them
+    as incompatible with "Python on Android aarch64". Passing an arch-specific
+    ``--python-platform`` (see :func:`termux_uv_python_platform`) makes uv
+    accept those local builds so ``hermes update`` / interrupted-install
+    recovery can finish. No-op when not Termux, not an ``uv pip install``, or
+    when the flag is already present.
+    """
+    if not _is_termux_env(env):
+        return cmd
+    if len(cmd) < 3:
+        return cmd
+    prog = Path(cmd[0]).name.lower()
+    if prog not in ("uv", "uv.exe") or cmd[1] != "pip":
+        return cmd
+    if "--python-platform" in cmd:
+        return cmd
+    try:
+        install_idx = cmd.index("install")
+    except ValueError:
+        return cmd
+    out = list(cmd)
+    out[install_idx + 1 : install_idx + 1] = [
+        "--python-platform",
+        termux_uv_python_platform(env),
+    ]
+    return out
+
+
+def prefer_termux_bionic_path(env: dict[str, str] | None = None) -> dict[str, str]:
+    """Put Termux's bionic ``$PREFIX/bin`` first on PATH.
+
+    Sessions under ``glibc-runner`` (e.g. Cursor Agent on Termux) often put
+    ``$PREFIX/glibc/bin`` ahead of ``$PREFIX/bin``. Child processes that are
+    *not* under the glibc runner then pick glibc ``bash``/``dirname``/``curl``
+    and fail with missing ``libdl.so``, which breaks clang wrappers and npm
+    scripts mid-``hermes update``. Prefacing PATH with the bionic bin keeps
+    native Termux tools preferred without removing glibc tools entirely.
+    """
+    base = dict(env if env is not None else os.environ)
+    if not _is_termux_env(base):
+        return base
+    prefix = (
+        base.get("PREFIX")
+        or base.get("TERMUX__PREFIX")
+        or "/data/data/com.termux/files/usr"
+    )
+    termux_bin = str(Path(prefix) / "bin")
+    parts = [p for p in base.get("PATH", "").split(":") if p and p != termux_bin]
+    base["PATH"] = ":".join([termux_bin, *parts])
+    return base
+
+
+def fix_termux_node_shebangs(project_root: Path) -> None:
+    """Rewrite ``#!/usr/bin/env`` node bins when Termux has no ``/usr/bin/env``.
+
+    Under glibc-runner / disabled termux-exec, npm scripts fail with
+    ``tsc: not found`` because the kernel cannot resolve ``/usr/bin/env``.
+    ``termux-fix-shebang`` rewrites them to ``$PREFIX/bin/env``. Best-effort
+    and silent when the helper or files are missing.
+    """
+    if not _is_termux_env():
+        return
+    if Path("/usr/bin/env").exists():
+        return
+    fixer = shutil.which("termux-fix-shebang")
+    if not fixer:
+        return
+    node_modules = Path(project_root) / "node_modules"
+    if not node_modules.is_dir():
+        return
+    targets: list[str] = []
+    for path in node_modules.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            with path.open("rb") as handle:
+                head = handle.read(24)
+        except OSError:
+            continue
+        if head.startswith(b"#!/usr/bin/env"):
+            targets.append(str(path))
+    if not targets:
+        return
+    for i in range(0, len(targets), 64):
+        subprocess.run(
+            [fixer, *targets[i : i + 64]],
+            cwd=str(project_root),
+            check=False,
+            capture_output=True,
+        )
+
 
 
 def _load_pyproject_project(root: Path) -> dict | None:
@@ -328,8 +468,11 @@ def _run_repair_install(specs: list[str], project_root: Path) -> bool:
             env = {**os.environ, "VIRTUAL_ENV": str(project_root / "venv")}
             env.pop("PYTHONHOME", None)
             env.pop("PYTHONPATH", None)
-            return _run_installer("uv", [uv, "pip", "install", "--force-reinstall", *specs],
-                                  project_root, env)
+            repair_cmd = [uv, "pip", "install", "--force-reinstall", *specs]
+            if _is_termux_env(env):
+                env = prefer_termux_bionic_path(env)
+                repair_cmd = with_uv_termux_python_platform(repair_cmd, env)
+            return _run_installer("uv", repair_cmd, project_root, env)
         print("  ⚠ Base interpreter is externally managed and no uv binary was "
               "found; retrying repair via pip with PEP 668 override.", file=sys.stderr)
     _run_ensurepip(project_root)

--- a/hermes_cli/_install_repair.py
+++ b/hermes_cli/_install_repair.py
@@ -28,11 +28,11 @@ def _is_windows() -> bool:
 
 def _is_termux_env(env: dict | None = None) -> bool:
     """Stdlib Termux probe (hermes_cli.main's version lives behind imports)."""
-    env = env if env is not None else os.environ
-    try:
-        return bool(env.get("TERMUX_VERSION")) or "com.termux" in env.get("PREFIX", "")
-    except Exception:
-        return False
+    return _er._is_termux_env(env)
+
+
+prefer_termux_bionic_path = _er.prefer_termux_bionic_path
+with_uv_termux_python_platform = _er.with_uv_termux_python_platform
 
 
 @contextlib.contextmanager
@@ -409,6 +409,9 @@ def _run_install_cmd(cmd: list[str], *, env: dict | None, root: Path) -> None:
 
     The caller's marker-keeping failure handling turns that into "retry next launch". See #87331.
     """
+    if _is_termux_env(env):
+        env = prefer_termux_bionic_path(env)
+        cmd = with_uv_termux_python_platform(cmd, env)
     scripts_dir = _venv_scripts_dir(root) if _is_windows() else None
     failed: list[str] = []
     moved = _quarantine_running_hermes_exe(scripts_dir, failed_out=failed) if scripts_dir else []

--- a/hermes_cli/main_install_repair.py
+++ b/hermes_cli/main_install_repair.py
@@ -452,6 +452,17 @@ def _run_install_with_heartbeat(
     t = threading.Thread(target=_heartbeat, daemon=True)
     t.start()
     try:
+        if _is_termux_env(env):
+            # Termux: prefer bionic PATH + arch-aware uv --python-platform so
+            # Android wheel-tag rejects and glibc-first PATH breakages don't
+            # strand updates (bare "linux" is x86_64 on uv 0.12+).
+            from hermes_cli._early_recovery import (
+                prefer_termux_bionic_path,
+                with_uv_termux_python_platform,
+            )
+
+            env = prefer_termux_bionic_path(env)
+            cmd = with_uv_termux_python_platform(cmd, env)
         subprocess.run(cmd, cwd=PROJECT_ROOT, check=True, env=env)
     finally:
         done.set()

--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -488,6 +488,18 @@ def _do_build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             _console_print("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
     build_env = _npm_lifecycle_env(with_hermes_node_path())
+    project_root = _web_project_root(web_dir)
+    from hermes_cli.main import _is_termux_startup_environment
+    if _is_termux_startup_environment():
+        from hermes_cli._early_recovery import (
+            fix_termux_node_shebangs,
+            prefer_termux_bionic_path,
+        )
+
+        build_env = prefer_termux_bionic_path(build_env)
+        # npm install may have left #!/usr/bin/env shebangs that Termux cannot
+        # execute when /usr/bin/env is missing — fix before tsc/vite run.
+        fix_termux_node_shebangs(project_root)
     _console_print("→ Building web UI...")
 
     npm_cwd, npm_workspace_args = _web_npm_install_context(web_dir)
@@ -499,6 +511,12 @@ def _do_build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     def _build() -> subprocess.CompletedProcess:
         # Streamed + idle-killed (never capture_output on a long Vite build: it
         # looks identical to a hang and users reboot mid-install).
+        if _is_termux_startup_environment():
+            from hermes_cli._early_recovery import fix_termux_node_shebangs
+
+            # npm install rewrites #!/usr/bin/env shebangs; on Termux without
+            # /usr/bin/env that surfaces as `tsc: not found`. Fix before each run.
+            fix_termux_node_shebangs(project_root)
         return _run_with_idle_timeout([npm, "run", "build"], cwd=web_dir, env=build_env)
 
     r1 = _install_web_deps(silent=True)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1225,6 +1225,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always restore stdio even on
     ``sys.exit``. Self-lock deferral deliberately does NOT run here (pre-fetch it stranded users
     on the OLD checkout in an exit-2 loop); it runs right before the dependency sync."""
+    if _m()._is_termux_env():
+        # Termux under glibc-runner often puts $PREFIX/glibc/bin first; child
+        # builds then pick broken glibc bash/dirname. Prefer bionic tools for
+        # the whole update process (also applied per-subprocess where we pass env).
+        from hermes_cli._early_recovery import prefer_termux_bionic_path
+
+        os.environ["PATH"] = prefer_termux_bionic_path()["PATH"]
+
     opts = _resolve_update_options(args, gateway_mode)
     gw_input_fn, assume_yes = opts.gw_input_fn, opts.assume_yes
 

--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -540,6 +540,17 @@ def _repair_node_deps_on_current_checkout(
     return bool(print_completion(completion_message))
 
 
+
+def _fix_termux_node_shebangs(project_root: Path) -> None:
+    """Rewrite ``#!/usr/bin/env`` node bins when Termux has no ``/usr/bin/env``.
+
+    Delegates to :func:`hermes_cli._early_recovery.fix_termux_node_shebangs`.
+    """
+    from hermes_cli._early_recovery import fix_termux_node_shebangs
+
+    fix_termux_node_shebangs(project_root)
+
+
 def _update_node_dependencies() -> list[str]:
     """Refresh Node deps for ui-tui and web. Returns labels whose npm install failed (empty on
     success) so the caller reports a partial update instead of ``Update complete!``.
@@ -604,6 +615,10 @@ def _update_node_dependencies() -> list[str]:
 
     from hermes_constants import with_hermes_node_path
     nixos_env = with_hermes_node_path(_m()._nixos_build_env())
+    if _m()._is_termux_env():
+        from hermes_cli._early_recovery import prefer_termux_bionic_path
+
+        nixos_env = prefer_termux_bionic_path(nixos_env)
 
     # capture_output=False is deliberate: postinstall scripts print download progress and
     # capturing makes a long download look hung.
@@ -612,6 +627,8 @@ def _update_node_dependencies() -> list[str]:
     result = _m()._run_npm_install_deterministic(
         npm, _m().PROJECT_ROOT, extra_args=tuple(install_args), capture_output=False, env=nixos_env)
     if result.returncode == 0:
+        if _m()._is_termux_env():
+            _fix_termux_node_shebangs(_m().PROJECT_ROOT)
         _record_npm_lockfile_hash(shared_hermes_root)
         print("  ✓ ui-tui, web workspaces installed (desktop skipped)")
         return []

--- a/tests/hermes_cli/test_termux_uv_platform.py
+++ b/tests/hermes_cli/test_termux_uv_platform.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from hermes_cli import _install_repair as install_repair
 from hermes_cli._early_recovery import (
     _is_termux_env,
     fix_termux_node_shebangs,
@@ -30,6 +31,52 @@ def test_fix_termux_node_shebangs_noop_off_termux(tmp_path: Path):
     run.assert_not_called()
 
 
+def test_fix_termux_node_shebangs_runs_fixer_for_discovered_bins(
+    tmp_path: Path, monkeypatch
+):
+    bin_dir = tmp_path / "node_modules" / ".bin"
+    bin_dir.mkdir(parents=True)
+    target = bin_dir / "tsc"
+    target.write_bytes(b"#!/usr/bin/env node\nconsole.log(1)\n")
+    noise = tmp_path / "node_modules" / "pkg" / "index.js"
+    noise.parent.mkdir(parents=True)
+    noise.write_bytes(b"#!/usr/bin/env node\n")
+
+    monkeypatch.setattr(
+        "hermes_cli._early_recovery._is_termux_env", lambda env=None: True
+    )
+    monkeypatch.setattr(
+        "hermes_cli._early_recovery.shutil.which",
+        lambda name: (
+            "/usr/bin/termux-fix-shebang"
+            if name == "termux-fix-shebang"
+            else None
+        ),
+    )
+
+    real_path = Path
+
+    class _FakeEnvPath:
+        def exists(self):
+            return False
+
+    def _path_factory(arg, *args, **kwargs):
+        if str(arg) == "/usr/bin/env":
+            return _FakeEnvPath()
+        return real_path(arg, *args, **kwargs)
+
+    monkeypatch.setattr("hermes_cli._early_recovery.Path", _path_factory)
+
+    with patch("hermes_cli._early_recovery.subprocess.run") as run:
+        fix_termux_node_shebangs(tmp_path)
+
+    run.assert_called_once()
+    args = run.call_args[0][0]
+    assert args[0] == "/usr/bin/termux-fix-shebang"
+    assert str(target) in args
+    assert str(noise) not in args
+
+
 def test_termux_uv_python_platform_aarch64():
     env = {"HOSTTYPE": "aarch64"}
     assert termux_uv_python_platform(env) == "aarch64-unknown-linux-gnu"
@@ -38,6 +85,10 @@ def test_termux_uv_python_platform_aarch64():
 def test_termux_uv_python_platform_x86_64():
     env = {"HOSTTYPE": "x86_64"}
     assert termux_uv_python_platform(env) == "x86_64-unknown-linux-gnu"
+
+
+def test_termux_uv_python_platform_unknown_arch_skips_bare_linux():
+    assert termux_uv_python_platform({"HOSTTYPE": "riscv64"}) == ""
 
 
 def test_termux_uv_python_platform_override():
@@ -61,6 +112,15 @@ def test_with_uv_termux_python_platform_injects_arch_flag():
         "-e",
         ".[termux-all]",
     ]
+
+
+def test_with_uv_termux_python_platform_noop_unknown_arch():
+    env = {
+        "TERMUX_VERSION": "1",
+        "HOSTTYPE": "riscv64",
+    }
+    cmd = ["uv", "pip", "install", "markupsafe"]
+    assert with_uv_termux_python_platform(cmd, env) == cmd
 
 
 def test_with_uv_termux_python_platform_noop_off_termux():
@@ -90,3 +150,39 @@ def test_prefer_termux_bionic_path_puts_prefix_bin_first():
 def test_prefer_termux_bionic_path_noop_off_termux():
     env = {"PATH": "/usr/bin:/bin"}
     assert prefer_termux_bionic_path(env) == env
+
+
+def test_install_repair_run_install_cmd_injects_termux_uv_platform(tmp_path: Path):
+    """Delegation: ``_run_install_cmd`` applies PATH + --python-platform on Termux."""
+    env = {
+        "TERMUX_VERSION": "0.118.3",
+        "PREFIX": "/data/data/com.termux/files/usr",
+        "HOSTTYPE": "aarch64",
+        "PATH": "/data/data/com.termux/files/usr/glibc/bin:/usr/bin",
+    }
+    cmd = ["uv", "pip", "install", "-e", ".[termux-all]"]
+    captured: dict = {}
+
+    def _fake_run(argv, cwd=None, check=None, env=None):
+        captured["argv"] = list(argv)
+        captured["env"] = dict(env) if env is not None else None
+        return MagicMock(returncode=0)
+
+    with (
+        patch.object(install_repair, "_is_windows", return_value=False),
+        patch.object(install_repair.subprocess, "run", side_effect=_fake_run),
+    ):
+        install_repair._run_install_cmd(cmd, env=env, root=tmp_path)
+
+    assert captured["argv"] == [
+        "uv",
+        "pip",
+        "install",
+        "--python-platform",
+        "aarch64-unknown-linux-gnu",
+        "-e",
+        ".[termux-all]",
+    ]
+    assert captured["env"]["PATH"].startswith(
+        "/data/data/com.termux/files/usr/bin:"
+    )

--- a/tests/hermes_cli/test_termux_uv_platform.py
+++ b/tests/hermes_cli/test_termux_uv_platform.py
@@ -1,0 +1,92 @@
+"""Termux uv / PATH helpers for Android wheel-tag and glibc-first PATH."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_cli._early_recovery import (
+    _is_termux_env,
+    fix_termux_node_shebangs,
+    prefer_termux_bionic_path,
+    termux_uv_python_platform,
+    with_uv_termux_python_platform,
+)
+
+
+def test_is_termux_env_true_for_termux_prefix():
+    assert _is_termux_env({"PREFIX": "/data/data/com.termux/files/usr"}) is True
+
+
+def test_is_termux_env_false_for_generic_linux_prefix():
+    assert _is_termux_env({"PREFIX": "/usr/local"}) is False
+    assert _is_termux_env({"PREFIX": "/opt/com.termux/other"}) is False
+
+
+def test_fix_termux_node_shebangs_noop_off_termux(tmp_path: Path):
+    (tmp_path / "node_modules").mkdir()
+    with patch("hermes_cli._early_recovery.subprocess.run") as run:
+        fix_termux_node_shebangs(tmp_path)
+    run.assert_not_called()
+
+
+def test_termux_uv_python_platform_aarch64():
+    env = {"HOSTTYPE": "aarch64"}
+    assert termux_uv_python_platform(env) == "aarch64-unknown-linux-gnu"
+
+
+def test_termux_uv_python_platform_x86_64():
+    env = {"HOSTTYPE": "x86_64"}
+    assert termux_uv_python_platform(env) == "x86_64-unknown-linux-gnu"
+
+
+def test_termux_uv_python_platform_override():
+    env = {"HOSTTYPE": "aarch64", "HERMES_UV_PYTHON_PLATFORM": "aarch64-linux-android"}
+    assert termux_uv_python_platform(env) == "aarch64-linux-android"
+
+
+def test_with_uv_termux_python_platform_injects_arch_flag():
+    env = {
+        "TERMUX_VERSION": "0.118.3",
+        "PREFIX": "/data/data/com.termux/files/usr",
+        "HOSTTYPE": "aarch64",
+    }
+    cmd = ["/usr/bin/uv", "pip", "install", "-e", ".[termux-all]"]
+    assert with_uv_termux_python_platform(cmd, env) == [
+        "/usr/bin/uv",
+        "pip",
+        "install",
+        "--python-platform",
+        "aarch64-unknown-linux-gnu",
+        "-e",
+        ".[termux-all]",
+    ]
+
+
+def test_with_uv_termux_python_platform_noop_off_termux():
+    cmd = ["uv", "pip", "install", "markupsafe"]
+    assert with_uv_termux_python_platform(cmd, {}) == cmd
+
+
+def test_with_uv_termux_python_platform_idempotent():
+    env = {"TERMUX_VERSION": "1", "HOSTTYPE": "aarch64"}
+    cmd = ["uv", "pip", "install", "--python-platform", "linux", "x"]
+    assert with_uv_termux_python_platform(cmd, env) == cmd
+
+
+def test_prefer_termux_bionic_path_puts_prefix_bin_first():
+    env = {
+        "TERMUX_VERSION": "0.118.3",
+        "PREFIX": "/data/data/com.termux/files/usr",
+        "PATH": "/data/data/com.termux/files/usr/glibc/bin:/opt/bin:/data/data/com.termux/files/usr/bin",
+    }
+    fixed = prefer_termux_bionic_path(env)
+    assert fixed["PATH"].startswith("/data/data/com.termux/files/usr/bin:")
+    assert "/data/data/com.termux/files/usr/glibc/bin" in fixed["PATH"]
+    # Original env untouched.
+    assert env["PATH"].startswith("/data/data/com.termux/files/usr/glibc/bin:")
+
+
+def test_prefer_termux_bionic_path_noop_off_termux():
+    env = {"PATH": "/usr/bin:/bin"}
+    assert prefer_termux_bionic_path(env) == env

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -267,6 +267,8 @@ Python … on Android aarch64
 ```
 
 use the same arch-specific flag (or set `HERMES_UV_PYTHON_PLATFORM`).
+On rare non-aarch64/x86_64 Termux hosts Hermes leaves `--python-platform`
+unset rather than injecting bare `linux`.
 
 Or use the Termux path with the stdlib venv + `pip` instead:
 

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -242,7 +242,33 @@ The blocker is currently the `voice` extra:
 
 ### `uv pip install` fails on Android
 
-Use the Termux path with the stdlib venv + `pip` instead:
+`hermes update` and interrupted-install recovery automatically pass an
+**arch-specific** `--python-platform` on Termux (for example
+`aarch64-unknown-linux-gnu` on arm64 devices) so locally built `linux_*`
+wheels (e.g. `markupsafe`) are accepted.
+
+Do **not** use bare `--python-platform linux` with uv 0.12+: that tag
+resolves to **x86_64** manylinux even on aarch64 Android and installs
+unloadable native extensions (symptom:
+`No module named 'pydantic_core._pydantic_core'`). Prefer
+`~/bin/opk-hermes-update.sh --repair-python` or re-run with the matching
+arch tag:
+
+```bash
+# aarch64 Termux / Android
+uv pip install -e '.[termux-all]' --python-platform aarch64-unknown-linux-gnu
+```
+
+If you are installing by hand with uv and see:
+
+```text
+The built wheel `…-linux_aarch64.whl` is not compatible with the current
+Python … on Android aarch64
+```
+
+use the same arch-specific flag (or set `HERMES_UV_PYTHON_PLATFORM`).
+
+Or use the Termux path with the stdlib venv + `pip` instead:
 
 ```bash
 python -m venv venv
@@ -251,6 +277,20 @@ export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
 python -m pip install --upgrade pip setuptools wheel
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
+
+### `tsc: not found` / `bad interpreter: /usr/bin/env` after npm install
+
+If `/usr/bin/env` is missing (common when termux-exec is inactive under
+glibc-runner), npm script shebangs break. `hermes update` rewrites them
+via `termux-fix-shebang` after a successful Node refresh. To fix an
+existing tree:
+
+```bash
+find node_modules -type f -exec grep -l '^#!/usr/bin/env' {} + | xargs -r termux-fix-shebang
+```
+
+Also ensure Termux's bionic tools win on PATH (put `$PREFIX/bin` first)
+so child builds do not pick glibc `bash`/`dirname` from `$PREFIX/glibc/bin`.
 
 ### `jiter` / `maturin` complains about `ANDROID_API_LEVEL`
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
@@ -193,7 +193,8 @@ uv pip install -e '.[termux-all]' --python-platform aarch64-unknown-linux-gnu
 ```
 
 若手动使用 uv 并看到兼容性拒绝，请使用同一架构参数（或设置
-`HERMES_UV_PYTHON_PLATFORM`）。
+`HERMES_UV_PYTHON_PLATFORM`）。在少见的非 aarch64/x86_64 Termux 主机上，
+Hermes 会跳过注入 `--python-platform`，而不是写入裸的 `linux`。
 
 或改用标准库 venv + `pip` 的 Termux 路径：
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
@@ -178,7 +178,24 @@ python -m pip install -e '.[termux]' -c constraints-termux.txt
 
 ### `uv pip install` 在 Android 上失败
 
-改用标准库 venv + `pip` 的 Termux 路径：
+`hermes update` 与中断安装恢复会在 Termux 上自动传入**按架构区分**的
+`--python-platform`（例如 arm64 设备上的 `aarch64-unknown-linux-gnu`），
+以便接受本地构建的 `linux_*` wheel（例如 `markupsafe`）。
+
+不要在 uv 0.12+ 上使用裸的 `--python-platform linux`：该标签会解析为
+**x86_64** manylinux，即使在 aarch64 Android 上也会装上无法加载的原生扩展
+（症状：`No module named 'pydantic_core._pydantic_core'`）。优先使用
+`~/bin/opk-hermes-update.sh --repair-python`，或加上匹配架构的参数：
+
+```bash
+# aarch64 Termux / Android
+uv pip install -e '.[termux-all]' --python-platform aarch64-unknown-linux-gnu
+```
+
+若手动使用 uv 并看到兼容性拒绝，请使用同一架构参数（或设置
+`HERMES_UV_PYTHON_PLATFORM`）。
+
+或改用标准库 venv + `pip` 的 Termux 路径：
 
 ```bash
 python -m venv venv
@@ -187,6 +204,18 @@ export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
 python -m pip install --upgrade pip setuptools wheel
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
+
+### npm 后出现 `tsc: not found` / `bad interpreter: /usr/bin/env`
+
+当缺少 `/usr/bin/env`（glibc-runner 下 termux-exec 未生效时常见）时，
+npm 脚本 shebang 会失效。`hermes update` 在 Node 刷新与每次 web 构建前
+会通过 `termux-fix-shebang` 重写。修复现有树：
+
+```bash
+find node_modules -type f -exec grep -l '^#!/usr/bin/env' {} + | xargs -r termux-fix-shebang
+```
+
+同时确保 PATH 优先使用 Termux bionic 工具（`$PREFIX/bin` 在前）。
 
 ### `jiter` / `maturin` 报错提示缺少 `ANDROID_API_LEVEL`
 


### PR DESCRIPTION
## What does this PR do?

Fixes Termux-specific `hermes update` and interrupted-install recovery failures caused by:

- **uv wheel platform tags**: uv 0.12+ may resolve bare `linux` to manylinux on aarch64 Android, rejecting locally built `linux_aarch64` wheels (`No module named pydantic_core._pydantic_core`).
- **glibc-first PATH ordering**: sessions under glibc-runner can prioritize `$PREFIX/glibc/bin` ahead of bionic `$PREFIX/bin`, causing child processes to pick incompatible `bash`/`curl` during update.
- **Broken Node shebangs**: npm script shims can fail with `tsc: not found` when `/usr/bin/env` is unavailable and `node_modules/.bin/*` still uses `#!/usr/bin/env node`.

All behavior is **Termux-gated** through `_is_termux_env()` (PREFIX / TERMUX_VERSION probe). Non-Termux Linux, macOS, and Windows behavior is unchanged.

## Scope and design notes

- `_install_repair` now uses shared `_early_recovery._is_termux_env` detection for consistency.
- This intentionally tightens probe behavior compared with ad-hoc `"com.termux"` substring checks.
- Unknown architectures skip uv platform injection (no bare `linux` fallback).
- Shebang rewriting is bounded to likely script dirs (`*/bin`, `.bin`) and small files only.

## Related issue

No existing issue was found; this was discovered while reproducing update/install failures on Termux (Android, aarch64) with uv 0.12+ and glibc-runner sessions.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Tests
- [x] Documentation update

## Changes made

- `hermes_cli/_early_recovery.py`
  - added `termux_uv_python_platform`, `with_uv_termux_python_platform`, `prefer_termux_bionic_path`, and `fix_termux_node_shebangs`
  - wired Termux uv platform flag into early repair installs
- `hermes_cli/_install_repair.py`
  - reused shared Termux helpers for core install/repair subprocess env
- `hermes_cli/main.py`, `hermes_cli/update_cmd.py`
  - applied bionic PATH preference + node shebang repair during Termux startup/update
- `tests/hermes_cli/test_termux_uv_platform.py`
  - added coverage for probe behavior, env injection, PATH ordering, shebang fixer, install delegation, and off-Termux no-ops
- `website/docs/getting-started/termux.md` (+ zh-Hans)
  - documented uv platform tag, PATH ordering, and shebang troubleshooting

## How to test

1. `pytest tests/hermes_cli/test_termux_uv_platform.py -q`
2. On Termux, simulate interrupted install/update and run `hermes update`; verify local aarch64 wheels load and npm scripts no longer fail with `tsc: not found`.
3. Off Termux, verify `with_uv_termux_python_platform` and `prefer_termux_bionic_path` are no-ops.

## Contributor checklist

- [x] Searched for existing issues/PRs
- [x] Conventional commit style used
- [x] PR is focused to this fix
- [x] Tests added/updated
- [x] Manual verification on Termux (Android, aarch64)
- [x] Relevant docs updated
- [x] Cross-platform impact reviewed (Termux-gated)
