### PR TITLE
fix(bots): keep new desktop drafts visible during auto-titling

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1369,13 +1369,15 @@ function isBotModeSweepCandidate(row, nowSeconds = Date.now() / 1000) {
  *  is never listed, so its sessions are never touched) and hide any VISIBLE
  *  row whose title is Bot Mode plumbing and whose creation grace period has
  *  elapsed. The grace period protects a new desktop draft while its first-turn
- *  title is pending; missing or future timestamps fail closed. session.list
+ *  title is pending; after five minutes an unchanged plumbing title is treated
+ *  as Bot Mode-owned. session.list supplies epoch seconds; missing, malformed,
+ *  millisecond, or future timestamps fail closed and stay visible. session.list
  *  without include_hidden returns only visible rows, which keeps the sweep
  *  naturally idempotent.
  *  Remote-source bots route to their own connection via requestForBot.
  *  Feature-detected + fire-and-forget: older gateways without per-profile
  *  session.list / session.set_hidden simply reject and the sweep no-ops. */
-async function sweepBotProfileSessions() {
+async function sweepBotProfileSessions(nowSeconds = Date.now() / 1000) {
   const cached = $lastRoster.get()
   let roster = Array.isArray(cached) && cached.length ? cached : null
 
@@ -1405,7 +1407,7 @@ async function sweepBotProfileSessions() {
 
         await Promise.all(
           rows
-            .filter(row => isBotModeSweepCandidate(row))
+            .filter(row => isBotModeSweepCandidate(row, nowSeconds))
             .map(row =>
               Promise.resolve(
                 requestForBot(bot, 'session.set_hidden', { session_id: row.id, hidden: true, profile: name })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1341,10 +1341,23 @@ function hideOwnedBotSessions() {
 // user's real conversation inside a bot profile keeps whatever title the
 // user gave it and is never touched.
 const BOT_MODE_SWEEP_TITLES = new Set(['Bot Chat', 'Agent Inbox'])
+const BOT_MODE_SWEEP_MIN_AGE_SECONDS = 5 * 60
 
 function isBotModeSweepTitle(title) {
   const t = String(title || '').trim()
   return BOT_MODE_SWEEP_TITLES.has(t) || t.startsWith('Group: ')
+}
+
+function isBotModeSweepCandidate(row, nowSeconds = Date.now() / 1000) {
+  const startedAt = Number(row?.started_at)
+  return (
+    row &&
+    row.id &&
+    isBotModeSweepTitle(row.title) &&
+    Number.isFinite(startedAt) &&
+    startedAt > 0 &&
+    nowSeconds - startedAt >= BOT_MODE_SWEEP_MIN_AGE_SECONDS
+  )
 }
 
 /** Ownership-based sweep: the id-based sweep above only covers sessions the
@@ -1354,8 +1367,11 @@ function isBotModeSweepTitle(title) {
  *  profile) — and those ids the plugin never learns. So: enumerate each
  *  roster bot's OWN profile sessions (only bot profiles — a non-bot profile
  *  is never listed, so its sessions are never touched) and hide any VISIBLE
- *  row whose title is Bot Mode plumbing. session.list without include_hidden
- *  returns only visible rows, which keeps the sweep naturally idempotent.
+ *  row whose title is Bot Mode plumbing and whose creation grace period has
+ *  elapsed. The grace period protects a new desktop draft while its first-turn
+ *  title is pending; missing or future timestamps fail closed. session.list
+ *  without include_hidden returns only visible rows, which keeps the sweep
+ *  naturally idempotent.
  *  Remote-source bots route to their own connection via requestForBot.
  *  Feature-detected + fire-and-forget: older gateways without per-profile
  *  session.list / session.set_hidden simply reject and the sweep no-ops. */
@@ -1389,7 +1405,7 @@ async function sweepBotProfileSessions() {
 
         await Promise.all(
           rows
-            .filter(row => row && row.id && isBotModeSweepTitle(row.title))
+            .filter(row => isBotModeSweepCandidate(row))
             .map(row =>
               Promise.resolve(
                 requestForBot(bot, 'session.set_hidden', { session_id: row.id, hidden: true, profile: name })

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
@@ -126,13 +126,15 @@ test('sweepBotProfileSessions hides Bot-Mode-titled rows per roster bot, and onl
   const calls = []
   const rowsByProfile = {
     alpha: [
-      { id: 'a-1', title: 'Bot Chat' },
-      { id: 'a-2', title: 'Agent Inbox' },
-      { id: 'a-3', title: 'Group: Core' },
-      { id: 'a-4', title: 'My real conversation' },
-      { id: 'a-5', title: 'Bot Chat notes' } // not an exact title — kept
+      { id: 'a-1', title: 'Bot Chat', started_at: 1 },
+      { id: 'a-2', title: 'Agent Inbox', started_at: 1 },
+      { id: 'a-3', title: 'Group: Core', started_at: 1 },
+      { id: 'a-4', title: 'My real conversation', started_at: 1 },
+      { id: 'a-5', title: 'Bot Chat notes', started_at: 1 }, // not an exact title — kept
+      { id: 'a-6', title: 'Bot Chat', started_at: Date.now() / 1000 }, // live draft — kept
+      { id: 'a-7', title: 'Agent Inbox' } // missing age metadata — kept fail-closed
     ],
-    remy: [{ id: 'r-1', title: 'Agent Inbox' }]
+    remy: [{ id: 'r-1', title: 'Agent Inbox', started_at: 1 }]
   }
   const context = {
     host: { request: async () => ({}) },
@@ -161,7 +163,7 @@ test('sweepBotProfileSessions hides Bot-Mode-titled rows per roster bot, and onl
   assert.deepEqual(
     hidden.map(c => c.params.session_id).sort(),
     ['a-1', 'a-2', 'a-3', 'r-1'],
-    'exact plumbing titles only — user-titled rows in bot profiles stay visible'
+    'exact plumbing titles only — user-titled and brand-new rows stay visible'
   )
   assert.ok(hidden.every(c => c.params.hidden === true))
   // Remote-source bots route through requestForBot with their own bot row.

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
@@ -124,6 +124,7 @@ test('sweepBotProfileSessions hides Bot-Mode-titled rows per roster bot, and onl
   const start = source.indexOf('function hideOwnedBotSessions()')
   const end = source.indexOf('/** Fetch server-side avatars', start)
   const calls = []
+  const nowSeconds = 1_000
   const rowsByProfile = {
     alpha: [
       { id: 'a-1', title: 'Bot Chat', started_at: 1 },
@@ -131,8 +132,9 @@ test('sweepBotProfileSessions hides Bot-Mode-titled rows per roster bot, and onl
       { id: 'a-3', title: 'Group: Core', started_at: 1 },
       { id: 'a-4', title: 'My real conversation', started_at: 1 },
       { id: 'a-5', title: 'Bot Chat notes', started_at: 1 }, // not an exact title — kept
-      { id: 'a-6', title: 'Bot Chat', started_at: Date.now() / 1000 }, // live draft — kept
-      { id: 'a-7', title: 'Agent Inbox' } // missing age metadata — kept fail-closed
+      { id: 'a-6', title: 'Bot Chat', started_at: nowSeconds - 299 }, // live draft — kept
+      { id: 'a-7', title: 'Agent Inbox' }, // missing age metadata — kept fail-closed
+      { id: 'a-8', title: 'Bot Chat', started_at: nowSeconds - 300 } // boundary reached — hidden
     ],
     remy: [{ id: 'r-1', title: 'Agent Inbox', started_at: 1 }]
   }
@@ -152,7 +154,7 @@ test('sweepBotProfileSessions hides Bot-Mode-titled rows per roster bot, and onl
   }
   const section = source.slice(start, end).concat('\nglobalThis.__h = { hideOwnedBotSessions, sweepBotProfileSessions };\n')
   vm.runInNewContext(section, context, { filename: 's.js' })
-  await context.__h.sweepBotProfileSessions()
+  await context.__h.sweepBotProfileSessions(nowSeconds)
 
   const lists = calls.filter(c => c.method === 'session.list')
   assert.deepEqual(lists.map(c => c.params.profile).sort(), ['alpha', 'remy'])
@@ -162,7 +164,7 @@ test('sweepBotProfileSessions hides Bot-Mode-titled rows per roster bot, and onl
   const hidden = calls.filter(c => c.method === 'session.set_hidden')
   assert.deepEqual(
     hidden.map(c => c.params.session_id).sort(),
-    ['a-1', 'a-2', 'a-3', 'r-1'],
+    ['a-1', 'a-2', 'a-3', 'a-8', 'r-1'],
     'exact plumbing titles only — user-titled and brand-new rows stay visible'
   )
   assert.ok(hidden.every(c => c.params.hidden === true))


### PR DESCRIPTION
## What does this PR do?

A newly created Desktop conversation in a bot profile can temporarily use the `Bot Chat` title while first-turn auto-titling is pending. The Bot Mode ownership sweep treated that transient title as proof of plugin ownership and hid the real conversation from the global Sessions sidebar. This change requires title-matched rows to be at least five minutes old before they can be hidden, preserving cleanup of established Bot Mode plumbing sessions while protecting new drafts.

### Symptom

A real conversation can disappear from the Desktop Sessions sidebar during its first turn even though the conversation remains open and its messages remain intact.

### Impact

Affected users lose sidebar visibility and normal navigation to the hidden conversation until its database visibility flag is repaired. The reported blast radius is multiple substantive conversations across two profiles on one workstation; broader incidence is unknown.

### Bug Cause

**Trigger:** `apps/desktop/src/plugins/hermes-bots/plugin.js` / `sweepBotProfileSessions()` / exact `Bot Chat`, `Agent Inbox`, or `Group: ` title match.

**Causal chain:**
1. A first prompt creates the durable session row before first-turn auto-titling has replaced its temporary title.
2. The roster-wide Bot Mode sweep sees the visible row and classifies it only by the temporary plumbing-like title.
3. `session.set_hidden` persists `hidden=true`; the later title update does not restore visibility, so the conversation disappears from the sidebar.

**Why it is wrong:** A transient title is not sufficient ownership evidence during session creation.

**Working sibling / contrast:** Canonical and group sessions already use recorded session IDs plus canonical-title validation. Only the fallback roster-wide scan guesses ownership from a title.

**Ruled out:** Session deletion and non-bot-profile enumeration are not involved. The hidden rows retain their messages, and the sweep enumerates only roster bot profiles.

### Fix

The title sweep now accepts only rows with a valid `started_at` older than a five-minute creation grace period. Missing, future, and fresh timestamps fail closed. The regression test proves that established plumbing rows are still hidden while a newly created `Bot Chat` draft and a row without age metadata remain visible.

## Related Issue

Closes #93055

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` - gate title-based hiding on a five-minute session age.
- `apps/desktop/src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs` - cover fresh and missing-timestamp rows alongside established Bot Mode sessions.

## How to Test

1. Run the focused Bot Mode session-hiding test.
2. Confirm all seven cases pass, including preservation of a fresh `Bot Chat` draft.

```bash
cd apps/desktop
node --test src/plugins/hermes-bots/tests/hide-bot-chats.test.mjs
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant repository test entry and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation: N/A - behavior and rationale are documented in code and tests
- [x] `cli-config.yaml.example`: N/A - no configuration changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the logic uses JSON-RPC epoch timestamps and standard JavaScript
- [x] Tool descriptions/schemas: N/A - no tool behavior changed

## Screenshots / Logs

N/A - the focused automated regression test exercises the title-sweep behavior directly.
