### PR TITLE
feat(desktop): publish Hermes Pet session-view evidence and restore session deep-link

### DIFF
--- a/apps/desktop/electron/hermes-pet-session-view.test.ts
+++ b/apps/desktop/electron/hermes-pet-session-view.test.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  HERMES_PET_SESSION_VIEW_MAX_RECENT,
+  petSessionViewFocusGuard,
+  readHermesPetSessionViewSnapshot,
+  recordHermesPetSessionView
+} from './hermes-pet-session-view'
+
+const temporaryDirectories: string[] = []
+
+function fixture() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-pet-view-'))
+  temporaryDirectories.push(directory)
+
+  return {
+    directory,
+    target: path.join(directory, 'hermes-pet-session-views-v1.json')
+  }
+}
+
+afterEach(() => {
+  while (temporaryDirectories.length) {
+    fs.rmSync(temporaryDirectories.pop()!, { force: true, recursive: true })
+  }
+})
+
+describe('Hermes Pet session view marker', () => {
+  it('writes only bounded identity/profile/time evidence atomically', () => {
+    const value = fixture()
+
+    for (let index = 0; index < HERMES_PET_SESSION_VIEW_MAX_RECENT + 2; index += 1) {
+      expect(
+        recordHermesPetSessionView(
+          value.target,
+          {
+            sessionID: `session-${index}`,
+            profile: index % 2 === 0 ? 'default' : 'automation'
+          },
+          { now: 100 + index, producerPID: 42 }
+        )
+      ).toEqual({ ok: true })
+    }
+
+    const snapshot = readHermesPetSessionViewSnapshot(value.target)
+    expect(snapshot?.schemaVersion).toBe(1)
+    expect(snapshot?.producerPID).toBe(42)
+    expect(snapshot?.recentViews).toHaveLength(HERMES_PET_SESSION_VIEW_MAX_RECENT)
+    expect(snapshot?.current?.sessionID).toBe(`session-${HERMES_PET_SESSION_VIEW_MAX_RECENT + 1}`)
+    expect(fs.readdirSync(value.directory).filter(entry => entry.includes('.tmp-'))).toEqual([])
+    expect(fs.readFileSync(value.target, 'utf8')).not.toMatch(/prompt|command|credential/)
+  })
+
+  it('replaces a revisit and clears current without dropping recent history', () => {
+    const value = fixture()
+
+    recordHermesPetSessionView(value.target, { sessionID: 'same', profile: '' }, { now: 10, producerPID: 9 })
+    recordHermesPetSessionView(value.target, { sessionID: 'same', profile: 'default' }, { now: 20, producerPID: 9 })
+    recordHermesPetSessionView(value.target, { sessionID: null }, { now: 21, producerPID: 9 })
+
+    expect(readHermesPetSessionViewSnapshot(value.target)).toMatchObject({
+      current: null,
+      recentViews: [{ sessionID: 'same', profile: 'default', viewedAt: 20 }]
+    })
+  })
+
+  it('rejects unsafe input and unsupported/corrupt snapshots', () => {
+    const value = fixture()
+
+    expect(
+      recordHermesPetSessionView(
+        value.target,
+        { sessionID: '../unsafe', profile: 'default' },
+        { now: 10, producerPID: 9 }
+      )
+    ).toEqual({ ok: false, error: 'invalid-session-view' })
+    expect(fs.existsSync(value.target)).toBe(false)
+
+    fs.writeFileSync(value.target, '{broken', 'utf8')
+    expect(readHermesPetSessionViewSnapshot(value.target)).toBeNull()
+    expect(
+      recordHermesPetSessionView(value.target, { sessionID: 'safe', profile: 'default' }, { now: 11, producerPID: 9 })
+    ).toEqual({ ok: true })
+
+    fs.writeFileSync(
+      value.target,
+      JSON.stringify({ schemaVersion: 2, updatedAt: 12, producerPID: 9, current: null, recentViews: [] }),
+      'utf8'
+    )
+    expect(readHermesPetSessionViewSnapshot(value.target)).toBeNull()
+  })
+})
+
+describe('petSessionViewFocusGuard (Electron sender-window hardening)', () => {
+  const liveFocusedWindow = { isDestroyed: () => false, isFocused: () => true }
+
+  it('rejects a missing, destroyed, or unfocused sender window', () => {
+    expect(petSessionViewFocusGuard(null)).toBe('not-focused')
+    expect(petSessionViewFocusGuard(undefined)).toBe('not-focused')
+    expect(petSessionViewFocusGuard({ isDestroyed: () => true, isFocused: () => true })).toBe('not-focused')
+    expect(petSessionViewFocusGuard({ isDestroyed: () => false, isFocused: () => false })).toBe('not-focused')
+  })
+
+  it('accepts a live focused sender window', () => {
+    expect(petSessionViewFocusGuard(liveFocusedWindow)).toBeNull()
+  })
+})

--- a/apps/desktop/electron/hermes-pet-session-view.ts
+++ b/apps/desktop/electron/hermes-pet-session-view.ts
@@ -1,0 +1,205 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const HERMES_PET_SESSION_VIEW_SCHEMA_VERSION = 1
+export const HERMES_PET_SESSION_VIEW_MAX_RECENT = 64
+
+const SAFE_IDENTIFIER = /^[A-Za-z0-9._~-]{1,256}$/
+
+export interface HermesPetSessionView {
+  sessionID: string
+  profile: string
+  viewedAt: number
+}
+
+export interface HermesPetSessionViewSnapshot {
+  schemaVersion: typeof HERMES_PET_SESSION_VIEW_SCHEMA_VERSION
+  updatedAt: number
+  producerPID: number
+  current: HermesPetSessionView | null
+  recentViews: HermesPetSessionView[]
+}
+
+export interface HermesPetSessionViewPayload {
+  sessionID: null | string
+  profile?: null | string
+}
+
+export type HermesPetSessionViewResult =
+  | { ok: true }
+  | { error: 'invalid-runtime' | 'invalid-session-view' | 'write-failed' | 'not-focused'; ok: false }
+
+export function safePetSessionIdentifier(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim()
+
+  return SAFE_IDENTIFIER.test(normalized) ? normalized : null
+}
+
+function normalizedProfile(value: unknown): string | null {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+
+  return safePetSessionIdentifier(normalized || 'default')
+}
+
+function normalizedView(value: unknown): HermesPetSessionView | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const candidate = value as Partial<HermesPetSessionView>
+  const sessionID = safePetSessionIdentifier(candidate.sessionID)
+  const profile = normalizedProfile(candidate.profile)
+  const viewedAt = Number(candidate.viewedAt)
+
+  if (!sessionID || !profile || !Number.isFinite(viewedAt) || viewedAt <= 0) {
+    return null
+  }
+
+  return { sessionID, profile, viewedAt }
+}
+
+/**
+ * Parse a marker without trusting it. A malformed or future marker is treated
+ * as absent so Pet can fail closed instead of acknowledging a completion from
+ * an unverified Desktop process.
+ */
+export function readHermesPetSessionViewSnapshot(targetPath: string): HermesPetSessionViewSnapshot | null {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(targetPath, 'utf8'))
+
+    if (!parsed || typeof parsed !== 'object') {
+      return null
+    }
+
+    const value = parsed as Partial<HermesPetSessionViewSnapshot>
+    const updatedAt = Number(value.updatedAt)
+    const producerPID = Number(value.producerPID)
+
+    if (
+      value.schemaVersion !== HERMES_PET_SESSION_VIEW_SCHEMA_VERSION ||
+      !Number.isFinite(updatedAt) ||
+      updatedAt < 0 ||
+      !Number.isSafeInteger(producerPID) ||
+      producerPID < 0 ||
+      !Array.isArray(value.recentViews) ||
+      value.recentViews.length > HERMES_PET_SESSION_VIEW_MAX_RECENT
+    ) {
+      return null
+    }
+
+    const recentViews = value.recentViews.map(normalizedView)
+
+    if (recentViews.some(view => view == null)) {
+      return null
+    }
+
+    const current = value.current == null ? null : normalizedView(value.current)
+
+    if (value.current != null && current == null) {
+      return null
+    }
+
+    return {
+      schemaVersion: HERMES_PET_SESSION_VIEW_SCHEMA_VERSION,
+      updatedAt,
+      producerPID,
+      current,
+      recentViews: recentViews as HermesPetSessionView[]
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeHermesPetSessionViewAtomic(targetPath: string, snapshot: HermesPetSessionViewSnapshot): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+
+  // Keep the temporary file beside the target so rename is atomic on every
+  // supported filesystem. Include a random suffix so multiple Desktop windows
+  // cannot accidentally rename one another's in-flight marker.
+  const temporary = `${targetPath}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`
+
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600
+    })
+    fs.renameSync(temporary, targetPath)
+  } finally {
+    try {
+      fs.unlinkSync(temporary)
+    } catch {
+      // The rename succeeded, or another cleanup path already removed it.
+    }
+  }
+}
+
+export function recordHermesPetSessionView(
+  targetPath: string,
+  payload: HermesPetSessionViewPayload | null | undefined,
+  { now = Date.now() / 1000, producerPID = process.pid }: { now?: number; producerPID?: number } = {}
+): HermesPetSessionViewResult {
+  const timestamp = Number(now)
+  const pid = Number(producerPID)
+
+  if (!Number.isFinite(timestamp) || timestamp <= 0 || !Number.isSafeInteger(pid) || pid <= 0) {
+    return { ok: false, error: 'invalid-runtime' }
+  }
+
+  if (!payload || typeof payload !== 'object' || !Object.hasOwn(payload, 'sessionID')) {
+    return { ok: false, error: 'invalid-session-view' }
+  }
+
+  const previous = readHermesPetSessionViewSnapshot(targetPath)
+  let recentViews = previous?.recentViews ?? []
+  let current: HermesPetSessionView | null = null
+
+  if (payload.sessionID != null) {
+    const sessionID = safePetSessionIdentifier(payload.sessionID)
+    const profile = normalizedProfile(payload.profile)
+
+    if (!sessionID || !profile) {
+      return { ok: false, error: 'invalid-session-view' }
+    }
+
+    current = { sessionID, profile, viewedAt: timestamp }
+    recentViews = recentViews.filter(view => view.sessionID !== sessionID || view.profile !== profile)
+    recentViews = [...recentViews, current].slice(-HERMES_PET_SESSION_VIEW_MAX_RECENT)
+  }
+
+  writeHermesPetSessionViewAtomic(targetPath, {
+    schemaVersion: HERMES_PET_SESSION_VIEW_SCHEMA_VERSION,
+    updatedAt: timestamp,
+    producerPID: pid,
+    current,
+    recentViews
+  })
+
+  return { ok: true }
+}
+
+/**
+ * Minimal structural view of an Electron BrowserWindow for the IPC sender
+ * guard. Frontmost-window status belongs to Electron, not the renderer, so a
+ * marker request is rejected when its sender window is missing, destroyed, or
+ * not focused — it must neither mint foreground evidence nor clear/overwrite
+ * the existing marker.
+ */
+export interface HermesPetSessionViewSenderWindow {
+  isDestroyed(): boolean
+  isFocused(): boolean
+}
+
+export function petSessionViewFocusGuard(
+  senderWindow: HermesPetSessionViewSenderWindow | null | undefined
+): 'not-focused' | null {
+  if (!senderWindow || senderWindow.isDestroyed() || !senderWindow.isFocused()) {
+    return 'not-focused'
+  }
+
+  return null
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -180,6 +180,7 @@ import {
   tightenSecretFileMode,
   writeSecretFileAtomic
 } from './hardening'
+import { petSessionViewFocusGuard, recordHermesPetSessionView } from './hermes-pet-session-view'
 import { cursorPointInWindow } from './hud-cursor'
 import { registerHudIpc } from './hud-ipc'
 import { snapHudBounds } from './hud-snap'
@@ -754,6 +755,10 @@ const DESKTOP_BACKEND_OWNERSHIP_PATH = path.join(app.getPath('userData'), 'backe
 // ~/.hermes/active_profile file. Unset (null) preserves the legacy behavior:
 // no --profile flag, so the backend honors active_profile / default.
 const DESKTOP_PROFILE_CONFIG_PATH = path.join(app.getPath('userData'), 'active-profile.json')
+// Content-free evidence consumed read-only by Hermes Pet. Electron's
+// userData path is `~/Library/Application Support/Hermes` on macOS (the app's
+// product name), and remains overrideable for hermetic Desktop tests.
+const HERMES_PET_SESSION_VIEW_PATH = path.join(app.getPath('userData'), 'hermes-pet-session-views-v1.json')
 // Mirrors hermes_cli.profiles._PROFILE_ID_RE so we never hand the backend a
 // value its profile resolver would reject and exit on.
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
@@ -12336,6 +12341,24 @@ ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
   touchPoolBackend(profile)
 
   return { ok: true }
+})
+ipcMain.handle('hermes:pet:session-viewed', (event, payload) => {
+  // Frontmost-window status belongs to Electron, not the renderer. A missing,
+  // destroyed, or unfocused sender window must neither mint foreground
+  // evidence nor clear/overwrite the existing marker.
+  if (petSessionViewFocusGuard(BrowserWindow.fromWebContents(event.sender))) {
+    return { ok: false, error: 'not-focused' }
+  }
+
+  try {
+    return recordHermesPetSessionView(HERMES_PET_SESSION_VIEW_PATH, payload, {
+      producerPID: process.pid
+    })
+  } catch (error) {
+    rememberLog(`[hermes-pet] session view marker failed: ${error instanceof Error ? error.message : String(error)}`)
+
+    return { ok: false, error: 'write-failed' }
+  }
 })
 ipcMain.handle('hermes:gateway:ws-url', async (_event, profile) => {
   return gatewayWsUrlIpcResult(() => freshGatewayWsUrl(profile))

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -18,6 +18,9 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getProfileRoutes: profiles => ipcRenderer.invoke('hermes:plugin-profile-routes', profiles),
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
   touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
+  // Content-free evidence consumed read-only by Hermes Pet. The renderer sends
+  // only the exact stored session identity and owning profile.
+  recordPetSessionViewed: payload => ipcRenderer.invoke('hermes:pet:session-viewed', payload),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
   // Registry-scoped fresh WS URL: { connectionId, profile } → result shape of
   // getGatewayWsUrl, minted against that connection's backend.

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -253,6 +253,14 @@ export function useDesktopIntegrations({
         return
       }
 
+      // hermes://session/<stored-id> — Hermes Pet's session tab/link. Navigate
+      // straight to that stored session's route.
+      if (payload.kind === 'session' && payload.name) {
+        navigate(sessionRoute(payload.name))
+
+        return
+      }
+
       const action = resolveDeepLinkAction(payload)
 
       if (action.type === 'composer-blueprint') {

--- a/apps/desktop/src/app/contrib/pet-session-view.test.ts
+++ b/apps/desktop/src/app/contrib/pet-session-view.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolvePetSessionViewPayload } from './pet-session-view'
+
+const baseInput = {
+  activeGatewayProfile: 'default',
+  activeSessionId: 'runtime-1',
+  currentView: 'chat',
+  documentVisible: true,
+  profileReady: true,
+  routedSessionId: 'stored-1',
+  resumeExhaustedSessionId: null,
+  resumeFailedSessionId: null,
+  runtimeIdByStoredSessionId: new Map([['stored-1', 'runtime-1']]),
+  selectedStoredSessionId: 'stored-1',
+  sessions: [{ id: 'stored-1', _lineage_root_id: null, profile: 'default' }],
+  windowFocused: true
+}
+
+describe('resolvePetSessionViewPayload', () => {
+  it('publishes the exact stored key only when the selected window is frontmost', () => {
+    expect(resolvePetSessionViewPayload(baseInput)).toEqual({
+      sessionID: 'stored-1',
+      profile: 'default'
+    })
+  })
+
+  it('fails closed during a compression lineage transition', () => {
+    expect(
+      resolvePetSessionViewPayload({
+        ...baseInput,
+        routedSessionId: 'lineage-root',
+        runtimeIdByStoredSessionId: new Map([['stored-tip', 'runtime-1']]),
+        selectedStoredSessionId: 'lineage-root',
+        sessions: [{ id: 'stored-tip', _lineage_root_id: 'lineage-root', profile: 'default' }]
+      })
+    ).toEqual({ sessionID: null })
+  })
+
+  it('does not mark a valid route while hidden or unfocused', () => {
+    expect(resolvePetSessionViewPayload({ ...baseInput, documentVisible: false })).toBeNull()
+    expect(resolvePetSessionViewPayload({ ...baseInput, windowFocused: false })).toBeNull()
+  })
+
+  it('clears marker evidence for selection or profile mismatches', () => {
+    expect(resolvePetSessionViewPayload({ ...baseInput, selectedStoredSessionId: 'other' })).toEqual({
+      sessionID: null
+    })
+    expect(
+      resolvePetSessionViewPayload({
+        ...baseInput,
+        activeGatewayProfile: 'automation',
+        sessions: [{ id: 'stored-1', _lineage_root_id: null, profile: 'default' }]
+      })
+    ).toEqual({ sessionID: null })
+  })
+
+  it('clears on invalid chat-surface, load, or route state', () => {
+    expect(resolvePetSessionViewPayload({ ...baseInput, currentView: 'artifacts' })).toEqual({ sessionID: null })
+    expect(resolvePetSessionViewPayload({ ...baseInput, profileReady: false })).toEqual({ sessionID: null })
+    expect(resolvePetSessionViewPayload({ ...baseInput, routedSessionId: null })).toEqual({ sessionID: null })
+    expect(resolvePetSessionViewPayload({ ...baseInput, activeSessionId: null })).toEqual({ sessionID: null })
+    expect(resolvePetSessionViewPayload({ ...baseInput, sessions: [] })).toEqual({ sessionID: null })
+    expect(
+      resolvePetSessionViewPayload({
+        ...baseInput,
+        resumeExhaustedSessionId: 'stored-1',
+        resumeFailedSessionId: 'stored-1'
+      })
+    ).toEqual({ sessionID: null })
+  })
+
+  it('clears until the runtime reverse-map settles on the routed key', () => {
+    expect(
+      resolvePetSessionViewPayload({
+        ...baseInput,
+        runtimeIdByStoredSessionId: new Map([['stored-other', 'runtime-1']])
+      })
+    ).toEqual({ sessionID: null })
+    expect(resolvePetSessionViewPayload({ ...baseInput, runtimeIdByStoredSessionId: new Map() })).toEqual({
+      sessionID: null
+    })
+  })
+})

--- a/apps/desktop/src/app/contrib/pet-session-view.ts
+++ b/apps/desktop/src/app/contrib/pet-session-view.ts
@@ -1,0 +1,89 @@
+import { normalizeProfileKey } from '@/store/profile'
+import { sessionMatchesStoredId } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+export interface PetSessionViewInput {
+  activeGatewayProfile: null | string | undefined
+  activeSessionId: null | string
+  currentView: string
+  documentVisible: boolean
+  profileReady: boolean
+  routedSessionId: null | string
+  resumeExhaustedSessionId: null | string
+  resumeFailedSessionId: null | string
+  runtimeIdByStoredSessionId: ReadonlyMap<string, string>
+  selectedStoredSessionId: null | string
+  sessions: readonly Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>[]
+  windowFocused: boolean
+}
+
+export type PetSessionViewPayload = { sessionID: null } | { profile: string; sessionID: string }
+
+/**
+ * Resolve only a fully selected, loaded, profile-matched chat into the
+ * content-free marker that Hermes Pet consumes. Invalid route/selection state
+ * returns a clear marker. A valid but backgrounded document returns `null` so
+ * the last foreground evidence is retained until the window is actually fronted.
+ */
+export function resolvePetSessionViewPayload(input: PetSessionViewInput): PetSessionViewPayload | null {
+  const {
+    activeGatewayProfile,
+    activeSessionId,
+    currentView,
+    documentVisible,
+    profileReady,
+    routedSessionId,
+    resumeExhaustedSessionId,
+    resumeFailedSessionId,
+    runtimeIdByStoredSessionId,
+    selectedStoredSessionId,
+    sessions,
+    windowFocused
+  } = input
+
+  if (
+    currentView !== 'chat' ||
+    !profileReady ||
+    !routedSessionId ||
+    selectedStoredSessionId !== routedSessionId ||
+    !activeSessionId ||
+    resumeFailedSessionId === routedSessionId ||
+    resumeExhaustedSessionId === routedSessionId
+  ) {
+    return { sessionID: null }
+  }
+
+  const stored = sessions.find(session => sessionMatchesStoredId(session, routedSessionId))
+
+  if (!stored) {
+    return { sessionID: null }
+  }
+
+  const profile = normalizeProfileKey(stored.profile)
+
+  // A route may come from the all-profiles list while the gateway is still
+  // re-homing. Never record a view under whichever profile happens to be live.
+  if (profile !== normalizeProfileKey(activeGatewayProfile)) {
+    return { sessionID: null }
+  }
+
+  // Pet's runtime snapshot identifies work by the backend's stored session key
+  // (the same key passed to AIAgent/session hooks), not Desktop's ephemeral
+  // renderer runtime id. During compression the durable key rotates; require
+  // the active runtime's reverse mapping to have settled on the exact routed
+  // key before publishing, otherwise a lineage root could acknowledge the
+  // wrong completion.
+  const runtimeStoredSessionId = [...runtimeIdByStoredSessionId.entries()].find(
+    ([, runtimeId]) => runtimeId === activeSessionId
+  )?.[0]
+
+  if (runtimeStoredSessionId !== routedSessionId) {
+    return { sessionID: null }
+  }
+
+  if (!documentVisible || !windowFocused) {
+    return null
+  }
+
+  return { sessionID: routedSessionId, profile }
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -150,6 +150,7 @@ import { useQuickEntryBridge } from './hooks/use-quick-entry-bridge'
 import { useSessionTileDelegate } from './hooks/use-session-tile-delegate'
 import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
+import { resolvePetSessionViewPayload } from './pet-session-view'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
 
@@ -855,6 +856,59 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     runtimeIdByStoredSessionId: runtimeIdByStoredSessionIdRef,
     sessions
   })
+
+  // Hermes Pet receives only content-free evidence that the exact stored
+  // session key is selected, loaded, profile-matched, visible, and frontmost
+  // in Desktop. A backgrounded valid route leaves the previous evidence in
+  // place; invalid or profile-mismatched state clears `current` fail-closed.
+  useEffect(() => {
+    const publishPetSessionView = () => {
+      const payload = resolvePetSessionViewPayload({
+        activeGatewayProfile,
+        activeSessionId,
+        currentView,
+        documentVisible: document.visibilityState === 'visible',
+        profileReady: boot.phase === 'renderer.ready',
+        routedSessionId,
+        resumeExhaustedSessionId,
+        resumeFailedSessionId,
+        runtimeIdByStoredSessionId: runtimeIdByStoredSessionIdRef.current,
+        selectedStoredSessionId,
+        sessions,
+        windowFocused: typeof document.hasFocus === 'function' && document.hasFocus()
+      })
+
+      if (payload == null) {
+        return
+      }
+
+      const result = window.hermesDesktop?.recordPetSessionViewed?.(payload)
+
+      if (result) {
+        void result.catch(() => undefined)
+      }
+    }
+
+    publishPetSessionView()
+    window.addEventListener('focus', publishPetSessionView)
+    document.addEventListener('visibilitychange', publishPetSessionView)
+
+    return () => {
+      window.removeEventListener('focus', publishPetSessionView)
+      document.removeEventListener('visibilitychange', publishPetSessionView)
+    }
+  }, [
+    activeGatewayProfile,
+    activeSessionId,
+    boot.phase,
+    currentView,
+    resumeExhaustedSessionId,
+    resumeFailedSessionId,
+    routedSessionId,
+    runtimeIdByStoredSessionIdRef,
+    selectedStoredSessionId,
+    sessions
+  ])
 
   // Pin/unpin the selected session (statusbar keybind + chat header) — pinned
   // on the durable lineage-root id so it survives auto-compression.

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -46,6 +46,12 @@ declare global {
       // Keepalive: mark a pool profile backend as recently used so the idle
       // reaper spares it while its chat is active.
       touchBackend: (profile?: string | null) => Promise<{ ok: boolean }>
+      // Content-free marker consumed read-only by Hermes Pet. It carries only
+      // the selected stored session identity and normalized owning profile.
+      recordPetSessionViewed?: (payload: {
+        sessionID: null | string
+        profile?: null | string
+      }) => Promise<{ ok: boolean; error?: string }>
       getGatewayWsUrl: (profile?: null | string) => Promise<GatewayWsUrlResult>
       // Open (or focus) a standalone OS window for a single chat session so
       // the user can work with multiple chats side by side. Returns ok:false


### PR DESCRIPTION
## Purpose

Hermes Pet shows Desktop's working status and acknowledges completed items from content-free evidence of which stored session is being viewed. Today Desktop never records that evidence, so the Pet activity tray cannot reflect the frontmost Desktop session and completed items stay visible. This PR wires the existing marker contract into Desktop and restores `hermes://session/<stored-id>` deep-link navigation used by Pet links.

## Changes (9 files)

- `apps/desktop/electron/hermes-pet-session-view.ts` (new): schema-v1 marker writer/reader — atomic tmp+rename writes, mode 0600, producerPID from the Electron main process, fail-closed reads (bad JSON / schema mismatch / unsafe ids / >64 entries -> treated as absent).
- `apps/desktop/electron/hermes-pet-session-view.test.ts` (new): bounded/atomic/content-free write, revisit/clear semantics, unsafe input rejection.
- `apps/desktop/electron/main.ts`: `hermes:pet:session-viewed` IPC handler; refuses when the sender window is missing/destroyed/unfocused; errors returned as `{ok:false, error}` without crashing the app.
- `apps/desktop/electron/preload.ts` + `apps/desktop/src/global.d.ts`: typed `recordPetSessionViewed` bridge (optional API, safe for older builds).
- `apps/desktop/src/app/contrib/pet-session-view.ts` (new): renderer resolver — emits the exact stored session key only when selected, loaded, profile-matched, visible and frontmost; clears on route/profile mismatch; fail-closed across compression-lineage transitions.
- `apps/desktop/src/app/contrib/pet-session-view.test.ts` (new): resolver boundary tests (hidden window, profile mismatch, lineage transitions).
- `apps/desktop/src/app/contrib/wiring.tsx`: focus/visibility-driven publish effect wired to the resolver.
- `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts`: `hermes://session/<stored-id>` navigates to the stored session's route.

## Tests

- vitest (electron project): hermes-pet-session-view — 5 passed
- vitest (ui project): pet-session-view — 6 passed
- vitest (ui project, boundary): use-desktop-integrations hook — 25 passed
- `npm run typecheck` (tsc: ui / electron / e2e) — passed

## Boundaries — no impact without Hermes Pet

- Marker is content-free by construction (session id/profile/timestamp only); tests assert no prompt/command/credential content.
- The IPC handler is inert unless the renderer publishes; the publish effect only fires on valid foreground state.
- No config keys, no new env vars, no cron/gateway/install changes.
- Filename and schemaVersion stay `hermes-pet-session-views-v1.json` / v1 — external Pet consumers keep working unchanged.
- Writes stay in the Electron main process (never the renderer), atomic, 0600; producerPID is always the main process pid (Pet aliveness check contract).
- The deep-link branch only handles the `session` kind; all other deep-link handling is unchanged.

## Verification note

Change extracted from a dirty local tree into an isolated worktree based on current upstream `main` (f293e720), hunks re-derived against the newer base; original local working tree untouched (preservation snapshot + hash comparison available on request).