### PR TITLE
fix(cron): keep hermes console script on child PATH

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -240,6 +240,41 @@ class TestProviderEnvBlocklist:
         assert "USER" in result_env
         assert "PATH" in result_env
 
+    def test_bare_hermes_resolves_from_sanitized_subprocess_path(self):
+        """Cron children can resolve Hermes even when the gateway PATH cannot."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        with patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value="/home/user/.local/bin",
+        ):
+            result = _sanitize_subprocess_env(
+                {
+                    "PATH": os.pathsep.join(["/usr/bin", "/bin"]),
+                    "HOME": "/home/user",
+                }
+            )
+
+        assert result["PATH"] == os.pathsep.join(
+            ["/home/user/.local/bin", "/usr/bin", "/bin"]
+        )
+
+    def test_bare_hermes_path_does_not_duplicate_existing_install_dir(self):
+        """The PATH repair is idempotent for already-correct environments."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        with patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value="/home/user/.local/bin",
+        ):
+            result = _sanitize_subprocess_env(
+                {"PATH": os.pathsep.join(["/home/user/.local/bin", "/usr/bin"])}
+            )
+
+        assert result["PATH"] == os.pathsep.join(
+            ["/home/user/.local/bin", "/usr/bin"]
+        )
+
     def test_self_env_blocked_vars_also_stripped(self):
         """Blocked vars in self.env are stripped; non-blocked vars pass through."""
         result_env = _run_with_env(self_env={

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -523,6 +523,14 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # against the repo layout before trusting it.
     _strip_hermes_owned_pythonpath_and_runtime_markers(sanitized)
 
+    # Keep bare ``hermes`` invocations available to child jobs even when the
+    # gateway was launched by a service manager or cron without the console
+    # script's directory on PATH.  The terminal environment already applies
+    # this invariant; Cron scripts use this sanitizer directly (#92998).
+    path_key = _path_env_key(sanitized)
+    if path_key is not None:
+        sanitized[path_key] = _prepend_hermes_bin_dir(sanitized.get(path_key, ""))
+
     _apply_windows_msys_bash_env_defaults(sanitized)
 
     sanitized = _scrub_delegated_child_kanban_env(sanitized)


### PR DESCRIPTION
## Summary

- keep the Hermes console-script directory on sanitized child-process PATHs
- make bare `hermes` calls from no-agent cron scripts resolve when the gateway was launched without the install directory on PATH
- cover PATH injection and idempotence with cross-platform regression tests

Fixes #92998

## Tests

- `python -m pytest tests/cron/test_cron_no_agent.py tests/cron/test_cron_script.py -q` — 44 passed, 2 skipped
- `python -m pytest tests/tools/test_local_env_blocklist.py -k "not PythonpathSelectiveStrip" -q` — 50 passed, 1 skipped
- `python -m py_compile tools/environments/local.py tests/tools/test_local_env_blocklist.py`
- `git diff --check`
