### PR TITLE
fix(gemini): wrap schema-bearing tool results as opaque text

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -368,6 +368,13 @@ def _looks_like_json_schema(node: Any) -> bool:
     HTTP 400 INVALID_ARGUMENT. A tool result that is itself a JSON Schema
     (e.g. the output of ``tool_describe`` for an MCP tool) must therefore be
     forwarded as opaque text rather than as a structured response.
+
+    Detection is deliberately structural, not semantic: any ``$ref`` value
+    shaped like a JSON pointer (``#/...``) demotes the whole result. Non-schema
+    data that happens to carry such a pointer is a false positive, but the raw
+    content is preserved verbatim either way, so the cost is fidelity-free.
+    The recursive walk is O(n) over the parsed value; tool-result payloads are
+    small, so this is negligible per turn.
     """
     if isinstance(node, dict):
         for key, value in node.items():

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -360,6 +360,26 @@ def _translate_tool_call_to_gemini(
     return part
 
 
+def _looks_like_json_schema(node: Any) -> bool:
+    """True if a parsed value contains a JSON-Schema-style ``$ref`` pointer.
+
+    Gemini 3 resolves ``$ref``/``$defs`` references inside a
+    functionResponse.response payload and rejects unknown pointers with
+    HTTP 400 INVALID_ARGUMENT. A tool result that is itself a JSON Schema
+    (e.g. the output of ``tool_describe`` for an MCP tool) must therefore be
+    forwarded as opaque text rather than as a structured response.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "$ref" and isinstance(value, str) and value.startswith("#/"):
+                return True
+            if _looks_like_json_schema(value):
+                return True
+    elif isinstance(node, list):
+        return any(_looks_like_json_schema(item) for item in node)
+    return False
+
+
 def _translate_tool_result_to_gemini(
     message: Dict[str, Any],
     tool_name_by_call_id: Optional[Dict[str, str]] = None,
@@ -381,6 +401,14 @@ def _translate_tool_result_to_gemini(
     try:
         parsed = json.loads(content) if content.strip().startswith(("{", "[")) else None
     except json.JSONDecodeError:
+        parsed = None
+    # Gemini 3 resolves JSON-Schema ``$ref`` pointers inside a
+    # functionResponse.response payload and rejects unknown references with
+    # HTTP 400 INVALID_ARGUMENT ("referenced name '#/$defs/...' does not match
+    # a display_name"; see vercel/ai#14369). A tool result that is itself a
+    # JSON Schema (e.g. tool_describe output for an MCP tool) must therefore
+    # be forwarded as opaque text, not as a structured response.
+    if isinstance(parsed, dict) and _looks_like_json_schema(parsed):
         parsed = None
     response = parsed if isinstance(parsed, dict) else {"output": content}
     function_response: Dict[str, Any] = {

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -180,6 +180,67 @@ def test_plain_json_tool_result_remains_structured():
     assert out["functionResponse"]["response"] == {"status": "ok", "count": 3}
 
 
+def test_deeply_nested_ref_is_detected():
+    """A ``$ref`` pointer buried several levels deep through mixed lists and
+    dicts still demotes the result to opaque text (recursion coverage)."""
+    from agent.gemini_native_adapter import _translate_tool_result_to_gemini
+
+    deep = {"a": [{"b": {"c": [{"$ref": "#/$defs/Deep"}]}}]}
+    msg = {
+        "role": "tool",
+        "tool_call_id": "call_3",
+        "name": "some_tool",
+        "content": json.dumps(deep),
+    }
+
+    out = _translate_tool_result_to_gemini(msg)
+
+    response = out["functionResponse"]["response"]
+    assert "output" in response
+    assert "#/$defs/Deep" in response["output"]
+
+
+def test_top_level_json_array_is_wrapped_as_opaque_text():
+    """A top-level JSON array is never forwarded as a structured response.
+
+    ``response = parsed if isinstance(parsed, dict) else {"output": content}``
+    already wraps lists, so a list of schemas cannot reach the Gemini 400 path.
+    """
+    from agent.gemini_native_adapter import _translate_tool_result_to_gemini
+
+    arr = [{"$ref": "#/$defs/SetCookieParam", "type": "object"}]
+    msg = {
+        "role": "tool",
+        "tool_call_id": "call_4",
+        "name": "some_tool",
+        "content": json.dumps(arr),
+    }
+
+    out = _translate_tool_result_to_gemini(msg)
+
+    response = out["functionResponse"]["response"]
+    assert "output" in response
+    assert "$ref" not in response
+
+
+def test_ref_value_without_pointer_prefix_remains_structured():
+    """Only values shaped like a JSON pointer (``#/...``) demote a result; a
+    ``$ref`` value that is not a pointer leaves the structured path intact."""
+    from agent.gemini_native_adapter import _translate_tool_result_to_gemini
+
+    payload = {"$ref": "not-a-pointer", "status": "ok"}
+    msg = {
+        "role": "tool",
+        "tool_call_id": "call_5",
+        "name": "some_tool",
+        "content": json.dumps(payload),
+    }
+
+    out = _translate_tool_result_to_gemini(msg)
+
+    assert out["functionResponse"]["response"] == payload
+
+
 
 
 def test_translate_native_response_surfaces_reasoning_and_tool_calls():

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -131,6 +131,55 @@ def test_consecutive_user_messages_merge_for_gemini_alternation():
     assert roles == ["user", "model"], roles
 
 
+def test_schema_bearing_tool_result_is_wrapped_as_opaque_text():
+    """A tool result whose content is itself a JSON Schema must not be
+    forwarded as a structured functionResponse.response.
+
+    Gemini 3 resolves ``$ref``/``$defs`` pointers inside a function response
+    payload and rejects unknown references with HTTP 400 INVALID_ARGUMENT
+    ("referenced name '#/$defs/...' does not match a display_name"; see
+    vercel/ai#14369). ``tool_describe`` output for an MCP tool is exactly such
+    a schema, so it must be wrapped as opaque text instead.
+    """
+    from agent.gemini_native_adapter import _translate_tool_result_to_gemini
+
+    schema = {
+        "$defs": {"SetCookieParam": {"type": "object"}},
+        "properties": {"cookies": {"$ref": "#/$defs/SetCookieParam"}},
+    }
+    msg = {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "name": "tool_describe",
+        "content": json.dumps(schema),
+    }
+
+    out = _translate_tool_result_to_gemini(msg, include_ids=True)
+
+    response = out["functionResponse"]["response"]
+    assert "$defs" not in response
+    assert "output" in response
+    # The raw schema text is preserved verbatim in the wrapped output.
+    assert "#/$defs/SetCookieParam" in response["output"]
+
+
+def test_plain_json_tool_result_remains_structured():
+    """Ordinary JSON tool results without a ``$ref`` pointer keep the
+    structured form (no regression to the existing structured-response path)."""
+    from agent.gemini_native_adapter import _translate_tool_result_to_gemini
+
+    msg = {
+        "role": "tool",
+        "tool_call_id": "call_2",
+        "name": "some_tool",
+        "content": json.dumps({"status": "ok", "count": 3}),
+    }
+
+    out = _translate_tool_result_to_gemini(msg)
+
+    assert out["functionResponse"]["response"] == {"status": "ok", "count": 3}
+
+
 
 
 def test_translate_native_response_surfaces_reasoning_and_tool_calls():


### PR DESCRIPTION
## Summary

Fixes a Gemini 3.x `400 INVALID_ARGUMENT` crash when a tool result is itself a JSON Schema.

The native adapter forwards any JSON-looking tool result as a structured `functionResponse.response`. Gemini 3 resolves `$ref`/`$defs` JSON-pointer references inside that payload and rejects unknown ones (`referenced name '#/$defs/...' does not match a display_name`), so `tool_describe` output for an MCP tool whose schema has `$defs` crashes the turn.

## Change

- Add `_looks_like_json_schema()` to detect a parsed value containing a `$ref` JSON pointer.
- In `_translate_tool_result_to_gemini`, wrap such results as opaque text instead of a structured response.
- Two regression tests: schema-bearing result → wrapped; plain JSON result → still structured.

## Test plan

- [x] Manual verification: schema-bearing result wrapped as opaque text, plain JSON unchanged, helper edge cases.
- [x] New unit tests in `tests/agent/test_gemini_native_adapter.py`.

Closes #93014
