### PR TITLE
fix(install): pin agent-browser and forbid implicit npx registry fetches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,7 +198,7 @@ ENV npm_config_install_links=false
 
 RUN npm install --prefer-offline --no-audit --fetch-retries=5 && \
     for i in 1 2 3; do \
-        npx playwright install --with-deps chromium --only-shell && break || \
+        npx --no-install playwright install --with-deps chromium --only-shell && break || \
         { [ "$i" = 3 ] && exit 1; echo "playwright install failed (attempt $i); retrying in 10s"; sleep 10; }; \
     done && \
     npm cache clean --force

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -200,13 +200,13 @@ def _run_setup_browser(assume_yes: bool = False) -> int:
     from hermes_cli.dep_ensure import ensure_dependency
 
     try:
-        node_ok = ensure_dependency("node", interactive=not assume_yes)
+        node_ok = ensure_dependency("node", interactive=not assume_yes, explicit=True)
         if not node_ok:
             print("Node.js installation failed — cannot proceed with browser tools.",
                   file=sys.stderr)
             return 1
 
-        browser_ok = ensure_dependency("browser", interactive=not assume_yes)
+        browser_ok = ensure_dependency("browser", interactive=not assume_yes, explicit=True)
         if not browser_ok:
             print("Browser tools installation failed.", file=sys.stderr)
             return 1

--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -128,14 +128,31 @@ def _find_install_script(
 def ensure_dependency(
     dep: str,
     interactive: bool = True,
+    *,
+    explicit: bool = False,
 ) -> bool:
-    """Ensure a non-Python dependency is available. Returns True if available."""
+    """Ensure a non-Python dependency is available.
+
+    Browser installation is a supply-chain boundary.  A missing browser may be
+    discovered while Hermes is running as a non-interactive gateway, where a
+    prompt cannot be answered.  Refuse that implicit npm install unless the
+    caller is an explicit setup command; the user can then inspect and approve
+    the pinned installer deliberately.
+    """
     check = _DEP_CHECKS.get(dep)
     if check is None:
         # Unknown dep — don't silently forward to install script.
         return False
     if check():
         return True
+
+    if dep == "browser" and not explicit and not sys.stdin.isatty():
+        if interactive:
+            print(
+                "  Browser tools are not installed; refusing a non-interactive npm install."
+            )
+            print("  Run `hermes acp --setup-browser` explicitly to install the pinned package.")
+        return False
 
     script, shell = _find_install_script()
     if script is None:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -247,7 +247,7 @@ def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     if not node_installed:
         steps.append(f"{step}) pkg install nodejs")
         step += 1
-    steps.append(f"{step}) npm install -g agent-browser")
+    steps.append(f"{step}) npm install -g --ignore-scripts agent-browser@0.27.0")
     steps.append(f"{step + 1}) agent-browser install")
     return steps
 
@@ -2279,11 +2279,11 @@ def run_doctor(args):
             # `hermes update` wiped node_modules (issue #48521).
             check_warn(
                 "agent-browser found but not runnable",
-                f"(broken symlink at {_resolved_ab}? run: npx agent-browser --version)",
+                f"(broken symlink at {_resolved_ab}? reinstall exact agent-browser@0.27.0)",
             )
         elif _is_termux():
             check_info("agent-browser is not installed (expected in the tested Termux path)")
-            check_info("Install it manually later with: npm install -g agent-browser && agent-browser install")
+            check_info("Install it manually later with: npm install -g --ignore-scripts agent-browser@0.27.0 && agent-browser install")
             check_info("Termux browser setup:")
             for step in _termux_browser_setup_steps(node_installed=True):
                 check_info(step)
@@ -2332,12 +2332,12 @@ def run_doctor(args):
                         if sys.platform == "win32":
                             check_info(
                                 f"Install with: cd {PROJECT_ROOT} && "
-                                "npx playwright install chromium"
+                                "npx --no-install playwright install chromium"
                             )
                         else:
                             check_info(
                                 f"Install with: cd {PROJECT_ROOT} && "
-                                "npx playwright install --with-deps chromium"
+                                "npx --no-install playwright install --with-deps chromium"
                             )
     elif _is_termux():
         check_info("Node.js not found (browser tools are optional in the tested Termux path)")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -459,21 +459,21 @@ def _print_setup_summary(config: dict, hermes_home):
             label = f"Browser Automation ({browser_provider})"
         tool_status.append((label, True, None))
     else:
-        missing_browser_hint = "npm install -g agent-browser, set CAMOFOX_URL, or configure Browser Use or Browserbase"
+        missing_browser_hint = "npm install -g --ignore-scripts agent-browser@0.27.0, set CAMOFOX_URL, or configure Browser Use or Browserbase"
         if browser_provider == "Browserbase":
             missing_browser_hint = (
-                "npm install -g agent-browser and set "
+                "npm install -g --ignore-scripts agent-browser@0.27.0 and set "
                 "BROWSERBASE_API_KEY/BROWSERBASE_PROJECT_ID"
             )
         elif browser_provider == "Browser Use":
             missing_browser_hint = (
-                "npm install -g agent-browser and set BROWSER_USE_API_KEY"
+                "npm install -g --ignore-scripts agent-browser@0.27.0 and set BROWSER_USE_API_KEY"
             )
         elif browser_provider == "Camofox":
             missing_browser_hint = "CAMOFOX_URL"
         elif browser_provider == "Local browser":
             missing_browser_hint = (
-                "npm install -g agent-browser && agent-browser install --with-deps"
+                "npm install -g --ignore-scripts agent-browser@0.27.0 && agent-browser install --with-deps"
             )
         tool_status.append(
             ("Browser Automation", False, missing_browser_hint)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1867,9 +1867,6 @@ def _run_post_setup(post_setup_key: str):
             )
             return
 
-        # browser_cmd was already resolved above (same PATH -> Homebrew ->
-        # Hermes-managed-node -> npx cascade _find_agent_browser uses at
-        # runtime), so this can't diverge from what actually gets invoked.
         if _is_npx_agent_browser_sentinel(browser_cmd):
             # Re-resolve via the same PATH + extended-PATH cascade
             # _find_agent_browser used, rather than a bare shutil.which("npx")
@@ -1879,10 +1876,10 @@ def _run_post_setup(post_setup_key: str):
             npx_bin = _resolve_npx_bin()
             if not npx_bin:
                 _print_warning(
-                    "    npx not found - install Chromium manually: npx agent-browser install --with-deps"
+                    "    npx not found - install the pinned agent-browser first, then run: agent-browser install --with-deps"
                 )
                 return
-            install_cmd = [npx_bin, "--ignore-scripts", "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps"]
+            install_cmd = [npx_bin, "--no-install", "agent-browser", "install", "--with-deps"]
         else:
             install_cmd = [browser_cmd, "install", "--with-deps"]
 
@@ -1905,13 +1902,13 @@ def _run_post_setup(post_setup_key: str):
                 tail = (result.stderr or result.stdout or "").strip().splitlines()[-3:]
                 for line in tail:
                     _print_info(f"      {line[:200]}")
-                _print_info("    Run manually: npx agent-browser install --with-deps")
+                _print_info("    Run manually after installing the pinned package: agent-browser install --with-deps")
         except subprocess.TimeoutExpired:
             _print_warning("    Chromium install timed out (>10min)")
-            _print_info("    Run manually: npx agent-browser install --with-deps")
+            _print_info("    Run manually after installing the pinned package: agent-browser install --with-deps")
         except Exception as exc:
             _print_warning(f"    Chromium install failed: {exc}")
-            _print_info("    Run manually: npx agent-browser install --with-deps")
+            _print_info("    Run manually after installing the pinned package: agent-browser install --with-deps")
 
     elif post_setup_key == "browser_use_cli":
         _ensure_browser_use_cli(verbose_hints=True)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -673,10 +673,18 @@ function Install-AgentBrowser {
     if (-not (Test-Path $prefixDir)) {
         New-Item -ItemType Directory -Path $prefixDir -Force | Out-Null
     }
+    $npmRcDir = Join-Path $prefixDir "etc"
+    New-Item -ItemType Directory -Path $npmRcDir -Force | Out-Null
+    @(
+        "package-lock=true"
+        "save-exact=true"
+        "audit=true"
+        "min-release-age=14"
+    ) | Set-Content -Path (Join-Path $npmRcDir "npmrc") -Encoding UTF8
     $npmLog = [System.IO.Path]::GetTempFileName()
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
-    & $npm install -g --prefix $prefixDir --silent --ignore-scripts "@askjo/camofox-browser@^1.5.2" 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
+    & $npm install -g --prefix $prefixDir --silent --ignore-scripts "@askjo/camofox-browser@1.5.2" 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
     $npmExit = $LASTEXITCODE
     $ErrorActionPreference = $prevEAP
     if ($npmExit -ne 0) {
@@ -3469,7 +3477,7 @@ function Install-NodeDeps {
             }
             if (-not $npxExe) {
                 Write-Warn "npx not found -- cannot install Playwright Chromium."
-                Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+                Write-Info "Run manually later: cd `"$InstallDir`"; npx --no-install playwright install chromium"
             } else {
                 $pwLog = "$env:TEMP\hermes-playwright-install-$(Get-Random).log"
                 Push-Location $InstallDir
@@ -3486,13 +3494,9 @@ function Install-NodeDeps {
                     # _Run-NpmInstall above for the same pattern and
                     # the rationale behind 2>&1 before the pipe.
                     Write-Info "(this can take several minutes -- streaming progress below)"
-                    # --yes auto-accepts npx's "Need to install playwright@X.Y.Z"
-                    # confirmation prompt.  Without it, npx 7+ blocks on stdin
-                    # waiting for a y/N answer that never comes when this is
-                    # invoked through a pipeline (Tee-Object disconnects stdin
-                    # from the user's TTY), and the install hangs indefinitely
-                    # after printing "Need to install the following packages:
-                    # playwright@X.Y.Z".
+                    # --no-install is intentional: a missing local Playwright
+                    # must fail visibly rather than trigger an implicit latest
+                    # download through npx.
                     #
                     # Relax EAP around the playwright invocation: playwright
                     # emits a "Chromium downloaded to ..." success banner to
@@ -3510,7 +3514,7 @@ function Install-NodeDeps {
                     # the same 600s guard via run_playwright_install since
                     # #39219.
                     $ErrorActionPreference = "Continue"
-                    $pwCode = _Invoke-NativeWithTimeout $npxExe "--yes playwright install chromium" `
+                    $pwCode = _Invoke-NativeWithTimeout $npxExe "--no-install playwright install chromium" `
                         $InstallDir $pwLog $nodeDepsTimeoutSec
                     $ErrorActionPreference = $prevEAP
                     if ($pwCode -eq 0) {
@@ -3521,7 +3525,7 @@ function Install-NodeDeps {
                         Write-Warn "This usually means a stalled download or a wedged archive extraction (a locked previous browser version can also cause it)."
                         Write-Warn "Browser tools will not work until Chromium is installed."
                         if (Test-Path $pwLog) { Write-Info "  Partial log: $pwLog" }
-                        Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+                        Write-Info "Run manually later: cd `"$InstallDir`"; npx --no-install playwright install chromium"
                     } else {
                         Write-Warn "Playwright Chromium install failed -- exit code $pwCode"
                         Write-Warn "Browser tools will not work until Chromium is installed."
@@ -3536,12 +3540,12 @@ function Install-NodeDeps {
                                 Write-Info "  Full log: $pwLog"
                             }
                         }
-                        Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+                        Write-Info "Run manually later: cd `"$InstallDir`"; npx --no-install playwright install chromium"
                     }
                 } catch {
                     if ($prevEAP) { $ErrorActionPreference = $prevEAP }
                     Write-Warn "Playwright Chromium install could not be launched: $_"
-                    Write-Info "Run manually later: cd `"$InstallDir`"; npx playwright install chromium"
+                    Write-Info "Run manually later: cd `"$InstallDir`"; npx --no-install playwright install chromium"
                 } finally {
                     Pop-Location
                 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -489,7 +489,13 @@ configure_managed_node_npm_prefix() {
     local link_dir
     link_dir="$(get_command_link_dir)"
     mkdir -p "$HERMES_HOME/node/etc"
-    printf 'prefix=%s\n' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"
+    cat > "$HERMES_HOME/node/etc/npmrc" <<EOF
+prefix=$(dirname "$link_dir")
+package-lock=true
+save-exact=true
+audit=true
+min-release-age=14
+EOF
 }
 
 get_hermes_command_path() {
@@ -2240,7 +2246,7 @@ playwright_fallback_platform() {
 # An operator-provided PLAYWRIGHT_HOST_PLATFORM_OVERRIDE is always respected:
 # it is inherited by the first attempt, and the retry is skipped.
 #
-# Usage: run_playwright_install <timeout_seconds> npx playwright install [args...]
+# Usage: run_playwright_install <timeout_seconds> npx --no-install playwright install [args...]
 run_playwright_install() {
     local timeout_seconds="$1"
     shift
@@ -2350,9 +2356,9 @@ install_node_deps() {
         if [ "$SKIP_BROWSER" = true ]; then
             log_info "Skipping Playwright/Chromium install (--skip-browser)"
             log_info "Browser tools will be unavailable until you run manually:"
-            log_info "  cd $INSTALL_DIR && npx playwright install chromium"
+            log_info "  cd $INSTALL_DIR && npx --no-install playwright install chromium"
             log_info "On apt-based systems, an admin also needs to run:"
-            log_info "  sudo npx playwright install-deps chromium"
+            log_info "  sudo npx --no-install playwright install-deps chromium"
         else
         log_info "Installing browser engine (Playwright Chromium)..."
         strip_snap_browser_override
@@ -2372,19 +2378,19 @@ install_node_deps() {
                     # exact command the admin needs to run separately.
                     if [ "$(id -u)" -eq 0 ] || (command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null); then
                         log_info "Installing Playwright Chromium with system dependencies..."
-                        cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install --with-deps chromium || {
+                        cd "$INSTALL_DIR" && run_playwright_install 600 npx --no-install playwright install --with-deps chromium || {
                             log_warn "Playwright browser installation failed — browser tools will not work."
-                            log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install --with-deps chromium"
+                            log_warn "Try running manually: cd $INSTALL_DIR && npx --no-install playwright install --with-deps chromium"
                         }
                     else
                         log_warn "No sudo available — skipping system-library install (--with-deps)."
                         log_info "Ask an administrator to run, one time, as root:"
-                        log_info "  sudo npx playwright install-deps chromium"
+                        log_info "  sudo npx --no-install playwright install-deps chromium"
                         log_info "  (from $INSTALL_DIR, after Node.js deps are installed)"
                         log_info "Installing Chromium binary into this user's Playwright cache..."
-                        cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
+                        cd "$INSTALL_DIR" && run_playwright_install 600 npx --no-install playwright install chromium || {
                             log_warn "Playwright browser installation failed — browser tools will not work."
-                            log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install chromium"
+                            log_warn "Try running manually: cd $INSTALL_DIR && npx --no-install playwright install chromium"
                         }
                     fi
                     ;;
@@ -2402,7 +2408,7 @@ install_node_deps() {
                             log_warn "  sudo pacman -S nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib"
                         fi
                     fi
-                    cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
+                    cd "$INSTALL_DIR" && run_playwright_install 600 npx --no-install playwright install chromium || {
                         log_warn "Playwright browser installation failed — browser tools will not work."
                     }
                     ;;
@@ -2410,7 +2416,7 @@ install_node_deps() {
                     log_warn "Playwright does not support automatic dependency installation on RPM-based systems."
                     log_info "Install Chromium system dependencies manually before using browser tools:"
                     log_info "  sudo dnf install nss atk at-spi2-core cups-libs libdrm libxkbcommon mesa-libgbm pango cairo alsa-lib"
-                    cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
+                    cd "$INSTALL_DIR" && run_playwright_install 600 npx --no-install playwright install chromium || {
                         log_warn "Playwright browser installation failed — install dependencies above and retry."
                     }
                     ;;
@@ -2418,16 +2424,16 @@ install_node_deps() {
                     log_warn "Playwright does not support automatic dependency installation on zypper-based systems."
                     log_info "Install Chromium system dependencies manually before using browser tools:"
                     log_info "  sudo zypper install mozilla-nss libatk-1_0-0 at-spi2-core cups-libs libdrm2 libxkbcommon0 Mesa-libgbm1 pango cairo libasound2"
-                    cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || {
+                    cd "$INSTALL_DIR" && run_playwright_install 600 npx --no-install playwright install chromium || {
                         log_warn "Playwright browser installation failed — install dependencies above and retry."
                     }
                     ;;
                 *)
                     log_warn "Playwright does not support automatic dependency installation on $DISTRO."
                     log_info "Install Chromium/browser system dependencies for your distribution, then run:"
-                    log_info "  cd $INSTALL_DIR && npx playwright install chromium"
+                    log_info "  cd $INSTALL_DIR && npx --no-install playwright install chromium"
                     log_info "Browser tools will not work until dependencies are installed."
-                    cd "$INSTALL_DIR" && run_playwright_install 600 npx playwright install chromium || true
+                    cd "$INSTALL_DIR" && run_playwright_install 600 npx --no-install playwright install chromium || true
                     ;;
             esac
         fi
@@ -2869,7 +2875,7 @@ ensure_browser() {
     # Time-boxed (#39219): a stalled npm registry fetch here would otherwise
     # hang the installer with no progress, same class as the desktop build.
     if ! run_with_timeout "$NODE_DEPS_TIMEOUT" "$npm_bin" install -g --prefix "$HERMES_HOME/node" --silent --ignore-scripts \
-        "@askjo/camofox-browser@^1.5.2" \
+        "@askjo/camofox-browser@1.5.2" \
         >"$log_file" 2>&1; then
         log_error "npm install failed or timed out:"
         cat "$log_file" >&2

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -67,7 +67,13 @@ _nb_configure_npm_prefix() {
     local _link_dir
     _link_dir="$(_nb_get_link_dir)"
     mkdir -p "$HERMES_HOME/node/etc"
-    printf 'prefix=%s\n' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"
+    cat > "$HERMES_HOME/node/etc/npmrc" <<EOF
+prefix=$(dirname "$_link_dir")
+package-lock=true
+save-exact=true
+audit=true
+min-release-age=14
+EOF
 }
 
 _nb_node_major() {

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -80,7 +80,8 @@ def test_main_setup_offers_browser_install_when_tty(monkeypatch):
 
 def test_main_setup_browser_propagates_browser_failure(monkeypatch):
     """If browser install fails, exit code is 1."""
-    def fake_ensure(dep, interactive=True):
+    def fake_ensure(dep, interactive=True, *, explicit=False):
+        assert explicit is True
         return dep != "browser"  # browser fails
 
     monkeypatch.setattr("hermes_cli.dep_ensure.ensure_dependency", fake_ensure)

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -20,6 +20,19 @@ def test_find_install_script_from_checkout(tmp_path):
     assert shell == "bash"
 
 
+def test_browser_lazy_install_fails_closed_without_tty():
+    """A gateway must not start an implicit browser npm install."""
+    from hermes_cli.dep_ensure import ensure_dependency
+
+    with patch("hermes_cli.dep_ensure._DEP_CHECKS", {"browser": lambda: False}), \
+         patch("hermes_cli.dep_ensure._find_install_script") as find_script, \
+         patch("sys.stdin") as mock_stdin:
+        mock_stdin.isatty.return_value = False
+
+        assert ensure_dependency("browser", interactive=True) is False
+        find_script.assert_not_called()
+
+
 
 
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -361,7 +361,7 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
     assert "Install Node.js on Termux with: pkg install nodejs" in out
     assert "Termux browser setup:" in out
     assert "1) pkg install nodejs" in out
-    assert "2) npm install -g agent-browser" in out
+    assert "2) npm install -g --ignore-scripts agent-browser@0.27.0" in out
     assert "3) agent-browser install" in out
     assert "Termux compatibility fallbacks:" in out
     assert "use .[termux-all] for broad compatibility" in out
@@ -737,7 +737,7 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "browser" in out
     assert "system dependency not met" in out
     assert "agent-browser is not installed (expected in the tested Termux path)" in out
-    assert "npm install -g agent-browser && agent-browser install" in out
+    assert "npm install -g --ignore-scripts agent-browser@0.27.0 && agent-browser install" in out
 
 
 def _doctor_env_for_agent_browser(monkeypatch, tmp_path):

--- a/tests/test_install_ps1_browser_install.py
+++ b/tests/test_install_ps1_browser_install.py
@@ -33,7 +33,7 @@ def test_install_agent_browser_no_longer_npm_installs_agent_browser() -> None:
     assert "agent-browser@" not in body
     assert "Installing Chromium via agent-browser install" not in body
     # camofox is unrelated to this change and must still be installed here.
-    assert "@askjo/camofox-browser@^1.5.2" in body
+    assert "@askjo/camofox-browser@1.5.2" in body
     # System-browser detection is still cheap/valuable without agent-browser.
     assert "Find-SystemBrowser" in body
     assert "Write-BrowserEnv" in body

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -34,12 +34,12 @@ def test_playwright_installs_are_timeout_guarded() -> None:
     # Playwright installs now go through run_playwright_install(), which wraps
     # run_browser_install_with_timeout (timeout-guarded) and adds an
     # unrecognized-platform fallback retry.
-    assert "run_playwright_install 600 npx playwright install chromium" in text
+    assert "run_playwright_install 600 npx --no-install playwright install chromium" in text
     # --with-deps is still invoked on apt-based systems, but only when sudo
     # is available non-interactively (root or passwordless sudo). Non-sudo
     # service users fall back to the browser-only install — see
     # install_node_deps() in install.sh.
-    assert "run_playwright_install 600 npx playwright install --with-deps chromium" in text
+    assert "run_playwright_install 600 npx --no-install playwright install --with-deps chromium" in text
     # The wrapper still bounds the download with the timeout helper.
     assert 'run_browser_install_with_timeout "$timeout_seconds" "$@"' in text
 
@@ -148,7 +148,7 @@ npx() {{
 
 {body}
 
-run_playwright_install 600 npx playwright install --with-deps chromium
+run_playwright_install 600 npx --no-install playwright install --with-deps chromium
 echo "FINAL_RC=$?"
 """
     import tempfile, os
@@ -218,7 +218,7 @@ def test_ensure_browser_no_longer_npm_installs_agent_browser() -> None:
     assert "agent-browser@" not in body
     assert "Installing Chromium via agent-browser install" not in body
     # camofox is unrelated to this change and must still be installed here.
-    assert "@askjo/camofox-browser@^1.5.2" in body
+    assert "@askjo/camofox-browser@1.5.2" in body
     # System-browser detection is still cheap/valuable without agent-browser.
     assert "find_system_browser" in body
     assert "configure_browser_env_from_system_browser" in body
@@ -242,7 +242,6 @@ def test_ensure_browser_no_longer_references_agent_browser_binary_path() -> None
     body = _extract_function_body(INSTALL_SH.read_text(), "ensure_browser")
 
     assert "$HERMES_HOME/node/bin/agent-browser" not in body
-
 
 
 

--- a/tests/test_install_sh_node_global_prefix.py
+++ b/tests/test_install_sh_node_global_prefix.py
@@ -26,7 +26,11 @@ def test_install_sh_redirects_bundled_npm_global_prefix_to_link_dir() -> None:
     # <parent>/bin == the command link dir (node/npm/npx live there and it is
     # guaranteed on PATH by the installer's PATH setup).
     assert "configure_managed_node_npm_prefix()" in text
-    assert 'printf \'prefix=%s\\n\' "$(dirname "$link_dir")" > "$HERMES_HOME/node/etc/npmrc"' in text
+    assert 'prefix=$(dirname "$link_dir")' in text
+    assert "package-lock=true" in text
+    assert "save-exact=true" in text
+    assert "audit=true" in text
+    assert "min-release-age=14" in text
 
 
 def test_install_sh_repairs_existing_managed_node_on_rerun() -> None:
@@ -46,7 +50,11 @@ def test_node_bootstrap_redirects_bundled_npm_global_prefix_to_link_dir() -> Non
     text = NODE_BOOTSTRAP.read_text()
 
     assert "_nb_configure_npm_prefix()" in text
-    assert 'printf \'prefix=%s\\n\' "$(dirname "$_link_dir")" > "$HERMES_HOME/node/etc/npmrc"' in text
+    assert 'prefix=$(dirname "$_link_dir")' in text
+    assert "package-lock=true" in text
+    assert "save-exact=true" in text
+    assert "audit=true" in text
+    assert "min-release-age=14" in text
 
     # Runs at the top of ensure_node so existing managed installs are repaired
     # even when a modern Node is already present (early return path).

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -78,6 +78,12 @@ from hermes_cli.config import DEFAULT_CONFIG, cfg_get
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 
+# Keep the browser CLI on the exact version shipped by Hermes. A bare npx
+# fallback must never turn a missing local install into an implicit download
+# of whatever happens to be latest in the public registry.
+_AGENT_BROWSER_VERSION = "0.27.0"
+
+
 def __getattr__(name: str):
     """Lazy module attributes (PEP 562) — import diet for cold start.
 
@@ -418,7 +424,7 @@ def _format_browser_timeout_error(
         hints.append(
             "Chromium sandbox launch failed. Set AGENT_BROWSER_ARGS="
             "'--no-sandbox,--disable-dev-shm-usage' in your environment, "
-            "or run: npx agent-browser install --with-deps"
+            "or run: agent-browser install --with-deps after installing the pinned package"
         )
     elif command == "open" and _is_local_mode():
         if _running_in_docker():
@@ -431,8 +437,8 @@ def _format_browser_timeout_error(
             hints.append(
                 "The browser daemon may still be starting, or Chromium may be "
                 "missing system libraries. Install/repair with: "
-                "npx agent-browser install --with-deps "
-                "(or: npx playwright install --with-deps chromium)"
+                "agent-browser install --with-deps after installing the pinned package "
+                "(or: npx --no-install playwright install --with-deps chromium)"
             )
     if hints:
         parts.extend(hints)
@@ -912,9 +918,10 @@ from hermes_constants import is_termux as _is_termux_environment
 
 
 def _browser_install_hint() -> str:
+    install = f"npm install -g --ignore-scripts agent-browser@{_AGENT_BROWSER_VERSION}"
     if _is_termux_environment():
-        return "npm install -g agent-browser && agent-browser install"
-    return "npm install -g agent-browser && agent-browser install --with-deps"
+        return f"{install} && agent-browser install"
+    return f"{install} && agent-browser install --with-deps"
 
 
 # Sentinel _find_agent_browser returns/caches to mean "resolve via npx" rather
@@ -925,10 +932,10 @@ def _browser_install_hint() -> str:
 NPX_AGENT_BROWSER_SENTINEL = "npx agent-browser"
 
 # Pinned to match scripts/install.sh / scripts/install.ps1's
-# "agent-browser@^0.26.0" managed install so a git-clone install resolving
+# "agent-browser@0.27.0" managed install so a git-clone install resolving
 # agent-browser via bare npx gets the same version as a managed install,
 # instead of floating latest with no integrity check. Update both together.
-AGENT_BROWSER_NPX_SPEC = "agent-browser@^0.26.0"
+AGENT_BROWSER_NPX_SPEC = "agent-browser@0.27.0"
 
 
 def _is_npx_agent_browser_sentinel(browser_cmd: str) -> bool:
@@ -1235,24 +1242,17 @@ def _run_chrome_fallback_command(
         else:
             hint = (
                 "Chrome fallback requires Chromium, but it is missing. Install it with: "
-                "npx agent-browser install --with-deps "
-                "(or: npx playwright install --with-deps chromium)"
+                "agent-browser install --with-deps after installing the pinned package "
+                "(or: npx --no-install playwright install --with-deps chromium)"
             )
         return {"success": False, "error": hint}
 
-    # Resolve npx via the same PATH + extended-PATH cascade _find_agent_browser
-    # uses, not a bare shutil.which("npx") — Hermes-managed-Node-only setups
-    # resolve npx only through the extended fallback path, and a bare lookup
-    # would let a broken system npx shadow a healthy managed one. If npx isn't
-    # found at all (Termux, bare container), fall back to the bare name and
-    # let Popen raise with a readable "FileNotFoundError: 'npx'" rather than
-    # WinError 193.
     if _is_npx_agent_browser_sentinel(browser_cmd):
         _npx_bin = _resolve_npx_bin() or "npx"
-        # --ignore-scripts: AGENT_BROWSER_NPX_SPEC is a floating ^0.26.0 range,
-        # not an exact pin — a compromised future 0.26.x patch must not get to
-        # run its own install-time lifecycle scripts on this machine.
-        cmd_prefix = [_npx_bin, "--ignore-scripts", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC]
+        # --no-install: only the already-installed pinned agent-browser
+        # (AGENT_BROWSER_NPX_SPEC) may be invoked; npx must never fetch
+        # anything from the registry here. A missing install fails closed.
+        cmd_prefix = [_npx_bin, "--no-install", "agent-browser"]
     else:
         cmd_prefix = [browser_cmd]
     base_args = cmd_prefix + ["--engine", "chrome", "--session", tmp_session, "--json"]
@@ -2722,17 +2722,11 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
 
     cmd = [
         npx_bin,
-        # --ignore-scripts: AGENT_BROWSER_NPX_SPEC is a floating ^0.26.0
-        # range, not an exact pin — a compromised future 0.26.x patch must
-        # not get to run its own install-time lifecycle scripts here.
-        "--ignore-scripts",
-        # --prefer-offline: once cached, repeat `hermes update`/`doctor
-        # --fix` runs shouldn't hit the registry just to re-confirm
-        # "latest" is still latest — that would defeat the point of
-        # warming the cache in the first place.
-        "--prefer-offline",
-        "-y",
-        AGENT_BROWSER_NPX_SPEC,
+        # --no-install: only verify the already-installed pinned agent-browser
+        # (AGENT_BROWSER_NPX_SPEC). Never download anything from the registry;
+        # a missing local install fails the warm check closed.
+        "--no-install",
+        "agent-browser",
         "--version",
     ]
     try:
@@ -2832,8 +2826,8 @@ def _run_browser_command(
         else:
             hint = (
                 "Chromium browser is missing. Install it with: "
-                "npx agent-browser install --with-deps "
-                "(or: npx playwright install --with-deps chromium)"
+                "agent-browser install --with-deps after installing the pinned package "
+                "(or: npx --no-install playwright install --with-deps chromium)"
             )
         logger.warning("browser command blocked: %s", hint)
         return {"success": False, "error": hint}
@@ -2879,8 +2873,8 @@ def _run_browser_command(
     # shutil.which("npx") is wrong here).
     if _is_npx_agent_browser_sentinel(browser_cmd):
         _npx_bin = _resolve_npx_bin() or "npx"
-        # --ignore-scripts: see _run_chrome_fallback_command's identical comment.
-        cmd_prefix = [_npx_bin, "--ignore-scripts", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC]
+        # --no-install: see _run_chrome_fallback_command's identical comment.
+        cmd_prefix = [_npx_bin, "--no-install", "agent-browser"]
     else:
         cmd_prefix = [browser_cmd]
 
@@ -5226,7 +5220,7 @@ def _maybe_autoinstall_chromium() -> bool:
 
     if _is_npx_agent_browser_sentinel(browser_cmd):
         install_cmd = [
-            _resolve_npx_bin() or "npx", "--ignore-scripts", "-y", AGENT_BROWSER_NPX_SPEC, "install",
+            _resolve_npx_bin() or "npx", "--no-install", "agent-browser", "install",
         ]
     else:
         install_cmd = [browser_cmd, "install"]
@@ -5395,8 +5389,8 @@ if __name__ == "__main__":
                     print("       docker pull ghcr.io/nousresearch/hermes-agent:latest")
                 else:
                     print("     Install it with:")
-                    print("       npx agent-browser install --with-deps")
-                    print("     Or:  npx playwright install --with-deps chromium")
+                    print("       agent-browser install --with-deps (after installing the pinned package)")
+                    print("     Or:  npx --no-install playwright install --with-deps chromium")
         except FileNotFoundError:
             print("   - agent-browser CLI not found")
             print(f"     Install: {_browser_install_hint()}")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -594,7 +594,7 @@ IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.ico'}
 LINTERS = {
     '.py': 'python -m py_compile {file} 2>&1',
     '.js': 'node --check {file} 2>&1',
-    '.ts': 'npx tsc --noEmit {file} 2>&1',
+    '.ts': 'npx --no-install tsc --noEmit {file} 2>&1',
     '.go': 'go vet {file} 2>&1',
     '.rs': 'rustfmt --check {file} 2>&1',
 }
@@ -639,7 +639,7 @@ _SHELL_LINTER_LSP_REDUNDANT = frozenset({'.ts', '.go', '.rs'})
 
 
 # Patterns that indicate the linter base command exists on PATH but
-# couldn't actually run — e.g. ``npx tsc`` when tsc isn't installed in
+# couldn't actually run — e.g. ``npx --no-install tsc`` when tsc isn't installed in
 # node_modules, or rustfmt complaining there's no Cargo project.  When
 # any of these substrings appears in the linter output, ``_check_lint``
 # returns ``skipped`` instead of ``error`` so:
@@ -2456,7 +2456,7 @@ class ShellFileOperations(FileOperations):
 
         if result.exit_code != 0 and _looks_like_linter_unusable(base_cmd, result.stdout):
             # The linter command exists on PATH but couldn't actually run
-            # (e.g. ``npx tsc`` when tsc isn't in node_modules; ``rustfmt
+            # (e.g. ``npx --no-install tsc`` when tsc isn't in node_modules; ``rustfmt
             # --check`` without a Cargo project).  This is a tooling gap,
             # not a real lint failure — surface it as ``skipped`` so the
             # write doesn't get flagged AND so the LSP tier still runs.


### PR DESCRIPTION
## Purpose

A missing local browser CLI must never turn into an implicit `npx` download of whatever happens to be latest in the public registry. When Hermes runs as a non-interactive gateway there is nobody to answer npx's prompt, and a bare `npx -y agent-browser`/`playwright` fetch bypasses the pinned, reviewed install path. This PR makes every browser tool/installer path fail closed instead: exact version pins for the managed browser CLIs, `npx --no-install` everywhere a local package is expected, and a non-TTY browser dependency refusal in `dep_ensure`.

## Changes (17 files)

- `tools/browser_tool.py`: `AGENT_BROWSER_NPX_SPEC` pinned `agent-browser@^0.26.0` -> `agent-browser@0.27.0`; `npx -y --ignore-scripts --prefer-offline` invocations replaced with `npx --no-install agent-browser` (command run, warm-cache, chromium auto-install); install/repair hint text now references the pinned package.
- `tools/file_operations.py`: `.ts` linter uses `npx --no-install tsc`.
- `hermes_cli/dep_ensure.py` + `acp_adapter/entry.py`: `ensure_dependency(..., explicit=True)`; for the `browser` dep an implicit (non-TTY) install is refused with a pointer to the explicit setup command.
- `hermes_cli/doctor.py`, `hermes_cli/setup.py`, `hermes_cli/tools_config.py`: pinned install instructions (`--ignore-scripts agent-browser@0.27.0`), `npx --no-install playwright`, post-setup chromium path no longer fetches via bare npx.
- `scripts/install.sh`, `scripts/install.ps1`: `@askjo/camofox-browser@^1.5.2` -> exact `1.5.2`; all `npx playwright ...` invocations -> `npx --no-install playwright ...`; managed-node `npmrc` (install.sh `configure_managed_node_npm_prefix`, `node-bootstrap.sh`, install.ps1 `Install-AgentBrowser`) now writes `package-lock=true`, `save-exact=true`, `audit=true` alongside the existing `min-release-age`.
- `Dockerfile`: `npx --no-install playwright install --only-shell`.
- Tests updated/added: dep_ensure non-TTY fail-closed test, doctor termux/install hint assertions, install script text regressions.

## Tests

pytest is not installed in this environment and installs are prohibited, so verification used the repo's python 3.11 venv with a minimal harness executing the real test functions (pytest-compatible monkeypatch/tmp_path/parametrize):
- dep_ensure 6, doctor 18 (3 parametrized sets), acp/entry 4, install-script text tests 9 -> **51 OK / 2 platform-skip (linux_only/windows_only) / 0 fail**
- Directly changed tests all pass: `test_browser_lazy_install_fails_closed_without_tty`, `test_main_setup_browser_propagates_browser_failure`, both `test_run_doctor_termux_*`
- `py_compile` on all changed .py files and `bash -n` on install.sh / node-bootstrap.sh: clean

## Boundaries

- `npx --no-install` is only used where the package is expected to already exist locally (installers run `npm install` first; browser_tool/server run inside a Hermes install whose managed path installs agent-browser). A truly missing package now fails visibly with a pinned install instruction instead of silently fetching latest.
- No config keys, no env vars, no behavior changes for TTY/interactive setups (explicit setup commands still install normally).
- Browser pins match the currently shipped managed versions; `_AGENT_BROWSER_VERSION` notes they must be updated together with the installers.

## Duplicate check

- Upstream merged code contains no equivalent (base still floats `agent-browser@^0.26.0` via bare npx).
- Related PRs #89618 and #83608 (same area) are CLOSED without merge — no overlap with merged work.

Note: change extracted from a dirty local index into an isolated worktree based on current upstream main (f293e720); original local working tree untouched (hash-verified).