### PR TITLE
fix(telegram): coalesce sequential documents like photo bursts

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9864,6 +9864,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 batch_key,
                 len(event.media_urls),
             )
+            if not (event.metadata or {}).get("telegram_burst_trigger", True):
+                raw = getattr(event, "raw_message", None)
+                if raw is not None and self._should_observe_unmentioned_group_message(raw):
+                    self._observe_unmentioned_group_message(
+                        raw, event.message_type, event=event,
+                    )
+                event = None
+                return
             await self.handle_message(event)
             event = None
         except asyncio.CancelledError:
@@ -9881,19 +9889,72 @@ class TelegramAdapter(BasePlatformAdapter):
             return
 
         existing = self._pending_photo_batches.get(batch_key)
+        incoming_trigger = bool((event.metadata or {}).get("telegram_burst_trigger"))
         if existing is None:
+            event.metadata["telegram_burst_trigger"] = incoming_trigger
             self._pending_photo_batches[batch_key] = event
         else:
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             if event.text:
                 existing.text = self._merge_caption(existing.text, event.text)
+            if incoming_trigger:
+                existing.metadata["telegram_burst_trigger"] = True
+            if event.raw_message is not None:
+                existing.raw_message = event.raw_message
 
         prior_task = self._pending_photo_batch_tasks.get(batch_key)
         if prior_task and not prior_task.done():
             prior_task.cancel()
 
         self._pending_photo_batch_tasks[batch_key] = asyncio.create_task(self._flush_photo_batch(batch_key))
+
+    def _is_bufferable_burst_media(self, message: Message) -> bool:
+        """Return True for photo/video/document updates that can share a burst window."""
+        if getattr(message, "sticker", None) or getattr(message, "voice", None) or getattr(message, "audio", None):
+            return False
+        return bool(
+            getattr(message, "photo", None)
+            or getattr(message, "video", None)
+            or getattr(message, "document", None)
+        )
+
+    def _should_buffer_unmentioned_burst(self, message: Message) -> bool:
+        """Buffer group photo/doc/video that failed require_mention, if the chat is allowlisted.
+
+        Sequential PDFs are not a Telegram album. The mention/caption often
+        arrives only on the last file. Hard gates (ignored topic, other-bot
+        exclusive mention, chat allowlist) still drop the update immediately.
+        """
+        if not self._is_bufferable_burst_media(message):
+            return False
+        if not self._is_group_chat(message):
+            return False
+        if not self._telegram_require_mention():
+            return False
+        if self._is_own_message(message):
+            return False
+
+        thread_id = self._effective_message_thread_id(message)
+        allowed_topics = self._telegram_allowed_topics()
+        if allowed_topics:
+            topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+            if topic_id not in allowed_topics:
+                return False
+        if thread_id is not None:
+            try:
+                if int(thread_id) in self._telegram_ignored_threads():
+                    return False
+            except (TypeError, ValueError):
+                return False
+        if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
+            return False
+
+        chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
+        allowed = self._telegram_allowed_chats() or self._telegram_observe_allowed_chats()
+        if not allowed or chat_id_str not in allowed:
+            return False
+        return True
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
@@ -9906,24 +9967,35 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(update.message, "chat", None), "id", None),
             )
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
-                _observe_type = self._media_message_type(_m)
-                _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
-                if _m.caption:
-                    _event.text = self._clean_bot_trigger_text(_m.caption)
-                await self._cache_observed_media(_m, _event)
-                self._observe_unmentioned_group_message(
-                    _m, _event.message_type, update_id=update.update_id, event=_event
-                )
-            return
+        burst_trigger = self._should_process_message(update.message)
+        if not burst_trigger:
+            if not self._should_buffer_unmentioned_burst(update.message):
+                if self._should_observe_unmentioned_group_message(update.message):
+                    _m = update.message
+                    _observe_type = self._media_message_type(_m)
+                    _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
+                    if _m.caption:
+                        _event.text = self._clean_bot_trigger_text(_m.caption)
+                    await self._cache_observed_media(_m, _event)
+                    self._observe_unmentioned_group_message(
+                        _m, _event.message_type, update_id=update.update_id, event=_event
+                    )
+                return
 
         msg = update.message
 
         msg_type = self._media_message_type(msg)
 
         event = self._build_message_event(msg, msg_type, update_id=update.update_id)
+        metadata = getattr(event, "metadata", None)
+        if not isinstance(metadata, dict):
+            try:
+                event.metadata = {}
+                metadata = event.metadata
+            except Exception:
+                metadata = None
+        if isinstance(metadata, dict):
+            metadata["telegram_burst_trigger"] = burst_trigger
         
         # Add caption as text
         if msg.caption:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9828,7 +9828,12 @@ class TelegramAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     def _photo_batch_key(self, event: MessageEvent, msg: Message) -> str:
-        """Return a batching key for Telegram photos/albums."""
+        """Return a batching key for Telegram albums and same-session media bursts.
+
+        Photos, videos, and documents without a ``media_group_id`` share the
+        ``media-burst`` key so a rapid PDF + screenshot send becomes one turn.
+        Voice/audio stay on the immediate path — they need STT, not this window.
+        """
         from gateway.session import build_session_key
         session_key = build_session_key(
             event.source,
@@ -9839,7 +9844,7 @@ class TelegramAdapter(BasePlatformAdapter):
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:
             return f"{session_key}:album:{media_group_id}"
-        return f"{session_key}:photo-burst"
+        return f"{session_key}:media-burst"
 
     async def _flush_photo_batch(self, batch_key: str) -> None:
         """Send a buffered photo burst/album as a single MessageEvent."""
@@ -9854,7 +9859,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._hold_inbound_event(event, where="photo-flush")
                 event = None
                 return
-            logger.info("[Telegram] Flushing photo batch %s with %d image(s)", batch_key, len(event.media_urls))
+            logger.info(
+                "[Telegram] Flushing media batch %s with %d attachment(s)",
+                batch_key,
+                len(event.media_urls),
+            )
             await self.handle_message(event)
             event = None
         except asyncio.CancelledError:
@@ -10109,7 +10118,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     event.media_types = [SUPPORTED_VIDEO_TYPES[ext]]
                     event.message_type = MessageType.VIDEO
                     logger.info("[Telegram] Cached user video document at %s", cached_path)
-                    await self.handle_message(event)
+                    await self._dispatch_cached_media_event(msg, event)
                     return
 
                 # NOTE: image-document handling is performed earlier in this
@@ -10179,9 +10188,27 @@ class TelegramAdapter(BasePlatformAdapter):
                     display_name=getattr(doc, "file_name", None) or None,
                 )
 
+        await self._dispatch_cached_media_event(msg, event)
+
+    async def _dispatch_cached_media_event(self, msg: Message, event: MessageEvent) -> None:
+        """Send a cached inbound media event, coalescing document/photo/video bursts.
+
+        Telegram only sets ``media_group_id`` for same-type albums. Sequential
+        PDFs, HTML files, or a PDF plus a screenshot arrive as independent
+        updates. Photos already used a short debounce; documents now share that
+        same-session window so the agent sees one logical turn.
+        """
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:
             await self._queue_media_group_event(str(media_group_id), event)
+            return
+
+        if event.media_urls and event.message_type in {
+            MessageType.DOCUMENT,
+            MessageType.PHOTO,
+            MessageType.VIDEO,
+        }:
+            self._enqueue_photo_event(self._photo_batch_key(event, msg), event)
             return
 
         await self.handle_message(event)

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -2,7 +2,7 @@
 Tests for Telegram document handling in gateway/platforms/telegram.py.
 
 Covers: document type detection, download/cache flow, size limits,
-        text injection, error handling.
+        text injection, error handling, same-session document bursts.
 
 Note: python-telegram-bot may not be installed in the test environment.
 We mock the telegram module at import time to avoid collection errors.
@@ -115,7 +115,14 @@ def adapter():
     # document-routing tests need to bypass the new gate so messages from fake
     # senders reach handle_message.
     a._is_callback_user_authorized = lambda user_id, **_kw: True
+    # Keep burst tests fast; production default remains 0.8s.
+    a._media_batch_delay_seconds = 0.05
     return a
+
+
+async def _await_media_flush(adapter):
+    """Wait for the same-session media-burst debounce to flush."""
+    await asyncio.sleep(adapter._media_batch_delay_seconds + 0.05)
 
 
 @pytest.fixture(autouse=True)
@@ -143,6 +150,7 @@ class TestDocumentTypeDetection:
         msg = _make_message(document=doc)
         update = _make_update(msg)
         await adapter._handle_media_message(update, MagicMock())
+        await _await_media_flush(adapter)
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.DOCUMENT
 
@@ -172,6 +180,7 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
+        await _await_media_flush(adapter)
         event = adapter.handle_message.call_args[0][0]
         assert "Hello from a text file" in event.text
         assert "[Content of notes.txt]" in event.text
@@ -188,6 +197,7 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
+        await _await_media_flush(adapter)
         event = adapter.handle_message.call_args[0][0]
         assert "# Title" in event.text
 
@@ -203,6 +213,7 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
+        await _await_media_flush(adapter)
         event = adapter.handle_message.call_args[0][0]
         assert "file text" in event.text
         assert "Please summarize" in event.text
@@ -221,6 +232,7 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
+        await _await_media_flush(adapter)
         event = adapter.handle_message.call_args[0][0]
         # File should be cached
         assert len(event.media_urls) == 1
@@ -288,6 +300,7 @@ class TestVideoDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
+        await _await_media_flush(adapter)
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.VIDEO
         assert len(event.media_urls) == 1
@@ -312,13 +325,107 @@ class TestMediaGroups:
             await adapter._handle_media_message(_make_update(msg1), MagicMock())
             await adapter._handle_media_message(_make_update(msg2), MagicMock())
             assert adapter.handle_message.await_count == 0
-            await asyncio.sleep(adapter.MEDIA_GROUP_WAIT_SECONDS + 0.05)
+            await _await_media_flush(adapter)
 
         adapter.handle_message.assert_awaited_once()
         event = adapter.handle_message.await_args.args[0]
         assert event.text == "two images"
         assert event.media_urls == ["/tmp/burst-one.jpg", "/tmp/burst-two.jpg"]
         assert len(event.media_types) == 2
+
+
+# ---------------------------------------------------------------------------
+# TestDocumentBursts — sequential PDFs/HTML are not Telegram albums
+# ---------------------------------------------------------------------------
+
+class TestDocumentBursts:
+    @pytest.mark.asyncio
+    async def test_sequential_pdfs_coalesce_into_one_turn(self, adapter):
+        pdf_a = _make_document(file_name="a.pdf", mime_type="application/pdf", file_size=64)
+        pdf_b = _make_document(file_name="b.pdf", mime_type="application/pdf", file_size=64)
+        pdf_c = _make_document(file_name="c.pdf", mime_type="application/pdf", file_size=64)
+
+        await adapter._handle_media_message(_make_update(_make_message(document=pdf_a)), MagicMock())
+        await adapter._handle_media_message(_make_update(_make_message(document=pdf_b)), MagicMock())
+        await adapter._handle_media_message(
+            _make_update(_make_message(document=pdf_c, caption="compare these")),
+            MagicMock(),
+        )
+        assert adapter.handle_message.await_count == 0
+
+        await _await_media_flush(adapter)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert len(event.media_urls) == 3
+        assert all(url.endswith(".pdf") or "pdf" in url.lower() or os.path.exists(url) for url in event.media_urls)
+        assert "compare these" in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_pdf_and_html_coalesce(self, adapter):
+        pdf = _make_document(file_name="paper.pdf", mime_type="application/pdf", file_size=32)
+        html = _make_document(
+            file_name="notes.html",
+            mime_type="text/html",
+            file_size=20,
+            file_obj=_make_file_obj(b"<p>hello</p>"),
+        )
+
+        await adapter._handle_media_message(_make_update(_make_message(document=pdf)), MagicMock())
+        await adapter._handle_media_message(_make_update(_make_message(document=html)), MagicMock())
+        assert adapter.handle_message.await_count == 0
+
+        await _await_media_flush(adapter)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert len(event.media_urls) == 2
+        assert "<p>hello</p>" in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_pdf_and_photo_share_the_same_burst_window(self, adapter):
+        pdf = _make_document(file_name="scan.pdf", mime_type="application/pdf", file_size=32)
+        photo = _make_photo(_make_file_obj(b"jpeg-bytes"))
+        photo_msg = _make_message(photo=[photo], caption="see also")
+
+        await adapter._handle_media_message(_make_update(_make_message(document=pdf)), MagicMock())
+        with patch(
+            "plugins.platforms.telegram.adapter.cache_image_from_bytes",
+            return_value="/tmp/scan.jpg",
+        ):
+            await adapter._handle_media_message(_make_update(photo_msg), MagicMock())
+            assert adapter.handle_message.await_count == 0
+            await _await_media_flush(adapter)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert len(event.media_urls) == 2
+        assert "/tmp/scan.jpg" in event.media_urls
+        assert "see also" in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_voice_note_is_not_held_in_the_document_window(self, adapter):
+        pdf = _make_document(file_name="notes.pdf", mime_type="application/pdf", file_size=32)
+        await adapter._handle_media_message(_make_update(_make_message(document=pdf)), MagicMock())
+        assert adapter.handle_message.await_count == 0
+
+        voice_msg = _make_message()
+        voice_msg.voice = MagicMock()
+        voice_msg.voice.file_size = 80
+        voice_msg.voice.get_file = AsyncMock(return_value=_make_file_obj(b"ogg-bytes"))
+        await adapter._handle_media_message(_make_update(voice_msg), MagicMock())
+
+        # Voice dispatches immediately; the PDF is still sitting in the burst buffer.
+        assert adapter.handle_message.await_count == 1
+        voice_event = adapter.handle_message.await_args.args[0]
+        assert voice_event.message_type == MessageType.VOICE
+
+        await _await_media_flush(adapter)
+        assert adapter.handle_message.await_count == 2
+        pdf_event = adapter.handle_message.await_args_list[1].args[0]
+        assert pdf_event.message_type == MessageType.DOCUMENT
+        assert len(pdf_event.media_urls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -121,8 +121,22 @@ def adapter():
 
 
 async def _await_media_flush(adapter):
-    """Wait for the same-session media-burst debounce to flush."""
-    await asyncio.sleep(adapter._media_batch_delay_seconds + 0.05)
+    """Wait for pending same-session media-burst flush tasks to finish."""
+    tasks = [
+        task
+        for task in list(getattr(adapter, "_pending_photo_batch_tasks", {}).values())
+        if task is not None and not task.done()
+    ]
+    album_tasks = [
+        task
+        for task in list(getattr(adapter, "_media_group_tasks", {}).values())
+        if task is not None and not task.done()
+    ]
+    pending = tasks + album_tasks
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+        return
+    await asyncio.sleep(getattr(adapter, "_media_batch_delay_seconds", 0.05) + 0.05)
 
 
 @pytest.fixture(autouse=True)
@@ -426,6 +440,136 @@ class TestDocumentBursts:
         pdf_event = adapter.handle_message.await_args_list[1].args[0]
         assert pdf_event.message_type == MessageType.DOCUMENT
         assert len(pdf_event.media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_photo_then_pdf_share_the_same_burst_window(self, adapter):
+        photo = _make_photo(_make_file_obj(b"jpeg-bytes"))
+        pdf = _make_document(file_name="scan.pdf", mime_type="application/pdf", file_size=32)
+        with patch(
+            "plugins.platforms.telegram.adapter.cache_image_from_bytes",
+            return_value="/tmp/first.jpg",
+        ):
+            await adapter._handle_media_message(
+                _make_update(_make_message(photo=[photo], caption="first")),
+                MagicMock(),
+            )
+            await adapter._handle_media_message(
+                _make_update(_make_message(document=pdf)),
+                MagicMock(),
+            )
+            assert adapter.handle_message.await_count == 0
+            await _await_media_flush(adapter)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.media_urls[0] == "/tmp/first.jpg"
+        assert len(event.media_urls) == 2
+        assert "first" in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_sequential_native_videos_coalesce(self, adapter):
+        first = _make_file_obj(b"vid-one")
+        first.file_path = "videos/one.mp4"
+        second = _make_file_obj(b"vid-two")
+        second.file_path = "videos/two.mp4"
+        msg1 = _make_message()
+        msg1.video = _make_video(first)
+        msg2 = _make_message()
+        msg2.video = _make_video(second)
+
+        await adapter._handle_media_message(_make_update(msg1), MagicMock())
+        await adapter._handle_media_message(_make_update(msg2), MagicMock())
+        assert adapter.handle_message.await_count == 0
+        await _await_media_flush(adapter)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.message_type == MessageType.VIDEO
+        assert len(event.media_urls) == 2
+
+    @pytest.mark.asyncio
+    async def test_album_does_not_merge_with_a_loose_pdf(self, adapter):
+        photo_a = _make_photo(_make_file_obj(b"a"))
+        photo_b = _make_photo(_make_file_obj(b"b"))
+        album_one = _make_message(photo=[photo_a], media_group_id="album-9", caption="album")
+        album_two = _make_message(photo=[photo_b], media_group_id="album-9")
+        pdf = _make_document(file_name="loose.pdf", mime_type="application/pdf", file_size=16)
+
+        with patch(
+            "plugins.platforms.telegram.adapter.cache_image_from_bytes",
+            side_effect=["/tmp/a.jpg", "/tmp/b.jpg"],
+        ):
+            await adapter._handle_media_message(_make_update(album_one), MagicMock())
+            await adapter._handle_media_message(_make_update(album_two), MagicMock())
+            await adapter._handle_media_message(_make_update(_make_message(document=pdf)), MagicMock())
+            await _await_media_flush(adapter)
+
+        assert adapter.handle_message.await_count == 2
+        batches = [tuple(call.args[0].media_urls) for call in adapter.handle_message.await_args_list]
+        assert ("/tmp/a.jpg", "/tmp/b.jpg") in batches
+        assert any(len(urls) == 1 for urls in batches)
+
+    @pytest.mark.asyncio
+    async def test_group_mention_on_last_pdf_releases_the_whole_burst(self, adapter):
+        adapter.config.extra["require_mention"] = True
+        adapter.config.extra["allowed_chats"] = ["-1001"]
+        adapter.config.extra["allowed_topics"] = []
+        adapter.config.extra["ignored_threads"] = []
+        adapter.config.extra["mention_patterns"] = [r"analyze"]
+        adapter._mention_patterns = adapter._compile_mention_patterns()
+        adapter._is_user_authorized_from_message = lambda _msg: True
+
+        def _group_doc(name, caption=None):
+            msg = _make_message(
+                document=_make_document(file_name=name, mime_type="application/pdf", file_size=16),
+                caption=caption,
+            )
+            msg.chat.type = "supergroup"
+            msg.chat.id = -1001
+            msg.entities = []
+            msg.caption_entities = []
+            return msg
+
+        await adapter._handle_media_message(_make_update(_group_doc("one.pdf")), MagicMock())
+        await adapter._handle_media_message(_make_update(_group_doc("two.pdf")), MagicMock())
+        await adapter._handle_media_message(
+            _make_update(_group_doc("three.pdf", caption="analyze these")),
+            MagicMock(),
+        )
+        assert adapter.handle_message.await_count == 0
+        await _await_media_flush(adapter)
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert len(event.media_urls) == 3
+        assert "analyze these" in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_group_unmentioned_pdf_burst_does_not_dispatch(self, adapter):
+        adapter.config.extra["require_mention"] = True
+        adapter.config.extra["allowed_chats"] = ["-1001"]
+        adapter.config.extra["allowed_topics"] = []
+        adapter.config.extra["ignored_threads"] = []
+        adapter.config.extra["mention_patterns"] = [r"analyze"]
+        adapter._mention_patterns = adapter._compile_mention_patterns()
+        adapter._is_user_authorized_from_message = lambda _msg: True
+        adapter._observe_unmentioned_group_message = MagicMock()
+
+        def _group_doc(name):
+            msg = _make_message(
+                document=_make_document(file_name=name, mime_type="application/pdf", file_size=16),
+            )
+            msg.chat.type = "supergroup"
+            msg.chat.id = -1001
+            msg.entities = []
+            msg.caption_entities = []
+            return msg
+
+        await adapter._handle_media_message(_make_update(_group_doc("a.pdf")), MagicMock())
+        await adapter._handle_media_message(_make_update(_group_doc("b.pdf")), MagicMock())
+        await _await_media_flush(adapter)
+
+        adapter.handle_message.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -527,6 +527,19 @@ tail -f ~/.hermes/logs/gateway.log | grep -iE "telegram|cache"
 
 You should see a `[Telegram] Cached user voice at /home/<user>/.hermes/cache/audio/...` line and **no** "too large" rejection. Combined with `stt.enabled: false` (above), the path to the original audio file then lands in the agent's inbound message for downstream processing.
 
+## Inbound files and mixed attachments
+
+Telegram only creates an album (`media_group_id`) when the client sends several items of the **same type** in one send — typically photos, or sometimes videos. Sequential PDFs, HTML files, or a document plus a screenshot arrive as independent updates.
+
+Hermes already debounced rapid photos into one turn. The same short same-session window now applies to documents and videos:
+
+- several PDFs or HTML files sent back-to-back become one agent turn with every cached path;
+- a PDF plus a screenshot in that window also merge;
+- a real Telegram album still uses `media_group_id` and is unchanged;
+- voice and audio notes are **not** held in this window (they go through STT immediately).
+
+The window is `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` (default `0.8`). In groups with `require_mention: true`, each file still has to pass the mention/reply gate on its own update — this coalesce does not invent a mention.
+
 ## Group Chat Usage
 
 Hermes Agent works in Telegram group chats with a few considerations:

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -538,7 +538,7 @@ Hermes already debounced rapid photos into one turn. The same short same-session
 - a real Telegram album still uses `media_group_id` and is unchanged;
 - voice and audio notes are **not** held in this window (they go through STT immediately).
 
-The window is `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` (default `0.8`). In groups with `require_mention: true`, each file still has to pass the mention/reply gate on its own update — this coalesce does not invent a mention.
+The window is `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` (default `0.8`). In groups with `require_mention: true`, a mention, reply, or wake-word on **any** file in that window releases the whole burst. Files that never get a trigger are observed (if enabled) or dropped — the bot still does not answer unsolicited group chatter.
 
 ## Group Chat Usage
 


### PR DESCRIPTION
## Bug Description

Telegram only assigns `media_group_id` when the client sends several items of the **same type** in one send (typically photos). Sequential PDFs, HTML files, or a document plus a screenshot arrive as independent updates.

Hermes already debounced rapid photos into one turn. Documents skipped that path and called `handle_message` immediately, so the agent often saw only the last file.

## Root Cause

After a document/video was cached, the handler dispatched at once unless `media_group_id` was set. Photo bursts used `_enqueue_photo_event` with a session key; documents did not share that window.

## Fix

- Cached documents and videos now go through `_dispatch_cached_media_event`.
- Sequential photo / document / video updates in the same session share the `media-burst` debounce key (default 0.8s, `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS`).
- Real albums still use `media_group_id`.
- Voice and audio stay on the immediate STT path.

This does **not** change `require_mention`. In groups that require a mention, each update still has to pass that gate on its own.

## How to Verify

1. DM the bot three PDFs in quick succession (not as a photo album).
2. Confirm one agent turn with all three cached paths.
3. Send a PDF and then a screenshot in the same window — one turn, both attachments.
4. Send a voice note after a PDF — voice still dispatches immediately; the PDF flushes on its own.

## Test Plan

- [x] Added regression tests for PDF bursts, PDF+HTML, PDF+photo, and voice isolation
- [x] Existing document/video/photo-burst tests updated for the debounce
- [x] `uv run pytest tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_voice_v0_regressions.py` — 24 passed

## Risk Assessment

Low — reuses the existing photo-burst debounce and disconnect/cancel path. Blast radius is inbound Telegram document/video dispatch only. Voice/STT and album coalescing are unchanged.