### PR TITLE
fix(install.ps1): initialize LastResolver before the resolved-path report

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -326,6 +326,12 @@ function Set-LongProfileEnvVars {
     return $rewrote
 }
 
+# ConvertTo-LongPath only assigns $script:LastResolver when a ~\d short path
+# actually needs expansion, so an ordinary long profile leaves it unset -- and
+# the ResolvedPathReport below reads it unconditionally, which is fatal under
+# Set-StrictMode before any stage starts. 'none' is the resolver's own value
+# for "nothing ran".
+$script:LastResolver = 'none'
 $script:NormalizedProfilePaths = Set-LongProfileEnvVars
 
 # Re-derive the install paths now that the env vars behind their defaults are

--- a/tests/test_install_ps1_resolver_strictmode.py
+++ b/tests/test_install_ps1_resolver_strictmode.py
@@ -1,0 +1,71 @@
+"""Regression: the ResolvedPathReport must not read an unset resolver.
+
+Issue #93017: fresh Windows installs died at the ``$script:ResolvedPathReport``
+block with ``The variable '$script:LastResolver' cannot be retrieved because
+it has not been set`` — before any install stage ran. The mechanism:
+``ConvertTo-LongPath`` short-circuits at the top for ordinary long paths
+(``-notmatch '~\\d'`` returns early, per the comment "skip every resolver for
+ordinary long paths, which is the overwhelmingly common case"), so
+``$script:LastResolver`` is only ever assigned when a 8.3 short path actually
+needs expansion. The report block read it unconditionally, which is fatal in
+a ``Set-StrictMode`` session (the reporter hit it through three different
+invocation styles, i.e. their host/session enables strict mode).
+
+The fix initializes ``$script:LastResolver = 'none'`` at script scope before
+``Set-LongProfileEnvVars`` can run any resolver — ``'none'`` being the
+resolver's own value for "nothing ran".
+
+install.ps1 only runs on Windows, so these tests lock the contract at the
+source-text level (same style as test_install_ps1_uv_install_fallback.py).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+def _ps1() -> str:
+    return _INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_last_resolver_initialized_at_script_scope():
+    source = _ps1()
+    match = re.search(r"^\$script:LastResolver = 'none'\s*$", source, re.MULTILINE)
+    assert match is not None, (
+        "$script:LastResolver must be initialized at script scope ('none') — "
+        "ConvertTo-LongPath only assigns it when a short path needs expanding, "
+        "so an ordinary long profile leaves it unset (#93017)"
+    )
+
+
+def test_initialization_precedes_resolver_run_and_report_read():
+    source = _ps1()
+    init = re.search(r"^\$script:LastResolver = 'none'\s*$", source, re.MULTILINE)
+    run = re.search(r"^\$script:NormalizedProfilePaths = Set-LongProfileEnvVars", source, re.MULTILINE)
+    read = re.search(r"^\s+resolver\s+= \$script:LastResolver\s*$", source, re.MULTILINE)
+    assert init and run and read, "init / Set-LongProfileEnvVars / report read must all exist"
+    assert init.start() < run.start() < read.start(), (
+        "initialization must come before Set-LongProfileEnvVars can invoke a "
+        "resolver, and before the ResolvedPathReport reads the variable"
+    )
+
+
+def test_convert_to_long_path_still_short_circuits_before_assigning():
+    """Pin the mechanism that leaves the variable unset on normal paths.
+
+    The early return for paths without an 8.3 alias is what makes the
+    initialization load-bearing: if someone removes the short-circuit the
+    resolver always assigns, but the guard is a deliberate performance
+    choice (skip Add-Type for the overwhelmingly common case) and must
+    stay — so the init must stay too.
+    """
+    source = _ps1()
+    start = source.index("function ConvertTo-LongPath")
+    body = source[start : start + 2000]
+    assert re.search(r"-notmatch '~\\d'", body), (
+        "ConvertTo-LongPath must keep its ordinary-long-path short-circuit "
+        "(the reason $script:LastResolver can be unset without an init)"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a hard failure in `install.ps1` on fresh Windows installs running under a `Set-StrictMode` session: the script died at the `$script:ResolvedPathReport` block (line 367) with `The variable '$script:LastResolver' cannot be retrieved because it has not been set` — before any install stage ran, identically across `irm | iex`, `[scriptblock]::Create`, and direct invocation. The mechanism: `ConvertTo-LongPath` short-circuits at the top for ordinary long paths (no `~\d` 8.3 alias — "the overwhelmingly common case" per its own comment), so `$script:LastResolver` is only ever assigned when a short path actually needs expansion. The report block read it unconditionally. The fix initializes `$script:LastResolver = 'none'` — the resolver's own value for "nothing ran" — at script scope before `Set-LongProfileEnvVars` can invoke any resolver.

## Related Issue

Fixes #93017

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.ps1`
  - initialize `$script:LastResolver = 'none'` immediately before `$script:NormalizedProfilePaths = Set-LongProfileEnvVars`, with a comment naming the short-circuit mechanism and the StrictMode failure mode
- `tests/test_install_ps1_resolver_strictmode.py` (new)
  - source-text contract tests in the established install.ps1 style (`test_install_ps1_uv_install_fallback.py`): the init must exist, must precede both the resolver invocation and the report read, and `ConvertTo-LongPath` must keep its ordinary-long-path short-circuit (the reason the init is load-bearing)

## How to Test

1. `.venv/bin/python -m pytest tests/test_install_ps1_resolver_strictmode.py tests/test_install_ps1_uv_install_fallback.py -q`
2. Observed result: 8 passed. Reverting only `scripts/install.ps1` to main makes the two contract tests fail (`2 failed, 1 passed`), confirming they pin the fix.
3. Manual check on Windows in a strict-mode session: `Set-StrictMode -Version Latest; irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex` should proceed past path resolution; `pwsh -File install.ps1 -ShowResolvedPaths` should print the JSON report with `"resolver": "none"` instead of throwing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (installer source-text suites green: 8/8)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon) — install.ps1 itself is Windows-only; contract locked at source-text level per repo convention

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the mechanism)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (this IS the Windows fix)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
