### PR TITLE
fix(update): exit non-zero when the upstream pull fails

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2711,6 +2711,26 @@ def _sync_fork_with_upstream(git_cmd: list[str], cwd: Path) -> bool:
     except Exception:
         return False
 
+def _abort_on_failed_upstream_sync() -> None:
+    """Abort the update after a FAILED upstream pull (never returns).
+
+    Called by the post-dependency call site in ``_cmd_update_impl`` when
+    ``_sync_with_upstream_if_needed()`` returned False AND the helper
+    actually reached the ``pull --ff-only upstream main`` step. The
+    early call site does NOT call this — it treats a False as a
+    possibly-skipped convenience (no upstream remote, declined prompt,
+    fetch/compare failure) and lets the later caller surface the real
+    pull failure. Without this helper, the run would fall through to
+    "Already up to date!" with exit 0 (#73108's inverse). The message
+    lives here once so the gateway and CLI flows cannot drift apart.
+    """
+    print()
+    print("X Update failed: could not pull from upstream.")
+    print("   Resolve manually, then re-run the update:")
+    print("     git pull upstream main")
+    sys.exit(1)
+
+
 def _sync_with_upstream_if_needed(
     git_cmd: list[str],
     cwd: Path,
@@ -8319,12 +8339,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         # Fork upstream sync logic (only for main branch on forks)
         if is_fork and branch == "main":
-            _m()._sync_with_upstream_if_needed(
+            if not _m()._sync_with_upstream_if_needed(
                 git_cmd,
                 _m().PROJECT_ROOT,
                 assume_yes=assume_yes,
                 input_fn=gw_input_fn,
-            )
+            ):
+                # A failed upstream pull must abort with a non-zero exit so
+                # Desktop / CI / the command-boundary receipt record a failure
+                # instead of a successful update (see the function docstring
+                # and #73108 for the sibling misreport). We do this only at
+                # the post-dependency call site so that early-call skipped
+                # cases (no upstream remote, declined prompt, fetch/compare
+                # failure) still let the regular origin/main update path run.
+                _abort_on_failed_upstream_sync()
 
         # Reinstall Python dependencies. Prefer .[all], but if one optional extra
         # breaks on this machine, keep base deps and reinstall the remaining extras

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -10,6 +10,11 @@ import pytest
 from hermes_cli.main import cmd_update, PROJECT_ROOT
 
 
+def _completed_process(returncode: int = 0):
+    """A minimal CompletedProcess stand-in for mocked subprocess.run calls."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode)
+
+
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
     """Build a side_effect function for subprocess.run that simulates git commands."""
 
@@ -418,6 +423,110 @@ class TestCmdUpdateBranchFallback:
         post_update_step.assert_called_once_with()
         captured = capsys.readouterr()
         assert "Already up to date!" not in captured.out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_fork_upstream_pull_failure_exits_nonzero_second_call_site(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        """Same failure contract at the post-dependency-sync call site.
+
+        The second ``is_fork`` sync runs after the regular update path. A
+        False there must abort via the same helper so both flows print an
+        identical message (#73679 covers its success counterpart).
+        """
+        from hermes_cli import main as hm
+
+        # commit_count="1" skips the commit_count == 0 early-return block so
+        # the run reaches the SECOND call site after dependency bookkeeping.
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(
+            hm, "_sync_with_upstream_if_needed", return_value=False
+        ), patch.object(
+            hm,
+            "_reload_updated_runtime_modules",
+            side_effect=SystemExit(0),
+        ) as post_update_step:
+            with pytest.raises(SystemExit) as exit_info:
+                cmd_update(mock_args)
+
+        assert exit_info.value.code == 1
+        post_update_step.assert_not_called()
+        captured = capsys.readouterr()
+        assert "Already up to date!" not in captured.out
+        assert "Update failed" in captured.out
+
+    def test_sync_bool_mapping_on_head_semantics(self, tmp_path):
+        """Unit-test the bool mapping of _sync_with_upstream_if_needed directly.
+
+        On current upstream/main the function returns True only when
+        origin/main was actually verified against the official upstream/main;
+        every path where the check never happened (prompt skipped or
+        declined, remote add failed, fetch or compare failed, pull failed)
+        returns False so the caller can avoid reporting the checkout as up
+        to date on the strength of an origin comparison alone (#97052
+        review). The post-dependency call site aborts on False.
+        """
+        from hermes_cli.update_cmd import _sync_with_upstream_if_needed
+
+        git_cmd = ["git"]
+        with patch(
+            "hermes_cli.update_cmd._has_upstream_remote", return_value=True
+        ) as has_upstream, patch(
+            "hermes_cli.update_cmd._should_skip_upstream_prompt", return_value=True
+        ), patch(
+            "hermes_cli.update_cmd.subprocess.run"
+        ) as mock_run, patch(
+            "hermes_cli.update_cmd._count_commits_between", return_value=0
+        ), patch(
+            "hermes_cli.update_cmd._sync_fork_with_upstream", return_value=True
+        ):
+            # Up-to-date fork → True (verified).
+            mock_run.return_value = _completed_process()
+            assert _sync_with_upstream_if_needed(git_cmd, tmp_path) is True
+            has_upstream.assert_called_once()
+
+            # Fetch failure → False (the check never happened).
+            mock_run.side_effect = [subprocess.CalledProcessError(1, ["git", "fetch"])]
+            assert _sync_with_upstream_if_needed(git_cmd, tmp_path) is False
+
+            # Compare failure → False (the check never happened).
+            mock_run.side_effect = None
+            mock_run.return_value = _completed_process()
+            with patch(
+                "hermes_cli.update_cmd._count_commits_between",
+                side_effect=lambda *a, **k: -1,
+            ):
+                assert _sync_with_upstream_if_needed(git_cmd, tmp_path) is False
+
+            # Failed pull --ff-only → False (must abort at the caller).
+            with patch(
+                "hermes_cli.update_cmd._count_commits_between",
+                side_effect=[0, 1],
+            ):
+                mock_run.side_effect = [
+                    _completed_process(),
+                    subprocess.CalledProcessError(128, ["git", "pull"]),
+                ]
+                assert _sync_with_upstream_if_needed(git_cmd, tmp_path) is False
+
+            # Successful pull → True (verified and advanced).
+            with patch(
+                "hermes_cli.update_cmd._count_commits_between",
+                side_effect=[0, 1],
+            ):
+                mock_run.side_effect = [
+                    _completed_process(),
+                    _completed_process(),
+                ]
+                assert _sync_with_upstream_if_needed(git_cmd, tmp_path) is True
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""


### PR DESCRIPTION
## What does this PR do?

On a fork, a **failed** upstream sync is silently reported as a successful no-op update with **exit code 0**.

`_sync_with_upstream_if_needed()` now returns a bool (True = origin/main was actually verified against official upstream; False = the check never happened — prompt skipped/declined, remote add failed, fetch/compare failed, or a failed `git pull --ff-only upstream main`). The **post-dependency** call site in `_cmd_update_impl` ignored that return value, so a failed pull fell through to `✓ Already up to date!` with exit 0. Desktop / CI / the update-receipt boundary read exit 0 as "update complete" while local HEAD never advanced — the user is never told the pull failed.

This is the **inverse** of #73108 / #73679: that fixed a *successful* upstream sync being misreported as "Already up to date!". This fixes a *failed* pull being misreported as a successful no-op.

### Reproduce (fork-based deployment behind upstream)

```
→ Fetching upstream...
→ Fork is N commit(s) behind upstream
→ Pulling from upstream...
fatal: Not possible to fast-forward, aborting.   # e.g. fork diverged
  ✗ Failed to pull from upstream. You may need to resolve conflicts manually.
✓ Already up to date!
$ echo $?
0          # ← the failed pull is reported as success
```

## Changes

- **`hermes_cli/update_cmd.py`**
  - New helper `_abort_on_failed_upstream_sync()` — prints the failure + remedy once and `sys.exit(1)`. (Return values from `_cmd_update_impl` are not propagated to the process exit code, so `sys.exit` is required rather than `return`.)
  - The **post-dependency call site** (the sync that runs after the regular update path) now checks the bool return and aborts via the helper when the sync reported failure.
  - The early call site (`commit_count == 0` path) is intentionally **not** aborted: upstream `be284cf5c` (#97052 review) migrated that path to `upstream_checked` semantics, which report "Up to date with your fork (official repo not checked)" instead of aborting — skip-as-decline stays a skip.
- **`tests/hermes_cli/test_cmd_update.py`**
  - `test_fork_upstream_pull_failure_exits_nonzero_second_call_site`: a failed upstream sync at the post-dependency call site exits non-zero and does **not** print "Already up to date!".
  - `test_sync_bool_mapping_on_head_semantics`: pins the bool contract on current HEAD semantics — fetch/compare/pull failure → False; up-to-date / origin-ahead / successful pull → True.

Note: this is a re-application of the earlier version of this PR onto current upstream/main after 1047 commits of refactor (original base b742be711; `ee751b7c8` was the previous rework). The diff is smaller now because upstream itself already migrated the early call site — the remaining hole is the post-dependency call site.

## How to test

```
cd hermes-agent
source .venv/bin/activate
python -m pytest tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_fork_upstream_pull_failure_exits_nonzero_second_call_site tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_sync_bool_mapping_on_head_semantics -q
```