### PR TITLE
fix(dashboard): engage the auth gate when a public URL is declared on a loopback bind

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -653,8 +653,11 @@ def should_require_auth(host: str, allow_public: bool = False) -> bool:
     """Return True iff the dashboard auth gate must be active.
 
     Truth table:
-      host == loopback        → False (no auth — local-only, trusted operator)
-      host != loopback        → True  (gate engages — OAuth or password required)
+      host != loopback       → True  (gate engages — OAuth or password required)
+      host == loopback,
+        no declared public URL → False (no auth — local-only, trusted operator)
+      host == loopback,
+        declared public URL    → True  (#93026 — something publishes this process)
 
     "Loopback" is 127.0.0.1, localhost, ::1. RFC1918 / CGNAT / link-local are
     deliberately treated as PUBLIC — a hostile device on the same LAN is exactly
@@ -667,8 +670,24 @@ def should_require_auth(host: str, allow_public: bool = False) -> bool:
     unauthenticated-public-dashboard hole behind the June 2026 ``hermes-0day``
     MCP-persistence campaign, where ``--insecure --host 0.0.0.0`` left the
     config/MCP/agent surface open to internet scanners.
+
+    A loopback bind no longer implies local-only exposure when the operator
+    declared a public URL (#93026): ``dashboard.public_url`` /
+    ``HERMES_DASHBOARD_PUBLIC_URL`` is the operator's statement that a reverse
+    proxy or tunnel on the same host publishes this process, so the bind
+    address no longer describes who can reach it. The declaration is local
+    configuration — not a request header — so it cannot be forged by a
+    caller, and failing closed is the safe direction for an exposed
+    deployment. If the resolver can't be consulted we keep the historical
+    loopback behavior rather than breaking local startups.
     """
-    return host not in _LOOPBACK_HOST_VALUES
+    if host not in _LOOPBACK_HOST_VALUES:
+        return True
+    try:
+        from hermes_cli.dashboard_auth.prefix import resolve_public_url
+        return bool(resolve_public_url())
+    except Exception:
+        return False
 
 
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -40,6 +40,19 @@ def client_loopback():
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _no_declared_public_url(monkeypatch):
+    """Pin the operator-declared public URL out of the gate's view.
+
+    should_require_auth() consults resolve_public_url() (#93026), which
+    reads HERMES_DASHBOARD_PUBLIC_URL and dashboard.public_url. The
+    autouse HERMES_HOME isolation already empties the config side; pin
+    the env side too so a developer's exported variable can't flip the
+    loopback rows of the truth table.
+    """
+    monkeypatch.delenv("HERMES_DASHBOARD_PUBLIC_URL", raising=False)
+
+
 @pytest.mark.parametrize("host,allow_public,expected", [
     ("127.0.0.1", False, False),
     ("127.0.0.1", True,  False),
@@ -57,6 +70,50 @@ def client_loopback():
 def test_should_require_auth_truth_table(host, allow_public, expected):
     from hermes_cli.web_server import should_require_auth
     assert should_require_auth(host, allow_public) is expected
+
+
+# ---------------------------------------------------------------------------
+# declared public URL engages the gate on a loopback bind (#93026)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_loopback_with_declared_public_url_requires_auth(monkeypatch, host):
+    """A reverse proxy publishing a loopback bind must get the auth gate."""
+    from hermes_cli.web_server import should_require_auth
+
+    monkeypatch.setattr(
+        "hermes_cli.dashboard_auth.prefix.resolve_public_url",
+        lambda: "https://hermes.example.com",
+    )
+    assert should_require_auth(host) is True
+
+
+def test_env_declared_public_url_requires_auth_on_loopback(monkeypatch):
+    """HERMES_DASHBOARD_PUBLIC_URL alone (no config.yaml entry) engages it."""
+    from hermes_cli.web_server import should_require_auth
+
+    monkeypatch.setenv("HERMES_DASHBOARD_PUBLIC_URL", "https://h.example.com")
+    assert should_require_auth("127.0.0.1") is True
+
+
+def test_resolver_failure_keeps_historical_loopback_behavior(monkeypatch):
+    """If the resolver blows up, don't break plain local startups."""
+    from hermes_cli.web_server import should_require_auth
+
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr(
+        "hermes_cli.dashboard_auth.prefix.resolve_public_url", _boom
+    )
+    assert should_require_auth("127.0.0.1") is False
+
+
+def test_non_loopback_unaffected_by_missing_public_url():
+    """The non-loopback rows never consult (or need) the resolver."""
+    from hermes_cli.web_server import should_require_auth
+    assert should_require_auth("0.0.0.0") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes #93026. `should_require_auth()` (`hermes_cli/web_server.py`) decided the dashboard auth gate purely from the bind address - loopback meant no auth, unconditionally. That is wrong for the loopback-behind-reverse-proxy topology (nginx/Caddy/cloudflared/Tailscale publishing `127.0.0.1`): the bind address no longer describes who can reach the dashboard, and the process cannot detect the proxy from request headers because forwarded headers are exactly what an attacker would forge.

The operator's own declaration already exists: `resolve_public_url()` (`HERMES_DASHBOARD_PUBLIC_URL` / `dashboard.public_url`) - local configuration, so it cannot be spoofed remotely. This PR consults it in the gate:

- **loopback + declared public URL** -> gate engages (fail closed; the operator described an exposed deployment)
- **loopback, no declaration** -> historical no-auth local behavior unchanged
- **non-loopback** -> gate engages, as before
- **resolver failure** -> falls back to the historical loopback behavior rather than breaking plain local startups

No new configuration surface - it reuses the documented field already used for OAuth callback construction.

The interactive password-provider prompt in `hermes dashboard` (`hermes_cli/main.py`) flows through the same predicate, so affected operators are offered setup on the spot; `start_server`'s existing fail-closed refusal (with per-provider skip reasons) remains the backstop.

Deliberately out of scope (as the issue notes): `_is_accepted_host()`/WebSocket Origin acceptance for the declared public host - covered by #68251/#90736/#65965/#62639.

Fixes #93026

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security hardening

## Changes Made

- `hermes_cli/web_server.py`: `should_require_auth()` consults `resolve_public_url()` on loopback binds (lazy import, exception-safe); docstring truth table updated.
- `tests/hermes_cli/test_dashboard_auth_gate.py`: autouse fixture pins `HERMES_DASHBOARD_PUBLIC_URL` out of the env so developer machines can't flip the loopback rows; new tests for declared-URL-on-loopback (config + env), resolver-failure fallback, and non-loopback independence.

## How to Test

1. `uv run pytest tests/hermes_cli/test_dashboard_auth_gate.py -q`
2. Manual: set `dashboard.public_url: https://h.example.com`, bind `127.0.0.1`, start `hermes dashboard` with no auth provider -> server now fails closed with provider-setup guidance instead of serving unauthenticated.

## Checklist

### Code

- [x] Contributing Guide read
- [x] Conventional Commits followed (`fix(dashboard):`)
- [x] Duplicates searched (#68251/#90736/#65965/#62639 cover Host/Origin, not the auth gate)
- [x] Only changes related to this fix
- [x] Related suites pass locally
- [x] Tested on Windows 11
