### PR TITLE
fix(security): enforce patched dependency floors (#41374)

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -86,13 +86,12 @@ class PlatformEntry:
     # fail at connect() time with a descriptive error.
     validate_config: Optional[Callable[[Any], bool]] = None
 
-    # ACTIVE dependency installer: make the platform's dependencies available,
-    # installing them (pip / lazy_deps) if needed.  Returns True once deps are
-    # importable, False if they could not be installed.  Called by
-    # ``create_adapter()`` when ``check_fn`` returns False — i.e. exactly at
-    # the moment the gateway is about to bring the platform up and the user
-    # has it enabled/configured.  None = no auto-install; a False ``check_fn``
-    # is then a hard block (correct for platforms with no optional deps).
+    # ACTIVE dependency verifier/installer: make the platform's dependencies
+    # available, installing them (pip / lazy_deps) if needed. Returns True once
+    # deps are importable, False if they could not be installed. Called by
+    # ``create_adapter()`` for configured adapters even when the passive probe
+    # is already true, because importability alone cannot prove exact security
+    # pins. None = no auto-install; a False ``check_fn`` is then a hard block.
     #
     # Why two fields (#79812): when the ACTIVE installer was registered as
     # ``check_fn``, every status display pip-installed SDKs as a side effect
@@ -620,14 +619,32 @@ class PlatformRegistry:
 
         Returns None if:
         - No entry registered for *name*
-        - check_fn() returns False and deps can't be installed
-          (no ensure_deps_fn, or ensure_deps_fn() returned False)
+        - dependencies can't be installed or verified
         - validate_config() returns False (misconfigured)
         - The factory raises an exception
         """
         entry = self.get(name)
         if entry is None:
             return None
+
+        # Validate configuration before any active dependency hook. This keeps
+        # passive status/configuration reads side-effect free and limits the
+        # active verifier to adapters the gateway is actually about to create.
+        if entry.validate_config is not None:
+            try:
+                if not entry.validate_config(config):
+                    logger.warning(
+                        "Platform '%s' config validation failed",
+                        entry.label,
+                    )
+                    return None
+            except Exception as e:
+                logger.warning(
+                    "Platform '%s' config validation error: %s",
+                    entry.label,
+                    e,
+                )
+                return None
 
         deps_ok = False
         try:
@@ -636,15 +653,13 @@ class PlatformRegistry:
             logger.warning(
                 "Platform '%s' check_fn raised: %s", entry.label, e
             )
-        if not deps_ok and entry.ensure_deps_fn is not None:
-            # Deps missing but the platform can install them on demand.
-            # This is the ONE place the active installer runs in the adapter
-            # path: the platform is enabled+configured and the gateway is
-            # about to connect it, so an install is what the user wants
-            # (#79812 — Teams' installer previously lived behind this very
-            # gate inside connect(), which could never be reached).
+        if entry.ensure_deps_fn is not None:
+            # The passive probe remains side-effect free for status displays,
+            # but configured adapter creation always runs the active verifier.
+            # A true passive result proves importability only; the active hook
+            # also proves exact security pins and rebinds stale module globals.
             logger.info(
-                "Platform '%s' dependencies missing — attempting install...",
+                "Platform '%s' dependencies require active verification...",
                 entry.label,
             )
             try:
@@ -664,22 +679,6 @@ class PlatformRegistry:
                 hint,
             )
             return None
-
-        if entry.validate_config is not None:
-            try:
-                if not entry.validate_config(config):
-                    logger.warning(
-                        "Platform '%s' config validation failed",
-                        entry.label,
-                    )
-                    return None
-            except Exception as e:
-                logger.warning(
-                    "Platform '%s' config validation error: %s",
-                    entry.label,
-                    e,
-                )
-                return None
 
         try:
             adapter = entry.adapter_factory(config)

--- a/hermes_cli/_early_recovery.py
+++ b/hermes_cli/_early_recovery.py
@@ -31,6 +31,9 @@ import sys
 import time
 from pathlib import Path
 
+from hermes_cli import _pip_security
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 # Core packages a failed lazy ``uv pip install`` is known to leave with intact
 # distribution metadata but wiped import files (#57828).  ``module`` is what we
 # probe via a real import; ``attr`` guards against an empty/stub module.
@@ -337,7 +340,7 @@ def _base_interpreter_is_externally_managed() -> bool:
 
 
 def _run_repair_install(specs: list[str], project_root: Path) -> bool:
-    """``uv pip`` (or stdlib ``pip``) force-reinstall of the given specs.
+    """``uv pip`` or floor-verified stdlib ``pip`` repair of the specs.
 
     Streams nothing to stdout (``hermes acp`` speaks JSON-RPC on stdout);
     output is captured and replayed to stderr only on failure.  Never raises.
@@ -383,24 +386,39 @@ def _run_repair_install(specs: list[str], project_root: Path) -> bool:
             file=sys.stderr,
         )
 
+    pip_cmd = [sys.executable, "-m", "pip"]
     try:
         subprocess.run(
             [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
             cwd=project_root,
             capture_output=True,
+            timeout=120,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except Exception:
         pass
-    pip_cmd = [sys.executable, "-m", "pip", "install", "--force-reinstall"]
+    pip_ok, pip_error = _pip_security.ensure_pip_floor(
+        pip_cmd,
+        runner=subprocess.run,
+        cwd=str(project_root),
+        creationflags=windows_hide_flags(),
+    )
+    if not pip_ok:
+        print(f"  ✗ Early venv repair refused: {pip_error}", file=sys.stderr)
+        return False
+    install_cmd = [*pip_cmd, "install", "--force-reinstall"]
     if externally_managed:
-        pip_cmd.append("--break-system-packages")
-    pip_cmd.extend(specs)
+        install_cmd.append("--break-system-packages")
     try:
         result = subprocess.run(
-            pip_cmd,
+            [*install_cmd, *specs],
             cwd=project_root,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",
+            timeout=600,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except Exception as exc:
         print(f"  ✗ Early venv repair could not run pip: {exc}", file=sys.stderr)

--- a/hermes_cli/_pip_security.py
+++ b/hermes_cli/_pip_security.py
@@ -1,0 +1,150 @@
+"""Stdlib-only guards for venv-managed pip installs.
+
+This module is intentionally dependency-light: ``hermes_cli._early_recovery``
+imports it before the normal CLI dependency graph is available.  Keep the
+version parser conservative and fail closed when ``pip --version`` does not
+prove a stable release at or above the security floor.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections.abc import Callable, Sequence
+from typing import Any
+
+
+MIN_PIP_VERSION = (26, 1, 2)
+MIN_PIP_SPEC = "pip>=26.1.2"
+
+# ``pip --version`` emits one authoritative record such as
+# ``pip 26.1.2 from /.../site-packages/pip (python 3.13)``.  Other output
+# (notably update warnings) can contain a misleading ``pip <version>`` token,
+# so only a canonical record is evidence for the floor.
+_PIP_CANONICAL_VERSION_LINE = re.compile(
+    r"^\s*pip\s+(?P<version>[^\s]+)\s+from\s+"
+    r"(?P<path>(?:/|[A-Za-z]:[\\/]|\\\\)[^\r\n\"]*[\\/]pip)"
+    r"(?:\s+\(python\s+\d+(?:\.\d+){1,3}\))?\s*$",
+    re.IGNORECASE,
+)
+_STABLE_VERSION = re.compile(
+    r"^(?P<release>\d+(?:\.\d+)*)(?:\.post\d+)?$",
+    re.IGNORECASE,
+)
+
+
+def stable_version_tuple(value: str) -> tuple[int, ...] | None:
+    """Return release components only for a stable version string.
+
+    This deliberately accepts a PEP 440 post-release (``1.2.3.post1``),
+    which is still a stable release for floor checks, but rejects every
+    pre/dev/rc/local or unknown suffix.  It is stdlib-only because callers in
+    early-recovery paths cannot assume ``packaging`` is importable.
+    """
+
+    if not isinstance(value, str):
+        return None
+    match = _STABLE_VERSION.fullmatch(value.strip())
+    if not match:
+        return None
+    try:
+        return tuple(int(part) for part in match.group("release").split("."))
+    except ValueError:
+        return None
+
+
+def pip_version_meets_floor(output: str) -> bool:
+    """Return whether ``pip --version`` output proves a stable floor.
+
+    Numeric-prefix parsing alone would accept ``26.1.2.dev0`` and
+    ``26.1.2.rc1`` as the final release, and warning text can mention a newer
+    pip than the installed interpreter.  Require exactly one canonical
+    ``pip <version> from <path>`` record. Only an exact release token or a
+    PEP 440 post-release suffix is accepted; pre/dev/rc/local, unknown,
+    malformed, missing, and conflicting records fail closed.
+    """
+
+    versions: list[tuple[int, ...]] = []
+    for line in (output or "").splitlines():
+        match = _PIP_CANONICAL_VERSION_LINE.fullmatch(line)
+        if not match:
+            continue
+        token = match.group("version")
+        version = stable_version_tuple(token)
+        if version is None:
+            return False
+        versions.append(version)
+    return len(versions) == 1 and versions[0] >= MIN_PIP_VERSION
+
+
+def ensure_pip_floor(
+    pip_cmd: Sequence[str],
+    *,
+    timeout: int = 120,
+    runner: Callable[..., Any] = subprocess.run,
+    creationflags: int = 0,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+) -> tuple[bool, str]:
+    """Upgrade and verify ``pip_cmd`` before a managed package transaction.
+
+    ``runner`` is injectable so callers can preserve their local subprocess
+    wrappers and tests can exercise the real command shape without spawning a
+    package manager.  The helper never raises for probe/upgrade failures.
+    """
+
+    def _run(args: Sequence[str], *, command_timeout: int):
+        kwargs: dict[str, Any] = {
+            "capture_output": True,
+            "text": True,
+            "encoding": "utf-8",
+            "errors": "replace",
+            "timeout": command_timeout,
+            "stdin": subprocess.DEVNULL,
+            "creationflags": creationflags,
+        }
+        if cwd is not None:
+            kwargs["cwd"] = cwd
+        if env is not None:
+            kwargs["env"] = env
+        return runner(list(args), **kwargs)
+
+    def _probe():
+        return _run([*pip_cmd, "--version"], command_timeout=15)
+
+    try:
+        probe = _probe()
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"pip floor probe failed: {exc}"
+    if probe.returncode != 0:
+        detail = (probe.stderr or probe.stdout or "").strip()
+        return False, f"pip floor probe failed: {detail or 'pip --version failed'}"
+    if pip_version_meets_floor(probe.stdout or ""):
+        return True, ""
+
+    try:
+        upgrade = _run(
+            [*pip_cmd, "install", "--upgrade", MIN_PIP_SPEC],
+            command_timeout=timeout,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"pip floor upgrade failed: {exc}"
+    if upgrade.returncode != 0:
+        detail = (upgrade.stderr or upgrade.stdout or "").strip()
+        return False, f"pip floor upgrade failed: {detail or 'pip install failed'}"
+
+    try:
+        verified = _probe()
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"pip floor verification failed: {exc}"
+    if verified.returncode != 0 or not pip_version_meets_floor(verified.stdout or ""):
+        detail = (verified.stderr or verified.stdout or "").strip()
+        return False, (
+            f"pip remains below {MIN_PIP_SPEC} after upgrade: "
+            f"{detail or 'version was not reported'}"
+        )
+    return True, ""
+
+
+class PipFloorError(RuntimeError):
+    """Raised when a managed direct-pip transaction cannot prove the floor."""

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -22,6 +22,7 @@ from hermes_cli.config import (
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
 from hermes_constants import agent_browser_runnable
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
@@ -823,11 +824,33 @@ def check_certificates(should_fix: bool = False, issues: "list | None" = None) -
     check_fail("SSL CA certificate bundle is broken", first_error)
     print("    → Repairing: force-reinstalling certifi...")
     try:
+        from hermes_cli import _pip_security
+
+        pip_cmd = [sys.executable, "-m", "pip"]
+        pip_ok, pip_error = _pip_security.ensure_pip_floor(
+            pip_cmd,
+            runner=subprocess.run,
+            timeout=300,
+            creationflags=windows_hide_flags(),
+        )
+        if not pip_ok:
+            # Keep a floor refusal distinct from a certifi transaction error;
+            # the former requires repairing pip before this command can make
+            # any package change.
+            check_fail("pip security floor unavailable", pip_error)
+            if issues is not None:
+                issues.append(
+                    f"Upgrade pip to >=26.1.2, then reinstall certifi: {sys.executable} -m pip install "
+                    "--force-reinstall certifi"
+                )
+            return
         result = subprocess.run(
-            [sys.executable, "-m", "pip", "install", "--force-reinstall", "certifi"],
+            [*pip_cmd, "install", "--force-reinstall", "certifi"],
             capture_output=True,
             text=True,
             timeout=300,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except Exception as exc:
         check_fail("certifi repair could not run pip", str(exc))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -66,7 +66,7 @@ except ModuleNotFoundError:
 # any dependency touching ``platform.uname()`` at import time flashes a
 # visible console when this process is windowless (pythonw gateway + every
 # kanban worker).  No-op on POSIX; never raises.
-from hermes_cli._subprocess_compat import suppress_platform_ver_console
+from hermes_cli._subprocess_compat import suppress_platform_ver_console, windows_hide_flags
 from hermes_cli.cli_output import line_input
 
 suppress_platform_ver_console()
@@ -96,6 +96,7 @@ from hermes_cli import _startup_fast  # noqa: E402
 # either. It is also the canonical home of the probe/repair tables reused by
 # the full recovery path below.
 from hermes_cli import _early_recovery as _early_recovery_mod
+from hermes_cli import _pip_security
 
 try:
     _early_recovery_mod.recover_if_needed()
@@ -9364,6 +9365,82 @@ _LAZY_REFRESH_REPAIR_PACKAGES: dict[str, str] = (
 )
 
 
+def _direct_pip_prefix(command: list[str]) -> list[str] | None:
+    """Extract the full interpreter prefix ending at the ``-m pip`` marker."""
+    for index in range(len(command) - 1):
+        if command[index : index + 2] == ["-m", "pip"]:
+            return command[: index + 2]
+    return None
+
+
+def _is_direct_pip_prefix(prefix: list[str]) -> bool:
+    """Return whether an install prefix invokes this interpreter's pip."""
+    return _direct_pip_prefix(prefix) == prefix
+
+
+def _ensure_direct_pip_floor(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Bootstrap and verify a direct-pip install target before use.
+
+    uv prefixes do not need this guard.  Direct prefixes may point at a venv
+    without pip (``uv venv`` deliberately omits it), so restore pip with
+    ensurepip before asking the shared floor helper to upgrade and verify it.
+    """
+    if not _is_direct_pip_prefix(install_cmd_prefix):
+        return
+
+    pip_cmd = list(install_cmd_prefix)
+    try:
+        probe = subprocess.run(
+            pip_cmd + ["--version"],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise _pip_security.PipFloorError(f"pip security floor unavailable: {exc}") from exc
+    if probe.returncode != 0:
+        try:
+            subprocess.run(
+                pip_cmd[:-2]
+                + ["-m", "ensurepip", "--upgrade", "--default-pip"],
+                cwd=PROJECT_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=120,
+                check=True,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            raise _pip_security.PipFloorError(
+                f"pip security floor unavailable: ensurepip failed: {exc}"
+            ) from exc
+
+    ok, detail = _pip_security.ensure_pip_floor(
+        pip_cmd,
+        runner=subprocess.run,
+        creationflags=windows_hide_flags(),
+        cwd=str(PROJECT_ROOT),
+        env=env,
+    )
+    if not ok:
+        raise _pip_security.PipFloorError(f"pip security floor unavailable: {detail}")
+
+
 def _run_package_only_install(
     cmd: list[str],
     *,
@@ -9375,6 +9452,9 @@ def _run_package_only_install(
     rewrite ``hermes.exe``. The editable-install quarantine path would rename
     shims without uv recreating them on Windows (#57828).
     """
+    direct_pip_prefix = _direct_pip_prefix(cmd)
+    if direct_pip_prefix is not None:
+        _ensure_direct_pip_floor(direct_pip_prefix, env=env)
     _run_install_with_heartbeat(cmd, env=env)
 
 
@@ -9513,7 +9593,7 @@ def _repair_broken_lazy_refresh_imports(
             install_cmd_prefix + ["install", "--force-reinstall", *specs],
             env=env,
         )
-    except subprocess.CalledProcessError as exc:
+    except (subprocess.CalledProcessError, _pip_security.PipFloorError) as exc:
         logger.warning("lazy refresh venv repair failed: %s", exc)
         return False
 
@@ -9645,6 +9725,10 @@ def _install_python_dependencies_with_optional_fallback(
     installs (#71510 fixed the ZIP path, #83335 fixed lazy-deps; this closes the
     shared helper for the remaining callers).
     """
+    # Every direct-pip branch, including update repair and interrupted-install
+    # recovery, must prove the stable pip security floor before installing any
+    # project dependency.  uv-managed branches remain on uv's resolver path.
+    _ensure_direct_pip_floor(install_cmd_prefix, env=env)
     scripts_dir = _venv_scripts_dir() if _is_windows() else None
 
     # A pip / site-packages install has no PROJECT_ROOT/venv; the caller still
@@ -11639,6 +11723,18 @@ def cmd_dashboard(args):
         _setup_logging_gui(mode="gui")
     except Exception:
         pass
+
+    # Re-check the complete dashboard contract before importing the modules.
+    # FastAPI can remain importable while its Starlette dependency is stale;
+    # relying on ImportError alone would then skip the security-floor repair.
+    try:
+        from tools.lazy_deps import ensure as _ensure_dashboard_deps
+
+        _ensure_dashboard_deps("tool.dashboard", prompt=False)
+    except Exception as e:
+        print("Web UI dependency security contract is unavailable.")
+        print(f"Dashboard dependency check failed: {e}")
+        sys.exit(1)
 
     try:
         import fastapi  # noqa: F401

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1332,7 +1332,10 @@ def setup_terminal_backend(config: dict):
     print_info(f"   Guide: {_DOCS_BASE}/user-guide/configuration#terminal-backend-configuration")
     print()
 
+    terminal_config = config.setdefault("terminal", {})
     current_backend = cfg_get(config, "terminal", "backend", default="local")
+    _missing_modal_mode = object()
+    previous_modal_mode = terminal_config.get("modal_mode", _missing_modal_mode)
     is_linux = _platform.system() == "Linux"
 
     # Build backend choices with descriptions
@@ -1478,18 +1481,30 @@ def setup_terminal_backend(config: dict):
             config["terminal"]["modal_mode"] = "direct"
             print_info("Requires a Modal account: https://modal.com")
 
-            # Check if modal SDK is installed
+            # Use the canonical lazy feature contract so the direct SDK is
+            # installed together with its patched aiohttp closure. This also
+            # repairs stale metadata when modal is already importable.
+            print_info("Ensuring modal SDK and runtime closure...")
             try:
-                __import__("modal")
-            except ImportError:
-                print_info("Installing modal SDK...")
-                from hermes_cli.tools_config import _pip_install
+                from tools.lazy_deps import ensure
 
-                result = _pip_install(["modal"])
-                if result.returncode == 0:
-                    print_success("modal SDK installed")
+                ensure("terminal.modal", prompt=False)
+                print_success("modal SDK ready")
+            except Exception as exc:
+                # Do not persist a backend whose exact SDK/runtime contract
+                # was not verified. Continue setup only after a successful
+                # lazy repair; credentials for a failed backend are not useful
+                # and can make the next startup fail less clearly.
+                config["terminal"]["backend"] = current_backend
+                if previous_modal_mode is _missing_modal_mode:
+                    config["terminal"].pop("modal_mode", None)
                 else:
-                    print_warning("Install failed — run manually: uv pip install modal")
+                    config["terminal"]["modal_mode"] = previous_modal_mode
+                print_error(
+                    "Modal SDK security contract unavailable; keeping the previous terminal backend."
+                )
+                print_info(f"  Error: {exc}")
+                return
 
             # Modal token
             print()
@@ -1519,20 +1534,23 @@ def setup_terminal_backend(config: dict):
         print_info("Each session gets a dedicated sandbox with filesystem persistence.")
         print_info("Sign up at: https://daytona.io")
 
-        # Check if daytona SDK is installed
+        # Use the canonical lazy feature contract so the direct SDK is
+        # installed together with its patched aiohttp closure. This also
+        # repairs stale metadata when daytona is already importable.
+        print_info("Ensuring daytona SDK and runtime closure...")
         try:
-            __import__("daytona")
-        except ImportError:
-            print_info("Installing daytona SDK...")
-            from hermes_cli.tools_config import _pip_install
+            from tools.lazy_deps import ensure
 
-            result = _pip_install(["daytona"])
-            if result.returncode == 0:
-                print_success("daytona SDK installed")
-            else:
-                print_warning("Install failed — run manually: uv pip install daytona")
-                if result.stderr:
-                    print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
+            ensure("terminal.daytona", prompt=False)
+            print_success("daytona SDK ready")
+        except Exception as exc:
+            # Keep configuration aligned with the verified runtime state.
+            config["terminal"]["backend"] = current_backend
+            print_error(
+                "Daytona SDK security contract unavailable; keeping the previous terminal backend."
+            )
+            print_info(f"  Error: {exc}")
+            return
 
         # Daytona API key
         print()
@@ -1561,37 +1579,21 @@ def setup_terminal_backend(config: dict):
         print_info("Requires the optional SDK: pip install 'hermes-agent[vercel]'")
 
         try:
-            __import__("vercel")
-        except ImportError:
-            print_info("Installing vercel SDK...")
-            import subprocess
+            # Use the canonical lazy contract so an importable but stale SDK
+            # is repaired and every resolver tier targets vercel==0.7.2.
+            # In particular, do not let a uv resolver failure fall through to
+            # an unpinned direct-pip install.
+            from tools.lazy_deps import ensure
 
-            # Managed uv first: $HERMES_HOME/bin is never on PATH, so a bare
-            # which() misses the uv Hermes installed. Bootstrapping one is
-            # welcome here — this is the interactive setup wizard, already
-            # mid-install, and the alternative tier is a pip that a `uv venv`
-            # venv may not even have.
-            from hermes_cli.managed_uv import ensure_uv
-
-            uv_bin = ensure_uv()
-            if uv_bin:
-                result = subprocess.run(
-                    [uv_bin, "pip", "install", "--python", sys.executable, "vercel"],
-                    capture_output=True,
-                    text=True,
-                )
-            else:
-                result = subprocess.run(
-                    [sys.executable, "-m", "pip", "install", "vercel"],
-                    capture_output=True,
-                    text=True,
-                )
-            if result.returncode == 0:
-                print_success("vercel SDK installed")
-            else:
-                print_warning("Install failed — run manually: pip install 'hermes-agent[vercel]'")
-                if result.stderr:
-                    print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
+            ensure("terminal.vercel", prompt=False)
+            print_success("vercel SDK ready")
+        except Exception as exc:
+            # Keep the previously selected backend rather than persisting a
+            # Vercel configuration whose exact SDK contract was not verified.
+            config["terminal"]["backend"] = current_backend
+            print_error("Vercel SDK security contract unavailable; keeping the previous terminal backend.")
+            print_info(f"  Error: {exc}")
+            return
 
         _prompt_vercel_sandbox_settings(config)
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
@@ -23,6 +24,7 @@ from hermes_cli.config import (
     cfg_get,
     load_config, save_config, get_env_value, save_env_value,
 )
+from hermes_cli import _pip_security
 from hermes_cli.colors import Colors, color
 from hermes_cli.nous_subscription import (
     MANAGED_FEATURE_COVERAGE_CATEGORY,
@@ -905,20 +907,46 @@ def _pip_install(
             pass
 
     pip_cmd = [sys.executable, "-m", "pip"]
+    # Keep the direct-pip recovery path within one caller-owned budget. The
+    # floor helper performs a probe, optional upgrade, and verification before
+    # the package install; independent per-process timeouts could otherwise
+    # make a failed uv attempt hang for several minutes more.
+    pip_deadline = time.monotonic() + max(float(timeout), 1.0)
+
+    def _remaining_timeout(limit: float, *, reserve: float = 0.0) -> int | None:
+        remaining = pip_deadline - time.monotonic() - reserve
+        if remaining <= 0:
+            return None
+        return max(1, min(int(limit), int(remaining)))
+
+    def _budget_failure(detail: str) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(
+            pip_cmd,
+            returncode=1,
+            stdout="",
+            stderr=f"pip install timed out: {detail}",
+        )
+
     try:
         # Probe for pip; bootstrap via ensurepip if missing (uv venv lacks it).
+        probe_timeout = _remaining_timeout(15)
+        if probe_timeout is None:
+            return _budget_failure("direct-pip budget exhausted before probe")
         probe = subprocess.run(
             pip_cmd + ["--version"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=15,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=probe_timeout,
             creationflags=_post_setup_no_window_flags(),
         )
         if probe.returncode != 0:
             raise FileNotFoundError("pip not in venv")
     except (subprocess.TimeoutExpired, FileNotFoundError):
         try:
+            ensurepip_timeout = _remaining_timeout(120)
+            if ensurepip_timeout is None:
+                return _budget_failure("direct-pip budget exhausted before ensurepip")
             subprocess.run(
                 [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120, check=True,
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=ensurepip_timeout, check=True,
                 creationflags=_post_setup_no_window_flags(),
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
@@ -928,9 +956,32 @@ def _pip_install(
                 stderr=f"pip not available and ensurepip failed: {e}",
             )
 
+    # Reserve the helper's fixed 15-second probe and verification windows so
+    # the subsequent package install still has a bounded slice of the same
+    # caller-owned budget.
+    floor_timeout = _remaining_timeout(timeout, reserve=30)
+    if floor_timeout is None:
+        return _budget_failure("direct-pip budget exhausted before floor verification")
+    pip_ok, pip_error = _pip_security.ensure_pip_floor(
+        pip_cmd,
+        runner=subprocess.run,
+        creationflags=_post_setup_no_window_flags(),
+        timeout=floor_timeout,
+    )
+    if not pip_ok:
+        return subprocess.CompletedProcess(
+            pip_cmd,
+            returncode=1,
+            stdout="",
+            stderr=pip_error,
+        )
+
+    install_timeout = _remaining_timeout(timeout)
+    if install_timeout is None:
+        return _budget_failure("direct-pip budget exhausted before package install")
     return subprocess.run(
         pip_cmd + ["install", *args],
-        capture_output=capture_output, text=True, encoding="utf-8", errors="replace", timeout=timeout,
+        capture_output=capture_output, text=True, encoding="utf-8", errors="replace", timeout=install_timeout,
         creationflags=_post_setup_no_window_flags(
             streams_to_console=not capture_output
         ),

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -37,6 +37,8 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
+from hermes_cli import _pip_security
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import venv_python_path
 
 logger = logging.getLogger(__name__)
@@ -1725,6 +1727,11 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
 
     pip_cmd = [_m().sys.executable, "-m", "pip"]
     if not uv_bin:
+        # Termux's uv bootstrap itself invokes pip.  Prove the floor before
+        # allowing that command to run so a successful bootstrap cannot bypass
+        # the security gate by taking the uv branch.
+        if _m()._is_termux_env():
+            _ensure_update_pip_floor(pip_cmd)
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
         # Same third-party UV-env isolation as the main update path (#83914):
@@ -1749,19 +1756,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
         # Some environments lose pip inside the venv; bootstrap it back with
         # ensurepip before trying the editable install.
-        try:
-            subprocess.run(
-                pip_cmd + ["--version"],
-                cwd=_m().PROJECT_ROOT,
-                check=True,
-                capture_output=True,
-            )
-        except subprocess.CalledProcessError:
-            subprocess.run(
-                [_m().sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                cwd=_m().PROJECT_ROOT,
-                check=True,
-            )
+        _ensure_update_pip_floor(pip_cmd)
         _m()._install_python_dependencies_with_optional_fallback(pip_cmd)
 
     install_prefix = [uv_bin, "pip"] if uv_bin else pip_cmd
@@ -2590,11 +2585,19 @@ def _upgrade_pip_before_lazy_refresh(
     Never raises.
     """
     try:
+        from tools.lazy_deps import _MIN_PIP_SPEC
+
         _m()._run_package_only_install(
-            install_cmd_prefix + ["install", "--upgrade", "pip"],
+            install_cmd_prefix + ["install", "--upgrade", _MIN_PIP_SPEC],
             env=env,
         )
-    except subprocess.CalledProcessError as exc:
+    except (
+        ImportError,
+        OSError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        _pip_security.PipFloorError,
+    ) as exc:
         logger.debug("pip upgrade before lazy refresh failed: %s", exc)
 
 
@@ -2699,6 +2702,61 @@ def _restore_active_tool_dependencies(
         print(f"  ⚠ {name} failed to restore: {reason}")
 
 
+def _ensure_update_pip_floor(pip_cmd: list[str]) -> None:
+    """Fail closed before any update-managed direct-pip transaction."""
+    try:
+        from tools.lazy_deps import _ensure_pip_floor
+    except (ImportError, OSError) as exc:
+        raise _pip_security.PipFloorError(
+            f"pip security floor unavailable: floor helper import failed: {exc}"
+        ) from exc
+
+    try:
+        probe = subprocess.run(
+            pip_cmd + ["--version"],
+            cwd=_m().PROJECT_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise _pip_security.PipFloorError(f"pip security floor unavailable: {exc}") from exc
+    if probe.returncode != 0:
+        try:
+            bootstrap = subprocess.run(
+                pip_cmd[:-2]
+                + ["-m", "ensurepip", "--upgrade", "--default-pip"],
+                cwd=_m().PROJECT_ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+                timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise _pip_security.PipFloorError(
+                f"pip security floor unavailable: ensurepip failed: {exc}"
+            ) from exc
+        if bootstrap.returncode != 0:
+            detail = (bootstrap.stderr or bootstrap.stdout or "").strip()
+            raise _pip_security.PipFloorError(
+                "pip security floor unavailable: ensurepip failed: "
+                f"{detail or 'no output'}"
+            )
+
+    ok, detail = _ensure_pip_floor(pip_cmd)
+    if not ok:
+        raise _pip_security.PipFloorError(f"pip security floor unavailable: {detail}")
+
+
 def _refresh_active_lazy_features(
     install_cmd_prefix: list[str] | None = None,
     *,
@@ -2763,6 +2821,9 @@ def _refresh_active_lazy_features(
     current = [f for f, s in results.items() if s == "current"]
     failed = [(f, s) for f, s in results.items() if s.startswith("failed:")]
     skipped = [(f, s) for f, s in results.items() if s.startswith("skipped:")]
+    restart_required = [
+        (f, s) for f, s in results.items() if s.startswith("restart-required:")
+    ]
 
     if refreshed:
         print(f"  ↑ {len(refreshed)} refreshed: {', '.join(refreshed)}")
@@ -2775,15 +2836,27 @@ def _refresh_active_lazy_features(
         reason = skipped[0][1].split(": ", 1)[-1]
         print(f"  · {len(skipped)} skipped ({reason}): {names}")
 
-    if not failed and not unexpected_failure:
-        return True
+    if restart_required:
+        names = ", ".join(f for f, _ in restart_required)
+        reason = restart_required[0][1].split(": ", 1)[-1]
+        print(f"  ⚠ {len(restart_required)} restart required ({reason}): {names}")
 
+    # Report ordinary failed refreshes before returning for a restart boundary
+    # so one stale loaded module does not hide independent feature failures.
     for feature, status in failed:
         reason = status.split(": ", 1)[-1]
-        # Clip noisy pip stderr to keep update output legible.
         if len(reason) > 200:
             reason = reason[:200] + "..."
         print(f"  ⚠ {feature} failed to refresh: {reason}")
+
+    if not failed and not restart_required and not unexpected_failure:
+        return True
+
+    # A stale module already resident in this process cannot be safely
+    # reloaded after its distribution is replaced. Leave the incomplete
+    # marker in place and require a fresh Hermes process before retrying.
+    if restart_required:
+        return False
 
     if install_cmd_prefix is None:
         print("  ⚠ Lazy refresh failed; rerun `hermes update` once resolved.")
@@ -6060,6 +6133,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 args,
                 had_desktop_app_before_update=had_desktop_app_before_update,
             )
+        except _pip_security.PipFloorError as exc:
+            print(f"✗ Update blocked: {exc}")
+            _m().sys.exit(1)
         finally:
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
         if gateway_mode:
@@ -6753,6 +6829,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         pip_cmd = [sys.executable, "-m", "pip"]
         if not uv_bin:
+            # `_ensure_uv_for_termux` installs uv through this pip command;
+            # prove the floor before permitting that bootstrap.
+            if _m()._is_termux_env():
+                _ensure_update_pip_floor(pip_cmd)
             uv_bin = _ensure_uv_for_termux(pip_cmd)
         install_group = "all"
 
@@ -6781,20 +6861,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
             # Some environments lose pip inside the venv; bootstrap it back with
             # ensurepip before trying the editable install.
-            pip_cmd = [sys.executable, "-m", "pip"]
-            try:
-                subprocess.run(
-                    pip_cmd + ["--version"],
-                    cwd=_m().PROJECT_ROOT,
-                    check=True,
-                    capture_output=True,
-                )
-            except subprocess.CalledProcessError:
-                subprocess.run(
-                    [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
-                    cwd=_m().PROJECT_ROOT,
-                    check=True,
-                )
+            _ensure_update_pip_floor(pip_cmd)
             if _m()._is_termux_env():
                 install_group = "termux-all"
                 print("  → Termux detected: using curated termux-all optional profile...")
@@ -8382,10 +8449,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print(f"⚠ {stage}: {e}")
             print("→ Falling back to ZIP download...")
             print()
-            desktop_build_ok = _update_via_zip(
-                args,
-                had_desktop_app_before_update=had_desktop_app_before_update,
-            )
+            try:
+                desktop_build_ok = _update_via_zip(
+                    args,
+                    had_desktop_app_before_update=had_desktop_app_before_update,
+                )
+            except _pip_security.PipFloorError as floor_exc:
+                print(f"✗ Update blocked: {floor_exc}")
+                _m().sys.exit(1)
             if gateway_mode:
                 _write_gateway_update_exit_code(desktop_build_ok)
         else:
@@ -8410,6 +8481,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             except Exception:
                 pass
             sys.exit(1)
+    except _pip_security.PipFloorError as e:
+        # A security-floor failure is an update dependency failure, not a git
+        # failure. Keep it on the normal friendly error path and never turn it
+        # into a traceback or an unsafe Windows ZIP fallback.
+        print(f"✗ Update blocked: {e}")
+        sys.exit(1)
 
 # --- Hoisted from the body of _cmd_update_impl (self-contained, no closure state) ---
 

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -31,6 +31,7 @@ import json
 import logging
 import os
 import re
+import threading
 import traceback
 import uuid
 from datetime import datetime, timezone
@@ -93,6 +94,68 @@ except Exception:
     dingtalk_robot_models = None
     open_api_models = None
     tea_util_models = None
+
+
+def _load_optional_card_sdk() -> bool:
+    """Rebind the optional AI-card/OpenAPI SDK globals after lazy install."""
+    global CARD_SDK_AVAILABLE
+    global dingtalk_card_client, dingtalk_card_models
+    global dingtalk_robot_client, dingtalk_robot_models
+    global open_api_models, tea_util_models
+    try:
+        from alibabacloud_dingtalk.card_1_0 import (
+            client as _card_client,
+            models as _card_models,
+        )
+        from alibabacloud_dingtalk.robot_1_0 import (
+            client as _robot_client,
+            models as _robot_models,
+        )
+        from alibabacloud_tea_openapi import models as _open_api_models
+        from alibabacloud_tea_util import models as _tea_util_models
+    except Exception:
+        # Keep the last known-good bindings alive for adapters already using
+        # them.  The caller receives False and can keep the optional feature
+        # disabled for a new adapter; tearing down process globals here would
+        # break healthy profiles that reconnect concurrently.
+        return False
+    dingtalk_card_client = _card_client
+    dingtalk_card_models = _card_models
+    dingtalk_robot_client = _robot_client
+    dingtalk_robot_models = _robot_models
+    open_api_models = _open_api_models
+    tea_util_models = _tea_util_models
+    CARD_SDK_AVAILABLE = True
+    return True
+
+
+# Active verification may run from concurrent profile reconnects.  Serialize
+# the optional package transaction and cache its result so waiting adapters do
+# not launch duplicate pip/uv repairs against the same environment.
+_CARD_DEPS_LOCK = threading.Lock()
+_CARD_DEPS_REPAIR_RESULT: Optional[bool] = None
+
+
+def ensure_dingtalk_card_deps() -> bool:
+    """Install and bind the optional card SDK when cards are configured."""
+    global _CARD_DEPS_REPAIR_RESULT
+    if CARD_SDK_AVAILABLE:
+        return True
+    with _CARD_DEPS_LOCK:
+        if CARD_SDK_AVAILABLE:
+            return True
+        if _CARD_DEPS_REPAIR_RESULT is not None:
+            return _CARD_DEPS_REPAIR_RESULT
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+
+            _lazy_ensure("platform.dingtalk_card", prompt=False)
+        except Exception as exc:
+            logger.debug("DingTalk card SDK is unavailable: %s", exc)
+            _CARD_DEPS_REPAIR_RESULT = False
+            return False
+        _CARD_DEPS_REPAIR_RESULT = _load_optional_card_sdk()
+        return _CARD_DEPS_REPAIR_RESULT
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator, compile_mention_patterns
@@ -171,13 +234,41 @@ def dingtalk_deps_present() -> bool:
     and runs from ``create_adapter()`` when this returns False (#79812).
     Credentials are gated separately via ``is_connected``/``validate_config``.
     """
-    return DINGTALK_STREAM_AVAILABLE and HTTPX_AVAILABLE
+    return (
+        DINGTALK_STREAM_AVAILABLE
+        and HTTPX_AVAILABLE
+        and not _DINGTALK_ACTIVE_CHECK_FAILED
+    )
+
+
+_DINGTALK_ACTIVE_CHECK_FAILED = False
+_DINGTALK_ACTIVE_CHECK_LOCK = threading.Lock()
+
+
+def _clear_dingtalk_bindings() -> None:
+    """Record failed verification without tearing down live bindings.
+
+    SDK modules are process-global while adapters are per profile.  A failed
+    repair for a new profile must fail closed for that candidate, but cannot
+    invalidate module objects still used by healthy adapters.
+    """
+    global _DINGTALK_ACTIVE_CHECK_FAILED
+    _DINGTALK_ACTIVE_CHECK_FAILED = True
 
 
 def ensure_dingtalk_deps() -> bool:
+    # Stream/HTTPX bindings and the availability latch are process-global;
+    # serialize active repair so concurrent profile checks cannot interleave
+    # a failed latch update with a successful rebind.
+    with _DINGTALK_ACTIVE_CHECK_LOCK:
+        return _ensure_dingtalk_deps()
+
+
+def _ensure_dingtalk_deps() -> bool:
     """ACTIVE deps-only installer (registry ``ensure_deps_fn``).
 
-    Lazy-installs dingtalk-stream/httpx and rebinds module globals.
+    Runs the feature contract on every active check so stale security pins are
+    repaired or fail closed, then rebinds module globals.
     Deliberately does NOT check credentials — ``ensure_deps_fn``'s contract
     is deps-only ("Returns True once deps are importable"); credentials are
     gated by ``is_connected``/``validate_config``.  Otherwise a platform
@@ -188,12 +279,12 @@ def ensure_dingtalk_deps() -> bool:
     """
     global DINGTALK_STREAM_AVAILABLE, dingtalk_stream, ChatbotMessage, CallbackMessage, AckMessage
     global HTTPX_AVAILABLE, httpx
-    if DINGTALK_STREAM_AVAILABLE and HTTPX_AVAILABLE:
-        return True
+    global _DINGTALK_ACTIVE_CHECK_FAILED
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("platform.dingtalk", prompt=False)
     except Exception:
+        _clear_dingtalk_bindings()
         return False
     try:
         import dingtalk_stream as _ds
@@ -201,15 +292,20 @@ def ensure_dingtalk_deps() -> bool:
         from dingtalk_stream.frames import CallbackMessage as _CBM, AckMessage as _AM
         import httpx as _httpx
     except Exception:
+        _clear_dingtalk_bindings()
         return False
     dingtalk_stream = _ds
     ChatbotMessage = _CM
     CallbackMessage = _CBM
     AckMessage = _AM
     httpx = _httpx
+    # The card/OpenAPI SDK is an optional capability.  A missing or broken
+    # card dependency must not take down the core Stream Mode transport.
+    _load_optional_card_sdk()
     DINGTALK_STREAM_AVAILABLE = True
     HTTPX_AVAILABLE = True
-    return True
+    _DINGTALK_ACTIVE_CHECK_FAILED = False
+    return DINGTALK_STREAM_AVAILABLE and HTTPX_AVAILABLE
 
 
 def check_dingtalk_requirements() -> bool:
@@ -296,6 +392,10 @@ class DingTalkAdapter(BasePlatformAdapter):
         # multiple conversations run concurrently.
         self._message_contexts: Dict[str, Any] = {}
         self._card_template_id: Optional[str] = extra.get("card_template_id")
+        # A missing optional card SDK must not block the event loop or cause a
+        # long package-manager retry on every reconnect. One attempted repair
+        # per adapter lifetime is enough; a later process restart can retry.
+        self._card_sdk_attempted = False
 
         # Chats for which we've already fired the Done reaction — prevents
         # double-firing across segment boundaries or parallel flows
@@ -346,6 +446,22 @@ class DingTalkAdapter(BasePlatformAdapter):
                 self._client_id, self._client_secret
             )
             self._stream_client = dingtalk_stream.DingTalkStreamClient(credential)
+
+            # AI cards are an optional capability.  Do not make the core
+            # Stream Mode transport depend on their SDK; install it only for
+            # an adapter explicitly configured with a card template.
+            if (
+                self._card_template_id
+                and not CARD_SDK_AVAILABLE
+                and not self._card_sdk_attempted
+            ):
+                self._card_sdk_attempted = True
+                if not await asyncio.to_thread(ensure_dingtalk_card_deps):
+                    logger.warning(
+                        "[%s] DingTalk card SDK unavailable; continuing "
+                        "without card streaming",
+                        self.name,
+                    )
 
             # Initialize card SDK if available and configured
             if CARD_SDK_AVAILABLE and self._card_template_id:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -487,36 +487,90 @@ def discord_deps_present() -> bool:
     (``check_discord_requirements``) is registered as ``ensure_deps_fn``
     and runs from ``create_adapter()`` when this returns False (#79812).
     """
-    return DISCORD_AVAILABLE
+    return DISCORD_AVAILABLE and not _DISCORD_ACTIVE_CHECK_FAILED
+
+
+_DISCORD_ACTIVE_CHECK_FAILED = False
+_DISCORD_ACTIVE_CHECK_LOCK = threading.Lock()
+
+_DISCORD_VIEW_CLASS_NAMES = (
+    "ExecApprovalView",
+    "SlashConfirmView",
+    "UpdatePromptView",
+    "ModelPickerView",
+    "ClarifyChoiceView",
+    "ChoicePickerView",
+)
+
+
+def _clear_discord_bindings() -> None:
+    """Record failed verification without tearing down live bindings."""
+    global _DISCORD_ACTIVE_CHECK_FAILED
+    _DISCORD_ACTIVE_CHECK_FAILED = True
 
 
 def check_discord_requirements() -> bool:
+    # SDK bindings and view classes are process-global while checks can run
+    # concurrently for multiplexed profiles.  Serialize the complete
+    # ensure/import/commit-or-rollback transaction so a failed candidate
+    # cannot restore over a concurrent successful binding.
+    with _DISCORD_ACTIVE_CHECK_LOCK:
+        return _check_discord_requirements()
+
+
+def _check_discord_requirements() -> bool:
     """Check if Discord dependencies are available.
 
-    Lazy-installs discord.py via ``tools.lazy_deps.ensure("platform.discord")``
-    on first call if not present. After successful install, re-binds module
-    globals so ``DISCORD_AVAILABLE`` becomes True.
+    Runs the feature contract on every active check so stale security pins are
+    repaired or fail closed even when discord.py is already importable. After
+    success, re-binds module globals so ``DISCORD_AVAILABLE`` is current.
     """
     global DISCORD_AVAILABLE, discord, DiscordMessage, Intents, commands
-    if DISCORD_AVAILABLE:
-        return True
+    global _DISCORD_ACTIVE_CHECK_FAILED
+    previous_bindings = {
+        name: globals().get(name)
+        for name in ("DISCORD_AVAILABLE", "discord", "DiscordMessage", "Intents", "commands")
+    }
+    _missing = object()
+    previous_view_classes = {
+        name: globals().get(name, _missing)
+        for name in _DISCORD_VIEW_CLASS_NAMES
+    }
+
+    def _restore_bindings() -> None:
+        global DISCORD_AVAILABLE, discord, DiscordMessage, Intents, commands
+        DISCORD_AVAILABLE = previous_bindings["DISCORD_AVAILABLE"]
+        discord = previous_bindings["discord"]
+        DiscordMessage = previous_bindings["DiscordMessage"]
+        Intents = previous_bindings["Intents"]
+        commands = previous_bindings["commands"]
+        for name, previous in previous_view_classes.items():
+            if previous is _missing:
+                globals().pop(name, None)
+            else:
+                globals()[name] = previous
+
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("platform.discord", prompt=False)
     except Exception:
+        _clear_discord_bindings()
         return False
     try:
         import discord as _discord
         from discord import Message as _DM, Intents as _Intents
         from discord.ext import commands as _commands
-    except ImportError:
+        discord = _discord
+        DiscordMessage = _DM
+        Intents = _Intents
+        commands = _commands
+        _define_discord_view_classes()
+    except Exception:
+        _restore_bindings()
+        _clear_discord_bindings()
         return False
-    discord = _discord
-    DiscordMessage = _DM
-    Intents = _Intents
-    commands = _commands
     DISCORD_AVAILABLE = True
-    _define_discord_view_classes()
+    _DISCORD_ACTIVE_CHECK_FAILED = False
     return True
 
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -88,6 +88,8 @@ except ImportError:
 # lark_oapi takes a noticeable amount of time to import.  Keep the gateway
 # configuration path responsive by importing it only when Feishu connects.
 lark = None  # type: ignore[assignment]
+
+_FEISHU_ACTIVE_CHECK_FAILED = False
 GetApplicationRequest = None  # type: ignore[assignment]
 CreateFileRequest = None  # type: ignore[assignment]
 CreateFileRequestBody = None  # type: ignore[assignment]
@@ -114,6 +116,7 @@ EventDispatcherHandler = None  # type: ignore[assignment]
 FeishuWSClient = None  # type: ignore[assignment]
 FEISHU_AVAILABLE = False
 _lark_import_lock = threading.Lock()
+_FEISHU_ACTIVE_CHECK_LOCK = threading.Lock()
 
 FEISHU_WEBSOCKET_AVAILABLE = websockets is not None
 FEISHU_WEBHOOK_AVAILABLE = aiohttp is not None
@@ -1458,27 +1461,63 @@ def feishu_deps_present() -> bool:
     ``ensure_deps_fn`` and runs from ``create_adapter()`` when this
     returns False (#79812).
     """
-    if FEISHU_AVAILABLE:
-        return True
     try:
         from tools.lazy_deps import is_available
-        return is_available("platform.feishu")
+        return (
+            is_available("platform.feishu")
+            and FEISHU_WEBHOOK_AVAILABLE
+            and FEISHU_WEBSOCKET_AVAILABLE
+            and not _FEISHU_ACTIVE_CHECK_FAILED
+        )
     except Exception:  # pragma: no cover — defensive
         return False
 
 
-def check_feishu_requirements() -> bool:
-    """Ensure Feishu dependencies are installed without importing the SDK."""
-    if FEISHU_AVAILABLE:
-        return True
+def _clear_feishu_transport_bindings() -> None:
+    """Record failed verification without tearing down live bindings."""
+    global _FEISHU_ACTIVE_CHECK_FAILED
+    _FEISHU_ACTIVE_CHECK_FAILED = True
 
-    from tools.lazy_deps import ensure
+
+def check_feishu_requirements() -> bool:
+    # Transport bindings and the failure latch are process-global.  Keep the
+    # lazy-repair transaction serialized across profile reconnects.
+    with _FEISHU_ACTIVE_CHECK_LOCK:
+        return _check_feishu_requirements()
+
+
+def _check_feishu_requirements() -> bool:
+    """Ensure Feishu dependencies and both transport runtimes are importable."""
+    global aiohttp, web, websockets
+    global FEISHU_WEBHOOK_AVAILABLE, FEISHU_WEBSOCKET_AVAILABLE
+    global _FEISHU_ACTIVE_CHECK_FAILED
 
     try:
+        # Keep the helper import inside the fail-closed boundary. Standalone
+        # or partially updated environments may not have tools.lazy_deps yet;
+        # that state must clear stale transport globals just like a resolver
+        # failure does.
+        from tools.lazy_deps import ensure
+
         ensure("platform.feishu", prompt=False)
-        return True
     except Exception:
+        _clear_feishu_transport_bindings()
         return False
+
+    try:
+        import aiohttp as _aiohttp
+        from aiohttp import web as _web
+        import websockets as _websockets
+    except Exception:
+        _clear_feishu_transport_bindings()
+        return False
+    aiohttp = _aiohttp
+    web = _web
+    websockets = _websockets
+    FEISHU_WEBHOOK_AVAILABLE = True
+    FEISHU_WEBSOCKET_AVAILABLE = True
+    _FEISHU_ACTIVE_CHECK_FAILED = False
+    return True
 
 
 class FeishuAdapter(BasePlatformAdapter):

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -15,24 +15,33 @@ import json
 import logging
 import os
 import re
+import threading
 import time
 import unicodedata
 from dataclasses import dataclass, field
 from typing import Callable, ClassVar, Dict, Optional, Any, Tuple, List
 
-import aiohttp
-
+# Keep this module importable when the optional Slack extra is absent.  The
+# caller's lazy dependency path can then install aiohttp before retrying the
+# import; importing it unconditionally here would fail before that recovery
+# path is reachable.
+aiohttp: Any = None
 try:
+    import aiohttp as _aiohttp
     from slack_bolt.async_app import AsyncApp
     from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
     from slack_sdk.web.async_client import AsyncWebClient
 
+    aiohttp = _aiohttp
     SLACK_AVAILABLE = True
 except ImportError:
     SLACK_AVAILABLE = False
     AsyncApp = Any
     AsyncSocketModeHandler = Any
     AsyncWebClient = Any
+
+_SLACK_ACTIVE_CHECK_FAILED = False
+_SLACK_ACTIVE_CHECK_LOCK = threading.Lock()
 
 import sys
 from pathlib import Path as _Path
@@ -307,7 +316,16 @@ def slack_deps_present() -> bool:
     (``check_slack_requirements``) is registered as ``ensure_deps_fn``
     and runs from ``create_adapter()`` when this returns False (#79812).
     """
-    return SLACK_AVAILABLE
+    # PlatformRegistry.create_adapter() always invokes the registered active
+    # ensure_deps_fn after this passive result, even when it is True.  Keep
+    # this probe side-effect free for status/configuration callers.
+    return SLACK_AVAILABLE and not _SLACK_ACTIVE_CHECK_FAILED
+
+
+def _clear_slack_bindings() -> None:
+    """Record failed verification without tearing down live bindings."""
+    global _SLACK_ACTIVE_CHECK_FAILED
+    _SLACK_ACTIVE_CHECK_FAILED = True
 
 
 @dataclass
@@ -323,13 +341,20 @@ class _NativeTaskCardStream:
 
 
 def check_slack_requirements() -> bool:
+    # SDK globals and the availability latch are process-global.  Keep the
+    # lazy-repair transaction atomic across multiplexed profile checks.
+    with _SLACK_ACTIVE_CHECK_LOCK:
+        return _check_slack_requirements()
+
+
+def _check_slack_requirements() -> bool:
     """Check if Slack dependencies are available.
 
-    Lazy-installs slack-bolt/slack-sdk via ``tools.lazy_deps.ensure("platform.slack")``
-    on first call if not present. Rebinds all module-level globals on success.
+    Runs the feature contract on every active check so stale security pins are
+    repaired or fail closed even when Slack is already importable. Rebinds all
+    module-level globals on success.
     """
-    if SLACK_AVAILABLE:
-        return True
+    global _SLACK_ACTIVE_CHECK_FAILED
 
     def _import():
         from slack_bolt.async_app import AsyncApp
@@ -345,9 +370,17 @@ def check_slack_requirements() -> bool:
             "SLACK_AVAILABLE": True,
         }
 
-    from tools.lazy_deps import ensure_and_bind
+    try:
+        from tools.lazy_deps import ensure_and_bind
 
-    return ensure_and_bind("platform.slack", _import, globals(), prompt=False)
+        if not ensure_and_bind("platform.slack", _import, globals(), prompt=False):
+            _clear_slack_bindings()
+            return False
+    except Exception:
+        _clear_slack_bindings()
+        return False
+    _SLACK_ACTIVE_CHECK_FAILED = False
+    return True
 
 
 def _collect_slack_block_mentions(blocks: list) -> list:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -29,6 +29,7 @@ import json
 import logging
 import os
 import sys
+import threading
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
 from urllib.parse import quote
@@ -63,6 +64,13 @@ try:
 except ValueError:
     # Test stubs may inject a module without ``__spec__``.
     TEAMS_SDK_AVAILABLE = "microsoft_teams" in _sys.modules
+
+_TEAMS_ACTIVE_CHECK_FAILED = False
+_TEAMS_ACTIVE_CHECK_LOCK = threading.Lock()
+
+
+class _TeamsActiveCheckBusy(RuntimeError):
+    """The process-global Teams verifier could not be acquired in time."""
 ClientOptions = None  # type: ignore[assignment,misc]
 App = None  # type: ignore[assignment,misc]
 ActivityContext = None  # type: ignore[assignment,misc]
@@ -130,6 +138,14 @@ _MAX_BODY_BYTES = 1_048_576
 # (d542894ad). Pin a host via TEAMS_HOST or extra.host.
 _DEFAULT_HOST = None
 _WEBHOOK_PATH = "/api/messages"
+
+# ``microsoft_teams`` imports ``dotenv`` at module import time.  The import
+# guard below temporarily replaces the process-global ``load_dotenv`` hook so
+# that third-party import cannot mutate Hermes' environment.  Teams reconnects
+# run the guard in worker threads, so the patch and its restoration must be a
+# single process-level critical section; otherwise an overlapping worker can
+# restore another worker's temporary no-op and leave dotenv suppressed.
+_DOTENV_SUPPRESSION_LOCK = threading.RLock()
 
 
 def _parse_bool(value: Any, *, default: bool = False) -> bool:
@@ -425,7 +441,11 @@ def check_requirements() -> bool:
     ``is_connected``/``validate_config``.  The ACTIVE lazy-installer is
     ``check_teams_requirements`` (registered as ``ensure_deps_fn``).
     """
-    return TEAMS_SDK_AVAILABLE and AIOHTTP_AVAILABLE
+    return (
+        TEAMS_SDK_AVAILABLE
+        and AIOHTTP_AVAILABLE
+        and not _TEAMS_ACTIVE_CHECK_FAILED
+    )
 
 
 def validate_config(config) -> bool:
@@ -664,36 +684,46 @@ def _suppress_third_party_dotenv() -> Iterator[None]:
     whatever ``.env`` sits above cwd — typically a root profile's secrets.
     Hermes owns dotenv loading; third-party import side effects must not.
     """
+    with _DOTENV_SUPPRESSION_LOCK:
+        try:
+            import dotenv as _dotenv
+        except ImportError:
+            yield
+            return
+        original = getattr(_dotenv, "load_dotenv", None)
+        if original is None:
+            yield
+            return
+        _dotenv.load_dotenv = lambda *args, **kwargs: False  # type: ignore[assignment]
+        try:
+            yield
+        finally:
+            _dotenv.load_dotenv = original  # type: ignore[assignment]
+
+
+def check_teams_requirements(*, timeout: Optional[float] = None) -> bool:
+    # The SDK bindings and failure latch are process-global.  Teams invokes
+    # this check from worker threads, so serialize the full transaction.
+    acquired = _TEAMS_ACTIVE_CHECK_LOCK.acquire(
+        timeout=-1 if timeout is None else max(0.0, float(timeout))
+    )
+    if not acquired:
+        raise _TeamsActiveCheckBusy
     try:
-        import dotenv as _dotenv
-    except ImportError:
-        yield
-        return
-    original = getattr(_dotenv, "load_dotenv", None)
-    if original is None:
-        yield
-        return
-    _dotenv.load_dotenv = lambda *args, **kwargs: False  # type: ignore[assignment]
-    try:
-        yield
+        return _check_teams_requirements()
     finally:
-        _dotenv.load_dotenv = original  # type: ignore[assignment]
+        _TEAMS_ACTIVE_CHECK_LOCK.release()
 
 
-def check_teams_requirements() -> bool:
+def _check_teams_requirements() -> bool:
     """Ensure the Teams SDK is importable, lazy-installing it on first use.
 
-    Lazy-installs ``microsoft-teams-apps`` via
-    ``tools.lazy_deps.ensure("platform.teams")`` if not present, then rebinds
-    all module-level SDK globals on success. Returns True once the SDK (and
-    aiohttp) are importable, False if they couldn't be installed/imported.
+    Runs the feature contract on every active check so stale security pins are
+    repaired or fail closed, then rebinds all module-level SDK globals on
+    success. Returns True once the SDK (and aiohttp) are importable, False if
+    they couldn't be installed/imported.
 
-    ``App is not None`` means symbols are already bound — ``TEAMS_SDK_AVAILABLE``
-    alone can be True from ``find_spec`` without an import having run yet.
     """
-    if App is not None and AIOHTTP_AVAILABLE:
-        return True
-
     def _import() -> dict:
         from aiohttp import web as _web
 
@@ -745,9 +775,24 @@ def check_teams_requirements() -> bool:
             "TEAMS_SDK_AVAILABLE": True,
         }
 
-    from tools.lazy_deps import ensure_and_bind
+    def _clear_bindings() -> None:
+        global _TEAMS_ACTIVE_CHECK_FAILED
+        _TEAMS_ACTIVE_CHECK_FAILED = True
 
-    return ensure_and_bind("platform.teams", _import, globals(), prompt=False)
+    try:
+        from tools.lazy_deps import ensure_and_bind
+        bound = ensure_and_bind(
+            "platform.teams", _import, globals(), prompt=False
+        )
+    except Exception:
+        _clear_bindings()
+        return False
+    if not bound:
+        _clear_bindings()
+        return False
+    global _TEAMS_ACTIVE_CHECK_FAILED
+    _TEAMS_ACTIVE_CHECK_FAILED = False
+    return True
 
 
 class TeamsAdapter(BasePlatformAdapter):
@@ -779,7 +824,25 @@ class TeamsAdapter(BasePlatformAdapter):
         # Defensive re-check: create_adapter() already ran the installer
         # (ensure_deps_fn) if deps were missing, but connect() can also be
         # reached via reconnect paths — re-run to bind SDK globals.
-        check_teams_requirements()
+        try:
+            deps_ok = await asyncio.to_thread(
+                check_teams_requirements, timeout=300.0
+            )
+        except _TeamsActiveCheckBusy:
+            self._set_fatal_error(
+                "MISSING_SDK",
+                "Microsoft Teams dependency verification is busy; retrying later.",
+                retryable=True,
+            )
+            return False
+        if not deps_ok:
+            self._set_fatal_error(
+                "MISSING_SDK",
+                "Microsoft Teams dependencies could not be verified or imported. "
+                "Restart Hermes after a lazy-install repair, then retry.",
+                retryable=False,
+            )
+            return False
         if not TEAMS_SDK_AVAILABLE:
             self._set_fatal_error(
                 "MISSING_SDK",

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -422,27 +422,49 @@ def telegram_deps_present() -> bool:
     (``check_telegram_requirements``) is registered as ``ensure_deps_fn``
     and runs from ``create_adapter()`` when this returns False (#79812).
     """
-    return TELEGRAM_AVAILABLE
+    # PlatformRegistry.create_adapter() always invokes the registered active
+    # ensure_deps_fn after this passive result, even when it is True.  Keep
+    # this probe side-effect free for status/configuration callers.
+    return TELEGRAM_AVAILABLE and not _TELEGRAM_ACTIVE_CHECK_FAILED
+
+
+_TELEGRAM_ACTIVE_CHECK_FAILED = False
+_TELEGRAM_ACTIVE_CHECK_LOCK = threading.Lock()
+
+
+def _clear_telegram_bindings() -> None:
+    """Record failed verification without tearing down live bindings."""
+    global _TELEGRAM_ACTIVE_CHECK_FAILED
+    _TELEGRAM_ACTIVE_CHECK_FAILED = True
 
 
 def check_telegram_requirements() -> bool:
+    # Telegram SDK aliases and the availability latch are process-global;
+    # serialize the complete active verification and rebind transaction.
+    with _TELEGRAM_ACTIVE_CHECK_LOCK:
+        return _check_telegram_requirements()
+
+
+def _check_telegram_requirements() -> bool:
     """Check if Telegram dependencies are available.
 
-    If python-telegram-bot is missing, attempts to lazy-install it via
-    ``tools.lazy_deps.ensure("platform.telegram")``. After a successful
-    install, re-imports the SDK and flips ``TELEGRAM_AVAILABLE`` to True
-    so the adapter's class-level type aliases get rebound.
+    Runs the canonical lazy feature contract on every active verification,
+    even when the SDK was importable during module discovery. That lets the
+    exact ``python-telegram-bot[webhooks]==22.6`` pin repair stale metadata
+    instead of treating an importable but vulnerable distribution as ready.
+    After a successful check, re-imports the SDK and rebinds every module-level
+    alias so a lazy install cannot leave stale globals behind.
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
     global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest, TypeHandler
-    if TELEGRAM_AVAILABLE:
-        return True
+    global _TELEGRAM_ACTIVE_CHECK_FAILED
     try:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("platform.telegram", prompt=False)
     except Exception:
+        _clear_telegram_bindings()
         return False
     try:
         from telegram import Update as _Update, Bot as _Bot, Message as _Message
@@ -460,25 +482,31 @@ def check_telegram_requirements() -> bool:
         )
         from telegram.constants import ParseMode as _PM, ChatType as _CtT
         from telegram.request import HTTPXRequest as _HR
-    except ImportError:
+    except Exception:
+        _clear_telegram_bindings()
         return False
-    Update = _Update
-    Bot = _Bot
-    Message = _Message
-    InlineKeyboardButton = _IKB
-    InlineKeyboardMarkup = _IKM
-    LinkPreviewOptions = _LPO
-    Application = _App
-    CommandHandler = _CH
-    CallbackQueryHandler = _CQH
-    TelegramMessageHandler = _MH
-    ContextTypes = _CT
-    filters = _filters
-    ParseMode = _PM
-    ChatType = _CtT
-    HTTPXRequest = _HR
-    TypeHandler = _TH
+    try:
+        Update = _Update
+        Bot = _Bot
+        Message = _Message
+        InlineKeyboardButton = _IKB
+        InlineKeyboardMarkup = _IKM
+        LinkPreviewOptions = _LPO
+        Application = _App
+        CommandHandler = _CH
+        CallbackQueryHandler = _CQH
+        TelegramMessageHandler = _MH
+        ContextTypes = _CT
+        filters = _filters
+        ParseMode = _PM
+        ChatType = _CtT
+        HTTPXRequest = _HR
+        TypeHandler = _TH
+    except Exception:
+        _clear_telegram_bindings()
+        return False
     TELEGRAM_AVAILABLE = True
+    _TELEGRAM_ACTIVE_CHECK_FAILED = False
     return True
 
 

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import socket as _socket
+import threading
 import time
 from typing import Any, Dict, List, Optional
 # Security: parse untrusted, pre-auth request bodies (WeCom callbacks) with
@@ -74,35 +75,81 @@ def check_wecom_callback_requirements() -> bool:
     Registry ``check_fn`` — must never install anything.  The ACTIVE
     lazy-installer is ``ensure_wecom_callback_requirements`` below.
     """
-    return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE and DEFUSEDXML_AVAILABLE
+    return (
+        AIOHTTP_AVAILABLE
+        and HTTPX_AVAILABLE
+        and DEFUSEDXML_AVAILABLE
+        and not _WECOM_CALLBACK_ACTIVE_CHECK_FAILED
+    )
+
+
+_WECOM_CALLBACK_ACTIVE_CHECK_FAILED = False
+_WECOM_CALLBACK_ACTIVE_CHECK_LOCK = threading.Lock()
+
+
+def _clear_wecom_callback_bindings() -> None:
+    """Record failed verification without tearing down live bindings."""
+    global _WECOM_CALLBACK_ACTIVE_CHECK_FAILED
+    _WECOM_CALLBACK_ACTIVE_CHECK_FAILED = True
 
 
 def ensure_wecom_callback_requirements() -> bool:
+    # Callback SDK aliases and the failure latch are process-global.  Keep
+    # bind/validate/rollback atomic across concurrent profile startups.
+    with _WECOM_CALLBACK_ACTIVE_CHECK_LOCK:
+        return _ensure_wecom_callback_requirements()
+
+
+def _ensure_wecom_callback_requirements() -> bool:
     """ACTIVE lazy-installer for the ``platform.wecom_callback`` feature.
 
     Registered as ``ensure_deps_fn``: the registry's ``create_adapter()``
     runs it when the passive probe fails, right before the gateway connects
-    the platform (#79812).  Installs ``defusedxml`` (the only non-core dep;
-    aiohttp/httpx ship with every messaging install) and rebinds the module
-    globals.  Before this hook existed, the passive ``check_fn`` returned
+    the platform (#79812).  Installs the explicit ``defusedxml`` and aiohttp
+    closure (callback mode can be enabled without another messaging extra)
+    and rebinds the module globals.  Before this hook existed, the passive ``check_fn`` returned
     False forever on installs without the ``wecom`` extra and the
     ``platform.wecom_callback`` LAZY_DEPS entry was never exercised.
     """
-    if check_wecom_callback_requirements():
-        return True
+    global _WECOM_CALLBACK_ACTIVE_CHECK_FAILED
 
     def _import() -> dict:
         import defusedxml.ElementTree as _ET
+        from aiohttp import web as _web
+        import httpx as _httpx
 
-        return {"ET": _ET, "DEFUSEDXML_AVAILABLE": True}
+        return {
+            "ET": _ET,
+            "DEFUSEDXML_AVAILABLE": True,
+            "web": _web,
+            "AIOHTTP_AVAILABLE": True,
+            "httpx": _httpx,
+            "HTTPX_AVAILABLE": True,
+        }
 
     try:
         from tools.lazy_deps import ensure_and_bind
     except Exception:  # pragma: no cover — defensive
+        _clear_wecom_callback_bindings()
         return False
-    if not ensure_and_bind("platform.wecom_callback", _import, globals(), prompt=False):
+    try:
+        bound = ensure_and_bind(
+            "platform.wecom_callback", _import, globals(), prompt=False
+        )
+    except Exception:
+        _clear_wecom_callback_bindings()
         return False
-    return check_wecom_callback_requirements()
+    if not bound:
+        _clear_wecom_callback_bindings()
+        return False
+    # A prior failed active attempt intentionally makes the passive probe
+    # fail closed.  Clear that marker only after a new bind has completed so
+    # this retry validates the rebound globals rather than its old latch.
+    _WECOM_CALLBACK_ACTIVE_CHECK_FAILED = False
+    if not check_wecom_callback_requirements():
+        _clear_wecom_callback_bindings()
+        return False
+    return True
 
 
 class WecomCallbackAdapter(BasePlatformAdapter):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ dependencies = [
   # urllib3 2.7.0 fixes GHSA-mf9v-mfxr-j63j (decompression-bomb bypass)
   # and GHSA-qccp-gfcp-xxvc (header leak across origins).
   "urllib3>=2.7.0,<3",
+  # Keep IDNA on the CVE-fixed floor as a direct dependency. It is otherwise
+  # only transitive (for example through requests/httpx), so a lock refresh
+  # could silently reintroduce a vulnerable version.
+  "idna==3.18",
   # PyJWT[crypto] pulls cryptography in transitively. Pin it here as well, so
   # that the WeCom and Weixin crypto paths cannot fall below the patched
   # version. 50.0.0 is the floor: it fixes CVE-2026-69247, a Bleichenbacher
@@ -170,28 +174,34 @@ anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]
-firecrawl = ["firecrawl-py==4.17.0"]
+firecrawl = ["firecrawl-py==4.17.0", "aiohttp==3.14.3"]
 parallel-web = ["parallel-web==0.4.2"]
 # Image generation backends
 fal = ["fal-client==0.13.1"]
 # Edge TTS — default TTS provider but still optional (users can pick
 # ElevenLabs / OpenAI / MiniMax instead).
-edge-tts = ["edge-tts==7.2.7"]
-modal = ["modal==1.3.4"]
-daytona = ["daytona==0.155.0"]
+edge-tts = ["edge-tts==7.2.7", "aiohttp==3.14.3"]
+modal = ["modal==1.3.4", "aiohttp==3.14.3"]
+daytona = ["daytona==0.155.0", "aiohttp==3.14.3"]
 vercel = ["vercel==0.7.2"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.6.1", "aiohttp==3.14.3"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
-messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
+# discord.py 2.7.1's voice extra still declares PyNaCl<1.6.  Keep the
+# published pip extra resolvable by declaring its voice dependencies directly:
+# discord.py itself, davey, and the fixed PyNaCl floor.  The lazy Discord path
+# mirrors this explicit contract and still applies the PyNaCl repair as a
+# separate transaction; remove the explicit davey/PyNaCl contract when
+# discord.py publishes compatible voice metadata.
+messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py==2.7.1", "davey==0.1.4", "PyNaCl==1.6.2", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
 matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in
 # replacement for stdlib xml.etree.ElementTree) to block billion-laughs
-# and XXE. aiohttp/httpx are already in [messaging]; defusedxml lands
-# here to keep the dependency local to wecom_callback's threat model.
-wecom = ["defusedxml==0.7.1"]
+# and XXE. aiohttp is pinned here too because callback mode is independently
+# lazy-installable; it cannot rely on another messaging feature having run.
+wecom = ["defusedxml==0.7.1", "aiohttp==3.14.3"]
 tts-premium = ["elevenlabs==1.59.0"]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime).
@@ -303,8 +313,8 @@ termux-all = [
   "hermes-agent[web]",
   "hermes-agent[pty]",
 ]
-dingtalk = ["dingtalk-stream==0.24.3", "alibabacloud-dingtalk==2.2.42", "qrcode==7.4.2"]
-feishu = ["lark-oapi==1.6.8", "qrcode==7.4.2"]
+dingtalk = ["dingtalk-stream==0.24.3", "alibabacloud-dingtalk==2.2.42", "qrcode==7.4.2", "aiohttp==3.14.3"]
+feishu = ["lark-oapi==1.6.8", "qrcode==7.4.2", "aiohttp==3.14.3", "websockets==15.0.1"]
 google = [
   # Required by the google-workspace skill (Gmail, Calendar, Drive, Contacts,
   # Sheets, Docs).  Declared here so dev environments (`uv sync --extra google`)

--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -10,8 +10,9 @@ Usage:
 """
 
 import os
-import sys
+import re
 import shutil
+import sys
 from pathlib import Path
 
 # Resolve project root
@@ -28,6 +29,24 @@ WARN = "\033[93m!\033[0m"
 
 # Track whether discord.py is available for later sections
 _discord_available = False
+_PYNACL_SECURITY_FLOOR = (1, 6, 2)
+
+
+def _pynacl_meets_security_floor(version):
+    """Return whether *version* is a stable PyNaCl release at the fixed floor."""
+    if not isinstance(version, str):
+        return False
+    # Future stable releases may add or remove release components. Require at
+    # least two numeric components, while retaining the strict stable-only and
+    # optional post-release contract.
+    match = re.fullmatch(r"(\d+(?:\.\d+)+)(?:\.post\d+)?", version)
+    if not match:
+        return False
+    try:
+        release = tuple(int(part) for part in match.group(1).split("."))
+    except ValueError:
+        return False
+    return release >= _PYNACL_SECURITY_FLOOR
 
 
 def mask(value):
@@ -69,22 +88,30 @@ def check_packages():
         _discord_available = True
         check("discord.py", True, f"v{discord.__version__}")
     except ImportError:
-        check("discord.py", False, "pip install discord.py[voice]")
+        check(
+            "discord.py",
+            False,
+            "pip install discord.py==2.7.1 davey==0.1.4 PyNaCl==1.6.2",
+        )
         ok = False
 
     # PyNaCl
     try:
         import nacl
         ver = getattr(nacl, "__version__", "unknown")
-        try:
-            import nacl.secret
-            nacl.secret.Aead(bytes(32))
-            check("PyNaCl", True, f"v{ver}")
-        except (AttributeError, Exception):
-            check("PyNaCl (Aead)", False, f"v{ver} — need >=1.5.0")
+        if not _pynacl_meets_security_floor(ver):
+            check("PyNaCl", False, f"v{ver} — need >=1.6.2")
             ok = False
+        else:
+            try:
+                import nacl.secret
+                nacl.secret.Aead(bytes(32))
+                check("PyNaCl", True, f"v{ver}")
+            except Exception:
+                check("PyNaCl (Aead)", False, f"v{ver} — Aead unavailable")
+                ok = False
     except ImportError:
-        check("PyNaCl", False, "pip install PyNaCl>=1.5.0")
+        check("PyNaCl", False, "pip install PyNaCl==1.6.2")
         ok = False
 
     # davey (DAVE E2EE)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -377,6 +377,10 @@ $script:ResolvedPathReport = @{
 $RepoUrlSsh = "git@github.com:NousResearch/hermes-agent.git"
 $RepoUrlHttps = "https://github.com/NousResearch/hermes-agent.git"
 $PythonVersion = "3.11"
+# Minimum pip for every venv-managed fallback install.  `ensurepip` only
+# guarantees presence and may bundle an older, vulnerable pip.
+$MinimumPipVersion = "26.1.2"
+$MinimumPipSpec = "pip>=$MinimumPipVersion"
 # Minor versions the installer accepts when the requested $PythonVersion isn't
 # available, in preference order.  uv discovers both uv-managed and system
 # interpreters, so this list also matches a pre-existing system Python.  Single
@@ -1081,6 +1085,165 @@ function Resolve-UvCmd {
     }
 
     throw "uv is not installed. Run install.ps1 -Stage uv first."
+}
+
+function Get-VenvPipVersion {
+    param([string]$PythonExe)
+
+    $output = & $PythonExe -m pip --version 2>&1
+    if ($LASTEXITCODE -ne 0) { return $null }
+    $canonicalVersions = @()
+    foreach ($rawLine in @($output)) {
+        $line = [string]$rawLine
+        # Warnings may mention another pip version; only trust one canonical
+        # ``pip <version> from <path>`` record emitted by ``pip --version``.
+        if ($line -notmatch '^\s*pip\s+([^\s]+)\s+from\s+(?:/|[A-Za-z]:[\\/]|\\\\)[^\r\n"]*[\\/]pip(?:\s+\(python\s+\d+(?:\.\d+){1,3}\))?\s*$') { continue }
+        $token = $Matches[1]
+        if ($token -notmatch '^(?<release>\d+(?:\.\d+){1,3})(?<suffix>.*)$') { return $null }
+        $release = $Matches['release']
+        $suffix = $Matches['suffix']
+        # A numeric prefix is not proof of the final release: reject dev,
+        # alpha, beta, rc, local, and unknown suffixes. Post releases remain
+        # stable and are valid when they are at or above the floor.
+        if ($suffix -and $suffix -notmatch '^\.post\d+$') { return $null }
+        try { $canonicalVersions += [version]$release } catch { return $null }
+    }
+    if ($canonicalVersions.Count -ne 1) { return $null }
+    return $canonicalVersions[0]
+}
+
+function Ensure-VenvPipFloor {
+    param([string]$PythonExe)
+
+    $minimum = [version]$MinimumPipVersion
+    $current = Get-VenvPipVersion $PythonExe
+    if ($current -and $current -ge $minimum) { return $true }
+
+    Write-Info "Ensuring venv pip >= $MinimumPipVersion ..."
+    & $PythonExe -m pip install --upgrade $MinimumPipSpec 2>&1 | ForEach-Object {
+        Write-Host "    $_"
+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warn "Could not upgrade pip to >= $MinimumPipVersion. Refusing venv package installation."
+        return $false
+    }
+
+    $current = Get-VenvPipVersion $PythonExe
+    if (-not $current -or $current -lt $minimum) {
+        Write-Warn "pip floor verification failed: venv has $($current -as [string]); need >= $MinimumPipVersion."
+        return $false
+    }
+    Write-Success "Venv pip floor verified ($current)"
+    return $true
+}
+
+function Test-VenvPackageExactVersion {
+    param(
+        [string]$PythonExe,
+        [string]$Spec
+    )
+
+    if ($Spec -notmatch '^([A-Za-z0-9_.-]+)==([0-9]+(?:\.[0-9]+){1,3})$') {
+        throw "Unsupported security package spec syntax: $Spec"
+    }
+    $package = $Matches[1]
+    $wanted = $Matches[2]
+    $probe = "from importlib.metadata import version; raise SystemExit(0 if version('$package') == '$wanted' else 1)"
+    & $PythonExe -c $probe 2>&1 | Out-Null
+    return $LASTEXITCODE -eq 0
+}
+
+function Test-VenvPackageSpecSatisfied {
+    param(
+        [string]$PythonExe,
+        [string]$Spec
+    )
+
+    if ($Spec -notmatch '^([A-Za-z0-9_.-]+)(?:\[[A-Za-z0-9_,.-]+\])?((?:===|==|!=|>=|<=|~=|>|<).+)$') {
+        throw "Unsupported package spec syntax: $Spec"
+    }
+    $package = $Matches[1]
+    $specifier = $Matches[2]
+    $probe = @"
+from importlib.metadata import version
+try:
+    from packaging.specifiers import SpecifierSet
+    from packaging.version import Version
+except Exception:
+    raise SystemExit(3)
+try:
+    installed = Version(version('$package'))
+except Exception:
+    raise SystemExit(1)
+raise SystemExit(0 if installed in SpecifierSet('$specifier') else 1)
+"@
+    & $PythonExe -c $probe 2>&1 | Out-Null
+    $probeExit = $LASTEXITCODE
+    if ($probeExit -eq 3) {
+        throw "Cannot verify '$Spec': the venv has no usable 'packaging' module"
+    }
+    return $probeExit -eq 0
+}
+
+function Test-VenvRuntimeImports {
+    param(
+        [string]$PythonExe,
+        [object[]]$Sdks
+    )
+
+    $failures = @()
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "SilentlyContinue"
+    try {
+        foreach ($sdk in $Sdks) {
+            $runtimeImports = @($sdk.Import)
+            $securitySpecs = @($sdk.SecuritySpecs | Where-Object { $_ })
+            $securityNames = @(
+                $securitySpecs | ForEach-Object {
+                    ($_ -replace '\s*(?:===|==|!=|>=|<=|~=|>|<).*$','').Trim()
+                }
+            )
+            $extraNames = @(
+                @($sdk.ExtraSpecs | Where-Object { $_ }) | ForEach-Object {
+                    ($_ -replace '\s*(?:===|==|!=|>=|<=|~=|>|<).*$','').Trim()
+                }
+            )
+            if ($securityNames -contains "aiohttp") {
+                # aiohttp's runtime import path exercises the closure, while
+                # these direct imports catch a partial --no-deps repair that
+                # leaves its metadata present but drops native/runtime deps.
+                $runtimeImports += @(
+                    "aiohttp",
+                    "aiohappyeyeballs",
+                    "aiosignal",
+                    "attrs",
+                    "frozenlist",
+                    "multidict",
+                    "propcache",
+                    "yarl"
+                )
+            }
+            if ($securityNames -contains "PyNaCl") {
+                $runtimeImports += @("nacl", "cffi")
+            }
+            if ($extraNames -contains "davey") {
+                $runtimeImports += "davey"
+            }
+            if ($extraNames -contains "brotlicffi") {
+                $runtimeImports += "brotlicffi"
+            }
+            foreach ($runtimeImport in @($runtimeImports | Where-Object { $_ } | Select-Object -Unique)) {
+                & $PythonExe -c "import $runtimeImport" 2>&1 | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Warn "  Runtime import failed: $runtimeImport (needed for $($sdk.Var))"
+                    $failures += "$($sdk.Var):$runtimeImport"
+                }
+            }
+        }
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    return @($failures)
 }
 
 function Resolve-AvailablePythonVersion {
@@ -3172,6 +3335,28 @@ function Write-BootstrapMarker {
     Write-Success "Bootstrap marker written: $markerPath"
 }
 
+function Remove-BootstrapMarker {
+    <#
+    A marker written before the platform-SDK stage is only valid if that
+    required stage also succeeds.  Invalidate it on any SDK-stage failure so
+    the desktop cannot skip its bootstrap recovery loop after a partial
+    install.
+    #>
+    $markerPath = Join-Path $InstallDir ".hermes-bootstrap-complete"
+    if (-not (Test-Path $markerPath)) {
+        return
+    }
+    try {
+        Remove-Item -LiteralPath $markerPath -Force -ErrorAction Stop
+    } catch {
+        throw "Could not invalidate bootstrap marker after platform-SDK failure: $_"
+    }
+    if (Test-Path $markerPath) {
+        throw "Bootstrap marker still exists after platform-SDK failure: $markerPath"
+    }
+    Write-Warn "Invalidated bootstrap marker after platform-SDK failure: $markerPath"
+}
+
 function Copy-ConfigTemplates {
     Write-Info "Setting up configuration files..."
     
@@ -4252,12 +4437,15 @@ function Install-PlatformSdks {
     $envLines = Get-Content $envPath -ErrorAction SilentlyContinue
 
     # Map: env var set in .env -> (import name, pip spec matching [messaging] extra).
-    # Specs mirror pyproject.toml to avoid version drift.
+    # Specs mirror pyproject.toml to avoid version drift. cffi is an
+    # intentional recovery-only direct closure pin for PyNaCl: it is
+    # transitive in the published messaging extra but must be explicit here
+    # because PyNaCl is repaired with --no-deps below.
     $sdkMap = @(
         @{ Var = "TELEGRAM_BOT_TOKEN"; Import = "telegram";  Spec = "python-telegram-bot[webhooks]>=22.6,<23" },
-        @{ Var = "DISCORD_BOT_TOKEN";  Import = "discord";   Spec = "discord.py[voice]>=2.7.1,<3" },
-        @{ Var = "SLACK_BOT_TOKEN";    Import = "slack_sdk"; Spec = "slack-sdk>=3.27.0,<4" },
-        @{ Var = "SLACK_APP_TOKEN";    Import = "slack_bolt";Spec = "slack-bolt>=1.18.0,<2" },
+        @{ Var = "DISCORD_BOT_TOKEN";  Import = "discord";   Spec = "discord.py==2.7.1"; ExtraSpecs = @("davey==0.1.4", "brotlicffi==1.2.0.1", "cffi==2.0.0"); SecuritySpecs = @("PyNaCl==1.6.2", "aiohttp==3.14.3") },
+        @{ Var = "SLACK_BOT_TOKEN";    Import = "slack_sdk"; Spec = "slack-sdk==3.43.0"; SecuritySpecs = @("aiohttp==3.14.3") },
+        @{ Var = "SLACK_APP_TOKEN";    Import = "slack_bolt";Spec = "slack-bolt==1.29.0"; SecuritySpecs = @("aiohttp==3.14.3") },
         @{ Var = "WHATSAPP_ENABLED";   Import = "qrcode";    Spec = "qrcode>=7.0,<8" }
     )
 
@@ -4285,19 +4473,64 @@ function Install-PlatformSdks {
     $ErrorActionPreference = "SilentlyContinue"
     try {
         $missing = @()
+        $missingRegularSpecs = @()
+        $allRegularSpecs = @()
+        $missingSecuritySpecs = @()
+        $allSecuritySpecs = @()
         foreach ($sdk in $needed) {
+            if ($allRegularSpecs -notcontains $sdk.Spec) {
+                $allRegularSpecs += $sdk.Spec
+            }
             & $pythonExe -c "import $($sdk.Import)" 2>&1 | Out-Null
-            if ($LASTEXITCODE -ne 0) {
+            $mainImportFailed = $LASTEXITCODE -ne 0
+            if ($mainImportFailed -or -not (Test-VenvPackageSpecSatisfied $pythonExe $sdk.Spec)) {
                 $missing += $sdk
-                Write-Warn "  $($sdk.Import) NOT importable (needed for $($sdk.Var))"
+                if ($missingRegularSpecs -notcontains $sdk.Spec) {
+                    $missingRegularSpecs += $sdk.Spec
+                }
+                if ($mainImportFailed) {
+                    Write-Warn "  $($sdk.Import) NOT importable (needed for $($sdk.Var))"
+                } else {
+                    Write-Warn "  $($sdk.Spec) NOT satisfied (needed for $($sdk.Var))"
+                }
             } else {
                 Write-Success "  $($sdk.Import) OK"
+            }
+            foreach ($extraSpec in @($sdk.ExtraSpecs | Where-Object { $_ })) {
+                if ($allRegularSpecs -notcontains $extraSpec) {
+                    $allRegularSpecs += $extraSpec
+                }
+                if (-not (Test-VenvPackageExactVersion $pythonExe $extraSpec)) {
+                    if ($missingRegularSpecs -notcontains $extraSpec) {
+                        $missingRegularSpecs += $extraSpec
+                    }
+                    Write-Warn "  $extraSpec NOT satisfied (needed for $($sdk.Var))"
+                }
+            }
+            foreach ($securitySpec in @($sdk.SecuritySpecs | Where-Object { $_ })) {
+                if ($allSecuritySpecs -notcontains $securitySpec) {
+                    $allSecuritySpecs += $securitySpec
+                }
+                if (-not (Test-VenvPackageExactVersion $pythonExe $securitySpec)) {
+                    if ($missingSecuritySpecs -notcontains $securitySpec) {
+                        $missingSecuritySpecs += $securitySpec
+                    }
+                    Write-Warn "  $securitySpec NOT satisfied (needed for $($sdk.Var))"
+                }
             }
         }
     } finally {
         $ErrorActionPreference = $prevEAP
     }
-    if ($missing.Count -eq 0) { return }
+    $runtimeImportFailures = @(Test-VenvRuntimeImports -PythonExe $pythonExe -Sdks $needed)
+    if ($missingRegularSpecs.Count -eq 0 -and $missingSecuritySpecs.Count -eq 0) {
+        if ($runtimeImportFailures.Count -gt 0) {
+            throw "Platform-SDK runtime verification failed for: $($runtimeImportFailures -join ', ')"
+        }
+        return
+    }
+
+    $manualSpec = if ($missingRegularSpecs.Count -gt 0) { $missingRegularSpecs[0] } else { $missingSecuritySpecs[0] }
 
     # Bootstrap pip into the venv if it isn't there.  `uv` creates venvs
     # without pip; ensurepip is the stdlib-blessed way to add it.
@@ -4310,19 +4543,81 @@ function Install-PlatformSdks {
             & $pythonExe -m ensurepip --upgrade 2>&1 | Out-Null
             if ($LASTEXITCODE -ne 0) {
                 Write-Warn "ensurepip failed -- can't auto-install missing SDKs."
-                Write-Info "Manual recovery: $UvCmd pip install `"$($missing[0].Spec)`""
-                return
+                Write-Info "Manual recovery: `"$pythonExe`" -m ensurepip --upgrade; `"$pythonExe`" -m pip install `"$manualSpec`""
+                throw "Platform-SDK security repair blocked: ensurepip failed"
             }
         }
 
-        foreach ($sdk in $missing) {
-            Write-Info "  Installing $($sdk.Spec) ..."
-            & $pythonExe -m pip install $sdk.Spec 2>&1 | ForEach-Object { Write-Host "    $_" }
+        if (-not (Ensure-VenvPipFloor $pythonExe)) {
+            Write-Warn "Refusing to install platform SDKs with a pip below the security floor."
+            Write-Info "Manual recovery: install pip >= $MinimumPipVersion, then rerun the installer."
+            throw "Platform-SDK security repair blocked: pip floor unavailable"
+        }
+
+        $regularInstallFailures = @()
+        foreach ($regularSpec in $missingRegularSpecs) {
+            Write-Info "  Installing $regularSpec ..."
+            & $pythonExe -m pip install $regularSpec 2>&1 | ForEach-Object { Write-Host "    $_" }
             if ($LASTEXITCODE -eq 0) {
-                Write-Success "  Installed $($sdk.Import)"
+                Write-Success "  Installed $regularSpec"
             } else {
-                Write-Warn "  Failed to install $($sdk.Spec). Recover manually: $pythonExe -m pip install `"$($sdk.Spec)`""
+                Write-Warn "  Failed to install $regularSpec. Recover manually: $pythonExe -m pip install `"$regularSpec`""
+                $regularInstallFailures += $regularSpec
             }
+        }
+        $remainingRegularSpecs = @(
+            $allRegularSpecs | Where-Object {
+                -not (Test-VenvPackageSpecSatisfied $pythonExe $_)
+            }
+        )
+        if ($regularInstallFailures.Count -gt 0 -or $remainingRegularSpecs.Count -gt 0) {
+            $failedRegularSpecs = @(
+                $regularInstallFailures + $remainingRegularSpecs | Select-Object -Unique
+            )
+            throw "Platform-SDK regular dependency repair failed for: $($failedRegularSpecs -join ', ')"
+        }
+        # Installing a Discord SDK can downgrade an initially-correct
+        # PyNaCl to its stale <1.6 dependency. Re-check every security spec
+        # after the regular SDK transaction, not only specs that were missing
+        # before it, and repair any downgrade before reporting success.
+        $securitySpecsToRepair = @(
+            $allSecuritySpecs | Where-Object {
+                -not (Test-VenvPackageExactVersion $pythonExe $_)
+            }
+        )
+        $securityInstallFailures = @()
+        foreach ($securitySpec in $securitySpecsToRepair) {
+            Write-Info "  Installing $securitySpec ..."
+            $securityInstallArgs = @()
+            $securityPackageName = (
+                $securitySpec -replace '\s*(?:===|==|!=|>=|<=|~=|>|<).*$', ''
+            ).Trim()
+            if ($securityPackageName -ieq "PyNaCl") {
+                # Only PyNaCl uses --no-deps: discord.py's stale voice
+                # metadata would otherwise reintroduce PyNaCl<1.6.  aiohttp
+                # must resolve its runtime closure (multidict, yarl, etc.).
+                $securityInstallArgs = @("--no-deps")
+            }
+            & $pythonExe -m pip install @securityInstallArgs $securitySpec 2>&1 | ForEach-Object { Write-Host "    $_" }
+            if ($LASTEXITCODE -eq 0) {
+                Write-Success "  Installed security floor $securitySpec"
+            } else {
+                Write-Warn "  Failed to install $securitySpec. Recover manually: $pythonExe -m pip install `"$securitySpec`""
+                $securityInstallFailures += $securitySpec
+            }
+        }
+        $remainingSecuritySpecs = @(
+            $allSecuritySpecs | Where-Object {
+                -not (Test-VenvPackageExactVersion $pythonExe $_)
+            }
+        )
+        if ($securityInstallFailures.Count -gt 0 -or $remainingSecuritySpecs.Count -gt 0) {
+            $failedSpecs = @($securityInstallFailures + $remainingSecuritySpecs | Select-Object -Unique)
+            throw "Platform-SDK security repair failed for: $($failedSpecs -join ', ')"
+        }
+        $runtimeImportFailures = @(Test-VenvRuntimeImports -PythonExe $pythonExe -Sdks $needed)
+        if ($runtimeImportFailures.Count -gt 0) {
+            throw "Platform-SDK runtime verification failed for: $($runtimeImportFailures -join ', ')"
         }
     } finally {
         $ErrorActionPreference = $prevEAP
@@ -4588,6 +4883,8 @@ $InstallStages += @(
     @{ Name = "path";             Title = "Adding Hermes to PATH";                Category = "finalize";     NeedsUserInput = $false; Worker = "Stage-Path" }
     @{ Name = "config-templates"; Title = "Writing configuration templates";      Category = "finalize";     NeedsUserInput = $false; Worker = "Stage-ConfigTemplates" }
     @{ Name = "platform-sdks";    Title = "Installing messaging platform SDKs";   Category = "finalize";     NeedsUserInput = $false; Worker = "Stage-PlatformSdks" }
+    # Only mark the installation complete after platform SDK verification;
+    # otherwise an interrupted SDK stage can leave a false-complete marker.
     @{ Name = "bootstrap-marker"; Title = "Marking install complete";              Category = "finalize";     NeedsUserInput = $false; Worker = "Stage-BootstrapMarker" }
     # Interactive stages.  In non-interactive mode these become no-ops; the
     # caller (GUI / CI) handles the equivalent UX themselves.
@@ -4633,7 +4930,21 @@ function Stage-NodeDeps         { Install-NodeDeps }
 function Stage-Desktop          { Install-DesktopVoiceDeps; Install-Desktop }
 function Stage-Path             { Set-PathVariable }
 function Stage-ConfigTemplates  { Copy-ConfigTemplates }
-function Stage-PlatformSdks     { Resolve-UvCmd; Install-PlatformSdks }
+function Stage-PlatformSdks     {
+    try {
+        Resolve-UvCmd
+        Install-PlatformSdks
+    } catch {
+        $failure = $_
+        try {
+            Remove-BootstrapMarker
+        } catch {
+            $markerFailure = $_
+            throw ("Platform SDK stage failed: {0}; bootstrap marker invalidation also failed: {1}" -f $failure.Exception.Message, $markerFailure.Exception.Message)
+        }
+        throw $failure
+    }
+}
 function Stage-BootstrapMarker  { Write-BootstrapMarker }
 function Stage-Configure        { Invoke-SetupWizard }
 function Stage-Gateway          { Start-GatewayIfConfigured }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,6 +57,11 @@ else
     INSTALL_DIR_EXPLICIT=false
 fi
 PYTHON_VERSION="3.11"
+# The non-Termux installer uses uv for every dependency transaction (including
+# the fallback ``uv pip`` tiers), so it never invokes the environment's pip.
+# The floor below is therefore applied only to the direct-pip Termux path;
+# runtime direct-pip recovery paths enforce the same floor independently.
+MIN_PIP_VERSION="26.1.2"
 NODE_VERSION="26"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
@@ -1505,7 +1510,54 @@ install_deps() {
             log_info "Using ANDROID_API_LEVEL=$ANDROID_API_LEVEL for Android wheel builds"
         fi
 
-        "$PIP_PYTHON" -m pip install --upgrade pip setuptools wheel >/dev/null
+        local pip_upgrade_output
+        local pip_version_output
+        if ! pip_upgrade_output="$("$PIP_PYTHON" -m pip install --upgrade "pip>=${MIN_PIP_VERSION}" setuptools wheel 2>&1)"; then
+            log_error "pip floor bootstrap failed; refusing to install Termux dependencies."
+            if [ -n "$pip_upgrade_output" ]; then
+                log_info "$pip_upgrade_output"
+            fi
+            exit 1
+        fi
+        if ! pip_version_output="$("$PIP_PYTHON" -m pip --version 2>&1)"; then
+            log_error "pip --version failed; refusing to install Termux dependencies."
+            exit 1
+        fi
+        if ! "$PIP_PYTHON" -c '
+import re
+import sys
+
+minimum = tuple(int(part) for part in sys.argv[1].split("."))
+canonical_versions = []
+for line in sys.argv[2].splitlines():
+    line_match = re.fullmatch(
+        r"\s*pip\s+([^\s]+)\s+from\s+"
+        r"(?:(?:/|[A-Za-z]:[\\/]|\\\\)[^\r\n\"]*[\\/]pip)"
+        r"(?:\s+\(python\s+\d+(?:\.\d+){1,3}\))?\s*",
+        line,
+        re.IGNORECASE,
+    )
+    if not line_match:
+        continue
+    token = line_match.group(1)
+    release_match = re.fullmatch(r"(\d+(?:\.\d+){1,3})(.*)", token)
+    if not release_match:
+        raise SystemExit(1)
+    suffix = release_match.group(2)
+    if suffix and not re.fullmatch(r"\.post\d+", suffix, re.IGNORECASE):
+        raise SystemExit(1)
+    try:
+        version = tuple(int(part) for part in release_match.group(1).split("."))
+    except ValueError:
+        raise SystemExit(1)
+    canonical_versions.append(version)
+if len(canonical_versions) == 1 and canonical_versions[0] >= minimum:
+    raise SystemExit(0)
+raise SystemExit(1)
+' "$MIN_PIP_VERSION" "$pip_version_output"; then
+            log_error "pip floor verification failed: need pip >= ${MIN_PIP_VERSION}."
+            exit 1
+        fi
 
         # On Android, psutil's setup.py rejects sys.platform == 'android' before
         # it ever invokes the C build, so the next pip install would fail at

--- a/scripts/install_psutil_android.py
+++ b/scripts/install_psutil_android.py
@@ -24,6 +24,8 @@ https://github.com/giampaolo/psutil/pull/2762 and ships a release.
 from __future__ import annotations
 
 import argparse
+import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -42,12 +44,44 @@ from hermes_cli.psutil_android import (
     PsutilAndroidInstallError,
     prepare_patched_psutil_sdist,
 )
-
+from hermes_cli import _pip_security
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 
 def _resolve_install_cmd(pip_arg: str | None, prefer_uv: bool) -> list[str]:
     if pip_arg:
-        return pip_arg.split()
+        try:
+            parts = shlex.split(pip_arg)
+        except ValueError as exc:
+            raise SystemExit(f"invalid --pip command quoting: {exc}") from exc
+        if not parts:
+            raise SystemExit("--pip command must not be empty")
+
+        # The shell caller passes the interpreter and ``-m pip`` as one
+        # argument.  An unquoted executable path containing spaces is split by
+        # shlex before we can inspect it, so reconstruct that path when the
+        # prefix clearly begins with an absolute path and ends in Python.
+        marker = next(
+            (
+                index
+                for index in range(len(parts) - 1)
+                if parts[index : index + 2] == ["-m", "pip"]
+            ),
+            None,
+        )
+        if marker is not None and marker > 1:
+            first = parts[0]
+            last = parts[marker - 1].lower()
+            first_is_path = first.startswith(("/", "\\")) or re.match(
+                r"^[A-Za-z]:[\\/]", first
+            )
+            last_is_python = bool(
+                re.search(r"(?:^|[\\/])python(?:\d(?:\.\d+)?)?(?:\.exe)?$", last)
+            )
+            has_option = any(token.startswith("-") for token in parts[:marker])
+            if first_is_path and last_is_python and not has_option:
+                parts = [" ".join(parts[:marker]), *parts[marker:]]
+        return parts
     if prefer_uv:
         uv = shutil.which("uv")
         if not uv:
@@ -57,6 +91,19 @@ def _resolve_install_cmd(pip_arg: str | None, prefer_uv: bool) -> list[str]:
     if auto_uv:
         return [auto_uv, "pip"]
     return [sys.executable, "-m", "pip"]
+
+
+def _is_direct_pip_command(command: list[str]) -> bool:
+    """Return whether *command* invokes pip rather than uv's pip frontend."""
+    launcher = Path(command[0]).name.lower() if command else ""
+    if launcher in {"uv", "uv.exe"}:
+        return False
+    if any(
+        command[index : index + 2] == ["-m", "pip"]
+        for index in range(len(command) - 1)
+    ):
+        return True
+    return bool(re.fullmatch(r"pip(?:3(?:\.\d+)?)?(?:\.exe)?", launcher))
 
 
 def main() -> int:
@@ -73,6 +120,17 @@ def main() -> int:
     args = parser.parse_args()
 
     install_cmd_prefix = _resolve_install_cmd(args.pip, args.uv)
+    if _is_direct_pip_command(install_cmd_prefix):
+        pip_ok, pip_error = _pip_security.ensure_pip_floor(
+            install_cmd_prefix,
+            creationflags=windows_hide_flags(),
+        )
+        if not pip_ok:
+            print(
+                f"✗ Refusing Android psutil install: pip security floor unavailable: {pip_error}",
+                file=sys.stderr,
+            )
+            return 1
 
     print(
         "→ Termux/Android: prebuilding psutil with Linux source path "
@@ -90,7 +148,11 @@ def main() -> int:
 
         cmd = install_cmd_prefix + ["install", "--no-build-isolation", str(src_root)]
         print(f"  $ {' '.join(cmd)}")
-        result = subprocess.run(cmd)
+        result = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
         if result.returncode != 0:
             return result.returncode
 

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -34,9 +34,50 @@ cd "$SCRIPT_DIR"
 export UV_NO_CONFIG=1
 
 PYTHON_VERSION="3.11"
+MIN_PIP_VERSION="26.1.2"
 
 is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
+}
+
+verify_pip_floor() {
+    local pip_version_output
+    if ! pip_version_output="$("$SETUP_PYTHON" -m pip --version 2>&1)"; then
+        return 1
+    fi
+    "$SETUP_PYTHON" - "$MIN_PIP_VERSION" "$pip_version_output" <<'PY'
+import re
+import sys
+
+minimum = tuple(int(part) for part in sys.argv[1].split("."))
+output = sys.argv[2]
+canonical_versions = []
+for line in output.splitlines():
+    line_match = re.fullmatch(
+        r"\s*pip\s+([^\s]+)\s+from\s+"
+        r"(?:(?:/|[A-Za-z]:[\\/]|\\\\)[^\r\n\"]*[\\/]pip)"
+        r"(?:\s+\(python\s+\d+(?:\.\d+){1,3}\))?\s*",
+        line,
+        re.IGNORECASE,
+    )
+    if not line_match:
+        continue
+    token = line_match.group(1)
+    release_match = re.fullmatch(r"(\d+(?:\.\d+){1,3})(.*)", token)
+    if not release_match:
+        raise SystemExit(1)
+    suffix = release_match.group(2)
+    if suffix and not re.fullmatch(r"\.post\d+", suffix, re.IGNORECASE):
+        raise SystemExit(1)
+    try:
+        version = tuple(int(part) for part in release_match.group(1).split("."))
+    except ValueError:
+        raise SystemExit(1)
+    canonical_versions.append(version)
+if len(canonical_versions) == 1 and canonical_versions[0] >= minimum:
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
 }
 
 get_command_link_dir() {
@@ -193,7 +234,11 @@ echo -e "${CYAN}→${NC} Installing dependencies..."
 if is_termux; then
     export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk 2>/dev/null || printf '%s' "${ANDROID_API_LEVEL:-}")"
     echo -e "${CYAN}→${NC} Termux detected — installing the tested Android bundle"
-    "$SETUP_PYTHON" -m pip install --upgrade pip setuptools wheel
+    "$SETUP_PYTHON" -m pip install --upgrade "pip>=${MIN_PIP_VERSION}" setuptools wheel
+    if ! verify_pip_floor; then
+        echo -e "${RED}✗${NC} pip floor verification failed; need stable pip >= ${MIN_PIP_VERSION}."
+        exit 1
+    fi
     if [ -f "constraints-termux.txt" ]; then
         "$SETUP_PYTHON" -m pip install -e ".[termux]" -c constraints-termux.txt || {
             echo -e "${YELLOW}⚠${NC} Termux bundle install failed, falling back to base install..."

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -26,18 +26,170 @@ from __future__ import annotations  # allow PEP 604 `X | None` on Python 3.9+
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 from importlib.metadata import version as _distribution_version
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.9 standalone copies
+    tomllib = None  # type: ignore[assignment]
+
 # Ensure sibling modules (_hermes_home) are importable when run standalone.
 _SCRIPTS_DIR = str(Path(__file__).resolve().parent)
 if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
+
+def _find_repo_root(script_path: Path) -> Path | None:
+    """Find a genuine Hermes checkout without trusting a sibling package.
+
+    Copied skill scripts may live below arbitrary directories.  A directory
+    that merely happens to contain ``hermes_cli`` is not enough evidence: a
+    fake package there could change the pip-floor behavior before the bundled
+    stdlib guard runs.  Require the repository's project metadata and the
+    shared early-import helper before importing anything from the ancestor.
+    """
+
+    for parent in script_path.parents:
+        pyproject = parent / "pyproject.toml"
+        helper = parent / "hermes_cli" / "_pip_security.py"
+        if tomllib is None or not pyproject.is_file() or not helper.is_file():
+            continue
+        try:
+            with pyproject.open("rb") as handle:
+                project = tomllib.load(handle).get("project", {})
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        if (
+            project.get("name") == "hermes-agent"
+            and project.get("scripts", {}).get("hermes") == "hermes_cli.main:main"
+        ):
+            return parent
+    return None
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+if _REPO_ROOT is not None and str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
 from _hermes_home import display_hermes_home, get_hermes_home
+
+try:
+    from hermes_cli._pip_security import ensure_pip_floor as _ensure_pip_floor
+except (ImportError, ModuleNotFoundError):  # standalone skill copy without repo
+    _ensure_pip_floor = None
+
+try:
+    from hermes_cli._subprocess_compat import windows_hide_flags as _windows_hide_flags
+except (ImportError, ModuleNotFoundError):  # standalone skill copy without repo
+    def _windows_hide_flags() -> int:
+        """Return the local no-console flag without importing Hermes."""
+        return int(getattr(subprocess, "CREATE_NO_WINDOW", 0)) if sys.platform == "win32" else 0
+
+_MIN_PIP_VERSION = (26, 1, 2)
+_MIN_PIP_SPEC = "pip>=26.1.2"
+_PIP_CANONICAL_VERSION_RE = re.compile(
+    r"^\s*pip\s+([^\s]+)\s+from\s+"
+    r"(?:(?:/|[A-Za-z]:[\\/]|\\\\)[^\r\n\"]*[\\/]pip)"
+    r"(?:\s+\(python\s+\d+(?:\.\d+){1,3}\))?\s*$",
+    re.IGNORECASE,
+)
+_PIP_RELEASE_RE = re.compile(r"^(\d+(?:\.\d+){1,3})(.*)$")
+
+
+def _bundled_pip_version_meets_floor(output: str) -> bool:
+    """Check a pip version using only stdlib code for standalone skill copies."""
+    versions = []
+    for line in (output or "").splitlines():
+        match = _PIP_CANONICAL_VERSION_RE.fullmatch(line)
+        if not match:
+            continue
+        token = match.group(1)
+        release_match = _PIP_RELEASE_RE.fullmatch(token)
+        if not release_match:
+            return False
+        suffix = release_match.group(2)
+        if suffix and not re.fullmatch(r"\.post\d+", suffix, re.IGNORECASE):
+            return False
+        try:
+            release = tuple(int(part) for part in release_match.group(1).split("."))
+        except ValueError:
+            return False
+        versions.append(release)
+    return len(versions) == 1 and versions[0] >= _MIN_PIP_VERSION
+
+
+def _bundled_ensure_pip_floor(
+    pip_cmd: list[str],
+    *,
+    timeout: int = 120,
+    creationflags: int | None = None,
+    runner=subprocess.run,
+) -> tuple[bool, str]:
+    """Upgrade and verify pip without importing the repository helper."""
+    hide_flags = _windows_hide_flags() if creationflags is None else creationflags
+    try:
+        probe = runner(
+            pip_cmd + ["--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+            stdin=subprocess.DEVNULL,
+            creationflags=hide_flags,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"pip floor probe failed: {exc}"
+    if probe.returncode != 0:
+        detail = (probe.stderr or probe.stdout or "").strip()
+        return False, f"pip floor probe failed: {detail or 'pip --version failed'}"
+    if _bundled_pip_version_meets_floor(probe.stdout or ""):
+        return True, ""
+
+    try:
+        upgrade = runner(
+            pip_cmd + ["install", "--upgrade", _MIN_PIP_SPEC],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+            creationflags=hide_flags,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"pip floor upgrade failed: {exc}"
+    if upgrade.returncode != 0:
+        detail = (upgrade.stderr or upgrade.stdout or "").strip()
+        return False, f"pip floor upgrade failed: {detail or 'pip install failed'}"
+
+    try:
+        verified = runner(
+            pip_cmd + ["--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+            stdin=subprocess.DEVNULL,
+            creationflags=hide_flags,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"pip floor verification failed: {exc}"
+    if verified.returncode != 0 or not _bundled_pip_version_meets_floor(
+        verified.stdout or ""
+    ):
+        detail = (verified.stderr or verified.stdout or "").strip()
+        return False, (
+            f"pip remains below {_MIN_PIP_SPEC} after upgrade: "
+            f"{detail or 'version was not reported'}"
+        )
+    return True, ""
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
@@ -134,20 +286,39 @@ def install_deps():
 
     print("Installing Google API dependencies...")
 
-    # First choice: pip in the current interpreter. Works for most installs.
-    try:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "--quiet"] + missing,
-            stdout=subprocess.DEVNULL,
-        )
-        remaining = _missing_required_packages()
-        if remaining:
-            print(f"ERROR: Dependencies remain stale after pip install: {' '.join(remaining)}")
-            return False
-        print("Dependencies installed.")
-        return True
-    except subprocess.CalledProcessError as e:
-        pip_error = e
+    # First choice: floor-verified pip in the current interpreter. Works for
+    # most installs, but a missing/unverifiable floor falls through to uv.
+    pip_cmd = [sys.executable, "-m", "pip"]
+    ensure_pip_floor = _ensure_pip_floor or _bundled_ensure_pip_floor
+    pip_ok, pip_detail = ensure_pip_floor(
+        pip_cmd,
+        runner=subprocess.run,
+        timeout=120,
+        creationflags=_windows_hide_flags(),
+    )
+    if pip_ok:
+        try:
+            subprocess.check_call(
+                pip_cmd + ["install", "--quiet"] + missing,
+                timeout=300,
+                stdout=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                creationflags=_windows_hide_flags(),
+            )
+            remaining = _missing_required_packages()
+            if remaining:
+                print(f"ERROR: Dependencies remain stale after pip install: {' '.join(remaining)}")
+                return False
+            print("Dependencies installed.")
+            return True
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            subprocess.TimeoutExpired,
+        ) as e:
+            pip_error = e
+    else:
+        pip_error = RuntimeError(pip_detail)
 
     # Fallback: the interpreter has no pip (the Hermes Docker image's venv is
     # built with `uv sync`, which does not bootstrap pip). `uv pip install
@@ -161,6 +332,8 @@ def install_deps():
                 [uv, "pip", "install", "--python", sys.executable, "--quiet"]
                 + missing,
                 stdout=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                creationflags=_windows_hide_flags(),
             )
             remaining = _missing_required_packages()
             if remaining:

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -1,5 +1,7 @@
 """Tests for DingTalk platform adapter."""
 import asyncio
+import sys
+import types
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -89,6 +91,90 @@ def _fake_dingtalk_optional_sdks(monkeypatch):
 
 
 class TestDingTalkRequirements:
+
+    def test_lazy_requirements_rebinds_optional_card_sdk_globals(self, monkeypatch):
+        """A post-install check must refresh Card/OpenAPI globals too."""
+        import plugins.platforms.dingtalk.adapter as dt
+
+        def module(name, **attrs):
+            value = types.ModuleType(name)
+            for key, item in attrs.items():
+                setattr(value, key, item)
+            return value
+
+        card_client = object()
+        card_models = object()
+        robot_client = object()
+        robot_models = object()
+        open_api_models = object()
+        tea_util_models = object()
+        card = module(
+            "alibabacloud_dingtalk.card_1_0",
+            client=card_client,
+            models=card_models,
+        )
+        robot = module(
+            "alibabacloud_dingtalk.robot_1_0",
+            client=robot_client,
+            models=robot_models,
+        )
+        dingtalk_pkg = module(
+            "alibabacloud_dingtalk",
+            card_1_0=card,
+            robot_1_0=robot,
+        )
+        tea_openapi = module(
+            "alibabacloud_tea_openapi", models=open_api_models
+        )
+        tea_util = module("alibabacloud_tea_util", models=tea_util_models)
+        stream_frames = module(
+            "dingtalk_stream.frames",
+            CallbackMessage=object,
+            AckMessage=object,
+        )
+        stream = module(
+            "dingtalk_stream",
+            ChatbotMessage=object,
+            frames=stream_frames,
+        )
+        for name, value in {
+            "alibabacloud_dingtalk": dingtalk_pkg,
+            "alibabacloud_dingtalk.card_1_0": card,
+            "alibabacloud_dingtalk.robot_1_0": robot,
+            "alibabacloud_tea_openapi": tea_openapi,
+            "alibabacloud_tea_util": tea_util,
+            "dingtalk_stream": stream,
+            "dingtalk_stream.frames": stream_frames,
+            "httpx": module("httpx"),
+        }.items():
+            monkeypatch.setitem(sys.modules, name, value)
+        monkeypatch.setattr(dt, "CARD_SDK_AVAILABLE", False)
+        monkeypatch.setattr(dt, "dingtalk_card_client", None)
+        monkeypatch.setattr(dt, "dingtalk_card_models", None)
+        monkeypatch.setattr(dt, "dingtalk_robot_client", None)
+        monkeypatch.setattr(dt, "dingtalk_robot_models", None)
+        monkeypatch.setattr(dt, "open_api_models", None)
+        monkeypatch.setattr(dt, "tea_util_models", None)
+        monkeypatch.setattr(dt, "DINGTALK_STREAM_AVAILABLE", False)
+        monkeypatch.setattr(dt, "HTTPX_AVAILABLE", False)
+        # ensure_dingtalk_deps() also rebinds these module globals; register
+        # them so monkeypatch restores the real SDK objects after the test.
+        monkeypatch.setattr(dt, "dingtalk_stream", None)
+        monkeypatch.setattr(dt, "ChatbotMessage", None)
+        monkeypatch.setattr(dt, "CallbackMessage", None)
+        monkeypatch.setattr(dt, "AckMessage", None)
+        monkeypatch.setattr(dt, "httpx", None)
+
+        with patch("tools.lazy_deps.ensure", autospec=True):
+            assert dt.ensure_dingtalk_deps() is True
+
+        assert dt.CARD_SDK_AVAILABLE is True
+        assert dt.dingtalk_card_client is card_client
+        assert dt.dingtalk_card_models is card_models
+        assert dt.dingtalk_robot_client is robot_client
+        assert dt.dingtalk_robot_models is robot_models
+        assert dt.open_api_models is open_api_models
+        assert dt.tea_util_models is tea_util_models
 
 
     def test_returns_false_when_env_vars_missing(self, monkeypatch):
@@ -200,6 +286,66 @@ class TestSend:
 
 
 class TestConnect:
+
+    @pytest.mark.asyncio
+    async def test_optional_card_repair_is_offloaded_and_attempted_once(
+        self, monkeypatch
+    ):
+        import plugins.platforms.dingtalk.adapter as dt
+
+        class FakeStreamMessage:
+            TOPIC = "topic"
+
+        class FakeStreamClient:
+            def __init__(self, credential):
+                self.credential = credential
+                self.handlers = []
+
+            def register_callback_handler(self, topic, handler):
+                self.handlers.append((topic, handler))
+
+        fake_stream = SimpleNamespace(
+            Credential=lambda client_id, client_secret: (client_id, client_secret),
+            DingTalkStreamClient=FakeStreamClient,
+            ChatbotMessage=FakeStreamMessage,
+        )
+        monkeypatch.setattr(dt, "dingtalk_stream", fake_stream)
+        monkeypatch.setattr(dt, "DINGTALK_STREAM_AVAILABLE", True)
+        monkeypatch.setattr(dt, "HTTPX_AVAILABLE", True)
+        monkeypatch.setattr(dt, "CARD_SDK_AVAILABLE", False)
+        fake_http = AsyncMock()
+        monkeypatch.setattr(
+            dt,
+            "httpx",
+            SimpleNamespace(AsyncClient=MagicMock(return_value=fake_http)),
+        )
+        calls = []
+
+        def fake_card_repair():
+            calls.append("repair")
+            return False
+
+        monkeypatch.setattr(dt, "ensure_dingtalk_card_deps", fake_card_repair)
+
+        async def _noop_stream(_adapter):
+            return None
+
+        monkeypatch.setattr(dt.DingTalkAdapter, "_run_stream", _noop_stream)
+        adapter = dt.DingTalkAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "client_id": "client",
+                    "client_secret": "secret",
+                    "card_template_id": "template",
+                },
+            )
+        )
+
+        assert await adapter.connect() is True
+        assert await adapter.connect() is True
+        assert calls == ["repair"]
+        assert adapter._card_sdk_attempted is True
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_feishu_lazy_import.py
+++ b/tests/gateway/test_feishu_lazy_import.py
@@ -28,6 +28,112 @@ def test_configured_feishu_dependency_check_does_not_load_sdk():
     ensure.assert_called_once_with("platform.feishu", prompt=False)
 
 
+def test_feishu_requirements_rebinds_webhook_modules_after_lazy_install():
+    """Both Feishu transports must rebind after a lazy install."""
+    feishu_adapter = _feishu_adapter_module()
+
+    with (
+        patch.object(feishu_adapter, "FEISHU_AVAILABLE", False),
+        patch.object(feishu_adapter, "aiohttp", None),
+        patch.object(feishu_adapter, "web", None),
+        patch.object(feishu_adapter, "websockets", None),
+        patch.object(feishu_adapter, "FEISHU_WEBHOOK_AVAILABLE", False),
+        patch.object(feishu_adapter, "FEISHU_WEBSOCKET_AVAILABLE", False),
+        patch("tools.lazy_deps.ensure", autospec=True) as ensure,
+    ):
+        assert feishu_adapter.check_feishu_requirements() is True
+        rebound = (
+            feishu_adapter.aiohttp,
+            feishu_adapter.web,
+            feishu_adapter.websockets,
+            feishu_adapter.FEISHU_WEBHOOK_AVAILABLE,
+            feishu_adapter.FEISHU_WEBSOCKET_AVAILABLE,
+        )
+
+    ensure.assert_called_once_with("platform.feishu", prompt=False)
+    assert rebound[0] is not None
+    assert rebound[1] is not None
+    assert rebound[2] is not None
+    assert rebound[3] is True
+    assert rebound[4] is True
+
+
+def test_feishu_passive_probe_does_not_trust_loaded_sdk_with_stale_metadata():
+    feishu_adapter = _feishu_adapter_module()
+
+    with (
+        patch.object(feishu_adapter, "FEISHU_AVAILABLE", True),
+        patch.object(feishu_adapter, "FEISHU_WEBHOOK_AVAILABLE", True),
+        patch("tools.lazy_deps.is_available", return_value=False) as available,
+    ):
+        assert feishu_adapter.feishu_deps_present() is False
+
+    available.assert_called_once_with("platform.feishu")
+
+
+def test_feishu_passive_probe_requires_websocket_runtime():
+    feishu_adapter = _feishu_adapter_module()
+
+    with (
+        patch.object(feishu_adapter, "FEISHU_AVAILABLE", True),
+        patch.object(feishu_adapter, "FEISHU_WEBHOOK_AVAILABLE", True),
+        patch.object(feishu_adapter, "FEISHU_WEBSOCKET_AVAILABLE", False),
+        patch("tools.lazy_deps.is_available", return_value=True),
+    ):
+        assert feishu_adapter.feishu_deps_present() is False
+
+
+def test_feishu_requirement_failure_preserves_loaded_transport_state():
+    """A failed active repair must not break already-running adapters."""
+    feishu_adapter = _feishu_adapter_module()
+
+    with (
+        patch.object(feishu_adapter, "FEISHU_AVAILABLE", True),
+        patch.object(feishu_adapter, "aiohttp", object()),
+        patch.object(feishu_adapter, "web", object()),
+        patch.object(feishu_adapter, "websockets", object()),
+        patch.object(feishu_adapter, "FEISHU_WEBHOOK_AVAILABLE", True),
+        patch.object(feishu_adapter, "FEISHU_WEBSOCKET_AVAILABLE", True),
+        patch.object(feishu_adapter, "_FEISHU_ACTIVE_CHECK_FAILED", False),
+        patch("tools.lazy_deps.ensure", side_effect=RuntimeError("resolver failed")),
+    ):
+        assert feishu_adapter.check_feishu_requirements() is False
+        assert feishu_adapter.FEISHU_AVAILABLE is True
+        assert feishu_adapter.aiohttp is not None
+        assert feishu_adapter.web is not None
+        assert feishu_adapter.websockets is not None
+        assert feishu_adapter.FEISHU_WEBHOOK_AVAILABLE is True
+        assert feishu_adapter.FEISHU_WEBSOCKET_AVAILABLE is True
+        assert feishu_adapter._FEISHU_ACTIVE_CHECK_FAILED is True
+        assert feishu_adapter.feishu_deps_present() is False
+
+
+def test_feishu_missing_lazy_helper_preserves_loaded_transport_state(monkeypatch):
+    """A missing helper must not tear down already-running adapters."""
+    import sys
+
+    feishu_adapter = _feishu_adapter_module()
+    with (
+        patch.object(feishu_adapter, "FEISHU_AVAILABLE", True),
+        patch.object(feishu_adapter, "aiohttp", object()),
+        patch.object(feishu_adapter, "web", object()),
+        patch.object(feishu_adapter, "websockets", object()),
+        patch.object(feishu_adapter, "FEISHU_WEBHOOK_AVAILABLE", True),
+        patch.object(feishu_adapter, "FEISHU_WEBSOCKET_AVAILABLE", True),
+        patch.object(feishu_adapter, "_FEISHU_ACTIVE_CHECK_FAILED", False),
+        patch.dict(sys.modules, {"tools.lazy_deps": None}),
+    ):
+        assert feishu_adapter.check_feishu_requirements() is False
+        assert feishu_adapter.FEISHU_AVAILABLE is True
+        assert feishu_adapter.aiohttp is not None
+        assert feishu_adapter.web is not None
+        assert feishu_adapter.websockets is not None
+        assert feishu_adapter.FEISHU_WEBHOOK_AVAILABLE is True
+        assert feishu_adapter.FEISHU_WEBSOCKET_AVAILABLE is True
+        assert feishu_adapter._FEISHU_ACTIVE_CHECK_FAILED is True
+        assert feishu_adapter.feishu_deps_present() is False
+
+
 def test_feishu_connect_loads_sdk_on_worker_thread():
     """The first SDK import is deferred until a configured adapter connects."""
     from gateway.config import PlatformConfig

--- a/tests/gateway/test_platform_lazy_security_recheck.py
+++ b/tests/gateway/test_platform_lazy_security_recheck.py
@@ -1,0 +1,531 @@
+"""Active platform hooks must not trust stale importability alone."""
+
+import sys
+import types
+import asyncio
+import concurrent.futures
+import threading
+import time
+
+import pytest
+
+
+def test_discord_active_hook_rechecks_feature_contract(monkeypatch):
+    import plugins.platforms.discord.adapter as module
+
+    monkeypatch.setattr(module, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(module, "_DISCORD_ACTIVE_CHECK_FAILED", False)
+    calls = []
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **kwargs: calls.append((feature, kwargs)),
+    )
+    monkeypatch.setattr(module, "_define_discord_view_classes", lambda: None)
+
+    assert module.check_discord_requirements() is True
+    assert calls == [("platform.discord", {"prompt": False})]
+
+
+def test_discord_active_hook_preserves_live_bindings_on_repair_failure(monkeypatch):
+    import plugins.platforms.discord.adapter as module
+
+    monkeypatch.setattr(module, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(module, "_DISCORD_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "discord", object())
+    monkeypatch.setattr(module, "DiscordMessage", object())
+    monkeypatch.setattr(module, "Intents", object())
+    monkeypatch.setattr(module, "commands", object())
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("stale")),
+    )
+
+    assert module.check_discord_requirements() is False
+    assert module.DISCORD_AVAILABLE is True
+    assert module.discord is not None
+    assert module.commands is not None
+    assert module._DISCORD_ACTIVE_CHECK_FAILED is True
+    assert module.discord_deps_present() is False
+
+
+def test_discord_active_hook_preserves_on_non_import_error(monkeypatch):
+    import builtins
+    import plugins.platforms.discord.adapter as module
+
+    monkeypatch.setattr(module, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(module, "_DISCORD_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "discord", object())
+    original_import = builtins.__import__
+
+    def fail_sdk_import(name, *args, **kwargs):
+        if name == "discord" or name.startswith("discord."):
+            raise RuntimeError("broken SDK initializer")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_sdk_import)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *_args, **_kwargs: None)
+
+    assert module.check_discord_requirements() is False
+    assert module.DISCORD_AVAILABLE is True
+    assert module.discord is not None
+    assert module._DISCORD_ACTIVE_CHECK_FAILED is True
+
+
+def test_discord_active_hook_restores_view_and_sdk_bindings_on_post_bind_failure(
+    monkeypatch,
+):
+    """A failed view setup must not replace a running adapter's SDK objects."""
+    import types
+
+    import plugins.platforms.discord.adapter as module
+
+    view_names = (
+        "ExecApprovalView",
+        "SlashConfirmView",
+        "UpdatePromptView",
+        "ModelPickerView",
+        "ClarifyChoiceView",
+        "ChoicePickerView",
+    )
+    sdk_names = ("DISCORD_AVAILABLE", "discord", "DiscordMessage", "Intents", "commands")
+    previous = {name: object() for name in (*sdk_names, *view_names)}
+    for name, value in previous.items():
+        monkeypatch.setitem(module.__dict__, name, value)
+
+    fake_discord = types.ModuleType("discord")
+    fake_discord.Message = object()
+    fake_discord.Intents = object()
+    fake_ext = types.ModuleType("discord.ext")
+    fake_commands = object()
+    fake_ext.commands = fake_commands
+    fake_discord.ext = fake_ext
+    monkeypatch.setitem(sys.modules, "discord", fake_discord)
+    monkeypatch.setitem(sys.modules, "discord.ext", fake_ext)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *_args, **_kwargs: None)
+
+    def fail_after_staging():
+        module.ExecApprovalView = object()
+        module.SlashConfirmView = object()
+        raise RuntimeError("incompatible Discord UI surface")
+
+    monkeypatch.setattr(module, "_define_discord_view_classes", fail_after_staging)
+
+    assert module.check_discord_requirements() is False
+    for name, value in previous.items():
+        assert module.__dict__[name] is value
+    assert module._DISCORD_ACTIVE_CHECK_FAILED is True
+
+
+def test_slack_active_hook_rechecks_feature_contract(monkeypatch):
+    import plugins.platforms.slack.adapter as module
+
+    monkeypatch.setattr(module, "SLACK_AVAILABLE", True)
+    monkeypatch.setattr(module, "_SLACK_ACTIVE_CHECK_FAILED", False)
+    calls = []
+
+    def fake_ensure_and_bind(feature, importer, target_globals, **kwargs):
+        calls.append((feature, kwargs))
+        return True
+
+    monkeypatch.setattr("tools.lazy_deps.ensure_and_bind", fake_ensure_and_bind)
+
+    assert module.check_slack_requirements() is True
+    assert calls == [("platform.slack", {"prompt": False})]
+
+
+def test_slack_active_hook_preserves_live_bindings_on_repair_failure(monkeypatch):
+    import plugins.platforms.slack.adapter as module
+
+    monkeypatch.setattr(module, "SLACK_AVAILABLE", True)
+    monkeypatch.setattr(module, "_SLACK_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "AsyncApp", object())
+    monkeypatch.setattr(module, "AsyncSocketModeHandler", object())
+    monkeypatch.setattr(module, "AsyncWebClient", object())
+    monkeypatch.setattr(module, "aiohttp", object())
+    monkeypatch.setattr("tools.lazy_deps.ensure_and_bind", lambda *args, **kwargs: False)
+
+    assert module.check_slack_requirements() is False
+    assert module.SLACK_AVAILABLE is True
+    assert module.aiohttp is not None
+    assert module.AsyncApp is not module.Any
+    assert module._SLACK_ACTIVE_CHECK_FAILED is True
+    assert module.slack_deps_present() is False
+
+
+def test_slack_active_checks_serialize_latch_updates(monkeypatch):
+    """A failed check that started first must not overwrite a later success."""
+    import plugins.platforms.slack.adapter as module
+
+    monkeypatch.setattr(module, "SLACK_AVAILABLE", True)
+    monkeypatch.setattr(module, "_SLACK_ACTIVE_CHECK_FAILED", False)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    calls = []
+
+    def fake_ensure_and_bind(*_args, **_kwargs):
+        calls.append(len(calls))
+        if len(calls) == 1:
+            first_started.set()
+            assert release_first.wait(timeout=2)
+            return False
+        second_entered.set()
+        return True
+
+    monkeypatch.setattr("tools.lazy_deps.ensure_and_bind", fake_ensure_and_bind)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(module.check_slack_requirements)
+        assert first_started.wait(timeout=2)
+        second = pool.submit(module.check_slack_requirements)
+        assert not second_entered.wait(timeout=0.1)
+        release_first.set()
+        assert first.result() is False
+        assert second.result() is True
+
+    assert calls == [0, 1]
+    assert module._SLACK_ACTIVE_CHECK_FAILED is False
+    assert module.slack_deps_present() is True
+
+
+def test_discord_active_checks_serialize_transactional_rebind(monkeypatch):
+    """A later successful Discord bind must survive an earlier failed check."""
+    import plugins.platforms.discord.adapter as module
+
+    fake_discord = types.ModuleType("discord")
+    fake_discord.Message = object()
+    fake_discord.Intents = object()
+    fake_ext = types.ModuleType("discord.ext")
+    fake_ext.commands = object()
+    fake_discord.ext = fake_ext
+    monkeypatch.setitem(sys.modules, "discord", fake_discord)
+    monkeypatch.setitem(sys.modules, "discord.ext", fake_ext)
+    monkeypatch.setattr(module, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(module, "_DISCORD_ACTIVE_CHECK_FAILED", False)
+    old_discord = object()
+    monkeypatch.setattr(module, "discord", old_discord)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    calls = []
+
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *_args, **_kwargs: None)
+
+    def fake_define_views():
+        calls.append(len(calls))
+        if len(calls) == 1:
+            first_started.set()
+            assert release_first.wait(timeout=2)
+            raise RuntimeError("candidate view classes are incompatible")
+        second_entered.set()
+
+    monkeypatch.setattr(module, "_define_discord_view_classes", fake_define_views)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(module.check_discord_requirements)
+        assert first_started.wait(timeout=2)
+        second = pool.submit(module.check_discord_requirements)
+        assert not second_entered.wait(timeout=0.1)
+        release_first.set()
+        assert first.result() is False
+        assert second.result() is True
+
+    assert calls == [0, 1]
+    assert module._DISCORD_ACTIVE_CHECK_FAILED is False
+    assert module.DISCORD_AVAILABLE is True
+    assert module.discord is fake_discord
+
+
+def test_dingtalk_active_hook_rechecks_feature_contract(monkeypatch):
+    import httpx
+    import plugins.platforms.dingtalk.adapter as module
+
+    fake_stream = types.ModuleType("dingtalk_stream")
+    fake_stream.ChatbotMessage = object
+    fake_frames = types.ModuleType("dingtalk_stream.frames")
+    fake_frames.CallbackMessage = object
+    fake_frames.AckMessage = object
+    monkeypatch.setitem(sys.modules, "dingtalk_stream", fake_stream)
+    monkeypatch.setitem(sys.modules, "dingtalk_stream.frames", fake_frames)
+    monkeypatch.setattr(module, "DINGTALK_STREAM_AVAILABLE", True)
+    monkeypatch.setattr(module, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(module, "_DINGTALK_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "dingtalk_stream", object())
+    monkeypatch.setattr(module, "httpx", httpx)
+    monkeypatch.setattr(module, "_load_optional_card_sdk", lambda: True)
+    calls = []
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **kwargs: calls.append((feature, kwargs)),
+    )
+
+    assert module.ensure_dingtalk_deps() is True
+    assert calls == [("platform.dingtalk", {"prompt": False})]
+
+
+def test_dingtalk_optional_card_failure_keeps_core_bindings(monkeypatch):
+    import httpx
+    import plugins.platforms.dingtalk.adapter as module
+
+    fake_stream = types.ModuleType("dingtalk_stream")
+    fake_stream.ChatbotMessage = object
+    fake_frames = types.ModuleType("dingtalk_stream.frames")
+    fake_frames.CallbackMessage = object
+    fake_frames.AckMessage = object
+    monkeypatch.setitem(sys.modules, "dingtalk_stream", fake_stream)
+    monkeypatch.setitem(sys.modules, "dingtalk_stream.frames", fake_frames)
+    monkeypatch.setattr(module, "DINGTALK_STREAM_AVAILABLE", False)
+    monkeypatch.setattr(module, "HTTPX_AVAILABLE", False)
+    monkeypatch.setattr(module, "CARD_SDK_AVAILABLE", False)
+    monkeypatch.setattr(module, "dingtalk_stream", None)
+    monkeypatch.setattr(module, "ChatbotMessage", None)
+    monkeypatch.setattr(module, "CallbackMessage", None)
+    monkeypatch.setattr(module, "AckMessage", None)
+    monkeypatch.setattr(module, "httpx", None)
+    monkeypatch.setattr(module, "_load_optional_card_sdk", lambda: False)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *_args, **_kwargs: None)
+
+    assert module.ensure_dingtalk_deps() is True
+    assert module.DINGTALK_STREAM_AVAILABLE is True
+    assert module.HTTPX_AVAILABLE is True
+    assert module.dingtalk_stream is fake_stream
+    assert module.httpx is httpx
+    assert module.CARD_SDK_AVAILABLE is False
+
+
+def test_dingtalk_card_repair_is_deferred_to_the_optional_feature(monkeypatch):
+    import plugins.platforms.dingtalk.adapter as module
+
+    monkeypatch.setattr(module, "CARD_SDK_AVAILABLE", False)
+    monkeypatch.setattr(module, "_CARD_DEPS_REPAIR_RESULT", None)
+    calls = []
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **kwargs: calls.append((feature, kwargs)),
+    )
+    monkeypatch.setattr(module, "_load_optional_card_sdk", lambda: True)
+
+    assert module.ensure_dingtalk_card_deps() is True
+    assert calls == [("platform.dingtalk_card", {"prompt": False})]
+
+
+def test_dingtalk_active_hook_preserves_live_bindings_on_repair_failure(monkeypatch):
+    import plugins.platforms.dingtalk.adapter as module
+
+    monkeypatch.setattr(module, "DINGTALK_STREAM_AVAILABLE", True)
+    monkeypatch.setattr(module, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(module, "_DINGTALK_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "dingtalk_stream", object())
+    monkeypatch.setattr(module, "ChatbotMessage", object())
+    monkeypatch.setattr(module, "CallbackMessage", object())
+    monkeypatch.setattr(module, "AckMessage", object())
+    monkeypatch.setattr(module, "httpx", object())
+    monkeypatch.setattr(module, "CARD_SDK_AVAILABLE", True)
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("stale")),
+    )
+
+    assert module.ensure_dingtalk_deps() is False
+    assert module.DINGTALK_STREAM_AVAILABLE is True
+    assert module.HTTPX_AVAILABLE is True
+    assert module.dingtalk_stream is not None
+    assert module.httpx is not None
+    assert module.CARD_SDK_AVAILABLE is True
+    assert module._DINGTALK_ACTIVE_CHECK_FAILED is True
+    assert module.dingtalk_deps_present() is False
+
+
+def test_dingtalk_failed_active_check_does_not_break_existing_adapter(monkeypatch):
+    import httpx
+    import plugins.platforms.dingtalk.adapter as module
+    from gateway.config import PlatformConfig
+
+    class _FailingHTTP:
+        async def post(self, *_args, **_kwargs):
+            raise RuntimeError("transport failed")
+
+    monkeypatch.setattr(module, "DINGTALK_STREAM_AVAILABLE", True)
+    monkeypatch.setattr(module, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(module, "_DINGTALK_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "dingtalk_stream", object())
+    monkeypatch.setattr(module, "httpx", httpx)
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("stale")),
+    )
+
+    adapter = module.DingTalkAdapter(
+        PlatformConfig(extra={"client_id": "id", "client_secret": "secret"})
+    )
+    adapter._http_client = _FailingHTTP()
+    adapter._session_webhooks["chat"] = (
+        "https://oapi.dingtalk.com/session",
+        10**15,
+    )
+
+    assert module.ensure_dingtalk_deps() is False
+    result = asyncio.run(adapter.send("chat", "hello"))
+    assert result.success is False
+    assert "transport failed" in (result.error or "")
+
+
+def test_telegram_active_hook_preserves_live_bindings_on_repair_failure(monkeypatch):
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "TELEGRAM_AVAILABLE", True)
+    monkeypatch.setattr(module, "_TELEGRAM_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "Update", object())
+    monkeypatch.setattr(module, "Bot", object())
+    monkeypatch.setattr(module, "HTTPXRequest", object())
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("stale")),
+    )
+
+    assert module.check_telegram_requirements() is False
+    assert module.TELEGRAM_AVAILABLE is True
+    assert module.Update is not module.Any
+    assert module.HTTPXRequest is not module.Any
+    assert module._TELEGRAM_ACTIVE_CHECK_FAILED is True
+    assert module.telegram_deps_present() is False
+
+
+def test_telegram_active_hook_preserves_on_non_import_error(monkeypatch):
+    import builtins
+    import plugins.platforms.telegram.adapter as module
+
+    monkeypatch.setattr(module, "TELEGRAM_AVAILABLE", True)
+    monkeypatch.setattr(module, "_TELEGRAM_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "Update", object())
+    original_import = builtins.__import__
+
+    def fail_sdk_import(name, *args, **kwargs):
+        if name == "telegram" or name.startswith("telegram."):
+            raise RuntimeError("broken SDK initializer")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_sdk_import)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *_args, **_kwargs: None)
+
+    assert module.check_telegram_requirements() is False
+    assert module.TELEGRAM_AVAILABLE is True
+    assert module.Update is not module.Any
+    assert module._TELEGRAM_ACTIVE_CHECK_FAILED is True
+
+
+def test_wecom_active_hook_preserves_live_bindings_on_repair_failure(monkeypatch):
+    import plugins.platforms.wecom.callback_adapter as module
+
+    monkeypatch.setattr(module, "DEFUSEDXML_AVAILABLE", True)
+    monkeypatch.setattr(module, "AIOHTTP_AVAILABLE", True)
+    monkeypatch.setattr(module, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(module, "_WECOM_CALLBACK_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "ET", object())
+    monkeypatch.setattr(module, "web", object())
+    monkeypatch.setattr(module, "httpx", object())
+    monkeypatch.setattr("tools.lazy_deps.ensure_and_bind", lambda *args, **kwargs: False)
+
+    assert module.ensure_wecom_callback_requirements() is False
+    assert module.DEFUSEDXML_AVAILABLE is True
+    assert module.AIOHTTP_AVAILABLE is True
+    assert module.HTTPX_AVAILABLE is True
+    assert module.ET is not None
+    assert module.web is not None
+    assert module.httpx is not None
+    assert module._WECOM_CALLBACK_ACTIVE_CHECK_FAILED is True
+    assert module.check_wecom_callback_requirements() is False
+
+
+def test_wecom_callback_active_check_recovers_after_a_failed_attempt(monkeypatch):
+    import plugins.platforms.wecom.callback_adapter as module
+
+    monkeypatch.setattr(module, "DEFUSEDXML_AVAILABLE", True)
+    monkeypatch.setattr(module, "AIOHTTP_AVAILABLE", True)
+    monkeypatch.setattr(module, "HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(module, "_WECOM_CALLBACK_ACTIVE_CHECK_FAILED", True)
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure_and_bind",
+        lambda *_args, **_kwargs: True,
+    )
+
+    assert module.ensure_wecom_callback_requirements() is True
+    assert module._WECOM_CALLBACK_ACTIVE_CHECK_FAILED is False
+    assert module.check_wecom_callback_requirements() is True
+
+
+def test_feishu_active_hook_preserves_on_non_import_error(monkeypatch):
+    import builtins
+    import plugins.platforms.feishu.adapter as module
+
+    monkeypatch.setattr(module, "FEISHU_AVAILABLE", True)
+    monkeypatch.setattr(module, "FEISHU_WEBHOOK_AVAILABLE", True)
+    monkeypatch.setattr(module, "FEISHU_WEBSOCKET_AVAILABLE", True)
+    monkeypatch.setattr(module, "_FEISHU_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "aiohttp", object())
+    original_import = builtins.__import__
+
+    def fail_transport_import(name, *args, **kwargs):
+        if name == "aiohttp" or name.startswith("aiohttp."):
+            raise RuntimeError("broken transport initializer")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_transport_import)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *_args, **_kwargs: None)
+
+    assert module.check_feishu_requirements() is False
+    assert module.FEISHU_AVAILABLE is True
+    assert module.FEISHU_WEBHOOK_AVAILABLE is True
+    assert module.FEISHU_WEBSOCKET_AVAILABLE is True
+    assert module._FEISHU_ACTIVE_CHECK_FAILED is True
+    assert module.feishu_deps_present() is False
+
+
+def test_teams_active_hook_preserves_on_non_import_error(monkeypatch):
+    import plugins.platforms.teams.adapter as module
+
+    monkeypatch.setattr(module, "AIOHTTP_AVAILABLE", True)
+    monkeypatch.setattr(module, "TEAMS_SDK_AVAILABLE", True)
+    monkeypatch.setattr(module, "_TEAMS_ACTIVE_CHECK_FAILED", False)
+    monkeypatch.setattr(module, "App", object())
+
+    def fail_bind(*_args, **_kwargs):
+        raise RuntimeError("broken SDK initializer")
+
+    monkeypatch.setattr("tools.lazy_deps.ensure_and_bind", fail_bind)
+
+    assert module.check_teams_requirements() is False
+    assert module.AIOHTTP_AVAILABLE is True
+    assert module.TEAMS_SDK_AVAILABLE is True
+    assert module.App is not None
+    assert module._TEAMS_ACTIVE_CHECK_FAILED is True
+    assert module.check_requirements() is False
+
+
+def test_teams_active_check_timeout_does_not_wait_for_another_worker(monkeypatch):
+    import plugins.platforms.teams.adapter as module
+
+    assert module._TEAMS_ACTIVE_CHECK_LOCK.acquire(timeout=0.1)
+    try:
+        with pytest.raises(module._TeamsActiveCheckBusy):
+            module.check_teams_requirements(timeout=0.01)
+    finally:
+        module._TEAMS_ACTIVE_CHECK_LOCK.release()
+
+
+def test_dingtalk_card_repair_is_coalesced_across_threads(monkeypatch):
+    import plugins.platforms.dingtalk.adapter as module
+
+    calls = []
+    monkeypatch.setattr(module, "CARD_SDK_AVAILABLE", False)
+    monkeypatch.setattr(module, "_CARD_DEPS_REPAIR_RESULT", None)
+    monkeypatch.setattr(module, "_load_optional_card_sdk", lambda: False)
+
+    def fake_ensure(*_args, **_kwargs):
+        calls.append(True)
+        time.sleep(0.05)
+
+    monkeypatch.setattr("tools.lazy_deps.ensure", fake_ensure)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: module.ensure_dingtalk_card_deps(), range(2)))
+
+    assert results == [False, False]
+    assert calls == [True]

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -119,7 +119,8 @@ class TestEnsureDepsFn:
     so create_adapter() returned None before connect() could lazy-install —
     the SDK never installed.  The inverse wiring (active installer as
     check_fn) made status displays pip-install SDKs as a side effect.
-    create_adapter() now runs ensure_deps_fn when check_fn is False.
+    create_adapter() now runs ensure_deps_fn for configured adapters, while
+    status/config loading continues to use only the passive check_fn.
     """
 
     def _entry(self, name, *, check_fn, ensure_deps_fn=None):
@@ -134,8 +135,8 @@ class TestEnsureDepsFn:
         )
         return entry, adapter
 
-    def test_deps_present_skips_installer(self):
-        """check_fn True → adapter created, ensure_deps_fn never called."""
+    def test_deps_present_runs_active_verifier(self):
+        """Passive importability must not bypass exact active verification."""
         reg = PlatformRegistry()
         installer = MagicMock(return_value=True)
         entry, adapter = self._entry(
@@ -143,7 +144,24 @@ class TestEnsureDepsFn:
         )
         reg.register(entry)
         assert reg.create_adapter("ready", MagicMock()) is adapter
-        installer.assert_not_called()
+        installer.assert_called_once()
+
+    def test_importable_but_stale_metadata_runs_active_repair(self):
+        """An importable stub must not bypass a stale exact-pin repair."""
+        reg = PlatformRegistry()
+        state = {"stale": True}
+
+        def repair():
+            assert state["stale"] is True
+            state["stale"] = False
+            return True
+
+        entry, adapter = self._entry(
+            "stale", check_fn=lambda: True, ensure_deps_fn=repair
+        )
+        reg.register(entry)
+        assert reg.create_adapter("stale", MagicMock()) is adapter
+        assert state["stale"] is False
 
     def test_missing_deps_runs_installer_then_creates(self):
         """check_fn False + ensure_deps_fn True → install runs, adapter created."""

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import threading
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -203,14 +204,62 @@ def _make_config(**extra):
 class TestTeamsRequirements:
 
 
+    def test_dotenv_suppression_restores_original_after_overlapping_checks(
+        self, monkeypatch
+    ):
+        """Overlapping threaded SDK imports must not leak the dotenv no-op."""
+        original_load_dotenv = lambda *args, **kwargs: "original"
+        fake_dotenv = types.ModuleType("dotenv")
+        fake_dotenv.load_dotenv = original_load_dotenv
+        monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+        first_ready = threading.Event()
+        second_entered = threading.Event()
+        first_finished = threading.Event()
+        errors = []
+
+        def first_worker():
+            try:
+                with _teams_mod._suppress_third_party_dotenv():
+                    first_ready.set()
+                    # If the second worker can enter concurrently, it saves
+                    # the first worker's temporary lambda as its original.
+                    second_entered.wait(timeout=2)
+                first_finished.set()
+            except BaseException as exc:  # pragma: no cover - assertion below
+                errors.append(exc)
+
+        def second_worker():
+            try:
+                with _teams_mod._suppress_third_party_dotenv():
+                    second_entered.set()
+                    first_finished.wait(timeout=2)
+            except BaseException as exc:  # pragma: no cover - assertion below
+                errors.append(exc)
+
+        first = threading.Thread(target=first_worker)
+        second = threading.Thread(target=second_worker)
+        first.start()
+        assert first_ready.wait(timeout=2)
+        second.start()
+        first.join(timeout=5)
+        second.join(timeout=5)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert errors == []
+        assert fake_dotenv.load_dotenv is original_load_dotenv
+
+
     def test_returns_true_when_deps_available(self, monkeypatch):
         monkeypatch.setattr(_teams_mod, "TEAMS_SDK_AVAILABLE", True)
         monkeypatch.setattr(_teams_mod, "AIOHTTP_AVAILABLE", True)
         assert check_requirements() is True
 
-    def test_check_teams_requirements_shortcircuits_when_present(self, monkeypatch):
-        # When SDK symbols are already bound and aiohttp is available, the
-        # active lazy-installer returns True immediately without re-importing.
+    def test_check_teams_requirements_rechecks_present_metadata(self, monkeypatch):
+        # Even when symbols are already bound, the active hook must re-run
+        # feature_missing/ensure so stale security pins are repaired or fail
+        # closed instead of being silently accepted.
         monkeypatch.setattr(_teams_mod, "App", object())
         monkeypatch.setattr(_teams_mod, "AIOHTTP_AVAILABLE", True)
         called = {"ensure_and_bind": 0}
@@ -223,7 +272,7 @@ class TestTeamsRequirements:
             "tools.lazy_deps.ensure_and_bind", _fake_ensure_and_bind
         )
         assert check_teams_requirements() is True
-        assert called["ensure_and_bind"] == 0
+        assert called["ensure_and_bind"] == 1
 
     def test_check_teams_requirements_lazy_installs_when_missing(self, monkeypatch):
         # When deps are missing, the active installer delegates to
@@ -347,8 +396,44 @@ class TestTeamsInteractiveSetup:
 
 class TestTeamsConnect:
     @pytest.mark.anyio
+    async def test_connect_fails_closed_when_active_requirement_check_fails(
+        self, monkeypatch
+    ):
+        """Stale/restart-required SDK state must not construct a server."""
+        monkeypatch.setattr(_teams_mod, "TEAMS_SDK_AVAILABLE", True)
+        monkeypatch.setattr(_teams_mod, "AIOHTTP_AVAILABLE", True)
+        monkeypatch.setattr(
+            _teams_mod, "check_teams_requirements", lambda **_kwargs: False
+        )
+        server_constructed = False
+
+        def _unexpected_application(*_args, **_kwargs):
+            nonlocal server_constructed
+            server_constructed = True
+            raise AssertionError("server must not be constructed")
+
+        monkeypatch.setattr(
+            _teams_mod.web,
+            "Application",
+            _unexpected_application,
+        )
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+
+        result = await adapter.connect()
+
+        assert result is False
+        assert server_constructed is False
+        assert adapter.fatal_error_code == "MISSING_SDK"
+
+    @pytest.mark.anyio
     async def test_connect_fails_without_sdk(self, monkeypatch):
         monkeypatch.setattr(_teams_mod, "TEAMS_SDK_AVAILABLE", False)
+        # Keep the transport dependency available so the active-hook cleanup
+        # exercised by this test does not leak a cleared AIOHTTP flag into
+        # later standalone-send cases.
+        monkeypatch.setattr(_teams_mod, "AIOHTTP_AVAILABLE", True)
         # Simulate the SDK being unavailable AND not installable (offline /
         # locked-down env): the lazy-installer can't rebind the globals, so
         # TEAMS_SDK_AVAILABLE stays False and connect() must fail.
@@ -747,5 +832,3 @@ class TestTeamsMediaAttachments:
         result = await adapter.send_document("19:abc@thread.v2", str(doc))
         assert result.success
         adapter._app.send.assert_awaited_once()
-
-

--- a/tests/gateway/test_telegram_connect.py
+++ b/tests/gateway/test_telegram_connect.py
@@ -27,3 +27,18 @@ class TestTelegramUnconfiguredNonRetryable:
         assert adapter.fatal_error_retryable is False
         assert adapter.fatal_error_code == "missing_dependency"
 
+
+def test_active_telegram_check_revalidates_exact_lazy_contract(monkeypatch):
+    """Importability must not bypass the exact active Telegram contract."""
+    ensure_calls = []
+    stale_alias = object()
+    monkeypatch.setattr(telegram_mod, "TELEGRAM_AVAILABLE", True)
+    monkeypatch.setattr(telegram_mod, "Update", stale_alias)
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **kwargs: ensure_calls.append((feature, kwargs)),
+    )
+
+    assert telegram_mod.check_telegram_requirements() is True
+    assert ensure_calls == [("platform.telegram", {"prompt": False})]
+    assert telegram_mod.Update is not stale_alias

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -10,6 +10,38 @@ from plugins.platforms.wecom.callback_adapter import WecomCallbackAdapter
 from plugins.platforms.wecom.wecom_crypto import WXBizMsgCrypt
 
 
+def test_wecom_lazy_requirements_rebind_all_optional_modules(monkeypatch):
+    """A post-install bind must refresh every optional runtime global."""
+    import plugins.platforms.wecom.callback_adapter as module
+
+    for name, value in (
+        ("ET", None),
+        ("web", None),
+        ("httpx", None),
+        ("DEFUSEDXML_AVAILABLE", False),
+        ("AIOHTTP_AVAILABLE", False),
+        ("HTTPX_AVAILABLE", False),
+    ):
+        monkeypatch.setattr(module, name, value)
+
+    def fake_ensure_and_bind(feature, importer, target_globals, **kwargs):
+        assert feature == "platform.wecom_callback"
+        target_globals.update(importer())
+        return True
+
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure_and_bind", fake_ensure_and_bind
+    )
+
+    assert module.ensure_wecom_callback_requirements() is True
+    assert module.ET is not None
+    assert module.web is not None
+    assert module.httpx is not None
+    assert module.DEFUSEDXML_AVAILABLE
+    assert module.AIOHTTP_AVAILABLE
+    assert module.HTTPX_AVAILABLE
+
+
 def _app(name="test-app", corp_id="ww1234567890", agent_id="1000002"):
     return {
         "name": name,
@@ -197,5 +229,4 @@ class TestWecomCallbackBodySizeLimit:
         oversized = b"<xml>" + b"A" * (_MAX_BODY + 1) + b"</xml>"
         response = await adapter._handle_callback(self._request(oversized))
         assert response.status == 413
-
 

--- a/tests/hermes_cli/test_certifi_repair.py
+++ b/tests/hermes_cli/test_certifi_repair.py
@@ -158,7 +158,11 @@ class TestDoctorCertificates:
 
             class _R:
                 returncode = 0
-                stdout = ""
+                stdout = (
+                    "pip 26.1.2 from /venv/site-packages/pip (python 3.13)"
+                    if cmd[-1] == "--version"
+                    else ""
+                )
                 stderr = ""
 
             return _R()
@@ -173,8 +177,12 @@ class TestDoctorCertificates:
         out = capsys.readouterr().out
 
         assert calls["pip"], "--fix must run a pip force-reinstall of certifi"
-        pip_cmd = calls["pip"][0]
-        assert "--force-reinstall" in pip_cmd and "certifi" in pip_cmd
+        pip_cmd = next(
+            (cmd for cmd in calls["pip"] if "--force-reinstall" in cmd),
+            None,
+        )
+        assert pip_cmd is not None, "--fix must run a pip force-reinstall of certifi"
+        assert "certifi" in pip_cmd
         assert calls["verify"] == 2, "must re-verify after the reinstall"
         assert "repaired" in out.lower()
         assert not issues
@@ -190,6 +198,29 @@ class TestDoctorCertificates:
         doctor_mod.check_certificates(should_fix=True, issues=[])
         out = capsys.readouterr().out
         assert "valid" in out.lower()
+
+    def test_floor_failure_is_reported_as_floor_failure(self, monkeypatch, capsys):
+        from hermes_cli import doctor as doctor_mod
+        from hermes_cli import _pip_security
+        from agent.errors import SSLConfigurationError
+
+        monkeypatch.setattr(
+            "agent.ssl_guard.verify_ca_bundle_with_fallback",
+            lambda: (_ for _ in ()).throw(SSLConfigurationError("broken bundle")),
+        )
+        monkeypatch.setattr(
+            _pip_security,
+            "ensure_pip_floor",
+            lambda *args, **kwargs: (False, "pip 24.0 is below the required floor"),
+        )
+        issues = []
+
+        doctor_mod.check_certificates(should_fix=True, issues=issues)
+
+        out = capsys.readouterr().out.lower()
+        assert "pip security floor unavailable" in out
+        assert "certifi repair could not run pip" not in out
+        assert issues and "upgrade pip" in issues[0].lower()
 
 
 # =========================================================================

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -16,6 +16,17 @@ def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
     def side_effect(cmd, **kwargs):
         joined = " ".join(str(c) for c in cmd)
 
+        # The update path now verifies the venv pip security floor before
+        # installing dependencies. Model a healthy pip for these git-focused
+        # command-flow tests instead of returning empty mocked output.
+        if "-m" in cmd and "pip" in cmd:
+            if "--version" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="pip 26.1.2 from /venv/site-packages/pip\n", stderr=""
+                )
+            if "install" in cmd and "--upgrade" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
         # git rev-parse --abbrev-ref HEAD  (get current branch)
         if "rev-parse" in joined and "--abbrev-ref" in joined:
             return subprocess.CompletedProcess(cmd, 0, stdout=f"{branch}\n", stderr="")
@@ -94,9 +105,6 @@ class TestCmdUpdateNpmLockfileCache:
     def _cache_file(hermes_root, project_root):
         cache_key = hashlib.sha256(str(project_root).encode()).hexdigest()[:12]
         return hermes_root / f".npm_lock_hash_{cache_key}"
-
-
-
     def test_record_npm_lockfile_hash(self, tmp_path, monkeypatch):
         from hermes_cli import main as hm
 
@@ -267,6 +275,104 @@ class TestUpdateManagedPythonEnvIsolation:
         assert ".hermes-runtime" in uv_env.get("UV_PYTHON_INSTALL_DIR", "")
         assert uv_env.get("UV_MANAGED_PYTHON") == "1"
         assert uv_env.get("UV_NO_CONFIG") == "1"
+
+
+def test_update_pip_floor_bounds_probe_and_ensurepip(monkeypatch):
+    """Update floor probes cannot hang before their friendly error path."""
+    from hermes_cli import update_cmd
+    import tools.lazy_deps as lazy_deps
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        if cmd[-1] == "--version":
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="missing")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(lazy_deps, "_ensure_pip_floor", lambda _cmd: (True, ""))
+
+    update_cmd._ensure_update_pip_floor(["python", "-m", "pip"])
+
+    assert calls[0][1]["timeout"] == 15
+    assert calls[1][1]["timeout"] == 120
+    assert all(call[1]["stdin"] is subprocess.DEVNULL for call in calls)
+    assert all("creationflags" in call[1] for call in calls)
+
+
+def test_update_pip_floor_reports_ensurepip_output(monkeypatch):
+    """A failed ensurepip bootstrap includes its diagnostic output."""
+    from hermes_cli import _pip_security, update_cmd
+    import tools.lazy_deps as lazy_deps
+
+    def fake_run(cmd, **kwargs):
+        if cmd[-1] == "--version":
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="missing")
+        return subprocess.CompletedProcess(
+            cmd, 1, stdout="bootstrap stdout", stderr="bootstrap stderr"
+        )
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(lazy_deps, "_ensure_pip_floor", lambda _cmd: (True, ""))
+
+    with pytest.raises(_pip_security.PipFloorError, match="bootstrap stderr"):
+        update_cmd._ensure_update_pip_floor(["python", "-m", "pip"])
+
+
+def test_update_pip_floor_helper_import_failure_is_friendly(monkeypatch):
+    """A broken lazy-deps import must remain an update floor failure."""
+    import builtins
+    from hermes_cli import _pip_security, update_cmd
+
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "tools.lazy_deps":
+            raise ImportError("lazy dependency helper unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    with pytest.raises(_pip_security.PipFloorError, match="floor helper import failed"):
+        update_cmd._ensure_update_pip_floor(["python", "-m", "pip"])
+
+
+def test_lazy_refresh_pip_upgrade_ignores_helper_import_failure(monkeypatch):
+    """Lazy-refresh upgrade is best effort and must never raise."""
+    import builtins
+    from hermes_cli import update_cmd
+
+    real_import = builtins.__import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "tools.lazy_deps":
+            raise ImportError("lazy dependency helper unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_import)
+    update_cmd._upgrade_pip_before_lazy_refresh(["python", "-m", "pip"])
+
+
+def test_lazy_refresh_pip_upgrade_ignores_floor_failure(monkeypatch):
+    """Best-effort lazy-refresh pip upgrade must swallow floor failures too."""
+    from hermes_cli import update_cmd
+
+    def raise_floor(*_args, **_kwargs):
+        raise update_cmd._pip_security.PipFloorError("pip floor unavailable")
+
+    monkeypatch.setattr(update_cmd._m(), "_run_package_only_install", raise_floor)
+    update_cmd._upgrade_pip_before_lazy_refresh(["python", "-m", "pip"])
+
+
+def test_lazy_refresh_pip_upgrade_ignores_timeout(monkeypatch):
+    """Best-effort lazy-refresh pip upgrade must swallow timeouts too."""
+    from hermes_cli import update_cmd
+
+    def raise_timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(["python", "-m", "pip"], 120)
+
+    monkeypatch.setattr(update_cmd._m(), "_run_package_only_install", raise_timeout)
+    update_cmd._upgrade_pip_before_lazy_refresh(["python", "-m", "pip"])
 
 
 class TestCmdUpdateBranchFallback:
@@ -659,6 +765,19 @@ class TestCmdUpdateBranchFlag:
         def side_effect(cmd, **kwargs):
             joined = " ".join(str(c) for c in cmd)
 
+            # Keep the shared pip-floor guard out of this branch-targeting
+            # test's git command assertions by modelling compliant pip output.
+            if "-m" in cmd and "pip" in cmd:
+                if "--version" in cmd:
+                    return subprocess.CompletedProcess(
+                        cmd,
+                        0,
+                        stdout="pip 26.1.2 from /venv/site-packages/pip\n",
+                        stderr="",
+                    )
+                if "install" in cmd and "--upgrade" in cmd:
+                    return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
             if "rev-parse" in joined and "--abbrev-ref" in joined:
                 return subprocess.CompletedProcess(cmd, 0, stdout=f"{current_branch}\n", stderr="")
 
@@ -873,6 +992,82 @@ class TestCmdUpdateZipBranchRefusal:
         assert "not supported" in out
         # No actual download attempted.
         assert "Downloading latest version" not in out
+
+
+def _patch_update_preamble(monkeypatch, tmp_path, *, git_checkout: bool):
+    """Keep floor-failure branch tests away from real update side effects."""
+    from hermes_cli import main as hm
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(update_cmd.sys, "platform", "win32")
+    monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+    if git_checkout:
+        (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(hm, "_run_pre_update_backup", lambda _args: None)
+    monkeypatch.setattr(hm, "_pause_windows_gateways_for_update", lambda: None)
+    monkeypatch.setattr(hm, "_resume_windows_gateways_after_update", lambda _token: None)
+    monkeypatch.setattr(hm, "_venv_scripts_dir", lambda: tmp_path)
+    monkeypatch.setattr(hm, "_detect_concurrent_hermes_instances", lambda _dir: [])
+    monkeypatch.setattr(hm, "_detect_venv_python_processes", lambda: [])
+    monkeypatch.setattr(hm, "_get_origin_url", lambda *_args: "https://github.com/NousResearch/hermes-agent.git")
+    monkeypatch.setattr(update_cmd, "_discard_lockfile_churn", lambda *_args: None)
+    monkeypatch.setattr(update_cmd, "_normalize_managed_eol", lambda *_args: None)
+    if git_checkout:
+        monkeypatch.setattr(
+            update_cmd.subprocess,
+            "run",
+            lambda cmd, **_kwargs: subprocess.CompletedProcess(
+                cmd, 0, stdout="", stderr=""
+            ),
+        )
+    return hm, update_cmd
+
+
+def test_update_zip_floor_failure_is_friendly_and_fail_closed(monkeypatch, tmp_path, capsys):
+    """A ZIP update must not report success when security repair is blocked."""
+    hm, update_cmd = _patch_update_preamble(monkeypatch, tmp_path, git_checkout=False)
+    monkeypatch.setattr(
+        update_cmd,
+        "_update_via_zip",
+        lambda _args, **_kwargs: (_ for _ in ()).throw(
+            update_cmd._pip_security.PipFloorError("pip 26.1.2 could not be verified")
+        ),
+    )
+
+    args = SimpleNamespace(yes=True, force=True, force_venv=True)
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._cmd_update_impl(args, gateway_mode=False)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Update blocked" in captured.out
+    assert "Traceback" not in captured.out
+    assert "Traceback" not in captured.err
+    assert hm.PROJECT_ROOT == tmp_path
+
+
+def test_update_git_floor_failure_is_friendly_and_fail_closed(monkeypatch, tmp_path, capsys):
+    """A Git/update path must convert a floor failure to its normal error path."""
+    hm, update_cmd = _patch_update_preamble(monkeypatch, tmp_path, git_checkout=True)
+    monkeypatch.setattr(
+        hm,
+        "_resolve_update_branch",
+        lambda _args: (_ for _ in ()).throw(
+            update_cmd._pip_security.PipFloorError("pip upgrade refused")
+        ),
+    )
+
+    args = SimpleNamespace(yes=True, force=True, force_venv=True)
+    with pytest.raises(SystemExit) as exc_info:
+        update_cmd._cmd_update_impl(args, gateway_mode=False)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Update blocked" in captured.out
+    assert "Traceback" not in captured.out
+    assert "Traceback" not in captured.err
+    assert hm.PROJECT_ROOT == tmp_path
 
 
 def test_is_termux_env_true_for_termux_prefix():
@@ -1372,3 +1567,26 @@ class TestUpdateNodeDependencies:
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"
+
+
+def test_lazy_refresh_reports_failures_before_restart_required_return(
+    monkeypatch, capsys
+):
+    """A restart boundary must not hide another feature's failed refresh."""
+    import hermes_cli.update_cmd as update_cmd
+    import tools.lazy_deps as lazy_deps
+
+    monkeypatch.setattr(lazy_deps, "active_features", lambda: ["a", "b"])
+    monkeypatch.setattr(
+        lazy_deps,
+        "refresh_active_features",
+        lambda **_kwargs: {
+            "a": "restart-required: restart required before lazy repair: nacl",
+            "b": "failed: resolver failed",
+        },
+    )
+
+    assert update_cmd._refresh_active_lazy_features() is False
+    out = capsys.readouterr().out
+    assert "restart required" in out
+    assert "b failed to refresh: resolver failed" in out

--- a/tests/hermes_cli/test_dashboard_web_dist_validation.py
+++ b/tests/hermes_cli/test_dashboard_web_dist_validation.py
@@ -36,6 +36,10 @@ def _args(**over):
 
 
 def _wire_common(main_mod, monkeypatch):
+    # Dashboard startup now rechecks the lazy dependency contract before
+    # importing FastAPI.  These tests isolate web-dist validation, so keep
+    # that dependency policy out of their filesystem assertions.
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
     monkeypatch.setattr(
         "hermes_cli.profiles.get_active_profile_name", lambda: "default"
     )
@@ -138,7 +142,6 @@ def test_skip_build_missing_dist_attempts_one_recovery_build(
 # ---------------------------------------------------------------------------
 # Desktop-inherited env isolation (issue #52945 / supersedes #52948, #67402)
 # ---------------------------------------------------------------------------
-
 
 
 

--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -283,7 +283,11 @@ def test_repair_install_falls_back_to_break_system_packages_without_uv(
         class R:
             returncode = 0
             stderr = ""
-            stdout = ""
+            stdout = (
+                "pip 26.1.2 from /venv/site-packages/pip"
+                if "--version" in cmd
+                else ""
+            )
 
         return R()
 
@@ -317,7 +321,11 @@ def test_repair_install_uses_plain_pip_when_not_externally_managed(
         class R:
             returncode = 0
             stderr = ""
-            stdout = ""
+            stdout = (
+                "pip 26.1.2 from /venv/site-packages/pip"
+                if "--version" in cmd
+                else ""
+            )
 
         return R()
 
@@ -535,9 +543,6 @@ def test_bump_marker_attempts_handles_missing_and_corrupt_bodies(tmp_path):
 
     m.write_text('{"attempts": 2}', encoding="utf-8")
     assert ir.bump_marker_attempts(m) == 3
-
-
-
 
 
 

--- a/tests/hermes_cli/test_lazy_refresh_venv_repair.py
+++ b/tests/hermes_cli/test_lazy_refresh_venv_repair.py
@@ -15,6 +15,92 @@ import pytest
 
 
 
+def test_package_only_install_detects_interpreter_flags_before_pip_marker(
+    monkeypatch,
+):
+    floor_prefixes: list[list[str]] = []
+    install_commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        m,
+        "_ensure_direct_pip_floor",
+        lambda prefix, *, env=None: floor_prefixes.append(prefix),
+    )
+    monkeypatch.setattr(
+        m,
+        "_run_install_with_heartbeat",
+        lambda cmd, *, env=None: install_commands.append(cmd),
+    )
+
+    command = ["python", "-E", "-m", "pip", "install", "pkg==1.0"]
+    m._run_package_only_install(command)
+
+    assert floor_prefixes == [["python", "-E", "-m", "pip"]]
+    assert install_commands == [command]
+
+
+def test_direct_pip_prefix_marker_extracts_full_prefix():
+    assert m._direct_pip_prefix(["python", "-E", "-m", "pip", "install"]) == [
+        "python",
+        "-E",
+        "-m",
+        "pip",
+    ]
+    assert m._direct_pip_prefix(["uv", "pip", "install"]) is None
+
+
+def test_direct_pip_floor_preserves_interpreter_flags_for_ensurepip(monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        if command[-1] == "--version":
+            return type("Result", (), {"returncode": 1, "stdout": "", "stderr": "missing"})()
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(m.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        m._pip_security,
+        "ensure_pip_floor",
+        lambda *args, **kwargs: (True, ""),
+    )
+
+    m._ensure_direct_pip_floor(["python", "-E", "-m", "pip"])
+
+    assert calls[1] == [
+        "python",
+        "-E",
+        "-m",
+        "ensurepip",
+        "--upgrade",
+        "--default-pip",
+    ]
+
+
+def test_early_repair_bounds_ensurepip_and_force_reinstall(monkeypatch, tmp_path):
+    import hermes_cli._early_recovery as early_recovery
+
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(early_recovery.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        early_recovery._pip_security,
+        "ensure_pip_floor",
+        lambda *args, **kwargs: (True, ""),
+    )
+
+    assert early_recovery._run_repair_install(["PyYAML==6.0.3"], tmp_path) is True
+
+    ensure_call = next(call for call in calls if "ensurepip" in call[0])
+    repair_call = next(call for call in calls if "--force-reinstall" in call[0])
+    assert ensure_call[1]["timeout"] == 120
+    assert repair_call[1]["timeout"] == 600
+
+
 def test_detect_returns_none_when_probe_subprocess_fails(tmp_path, monkeypatch):
     python = tmp_path / "python"
     python.write_text("", encoding="utf-8")
@@ -81,6 +167,26 @@ def test_repair_runs_force_reinstall_with_pyproject_pins(
         ]
     ]
     assert detect_calls["count"] == 1
+
+
+def test_repair_handles_pip_floor_failure_without_raising(monkeypatch):
+    """A floor refusal is a failed repair, not an uncaught update traceback."""
+    monkeypatch.setattr(
+        m,
+        "_run_package_only_install",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            m._pip_security.PipFloorError("pip floor unavailable")
+        ),
+    )
+    monkeypatch.setattr(
+        m,
+        "_lazy_refresh_repair_specs",
+        lambda _packages: ["pyyaml==6.0.3"],
+    )
+
+    assert m._repair_broken_lazy_refresh_imports(
+        ["python", "-m", "pip"], ["PyYAML"]
+    ) is False
 
 
 def test_refresh_repairs_venv_after_lazy_failure(tmp_path, monkeypatch, capsys):
@@ -253,10 +359,6 @@ def test_cmd_update_captures_and_propagates_pre_rebuild_snapshot(
             expected_env,
         )
     ]
-
-
-
-
 
 
 

--- a/tests/hermes_cli/test_memory_setup_provider_arg.py
+++ b/tests/hermes_cli/test_memory_setup_provider_arg.py
@@ -55,6 +55,12 @@ class TestInstallDependenciesRunner:
             calls.append(cmd)
             if run_behavior:
                 return run_behavior(cmd)
+            if cmd[-1] == "--version":
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="pip 26.1.2 from /venv/site-packages/pip (python 3.13)",
+                    stderr="",
+                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         # The hermetic conftest sets HERMES_DISABLE_LAZY_INSTALLS=1 so no test
@@ -86,9 +92,18 @@ class TestInstallDependenciesRunner:
 
     def test_bootstraps_pip_via_ensurepip_when_missing(self, tmp_path):
         """Neither uv nor pip -> ensurepip bootstrap, then pip install."""
+        probes = {"count": 0}
+
         def behavior(cmd):
             if cmd[-1] == "--version":
-                return SimpleNamespace(returncode=1, stdout="", stderr="")
+                probes["count"] += 1
+                if probes["count"] == 1:
+                    return SimpleNamespace(returncode=1, stdout="", stderr="")
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="pip 26.1.2 from /venv/site-packages/pip (python 3.13)",
+                    stderr="",
+                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         calls, py = self._run_with_missing_dep(tmp_path, lambda b: None, behavior)

--- a/tests/hermes_cli/test_psutil_android_extract.py
+++ b/tests/hermes_cli/test_psutil_android_extract.py
@@ -109,11 +109,17 @@ def test_install_psutil_android_script_uses_patched_tree(tmp_path, monkeypatch, 
         shutil.copyfile(archive, dest)
         return str(dest), None
 
-    def fake_subprocess_run(cmd: list[str]):
+    def fake_subprocess_run(cmd: list[str], **_kwargs):
+        if cmd[-1] == "--version":
+            return type(
+                "RunResult",
+                (),
+                {"returncode": 0, "stdout": "pip 26.1.2 from /venv/lib/python3.13/site-packages/pip", "stderr": ""},
+            )()
         src_root = Path(cmd[-1])
         patched = (src_root / "psutil" / "_common.py").read_text(encoding="utf-8")
         assert REPLACEMENT in patched
-        return type("RunResult", (), {"returncode": 0})()
+        return type("RunResult", (), {"returncode": 0, "stdout": "", "stderr": ""})()
 
     monkeypatch.setattr(installer.sys, "argv", ["install_psutil_android.py"])
     monkeypatch.setattr(installer, "_resolve_install_cmd", lambda *_args: ["python", "-m", "pip"])
@@ -124,3 +130,67 @@ def test_install_psutil_android_script_uses_patched_tree(tmp_path, monkeypatch, 
 
     captured = capsys.readouterr()
     assert "psutil installed via Android compatibility shim" in captured.out
+
+
+def test_install_psutil_android_direct_pip_requires_security_floor(monkeypatch, capsys):
+    """The standalone direct-pip fallback must fail closed below the floor."""
+    import scripts.install_psutil_android as installer
+
+    monkeypatch.setattr(installer.sys, "argv", ["install_psutil_android.py"])
+    monkeypatch.setattr(
+        installer,
+        "_resolve_install_cmd",
+        lambda *_args: ["python", "-m", "pip"],
+    )
+    monkeypatch.setattr(
+        installer._pip_security,
+        "ensure_pip_floor",
+        lambda *_args, **_kwargs: (False, "pip remains below pip>=26.1.2"),
+    )
+    monkeypatch.setattr(
+        installer.urllib.request,
+        "urlretrieve",
+        lambda *_args, **_kwargs: pytest.fail("download must not start below pip floor"),
+    )
+
+    assert installer.main() == 1
+    assert "pip security floor unavailable" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (["python", "-m", "pip"], True),
+        (["pip"], True),
+        (["pip3"], True),
+        (["pip3.13"], True),
+        (["pip3.13.exe"], True),
+        (["/usr/local/bin/pip3.13"], True),
+        (["uv", "pip"], False),
+        (["pipx", "runpip"], False),
+    ],
+)
+def test_install_psutil_android_recognizes_versioned_pip_launchers(command, expected):
+    import scripts.install_psutil_android as installer
+
+    assert installer._is_direct_pip_command(command) is expected
+
+
+def test_install_psutil_android_preserves_pip_executable_paths_with_spaces():
+    import scripts.install_psutil_android as installer
+
+    command = installer._resolve_install_cmd(
+        "/srv/Hermes Agent/venv/bin/python -m pip",
+        prefer_uv=False,
+    )
+
+    assert command == ["/srv/Hermes Agent/venv/bin/python", "-m", "pip"]
+    assert installer._is_direct_pip_command(command) is True
+
+
+def test_install_psutil_android_detects_pip_marker_before_install_args():
+    import scripts.install_psutil_android as installer
+
+    assert installer._is_direct_pip_command(
+        ["python", "-E", "-m", "pip", "install"]
+    ) is True

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -4,6 +4,7 @@ import os
 import json
 import types
 
+import pytest
 
 from hermes_cli.config import load_config, save_config
 from hermes_cli import setup as setup_mod
@@ -160,6 +161,11 @@ def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tm
         ),
     )
     monkeypatch.setitem(sys.modules, "swe_rex", object())
+    ensured = []
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **kwargs: ensured.append((feature, kwargs)),
+    )
 
     from hermes_cli.setup import setup_terminal_backend
 
@@ -167,6 +173,97 @@ def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tm
 
     assert config["terminal"]["backend"] == "modal"
     assert config["terminal"]["modal_mode"] == "direct"
+    assert ensured == [("terminal.modal", {"prompt": False})]
+
+
+def test_daytona_setup_uses_lazy_runtime_closure(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("DAYTONA_API_KEY", raising=False)
+    config = load_config()
+
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice",
+        lambda question, choices, default=0: (
+            4 if question == "Select terminal backend:" else default
+        ),
+    )
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: "daytona-key")
+    ensured = []
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **kwargs: ensured.append((feature, kwargs)),
+    )
+
+    from hermes_cli.setup import setup_terminal_backend
+
+    setup_terminal_backend(config)
+
+    assert config["terminal"]["backend"] == "daytona"
+    assert ensured == [("terminal.daytona", {"prompt": False})]
+
+
+@pytest.mark.parametrize(
+    ("backend_index", "feature", "message"),
+    [
+        (2, "terminal.modal", "Modal SDK security contract unavailable"),
+        (4, "terminal.daytona", "Daytona SDK security contract unavailable"),
+    ],
+)
+def test_terminal_sdk_failure_restores_previous_backend(
+    tmp_path, monkeypatch, backend_index, feature, message, capsys
+):
+    """A failed exact SDK repair must not persist or continue a backend."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.setup.managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice",
+        lambda question, choices, default=0: (
+            backend_index if question == "Select terminal backend:" else default
+        ),
+    )
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature_name, **kwargs: (_ for _ in ()).throw(
+            RuntimeError(f"{feature_name} resolver failed")
+        ),
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "prompt",
+        lambda *args, **kwargs: pytest.fail("credentials must not be requested after SDK failure"),
+    )
+    config = load_config()
+
+    setup_mod.setup_terminal_backend(config)
+
+    assert config["terminal"]["backend"] == "local"
+    out = capsys.readouterr().out
+    assert message in out
+
+
+def test_modal_sdk_failure_restores_previous_modal_mode(tmp_path, monkeypatch):
+    """A failed Modal repair must not leave a half-applied mode selection."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.setup.managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice",
+        lambda question, choices, default=0: (
+            2 if question == "Select terminal backend:" else default
+        ),
+    )
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature_name, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("modal resolver failed")
+        ),
+    )
+    config = load_config()
+    config["terminal"]["modal_mode"] = "managed"
+
+    setup_mod.setup_terminal_backend(config)
+
+    assert config["terminal"]["backend"] == "local"
+    assert config["terminal"]["modal_mode"] == "managed"
 
 
 # test_setup_slack_* moved to tests/gateway/test_slack_plugin_setup.py — the
@@ -178,6 +275,11 @@ def test_vercel_setup_configures_access_token_auth(tmp_path, monkeypatch):
     _clear_vercel_env(monkeypatch)
     monkeypatch.setenv("VERCEL_OIDC_TOKEN", "old-oidc")
     monkeypatch.setitem(sys.modules, "vercel", types.ModuleType("vercel"))
+    ensured = []
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **kwargs: ensured.append((feature, kwargs)),
+    )
     config = load_config()
 
     def fake_prompt_choice(question, choices, default=0):
@@ -202,6 +304,7 @@ def test_vercel_setup_configures_access_token_auth(tmp_path, monkeypatch):
     assert os.environ["VERCEL_TOKEN"] == "token"
     assert os.environ["VERCEL_PROJECT_ID"] == "project"
     assert os.environ["VERCEL_TEAM_ID"] == "team"
+    assert ensured == [("terminal.vercel", {"prompt": False})]
 
 
 def test_vercel_setup_prefills_project_and_team_from_link_file(tmp_path, monkeypatch):
@@ -218,6 +321,11 @@ def test_vercel_setup_prefills_project_and_team_from_link_file(tmp_path, monkeyp
     )
     monkeypatch.chdir(nested)
     monkeypatch.setitem(sys.modules, "vercel", types.ModuleType("vercel"))
+    ensured = []
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda feature, **kwargs: ensured.append((feature, kwargs)),
+    )
     config = load_config()
     config["terminal"]["container_disk"] = 999
 
@@ -250,3 +358,34 @@ def test_vercel_setup_prefills_project_and_team_from_link_file(tmp_path, monkeyp
     assert os.environ["VERCEL_TEAM_ID"] == "linked-team"
     assert defaults["    Vercel project ID"] == "linked-project"
     assert defaults["    Vercel team ID"] == "linked-team"
+    assert ensured == [("terminal.vercel", {"prompt": False})]
+
+
+def test_vercel_setup_refuses_unverified_sdk_and_preserves_backend(tmp_path, monkeypatch):
+    """A failed exact contract must not persist a Vercel backend."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_vercel_env(monkeypatch)
+    monkeypatch.delitem(sys.modules, "vercel", raising=False)
+    monkeypatch.setattr(
+        "tools.lazy_deps.ensure",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("uv resolver policy rejected vercel==0.7.2")
+        ),
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "_prompt_vercel_sandbox_settings",
+        lambda *_args, **_kwargs: pytest.fail("Vercel settings must not run after SDK failure"),
+    )
+    monkeypatch.setattr(
+        setup_mod,
+        "prompt_choice",
+        lambda question, choices, default=0: (
+            5 if question == "Select terminal backend:" else default
+        ),
+    )
+    config = load_config()
+
+    setup_mod.setup_terminal_backend(config)
+
+    assert config["terminal"]["backend"] == "local"

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -23,6 +23,13 @@ def _make_run_side_effect(
     def side_effect(cmd, **kwargs):
         joined = " ".join(str(c) for c in cmd)
 
+        if cmd and cmd[-1] == "--version" and "pip" in cmd:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="pip 26.1.2 from /venv/site-packages/pip (python 3.13)",
+                stderr="",
+            )
         if "rev-parse" in joined and "--abbrev-ref" in joined:
             return subprocess.CompletedProcess(cmd, 0, stdout=f"{branch}\n", stderr="")
         if "rev-parse" in joined and "--verify" in joined:

--- a/tests/hermes_cli/test_update_zip_symlink_reject.py
+++ b/tests/hermes_cli/test_update_zip_symlink_reject.py
@@ -122,7 +122,20 @@ def test_update_via_zip_accepts_normal_member(tmp_path, monkeypatch, capsys):
     with patch("urllib.request.urlretrieve", side_effect=fake_urlretrieve), \
          patch("subprocess.run") as fake_run, \
          patch("subprocess.check_call"):
-        fake_run.return_value = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        def fake_run_result(cmd, **_kwargs):
+            if cmd and cmd[-1] == "--version" and "pip" in cmd:
+                return type(
+                    "R",
+                    (),
+                    {
+                        "returncode": 0,
+                        "stdout": "pip 26.1.2 from /venv/site-packages/pip (python 3.13)",
+                        "stderr": "",
+                    },
+                )()
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        fake_run.side_effect = fake_run_result
         try:
             hermes_main._update_via_zip(args)
         except SystemExit:

--- a/tests/skills/test_google_workspace_setup.py
+++ b/tests/skills/test_google_workspace_setup.py
@@ -68,6 +68,11 @@ def test_installer_repairs_stale_transitives(setup_module, monkeypatch):
         "_missing_required_packages",
         lambda: next(states),
     )
+    monkeypatch.setattr(
+        setup_module,
+        "_ensure_pip_floor",
+        lambda *args, **kwargs: (True, ""),
+    )
     calls = []
     monkeypatch.setattr(
         setup_module.subprocess,
@@ -88,3 +93,175 @@ def test_installer_repairs_stale_transitives(setup_module, monkeypatch):
             "pyasn1==0.6.4",
         ]
     ]
+
+
+def test_standalone_pip_install_is_bounded_and_timeout_is_failure(
+    setup_module, monkeypatch
+):
+    states = iter([["google-auth==2.55.1"]])
+    monkeypatch.setattr(setup_module, "_missing_required_packages", lambda: next(states))
+    monkeypatch.setattr(
+        setup_module,
+        "_ensure_pip_floor",
+        lambda *args, **kwargs: (True, ""),
+    )
+    monkeypatch.setattr(setup_module.shutil, "which", lambda _name: None)
+    calls = []
+
+    def timed_out(argv, **kwargs):
+        calls.append((argv, kwargs))
+        raise setup_module.subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    monkeypatch.setattr(setup_module.subprocess, "check_call", timed_out)
+
+    assert setup_module.install_deps() is False
+    assert calls[0][1]["timeout"] == 300
+
+
+def test_standalone_copy_uses_bundled_pip_floor_guard(setup_module, monkeypatch):
+    """A copied skill must still verify pip before its direct install."""
+    states = iter(
+        [
+            ["google-auth==2.55.1"],
+            [],
+        ]
+    )
+    monkeypatch.setattr(setup_module, "_ensure_pip_floor", None)
+    monkeypatch.setattr(
+        setup_module,
+        "_missing_required_packages",
+        lambda: next(states),
+    )
+    floor_probes = []
+    installs = []
+
+    def fake_run(argv, **kwargs):
+        floor_probes.append((argv, kwargs))
+        return type(
+            "RunResult",
+            (),
+            {
+                "returncode": 0,
+                "stdout": "pip 26.1.2 from /standalone/site-packages/pip",
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr(setup_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        setup_module.subprocess,
+        "check_call",
+        lambda argv, **_kwargs: installs.append(argv),
+    )
+
+    assert setup_module.install_deps() is True
+    assert floor_probes and floor_probes[0][0][-1] == "--version"
+    assert installs == [
+        [
+            setup_module.sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--quiet",
+            "google-auth==2.55.1",
+        ]
+    ]
+
+
+def test_standalone_copy_fails_closed_when_pip_probe_errors(setup_module):
+    result = setup_module._bundled_ensure_pip_floor(
+        ["python", "-m", "pip"],
+        runner=lambda *_args, **_kwargs: type(
+            "RunResult",
+            (),
+            {"returncode": 1, "stdout": "", "stderr": "pip unavailable"},
+        )(),
+    )
+    assert result[0] is False
+    assert "probe failed" in result[1]
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        (
+            "WARNING: pip 99.0 is available\n"
+            "pip 26.1.1 from /standalone/site-packages/pip",
+            False,
+        ),
+        ("WARNING: pip 99.0 is available", False),
+        ("pip 26.1.2 from    ", False),
+        ("pip 26.1.2 from", False),
+        ("pip 26.1.2, from /standalone/pip", False),
+        ("pip 26.1.2) from /standalone/pip", False),
+        (
+            "pip 26.1.2 from /standalone/site-packages/pip [unexpected extra]",
+            False,
+        ),
+        (
+            "pip 26.1.2 from /standalone/site-packages/pip trailing",
+            False,
+        ),
+        (
+            "pip 26.1.2 from /standalone/site-packages/pip (python 3.13)",
+            True,
+        ),
+        (
+            "pip 26.1.2 from /srv/Hermes Agent/venv/site-packages/pip "
+            "(python 3.13)",
+            True,
+        ),
+        (
+            r"pip 26.1.2 from C:\Program Files\Hermes Agent\venv\Lib"
+            r"\site-packages\pip (python 3.13)",
+            True,
+        ),
+        (
+            "pip 26.1.2 from /home/user/[work]/'venv'/site-packages/pip",
+            True,
+        ),
+        (
+            "pip 26.1.2 from '/srv/Hermes Agent/venv/site-packages/pip' "
+            "(python 3.13)",
+            False,
+        ),
+        (
+            "WARNING: pip 99.0 is available\n"
+            "pip 26.1.2 from /standalone/site-packages/pip",
+            True,
+        ),
+        (
+            "pip 26.1.2 from /standalone/site-packages/pip\n"
+            "pip 26.1.2 from /other/site-packages/pip",
+            False,
+        ),
+    ],
+)
+def test_bundled_pip_floor_requires_one_canonical_record(
+    setup_module, output, expected
+):
+    assert setup_module._bundled_pip_version_meets_floor(output) is expected
+
+
+def test_shallow_standalone_copy_repo_search_has_no_fixed_parent_index(
+    setup_module,
+):
+    """A shallow copied script must fall back instead of indexing parents."""
+    assert setup_module._find_repo_root(Path("/setup.py")) is None
+
+
+def test_standalone_copy_ignores_fake_hermes_ancestor(setup_module, tmp_path):
+    """A fake sibling package must not become the trusted floor helper."""
+    fake_root = tmp_path / "fake-hermes"
+    (fake_root / "hermes_cli").mkdir(parents=True)
+    (fake_root / "hermes_cli" / "_pip_security.py").write_text(
+        "def ensure_pip_floor(*args, **kwargs): raise AssertionError('fake')\n",
+        encoding="utf-8",
+    )
+    (fake_root / "pyproject.toml").write_text(
+        '[project]\nname = "unrelated-project"\n',
+        encoding="utf-8",
+    )
+
+    copied_script = fake_root / "copied" / "setup.py"
+    assert setup_module._find_repo_root(copied_script) is None

--- a/tests/test_dependency_security_floors.py
+++ b/tests/test_dependency_security_floors.py
@@ -1,0 +1,662 @@
+"""Regression contracts for the #41374 installer dependency floors."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import _pip_security
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+UPDATE_CMD = REPO_ROOT / "hermes_cli" / "update_cmd.py"
+MAIN_CMD = REPO_ROOT / "hermes_cli" / "main.py"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _load_voice_doctor():
+    path = REPO_ROOT / "scripts" / "discord-voice-doctor.py"
+    spec = importlib.util.spec_from_file_location("discord_voice_doctor", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _function_body(source: str, name: str) -> str:
+    start = source.index(f"function {name}")
+    brace = source.index("{", start)
+    depth = 0
+    quote = None
+    in_comment = False
+    index = brace
+    while index < len(source):
+        char = source[index]
+        if in_comment:
+            if char == "\n":
+                in_comment = False
+            index += 1
+            continue
+        if quote is not None:
+            # PowerShell uses a backtick to escape the next character and
+            # doubled single quotes to embed a quote in a literal.
+            if char == "`":
+                index += 2
+                continue
+            if char == quote:
+                if quote == "'" and index + 1 < len(source) and source[index + 1] == "'":
+                    index += 2
+                    continue
+                quote = None
+            index += 1
+            continue
+        if char == "#":
+            in_comment = True
+        elif char in {"'", '"'}:
+            quote = char
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                body = source[brace : index + 1]
+                assert body.count("\n") > 1, f"suspicious body slice for {name}"
+                return body
+        index += 1
+    raise AssertionError(f"unterminated function body for {name}")
+
+
+def test_windows_discord_recovery_carries_direct_security_pins() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    body = _function_body(source, "Install-PlatformSdks")
+
+    assert 'SecuritySpecs = @("PyNaCl==1.6.2", "aiohttp==3.14.3")' in body
+    assert 'Spec = "discord.py==2.7.1"' in body
+    assert 'ExtraSpecs = @("davey==0.1.4", "brotlicffi==1.2.0.1", "cffi==2.0.0")' in body
+    assert 'foreach ($extraSpec in @($sdk.ExtraSpecs | Where-Object { $_ }))' in body
+    assert 'foreach ($securitySpec in @($sdk.SecuritySpecs | Where-Object { $_ }))' in body
+    assert "Test-VenvPackageExactVersion" in body
+    assert "Ensure-VenvPipFloor" in body
+    assert body.index("Ensure-VenvPipFloor") < body.index(
+        "foreach ($regularSpec in $missingRegularSpecs)"
+    )
+    assert "securityInstallFailures" in body
+    assert "regularInstallFailures" in body
+    assert "remainingRegularSpecs" in body
+    assert '"davey==0.1.4"' in body
+    assert '"brotlicffi==1.2.0.1"' in body
+    assert "allSecuritySpecs" in body
+    assert "securitySpecsToRepair" in body
+    assert "remainingSecuritySpecs" in body
+    assert body.index("securitySpecsToRepair") > body.index(
+        "foreach ($regularSpec in $missingRegularSpecs)"
+    )
+    assert body.count("$allSecuritySpecs | Where-Object") >= 2
+    assert '$securityPackageName -ieq "PyNaCl"' in body
+    assert '$securityInstallArgs = @("--no-deps")' in body
+    assert "pip install @securityInstallArgs $securitySpec" in body
+    assert "pip install --no-deps $securitySpec" not in body
+    assert "Test-VenvRuntimeImports" in body
+    assert "runtimeImportFailures" in body
+    assert '"multidict"' in source
+    assert '"cffi"' in source
+    assert "throw \"Platform-SDK security repair failed" in body
+
+
+def test_windows_security_spec_syntax_fails_closed() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    helper = _function_body(source, "Test-VenvPackageExactVersion")
+    assert 'throw "Unsupported security package spec syntax: $Spec"' in helper
+
+
+def test_windows_slack_recovery_carries_aiohttp_security_pin() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    body = _function_body(source, "Install-PlatformSdks")
+    assert 'Import = "slack_sdk"' in body
+    assert 'Import = "slack_bolt"' in body
+    assert 'Spec = "slack-sdk==3.43.0"' in body
+    assert 'Spec = "slack-bolt==1.29.0"' in body
+    assert 'SecuritySpecs = @("aiohttp==3.14.3")' in body
+    assert "recovery-only direct closure pin" in body
+
+
+def test_windows_security_repair_checks_runtime_closure_after_metadata() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    body = _function_body(source, "Install-PlatformSdks")
+
+    runtime_call = "Test-VenvRuntimeImports -PythonExe $pythonExe -Sdks $needed"
+    assert body.count(runtime_call) == 2
+    assert body.index(runtime_call) < body.index(
+        "if ($missingRegularSpecs.Count -eq 0"
+    )
+    assert body.rindex(runtime_call) > body.index("$remainingSecuritySpecs")
+    assert 'throw "Platform-SDK runtime verification failed' in body
+    assert '"aiohappyeyeballs"' in source
+    assert '"multidict"' in source
+    assert '"nacl"' in source
+    assert '"cffi"' in source
+
+
+def test_slack_adapter_defers_optional_aiohttp_import() -> None:
+    source = (REPO_ROOT / "plugins" / "platforms" / "slack" / "adapter.py").read_text(
+        encoding="utf-8"
+    )
+    sentinel = "aiohttp: Any = None"
+    assert sentinel in source
+    assert "import aiohttp as _aiohttp" in source
+    assert source.index(sentinel) < source.index("def slack_deps_present")
+    assert source.index("import aiohttp as _aiohttp") > source.index("try:")
+
+
+def test_feishu_lazy_contract_rebinds_websocket_runtime() -> None:
+    source = (REPO_ROOT / "plugins/platforms/feishu/adapter.py").read_text(
+        encoding="utf-8"
+    )
+    assert "import websockets" in source
+    assert "FEISHU_WEBSOCKET_AVAILABLE" in source
+    assert "import websockets as _websockets" in source
+    assert "websockets = _websockets" in source
+
+
+def test_dingtalk_lazy_contract_rebinds_card_sdk_runtime() -> None:
+    source = (REPO_ROOT / "plugins/platforms/dingtalk/adapter.py").read_text(
+        encoding="utf-8"
+    )
+    assert "def _load_optional_card_sdk" in source
+    assert "_load_optional_card_sdk()" in source
+    assert "CARD_SDK_AVAILABLE = True" in source
+
+
+def test_dingtalk_stream_contract_keeps_card_sdk_optional() -> None:
+    """Basic Stream Mode must not install the optional AI-card SDK."""
+    from tools.lazy_deps import LAZY_DEPS
+
+    assert "alibabacloud-dingtalk==2.2.42" not in LAZY_DEPS["platform.dingtalk"]
+    assert LAZY_DEPS["platform.dingtalk_card"] == (
+        "alibabacloud-dingtalk==2.2.42",
+    )
+
+
+def test_windows_ensurepip_recovery_verifies_the_pip_floor() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    helper = _function_body(source, "Ensure-VenvPipFloor")
+
+    assert '$MinimumPipVersion = "26.1.2"' in source
+    assert '$MinimumPipSpec = "pip>=$MinimumPipVersion"' in source
+    assert "ensurepip" in _function_body(source, "Install-PlatformSdks")
+    assert "pip install --upgrade $MinimumPipSpec" in helper
+    assert helper.count("Get-VenvPipVersion") >= 2
+    assert "return $false" in helper
+    runtime_helper = _function_body(source, "Test-VenvRuntimeImports")
+    assert "$securityNames" in runtime_helper
+    assert "$extraNames" in runtime_helper
+    assert "$securityPackageName" in source
+
+
+def test_windows_pip_probe_ignores_warning_lines() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    helper = _function_body(source, "Get-VenvPipVersion")
+    assert "foreach ($rawLine in @($output))" in helper
+    assert (
+        r"from\s+(?:/|[A-Za-z]:[\\/]|\\\\)"
+        in helper
+    )
+    assert "(?:\\s+\\(python\\s+\\d+(?:\\.\\d+){1,3}\\))?\\s*$" in helper
+    assert "$canonicalVersions" in helper
+    assert "$canonicalVersions.Count -ne 1" in helper
+    assert "continue" in helper
+    assert "TrimEnd" not in helper
+    assert r"\[\]" not in helper
+    assert r'[^\r\n"]*' in helper
+
+
+def test_termux_pip_bootstrap_uses_and_verifies_the_floor() -> None:
+    source = INSTALL_SH.read_text(encoding="utf-8")
+
+    assert 'MIN_PIP_VERSION="26.1.2"' in source
+    assert 'pip install --upgrade "pip>=${MIN_PIP_VERSION}"' in source
+    assert 'pip --version' in source
+    assert '"$MIN_PIP_VERSION" "$pip_version_output"' in source
+    assert "minimum = tuple(int(part) for part in sys.argv[1].split(\".\"))" in source
+    assert "if len(canonical_versions) == 1 and canonical_versions[0] >= minimum:" in source
+    assert "release_match = re.fullmatch" in source
+    assert r"\.post\d+" in source
+    assert "canonical_versions = []" in source
+    assert "line_match = re.fullmatch" in source
+    assert "len(canonical_versions) == 1" in source
+    assert "pip_upgrade_output" in source
+    assert "pip floor bootstrap failed" in source
+
+
+def test_legacy_setup_pip_floor_scans_all_version_candidates() -> None:
+    source = (REPO_ROOT / "setup-hermes.sh").read_text(encoding="utf-8")
+    assert "canonical_versions = []" in source
+    assert "line_match = re.fullmatch" in source
+    assert "len(canonical_versions) == 1" in source
+    assert "raise SystemExit(1)" in source
+
+
+@pytest.mark.parametrize(
+    ("script_path", "start_marker", "end_marker"),
+    [
+        (
+            INSTALL_SH,
+            '"$PIP_PYTHON" -c \'\n',
+            '\n\' "$MIN_PIP_VERSION"',
+        ),
+        (
+            REPO_ROOT / "setup-hermes.sh",
+            '"$SETUP_PYTHON" - "$MIN_PIP_VERSION" "$pip_version_output" <<\'PY\'\n',
+            "\nPY",
+        ),
+    ],
+)
+def test_shell_pip_floor_parsers_skip_bad_candidates_and_find_stable_release(
+    script_path: Path, start_marker: str, end_marker: str
+) -> None:
+    source = script_path.read_text(encoding="utf-8")
+    start = source.index(start_marker) + len(start_marker)
+    end = source.index(end_marker, start)
+    parser = source[start:end]
+    cases = (
+        # A high warning must not override the lower authoritative record.
+        (
+            "WARNING: pip 99.0 is outdated\n"
+            "pip 26.1.1 from /venv/site-packages/pip",
+            False,
+        ),
+        # A noncanonical warning alone is not version evidence.
+        ("WARNING: pip 99.0 is available", False),
+        ("pip 26.1.2 from    ", False),
+        ("pip 26.1.2 from", False),
+        ("pip 26.1.2, from /venv/site-packages/pip", False),
+        ("pip 26.1.2) from /venv/site-packages/pip", False),
+        (
+            "pip 26.1.2 from /venv/site-packages/pip [unexpected extra]",
+            False,
+        ),
+        ("pip 26.1.2 from /venv/site-packages/pip trailing", False),
+        (
+            "pip 26.1.2 from /venv/site-packages/pip (python 3.13)",
+            True,
+        ),
+        (
+            "pip 26.1.2 from /srv/Hermes Agent/venv/site-packages/pip "
+            "(python 3.13)",
+            True,
+        ),
+        (
+            r"pip 26.1.2 from C:\Program Files\Hermes Agent\venv\Lib"
+            r"\site-packages\pip (python 3.13)",
+            True,
+        ),
+        (
+            "pip 26.1.2 from /home/user/[work]/'venv'/site-packages/pip",
+            True,
+        ),
+        (
+            "pip 26.1.2 from '/srv/Hermes Agent/venv/site-packages/pip' "
+            "(python 3.13)",
+            False,
+        ),
+        # A warning may accompany one valid canonical record.
+        (
+            "warning pip 99.0 is outdated\n"
+            "pip 26.1.2.post1 from /venv/site-packages/pip",
+            True,
+        ),
+        # Conflicting/duplicate canonical records fail closed.
+        (
+            "pip 26.1.2 from /venv/site-packages/pip\n"
+            "pip 26.1.2 from /other/site-packages/pip",
+            False,
+        ),
+        (
+            "noise pip ???\n"
+            "pip 26.1.2.post1 from /venv/site-packages/pip",
+            True,
+        ),
+    )
+    for output, expected in cases:
+        result = subprocess.run(
+            [sys.executable, "-", "26.1.2", output],
+            input=parser,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+        assert (result.returncode == 0) is expected, (output, result.stderr)
+
+
+def test_termux_shell_floor_probes_fail_closed_on_pip_version_error() -> None:
+    install = INSTALL_SH.read_text(encoding="utf-8")
+    legacy = (REPO_ROOT / "setup-hermes.sh").read_text(encoding="utf-8")
+    assert 'if ! pip_version_output="$("$PIP_PYTHON" -m pip --version 2>&1)"; then' in install
+    assert 'if ! pip_version_output="$("$SETUP_PYTHON" -m pip --version 2>&1)"; then' in legacy
+    assert '"$MIN_PIP_VERSION" "$pip_version_output"' in legacy
+
+
+def test_update_no_uv_paths_verify_the_pip_floor() -> None:
+    source = UPDATE_CMD.read_text(encoding="utf-8")
+
+    assert "from tools.lazy_deps import _ensure_pip_floor" in source
+    assert source.count("_ensure_update_pip_floor(pip_cmd)") >= 2
+    assert "_MIN_PIP_SPEC" in source
+    start = source.index("def _ensure_update_pip_floor")
+    end = source.index("\ndef _refresh_active_lazy_features", start)
+    helper = source[start:end]
+    assert "timeout=15" in helper
+    assert "timeout=120" in helper
+    assert "floor helper import failed" in helper
+    upgrade_start = source.index("def _upgrade_pip_before_lazy_refresh")
+    upgrade_end = source.index("\ndef _ensure_update_pip_floor", upgrade_start)
+    upgrade_helper = source[upgrade_start:upgrade_end]
+    assert "except (" in upgrade_helper
+    assert "ImportError" in upgrade_helper
+    assert "OSError" in upgrade_helper
+    assert "subprocess.CalledProcessError" in upgrade_helper
+    assert "subprocess.TimeoutExpired" in upgrade_helper
+    assert "_pip_security.PipFloorError" in upgrade_helper
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("pip 26.1.1 from /venv/site-packages/pip (python 3.13)", False),
+        ("pip 26.1.2 from /venv/site-packages/pip (python 3.13)", True),
+        ("pip 26.1.2.post1 from /venv/site-packages/pip (python 3.13)", True),
+        (
+            "WARNING: pip 99.0 is available\npip 26.1.1 from /venv/site-packages/pip",
+            False,
+        ),
+        ("WARNING: pip 99.0 is available", False),
+        ("pip 26.1.2 from    ", False),
+        ("pip 26.1.2 from", False),
+        (
+            "WARNING: pip 99.0 is available\npip 26.1.2 from /venv/site-packages/pip",
+            True,
+        ),
+        (
+            "pip 26.1.2 from /venv/site-packages/pip\n"
+            "pip 26.1.2 from /other/site-packages/pip",
+            False,
+        ),
+        ("pip 26.1.2.dev0 from /venv/site-packages/pip (python 3.13)", False),
+        ("pip 26.1.2.rc1 from /venv/site-packages/pip (python 3.13)", False),
+        ("pip 26.1.2rc1 from /venv/site-packages/pip (python 3.13)", False),
+        ("pip 26.1.2+local from /venv/site-packages/pip (python 3.13)", False),
+        ("pip 26.1.2, from /venv/site-packages/pip (python 3.13)", False),
+        ("pip 26.1.2) from /venv/site-packages/pip (python 3.13)", False),
+        (
+            "pip 26.1.2 from /home/user/[work]/venv/site-packages/pip",
+            True,
+        ),
+        (
+            "pip 26.1.2 from /home/user/'work'/venv/site-packages/pip",
+            True,
+        ),
+        (
+            "pip 26.1.2 from /srv/Hermes Agent/venv/site-packages/pip "
+            "(python 3.13)",
+            True,
+        ),
+        (
+            r"pip 26.1.2 from C:\Program Files\Hermes Agent\venv\Lib"
+            r"\site-packages\pip (python 3.13)",
+            True,
+        ),
+        (
+            "pip 26.1.2 from '/srv/Hermes Agent/venv/site-packages/pip' "
+            "(python 3.13)",
+            False,
+        ),
+        (
+            "pip 26.1.2 from /venv/site-packages/pip [unexpected extra]",
+            False,
+        ),
+        ("pip 26.1.2 from /venv/site-packages/pip trailing", False),
+        (
+            "pip 26.1.2 from /venv/site-packages/pip (python 3.13)",
+            True,
+        ),
+    ],
+)
+def test_pip_floor_accepts_only_stable_versions(output: str, expected: bool) -> None:
+    assert _pip_security.pip_version_meets_floor(output) is expected
+
+
+def test_pip_floor_does_not_normalize_punctuated_version_tokens() -> None:
+    assert not _pip_security.pip_version_meets_floor(
+        "pip 26.1.2, from /venv/site-packages/pip"
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("1.6.2", (1, 6, 2)),
+        ("1.6.2.post1", (1, 6, 2)),
+        ("1.6.2.dev0", None),
+        ("1.6.2rc1", None),
+        ("1.6.2+local", None),
+        ("1.6.2.vendor", None),
+    ],
+)
+def test_shared_stable_version_evidence_rejects_nonstable_values(
+    value: str, expected: tuple[int, ...] | None
+) -> None:
+    assert _pip_security.stable_version_tuple(value) == expected
+
+
+def test_messaging_extra_uses_explicit_discord_voice_contract() -> None:
+    """Published pip metadata must keep voice support at the fixed floor."""
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    messaging = data["project"]["optional-dependencies"]["messaging"]
+    assert "discord.py==2.7.1" in messaging
+    assert "davey==0.1.4" in messaging
+    assert "brotlicffi==1.2.0.1" in messaging
+    assert "PyNaCl==1.6.2" in messaging
+
+    # Avoid discord.py's stale [voice] resolver metadata while retaining its
+    # voice runtime dependencies explicitly at known-compatible versions.
+    assert not any(spec.startswith("discord.py[voice]") for spec in messaging)
+    assert re.search(r"davey==0\.1\.4", " ".join(messaging))
+    assert re.search(r"PyNaCl==1\.6\.2", " ".join(messaging))
+    assert re.search(r"discord\.py==2\.7\.1", " ".join(messaging))
+
+
+def test_lazy_aiohttp_security_roots_are_explicitly_pinned() -> None:
+    """Every supported lazy SDK root carries the patched aiohttp contract."""
+    from tools.lazy_deps import LAZY_DEPS
+
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    expected = {
+        "platform.dingtalk": "dingtalk",
+        "platform.feishu": "feishu",
+        "search.firecrawl": "firecrawl",
+        "tts.edge": "edge-tts",
+        "memory.hindsight": "hindsight",
+        "terminal.modal": "modal",
+        "terminal.daytona": "daytona",
+        # Callback mode has its own lazy installer and can be enabled without
+        # the broader messaging extra, so it must carry the closure too.
+        "platform.wecom_callback": "wecom",
+    }
+    for feature, extra in expected.items():
+        assert "aiohttp==3.14.3" in LAZY_DEPS[feature], feature
+        assert "aiohttp==3.14.3" in data["project"]["optional-dependencies"][extra]
+
+
+def test_messaging_security_pin_is_in_the_committed_lock() -> None:
+    """Keep the fail-closed published extra and uv metadata in sync."""
+    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    project = next(
+        package
+        for package in lock["package"]
+        if package.get("name") == "hermes-agent"
+        and package.get("source") == {"editable": "."}
+    )
+    messaging = project["optional-dependencies"]["messaging"]
+    assert {item["name"] for item in messaging} >= {"davey", "discord-py", "pynacl"}
+    requires_dist = project["metadata"]["requires-dist"]
+    assert {
+        item["specifier"]
+        for item in requires_dist
+        if item["name"] == "pynacl" and item.get("marker") == "extra == 'messaging'"
+    } == {"==1.6.2"}
+    assert {
+        item["specifier"]
+        for item in requires_dist
+        if item["name"] == "davey" and item.get("marker") == "extra == 'messaging'"
+    } == {"==0.1.4"}
+    assert {
+        item.get("extras")
+        for item in requires_dist
+        if item["name"] == "discord-py" and item.get("marker") == "extra == 'messaging'"
+    } == {None}
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("1.5.0", False),
+        ("1.6.2.dev0", False),
+        ("1.6.2rc1", False),
+        ("1.6.2+local", False),
+        ("1.6.2", True),
+        ("1.6.2.post1", True),
+    ],
+)
+def test_discord_voice_doctor_rejects_nonfixed_pynacl(version: str, expected: bool) -> None:
+    doctor = _load_voice_doctor()
+    assert doctor._pynacl_meets_security_floor(version) is expected
+
+
+@pytest.mark.parametrize("version", ["1.6.2.1", "2.0", "2.0.0.post1"])
+def test_discord_voice_doctor_accepts_future_stable_pynacl_releases(version: str) -> None:
+    doctor = _load_voice_doctor()
+    assert doctor._pynacl_meets_security_floor(version) is True
+
+
+def test_discord_voice_doctor_guidance_uses_fixed_voice_contract() -> None:
+    source = (REPO_ROOT / "scripts" / "discord-voice-doctor.py").read_text(
+        encoding="utf-8"
+    )
+    assert "discord.py==2.7.1 davey==0.1.4 PyNaCl==1.6.2" in source
+    assert "need >=1.6.2" in source
+    assert "pip install PyNaCl==1.6.2" in source
+
+
+def test_update_termux_uv_bootstrap_is_after_floor_gate() -> None:
+    source = UPDATE_CMD.read_text(encoding="utf-8")
+    first_bootstrap = source.index("_ensure_uv_for_termux(pip_cmd)")
+    preceding = source[:first_bootstrap]
+    assert preceding.rfind("_ensure_update_pip_floor(pip_cmd)") > preceding.rfind(
+        "if not uv_bin:"
+    )
+    assert source.count("except _pip_security.PipFloorError") >= 2
+
+
+def test_direct_pip_recovery_paths_reuse_the_shared_floor_guard() -> None:
+    main = (REPO_ROOT / "hermes_cli/main.py").read_text(encoding="utf-8")
+    early = (REPO_ROOT / "hermes_cli/_early_recovery.py").read_text(encoding="utf-8")
+    tools = (REPO_ROOT / "hermes_cli/tools_config.py").read_text(encoding="utf-8")
+    setup = (REPO_ROOT / "hermes_cli/setup.py").read_text(encoding="utf-8")
+    google = (
+        REPO_ROOT / "skills/productivity/google-workspace/scripts/setup.py"
+    ).read_text(encoding="utf-8")
+    legacy = (REPO_ROOT / "setup-hermes.sh").read_text(encoding="utf-8")
+
+    assert "_ensure_direct_pip_floor(install_cmd_prefix" in main
+    assert "_pip_security.ensure_pip_floor" in main
+    assert "_pip_security.ensure_pip_floor" in early
+    assert "_pip_security.ensure_pip_floor" in tools
+    assert 'ensure("terminal.vercel", prompt=False)' in setup
+    assert 'result = _pip_install(["vercel"]' not in setup
+    assert "_ensure_pip_floor" in google
+    assert 'pip>=${MIN_PIP_VERSION}' in legacy
+    assert "verify_pip_floor" in legacy
+
+
+def test_tools_config_direct_pip_recovery_has_one_timeout_budget() -> None:
+    source = (REPO_ROOT / "hermes_cli/tools_config.py").read_text(encoding="utf-8")
+    helper = source[source.index("def _pip_install("):source.index("\n\n\n# The asset-probe", source.index("def _pip_install("))]
+    assert "pip_deadline = time.monotonic()" in helper
+    assert "_remaining_timeout" in helper
+    assert "floor_timeout" in helper
+    assert "install_timeout" in helper
+
+
+def test_google_workspace_standalone_copy_keeps_a_local_floor_guard() -> None:
+    source = (
+        REPO_ROOT / "skills/productivity/google-workspace/scripts/setup.py"
+    ).read_text(encoding="utf-8")
+    assert '_MIN_PIP_SPEC = "pip>=26.1.2"' in source
+    assert "def _bundled_pip_version_meets_floor" in source
+    assert "def _bundled_ensure_pip_floor" in source
+    assert "ensure_pip_floor = _ensure_pip_floor or _bundled_ensure_pip_floor" in source
+
+
+def test_direct_pip_recovery_callers_hide_windows_console_and_close_stdin() -> None:
+    paths = (
+        REPO_ROOT / "hermes_cli/_early_recovery.py",
+        REPO_ROOT / "hermes_cli/doctor.py",
+        REPO_ROOT / "skills/productivity/google-workspace/scripts/setup.py",
+        REPO_ROOT / "scripts/install_psutil_android.py",
+    )
+    for path in paths:
+        source = path.read_text(encoding="utf-8")
+        assert "windows_hide_flags" in source, path
+        assert "subprocess.DEVNULL" in source, path
+
+
+def test_windows_platform_sdk_stage_precedes_bootstrap_marker() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    stages = source[source.index('$InstallStages += @(') :]
+    assert stages.index('Name = "platform-sdks"') < stages.index(
+        'Name = "bootstrap-marker"'
+    )
+    stage = _function_body(source, "Stage-PlatformSdks")
+    assert "Remove-BootstrapMarker" in stage
+    assert "try" in stage and "catch" in stage
+
+
+def test_windows_platform_sdk_failure_invalidates_bootstrap_marker() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    helper = _function_body(source, "Remove-BootstrapMarker")
+    assert 'Join-Path $InstallDir ".hermes-bootstrap-complete"' in helper
+    assert "Remove-Item -LiteralPath $markerPath -Force" in helper
+    assert "Bootstrap marker still exists" in helper
+
+
+def test_windows_platform_sdk_preserves_original_and_marker_errors() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    stage = _function_body(source, "Stage-PlatformSdks")
+    assert "$failure = $_" in stage
+    assert "$markerFailure = $_" in stage
+    assert "Platform SDK stage failed:" in stage
+    assert "bootstrap marker invalidation also failed:" in stage
+
+
+def test_windows_sdk_spec_probe_fails_closed_when_packaging_is_unavailable() -> None:
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    helper = _function_body(source, "Test-VenvPackageSpecSatisfied")
+    assert "raise SystemExit(3)" in helper
+    assert "$probeExit = $LASTEXITCODE" in helper
+    assert "no usable 'packaging' module" in helper
+
+
+def test_dashboard_startup_rechecks_lazy_security_floor_before_imports() -> None:
+    """An importable FastAPI must not bypass a stale Starlette repair."""
+    source = MAIN_CMD.read_text(encoding="utf-8")
+    ensure_call = '_ensure_dashboard_deps("tool.dashboard", prompt=False)'
+    assert ensure_call in source
+    assert source.index(ensure_call) < source.index("import fastapi", source.index(ensure_call))

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -64,6 +64,7 @@ def test_faster_whisper_is_not_a_base_dependency():
 # [dev]) so we pin it directly in every extra that exposes a server surface and
 # enforce the floor in both pyproject and the committed lockfile.
 _STARLETTE_CVE_FLOOR = (1, 0, 1)
+_IDNA_CVE_FLOOR = (3, 15)
 _UPDATE_DOWNGRADE_GUARD_FLOORS = {
     # `hermes update` reinstalls exact pins from pyproject/lazy_deps. These
     # reviewed CVE pins must not slide back to stale versions that downgrade
@@ -74,16 +75,45 @@ _UPDATE_DOWNGRADE_GUARD_FLOORS = {
 }
 
 
+_STABLE_VERSION_RE = re.compile(
+    r"^(?P<release>\d+(?:\.\d+)*)(?:\.post\d+)?$",
+    re.IGNORECASE,
+)
+
+
 def _version_tuple(spec: str) -> tuple[int, ...]:
-    # "1.0.1" -> (1, 0, 1); tolerant of pre/post suffixes by truncating.
-    head = spec.split("+", 1)[0]
-    parts = []
-    for chunk in head.split("."):
-        digits = "".join(ch for ch in chunk if ch.isdigit())
-        if not digits:
-            break
-        parts.append(int(digits))
-    return tuple(parts)
+    """Parse a stable release, preserving optional post-release semantics.
+
+    Security-floor checks must not turn a prerelease suffix into digits (for
+    example, ``3.15rc1`` must not become ``(3, 151)``). Post releases are
+    stable and compare at the same release floor.
+    """
+    match = _STABLE_VERSION_RE.fullmatch(spec.strip())
+    if not match:
+        raise ValueError(f"unsupported non-stable version: {spec!r}")
+    return tuple(int(part) for part in match.group("release").split("."))
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("3.15", (3, 15)),
+        ("3.15.0", (3, 15, 0)),
+        ("3.15.post1", (3, 15)),
+        ("3.15.0.post2", (3, 15, 0)),
+    ],
+)
+def test_version_tuple_accepts_stable_releases(version, expected):
+    assert _version_tuple(version) == expected
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["3.15rc1", "3.15.0.dev1", "3.15.0a1", "3.15.0+local", "3.15-beta1"],
+)
+def test_version_tuple_rejects_prerelease_and_local_versions(version):
+    with pytest.raises(ValueError, match="non-stable"):
+        _version_tuple(version)
 
 
 def test_starlette_pinned_above_cve_2026_48710_floor_in_pyproject():
@@ -209,6 +239,33 @@ def _pyproject_pinned_specs():
     return specs
 
 
+def test_idna_security_floor_is_direct_and_locked():
+    """Keep the #41374 IDNA floor durable across future lock refreshes.
+
+    IDNA is normally pulled transitively by HTTP clients.  A transitive
+    resolution at the fixed version is not enough: without a direct core pin,
+    a later resolver change can select a vulnerable version while the
+    application still appears to have the same top-level dependencies.
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    core_pins = _pins_from_specs(data["project"]["dependencies"])
+    idna_pins = core_pins.get("idna")
+
+    assert idna_pins and len(idna_pins) == 1, (
+        "idna must have one exact core pin so the CVE-fixed floor is not only "
+        "an incidental transitive resolution"
+    )
+    pinned_version = next(iter(idna_pins))
+    assert _version_tuple(pinned_version) >= _IDNA_CVE_FLOOR, (
+        f"idna=={pinned_version} is below the #41374 fixed floor "
+        f"{'.'.join(map(str, _IDNA_CVE_FLOOR))}"
+    )
+    assert _locked_versions("idna") == {pinned_version}, (
+        "uv.lock must resolve the same idna version enforced by the direct "
+        "pyproject pin"
+    )
+
+
 def _lazy_deps_pinned_specs():
     """Extract every string literal inside the LAZY_DEPS dict via AST.
 
@@ -332,16 +389,24 @@ def _lazy_deps_by_feature():
 # each security package -> the lazy features that bundle an SDK pulling it and
 # must therefore carry the same pin as the pyproject extra.
 _REQUIRED_SECURITY_PINS = {
-    # Every lazy messaging feature whose SDK pulls aiohttp transitively must
-    # carry the patched floor directly: discord.py (aiohttp<4), slack-bolt,
-    # mautrix/aiohttp-socks (aiohttp<4 / >=3.10), and microsoft-teams-apps —
-    # none of those upper/lower bounds excludes a vulnerable already-installed
-    # aiohttp, so the lazy path would not upgrade it without an explicit pin.
+    # Every supported lazy SDK root whose runtime can use aiohttp must carry
+    # the patched floor directly. Resolver ranges on messaging SDKs do not
+    # exclude a vulnerable already-installed aiohttp, and independent lazy
+    # roots (search, TTS, memory, terminal, and callback mode) cannot rely on
+    # another feature having repaired the package first.
     "aiohttp": {
         "platform.discord",
         "platform.slack",
         "platform.matrix",
         "platform.teams",
+        "platform.dingtalk",
+        "platform.feishu",
+        "platform.wecom_callback",
+        "search.firecrawl",
+        "tts.edge",
+        "memory.hindsight",
+        "terminal.modal",
+        "terminal.daytona",
     },
 }
 

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -392,6 +392,7 @@ def test_lazy_deps_uv_install_hides_console_window(monkeypatch):
     assert len(spawns) == 1, captured
     cmd, kwargs = spawns[0]
     assert cmd[:3] == ["/usr/bin/uv", "pip", "install"]
+    assert "--project" in cmd
     assert kwargs["creationflags"] == _CREATE_NO_WINDOW
     assert kwargs["stdin"] == subprocess.DEVNULL
 

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -13,6 +13,9 @@ call is mocked — we never actually shell out during unit tests.
 from __future__ import annotations
 
 
+import sys
+from types import SimpleNamespace
+
 import pytest
 
 import tools.lazy_deps as ld
@@ -75,6 +78,11 @@ class TestSpecSafety:
 
 
 class TestAllowlist:
+    def test_discord_carries_the_pynacl_security_pin(self):
+        specs = ld.feature_specs("platform.discord")
+        assert "PyNaCl==1.6.2" in specs
+        assert "cffi" in specs
+
     def test_unknown_feature_raises(self, monkeypatch):
         monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
         with pytest.raises(ld.FeatureUnavailable, match="not in LAZY_DEPS"):
@@ -156,6 +164,65 @@ class TestEnsure:
         with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
             ld.ensure("test.cache", prompt=False)
 
+    def test_aiohttp_repair_requires_restart_when_submodule_is_preloaded(
+        self, monkeypatch
+    ):
+        sentinel = object()
+        monkeypatch.setitem(sys.modules, "aiohttp.web", sentinel)
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.aiohttp", ("aiohttp==3.14.3",))
+        monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: False)
+
+        with pytest.raises(ld.FeatureUnavailable, match="restart required"):
+            ld.ensure("test.aiohttp", prompt=False)
+
+    def test_feishu_lark_repair_requires_restart_when_sdk_is_preloaded(
+        self, monkeypatch
+    ):
+        sentinel = object()
+        monkeypatch.setitem(sys.modules, "lark_oapi", sentinel)
+        monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: False)
+
+        with pytest.raises(ld.FeatureUnavailable, match="restart required") as exc_info:
+            ld.ensure("platform.feishu", prompt=False)
+
+        assert "lark-oapi==1.6.8" in str(exc_info.value)
+        assert "lark_oapi" in str(exc_info.value)
+
+    @pytest.mark.parametrize("module_name", ["nacl", "_cffi_backend"])
+    def test_discord_compiled_repair_requires_restart_before_ensure_and_bind(
+        self, monkeypatch, module_name
+    ):
+        sentinel = object()
+        for loaded_name in tuple(sys.modules):
+            if loaded_name == module_name or loaded_name.startswith(
+                f"{module_name}."
+            ):
+                monkeypatch.delitem(sys.modules, loaded_name, raising=False)
+        monkeypatch.setitem(sys.modules, module_name, sentinel)
+        monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: False)
+        imported = []
+
+        with pytest.raises(
+            ld.FeatureUnavailable, match="restart required"
+        ) as exc_info:
+            ld.ensure("platform.discord", prompt=False)
+        assert module_name in str(exc_info.value)
+
+        def importer():
+            imported.append(True)
+            return {}
+
+        assert (
+            ld.ensure_and_bind(
+                "platform.discord",
+                importer,
+                {},
+                prompt=False,
+            )
+            is False
+        )
+        assert imported == []
+
 
 # ---------------------------------------------------------------------------
 # is_available
@@ -202,6 +269,83 @@ class TestIsSatisfiedVersionAware:
         self._fake_version(monkeypatch, {"honcho-ai": "2.2.0"})
         assert ld._is_satisfied("honcho-ai==2.2.0") is True
 
+    def test_discord_repairs_an_already_installed_old_pynacl(self, monkeypatch):
+        self._fake_version(
+            monkeypatch,
+            {
+                "discord.py": "2.7.1",
+                "brotlicffi": "1.2.0.1",
+                "aiohttp": "3.14.3",
+                "PyNaCl": "1.5.0",
+            },
+        )
+        assert "PyNaCl==1.6.2" in ld.feature_missing("platform.discord")
+
+    @pytest.mark.parametrize(
+        "installed",
+        ["1.6.2+local", "1.6.2.dev0", "1.6.2rc1", "not-a-version"],
+    )
+    def test_security_pin_rejects_unstable_or_malformed_pynacl_metadata(
+        self, monkeypatch, installed
+    ):
+        self._fake_version(monkeypatch, {"PyNaCl": installed})
+
+        assert "PyNaCl==1.6.2" in ld.feature_missing("platform.discord")
+
+    def test_security_pin_fails_closed_when_packaging_is_unavailable(
+        self, monkeypatch
+    ):
+        self._fake_version(monkeypatch, {"PyNaCl": "1.6.2"})
+        import builtins
+
+        real_import = builtins.__import__
+
+        def block_packaging(name, *args, **kwargs):
+            if name == "packaging" or name.startswith("packaging."):
+                raise ImportError("packaging intentionally unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", block_packaging)
+
+        assert "PyNaCl==1.6.2" in ld.feature_missing("platform.discord")
+
+    def test_security_pin_accepts_stable_pynacl_post_release(self, monkeypatch):
+        self._fake_version(monkeypatch, {"PyNaCl": "1.6.2.post1"})
+
+        assert ld._is_satisfied("PyNaCl==1.6.2") is True
+
+    def test_ensure_repairs_local_pynacl_metadata(self, monkeypatch):
+        for name in tuple(sys.modules):
+            if name in {"nacl", "_cffi_backend", "aiohttp"} or name.startswith(
+                ("nacl.", "aiohttp.")
+            ):
+                monkeypatch.delitem(sys.modules, name, raising=False)
+        installed_versions = {
+            "discord.py": "2.7.1",
+            "davey": "0.1.4",
+            "brotlicffi": "1.2.0.1",
+            "cffi": "2.0.0",
+            "PyNaCl": "1.6.2+local",
+            "aiohttp": "3.14.3",
+        }
+        self._fake_version(monkeypatch, installed_versions)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        installed = []
+
+        def fake_install(specs, **kwargs):
+            installed.extend(specs)
+            for spec in specs:
+                if "==" in spec:
+                    package, wanted = spec.split("==", 1)
+                    installed_versions[package] = wanted
+            return ld._InstallResult(True, "ok", "")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+
+        ld.ensure("platform.discord", prompt=False)
+
+        assert installed == ["PyNaCl==1.6.2"]
+
 
     def test_range_within_returns_true(self, monkeypatch):
         self._fake_version(monkeypatch, {"slack-bolt": "1.27.0"})
@@ -222,6 +366,7 @@ class TestIsSatisfiedVersionAware:
     def test_extras_block_mismatch_returns_false(self, monkeypatch):
         self._fake_version(monkeypatch, {"mautrix": "0.20.0"})
         assert ld._is_satisfied("mautrix[encryption]==0.21.0") is False
+
 
     def test_trace_upload_hub_at_core_locked_version_is_current(self, monkeypatch):
         """#60783 regression: refresh must not churn the shared hub install.
@@ -291,6 +436,230 @@ class TestIsSatisfiedVersionAware:
         ld.ensure(feature, prompt=False)
 
         assert tuple(installed) == expected_repairs
+
+
+def test_pip_fallback_upgrades_and_verifies_the_security_floor(monkeypatch):
+    """A vulnerable ensurepip result cannot flow into a lazy package install."""
+    import hermes_cli.managed_uv as managed_uv
+
+    calls = []
+    version_outputs = iter(
+        [
+            (1, "", "pip is not installed"),
+            (0, "pip 24.0 from /venv/lib/python3.11/site-packages/pip (python 3.11)", ""),
+            (0, "pip 26.1.2 from /venv/lib/python3.11/site-packages/pip (python 3.11)", ""),
+        ]
+    )
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[-1] == "--version":
+            returncode, stdout, stderr = next(version_outputs)
+            return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+        if "ensurepip" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="installed", stderr="")
+
+    monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+    monkeypatch.setattr(ld.shutil, "which", lambda name: None)
+    monkeypatch.setattr(managed_uv, "resolve_uv", lambda: None)
+    monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+    result = ld._venv_pip_install(("left-pad",))
+
+    assert result.success is True
+    assert any(
+        cmd[-3:] == ["install", "--upgrade", "pip>=26.1.2"] for cmd in calls
+    )
+    assert any(cmd[-2:] == ["install", "left-pad"] for cmd in calls)
+
+
+def test_pip_fallback_fails_closed_when_floor_upgrade_fails(monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[-1] == "--version":
+            return SimpleNamespace(
+                returncode=0,
+                stdout="pip 24.0 from /venv/lib/python3.11/site-packages/pip (python 3.11)",
+                stderr="",
+            )
+        if cmd[-3:] == ["install", "--upgrade", "pip>=26.1.2"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr="network down")
+        pytest.fail(f"package install must not run before pip floor verification: {cmd}")
+
+    monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+    monkeypatch.setattr(ld.shutil, "which", lambda name: None)
+    monkeypatch.setattr(managed_uv, "resolve_uv", lambda: None)
+    monkeypatch.setattr(ld.subprocess, "run", fake_run)
+
+    result = ld._venv_pip_install(("left-pad",))
+
+    assert result.success is False
+    assert "pip floor upgrade failed" in result.stderr
+
+
+def test_pip_fallback_applies_pynacl_override_after_discord_resolution(monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[-1] == "--version":
+            return SimpleNamespace(
+                returncode=0,
+                stdout="pip 26.1.2 from /venv/lib/python3.11/site-packages/pip (python 3.11)",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="installed", stderr="")
+
+    monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+    monkeypatch.setattr(ld.shutil, "which", lambda name: None)
+    monkeypatch.setattr(managed_uv, "resolve_uv", lambda: None)
+    monkeypatch.setattr(ld.subprocess, "run", fake_run)
+    monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: True)
+    monkeypatch.setattr(ld, "_is_present", lambda _spec: True)
+
+    result = ld._venv_pip_install(ld.feature_specs("platform.discord"))
+
+    assert result.success is True
+    discord_install = next(cmd for cmd in calls if "discord.py==2.7.1" in cmd)
+    pynacl_install = next(cmd for cmd in calls if "PyNaCl==1.6.2" in cmd)
+    assert "PyNaCl==1.6.2" not in discord_install
+    assert "discord.py==2.7.1" not in pynacl_install
+    assert "davey==0.1.4" in discord_install
+
+
+def test_uv_fallback_applies_pynacl_override_in_a_second_transaction(monkeypatch):
+    """uv pip does not consume the project's uv override metadata."""
+    import subprocess
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "installed", "")
+
+    monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+    monkeypatch.setattr("hermes_cli.managed_uv.resolve_uv", lambda: "uv")
+    monkeypatch.setattr(ld.subprocess, "run", fake_run)
+    monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: True)
+    monkeypatch.setattr(ld, "_is_present", lambda _spec: True)
+
+    result = ld._venv_pip_install(ld.feature_specs("platform.discord"))
+
+    assert result.success is True
+    installs = [cmd for cmd in calls if cmd[:3] == ["uv", "pip", "install"]]
+    assert len(installs) == 2
+    assert "PyNaCl==1.6.2" not in installs[0]
+    assert installs[1][-1] == "PyNaCl==1.6.2"
+    assert "discord.py==2.7.1" not in installs[1]
+
+
+def test_pip_fallback_runs_override_when_pynacl_is_the_only_missing_spec(monkeypatch):
+    """A singleton security repair must not issue an empty pip install."""
+    import hermes_cli.managed_uv as managed_uv
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[-1] == "--version":
+            return SimpleNamespace(
+                returncode=0,
+                stdout="pip 26.1.2 from /venv/site-packages/pip (python 3.13)",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="installed", stderr="")
+
+    monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+    monkeypatch.setattr(ld.shutil, "which", lambda name: None)
+    monkeypatch.setattr(managed_uv, "resolve_uv", lambda: None)
+    monkeypatch.setattr(ld.subprocess, "run", fake_run)
+    monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: True)
+    monkeypatch.setattr(ld, "_is_present", lambda _spec: True)
+
+    result = ld._venv_pip_install(("PyNaCl==1.6.2",))
+
+    assert result.success is True
+    installs = [cmd for cmd in calls if "install" in cmd]
+    assert len(installs) == 1
+    assert installs[0][-2:] == ["install", "PyNaCl==1.6.2"]
+
+
+def test_pip_override_failure_retries_exact_repair_and_fails_closed(monkeypatch):
+    """A failed second transaction cannot report success with old PyNaCl."""
+    import hermes_cli.managed_uv as managed_uv
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[-1] == "--version":
+            return SimpleNamespace(
+                returncode=0,
+                stdout="pip 26.1.2 from /venv/site-packages/pip (python 3.13)",
+                stderr="",
+            )
+        if "PyNaCl==1.6.2" in cmd and "--no-deps" not in cmd:
+            return SimpleNamespace(returncode=1, stdout="", stderr="resolver failed")
+        if "--no-deps" in cmd:
+            return SimpleNamespace(returncode=1, stdout="", stderr="repair failed")
+        return SimpleNamespace(returncode=0, stdout="installed", stderr="")
+
+    monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+    monkeypatch.setattr(ld.shutil, "which", lambda _: None)
+    monkeypatch.setattr(managed_uv, "resolve_uv", lambda: None)
+    monkeypatch.setattr(ld.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        ld,
+        "_is_satisfied",
+        lambda spec: spec != "PyNaCl==1.6.2",
+    )
+    monkeypatch.setattr(ld, "_is_present", lambda _spec: True)
+
+    result = ld._venv_pip_install(ld.feature_specs("platform.discord"))
+
+    assert result.success is False
+    assert any("--no-deps" in cmd and "PyNaCl==1.6.2" in cmd for cmd in calls)
+    assert "remains below PyNaCl==1.6.2" in result.stderr
+
+
+@pytest.mark.parametrize("use_uv", [False, True])
+def test_exact_pynacl_success_fails_closed_without_runtime_cffi(monkeypatch, use_uv):
+    """Both installer tiers must reject a PyNaCl-only repair without cffi."""
+    import subprocess
+
+    import hermes_cli.managed_uv as managed_uv
+
+    calls = []
+
+    def fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        if not use_uv and cmd[-1] == "--version":
+            return SimpleNamespace(
+                returncode=0,
+                stdout="pip 26.1.2 from /venv/site-packages/pip",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, "installed", "")
+
+    monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+    monkeypatch.setattr(ld.shutil, "which", lambda _: None)
+    monkeypatch.setattr(managed_uv, "resolve_uv", lambda: "uv" if use_uv else None)
+    monkeypatch.setattr(ld.subprocess, "run", fake_run)
+    monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: True)
+    monkeypatch.setattr(ld, "_is_present", lambda spec: spec != "cffi")
+
+    result = ld._venv_pip_install(("PyNaCl==1.6.2",))
+
+    assert result.success is False
+    assert "cffi" in result.stderr
+    assert any("PyNaCl==1.6.2" in cmd for cmd in calls)
 
 
 # ---------------------------------------------------------------------------
@@ -412,6 +781,55 @@ class TestRefreshActiveFeatures:
         assert result["a.ok"] == "current"
         assert result["b.fail"].startswith("failed:")
 
+    def test_preloaded_module_reports_restart_required(self, monkeypatch):
+        monkeypatch.setattr(ld, "active_features", lambda: ["a.stale"])
+        monkeypatch.setitem(ld.LAZY_DEPS, "a.stale", ("PyNaCl==1.6.2",))
+        monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: False)
+        monkeypatch.setitem(sys.modules, "nacl", object())
+
+        result = ld.refresh_active_features(prompt=False)
+
+        assert result["a.stale"].startswith("restart-required:")
+        assert "restart required" in result["a.stale"]
+
+    def test_preloaded_aiohttp_reports_restart_required(self, monkeypatch):
+        """A stale aiohttp module must not survive an in-process repair."""
+        monkeypatch.setattr(ld, "active_features", lambda: ["a.stale"])
+        monkeypatch.setitem(ld.LAZY_DEPS, "a.stale", ("aiohttp==3.14.3",))
+        monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: False)
+        monkeypatch.setitem(sys.modules, "aiohttp", object())
+
+        result = ld.refresh_active_features(prompt=False)
+
+        assert result["a.stale"].startswith("restart-required:")
+        assert "aiohttp" in result["a.stale"]
+
+    def test_pynacl_override_is_split_with_pep503_spelling(self, monkeypatch):
+        """Case/underscore spelling must still get the exact repair step."""
+        import subprocess
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, "installed", "")
+
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr("hermes_cli.managed_uv.resolve_uv", lambda: "uv")
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: True)
+        monkeypatch.setattr(ld, "_is_present", lambda _spec: True)
+
+        result = ld._venv_pip_install(
+            ("discord.py==2.7.1", "pynacl==1.6.2", "cffi==2.0.0")
+        )
+
+        assert result.success is True
+        installs = [cmd for cmd in calls if cmd[:3] == ["uv", "pip", "install"]]
+        assert len(installs) == 2
+        assert "pynacl==1.6.2" not in installs[0]
+        assert installs[1][-1] == "pynacl==1.6.2"
+
 
 # ---------------------------------------------------------------------------
 # install_specs — manifest-driven installs (dashboard memory providers etc.)
@@ -467,6 +885,62 @@ class TestInstallSpecs:
         )
         result = ld.install_specs(["honcho-ai==2.2.0", "pkg; rm -rf /"])
         assert result.blocked is True
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "PyNaCl==1.5.0",
+            "aiohttp==3.14.1",
+            "idna==3.14",
+            "pip==24.0",
+            "PyNaCl",
+            "aiohttp",
+            "idna",
+            "pip",
+            "idna<4",
+        ],
+    )
+    def test_security_managed_manifest_specs_reject_vulnerable_floors(
+        self, monkeypatch, spec
+    ):
+        """Manifest installs cannot bypass the shared dependency floors."""
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("vulnerable spec must be blocked before pip"),
+        )
+
+        result = ld.install_specs([spec])
+
+        assert result.ok is False
+        assert result.blocked is True
+        assert "security floor" in result.reason
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "PyNaCl==1.6.2",
+            "aiohttp>=3.14.3",
+            "idna>=3.15,<4",
+            "pip>=26.1.2",
+            "honcho-ai==2.2.0",
+        ],
+    )
+    def test_security_managed_manifest_specs_accept_safe_requirements(
+        self, monkeypatch, spec
+    ):
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld,
+            "_venv_pip_install",
+            lambda *a, **kw: ld._InstallResult(True, "installed", ""),
+        )
+
+        result = ld.install_specs([spec])
+
+        assert result.ok is True
+        assert result.blocked is False
 
 
     def test_never_raises_on_unexpected_error(self, monkeypatch):

--- a/tests/tools/test_lazy_deps_durable_target.py
+++ b/tests/tools/test_lazy_deps_durable_target.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import sysconfig
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -104,6 +105,85 @@ class TestAbiStamp:
         finally:
             os.chmod(ro_parent, 0o700)  # let pytest clean up
 
+    def test_unstamped_nonempty_target_is_cleared_and_stamped(self, tmp_path):
+        target = tmp_path / "lazy"
+        target.mkdir()
+        (target / "untrusted-package").mkdir()
+        (target / "untrusted-package" / "module.py").write_text(
+            "SENTINEL = True\n", encoding="utf-8"
+        )
+
+        assert ld._ensure_target_ready(target) is None
+        assert not (target / "untrusted-package").exists()
+        assert (
+            (target / ld._TARGET_STAMP_NAME).read_text().strip()
+            == ld._python_abi_tag()
+        )
+
+    def test_stale_abi_target_is_wiped_before_stamp_rewrite(self, tmp_path):
+        target = tmp_path / "lazy"
+        target.mkdir()
+        (target / ld._TARGET_STAMP_NAME).write_text("stale-abi", encoding="utf-8")
+        (target / "stale-package").mkdir()
+
+        assert ld._ensure_target_ready(target) is None
+        assert not (target / "stale-package").exists()
+        assert (
+            (target / ld._TARGET_STAMP_NAME).read_text().strip()
+            == ld._python_abi_tag()
+        )
+
+    def test_symlink_target_is_rejected_without_wiping_link_target(self, tmp_path):
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        sentinel = victim / "sentinel"
+        sentinel.write_text("keep", encoding="utf-8")
+        target = tmp_path / "lazy"
+        target.symlink_to(victim, target_is_directory=True)
+
+        error = ld._ensure_target_ready(target)
+
+        assert error is not None
+        assert "must not be a symlink" in error
+        assert sentinel.read_text(encoding="utf-8") == "keep"
+        assert not (victim / ld._TARGET_STAMP_NAME).exists()
+
+
+class TestDurableTargetActivation:
+    def test_activation_runs_readiness_before_append(self, tmp_path, monkeypatch):
+        target = tmp_path / "lazy"
+        target.mkdir()
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(target))
+        calls = []
+        monkeypatch.setattr(
+            ld, "_ensure_target_ready", lambda _target: calls.append("ready") or None
+        )
+        monkeypatch.setattr(
+            ld, "_activate_target_on_syspath", lambda _target: calls.append("append")
+        )
+
+        ld.activate_durable_lazy_target()
+
+        assert calls == ["ready", "append"]
+
+    def test_activation_refuses_unready_target(self, tmp_path, monkeypatch):
+        target = tmp_path / "lazy"
+        target.mkdir()
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(target))
+        calls = []
+        monkeypatch.setattr(
+            ld,
+            "_ensure_target_ready",
+            lambda _target: "lazy install target could not be cleared",
+        )
+        monkeypatch.setattr(
+            ld, "_activate_target_on_syspath", lambda _target: calls.append("append")
+        )
+
+        ld.activate_durable_lazy_target()
+
+        assert calls == []
+
 
 # ---------------------------------------------------------------------------
 # sys.path append ordering (the core-wins invariant, unit level)
@@ -137,6 +217,23 @@ class TestSysPathAppend:
         finally:
             sys.path[:] = saved
 
+    def test_activation_does_not_execute_target_pth_code(self, tmp_path):
+        target = tmp_path / "lazy"
+        target.mkdir()
+        marker = tmp_path / "pth-ran"
+        (target / "untrusted.pth").write_text(
+            f"import pathlib; pathlib.Path({str(marker)!r}).write_text('ran')\n",
+            encoding="utf-8",
+        )
+        saved = list(sys.path)
+        try:
+            ld._activate_target_on_syspath(target)
+            assert str(target) in sys.path
+            assert sys.path.index(str(target)) >= len(saved)
+            assert not marker.exists()
+        finally:
+            sys.path[:] = saved
+
 
 # ---------------------------------------------------------------------------
 # Install path: arg construction (network-free) + a real install (opt-in).
@@ -160,7 +257,9 @@ class TestInstallArgConstruction:
         def fake_run(cmd, *a, **k):
             # The pip --version probe must look healthy so we reach install.
             if "--version" in cmd:
-                return subprocess.CompletedProcess(cmd, 0, "pip 24.0", "")
+                return subprocess.CompletedProcess(
+                    cmd, 0, "pip 26.1.2 from /venv/site-packages/pip", ""
+                )
             captured["cmd"] = cmd
             return subprocess.CompletedProcess(cmd, 0, "ok", "")
 
@@ -179,6 +278,168 @@ class TestInstallArgConstruction:
         # ...and the spec is last.
         assert cmd[-1] == "somepkg==1.2.3"
 
+    def test_core_constraints_exclude_stale_pynacl_override(self, monkeypatch):
+        """A stale core PyNaCl pin must not block the exact repair transaction."""
+        distributions = [
+            SimpleNamespace(metadata={"Name": "PyNaCl"}, version="1.5.0"),
+            SimpleNamespace(metadata={"Name": "aiohttp"}, version="3.14.3"),
+        ]
+        monkeypatch.setattr(
+            "importlib.metadata.distributions", lambda: distributions
+        )
+
+        constraints = ld._core_constraints_file()
+        assert constraints is not None
+        try:
+            content = constraints.read_text(encoding="utf-8")
+        finally:
+            constraints.unlink(missing_ok=True)
+
+        assert "pynacl" not in content.lower()
+        assert "aiohttp==3.14.3" in content
+
+    def test_core_constraints_exclude_explicit_backend_pins(self, monkeypatch):
+        """Explicit backend specs must not inherit conflicting core pins."""
+        distributions = [
+            SimpleNamespace(metadata={"Name": "davey"}, version="0.1.6"),
+            SimpleNamespace(metadata={"Name": "aiohttp"}, version="3.14.2"),
+            SimpleNamespace(metadata={"Name": "slack-bolt"}, version="1.27.0"),
+            SimpleNamespace(metadata={"Name": "slack-sdk"}, version="3.40.1"),
+            SimpleNamespace(metadata={"Name": "packaging"}, version="25.0"),
+        ]
+        monkeypatch.setattr(
+            "importlib.metadata.distributions", lambda: distributions
+        )
+
+        constraints = ld._core_constraints_file(
+            ("davey==0.1.4", "aiohttp==3.14.3", "slack-bolt==1.29.0", "slack-sdk==3.43.0")
+        )
+        assert constraints is not None
+        try:
+            content = constraints.read_text(encoding="utf-8")
+        finally:
+            constraints.unlink(missing_ok=True)
+
+        assert "packaging==25.0" in content
+        for package in ("davey", "aiohttp", "slack-bolt", "slack-sdk"):
+            assert not any(line.lower().startswith(f"{package}==") for line in content.splitlines())
+
+    def test_core_constraints_normalize_underscore_and_hyphen_names(self, monkeypatch):
+        """PEP 503-equivalent spellings must exclude the same core pin."""
+        distributions = [
+            SimpleNamespace(metadata={"Name": "slack_sdk"}, version="3.40.1"),
+            SimpleNamespace(metadata={"Name": "davey"}, version="0.1.6"),
+        ]
+        monkeypatch.setattr(
+            "importlib.metadata.distributions", lambda: distributions
+        )
+
+        constraints = ld._core_constraints_file(("slack-sdk==3.43.0",))
+        assert constraints is not None
+        try:
+            content = constraints.read_text(encoding="utf-8")
+        finally:
+            constraints.unlink(missing_ok=True)
+
+        assert "slack_sdk==3.40.1" not in content
+        assert "davey==0.1.6" in content
+
+    def test_core_constraints_skip_unsafe_metadata(self, monkeypatch):
+        """Metadata cannot inject pip options or unstable constraint pins."""
+        distributions = [
+            SimpleNamespace(
+                metadata={"Name": "--index-url https://evil.example/simple"},
+                version="1.0",
+            ),
+            SimpleNamespace(metadata={"Name": "unsafe-name"}, version="1.2.3.dev1"),
+            SimpleNamespace(metadata={"Name": "safe_package"}, version="1.2.3.post1"),
+        ]
+        monkeypatch.setattr(
+            "importlib.metadata.distributions", lambda: distributions
+        )
+
+        constraints = ld._core_constraints_file()
+        assert constraints is not None
+        try:
+            content = constraints.read_text(encoding="utf-8")
+        finally:
+            constraints.unlink(missing_ok=True)
+
+        assert "--index-url" not in content
+        assert "evil.example" not in content
+        assert "unsafe-name" not in content
+        assert "safe-package==1.2.3.post1" in content
+
+    def test_durable_install_rejects_stale_core_backend_specs(self, monkeypatch, tmp_path):
+        """Append-only targets must not claim to repair stale core packages."""
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(tmp_path / "lazy"))
+        # This regression targets durable-target ownership, not the separate
+        # restart boundary for already-loaded stale modules.
+        monkeypatch.setattr(ld, "_preloaded_stale_module_conflicts", lambda _specs: ())
+        stale = {"davey", "aiohttp", "slack-bolt", "slack-sdk"}
+        monkeypatch.setattr(
+            ld,
+            "_is_present",
+            lambda spec: ld._pkg_name_from_spec(spec) in stale,
+        )
+        monkeypatch.setattr(ld, "_is_satisfied", lambda _spec: False)
+        monkeypatch.setattr(
+            ld,
+            "_ensure_target_ready",
+            lambda _target: None,
+        )
+
+        result = ld._venv_pip_install(
+            (
+                "davey==0.1.4",
+                "aiohttp==3.14.3",
+                "slack-bolt==1.29.0",
+                "slack-sdk==3.43.0",
+            )
+        )
+
+        assert result.success is False
+        assert "core package(s)" in result.stderr
+        assert "must be repaired before durable lazy install" in result.stderr
+        assert "append-only sys.path" in result.stderr
+        assert "davey==0.1.4" in result.stderr
+
+    def test_durable_install_repairs_target_owned_stale_distribution(
+        self, monkeypatch, tmp_path
+    ):
+        """A stale package already in the target is repairable in place."""
+        target = tmp_path / "lazy"
+        dist_info = target / "stale_pkg-0.5.0.dist-info"
+        dist_info.mkdir(parents=True)
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: stale-pkg\nVersion: 0.5.0\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv(ld._LAZY_TARGET_ENV, str(target))
+        monkeypatch.syspath_prepend(str(target))
+        monkeypatch.setattr(ld.shutil, "which", lambda _: None)
+        monkeypatch.setattr(
+            "hermes_cli.managed_uv.resolve_uv", lambda: None
+        )
+        captured = {}
+
+        def fake_run(cmd, *args, **kwargs):
+            if "--version" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 0, "pip 26.1.2 from /venv/site-packages/pip", ""
+                )
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, "ok", "")
+
+        monkeypatch.setattr(ld.subprocess, "run", fake_run)
+        monkeypatch.setattr(ld, "_activate_target_on_syspath", lambda _t: None)
+
+        result = ld._venv_pip_install(("stale-pkg==1.0.0",))
+
+        assert result.success, result.stderr
+        assert captured["cmd"][-1] == "stale-pkg==1.0.0"
+        assert "core package(s)" not in result.stderr
+
     def test_no_target_args_in_venv_scoped_mode(self, monkeypatch):
         # Env unset → plain venv-scoped install, no --target / --constraint.
         monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
@@ -187,7 +448,9 @@ class TestInstallArgConstruction:
 
         def fake_run(cmd, *a, **k):
             if "--version" in cmd:
-                return subprocess.CompletedProcess(cmd, 0, "pip 24.0", "")
+                return subprocess.CompletedProcess(
+                    cmd, 0, "pip 26.1.2 from /venv/site-packages/pip", ""
+                )
             captured["cmd"] = cmd
             return subprocess.CompletedProcess(cmd, 0, "ok", "")
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -71,7 +71,6 @@ import logging
 import os
 import re
 import shutil
-import site
 import subprocess
 import sys
 import sysconfig
@@ -80,8 +79,61 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli import _pip_security
 
 logger = logging.getLogger(__name__)
+
+# pip is only used as a fallback when uv is unavailable.  Keep that
+# venv-managed path on the security floor from issue #41374 instead of
+# trusting whatever version ensurepip happened to bundle with Python.
+_MIN_PIP_VERSION = _pip_security.MIN_PIP_VERSION
+_MIN_PIP_SPEC = _pip_security.MIN_PIP_SPEC
+_PYNACL_SECURITY_SPEC = "PyNaCl==1.6.2"
+# A stale core PyNaCl installation must not constrain the ordinary durable
+# transaction.  The target is append-only, so the install path separately
+# rejects stale core copies of every explicitly managed package rather than
+# allowing a target copy to be reported as active when core wins on sys.path.
+_CONSTRAINT_EXCLUDED_PACKAGES = frozenset({"pynacl"})
+# These packages carry security-sensitive exact/floor contracts in
+# ``LAZY_DEPS`` or the published extras.  Their metadata is evidence for a
+# repair decision, so a missing ``packaging`` module or an unstable/malformed
+# version must fail closed instead of falling back to presence-only behavior.
+_SECURITY_VERSIONED_PACKAGES = frozenset(
+    {
+        "aiohttp",
+        "anthropic",
+        "cryptography",
+        "httplib2",
+        "idna",
+        "pynacl",
+        "pyasn1",
+        "python-multipart",
+        "requests",
+        "starlette",
+        "urllib3",
+    }
+)
+
+# Manifest-driven installs do not go through the static ``LAZY_DEPS`` map, so
+# keep the small set of dependency floors that must hold for every runtime
+# install in one explicit policy table.  A manifest may still choose a newer
+# version or a compatible range, but it must prove that every candidate is at
+# or above the floor before it reaches pip.
+_SECURITY_INSTALL_FLOORS = {
+    "pynacl": "1.6.2",
+    "aiohttp": "3.14.3",
+    "idna": "3.15",
+    "pip": "26.1.2",
+}
+
+# Core metadata is normally produced by trusted build tooling, but the
+# durable-target constraint file is later parsed by pip as an argument-like
+# requirements file.  Keep the interpolation boundary deliberately narrower
+# than Core Metadata: only canonical package names and stable release tokens
+# may cross it.  In particular, a metadata name beginning with ``--`` must
+# never become a pip option such as ``--index-url``.
+_CONSTRAINT_NAME_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+_CONSTRAINT_VERSION_RE = re.compile(r"\d+(?:\.\d+)*(?:\.post\d+)?\Z")
 
 
 # =============================================================================
@@ -116,7 +168,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Web search backends ───────────────────────────────────────────────
     "search.exa": ("exa-py==2.10.2",),
-    "search.firecrawl": ("firecrawl-py==4.17.0",),
+    "search.firecrawl": ("firecrawl-py==4.17.0", "aiohttp==3.14.3"),
     "search.parallel": ("parallel-web==0.4.2",),
 
     # ─── Monitoring ─────────────────────────────────────────────────────────
@@ -138,7 +190,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # 2.4.6 was removed and clean releases resumed (2.4.7, 2.4.8). Voxtral
     # STT + TTS share the same SDK.
     "tts.mistral": ("mistralai==2.4.8",),
-    "tts.edge": ("edge-tts==7.2.7",),
+    "tts.edge": ("edge-tts==7.2.7", "aiohttp==3.14.3"),
     "tts.elevenlabs": ("elevenlabs==1.59.0",),
 
     # ─── Speech-to-text providers ──────────────────────────────────────────
@@ -191,7 +243,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.6.1", "aiohttp==3.14.3"),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the
@@ -209,9 +261,21 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # back to google's `Brotli` package (1-arg API), and any .txt/.md/.doc
     # uploaded to the Discord gateway fails to decode at att.read() with
     # "Can not decode content-encoding: br" — see #12511 / #15744.
+    # Keep the voice-only dependencies explicit instead of requesting
+    # discord.py[voice].  discord.py 2.7.1's published voice metadata still
+    # declares PyNaCl<1.6, which conflicts with the security floor below;
+    # davey is the only additional voice dependency needed by the adapter.
     "platform.discord": (
-        "discord.py[voice]==2.7.1",
+        "discord.py==2.7.1",
+        "davey==0.1.4",
         "brotlicffi==1.2.0.1",
+        # PyNaCl's runtime imports cffi. Keep presence explicit because the
+        # exact PyNaCl --no-deps recovery cannot install transitive packages.
+        "cffi",
+        # Keep this direct pin because the lazy uv/pip invocation may run
+        # outside the project root and therefore cannot rely on pyproject's
+        # resolver metadata or uv override-dependencies.
+        "PyNaCl==1.6.2",
         # discord.py pulls aiohttp transitively (>=3.7.4,<4) as its HTTP
         # backbone. Pin the patched floor here too so the lazy Discord path
         # can't keep an already-installed vulnerable aiohttp satisfying that
@@ -235,17 +299,28 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     ),
     "platform.dingtalk": (
         "dingtalk-stream==0.24.3",
-        "alibabacloud-dingtalk==2.2.42",
         "qrcode==7.4.2",
+        "aiohttp==3.14.3",
     ),
+    # DingTalk's AI-card/robot SDK is optional.  Keep it out of the core
+    # Stream Mode contract so a missing or broken card dependency cannot
+    # prevent ordinary text messaging from starting.  The adapter requests
+    # this feature only when a card template is configured.
+    "platform.dingtalk_card": ("alibabacloud-dingtalk==2.2.42",),
     "platform.feishu": (
         "lark-oapi==1.6.8",
         "qrcode==7.4.2",
+        # The webhook transport imports aiohttp.web independently of lark-oapi.
+        "aiohttp==3.14.3",
+        # Websocket mode is the default Feishu transport and must remain
+        # usable after a lazy install, even when it was absent at import time.
+        "websockets==15.0.1",
     ),
     # WeCom callback-mode adapter — parses untrusted XML POST bodies. Pulls
-    # defusedxml only; aiohttp/httpx are core dependencies of every messaging
-    # adapter and ship via `platform.discord` / `platform.slack` / etc.
-    "platform.wecom_callback": ("defusedxml==0.7.1",),
+    # defusedxml protects callback XML and aiohttp provides the callback web
+    # server. Keep both explicit because callback-mode can be lazy-installed
+    # independently of the broader messaging extras.
+    "platform.wecom_callback": ("defusedxml==0.7.1", "aiohttp==3.14.3"),
     # Microsoft Teams adapter — microsoft-teams-apps pulls a heavy tree
     # (microsoft-teams-api/cards/common, dependency-injector, msal). Lazy-
     # installed on demand like every other messaging platform; also exposed
@@ -253,8 +328,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "platform.teams": ("microsoft-teams-apps==2.0.13.4", "aiohttp==3.14.3"),  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 
     # ─── Terminal backends ─────────────────────────────────────────────────
-    "terminal.modal": ("modal==1.3.4",),
-    "terminal.daytona": ("daytona==0.155.0",),
+    "terminal.modal": ("modal==1.3.4", "aiohttp==3.14.3"),
+    "terminal.daytona": ("daytona==0.155.0", "aiohttp==3.14.3"),
     "terminal.vercel": ("vercel==0.7.2",),
 
     # ─── Skills ────────────────────────────────────────────────────────────
@@ -369,6 +444,30 @@ class _InstallResult:
 # =============================================================================
 
 
+def _pip_version_meets_floor(output: str) -> bool:
+    """Return whether ``pip --version`` output proves the required floor."""
+    return _pip_security.pip_version_meets_floor(output)
+
+
+def _ensure_pip_floor(
+    pip_cmd: list[str], *, timeout: int = 120
+) -> tuple[bool, str]:
+    """Require a venv-managed pip at or above the security floor.
+
+    ``ensurepip`` only guarantees that *some* pip is present.  If its bundled
+    version is below the floor, upgrade it explicitly and verify the result;
+    an unavailable or unverifiable floor is a hard failure for the fallback
+    install path.
+    """
+
+    return _pip_security.ensure_pip_floor(
+        pip_cmd,
+        timeout=timeout,
+        runner=subprocess.run,
+        creationflags=windows_hide_flags(),
+    )
+
+
 # Environment variable that redirects lazy installs away from the (sealed)
 # agent venv and into a writable directory on a durable volume. Set by the
 # Docker image to /opt/data/lazy-packages. This is an internal bridge var,
@@ -412,11 +511,13 @@ def _lazy_install_target() -> Optional[Path]:
 def _ensure_target_ready(target: Path) -> Optional[str]:
     """Create the target dir and validate its ABI stamp.
 
-    If the stamp is missing it is written. If it is present but records a
+    If the stamp is missing, any existing contents are treated as untrusted
+    and wiped before the target is used. If it is present but records a
     different interpreter ABI than the one now running (e.g. the container
     image was rebuilt onto a newer Python), the directory's contents are
-    wiped and the stamp rewritten, so stale compiled wheels can't be
-    imported against an incompatible interpreter.
+    likewise wiped and the stamp rewritten, so stale compiled wheels can't
+    be imported against an incompatible interpreter. Every wipe is verified;
+    a target that cannot be cleared fails closed.
 
     Returns ``None`` on success, or an error string if the directory can't
     be created / written (e.g. read-only mount, permission error).
@@ -424,26 +525,42 @@ def _ensure_target_ready(target: Path) -> Optional[str]:
     want = _python_abi_tag()
     stamp = target / _TARGET_STAMP_NAME
     try:
+        # Never follow a user-controlled target-root symlink.  The unstamped
+        # and ABI-mismatch paths below recursively remove the target contents;
+        # accepting a symlink here would let that wipe an unrelated directory.
+        if target.is_symlink():
+            return f"lazy install target {target} must not be a symlink"
         if target.exists():
             have = ""
             try:
                 have = stamp.read_text(encoding="utf-8").strip()
             except (OSError, FileNotFoundError):
                 have = ""
-            if have and have != want:
+            if not have:
+                logger.info(
+                    "Lazy install target %s has no ABI stamp; wiping "
+                    "untrusted contents before activation.",
+                    target,
+                )
+            elif have != want:
                 logger.info(
                     "Lazy install target %s was built for ABI %r but running "
                     "ABI is %r; wiping stale packages.",
                     target, have, want,
                 )
+            if not have or have != want:
                 for child in target.iterdir():
                     if child.is_dir() and not child.is_symlink():
-                        shutil.rmtree(child, ignore_errors=True)
+                        shutil.rmtree(child)
                     else:
-                        try:
-                            child.unlink()
-                        except OSError:
-                            pass
+                        child.unlink()
+                remaining = tuple(target.iterdir())
+                if remaining:
+                    names = ", ".join(str(child.name) for child in remaining[:3])
+                    return (
+                        f"lazy install target {target} could not be cleared; "
+                        f"remaining entries: {names}"
+                    )
         target.mkdir(parents=True, exist_ok=True)
         stamp.write_text(want, encoding="utf-8")
     except OSError as e:
@@ -456,21 +573,15 @@ def _activate_target_on_syspath(target: Path) -> None:
 
     Appended to the END (never prepended) so the agent's own venv
     site-packages takes precedence on every name collision. Idempotent.
-    Uses :func:`site.addsitedir` so ``.pth`` files (namespace packages,
-    editable installs) inside the target are honoured, then enforces the
-    append ordering — ``addsitedir`` would otherwise insert near the front.
+    Deliberately do not use :func:`site.addsitedir`: processing a ``.pth``
+    file executes arbitrary import statements, which would turn a writable
+    durable package directory into a code-execution hook at every startup.
+    Packages and namespace packages directly under the target remain
+    importable through the ordinary ``sys.path`` entry.
     """
     target_str = str(target)
-    # Snapshot existing entries so we can restore precedence afterwards.
-    before = list(sys.path)
-    if target_str not in before:
-        site.addsitedir(target_str)
-    # site.addsitedir may have inserted target (and any .pth-added dirs) at
-    # the front. Move every newly-added entry to the end, preserving the
-    # core venv's precedence. New entries are those not present `before`.
-    new_entries = [p for p in sys.path if p not in before]
-    if new_entries:
-        sys.path[:] = [p for p in sys.path if p not in new_entries] + new_entries
+    if target_str not in sys.path:
+        sys.path.append(target_str)
     # importlib.metadata caches the path-based distribution finder; clear it
     # so a just-activated dir is visible to version() checks this process.
     try:
@@ -492,8 +603,13 @@ def activate_durable_lazy_target() -> None:
     if target is None:
         return
     try:
-        if target.exists():
-            _activate_target_on_syspath(target)
+        if not target.exists():
+            return
+        error = _ensure_target_ready(target)
+        if error:
+            logger.debug("Refusing to activate durable lazy target: %s", error)
+            return
+        _activate_target_on_syspath(target)
     except Exception as e:  # pragma: no cover - defensive
         logger.debug("Failed to activate durable lazy target %s: %s", target, e)
 
@@ -573,6 +689,11 @@ def _pkg_name_from_spec(spec: str) -> str:
     return m.group(1) if m else spec
 
 
+def _normalize_distribution_name(name: str) -> str:
+    """Normalize distribution names according to the PEP 503 spelling."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 def _specifier_from_spec(spec: str) -> str:
     """Extract just the version-specifier portion of a pip spec.
 
@@ -587,6 +708,61 @@ def _specifier_from_spec(spec: str) -> str:
     return spec[m.end():]
 
 
+def _is_security_versioned_spec(spec: str) -> bool:
+    """Whether ``spec`` requires strict stable-version evidence."""
+
+    package = _pkg_name_from_spec(spec).replace("_", "-").lower()
+    return package in _SECURITY_VERSIONED_PACKAGES
+
+
+def _security_install_spec_error(spec: str) -> str | None:
+    """Return a reason when an arbitrary manifest spec misses a security floor.
+
+    ``install_specs`` accepts package names from runtime manifests rather than
+    the checked-in allowlist.  For the packages with known security floors, a
+    bare name or an upper-bound-only requirement is not enough evidence: pip
+    could resolve a vulnerable release.  Require an explicit lower-bound,
+    compatible, or exact requirement whose version is at least the floor.
+    ``packaging`` is already a normal Hermes dependency; if it is unavailable
+    while validating an untrusted manifest, fail closed instead of guessing.
+    """
+    package = _normalize_distribution_name(_pkg_name_from_spec(spec))
+    floor_text = _SECURITY_INSTALL_FLOORS.get(package)
+    if floor_text is None:
+        return None
+
+    spec_tail = _specifier_from_spec(spec)
+    if not spec_tail:
+        return f"{package} requires an explicit security floor >= {floor_text}"
+
+    try:
+        from packaging.specifiers import InvalidSpecifier, SpecifierSet
+        from packaging.version import InvalidVersion, Version
+
+        floor = Version(floor_text)
+        specifiers = SpecifierSet(spec_tail)
+    except (ImportError, InvalidSpecifier, InvalidVersion, TypeError, ValueError):
+        return f"{package} has an unverifiable security floor >= {floor_text}"
+
+    # A lower-bound, compatible, or exact clause at/above the floor proves
+    # that pip cannot select a vulnerable release.  Wildcard exact matches
+    # (for example ``==3.14.*``) are intentionally rejected because they also
+    # admit releases below the fixed floor.
+    for requirement in specifiers:
+        if requirement.operator not in {">=", ">", "~=", "==", "==="}:
+            continue
+        if "*" in requirement.version:
+            continue
+        try:
+            bound = Version(requirement.version)
+        except InvalidVersion:
+            continue
+        if bound >= floor:
+            return None
+
+    return f"{package} requires an explicit security floor >= {floor_text}"
+
+
 def _is_satisfied(spec: str) -> bool:
     """Is ``spec`` already satisfied in the current env?
 
@@ -596,14 +772,15 @@ def _is_satisfied(spec: str) -> bool:
     ``hermes update`` propagate pin bumps in :data:`LAZY_DEPS` to already-
     installed backends instead of silently leaving stale versions in place.
 
-    If ``packaging`` is unavailable for any reason (it's a transitive of
-    pip so this should never happen), we fall back to a presence-only check
-    so we err on the side of "don't churn".
+    Ordinary non-security specs retain the historical presence-only fallback
+    when ``packaging`` is unavailable. Security-managed specs do not: their
+    installed metadata must prove a stable release, otherwise the caller must
+    perform the repair.
     """
     pkg = _pkg_name_from_spec(spec)
     try:
         from importlib.metadata import PackageNotFoundError, version
-    except ImportError:
+    except Exception:
         return False
     try:
         installed = version(pkg)
@@ -617,18 +794,48 @@ def _is_satisfied(spec: str) -> bool:
         # Bare ``"package"`` — no version constraint, presence is enough.
         return True
 
+    strict_security = _is_security_versioned_spec(spec)
+
     try:
         from packaging.specifiers import InvalidSpecifier, SpecifierSet
         from packaging.version import InvalidVersion, Version
     except ImportError:
-        # packaging unavailable — fall back to "installed counts as satisfied".
-        return True
+        # A security repair cannot be skipped without version evidence.
+        return False if strict_security else True
+
+    if strict_security and _pip_security.stable_version_tuple(installed) is None:
+        # PEP 440 equality accepts local versions (e.g. 1.6.2+vendor), while
+        # prerelease/dev/unknown suffixes can also be numerically misleading.
+        # Accept only a stable release, with optional .postN, as evidence.
+        return False
+
+    if strict_security and spec_tail.startswith("==") and "," not in spec_tail:
+        # ``packaging`` treats ``==1.6.2.post1`` as distinct from
+        # ``==1.6.2``. For the security floor, a stable post-release of the
+        # pinned release is intentionally acceptable; it contains the same
+        # release line plus the post-release fixes. Keep this narrow and only
+        # apply it when both sides are otherwise stable.
+        expected_text = spec_tail[2:]
+        if _pip_security.stable_version_tuple(expected_text) is not None:
+            try:
+                installed_version = Version(installed)
+                expected_version = Version(expected_text)
+            except InvalidVersion:
+                return False
+            if (
+                expected_version.post is None
+                and installed_version.post is not None
+                and installed_version.release == expected_version.release
+            ):
+                return True
 
     try:
         return Version(installed) in SpecifierSet(spec_tail)
     except (InvalidSpecifier, InvalidVersion, Exception):
-        # Malformed spec or installed version we can't parse — don't churn.
-        return True
+        # Malformed spec or installed version we can't parse. A security
+        # contract must repair/fail closed; ordinary lazy specs retain the
+        # historical no-churn fallback.
+        return False if strict_security else True
 
 
 def _is_present(spec: str) -> bool:
@@ -640,7 +847,7 @@ def _is_present(spec: str) -> bool:
     pkg = _pkg_name_from_spec(spec)
     try:
         from importlib.metadata import PackageNotFoundError, version
-    except ImportError:
+    except Exception:
         return False
     try:
         version(pkg)
@@ -651,7 +858,120 @@ def _is_present(spec: str) -> bool:
         return False
 
 
-def _core_constraints_file() -> Optional[Path]:
+_PACKAGE_IMPORT_ROOT_ALIASES: dict[str, tuple[str, ...]] = {
+    # Distribution names do not always match their import package.
+    "alibabacloud-dingtalk": ("alibabacloud_dingtalk",),
+    "alibabacloud-tea-openapi": ("alibabacloud_tea_openapi",),
+    "alibabacloud-tea-util": ("alibabacloud_tea_util",),
+    "discord.py": ("discord",),
+    "google-api-python-client": ("googleapiclient",),
+    "google-auth-httplib2": ("google_auth_httplib2",),
+    "google-auth-oauthlib": ("google_auth_oauthlib",),
+    "lark-oapi": ("lark_oapi",),
+    "microsoft-teams-apps": ("microsoft_teams",),
+    "python-telegram-bot": ("telegram",),
+    "slack-bolt": ("slack_bolt",),
+    "slack-sdk": ("slack_sdk",),
+}
+
+# Only compiled/security-critical roots need a process-restart boundary when
+# their distribution is repaired. Pure-Python packages such as aiohttp can be
+# rebound by their active adapter hooks; blocking every aiohttp submodule here
+# would turn ordinary lazy refreshes into unnecessary restart requirements.
+_PRELOADED_COMPILED_IMPORT_ROOTS: dict[str, tuple[str, ...]] = {
+    "pynacl": ("nacl",),
+    "cffi": ("_cffi_backend",),
+    # Feishu's deferred SDK is imported only at connect time, but adapters
+    # retain its module-level request/client classes for their whole process
+    # lifetime.  A lazy repair cannot safely replace an already-loaded stale
+    # lark-oapi tree in place; require a fresh Hermes process instead.
+    "lark-oapi": ("lark_oapi",),
+    # aiohttp is pure Python, but its active adapters retain module-level
+    # references across a lazy repair.  Replacing its distribution in-process
+    # can therefore leave stale web/client classes bound just like a compiled
+    # package. Require a fresh Hermes process before reporting readiness.
+    "aiohttp": ("aiohttp",),
+}
+
+
+def _managed_import_roots(spec: str) -> tuple[str, ...]:
+    """Return import roots whose objects can be left stale by a repair."""
+    package = _pkg_name_from_spec(spec).lower()
+    aliases = _PACKAGE_IMPORT_ROOT_ALIASES.get(package)
+    if aliases is not None:
+        return aliases
+    normalized = package.replace("-", "_").replace(".", "_")
+    roots = [normalized]
+    if package == "pynacl":
+        roots.append("nacl")
+    elif package == "cffi":
+        roots.append("_cffi_backend")
+    return tuple(dict.fromkeys(roots))
+
+
+def _preloaded_stale_module_conflicts(
+    specs: tuple[str, ...],
+) -> tuple[tuple[str, str], ...]:
+    """Find stale managed packages already loaded in this interpreter.
+
+    Pip can replace a distribution's files and metadata without changing
+    module objects already present in sys.modules. Rebinding those objects in
+    place is unsafe, especially for compiled packages, so a lazy repair must
+    stop at an explicit process-restart boundary.
+    """
+    conflicts: list[tuple[str, str]] = []
+    loaded_names = tuple(
+        name for name, module in sys.modules.items() if module is not None
+    )
+    for spec in specs:
+        if _is_satisfied(spec):
+            continue
+        package = _pkg_name_from_spec(spec).replace("_", "-").lower()
+        roots = _PRELOADED_COMPILED_IMPORT_ROOTS.get(package, ())
+        if not roots:
+            continue
+        for name in loaded_names:
+            if any(name == root or name.startswith(f"{root}.") for root in roots):
+                conflicts.append((spec, name))
+    return tuple(conflicts)
+
+
+def _preloaded_stale_module_reason(
+    conflicts: tuple[tuple[str, str], ...],
+) -> str:
+    details = ", ".join(f"{spec} ({name})" for spec, name in conflicts)
+    return (
+        "restart required before lazy repair: managed package module(s) "
+        f"already loaded with stale metadata: {details}; restart Hermes "
+        "before retrying so imports bind the repaired files"
+    )
+
+
+def _distribution_is_target_owned(spec: str, target: Path) -> bool:
+    """Return whether the visible distribution for ``spec`` lives in target.
+
+    Durable targets are appended to ``sys.path`` and may already be active in
+    this process. A stale target-owned distribution is repairable in place;
+    only a stale distribution resolved from outside the target is core-owned
+    and must fail closed because the append-only target cannot shadow it.
+    """
+
+    try:
+        from importlib.metadata import distribution
+
+        location = Path(distribution(_pkg_name_from_spec(spec)).locate_file(""))
+        target_root = target.resolve()
+        location = location.resolve()
+        return location == target_root or target_root in location.parents
+    except Exception:
+        # Unknown ownership is unsafe to treat as target-owned. The caller
+        # therefore preserves the core fail-closed behavior.
+        return False
+
+
+def _core_constraints_file(
+    exclude_packages: tuple[str, ...] = (),
+) -> Optional[Path]:
     """Write a pip constraints file pinning every package already importable
     in the core environment to its installed version.
 
@@ -666,6 +986,14 @@ def _core_constraints_file() -> Optional[Path]:
       at install time (resolver conflict) rather than silently installing a
       shadowed copy that can never win on sys.path anyway.
 
+    The PyNaCl security override is intentionally excluded. Explicitly
+    managed backend packages supplied by the caller are excluded as well:
+    their requested versions must not be turned into stale core constraints.
+    Because the durable target is append-only, the caller rejects an already
+    installed but stale core copy before running the transaction; otherwise
+    the target copy would lose on sys.path and the stale core package would
+    silently remain active.
+
     Returns the path to a temp constraints file, or None if enumeration
     failed (in which case the caller installs without constraints — still
     safe, just less tidy).
@@ -678,16 +1006,34 @@ def _core_constraints_file() -> Optional[Path]:
         import tempfile
         lines = []
         seen = set()
+        excluded = {
+            _normalize_distribution_name(name)
+            for name in _CONSTRAINT_EXCLUDED_PACKAGES
+        }
+        excluded.update(
+            _normalize_distribution_name(_pkg_name_from_spec(spec))
+            for spec in exclude_packages
+        )
         for dist in distributions():
             name = dist.metadata["Name"] if dist.metadata else None
             ver = dist.version
-            if not name or not ver:
+            if not isinstance(name, str) or not isinstance(ver, str):
                 continue
-            key = name.lower()
+            key = _normalize_distribution_name(name)
+            if not _CONSTRAINT_NAME_RE.fullmatch(key):
+                continue
+            version_text = ver.strip()
+            if (
+                not _CONSTRAINT_VERSION_RE.fullmatch(version_text)
+                or _pip_security.stable_version_tuple(version_text) is None
+            ):
+                continue
+            if key in excluded:
+                continue
             if key in seen:
                 continue
             seen.add(key)
-            lines.append(f"{name}=={ver}")
+            lines.append(f"{key}=={version_text}")
         if not lines:
             return None
         fd, path = tempfile.mkstemp(prefix="hermes-core-constraints-", suffix=".txt")
@@ -718,14 +1064,72 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
     if not specs:
         return _InstallResult(True, "", "")
 
+    preloaded_conflicts = _preloaded_stale_module_conflicts(specs)
+    if preloaded_conflicts:
+        return _InstallResult(
+            False,
+            "",
+            _preloaded_stale_module_reason(preloaded_conflicts),
+        )
+
     target = _lazy_install_target()
     constraints: Optional[Path] = None
+    # Keep the exact security override in a separate transaction.  In
+    # particular, a durable target may be paired with a stale core venv, and
+    # uv/pip invoked outside the project do not consume pyproject's
+    # override-dependencies.  The ordinary Discord requirements intentionally
+    # omit discord.py's stale [voice] metadata; the exact transaction still
+    # makes the security invariant explicit and repairs pre-existing installs.
+    # Match the managed override by normalized distribution name and exact
+    # version, not by spelling. Pip/metadata accept case and ``-_.``
+    # variations (for example ``pynacl==1.6.2``), and leaving one of those
+    # spellings in the regular resolver transaction can reintroduce the
+    # discord.py voice upper bound before the exact repair runs.
+    override_specs = tuple(
+        spec
+        for spec in specs
+        if _normalize_distribution_name(_pkg_name_from_spec(spec))
+        == _normalize_distribution_name(_pkg_name_from_spec(_PYNACL_SECURITY_SPEC))
+        and _specifier_from_spec(spec) == "==1.6.2"
+    )
+    regular_specs = tuple(spec for spec in specs if spec not in override_specs)
 
     if target is not None:
+        # Create/validate the target and clear ABI-incompatible contents before
+        # inspecting ownership. A stale target-only distribution is then
+        # eligible for repair; a stale core distribution remains protected by
+        # the append-only sys.path invariant.
         err = _ensure_target_ready(target)
         if err:
             return _InstallResult(False, "", err)
-        constraints = _core_constraints_file()
+        # An append-only durable target cannot override a package that is
+        # already present in the sealed/core venv. Excluding these packages
+        # from the generated constraints lets the resolver proceed when the
+        # core version is absent or already compatible; this preflight makes
+        # an incompatible core-owned package fail closed instead of silently
+        # winning over the requested target version at import time.
+        stale_core_specs = tuple(
+            spec
+            for spec in specs
+            if (
+                _is_present(spec)
+                and not _is_satisfied(spec)
+                and not _distribution_is_target_owned(spec, target)
+            )
+        )
+        if stale_core_specs:
+            return _InstallResult(
+                False,
+                "",
+                "core package(s) "
+                f"{', '.join(stale_core_specs)} must be repaired before "
+                "durable lazy install; append-only sys.path cannot replace "
+                "them, so refresh the core environment before enabling this "
+                "feature",
+            )
+        constraints = _core_constraints_file(
+            tuple(_pkg_name_from_spec(spec) for spec in specs)
+        )
 
     target_args: list[str] = []
     if target is not None:
@@ -734,6 +1138,32 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
     constraint_args: list[str] = []
     if constraints is not None:
         constraint_args = ["--constraint", str(constraints)]
+
+    def _security_specs_satisfied() -> bool:
+        """Re-read the active environment's exact security override state."""
+        try:
+            import importlib
+            importlib.invalidate_caches()
+            import importlib.metadata as _md
+            if hasattr(_md, "_cache_clear"):
+                _md._cache_clear()  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        if not override_specs:
+            return True
+        # PyNaCl imports cffi at runtime. The exact --no-deps retry cannot
+        # supply that transitive dependency, so do not report a repaired
+        # Discord feature unless cffi is present too.
+        return all(_is_satisfied(spec) for spec in override_specs) and _is_present(
+            "cffi"
+        )
+
+    project_root = Path(__file__).resolve().parents[1]
+    project_args = (
+        ["--project", str(project_root)]
+        if (project_root / "pyproject.toml").is_file()
+        else []
+    )
 
     try:
         venv_root = Path(sys.executable).parent.parent
@@ -756,21 +1186,90 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             uv_bin = shutil.which("uv")
         if uv_bin:
             try:
-                r = subprocess.run(
-                    [uv_bin, "pip", "install", *target_args, *constraint_args, *specs],
-                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout, env=uv_env,
-                    stdin=subprocess.DEVNULL,
-                    creationflags=windows_hide_flags(),
+                stdout = ""
+                stderr = ""
+                transactions = (
+                    ((regular_specs, constraint_args), (override_specs, []))
+                    if override_specs
+                    else ((regular_specs, constraint_args),)
                 )
-                if r.returncode == 0:
-                    if target is not None:
-                        _activate_target_on_syspath(target)
-                    return _InstallResult(True, r.stdout or "", r.stderr or "")
-                logger.debug("uv pip install failed: %s", r.stderr)
-                # A resolver failure is authoritative. Falling through to pip
-                # here would silently discard uv policy such as exclude-newer
-                # and could install a release that the project quarantined.
-                return _InstallResult(False, r.stdout or "", r.stderr or "")
+                for transaction_specs, transaction_constraints in transactions:
+                    if not transaction_specs:
+                        continue
+                    r = subprocess.run(
+                        [
+                            uv_bin,
+                            "pip",
+                            "install",
+                            *project_args,
+                            *target_args,
+                            *transaction_constraints,
+                            *transaction_specs,
+                        ],
+                        capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout, env=uv_env,
+                        stdin=subprocess.DEVNULL,
+                        creationflags=windows_hide_flags(),
+                    )
+                    stdout += r.stdout or ""
+                    stderr += r.stderr or ""
+                    if r.returncode != 0:
+                        if transaction_specs == override_specs and override_specs:
+                            # A failed resolver/network attempt must not leave
+                            # the feature looking repaired. Retry the exact
+                            # package without dependency resolution: this is
+                            # both a useful transient-network recovery and a
+                            # final guard against discord.py's stale voice
+                            # upper bound re-entering the transaction.
+                            retry = subprocess.run(
+                                [
+                                    uv_bin,
+                                    "pip",
+                                    "install",
+                                    "--no-deps",
+                                    *project_args,
+                                    *target_args,
+                                    *override_specs,
+                                ],
+                                capture_output=True,
+                                text=True,
+                                encoding="utf-8",
+                                errors="replace",
+                                timeout=timeout,
+                                env=uv_env,
+                                stdin=subprocess.DEVNULL,
+                                creationflags=windows_hide_flags(),
+                            )
+                            stdout += retry.stdout or ""
+                            stderr += retry.stderr or ""
+                            if retry.returncode == 0:
+                                if target is not None:
+                                    _activate_target_on_syspath(target)
+                                if _security_specs_satisfied():
+                                    continue
+                            if not _security_specs_satisfied():
+                                stderr += (
+                                    "\nExact PyNaCl security repair failed or "
+                                    "the active environment remains below "
+                                    "PyNaCl==1.6.2 or is missing runtime cffi."
+                                )
+                        logger.debug("uv pip install failed: %s", r.stderr)
+                        # A resolver failure is authoritative. Falling through
+                        # to pip here would silently discard uv policy such as
+                        # exclude-newer and could install a quarantined release.
+                        return _InstallResult(False, stdout, stderr)
+                    if transaction_specs == override_specs and override_specs:
+                        if target is not None:
+                            _activate_target_on_syspath(target)
+                        if not _security_specs_satisfied():
+                            stderr += (
+                                "\nExact PyNaCl security repair succeeded but "
+                                "the active environment is missing PyNaCl's "
+                                "runtime cffi dependency."
+                            )
+                            return _InstallResult(False, stdout, stderr)
+                if target is not None:
+                    _activate_target_on_syspath(target)
+                return _InstallResult(True, stdout, stderr)
             except subprocess.TimeoutExpired as e:
                 logger.debug("uv invocation failed: %s", e)
                 return _InstallResult(False, "", f"uv pip install timed out: {e}")
@@ -803,16 +1302,80 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 return _InstallResult(False, "",
                                       f"pip not available and ensurepip failed: {e}")
 
+        pip_ok, pip_error = _ensure_pip_floor(pip_cmd, timeout=120)
+        if not pip_ok:
+            return _InstallResult(False, "", pip_error)
+
+        # Apply the same split transaction strategy as uv above.  In
+        # particular, skip an empty regular transaction when PyNaCl is the
+        # only missing spec; ``pip install`` with no requirements fails before
+        # the exact security repair can run.
         try:
-            r = subprocess.run(
-                pip_cmd + ["install", *target_args, *constraint_args, *specs],
-                capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
-                stdin=subprocess.DEVNULL,
-                creationflags=windows_hide_flags(),
-            )
-            if r.returncode == 0 and target is not None:
+            stdout = ""
+            stderr = ""
+            if regular_specs:
+                r = subprocess.run(
+                    pip_cmd + ["install", *target_args, *constraint_args, *regular_specs],
+                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
+                    stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
+                )
+                stdout += r.stdout or ""
+                stderr += r.stderr or ""
+                if r.returncode != 0:
+                    return _InstallResult(False, stdout, stderr)
+            if override_specs:
+                override = subprocess.run(
+                    pip_cmd + ["install", *target_args, *override_specs],
+                    capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=timeout,
+                    stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
+                )
+                stdout += override.stdout or ""
+                stderr += override.stderr or ""
+                if override.returncode != 0:
+                    # The regular transaction is deliberately allowed to
+                    # complete before this exact repair, but a failed second
+                    # step must be retried and verified rather than returning
+                    # a successful install with a vulnerable PyNaCl left in
+                    # the venv.  ``--no-deps`` avoids re-entering stale voice
+                    # metadata on the repair attempt.
+                    retry = subprocess.run(
+                        pip_cmd + ["install", "--no-deps", *target_args, *override_specs],
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        timeout=timeout,
+                        stdin=subprocess.DEVNULL,
+                        creationflags=windows_hide_flags(),
+                    )
+                    stdout += retry.stdout or ""
+                    stderr += retry.stderr or ""
+                    if retry.returncode == 0:
+                        if target is not None:
+                            _activate_target_on_syspath(target)
+                        if _security_specs_satisfied():
+                            return _InstallResult(True, stdout, stderr)
+                    if not _security_specs_satisfied():
+                        stderr += (
+                            "\nExact PyNaCl security repair failed or the active "
+                            "environment remains below PyNaCl==1.6.2 or is missing "
+                            "runtime cffi."
+                        )
+                    return _InstallResult(False, stdout, stderr)
+                if target is not None:
+                    _activate_target_on_syspath(target)
+                if not _security_specs_satisfied():
+                    stderr += (
+                        "\nExact PyNaCl security repair succeeded but the "
+                        "active environment is missing PyNaCl's runtime cffi "
+                        "dependency."
+                    )
+                    return _InstallResult(False, stdout, stderr)
+            if target is not None:
                 _activate_target_on_syspath(target)
-            return _InstallResult(r.returncode == 0, r.stdout or "", r.stderr or "")
+            return _InstallResult(True, stdout, stderr)
         except subprocess.TimeoutExpired as e:
             return _InstallResult(False, "", f"pip install timed out: {e}")
         except Exception as e:
@@ -862,6 +1425,14 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
     missing = feature_missing(feature)
     if not missing:
         return
+
+    preloaded_conflicts = _preloaded_stale_module_conflicts(missing)
+    if preloaded_conflicts:
+        raise FeatureUnavailable(
+            feature,
+            missing,
+            _preloaded_stale_module_reason(preloaded_conflicts),
+        )
 
     unsupported = _unsupported_feature_reason(feature)
     if unsupported:
@@ -1054,6 +1625,13 @@ def install_specs(specs: list[str] | tuple[str, ...], *, timeout: int = 300) -> 
                 ok=False, blocked=True,
                 reason=f"refusing to install unsafe spec {spec!r}",
             )
+        security_error = _security_install_spec_error(spec)
+        if security_error is not None:
+            return InstallSpecsResult(
+                ok=False,
+                blocked=True,
+                reason=f"refusing to install insecure spec {spec!r}: {security_error}",
+            )
 
     if not _allow_lazy_installs():
         target = _lazy_install_target()
@@ -1130,6 +1708,8 @@ def refresh_active_features(*, prompt: bool = False) -> dict[str, str]:
         ``"failed: <reason>"`` — install attempt failed; caller decides
                                   whether to surface it (we don't raise)
         ``"skipped: <reason>"`` — gated off (config flag, user decline)
+        ``"restart-required: <reason>"`` — a stale loaded module requires a
+                                             fresh Hermes process
 
     Intended for ``hermes update``. Never raises; lazy-install failures
     here must not block the rest of the update flow.
@@ -1182,6 +1762,8 @@ def _refresh_features(
                 or e.reason.startswith("unsupported ")
             ):
                 results[feature] = f"skipped: {e.reason}"
+            elif e.reason.startswith("restart required before lazy repair:"):
+                results[feature] = f"restart-required: {e.reason}"
             else:
                 results[feature] = f"failed: {e.reason}"
         except Exception as e:
@@ -1235,7 +1817,7 @@ def ensure_and_bind(
 
     try:
         bindings = importer()
-    except ImportError:
+    except Exception:
         return False
 
     target_globals.update(bindings)

--- a/uv.lock
+++ b/uv.lock
@@ -1104,12 +1104,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/a7/17208c3b3f92319e7fad259f1c6d5a5baf8fd0654c54846ced329f83c3eb/discord_py-2.7.1-py3-none-any.whl", hash = "sha256:849dca2c63b171146f3a7f3f8acc04248098e9e6203412ce3cf2745f284f7439", size = 1227550, upload-time = "2026-03-03T18:40:44.492Z" },
 ]
 
-[package.optional-dependencies]
-voice = [
-    { name = "davey" },
-    { name = "pynacl" },
-]
-
 [[package]]
 name = "distro"
 version = "1.9.0"
@@ -1579,6 +1573,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "fire" },
     { name = "httpx", extra = ["socks"] },
+    { name = "idna" },
     { name = "jinja2" },
     { name = "markdown" },
     { name = "nemo-relay", marker = "(platform_machine == 'aarch64' and 'android' not in platform_release and sys_platform == 'linux') or (platform_machine == 'x86_64' and 'android' not in platform_release and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')" },
@@ -1642,6 +1637,7 @@ computer-use = [
     { name = "starlette" },
 ]
 daytona = [
+    { name = "aiohttp" },
     { name = "daytona" },
 ]
 dev = [
@@ -1656,11 +1652,13 @@ dev = [
     { name = "ty" },
 ]
 dingtalk = [
+    { name = "aiohttp" },
     { name = "alibabacloud-dingtalk" },
     { name = "dingtalk-stream" },
     { name = "qrcode" },
 ]
 edge-tts = [
+    { name = "aiohttp" },
     { name = "edge-tts" },
 ]
 exa = [
@@ -1670,10 +1668,13 @@ fal = [
     { name = "fal-client" },
 ]
 feishu = [
+    { name = "aiohttp" },
     { name = "lark-oapi" },
     { name = "qrcode" },
+    { name = "websockets" },
 ]
 firecrawl = [
+    { name = "aiohttp" },
     { name = "firecrawl-py" },
 ]
 google = [
@@ -1685,6 +1686,7 @@ google = [
     { name = "pyasn1" },
 ]
 hindsight = [
+    { name = "aiohttp" },
     { name = "hindsight-client" },
 ]
 homeassistant = [
@@ -1711,7 +1713,9 @@ mem0 = [
 messaging = [
     { name = "aiohttp" },
     { name = "brotlicffi" },
-    { name = "discord-py", extra = ["voice"] },
+    { name = "davey" },
+    { name = "discord-py" },
+    { name = "pynacl" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "qrcode" },
     { name = "slack-bolt" },
@@ -1721,6 +1725,7 @@ mistral = [
     { name = "mistralai" },
 ]
 modal = [
+    { name = "aiohttp" },
     { name = "modal" },
 ]
 otlp = [
@@ -1802,6 +1807,7 @@ web = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 wecom = [
+    { name = "aiohttp" },
     { name = "defusedxml" },
 ]
 youtube = [
@@ -1812,12 +1818,20 @@ youtube = [
 requires-dist = [
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = "==0.9.0" },
     { name = "ai-edge-litert", marker = "sys_platform == 'darwin' and extra == 'wake'", specifier = "==2.1.6" },
+    { name = "aiohttp", marker = "extra == 'feishu'", specifier = "==3.14.3" },
+    { name = "aiohttp", marker = "extra == 'daytona'", specifier = "==3.14.3" },
+    { name = "aiohttp", marker = "extra == 'dingtalk'", specifier = "==3.14.3" },
+    { name = "aiohttp", marker = "extra == 'edge-tts'", specifier = "==3.14.3" },
+    { name = "aiohttp", marker = "extra == 'firecrawl'", specifier = "==3.14.3" },
+    { name = "aiohttp", marker = "extra == 'hindsight'", specifier = "==3.14.3" },
     { name = "aiohttp", marker = "extra == 'homeassistant'", specifier = "==3.14.3" },
     { name = "aiohttp", marker = "extra == 'matrix'", specifier = "==3.14.3" },
     { name = "aiohttp", marker = "extra == 'messaging'", specifier = "==3.14.3" },
+    { name = "aiohttp", marker = "extra == 'modal'", specifier = "==3.14.3" },
     { name = "aiohttp", marker = "extra == 'slack'", specifier = "==3.14.3" },
     { name = "aiohttp", marker = "extra == 'sms'", specifier = "==3.14.3" },
     { name = "aiohttp", marker = "extra == 'teams'", specifier = "==3.14.3" },
+    { name = "aiohttp", marker = "extra == 'wecom'", specifier = "==3.14.3" },
     { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = "==0.11.0" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = "==0.22.1" },
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = "==2.2.42" },
@@ -1830,11 +1844,12 @@ requires-dist = [
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "cryptography", specifier = "==50.0.0" },
+    { name = "davey", marker = "extra == 'messaging'", specifier = "==0.1.4" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
     { name = "dingtalk-stream", marker = "extra == 'dingtalk'", specifier = "==0.24.3" },
-    { name = "discord-py", extras = ["voice"], marker = "extra == 'messaging'", specifier = "==2.7.1" },
+    { name = "discord-py", marker = "extra == 'messaging'", specifier = "==2.7.1" },
     { name = "edge-tts", marker = "extra == 'edge-tts'", specifier = "==7.2.7" },
     { name = "elevenlabs", marker = "extra == 'tts-premium'", specifier = "==1.59.0" },
     { name = "exa-py", marker = "extra == 'exa'", specifier = "==2.10.2" },
@@ -1875,6 +1890,7 @@ requires-dist = [
     { name = "httpx2", marker = "extra == 'computer-use'", specifier = "==2.7.0" },
     { name = "httpx2", marker = "extra == 'dev'", specifier = "==2.7.0" },
     { name = "httpx2", marker = "extra == 'mcp'", specifier = "==2.7.0" },
+    { name = "idna", specifier = "==3.18" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.6.8" },
     { name = "markdown", specifier = "==3.10.2" },
@@ -1905,6 +1921,7 @@ requires-dist = [
     { name = "pyasn1", marker = "extra == 'google'", specifier = "==0.6.4" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
+    { name = "pynacl", marker = "extra == 'messaging'", specifier = "==1.6.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
@@ -1917,6 +1934,7 @@ requires-dist = [
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "qrcode", marker = "extra == 'dingtalk'", specifier = "==7.4.2" },
     { name = "qrcode", marker = "extra == 'feishu'", specifier = "==7.4.2" },
+    { name = "websockets", marker = "extra == 'feishu'", specifier = "==15.0.1" },
     { name = "qrcode", marker = "extra == 'messaging'", specifier = "==7.4.2" },
     { name = "requests", specifier = "==2.33.0" },
     { name = "rich", specifier = "==14.3.3" },


### PR DESCRIPTION
Hermes pinned advisory-fixed package versions but direct-pip recovery and lazy
platform installers could still run through an old pip or trust importable
SDKs with stale distribution metadata. IDNA was only transitively resolved,
and discord.py's published voice extra constrained PyNaCl below the fixed floor.

Pin the current IDNA resolution directly, verify pip >=26.1.2 before every
managed direct-pip transaction, and make lazy platform checks revalidate and
repair their declared distributions. Preserve uv-managed install paths,
current cryptography/MCP/Node upgrades, live SDK bindings, and retryable
platform behavior while failing closed on unverifiable floors or unsafe
targets.

Fixes #41374

## Validation

- Affected deterministic suite: 509 passed, 0 failed, 5 skipped
- Ruff on all changed Python files
- Shell syntax checks for changed installers
- `uv lock --check`
- Positive and negative pip-floor controls
- Merge-tree and diff checks against current `main`

## Not checked

- Five Windows-only tests were skipped on the Linux host; they run in the Windows CI lane.
- The repository-wide suite requires optional ACP and Anthropic dependencies absent from the task-local environment; the complete affected suite passed.
- CodeRabbit was skipped under the repository's P2 policy.

## Agent disclosure

This PR was prepared by GPT-5.6 Sol with xhigh reasoning in the Codex Desktop harness. The account owner loosely reviews my actions and receives the usual notifications from GitHub.
