### PR TITLE
fix(bot-mode): bound the Bots home re-front so the view stops strobing

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -224,6 +224,10 @@ const $botsHomeFronted = atom(false)
 
 let botsHomeClose = null
 let suppressBotsHomeReopen = false
+// Latched while a re-front attempt has not yet been answered with visibility.
+// Cleared the moment the home is actually fronted, and whenever the tab is
+// retired — a fresh open starts the budget over. See openBotsHomeWorkspace.
+let botsHomeRefrontTried = false
 
 function saveSelectedRosterBot(bot) {
   const key = botRosterKey(bot)
@@ -12546,6 +12550,10 @@ function closeBotsHomeWorkspace() {
   const close = botsHomeClose
   botsHomeClose = null
   suppressBotsHomeReopen = true
+  // Retiring the tab ends the current attempt's budget: the next open is a
+  // new surface, and it gets its own re-front chance. The re-front path sets
+  // the latch again AFTER calling us, so this cannot erase its own attempt.
+  botsHomeRefrontTried = false
 
   try {
     close()
@@ -12633,10 +12641,27 @@ function openBotsHomeWorkspace(explicit = false) {
   // and each of those either legitimately claims the center or cleared it.
   if (botsHomeClose) {
     if (botsHomeVisible()) {
+      botsHomeRefrontTried = false
+
+      return true
+    }
+
+    // A re-front is a close + re-open, so it REMOUNTS the whole Bots view.
+    // That is affordable once, against the backgrounded-tab case above. It is
+    // not affordable per signal: the shell does not always answer a reveal
+    // with the active slot (revealTreePane returns early for a pane in
+    // $hiddenTreePanes without activating it; a minimized zone and a pane the
+    // tree never adopted are never visible either). Pinned in one of those
+    // states the old code re-fronted on every passive pass — sidebar flips,
+    // focus churn and group changes all reach here — and the view strobed.
+    // One attempt proves whether this shell will front the tab; if it will
+    // not, keep the surface and wait for a signal that changes the answer.
+    if (botsHomeRefrontTried && !explicit) {
       return true
     }
 
     closeBotsHomeWorkspace()
+    botsHomeRefrontTried = true
   }
 
   try {
@@ -12653,6 +12678,15 @@ function openBotsHomeWorkspace(explicit = false) {
         }
       }
     })
+
+    // The reveal has already either granted the tab its zone's active slot or
+    // refused it, so settle the re-front budget on that answer directly rather
+    // than waiting for a visibility notification to schedule another pass. A
+    // computed store stays silent when the value does not change, so on the
+    // shells that refuse, no such pass is coming.
+    if (botsHomeVisible()) {
+      botsHomeRefrontTried = false
+    }
 
     return typeof botsHomeClose === 'function'
   } catch {

--- a/apps/desktop/src/plugins/hermes-bots/tests/bots-home-refront-loop.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bots-home-refront-loop.test.mjs
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Re-fronting the Bots home is a CLOSE followed by an OPEN of the workspace
+// tab, which tears down and rebuilds the whole Bots view. The re-front branch
+// runs whenever a passive reconcile finds the tab open but not holding its
+// zone's active slot — and it is completely unbounded: it re-fronts again on
+// every pass, for as long as that condition holds.
+//
+// The condition is not always transient. `revealTreePane` returns early for a
+// pane in `$hiddenTreePanes` WITHOUT activating it, `isPaneVisible` is false
+// for a minimized zone, and a pane the tree never adopted has no group at all.
+// Pinned in that state, every surface sync the plugin runs — sidebar
+// visibility flips, focus churn, group changes all call syncWorkspaceSurfaces
+// — costs one full remount of the Bots view. That is the strobe in the bug
+// report's screen recording: successive frames differ only by text
+// re-rasterization across the whole view, the signature of a remount rather
+// than a repaint.
+//
+// The invariant: a PASSIVE reconcile gets one re-front attempt. If the shell
+// does not grant visibility, the plugin stops rather than remounting on every
+// subsequent signal. An explicit user gesture is still always honored.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+/** A shell whose reveal does NOT hand the tab its zone's active slot, modelled
+ *  on `revealTreePane`'s hidden-pane early return. `grantsVisibility: true`
+ *  restores the cooperative shell so the same harness covers both directions. */
+function load({ grantsVisibility = false } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = {
+      get: () => values.get(slot),
+      set: value => {
+        values.set(slot, value)
+        for (const fn of slot.__listeners || []) {
+          fn(value)
+        }
+      },
+      listen: fn => {
+        slot.__listeners = [...(slot.__listeners || []), fn]
+        return () => {
+          slot.__listeners = (slot.__listeners || []).filter(entry => entry !== fn)
+        }
+      }
+    }
+    values.set(slot, initial)
+    return slot
+  }
+
+  const opened = []
+  const closed = []
+  const visible = new Map()
+  const watchers = new Map()
+
+  // Synchronous notification, like a nanostores computed over $layoutTree.
+  const setVisible = (paneId, value) => {
+    if (visible.get(paneId) === value) {
+      return
+    }
+
+    visible.set(paneId, value)
+    for (const fn of watchers.get(paneId) || []) {
+      fn(value)
+    }
+  }
+
+  const host = {
+    state: {
+      profile: { get: () => 'default', listen: () => undefined },
+      gateway: { get: () => 'open', listen: () => undefined },
+      focusedStoredSessionId: atom(null)
+    },
+    request: async () => ({}),
+    requestProfile: async () => ({}),
+    openSession: async () => undefined,
+    setWorkspaceScope: () => true,
+    notify: () => undefined,
+    notifyError: () => undefined,
+    ensureAgent: async () => undefined,
+    activeConnectionId: () => 'local',
+    openWorkspace: (id, options) => {
+      const paneId = `plugin-workspace:${id}`
+      const entry = { id, options }
+      opened.push(entry)
+      setVisible(paneId, grantsVisibility)
+
+      return () => {
+        closed.push(entry)
+        setVisible(paneId, false)
+        options.onClose?.()
+      }
+    },
+    paneVisibility: paneId => ({
+      get: () => visible.get(paneId) ?? false,
+      listen: fn => {
+        watchers.set(paneId, [...(watchers.get(paneId) || []), fn])
+        return () => watchers.set(paneId, (watchers.get(paneId) || []).filter(entry => entry !== fn))
+      }
+    })
+  }
+
+  const context = {
+    atom,
+    haptic: () => undefined,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host,
+    queryClient: { invalidateQueries: () => undefined },
+    navigator: { clipboard: { writeText: async () => undefined } },
+    sdk: new Proxy({}, { get: () => undefined })
+  }
+
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(`
+globalThis.__refront = {
+  syncBotsHomeWorkspace,
+  openBotsHomeWorkspace,
+  closeBotsHomeWorkspace,
+  botsHomeVisible,
+  BOTS_HOME_PANE_ID,
+  $botsPaneVisible,
+  $openBotChat
+};
+`)
+
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+
+  return { ...context.__refront, closed, host, opened, setVisible }
+}
+
+test('a passive reconcile re-fronts the home once, not forever', () => {
+  const t = load({ grantsVisibility: false })
+  t.$botsPaneVisible.set(true)
+
+  // First pass opens the tab. The shell does not front it.
+  t.syncBotsHomeWorkspace()
+  assert.equal(t.opened.length, 1)
+  assert.equal(t.botsHomeVisible(), false, 'the shell withheld the active slot')
+
+  // Every later passive pass sees "open but not visible" and takes the
+  // re-front branch. Before the fix each pass closed and re-opened the tab,
+  // remounting the whole Bots view — 20 passes, 20 remounts.
+  for (let i = 0; i < 20; i++) {
+    t.syncBotsHomeWorkspace()
+  }
+
+  assert.equal(t.opened.length, 2, 'exactly one re-front attempt, then the plugin stops')
+  assert.equal(t.closed.length, 1)
+})
+
+test('giving up on the re-front still leaves the tab open', () => {
+  const t = load({ grantsVisibility: false })
+  t.$botsPaneVisible.set(true)
+
+  t.syncBotsHomeWorkspace()
+  for (let i = 0; i < 5; i++) {
+    t.syncBotsHomeWorkspace()
+  }
+
+  // Bounding the retries must not degrade into closing the home: the Bots tab
+  // would fall through to the ownerless Sessions composer, which is the exact
+  // hole the home exists to plug. Stop re-fronting, keep the surface.
+  assert.equal(t.closed.length, 1, 'one close, from the single re-front — not a teardown')
+  assert.equal(t.opened.length, 2)
+})
+
+test('a cooperative shell still gets its one legitimate re-front', () => {
+  const t = load({ grantsVisibility: true })
+  t.$botsPaneVisible.set(true)
+
+  t.syncBotsHomeWorkspace()
+  assert.equal(t.opened.length, 1)
+  assert.equal(t.botsHomeVisible(), true)
+
+  // A persisted layout can restore the tab BEHIND the core draft pane. The
+  // home must still reclaim the active slot — the fix bounds retries, it does
+  // not remove the re-front (bots-home.test.mjs pins this case too).
+  t.setVisible(t.BOTS_HOME_PANE_ID, false)
+  t.syncBotsHomeWorkspace()
+
+  assert.equal(t.opened.length, 2, 're-opened to reclaim the active slot')
+  assert.equal(t.botsHomeVisible(), true)
+
+  // And having converged, the plugin is free to re-front again the next time
+  // the tab is genuinely backgrounded: the bound is per-attempt, not one-shot.
+  t.setVisible(t.BOTS_HOME_PANE_ID, false)
+  t.syncBotsHomeWorkspace()
+
+  assert.equal(t.opened.length, 3)
+})
+
+test('an explicit gesture is never blocked by the passive bound', () => {
+  const t = load({ grantsVisibility: false })
+  t.$botsPaneVisible.set(true)
+
+  t.syncBotsHomeWorkspace()
+  for (let i = 0; i < 5; i++) {
+    t.syncBotsHomeWorkspace()
+  }
+  const passive = t.opened.length
+
+  // The user clicked a bot whose owner is unavailable: the home IS the
+  // destination, so the gesture must re-front even though passive reconciles
+  // have given up on this shell.
+  t.openBotsHomeWorkspace(true)
+
+  assert.equal(t.opened.length, passive + 1, 'an explicit open always re-fronts')
+})


### PR DESCRIPTION
## Summary

Reported alongside "[Bots] I cannot interact with the cronjobs when I'm in the bot section" — the reporter's screen recording shows the Bots view blinking. This PR is the blinking half; the inert cronjob rows are #93013 and the two are independent.

Re-fronting the Bots home tab is a close followed by a re-open, which tears down and rebuilds the entire Bots view. `openBotsHomeWorkspace` took that path on **every** passive reconcile that found the tab open but not holding its zone's active slot, and nothing bounded the retries:

```js
if (botsHomeClose) {
  if (botsHomeVisible()) return true
  closeBotsHomeWorkspace()   // ← remount, unconditionally, every pass
}
```

The `!botsHomeVisible()` condition is not always transient:

- `revealTreePane` returns early for a pane in `$hiddenTreePanes` — it un-hides it and returns **without** activating it (`store.ts` ~1062–1068);
- `isPaneVisible` is false whenever the zone is minimized;
- a pane the tree never adopted has no group to be active in at all.

Pinned in any of those states, every signal that reaches a surface sync — `$sidebarVisible` flips, focus churn, group changes — bought one more full remount of the view.

**Evidence from the recording.** Differencing consecutive frames, the changed pixels are the outlines of the heading, body text and bot avatar across the whole view, plus a scrollbar blinking in and out at the right edge — text re-rasterization, i.e. a remount, not a repaint. The swaps come in pairs at 14.30/14.40, 14.70/14.75, 15.15/15.20, 15.50/15.55 s (~0.4 s apart, identical ~10,200-pixel footprint each), with isolated instances of the same footprint at 2.80 s and 5.00 s.

## The fix

A passive reconcile gets one attempt. By the time `openWorkspace` returns, the reveal has already granted or refused the active slot, so the budget settles on that answer directly rather than waiting for a visibility notification to schedule another pass — a computed store stays silent when the value does not change, so on the shells that refuse, no such pass is coming. Retiring the tab starts a fresh budget, and an explicit gesture is never blocked.

Giving up **keeps the surface open** rather than closing it: a closed home drops the Bots tab through to the ownerless Sessions composer, which is the hole the home exists to plug.

Scope note: I deliberately left `syncRoutinesPane` alone. Routines adoption passes `activate: false` and a re-register of an already-in-tree pane is a no-op, so it cannot steal the active tab and does not feed this cycle.

## Test plan

- [x] `cd apps/desktop && node --test src/plugins/hermes-bots/tests/bots-home-refront-loop.test.mjs` — 4/4 pass; **2/4 fail on unpatched `main`** (the first case remounts 21 times for 21 passive passes).
- [x] `cd apps/desktop && npm run check:test:plugins` — 485/485 pass, including the existing `bots-home.test.mjs` re-front contract ("a persisted layout that restored the home behind the draft gets re-fronted"), which still holds.
- [x] `npx eslint src/plugins/hermes-bots/tests/bots-home-refront-loop.test.mjs` — clean.
- [ ] Manual: open Bot Mode with the Bots home in the center and confirm the view no longer blinks while clicking around the pane.