### PR TITLE
feat(models): add Muse Spark contributor to OpenRouter

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -128,6 +128,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # Meta
     ("meta/muse-spark-1.2",                    ""),
+    ("meta/muse-spark-1.2-contributor",        ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-21T20:49:36Z",
+  "updated_at": "2026-08-23T17:16:11Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -143,6 +143,10 @@
         },
         {
           "id": "meta/muse-spark-1.2",
+          "description": ""
+        },
+        {
+          "id": "meta/muse-spark-1.2-contributor",
           "description": ""
         },
         {


### PR DESCRIPTION
## Summary

- add `meta/muse-spark-1.2-contributor` to the curated OpenRouter model list
- regenerate the hosted model catalog so existing Hermes installations receive it without a release

OpenRouter currently advertises the model with `tools` and `tool_choice` support, so it passes Hermes’ tool-capability filter.

## Test plan

- [x] `./scripts/run_tests.sh tests/hermes_cli/test_models.py tests/hermes_cli/test_model_catalog.py` (98 passed)
- [x] live OpenRouter catalog intersection returns `meta/muse-spark-1.2-contributor` in the filtered picker list