### PR TITLE
fix(config): scope custom-provider context_length lookup by provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2576,6 +2576,7 @@ def init_agent(
                 model=agent.model,
                 base_url=agent.base_url,
                 custom_providers=_custom_providers,
+                provider=agent.provider,
             )
             if _cp_ctx_resolved:
                 _config_context_length = int(_cp_ctx_resolved)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2576,7 +2576,7 @@ def init_agent(
                 model=agent.model,
                 base_url=agent.base_url,
                 custom_providers=_custom_providers,
-                provider=agent.provider,
+                provider=getattr(agent, "provider", None),
             )
             if _cp_ctx_resolved:
                 _config_context_length = int(_cp_ctx_resolved)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2881,7 +2881,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             model=agent.model,
             base_url=agent.base_url,
             custom_providers=_sm_custom_providers,
-            provider=agent.provider,
+            provider=getattr(agent, "provider", None),
         )
     except Exception:
         _destination_context_intent = None

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2881,6 +2881,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             model=agent.model,
             base_url=agent.base_url,
             custom_providers=_sm_custom_providers,
+            provider=agent.provider,
         )
     except Exception:
         _destination_context_intent = None

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2926,6 +2926,7 @@ def get_model_context_length(
                 model=model,
                 base_url=base_url,
                 custom_providers=custom_providers,
+                provider=provider,
             )
             if cp_ctx:
                 return cp_ctx

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2971,6 +2971,7 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
                 model=resolved_model,
                 base_url=base_url,
                 custom_providers=custom_providers,
+                provider=provider,
             )
             if custom_ctx:
                 config_context_length = custom_ctx
@@ -18663,6 +18664,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             model=_msg_model,
                             base_url=_msg_base_url,
                             custom_providers=_msg_custom_providers,
+                            provider=_msg_model_cfg.get("provider"),
                         )
                         if _msg_custom_ctx:
                             _msg_config_ctx = _msg_custom_ctx
@@ -19553,6 +19555,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             model=_hyg_model,
                             base_url=_hyg_base_url,
                             custom_providers=_hyg_custom_providers,
+                            provider=_hyg_provider,
                         )
                         if _hyg_custom_ctx:
                             _hyg_config_context_length = int(_hyg_custom_ctx)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1804,13 +1804,22 @@ def get_custom_provider_context_length(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
     config: Optional[Dict[str, Any]] = None,
-    provider: Optional[str] = "",
+    provider: Optional[str] = None,
 ) -> Optional[int]:
     """Look up a per-model ``context_length`` override from ``custom_providers``.
 
     Matches any entry whose normalized route identity equals ``base_url`` and
     returns ``custom_providers[i].models.<model>.context_length`` if present and
     valid.  Returns ``None`` when no override applies.
+
+    When ``provider`` is supplied, matching is scoped to entries whose provider
+    identity equals it (case-insensitive).  Provider identity precedence is
+    ``provider_key`` > ``name`` > ``slug``; entries carrying none of those are
+    treated as identity-less legacy entries and only match as a fallback after
+    no identified entry did.  This keeps multiple providers sharing one
+    base_url (an OpenAI-compatible aggregator such as new-api/one-api) with
+    identically named but differently sized models from resolving to whichever
+    entry appears first in config order.
 
     This is the single source of truth for custom-provider context overrides,
     used by:
@@ -1843,38 +1852,60 @@ def get_custom_provider_context_length(
 
     provider_lower = (provider or "").strip().lower()
 
-    for entry in custom_providers:
+    def _entry_identity(entry: Any) -> str:
         if not isinstance(entry, dict):
-            continue
-        # Provider-scoped match: when a provider is supplied, only entries whose
-        # provider_key/name/slug match it are eligible. Multiple providers can
-        # share one base_url (e.g. an OpenAI-compatible aggregator such as
-        # new-api/one-api) and serve identically named models with different
-        # context windows; matching on base_url alone would resolve whichever
-        # provider appears first in config order instead of the one in use.
-        if provider_lower:
-            entry_provider = str(
-                entry.get("provider_key") or entry.get("name") or entry.get("slug") or ""
-            ).strip().lower()
-            if entry_provider and entry_provider != provider_lower:
-                continue
+            return ""
+        return str(
+            entry.get("provider_key") or entry.get("name") or entry.get("slug") or ""
+        ).strip().lower()
+
+    def _match_ctx(entry: Any) -> Optional[int]:
+        """Return the per-model context override for one entry, or ``None``."""
+        if not isinstance(entry, dict):
+            return None
         entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
-            continue
+            return None
         models = entry.get("models")
         if not isinstance(models, dict):
-            continue
+            return None
         model_cfg = models.get(model)
         if not isinstance(model_cfg, dict):
-            continue
+            return None
         raw_ctx = model_cfg.get("context_length")
         if raw_ctx is None:
-            continue
+            return None
         try:
             ctx = int(raw_ctx)
         except (TypeError, ValueError):
+            return None
+        return ctx if ctx > 0 else None
+
+    if not provider_lower:
+        # Legacy callers without a provider keep the historical
+        # first-match-in-config-order behaviour.
+        for entry in custom_providers:
+            ctx = _match_ctx(entry)
+            if ctx:
+                return ctx
+        return None
+
+    # Provider-scoped lookup. First pass: only entries whose identity equals the
+    # requested provider. An identity-less legacy entry must NOT win over a
+    # correctly named one purely by appearing earlier in config order.
+    for entry in custom_providers:
+        if _entry_identity(entry) != provider_lower:
             continue
-        if ctx > 0:
+        ctx = _match_ctx(entry)
+        if ctx:
+            return ctx
+    # Second pass: identity-less legacy entries are the fallback once no
+    # identified entry matched.
+    for entry in custom_providers:
+        if _entry_identity(entry):
+            continue
+        ctx = _match_ctx(entry)
+        if ctx:
             return ctx
     return None
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1804,6 +1804,7 @@ def get_custom_provider_context_length(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
     config: Optional[Dict[str, Any]] = None,
+    provider: Optional[str] = "",
 ) -> Optional[int]:
     """Look up a per-model ``context_length`` override from ``custom_providers``.
 
@@ -1840,9 +1841,23 @@ def get_custom_provider_context_length(
     if not target_url:
         return None
 
+    provider_lower = (provider or "").strip().lower()
+
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
+        # Provider-scoped match: when a provider is supplied, only entries whose
+        # provider_key/name/slug match it are eligible. Multiple providers can
+        # share one base_url (e.g. an OpenAI-compatible aggregator such as
+        # new-api/one-api) and serve identically named models with different
+        # context windows; matching on base_url alone would resolve whichever
+        # provider appears first in config order instead of the one in use.
+        if provider_lower:
+            entry_provider = str(
+                entry.get("provider_key") or entry.get("name") or entry.get("slug") or ""
+            ).strip().lower()
+            if entry_provider and entry_provider != provider_lower:
+                continue
         entry_url = normalize_route_base_url(entry.get("base_url"))
         if not entry_url or entry_url != target_url:
             continue

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -196,9 +196,10 @@ class TestProviderScopedContextLength:
             == 500_000
         )
 
-    def test_entry_without_provider_identity_still_matches_when_scoped(self):
-        """Legacy custom_providers entries carry no name/provider_key; they
-        must remain reachable under a scoped lookup rather than being skipped."""
+    def test_identityless_entry_is_fallback_when_no_identified_entry_matches(self):
+        """Legacy custom_providers entries carry no name/provider_key; under a
+        scoped lookup they remain reachable, but only as a fallback after no
+        identified entry matched."""
         legacy_only = [
             {
                 "base_url": "http://127.0.0.1:3000/v1",
@@ -210,6 +211,33 @@ class TestProviderScopedContextLength:
                 "m", "http://127.0.0.1:3000/v1", legacy_only, provider="anything"
             )
             == 128_000
+        )
+
+    def test_identityless_entry_does_not_shadow_named_entry(self):
+        """An identity-less legacy entry placed before a correctly named one
+        must NOT win the scoped lookup just because it appears first in config
+        order — that is exactly the misresolution provider scoping exists to
+        prevent."""
+        mixed = [
+            {
+                "base_url": "http://127.0.0.1:3000/v1",
+                "models": {"gpt-5.6-terra": {"context_length": 128_000}},
+            },
+            {
+                "provider_key": "market-aigw",
+                "name": "market-aigw",
+                "base_url": "http://127.0.0.1:3000/v1",
+                "models": {"gpt-5.6-terra": {"context_length": 1_050_000}},
+            },
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "gpt-5.6-terra",
+                "http://127.0.0.1:3000/v1",
+                mixed,
+                provider="market-aigw",
+            )
+            == 1_050_000
         )
 
 

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -121,6 +121,98 @@ class TestGetCustomProviderModelCapability:
 
 
 
+class TestProviderScopedContextLength:
+    """Multiple providers may share one base_url (e.g. an OpenAI-compatible
+    aggregator such as new-api/one-api) while serving identically named models
+    with different context windows. The lookup must scope by provider when one
+    is supplied instead of resolving whichever entry appears first in config
+    order.
+    """
+
+    CUSTOM = [
+        {
+            "provider_key": "coding-plan-gpt",
+            "name": "coding-plan-gpt",
+            "base_url": "http://127.0.0.1:3000/v1",
+            "models": {"gpt-5.6-terra": {"context_length": 500_000}},
+        },
+        {
+            "provider_key": "market-aigw",
+            "name": "market-aigw",
+            "base_url": "http://127.0.0.1:3000/v1",
+            "models": {"gpt-5.6-terra": {"context_length": 1_050_000}},
+        },
+    ]
+
+    def test_same_model_on_shared_base_url_resolves_per_provider(self):
+        assert (
+            get_custom_provider_context_length(
+                "gpt-5.6-terra",
+                "http://127.0.0.1:3000/v1",
+                self.CUSTOM,
+                provider="market-aigw",
+            )
+            == 1_050_000
+        )
+        assert (
+            get_custom_provider_context_length(
+                "gpt-5.6-terra",
+                "http://127.0.0.1:3000/v1",
+                self.CUSTOM,
+                provider="coding-plan-gpt",
+            )
+            == 500_000
+        )
+
+    def test_provider_lookup_is_case_insensitive(self):
+        assert (
+            get_custom_provider_context_length(
+                "gpt-5.6-terra",
+                "http://127.0.0.1:3000/v1",
+                self.CUSTOM,
+                provider="Market-AIGW",
+            )
+            == 1_050_000
+        )
+
+    def test_unknown_provider_does_not_match_any_entry(self):
+        assert (
+            get_custom_provider_context_length(
+                "gpt-5.6-terra",
+                "http://127.0.0.1:3000/v1",
+                self.CUSTOM,
+                provider="no-such-provider",
+            )
+            is None
+        )
+
+    def test_no_provider_keeps_first_match_order(self):
+        """Backward compatibility: legacy callers without a provider keep the
+        historical first-match-in-config-order behaviour."""
+        assert (
+            get_custom_provider_context_length(
+                "gpt-5.6-terra", "http://127.0.0.1:3000/v1", self.CUSTOM
+            )
+            == 500_000
+        )
+
+    def test_entry_without_provider_identity_still_matches_when_scoped(self):
+        """Legacy custom_providers entries carry no name/provider_key; they
+        must remain reachable under a scoped lookup rather than being skipped."""
+        legacy_only = [
+            {
+                "base_url": "http://127.0.0.1:3000/v1",
+                "models": {"m": {"context_length": 128_000}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(
+                "m", "http://127.0.0.1:3000/v1", legacy_only, provider="anything"
+            )
+            == 128_000
+        )
+
+
 class TestGetModelContextLengthHonorsOverride:
     """agent.model_metadata.get_model_context_length must honor the
     custom_providers override at step 0b — before any probe, cache hit,


### PR DESCRIPTION
## Summary

`get_custom_provider_context_length()` matched `custom_providers` entries on **base_url + model id alone**, ignoring which provider the lookup was for. Multiple providers can legitimately share one base_url — an OpenAI-compatible aggregator such as new-api/one-api fronting several upstream accounts is a common setup — and serve identically named models with different context windows. In that configuration every context-length resolution path picked whichever matching entry appeared first in config order.

## Observed symptom

Two configured providers (`coding-plan-gpt` and `market-aigw`) both point at `http://127.0.0.1:3000/v1` and both define `gpt-5.6-terra-2026-07-09`:

```yaml
providers:
  coding-plan-gpt:
    base_url: http://127.0.0.1:3000/v1
    models:
      gpt-5.6-terra-2026-07-09: {context_length: 500000}
  market-aigw:
    base_url: http://127.0.0.1:3000/v1
    models:
      gpt-5.6-terra-2026-07-09: {context_length: 1050000}
```

Selecting the model under `market-aigw` resolved its per-model override to **500,000** (the other provider's value). The wrong value propagated to every consumer of the resolution chain: status-bar display, `/model` switch confirmation, compression feasibility checks, gateway `/info` — and in our case surfaced as a hard failure when a large `@` reference was rejected against the wrong 50% limit.

## Fix

Add an optional `provider` parameter to `get_custom_provider_context_length()`. When supplied, only entries whose `provider_key`/`name`/`slug` equals it (case-insensitive) are eligible; entries without any provider identity remain reachable so hand-written legacy `custom_providers:` blocks keep working. Callers that pass no provider keep the historical first-match-in-config-order behaviour.

All six call sites now thread the active provider through:
- `agent/model_metadata.py` (resolution step 0c)
- `agent/agent_init.py` (startup)
- `agent/agent_runtime_helpers.py` (mid-session `/model` switch)
- `gateway/run.py` ×3 (gateway startup, message-path resolution, auxiliary compression)

## Testing

- New `TestProviderScopedContextLength` regression tests: per-provider resolution of the shared-base_url same-model collision, case-insensitive matching, unknown-provider miss, backward-compatible no-provider ordering, and legacy entries lacking a provider identity.
- Full file: `14 passed` (9 pre-existing + 5 new).
- Manually verified against a live new-api aggregator: same model now resolves to 1,050,000 under `market-aigw` and 500,000 under `coding-plan-gpt`; no-provider calls unchanged.