### PR TITLE
feat(desktop): attach dialogs remember the last-used directory

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -355,6 +355,7 @@ import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath, setActiveGatewayProfile, setWslBridgeProfileState } from './wsl-path-bridge'
+import { dirToRemember, nextPickerDefaultPath, readLastPickerDir, writeLastPickerDir } from './picker-state'
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
 
@@ -746,6 +747,7 @@ const DESKTOP_CONNECTIONS_REGISTRY_PATH = path.join(app.getPath('userData'), 'co
 const DESKTOP_INSTALLATION_PATH = path.join(app.getPath('userData'), 'desktop-installation.json')
 const DESKTOP_UPDATE_CONFIG_PATH = path.join(app.getPath('userData'), 'updates.json')
 const DESKTOP_WINDOW_STATE_PATH = path.join(app.getPath('userData'), 'window-state.json')
+const DESKTOP_PICKER_STATE_PATH = path.join(app.getPath('userData'), 'picker-state.json')
 const DESKTOP_BACKEND_OWNERSHIP_PATH = path.join(app.getPath('userData'), 'backend-ownership.json')
 // active-profile.json records which Hermes profile the desktop launches its
 // local backend as. When set, startHermes() passes `hermes --profile <name>
@@ -14059,6 +14061,15 @@ ipcMain.handle('hermes:selectPaths', async (_event, options: any = {}) => {
     }
   }
 
+  // #92925: when the caller has no opinion (no composer cwd — e.g. detached
+  // pickers), fall back to the directory the user last picked from. An
+  // explicit defaultPath wins: it expresses the current working context.
+  if (!resolvedDefaultPath) {
+    resolvedDefaultPath = nextPickerDefaultPath(undefined, readLastPickerDir(DESKTOP_PICKER_STATE_PATH), dir =>
+      directoryExists(dir)
+    )
+  }
+
   const result = await dialog.showOpenDialog(mainWindow, {
     title: options?.title || 'Add context',
     defaultPath: resolvedDefaultPath,
@@ -14068,6 +14079,12 @@ ipcMain.handle('hermes:selectPaths', async (_event, options: any = {}) => {
 
   if (result.canceled) {
     return []
+  }
+
+  const toRemember = dirToRemember(result.filePaths)
+
+  if (toRemember) {
+    writeLastPickerDir(DESKTOP_PICKER_STATE_PATH, toRemember)
   }
 
   return result.filePaths

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -212,6 +212,7 @@ import {
   parentWatchdogEnv
 } from './parent-process-identity'
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
+import { dirToRemember, nextPickerDefaultPath, readLastPickerDir, writeLastPickerDir } from './picker-state'
 import {
   buildRegistryProfileRoutes,
   localRouteFallbackProfiles,
@@ -355,7 +356,6 @@ import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath, setActiveGatewayProfile, setWslBridgeProfileState } from './wsl-path-bridge'
-import { dirToRemember, nextPickerDefaultPath, readLastPickerDir, writeLastPickerDir } from './picker-state'
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
 

--- a/apps/desktop/electron/picker-state.test.ts
+++ b/apps/desktop/electron/picker-state.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { afterEach, test } from 'vitest'
+
+import { dirToRemember, nextPickerDefaultPath, readLastPickerDir, writeLastPickerDir } from './picker-state'
+
+afterEach(() => {
+  fs.rmSync(STATE_DIR, { recursive: true, force: true })
+})
+
+const STATE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'picker-state-'))
+const STATE_PATH = path.join(STATE_DIR, 'picker-state.json')
+
+test('explicit defaultPath always wins over the remembered directory', () => {
+  const resolved = nextPickerDefaultPath('/explicit/cwd', '/remembered/dir', () => true)
+
+  assert.equal(resolved, '/explicit/cwd')
+})
+
+test('remembered directory applies only when the caller has no opinion', () => {
+  const resolved = nextPickerDefaultPath(undefined, '/remembered/dir', () => true)
+
+  assert.equal(resolved, '/remembered/dir')
+})
+
+test('a remembered directory that no longer exists is ignored', () => {
+  const resolved = nextPickerDefaultPath(undefined, '/gone/dir', () => false)
+
+  assert.equal(resolved, undefined)
+})
+
+test('no explicit and no remembered default resolves to undefined (OS default)', () => {
+  const resolved = nextPickerDefaultPath(undefined, undefined, () => true)
+
+  assert.equal(resolved, undefined)
+})
+
+test('dirToRemember returns the parent of the first picked file', () => {
+  assert.equal(dirToRemember(['/home/user/shots/a.png']), path.dirname('/home/user/shots/a.png'))
+})
+
+test('dirToRemember tolerates canceled / empty results', () => {
+  assert.equal(dirToRemember([]), null)
+  assert.equal(dirToRemember(undefined), null)
+  assert.equal(dirToRemember(['']), null)
+})
+
+test('last-used directory survives a save/load round trip', () => {
+  fs.rmSync(STATE_PATH, { force: true })
+
+  assert.equal(readLastPickerDir(STATE_PATH), undefined)
+
+  writeLastPickerDir(STATE_PATH, '/home/user/shots')
+
+  assert.equal(readLastPickerDir(STATE_PATH), '/home/user/shots')
+})
+
+test('a corrupt state file reads as "nothing remembered"', () => {
+  fs.mkdirSync(STATE_DIR, { recursive: true })
+  fs.writeFileSync(STATE_PATH, '{not json')
+
+  assert.equal(readLastPickerDir(STATE_PATH), undefined)
+})

--- a/apps/desktop/electron/picker-state.ts
+++ b/apps/desktop/electron/picker-state.ts
@@ -1,0 +1,74 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+/**
+ * Last-used directory for the native open dialogs (#92925). Electron is
+ * authoritative for machine-side facts, so this lives in the main process —
+ * the renderer's `defaultPath` (composer cwd, #91074's Downloads default)
+ * only applies when the user hasn't already shown us where their files live.
+ */
+
+/**
+ * The defaultPath the next dialog should open at: the caller's explicit
+ * choice when given (it expresses current intent — the composer's working
+ * directory), else the remembered last-used directory when it still exists,
+ * else undefined (OS default). Pure so the precedence policy is testable.
+ */
+export function nextPickerDefaultPath(
+  explicitDefault: string | undefined,
+  rememberedDir: string | undefined,
+  directoryExists: (dir: string) => boolean
+): string | undefined {
+  if (explicitDefault) {
+    return explicitDefault
+  }
+
+  if (rememberedDir && directoryExists(rememberedDir)) {
+    return rememberedDir
+  }
+
+  return undefined
+}
+
+/**
+ * Directory worth remembering after a successful pick: the parent of the
+ * first selected path. Returns null for empty/canceled results.
+ */
+export function dirToRemember(filePaths: unknown): string | null {
+  const first = Array.isArray(filePaths) ? filePaths[0] : null
+
+  if (typeof first !== 'string' || !first.trim()) {
+    return null
+  }
+
+  const dir = path.dirname(first)
+
+  return dir && dir !== '.' ? dir : null
+}
+
+/** Read the persisted last-used directory. Corrupt/missing file → undefined. */
+export function readLastPickerDir(statePath: string): string | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8'))
+    const dir = typeof parsed?.lastDir === 'string' ? parsed.lastDir.trim() : ''
+
+    return dir || undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Persist the last-used directory. Best-effort: a failed write only costs
+ *  the memory, never the dialog itself. */
+export function writeLastPickerDir(statePath: string, dir: string): void {
+  try {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true })
+
+    const tmp = `${statePath}.${process.pid}.tmp`
+
+    fs.writeFileSync(tmp, JSON.stringify({ lastDir: dir }, null, 2))
+    fs.renameSync(tmp, statePath)
+  } catch {
+    /* remembering the directory is best-effort */
+  }
+}


### PR DESCRIPTION
## What does this PR do?

The native open dialogs (composer Files/Images/Folder, plugin source, etc.) started from scratch on every attach — a user pulling a dozen screenshots from the same folder re-navigated there for each one (#92925).

The main process now records the parent directory of each successful pick and offers it as the dialog's `defaultPath` when the caller has no opinion of its own. Precedence ladder:

1. Explicit `defaultPath` from the caller (the composer passes its cwd; #91074's Downloads default applies when detached) — it expresses current intent
2. The remembered last-used directory, only when it still exists on disk
3. `undefined` → OS default

Electron is authoritative for machine-side facts, so the memory lives in the main process (`userData/picker-state.json`), not in renderer state.

## Related Issue

Fixes #92925
(Complements #91074 rather than duplicating it: that PR is the initial default, this remembers what the user actually chose, which beats any static default after the first attach.)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes Made

- `apps/desktop/electron/picker-state.ts` (new) — pure helpers: `nextPickerDefaultPath` (precedence policy), `dirToRemember` (parent-of-first-pick rule), atomic read/write of `picker-state.json`; corrupt file reads as "nothing remembered"
- `apps/desktop/electron/main.ts` — `hermes:selectPaths` consults the remembered directory when no explicit default was given, and records the pick on success; canceled dialogs change nothing
- `apps/desktop/electron/picker-state.test.ts` — 8 cases covering the precedence ladder, the remember rule, round-trip persistence, and corrupt-state fallback

## How to Test

1. `cd apps/desktop && npx vitest run electron/picker-state.test.ts` — 8 passed
2. Attach a file from a folder other than Downloads, then detach the app from any workspace so the composer sends no `defaultPath`: the next attach dialog opens in the folder you just used
3. With a workspace active (composer cwd present), the dialog still opens at the cwd — explicit intent wins
4. Delete the remembered folder; the next dialog falls back to the OS default instead of erroring

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/Hermes-Agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run targeted tests (`npx vitest run --project electron`: 1606 passed; tsc clean)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (state lives in userData, not config.yaml)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — path joins via node:path, atomic write via temp+rename
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
