### PR TITLE
fix(agent): recognize proxied google surfaces as native Gemini REST endpoints

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2496,7 +2496,11 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             agent._client_log_context(),
         )
         return client
-    if agent.provider == "gemini":
+    # Gemini native client also for proxied google surfaces (e.g. Palantir
+    # Foundry /api/v2/llm/proxy/google/v1): is_native_gemini_base_url()
+    # recognizes them, so dispatch must not gate on provider id alone.
+    _ck_base = str(client_kwargs.get("base_url", "") or "").lower()
+    if agent.provider == "gemini" or "/api/v2/llm/proxy/google" in _ck_base:
         from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
         base_url = str(client_kwargs.get("base_url", "") or "")

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -90,6 +90,13 @@ def is_native_gemini_base_url(base_url: str) -> bool:
     normalized = str(base_url or "").strip().rstrip("/").lower()
     if not normalized:
         return False
+    # Palantir Foundry's google surface proxies Gemini-native REST under
+    # /api/v2/llm/proxy/google/v1 (verified 2026-06-10: dispatch fell through
+    # to the OpenAI SDK, which appends /v1beta and sends the wrong shape —
+    # HTTP 404). Upstream's check only matches the public Google host;
+    # recognize the proxy surface too.
+    if "/api/v2/llm/proxy/google" in normalized:
+        return not normalized.endswith("/openai")
     if "generativelanguage.googleapis.com" not in normalized:
         return False
     return not normalized.endswith("/openai")


### PR DESCRIPTION
## Problem

Hermes dispatches provider clients by provider id: the native Gemini client
(`GeminiNativeClient`) is only built when `agent.provider == "gemini"`. A
Gemini-native endpoint reached through a generic proxy surface — e.g. Palantir
Foundry's google proxy at `<org>.palantirfoundry.co.uk/api/v2/llm/proxy/google/v1`
— runs under a different provider id, so dispatch falls through to the OpenAI
SDK path.

The OpenAI SDK then appends `/v1beta` to the base URL and sends an
OpenAI-shaped payload to a Gemini-native REST endpoint:

```
HTTP 404 (wrong URL shape)
```

Verified 2026-06-10 against a live Foundry google-proxy surface.

## Fix

Two small, symmetric changes:

1. `is_native_gemini_base_url()` (`agent/gemini_native_adapter.py`) now
   recognizes URLs containing `/api/v2/llm/proxy/google` as native Gemini
   REST surfaces (same `/openai` exclusion as the public Google host).
2. The dispatch gate in `create_openai_client()`
   (`agent/agent_runtime_helpers.py`) no longer keys on provider id alone:
   it also takes the native-client branch when `client_kwargs["base_url"]`
   matches that same proxy pattern, so `is_native_gemini_base_url()` gets
   to decide for these URLs.

Behavior for all existing setups is unchanged: pure OpenAI-compat proxy
surfaces still route through the OpenAI SDK; only Gemini-native REST
surfaces are affected.

## Tests

Verified against the Hermes venv on this branch:

- proxy google surface → recognized as native
- `generativelanguage.googleapis.com` → still recognized as native
- `/openai` suffixed surface → not native (unchanged)
- unrelated host → not native (unchanged)

Happy to add these as unit tests in `tests/agent/` if you prefer them
in-repo — say the word and I'll push a follow-up commit.
