### PR TITLE
fix(cron): surface gateway liveness in cronjob tool results

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -271,6 +271,18 @@ _API_CALL_MODULES = frozenset({
     "chat_completion_helpers",
 })
 
+# Maximum total outer-loop exceptions tolerated within one user turn before
+# the loop gives up (#92450). The turn budget is unlimited by default
+# (``max_iterations = sys.maxsize``), so the historical "near the limit"
+# guard no longer stops a turn whose outer loop keeps raising: permanent
+# failures spun at ~64 retries/s, pegged a core, and overwrote the rotated
+# agent.log history (days of diagnostic context) within minutes. The inner
+# retry/fallback machinery owns transient API recovery and terminates on its
+# own; only exceptions that ESCAPE it reach this bound, so the cap can be
+# small. Still scaled down by a tiny explicit ``max_iterations`` so a
+# manually bounded budget keeps governing.
+_MAX_OUTER_LOOP_ERRORS = 8
+
 
 def _moa_client_consumes_prepared_request(client: Any) -> bool:
     """True when ``client`` is the in-process MoA facade.
@@ -1896,6 +1908,8 @@ def run_conversation(
     failed = False
     codex_ack_continuations = 0
     length_continue_retries = 0
+    # Total outer-loop exceptions this turn (#92450) — see _MAX_OUTER_LOOP_ERRORS.
+    _outer_error_count = 0
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
@@ -8298,6 +8312,11 @@ def run_conversation(
                 break
             
         except Exception as e:
+            # Count every escaped exception against the per-turn bound before
+            # classification — permanent failures must terminate even when the
+            # turn budget is unlimited (#92450).
+            _outer_error_count += 1
+
             # Phase-aware error classification. The huge outer try/except spans
             # both the actual API request and all local post-processing of the
             # returned assistant message. Deterministic local bugs (e.g.
@@ -8376,14 +8395,23 @@ def run_conversation(
 
             # If we're near the limit, break to avoid infinite loops.
             # Local processing errors are deterministic — stop immediately
-            # rather than retrying until the budget is exhausted.
+            # rather than retrying until the budget is exhausted. Repeated
+            # outer-loop errors stop after a small per-turn cap: with
+            # max_iterations now unlimited by default, a permanent failure
+            # would otherwise spin forever and overwrite the rotated log
+            # history within minutes (#92450).
+            _outer_error_cap = min(_MAX_OUTER_LOOP_ERRORS, max(1, agent.max_iterations))
             if (
                 _is_local_processing_error
                 or api_call_count >= agent.max_iterations - 1
+                or _outer_error_count >= _outer_error_cap
             ):
                 if _is_local_processing_error:
                     _turn_exit_reason = f"local_processing_error({error_msg[:80]})"
                     final_response = f"I apologize, but I encountered an error while processing the model response: {error_msg}"
+                elif _outer_error_count >= _outer_error_cap:
+                    _turn_exit_reason = f"repeated_outer_errors({error_msg[:80]})"
+                    final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                 else:
                     _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
                     final_response = f"I apologize, but I encountered repeated errors: {error_msg}"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30451,6 +30451,37 @@ def _gateway_stderr_formatter() -> logging.Formatter:
     return RedactingFormatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
 
 
+def _replace_target_belongs_to_other_profile(existing_pid: int) -> bool:
+    """Return True when ``--replace`` must refuse to signal ``existing_pid``.
+
+    The PID file is HERMES_HOME-scoped, but a poisoned/stale record (e.g. one
+    cloned into a new profile by an older ``create_profile``, #89315) can point
+    at another profile's LIVE gateway. Killing it starts the cross-profile
+    SIGTERM restart loop the duplicate-instance guard was never meant to allow.
+    When the live process's readable command line identifies it as belonging to
+    a different profile than ours (this HERMES_HOME), replacement is refused.
+    Probe failures return False so same-home replaces keep their existing
+    identity-checked behavior.
+    """
+    try:
+        from gateway.status import (
+            _get_process_hermes_home,
+            _read_process_cmdline,
+            _command_line_belongs_to_profile,
+        )
+        live_cmdline = _read_process_cmdline(existing_pid)
+        if not live_cmdline:
+            return False
+        return not _command_line_belongs_to_profile(
+            live_cmdline, _get_process_hermes_home()
+        )
+    except Exception:
+        logger.debug(
+            "cross-profile --replace guard probe failed", exc_info=True
+        )
+        return False
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -30497,6 +30528,17 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     existing_pid = get_running_pid()
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
+            if _replace_target_belongs_to_other_profile(existing_pid):
+                from gateway.status import _get_process_hermes_home
+
+                logger.error(
+                    "Refusing --replace: PID %d belongs to a different "
+                    "profile's gateway (HERMES_HOME %s). Remove the stale "
+                    "PID record or stop the owning profile explicitly.",
+                    existing_pid,
+                    _get_process_hermes_home(),
+                )
+                return False
             existing_start_time = get_process_start_time(existing_pid)
             logger.info(
                 "Replacing existing gateway instance (PID %d) with --replace.",

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1209,6 +1209,16 @@ def create_profile(
         for subdir in _PROFILE_DIRS:
             (profile_dir / subdir).mkdir(parents=True, exist_ok=True)
 
+        if source_dir is not None and clone_config:
+            # Runtime files must never survive a clone (#89315). The desktop's
+            # "new profile" flow uses clone_config, so a poisoned source-side
+            # gateway.pid / gateway_state.json / processes.json previously rode
+            # along: a later --replace in the new profile read the inherited
+            # record and SIGTERMed another profile's live gateway, feeding the
+            # cross-profile restart loop. Same strip contract as clone_all.
+            for stale in _CLONE_ALL_STRIP:
+                (profile_dir / stale).unlink(missing_ok=True)
+
         # Clone config files from source
         if source_dir is not None:
             for filename in _CLONE_CONFIG_FILES:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3914,6 +3914,13 @@ class AIAgent:
                 + "an error occurred near the iteration limit before a final "
                 "answer. Check the tool output above, then send `continue`."
             )
+        if reason.startswith("repeated_outer_errors"):
+            return (
+                prefix
+                + "the turn kept failing with repeated errors and was stopped "
+                "early instead of retrying forever. Check the errors above, "
+                "then send `continue` to retry."
+            )
         if reason == "pending_tool_result":
             return (
                 prefix

--- a/tests/cron/test_87033_cronjob_gateway_liveness.py
+++ b/tests/cron/test_87033_cronjob_gateway_liveness.py
@@ -1,0 +1,148 @@
+"""Tests for issue #87033 — the cronjob tool must surface gateway liveness.
+
+The builtin cron ticker only runs inside the gateway process. Before the
+fix, ``cronjob(action="create")`` returned a clean success even with no
+gateway running, so the agent confidently told the user a recurring task
+was scheduled while the job could never fire. The CLI already warned
+(``hermes cron list`` / ``hermes cron status``); the agent path did not.
+
+Contract pinned here:
+
+* create with a live gateway → ``gateway_running: true``, no warning;
+* create with no gateway → ``gateway_running: false`` + explicit warning
+  telling the model the job is saved but will not fire yet;
+* non-builtin scheduler providers are exempt (they fire without the gateway);
+* a failed liveness probe stays neutral (``gateway_running: null``) instead
+  of claiming either way.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME for each test so jobs don't leak."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "cron").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+def _create_job() -> dict:
+    from tools.cronjob_tools import cronjob
+
+    return json.loads(
+        cronjob(
+            action="create",
+            schedule="every 10m",
+            prompt="say hi",
+            name="liveness-probe-job",
+            deliver="local",
+        )
+    )
+
+
+class TestCreateSurfacesGatewayLiveness:
+    def test_create_with_gateway_running_has_no_warning(self, hermes_env):
+        with patch_liveness(provider="builtin", pids=[12345]) as patches:
+            result = _create_job()
+
+        assert result["success"] is True
+        assert result["gateway_running"] is True
+        assert "warning" not in result
+
+    def test_create_without_gateway_warns_not_scheduled(self, hermes_env):
+        with (
+            patch_liveness(provider="builtin", pids=[]),
+        ):
+            result = _create_job()
+
+        assert result["success"] is True, (
+            "the job itself is still created successfully"
+        )
+        assert result["gateway_running"] is False
+        warning = result.get("warning", "")
+        assert "not running" in warning.lower()
+        assert "will NOT fire" in warning, (
+            "the model must be told the job won't fire (#87033)"
+        )
+        assert "gateway" in warning.lower()
+
+    def test_non_builtin_provider_is_exempt(self, hermes_env):
+        """External schedulers (e.g. Chronos) fire without the gateway —
+        no false alarm may be raised for them."""
+        with patch_liveness(provider="chronos", pids=[]):
+            result = _create_job()
+
+        assert result["success"] is True
+        assert result["gateway_running"] is True
+        assert "warning" not in result
+
+    def test_failed_probe_stays_neutral(self, hermes_env):
+        """If liveness cannot be determined, say nothing either way."""
+        with patch_liveness(provider=None, pids=[]):  # probe raises → None
+            result = _create_job()
+
+        assert result["success"] is True
+        assert result["gateway_running"] is None
+        assert "warning" not in result
+
+
+# ---------------------------------------------------------------------------
+
+
+from contextlib import ExitStack
+
+
+class _LivenessPatches:
+    """Context manager patching the provider/gateway-pid probes."""
+
+    def __init__(self, *, provider, pids):
+        self._provider = provider
+        self._pids = pids
+
+    def __enter__(self):
+        from unittest.mock import patch
+
+        self._stack = ExitStack()
+
+        def _fake_provider_name():
+            if self._provider is None:
+                raise RuntimeError("probe failure")
+            return self._provider
+
+        self._stack.enter_context(
+            patch(
+                "hermes_cli.cron._active_cron_provider_name",
+                side_effect=_fake_provider_name,
+            )
+        )
+        self._stack.enter_context(
+            patch(
+                "hermes_cli.gateway.find_gateway_pids",
+                return_value=list(self._pids),
+            )
+        )
+        return self
+
+    def __exit__(self, *exc):
+        return self._stack.__exit__(*exc)
+
+
+def patch_liveness(*, provider, pids):
+    return _LivenessPatches(provider=provider, pids=pids)

--- a/tests/run_agent/test_92450_outer_error_retry_bound.py
+++ b/tests/run_agent/test_92450_outer_error_retry_bound.py
@@ -1,0 +1,203 @@
+"""Tests for issue #92450 — outer-loop error retries must be bounded even
+when the turn budget (``max_iterations``) is unlimited.
+
+Before the fix, the outer ``except`` in ``run_conversation`` only left the
+loop on a local-processing error (#66267) or when
+``api_call_count >= agent.max_iterations - 1``. With the default budget now
+unlimited (``sys.maxsize``), a permanent failure that escaped the inner
+retry/fallback machinery spun forever (~64 retries/s measured in the issue),
+pegged a core, and overwrote days of rotated agent.log history within
+minutes.
+
+Injection points reflect the real escape path: exceptions raised INSIDE the
+inner retry loop (transport errors from ``create()``, normalization,
+fallbacks, ...) never reach the outer handler — that machinery recovers or
+terminates on its own. The outer handler sees failures from the final
+response assembly, e.g. ``_build_assistant_message`` (a chat-completion-
+helpers callable, so such crashes classify as RETRYABLE, never local —
+exactly the spin shape reported in the issue).
+
+The fix adds a small per-turn cap on total outer-loop exceptions
+(``_MAX_OUTER_LOOP_ERRORS``, scaled down by a tiny explicit
+``max_iterations``). These tests pin the behavior contract:
+
+* repeated escaping errors must terminate the turn within the cap;
+* a turn that recovers after early escaping failures must complete normally;
+* local-processing errors still exit immediately (#66267 unchanged);
+* a finite ``max_iterations`` still exhausts via the original near-limit path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def loop_agent():
+    """AIAgent with a mocked OpenAI client (mirrors test_run_agent's fixture)
+    so we can stage responses on ``.chat.completions.create``."""
+    from run_agent import AIAgent
+    from tests.run_agent.test_run_agent import _mock_response
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        # Every API call itself SUCCEEDS — #92450's spin happens after the
+        # response arrives, when final-response assembly keeps crashing.
+        agent.client.chat.completions.create.side_effect = (
+            lambda *a, **k: _mock_response(content="ok", finish_reason="stop")
+        )
+        return agent
+
+
+class _PermanentError(Exception):
+    """An error type no recovery path classifies as retryable-local."""
+
+
+def _make_local_frame_raiser():
+    """Compile a raiser whose frame filename lives in a local-processing
+    module, so the production traceback classifier (#66267) sees it as a
+    deterministic local bug — without mocking away the classifier itself."""
+    namespace = {}
+    code = compile(
+        "def _raise(exc):\n    raise exc\n",
+        filename="/agent/agent_runtime_helpers.py",
+        mode="exec",
+    )
+    exec(code, namespace)
+    return namespace["_raise"]
+
+
+class TestOuterErrorRetryBound:
+    def test_repeated_escaping_errors_are_bounded(self, loop_agent):
+        """A permanent final-assembly failure that escapes every retry layer
+        must end the turn within the per-turn error cap instead of spinning
+        forever under the unlimited default budget."""
+        boom = _PermanentError("permanent assembly contract violation")
+
+        with (
+            patch.object(
+                loop_agent, "_build_assistant_message", side_effect=boom
+            ),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("hello")
+
+        # The bound path returns an apology as final_response with
+        # failed=False (same contract as the legacy near-limit exit), so the
+        # meaningful assertions are: bounded call count + dedicated exit
+        # reason + apology text.
+        assert result["api_calls"] <= 8, (
+            "The loop must give up within the per-turn error bound instead "
+            "of retrying an unlimited-budget failure forever."
+        )
+        assert result["turn_exit_reason"].startswith("repeated_outer_errors"), (
+            f"unexpected exit reason: {result['turn_exit_reason']}"
+        )
+        assert "repeated errors" in (result["final_response"] or "")
+
+    def test_recovery_after_failures_completes_normally(self, loop_agent):
+        """Early escaping failures followed by success must NOT trip the new
+        bound — the turn completes and the reply is delivered."""
+        good_msg = {
+            "role": "assistant",
+            "content": "Recovered fine.",
+            "finish_reason": "stop",
+        }
+
+        with (
+            patch.object(
+                loop_agent,
+                "_build_assistant_message",
+                side_effect=[
+                    _PermanentError("transient assembly hiccup"),
+                    _PermanentError("transient assembly hiccup"),
+                    dict(good_msg),
+                ],
+            ),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("hello")
+
+        # final_response comes from the raw provider content ("ok"), so the
+        # recovery contract is: clean text_response exit exactly on the 3rd
+        # call, marked completed — proving the two earlier escapes did not
+        # trip the new bound.
+        assert result["completed"] is True, (
+            f"turn should recover: exit={result.get('turn_exit_reason')}"
+        )
+        assert result["failed"] is False
+        assert result["api_calls"] == 3
+        assert result["turn_exit_reason"].startswith("text_response"), (
+            f"unexpected exit reason: {result['turn_exit_reason']}"
+        )
+
+    def test_local_processing_error_still_exits_immediately(self, loop_agent):
+        """#66267 regression guard: a deterministic local bug exits on first
+        occurrence — the new counter must not delay or change that exit."""
+        raiser = _make_local_frame_raiser()
+        boom = TypeError("list content fed into a str regex helper")
+
+        with (
+            patch.object(
+                loop_agent,
+                "_strip_think_blocks",
+                side_effect=lambda text: raiser(boom),
+            ),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("hello")
+
+        assert result["turn_exit_reason"].startswith("local_processing_error"), (
+            f"unexpected exit reason: {result['turn_exit_reason']}"
+        )
+        assert result["api_calls"] == 1, (
+            "A local processing error must stop immediately on first "
+            "occurrence, not consume retries."
+        )
+
+    def test_finite_budget_still_governs_near_limit_exit(self, loop_agent):
+        """With a small explicit max_iterations the ORIGINAL near-limit path
+        fires (unchanged reason string), not the new repeated-error path."""
+        loop_agent.max_iterations = 3
+        boom = _PermanentError("permanent assembly failure")
+
+        with (
+            patch.object(
+                loop_agent, "_build_assistant_message", side_effect=boom
+            ),
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("hello")
+
+        # Budget of 3 → the legacy guard fires on error #2 (api_call_count 2
+        # >= 3 - 1); the new cap would fire at error #3, so the legacy path
+        # must win here.
+        assert result["turn_exit_reason"].startswith(
+            "error_near_max_iterations"
+        ), f"legacy near-limit path must govern: {result['turn_exit_reason']}"

--- a/tests/test_89315_profile_clone_gateway_isolation.py
+++ b/tests/test_89315_profile_clone_gateway_isolation.py
@@ -1,0 +1,181 @@
+"""Tests for issue #89315 — Desktop "new profile" must not seed a gateway
+kill-loop across profiles.
+
+Two surfaces are pinned:
+
+1. ``create_profile(clone_config=True)`` (the desktop's default clone path)
+   must strip gateway runtime files the way ``--clone-all`` already does. A
+   stale/poisoned ``gateway.pid`` / ``gateway_state.json`` / ``processes.json``
+   riding along into a fresh profile later steers that profile's ``--replace``
+   at another profile's live gateway PID (the restart loop's fuel).
+
+2. ``_replace_target_belongs_to_other_profile()`` — the guard consulted by
+   ``start_gateway(replace=True)`` — must identify a live process whose
+   readable command line belongs to a different profile and refuse, while a
+   same-home cmdline and unreadable cmdlines keep the legacy behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME mirroring tests/hermes_cli/test_profiles.py."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    return tmp_path
+
+
+class TestCloneConfigStripsGatewayRuntimeFiles:
+    def test_runtime_files_do_not_survive_clone_config(self, profile_env):
+        """A source profile's gateway runtime files must not ride along on
+        the desktop's default clone_config path (#89315)."""
+        from hermes_cli.profiles import create_profile
+
+        default_home = profile_env / ".hermes"
+        (default_home / "config.yaml").write_text("model: test\n")
+        (default_home / ".env").write_text("KEY=val\n")
+        # Poisoned runtime files in the SOURCE — as left by a crash loop.
+        poisoned_pid = {
+            "pid": 999991,
+            "kind": "hermes-gateway",
+            "start_time": 1234567890,
+        }
+        (default_home / "gateway.pid").write_text(json.dumps(poisoned_pid))
+        (default_home / "gateway_state.json").write_text(
+            json.dumps({"pid": 999991})
+        )
+        (default_home / "processes.json").write_text(
+            json.dumps({"gateways": []})
+        )
+
+        profile_dir = create_profile("tim", clone_config=True, no_alias=True)
+
+        assert (profile_dir / "config.yaml").exists(), (
+            "clone_config must still copy the config files themselves"
+        )
+        for stale in ("gateway.pid", "gateway_state.json", "processes.json"):
+            assert not (profile_dir / stale).exists(), (
+                f"{stale} survived the clone and can steer --replace at "
+                "another profile's gateway (#89315)"
+            )
+
+    def test_clone_config_without_runtime_files_still_works(self, profile_env):
+        """No runtime files in source → clone unaffected (no false failure)."""
+        from hermes_cli.profiles import create_profile
+
+        default_home = profile_env / ".hermes"
+        (default_home / "config.yaml").write_text("model: test\n")
+
+        profile_dir = create_profile(
+            "clean", clone_config=True, no_alias=True
+        )
+        assert (profile_dir / "config.yaml").exists()
+
+
+class TestReplaceTargetProfileGuard:
+    def test_foreign_profile_cmdline_is_refused(self, profile_env):
+        """A cmdline advertising another profile must trip the refusal."""
+        from gateway.run import _replace_target_belongs_to_other_profile
+
+        with (
+            patch(
+                "gateway.status._read_process_cmdline",
+                return_value=(
+                    "/usr/bin/python -m hermes_cli.main --profile tim "
+                    "gateway run"
+                ),
+            ),
+            patch(
+                "gateway.status._get_process_hermes_home",
+                return_value=profile_env / ".hermes",
+            ),
+        ):
+            assert _replace_target_belongs_to_other_profile(424242) is True
+
+    def test_same_profile_cmdline_is_allowed(self, profile_env):
+        """A bare/default-gateway cmdline matching this home must pass."""
+        from gateway.run import _replace_target_belongs_to_other_profile
+
+        with (
+            patch(
+                "gateway.status._read_process_cmdline",
+                return_value="python -m hermes_cli.main gateway run",
+            ),
+            patch(
+                "gateway.status._get_process_hermes_home",
+                return_value=profile_env / ".hermes",
+            ),
+        ):
+            assert _replace_target_belongs_to_other_profile(424242) is False
+
+    def test_unreadable_cmdline_falls_open(self, profile_env):
+        """When the cmdline cannot be read (Windows/permissions), the guard
+        stays out of the way — legacy identity checks remain authoritative."""
+        from gateway.run import _replace_target_belongs_to_other_profile
+
+        with patch(
+            "gateway.status._read_process_cmdline", return_value=None
+        ):
+            assert _replace_target_belongs_to_other_profile(424242) is False
+
+    def test_named_profile_home_accepts_own_flag_and_refuses_bare(self):
+        """The issue #89315 shape: profile 'tim' (HERMES_HOME under
+        profiles/tim) must accept a '--profile tim' target and refuse a
+        bare default-profile gateway."""
+        from pathlib import Path as _P
+
+        from gateway.run import _replace_target_belongs_to_other_profile
+
+        tim_home = _P("/home/x/.hermes/profiles/tim")
+
+        with (
+            patch(
+                "gateway.status._read_process_cmdline",
+                return_value="python -m hermes_cli.main --profile tim gateway run",
+            ),
+            patch(
+                "gateway.status._get_process_hermes_home",
+                return_value=tim_home,
+            ),
+        ):
+            assert _replace_target_belongs_to_other_profile(1) is False
+
+        with (
+            patch(
+                "gateway.status._read_process_cmdline",
+                return_value="python -m hermes_cli.main gateway run",
+            ),
+            patch(
+                "gateway.status._get_process_hermes_home",
+                return_value=tim_home,
+            ),
+        ):
+            assert _replace_target_belongs_to_other_profile(2) is True
+
+    def test_default_home_refuses_named_profile_target(self):
+        """Mirror case: default root home must refuse a '--profile <x>'
+        target recorded in its PID file."""
+        from pathlib import Path as _P
+
+        from gateway.run import _replace_target_belongs_to_other_profile
+
+        with (
+            patch(
+                "gateway.status._read_process_cmdline",
+                return_value="python -m hermes_cli.main --profile sam gateway run",
+            ),
+            patch(
+                "gateway.status._get_process_hermes_home",
+                return_value=_P("/home/x/.hermes"),
+            ),
+        ):
+            assert _replace_target_belongs_to_other_profile(3) is True

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1223,6 +1223,28 @@ def _apply_continuity(
     return refs or None
 
 
+def _builtin_gateway_liveness() -> Optional[bool]:
+    """Gateway liveness for the builtin cron scheduler, or None when unknown.
+
+    Mirrors the CLI's ``_warn_if_gateway_not_running`` heuristic (#87033): the
+    builtin ticker only runs inside the gateway process, so a scheduled job
+    with no live gateway can never fire. Non-builtin providers (e.g. Chronos)
+    fire through their own machinery and are deliberately exempt — a missing
+    gateway process means nothing for them. ``None`` = probe failed; callers
+    must not claim either way.
+    """
+    try:
+        from hermes_cli.cron import _active_cron_provider_name
+
+        if _active_cron_provider_name() != "builtin":
+            return True  # external provider fires jobs without the gateway
+        from hermes_cli.gateway import find_gateway_pids
+
+        return bool(find_gateway_pids())
+    except Exception:
+        return None
+
+
 def cronjob(
     action: str,
     job_id: Optional[str] = None,
@@ -1368,22 +1390,38 @@ def cronjob(
             _local_notice = _local_delivery_notice(job, _normalize_deliver_param(deliver))
             if _local_notice:
                 _create_message = f"{_create_message} {_local_notice}"
-            return json.dumps(
-                {
-                    "success": True,
-                    "job_id": job["id"],
-                    "name": job["name"],
-                    "skill": job.get("skill"),
-                    "skills": job.get("skills", []),
-                    "schedule": job["schedule_display"],
-                    "repeat": _repeat_display(job),
-                    "deliver": job.get("deliver", "local"),
-                    "next_run_at": job["next_run_at"],
-                    "job": _format_job(job),
-                    "message": _create_message,
-                },
-                indent=2,
-            )
+            # Gateway liveness surfacing (#87033): the builtin scheduler's
+            # ticker lives in the gateway process, so a job created with no
+            # gateway running is stored but will never fire. Tell the model
+            # here — the CLI already warns, but the agent path saw only a
+            # clean success and confidently told the user it was scheduled.
+            _gw_running = _builtin_gateway_liveness()
+            _result = {
+                "success": True,
+                "job_id": job["id"],
+                "name": job["name"],
+                "skill": job.get("skill"),
+                "skills": job.get("skills", []),
+                "schedule": job["schedule_display"],
+                "repeat": _repeat_display(job),
+                "deliver": job.get("deliver", "local"),
+                "next_run_at": job["next_run_at"],
+                "job": _format_job(job),
+                "message": _create_message,
+            }
+            if _gw_running is False:
+                _result["gateway_running"] = False
+                _result["warning"] = (
+                    "The Hermes gateway is not running — this job is saved "
+                    "but will NOT fire until the gateway is started "
+                    "(hermes gateway install / hermes gateway start). "
+                    "Tell the user the task is scheduled but not active yet."
+                )
+            elif _gw_running is None:
+                _result["gateway_running"] = None
+            else:
+                _result["gateway_running"] = True
+            return json.dumps(_result, indent=2)
 
         if normalized == "list":
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]


### PR DESCRIPTION
## Summary

Fixes #87033

The builtin cron ticker only runs inside the gateway process. The CLI already surfaces this — `hermes cron list` and `hermes cron status` both warn when no gateway is running — but that check lives in `hermes_cli/cron.py` and never reached the model-facing `cronjob` tool. Result: with no gateway installed, `cronjob(action="create")\)" returned a clean success, the agent told the user the recurring task was scheduled, and the job sat inert forever.

This PR mirrors the CLI's liveness heuristic in the tool's create path and attaches a **tri-state `gateway_running` field** to the success payload:

| Value | Meaning | Extra field |
|---|---|---|
| `true` | Gateway running, **or** a non-builtin scheduler provider owns firing (e.g. Chronos fires via webhook without the gateway — exempt by design, same as the CLI heuristic) | — |
| `false` | No live gateway: job is saved but will not fire | `warning` telling the model to relay "scheduled but not active yet" |
| `null` | Probe failed | claim neither way |

The warning text explicitly instructs the model: *"Tell the user the task is scheduled but not active yet."* — turning the silent-failure class from the issue into a relayable caveat.

## Design notes

- Reuses exactly the CLI's primitives (`_active_cron_provider_name`, `find_gateway_pids`) so both paths can never disagree about what "gateway running" means.
- Probe failures return `None` rather than guessing — the tool must not claim liveness it cannot verify.
- Output-only change: no new parameters, so `CRONJOB_SCHEMA` (input contract) is untouched; all existing JSON consumers use `.get()` and tolerate additive fields.

## Test Plan

New tests in `tests/cron/test_87033_cronjob_gateway_liveness.py`:

- [x] create with live gateway → `gateway_running: true`, no warning
- [x] create with no gateway → `gateway_running: false` + warning naming that the job "will NOT fire"
- [x] non-builtin provider → exempt (`true`, no false alarm)
- [x] failed probe → neutral `null`

Regression runs (all green):

- `tests/cron/`: test_cron_no_agent, test_cronjob_schema, test_scheduler_provider, test_cron_context_from, test_cron_bot_chat_delivery, test_cron_workdir → **104 passed**
- `python -m py_compile` clean