### PR TITLE
fix(windows): validate skill frontmatter newlines

### DIFF
--- a/docs/windows-skill-frontmatter.md
+++ b/docs/windows-skill-frontmatter.md
@@ -1,0 +1,51 @@
+# Windows Skill Frontmatter Validation
+
+Hermes skills use `SKILL.md` files with YAML frontmatter followed by Markdown
+content. On Windows, an installation or update path must preserve real newline
+characters. Literal `\n` sequences are not equivalent to line breaks.
+
+## Validation
+
+Run:
+
+```powershell
+pwsh -File .\scripts\validate-skill-frontmatter.ps1 `
+  -SkillsRoot "$env:LOCALAPPDATA\hermes\skills"
+```
+
+Validate selected skills:
+
+```powershell
+pwsh -File .\scripts\validate-skill-frontmatter.ps1 `
+  -SkillsRoot "$env:LOCALAPPDATA\hermes\skills" `
+  -SkillName '3-statement-model','adversarial-ux-test','bioinformatics'
+```
+
+The validator checks:
+
+- YAML opening delimiter at the first line;
+- closing frontmatter delimiter;
+- `name` and `description`;
+- directory name matching the declared skill name;
+- non-empty Markdown body;
+- absence of literal `\n` sequences.
+
+The validator is read-only. It does not rewrite installed files or silently
+change skill content.
+
+## Reproduction
+
+If an installer or updater serializes newline escapes literally, the first
+line may appear as:
+
+```text
+---\nmetadata:
+```
+
+The validator reports this as invalid instead of accepting a malformed file.
+
+## Scope
+
+This check is intentionally separate from skill content. A repair operation
+should create a backup and require explicit user confirmation before writing
+changes.

--- a/scripts/validate-skill-frontmatter.ps1
+++ b/scripts/validate-skill-frontmatter.ps1
@@ -1,0 +1,117 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$SkillsRoot,
+
+    [string[]]$SkillName
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-SkillFile {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$Path,
+
+        [Parameter(Mandatory=$true)]
+        [string]$ExpectedName
+    )
+
+    if(-not (Test-Path -LiteralPath $Path -PathType Leaf)){
+        return [PSCustomObject]@{
+            Path = $Path
+            Skill = $ExpectedName
+            Valid = $false
+            Reason = 'SKILL.md not found'
+        }
+    }
+
+    $bytes = [IO.File]::ReadAllBytes($Path)
+    $text = [Text.Encoding]::UTF8.GetString($bytes)
+    $lines = $text -split '\r?\n'
+
+    if($text.Contains('\n')){
+        return [PSCustomObject]@{
+            Path = $Path
+            Skill = $ExpectedName
+            Valid = $false
+            Reason = 'literal backslash-n sequence found'
+        }
+    }
+
+    $starts = $lines.Count -gt 0 -and $lines[0] -ceq '---'
+    $closingIndex = -1
+
+    for($i = 1; $i -lt $lines.Count; $i++){
+        if($lines[$i] -ceq '---'){
+            $closingIndex = $i
+            break
+        }
+    }
+
+    $nameLine = $lines |
+        Where-Object { $_ -match '^name:\s*\S+' } |
+        Select-Object -First 1
+
+    $descriptionLine = $lines |
+        Where-Object { $_ -match '^description:\s*\S+' } |
+        Select-Object -First 1
+
+    $declaredName = ''
+
+    if($nameLine){
+        $declaredName = ($nameLine -replace '^name:\s*','').Trim()
+    }
+
+    $bodyPresent = $false
+
+    if($closingIndex -ge 0 -and $closingIndex + 1 -lt $lines.Count){
+        $body = ($lines[($closingIndex + 1)..($lines.Count - 1)] -join "`n").Trim()
+        $bodyPresent = $body.Length -gt 0
+    }
+
+    [PSCustomObject]@{
+        Path = $Path
+        Skill = $ExpectedName
+        Valid = (
+            $starts -and
+            $closingIndex -gt 0 -and
+            $null -ne $nameLine -and
+            $null -ne $descriptionLine -and
+            $declaredName -ceq $ExpectedName -and
+            $bodyPresent
+        )
+        StartsWithDelimiter = $starts
+        FrontmatterClosed = ($closingIndex -gt 0)
+        NameMatches = ($declaredName -ceq $ExpectedName)
+        DescriptionPresent = ($null -ne $descriptionLine)
+        BodyPresent = $bodyPresent
+        LiteralBackslashN = $text.Contains('\n')
+        SHA256 = (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash
+    }
+}
+
+if(-not $SkillName -or $SkillName.Count -eq 0){
+    $files = Get-ChildItem -LiteralPath $SkillsRoot -Recurse -Filter 'SKILL.md' -File
+} else {
+    $files = foreach($name in $SkillName){
+        $path = Join-Path (Join-Path $SkillsRoot $name) 'SKILL.md'
+
+        if(-not (Test-Path -LiteralPath $path -PathType Leaf)){
+            throw "Skill non trovata: $name"
+        }
+
+        Get-Item -LiteralPath $path
+    }
+}
+
+$results = foreach($file in $files){
+    $name = Split-Path (Split-Path $file.FullName -Parent) -Leaf
+    Test-SkillFile -Path $file.FullName -ExpectedName $name
+}
+
+$results | Format-Table -AutoSize
+
+if($results.Valid -contains $false){
+    exit 1
+}


### PR DESCRIPTION
## Summary

Add a read-only PowerShell validator for Hermes skill frontmatter on Windows.

## Problem

A local Windows installation produced malformed `SKILL.md` files containing
literal `\n` sequences instead of actual newline characters. This made
frontmatter validation fail even when skill metadata and body were present.

## Changes

- Add `scripts/validate-skill-frontmatter.ps1`.
- Add `docs/windows-skill-frontmatter.md`.
- Validate YAML delimiters, `name`, `description`, body presence, and directory/name consistency.
- Detect literal `\n` sequences explicitly.
- Keep validation read-only; the script does not rewrite installed files.

## Validation

Tested with PowerShell 7.6.3 against the installed Hermes skill tree.
The validator completed successfully across the local skill directory.

## Scope

This PR does not modify the upstream content of existing skills.