### PR TITLE
plugins(index): add glm-quota — GLM Coding Plan quota monitor

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,18 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "glm-quota",
+      "description": "GLM Coding Plan quota monitor — statusbar chip + pane showing 5h/weekly/tools usage and reset times (Z.AI & Zhipu).",
+      "author": "iftoif",
+      "tags": ["glm", "zai", "zhipu", "quota", "monitor", "desktop", "statusbar"],
+      "repo": "iftoif/glm-quota",
+      "ref": "c2ef4335be907bb0769ebd8f341cb3d01ad7b08f",
+      "homepage": "https://github.com/iftoif/glm-quota",
+      "capabilities": ["dashboard", "desktop"],
+      "api_version": 1,
+      "added_at": "2026-08-24"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a community plugin index entry for **glm-quota** ([iftoif/glm-quota](https://github.com/iftoif/glm-quota)), pinned to commit `c2ef433`.

A Hermes Desktop plugin that monitors GLM Coding Plan usage (Z.AI / Zhipu):

- **Statusbar chip** — `● GLM <5h>% / <week>% ↻<countdown>`; color escalates green → yellow (70%) → red (90%); hover shows both windows' reset times; click to refresh.
- **Dock pane** — progress bars for the 5-hour window, weekly quota, and monthly tools quota, each with reset countdown.
- **Python backend** runs inside the gateway: reads `GLM_API_KEY` from Hermes' own `.env` (`ZAI_API_KEY`/`ZHIPU_API_KEY` also accepted), calls the official monitor endpoint (`/api/monitor/usage/quota/limit`, raw-key auth), 60s shared cache, and falls back to `open.bigmodel.cn` if `api.z.ai` is unreachable.
- No third-party hops: the key stays local, requests go directly to Z.AI / Zhipu.

## Verification

- `hermes plugins doctor` passes on the packaged layout and on a fresh public clone.
- Backend E2E against the live API (both system python and the Hermes venv): `ok: true`, all three windows returned.
- Desktop half render-smoke tested through the app's real loader mechanism (import-map rewrite + dynamic import): chip + pane registered, 26 component invocations across 4 query states, no exceptions.

## Install (works today, pre-index)

```bash
hermes plugins install iftoif/glm-quota --enable
```

Then fully restart the desktop app (⌘Q → reopen) so the gateway mounts the plugin's backend routes.