### PR TITLE
fix(install): initialize LastResolver so StrictMode hosts can install

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -145,6 +145,14 @@ try {
 
 $script:LongProfileRoot = $null
 
+# Which resolver produced the final paths ('kernel32' | 'com' | 'profile-root'
+# | 'skipped-long-path' | 'none'). Initialized so the report at the entry-point
+# dispatch never reads an unset variable -- under a caller's Set-StrictMode
+# (common in pwsh profiles; #93017) that read throws
+# "The variable '$script:LastResolver' cannot be retrieved because it has not
+# been set" and kills the whole install before any stage runs.
+$script:LastResolver = 'none'
+
 function Write-PathDiag {
     # Diagnostics for this block go to stderr, never stdout: the stage protocol
     # hands drivers a single line of JSON on stdout and a stray note would break
@@ -248,7 +256,10 @@ function ConvertTo-LongPath {
     if ([string]::IsNullOrWhiteSpace($Path)) { return $Path }
     # Only 8.3 short names carry a tilde+digit ("~1"); skip every resolver for
     # ordinary long paths, which is the overwhelmingly common case.
-    if ($Path -notmatch '~\d') { return $Path }
+    if ($Path -notmatch '~\d') {
+        $script:LastResolver = 'skipped-long-path'
+        return $Path
+    }
 
     # 1. kernel32. Compiled on first use only, so a normal profile never pays
     #    the Add-Type cost (this file is re-entered once per install stage).


### PR DESCRIPTION
## What does this PR do?

Fixes #93017. `install.ps1` died at line 367 with `InvalidOperation: The variable '$script:LastResolver' cannot be retrieved because it has not been set` before any install stage ran, on fresh installs where every path involved is already long.

**Root cause.** `ConvertTo-LongPath()` early-returns for paths without a tilde+digit (`if ($Path -notmatch '~\d') { return $Path }`) - the overwhelmingly common case, as its own comment says. All three `$script:LastResolver = ...` assignments sit *after* that early return, so on an ordinary machine the variable is never assigned. The resolved-path report built for the entry-point dispatch then reads it (`resolver = $script:LastResolver`). Without strict mode the read silently yields nothing; under a caller's `Set-StrictMode` (common in PowerShell 7 profiles, and inherited by `irm | iex` and `& scriptblock` invocations alike) it throws and kills the install - exactly the reporter's three invocation methods failing identically.

**Reproduced on clean `main`** (Windows, `Set-StrictMode -Version Latest`, all-long env paths):

```
The variable '$script:LastResolver' cannot be retrieved because it has not been set.
At scripts\install.ps1:367 char:25
+     resolver          = $script:LastResolver
```

**Fix.**

1. Initialize `$script:LastResolver = 'none'` alongside the existing `$script:LongProfileRoot = $null` script-state declaration.
2. The non-tilde early return now records `'skipped-long-path'`, so the report stays truthful instead of silently inheriting whatever an earlier call left behind.

Verified end-to-end via `-ShowResolvedPaths`: the previously-crashing scenario now emits its JSON report normally; the short-path scenario still reports `kernel32` resolution unchanged.

Fixes #93017

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `scripts/install.ps1`: initialize `$script:LastResolver`; label the skip-long-path early return.

## How to Test

```powershell
Set-StrictMode -Version Latest
$env:TEMP = 'C:\Windows\Temp'   # force all-long paths so every resolver is skipped
powershell -NoProfile -ExecutionPolicy Bypass -File scripts\install.ps1 -ShowResolvedPaths
```

Before: the InvalidOperation above. After: JSON with `"resolver":"skipped-long-path"`.

## Checklist

### Code

- [x] Contributing Guide read
- [x] Conventional Commits followed (`fix(install):`)
- [x] Duplicates searched
- [x] Only changes related to this fix
- [x] Reproduced on clean main, fix verified via real installer run (`-ShowResolvedPaths`)
- [x] Tested on Windows 11
