### PR TITLE
fix(memory): install profile secret scope in hindsight background threads

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -50,6 +50,7 @@ from typing import Any, Callable, Dict, List, Optional
 from agent.secret_scope import (
     build_profile_secret_scope,
     get_secret,
+    is_multiplex_active,
     reset_secret_scope,
     set_secret_scope,
 )
@@ -57,6 +58,7 @@ from agent.secret_scope import (
 from agent.memory_provider import MemoryProvider, RecallStatus
 from hermes_constants import (
     get_hermes_home,
+    get_hermes_home_override,
     reset_hermes_home_override,
     set_hermes_home_override,
 )
@@ -755,8 +757,23 @@ class HindsightMemoryProvider(MemoryProvider):
         self._api_key = None
         # Captured at construction time: under multiplexing the constructor
         # runs inside the adapter's per-profile context, while the background
-        # threads spawned later do not (see _profile_scope).
+        # threads spawned later do not (see _profile_scope). The scope mapping
+        # is built once here and reused by every background body — building it
+        # per job would re-parse the profile .env on each retain/recall for no
+        # benefit (the snapshot tracks this provider instance's lifecycle).
         self._profile_home = Path(get_hermes_home())
+        self._profile_secret_scope = build_profile_secret_scope(self._profile_home)
+        if is_multiplex_active() and get_hermes_home_override() is None:
+            # Constructed with no profile override active while multiplexing:
+            # _profile_home likely baked in the process-default home, and every
+            # background secret read will resolve against that profile. Almost
+            # certainly a misconstruction — make it diagnosable in debug logs.
+            logger.debug(
+                "HindsightMemoryProvider constructed under multiplexing without "
+                "a HERMES_HOME override; captured home %s is likely the "
+                "process default rather than a profile home",
+                self._profile_home,
+            )
         self._api_url = _DEFAULT_API_URL
         self._bank_id = "hermes"
         self._budget = "mid"
@@ -1493,9 +1510,16 @@ class HindsightMemoryProvider(MemoryProvider):
         #76574/#86402), so every background body re-installs the scope this
         instance captured at construction — mirroring the gateway's thread
         wrapping (gateway/run.py).
+
+        The scope mapping is built ONCE at construction and reused: retain
+        jobs and recalls are network-bound, so re-parsing the profile .env per
+        job would only add filesystem IO. Mid-session .env edits are picked up
+        when the provider instance is recreated (gateway session lifecycle);
+        the daemon-restart path reads config changes separately via
+        _build/_materialize_embedded_profile_env.
         """
         home_token = set_hermes_home_override(str(self._profile_home))
-        secret_token = set_secret_scope(build_profile_secret_scope(self._profile_home))
+        secret_token = set_secret_scope(self._profile_secret_scope)
         try:
             yield
         finally:
@@ -1811,51 +1835,54 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._mode = "disabled"
                 return
 
-            def _start_daemon():
-                with self._profile_scope():
-                    _start_daemon_scoped()
-
-            def _start_daemon_scoped():
-                import traceback
-                log_dir = get_hermes_home() / "logs"
-                log_dir.mkdir(parents=True, exist_ok=True)
-                log_path = log_dir / "hindsight-embed.log"
-                try:
-                    # Redirect the daemon manager's Rich console to our log file
-                    # instead of stderr. This avoids global fd redirects that
-                    # would capture output from other threads.
-                    import hindsight_embed.daemon_embed_manager as dem
-                    from rich.console import Console
-                    dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
-
-                    client = self._get_client()
-                    profile = self._config.get("profile", "hermes")
-
-                    # Update the profile .env to match our current config so
-                    # the daemon always starts with the right settings.
-                    # If the config changed and the daemon is running, stop it.
-                    profile_env = _embedded_profile_env_path(self._config)
-                    expected_env = _build_embedded_profile_env(self._config)
-                    saved = _load_simple_env(profile_env)
-                    config_changed = saved != expected_env
-
-                    if config_changed:
-                        profile_env = _materialize_embedded_profile_env(self._config)
-                        if client._manager.is_running(profile):
-                            with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
-
-                    client._ensure_started()
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write("\n=== Daemon started successfully ===\n")
-                except Exception as e:
-                    with open(log_path, "a", encoding="utf-8") as f:
-                        f.write(f"\n=== Daemon startup failed: {e} ===\n")
-                        traceback.print_exc(file=f)
-
-            t = threading.Thread(target=_start_daemon, daemon=True, name="hindsight-daemon-start")
+            t = threading.Thread(
+                target=self._spawn_embedded_daemon, daemon=True, name="hindsight-daemon-start"
+            )
             t.start()
+
+    def _spawn_embedded_daemon(self):
+        """Run the embedded daemon startup under this profile's secret scope."""
+        with self._profile_scope():
+            self._daemon_start_body()
+
+    def _daemon_start_body(self):
+        import traceback
+        log_dir = get_hermes_home() / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "hindsight-embed.log"
+        try:
+            # Redirect the daemon manager's Rich console to our log file
+            # instead of stderr. This avoids global fd redirects that
+            # would capture output from other threads.
+            import hindsight_embed.daemon_embed_manager as dem
+            from rich.console import Console
+            dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
+
+            client = self._get_client()
+            profile = self._config.get("profile", "hermes")
+
+            # Update the profile .env to match our current config so
+            # the daemon always starts with the right settings.
+            # If the config changed and the daemon is running, stop it.
+            profile_env = _embedded_profile_env_path(self._config)
+            expected_env = _build_embedded_profile_env(self._config)
+            saved = _load_simple_env(profile_env)
+            config_changed = saved != expected_env
+
+            if config_changed:
+                profile_env = _materialize_embedded_profile_env(self._config)
+                if client._manager.is_running(profile):
+                    with open(log_path, "a", encoding="utf-8") as f:
+                        f.write("\n=== Config changed, restarting daemon ===\n")
+                    client._manager.stop(profile)
+
+            client._ensure_started()
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write("\n=== Daemon started successfully ===\n")
+        except Exception as e:
+            with open(log_path, "a", encoding="utf-8") as f:
+                f.write(f"\n=== Daemon startup failed: {e} ===\n")
+                traceback.print_exc(file=f)
 
     def system_prompt_block(self) -> str:
         if self._memory_mode == "context":
@@ -1995,25 +2022,27 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._recall_disabled():
             return
 
-        def _run():
-            # Ensure the just-completed turn's retain is recall-visible on the
-            # server before we recall, so the warmed context for the next turn
-            # includes it. This waits for the local writer queue to drain AND
-            # for the server-side async retain op(s) to complete (an explicit
-            # read-after-write signal), because async retain returns on
-            # acceptance rather than durability. Runs on the background prefetch
-            # thread, never the reply path, so it adds no response latency.
-            with self._profile_scope():
-                if self._prefetch_waits_for_retain:
-                    self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
-                recalled = self._do_recall(query)
-                if recalled.text:
-                    with self._prefetch_lock:
-                        self._prefetch_result = recalled.text
-                        self._prefetch_count = recalled.count
-
-        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
+        self._prefetch_thread = threading.Thread(
+            target=self._prefetch_background, args=(query,), daemon=True, name="hindsight-prefetch"
+        )
         self._prefetch_thread.start()
+
+    def _prefetch_background(self, query: str) -> None:
+        # Ensure the just-completed turn's retain is recall-visible on the
+        # server before we recall, so the warmed context for the next turn
+        # includes it. This waits for the local writer queue to drain AND
+        # for the server-side async retain op(s) to complete (an explicit
+        # read-after-write signal), because async retain returns on
+        # acceptance rather than durability. Runs on the background prefetch
+        # thread, never the reply path, so it adds no response latency.
+        with self._profile_scope():
+            if self._prefetch_waits_for_retain:
+                self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
+            recalled = self._do_recall(query)
+            if recalled.text:
+                with self._prefetch_lock:
+                    self._prefetch_result = recalled.text
+                    self._prefetch_count = recalled.count
 
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -40,15 +40,26 @@ import queue
 import sys
 import threading
 import time
+from contextlib import contextmanager
+from pathlib import Path
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
 
-from agent.secret_scope import get_secret
+from agent.secret_scope import (
+    build_profile_secret_scope,
+    get_secret,
+    reset_secret_scope,
+    set_secret_scope,
+)
 
 from agent.memory_provider import MemoryProvider, RecallStatus
-from hermes_constants import get_hermes_home
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 from tools.registry import tool_error
 from hermes_cli.config import cfg_get
 
@@ -742,6 +753,10 @@ class HindsightMemoryProvider(MemoryProvider):
     def __init__(self):
         self._config = None
         self._api_key = None
+        # Captured at construction time: under multiplexing the constructor
+        # runs inside the adapter's per-profile context, while the background
+        # threads spawned later do not (see _profile_scope).
+        self._profile_home = Path(get_hermes_home())
         self._api_url = _DEFAULT_API_URL
         self._bank_id = "hermes"
         self._budget = "mid"
@@ -1467,6 +1482,26 @@ class HindsightMemoryProvider(MemoryProvider):
                 return False
             time.sleep(self._RETAIN_OP_POLL_INTERVAL_S)
 
+    @contextmanager
+    def _profile_scope(self):
+        """Install this profile's secret scope + HERMES_HOME override.
+
+        Background threads (writer, daemon start, prefetch) are spawned raw,
+        without the constructing context's contextvars. Under multiplexing
+        ``get_secret`` fails closed on unscoped reads rather than risk
+        returning another profile's credential (#92608; same family as
+        #76574/#86402), so every background body re-installs the scope this
+        instance captured at construction — mirroring the gateway's thread
+        wrapping (gateway/run.py).
+        """
+        home_token = set_hermes_home_override(str(self._profile_home))
+        secret_token = set_secret_scope(build_profile_secret_scope(self._profile_home))
+        try:
+            yield
+        finally:
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
+
     def _writer_loop(self) -> None:
         """Drain the retain queue serially. Exits on sentinel.
 
@@ -1484,7 +1519,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 if job is _WRITER_SENTINEL:
                     return
                 try:
-                    job()
+                    with self._profile_scope():
+                        job()
                 except Exception as exc:
                     logger.warning("Hindsight retain failed: %s", exc, exc_info=True)
             finally:
@@ -1776,6 +1812,10 @@ class HindsightMemoryProvider(MemoryProvider):
                 return
 
             def _start_daemon():
+                with self._profile_scope():
+                    _start_daemon_scoped()
+
+            def _start_daemon_scoped():
                 import traceback
                 log_dir = get_hermes_home() / "logs"
                 log_dir.mkdir(parents=True, exist_ok=True)
@@ -1963,13 +2003,14 @@ class HindsightMemoryProvider(MemoryProvider):
             # read-after-write signal), because async retain returns on
             # acceptance rather than durability. Runs on the background prefetch
             # thread, never the reply path, so it adds no response latency.
-            if self._prefetch_waits_for_retain:
-                self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
-            recalled = self._do_recall(query)
-            if recalled.text:
-                with self._prefetch_lock:
-                    self._prefetch_result = recalled.text
-                    self._prefetch_count = recalled.count
+            with self._profile_scope():
+                if self._prefetch_waits_for_retain:
+                    self._wait_for_retains_drained(self._prefetch_retain_drain_timeout)
+                recalled = self._do_recall(query)
+                if recalled.text:
+                    with self._prefetch_lock:
+                        self._prefetch_result = recalled.text
+                        self._prefetch_count = recalled.count
 
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1561,3 +1561,110 @@ class TestClientAutoUpgradeRoutesThroughLazyDeps:
         assert len(calls) == 1  # attempted exactly once, init still completed
         assert any("runtime installs are disabled" in r.getMessage()
                    for r in caplog.records)
+
+
+class TestBackgroundSecretScope:
+    """Background threads must re-install the captured profile scope (#92608).
+
+    Under multiplexing, get_secret fails closed on unscoped reads rather
+    than risk leaking another profile's credential. The writer/daemon/
+    prefetch threads are spawned raw (no contextvars propagation), so each
+    body wraps itself in _profile_scope using the home captured at
+    construction — same contract as gateway/run.py's thread wrapping.
+    """
+
+    @staticmethod
+    def _bare_provider(home):
+        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
+        provider._profile_home = home
+        provider._retain_queue = __import__("queue").Queue()
+        provider._shutting_down = __import__("threading").Event()
+        return provider
+
+    def test_writer_job_reads_profile_secret_and_resets_scope(self, tmp_path):
+        import queue as _queue
+        import threading as _threading
+
+        from agent.secret_scope import current_secret_scope
+        from plugins.memory.hindsight import (
+            _WRITER_SENTINEL,
+            get_secret as plugin_get_secret,
+        )
+
+        (tmp_path / ".env").write_text("HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8")
+        observed = {}
+
+        def job():
+            observed["scope"] = current_secret_scope()
+            observed["key"] = plugin_get_secret("HINDSIGHT_LLM_API_KEY", "MISSING")
+
+        provider = self._bare_provider(tmp_path)
+        provider._retain_queue = _queue.Queue()
+        provider._shutting_down = _threading.Event()
+        provider._retain_queue.put(job)
+        provider._retain_queue.put(_WRITER_SENTINEL)
+        provider._writer_loop()
+
+        assert observed["key"] == "scope-key"
+        assert observed["scope"] is not None
+        # Scope must not leak past the thread body.
+        assert current_secret_scope() is None
+
+    def test_writer_job_sees_captured_hermes_home(self, tmp_path, monkeypatch):
+        import queue as _queue
+        import threading as _threading
+
+        from hermes_constants import get_hermes_home as real_get_hermes_home
+        from plugins.memory.hindsight import _WRITER_SENTINEL
+
+        fake_process_home = tmp_path / "elsewhere"
+        monkeypatch.setenv("HERMES_HOME", str(fake_process_home))
+        observed = {}
+
+        def job():
+            observed["home"] = real_get_hermes_home()
+
+        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
+        provider._profile_home = tmp_path
+        provider._retain_queue = _queue.Queue()
+        provider._shutting_down = _threading.Event()
+        provider._retain_queue.put(job)
+        provider._retain_queue.put(_WRITER_SENTINEL)
+        provider._writer_loop()
+
+        assert observed["home"] == tmp_path
+
+    def test_unscoped_read_fails_closed_under_multiplex(self, monkeypatch):
+        from agent import secret_scope as secret_scope_module
+
+        monkeypatch.setattr(secret_scope_module, "_MULTIPLEX_ACTIVE", True)
+        with pytest.raises(secret_scope_module.UnscopedSecretError):
+            secret_scope_module.get_secret("HINDSIGHT_LLM_API_KEY", "")
+
+    def test_writer_job_survives_fail_closed_multiplex_guard(self, tmp_path, monkeypatch):
+        """The reported crash shape: multiplex on, key only in profile .env,
+        read from the raw writer thread — must succeed inside the scope."""
+        import queue as _queue
+        import threading as _threading
+
+        from agent import secret_scope as secret_scope_module
+        from plugins.memory.hindsight import _WRITER_SENTINEL
+
+        monkeypatch.setattr(secret_scope_module, "_MULTIPLEX_ACTIVE", True)
+        (tmp_path / ".env").write_text("HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8")
+        observed = {}
+
+        def job():
+            observed["key"] = secret_scope_module.get_secret(
+                "HINDSIGHT_LLM_API_KEY", "MISSING"
+            )
+
+        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
+        provider._profile_home = tmp_path
+        provider._retain_queue = _queue.Queue()
+        provider._shutting_down = _threading.Event()
+        provider._retain_queue.put(job)
+        provider._retain_queue.put(_WRITER_SENTINEL)
+        provider._writer_loop()  # must not raise UnscopedSecretError
+
+        assert observed["key"] == "scope-key"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -6,10 +6,12 @@ turn counting, tags), and schema completeness.
 """
 
 import json
+import queue
 import os
 import re
 import stat
 import sys
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -18,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from hermes_cli.memory_setup import _CANCELLED
+from agent.secret_scope import build_profile_secret_scope
 from plugins.memory.hindsight import (
     HindsightMemoryProvider,
     RECALL_SCHEMA,
@@ -1569,29 +1572,61 @@ class TestBackgroundSecretScope:
     Under multiplexing, get_secret fails closed on unscoped reads rather
     than risk leaking another profile's credential. The writer/daemon/
     prefetch threads are spawned raw (no contextvars propagation), so each
-    body wraps itself in _profile_scope using the home captured at
-    construction — same contract as gateway/run.py's thread wrapping.
+    body wraps itself in _profile_scope using the home + scope mapping
+    captured at construction — same contract as gateway/run.py's thread
+    wrapping.
     """
 
     @staticmethod
-    def _bare_provider(home):
+    def _bare_provider(home, **attrs):
         provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
         provider._profile_home = home
-        provider._retain_queue = __import__("queue").Queue()
-        provider._shutting_down = __import__("threading").Event()
+        provider._profile_secret_scope = build_profile_secret_scope(home)
+        provider._retain_queue = queue.Queue()
+        provider._shutting_down = threading.Event()
+        for name, value in attrs.items():
+            setattr(provider, name, value)
         return provider
 
-    def test_writer_job_reads_profile_secret_and_resets_scope(self, tmp_path):
-        import queue as _queue
-        import threading as _threading
+    @pytest.fixture
+    def multiplex_on(self):
+        """Activate multiplex mode via the public hook, restoring after."""
+        from agent import secret_scope as secret_scope_module
 
+        secret_scope_module.set_multiplex_active(True)
+        yield
+        secret_scope_module.set_multiplex_active(False)
+
+    @pytest.fixture
+    def sync_threads(self, monkeypatch):
+        """Make hindsight's Thread(...) spawns synchronous and capturable."""
+        started = []
+
+        class _SyncThread:
+            def __init__(self, target=None, args=(), daemon=False, name=None):
+                self._target = target
+                self._args = args
+                self.name = name
+                started.append(self)
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.threading.Thread", _SyncThread
+        )
+        return started
+
+    def test_writer_job_reads_profile_secret_and_resets_scope(self, tmp_path):
         from agent.secret_scope import current_secret_scope
         from plugins.memory.hindsight import (
             _WRITER_SENTINEL,
             get_secret as plugin_get_secret,
         )
 
-        (tmp_path / ".env").write_text("HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8")
+        (tmp_path / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8"
+        )
         observed = {}
 
         def job():
@@ -1599,8 +1634,6 @@ class TestBackgroundSecretScope:
             observed["key"] = plugin_get_secret("HINDSIGHT_LLM_API_KEY", "MISSING")
 
         provider = self._bare_provider(tmp_path)
-        provider._retain_queue = _queue.Queue()
-        provider._shutting_down = _threading.Event()
         provider._retain_queue.put(job)
         provider._retain_queue.put(_WRITER_SENTINEL)
         provider._writer_loop()
@@ -1611,9 +1644,6 @@ class TestBackgroundSecretScope:
         assert current_secret_scope() is None
 
     def test_writer_job_sees_captured_hermes_home(self, tmp_path, monkeypatch):
-        import queue as _queue
-        import threading as _threading
-
         from hermes_constants import get_hermes_home as real_get_hermes_home
         from plugins.memory.hindsight import _WRITER_SENTINEL
 
@@ -1624,47 +1654,134 @@ class TestBackgroundSecretScope:
         def job():
             observed["home"] = real_get_hermes_home()
 
-        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
-        provider._profile_home = tmp_path
-        provider._retain_queue = _queue.Queue()
-        provider._shutting_down = _threading.Event()
+        provider = self._bare_provider(tmp_path)
         provider._retain_queue.put(job)
         provider._retain_queue.put(_WRITER_SENTINEL)
         provider._writer_loop()
 
         assert observed["home"] == tmp_path
 
-    def test_unscoped_read_fails_closed_under_multiplex(self, monkeypatch):
-        from agent import secret_scope as secret_scope_module
+    def test_unscoped_read_fails_closed_under_multiplex(self, multiplex_on):
+        from agent.secret_scope import (
+            get_secret as scope_get_secret,
+            UnscopedSecretError,
+        )
 
-        monkeypatch.setattr(secret_scope_module, "_MULTIPLEX_ACTIVE", True)
-        with pytest.raises(secret_scope_module.UnscopedSecretError):
-            secret_scope_module.get_secret("HINDSIGHT_LLM_API_KEY", "")
+        with pytest.raises(UnscopedSecretError):
+            scope_get_secret("HINDSIGHT_LLM_API_KEY", "")
 
-    def test_writer_job_survives_fail_closed_multiplex_guard(self, tmp_path, monkeypatch):
+    def test_writer_job_survives_fail_closed_multiplex_guard(
+        self, tmp_path, multiplex_on
+    ):
         """The reported crash shape: multiplex on, key only in profile .env,
         read from the raw writer thread — must succeed inside the scope."""
-        import queue as _queue
-        import threading as _threading
-
-        from agent import secret_scope as secret_scope_module
+        from agent.secret_scope import get_secret as scope_get_secret
         from plugins.memory.hindsight import _WRITER_SENTINEL
 
-        monkeypatch.setattr(secret_scope_module, "_MULTIPLEX_ACTIVE", True)
-        (tmp_path / ".env").write_text("HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8")
+        (tmp_path / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8"
+        )
         observed = {}
 
         def job():
-            observed["key"] = secret_scope_module.get_secret(
-                "HINDSIGHT_LLM_API_KEY", "MISSING"
-            )
+            observed["key"] = scope_get_secret("HINDSIGHT_LLM_API_KEY", "MISSING")
 
-        provider = HindsightMemoryProvider.__new__(HindsightMemoryProvider)
-        provider._profile_home = tmp_path
-        provider._retain_queue = _queue.Queue()
-        provider._shutting_down = _threading.Event()
+        provider = self._bare_provider(tmp_path)
         provider._retain_queue.put(job)
         provider._retain_queue.put(_WRITER_SENTINEL)
-        provider._writer_loop()  # must not raise UnscopedSecretError
+        provider._writer_loop()
 
         assert observed["key"] == "scope-key"
+
+    def test_prefetch_body_runs_inside_captured_profile_scope(self, tmp_path, sync_threads):
+        from agent.secret_scope import current_secret_scope
+        from hermes_constants import get_hermes_home as real_get_hermes_home
+
+        (tmp_path / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8"
+        )
+        observed = {}
+
+        def fake_recall(query, *, session_id=""):
+            observed["scope"] = current_secret_scope()
+            observed["home"] = real_get_hermes_home()
+            return SimpleNamespace(text="hit", count=1)
+
+        provider = self._bare_provider(
+            tmp_path,
+            _recall_sync=False,
+            _memory_mode="hybrid",
+            _auto_recall=True,
+            _prefetch_waits_for_retain=False,
+            _prefetch_retain_drain_timeout=1.0,
+            _prefetch_lock=threading.Lock(),
+            _prefetch_result=None,
+            _prefetch_count=0,
+            _do_recall=fake_recall,
+        )
+        provider.queue_prefetch("query", session_id="s")
+        assert len(sync_threads) == 1
+        sync_threads[0]._target(*sync_threads[0]._args)
+
+        assert observed["scope"] is not None
+        assert observed["home"] == tmp_path
+        assert current_secret_scope() is None
+
+    def test_daemon_start_body_runs_inside_captured_profile_scope(
+        self, tmp_path, multiplex_on, sync_threads, monkeypatch
+    ):
+        import types
+
+        from agent.secret_scope import (
+            current_secret_scope,
+            get_secret as scope_get_secret,
+        )
+        from hermes_constants import get_hermes_home as real_get_hermes_home
+
+        (tmp_path / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=scope-key\n", encoding="utf-8"
+        )
+
+        # Stub hindsight_embed + rich so the scoped body can run end-to-end
+        # without the real packages installed.
+        dem_mod = types.ModuleType("hindsight_embed.daemon_embed_manager")
+        dem_mod.console = None
+        he_pkg = types.ModuleType("hindsight_embed")
+        he_pkg.daemon_embed_manager = dem_mod
+        rich_console_mod = types.ModuleType("rich.console")
+        rich_console_mod.Console = lambda **kwargs: object()
+        rich_pkg = types.ModuleType("rich")
+        rich_pkg.console = rich_console_mod
+        monkeypatch.setitem(sys.modules, "hindsight_embed", he_pkg)
+        monkeypatch.setitem(sys.modules, "hindsight_embed.daemon_embed_manager", dem_mod)
+        monkeypatch.setitem(sys.modules, "rich", rich_pkg)
+        monkeypatch.setitem(sys.modules, "rich.console", rich_console_mod)
+
+        observed = {}
+
+        def fake_get_client():
+            observed["scope"] = current_secret_scope()
+            observed["home"] = real_get_hermes_home()
+            observed["key"] = scope_get_secret("HINDSIGHT_LLM_API_KEY", "MISSING")
+            return SimpleNamespace(
+                _manager=SimpleNamespace(is_running=lambda profile: False),
+                _ensure_started=lambda: None,
+            )
+
+        provider = self._bare_provider(
+            tmp_path,
+            _config={
+                "profile": "p",
+                "llm_provider": "openai_compatible",
+                "llm_base_url": "http://127.0.0.1:9002/v1",
+                "llm_model": "m",
+            },
+            _get_client=fake_get_client,
+        )
+        provider._spawn_embedded_daemon()
+
+        assert observed["scope"] is not None
+        assert observed["key"] == "scope-key"
+        assert observed["home"] == tmp_path
+        # Scope must reset even though the body left log/env artifacts.
+        assert current_secret_scope() is None


### PR DESCRIPTION
Fixes #92608

## What & why

Under gateway multiplexing, `get_secret` fails closed on unscoped reads rather
than risk returning another profile's credential (`agent/secret_scope.py`).
Hindsight's background threads — the retain **writer loop**, the embedded
**daemon-start** thread, and the **prefetch** thread — are spawned raw with no
contextvars propagation, so `_get_client()`'s
`get_secret("HINDSIGHT_LLM_API_KEY")` raised `UnscopedSecretError` every time:
the `local_embedded` daemon could never boot and every retain failed, exactly
as reported. Same root-cause family as #76574 / #86402.

The fix mirrors the established contract in `gateway/run.py` (and the
web-server flow runner): capture the profile `HERMES_HOME` once at provider
construction — which always runs inside the adapter's per-profile context —
and have each background body re-install both overrides through a
`_profile_scope()` context manager:

```python
home_token = set_hermes_home_override(str(self._profile_home))
secret_token = set_secret_scope(build_profile_secret_scope(self._profile_home))
```

Design notes:
- The writer loop wraps **per job**, not the whole loop — a retain that saves
  an updated `.env` mid-session is visible to later jobs, and the sentinel
  exit path is untouched.
- The module-level `_build_embedded_profile_env` read (a third unreported
  unscooped site) runs inside the daemon-start body, so it is covered.
- Non-multiplex deployments are unaffected: the scope is installed either way,
  but with multiplex off `get_secret` treats it as a `.env` overlay over
  `os.environ`, preserving legacy behavior.

## How to test

New tests in `tests/plugins/memory/test_hindsight_provider.py::TestBackgroundSecretScope`, all daemon-free:

- writer job reads `HINDSIGHT_LLM_API_KEY` from the captured profile `.env`
  and the scope is **reset** after the thread body
- a writer job observes `get_hermes_home()` == the captured home even when the
  process env points elsewhere
- under `_MULTIPLEX_ACTIVE=True`, an unscoped read still raises
  `UnscopedSecretError` (guard intact)
- the reported crash shape: multiplex on + key only in profile `.env` + raw
  writer thread → job succeeds inside the scope

Suite: full `tests/plugins/memory/` via `scripts/run_tests.sh` → 338 passed;
the 6 `test_hindsight_provider.py` and 1 `test_openviking_provider.py`
failures are pre-existing on clean `main` (verified by stashing this change —
identical failure sets). macOS 26, Python 3.11.
