### PR TITLE
fix(desktop): show the in-app browser in Bot Mode

### DIFF
--- a/apps/desktop/src/app/chat/pane-mirror.test.ts
+++ b/apps/desktop/src/app/chat/pane-mirror.test.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 import { afterEach, describe, expect, it } from 'vitest'
 
+import { contributesToWorkspace } from '@/components/pane-shell/workspace-scope'
 import { registry } from '@/contrib/registry'
 
 import { paneMirror } from './pane-mirror'
@@ -76,5 +77,25 @@ describe('paneMirror workspace scope', () => {
       workspaceMode: undefined,
       workspaceOwnerKey: undefined
     })
+  })
+
+  it('keeps an unscoped Browser tile visible in Bot Mode', () => {
+    const mirror = setup({})
+    mirror.source.set([{ id: 'url:browser' }])
+
+    const pane = mirror.contribution('url:browser')
+
+    expect(contributesToWorkspace(pane, 'sessions')).toBe(true)
+    expect(contributesToWorkspace(pane, 'bots', 'bot:connection-a::default')).toBe(true)
+  })
+
+  it('hides a Sessions-only Browser tile from Bot Mode', () => {
+    const mirror = setup({ workspaceMode: 'sessions' })
+    mirror.source.set([{ id: 'url:browser' }])
+
+    const pane = mirror.contribution('url:browser')
+
+    expect(contributesToWorkspace(pane, 'sessions')).toBe(true)
+    expect(contributesToWorkspace(pane, 'bots', 'bot:connection-a::default')).toBe(false)
   })
 })

--- a/apps/desktop/src/app/chat/preview-tile.test.ts
+++ b/apps/desktop/src/app/chat/preview-tile.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./right-rail/preview', () => ({
+  PreviewTilePane: () => null
+}))
+
+vi.mock('./right-rail/preview-console-store', () => ({
+  forgetPreviewConsole: () => undefined
+}))
+
+import { contributesToWorkspace } from '@/components/pane-shell/workspace-scope'
+import { registry } from '@/contrib/registry'
+import { closeRightRail, openPreview } from '@/store/preview'
+
+import { watchPreviewTiles } from './preview-tile'
+
+beforeAll(() => {
+  watchPreviewTiles()
+})
+
+afterEach(() => {
+  closeRightRail()
+})
+
+function browserPane() {
+  return registry.getArea('panes').find(entry => entry.id === 'preview-tile:url:browser')
+}
+
+describe('preview tiles in Bot Mode', () => {
+  it('registers the in-app Browser as a global pane so Bot Mode can show it', () => {
+    openPreview(
+      { kind: 'url', label: 'example.com', source: 'https://example.com', url: 'https://example.com' },
+      'explicit-link'
+    )
+
+    const pane = browserPane()
+
+    expect(pane).toBeTruthy()
+    expect(pane?.workspaceMode).toBeUndefined()
+    expect(contributesToWorkspace(pane, 'sessions')).toBe(true)
+    expect(contributesToWorkspace(pane, 'bots', 'bot:connection-a::default')).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -122,7 +122,10 @@ export function watchPreviewTiles(): void {
 
 const watchPreviewTileMirror = paneMirror<{ id: string }>({
   source: $previewTabs,
-  workspaceMode: 'sessions',
+  // Unscoped on purpose. `$previewTabs` is one global Browser/file surface —
+  // clicking a link in a bot chat must open the same pane Sessions already
+  // shows. Scoping this to `sessions` filtered the pane out of Bot Mode, so
+  // `openPreview` ran and the click looked like a no-op.
   key: tab => tab.id,
   prefix: PREVIEW_TILE_PREFIX,
   // Identical to route (page) tiles: its own zone docked beside main, sized by

--- a/apps/desktop/src/components/pane-shell/tree/renderer/workspace-scope.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/workspace-scope.test.tsx
@@ -97,4 +97,43 @@ describe('TreeGroup workspace scope', () => {
     expect(visibleTabs()).toEqual(['session-a'])
     expect(container?.textContent).toContain('Session A content')
   })
+
+  it('keeps a global Browser pane visible in Bot Mode', () => {
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    register('bot-a', 'Bot A', { workspaceMode: 'bots', workspaceOwnerKey: 'connection-a::default' })
+    register('preview-tile:url:browser', 'Browser')
+
+    const node: GroupNode = {
+      active: 'bot-a',
+      id: 'workspace-scope-zone',
+      panes: ['bot-a', 'preview-tile:url:browser'],
+      tabStrip: 'always',
+      type: 'group'
+    }
+
+    act(() => setWorkspaceScope('bots', 'connection-a::default'))
+    render(<TreeGroup node={node} parentAxis="column" />)
+
+    expect(visibleTabs()).toEqual(['bot-a', 'preview-tile:url:browser'])
+  })
+
+  it('hides a Sessions-only Browser pane in Bot Mode', () => {
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    register('bot-a', 'Bot A', { workspaceMode: 'bots', workspaceOwnerKey: 'connection-a::default' })
+    register('preview-tile:url:browser', 'Browser', { workspaceMode: 'sessions' })
+
+    const node: GroupNode = {
+      active: 'bot-a',
+      id: 'workspace-scope-zone',
+      panes: ['bot-a', 'preview-tile:url:browser'],
+      tabStrip: 'always',
+      type: 'group'
+    }
+
+    act(() => setWorkspaceScope('bots', 'connection-a::default'))
+    render(<TreeGroup node={node} parentAxis="column" />)
+
+    expect(visibleTabs()).toEqual(['bot-a'])
+    expect(container?.textContent).not.toContain('Browser content')
+  })
 })


### PR DESCRIPTION
## Summary
- Clicking a link in a bot chat now opens the in-app browser, same as Sessions.
- Preview/browser panes were scoped to Sessions, so Bot Mode ran `openPreview` but hid the pane — the click looked like a no-op.
- Workaround until this lands: Cmd/Ctrl-click the link to open the system browser.

## Test plan
- [ ] In Desktop Bot Mode, click an `https://` link in a bot chat — the in-app Browser pane opens.
- [ ] Switch to Sessions, click the same kind of link — still opens in-app.
- [ ] Cmd-click (Mac) / Ctrl-click (Windows) still opens the system browser.
- [ ] From `apps/desktop`: `npm run test:ui -- src/app/chat/preview-tile.test.ts src/app/chat/pane-mirror.test.ts src/components/pane-shell/tree/renderer/workspace-scope.test.tsx`
