### PR TITLE
test(agent): stop truncation-warning ContextVar leaking between test files

### DIFF
--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -38,6 +38,18 @@ from agent.prompt_builder import (
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
 
 
+@pytest.fixture(autouse=True)
+def _drain_truncation_warnings():
+    """Leave no truncation warnings in the shared thread context.
+
+    Truncation warnings ride a ContextVar; under plain ``pytest`` (no
+    per-file subprocess isolation) anything this file records leaks into
+    later files' contexts and breaks their assertions/ordering.
+    """
+    yield
+    drain_truncation_warnings()
+
+
 # =========================================================================
 # Guidance constants
 # =========================================================================

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -24,6 +24,11 @@ def _make_agent(**overrides):
         platform="",
         pass_session_id=False,
         session_id="",
+        # build_system_prompt drains pending truncation warnings and
+        # forwards each to this; a warning left in the ContextVar by an
+        # earlier test file (they share one thread's context under plain
+        # pytest) must not make this stub AttributeError.
+        _emit_status=lambda *_args, **_kwargs: None,
     )
     base.update(overrides)
     return SimpleNamespace(**base)


### PR DESCRIPTION
## What does this PR do?

Fixes the order-dependent test failure from #93018: `pytest tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py` failed `test_build_system_prompt_records_stable_prefix` with ``AttributeError: '...SimpleNamespace' object has no attribute '_emit_status'`` because a truncation warning recorded by an earlier file stayed in the shared thread context (the warning store is a `ContextVar`; plain `pytest` runs both files in one process/thread), and `build_system_prompt()` drains pending warnings into `agent._emit_status(warning)`.

Both sides are hardened:

- **Producer**: `tests/agent/test_prompt_builder.py` gains an autouse fixture that drains truncation warnings after every test, so nothing leaks out of the file.
- **Consumer**: `tests/agent/test_system_prompt.py::_make_agent()` stub gains a no-op `_emit_status`, so even a stray warning from elsewhere is harmless.

Verified: the previously failing ordering now passes; reverse ordering still passes.

Note: on Windows hosts `test_coding_prompt_preserves_legacy_workspace_order` fails standalone on clean `main` too - that is a separate pre-existing platform issue, not addressed here.

Fixes #93018

## Type of Change

- [x] Tests (adding or improving test coverage)

## Changes Made

- `tests/agent/test_system_prompt.py`: `_make_agent()` adds `_emit_status` no-op stub.
- `tests/agent/test_prompt_builder.py`: autouse `_drain_truncation_warnings` fixture.

## How to Test

1. `pytest tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py -q` (previously 1 failure)
2. `pytest tests/agent/test_system_prompt.py tests/agent/test_prompt_builder.py -q` (still green)

## Checklist

### Code

- [x] Contributing Guide read
- [x] Conventional Commits followed (`test(agent):`)
- [x] Duplicates searched
- [x] Only changes related to this fix
- [x] Targeted suites pass in both orderings
- [x] Tested on Windows 11
