### PR TITLE
test(agent): stop truncation-warning ContextVar leaking across test files

### DIFF
--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -101,6 +101,12 @@ class TestTruncateContent:
         monkeypatch.setattr("hermes_cli.config.load_config", default_load_config)
         monkeypatch.setattr("hermes_cli.config.load_config_readonly", default_load_config)
 
+        yield
+        # Teardown drain: truncation warnings live in a ContextVar on the main
+        # thread and would otherwise survive this module into later test files
+        # (order-dependent failure in test_system_prompt.py, #93018).
+        drain_truncation_warnings()
+
 
 
     def test_long_content_truncated(self):

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -19,6 +19,11 @@ def _make_agent(**overrides):
         _kanban_worker_guidance="",
         _memory_store=None,
         _memory_manager=None,
+        # build_system_prompt drains pending truncation warnings through
+        # agent._emit_status; the warning store is a ContextVar that survives
+        # across test files on the main thread, so a stray warning from
+        # another module must not break this contract (#93018).
+        _emit_status=lambda _warning: None,
         model="",
         provider="",
         platform="",


### PR DESCRIPTION
Fixes #93018

## What & why

\`test_system_prompt.py::test_build_system_prompt_records_stable_prefix\` failed
whenever \`test_prompt_builder.py\` ran first in the same process (reproduced on
\`origin/main\` before any local PRs): truncation warnings accumulate in a
main-thread ContextVar (\`_truncation_warnings\`), a leftover from the
prompt_builder module survived into \`build_system_prompt\`'s drain loop, and
the loop called \`agent._emit_status(warning)\` on the test's SimpleNamespace
agent — which never stubbed that attribute.

Two-sided fix per the issue's suggestion:

1. **Consumer hardening** — \`_make_agent()\` stubs \`\_emit\_status\` as a no-op.
   The test's contract is prefix stability under any warnings, not absence of
   warnings.
2. **Producer hygiene** — \`TestTruncateContent\`'s autouse fixture now drains
   on **teardown** as well as setup, so the module cannot export truncation
   state to later files regardless of which test recorded last.

## How to test

\`\`\`bash
pytest tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py -q
# failed (1) before this change; passes after
pytest tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py -q
# passed before and after (no regression)
\`\`\`

Both orderings green via \`scripts/run_tests.sh\`: 104 passed, 0 failed,
1 skipped at head. macOS 26, Python 3.11; test-only change.

## Note

\`check-windows-footguns.py\` reports bare \`\_\_write\_text\`\_\_ calls in these two
files — all pre-existing on main (none in this diff's hunks); left untouched
to keep the change single-purpose.
