### PR TITLE
perf(mcp): skip npx's resident parent when the package is already cached

### DIFF
--- a/tests/tools/test_mcp_npx_cached_bin.py
+++ b/tests/tools/test_mcp_npx_cached_bin.py
@@ -154,7 +154,55 @@ def test_swap_happens_after_the_osv_call_in_source():
 
     src = _P(__file__).resolve().parents[2] / "tools" / "mcp_tool.py"
     text = src.read_text(encoding="utf-8")
-    osv_at = text.index("check_package_for_malware, command, args")
-    swap_at = text.index("cached = _npx_cached_bin(args)")
+    osv_needle = "check_package_for_malware, command, args"
+    swap_needle = "cached = _npx_cached_bin(args)"
+    # Report a rename explicitly: a bare .index() ValueError here reads like a
+    # broken test rather than "someone renamed the thing this guards".
+    assert osv_needle in text, (
+        f"cannot find the OSV preflight call ({osv_needle!r}) — it was renamed; "
+        "update this guard and re-verify the swap still happens after it"
+    )
+    assert swap_needle in text, (
+        f"cannot find the npx swap ({swap_needle!r}) — it was renamed; update "
+        "this guard and re-verify it still happens after the OSV preflight"
+    )
 
-    assert osv_at < swap_at, "the npx swap must not precede the OSV malware preflight"
+    assert text.index(osv_needle) < text.index(swap_needle), (
+        "the npx swap now precedes the OSV malware preflight, which silently "
+        "disables it: _infer_ecosystem keys off the command basename being "
+        "npx/uvx/pipx, so a rewritten command yields no ecosystem and "
+        "check_package_for_malware returns None"
+    )
+
+
+def test_windows_selects_launchers_never_the_sh_script():
+    """On Windows the extensionless sh script must never be chosen.
+
+    npm lays down three siblings per bin — `<name>`, `<name>.cmd`,
+    `<name>.ps1` — and spawning the sh one from a Windows process fails, while
+    `os.access(X_OK)` there is effectively an existence check and cannot tell
+    them apart. Tested through the injectable helper rather than by patching
+    `os.name`, which breaks path handling process-wide (it took pytest's own
+    traceback formatting down when I tried).
+    """
+    from tools.mcp_tool import _npx_bin_candidates
+
+    win = _npx_bin_candidates("/c/bin", "mcp-linear", windows=True)
+    assert win == ["/c/bin/mcp-linear.cmd", "/c/bin/mcp-linear.exe"]
+    assert not any(c.endswith("mcp-linear") for c in win), "sh script must not be a candidate"
+
+    assert _npx_bin_candidates("/bin", "mcp-linear", windows=False) == ["/bin/mcp-linear"]
+
+
+def test_posix_resolution_uses_the_helper(tmp_path):
+    """The resolver honours the helper's ordering (POSIX path end-to-end)."""
+    target = _cache(tmp_path, package="mcp-linear", bin_field={"mcp-linear": "i.js"})
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) == (str(target), [])
+
+
+def test_flag_after_the_spec_is_left_to_npx(tmp_path):
+    """`npx pkg -y` would forward -y to the server; that shape stays with npx."""
+    _cache(tmp_path, package="mcp-linear", bin_field={"mcp-linear": "i.js"})
+
+    assert _npx_cached_bin(["mcp-linear", "-y"]) is None

--- a/tests/tools/test_mcp_npx_cached_bin.py
+++ b/tests/tools/test_mcp_npx_cached_bin.py
@@ -1,0 +1,160 @@
+"""``npx -y <pkg>`` should spawn the cached binary, not a resident `npm exec`.
+
+`npx` resolves the package and then FORKS, staying alive as the real server's
+parent for the whole process lifetime while doing no work. Measured on a
+4-agent host that is ~48 MB of private memory per MCP server — and it buys
+nothing, because Hermes already wraps the child in its own parent-death
+watchdog, so npx's supervision is a second parent nobody reads.
+
+Removing it must stay conservative: a cache miss, a version-pinned spec, or an
+ambiguous ``bin`` map all fall back to plain `npx` so a cold machine still
+installs normally.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from tools.mcp_tool import _npx_cached_bin
+
+
+def _cache(tmp_path, *, package, deps=None, bin_field, make_bin=True, entry="abc123"):
+    """Build a fake npx cache entry the way npm lays one out."""
+    root = tmp_path / ".npm" / "_npx" / entry
+    (root / "node_modules" / package).mkdir(parents=True)
+    (root / "package.json").write_text(
+        json.dumps({"dependencies": deps if deps is not None else {package: "^1.0.0"}}),
+        encoding="utf-8",
+    )
+    (root / "node_modules" / package / "package.json").write_text(
+        json.dumps({"name": package, "bin": bin_field}), encoding="utf-8"
+    )
+    bindir = root / "node_modules" / ".bin"
+    bindir.mkdir(parents=True, exist_ok=True)
+    name = bin_field if isinstance(bin_field, str) else list(bin_field)[0]
+    target = bindir / (os.path.basename(package) if isinstance(bin_field, str) else name)
+    if make_bin:
+        target.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+        target.chmod(0o755)
+    return target
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv("npm_config_cache", str(tmp_path / ".npm"))
+    yield
+
+
+def test_cached_package_resolves_to_its_binary(tmp_path):
+    target = _cache(tmp_path, package="mcp-linear", bin_field={"mcp-linear": "dist/index.js"})
+
+    got = _npx_cached_bin(["-y", "mcp-linear"])
+
+    assert got == (str(target), [])
+
+
+def test_scoped_package_and_trailing_args_survive(tmp_path):
+    target = _cache(
+        tmp_path,
+        package="@tacticlaunch/mcp-linear",
+        bin_field={"mcp-linear": "dist/index.js"},
+    )
+
+    got = _npx_cached_bin(["-y", "@tacticlaunch/mcp-linear", "--port", "7"])
+
+    assert got == (str(target), ["--port", "7"])
+
+
+def test_uncached_package_falls_back_to_npx(tmp_path):
+    _cache(tmp_path, package="something-else", bin_field={"something-else": "i.js"})
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) is None
+
+
+def test_version_pinned_spec_is_left_to_npx(tmp_path):
+    _cache(tmp_path, package="mcp-linear", bin_field={"mcp-linear": "dist/index.js"})
+
+    # The user pinned a build; npx owns that resolution and the cache key for
+    # a different version would not match this entry.
+    assert _npx_cached_bin(["-y", "mcp-linear@1.2.3"]) is None
+
+
+def test_ambiguous_bin_map_is_left_to_npx(tmp_path):
+    _cache(
+        tmp_path,
+        package="multi",
+        bin_field={"one": "a.js", "two": "b.js"},
+    )
+
+    # Which bin npx would choose is not ours to guess.
+    assert _npx_cached_bin(["-y", "multi"]) is None
+
+
+def test_missing_or_non_executable_binary_falls_back(tmp_path):
+    _cache(
+        tmp_path,
+        package="mcp-linear",
+        bin_field={"mcp-linear": "dist/index.js"},
+        make_bin=False,
+    )
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) is None
+
+
+def test_no_cache_directory_at_all(tmp_path, monkeypatch):
+    monkeypatch.setenv("npm_config_cache", str(tmp_path / "nope"))
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) is None
+
+
+def test_corrupt_cache_manifest_is_skipped(tmp_path):
+    root = tmp_path / ".npm" / "_npx" / "broken"
+    root.mkdir(parents=True)
+    (root / "package.json").write_text("{ not json", encoding="utf-8")
+
+    assert _npx_cached_bin(["-y", "mcp-linear"]) is None
+
+
+@pytest.mark.parametrize("args", [[], ["-y"], ["--yes"], ["-p", "x"], None, "notalist"])
+def test_unusable_args_are_ignored(args):
+    assert _npx_cached_bin(args) is None
+
+
+def test_osv_preflight_runs_before_the_swap():
+    """The malware gate must still see `npx` + the package name.
+
+    `_infer_ecosystem` keys off the command basename, so a command already
+    rewritten to `.../node_modules/.bin/mcp-linear` yields no ecosystem and
+    `check_package_for_malware` returns None — the gate silently becomes a
+    no-op. This pins the ordering: OSV inspects the original invocation.
+    """
+    from tools.osv_check import _infer_ecosystem, _parse_package_from_args
+
+    # What the preflight sees today, before any swap.
+    assert _infer_ecosystem("npx") == "npm"
+    assert _parse_package_from_args(["-y", "@tacticlaunch/mcp-linear"], "npm")[0] == (
+        "@tacticlaunch/mcp-linear"
+    )
+
+    # What it would see if the swap happened first — nothing.
+    assert _infer_ecosystem("/home/u/.npm/_npx/abc/node_modules/.bin/mcp-linear") is None
+
+
+def test_swap_happens_after_the_osv_call_in_source():
+    """Structural guard for the ordering above.
+
+    The swap and the preflight live in one async function; a future edit that
+    moves the swap earlier would disable the malware gate silently, and no
+    unit test of either piece alone would notice.
+    """
+    from pathlib import Path as _P
+
+    src = _P(__file__).resolve().parents[2] / "tools" / "mcp_tool.py"
+    text = src.read_text(encoding="utf-8")
+    osv_at = text.index("check_package_for_malware, command, args")
+    swap_at = text.index("cached = _npx_cached_bin(args)")
+
+    assert osv_at < swap_at, "the npx swap must not precede the OSV malware preflight"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1040,6 +1040,90 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     return resolved_command, resolved_env
 
 
+def _npx_cached_bin(args: list) -> Optional[tuple]:
+    """Resolve ``npx -y <pkg>`` to the already-installed binary, or None.
+
+    ``npx`` resolves the package and then FORKS: it stays resident as the
+    parent of the real server for the whole process lifetime, doing no work.
+    Measured on a 4-agent host, that is ~48 MB of private memory per MCP
+    server — and it buys nothing here, because Hermes already supervises the
+    child itself (``_wrap_command_with_watchdog``), so npx's supervision is a
+    second parent nobody reads.
+
+    When the package is already in npx's cache we can spawn its binary
+    directly and drop the middle process. A cache miss returns None and the
+    caller falls back to ``npx`` unchanged, so the first run still installs
+    and nothing regresses on a cold machine.
+
+    Deliberately conservative — returns None for anything unusual:
+    a version-pinned spec (``pkg@1.2.3``), extra npx flags, a package whose
+    manifest declares no single obvious bin, or any unreadable cache entry.
+
+    Returns ``(binary_path, remaining_args)`` or None.
+    """
+    if not isinstance(args, list) or not args:
+        return None
+
+    rest = list(args)
+    while rest and rest[0] in ("-y", "--yes"):
+        rest.pop(0)
+    if not rest:
+        return None
+
+    spec = str(rest[0])
+    # A version pin means the user asked for a specific build; npx owns that
+    # resolution and the cache key may not match. Scoped names keep their
+    # leading '@', so only an '@' AFTER the scope is a version separator.
+    if "@" in (spec[1:] if spec.startswith("@") else spec):
+        return None
+    if not spec or spec.startswith("-"):
+        return None
+
+    cache_root = os.environ.get("npm_config_cache") or os.path.join(
+        os.path.expanduser("~"), ".npm"
+    )
+    npx_root = os.path.join(cache_root, "_npx")
+    if not os.path.isdir(npx_root):
+        return None
+
+    try:
+        entries = os.listdir(npx_root)
+    except OSError:
+        return None
+
+    for entry in entries:
+        manifest = os.path.join(npx_root, entry, "package.json")
+        try:
+            with open(manifest, "r", encoding="utf-8") as fh:
+                deps = (json.load(fh) or {}).get("dependencies") or {}
+        except (OSError, ValueError, TypeError):
+            continue
+        if spec not in deps:
+            continue
+
+        pkg_json = os.path.join(npx_root, entry, "node_modules", spec, "package.json")
+        try:
+            with open(pkg_json, "r", encoding="utf-8") as fh:
+                bin_field = (json.load(fh) or {}).get("bin")
+        except (OSError, ValueError, TypeError):
+            continue
+
+        if isinstance(bin_field, str):
+            names = [os.path.basename(spec)]
+        elif isinstance(bin_field, dict) and len(bin_field) == 1:
+            names = list(bin_field.keys())
+        else:
+            # Zero or several bins: which one npx would pick is not ours to
+            # guess. Let npx decide.
+            continue
+
+        candidate = os.path.join(npx_root, entry, "node_modules", ".bin", names[0])
+        if os.path.exists(candidate) and os.access(candidate, os.X_OK):
+            return candidate, rest[1:]
+
+    return None
+
+
 def _wrap_command_with_watchdog(command: str, args: list) -> tuple[str, list]:
     """Wrap a stdio MCP server command in the parent-death watchdog supervisor.
 
@@ -3046,6 +3130,24 @@ class MCPServerTask:
             raise ValueError(
                 f"MCP server '{self.name}': {malware_error}"
             )
+
+        # npx resolves the package and then FORKS, staying resident as the
+        # real server's parent for nothing (~48 MB per MCP server, measured).
+        # Hermes already supervises the child below, so when the package is
+        # cached we spawn its binary directly and drop that middle process.
+        # Deliberately AFTER the OSV preflight: the check keys off the command
+        # basename being `npx`, so swapping first would silently turn the
+        # malware gate into a no-op. Cache miss leaves npx untouched.
+        if os.path.basename(command).lower().startswith("npx"):
+            cached = _npx_cached_bin(args)
+            if cached:
+                direct_command, direct_args = cached
+                logger.debug(
+                    "MCP server '%s': using cached npx binary %s (skipping the "
+                    "resident `npm exec` parent)",
+                    self.name, direct_command,
+                )
+                command, args = direct_command, direct_args
 
         # Wrap the real command in a parent-death watchdog supervisor so an
         # ungraceful exit of this Hermes process (kill -9, crash, force-quit)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1040,6 +1040,26 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
     return resolved_command, resolved_env
 
 
+def _npx_bin_candidates(bin_dir: str, name: str, *, windows: Optional[bool] = None) -> list:
+    """Launcher paths to try for *name* inside an npx cache's ``.bin``, in order.
+
+    On Windows that directory holds three siblings per bin — the extensionless
+    sh script, ``<name>.cmd`` and ``<name>.ps1``. Spawning the sh one from a
+    Windows process fails, and ``os.access(X_OK)`` there is effectively an
+    existence check, so it cannot tell them apart. Select by extension instead,
+    the same precedence ``hermes_constants._candidate_node_command_names``
+    already uses for npm/npx/node; when no launcher exists the caller falls
+    back to npx rather than spawning something that will not run.
+
+    ``windows`` is injectable so the platform branch is testable without
+    monkeypatching ``os.name`` (which breaks path handling process-wide).
+    """
+    is_windows = os.name == "nt" if windows is None else windows
+    if is_windows:
+        return [os.path.join(bin_dir, name + ext) for ext in (".cmd", ".exe")]
+    return [os.path.join(bin_dir, name)]
+
+
 def _npx_cached_bin(args: list) -> Optional[tuple]:
     """Resolve ``npx -y <pkg>`` to the already-installed binary, or None.
 
@@ -1068,6 +1088,12 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
     while rest and rest[0] in ("-y", "--yes"):
         rest.pop(0)
     if not rest:
+        return None
+
+    # `npx pkg -y` (flag AFTER the spec) is an unusual shape: those args are
+    # forwarded verbatim to the resolved binary, which would hand the server a
+    # flag npx would have eaten. Leave anything like that to npx.
+    if any(str(a) in ("-y", "--yes") for a in rest[1:]):
         return None
 
     spec = str(rest[0])
@@ -1117,9 +1143,10 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
             # guess. Let npx decide.
             continue
 
-        candidate = os.path.join(npx_root, entry, "node_modules", ".bin", names[0])
-        if os.path.exists(candidate) and os.access(candidate, os.X_OK):
-            return candidate, rest[1:]
+        bin_dir = os.path.join(npx_root, entry, "node_modules", ".bin")
+        for candidate in _npx_bin_candidates(bin_dir, names[0]):
+            if os.path.exists(candidate) and os.access(candidate, os.X_OK):
+                return candidate, rest[1:]
 
     return None
 


### PR DESCRIPTION
## Problem

A stdio MCP server configured the way this repo's own docs show it —

```yaml
mcp_servers:
  linear:
    command: npx
    args: ["-y", "@tacticlaunch/mcp-linear"]
```

— produces a **three**-process chain per server:

```
mcp_stdio_watchdog.py  (13 MB)  ->  npm exec @tacticlaunch/mcp-linear  (48 MB)  ->  node .../.bin/mcp-linear  (49 MB)
```

`npx` resolves the package and then **forks**, staying resident as the real server's parent for the
whole process lifetime while doing no work. That middle process is ~48 MB of private memory per MCP
server, and it buys nothing here: Hermes already wraps the child in its own parent-death watchdog
(`_wrap_command_with_watchdog`), so npx's supervision is a second parent nobody reads.

It multiplies by servers × gateways. On a Mac mini running four agent gateways plus the dashboard —
ten stdio MCP servers — five resident `npm exec` parents were holding memory on a host that was
actively swapping.

## Change

When the package is already in npx's cache, spawn its binary directly and drop the middle process.
A cache miss changes nothing — the command stays `npx`, so a cold machine still installs on first
run and no behaviour is lost.

**The swap happens after the OSV malware preflight, deliberately.** `_infer_ecosystem` keys off the
command basename being `npx`/`uvx`/`pipx`, so rewriting the command first makes
`check_package_for_malware` return `None` and silently turns the malware gate into a no-op. Two
tests pin the ordering — one behavioural, one structural — because a future edit that moved the swap
earlier would disable the check without failing any test of either piece alone.

That ordering is also why this belongs in code rather than in user config: pointing `command`
straight at the cached path (the obvious workaround) costs you the preflight. I measured that the
hard way.

Conservative by construction. It falls back to `npx` for:
- a version-pinned spec (`pkg@1.2.3`) — npx owns that resolution and the cache key may differ;
- an ambiguous or absent `bin` map — which binary npx would choose is not ours to guess;
- a missing or non-executable binary, an unreadable cache entry, or no cache directory at all.

Honours `npm_config_cache`.

## Measured

Same host, four agent gateways + dashboard, ten stdio MCP servers, before → after:

| | before | after |
|---|---|---|
| resident `npm exec` parents | 5 | **0** |
| tracked footprint | 1531 MB | **1324 MB** |
| processes | 30 | **25** |

`phys_footprint` throughout, not RSS — summing RSS overstates by ~400 MB here because the venv's
library text is resident once and shared across the gateways.

Per server the saving is ~38 MB rather than the full 48 MB: the directly-spawned node grows from
~49 MB to ~59 MB, absorbing pages the shim used to hold. Worth stating plainly so nobody expects
the shim's whole footprint back.

Every MCP server kept working; tool calls verified against a live Linear server after the change.

## Testing

`tests/tools/test_mcp_npx_cached_bin.py` (16):

- resolves a cached package to its binary, plain and scoped, preserving trailing args;
- falls back to npx for: uncached package, version-pinned spec, ambiguous `bin` map, missing or
  non-executable binary, corrupt cache manifest, absent cache dir, and unusable `args` shapes;
- pins the OSV ordering behaviourally (`_infer_ecosystem` on a rewritten command yields no
  ecosystem) and structurally (the swap must appear after the preflight call in source).

Neutering the resolver fails exactly the two resolution tests and none of the fourteen fallback
pins. 66 passed across this file plus neighbouring MCP suites; `ruff` clean.
