### PR TITLE
fix(e2e): resolve the Electron dev binary across platforms and layouts

### DIFF
--- a/apps/desktop/e2e/electron-binary.ts
+++ b/apps/desktop/e2e/electron-binary.ts
@@ -1,0 +1,82 @@
+import { spawnSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/**
+ * Platform-correct filename/layout for the electron npm package's bundled
+ * binary (#92846): `electron.exe` on Windows, an app bundle on macOS, and a
+ * plain executable on Linux.
+ */
+function bundledBinaryName(platform: string): string | null {
+  if (platform === 'win32') {
+    return 'electron.exe'
+  }
+
+  if (platform === 'darwin') {
+    return path.join('Electron.app', 'Contents', 'MacOS', 'Electron')
+  }
+
+  return 'electron'
+}
+
+/**
+ * Candidate paths for the Electron dev binary, most-preferred first.
+ *
+ * Two real layouts exist (#92846): npm may hoist electron to the repo root
+ * (classic POSIX workspaces), or the desktop package may own its own copy
+ * under apps/desktop/node_modules (the normal layout on Windows).
+ */
+export function electronBinaryCandidates(
+  repoRoot: string,
+  desktopRoot: string,
+  platform: string = process.platform,
+): string[] {
+  const exe = bundledBinaryName(platform)
+
+  if (!exe) {
+    return []
+  }
+
+  return [
+    path.join(repoRoot, 'node_modules', 'electron', 'dist', exe),
+    path.join(desktopRoot, 'node_modules', 'electron', 'dist', exe),
+  ]
+}
+
+/**
+ * Find the Electron dev binary: node_modules layouts first (hoisted, then
+ * desktop-local), then PATH (`where` on Windows, `which` on POSIX).
+ *
+ * Lives outside fixtures.ts so it stays importable from unit tests —
+ * fixtures.ts registers Playwright hooks at import time.
+ */
+export function findElectronBinary(
+  repoRoot: string,
+  desktopRoot: string,
+  platform: string = process.platform,
+): string {
+  for (const candidate of electronBinaryCandidates(repoRoot, desktopRoot, platform)) {
+    if (fs.existsSync(candidate)) {
+      return candidate
+    }
+  }
+
+  const lookup = platform === 'win32' ? 'where' : 'which'
+
+  const result = spawnSync(lookup, ['electron'], {
+    encoding: 'utf8',
+  })
+
+  if (result.status === 0 && result.stdout.trim()) {
+    // `where` may report several matches; any first line is a usable binary.
+    const firstMatch = result.stdout.trim().split(/\r?\n/)[0].trim()
+
+    if (firstMatch) {
+      return firstMatch
+    }
+  }
+
+  throw new Error(
+    'Electron binary not found. Run "npm install" from the repo root to install devDependencies.',
+  )
+}

--- a/apps/desktop/e2e/fixtures.test.ts
+++ b/apps/desktop/e2e/fixtures.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import * as fs from 'node:fs'
+import { join } from 'node:path'
+
+import { test } from 'vitest'
+
+import { electronBinaryCandidates, findElectronBinary } from './electron-binary'
+
+test('windows candidates use electron.exe, not the extensionless name (#92846)', () => {
+  const [repoHoisted, desktopLocal] = electronBinaryCandidates(
+    '/repo',
+    '/repo/apps/desktop',
+    'win32',
+  )
+
+  assert.ok(repoHoisted.endsWith('electron.exe'), `expected .exe, got ${repoHoisted}`)
+  assert.ok(desktopLocal.endsWith('electron.exe'), `expected .exe, got ${desktopLocal}`)
+})
+
+test('macOS candidates point inside the Electron.app bundle', () => {
+  const [repoHoisted] = electronBinaryCandidates('/repo', '/repo/apps/desktop', 'darwin')
+
+  assert.ok(
+    repoHoisted.endsWith(join('Electron.app', 'Contents', 'MacOS', 'Electron')),
+    `expected app-bundle path, got ${repoHoisted}`,
+  )
+})
+
+test('linux candidates keep the extensionless binary name', () => {
+  const [repoHoisted] = electronBinaryCandidates('/repo', '/repo/apps/desktop', 'linux')
+
+  assert.ok(repoHoisted.endsWith(join('dist', 'electron')))
+  assert.ok(!repoHoisted.endsWith('.exe'))
+})
+
+test('desktop-local layout is searched after the hoisted one (windows node_modules)', () => {
+  const [, desktopLocal] = electronBinaryCandidates('/repo', '/repo/apps/desktop', 'win32')
+
+  assert.equal(
+    desktopLocal,
+    join('/repo', 'apps', 'desktop', 'node_modules', 'electron', 'dist', 'electron.exe'),
+  )
+})
+
+test('findElectronBinary resolves the real bundled binary in this checkout', () => {
+  // This repo has electron installed; the resolver must find it without
+  // touching PATH.
+  const found = findElectronBinary(REPO_ROOT, DESKTOP_ROOT)
+
+  assert.ok(fs.existsSync(found), `resolved binary must exist, got ${found}`)
+  assert.ok(
+    found.startsWith(join(REPO_ROOT, 'node_modules', 'electron', 'dist')) ||
+      found.startsWith(join(DESKTOP_ROOT, 'node_modules', 'electron', 'dist')),
+    `resolved from node_modules, got ${found}`,
+  )
+})
+
+// Real checkout roots for the live-resolution test above.
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..')
+const DESKTOP_ROOT = join(import.meta.dirname, '..')

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -20,14 +20,14 @@
  * Prerequisite: `npm run build` must have been run so that `dist/` exists.
  */
 
-import { spawnSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
 import { _electron, type ElectronApplication, type Page } from '@playwright/test'
 
-import { startMockServer, type MockServerOptions } from './mock-server'
+import { findElectronBinary } from './electron-binary'
+import { type MockServerOptions, startMockServer } from './mock-server'
 import { installErrorBannerGuard } from './test'
 
 const DESKTOP_ROOT = path.resolve(import.meta.dirname, '..')
@@ -280,31 +280,34 @@ function assertDistBuilt(): void {
 }
 
 /**
+ * Candidate paths for the Electron dev binary, most-preferred first.
+ *
+ * Two real layouts exist (#92846): npm may hoist electron to the repo root
+ * (classic POSIX workspaces), or the desktop package may own its own copy
+ * under apps/desktop/node_modules (the normal layout on Windows). The binary
+ * itself is `electron.exe` on Windows and `electron` everywhere else.
+ */
+export function electronBinaryCandidates(
+  repoRoot: string,
+  desktopRoot: string,
+  platform: string = process.platform,
+): string[] {
+  const exe = platform === 'win32' ? 'electron.exe' : 'electron'
+
+  return [
+    path.join(repoRoot, 'node_modules', 'electron', 'dist', exe),
+    path.join(desktopRoot, 'node_modules', 'electron', 'dist', exe),
+  ]
+}
+
+/**
  * Find the Electron binary. In the nix devshell, `electron` is on PATH.
  * As a fallback, use the node_modules/.bin/electron from the desktop package.
+ *
+ * Delegates to ./electron-binary (kept hook-free so unit tests can import it).
  */
 export function findElectron(): string {
-  // In dev mode, we use the `electron` binary directly (not the packaged app).
-  // The dev:electron script in package.json does exactly this: `electron .`
-  // after building. We replicate that here.
-  const localElectron = path.join(REPO_ROOT, 'node_modules', 'electron', 'dist', 'electron')
-
-  if (fs.existsSync(localElectron)) {
-    return localElectron
-  }
-
-  // Fall back to PATH
-  const result = spawnSync('which', ['electron'], {
-    encoding: 'utf8',
-  })
-
-  if (result.status === 0 && result.stdout.trim()) {
-    return result.stdout.trim()
-  }
-
-  throw new Error(
-    'Electron binary not found. Run "npm install" from the repo root to install devDependencies.',
-  )
+  return findElectronBinary(REPO_ROOT, DESKTOP_ROOT)
 }
 
 /**
@@ -632,6 +635,7 @@ export async function waitForAppReady(fixture: MockBackendFixture | NoProviderFi
       // `position: fixed; inset: 0`. If the hit element or an ancestor
       // is a full-viewport fixed overlay, we're still covered.
       let node: Element | null = el
+
       while (node) {
         const cs = window.getComputedStyle(node)
 

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -20,7 +20,7 @@ const electronNative: TestProjectConfiguration = {
   test: {
     name: 'electron',
     environment: 'node',
-    include: ['electron/**/*.test.ts', 'scripts/**.test.{ts,mjs}'],
+    include: ['electron/**/*.test.ts', 'scripts/**.test.{ts,mjs}', 'e2e/*.test.ts'],
     exclude: ['scripts/run-short-session-hang-repro.test.mjs']
   }
 }


### PR DESCRIPTION
## What does this PR do?

`findElectron()` in `apps/desktop/e2e/fixtures.ts` hardcoded one candidate path — `<repo>/node_modules/electron/dist/electron` — so every desktop e2e spec aborted in the fixture on Windows (#92846): npm lays the package out under `apps/desktop/node_modules` there, and the binary is `electron.exe`. macOS additionally bundles the binary inside `Electron.app/Contents/MacOS/Electron` rather than `dist/electron`, which this PR also handles.

The resolver now follows an ordered ladder (per the desktop engineering guide's "observable ladder" shape):

1. Repo-root hoisted `node_modules/electron/dist/<platform binary>`
2. Desktop-local `apps/desktop/node_modules/electron/dist/<platform binary>`
3. PATH via `where` (Windows) / `which`, taking the first match

The lookup lives in a new hook-free module (`e2e/electron-binary.ts`) so unit tests can import it — `fixtures.ts` registers Playwright hooks at import time and cannot be loaded under vitest.

## Related Issue

Fixes #92846

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/e2e/electron-binary.ts` (new) — platform-exact bundled binary name, hoisted→desktop-local node_modules ladder, PATH fallback; pure and unit-testable
- `apps/desktop/e2e/fixtures.ts` — `findElectron()` becomes a thin delegate with unchanged behavior for the POSIX hoisted layout
- `apps/desktop/vitest.config.ts` — `e2e/*.test.ts` joins the `electron` vitest project, so fixture helpers get real CI coverage
- `apps/desktop/e2e/fixtures.test.ts` — covers `.exe` naming on win32, app-bundle path on darwin, extensionless on linux, ladder order, and live resolution in a real checkout

## How to Test

1. `cd apps/desktop && npx vitest run e2e/fixtures.test.ts` — all five cases pass
2. On Windows: `npx playwright test e2e/boot.spec.ts` no longer fails at `findElectron` with "Electron binary not found" when electron is installed
3. POSIX hoisted checkouts resolve the identical binary as before (same first rung)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/Hermes-Agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted tests (`npx vitest run --project electron`: 1603 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon); Windows path verified by construction against npm's documented layout

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — that is the point of the PR
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
