### PR TITLE
fix(code-exec): report the real cancellation source for interrupted runs

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -125,7 +125,11 @@ def _interrupt_background_review(review_agent: Any) -> None:
         try:
             from agent.interrupt_compat import request_hard_interrupt
 
-            request_hard_interrupt(review_agent, "superseded by a new live turn")
+            request_hard_interrupt(
+                review_agent,
+                "superseded by a new live turn",
+                tool_reason="background review superseded",
+            )
         except Exception:
             logger.debug(
                 "Failed to cancel in-flight background review for a new turn",

--- a/agent/interrupt_compat.py
+++ b/agent/interrupt_compat.py
@@ -6,12 +6,38 @@ import inspect
 from typing import Any
 
 
-def request_hard_interrupt(agent: Any, message: str | None = None) -> bool:
+def _accepts_keyword(callable_obj: Any, name: str) -> bool:
+    """Return whether a callable explicitly supports a keyword argument."""
+    try:
+        parameters = inspect.signature(callable_obj).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        or (
+            parameter.name == name
+            and parameter.kind is not inspect.Parameter.POSITIONAL_ONLY
+        )
+        for parameter in parameters
+    )
+
+
+def request_hard_interrupt(
+    agent: Any,
+    message: str | None = None,
+    *,
+    tool_reason: str | None = None,
+) -> bool:
     """Request an explicit stop, falling back to the legacy interrupt ABI.
 
     New agents expose ``hard_interrupt(message=None)``. Third-party agents and
     old test doubles may only expose ``interrupt(message=None)``; keep those
-    usable without sending the newer ``hard_cancel=`` keyword they do not know.
+    usable without sending newer keyword arguments they do not know.
+
+    ``message`` is diagnostic/control-plane text. ``tool_reason`` is a trusted,
+    fixed category that may be exposed in model-visible tool cancellation
+    output. It is only forwarded when the modern callable explicitly supports
+    that channel.
     Returns ``False`` only when neither callable is available.
     """
     # Avoid treating a dynamic ``__getattr__`` proxy (notably an unspecced
@@ -28,8 +54,11 @@ def request_hard_interrupt(agent: Any, message: str | None = None) -> bool:
         interrupt = getattr(agent, "interrupt", None)
     if not callable(interrupt):
         return False
+    kwargs = {}
+    if tool_reason is not None and _accepts_keyword(interrupt, "tool_reason"):
+        kwargs["tool_reason"] = tool_reason
     if message is None:
-        interrupt()
+        interrupt(**kwargs)
     else:
-        interrupt(message)
+        interrupt(message, **kwargs)
     return True

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -307,7 +307,9 @@ class SubagentLifecycleService:
             )
         try:
             accepted = request_hard_interrupt(
-                agent, f"Lifecycle cancellation requested: {reason[:500]}"
+                agent,
+                f"Lifecycle cancellation requested: {reason[:500]}",
+                tool_reason="subagent cancellation requested",
             )
         except Exception:
             return SubagentCancelResult(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -891,7 +891,11 @@ def _run_sequential_tool_execution_middleware(
             # tids, but the worker may have registered after the fan-out ran.
             for tid in worker_tid:
                 try:
-                    _ra()._set_interrupt(True, tid)
+                    _ra()._set_interrupt(
+                        True,
+                        tid,
+                        reason=getattr(agent, "_tool_interrupt_reason", None),
+                    )
                 except Exception:
                     pass
             # Give a cooperative tool a moment to notice its per-thread
@@ -902,13 +906,17 @@ def _run_sequential_tool_execution_middleware(
                 return future.result()
             timed_out = True  # reuse the abandon-shutdown path in finally
             future.cancel()
+            interrupt_reason = (
+                getattr(agent, "_tool_interrupt_reason", None)
+                or "interrupt requested"
+            )
             message = (
-                f"[Tool execution cancelled — {function_name} was abandoned "
-                "after user interrupt]"
+                f"[Tool execution cancelled — {function_name} was abandoned: "
+                f"{interrupt_reason}]"
             )
             logger.info(
-                "sequential tool %s abandoned after user interrupt (%.1fs elapsed)",
-                function_name, time.monotonic() - started,
+                "sequential tool %s abandoned due to %s (%.1fs elapsed)",
+                function_name, interrupt_reason, time.monotonic() - started,
             )
             trace = middleware_trace if middleware_trace is not None else []
             _emit_terminal_post_tool_call(
@@ -920,8 +928,8 @@ def _run_sequential_tool_execution_middleware(
                 tool_call_id=tool_call_id,
                 duration_ms=int((time.monotonic() - started) * 1000),
                 status="cancelled",
-                error_type="keyboard_interrupt",
-                error_message="Tool execution cancelled by user interrupt",
+                error_type="tool_interrupted",
+                error_message=f"Tool execution cancelled: {interrupt_reason}",
                 middleware_trace=list(trace),
             )
             return _ManagedToolResult(
@@ -1298,7 +1306,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # the tool returns True on the next poll.
         if agent._interrupt_requested:
             try:
-                _ra()._set_interrupt(True, _worker_tid)
+                _ra()._set_interrupt(
+                    True,
+                    _worker_tid,
+                    reason=getattr(agent, "_tool_interrupt_reason", None),
+                )
             except Exception:
                 pass
         # Set the activity callback on THIS worker thread so

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1331,10 +1331,15 @@ def build_turn_context(
     # Clear stale per-thread interrupt state, preserving a pending interrupt.
     ra()._set_interrupt(False, agent._execution_thread_id)
     if agent._interrupt_requested:
-        ra()._set_interrupt(True, agent._execution_thread_id)
+        ra()._set_interrupt(
+            True,
+            agent._execution_thread_id,
+            reason=getattr(agent, "_tool_interrupt_reason", None),
+        )
         agent._interrupt_thread_signal_pending = False
     else:
         agent._interrupt_message = None
+        agent._tool_interrupt_reason = None
         agent._interrupt_thread_signal_pending = False
 
     # Notify memory providers of the new turn (BEFORE prefetch_all).

--- a/run_agent.py
+++ b/run_agent.py
@@ -3255,7 +3255,13 @@ class AIAgent:
                 logging.warning(f"Failed to save session log: {e}")
 
 
-    def interrupt(self, message: Optional[str] = None, *, hard_cancel: bool = False) -> None:
+    def interrupt(
+        self,
+        message: Optional[str] = None,
+        *,
+        hard_cancel: bool = False,
+        tool_reason: Optional[str] = None,
+    ) -> None:
         """
         Request the agent to interrupt its current tool-calling loop.
         
@@ -3271,6 +3277,8 @@ class AIAgent:
             hard_cancel: Mark this as an explicit stop rather than a redirect or
                          incoming-message interrupt. Compression may honor this
                          atomic signal even while ordinary interrupts are masked.
+            tool_reason: Trusted fixed category safe to expose in tool output.
+                         Arbitrary diagnostic or caller text belongs in message.
         
         Example (CLI):
             # In a separate input thread:
@@ -3310,7 +3318,7 @@ class AIAgent:
         # ordinary interrupts may carry the user's full next message, which
         # must not be copied into tool output.
         tool_interrupt_reason = (
-            (message or "explicit stop requested")
+            (tool_reason or "explicit stop requested")
             if hard_cancel
             else ("user sent a new message" if message else "user interrupt")
         )
@@ -3397,7 +3405,11 @@ class AIAgent:
         for child in children_copy:
             try:
                 if hard_cancel:
-                    request_hard_interrupt(child, message)
+                    request_hard_interrupt(
+                        child,
+                        message,
+                        tool_reason=tool_interrupt_reason,
+                    )
                 else:
                     child.interrupt(message)
             except Exception as e:
@@ -3405,7 +3417,12 @@ class AIAgent:
         if not self.quiet_mode:
             print("\n⚡ Interrupt requested" + (f": '{message[:40]}...'" if message and len(message) > 40 else f": '{message}'" if message else ""))
 
-    def hard_interrupt(self, message: Optional[str] = None) -> None:
+    def hard_interrupt(
+        self,
+        message: Optional[str] = None,
+        *,
+        tool_reason: Optional[str] = None,
+    ) -> None:
         """Request an explicit stop while preserving ``interrupt()`` ABI.
 
         Frontends can feature-detect this method and fall back to the legacy
@@ -3414,7 +3431,12 @@ class AIAgent:
         # Deliberately bypass dynamic dispatch: subclasses written against the
         # legacy interrupt(message=None) ABI may override interrupt without the
         # newer keyword-only hard_cancel argument.
-        AIAgent.interrupt(self, message, hard_cancel=True)
+        AIAgent.interrupt(
+            self,
+            message,
+            hard_cancel=True,
+            tool_reason=tool_reason,
+        )
 
     def clear_interrupt(self, *, preserve_redirect: bool = False) -> bool:
         """Clear the interrupt request and per-thread tool signal.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3306,17 +3306,28 @@ class AIAgent:
                     )
             event.set()
 
+        # Keep tool cancellation attribution separate from _interrupt_message:
+        # ordinary interrupts may carry the user's full next message, which
+        # must not be copied into tool output.
+        tool_interrupt_reason = (
+            (message or "explicit stop requested")
+            if hard_cancel
+            else ("user sent a new message" if message else "user interrupt")
+        )
+
         _redirect_lock = getattr(self, "_pending_redirect_lock", None)
         if _redirect_lock is not None:
             with _redirect_lock:
                 self._interrupt_requested = True
                 self._interrupt_message = message
+                self._tool_interrupt_reason = tool_interrupt_reason
                 if hard_cancel:
                     _admit_hard_cancel()
                 self._pending_redirect = None
         else:
             self._interrupt_requested = True
             self._interrupt_message = message
+            self._tool_interrupt_reason = tool_interrupt_reason
             if hard_cancel:
                 _admit_hard_cancel()
             self._pending_redirect = None
@@ -3349,7 +3360,11 @@ class AIAgent:
         # Scope the interrupt to this agent's execution thread so other
         # agents running in the same process (gateway) are not affected.
         if self._execution_thread_id is not None:
-            _set_interrupt(True, self._execution_thread_id)
+            _set_interrupt(
+                True,
+                self._execution_thread_id,
+                reason=tool_interrupt_reason,
+            )
             self._interrupt_thread_signal_pending = False
         else:
             # The interrupt arrived before run_conversation() finished
@@ -3373,7 +3388,7 @@ class AIAgent:
                 _worker_tids = list(_tracker)
             for _wtid in _worker_tids:
                 try:
-                    _set_interrupt(True, _wtid)
+                    _set_interrupt(True, _wtid, reason=tool_interrupt_reason)
                 except Exception:
                     pass
         # Propagate interrupt to any running child agents (subagent delegation)
@@ -3415,6 +3430,7 @@ class AIAgent:
                     return False
                 self._interrupt_requested = False
                 self._interrupt_message = None
+                self._tool_interrupt_reason = None
                 getattr(self, "_hard_interrupt_requested", threading.Event()).clear()
                 if not preserve_redirect:
                     self._pending_redirect = None
@@ -3423,6 +3439,7 @@ class AIAgent:
                 return False
             self._interrupt_requested = False
             self._interrupt_message = None
+            self._tool_interrupt_reason = None
             getattr(self, "_hard_interrupt_requested", threading.Event()).clear()
             if not preserve_redirect:
                 self._pending_redirect = None

--- a/tests/agent/test_interrupt_compat.py
+++ b/tests/agent/test_interrupt_compat.py
@@ -10,13 +10,18 @@ from agent.interrupt_compat import request_hard_interrupt
 
 class _ModernAgent:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str | None]] = []
+        self.calls: list[tuple[str, str | None, str | None]] = []
 
-    def hard_interrupt(self, message: str | None = None) -> None:
-        self.calls.append(("hard", message))
+    def hard_interrupt(
+        self,
+        message: str | None = None,
+        *,
+        tool_reason: str | None = None,
+    ) -> None:
+        self.calls.append(("hard", message, tool_reason))
 
     def interrupt(self, message: str | None = None) -> None:
-        self.calls.append(("soft", message))
+        self.calls.append(("soft", message, None))
 
 
 class _LegacyAgent:
@@ -32,7 +37,22 @@ def test_explicit_producer_prefers_feature_detected_hard_interrupt() -> None:
 
     assert request_hard_interrupt(agent, "stop now") is True
 
-    assert agent.calls == [("hard", "stop now")]
+    assert agent.calls == [("hard", "stop now", None)]
+
+
+def test_safe_tool_reason_only_reaches_supporting_modern_agent() -> None:
+    modern = _ModernAgent()
+    legacy = _LegacyAgent()
+
+    assert request_hard_interrupt(
+        modern, "private diagnostic", tool_reason="fixed category"
+    )
+    assert request_hard_interrupt(
+        legacy, "private diagnostic", tool_reason="fixed category"
+    )
+
+    assert modern.calls == [("hard", "private diagnostic", "fixed category")]
+    assert legacy.calls == [("legacy", "private diagnostic")]
 
 
 def test_explicit_producer_falls_back_to_old_interrupt_signature() -> None:
@@ -100,4 +120,4 @@ def test_tui_subagent_interrupt_is_an_explicit_hard_stop() -> None:
         with delegate_tool._active_subagents_lock:
             delegate_tool._active_subagents.pop(subagent_id, None)
 
-    assert agent.calls == [("hard", f"Interrupted via TUI ({subagent_id})")]
+    assert agent.calls == [("hard", f"Interrupted via TUI ({subagent_id})", None)]

--- a/tests/agent/test_subagent_lifecycle.py
+++ b/tests/agent/test_subagent_lifecycle.py
@@ -25,14 +25,18 @@ class FakeChild:
         self.model = "test-model"
         self.interrupted = False
         self.interrupt_kind = None
+        self.interrupt_message = None
+        self.tool_reason = None
 
     def interrupt(self, _reason):
         self.interrupted = True
         self.interrupt_kind = "soft"
 
-    def hard_interrupt(self, _reason):
+    def hard_interrupt(self, reason, *, tool_reason=None):
         self.interrupted = True
         self.interrupt_kind = "hard"
+        self.interrupt_message = reason
+        self.tool_reason = tool_reason
 
 
 @pytest.fixture
@@ -90,6 +94,8 @@ def test_cancel_uses_explicit_hard_interrupt(lifecycle):
     assert lifecycle.cancel(handle, reason="explicit user cancel").accepted
 
     assert record.agent.interrupt_kind == "hard"
+    assert "explicit user cancel" in record.agent.interrupt_message
+    assert record.agent.tool_reason == "subagent cancellation requested"
     lifecycle.wait(handle, timeout_seconds=1)
 
 

--- a/tests/run_agent/test_interrupt_propagation.py
+++ b/tests/run_agent/test_interrupt_propagation.py
@@ -84,13 +84,25 @@ class TestInterruptPropagationToChild(unittest.TestCase):
         assert get_interrupt_reason() == "user sent a new message"
         assert "private follow-up text" not in get_interrupt_reason()
 
-    def test_hard_interrupt_records_control_reason(self):
+    def test_hard_interrupt_does_not_expose_diagnostic_message(self):
         agent = self._make_bare_agent()
         agent._execution_thread_id = threading.current_thread().ident
 
-        agent.hard_interrupt("superseded by a new live turn")
+        agent.hard_interrupt("PRIVATE_CALLER_DETAIL")
 
-        assert get_interrupt_reason() == "superseded by a new live turn"
+        assert get_interrupt_reason() == "explicit stop requested"
+        assert "PRIVATE_CALLER_DETAIL" not in get_interrupt_reason()
+
+    def test_hard_interrupt_records_explicit_safe_tool_reason(self):
+        agent = self._make_bare_agent()
+        agent._execution_thread_id = threading.current_thread().ident
+
+        agent.hard_interrupt(
+            "PRIVATE_CALLER_DETAIL",
+            tool_reason="background review superseded",
+        )
+
+        assert get_interrupt_reason() == "background review superseded"
 
     def test_active_turn_redirect_does_not_set_hard_cancel(self):
         agent = self._make_bare_agent()

--- a/tests/run_agent/test_interrupt_propagation.py
+++ b/tests/run_agent/test_interrupt_propagation.py
@@ -9,7 +9,7 @@ import time
 import unittest
 from unittest.mock import MagicMock
 
-from tools.interrupt import set_interrupt, is_interrupted
+from tools.interrupt import get_interrupt_reason, set_interrupt, is_interrupted
 
 
 class TestInterruptPropagationToChild(unittest.TestCase):
@@ -74,6 +74,23 @@ class TestInterruptPropagationToChild(unittest.TestCase):
 
         assert agent._interrupt_requested is True
         assert not agent._hard_interrupt_requested.is_set()
+
+    def test_message_interrupt_records_source_without_user_text(self):
+        agent = self._make_bare_agent()
+        agent._execution_thread_id = threading.current_thread().ident
+
+        agent.interrupt("private follow-up text")
+
+        assert get_interrupt_reason() == "user sent a new message"
+        assert "private follow-up text" not in get_interrupt_reason()
+
+    def test_hard_interrupt_records_control_reason(self):
+        agent = self._make_bare_agent()
+        agent._execution_thread_id = threading.current_thread().ident
+
+        agent.hard_interrupt("superseded by a new live turn")
+
+        assert get_interrupt_reason() == "superseded by a new live turn"
 
     def test_active_turn_redirect_does_not_set_hard_cancel(self):
         agent = self._make_bare_agent()

--- a/tests/run_agent/test_sequential_tool_timeout.py
+++ b/tests/run_agent/test_sequential_tool_timeout.py
@@ -215,8 +215,17 @@ def test_sequential_tool_timeout_suppresses_late_terminal_event(tmp_path, monkey
     ]
 
 
-def test_sequential_tool_interrupt_reports_hard_cancel_reason(tmp_path, monkeypatch):
+def test_sequential_tool_interrupt_hides_lifecycle_cancel_detail(tmp_path, monkeypatch):
+    from agent.subagent_lifecycle import (
+        SubagentLaunchRequest,
+        SubagentLifecycleService,
+        SubagentState,
+    )
+
     agent = _make_agent(tmp_path)
+    agent._subagent_id = "sa-lifecycle-cancel-output"
+    agent._delegate_role = "leaf"
+    agent._delegate_depth = 1
     first_started = threading.Event()
     release_first = threading.Event()
     terminal_events: list[dict] = []
@@ -226,14 +235,34 @@ def test_sequential_tool_interrupt_reports_hard_cancel_reason(tmp_path, monkeypa
         release_first.wait()
         return "late result"
 
-    def _interrupt():
-        assert first_started.wait(timeout=5)
-        agent.hard_interrupt("superseded by a new live turn")
-
-    interrupter = threading.Thread(target=_interrupt, daemon=True)
-    interrupter.start()
     messages: list[dict] = []
+
+    def _run_child(*_args, **_kwargs):
+        execute_tool_calls_sequential(
+            agent,
+            SimpleNamespace(tool_calls=[_tool_call("hung")]),
+            messages,
+            "task",
+        )
+        return {
+            "status": "interrupted",
+            "summary": None,
+            "api_calls": 0,
+            "duration_seconds": 0,
+        }
+
     monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "30")
+    monkeypatch.setattr(
+        "tools.delegate_tool._build_child_preserving_parent_tools",
+        lambda **_kwargs: agent,
+    )
+    monkeypatch.setattr("tools.delegate_tool._run_child_lifecycle", _run_child)
+    lifecycle = SubagentLifecycleService(
+        lambda: SimpleNamespace(
+            session_id="parent-lifecycle-cancel-output",
+            enabled_toolsets=["file"],
+        )
+    )
 
     try:
         with (
@@ -243,18 +272,20 @@ def test_sequential_tool_interrupt_reports_hard_cancel_reason(tmp_path, monkeypa
                 side_effect=lambda *_args, **kwargs: terminal_events.append(kwargs),
             ),
         ):
-            execute_tool_calls_sequential(
-                agent,
-                SimpleNamespace(tool_calls=[_tool_call("hung")]),
-                messages,
-                "task",
-            )
+            handle = lifecycle.launch(SubagentLaunchRequest(goal="cancel output test"))
+            assert first_started.wait(timeout=5)
+            assert lifecycle.cancel(
+                handle,
+                reason="PRIVATE_LIFECYCLE_REASON_DO_NOT_COPY",
+            ).accepted
+            assert lifecycle.wait(handle, timeout_seconds=5).state is SubagentState.CANCELLED
     finally:
         release_first.set()
-        interrupter.join(timeout=2)
 
-    assert "superseded by a new live turn" in messages[0]["content"]
+    assert "subagent cancellation requested" in messages[0]["content"]
+    assert "PRIVATE_LIFECYCLE_REASON_DO_NOT_COPY" not in messages[0]["content"]
     assert "user interrupt" not in messages[0]["content"]
+    assert "PRIVATE_LIFECYCLE_REASON_DO_NOT_COPY" not in terminal_events[0]["error_message"]
     assert terminal_events[0]["error_type"] == "tool_interrupted"
 
 

--- a/tests/run_agent/test_sequential_tool_timeout.py
+++ b/tests/run_agent/test_sequential_tool_timeout.py
@@ -215,6 +215,49 @@ def test_sequential_tool_timeout_suppresses_late_terminal_event(tmp_path, monkey
     ]
 
 
+def test_sequential_tool_interrupt_reports_hard_cancel_reason(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    terminal_events: list[dict] = []
+
+    def _dispatch(*_args, **_kwargs):
+        first_started.set()
+        release_first.wait()
+        return "late result"
+
+    def _interrupt():
+        assert first_started.wait(timeout=5)
+        agent.hard_interrupt("superseded by a new live turn")
+
+    interrupter = threading.Thread(target=_interrupt, daemon=True)
+    interrupter.start()
+    messages: list[dict] = []
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "30")
+
+    try:
+        with (
+            patch("run_agent.handle_function_call", side_effect=_dispatch),
+            patch(
+                "agent.tool_executor._emit_terminal_post_tool_call",
+                side_effect=lambda *_args, **kwargs: terminal_events.append(kwargs),
+            ),
+        ):
+            execute_tool_calls_sequential(
+                agent,
+                SimpleNamespace(tool_calls=[_tool_call("hung")]),
+                messages,
+                "task",
+            )
+    finally:
+        release_first.set()
+        interrupter.join(timeout=2)
+
+    assert "superseded by a new live turn" in messages[0]["content"]
+    assert "user interrupt" not in messages[0]["content"]
+    assert terminal_events[0]["error_type"] == "tool_interrupted"
+
+
 @pytest.mark.parametrize(
     "clarify_timeout",
     [resolve_clarify_timeout({}), 0],

--- a/tests/tools/test_approved_command_clean_slate.py
+++ b/tests/tools/test_approved_command_clean_slate.py
@@ -232,5 +232,8 @@ def test_execute_code_non_approved_still_interrupts_on_stale_bit(monkeypatch):
 
     # Killed on the first poll before the script can print.
     assert "CODE_DONE" not in result["output"], result
+    assert result["status"] == "interrupted", result
+    assert result["output"] == "[execution interrupted]"
+    assert "user sent a new message" not in result["output"]
 
 

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -46,6 +46,7 @@ from tools.code_execution_tool import (
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
     _execute_remote,
+    _format_interrupted_output,
 )
 from tools.registry import registry
 
@@ -79,6 +80,33 @@ class TestSandboxRequirements(unittest.TestCase):
         self.assertEqual(EXECUTE_CODE_SCHEMA["name"], "execute_code")
         self.assertIn("code", EXECUTE_CODE_SCHEMA["parameters"]["properties"])
         self.assertIn("code", EXECUTE_CODE_SCHEMA["parameters"]["required"])
+
+
+class TestInterruptedOutput(unittest.TestCase):
+    def tearDown(self):
+        from tools.interrupt import set_interrupt
+
+        set_interrupt(False)
+
+    def test_uses_recorded_interrupt_source(self):
+        from tools.interrupt import set_interrupt
+
+        set_interrupt(True, reason="superseded by a new live turn")
+
+        self.assertEqual(
+            _format_interrupted_output("partial output"),
+            "partial output\n[execution interrupted — superseded by a new live turn]",
+        )
+
+    def test_unknown_interrupt_source_is_neutral(self):
+        from tools.interrupt import set_interrupt
+
+        set_interrupt(True)
+
+        self.assertEqual(
+            _format_interrupted_output(""),
+            "[execution interrupted]",
+        )
 
 
 class TestHermesToolsGeneration(unittest.TestCase):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1060,6 +1060,19 @@ def _rpc_poll_loop(
             stop_event.wait(poll_interval)
 
 
+def _format_interrupted_output(stdout_text: str) -> str:
+    """Append an interruption marker without guessing who caused it."""
+    from tools.interrupt import get_interrupt_reason
+
+    reason = get_interrupt_reason()
+    marker = (
+        f"[execution interrupted — {reason}]"
+        if reason
+        else "[execution interrupted]"
+    )
+    return f"{stdout_text}\n{marker}" if stdout_text else marker
+
+
 def _execute_remote(
     code: str,
     task_id: Optional[str],
@@ -1238,9 +1251,7 @@ def _execute_remote(
             duration, timeout, tool_call_counter[0],
         )
     elif status == "interrupted":
-        result["output"] = (
-            stdout_text + "\n[execution interrupted — user sent a new message]"
-        )
+        result["output"] = _format_interrupted_output(stdout_text)
     elif exit_code != 0:
         result["status"] = "error"
         result["error"] = f"Script exited with code {exit_code}"
@@ -1693,7 +1704,7 @@ def execute_code(
                 duration, timeout, tool_call_counter[0],
             )
         elif status == "interrupted":
-            result["output"] = stdout_text + "\n[execution interrupted — user sent a new message]"
+            result["output"] = _format_interrupted_output(stdout_text)
         elif exit_code != 0:
             result["status"] = "error"
             result["error"] = stderr_text or f"Script exited with code {exit_code}"

--- a/tools/interrupt.py
+++ b/tools/interrupt.py
@@ -31,25 +31,39 @@ if _DEBUG_INTERRUPT:
     # Force our own logger back to INFO so the trace is visible in agent.log.
     logger.setLevel(logging.INFO)
 
-# Set of thread idents that have been interrupted.
+# Set of thread idents that have been interrupted, plus an optional
+# user-safe cause for each signal. The cause deliberately does not contain an
+# incoming user's message text.
 _interrupted_threads: set[int] = set()
+_interrupt_reasons: dict[int, str] = {}
 _lock = threading.Lock()
 
 
-def set_interrupt(active: bool, thread_id: int | None = None) -> None:
+def set_interrupt(
+    active: bool,
+    thread_id: int | None = None,
+    *,
+    reason: str | None = None,
+) -> None:
     """Set or clear interrupt for a specific thread.
 
     Args:
         active: True to signal interrupt, False to clear it.
         thread_id: Target thread ident.  When None, targets the
                    current thread (backward compat for CLI/tests).
+        reason: Optional user-safe cause for the interrupt.
     """
     tid = thread_id if thread_id is not None else threading.current_thread().ident
     with _lock:
         if active:
             _interrupted_threads.add(tid)
+            if reason:
+                _interrupt_reasons[tid] = reason
+            else:
+                _interrupt_reasons.pop(tid, None)
         else:
             _interrupted_threads.discard(tid)
+            _interrupt_reasons.pop(tid, None)
         _snapshot = set(_interrupted_threads) if _DEBUG_INTERRUPT else None
     if _DEBUG_INTERRUPT:
         logger.info(
@@ -68,6 +82,13 @@ def is_interrupted() -> bool:
     tid = threading.current_thread().ident
     with _lock:
         return tid in _interrupted_threads
+
+
+def get_interrupt_reason() -> str | None:
+    """Return the user-safe interrupt cause for the current thread, if known."""
+    tid = threading.current_thread().ident
+    with _lock:
+        return _interrupt_reasons.get(tid)
 
 
 def clear_current_thread_interrupt() -> None:


### PR DESCRIPTION
## What does this PR do?

Interrupted `execute_code` runs no longer claim that the user sent a new message when cancellation came from background review teardown, an explicit stop, or an unknown source. Hermes now preserves a user-safe interrupt reason per tool thread, labels real incoming-message interrupts without copying the user's message text, and falls back to neutral interruption text when no reason exists.

### Symptom

Any local or remote `execute_code` result with interrupted status appended a marker claiming that the user sent a new message, even when no user message existed.

### Impact

Users receive a false explanation for an aborted tool run, which obscures internal cancellation sources and makes incident diagnosis misleading. The reported run stopped before executing any sandbox work; no data loss or security impact was established.

### Bug Cause

**Trigger:** `tools/code_execution_tool.py` interrupted-result formatting for local and remote execution.

**Causal chain:**
1. An agent interrupt sets a thread-scoped Boolean that stops the sandbox process with interrupted status.
2. The per-thread tool signal previously discarded whether the interrupt came from a user message, a hard cancellation, or an unknown source.
3. Both `execute_code` paths mapped every interrupted status to the same hardcoded user-message claim.

**Why it is wrong:** The formatter asserted a source that its input state could not prove.

**Working sibling / contrast:** Turn finalization already retains `agent._interrupt_message`, so non-tool callers can distinguish a message-bearing interrupt from control cancellation.

**Ruled out:** The sandbox child does not generate the false source text; it only returns exit code 130 / interrupted status. The incorrect attribution was added during parent-side result formatting.

### Fix

- Store an optional user-safe reason beside each per-thread interrupt bit and clear both atomically.
- Classify ordinary message interrupts without copying user text, while preserving explicit hard-cancel reasons.
- Propagate the reason to execution and tool-worker threads, including late worker registration races.
- Use one shared formatter for local and remote `execute_code`, with neutral output when the reason is unknown.
- Apply the same attribution to sequential tools that must be abandoned after their cooperative grace period.

## Related Issue

Closes #93053

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/interrupt.py` - retain an optional thread-scoped interruption reason.
- `run_agent.py`, `agent/turn_context.py`, `agent/tool_executor.py` - classify and propagate cancellation sources without leaking incoming message text.
- `tools/code_execution_tool.py` - format local and remote interruption output from the recorded source or neutral fallback.
- `tests/` - cover user-message classification, hard-cancel attribution, neutral fallback, late sequential-tool cancellation, and local execute-code behavior.

## How to Test

1. Run the focused interrupt and sequential-tool suites:

```bash
scripts/run_tests.sh tests/run_agent/test_interrupt_propagation.py tests/run_agent/test_sequential_tool_timeout.py tests/run_agent/test_concurrent_interrupt.py -q
```

2. Run the execute-code interruption regressions:

```bash
scripts/run_tests.sh tests/tools/test_code_execution.py -k TestInterruptedOutput -q
scripts/run_tests.sh tests/tools/test_approved_command_clean_slate.py -k non_approved_still_interrupts -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A because this corrects runtime diagnostic output
- [x] Config example update is N/A because no config keys changed
- [x] Architecture guide update is N/A because the existing interrupt mechanism remains intact
- [x] Cross-platform impact was considered; the local and remote execution paths share the same formatter
- [x] Tool schema update is N/A because the execute-code request and response schema are unchanged

## Screenshots / Logs

N/A - automated regressions cover the text-only interruption output.
