### PR TITLE
fix(mcp): support SDK snake-case read-only hint

### DIFF
--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -245,3 +245,12 @@ class TestAnnotationCaptureAtDiscovery:
         assert mcp_tool._annotation_read_only_hint(
             SimpleNamespace()
         ) is False
+
+    def test_mcp_sdk_snake_case_annotation_supported(self):
+        """Current MCP SDK objects expose Pydantic's snake_case field name."""
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=SimpleNamespace(read_only_hint=True))
+        ) is True
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=SimpleNamespace(read_only_hint="yes"))
+        ) is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4363,10 +4363,11 @@ def _normalize_server_trust(value: Any) -> str:
 def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     """Return True only when the tool's annotations carry readOnlyHint=True.
 
-    Accepts both SDK annotation objects (attribute access) and plain dicts
-    (schema-cache JSON). Anything else — missing annotations, missing key,
-    non-bool truthy values — is False: unknown metadata means the tool must
-    be treated as write-capable.
+    Accepts MCP SDK annotation objects, whose Pydantic field is exposed as
+    ``read_only_hint``, legacy/test objects using the wire alias
+    ``readOnlyHint``, and plain schema-cache dicts. Anything else — missing
+    annotations, missing key, non-bool truthy values — is False: unknown
+    metadata means the tool must be treated as write-capable.
     """
     annotations = getattr(mcp_tool, "annotations", None)
     if annotations is None:
@@ -4374,7 +4375,9 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     if isinstance(annotations, dict):
         hint = annotations.get("readOnlyHint")
     else:
-        hint = getattr(annotations, "readOnlyHint", None)
+        hint = getattr(annotations, "read_only_hint", None)
+        if hint is None:
+            hint = getattr(annotations, "readOnlyHint", None)
     return hint is True
 
 


### PR DESCRIPTION
## Summary
- recognize the MCP SDK Pydantic `read_only_hint` attribute
- retain compatibility with the wire alias `readOnlyHint`
- fail closed for non-boolean truthy values

## Validation
- focused annotation compatibility assertions pass
- Python compilation and `git diff --check` pass
- HermesOps live MCP schema validators pass against the updated runtime