### PR TITLE
feat(skills): add steam-intel-vulkan-fix optional skill

### DIFF
--- a/optional-skills/gaming/steam-intel-vulkan-fix/SKILL.md
+++ b/optional-skills/gaming/steam-intel-vulkan-fix/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: steam-intel-vulkan-fix
+description: "Fix Steam game crashes on Intel GPUs by forcing D3D11."
+version: 0.1.0
+author: "Gerardo Chara (charanoway10), Hermes Agent"
+license: MIT
+platforms: [windows]
+metadata:
+  hermes:
+    tags: [steam, gaming, intel, vulkan, crash, troubleshooting]
+    related_skills: []
+---
+
+# Steam Intel Vulkan Crash Fix
+
+Diagnoses Steam games that crash at startup with an Access Violation in Intel's Vulkan driver (`igvk64.dll`) and fixes them by forcing the DirectX 11 renderer through Steam launch options. Applies to KEX-engine titles (Quake rerelease, DOOM 64, etc.) and any Steam game whose crashlog points at `igvk64.dll`.
+
+## When to Use
+
+- A Steam game crashes at launch and its crashlog (or Windows Event Viewer) shows an Access Violation (`0xc0000005`) in `igvk64.dll` or `ig9icd64.dll`
+- The game worked before a recent update and now dies during renderer/shader initialization on an Intel GPU
+- User asks why a Steam game stopped launching on Intel graphics (Iris Xe / UHD / Arc)
+
+Don't use for: games that crash in other modules (`.exe` code paths, third-party DLLs), or non-Steam games — same launch-options trick exists but the persistence mechanism differs.
+
+## Prerequisites
+
+- Steam installed on Windows and the game installed (Steam Library path: `C:\Program Files (x86)\Steam\steamapps\common\<game>\`)
+- A crashlog or error text naming the faulting module (KEX engine writes `crashlog.txt` next to the game exe)
+- Permission to close Steam briefly when editing `localconfig.vdf` (Steam overwrites it on exit if it is running)
+
+## How to Run
+
+1. Read the crashlog with `read_file(path=<game_dir>/crashlog.txt)` and confirm the faulting module is `igvk64.dll`.
+2. Apply the fix (two routes, pick one):
+   - **UI route (no file edits):** user adds `+r_rhirenderfamily d3d11` in Steam → game Properties → Launch Options.
+   - **File route (agent-driven):** close Steam, edit `localconfig.vdf` (backup first), relaunch Steam.
+3. Launch the game from Steam and verify the process survives startup and no new crashlog is written.
+
+## Quick Reference
+
+- Fault signature: `Access Violation Exception (0xc0000005) in module igvk64.dll`
+- Fix: force D3D11 → `+r_rhirenderfamily d3d11`
+- Per-game config: `C:\Program Files (x86)\Steam\userdata\<steamid>\config\localconfig.vdf`, section `"apps" → "<appid>"` → `"LaunchOptions"`
+- `appid` for Quake: 2310 (find others via `steamdb.info` or the game's store URL)
+- Verify: `tasklist | grep -i <game>` after 30 s; crashlog mtime must stay unchanged
+
+## Procedure
+
+1. **Confirm the faulting module.** Read the crashlog: `read_file(path="C:/Program Files (x86)/Steam/steamapps/common/<game>/crashlog.txt")`. Look for `in module igvk64.dll` (Intel Vulkan). Also confirm the GPU is Intel via `powershell.exe -NoProfile -Command 'Get-CimInstance Win32_VideoController | Select-Object Name, DriverVersion | Format-List'` — a recent driver does NOT rule out the bug; the game update is usually the trigger.
+2. **Check for a known bug.** Search the web for the game name + `igvk64.dll` + game version: `web_search(query="<game> crash igvk64.dll <version>")`. If a Steam Community thread exists, the fix is community-validated.
+3. **Apply the launch option (UI route).** Ask the user to open Steam → game → Properties → Launch Options and paste `+r_rhirenderfamily d3d11`. This is the zero-risk path when the user is at the machine.
+4. **Apply the launch option (file route, agent-driven).**
+   a. Close Steam: `terminal(command="C:/Program Files (x86)/Steam/steam.exe -shutdown")`, then `taskkill //F //T //IM steam.exe` if it lingers.
+   b. Locate the user config: `terminal(command="ls 'C:/Program Files (x86)/Steam/userdata'")` to get the `<steamid>` folder.
+   c. Backup: `terminal(command="cp <vdf> <vdf>.bak")`.
+   d. Find the app's block: `search_files(pattern='"<appid>"', path='<vdf>')`, then `patch` the block to add `"LaunchOptions" "+r_rhirenderfamily d3d11"` (tabs preserved; the VDF parser tolerates fuzzy whitespace matching).
+   e. Relaunch Steam: `terminal(command="C:/Program Files (x86)/Steam/steam.exe -silent", background=true)`.
+5. **Verify.** Launch the game via Steam (`powershell.exe -NoProfile -Command 'Start-Process "steam://rungameid/<appid>"'`), wait ~30 s, then confirm: process alive (`tasklist`) and crashlog mtime unchanged (`stat -c "%y" <crashlog>`). A NEW crashlog means the fix did not take — check the LaunchOptions landed and the game is not using a different renderer flag.
+6. **Document.** If the user keeps an Obsidian vault, log the case (problem, evidence, fix, how to revert) and commit.
+
+## Pitfalls
+
+- **Do not edit `localconfig.vdf` while Steam runs** — Steam rewrites it on exit and silently discards your edit. Always close Steam first and back up.
+- **Launching the game exe directly from a shell is not a valid test** — without Steam's launcher context the process exits cleanly (no crashlog written), which looks like success but proves nothing. Always test through `steam://rungameid/<appid>`.
+- **`igvk64.dll` crash ≠ old driver.** Recent Intel drivers still hit this on broken game builds; check the game's changelog/forums before blaming the driver.
+- **Rendering API flag differs per engine.** KEX uses `r_rhirenderfamily`; other engines use `-d3d11`, `-dx11`, or a config file. Search the game's forums for the correct flag.
+- **bash cannot always exec game exes directly** (MSYS permission quirks on `Program Files` paths) — use PowerShell `Start-Process` or Steam for launching.
+- Reverting later: delete the `LaunchOptions` line (or the whole string) once the vendor fixes the Vulkan path.
+
+## Verification
+
+- [ ] Crashlog names `igvk64.dll` as faulting module before the fix
+- [ ] `LaunchOptions` present under `"apps" → "<appid>"` in `localconfig.vdf`
+- [ ] Game process alive 30 s after launch via Steam (no crash dialog, no new crashlog)
+- [ ] `stat` on crashlog shows unchanged mtime after a successful launch

--- a/tests/skills/test_steam_intel_vulkan_fix_skill.py
+++ b/tests/skills/test_steam_intel_vulkan_fix_skill.py
@@ -1,0 +1,68 @@
+"""Tests for the `steam-intel-vulkan-fix` skill.
+
+The skill's whole job is routing a very specific crash signature (Access
+Violation in igvk64.dll) to a specific, safe remediation (force D3D11 via
+Steam launch options). These tests keep that routing honest: the fault
+signature and the fix must both be present and unambiguous, and the skill
+must never bake in machine-local paths that break for other users.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO / "optional-skills" / "gaming" / "steam-intel-vulkan-fix"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_frontmatter_has_required_fields(skill_text):
+    """A skill that fails to load is invisible to every agent."""
+    assert skill_text.startswith("---")
+    assert re.search(r"\n---\s*\n", skill_text[3:]), "frontmatter not closed"
+    for field in ("name:", "description:", "version:", "author:", "license:", "platforms:"):
+        assert field in skill_text.split("---", 2)[1], f"missing frontmatter field: {field}"
+
+
+def test_description_within_hardline_budget(skill_text):
+    """Repo review rejects descriptions over 60 chars (index truncates at 57)."""
+    fm = skill_text.split("---", 2)[1]
+    m = re.search(r'description:\s*"?([^"\n]+)"?', fm)
+    assert m, "no description found"
+    desc = m.group(1).strip()
+    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline: 60)"
+    assert desc.endswith("."), "description must end with a period"
+
+
+def test_fault_signature_is_routed(skill_text):
+    """The skill must name the exact crash signature it exists to fix."""
+    assert "igvk64.dll" in skill_text
+    assert "0xc0000005" in skill_text
+    assert "+r_rhirenderfamily d3d11" in skill_text
+
+
+def test_launch_options_persistence_is_documented(skill_text):
+    """The fix must include the persistent (localconfig.vdf) route, not only the UI route."""
+    assert "localconfig.vdf" in skill_text
+    assert "LaunchOptions" in skill_text
+    assert "backup" in skill_text.lower()
+
+
+def test_no_machine_local_paths(skill_text):
+    """Committed skills must not bake in the author's machine paths."""
+    banned = re.compile(r"/home/|/Users/(?!.*Steam)|C:\\Users\\[^S]|AppData/Local/hermes")
+    for line in skill_text.splitlines():
+        assert not banned.search(line), f"machine-local path in line: {line}"
+
+
+def test_body_has_verification_section(skill_text):
+    """Every repo skill must say how to prove it worked."""
+    assert re.search(r"## Verification", skill_text)

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -120,6 +120,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**minecraft-modpack-server**](/docs/user-guide/skills/optional/gaming/gaming-minecraft-modpack-server) | Host modded Minecraft servers (CurseForge, Modrinth). |
 | [**pokemon-player**](/docs/user-guide/skills/optional/gaming/gaming-pokemon-player) | Play Pokemon via headless emulator + RAM reads. |
+| [**steam-intel-vulkan-fix**](/docs/user-guide/skills/optional/gaming/gaming-steam-intel-vulkan-fix) | Fix Steam game crashes on Intel GPUs by forcing D3D11. |
 
 ## health
 

--- a/website/docs/user-guide/skills/optional/gaming/gaming-steam-intel-vulkan-fix.md
+++ b/website/docs/user-guide/skills/optional/gaming/gaming-steam-intel-vulkan-fix.md
@@ -1,0 +1,93 @@
+---
+title: "Steam Intel Vulkan Fix — Fix Steam game crashes on Intel GPUs by forcing D3D11"
+sidebar_label: "Steam Intel Vulkan Fix"
+description: "Fix Steam game crashes on Intel GPUs by forcing D3D11"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Steam Intel Vulkan Fix
+
+Fix Steam game crashes on Intel GPUs by forcing D3D11.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/gaming/steam-intel-vulkan-fix` |
+| Path | `optional-skills/gaming\steam-intel-vulkan-fix` |
+| Version | `0.1.0` |
+| Author | Gerardo Chara (charanoway10), Hermes Agent |
+| License | MIT |
+| Platforms | windows |
+| Tags | `steam`, `gaming`, `intel`, `vulkan`, `crash`, `troubleshooting` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Steam Intel Vulkan Crash Fix
+
+Diagnoses Steam games that crash at startup with an Access Violation in Intel's Vulkan driver (`igvk64.dll`) and fixes them by forcing the DirectX 11 renderer through Steam launch options. Applies to KEX-engine titles (Quake rerelease, DOOM 64, etc.) and any Steam game whose crashlog points at `igvk64.dll`.
+
+## When to Use
+
+- A Steam game crashes at launch and its crashlog (or Windows Event Viewer) shows an Access Violation (`0xc0000005`) in `igvk64.dll` or `ig9icd64.dll`
+- The game worked before a recent update and now dies during renderer/shader initialization on an Intel GPU
+- User asks why a Steam game stopped launching on Intel graphics (Iris Xe / UHD / Arc)
+
+Don't use for: games that crash in other modules (`.exe` code paths, third-party DLLs), or non-Steam games — same launch-options trick exists but the persistence mechanism differs.
+
+## Prerequisites
+
+- Steam installed on Windows and the game installed (Steam Library path: `C:\Program Files (x86)\Steam\steamapps\common\<game>\`)
+- A crashlog or error text naming the faulting module (KEX engine writes `crashlog.txt` next to the game exe)
+- Permission to close Steam briefly when editing `localconfig.vdf` (Steam overwrites it on exit if it is running)
+
+## How to Run
+
+1. Read the crashlog with `read_file(path=<game_dir>/crashlog.txt)` and confirm the faulting module is `igvk64.dll`.
+2. Apply the fix (two routes, pick one):
+   - **UI route (no file edits):** user adds `+r_rhirenderfamily d3d11` in Steam → game Properties → Launch Options.
+   - **File route (agent-driven):** close Steam, edit `localconfig.vdf` (backup first), relaunch Steam.
+3. Launch the game from Steam and verify the process survives startup and no new crashlog is written.
+
+## Quick Reference
+
+- Fault signature: `Access Violation Exception (0xc0000005) in module igvk64.dll`
+- Fix: force D3D11 → `+r_rhirenderfamily d3d11`
+- Per-game config: `C:\Program Files (x86)\Steam\userdata\<steamid>\config\localconfig.vdf`, section `"apps" → "<appid>"` → `"LaunchOptions"`
+- `appid` for Quake: 2310 (find others via `steamdb.info` or the game's store URL)
+- Verify: `tasklist | grep -i <game>` after 30 s; crashlog mtime must stay unchanged
+
+## Procedure
+
+1. **Confirm the faulting module.** Read the crashlog: `read_file(path="C:/Program Files (x86)/Steam/steamapps/common/<game>/crashlog.txt")`. Look for `in module igvk64.dll` (Intel Vulkan). Also confirm the GPU is Intel via `powershell.exe -NoProfile -Command 'Get-CimInstance Win32_VideoController | Select-Object Name, DriverVersion | Format-List'` — a recent driver does NOT rule out the bug; the game update is usually the trigger.
+2. **Check for a known bug.** Search the web for the game name + `igvk64.dll` + game version: `web_search(query="<game> crash igvk64.dll <version>")`. If a Steam Community thread exists, the fix is community-validated.
+3. **Apply the launch option (UI route).** Ask the user to open Steam → game → Properties → Launch Options and paste `+r_rhirenderfamily d3d11`. This is the zero-risk path when the user is at the machine.
+4. **Apply the launch option (file route, agent-driven).**
+   a. Close Steam: `terminal(command="C:/Program Files (x86)/Steam/steam.exe -shutdown")`, then `taskkill //F //T //IM steam.exe` if it lingers.
+   b. Locate the user config: `terminal(command="ls 'C:/Program Files (x86)/Steam/userdata'")` to get the `<steamid>` folder.
+   c. Backup: `terminal(command="cp <vdf> <vdf>.bak")`.
+   d. Find the app's block: `search_files(pattern='"<appid>"', path='<vdf>')`, then `patch` the block to add `"LaunchOptions" "+r_rhirenderfamily d3d11"` (tabs preserved; the VDF parser tolerates fuzzy whitespace matching).
+   e. Relaunch Steam: `terminal(command="C:/Program Files (x86)/Steam/steam.exe -silent", background=true)`.
+5. **Verify.** Launch the game via Steam (`powershell.exe -NoProfile -Command 'Start-Process "steam://rungameid/<appid>"'`), wait ~30 s, then confirm: process alive (`tasklist`) and crashlog mtime unchanged (`stat -c "%y" <crashlog>`). A NEW crashlog means the fix did not take — check the LaunchOptions landed and the game is not using a different renderer flag.
+6. **Document.** If the user keeps an Obsidian vault, log the case (problem, evidence, fix, how to revert) and commit.
+
+## Pitfalls
+
+- **Do not edit `localconfig.vdf` while Steam runs** — Steam rewrites it on exit and silently discards your edit. Always close Steam first and back up.
+- **Launching the game exe directly from a shell is not a valid test** — without Steam's launcher context the process exits cleanly (no crashlog written), which looks like success but proves nothing. Always test through `steam://rungameid/<appid>`.
+- **`igvk64.dll` crash ≠ old driver.** Recent Intel drivers still hit this on broken game builds; check the game's changelog/forums before blaming the driver.
+- **Rendering API flag differs per engine.** KEX uses `r_rhirenderfamily`; other engines use `-d3d11`, `-dx11`, or a config file. Search the game's forums for the correct flag.
+- **bash cannot always exec game exes directly** (MSYS permission quirks on `Program Files` paths) — use PowerShell `Start-Process` or Steam for launching.
+- Reverting later: delete the `LaunchOptions` line (or the whole string) once the vendor fixes the Vulkan path.
+
+## Verification
+
+- [ ] Crashlog names `igvk64.dll` as faulting module before the fix
+- [ ] `LaunchOptions` present under `"apps" → "<appid>"` in `localconfig.vdf`
+- [ ] Game process alive 30 s after launch via Steam (no crash dialog, no new crashlog)
+- [ ] `stat` on crashlog shows unchanged mtime after a successful launch

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -462,6 +462,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/optional/gaming/gaming-minecraft-modpack-server',
                     'user-guide/skills/optional/gaming/gaming-pokemon-player',
+                    'user-guide/skills/optional/gaming/gaming-steam-intel-vulkan-fix',
                   ],
                 },
                 {


### PR DESCRIPTION
## Summary

New optional skill `steam-intel-vulkan-fix` (category: gaming) that diagnoses and fixes Steam games crashing at startup on Intel GPUs with an Access Violation in Intel's Vulkan driver (`igvk64.dll`).

Real-world trigger: Quake rerelease v1.0.5582 (August 2026 update) crashes on Intel Iris Xe/UHD with `0xc0000005 in module igvk64.dll` during compute-shader compilation. The fix forces the D3D11 renderer via Steam launch options (`+r_rhirenderfamily d3d11`), persisted either through the Steam UI or by editing `localconfig.vdf` (with backup, Steam closed).

## Changes

- `optional-skills/gaming/steam-intel-vulkan-fix/SKILL.md` — full procedure: fault-signature confirmation, known-bug check, UI and file routes, verification, pitfalls (VDF editing rules, invalid direct-exe launch tests, engine-specific renderer flags)
- `tests/skills/test_steam_intel_vulkan_fix_skill.py` — 6 tests: frontmatter requirements, 60-char description hardline, fault signature routing, persistence documentation, no machine-local paths, verification section
- Docs regenerated: skill page, one catalog row, one sidebar entry (scope-disciplined diff)

## Testing

`pytest tests/skills/test_steam_intel_vulkan_fix_skill.py -q` → 6 passed.

## Author

Gerardo (charanoway10), with Hermes Agent.