### PR TITLE
test(agent): isolate truncation warnings between tests

### DIFF
--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -1,0 +1,13 @@
+"""Shared pytest fixtures for agent tests."""
+
+import pytest
+
+from agent.prompt_builder import drain_truncation_warnings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_truncation_warnings():
+    """Keep prompt truncation warnings from leaking between agent tests."""
+    drain_truncation_warnings()
+    yield
+    drain_truncation_warnings()


### PR DESCRIPTION
Fixes #93018

## Problem
`tests/agent/test_prompt_builder.py` can leave `prompt_builder` truncation warnings in the current `ContextVar`. When a later agent test calls `build_system_prompt()`, those stale warnings are drained and forwarded to `_emit_status`, making the suite order-dependent.

## Root cause
The existing truncation fixture only drains warnings at test setup. Tests that record a warning without draining it can therefore leak that state into the next test running in the same pytest context.

## Fix
Add an autouse fixture for `tests/agent/` that drains truncation warnings both before and after each test. This keeps the production `ContextVar` behavior unchanged while making test boundaries deterministic.

## Scope
- test infrastructure only
- no production behavior changes
- no changes to warning semantics inside a test

## Validation
The target regression is the issue reproducer:
`pytest tests/agent/test_prompt_builder.py tests/agent/test_system_prompt.py -q`

I could not run the suite in this automation environment because outbound DNS to github.com is unavailable for cloning; hosted CI is the execution gate for this commit. The patch is intentionally isolated to a new pytest fixture file.
