### PR TITLE
fix(gateway): keep Telegram bots receiving after silent network stalls

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -638,6 +638,12 @@ _POLLING_ERROR_TASK_STUCK_TIMEOUT = 300.0
 # A generation is not healthy until the dedicated getUpdates request returns
 # successfully. This exceeds a normal long-poll cycle for healthy idle bots.
 _POLLING_PROGRESS_TIMEOUT = 60.0
+# Steady-state polling must keep completing getUpdates round trips. The general
+# Bot API pool can stay healthy while the dedicated long-poll pool wedges, and
+# pending_update_count is not guaranteed to expose that split immediately.
+# Two normal heartbeat intervals leaves ample room for healthy long polls while
+# bounding a silent steady-state stall.
+_POLLING_STALL_TIMEOUT = 180.0
 # Telegram transcodes an uploaded video before it answers sendVideo, so the
 # wait for the response is unrelated to how fast the bytes went out and can
 # outlast the 20s read timeout the rest of the Bot API is tuned for. Only
@@ -828,6 +834,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_generation: int = 0
         self._polling_progress_event = asyncio.Event()
         self._polling_progress_accepting: bool = False
+        self._polling_last_progress_at: Optional[float] = None
         self._polling_progress_verifier_task: Optional[asyncio.Task] = None
         self._polling_teardown_started: bool = False
         self._polling_error_callback_ref = None
@@ -2552,6 +2559,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_generation = getattr(self, "_polling_generation", 0) + 1
         self._polling_progress_event = asyncio.Event()
         self._polling_progress_accepting = True
+        self._polling_last_progress_at = time.monotonic()
         self._send_path_degraded = True
         return self._polling_generation, self._polling_progress_event
 
@@ -2563,6 +2571,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if generation != self._polling_generation:
             return
+        self._polling_last_progress_at = time.monotonic()
         if not self._polling_progress_event.is_set():
             # The first confirmed getUpdates round-trip of this generation
             # resolves the "health pending getUpdates progress" line both
@@ -3194,6 +3203,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 # handle Telegram just reported before anything routes on it.
                 self._bot_identity_checked_at = time.monotonic()
                 self._note_bot_username(getattr(bot, "username", None))
+                last_progress = getattr(self, "_polling_last_progress_at", None)
+                if last_progress is not None:
+                    stalled_for = max(0.0, time.monotonic() - last_progress)
+                    if stalled_for >= _POLLING_STALL_TIMEOUT:
+                        self._schedule_polling_recovery(
+                            RuntimeError(
+                                "getUpdates stalled for %.0fs while the general "
+                                "Telegram API path remained healthy" % stalled_for
+                            ),
+                            reason="steady-state getUpdates progress watchdog",
+                        )
+                        continue
                 # get_me() succeeded — the general/send request path is healthy.
                 # That does NOT prove the getUpdates consumer is alive: PTB can
                 # report updater.running=True while the long-poll task is wedged,

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -538,6 +538,44 @@ async def test_heartbeat_loop_skips_reconnect_if_already_in_progress():
         pass
 
 
+@pytest.mark.asyncio
+async def test_heartbeat_restarts_when_getupdates_progress_goes_stale(monkeypatch):
+    """A healthy general API path must not mask a wedged getUpdates pool."""
+    adapter = _make_adapter()
+    adapter._handle_polling_network_error = AsyncMock()
+
+    mock_app = MagicMock()
+    mock_app.updater.running = True
+    mock_app.bot.get_me = AsyncMock(return_value=MagicMock())
+    mock_app.bot.get_webhook_info = AsyncMock(
+        return_value=MagicMock(pending_update_count=0)
+    )
+    adapter._app = mock_app
+
+    clock = [1000.0]
+    monkeypatch.setattr(tg_adapter.time, "monotonic", lambda: clock[0])
+    generation, _ = adapter._begin_polling_generation()
+    adapter._record_polling_progress(generation)
+    clock[0] += 200.0
+
+    sleep_calls = 0
+
+    async def fast_sleep(_seconds):
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls >= 2:
+            raise asyncio.CancelledError()
+
+    with patch("asyncio.sleep", side_effect=fast_sleep):
+        await adapter._polling_heartbeat_loop()
+    await asyncio.sleep(0)
+
+    adapter._handle_polling_network_error.assert_awaited_once()
+    error = adapter._handle_polling_network_error.await_args.args[0]
+    assert "getUpdates" in str(error)
+    assert "stalled" in str(error)
+
+
 async def _heartbeat_exception_case(exc, *, pending_probe=False):
     adapter = _make_adapter()
     reconnect_handler = AsyncMock()


### PR DESCRIPTION
## What does this PR do?

Telegram bots now recover when the dedicated getUpdates connection stops making progress even though the general Bot API connection remains healthy. Without this fix, the gateway process can stay alive while incoming messages remain unread until the operator restarts it.

### Symptom

Polling starts successfully and reports a healthy generation, then incoming Telegram messages stop reaching Hermes. The gateway process remains alive and the general Telegram API path may still be reachable, so the existing connectivity probe does not necessarily trigger recovery.

### Impact

Affected polling-mode Telegram gateways silently stop receiving messages. Operators must restart the gateway to restore delivery, and messages remain queued on Telegram until polling resumes.

### Bug Cause

**Trigger:** `plugins/platforms/telegram/adapter.py:3203` / `TelegramAdapter._polling_heartbeat_loop()` after a successful initial getUpdates generation later stops completing requests.

**Causal chain:**
1. A proxy or route transition wedges the dedicated getUpdates request pool after initial polling health was established.
2. The steady-state heartbeat verifies only the separate general request path and server-side pending update count; it does not retain the timestamp of the latest successful getUpdates round trip.
3. If the general path remains healthy and the pending count does not expose the split, no recovery is scheduled and the bot stays silently deaf.

**Why it is wrong:** Initial generation progress proves only startup health. It cannot prove that the same polling generation continues to make progress for the rest of the adapter lifetime.

**Working sibling / contrast:** Polling errors that raise normally already enter `_handle_polling_network_error()`, and startup polling is guarded by a generation progress deadline. The missing case is a steady-state getUpdates request that remains wedged without raising.

**Ruled out:** The issue reporter verified proxy reachability and reproduced the failure with explicit proxy configuration. Authorization and duplicate gateway processes were also ruled out because polling initially connected successfully and unread updates remained on Telegram.

### Fix

Track the monotonic timestamp of every successful getUpdates response for the active polling generation. The existing persistent heartbeat now treats 180 seconds without getUpdates progress as a polling stall when the general Bot API path is still healthy, logs the degraded state, and routes recovery through the existing guarded reconnect and adapter-rebuild ladder.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` - track steady-state getUpdates progress and recover stale polling generations.
- `tests/gateway/test_telegram_network_reconnect.py` - reproduce the healthy-general-path and stalled-polling-path split.

## How to Test

1. Start a Windows Telegram polling gateway through a proxy or TUN route.
2. Interrupt the dedicated long-poll path while keeping the general Bot API path reachable.
3. Confirm the heartbeat logs a steady-state getUpdates stall and the existing recovery ladder rebuilds polling without a full process restart.
4. Automated verification already run locally (18 passed):

```bash
scripts/run_tests.sh tests/gateway/test_telegram_network_reconnect.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant Telegram reconnect tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the automated reproduction on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is internal and covered by code comments
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no tool schema changed

## Screenshots / Logs

N/A; the regression is covered by the automated polling heartbeat test.
