### PR TITLE
fix(stt): surface the selection-specific error for explicit openai STT

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1244,3 +1244,107 @@ class TestRunCommandSttIdleTimeout:
             )
 
         assert "starting pass 1" in (excinfo.value.stderr or "")
+
+
+# ============================================================================
+# Explicit openai selection keeps its selection-specific error (#93045)
+# ============================================================================
+
+class TestExplicitOpenaiSelectionError:
+    """A managed-route outage must not be reported as generic setup guidance.
+
+    When ``_resolve_openai_audio_client_config()`` raises its
+    selection-specific ValueError (managed openai-audio gateway unavailable,
+    with the ``hermes tools`` remediation for managed-Nous users), the old
+    boolean probe flattened it into False — the log said "no API key" and
+    the transcription result returned the all-provider install hint,
+    pointing operators at unrelated setup instead of their managed route.
+    """
+
+    def _no_openai_credentials(self, monkeypatch):
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "tools.transcription_tools.resolve_openai_audio_api_key",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools.resolve_managed_tool_gateway",
+            lambda vendor: None,
+        )
+
+    def test_get_provider_openai_none_not_generic_when_managed_route_down(
+        self, monkeypatch, caplog
+    ):
+        self._no_openai_credentials(monkeypatch)
+        monkeypatch.setattr(
+            "tools.transcription_tools.managed_nous_tools_enabled", lambda: True
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config", lambda: {}
+        )
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", False):
+            from tools.transcription_tools import _get_provider
+
+            with caplog.at_level("WARNING"):
+                result = _get_provider({"provider": "openai"})
+
+        assert result == "none"
+        warning = caplog.records[-1].getMessage()
+        assert "unavailable" in warning
+        # The selection-specific blocker is named, not a bare API-key hint.
+        assert "managed" in warning or "gateway" in warning
+        assert "no API key available" not in warning
+
+    def test_dispatch_returns_selection_specific_error(self, monkeypatch):
+        """The final transcription result carries the managed-route error and
+        its hermes tools remediation instead of the all-provider install
+        hint."""
+        self._no_openai_credentials(monkeypatch)
+        monkeypatch.setattr(
+            "tools.transcription_tools.managed_nous_tools_enabled", lambda: True
+        )
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config", lambda: {}
+        )
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch(
+                 "tools.transcription_tools.nous_tool_gateway_unavailable_message",
+                 lambda what: f"managed route down for {what}; run `hermes tools`",
+             ):
+            from tools.transcription_tools import _dispatch_stt_provider
+
+            result = _dispatch_stt_provider(
+                "/tmp/nonexistent.wav", "none", {"provider": "openai"}
+            )
+
+        assert result["success"] is False
+        assert "managed route down" in result["error"]
+        assert "hermes tools" in result["error"]
+        assert "No STT provider available" not in result["error"]
+
+    def test_auto_detect_none_keeps_generic_hint(self, monkeypatch):
+        """Auto-detect with no credentials at all still returns the generic
+        all-provider hint — the selection-specific branch must not fire
+        without an explicit provider choice."""
+        self._no_openai_credentials(monkeypatch)
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config", lambda: {}
+        )
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch(
+                 "tools.transcription_tools._has_local_command", return_value=False
+             ), \
+             patch(
+                 "tools.transcription_tools._try_lazy_install_stt",
+                 return_value=False,
+             ):
+            from tools.transcription_tools import _dispatch_stt_provider
+
+            result = _dispatch_stt_provider("/tmp/x.wav", "none", {})
+
+        assert result["success"] is False
+        assert "No STT provider available" in result["error"]

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1084,8 +1084,20 @@ def _get_provider(stt_config: dict) -> str:
             return "none"
 
         if provider == "openai":
-            if _HAS_OPENAI and _has_openai_audio_backend():
-                return "openai"
+            if _HAS_OPENAI:
+                # Resolve directly instead of via the boolean probe: the
+                # probe flattens _resolve_openai_audio_client_config's
+                # selection-specific ValueError into False, so a managed
+                # openai-audio gateway outage would be logged as a generic
+                # "no API key" hint (#93045).
+                try:
+                    _resolve_openai_audio_client_config()
+                    return "openai"
+                except ValueError as exc:
+                    logger.warning(
+                        "STT provider 'openai' configured but unavailable: %s", exc
+                    )
+                    return "none"
             logger.warning(
                 "STT provider 'openai' configured but no API key available"
             )
@@ -3156,6 +3168,16 @@ def _dispatch_stt_provider(
         and provider_key != "none"
     ):
         return _unregistered_stt_provider_error(provider_key)
+
+    # An explicit openai selection flattened to "none" carries a
+    # selection-specific reason (e.g. the managed openai-audio gateway is
+    # unavailable). Surface it — with its `hermes tools` remediation —
+    # instead of the all-provider setup hint (#93045).
+    if provider_key == "none" and str(stt_config.get("provider") or "") == "openai" and _HAS_OPENAI:
+        try:
+            _resolve_openai_audio_client_config()
+        except ValueError as exc:
+            return {"success": False, "transcript": "", "error": str(exc)}
 
     # No provider available
     return {


### PR DESCRIPTION
## What does this PR do?

Makes an explicit `stt.provider: openai` selection report its real blocker instead of generic setup guidance. When the managed `openai-audio` gateway is unavailable, `_resolve_openai_audio_client_config()` already raises a `ValueError` that names the blocker and — for managed-Nous users — appends the `hermes tools` remediation. But the explicit-openai branch of `_get_provider()` checked availability through the boolean `_has_openai_audio_backend()` probe, which flattens that `ValueError` into `False`. The log then claimed "STT provider 'openai' configured but no API key available" and the transcription result fell through to the all-provider "No STT provider available. Install faster-whisper … set GROQ_API_KEY …" hint — directing operators toward unrelated provider setup when their managed route is what's down.

Two changes, both in the explicit-selection path (auto-detect is untouched):

- `_get_provider()` resolves `_resolve_openai_audio_client_config()` directly (same gate: `_HAS_OPENAI` + the resolver succeeding ≡ the old probe), so the warning names the actual blocker instead of a bare API-key hint.
- `_dispatch_stt_provider()`'s "none" fallback re-resolves the config when the config explicitly chose `openai` and returns its `ValueError` message as the transcription error. The generic all-provider hint remains the answer for auto-detect with no credentials.

No fallback is added — an unavailable selection still resolves to `none`; it just says why.

## Related Issue

Fixes #93045

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/transcription_tools.py`
  - `_get_provider()` explicit `openai` branch: replace the `_has_openai_audio_backend()` probe with a direct `_resolve_openai_audio_client_config()` call in a try/except so the warning carries the selection-specific message (comment names the probe-flattening mechanism)
  - `_dispatch_stt_provider()` "No provider available" fallback: when the config explicitly chose `openai` and the package is present, re-resolve and return the selection-specific error dict instead of the all-provider install hint (comment marks the explicit-choice-only guard)
- `tests/tools/test_transcription_tools.py`
  - new `TestExplicitOpenaiSelectionError` class: `_get_provider` names the managed-route blocker (and not "no API key") when the managed gateway is down; the dispatch result carries the `hermes tools` remediation (and not the generic hint) for an explicit openai choice; auto-detect with no credentials still gets the generic hint (guard against over-firing)

## How to Test

1. `.venv/bin python -m pytest tests/tools/test_transcription_tools.py -q`
2. Observed result: all provider-selection and dispatch tests pass (50 passed in the full file on a warm env; 4 pre-existing environment failures — psutil/model-correction mocks — reproduce identically on unmodified main and are unrelated). Reverting only `tools/transcription_tools.py` makes exactly the two selection-specific tests fail (`2 failed, 1 passed`), confirming they pin the new reporting.
3. Manual check matching the issue's repro: configure `stt.provider: openai`, clear `VOICE_TOOLS_OPENAI_KEY`/`OPENAI_API_KEY`, and disable the managed `openai-audio` gateway — a transcription call now returns the selection-specific error naming the managed route (with the `hermes tools` remediation for managed-Nous users) instead of "No STT provider available. Install faster-whisper …".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full transcription suite; 4 failures reproduce identically on unmodified main — environment deps, not this diff)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comments name the mechanism)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python error-propagation change)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
