### PR TITLE
Fix self-inflicted lockout: secure_parent_dir() chmod's /opt/hermes to 0700

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -298,7 +298,7 @@ RUN uv pip install --no-cache-dir --no-deps -e "."
 USER root
 RUN mkdir -p /opt/hermes/bin && \
     cp /opt/hermes/docker/hermes-exec-shim.sh /opt/hermes/bin/hermes && \
-    chmod 0755 /opt/hermes/bin/hermes && \
+    chmod 0755 /opt/hermes /opt/hermes/bin/hermes && \
     printf 'docker\n' > /opt/hermes/.install_method
 # The ``.install_method`` stamp is baked next to the running code (the install
 # tree), NOT into $HERMES_HOME. $HERMES_HOME (/opt/data) is a shared data

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1023,6 +1023,15 @@ def secure_parent_dir(path: Path) -> None:
     # Refuse root and its direct children (/usr, /home, /var, /tmp, …).
     if parent == Path("/") or len(parent.parts) < 3:
         return
+    # Refuse /opt/hermes. The install dir lives on the image layer;
+    # chmodding it to 0700 breaks hermes-user traversal and produces
+    # spurious "Permission denied" on every new exec until manual
+    # `chmod 0755 /opt/hermes`. Reproducer: any auth write to a file
+    # directly under /opt/hermes (e.g. /opt/hermes/auth.json when
+    # HERMES_HOME resolves there) triggers the 0700 chmod and locks
+    # out UID 10000. See issue #25821 follow-up.
+    if str(parent) == "/opt/hermes":
+        return
     try:
         os.chmod(parent, 0o700)
     except OSError:


### PR DESCRIPTION
## Problem

`secure_parent_dir()` is called before credential file writes to harden the parent dir to `0700`. Its existing safety check refuses only paths with fewer than 3 path parts, but `/opt/hermes` is exactly 3 parts (`['', 'opt', 'hermes']`), so it passes and gets chmod'd to `0700`. UID 10000 (the unprivileged `hermes` user) cannot then traverse the install dir and every new exec fails with `Permission denied` until a manual `chmod 0755 /opt/hermes`.

Reproducer: any auth write to a file directly under `/opt/hermes` (e.g. `/opt/hermes/auth.json` when `HERMES_HOME` resolves there, or any new credential file landed directly under the install dir).

This has been observed in production twice:
- 2026-07-06 21:36:57 UTC - initial incident, took down the running gateway's ability to spawn new processes
- 2026-08-22 ~16:00 UTC - second occurrence despite an earlier cont-init workaround

## Fix

Two complementary changes:

1. **`hermes_constants.py`** - `secure_parent_dir()` now early-returns when `parent == /opt/hermes`, with a comment explaining the reproducer so future maintainers don't accidentally remove it.

2. **`Dockerfile`** - the install step now does `chmod 0755 /opt/hermes /opt/hermes/bin/hermes` (was just `/opt/hermes/bin/hermes`). So fresh builds start with the install dir traversable and the lockout cannot occur at all.

## Testing

Reproduce in current main:
```python
from pathlib import Path
from hermes_constants import secure_parent_dir
import os
secure_parent_dir(Path('/opt/hermes/auth.json'))
print(oct(os.lstat('/opt/hermes').st_mode)[-3:])  # prints 700 - bug
```

After the patch:
```python
secure_parent_dir(Path('/opt/hermes/auth.json'))
print(oct(os.lstat('/opt/hermes').st_mode)[-3:])  # unchanged
```

## Related

- Original issue: #25821 (the existing `< 3 parts` safety check)
- Fix is minimal and surgical - no behavior change for other paths
- No new dependencies, no API changes
