### PR TITLE
fix(gateway): isolate shared-adapter multiplex cron delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3038,6 +3038,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             pconfig = config.platforms.get(platform)
             runtime_adapter = None
 
+        # An explicitly supplied native adapter is the authenticated transport
+        # for a running gateway, even when this isolated profile has no local
+        # platform config.  Keep the exception tied to the live gateway loop so
+        # standalone and stopped-gateway delivery remain fail-closed.
+        live_adapter_ready = (
+            runtime_adapter is not None
+            and loop is not None
+            and getattr(loop, "is_running", lambda: False)()
+        )
+        live_native_adapter_ready = (
+            live_adapter_ready
+            and transport is not None
+            and not transport.is_relay
+        )
+
         if transport is not None and transport.is_relay:
             # A relay transport carries the RELAY adapter's config, and
             # resolve_delivery_transport already applied relay's enablement
@@ -3049,27 +3064,25 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             if pconfig is None:
                 from gateway.config import PlatformConfig
                 pconfig = PlatformConfig(enabled=True)
-        elif not pconfig or not pconfig.enabled:
+        elif (not pconfig or not pconfig.enabled) and not (
+            pconfig is None and live_native_adapter_ready
+        ):
             msg = f"platform '{platform_name}' not configured/enabled"
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
             continue
+        standalone_fallback_available = pconfig is not None
 
         # Prefer the resolved live transport when the gateway is running. This
         # supports E2EE native adapters and relay-fronted logical platforms.
         # The live-send path (which SEEDS the flat in_channel continuation
         # session via _seed_cron_channel_session) needs not just a live adapter
-        # but a running event loop to schedule the async send onto. Compute that
-        # gate ONCE so the in_channel thread_id clear below stays in lockstep
+        # but a running event loop to schedule the async send onto. That gate is
+        # computed once above so the in_channel thread_id clear stays in lockstep
         # with the live-send/seed block further down (they used to drift): an
         # adapter can be present while the loop is absent/not-running, in which
         # case the live-send block is skipped and delivery falls through to the
         # standalone path — which cannot seed the flat session (r3609147550).
-        live_adapter_ready = (
-            runtime_adapter is not None
-            and loop is not None
-            and getattr(loop, "is_running", lambda: False)()
-        )
         delivered = False
         target_errors = []
 
@@ -3338,12 +3351,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     f"live adapter send to {platform_name}:{chat_id} "
                                     "timed out before the coroutine was dispatched"
                                 )
-                                logger.warning(
-                                    "Job '%s': %s, falling back to standalone",
-                                    job["id"], msg,
-                                )
+                                if standalone_fallback_available:
+                                    logger.warning(
+                                        "Job '%s': %s, falling back to standalone",
+                                        job["id"], msg,
+                                    )
+                                else:
+                                    logger.warning("Job '%s': %s", job["id"], msg)
                                 target_errors.append(msg)
-                                adapter_ok = False  # fall through to standalone path
+                                adapter_ok = False
                                 timeout_handled = True
                             else:
                                 timed_out = True
@@ -3400,7 +3416,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     f"live adapter send to {platform_name}:{chat_id} "
                                     f"returned unconfirmed result ({shape}, error={err})"
                                 )
-                                if transport is not None and transport.is_relay:
+                                if (
+                                    transport is not None and transport.is_relay
+                                ) or not standalone_fallback_available:
                                     logger.warning("Job '%s': %s", job["id"], msg)
                                 else:
                                     logger.warning(
@@ -3537,7 +3555,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
                 if not any(err_msg in err for err in target_errors):
                     target_errors.append(err_msg)
-                if transport is not None and transport.is_relay:
+                if (
+                    transport is not None and transport.is_relay
+                ) or not standalone_fallback_available:
                     logger.warning("Job '%s': %s", job["id"], err_msg)
                 else:
                     logger.warning(
@@ -3546,6 +3566,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
 
         if not delivered:
+            if live_native_adapter_ready and not standalone_fallback_available:
+                # This profile has no standalone credential/config of its own.
+                # The resolved gateway adapter was the only permitted transport;
+                # never fall through to a sender that could consult process-wide
+                # (Default-profile) credentials after the live send fails.
+                if not target_errors:
+                    target_errors.append(
+                        f"live adapter delivery to {platform_name}:{chat_id} failed"
+                    )
+                delivery_errors.extend(target_errors)
+                continue
             if transport is not None and transport.is_relay:
                 # Relay owns the logical destination and its connector owns the
                 # platform credential. A native retry could duplicate delivery
@@ -6624,39 +6655,51 @@ def run_one_job(
     run cooperatively — agent interruption AND script process-tree kill —
     through the single fenced completion path.
     """
-    claim = job.get("fire_claim")
-    fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
-    execution_token = object()
     profile_home = _get_hermes_home().resolve()
-    with _running_lock:
-        _running_fire_owners.setdefault(job["id"], {})[execution_token] = (
-            fire_owner or None,
-            profile_home,
-        )
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+    hydrate_profile_secret_sources(profile_home)
+    scope_token = set_secret_scope(build_profile_secret_scope(profile_home))
     try:
-        return _run_with_fire_claim_heartbeat(
-            job,
-            lambda lost_ownership: _run_one_job_body(
-                job,
-                adapters=adapters,
-                loop=loop,
-                verbose=verbose,
-                extra_prompt=extra_prompt,
-                fire_claim_lost=(
-                    _CombinedCancelEvent(lost_ownership, cancel_event)
-                    if cancel_event is not None
-                    else lost_ownership
-                ),
-                execution_token=execution_token,
-            ),
-        )
-    finally:
+        claim = job.get("fire_claim")
+        fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
+        execution_token = object()
         with _running_lock:
-            executions = _running_fire_owners.get(job["id"])
-            if executions is not None:
-                executions.pop(execution_token, None)
-                if not executions:
-                    _running_fire_owners.pop(job["id"], None)
+            _running_fire_owners.setdefault(job["id"], {})[execution_token] = (
+                fire_owner or None,
+                profile_home,
+            )
+        try:
+            return _run_with_fire_claim_heartbeat(
+                job,
+                lambda lost_ownership: _run_one_job_body(
+                    job,
+                    adapters=adapters,
+                    loop=loop,
+                    verbose=verbose,
+                    extra_prompt=extra_prompt,
+                    fire_claim_lost=(
+                        _CombinedCancelEvent(lost_ownership, cancel_event)
+                        if cancel_event is not None
+                        else lost_ownership
+                    ),
+                    execution_token=execution_token,
+                ),
+            )
+        finally:
+            with _running_lock:
+                executions = _running_fire_owners.get(job["id"])
+                if executions is not None:
+                    executions.pop(execution_token, None)
+                    if not executions:
+                        _running_fire_owners.pop(job["id"], None)
+    finally:
+        reset_secret_scope(scope_token)
 
 
 def _run_one_job_body(
@@ -6728,22 +6771,10 @@ def _run_one_job_body(
         # becomes running only immediately before the actual run.
         mark_execution_running(execution_id)
 
-        # Run the job under the profile's secret scope. get_secret() fails
-        # closed outside a scope once profile isolation is in play (multiple
-        # gateway profiles / room→profile multiplexing), and cron fires from
-        # the ticker thread where no per-turn scope is installed — so
-        # resolve_runtime_provider() raised UnscopedSecretError before model
-        # selection, breaking every cron job. Mirrors the per-turn pattern in
-        # gateway/run.py (_profile_runtime_scope).
-        from agent.secret_scope import (
-            build_profile_secret_scope,
-            reset_secret_scope,
-            set_secret_scope,
-        )
-
-        _scope_token = set_secret_scope(
-            build_profile_secret_scope(_get_hermes_home())
-        )
+        # run_one_job() keeps the profile secret scope installed across this
+        # entire body, including both execution and delivery. Resetting it
+        # after run_job() would let delivery config read process-global
+        # credentials belonging to the Default profile.
         # Defer the cron agent's async-resource teardown until AFTER delivery.
         # run_job normally closes the agent (and reaps stale async clients) in
         # its finally block; doing that before _deliver_result runs means the
@@ -6775,9 +6806,6 @@ def _run_one_job_body(
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
             raise
-        finally:
-            reset_secret_scope(_scope_token)
-
         if _fire_claim_ownership_lost():
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1708,6 +1708,17 @@ def _maybe_mirror_cron_delivery(
         session_store = getattr(adapter, "_session_store", None)
         if (
             session_store is not None
+            and getattr(session_store.config, "multiplex_profiles", False)
+            and getattr(session_store, "_db", None) is None
+        ):
+            logger.debug(
+                "Job '%s': delivery mirror skipped for %s:%s "
+                "(multiplex session DB unavailable)",
+                job.get("id", "?"), platform_name, chat_id,
+            )
+            return
+        if (
+            session_store is not None
             and getattr(session_store, "_db", None) is not None
         ):
             session_key_prefix = None
@@ -1869,7 +1880,6 @@ def _seed_cron_thread_session(
         from gateway.config import Platform
         from gateway.session import SessionSource
 
-        seeded_session_id: Optional[str] = None
         session_store = getattr(adapter, "_session_store", None)
         if session_store is not None:
             try:
@@ -1933,7 +1943,6 @@ def _seed_cron_thread_session(
             thread_id=str(thread_id),
             user_id="system:cron",
             role="user",
-            session_id=seeded_session_id,
         )
         if ok:
             logger.info(
@@ -2009,7 +2018,6 @@ def _seed_cron_channel_session(
 
         chat_type = "dm" if is_dm else "group"
         session_store = getattr(adapter, "_session_store", None)
-        seeded_session_id: Optional[str] = None
         if session_store is not None:
             try:
                 platform_enum = Platform(platform_name.lower())
@@ -2056,7 +2064,6 @@ def _seed_cron_channel_session(
             source_label="cron",
             thread_id=None,
             user_id=str(user_id) if user_id else None,
-            session_id=seeded_session_id,
             role="user",
         )
         if ok:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1682,17 +1682,16 @@ def _maybe_mirror_cron_delivery(
     user_id: Optional[str] = None,
     *,
     enabled: bool = False,
+    adapter=None,
 ) -> None:
     """Best-effort mirror of a cron delivery into the origin chat's session.
 
     No-op unless ``enabled`` (resolved once by the caller, and already scoped to
-    the origin target — see ``_target_matches_origin``). Reuses the shipped
-    ``mirror_to_session`` so cron rides exactly the same path that interactive
-    ``send_message`` mirroring already uses, including passing ``user_id`` so a
-    per-user-isolated group chat resolves to the exact member who scheduled the
-    job (parity with ``send_message``). All failures are swallowed — a delivery
-    that succeeded must never be reported as failed because the transcript
-    mirror hit a problem.
+    the origin target — see ``_target_matches_origin``). Live gateway delivery
+    uses the adapter's SessionStore so multiplex lookups can be constrained to
+    the active profile namespace; standalone delivery reuses ``mirror_to_session``.
+    All failures are swallowed — a delivery that succeeded must never be
+    reported as failed because the transcript mirror hit a problem.
 
     Because the caller only enables this for the target that equals the job's
     origin conversation, the session is expected to exist (the job was born in
@@ -1706,6 +1705,48 @@ def _maybe_mirror_cron_delivery(
     if not text:
         return
     try:
+        session_store = getattr(adapter, "_session_store", None)
+        if (
+            session_store is not None
+            and getattr(session_store, "_db", None) is not None
+        ):
+            session_key_prefix = None
+            if getattr(session_store.config, "multiplex_profiles", False):
+                from hermes_cli.profiles import get_active_profile_name
+
+                profile_name = get_active_profile_name() or "default"
+                namespace = "main" if profile_name == "default" else profile_name
+                session_key_prefix = f"agent:{namespace}:"
+            session_id = session_store._db.find_session_by_origin(
+                platform=platform_name,
+                chat_id=str(chat_id),
+                thread_id=thread_id,
+                user_id=user_id,
+                session_key_prefix=session_key_prefix,
+            )
+            if not session_id:
+                logger.debug(
+                    "Job '%s': delivery mirror skipped for %s:%s "
+                    "(no matching profile-scoped gateway session)",
+                    job.get("id", "?"), platform_name, chat_id,
+                )
+                return
+            session_store.append_to_transcript(
+                session_id,
+                {
+                    "role": "user",
+                    "content": (
+                        f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n"
+                        f"{text}"
+                    ),
+                },
+            )
+            logger.info(
+                "Job '%s': mirrored delivery into %s:%s session transcript",
+                job.get("id", "?"), platform_name, chat_id,
+            )
+            return
+
         from gateway.mirror import mirror_to_session
 
         # Mirror as a USER turn with a labelled prefix, NOT an assistant turn.
@@ -1798,7 +1839,7 @@ def _seed_cron_thread_session(
     record of it ("what is Task #2?"). We create the thread-keyed session (the
     same key the user's reply will resolve to — ``build_session_key`` keys
     threads as participant-shared, so no ``user_id`` is needed) and append the
-    brief as an assistant turn via the shipped ``mirror_to_session``.
+    brief directly to that exact session through the adapter's live store.
 
     ``scope_id`` is the workspace/server scope (Slack team id).
     ``build_session_key`` embeds it in every Slack key, so a scoped reply's
@@ -1858,13 +1899,24 @@ def _seed_cron_thread_session(
                     thread_id=str(thread_id),
                     scope_id=str(scope_id) if scope_id else None,
                 )
-                # Ensure the thread-keyed session row exists so the mirror has
-                # a target and the user's later reply joins the same session.
-                # Capture the exact id — the mirror writes into THIS row, not
-                # an origin-heuristic rediscovery (which bails on populated
-                # chats; same class as the flat-seed live failure 2026-08-19).
-                _entry = session_store.get_or_create_session(dest_source)
-                seeded_session_id = getattr(_entry, "session_id", None)
+                # Seed the exact thread-keyed session through the live store;
+                # do not re-discover it through process-global origin lookup.
+                entry = session_store.get_or_create_session(dest_source)
+                session_store.append_to_transcript(
+                    entry.session_id,
+                    {
+                        "role": "user",
+                        "content": (
+                            f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n"
+                            f"{text}"
+                        ),
+                    },
+                )
+                logger.info(
+                    "Job '%s': opened continuable thread %s on %s:%s and seeded the brief",
+                    job.get("id", "?"), thread_id, platform_name, chat_id,
+                )
+                return
 
         from gateway.mirror import mirror_to_session
 
@@ -1976,14 +2028,24 @@ def _seed_cron_channel_session(
                     # when the seed carries it too (see thread-seed docstring).
                     scope_id=str(scope_id) if scope_id else None,
                 )
-                # Create the flat session row so the mirror has a target and the
-                # user's later plain reply joins the SAME session. Capture the
-                # exact session id: the mirror must write into THIS row, not
-                # re-discover it via origin heuristics (which bail out on
-                # populated chats where the flat session coexists with
-                # per-message thread sessions — live failure, Alice 2026-08-19).
-                _entry = session_store.get_or_create_session(dest_source)
-                seeded_session_id = getattr(_entry, "session_id", None)
+                # Seed the exact flat session through the live store; do not
+                # re-discover it through process-global origin lookup.
+                entry = session_store.get_or_create_session(dest_source)
+                session_store.append_to_transcript(
+                    entry.session_id,
+                    {
+                        "role": "user",
+                        "content": (
+                            f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n"
+                            f"{text}"
+                        ),
+                    },
+                )
+                logger.info(
+                    "Job '%s': seeded flat in_channel session on %s:%s (chat_type=%s)",
+                    job.get("id", "?"), platform_name, chat_id, chat_type,
+                )
+                return True
 
         from gateway.mirror import mirror_to_session
 
@@ -3037,6 +3099,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             # which uses the logical platform's configured credential.
             pconfig = config.platforms.get(platform)
             runtime_adapter = None
+        is_relay_transport = transport is not None and transport.is_relay
 
         # An explicitly supplied native adapter is the authenticated transport
         # for a running gateway, even when this isolated profile has no local
@@ -3050,10 +3113,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         live_native_adapter_ready = (
             live_adapter_ready
             and transport is not None
-            and not transport.is_relay
+            and not is_relay_transport
         )
 
-        if transport is not None and transport.is_relay:
+        if is_relay_transport:
             # A relay transport carries the RELAY adapter's config, and
             # resolve_delivery_transport already applied relay's enablement
             # rule (config block absent OR enabled). The logical platform is
@@ -3416,9 +3479,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     f"live adapter send to {platform_name}:{chat_id} "
                                     f"returned unconfirmed result ({shape}, error={err})"
                                 )
-                                if (
-                                    transport is not None and transport.is_relay
-                                ) or not standalone_fallback_available:
+                                if is_relay_transport or not standalone_fallback_available:
                                     logger.warning("Job '%s': %s", job["id"], msg)
                                 else:
                                     logger.warning(
@@ -3451,7 +3512,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # lost.
                 if adapter_ok and not timed_out and media_files:
                     routed_media_metadata = dict(media_metadata or {})
-                    if transport is not None and transport.is_relay:
+                    if is_relay_transport:
                         routed_media_metadata["_relay_logical_platform"] = platform.value
                         logical_home = config.get_home_channel(platform)
                         if logical_home is not None and logical_home.chat_id == chat_id:
@@ -3550,14 +3611,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         job, platform_name, chat_id, mirror_text,
                         thread_id=thread_id, user_id=origin_user_id,
                         enabled=mirror_this_target and not thread_seeded and not inchannel_seeded,
+                        adapter=runtime_adapter,
                     )
             except Exception as e:
                 err_msg = f"live adapter delivery to {platform_name}:{chat_id} failed: {e}"
                 if not any(err_msg in err for err in target_errors):
                     target_errors.append(err_msg)
-                if (
-                    transport is not None and transport.is_relay
-                ) or not standalone_fallback_available:
+                if is_relay_transport or not standalone_fallback_available:
                     logger.warning("Job '%s': %s", job["id"], err_msg)
                 else:
                     logger.warning(
@@ -3577,7 +3637,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
                 delivery_errors.extend(target_errors)
                 continue
-            if transport is not None and transport.is_relay:
+            if is_relay_transport:
                 # Relay owns the logical destination and its connector owns the
                 # platform credential. A native retry could duplicate delivery
                 # and cannot be authenticated correctly, so fail closed.
@@ -3683,6 +3743,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 job, platform_name, chat_id, mirror_text,
                 thread_id=thread_id, user_id=origin_user_id,
                 enabled=mirror_this_target and not thread_seeded,
+                adapter=runtime_adapter,
             )
 
     if policy_drop_errors:

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import inspect
 import threading
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from typing import Any
 
 # Cap for the exponential tick backoff applied while consecutive ticks fail
@@ -62,6 +63,35 @@ def _note_tick_failure(exc: BaseException, consecutive_failures: int) -> int:
         _reclaim_fds_best_effort()
         return consecutive_failures + 1
     return 0
+
+
+@contextmanager
+def _profile_cron_scope(profile_home):
+    """Keep one multiplex profile authoritative for a complete ticker step."""
+    from pathlib import Path
+
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    home = Path(profile_home)
+    home_token = set_hermes_home_override(str(home))
+    try:
+        hydrate_profile_secret_sources(home)
+        secret_token = set_secret_scope(build_profile_secret_scope(home))
+        try:
+            yield
+        finally:
+            reset_secret_scope(secret_token)
+    finally:
+        reset_hermes_home_override(home_token)
 
 
 class CronScheduler(ABC):
@@ -511,6 +541,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        adapter_resolver=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -538,6 +569,7 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                adapter_resolver=adapter_resolver,
             )
             return
 
@@ -609,6 +641,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        adapter_resolver=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -626,8 +659,6 @@ class InProcessCronScheduler(CronScheduler):
             record_ticker_heartbeat,
             use_cron_store,
         )
-        from hermes_constants import set_hermes_home_override, reset_hermes_home_override
-
         logger = logging.getLogger("cron.scheduler_provider")
         logger.info(
             "Multiplex cron scheduler started for %d profile(s): %s",
@@ -638,8 +669,7 @@ class InProcessCronScheduler(CronScheduler):
         # Recovery + initial heartbeat for every profile.
         for entry in profile_homes:
             home = entry[1] if isinstance(entry, tuple) else entry
-            home_token = set_hermes_home_override(str(home))
-            try:
+            with _profile_cron_scope(home):
                 with use_cron_store(home):
                     recovered = self.recover_interrupted()
                     if recovered:
@@ -649,8 +679,6 @@ class InProcessCronScheduler(CronScheduler):
                             home,
                         )
                     record_ticker_heartbeat()
-            finally:
-                reset_hermes_home_override(home_token)
 
         consecutive_failures = 0
         while not stop_event.is_set():
@@ -661,19 +689,24 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in profile_homes:
+                        profile_name = (
+                            entry[0] if isinstance(entry, tuple) else "default"
+                        )
                         home = entry[1] if isinstance(entry, tuple) else entry
-                        home_token = set_hermes_home_override(str(home))
-                        try:
+                        with _profile_cron_scope(home):
                             with use_cron_store(home):
+                                profile_adapters = (
+                                    adapter_resolver(profile_name)
+                                    if adapter_resolver is not None
+                                    else adapters
+                                )
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=profile_adapters,
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,
                                 )
-                        finally:
-                            reset_hermes_home_override(home_token)
                 ok = True
             except BaseException as e:
                 logger.error("Cron tick error: %s", e, exc_info=True)
@@ -685,8 +718,7 @@ class InProcessCronScheduler(CronScheduler):
             # Record per-profile heartbeat after each tick cycle.
             for entry in profile_homes:
                 home = entry[1] if isinstance(entry, tuple) else entry
-                home_token = set_hermes_home_override(str(home))
-                try:
+                with _profile_cron_scope(home):
                     with use_cron_store(home):
                         record_ticker_heartbeat(success=ok)
                         # Surface the failure reason (or clear it) per profile
@@ -696,8 +728,6 @@ class InProcessCronScheduler(CronScheduler):
                             clear_ticker_error()
                         elif _tick_error:
                             record_ticker_error(_tick_error)
-                finally:
-                    reset_hermes_home_override(home_token)
             if ok:
                 consecutive_failures = 0
             stop_event.wait(_backoff_wait_seconds(interval, consecutive_failures))

--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -108,6 +108,12 @@ If no route matches, the message uses the default/active profile.
 Because `gateway_runner` is injected for **all** adapters (declared on `BasePlatformAdapter`),
 every platform goes through this path — not just Discord.
 
+Durable session recovery is profile-fail-closed. If the exact session-key lookup misses and
+the gateway falls back to platform/chat/user identity, it resumes a row only when that
+row's `agent:<profile>` namespace matches the requested profile. A newly routed named
+profile never adopts an older `agent:main` transcript from the same channel; rows without
+a profile-attributable key are recoverable only for the default profile.
+
 ## Relationship to multiplexing
 
 `profile_routes` requires `gateway.multiplex_profiles: true`. Multiplexing is what
@@ -115,3 +121,19 @@ activates the per-profile runtime scope (per-profile `HERMES_HOME`, secret scope
 profile-namespaced session keys); routing is the decision layer that picks *which*
 profile a given guild/channel/thread lands in. With multiplexing off, `profile_routes`
 is ignored entirely — behavior is byte-identical to a single-profile gateway.
+
+Every multiplex cron tick stays inside one profile's `HERMES_HOME` and secret scope
+through agent execution **and delivery**. Default ticks use the primary gateway adapter
+map. For a named profile, a platform present in its local scoped config is profile-owned:
+its connected adapter is used, and an explicit disable, missing/failed own adapter, or
+failed own live send never falls back to the primary adapter. A platform absent from the
+named profile config may intentionally reuse the primary live adapter as the gateway's
+shared transport. If that shared live send fails and the named profile has no standalone
+configuration of its own, delivery fails closed.
+
+Profile config and credentials are never inherited, copied, or merged from Default;
+process-global Default credentials are ignored while loading the named profile. The
+shared-adapter exception requires a running gateway loop and a present live adapter, so
+standalone, no-loop, stopped-loop, missing-adapter, and explicit-disable paths retain
+their strict configured/enabled checks. Relay-fronted delivery keeps its existing,
+separate process-owned transport rules.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2214,6 +2214,42 @@ def _multiplex_profile_homes(config: object) -> list[tuple[str, "Path"]]:
     )
 
 
+def _cron_adapters_for_profile(runner: "GatewayRunner", profile_name: str):
+    """Resolve the live delivery transports owned or shared by one profile.
+
+    A named profile owns every platform present in its scoped gateway config,
+    including explicit disables and adapters that failed to connect. Those
+    entries therefore mask the primary adapter instead of silently sending as
+    the Default bot. Platforms absent from the named config may intentionally
+    reuse the primary live transport. Relay remains process-owned and keeps its
+    existing multiplex behavior.
+
+    The caller must invoke this under that profile's home + secret scope so
+    ``load_gateway_config`` cannot discover Default credentials in os.environ.
+    """
+    primary_adapters = getattr(runner, "adapters", None) or {}
+    active_profile_name = getattr(runner, "_active_profile_name", None)
+    primary_profile = (
+        active_profile_name()
+        if callable(active_profile_name)
+        else "default"
+    )
+    if profile_name == primary_profile:
+        return primary_adapters
+
+    from gateway.config import Platform, load_gateway_config
+
+    profile_config = load_gateway_config()
+    resolved = dict(primary_adapters)
+    for platform in profile_config.platforms:
+        if platform is not Platform.RELAY:
+            resolved.pop(platform, None)
+    resolved.update(
+        (getattr(runner, "_profile_adapters", None) or {}).get(profile_name, {})
+    )
+    return resolved
+
+
 @_contextmanager
 def _profile_runtime_scope(profile_home: "Path"):
     """Scope config/skills/memory AND credentials to a profile for one turn.
@@ -31020,6 +31056,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                cron_start_kwargs["adapter_resolver"] = (
+                    lambda profile_name: _cron_adapters_for_profile(
+                        runner, profile_name
+                    )
+                )
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2219,34 +2219,46 @@ def _cron_adapters_for_profile(runner: "GatewayRunner", profile_name: str):
 
     A named profile owns every platform present in its scoped gateway config,
     including explicit disables and adapters that failed to connect. Those
-    entries therefore mask the primary adapter instead of silently sending as
+    entries therefore mask the Default adapter instead of silently sending as
     the Default bot. Platforms absent from the named config may intentionally
-    reuse the primary live transport. Relay remains process-owned and keeps its
+    reuse the Default live transport. Relay remains process-owned and keeps its
     existing multiplex behavior.
 
     The caller must invoke this under that profile's home + secret scope so
     ``load_gateway_config`` cannot discover Default credentials in os.environ.
     """
     primary_adapters = getattr(runner, "adapters", None) or {}
+    profile_adapters = getattr(runner, "_profile_adapters", None) or {}
     active_profile_name = getattr(runner, "_active_profile_name", None)
     primary_profile = (
         active_profile_name()
         if callable(active_profile_name)
         else "default"
     )
-    if profile_name == primary_profile:
-        return primary_adapters
-
     from gateway.config import Platform, load_gateway_config
 
+    default_adapters = (
+        primary_adapters
+        if primary_profile == "default"
+        else profile_adapters.get("default", {})
+    )
+    resolved = dict(default_adapters)
+    relay_adapter = primary_adapters.get(Platform.RELAY)
+    if relay_adapter is not None:
+        resolved[Platform.RELAY] = relay_adapter
+    if profile_name == "default":
+        return resolved
+
     profile_config = load_gateway_config()
-    resolved = dict(primary_adapters)
     for platform in profile_config.platforms:
         if platform is not Platform.RELAY:
             resolved.pop(platform, None)
-    resolved.update(
-        (getattr(runner, "_profile_adapters", None) or {}).get(profile_name, {})
+    owned_adapters = (
+        primary_adapters
+        if profile_name == primary_profile
+        else profile_adapters.get(profile_name, {})
     )
+    resolved.update(owned_adapters)
     return resolved
 
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1912,11 +1912,21 @@ class SessionStore:
         requested_session_key: str,
         recovered: Dict[str, Any],
     ) -> bool:
-        """Prevent non-multiplexed gateways from reviving another profile's row."""
-        if getattr(self.config, "multiplex_profiles", False):
-            return True
-
+        """Prevent durable peer fallback from crossing a profile namespace."""
         recovered_key = str(recovered.get("session_key") or "")
+        requested_profile = self._profile_from_session_key(requested_session_key)
+
+        if getattr(self.config, "multiplex_profiles", False):
+            if requested_profile is None:
+                return False
+            if not recovered_key:
+                return requested_profile == "default"
+            recovered_profile = self._profile_from_session_key(recovered_key)
+            return (
+                recovered_profile is not None
+                and recovered_profile == requested_profile
+            )
+
         if not recovered_key or recovered_key == requested_session_key:
             return True
 
@@ -2129,9 +2139,8 @@ class SessionStore:
             recovered=recovered,
         ):
             logger.warning(
-                "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "Gateway session DB recovery ignored %s for %s because the "
+                "durable row belongs to a different profile namespace",
                 recovered.get("session_key"),
                 session_key,
             )
@@ -2206,9 +2215,8 @@ class SessionStore:
             recovered=recovered,
         ):
             logger.warning(
-                "Gateway session DB recovery ignored %s for %s because "
-                "multiplex_profiles is disabled and the row belongs to a "
-                "different profile",
+                "Gateway session DB recovery ignored %s for %s because the "
+                "durable row belongs to a different profile namespace",
                 recovered.get("session_key"),
                 session_key,
             )

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1906,7 +1906,7 @@ class SessionStore:
         except Exception:
             return "default"
 
-    def _recovered_row_allowed_for_active_profile(
+    def _recovered_row_allowed_for_profile(
         self,
         *,
         requested_session_key: str,
@@ -2134,7 +2134,7 @@ class SessionStore:
             return None
         if not self._recovered_row_matches_source_scope(recovered, source):
             return None
-        if not self._recovered_row_allowed_for_active_profile(
+        if not self._recovered_row_allowed_for_profile(
             requested_session_key=session_key,
             recovered=recovered,
         ):
@@ -2210,7 +2210,7 @@ class SessionStore:
             return None
         if not self._recovered_row_matches_source_scope(recovered, source):
             return None
-        if not self._recovered_row_allowed_for_active_profile(
+        if not self._recovered_row_allowed_for_profile(
             requested_session_key=session_key,
             recovered=recovered,
         ):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5649,14 +5649,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         chat_id: str,
         thread_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        session_key_prefix: Optional[str] = None,
     ) -> Optional[str]:
         """Find the most recent live session_id for a platform + chat origin.
 
         Equivalent of gateway/mirror's sessions.json scan: matches on
-        source + chat_id (+ thread_id when provided).  When ``user_id`` is
-        provided, exact sender matches are preferred; if multiple distinct
-        users share the chat and none matches, returns None rather than
-        contaminating another participant's session.
+        source + chat_id (+ thread_id when provided). ``session_key_prefix``
+        optionally confines the lookup to one multiplex profile namespace.
+        When ``user_id`` is provided, exact sender matches are preferred; if
+        multiple distinct users share the chat and none matches, returns None
+        rather than contaminating another participant's session.
         """
         if not platform or chat_id in (None, ""):
             return None
@@ -5668,6 +5670,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
               AND ended_at IS NULL
         """
         params: list = [platform, str(chat_id)]
+        if session_key_prefix:
+            query += " AND SUBSTR(session_key, 1, ?) = ?"
+            params.extend([len(session_key_prefix), session_key_prefix])
         if thread_id is not None:
             query += " AND COALESCE(thread_id, '') = ?"
             params.append(str(thread_id))

--- a/tests/cron/test_profile_live_native_delivery.py
+++ b/tests/cron/test_profile_live_native_delivery.py
@@ -246,6 +246,30 @@ def test_live_cron_mirror_filters_the_shared_db_by_profile(tmp_path):
         db.close()
 
 
+def test_live_cron_mirror_does_not_use_global_fallback_without_multiplex_db():
+    """A degraded shared store must not rediscover another profile's row."""
+    store = SimpleNamespace(
+        _db=None,
+        config=GatewayConfig(multiplex_profiles=True),
+        append_to_transcript=MagicMock(),
+    )
+    adapter = SimpleNamespace(_session_store=store)
+
+    with patch("gateway.mirror.mirror_to_session") as mirror:
+        _maybe_mirror_cron_delivery(
+            {"id": "reports-cron"},
+            "discord",
+            "123",
+            "Reports-only output",
+            user_id="user-1",
+            enabled=True,
+            adapter=adapter,
+        )
+
+    mirror.assert_not_called()
+    store.append_to_transcript.assert_not_called()
+
+
 def test_named_profile_adapter_resolution_owns_local_platform_boundaries(
     tmp_path, monkeypatch
 ):

--- a/tests/cron/test_profile_live_native_delivery.py
+++ b/tests/cron/test_profile_live_native_delivery.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from agent import secret_scope
 import cron.scheduler as scheduler
-from cron.scheduler import _deliver_result
+from cron.scheduler import _deliver_result, _maybe_mirror_cron_delivery
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.run import _cron_adapters_for_profile, _profile_runtime_scope
 
@@ -163,6 +163,87 @@ def test_named_active_profile_uses_its_primary_adapter_map():
     ) == {
         Platform.DISCORD: primary_discord
     }
+
+
+def test_named_active_gateway_shares_only_default_owned_adapters():
+    """The active named profile must not become the shared transport owner."""
+    ops_discord = object()
+    default_discord = object()
+    default_telegram = object()
+    runner = SimpleNamespace(
+        adapters={Platform.DISCORD: ops_discord},
+        _profile_adapters={
+            "default": {
+                Platform.DISCORD: default_discord,
+                Platform.TELEGRAM: default_telegram,
+            },
+            "reports": {},
+        },
+        _active_profile_name=lambda: "ops",
+    )
+
+    with patch(
+        "gateway.config.load_gateway_config",
+        return_value=GatewayConfig(platforms={}),
+    ):
+        reports = _cron_adapters_for_profile(
+            runner,  # type: ignore[arg-type]
+            "reports",
+        )
+
+    assert reports == {
+        Platform.DISCORD: default_discord,
+        Platform.TELEGRAM: default_telegram,
+    }
+
+
+def test_live_cron_mirror_filters_the_shared_db_by_profile(tmp_path):
+    """A Default cron must not append to a newer named-profile peer row."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        db.create_session(
+            "default-session",
+            "discord",
+            user_id="user-1",
+            session_key="agent:main:discord:dm:123",
+            chat_id="123",
+            chat_type="dm",
+        )
+        db.create_session(
+            "ops-session",
+            "discord",
+            user_id="user-1",
+            session_key="agent:ops:discord:dm:123",
+            chat_id="123",
+            chat_type="dm",
+        )
+        store = SimpleNamespace(
+            _db=db,
+            config=GatewayConfig(multiplex_profiles=True),
+            append_to_transcript=MagicMock(),
+        )
+        adapter = SimpleNamespace(_session_store=store)
+
+        with patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value="default",
+        ):
+            _maybe_mirror_cron_delivery(
+                {"id": "default-cron"},
+                "discord",
+                "123",
+                "Default-only report",
+                user_id="user-1",
+                enabled=True,
+                adapter=adapter,
+            )
+
+        store.append_to_transcript.assert_called_once()
+        assert store.append_to_transcript.call_args.args[0] == "default-session"
+    finally:
+        db.close()
 
 
 def test_named_profile_adapter_resolution_owns_local_platform_boundaries(

--- a/tests/cron/test_profile_live_native_delivery.py
+++ b/tests/cron/test_profile_live_native_delivery.py
@@ -1,0 +1,314 @@
+"""Named-profile cron delivery through a live native gateway adapter."""
+
+import asyncio
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agent import secret_scope
+import cron.scheduler as scheduler
+from cron.scheduler import _deliver_result
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.run import _cron_adapters_for_profile, _profile_runtime_scope
+
+
+def _run_coroutine_now(coro, _loop):
+    future = Future()
+    try:
+        future.set_result(asyncio.run(coro))
+    except BaseException as exc:  # noqa: BLE001
+        future.set_exception(exc)
+    return future
+
+
+def _deliver(config, *, adapter_available, loop, adapter_success=True):
+    adapter = AsyncMock()
+    adapter.send.return_value = MagicMock(
+        success=adapter_success,
+        error=None if adapter_success else "gateway send failed",
+        raw_response=None,
+    )
+    adapter.splits_long_messages = False
+    standalone_send = AsyncMock(return_value={"success": True})
+    job = {
+        "id": "str-cron",
+        "deliver": "origin",
+        "origin": {"platform": "discord", "chat_id": "123"},
+    }
+
+    with (
+        patch("gateway.config.load_gateway_config", return_value=config),
+        patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+        patch("asyncio.run_coroutine_threadsafe", side_effect=_run_coroutine_now),
+        patch("tools.send_message_tool._send_to_platform", new=standalone_send),
+    ):
+        result = _deliver_result(
+            job,
+            "Named-profile report.",
+            adapters={Platform.DISCORD: adapter} if adapter_available else {},
+            loop=loop,
+        )
+
+    return result, adapter, standalone_send
+
+
+def _running_loop():
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    return loop
+
+
+def test_named_profile_uses_live_native_adapter_without_local_platform_config():
+    """The running gateway adapter is the authenticated delivery transport."""
+    result, adapter, standalone_send = _deliver(
+        GatewayConfig(platforms={}),
+        adapter_available=True,
+        loop=_running_loop(),
+    )
+
+    assert result is None
+    adapter.send.assert_awaited_once()
+    standalone_send.assert_not_awaited()
+
+
+def test_failed_live_native_delivery_without_config_does_not_fallback_standalone():
+    result, adapter, standalone_send = _deliver(
+        GatewayConfig(platforms={}),
+        adapter_available=True,
+        loop=_running_loop(),
+        adapter_success=False,
+    )
+
+    assert "gateway send failed" in result
+    adapter.send.assert_awaited_once()
+    standalone_send.assert_not_awaited()
+
+
+def test_standalone_delivery_without_platform_config_stays_rejected():
+    result, adapter, standalone_send = _deliver(
+        GatewayConfig(platforms={}),
+        adapter_available=False,
+        loop=None,
+    )
+
+    assert result == "platform 'discord' not configured/enabled"
+    adapter.send.assert_not_awaited()
+    standalone_send.assert_not_awaited()
+
+
+def test_live_native_adapter_without_gateway_loop_stays_rejected():
+    result, adapter, standalone_send = _deliver(
+        GatewayConfig(platforms={}),
+        adapter_available=True,
+        loop=None,
+    )
+
+    assert result == "platform 'discord' not configured/enabled"
+    adapter.send.assert_not_awaited()
+    standalone_send.assert_not_awaited()
+
+
+def test_live_native_adapter_on_stopped_gateway_loop_stays_rejected():
+    loop = MagicMock()
+    loop.is_running.return_value = False
+    result, adapter, standalone_send = _deliver(
+        GatewayConfig(platforms={}),
+        adapter_available=True,
+        loop=loop,
+    )
+
+    assert result == "platform 'discord' not configured/enabled"
+    adapter.send.assert_not_awaited()
+    standalone_send.assert_not_awaited()
+
+
+def test_running_gateway_loop_without_native_adapter_stays_rejected():
+    result, adapter, standalone_send = _deliver(
+        GatewayConfig(platforms={}),
+        adapter_available=False,
+        loop=_running_loop(),
+    )
+
+    assert result == "platform 'discord' not configured/enabled"
+    adapter.send.assert_not_awaited()
+    standalone_send.assert_not_awaited()
+
+
+def test_explicitly_disabled_native_platform_stays_rejected():
+    result, adapter, standalone_send = _deliver(
+        GatewayConfig(
+            platforms={Platform.DISCORD: PlatformConfig(enabled=False)},
+        ),
+        adapter_available=True,
+        loop=_running_loop(),
+    )
+
+    assert result == "platform 'discord' not configured/enabled"
+    adapter.send.assert_not_awaited()
+    standalone_send.assert_not_awaited()
+
+
+def test_named_active_profile_uses_its_primary_adapter_map():
+    """A gateway started from a named profile still owns runner.adapters."""
+    primary_discord = object()
+    runner = SimpleNamespace(
+        adapters={Platform.DISCORD: primary_discord},
+        _profile_adapters={},
+        _active_profile_name=lambda: "ops",
+    )
+
+    assert _cron_adapters_for_profile(
+        runner,  # type: ignore[arg-type]
+        "ops",
+    ) == {
+        Platform.DISCORD: primary_discord
+    }
+
+
+def test_named_profile_adapter_resolution_owns_local_platform_boundaries(
+    tmp_path, monkeypatch
+):
+    """Connected and failed local adapters must both mask the primary bot."""
+    profile_home = tmp_path / "profiles" / "ops"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        "DISCORD_BOT_TOKEN=ops-token\n", encoding="utf-8"
+    )
+    (profile_home / "config.yaml").write_text(
+        "platforms:\n  discord:\n    enabled: true\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "default-process-token")
+
+    primary_discord = object()
+    primary_telegram = object()
+    own_discord = object()
+    runner = SimpleNamespace(
+        adapters={
+            Platform.DISCORD: primary_discord,
+            Platform.TELEGRAM: primary_telegram,
+        },
+        _profile_adapters={"ops": {Platform.DISCORD: own_discord}},
+    )
+
+    previous = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        with _profile_runtime_scope(profile_home):
+            connected = _cron_adapters_for_profile(runner, "ops")
+            runner._profile_adapters["ops"] = {}
+            failed = _cron_adapters_for_profile(runner, "ops")
+    finally:
+        secret_scope.set_multiplex_active(previous)
+
+    assert connected[Platform.DISCORD] is own_discord
+    assert connected[Platform.TELEGRAM] is primary_telegram
+    assert Platform.DISCORD not in failed
+    assert failed[Platform.TELEGRAM] is primary_telegram
+
+
+def test_named_profile_absent_platform_may_share_primary_live_adapter(
+    tmp_path, monkeypatch
+):
+    """A Default process token does not turn an absent profile block local."""
+    profile_home = tmp_path / "profiles" / "reports"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text("", encoding="utf-8")
+    (profile_home / "config.yaml").write_text("cron: {}\n", encoding="utf-8")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "default-process-token")
+
+    primary_discord = object()
+    runner = SimpleNamespace(
+        adapters={Platform.DISCORD: primary_discord},
+        _profile_adapters={"reports": {}},
+    )
+
+    previous = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        with _profile_runtime_scope(profile_home):
+            resolved = _cron_adapters_for_profile(runner, "reports")
+    finally:
+        secret_scope.set_multiplex_active(previous)
+
+    assert resolved[Platform.DISCORD] is primary_discord
+
+
+def test_run_and_delivery_scope_ignore_process_global_discord_token(
+    tmp_path, monkeypatch
+):
+    """Real config loading cannot authorize Default standalone fallback."""
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    profile_home = tmp_path / "profiles" / "reports"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text("", encoding="utf-8")
+    (profile_home / "config.yaml").write_text(
+        "cron:\n  wrap_response: false\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "default-process-token")
+
+    shared_adapter = AsyncMock()
+    shared_adapter.send.return_value = MagicMock(
+        success=False,
+        error="shared gateway send failed",
+        raw_response=None,
+    )
+    shared_adapter.splits_long_messages = False
+    standalone_send = AsyncMock(return_value={"success": True})
+    marked = []
+
+    monkeypatch.setattr(
+        scheduler,
+        "run_job",
+        lambda *_args, **_kwargs: (True, "output", "Named report", None),
+    )
+    monkeypatch.setattr(
+        scheduler, "save_job_output", lambda job_id, _output: f"/tmp/{job_id}.txt"
+    )
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda _exec_id: None)
+    monkeypatch.setattr(
+        scheduler, "create_execution", lambda *_args, **_kwargs: {"id": "exec-report"}
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_run",
+        lambda *args, **kwargs: marked.append((args, kwargs)) or True,
+    )
+    monkeypatch.setattr(scheduler, "finish_execution", lambda *_args, **_kwargs: None)
+
+    home_token = set_hermes_home_override(str(profile_home))
+    previous = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        with (
+            patch(
+                "asyncio.run_coroutine_threadsafe",
+                side_effect=_run_coroutine_now,
+            ),
+            patch(
+                "tools.send_message_tool._send_to_platform",
+                new=standalone_send,
+            ),
+        ):
+            processed = scheduler.run_one_job(
+                {
+                    "id": "reports-cron",
+                    "deliver": "origin",
+                    "origin": {"platform": "discord", "chat_id": "123"},
+                },
+                adapters={Platform.DISCORD: shared_adapter},
+                loop=_running_loop(),
+            )
+    finally:
+        secret_scope.set_multiplex_active(previous)
+        reset_hermes_home_override(home_token)
+
+    assert processed is True
+    shared_adapter.send.assert_awaited_once()
+    standalone_send.assert_not_awaited()
+    assert "shared gateway send failed" in marked[0][1]["delivery_error"]
+    assert secret_scope.current_secret_scope() is None

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -342,18 +342,23 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     (tmp_path / ".env").write_text("OPENROUTER_BASE_URL=https://openrouter.ai/api/v1\n")
     monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
 
-    scope_during_run = {}
+    observed = {}
 
     def fake_run_job(job, *, defer_agent_teardown=None, **kw):
         # This is where resolve_runtime_provider() would read a secret. Prove a
         # scope is installed and the profile's secret resolves without raising.
-        scope_during_run["scope"] = ss.current_secret_scope()
-        scope_during_run["base_url"] = ss.get_secret("OPENROUTER_BASE_URL")
+        observed["run_scope"] = ss.current_secret_scope()
+        observed["run_base_url"] = ss.get_secret("OPENROUTER_BASE_URL")
         return (True, "out", "final", None)
+
+    def fake_deliver(*_args, **_kwargs):
+        observed["delivery_scope"] = ss.current_secret_scope()
+        observed["delivery_base_url"] = ss.get_secret("OPENROUTER_BASE_URL")
+        return None
 
     monkeypatch.setattr(s, "run_job", fake_run_job)
     monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
-    monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
     monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
 
     ss.set_multiplex_active(True)
@@ -364,9 +369,10 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
 
     assert ok is True
     # Scope was installed during run_job and the profile secret resolved.
-    assert scope_during_run["scope"] is not None
-    assert scope_during_run["base_url"] == "https://openrouter.ai/api/v1"
+    assert observed["run_scope"] is not None
+    assert observed["run_base_url"] == "https://openrouter.ai/api/v1"
+    assert observed["delivery_scope"] is observed["run_scope"]
+    assert observed["delivery_base_url"] == "https://openrouter.ai/api/v1"
     # And it was torn down after run_one_job returned (no leak).
     assert ss.current_secret_scope() is None
-
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2313,26 +2313,29 @@ class TestCronDeliveryMirror:
 
     def test_seed_thread_session_creates_session_and_mirrors(self):
         """Seeding a freshly-opened thread creates the thread-keyed session via
-        the adapter's live store and appends the brief via mirror_to_session."""
+        the adapter's live store and appends the brief to that exact session."""
         from cron.scheduler import _seed_cron_thread_session
 
         store = MagicMock()
+        store.get_or_create_session.return_value.session_id = "thread-session"
         adapter = MagicMock()
         adapter._session_store = store
 
-        with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
-            _seed_cron_thread_session(
-                {"id": "j1"}, adapter, "telegram", "123", "9001",
-                "Daily brief Task #2", chat_name="Ops",
-            )
+        _seed_cron_thread_session(
+            {"id": "j1"}, adapter, "telegram", "123", "9001",
+            "Daily brief Task #2", chat_name="Ops",
+        )
 
         # Session row created for the thread, then brief mirrored into it.
         store.get_or_create_session.assert_called_once()
         seeded_source = store.get_or_create_session.call_args[0][0]
         assert seeded_source.chat_type == "thread"
         assert seeded_source.thread_id == "9001"
-        mirror_mock.assert_called_once()
-        assert mirror_mock.call_args.kwargs.get("thread_id") == "9001"
+        store.append_to_transcript.assert_called_once()
+        session_id, message = store.append_to_transcript.call_args.args
+        assert session_id == "thread-session"
+        assert message["role"] == "user"
+        assert message["content"].startswith("[Cron delivery: j1]")
 
 
 class TestCronContinuableSurfaceInChannel:
@@ -2449,14 +2452,14 @@ class TestCronContinuableSurfaceInChannel:
         from gateway.config import Platform
 
         store = MagicMock()
+        store.get_or_create_session.return_value.session_id = "channel-session"
         adapter = MagicMock()
         adapter._session_store = store
 
-        with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
-            ok = _seed_cron_channel_session(
-                {"id": "j1", "name": "Brief"}, adapter, "slack", "C123",
-                "Daily brief", is_dm=False, user_id="U_HUMAN", chat_name="ops",
-            )
+        ok = _seed_cron_channel_session(
+            {"id": "j1", "name": "Brief"}, adapter, "slack", "C123",
+            "Daily brief", is_dm=False, user_id="U_HUMAN", chat_name="ops",
+        )
         assert ok is True
         seeded_source = store.get_or_create_session.call_args[0][0]
         seed_key = build_session_key(seeded_source)
@@ -2471,9 +2474,11 @@ class TestCronContinuableSurfaceInChannel:
             f"seed key {seed_key} != inbound reply key {build_session_key(inbound)} "
             "— the reply would NOT continue the seeded session"
         )
-        mirror_mock.assert_called_once()
-        assert mirror_mock.call_args.kwargs.get("thread_id") is None
-        assert mirror_mock.call_args.kwargs.get("user_id") == "U_HUMAN"
+        store.append_to_transcript.assert_called_once()
+        session_id, message = store.append_to_transcript.call_args.args
+        assert session_id == "channel-session"
+        assert message["role"] == "user"
+        assert message["content"].startswith("[Cron delivery: Brief]")
 
     def test_in_channel_seed_fires_without_attach_to_session(self):
         """REGRESSION (live, Alice 2026-08-19): the in_channel seed was gated on
@@ -2652,15 +2657,18 @@ class TestCronContinuableSurfaceInChannel:
         adapter = MagicMock()
         adapter._session_store = store
 
-        with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
-            ok = _seed_cron_channel_session(
-                {"id": "j1", "name": "Brief"}, adapter, "slack", "D0BJTDCSR7C",
-                "Daily brief", is_dm=True, user_id="U_HUMAN", chat_name=None,
-            )
+        ok = _seed_cron_channel_session(
+            {"id": "j1", "name": "Brief"}, adapter, "slack", "D0BJTDCSR7C",
+            "Daily brief", is_dm=True, user_id="U_HUMAN", chat_name=None,
+        )
         assert ok is True
-        # The mirror received the exact created session id — origin-scan
+        # The brief is appended directly to the exact created row — origin-scan
         # heuristics (and their populated-chat bail-out) are out of the path.
-        assert mirror_mock.call_args.kwargs.get("session_id") == "sess-flat-exact"
+        store.append_to_transcript.assert_called_once()
+        session_id, message = store.append_to_transcript.call_args.args
+        assert session_id == "sess-flat-exact"
+        assert message["role"] == "user"
+        assert message["content"].startswith("[Cron delivery: Brief]")
 
     def test_in_channel_also_seeds_thread_surface_of_delivered_brief(self):
         """REGRESSION (live, Alice 2026-08-19 19:19): the user replied IN THE

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -640,3 +640,79 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
 
 
+def test_multiplex_ticker_resolves_adapters_inside_each_profile_scope(
+    tmp_path, monkeypatch
+):
+    """The adapter resolver sees the same home and secret scope as tick()."""
+    from agent import secret_scope
+    from cron.scheduler_provider import InProcessCronScheduler
+    from hermes_constants import get_hermes_home
+
+    default_home = tmp_path / "default"
+    named_home = tmp_path / "profiles" / "ops"
+    for home, token in (
+        (default_home, "default-token"),
+        (named_home, "ops-token"),
+    ):
+        (home / "cron").mkdir(parents=True)
+        (home / ".env").write_text(
+            f"DISCORD_BOT_TOKEN={token}\n", encoding="utf-8"
+        )
+
+    profile_homes = [("default", default_home), ("ops", named_home)]
+    resolved = {
+        "default": {"discord": object()},
+        "ops": {"discord": object()},
+    }
+    resolver_observations = []
+    tick_observations = []
+
+    def adapter_resolver(profile_name):
+        resolver_observations.append(
+            (
+                profile_name,
+                get_hermes_home().resolve(),
+                secret_scope.get_secret("DISCORD_BOT_TOKEN"),
+            )
+        )
+        return resolved[profile_name]
+
+    stop = threading.Event()
+
+    def tracking_tick(*_args, adapters=None, **_kwargs):
+        tick_observations.append(
+            (
+                get_hermes_home().resolve(),
+                secret_scope.get_secret("DISCORD_BOT_TOKEN"),
+                adapters,
+            )
+        )
+        if len(tick_observations) == len(profile_homes):
+            stop.set()
+        return 0
+
+    previous = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        with patch("cron.scheduler.tick", side_effect=tracking_tick), patch(
+            "cron.jobs.record_ticker_heartbeat", lambda **_kwargs: None
+        ):
+            InProcessCronScheduler().start(
+                stop,
+                interval=0,
+                profile_homes=profile_homes,
+                adapter_resolver=adapter_resolver,
+            )
+    finally:
+        secret_scope.set_multiplex_active(previous)
+
+    assert resolver_observations == [
+        ("default", default_home.resolve(), "default-token"),
+        ("ops", named_home.resolve(), "ops-token"),
+    ]
+    assert tick_observations == [
+        (default_home.resolve(), "default-token", resolved["default"]),
+        (named_home.resolve(), "ops-token", resolved["ops"]),
+    ]
+    assert secret_scope.current_secret_scope() is None
+

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -172,3 +172,151 @@ class TestSessionStoreUnmultiplexedRecovery:
         assert recovered.session_id == "sess-coder"
         assert recovered.session_key == "agent:main:telegram:dm:99"
         assert store._db.reopened == ["sess-coder"]
+
+
+class TestSessionStoreMultiplexRecoveryIsolation:
+    """Durable peer fallback must not cross a multiplex profile namespace."""
+
+    def _store_with_row(self, tmp_path, row):
+        config = GatewayConfig(multiplex_profiles=True)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        recovering_db = _RecoveringDB(row)
+        object.__setattr__(store, "_db", recovering_db)
+        store._loaded = True
+        return store, recovering_db
+
+    def _recover(self, store, *, requested_key, profile):
+        source = _src(chat_id="99", chat_type="dm", profile=profile)
+        return store._recover_session_from_db(
+            session_key=requested_key,
+            source=source,
+            now=datetime.fromtimestamp(1700000001),
+        )
+
+    def test_allows_exact_named_profile_recovery(self, tmp_path):
+        store, recovering_db = self._store_with_row(
+            tmp_path,
+            {
+                "id": "sess-str",
+                "started_at": 1700000000,
+                "session_key": "agent:str:telegram:dm:99",
+            },
+        )
+
+        recovered = self._recover(
+            store,
+            requested_key="agent:str:telegram:dm:99",
+            profile="str",
+        )
+
+        assert recovered is not None
+        assert recovered.session_id == "sess-str"
+        assert recovering_db.reopened == ["sess-str"]
+
+    @pytest.mark.parametrize(
+        ("requested_key", "profile", "recovered_key"),
+        [
+            (
+                "agent:str:telegram:dm:99",
+                "str",
+                "agent:main:telegram:dm:99",
+            ),
+            (
+                "agent:main:telegram:dm:99",
+                None,
+                "agent:str:telegram:dm:99",
+            ),
+            (
+                "agent:str:telegram:dm:99",
+                "str",
+                None,
+            ),
+        ],
+    )
+    def test_rejects_cross_profile_or_unattributed_recovery(
+        self, tmp_path, requested_key, profile, recovered_key
+    ):
+        store, recovering_db = self._store_with_row(
+            tmp_path,
+            {
+                "id": "wrong-profile-session",
+                "started_at": 1700000000,
+                "session_key": recovered_key,
+            },
+        )
+
+        recovered = self._recover(
+            store,
+            requested_key=requested_key,
+            profile=profile,
+        )
+
+        assert recovered is None
+        assert recovering_db.reopened == []
+
+    def test_default_keeps_legacy_missing_key_recovery(self, tmp_path):
+        store, recovering_db = self._store_with_row(
+            tmp_path,
+            {
+                "id": "legacy-default-session",
+                "started_at": 1700000000,
+                "session_key": None,
+            },
+        )
+
+        recovered = self._recover(
+            store,
+            requested_key="agent:main:telegram:dm:99",
+            profile=None,
+        )
+
+        assert recovered is not None
+        assert recovered.session_id == "legacy-default-session"
+        assert recovering_db.reopened == ["legacy-default-session"]
+
+    def test_real_db_does_not_adopt_default_transcript_for_named_profile(
+        self, tmp_path, monkeypatch
+    ):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        sessions_dir = tmp_path / "sessions"
+        default_source = _src(
+            platform=Platform.DISCORD,
+            chat_id="route-channel",
+            chat_type="group",
+            user_id="cyril",
+        )
+        original = SessionStore(
+            sessions_dir=sessions_dir,
+            config=GatewayConfig(multiplex_profiles=False),
+        )
+        default_entry = original.get_or_create_session(default_source)
+        original.append_to_transcript(
+            default_entry.session_key,
+            {"role": "user", "content": "default-only context"},
+        )
+        assert original._db is not None
+        original._db.close()
+
+        restarted = SessionStore(
+            sessions_dir=sessions_dir,
+            config=GatewayConfig(multiplex_profiles=True),
+        )
+        str_source = _src(
+            platform=Platform.DISCORD,
+            chat_id="route-channel",
+            chat_type="group",
+            user_id="cyril",
+            profile="str",
+        )
+
+        routed_entry = restarted.get_or_create_session(str_source)
+
+        assert default_entry.session_key.startswith("agent:main:")
+        assert routed_entry.session_key.startswith("agent:str:")
+        assert routed_entry.session_id != default_entry.session_id
+        assert restarted.load_transcript(routed_entry.session_id) == []
+        assert restarted._db is not None
+        restarted._db.close()


### PR DESCRIPTION
## Problem

A multiplexed gateway can intentionally keep messaging credentials only in the Default/control-plane profile while routing named profiles by channel. In that supported shape, named-profile cron jobs can execute correctly but fail preflight or delivery because the target profile has no local platform block. The inverse failure is worse: a live adapter or durable-session fallback can be reused without proving that the exact chat was routed to the profile, which risks cross-profile delivery or transcript contamination.

## Fix

- keep each multiplex cron tick inside its profile home and secret scope through preflight, execution, output, and delivery;
- authorize reuse of the Default live adapter only for the immutable route-selected profile and exact destination;
- preserve profile-owned platform masking, explicit disables, standalone checks, relay behavior, and fail-closed fallback semantics;
- make adapter selection explicit when the gateway itself runs from a named profile;
- scope durable session recovery and cron transcript mirroring to the owning profile namespace;
- fail closed instead of using the global transcript lookup when a multiplex profile has no live session DB;
- seed continuable cron sessions through the exact live `SessionStore` entry instead of a cross-profile origin lookup;
- document the shared-control-plane contract.

This is complementary to #80876: that PR routes through per-profile bots/adapters. This PR covers the single Default-owned transport design without copying credentials or config into named profiles. It also adds stricter route authorization and transcript/session isolation around that path.

## Validation

- rebased onto the current `origin/main` head before the latest push;
- `474 passed, 2 skipped` across cron delivery, scheduler, multiplex gateway, session and state suites;
- Ruff passed on every changed Python file;
- `git diff --check origin/main...HEAD` passed;
- `$simplify` and `$review-loop` found and fixed additional P1/P2 isolation gaps before the final run.

No credentials, profile data, or user-specific configuration are included.