### PR TITLE
fix(bot-mode): a cronjob row opens — clicking one in the Bots pane no longer does nothing

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9767,7 +9767,117 @@ function scheduleLabel(schedule) {
   return schedule || ''
 }
 
-function RoutineRow({ job, owner }) {
+/** Absolute + relative rendering of a cron timestamp, or null when the job
+ *  has never carried one (a job that has not run yet has no `last_run_at`). */
+function routineTimestamp(value) {
+  const ms = value ? new Date(value).getTime() : Number.NaN
+  return Number.isFinite(ms) ? `${relativeTime(ms)} · ${new Date(ms).toLocaleString()}` : null
+}
+
+/** The facts `cron.manage list` already sends with every job, as label/value
+ *  rows. Pure so the detail contract is testable without a renderer, and so
+ *  the dialog cannot invent a field the gateway never sent: an absent value
+ *  drops its row instead of rendering "undefined". */
+function routineDetailRows(job) {
+  const paused = job?.enabled === false || job?.state === 'paused'
+  const label = scheduleLabel(job?.schedule)
+  const raw = String(job?.schedule || '').trim()
+
+  return [
+    ['Status', paused ? 'Paused' : 'Active'],
+    ['Schedule', label],
+    // `scheduleLabel` humanizes "every 1440m" and cron expressions; keep the
+    // raw string when it says something the label dropped.
+    ['Schedule (raw)', raw && raw !== label ? raw : null],
+    ['Repeat', job?.repeat],
+    ['Next run', paused ? null : routineTimestamp(job?.next_run_at)],
+    ['Last run', routineTimestamp(job?.last_run_at)],
+    ['Last result', job?.last_status],
+    ['Delivers to', job?.deliver],
+    ['Model', job?.model],
+    ['Working directory', job?.workdir]
+  ]
+    .filter(([, value]) => typeof value === 'string' && value.trim())
+    .map(([name, value]) => ({ label: name, value: value.trim() }))
+}
+
+/** Why a job is not doing what the user expects. The row only ever showed
+ *  "paused"; the scheduler's own reason and the last fire/delivery failures
+ *  had no surface in Bot Mode at all. */
+function routineDetailIssue(job) {
+  const reasons = [job?.last_fire_error, job?.last_delivery_error, job?.paused_reason]
+  const first = reasons.find(value => typeof value === 'string' && value.trim())
+
+  return first ? first.trim() : null
+}
+
+/** Read-only inspector for one cronjob, rendered from the list payload the
+ *  pane already holds — no extra RPC, and no second mutation path beside the
+ *  row's own switch and delete. */
+function RoutineDetailDialog({ job, onClose, open }) {
+  const rows = job ? routineDetailRows(job) : []
+  const issue = job ? routineDetailIssue(job) : null
+  const instruction = String(job?.prompt_preview || '').trim()
+
+  return jsx(Dialog, {
+    open: Boolean(open && job),
+    onOpenChange: value => {
+      if (!value) {
+        onClose()
+      }
+    },
+    children: jsxs(DialogContent, {
+      className: 'max-w-md',
+      children: [
+        jsxs(DialogHeader, {
+          children: [
+            jsx(DialogTitle, { className: 'truncate', children: routineTitle(job) }),
+            jsx(DialogDescription, { children: 'What this cronjob runs, and when it runs next.' })
+          ]
+        }),
+        jsxs('div', {
+          className: 'grid gap-3.5',
+          children: [
+            issue
+              ? jsx('div', {
+                  className:
+                    'rounded-md border border-(--ui-stroke-secondary) px-3 py-2 text-xs leading-5 text-(--ui-accent)',
+                  children: issue
+                })
+              : null,
+            jsx('div', {
+              className: 'grid gap-1.5',
+              children: rows.map(row =>
+                jsxs('div', {
+                  className: 'flex items-baseline justify-between gap-3 text-xs',
+                  children: [
+                    jsx('span', { className: 'shrink-0 text-(--ui-text-tertiary)', children: row.label }),
+                    jsx('span', { className: 'min-w-0 truncate text-right', children: row.value })
+                  ]
+                }, row.label)
+              )
+            }),
+            instruction
+              ? labeled(
+                  'Instruction',
+                  jsx('div', {
+                    className:
+                      'max-h-48 overflow-y-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-secondary) px-3 py-2 text-xs leading-5 text-(--ui-text-secondary)',
+                    children: instruction
+                  })
+                )
+              : null
+          ]
+        }),
+        jsx(DialogFooter, {
+          children: jsx(Button, { variant: 'secondary', onClick: onClose, children: 'Close' })
+        })
+      ]
+    })
+  })
+}
+
+function RoutineRow({ job, onOpen, owner }) {
   const profile = typeof owner === 'string' ? owner : owner?.name
   const [busy, setBusy] = useState(false)
   // Optimistic overlay: null = trust server state. Set immediately on
@@ -9812,13 +9922,24 @@ function RoutineRow({ job, owner }) {
       jsxs('div', {
         className: 'flex items-center gap-2',
         children: [
-          jsx('span', {
-            'aria-hidden': true,
-            className: cn('size-1.5 shrink-0 rounded-full', active ? 'bg-emerald-500' : 'bg-(--ui-text-quaternary)')
-          }),
-          jsx('span', {
-            className: cn('min-w-0 flex-1 truncate text-xs font-medium', !active && 'text-(--ui-text-tertiary)'),
-            children: routineTitle(job)
+          // The row's own button, not a click handler on the card: the switch
+          // and delete control are siblings, so opening the details can never
+          // swallow a toggle (and a nested button would be invalid markup).
+          jsxs('button', {
+            type: 'button',
+            title: 'Cronjob details',
+            className: 'flex min-w-0 flex-1 items-center gap-2 text-left transition-colors hover:text-foreground',
+            onClick: () => onOpen?.(job),
+            children: [
+              jsx('span', {
+                'aria-hidden': true,
+                className: cn('size-1.5 shrink-0 rounded-full', active ? 'bg-emerald-500' : 'bg-(--ui-text-quaternary)')
+              }),
+              jsx('span', {
+                className: cn('min-w-0 flex-1 truncate text-xs font-medium', !active && 'text-(--ui-text-tertiary)'),
+                children: routineTitle(job)
+              })
+            ]
           }),
           jsx(Switch, {
             checked: active,
@@ -10288,6 +10409,10 @@ function RoutinesPane() {
   const { data, error, isLoading, refetch } = useRoutines(owner)
   const [createOpen, setCreateOpen] = useState(false)
   const [createOwner, setCreateOwner] = useState(null)
+  // Hold the id, not the record: the 20s poll replaces every job object, and
+  // an open inspector must follow the live row (next run, pause, last error)
+  // instead of freezing the snapshot that was on screen when it opened.
+  const [detailJobId, setDetailJobId] = useState(null)
   const createTarget = owner ? routineCreateTarget(createOwner, bot) : null
 
   const openCreate = () => {
@@ -10311,6 +10436,7 @@ function RoutinesPane() {
     $lastJobs.set(view.live)
   }
   const jobs = view.jobs
+  const detailJob = detailJobId ? jobs.find(job => job.job_id === detailJobId) || null : null
   const staleNotice = error && !view.live && view.all.length
     ? 'Could not refresh cronjobs. Showing the last list we had.'
     : null
@@ -10414,9 +10540,16 @@ function RoutinesPane() {
               className: 'min-h-0 flex-1',
               children: jsx('div', {
                 className: 'grid gap-1.5 px-2.5 py-2',
-                children: jobs.map(job => jsx(RoutineRow, { job, owner }, job.job_id))
+                children: jobs.map(job =>
+                  jsx(RoutineRow, { job, onOpen: opened => setDetailJobId(opened.job_id), owner }, job.job_id)
+                )
               })
             }),
+      jsx(RoutineDetailDialog, {
+        job: detailJob,
+        open: Boolean(detailJob),
+        onClose: () => setDetailJobId(null)
+      }),
       jsx(CreateRoutineDialog, {
         bot: createTarget,
         open: createOpen,

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-detail.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-detail.test.mjs
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Bot Mode's Cronjobs rows were inert: the only interactive controls were the
+// enable switch and the hover-only delete button, so clicking a cronjob to see
+// what it runs, when it runs next, or why it stopped did nothing at all. The
+// gateway already ships every one of those facts with `cron.manage list`, so
+// the inspector reads the record the pane is holding — no extra RPC, and no
+// second mutation path beside the row's own switch and delete.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const node = (type, props = {}) => ({ props, type })
+  const context = {
+    atom,
+    Button: 'Button',
+    Codicon: 'Codicon',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    cn: (...parts) => parts.filter(Boolean).join(' '),
+    Dialog: 'Dialog',
+    DialogContent: 'DialogContent',
+    DialogDescription: 'DialogDescription',
+    DialogFooter: 'DialogFooter',
+    DialogHeader: 'DialogHeader',
+    DialogTitle: 'DialogTitle',
+    document: { createElement: () => ({}), getElementById: () => null, head: { appendChild: () => undefined } },
+    host: { state: { profile: { listen: () => undefined } } },
+    jsx: node,
+    jsxs: node,
+    PALETTE_AREA: 'palette',
+    relativeTime: () => 'in 5 min',
+    Switch: 'Switch',
+    Tip: 'Tip',
+    useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined]
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(`
+      globalThis.__api = { RoutineDetailDialog, RoutineRow, routineDetailIssue, routineDetailRows };
+    `)
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context.__api
+}
+
+/** Depth-first walk over the stubbed element tree. */
+function collect(node, match, found = []) {
+  if (Array.isArray(node)) {
+    for (const child of node) collect(child, match, found)
+    return found
+  }
+
+  if (!node || typeof node !== 'object') {
+    return found
+  }
+
+  if (match(node)) {
+    found.push(node)
+  }
+
+  return collect(node.props?.children, match, found)
+}
+
+function textOf(node) {
+  return collect(node, entry => typeof entry.props?.children === 'string')
+    .map(entry => entry.props.children)
+    .join(' | ')
+}
+
+const activeJob = {
+  deliver: 'bot-chat',
+  enabled: true,
+  job_id: 'job-1',
+  last_run_at: '2026-08-23T09:00:00Z',
+  last_status: 'success',
+  name: '[bot:notetaker] Morning digest',
+  next_run_at: '2026-08-23T10:00:00Z',
+  prompt_preview: 'Summarize yesterday and post it.',
+  repeat: 'forever',
+  schedule: 'every 1440m'
+}
+
+// ── the facts the row never showed ──────────────────────────────────────────
+
+test('detail rows only carry fields the gateway actually sent', () => {
+  const { routineDetailRows } = load()
+  const rows = routineDetailRows({ enabled: true, job_id: 'bare', name: 'Bare', schedule: 'every 1h' })
+  const labels = rows.map(row => row.label)
+
+  // A job that has never run carries no last_run_at/last_status/model; those
+  // rows must be absent rather than rendering an empty or "undefined" value.
+  assert.ok(!labels.includes('Last run'))
+  assert.ok(!labels.includes('Last result'))
+  assert.ok(!labels.includes('Model'))
+  assert.ok(rows.every(row => row.value.trim().length > 0))
+})
+
+test('an active job reports its next run; a paused one does not claim one', () => {
+  const { routineDetailRows } = load()
+  const value = (rows, label) => rows.find(row => row.label === label)?.value
+
+  const active = routineDetailRows(activeJob)
+  assert.equal(value(active, 'Status'), 'Active')
+  assert.ok(value(active, 'Next run'))
+
+  const paused = routineDetailRows({ ...activeJob, enabled: false, state: 'paused' })
+  assert.equal(value(paused, 'Status'), 'Paused')
+  assert.equal(value(paused, 'Next run'), undefined, 'a paused job has no next run to promise')
+  assert.ok(value(paused, 'Last run'), 'history it does have is still shown')
+})
+
+test('the raw schedule appears only when the humanized label dropped something', () => {
+  const { routineDetailRows } = load()
+  const raw = rows => rows.find(row => row.label === 'Schedule (raw)')?.value
+
+  // "every 1440m" humanizes to "Daily" — the raw form still carries the cadence.
+  assert.equal(raw(routineDetailRows(activeJob)), 'every 1440m')
+  // A schedule the label passes through unchanged would only be duplicated.
+  const passthrough = routineDetailRows({ ...activeJob, schedule: '0 9 * * 1-5' })
+  assert.equal(raw(passthrough), undefined)
+  assert.equal(passthrough.find(row => row.label === 'Schedule')?.value, '0 9 * * 1-5')
+})
+
+test('a failing or scheduler-paused job explains itself, in failure order', () => {
+  const { routineDetailIssue } = load()
+
+  assert.equal(routineDetailIssue(activeJob), null)
+  assert.equal(routineDetailIssue({ ...activeJob, paused_reason: 'too many failures' }), 'too many failures')
+  assert.equal(
+    routineDetailIssue({ ...activeJob, last_delivery_error: 'telegram 401', paused_reason: 'too many failures' }),
+    'telegram 401'
+  )
+  assert.equal(
+    routineDetailIssue({
+      ...activeJob,
+      last_delivery_error: 'telegram 401',
+      last_fire_error: 'model timeout',
+      paused_reason: 'too many failures'
+    }),
+    'model timeout',
+    'the run that never happened outranks the delivery of a run that did'
+  )
+})
+
+// ── the row is reachable ────────────────────────────────────────────────────
+
+test('the row title is a button that opens THIS job', () => {
+  const { RoutineRow } = load()
+  const opened = []
+  const tree = RoutineRow({ job: activeJob, onOpen: job => opened.push(job), owner: 'notetaker' })
+  const buttons = collect(tree, entry => entry.type === 'button' && typeof entry.props.onClick === 'function')
+
+  assert.ok(buttons.length >= 1, 'the row exposes at least one activation target')
+  const [title] = buttons
+  title.props.onClick()
+  assert.deepEqual(opened, [activeJob])
+})
+
+test('opening the details cannot swallow the switch or the delete control', () => {
+  const { RoutineRow } = load()
+  const tree = RoutineRow({ job: activeJob, onOpen: () => undefined, owner: 'notetaker' })
+  const openers = collect(tree, entry => entry.props?.title === 'Cronjob details')
+
+  assert.equal(openers.length, 1)
+  // The switch and the delete button must not live INSIDE the opener: a click
+  // on them would otherwise also open the inspector (and nested interactive
+  // elements are invalid markup).
+  assert.deepEqual(collect(openers[0], entry => entry.type === 'Switch'), [])
+  assert.deepEqual(collect(openers[0], entry => entry.type === 'Tip'), [])
+  assert.equal(collect(tree, entry => entry.type === 'Switch').length, 1)
+})
+
+// ── the inspector ───────────────────────────────────────────────────────────
+
+test('the inspector renders the job’s instruction and its failure', () => {
+  const { RoutineDetailDialog } = load()
+  const job = { ...activeJob, last_fire_error: 'model timeout' }
+  const rendered = textOf(RoutineDetailDialog({ job, onClose: () => undefined, open: true }))
+
+  assert.match(rendered, /Morning digest/)
+  assert.match(rendered, /Summarize yesterday and post it\./)
+  assert.match(rendered, /model timeout/)
+  assert.doesNotMatch(rendered, /\[bot:notetaker\]/, 'the routing tag is plumbing, not a title')
+})
+
+test('the inspector stays shut without a job to inspect', () => {
+  const { RoutineDetailDialog } = load()
+
+  assert.equal(RoutineDetailDialog({ job: null, onClose: () => undefined, open: true }).props.open, false)
+  assert.equal(RoutineDetailDialog({ job: activeJob, onClose: () => undefined, open: false }).props.open, false)
+  assert.equal(RoutineDetailDialog({ job: activeJob, onClose: () => undefined, open: true }).props.open, true)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-owner.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-owner.test.mjs
@@ -17,20 +17,44 @@ function load() {
     return slot
   }
   const invalidations = []
+  const requests = []
+  const node = (type, props = {}) => ({ props, type })
   const context = {
     atom,
+    Button: 'Button',
+    Codicon: 'Codicon',
+    cn: (...parts) => parts.filter(Boolean).join(' '),
+    Dialog: 'Dialog',
+    DialogContent: 'DialogContent',
+    DialogDescription: 'DialogDescription',
+    DialogFooter: 'DialogFooter',
+    DialogHeader: 'DialogHeader',
+    DialogTitle: 'DialogTitle',
     host: {
       state: {
         profile: { get: () => 'ops', listen: () => undefined },
         gateway: { get: () => 'open', listen: () => undefined }
       },
-      request: async () => ({ jobs: [] }),
+      request: async (method, params) => {
+        requests.push({ method, params })
+        return { jobs: [] }
+      },
+      requestProfile: async (route, method, params) => {
+        requests.push({ method, params, route })
+        return { jobs: [] }
+      },
       notify: () => undefined,
       notifyError: () => undefined
     },
+    jsx: node,
+    jsxs: node,
     queryClient: {
       invalidateQueries: async options => invalidations.push(options)
     },
+    relativeTime: () => 'in 5 min',
+    Switch: 'Switch',
+    Tip: 'Tip',
+    useState: initial => [typeof initial === 'function' ? initial() : initial, () => undefined],
     PALETTE_AREA: 'palette',
     COMPOSER_AREAS: { middleware: 'middleware' },
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } }
@@ -42,9 +66,26 @@ function load() {
     .replace(/^import .* from 'react'\r?\n/m, '')
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
-    .concat('\nglobalThis.__routineOwners = { routineCreateTarget, invalidateRoutineOwner };\n')
+    .concat('\nglobalThis.__routineOwners = { RoutineRow, routineCreateTarget, invalidateRoutineOwner };\n')
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
-  return { ...context, invalidations }
+  return { ...context, invalidations, requests }
+}
+
+/** Depth-first search over the stubbed element tree. */
+function find(node, match) {
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const hit = find(child, match)
+      if (hit) return hit
+    }
+    return null
+  }
+
+  if (!node || typeof node !== 'object') {
+    return null
+  }
+
+  return match(node) ? node : find(node.props?.children, match)
 }
 
 test('routine creation keeps its captured owner while another bot becomes active', () => {
@@ -63,12 +104,28 @@ test('routine mutation invalidates only its immutable owner cache', async () => 
   }])
 })
 
-test('source contract: row mutations invalidate the profile that owned the request', () => {
-  assert.match(
-    pluginSource,
-    /function RoutineRow\(\{ job, owner \}\)[\s\S]*await requestForBot\(owner, 'cron\.manage',[\s\S]*await invalidateRoutineOwner\(owner\)/
-  )
-  assert.doesNotMatch(pluginSource, /function RoutineRow\(\{ job, onChanged, profile \}\)/)
+test('a row mutation addresses — and invalidates — the owner that rendered it', async () => {
+  const runtime = load()
+  const row = runtime.__routineOwners.RoutineRow({
+    job: { enabled: true, job_id: 'digest', name: '[bot:ops] Digest', schedule: 'every 1h' },
+    onOpen: () => undefined,
+    owner: 'ops'
+  })
+
+  const toggle = find(row, node => node.type === 'Switch')
+  assert.ok(toggle, 'the row still exposes its enable switch')
+
+  // 'ops' is the row's owner while the live gateway may already be on another
+  // bot: both the RPC and the cache eviction must name the owner, not the
+  // ambient profile.
+  await toggle.props.onCheckedChange(false)
+
+  assert.deepEqual(plain(runtime.requests), [
+    { method: 'cron.manage', params: { action: 'pause', name: 'digest', profile: 'ops' } }
+  ])
+  assert.deepEqual(plain(runtime.invalidations), [
+    { queryKey: ['hermes-bots', 'routines', 'ops'], exact: true }
+  ])
 })
 
 test('source contract: create mutations and dialog state retain one owner', () => {


### PR DESCRIPTION
## Summary

In the Bots pane, the Cronjobs rows are inert. The only interactive controls are the enable switch and the hover-only delete button, so clicking a cronjob to see what it runs, when it runs next, or why it stopped does nothing at all — while the same job on the main Cron page (`src/app/cron/`) opens a full detail panel. Reported as "I cannot interact with the cronjobs when I'm in the bot section."

The gateway already ships every one of those facts with `cron.manage list` (`schedule`, `repeat`, `next_run_at`, `last_run_at`, `last_status`, `deliver`, `model`, `workdir`, `prompt_preview`, plus `last_fire_error` / `last_delivery_error` / `paused_reason`). None of it had a surface in Bot Mode — a job that is failing every run reads exactly like a healthy paused one, because the row's second line only ever says `paused`.

- `RoutineRow`'s title becomes a real button that opens a read-only inspector rendered from the record the pane already holds. No extra RPC, no backend change, no second mutation path beside the row's own switch and delete.
- The switch and the delete button stay **siblings** of the opener rather than children, so a toggle can never be swallowed by the open (and a nested interactive element would be invalid markup).
- The inspector tracks the job by `job_id`, not by object, so the pane's 20s poll keeps an open panel live (next run, pause, new error) instead of freezing the snapshot it opened with.

`routine-owner.test.mjs` had a source-regex test matching `function RoutineRow({ job, owner })` against the plugin text, so it failed on a parameter addition that changed no behavior. Per `AGENTS.md` ("Never read source code in tests") it is replaced with the invariant it was reaching for: toggling the switch sends `cron.manage` for the owner that rendered the row and evicts that owner's cache key.

## Test plan

- [x] `cd apps/desktop && node --test src/plugins/hermes-bots/tests/routine-detail.test.mjs` — 8/8 pass; all 8 fail against `main` before the fix.
- [x] `cd apps/desktop && npm run check:test:plugins` — 489/489 pass (was 488 + the converted source-regex test).
- [x] `npx eslint src/plugins/hermes-bots/tests/routine-*.test.mjs` — clean.
- [ ] Manual: open Bot Mode → Cronjobs, click a job row → the inspector opens with its schedule, next/last run, instruction, and any last error; toggling the switch or hitting delete still works without opening the panel.