### PR TITLE
fix(agent): self-heal strict-proxy 400s on echoed reasoning_details

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -909,6 +909,32 @@ def classify_api_error(
             should_fallback=True,
         )
 
+    # Strict Anthropic/OpenAI-compat proxies (Palantir Foundry LLM proxy,
+    # Mistral, ...) reject the ``reasoning_details`` field Hermes echoes back
+    # for multi-turn reasoning continuity: HTTP 400 with
+    # ``{unrecognizedProperty=reasoning_details}`` / "unrecognized field".
+    # Unlike the signature/frozen-block cases below this carries no
+    # "thinking" token, so it fell through to a non-retryable format_error
+    # and the turn hard-aborted (observed on opus subagents doing many
+    # tool-call steps: the prior step's reasoning_details rides into the
+    # next request and the strict proxy rejects the whole call). Same
+    # recovery applies — strip all reasoning_details and retry — so route
+    # it to the thinking_signature handler in conversation_loop.py.
+    if (
+        status_code == 400
+        and "reasoning_details" in error_msg
+        and (
+            "unrecognized" in error_msg
+            or "unknown" in error_msg
+            or "invalid" in error_msg
+        )
+    ):
+        return _result(
+            FailoverReason.thinking_signature,
+            retryable=True,
+            should_compress=False,
+        )
+
     # Anthropic thinking block recovery (400).  Two distinct failure modes,
     # same recovery (strip all reasoning_details and retry without thinking
     # blocks — see the thinking_signature handler in conversation_loop.py):

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -920,15 +920,27 @@ def classify_api_error(
     # next request and the strict proxy rejects the whole call). Same
     # recovery applies — strip all reasoning_details and retry — so route
     # it to the thinking_signature handler in conversation_loop.py.
+    # Lowercased once so capitalized proxy variants ("Unrecognized request
+    # argument supplied", "Unknown field:") match too.
+    _rd_msg = error_msg.lower()
     if (
         status_code == 400
-        and "reasoning_details" in error_msg
+        and "reasoning_details" in _rd_msg
         and (
-            "unrecognized" in error_msg
-            or "unknown" in error_msg
-            or "invalid" in error_msg
+            "unrecognized" in _rd_msg
+            or "unknown" in _rd_msg
+            or "invalid" in _rd_msg
         )
     ):
+        # The keyword net is deliberately broad: a 400 that merely mentions
+        # reasoning_details plus one of these words routes here even when the
+        # real problem was elsewhere. Recovery is harmless either way (retry
+        # omits the field), but log it so one-round-trip misroutes stay
+        # visible in traces instead of being silently absorbed.
+        logger.warning(
+            "400 mentions reasoning_details + unrecognized/unknown/invalid "
+            "(strict-proxy shape) — routing to thinking_signature strip-and-retry"
+        )
         return _result(
             FailoverReason.thinking_signature,
             retryable=True,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1441,3 +1441,60 @@ class TestServerInjectedParameterRejection:
         assert result.retryable is False
 
 
+class TestUnrecognizedReasoningDetailsSelfHeal:
+    """Strict proxies (Palantir Foundry, ...) 400 on the echoed
+    ``reasoning_details`` field. Must route to the thinking_signature
+    strip-and-retry path instead of hard-aborting as format_error.
+    See PR #93035."""
+
+    def test_foundry_unrecognized_property_shape_self_heals(self):
+        """Exact Foundry wire shape (lowercase keywords)."""
+        e = MockAPIError(
+            "400 INVALID_ARGUMENT unsafeParams "
+            "{unrecognizedProperty=reasoning_details} Request contained an unrecognized field",
+            status_code=400,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_capitalized_unknown_field_variant_self_heals(self):
+        """Capitalized proxy variants must match too — regression for the
+        case-sensitive first cut."""
+        e = MockAPIError(
+            "Unknown field: reasoning_details",
+            status_code=400,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_capitalized_unrecognized_argument_variant_self_heals(self):
+        e = MockAPIError(
+            "Unrecognized request argument supplied: reasoning_details",
+            status_code=400,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_mention_without_keywords_stays_non_retryable(self):
+        """Negative control: a 400 that mentions reasoning_details but none of
+        the keyword markers keeps failing fast."""
+        e = MockAPIError(
+            "reasoning_details failed validation",
+            status_code=400,
+        )
+        result = classify_api_error(e)
+        assert result.reason != FailoverReason.thinking_signature
+
+    def test_other_400_without_reasoning_details_untouched(self):
+        e = MockAPIError(
+            "invalid_request_error: bad tool schema",
+            status_code=400,
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+


### PR DESCRIPTION
## Problem

Hermes intentionally keeps `reasoning_details` on the outgoing
chat_completions copy for OpenRouter multi-turn reasoning continuity. Strict
Anthropic/OpenAI-compatible proxies reject that unknown field with:

```
400 INVALID_ARGUMENT
unsafeParams: {unrecognizedProperty=reasoning_details}
Request contained an unrecognized field
```

This message carries no "thinking" token, so it fell through the 400
classification to a non-retryable `format_error`: the turn hard-aborted and,
because fallback never fires for format errors, a session that had once
routed to such a proxy kept failing until `/new`.

Observed on opus subagents doing many tool-call steps: the prior step's
echoed `reasoning_details` rides into the next request, and the first call
through the strict proxy rejects the whole request.

## Fix

One classification branch in `classify_api_error()`
(`agent/error_classifier.py`), placed next to the existing Anthropic
thinking-block recovery (same recovery path):

- pattern: status 400 AND message contains `reasoning_details` AND one of
  `unrecognized` / `unknown` / `invalid`
- routes to `FailoverReason.thinking_signature`, whose existing handler in
  `conversation_loop.py` strips all `reasoning_details` and retries — the
  turn self-heals instead of aborting.

Deliberately not gated on provider id: OpenRouter can proxy these errors
from Anthropic-shaped backends, so message-shape matching is the reliable
signal (same reasoning as the adjacent thinking-block branch).

## Tests

Verified against the Hermes venv on this branch:

- `unrecognizedProperty=reasoning_details` 400 → classified as
  `thinking_signature`, retryable (self-heal path)
- an unrelated 400 (`bad tool schema`) → still `format_error` (no
  misclassification)
