### PR TITLE
fix(agent): surface Nous tool request failures instead of empty replies

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -92,6 +92,7 @@ from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
 # finalizer at turn end.
 from agent.turn_finalizer import finalize_turn
+from agent.transports.chat_completions import PROVIDER_FAILURE_FINISH_REASONS
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent import empty_response_guard as _empty_guard
 from hermes_constants import PARTIAL_STREAM_STUB_ID
@@ -3505,6 +3506,98 @@ def run_conversation(
                             force=True,
                         )
                         finish_reason = "length"
+
+                # Some OpenAI-compatible aggregators expose an upstream
+                # transport failure only as ``native_finish_reason`` while
+                # projecting the public finish reason as a clean ``stop``.
+                # The chat-completions transport promotes that signal. When
+                # the response has no usable payload, do not route it through
+                # the generic empty-response retries: the provider already
+                # told us the unchanged request failed upstream.
+                if finish_reason in PROVIDER_FAILURE_FINISH_REASONS:
+                    _provider_error_content = (
+                        getattr(assistant_message, "content", None) or ""
+                    )
+                    _provider_error_tools = bool(
+                        getattr(assistant_message, "tool_calls", None)
+                    )
+                    _provider_error_reasoning = (
+                        agent._extract_reasoning(assistant_message) or ""
+                    )
+                    if (
+                        not str(_provider_error_content).strip()
+                        and not _provider_error_tools
+                        and not str(_provider_error_reasoning).strip()
+                    ):
+                        _provider_error_detail = (
+                            f"upstream provider ended the request with "
+                            f"{finish_reason} before returning content or tool calls"
+                        )
+                        agent._invoke_api_request_error_hook(
+                            task_id=effective_task_id,
+                            turn_id=turn_id,
+                            api_request_id=api_request_id,
+                            api_call_count=api_call_count,
+                            api_start_time=api_start_time,
+                            api_kwargs=api_kwargs,
+                            error_type="ProviderResponseError",
+                            error_message=_provider_error_detail,
+                            status_code=None,
+                            retry_count=retry_count,
+                            max_retries=max_retries,
+                            retryable=True,
+                            reason=FailoverReason.server_error.value,
+                        )
+
+                        if agent._has_pending_fallback():
+                            agent._buffer_status(
+                                f"⚠️ Upstream provider returned {finish_reason} — "
+                                "trying fallback..."
+                            )
+                        if agent._try_activate_fallback():
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt
+                            )
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            _retry.restart_with_rebuilt_messages = True
+                            break
+
+                        if thinking_spinner:
+                            thinking_spinner.stop("")
+                            thinking_spinner = None
+                        if agent.thinking_callback:
+                            agent.thinking_callback("")
+                        agent._flush_status_buffer()
+                        agent._emit_status(
+                            f"❌ Upstream provider returned {finish_reason} "
+                            "without a response"
+                        )
+                        _provider_error_response = (
+                            "⚠️ The upstream provider could not complete this "
+                            f"request ({finish_reason}). It returned no content "
+                            "or tool calls. Try again or switch models."
+                        )
+                        append_message(messages, {
+                            "role": "assistant",
+                            "content": _provider_error_response,
+                        })
+                        agent._cleanup_task_resources(effective_task_id)
+                        agent._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": _provider_error_response,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _provider_error_detail,
+                            "failure_reason": FailoverReason.server_error.value,
+                            "failure_retryable": True,
+                            "turn_exit_reason": (
+                                f"provider_response_error({finish_reason})"
+                            ),
+                        }
 
                 # ── Content-policy refusal (HTTP 200) ──────────────────
                 # The model — or the provider's safety system — returned a

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -28,6 +28,14 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
+PROVIDER_FAILURE_FINISH_REASONS = frozenset({
+    "error",
+    "network_error",
+    "server_error",
+    "upstream_error",
+})
+
+
 def _static_prompt_instructions(messages: list[dict[str, Any]]) -> str:
     """Return the stable system/developer prefix used for cache routing.
 
@@ -892,6 +900,23 @@ class ChatCompletionsTransport(ProviderTransport):
         if isinstance(_fr, int):
             _fr = str(_fr)
         finish_reason = _fr or "stop"
+        native_finish_reason = getattr(choice, "native_finish_reason", None)
+        if native_finish_reason is None and hasattr(choice, "model_extra"):
+            choice_extra = getattr(choice, "model_extra", None) or {}
+            if isinstance(choice_extra, dict):
+                native_finish_reason = choice_extra.get("native_finish_reason")
+        if isinstance(native_finish_reason, str):
+            native_finish_reason = native_finish_reason.strip().lower()
+            if (
+                finish_reason == "stop"
+                and native_finish_reason in PROVIDER_FAILURE_FINISH_REASONS
+            ):
+                # Aggregators can project an upstream failure as a successful
+                # OpenAI-compatible stop. Preserve the stronger native signal
+                # so the loop does not retry it as an unexplained empty answer.
+                finish_reason = native_finish_reason
+        else:
+            native_finish_reason = None
 
         tool_calls = None
         message_tool_calls = getattr(msg, "tool_calls", None)
@@ -959,6 +984,8 @@ class ChatCompletionsTransport(ProviderTransport):
                 reasoning_content = model_extra["reasoning_content"]
 
         provider_data: Dict[str, Any] = {}
+        if native_finish_reason is not None:
+            provider_data["native_finish_reason"] = native_finish_reason
         if reasoning_content is not None:
             provider_data["reasoning_content"] = reasoning_content
         rd = getattr(msg, "reasoning_details", None)

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -168,3 +168,41 @@ class TestAnthropicTransport:
         assert system is not None
         # Messages should only have user
         assert len(msgs) >= 1
+
+
+class TestChatCompletionsTransport:
+    def test_native_network_error_overrides_clean_public_stop(self):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content="", tool_calls=None),
+                finish_reason="stop",
+                model_extra={"native_finish_reason": "network_error"},
+            )],
+            usage=None,
+        )
+
+        normalized = ChatCompletionsTransport().normalize_response(response)
+
+        assert normalized.finish_reason == "network_error"
+        assert normalized.provider_data == {
+            "native_finish_reason": "network_error",
+        }
+
+    def test_native_stop_does_not_change_public_finish_reason(self):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content="done", tool_calls=None),
+                finish_reason="stop",
+                model_extra={"native_finish_reason": "stop"},
+            )],
+            usage=None,
+        )
+
+        normalized = ChatCompletionsTransport().normalize_response(response)
+
+        assert normalized.finish_reason == "stop"
+        assert normalized.content == "done"

--- a/tests/run_agent/test_empty_terminal_reasoning_surface.py
+++ b/tests/run_agent/test_empty_terminal_reasoning_surface.py
@@ -81,6 +81,24 @@ def _truly_empty_response():
     )
 
 
+def _native_network_error_response():
+    return SimpleNamespace(
+        choices=[SimpleNamespace(
+            message=SimpleNamespace(
+                content="",
+                reasoning=None,
+                reasoning_content=None,
+                reasoning_details=None,
+                tool_calls=None,
+            ),
+            finish_reason="stop",
+            model_extra={"native_finish_reason": "network_error"},
+        )],
+        usage=None,
+        model="test-model",
+    )
+
+
 def test_exhausted_reasoning_only_delivers_labeled_excerpt(tmp_path, monkeypatch):
     """After the full ladder is exhausted on reasoning-only responses, the
     delivered text is the labeled excerpt — not a bare '(empty)' — while the
@@ -159,3 +177,24 @@ def test_reasoning_never_promoted_before_ladder_exhaustion(tmp_path, monkeypatch
 
     assert result["final_response"] == "42."
     assert "only internal reasoning" not in result["final_response"]
+
+
+def test_native_network_error_surfaces_without_empty_retries(tmp_path, monkeypatch):
+    agent = _build_agent(tmp_path, monkeypatch)
+    calls = 0
+
+    def _respond(api_kwargs):
+        nonlocal calls
+        calls += 1
+        return _native_network_error_response()
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _respond)
+    monkeypatch.setattr("agent.conversation_loop.jittered_backoff", lambda *a, **k: 0)
+
+    result = agent.run_conversation("hello?")
+
+    assert calls == 1
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "provider_response_error(network_error)"
+    assert "network_error" in result["final_response"]
+    assert "(empty)" not in result["final_response"]


### PR DESCRIPTION
## What does this PR do?

Tool-enabled requests that are rejected by an upstream model no longer burn the generic empty-response retry budget and end as an unexplained empty reply when the provider includes a native failure reason. Hermes now preserves that signal, tries a configured fallback immediately, or surfaces a clear retryable provider error.

### Symptom

With Nous Portal `stealth/ox-alpha`, a tool-enabled request can return HTTP 200 with public `finish_reason=stop`, no content, reasoning, tool calls, or usage, and a native `network_error`. Hermes previously retried the unchanged request and ended with `empty_response_exhausted`.

### Impact

Users receive no model answer or actionable provider error, and Hermes repeats an upstream request that the provider has already identified as failed. The reported failure affects CLI and Telegram sessions using this model with tools enabled.

### Bug Cause

**Trigger:** `agent/transports/chat_completions.py:ChatCompletionsTransport.normalize_response` receives a choice whose public finish reason is `stop` but whose native finish reason is `network_error`.

**Causal chain:**
1. The upstream tool route fails and the aggregator returns an empty OpenAI-compatible choice with a native failure reason.
2. Response normalization discards the native finish reason and treats the choice as a clean `stop`.
3. The conversation loop classifies the result as an unexplained empty completion, retries it, and eventually reports an empty-response exhaustion instead of the provider failure.

**Why it is wrong:** The stronger provider failure signal is lost at the transport boundary, so the retry policy cannot distinguish a signaled upstream error from an unsignaled empty model response.

**Working sibling / contrast:** Ordinary `stop` responses with content keep their existing behavior. A configured fallback remains eligible and is attempted before the provider error is returned.

**Ruled out:** The live Nous model catalog still advertises `tools` for `stealth/ox-alpha`, and the same model responds without tools. Permanently disabling or silently stripping tools would destroy an advertised agent capability rather than report the upstream failure correctly.

### Fix

- Preserve `native_finish_reason` in normalized provider metadata.
- Promote recognized native provider failures when the public reason incorrectly says `stop`.
- For an empty signaled provider failure, skip generic empty retries, try a configured fallback, and otherwise return a structured retryable provider error.
- Add transport and full conversation-loop regressions for the exact response shape and a normal-stop control.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py` - preserve and promote native provider failure finish reasons.
- `agent/conversation_loop.py` - route empty signaled failures through fallback or a clear provider-error terminal.
- `tests/agent/transports/test_transport.py` - cover native failure normalization and normal-stop behavior.
- `tests/run_agent/test_empty_terminal_reasoning_surface.py` - prove the failure surfaces after one request instead of empty retries.

## How to Test

1. Run the focused response-shape and conversation-loop regressions.
2. Run the chat-completions transport and empty-response regression suites.

```bash
scripts/run_tests.sh tests/agent/transports/test_transport.py tests/run_agent/test_empty_terminal_reasoning_surface.py -q
scripts/run_tests.sh tests/agent/transports/ tests/agent/test_empty_response_guard.py tests/run_agent/test_turn_completion_explainer.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A. Automated regressions exercise the exact provider response shape without including credentials or response content.
