### PR TITLE
fix(desktop): stop Command Center inheriting Kanban worker identity

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -10,7 +10,8 @@ import {
   hermesManagedNodePathEntries,
   normalizeHermesHomeRoot,
   pathEnvKey,
-  POSIX_SANE_PATH_ENTRIES
+  POSIX_SANE_PATH_ENTRIES,
+  sanitizeInheritedDesktopEnv
 } from './backend-env'
 
 test('desktop backend PATH adds Hermes-managed bins and missing POSIX sane entries', () => {
@@ -188,4 +189,53 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
 
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {
   assert.equal(appendUniquePathEntries([':/a::/b', ['/a', '/c']], { delimiter: ':' }), '/a:/b:/c')
+})
+
+test('sanitizeInheritedDesktopEnv strips worker lifecycle and resets desk profile', () => {
+  const env = {
+    HERMES_PROFILE: 'company-infra',
+    HERMES_HOME: '/Users/shermanlye/.hermes/profiles/company-infra',
+    HERMES_KANBAN_TASK: 't_22bb7847',
+    HERMES_KANBAN_RUN_ID: '45',
+    HERMES_KANBAN_CLAIM_LOCK: 'host:1',
+    HERMES_KANBAN_WORKSPACE: '/tmp/ws',
+    HERMES_KANBAN_BRANCH: 'infra/x',
+    HERMES_KANBAN_BOARD: 'personal',
+    HERMES_KANBAN_DB: '/tmp/kanban.db',
+    HERMES_SESSION_SOURCE: 'kanban',
+    HERMES_SESSION_ID: '20260823_230728_ce516e',
+    PATH: '/usr/bin'
+  }
+
+  sanitizeInheritedDesktopEnv(env, { pathModule: path.posix })
+
+  assert.equal(env.HERMES_KANBAN_TASK, undefined)
+  assert.equal(env.HERMES_KANBAN_RUN_ID, undefined)
+  assert.equal(env.HERMES_KANBAN_CLAIM_LOCK, undefined)
+  assert.equal(env.HERMES_KANBAN_WORKSPACE, undefined)
+  assert.equal(env.HERMES_KANBAN_BRANCH, undefined)
+  assert.equal(env.HERMES_KANBAN_BOARD, 'personal')
+  assert.equal(env.HERMES_PROFILE, undefined)
+  assert.equal(env.HERMES_HOME, '/Users/shermanlye/.hermes')
+  assert.equal(env.HERMES_SESSION_SOURCE, undefined)
+  assert.equal(env.PATH, '/usr/bin')
+})
+
+test('sanitizeInheritedDesktopEnv keeps an explicit desk profile', () => {
+  const env = {
+    HERMES_PROFILE: 'company-infra',
+    HERMES_HOME: '/Users/x/.hermes/profiles/company-infra',
+    HERMES_KANBAN_TASK: 't_1'
+  }
+
+  sanitizeInheritedDesktopEnv(env, { explicitProfile: 'company-cpo', pathModule: path.posix })
+  assert.equal(env.HERMES_PROFILE, 'company-cpo')
+  assert.equal(env.HERMES_KANBAN_TASK, undefined)
+})
+
+test('sanitizeInheritedDesktopEnv is a noop without worker identity', () => {
+  const env = { HERMES_HOME: '/Users/x/.hermes', HERMES_KANBAN_BOARD: 'personal' }
+  sanitizeInheritedDesktopEnv(env, { pathModule: path.posix })
+  assert.equal(env.HERMES_HOME, '/Users/x/.hermes')
+  assert.equal(env.HERMES_KANBAN_BOARD, 'personal')
 })

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -118,6 +118,66 @@ function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatfor
   return resolved
 }
 
+const KANBAN_LIFECYCLE_ENV_KEYS = Object.freeze([
+  'HERMES_KANBAN_TASK',
+  'HERMES_KANBAN_RUN_ID',
+  'HERMES_KANBAN_WORKSPACE',
+  'HERMES_KANBAN_WORKSPACES_ROOT',
+  'HERMES_KANBAN_CLAIM_LOCK',
+  'HERMES_KANBAN_BRANCH',
+  'HERMES_KANBAN_GOAL_MODE',
+  'HERMES_KANBAN_GOAL_MAX_TURNS'
+])
+
+const WORKER_SESSION_KEYS = Object.freeze(['HERMES_SESSION_ID', 'HERMES_SINGLE_QUERY_SESSION'])
+
+function inheritedKanbanLifecycle(env: Record<string, string | undefined> = {}) {
+  if (KANBAN_LIFECYCLE_ENV_KEYS.some(key => String(env?.[key] || '').trim())) {
+    return true
+  }
+
+  return String(env?.HERMES_SESSION_SOURCE || '').trim().toLowerCase() === 'kanban'
+}
+
+/**
+ * Drop dispatcher worker ownership inherited by Hermes.app / its backend.
+ * Mutates *env* and returns it. Board routing pins (BOARD / DB) stay.
+ */
+function sanitizeInheritedDesktopEnv(
+  env: Record<string, string | undefined> = {},
+  { explicitProfile = null, pathModule = pathModuleForPlatform(process.platform) }: any = {}
+) {
+  if (!inheritedKanbanLifecycle(env)) {
+    return env
+  }
+
+  for (const key of KANBAN_LIFECYCLE_ENV_KEYS) {
+    delete env[key]
+  }
+
+  if (String(env.HERMES_SESSION_SOURCE || '').trim().toLowerCase() === 'kanban') {
+    delete env.HERMES_SESSION_SOURCE
+  }
+
+  for (const key of WORKER_SESSION_KEYS) {
+    delete env[key]
+  }
+
+  if (env.HERMES_HOME) {
+    env.HERMES_HOME = normalizeHermesHomeRoot(env.HERMES_HOME, { pathModule })
+  }
+
+  const chosen = typeof explicitProfile === 'string' ? explicitProfile.trim() : ''
+
+  if (chosen && chosen !== 'default') {
+    env.HERMES_PROFILE = chosen
+  } else {
+    delete env.HERMES_PROFILE
+  }
+
+  return env
+}
+
 function buildDesktopBackendEnv({
   hermesHome,
   pythonPathEntries = [],
@@ -155,7 +215,10 @@ export {
   buildDesktopBackendPath,
   delimiterForPlatform,
   hermesManagedNodePathEntries,
+  inheritedKanbanLifecycle,
+  KANBAN_LIFECYCLE_ENV_KEYS,
   normalizeHermesHomeRoot,
   pathEnvKey,
-  POSIX_SANE_PATH_ENTRIES
+  POSIX_SANE_PATH_ENTRIES,
+  sanitizeInheritedDesktopEnv
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -34,7 +34,7 @@ import { classifyActiveRuntime } from './active-runtime-state'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
-import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
+import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot, sanitizeInheritedDesktopEnv } from './backend-env'
 import { isReauthRequiredError, makeNousCloudBackendDownError, waitForHermesReady } from './backend-health'
 import { backendCommandMatches, createBackendOwnership, createBackendShutdownCoordinator } from './backend-ownership'
 import {
@@ -670,6 +670,12 @@ if (INSTALL_STAMP) {
 // HERMES_DESKTOP_USER_DATA_DIR (used by test:desktop:fresh) puts the sandbox
 // HERMES_HOME beneath the throwaway userData dir so a fresh-install run never
 // touches the user's real ~/.hermes / %LOCALAPPDATA%\hermes.
+//
+// If this process was launched by a Kanban worker (packaged install / hermes
+// desktop / updater open), drop inherited lifecycle ownership and worker
+// profile BEFORE resolveHermesHome() so Command Center is the desk profile.
+sanitizeInheritedDesktopEnv(process.env)
+
 function resolveHermesHome() {
   if (process.env.HERMES_HOME) {
     return normalizeHermesHomeRoot(process.env.HERMES_HOME)

--- a/hermes_cli/desktop_identity.py
+++ b/hermes_cli/desktop_identity.py
@@ -1,0 +1,143 @@
+"""Keep interactive Desktop / gateway hosts from inheriting Kanban worker identity.
+
+A dispatcher worker that relaunches Hermes.app (packaged install, ``hermes
+desktop``, detached updater ``open``) otherwise copies ``HERMES_KANBAN_*``
+lifecycle ownership and ``HERMES_PROFILE`` into the long-lived Command Center
+process. Interactive turns then load the worker protocol and act as the
+worker's profile instead of the user's desk profile.
+
+This module sanitizes launch env *copies*. ``apply_desktop_host_env_isolation``
+mutates a host mapping on purpose for ``hermes serve`` / ``dashboard``. Do not
+point it at a live worker's ``os.environ`` — cron Bot Chat (PO-0015) and
+in-process cron isolation depend on the worker process keeping those variables.
+"""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Mapping, MutableMapping
+
+# Task / run ownership. BOARD and DB stay: they are board routing pins, the
+# same pair PO-0015 Bot Chat and BF-0016 child-chat isolation keep.
+KANBAN_LIFECYCLE_ENV_KEYS: tuple[str, ...] = (
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_RUN_ID",
+    "HERMES_KANBAN_WORKSPACE",
+    "HERMES_KANBAN_WORKSPACES_ROOT",
+    "HERMES_KANBAN_CLAIM_LOCK",
+    "HERMES_KANBAN_BRANCH",
+    "HERMES_KANBAN_GOAL_MODE",
+    "HERMES_KANBAN_GOAL_MAX_TURNS",
+)
+
+_WORKER_SESSION_KEYS: tuple[str, ...] = (
+    "HERMES_SESSION_ID",
+    "HERMES_SINGLE_QUERY_SESSION",
+)
+
+
+def _path_for(value: str):
+    if "\\" in value and value[1:3] == ":\\":
+        return PureWindowsPath(value)
+    return PurePosixPath(value)
+
+
+def inherited_kanban_lifecycle(env: Mapping[str, str]) -> bool:
+    """True when *env* carries dispatcher worker lifecycle ownership."""
+    if any((env.get(key) or "").strip() for key in KANBAN_LIFECYCLE_ENV_KEYS):
+        return True
+    return (env.get("HERMES_SESSION_SOURCE") or "").strip().lower() == "kanban"
+
+
+def default_desk_home(env: Mapping[str, str]) -> str | None:
+    """Peel ``<root>/profiles/<name>`` back to the Hermes root."""
+    home = (env.get("HERMES_HOME") or "").strip()
+    if not home:
+        return None
+    path = _path_for(home)
+    if path.parent.name.lower() == "profiles":
+        return str(path.parent.parent)
+    return home
+
+
+def sanitize_desktop_host_env(
+    env: Mapping[str, str],
+    *,
+    explicit_profile: str | None = None,
+) -> dict[str, str]:
+    """Return a Desktop/gateway host env without inherited worker ownership.
+
+    * Always drops lifecycle keys. Board routing pins are kept.
+    * If this env looked like a worker and no explicit desk profile was
+      requested, drop ``HERMES_PROFILE`` and peel profile-scoped ``HERMES_HOME``.
+    * ``explicit_profile`` is the user's chosen desk profile (``-p`` / Desktop
+      ``active-profile.json``) and wins over the worker's profile.
+    * The input mapping is never mutated.
+    """
+    cleaned = dict(env)
+    had_lifecycle = inherited_kanban_lifecycle(cleaned)
+
+    for key in KANBAN_LIFECYCLE_ENV_KEYS:
+        cleaned.pop(key, None)
+
+    if had_lifecycle:
+        if (cleaned.get("HERMES_SESSION_SOURCE") or "").strip().lower() == "kanban":
+            cleaned.pop("HERMES_SESSION_SOURCE", None)
+        for key in _WORKER_SESSION_KEYS:
+            cleaned.pop(key, None)
+        peeled = default_desk_home(cleaned)
+        if peeled:
+            cleaned["HERMES_HOME"] = peeled
+        if explicit_profile:
+            name = explicit_profile.strip()
+            if name and name != "default":
+                cleaned["HERMES_PROFILE"] = name
+            else:
+                cleaned.pop("HERMES_PROFILE", None)
+        else:
+            cleaned.pop("HERMES_PROFILE", None)
+
+    elif explicit_profile:
+        name = explicit_profile.strip()
+        if name and name != "default":
+            cleaned["HERMES_PROFILE"] = name
+
+    return cleaned
+
+
+def apply_desktop_host_env_isolation(
+    env: MutableMapping[str, str],
+    *,
+    explicit_profile: str | None = None,
+) -> bool:
+    """Sanitize *env* in place. Returns True when the mapping changed."""
+    cleaned = sanitize_desktop_host_env(env, explicit_profile=explicit_profile)
+    if cleaned == dict(env):
+        return False
+    for key in list(env):
+        if key not in cleaned:
+            del env[key]
+    env.update(cleaned)
+    return True
+
+
+def explicit_profile_from_argv(argv: list[str] | tuple[str, ...] | None) -> str | None:
+    """Return ``-p`` / ``--profile`` from *argv*, or None."""
+    if not argv:
+        return None
+    args = list(argv)
+    if args and args[0].endswith(("hermes", "hermes.exe", "python", "python3", "python.exe")):
+        args = args[1:]
+        if args and args[0] in {"-m",} and len(args) > 1:
+            args = args[2:]
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--":
+            break
+        if arg in {"--profile", "-p"} and i + 1 < len(args):
+            return args[i + 1]
+        if arg.startswith("--profile="):
+            return arg.split("=", 1)[1]
+        i += 1
+    return None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8080,9 +8080,21 @@ def cmd_gui(args: argparse.Namespace):
             print(f"✓ Desktop packaged app ready: {packaged_executable} (not launching; --build-only)")
         return
 
+    # A kanban worker that relaunches Desktop must not donate its lifecycle
+    # ownership or profile to Hermes.app. Sanitize a *copy* so this worker's
+    # claim heartbeat keeps the original os.environ. See desktop_identity.
+    from hermes_cli.desktop_identity import (
+        explicit_profile_from_argv,
+        sanitize_desktop_host_env,
+    )
+
+    launch_env = sanitize_desktop_host_env(
+        env, explicit_profile=explicit_profile_from_argv(sys.argv)
+    )
+
     if source_mode:
         print("→ Launching Hermes Desktop from source build...")
-        launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
+        launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=launch_env, check=False)
         sys.exit(launch_result.returncode)
 
     if packaged_executable is None:
@@ -8100,7 +8112,7 @@ def cmd_gui(args: argparse.Namespace):
 
     launch_command.extend(config_electron_flags)
     print(f"→ Launching packaged Hermes Desktop: {' '.join(launch_command)}")
-    launch_result = subprocess.run(launch_command, cwd=desktop_dir, env=env, check=False)
+    launch_result = subprocess.run(launch_command, cwd=desktop_dir, env=launch_env, check=False)
     sys.exit(launch_result.returncode)
 
 
@@ -11524,6 +11536,18 @@ def cmd_dashboard(args):
             os.environ.pop("HERMES_WEB_DIST", None)
     if not _headless_backend:
         os.environ.pop("HERMES_SERVE_HEADLESS", None)
+
+    # Interactive serve/dashboard is never a dispatcher worker. Inherited
+    # HERMES_KANBAN_* / worker HERMES_PROFILE would make Command Center
+    # sessions believe they own that card. Explicit -p wins.
+    from hermes_cli.desktop_identity import (
+        apply_desktop_host_env_isolation,
+        explicit_profile_from_argv,
+    )
+
+    apply_desktop_host_env_isolation(
+        os.environ, explicit_profile=explicit_profile_from_argv(sys.argv)
+    )
 
     # ── Unified profile launch routing ────────────────────────────────
     # The dashboard is a MACHINE management surface: it can read/write any

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -322,6 +322,21 @@ launch_app() { # attempted BEFORE the terminal event (launch acceptance is
   # part of the outcome — gille's review). Returns nonzero when a launch
   # was due but did not verifiably happen; caller downgrades to manual.
   [ -n "$RELAUNCH_TARGET" ] || return 0
+  # A Kanban worker that spawned this updater must not donate lifecycle
+  # ownership or its profile to the relaunched Desktop (linux setsid inherits
+  # this env; Electron also sanitizes at boot for macOS `open`).
+  local _had_worker=0
+  [ -n "${HERMES_KANBAN_TASK:-}${HERMES_KANBAN_RUN_ID:-}${HERMES_KANBAN_CLAIM_LOCK:-}${HERMES_KANBAN_WORKSPACE:-}${HERMES_KANBAN_BRANCH:-}" ] && _had_worker=1
+  [ "${HERMES_SESSION_SOURCE:-}" = "kanban" ] && _had_worker=1
+  unset HERMES_KANBAN_TASK HERMES_KANBAN_RUN_ID HERMES_KANBAN_WORKSPACE \
+    HERMES_KANBAN_WORKSPACES_ROOT HERMES_KANBAN_CLAIM_LOCK HERMES_KANBAN_BRANCH \
+    HERMES_KANBAN_GOAL_MODE HERMES_KANBAN_GOAL_MAX_TURNS
+  if [ "$_had_worker" = 1 ]; then
+    unset HERMES_PROFILE HERMES_SESSION_SOURCE HERMES_SESSION_ID HERMES_SINGLE_QUERY_SESSION
+    case "${HERMES_HOME:-}" in
+      */profiles/*) HERMES_HOME="${HERMES_HOME%/*/*}"; export HERMES_HOME ;;
+    esac
+  fi
   if [ "$(uname)" = "Darwin" ]; then
     # A supplied target that no longer exists is a REJECTED launch (the
     # swap failed badly or the bundle vanished) — not "no launch due".

--- a/tests/hermes_cli/test_desktop_command_center_env.py
+++ b/tests/hermes_cli/test_desktop_command_center_env.py
@@ -1,0 +1,175 @@
+"""Desktop Command Center must not inherit Kanban worker identity.
+
+PO-0021 / live incident 2026-08-24: Hermes.app relaunched from a packaged
+install running inside a dispatcher worker inherited HERMES_PROFILE=company-infra
+and HERMES_KANBAN_TASK/RUN_ID/CLAIM_LOCK/WORKSPACE. Interactive Command Center
+turns then received the kanban-worker protocol and acted as Infra.
+
+This is a third isolation path, distinct from:
+- PO-0015 cron Bot Chat strip (child env copy; parent os.environ untouched)
+- BF-0016 nested ``hermes chat`` child isolation
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _worker_desktop_env(**extra: str) -> dict[str, str]:
+    """Env captured from the 2026-08-24 Hermes.app contamination."""
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": "/Users/shermanlye",
+        "HERMES_PROFILE": "company-infra",
+        "HERMES_HOME": "/Users/shermanlye/.hermes/profiles/company-infra",
+        "HERMES_KANBAN_TASK": "t_22bb7847",
+        "HERMES_KANBAN_RUN_ID": "45",
+        "HERMES_KANBAN_CLAIM_LOCK": "Shermans-MacBook-Pro.local:20597",
+        "HERMES_KANBAN_WORKSPACE": "/Users/shermanlye/.hermes/kanban/boards/personal/workspaces/t_22bb7847",
+        "HERMES_KANBAN_WORKSPACES_ROOT": "/Users/shermanlye/.hermes/kanban/boards/personal/workspaces",
+        "HERMES_KANBAN_BRANCH": "infra/desktop-group-room-owner-tag-20260823",
+        "HERMES_KANBAN_BOARD": "personal",
+        "HERMES_KANBAN_DB": "/Users/shermanlye/.hermes/kanban/boards/personal/kanban.db",
+        "HERMES_SESSION_SOURCE": "kanban",
+        "HERMES_SESSION_ID": "20260823_230728_ce516e",
+        "HERMES_SINGLE_QUERY_SESSION": "1",
+        "HERMES_INTERACTIVE": "1",
+        "HERMES_AGENT": "true",
+    }
+    env.update(extra)
+    return env
+
+
+def test_sanitize_desktop_host_env_drops_lifecycle_ownership_and_worker_profile():
+    from hermes_cli.desktop_identity import sanitize_desktop_host_env
+
+    src = _worker_desktop_env()
+    cleaned = sanitize_desktop_host_env(src)
+
+    assert src["HERMES_KANBAN_TASK"] == "t_22bb7847"
+    assert "HERMES_KANBAN_TASK" not in cleaned
+    assert "HERMES_KANBAN_RUN_ID" not in cleaned
+    assert "HERMES_KANBAN_CLAIM_LOCK" not in cleaned
+    assert "HERMES_KANBAN_WORKSPACE" not in cleaned
+    assert "HERMES_KANBAN_WORKSPACES_ROOT" not in cleaned
+    assert "HERMES_KANBAN_BRANCH" not in cleaned
+    assert cleaned.get("HERMES_KANBAN_BOARD") == "personal"
+    assert cleaned.get("HERMES_KANBAN_DB", "").endswith("kanban.db")
+    assert "HERMES_PROFILE" not in cleaned
+    assert cleaned["HERMES_HOME"] == "/Users/shermanlye/.hermes"
+    assert cleaned.get("HERMES_SESSION_SOURCE") != "kanban"
+    assert "HERMES_SESSION_ID" not in cleaned
+    assert "HERMES_SINGLE_QUERY_SESSION" not in cleaned
+    assert cleaned.get("HERMES_INTERACTIVE") == "1"
+    assert cleaned.get("PATH") == "/usr/bin:/bin"
+
+
+def test_sanitize_desktop_host_env_keeps_explicit_desk_profile():
+    from hermes_cli.desktop_identity import sanitize_desktop_host_env
+
+    cleaned = sanitize_desktop_host_env(
+        _worker_desktop_env(),
+        explicit_profile="company-cpo",
+    )
+    assert cleaned["HERMES_PROFILE"] == "company-cpo"
+    assert "HERMES_KANBAN_TASK" not in cleaned
+
+
+def test_sanitize_desktop_host_env_is_noop_without_worker_identity():
+    from hermes_cli.desktop_identity import sanitize_desktop_host_env
+
+    src = {
+        "PATH": "/usr/bin",
+        "HERMES_HOME": "/Users/shermanlye/.hermes",
+        "HERMES_KANBAN_BOARD": "personal",
+    }
+    cleaned = sanitize_desktop_host_env(src)
+    assert cleaned["HERMES_HOME"] == "/Users/shermanlye/.hermes"
+    assert cleaned["HERMES_KANBAN_BOARD"] == "personal"
+    assert "HERMES_PROFILE" not in cleaned
+
+
+def test_apply_host_isolation_mutates_only_the_given_mapping():
+    from hermes_cli.desktop_identity import apply_desktop_host_env_isolation
+
+    env = _worker_desktop_env()
+    changed = apply_desktop_host_env_isolation(env)
+    assert changed is True
+    assert "HERMES_KANBAN_TASK" not in env
+    assert env["HERMES_HOME"] == "/Users/shermanlye/.hermes"
+
+
+def test_gui_launch_env_does_not_inherit_worker_lifecycle(tmp_path, monkeypatch):
+    """``hermes desktop`` from a worker must not relaunch Hermes.app as that worker."""
+    from hermes_cli import main as cli_main
+
+    root = tmp_path / "hermes-agent"
+    desktop_dir = root / "apps" / "desktop"
+    desktop_dir.mkdir(parents=True)
+    (desktop_dir / "package.json").write_text("{}", encoding="utf-8")
+    exe = desktop_dir / "release" / "mac-arm64" / "Hermes.app" / "Contents" / "MacOS" / "Hermes"
+    if __import__("sys").platform == "darwin":
+        packaged = exe
+    elif __import__("sys").platform == "win32":
+        packaged = desktop_dir / "release" / "win-unpacked" / "Hermes.exe"
+    else:
+        packaged = desktop_dir / "release" / "linux-unpacked" / "hermes"
+    packaged.parent.mkdir(parents=True, exist_ok=True)
+    packaged.write_text("", encoding="utf-8")
+    if __import__("sys").platform not in ("darwin", "win32"):
+        (packaged.parent / "chrome-sandbox").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    for key, value in _worker_desktop_env().items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg-data"))
+    monkeypatch.setenv("GNOME_KEYRING_CONTROL", "/run/user/1000/keyring")
+    monkeypatch.delenv("KDE_SESSION_VERSION", raising=False)
+    monkeypatch.delenv("KDE_FULL_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_DESKTOP_PASSWORD_STORE", raising=False)
+
+    launch_envs: list[dict] = []
+
+    def _capture_run(*args, **kwargs):
+        env = kwargs.get("env")
+        if env and args and args[0] and str(args[0][0]) == str(packaged):
+            launch_envs.append(dict(env))
+        return subprocess.CompletedProcess(args[0] if args else ["hermes"], 0)
+
+    ns = argparse.Namespace(
+        skip_build=True,
+        build_only=False,
+        force_build=False,
+        source=False,
+        fake_boot=False,
+        ignore_existing=False,
+        hermes_root=None,
+        cwd=None,
+    )
+    from unittest.mock import patch
+
+    with (
+        patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True),
+        patch("hermes_cli.main._register_linux_desktop_entry"),
+        patch("hermes_cli.main.subprocess.run", side_effect=_capture_run),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli_main.cmd_gui(ns)
+
+    assert exc.value.code == 0
+    assert launch_envs, "packaged desktop launch env was not captured"
+    launched = launch_envs[0]
+    assert "HERMES_KANBAN_TASK" not in launched
+    assert "HERMES_KANBAN_RUN_ID" not in launched
+    assert "HERMES_KANBAN_CLAIM_LOCK" not in launched
+    assert "HERMES_KANBAN_WORKSPACE" not in launched
+    assert "HERMES_KANBAN_BRANCH" not in launched
+    assert launched.get("HERMES_PROFILE") != "company-infra"
+    assert launched.get("HERMES_HOME") == "/Users/shermanlye/.hermes"
+    # Parent worker env must stay intact so the dispatcher claim/heartbeat survives.
+    assert __import__("os").environ["HERMES_KANBAN_TASK"] == "t_22bb7847"
+    assert __import__("os").environ["HERMES_PROFILE"] == "company-infra"


### PR DESCRIPTION
## Bug Description

Interactive Desktop Command Center inherited Kanban worker identity. After a packaged Hermes.app relaunch from a dispatcher worker (live: pid 5478, 2026-08-23 23:26 +08, during PO-0018), the Desktop process env still had `HERMES_PROFILE=company-infra`, `HERMES_HOME=.../profiles/company-infra`, `HERMES_KANBAN_TASK=t_22bb7847`, `HERMES_KANBAN_RUN_ID=45`, and `HERMES_SESSION_SOURCE=kanban`.

Command Center UI title stayed "default". Interactive turns received the kanban-worker protocol (`You are a Hermes kanban worker… t_22bb7847 is still running`) and did product work in-chat instead of handing off to specialists.

This is a **third isolation path**, distinct from:

- cron Bot Chat strip (PO-0015) — child env copy; parent `os.environ` untouched
- nested `hermes chat` child isolation (BF-0016 / #92416) — not landed here; not weakened

## Root Cause

`hermes desktop` / packaged launch used `with_hermes_node_path()` (`os.environ` copy) as the Electron/`Hermes.app` env. Electron then spread `process.env` into the `hermes serve` backend. Lifecycle ownership and the worker profile became process-global for every Command Center session.

macOS `open` from the updater is usually launchd-clean; Linux `setsid` inherits. Electron `app.relaunch()` also keeps env. Defense in depth is required.

## Fix

- New `hermes_cli/desktop_identity.py`: drop TASK / RUN_ID / WORKSPACE / WORKSPACES_ROOT / CLAIM_LOCK / BRANCH / goal keys; keep BOARD / DB routing pins; peel `/profiles/<name>` home; drop worker `HERMES_PROFILE` unless `-p` / explicit desk profile.
- `cmd_gui` sanitizes a **copy** for launch only (worker claim heartbeat stays intact).
- Electron `sanitizeInheritedDesktopEnv(process.env)` runs before `resolveHermesHome()`.
- `cmd_dashboard` / `serve` host isolation for inherited worker env.
- posix updater `launch_app` unsets worker identity before `open` / `setsid`.

## How to Verify

1. Targeted Python isolation + PO-0015 sibling suites (see Test Plan).
2. From a fake worker env, `sanitize_desktop_host_env` / `cmd_gui` launch env has no lifecycle ownership and `HERMES_HOME` is the desk root, not `.../profiles/company-infra`.
3. Explicit `-p company-cpo` is preserved.
4. Cron Bot Chat / in-process cron isolation tests still pass.

Live Command Center on this host was **not** restarted. pid 5478 remains contaminated until a user-requested Desktop relaunch after this lands.

## Test Plan

- [x] `tests/hermes_cli/test_desktop_command_center_env.py` (5 tests, including simulated worker→desktop launch)
- [x] `tests/hermes_cli/test_gui_command.py`
- [x] `tests/cron/test_cron_bot_chat_delivery.py`
- [x] `tests/cron/test_cron_kanban_env_isolation.py`
- [x] Electron sanitizer behavior (`sanitizeInheritedDesktopEnv`)

Result on this branch (clean worktree of `origin/main` `f293e7206b`): **40 passed** on the isolation + PO-0015 suites.

## Risk Assessment

Low / medium. Blast radius is Desktop/gateway **host** env inheritance. Dispatcher `_default_spawn` still injects ownership into real workers. BOARD/DB pins remain. Worker `os.environ` is not cleared on `hermes desktop` (copy only).

## Residual

Existing running Hermes.app processes that already inherited worker env stay dirty until relaunch. This PR does not restart a live Desktop.
