### PR TITLE
test(system-prompt): make build_system_prompt unit test robust to leaked truncation warnings (fixes #93018)

### DIFF
--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -766,6 +766,17 @@ class TestPromptBuilderConstants:
 # =========================================================================
 
 class TestEnvironmentHints:
+    @pytest.fixture(autouse=True)
+    def _drain_truncation_warnings(self):
+        """Drain any truncation warnings recorded during this test so they
+        don't leak into the context of tests in other files (which may run
+        after this one). build_system_prompt() forwards drained warnings to
+        agent._emit_status(), and unit-test agents without that attribute
+        raise AttributeError — see #93018."""
+        from agent.prompt_builder import drain_truncation_warnings
+        drain_truncation_warnings()
+        yield
+        drain_truncation_warnings()
 
 
 

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -24,6 +24,12 @@ def _make_agent(**overrides):
         platform="",
         pass_session_id=False,
         session_id="",
+        # build_system_prompt drains pending truncation warnings and forwards
+        # each to agent._emit_status(). The unit-test agent is a plain
+        # SimpleNamespace, so give it a no-op status sink: otherwise any
+        # warning leaked into the current context (e.g. by another test file
+        # that ran first and recorded one) raises AttributeError. See #93018.
+        _emit_status=lambda _warning: None,
     )
     base.update(overrides)
     return SimpleNamespace(**base)


### PR DESCRIPTION
## Summary

Fixes #93018 — order-dependent test failure between `test_prompt_builder.py` and `test_system_prompt.py`.

## Problem

`test_prompt_builder.py` records truncation warnings into a `contextvars.ContextVar` (`_truncation_warnings` in `agent/prompt_builder.py`). When that file runs *before* `test_system_prompt.py`, the leaked warning makes `build_system_prompt()` (agent/system_prompt.py:926-927) call `agent._emit_status(warning)` on the test's `SimpleNamespace` mock, which has no such attribute:

```
AttributeError: 'types.SimpleNamespace' object has no attribute '_emit_status'
```

Reproduces on pristine `origin/main` (verified at `261a4ef`, no local changes). Order-dependent:
- `pytest test_prompt_builder.py test_system_prompt.py` → 1 failed
- `pytest test_system_prompt.py test_prompt_builder.py` → 108 passed

## Fix (test-only, no production change)

1. **`_make_agent()` in `test_system_prompt.py`** gains a no-op `_emit_status` sink, so `build_system_prompt()` is robust to any stray warning regardless of test ordering.
2. **`TestEnvironmentHints` in `test_prompt_builder.py`** gains an autouse fixture that drains `_truncation_warnings` before and after each test, so this file never leaks warnings into tests that run after it.

## Verification

Both run orders now pass 108/108:
- `pytest test_prompt_builder.py test_system_prompt.py -q` → 108 passed
- `pytest test_system_prompt.py test_prompt_builder.py -q` → 108 passed

And the previously-failing test specifically:
- `pytest test_prompt_builder.py test_system_prompt.py::test_build_system_prompt_records_stable_prefix -q` → 76 passed
