### PR TITLE
fix(auth): persist borrowed xAI refreshes to root owner

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -32,6 +32,7 @@ from hermes_cli.auth import (
     _load_auth_store,
     _load_provider_state,
     _load_provider_state_with_source,
+    _read_credential_pool_with_source,
     _resolve_kimi_base_url,
     _resolve_zai_base_url,
     _same_path,
@@ -648,9 +649,20 @@ def _write_through_provider_state_to_global_root(
 
 
 class CredentialPool:
-    def __init__(self, provider: str, entries: List[PooledCredential]):
+    def __init__(
+        self,
+        provider: str,
+        entries: List[PooledCredential],
+        *,
+        persistence_path: Optional[Path] = None,
+    ):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
+        # Explicit ownership for profile-fallback rows.  Currently only xAI
+        # opts into write-back because its rotating refresh token makes a
+        # profile shadow destructive; normal/profile-owned pools retain the
+        # existing local-store behavior (None).
+        self._persistence_path = persistence_path
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
         # RLock: the mutation primitives below (_replace_entry/_persist)
@@ -782,6 +794,7 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                target_path=self._persistence_path,
             )
 
     def _is_terminal_auth_failure(
@@ -1326,7 +1339,8 @@ class CredentialPool:
                 else self._sync_xai_oauth_entry_from_pool_store
             )
             with _auth_store_lock(
-                timeout_seconds=self._single_use_refresh_lock_timeout()
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+                target_path=self._persistence_path,
             ):
                 synced = sync_entry(entry)
                 if self.provider == "openai-codex":
@@ -2366,6 +2380,7 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=[removed.id],
+                target_path=self._persistence_path,
             )
             if self._current_id == removed.id:
                 self._current_id = None
@@ -3129,9 +3144,28 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
     return changed, active_sources
 
 
+# Providers whose refresh token ROTATES on every refresh. A borrowed pool
+# row from the global root store must write its refresh back to that owner:
+# persisting it into the borrowing profile creates a shadow copy while the
+# root keeps the consumed token — poisoning every other consumer. Providers
+# with stable refresh tokens keep the ordinary profile-write behavior.
+_ROTATING_REFRESH_PROVIDERS = {"xai-oauth"}
+
+
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
-    raw_entries = read_credential_pool(provider)
+    persistence_path: Optional[Path] = None
+    if provider in _ROTATING_REFRESH_PROVIDERS:
+        raw_entries, source_path = _read_credential_pool_with_source(provider)
+        global_path = _global_auth_file_path()
+        if (
+            source_path is not None
+            and global_path is not None
+            and _same_path(source_path, global_path)
+        ):
+            persistence_path = source_path
+    else:
+        raw_entries = list(read_credential_pool(provider))
     disk_ids = {
         entry.get("id")
         for entry in raw_entries
@@ -3191,5 +3225,6 @@ def load_pool(provider: str) -> CredentialPool:
             provider,
             [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
             removed_ids=disk_ids - new_ids,
+            target_path=persistence_path,
         )
-    return CredentialPool(provider, entries)
+    return CredentialPool(provider, entries, persistence_path=persistence_path)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1621,7 +1621,9 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     ``hermes auth add <provider>`` inside the profile, profile entries
     fully shadow global for that provider on the next read.
 
-    Writes always go to the profile (``write_credential_pool`` is unchanged).
+    Ordinary writes target the profile. Internal refresh paths may retain the
+    source path separately and write a rotating borrowed credential back to
+    the store that owns it.
     See issue #18594 follow-up.
     """
     auth_store = _load_auth_store()
@@ -1653,6 +1655,32 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     # Profile has no entries for this provider — fall back to global.
     global_entries = global_pool.get(provider_id)
     return list(global_entries) if isinstance(global_entries, list) else []
+
+
+def _read_credential_pool_with_source(
+    provider_id: str,
+) -> tuple[List[Dict[str, Any]], Optional[Path]]:
+    """Return one pool slice and the auth store that owns it.
+
+    The public read helper intentionally hides profile fallback provenance.
+    Refresh paths for rotating credentials need it so they can update the row
+    they borrowed instead of creating a profile-local shadow.
+    """
+    auth_store = _load_auth_store()
+    pool = auth_store.get("credential_pool")
+    if isinstance(pool, dict):
+        entries = pool.get(provider_id)
+        if isinstance(entries, list) and entries:
+            return list(entries), _auth_file_path()
+
+    global_path = _global_auth_file_path()
+    global_store = _load_global_auth_store()
+    global_pool = global_store.get("credential_pool") if global_store else None
+    if isinstance(global_pool, dict):
+        entries = global_pool.get(provider_id)
+        if isinstance(entries, list) and entries:
+            return list(entries), global_path
+    return [], None
 
 
 _POOL_STATUS_FIELDS = (
@@ -1727,6 +1755,7 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    target_path: Optional[Path] = None,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1747,8 +1776,8 @@ def write_credential_pool(
     merge does not resurrect them from the on-disk copy.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    with _auth_store_lock(target_path=target_path):
+        auth_store = _load_auth_store(target_path)
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
             pool = {}
@@ -1786,7 +1815,7 @@ def write_credential_pool(
                 continue
             merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
         pool[provider_id] = merged
-        return _save_auth_store(auth_store)
+        return _save_auth_store(auth_store, target_path=target_path)
 
 
 def suppress_credential_source(provider_id: str, source: str) -> None:

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -200,6 +200,147 @@ def test_write_credential_pool_targets_profile_not_global(profile_env):
     assert [e["id"] for e in read_credential_pool("openrouter")] == ["prof-new"]
 
 
+def test_xai_global_pool_refresh_rotates_root_without_profile_shadow(
+    profile_env, monkeypatch
+):
+    """A profile refreshing a borrowed xAI row must persist to its owner.
+
+    xAI refresh tokens rotate.  Writing the refreshed row into the borrowing
+    profile creates a shadow while leaving root with the consumed token, so a
+    second profile later retries the stale refresh token.
+    """
+    from agent.credential_pool import load_pool
+
+    profile_b = profile_env["global"] / "profiles" / "reviewer"
+    profile_b.mkdir(parents=True)
+    root_auth = profile_env["global"] / "auth.json"
+    _write(root_auth, _make_auth_store(pool={
+        "xai-oauth": [{
+            "id": "root-xai",
+            "label": "root device login",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "root-access-before-refresh",
+            "refresh_token": "root-refresh-before-refresh",
+            "base_url": "https://api.x.ai/v1",
+        }],
+    }, providers={}))
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_OAUTH_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_access_token_is_expiring",
+        lambda access_token, *_args, **_kwargs: access_token
+        == "root-access-before-refresh",
+    )
+    refresh_calls = []
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": "root-access-after-refresh",
+            "refresh_token": "root-refresh-after-refresh",
+            "last_refresh": "2026-08-12T12:00:00+00:00",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", fake_refresh)
+
+    pool = load_pool("xai-oauth")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.access_token == "root-access-after-refresh"
+    assert refresh_calls == [
+        ("root-access-before-refresh", "root-refresh-before-refresh")
+    ]
+
+    root_store = json.loads(root_auth.read_text())
+    root_entry = root_store["credential_pool"]["xai-oauth"][0]
+    assert root_entry["access_token"] == "root-access-after-refresh"
+    assert root_entry["refresh_token"] == "root-refresh-after-refresh"
+    assert "xai-oauth" not in root_store.get("providers", {})
+    profile_auth = profile_env["profile"] / "auth.json"
+    assert not profile_auth.exists() or "xai-oauth" not in json.loads(
+        profile_auth.read_text()
+    ).get("credential_pool", {})
+    assert not profile_auth.exists() or "xai-oauth" not in json.loads(
+        profile_auth.read_text()
+    ).get("providers", {})
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_b))
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_access_token_is_expiring", lambda *_args, **_kwargs: False
+    )
+    second_profile_entry = load_pool("xai-oauth").select()
+    assert second_profile_entry is not None
+    assert second_profile_entry.access_token == "root-access-after-refresh"
+    assert second_profile_entry.refresh_token == "root-refresh-after-refresh"
+    assert not (profile_b / "auth.json").exists()
+
+    # Status persistence follows the same owner and must not create a shadow.
+    pool.mark_exhausted_and_rotate(status_code=429)
+    root_store = json.loads(root_auth.read_text())
+    assert root_store["credential_pool"]["xai-oauth"][0]["last_status"] == (
+        "exhausted"
+    )
+    assert not profile_auth.exists() or "xai-oauth" not in json.loads(
+        profile_auth.read_text()
+    ).get("credential_pool", {})
+    assert not (profile_b / "auth.json").exists()
+
+
+def test_profile_owned_xai_pool_refresh_stays_local(profile_env, monkeypatch):
+    """Ownership routing must not redirect a real profile pool to root."""
+    from agent.credential_pool import load_pool
+
+    root_auth = profile_env["global"] / "auth.json"
+    profile_auth = profile_env["profile"] / "auth.json"
+    _write(root_auth, _make_auth_store(pool={
+        "openrouter": [{
+            "id": "root-other-provider",
+            "source": "manual",
+            "auth_type": "api_key",
+            "access_token": "root-other-token",
+        }],
+    }, providers={}))
+    _write(profile_auth, _make_auth_store(pool={
+        "xai-oauth": [{
+            "id": "profile-xai",
+            "source": "manual:device_code",
+            "auth_type": "oauth",
+            "priority": 0,
+            "access_token": "profile-access-before",
+            "refresh_token": "profile-refresh-before",
+        }],
+    }, providers={}))
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_OAUTH_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_access_token_is_expiring",
+        lambda access_token, *_args, **_kwargs: access_token == "profile-access-before",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_xai_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": "profile-access-after",
+            "refresh_token": "profile-refresh-after",
+        },
+    )
+
+    selected = load_pool("xai-oauth").select()
+    assert selected is not None
+    assert selected.access_token == "profile-access-after"
+    profile_store = json.loads(profile_auth.read_text())
+    assert profile_store["credential_pool"]["xai-oauth"][0]["refresh_token"] == (
+        "profile-refresh-after"
+    )
+    assert "xai-oauth" not in profile_store.get("providers", {})
+    root_store = json.loads(root_auth.read_text())
+    assert "xai-oauth" not in root_store.get("credential_pool", {})
+    assert root_store["credential_pool"]["openrouter"][0]["access_token"] == (
+        "root-other-token"
+    )
+
+
 
 
 def test_auth_lock_reentrancy_is_scoped_after_profile_context_switch(profile_env):


### PR DESCRIPTION
## What does this PR do?

Fixes lost xAI OAuth credentials when a **profile** borrows the **root-owned** xai-oauth credential pool via the profile fallback (#18594): xAI rotates the refresh token on every refresh, but pool writes always targeted the profile's auth store. The first refresh inside a profile therefore created a profile-local shadow copy holding the fresh token, while the root store silently kept the now-consumed token. The next consumer of the root store (the root install itself, or any other profile) then failed auth with an invalid refresh token.

The pool now remembers which auth store a borrowed slice actually came from and persists refreshes back to that owner. The write-back is deliberately scoped to `xai-oauth` — the only pooled provider with a rotating refresh token where a shadow copy is destructive; all other providers keep the existing profile-write behavior.

## Related Issue

No existing issue found (searched for xAI refresh/credential pool); behavior described above. Follow-up to the profile-fallback semantics of #18594.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` — new internal `_read_credential_pool_with_source()` returning the pool slice together with the auth store path that owns it; `write_credential_pool()` accepts an optional `target_path`.
- `agent/credential_pool.py` — `load_pool()` records the source path for xai-oauth when the slice came from the global store; `CredentialPool` carries it as `persistence_path` and uses it for `_persist`, entry removal, and the single-use refresh lock, so refresh results land in the owning store.
- `tests/hermes_cli/test_auth_profile_fallback.py` — regression tests covering the borrowed-refresh write-back and that profile-owned pools are unaffected.

## How to Test

1. `python -m pytest tests/hermes_cli/test_auth_profile_fallback.py -q`
2. Manual: authenticate xai-oauth in the root install only; run an agent in a profile (no profile-local xai pool) until a token refresh occurs; inspect both auth stores — the refreshed token must be in the **root** store, and no `credential_pool.xai-oauth` shadow must appear in the profile store.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [ ] Full `pytest tests/ -q`: not completed locally (run was interrupted by a machine suspend); this change's test files pass (see How to Test) and a broad 1,219-test gateway/cron/cli selection passed today on the integrated branch — deferring the authoritative full run to CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstring of `read_credential_pool()` updated to describe the ownership-aware write path
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — path comparison uses the existing `_same_path` helper
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Running in production since 2026-08-13 on a multi-profile WSL2 install where one profile (grok-4.5 primary) borrows the root xAI credential; before the fix the root install lost its refresh token on every profile-side rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
