### PR TITLE
fix(gateway): ws-orphan reaper leaves the canonical Bot Chat resumable

### DIFF
--- a/tests/tui_gateway/test_canonical_bot_chat_reap.py
+++ b/tests/tui_gateway/test_canonical_bot_chat_reap.py
@@ -1,0 +1,114 @@
+"""Tests for #92687: the ws-orphan reaper must not end the canonical Bot Chat.
+
+Bot Mode's forever-chat is identified by ``(profile_name,
+title='Bot Chat')``, not by stored session ids. When the desktop's WS drops
+for the reap grace window, ``_finalize_session(end_reason='ws_orphan_reap')``
+used to end that row — archiving it out from under every future open. The
+plugin's recreate then collides with the global title UNIQUE index and forks
+throwaway auto-titled sessions, so the bot appears to have "lost its memory".
+
+The fix: an *accidental* end reason (ws_orphan_reap) hitting a canonical Bot
+Chat row skips only the DB end-write; explicit user boundaries still end it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from tui_gateway.server import (
+    _finalize_session,
+    _is_canonical_bot_chat_row,
+)
+
+
+def _make_session(session_id="sess_1"):
+    agent = MagicMock()
+    agent.session_id = session_id
+    return {
+        "agent": agent,
+        "history": [{"role": "user", "content": "x"}],
+        "history_lock": None,
+        "session_key": session_id,
+    }
+
+
+def _canonical_row(**overrides):
+    row = {"id": "sess_1", "source": "desktop", "profile_name": "default",
+           "title": "Bot Chat"}
+    row.update(overrides)
+    return row
+
+
+class TestIsCanonicalBotChatRow:
+    def test_matches_profile_scoped_title(self):
+        assert _is_canonical_bot_chat_row(_canonical_row()) is True
+
+    def test_requires_a_profile(self):
+        assert _is_canonical_bot_chat_row(_canonical_row(profile_name="")) is False
+        assert _is_canonical_bot_chat_row(_canonical_row(profile_name=None)) is False
+
+    def test_title_match_is_exact(self):
+        assert _is_canonical_bot_chat_row(_canonical_row(title="Bot Chat #2")) is False
+        assert _is_canonical_bot_chat_row(_canonical_row(title="bot chat")) is False
+
+    def test_none_and_empty_rows_are_not(self):
+        assert _is_canonical_bot_chat_row(None) is False
+        assert _is_canonical_bot_chat_row({}) is False
+
+
+class TestFinalizeSkipsAccidentalReapOfCanonicalBotChat:
+    @patch("tui_gateway.server._get_db")
+    def test_ws_orphan_reap_does_not_end_the_canonical_row(self, mock_get_db):
+        db = MagicMock()
+        db.get_session.return_value = _canonical_row()
+        mock_get_db.return_value = db
+
+        _finalize_session(_make_session(), end_reason="ws_orphan_reap")
+
+        db.end_session.assert_not_called()
+
+    @patch("tui_gateway.server._get_db")
+    def test_explicit_user_close_still_ends_it(self, mock_get_db):
+        """tui_close / session.close are real boundaries — keep ending the
+        row so a deliberately closed Bot Chat doesn't haunt /resume."""
+        db = MagicMock()
+        db.get_session.return_value = _canonical_row()
+        mock_get_db.return_value = db
+
+        _finalize_session(_make_session(), end_reason="tui_close")
+
+        db.end_session.assert_called_once_with("sess_1", "tui_close")
+
+    @patch("tui_gateway.server._get_db")
+    def test_reap_of_an_ordinary_desktop_session_still_ends_it(self, mock_get_db):
+        """Only the canonical title is protected; every other desktop session
+        keeps the pre-existing reap behavior."""
+        db = MagicMock()
+        db.get_session.return_value = _canonical_row(title="Tell me about yourself")
+        mock_get_db.return_value = db
+
+        _finalize_session(_make_session(), end_reason="ws_orphan_reap")
+
+        db.end_session.assert_called_once_with("sess_1", "ws_orphan_reap")
+
+    @patch("tui_gateway.server._get_db")
+    def test_gateway_owned_sessions_keep_their_own_guard(self, mock_get_db):
+        """The #60609 gateway-owner guard must keep working for Bot rows that
+        ride a gateway platform source."""
+        db = MagicMock()
+        db.get_session.return_value = _canonical_row(source="telegram")
+        mock_get_db.return_value = db
+
+        _finalize_session(_make_session(), end_reason="ws_orphan_reap")
+
+        db.end_session.assert_not_called()
+
+    @patch("tui_gateway.server._get_db")
+    def test_missing_row_still_ended_on_reap(self, mock_get_db):
+        """No state.db row → can't be a canonical chat — keep the legacy
+        behavior."""
+        db = MagicMock()
+        db.get_session.return_value = None
+        mock_get_db.return_value = db
+
+        _finalize_session(_make_session(), end_reason="ws_orphan_reap")
+
+        db.end_session.assert_called_once_with("sess_1", "ws_orphan_reap")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -744,6 +744,34 @@ def _is_gateway_owned_source(source: str) -> bool:
         return False
 
 
+# Bot Mode's per-profile forever-chat is identified by this exact title (the
+# hermes-bots desktop plugin resolves canonical identity by
+# ``(profile_name, title='Bot Chat')``, not by stored ids).
+CANONICAL_BOT_CHAT_TITLE = "Bot Chat"
+
+# End reasons that describe an *accidental* transport loss rather than an
+# intentional conversation boundary. ``ws_orphan_reap`` is already treated as
+# recoverable for gateway-peer rows (#60609 family); the same leniency applies
+# to Bot Chats below.
+_ACCIDENTAL_END_REASONS = frozenset({"ws_orphan_reap"})
+
+
+def _is_canonical_bot_chat_row(row: dict | None) -> bool:
+    """True when the state.db row is the per-profile canonical Bot Chat.
+
+    The row's ``profile_name`` scopes the identity; the title match is exact.
+    """
+    if not row:
+        return False
+
+    title = str(row.get("title") or "").strip()
+
+    return bool(
+        str(row.get("profile_name") or "").strip()
+        and title == CANONICAL_BOT_CHAT_TITLE
+    )
+
+
 def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> None:
     """Best-effort finalize hook + memory commit for a session.
 
@@ -840,12 +868,33 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
                     # Ending a gateway session in state.db triggers a Groundhog
                     # Day routing loop: the gateway's #54878 self-heal detects
                     # the stale entry, recovers to the parent session, context
-                    # compression splits back to the reaped child, and the cycle
-                    # repeats on every inbound message.  (#60609)
+                    # compression splits back to the reaped child, and the
+                    # cycle repeats on every inbound message.  (#60609)
                     row = db.get_session(session_id)
                     source = (row or {}).get("source", "")
                     _tui_owns_lifecycle = not _is_gateway_owned_source(source)
-                    if _tui_owns_lifecycle:
+                    if (
+                        _tui_owns_lifecycle
+                        and end_reason in _ACCIDENTAL_END_REASONS
+                        and _is_canonical_bot_chat_row(row)
+                    ):
+                        # Don't END Bot Mode's canonical forever-chat on an
+                        # accidental reap either (#92687): its durable identity
+                        # is (profile_name, title='Bot Chat') — an ended row
+                        # archives it out from under every future open, the
+                        # plugin's recreate then collides with the title UNIQUE
+                        # index and forks throwaway sessions instead. Leave the
+                        # row open so reconnect resume finds it; the in-process
+                        # teardown below proceeds unchanged. An explicit user
+                        # boundary (tui_close, session.close, /new) still ends
+                        # it normally.
+                        logger.info(
+                            "skipping %s end-write for canonical Bot Chat row "
+                            "%s; leaving it open for reconnect resume",
+                            end_reason,
+                            session_id,
+                        )
+                    elif _tui_owns_lifecycle:
                         db.end_session(session_id, end_reason)
         except Exception:
             pass


### PR DESCRIPTION
## What does this PR do?

Bot Mode's forever-chat is identified by `(profile_name, title='Bot Chat')`, not by stored session ids. When the desktop's WebSocket stayed down past `_WS_ORPHAN_REAP_GRACE_S`, `_finalize_session(end_reason='ws_orphan_reap')` ended that durable row — which archives it. On reopen, `findExistingCanonicalChat` located the archived row correctly but the open path rejected it; the plugin's recreate then collided with the global `idx_sessions_title_unique` index and forked throwaway auto-titled sessions (`Tell me about yourself #N`, ...). The bot appeared to have lost its memory, with hundreds of messages of history invisible from every UI path (#92687).

`ws_orphan_reap` is already classified as an *accidental, recoverable* end reason elsewhere in the codebase — `promote_to_session_reset` and `find_latest_gateway_session_for_peer` both treat it as recoverable. This PR extends that same leniency to the canonical Bot Chat at the write site: when an accidental reap reason targets a profile-scoped `Bot Chat` row, only the DB end-write is skipped (with an info log); in-process teardown still runs.

Explicit user boundaries are untouched: `tui_close`, `session.close`, `/new` still end the row normally. Ordinary sessions are unaffected, and the #60609 gateway-owner guard keeps precedence (it runs first).

## Related Issue

Fixes #92687

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`
  - `CANONICAL_BOT_CHAT_TITLE = 'Bot Chat'` + `_is_canonical_bot_chat_row()` — identity check requiring a non-empty `profile_name` and exact title match
  - `_ACCIDENTAL_END_REASONS = {'ws_orphan_reap'}` — the accidental-reason set, kept deliberately narrow
  - In `_finalize_session`: when the TUI owns lifecycle, the end reason is accidental, and the row is a canonical Bot Chat, skip `db.end_session(...)` and log why
- `tests/tui_gateway/test_canonical_bot_chat_reap.py` (new) — mirrors the existing `test_gateway_owned_session_reap.py` conventions

## How to Test

1. `python3 -m pytest tests/tui_gateway/test_canonical_bot_chat_reap.py tests/tui_gateway/test_gateway_owned_session_reap.py -q` → 16 passed
2. Repro of the original bug on main: desktop Bot Chat open → kill WS for at least the reap grace → observe `state.db`: canonical row gets `ended_at`/`end_reason='ws_orphan_reap'`. With this branch the row stays open while teardown still proceeds.
3. Explicit close still works: `session.close` / app quit ends the row as before (covered by test).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run targeted tests (full `tests/tui_gateway/`: all green except one pre-existing unrelated failure also present on clean main)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon)

### Documentation and Housekeeping

- [ ] I've updated relevant documentation — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure Python logic, no platform-specific paths
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A