### PR TITLE
fix(providers): honor target_model on the custom-provider resolve path

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1889,6 +1889,13 @@ def resolve_runtime_provider(
     )
     if custom_runtime:
         custom_runtime["requested_provider"] = requested_provider
+        # Per-call model intent outranks the provider-level default, mirroring
+        # the ``target_model or model_cfg.get("default")`` precedence every
+        # other branch here already applies (#93092). Without this, a task's
+        # explicit model (e.g. auxiliary.background_review's ``model``) loses
+        # silently to ``custom_providers.<name>.model``.
+        if target_model:
+            custom_runtime["model"] = target_model
         return custom_runtime
 
     # If provider is "auto" (or unset) but config.yaml has an explicit base_url

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1655,6 +1655,81 @@ def test_resolve_runtime_provider_opencode_free_keyless_despite_exhausted_pool(m
     assert resolved["default_headers"]["Authorization"] == ""
 
 
+def _omniroute_provider(with_default_model: bool) -> dict:
+    """Fixture provider entry for the target_model precedence tests (#93092).
+
+    No credentials on purpose: the resolver falls through to its
+    no-key-required default, which keeps these tests about model precedence.
+    """
+    entry = {
+        "name": "OmniRoute",
+        "base_url": "http://1.2.3.4:1234/v1",
+    }
+    if with_default_model:
+        entry["model"] = "hermes"
+    return entry
+
+
+def test_target_model_outranks_custom_provider_default_model(monkeypatch):
+    """A per-call target_model must win over custom_providers.<name>.model.
+
+    Regression for #93092: an auxiliary task requesting
+    ``provider: custom:<name>`` + ``model: <X>`` used to get the provider's
+    top-level default model back, silently dropping the configured task model.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {"custom_providers": [_omniroute_provider(with_default_model=True)]},
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom:omniroute",
+        target_model="Curador",
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["model"] == "Curador"
+
+
+def test_custom_provider_default_model_stands_without_target_model(monkeypatch):
+    """No target_model → the provider-level default keeps today's behavior."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {"custom_providers": [_omniroute_provider(with_default_model=True)]},
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:omniroute")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["model"] == "hermes"
+
+
+def test_target_model_sets_model_when_provider_has_no_default(monkeypatch):
+    """target_model still lands in the runtime when the provider declares no
+    top-level model — callers read rt["model"] as the effective task model."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {"custom_providers": [_omniroute_provider(with_default_model=False)]},
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom:omniroute",
+        target_model="Curador",
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["model"] == "Curador"
+
+
 def test_resolve_runtime_provider_opencode_free_missing_env_still_resolves(monkeypatch):
     """OpenCode Free resolves keylessly with no env var configured at all —
     the provider declares no credentials."""


### PR DESCRIPTION
## What does this PR do?

Makes `resolve_runtime_provider()` honor a caller's explicit `target_model` on the named-custom-provider path, closing a precedence gap against every other branch in the same function.

Today the custom branch (`_resolve_named_custom_runtime`) fills the returned runtime's `model` key from the provider-level `custom_providers.<name>.model` default — on both the credential-pool and non-pool paths — and `resolve_runtime_provider()` returns it as-is, never consulting `target_model`. Every other branch already applies `target_model or model_cfg.get("default")` precedence (generic explicit path, Nous, opencode, Azure Foundry), so the custom branch is the one place where a per-call model silently loses to the provider default.

Concrete impact (#93092): an `auxiliary.background_review` task configured with `provider: custom:<name>` + `model: <X>` resolves to the provider's default model instead of `X`. `_resolve_review_runtime()` then marks the fork `routed=True` and replays a compact digest instead of full history — so the review runs on the *parent's* model *with* digest quality loss, paying the routed-path cost for zero benefit, with no warning anywhere.

The fix applies the same precedence at the custom branch return: when `target_model` is set, it overrides the runtime's `model`. A `target_model` of `None` keeps today's behavior exactly.

## Related Issue

Fixes #93092

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py` — in `resolve_runtime_provider()`'s named-custom branch, set `custom_runtime["model"] = target_model` before returning when `target_model` is provided, mirroring the `target_model or default` precedence used by the other branches. Single point covers all of `_resolve_named_custom_runtime()`'s internal return paths (bare-custom direct alias, credential pool, plain custom entry).
- `tests/hermes_cli/test_runtime_provider_resolution.py` — three regression tests: target_model outranks the provider default; the provider default stands when no target_model is passed; target_model lands in the runtime even when the provider declares no top-level model.

## How to Test

`pytest tests/hermes_cli/test_runtime_provider_resolution.py -q` — should pass (64 passed), including the three new tests.

- `test_target_model_outranks_custom_provider_default_model`: provider entry with `model: hermes`, resolved with `target_model="Curador"` → `rt["model"] == "Curador"`. Observed result: on unpatched main this fails (`rt["model"] == "hermes"`); with this PR it passes.
- `test_custom_provider_default_model_stands_without_target_model`: same provider entry, no target_model → `rt["model"] == "hermes"` (today's behavior preserved; passes on main too by design).
- `test_target_model_sets_model_when_provider_has_no_default`: provider entry without a top-level model, resolved with `target_model="Curador"` → `rt["model"] == "Curador"`. Observed result: on unpatched main the key is absent; with this PR it carries the caller's intent.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (precedence rationale in the branch comment)
- [x] Tests added that prove the fix works
- [x] New and existing unit tests pass locally (64 passed in the resolution suite)
- [x] Platform: macOS (logic is platform-independent provider resolution)
