### PR TITLE
scripts: Windows safe update script for preserving .env

### DIFF
--- a/docs/windows-safe-update.md
+++ b/docs/windows-safe-update.md
@@ -1,0 +1,67 @@
+# Windows Safe Update Script
+
+This script preserves your `.env` configuration when running `hermes update`.
+
+## Why?
+
+By default, `hermes update --force` overwrites the `.env` file with the default configuration, losing all your custom settings (headless mode, CDP ports, memory services, etc.).
+
+This script:
+1. Saves your `.env` before the update
+2. Runs `hermes update`
+3. Restores your `.env` after the update
+
+## Usage
+
+### Basic update
+```powershell
+.\scripts\windows-safe-update.ps1
+```
+
+### Force update
+```powershell
+.\scripts\windows-safe-update.ps1 -Force
+```
+
+## What it preserves
+
+- `BROWSER_USE_HEADLESS`
+- `BROWSER_USE_CDP_PORT`
+- `BROWSER_USE_BROWSER`
+- `BROWSER_USE_ARGS`
+- `MEMORY_CORE_URL`
+- `MEMORY_HUB_URL`
+- `KNOWLEDGE_API_URL`
+- `SEARXNG_URL`
+- All other custom `.env` settings
+
+## Alternative: PowerShell Alias
+
+For even easier usage, add this to your PowerShell profile:
+
+```powershell
+function Update-Hermes {
+    param([switch]$Force)
+    $EnvFile = "$env:LOCALAPPDATA\hermes\hermes-agent\.env"
+    $PreUpdateBackup = "$EnvFile.pre-update"
+    if (Test-Path $EnvFile) {
+        Copy-Item -Path $EnvFile -Destination $PreUpdateBackup -Force
+    }
+    if ($Force) { hermes update --force } else { hermes update }
+    if (Test-Path $PreUpdateBackup) {
+        Copy-Item -Path $PreUpdateBackup -Destination $EnvFile -Force
+        Remove-Item -Path $PreUpdateBackup -Force -ErrorAction SilentlyContinue
+    }
+}
+Set-Alias hermes-update Update-Hermes
+```
+
+Then just run:
+```powershell
+hermes-update -Force
+```
+
+## Author
+
+Contributed by: Fabrizio (AI Systems Architect)
+Date: August 23, 2026

--- a/scripts/windows-safe-update.ps1
+++ b/scripts/windows-safe-update.ps1
@@ -1,0 +1,42 @@
+# Hermes Safe Update Script for Windows
+# Preserves .env configuration across updates
+# Usage: .\scripts\windows-safe-update.ps1 [-Force]
+
+param([switch]$Force)
+
+Write-Host "=== HERMES SAFE UPDATE ===" -ForegroundColor Cyan
+Write-Host ""
+
+$EnvFile = "$env:LOCALAPPDATA\hermes\hermes-agent\.env"
+$PreUpdateBackup = "$EnvFile.pre-update"
+
+# 1. Save .env
+if (Test-Path $EnvFile) {
+    Copy-Item -Path $EnvFile -Destination $PreUpdateBackup -Force
+    Write-Host "📦 Backup .env saved" -ForegroundColor Green
+}
+
+# 2. Run update
+Write-Host "🔄 Running update..." -ForegroundColor Yellow
+Write-Host ""
+if ($Force) {
+    hermes update --force
+} else {
+    hermes update
+}
+$exitCode = $LASTEXITCODE
+Write-Host ""
+
+# 3. Restore .env
+if (Test-Path $PreUpdateBackup) {
+    Copy-Item -Path $PreUpdateBackup -Destination $EnvFile -Force
+    Remove-Item -Path $PreUpdateBackup -Force -ErrorAction SilentlyContinue
+    Write-Host "✅ Configuration restored" -ForegroundColor Green
+}
+
+Write-Host ""
+if ($exitCode -eq 0) {
+    Write-Host "=== UPDATE COMPLETE ===" -ForegroundColor Green
+} else {
+    Write-Host "=== UPDATE FAILED (exit code: $exitCode) ===" -ForegroundColor Red
+}


### PR DESCRIPTION
## Summary

This PR adds a Windows PowerShell script that preserves `.env` configuration across `hermes update` operations.

## Problem

By default, `hermes update --force` overwrites the `.env` file with default configuration, losing all custom settings.

## Solution

`scripts/windows-safe-update.ps1` automatically:
1. Saves `.env` before update
2. Runs `hermes update`
3. Restores `.env` after update

## Files

- `scripts/windows-safe-update.ps1` - Safe update script
- `docs/windows-safe-update.md` - Usage documentation

## Testing

Tested on Windows 11 with Hermes Agent v0.20.5

---

**Contributed by**: Fabrizio (AI Systems Architect)
**Date**: August 23, 2026