### PR TITLE
fix(mcp): harden headless OAuth callback lifecycle

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -807,7 +807,7 @@ class TestNonInteractiveFailFastAtCallbackBoundary:
 
         # Binding the callback listener or entering the poll loop is the bug.
         fake_server = MagicMock(side_effect=AssertionError("must not bind callback listener"))
-        monkeypatch.setattr(mod, "HTTPServer", fake_server)
+        monkeypatch.setattr(mod, "ThreadingHTTPServer", fake_server)
 
         async def no_sleep(_seconds):
             raise AssertionError("must not wait for the callback timeout")
@@ -1027,9 +1027,11 @@ class TestWaitForCallbackSkipIntegration:
         mod._oauth_port = _find_free_port()
         monkeypatch.setattr(mod, "_is_interactive", lambda: True)
         monkeypatch.setattr("sys.stdin", MagicMock(readline=lambda: "skip\n"))
+        monkeypatch.setattr(mod, "_read_paste_line", lambda _stop: "skip\n")
 
         async def instant_sleep(_):
             pass
+
         with patch.object(mod.asyncio, "sleep", instant_sleep):
             with pytest.raises(OAuthNonInteractiveError, match="user_skipped"):
                 asyncio.run(_wait_for_callback())
@@ -1069,7 +1071,7 @@ def test_wait_for_callback_port_in_use_reports_clear_error(monkeypatch):
 
     monkeypatch.setattr(mo, "_is_interactive", lambda: True)
     with patch.object(mo, "_oauth_port", 54321), patch.object(
-        mo, "HTTPServer", side_effect=OSError("address already in use")
+        mo, "ThreadingHTTPServer", side_effect=OSError("address already in use")
     ):
         with pytest.raises(mo.OAuthNonInteractiveError) as excinfo:
             asyncio.run(mo._wait_for_callback())

--- a/tests/tools/test_mcp_oauth_single_attempt.py
+++ b/tests/tools/test_mcp_oauth_single_attempt.py
@@ -1,0 +1,390 @@
+"""Regression tests for explicit headless MCP OAuth login attempts."""
+
+import asyncio
+import logging
+import socket
+import threading
+import time
+import urllib.request
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _send_callback_when_ready(url: str) -> None:
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(url, timeout=1).close()
+            return
+        except OSError:
+            time.sleep(0.01)
+    raise AssertionError(f"callback listener never became ready: {url}")
+
+
+def _send_callback_then_secondary_get(callback_url: str, secondary_url: str) -> None:
+    _send_callback_when_ready(callback_url)
+    urllib.request.urlopen(secondary_url, timeout=1).close()
+
+
+def _assert_port_released(port: int) -> None:
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        probe.bind(("127.0.0.1", port))
+    finally:
+        probe.close()
+
+
+def _callback_pair(result) -> tuple[str, str | None]:
+    if hasattr(result, "code"):
+        return result.code, result.state
+    return result
+
+
+def _connect_when_ready(port: int) -> socket.socket:
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            client.connect(("127.0.0.1", port))
+            return client
+        except OSError:
+            client.close()
+            time.sleep(0.01)
+    raise AssertionError(f"callback listener never became ready on port {port}")
+
+
+@pytest.mark.asyncio
+async def test_forced_headless_oauth_eof_does_not_retry_authorization(monkeypatch):
+    """One explicit login must not turn paste-channel EOF into OAuth retries."""
+    import tools.mcp_oauth as oauth
+    import tools.mcp_tool as mcp_tool
+
+    stdin = MagicMock()
+    stdin.isatty.return_value = False
+    stdin.readline.return_value = ""
+    monkeypatch.setattr(oauth.sys, "stdin", stdin)
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_sdk", lambda: None)
+
+    authorization_attempts: list[int] = []
+    port = oauth._find_free_port()
+    server = mcp_tool.MCPServerTask("headless-oauth")
+
+    async def fail_after_eof(_self, _config):
+        authorization_attempts.append(len(authorization_attempts) + 1)
+        waiter = oauth._make_callback_waiter(port, timeout=0.0)
+        await waiter()
+
+    async def stop_after_retry_budget(_self, *, timeout):
+        return "shutdown"
+
+    monkeypatch.setattr(mcp_tool.MCPServerTask, "_run_http", fail_after_eof)
+    monkeypatch.setattr(
+        mcp_tool.MCPServerTask,
+        "_wait_for_reconnect_or_shutdown",
+        stop_after_retry_budget,
+    )
+    monkeypatch.setattr(mcp_tool, "_jittered", lambda _seconds: 0.0)
+
+    with oauth.force_interactive_oauth():
+        await server.run(
+            {
+                "url": "https://mcp.example.test/mcp",
+                "auth": "oauth",
+                "skip_preflight": True,
+            }
+        )
+
+    assert authorization_attempts == [1]
+    assert isinstance(server._error, oauth.OAuthNonInteractiveError)
+    assert server._ready.is_set()
+    stdin.readline.assert_not_called()
+    _assert_port_released(port)
+
+
+@pytest.mark.asyncio
+async def test_forced_headless_loopback_callback_completes_without_paste(monkeypatch):
+    """A non-TTY explicit login still accepts its original loopback callback."""
+    import tools.mcp_oauth as oauth
+
+    stdin = MagicMock()
+    stdin.isatty.return_value = False
+    stdin.readline.side_effect = AssertionError("non-TTY stdin must not be read")
+    monkeypatch.setattr(oauth.sys, "stdin", stdin)
+    port = oauth._find_free_port()
+    waiter = oauth._make_callback_waiter(port, timeout=5.0)
+    callback = (
+        f"http://127.0.0.1:{port}/callback"
+        "?code=fake-loopback-code&state=fake-loopback-state"
+    )
+
+    with oauth.force_interactive_oauth():
+        sender = threading.Thread(
+            target=_send_callback_when_ready,
+            args=(callback,),
+            daemon=True,
+        )
+        sender.start()
+        result = await waiter()
+        sender.join(timeout=5)
+
+    assert _callback_pair(result) == ("fake-loopback-code", "fake-loopback-state")
+    stdin.readline.assert_not_called()
+    _assert_port_released(port)
+
+
+@pytest.mark.asyncio
+async def test_loopback_callback_result_survives_secondary_get(monkeypatch):
+    """A browser follow-up request must not erase the terminal callback result."""
+    import tools.mcp_oauth as oauth
+
+    stdin = MagicMock()
+    stdin.isatty.return_value = False
+    monkeypatch.setattr(oauth.sys, "stdin", stdin)
+    port = oauth._find_free_port()
+    callback = (
+        f"http://127.0.0.1:{port}/callback"
+        "?code=fake-latched-code&state=fake-latched-state"
+    )
+    secondary = f"http://127.0.0.1:{port}/favicon.ico"
+
+    with oauth.force_interactive_oauth():
+        sender = threading.Thread(
+            target=_send_callback_then_secondary_get,
+            args=(callback, secondary),
+            daemon=True,
+        )
+        sender.start()
+        result = await oauth._make_callback_waiter(port, timeout=1.0)()
+        sender.join(timeout=5)
+
+    assert not sender.is_alive()
+    assert _callback_pair(result) == ("fake-latched-code", "fake-latched-state")
+    _assert_port_released(port)
+
+
+@pytest.mark.asyncio
+async def test_loopback_callback_does_not_log_code_or_state(monkeypatch, caplog):
+    """HTTP request logging must not expose OAuth callback credentials."""
+    import tools.mcp_oauth as oauth
+
+    stdin = MagicMock()
+    stdin.isatty.return_value = False
+    monkeypatch.setattr(oauth.sys, "stdin", stdin)
+    port = oauth._find_free_port()
+    code = "fake-secret-callback-code"
+    state = "fake-secret-callback-state"
+    callback = f"http://127.0.0.1:{port}/callback?code={code}&state={state}"
+
+    with (
+        oauth.force_interactive_oauth(),
+        caplog.at_level(logging.DEBUG, logger="tools.mcp_oauth"),
+    ):
+        sender = threading.Thread(
+            target=_send_callback_when_ready,
+            args=(callback,),
+            daemon=True,
+        )
+        sender.start()
+        result = await oauth._make_callback_waiter(port, timeout=5.0)()
+        sender.join(timeout=5)
+
+    assert _callback_pair(result) == (code, state)
+    assert code not in caplog.text
+    assert state not in caplog.text
+    _assert_port_released(port)
+
+
+@pytest.mark.asyncio
+async def test_state_mismatch_is_redacted_before_sdk_and_application_logs(
+    monkeypatch, caplog
+):
+    """A mismatched callback must not expose either OAuth state in any logger."""
+    from mcp.client.auth import OAuthFlowError
+
+    import tools.mcp_oauth as oauth
+    import tools.mcp_oauth_manager as oauth_manager
+
+    provider_classes = [
+        provider_class
+        for provider_class in (
+            oauth._get_hermes_oauth_provider_class(),
+            oauth_manager._HERMES_PROVIDER_CLS,
+        )
+        if provider_class is not None
+    ]
+    assert len(provider_classes) == 2
+    upstream_provider = provider_classes[0].__bases__[0]
+    received_state = "fake-received-secret-state"
+    expected_state = "fake-expected-secret-state"
+
+    async def raise_state_mismatch(_self):
+        raise OAuthFlowError(
+            f"State parameter mismatch: {received_state} != {expected_state}"
+        )
+
+    monkeypatch.setattr(
+        upstream_provider,
+        "_perform_authorization",
+        raise_state_mismatch,
+    )
+    with caplog.at_level(logging.DEBUG):
+        caught_errors = []
+        for provider_class in provider_classes:
+            provider = object.__new__(provider_class)
+            with pytest.raises(OAuthFlowError) as caught:
+                await provider._perform_authorization()
+            caught_errors.append(caught.value)
+
+            try:
+                raise caught.value
+            except OAuthFlowError:
+                logging.getLogger("mcp.client.auth.oauth2").exception("OAuth flow error")
+            logging.getLogger("tools.mcp_tool").warning(
+                "MCP initial authentication failed: %s", caught.value
+            )
+
+    assert [str(error) for error in caught_errors] == [
+        "OAuth state parameter mismatch",
+        "OAuth state parameter mismatch",
+    ]
+    assert received_state not in caplog.text
+    assert expected_state not in caplog.text
+
+
+@pytest.mark.linux_only
+@pytest.mark.asyncio
+async def test_tty_paste_callback_completes_and_releases_listener(monkeypatch):
+    """Usable paste-back remains supported and closes its loopback listener."""
+    import os
+    import pty
+
+    import tools.mcp_oauth as oauth
+
+    master_fd, slave_fd = pty.openpty()
+    stdin = os.fdopen(os.dup(slave_fd), "r", encoding="utf-8", buffering=1)
+    monkeypatch.setattr(oauth.sys, "stdin", stdin)
+    port = oauth._find_free_port()
+
+    try:
+        os.write(
+            master_fd,
+            b"https://mcp.example.test/callback"
+            b"?code=fake-paste-code&state=fake-paste-state\n",
+        )
+        result = await oauth._make_callback_waiter(port, timeout=5.0)()
+    finally:
+        stdin.close()
+        os.close(master_fd)
+        os.close(slave_fd)
+
+    assert _callback_pair(result) == ("fake-paste-code", "fake-paste-state")
+    _assert_port_released(port)
+
+
+@pytest.mark.linux_only
+@pytest.mark.asyncio
+async def test_loopback_callback_stops_tty_reader_before_next_flow_input(monkeypatch):
+    """Loopback completion must leave later TTY input for the next flow."""
+    import os
+    import pty
+    import select
+
+    import tools.mcp_oauth as oauth
+
+    master_fd, slave_fd = pty.openpty()
+    stdin = os.fdopen(os.dup(slave_fd), "r", encoding="utf-8", buffering=1)
+    monkeypatch.setattr(oauth.sys, "stdin", stdin)
+    port = oauth._find_free_port()
+    callback = (
+        f"http://127.0.0.1:{port}/callback"
+        "?code=fake-loopback-code&state=fake-loopback-state"
+    )
+
+    try:
+        sender = threading.Thread(
+            target=_send_callback_when_ready,
+            args=(callback,),
+            daemon=True,
+        )
+        sender.start()
+        result = await oauth._make_callback_waiter(port, timeout=5.0)()
+        sender.join(timeout=5)
+
+        assert not sender.is_alive()
+        assert _callback_pair(result) == (
+            "fake-loopback-code",
+            "fake-loopback-state",
+        )
+
+        os.write(master_fd, b"next-flow-input\n")
+        await asyncio.sleep(0.1)
+        readable, _, _ = select.select([stdin], [], [], 1.0)
+        assert readable, "the completed OAuth flow consumed the next flow's TTY input"
+        assert stdin.readline() == "next-flow-input\n"
+    finally:
+        stdin.close()
+        os.close(master_fd)
+        os.close(slave_fd)
+
+    _assert_port_released(port)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", ["skip", "cancel"])
+async def test_tty_skip_or_cancel_releases_listener(monkeypatch, decision):
+    """Explicit skip stays non-fatal and deterministically closes the port."""
+    import tools.mcp_oauth as oauth
+
+    stdin = MagicMock()
+    stdin.isatty.return_value = True
+    stdin.readline.return_value = decision + "\n"
+    monkeypatch.setattr(oauth.sys, "stdin", stdin)
+    monkeypatch.setattr(
+        oauth,
+        "_read_paste_line",
+        lambda _stop: stdin.readline(),
+    )
+    port = oauth._find_free_port()
+
+    with pytest.raises(oauth.OAuthNonInteractiveError, match="user_skipped"):
+        await oauth._make_callback_waiter(port, timeout=5.0)()
+
+    _assert_port_released(port)
+
+
+def test_stalled_callback_client_cannot_block_timeout_or_port_cleanup(monkeypatch):
+    """An incomplete HTTP request must not hold the callback listener open."""
+    import tools.mcp_oauth as oauth
+
+    stdin = MagicMock()
+    stdin.isatty.return_value = False
+    monkeypatch.setattr(oauth.sys, "stdin", stdin)
+    port = oauth._find_free_port()
+    outcome: list[BaseException] = []
+
+    def run_waiter() -> None:
+        try:
+            with oauth.force_interactive_oauth():
+                asyncio.run(oauth._make_callback_waiter(port, timeout=0.1)())
+        except BaseException as exc:
+            outcome.append(exc)
+
+    runner = threading.Thread(target=run_waiter, daemon=True)
+    runner.start()
+    client = _connect_when_ready(port)
+    try:
+        client.sendall(b"GET /callback?code=fake-partial-code")
+        runner.join(timeout=2.0)
+        completed_while_client_stalled = not runner.is_alive()
+    finally:
+        client.close()
+        runner.join(timeout=2.0)
+
+    assert completed_while_client_stalled, (
+        "callback timeout blocked on a client that never completed its request"
+    )
+    assert len(outcome) == 1
+    assert isinstance(outcome[0], oauth.OAuthNonInteractiveError)
+    _assert_port_released(port)

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -56,13 +56,18 @@ import threading
 import time
 import webbrowser
 from contextlib import contextmanager
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 from hermes_constants import secure_parent_dir
 
 logger = logging.getLogger(__name__)
+
+_CALLBACK_REQUEST_TIMEOUT_SECONDS = 0.5
+_CALLBACK_SERVER_JOIN_TIMEOUT_SECONDS = 1.0
+_PASTE_READER_POLL_INTERVAL_SECONDS = 0.05
+_PASTE_READER_JOIN_TIMEOUT_SECONDS = 1.0
 
 # ---------------------------------------------------------------------------
 # Lazy imports -- MCP SDK with OAuth support is optional
@@ -165,10 +170,11 @@ _oauth_interactive_enabled: "contextvars.ContextVar[bool]" = contextvars.Context
 )
 
 # Forces _is_interactive() past the stdin-TTY check for flows driven from a
-# GUI (dashboard/desktop REST): the browser + localhost callback server do all
-# the work there, and the stdin paste fallback degrades harmlessly (EOF is
-# swallowed by _paste_callback_reader). Suppression still wins — background
-# discovery must never start a browser flow.
+# GUI (dashboard/desktop REST) or an explicit ``hermes mcp login`` command:
+# the browser + localhost callback server do all the work there. This permits
+# the authorization flow; it does NOT make stdin a usable paste channel (see
+# _paste_callback_available). Suppression still wins — background discovery
+# must never start a browser flow.
 _oauth_interactive_forced: "contextvars.ContextVar[bool]" = contextvars.ContextVar(
     "_oauth_interactive_forced", default=False
 )
@@ -328,6 +334,24 @@ def _is_interactive() -> bool:
         return False
     if _oauth_interactive_forced.get():
         return True
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _paste_callback_available() -> bool:
+    """Return True only when stdin itself can accept paste-back input.
+
+    ``force_interactive_oauth`` means a user explicitly authorized a browser
+    flow even though the process may have pipe/FIFO stdin (desktop, TUI, or a
+    background terminal). Treating that override as proof of a readable TTY
+    starts a competing ``readline()`` which immediately sees EOF and can race
+    the launcher's own stdin lifecycle. Keep the loopback listener available
+    in those flows, but offer paste-back only for a real terminal stdin.
+    """
+    if not _oauth_interactive_enabled.get():
+        return False
     try:
         return sys.stdin.isatty()
     except (AttributeError, ValueError):
@@ -743,6 +767,40 @@ def _authorization_code_result(code: str, state: "str | None", iss: "str | None"
     return AuthorizationCodeResult(code=code, state=state, iss=iss)
 
 
+def _try_set_callback_result(
+    result: dict[str, Any],
+    *,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+    iss: str | None = None,
+) -> bool:
+    """Atomically latch the first terminal callback result."""
+    if code is None and error is None:
+        return False
+
+    lock = result.get("_lock")
+    if lock is None:
+        if result.get("auth_code") is not None or result.get("error") is not None:
+            return False
+        result.update(auth_code=code, state=state, error=error, iss=iss)
+        return True
+
+    with lock:
+        if result.get("auth_code") is not None or result.get("error") is not None:
+            return False
+        result.update(auth_code=code, state=state, error=error, iss=iss)
+        return True
+
+
+def _callback_result_is_terminal(result: dict[str, Any]) -> bool:
+    lock = result.get("_lock")
+    if lock is None:
+        return result.get("auth_code") is not None or result.get("error") is not None
+    with lock:
+        return result.get("auth_code") is not None or result.get("error") is not None
+
+
 def _make_callback_handler() -> tuple[type, dict]:
     """Create a per-flow callback HTTP handler class with its own result dict.
 
@@ -753,9 +811,17 @@ def _make_callback_handler() -> tuple[type, dict]:
     """
     result: dict[str, Any] = {
         "auth_code": None, "state": None, "error": None, "iss": None,
+        "_lock": threading.Lock(),
     }
 
     class _Handler(BaseHTTPRequestHandler):
+        def setup(self) -> None:
+            # A browser/probe can connect and then never finish its request.
+            # Bound reads so that accepted callback connections cannot retain
+            # handler resources indefinitely after the listener shuts down.
+            self.request.settimeout(_CALLBACK_REQUEST_TIMEOUT_SECONDS)
+            super().setup()
+
         def do_GET(self) -> None:  # noqa: N802
             params = parse_qs(urlparse(self.path).query)
             code = params.get("code", [None])[0]
@@ -768,10 +834,12 @@ def _make_callback_handler() -> tuple[type, dict]:
             # here would break login against those providers.
             iss = params.get("iss", [None])[0]
 
-            result["auth_code"] = code
-            result["state"] = state
-            result["error"] = error
-            result["iss"] = iss
+            # Browsers commonly follow the callback with /favicon.ico. Only a
+            # real terminal response may win, and the first code/error stays
+            # latched so a later request cannot erase or replace it.
+            _try_set_callback_result(
+                result, code=code, state=state, error=error, iss=iss
+            )
 
             body = (
                 "<html><body><h2>Authorization Successful</h2>"
@@ -786,7 +854,10 @@ def _make_callback_handler() -> tuple[type, dict]:
             self.wfile.write(body.encode())
 
         def log_message(self, fmt: str, *args: Any) -> None:
-            logger.debug("OAuth callback: %s", fmt % args)
+            # BaseHTTPRequestHandler includes the full request target in its
+            # default message. OAuth callback targets contain the code and
+            # state, so never forward the formatted request line to logs.
+            logger.debug("OAuth callback HTTP request handled")
 
     return _Handler, result
 
@@ -984,7 +1055,7 @@ def _make_callback_waiter(
         # TIME_WAIT socket from a previous flow cannot block the next one
         # (#44590).
         try:
-            server = HTTPServer(
+            server = ThreadingHTTPServer(
                 ("127.0.0.1", port), handler_cls, bind_and_activate=False
             )
             reserved = _reserved_sockets.pop(port, None)
@@ -1010,7 +1081,19 @@ def _make_callback_waiter(
                 "in the server config, then retry."
             ) from exc
 
-        server_thread = threading.Thread(target=server.handle_request, daemon=True)
+        # Keep accepting until the async waiter has a terminal result. A
+        # one-shot ``handle_request`` thread can stay blocked in accept/select
+        # after paste, skip, EOF-driven cancellation, or timeout wins; merely
+        # closing the server socket from another thread does not synchronously
+        # reap that waiter and the callback port can still be owned when the
+        # surrounding MCP transport retries. The threaded server also keeps
+        # ``serve_forever`` responsive when a client connects but never sends a
+        # complete request; each bounded handler runs independently.
+        server_thread = threading.Thread(
+            target=server.serve_forever,
+            kwargs={"poll_interval": 0.1},
+            daemon=True,
+        )
         server_thread.start()
 
         # Optional paste-fallback thread: only on interactive TTYs. Reads one
@@ -1018,7 +1101,8 @@ def _make_callback_waiter(
         # result dict. The HTTP listener and this thread race for the result;
         # whichever fills it first wins.
         paste_thread: threading.Thread | None = None
-        if _is_interactive():
+        paste_stop = threading.Event()
+        if _paste_callback_available():
             print(
                 "\n  Or paste the redirect URL here (or the ``?code=...&state=...`` "
                 "portion) and press Enter. Type ``skip`` + Enter to continue "
@@ -1027,7 +1111,10 @@ def _make_callback_waiter(
                 flush=True,
             )
             paste_thread = threading.Thread(
-                target=_paste_callback_reader, args=(result,), daemon=True
+                target=_paste_callback_reader,
+                args=(result, paste_stop),
+                name=f"mcp-oauth-paste-{port}",
+                daemon=True,
             )
             paste_thread.start()
 
@@ -1035,12 +1122,21 @@ def _make_callback_waiter(
         elapsed = 0.0
         try:
             while elapsed < timeout:
-                if result["auth_code"] is not None or result["error"] is not None:
+                if _callback_result_is_terminal(result):
                     break
                 await asyncio.sleep(poll_interval)
                 elapsed += poll_interval
         finally:
+            paste_stop.set()
+            if paste_thread is not None:
+                paste_thread.join(timeout=_PASTE_READER_JOIN_TIMEOUT_SECONDS)
+                if paste_thread.is_alive():
+                    logger.warning("OAuth paste reader did not stop promptly")
+            server.shutdown()
             server.server_close()
+            server_thread.join(timeout=_CALLBACK_SERVER_JOIN_TIMEOUT_SECONDS)
+            if server_thread.is_alive():
+                logger.warning("OAuth callback listener did not stop promptly")
 
         if result["error"] == _USER_SKIPPED_SENTINEL:
             raise OAuthNonInteractiveError("user_skipped")
@@ -1069,7 +1165,83 @@ def _make_callback_waiter(
     return _wait
 
 
-def _paste_callback_reader(result: dict) -> None:
+def _read_windows_paste_line(stop_event: threading.Event) -> str | None:
+    """Poll a Windows console for one line without an uncancellable read."""
+    try:
+        import msvcrt as _msvcrt
+    except ImportError:  # pragma: no cover - only reachable on Windows
+        return None
+    msvcrt: Any = _msvcrt
+
+    chars: list[str] = []
+    while not stop_event.wait(_PASTE_READER_POLL_INTERVAL_SECONDS):
+        while msvcrt.kbhit():
+            if stop_event.is_set():
+                return None
+            char = msvcrt.getwch()
+            if char in {"\r", "\n"}:
+                return "".join(chars) + "\n"
+            if char == "\x03":
+                raise KeyboardInterrupt
+            if char == "\x1a":
+                return ""
+            if char in {"\x00", "\xe0"}:
+                if msvcrt.kbhit():
+                    msvcrt.getwch()
+                continue
+            if char == "\b":
+                if chars:
+                    chars.pop()
+                continue
+            chars.append(char)
+    return None
+
+
+def _read_paste_line(stop_event: threading.Event) -> str | None:
+    """Wait for one TTY line while remaining responsive to cancellation."""
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        return _read_windows_paste_line(stop_event)
+
+    try:
+        import select
+
+        stdin_fd = sys.stdin.fileno()
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+
+    line = bytearray()
+    while not stop_event.is_set():
+        try:
+            readable, _, _ = select.select(
+                [stdin_fd], [], [], _PASTE_READER_POLL_INTERVAL_SECONDS
+            )
+        except (OSError, TypeError, ValueError):
+            return None
+        if stop_event.is_set():
+            return None
+        if readable:
+            # Read one byte at a time instead of entering TextIOWrapper.readline:
+            # on a raw or otherwise unusual TTY, readiness may mean only one
+            # character is available, and readline would become uncancellable
+            # again while waiting for the newline.
+            try:
+                char = os.read(stdin_fd, 1)
+            except OSError:
+                return None
+            if not char:
+                return ""
+            line.extend(char)
+            if char in {b"\r", b"\n"}:
+                return line.decode(
+                    getattr(sys.stdin, "encoding", None) or "utf-8",
+                    errors="replace",
+                )
+    return None
+
+
+def _paste_callback_reader(
+    result: dict, stop_event: threading.Event | None = None
+) -> None:
     """Read one line from stdin, parse it as an OAuth redirect, write to result.
 
     Accepts any of:
@@ -1085,7 +1257,11 @@ def _paste_callback_reader(result: dict) -> None:
     fallback alongside the HTTP listener, which remains the primary path.
     """
     try:
-        line = sys.stdin.readline()
+        line = (
+            sys.stdin.readline()
+            if stop_event is None
+            else _read_paste_line(stop_event)
+        )
     except (KeyboardInterrupt, OSError, ValueError):
         return
     if not line:
@@ -1094,18 +1270,13 @@ def _paste_callback_reader(result: dict) -> None:
     if not line:
         return
 
-    # Skip if HTTP listener already won.
-    if result.get("auth_code") is not None or result.get("error") is not None:
-        return
-
     # Skip token: user explicitly opted out of authorization. Mark the
     # result with a sentinel error string that _wait_for_callback maps
     # to OAuthNonInteractiveError (already handled by mcp_tool.py as a
     # non-fatal "skip this server and continue startup" path).
     if line.lower() in _SKIP_TOKENS:
-        if result.get("auth_code") is not None or result.get("error") is not None:
+        if not _try_set_callback_result(result, error=_USER_SKIPPED_SENTINEL):
             return
-        result["error"] = _USER_SKIPPED_SENTINEL
         print(
             "  OAuth skipped. Run `hermes mcp login <server>` later to "
             "authenticate, or set ``enabled: false`` on that server in "
@@ -1143,14 +1314,10 @@ def _paste_callback_reader(result: dict) -> None:
         )
         return
 
-    # One more race-check before writing.
-    if result.get("auth_code") is not None or result.get("error") is not None:
+    if not _try_set_callback_result(
+        result, code=code, state=state, error=error, iss=iss
+    ):
         return
-
-    result["auth_code"] = code
-    result["state"] = state
-    result["error"] = error
-    result["iss"] = iss
     if code:
         print("  Got authorization code from paste — completing flow.", file=sys.stderr)
 
@@ -1194,6 +1361,17 @@ def _get_hermes_oauth_provider_class() -> type | None:
             if ua:
                 request.headers["User-Agent"] = ua
             return request
+
+        async def _perform_authorization(self):
+            """Redact callback state before the SDK logs a mismatch failure."""
+            from mcp.client.auth import OAuthFlowError
+
+            try:
+                return await super()._perform_authorization()
+            except OAuthFlowError as exc:
+                if str(exc).startswith("State parameter mismatch:"):
+                    raise OAuthFlowError("OAuth state parameter mismatch") from None
+                raise
 
         def _coerce_client_secret_post(self) -> None:
             info = getattr(self.context, "client_info", None)

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -156,6 +156,17 @@ def _make_hermes_provider_class() -> Optional[type]:
                 request.headers["User-Agent"] = ua
             return request
 
+        async def _perform_authorization(self):
+            """Redact callback state before the SDK logs a mismatch failure."""
+            from mcp.client.auth import OAuthFlowError
+
+            try:
+                return await super()._perform_authorization()
+            except OAuthFlowError as exc:
+                if str(exc).startswith("State parameter mismatch:"):
+                    raise OAuthFlowError("OAuth state parameter mismatch") from None
+                raise
+
         def _coerce_client_secret_post(self) -> None:
             """Use client_secret_post when dynamic registration returned a secret.
 


### PR DESCRIPTION
## What does this PR do?

Hardens the explicit MCP OAuth login path used on headless hosts.

A non-TTY paste channel could turn EOF into reconnect-driven authorization retries, while the loopback callback listener and blocking TTY reader could outlive a completed flow. Concurrent HTTP/paste callbacks could also overwrite the first result, and callback/state errors exposed OAuth query values in logs.

This change keeps one login attempt single-flight, preserves the original loopback callback in non-TTY mode, deterministically shuts down and joins the listener, atomically latches the first terminal result, makes the TTY reader cancellable, and redacts callback/state values in both OAuth provider paths.

Related: #57836, #73997. I also reviewed the partial overlap in #74027 and the much broader #84963; neither covers this complete minimal callback/TTY/result/redaction contract.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/mcp_oauth.py`: non-TTY gating, bounded listener teardown, first-result latch, cancellable paste reader, and callback/state log redaction.
- `tools/mcp_oauth_manager.py`: the same state-mismatch redaction on the cached-provider path.
- `tests/tools/test_mcp_oauth_single_attempt.py`: end-to-end regressions for the headless, loopback, TTY, teardown, latch, and redaction cases.

## How to Test

```bash
HERMES_PYTHON=/tmp/hermes-upstream-pr-venv/bin/python scripts/run_tests.sh \
  tests/tools/test_mcp_oauth.py \
  tests/tools/test_mcp_oauth_single_attempt.py \
  tests/tools/test_mcp_oauth_user_agent.py \
  tests/tools/test_mcp_oauth_metadata.py \
  tests/tools/test_mcp_oauth_manager.py \
  tests/tools/test_mcp_oauth_integration.py \
  tests/tools/test_mcp_oauth_cold_load_expiry.py \
  tests/tools/test_mcp_oauth_bidirectional.py \
  tests/tools/test_mcp_dashboard_oauth.py \
  tests/hermes_cli/test_mcp_dashboard_oauth.py \
  tests/tools/test_mcp_failure_classification.py -q
```

Result on Linux 6.8: 134 passed. TDD check against current `main` production files: the new regression file fails 8 cases for the expected EOF/listener/latch/TTY/redaction reasons; restored branch passes all 10 cases.

`ruff check` on all changed Python files and `git diff --check origin/main...HEAD` also pass.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed PRs/issues for overlap
- [x] This PR contains only this OAuth callback lifecycle fix
- [x] I've added regression tests
- [x] Tested on Linux 6.8
- [x] Documentation/config/schema changes are N/A

Provenance: this is a byte-identical replay of the locally reviewed cumulative patch from `aa3491815a...` through `5bafded1e7...` onto upstream `f293e7206b...` (diff SHA-256 `1709c6d1e7d188a46d1d8d7d7805bc7727668c07a8a96febec51aa7f179ccd1a`).