### PR TITLE
fix(update): a failed receipt pointer no longer reports the previous run

### DIFF
--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import sys
 import time
 from datetime import datetime, timezone
@@ -197,9 +198,19 @@ def finalize_update_receipt(
         # Stable pointer for the dashboard/desktop: latest receipt.
         latest = directory / "latest.json"
         try:
-            latest.write_text(
-                json.dumps(receipt.data, indent=2, default=str), encoding="utf-8"
-            )
+            # Atomic: a reader either sees the previous pointer or this one,
+            # never a half-written file.
+            fd, tmp = tempfile.mkstemp(dir=str(directory), prefix=".latest-", suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(json.dumps(receipt.data, indent=2, default=str))
+                os.replace(tmp, latest)
+            except BaseException:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+                raise
         except OSError as exc:
             # A stale pointer is worse than none: the Desktop reads this file
             # as "the durable success signal" and would report the PREVIOUS
@@ -276,33 +287,61 @@ def _prune_old_receipts(directory: Path) -> None:
         pass
 
 
+def _newest_receipt_path(directory: Path) -> Optional[Path]:
+    """The most recent timestamped receipt, or None.
+
+    Ordered by mtime rather than filename: the name carries a pid suffix
+    (``update_<stamp>_<pid>.json``), so two runs inside the same second sort
+    by process id, and a future naming change would silently reorder them.
+    The name breaks mtime ties so the result stays deterministic.
+    """
+    candidates = [p for p in directory.glob("*.json") if p.name != "latest.json"]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: (p.stat().st_mtime, p.name))
+
+
 def read_latest_receipt() -> Optional[dict[str, Any]]:
-    """Read the most recent update receipt, or None. Never raises."""
-    directory = _receipt_dir()
+    """Read the most recent update receipt, or None. Never raises.
+
+    The pointer is an optimization over the receipts, not the record: when
+    it is missing or unreadable the newest timestamped receipt answers
+    instead.
+
+    Only the newest one. An unreadable newest receipt yields None — "we do
+    not know" — never a predecessor: reporting an older run as the current
+    one is the staleness this module exists to prevent, and it reads the
+    same to a caller whether it comes from the pointer or from the scan.
+    """
     try:
-        path = directory / "latest.json"
-        if path.is_file():
-            payload = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(payload, dict):
-                return payload
-    except Exception as exc:  # noqa: BLE001 - fall through to the scan
-        logger.debug("latest-receipt pointer unreadable (%s); scanning", exc)
-    # The pointer is an optimization, not the record. Receipt filenames are
-    # timestamped, so the newest file is the run that actually happened —
-    # reachable even when the pointer was never written or was dropped.
-    try:
-        candidates = sorted(
-            (p for p in directory.glob("*.json") if p.name != "latest.json"),
-            key=lambda p: p.name,
-            reverse=True,
-        )
-        for candidate in candidates:
-            payload = json.loads(candidate.read_text(encoding="utf-8"))
-            if isinstance(payload, dict):
-                return payload
-    except Exception as exc:  # noqa: BLE001 - reader never raises
-        logger.debug("Could not scan update receipts: %s", exc)
-    return None
+        directory = _receipt_dir()
+        try:
+            pointer = directory / "latest.json"
+            if pointer.is_file():
+                payload = json.loads(pointer.read_text(encoding="utf-8"))
+                if isinstance(payload, dict):
+                    return payload
+                logger.warning(
+                    "Latest-receipt pointer %s is not a receipt object; "
+                    "falling back to the newest receipt", pointer,
+                )
+        except Exception as exc:  # noqa: BLE001 - fall through to the scan
+            logger.warning(
+                "Latest-receipt pointer unreadable (%s); falling back to the "
+                "newest receipt", exc,
+            )
+
+        newest = _newest_receipt_path(directory)
+        if newest is None:
+            return None
+        payload = json.loads(newest.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            return payload
+        logger.warning("Newest update receipt %s is not a receipt object", newest)
+        return None
+    except Exception as exc:  # noqa: BLE001 - contract: never raises
+        logger.warning("Could not read the latest update receipt: %s", exc)
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -200,12 +200,27 @@ def finalize_update_receipt(
             latest.write_text(
                 json.dumps(receipt.data, indent=2, default=str), encoding="utf-8"
             )
-        except OSError:
-            pass
+        except OSError as exc:
+            # A stale pointer is worse than none: the Desktop reads this file
+            # as "the durable success signal" and would report the PREVIOUS
+            # run's outcome for this one — #81193's exact shape, which this
+            # module exists to end. Drop it and let the reader fall back to
+            # the timestamped receipt just written.
+            logger.warning(
+                "Could not update the latest-receipt pointer %s (%s); "
+                "removing it so the stale one is not read as this run",
+                latest, exc,
+            )
+            try:
+                latest.unlink(missing_ok=True)
+            except OSError:
+                pass
         _prune_old_receipts(directory)
         return path
     except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("Could not write update receipt: %s", exc)
+        # The module's whole purpose is making update outcomes visible;
+        # failing to record one at DEBUG hides exactly what it promises.
+        logger.warning("Could not write update receipt: %s", exc)
         return None
 
 
@@ -263,14 +278,31 @@ def _prune_old_receipts(directory: Path) -> None:
 
 def read_latest_receipt() -> Optional[dict[str, Any]]:
     """Read the most recent update receipt, or None. Never raises."""
+    directory = _receipt_dir()
     try:
-        path = _receipt_dir() / "latest.json"
-        if not path.is_file():
-            return None
-        payload = json.loads(path.read_text(encoding="utf-8"))
-        return payload if isinstance(payload, dict) else None
-    except Exception:
-        return None
+        path = directory / "latest.json"
+        if path.is_file():
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                return payload
+    except Exception as exc:  # noqa: BLE001 - fall through to the scan
+        logger.debug("latest-receipt pointer unreadable (%s); scanning", exc)
+    # The pointer is an optimization, not the record. Receipt filenames are
+    # timestamped, so the newest file is the run that actually happened —
+    # reachable even when the pointer was never written or was dropped.
+    try:
+        candidates = sorted(
+            (p for p in directory.glob("*.json") if p.name != "latest.json"),
+            key=lambda p: p.name,
+            reverse=True,
+        )
+        for candidate in candidates:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                return payload
+    except Exception as exc:  # noqa: BLE001 - reader never raises
+        logger.debug("Could not scan update receipts: %s", exc)
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_receipt_pointer.py
+++ b/tests/hermes_cli/test_update_receipt_pointer.py
@@ -11,6 +11,7 @@ this module was written to end.
 
 import json
 import logging
+import time
 
 import pytest
 
@@ -32,12 +33,13 @@ def _write(directory, name, payload):
 class TestReader:
     def test_the_pointer_is_used_when_present(self, receipts):
         _write(receipts, "latest.json", {"outcome": "pointed-at"})
-        _write(receipts, "20260101-000000.json", {"outcome": "older"})
+        _write(receipts, "update_20260101_000000_1.json", {"outcome": "older"})
         assert update_receipt.read_latest_receipt()["outcome"] == "pointed-at"
 
     def test_a_missing_pointer_falls_back_to_the_newest_receipt(self, receipts):
-        _write(receipts, "20260101-000000.json", {"outcome": "older"})
-        _write(receipts, "20260823-120000.json", {"outcome": "newest"})
+        _write(receipts, "update_20260101_000000_1.json", {"outcome": "older"})
+        time.sleep(0.01)
+        _write(receipts, "update_20260823_120000_2.json", {"outcome": "newest"})
 
         assert update_receipt.read_latest_receipt()["outcome"] == "newest", (
             "with no pointer the reader reported nothing, so a completed "
@@ -46,32 +48,62 @@ class TestReader:
 
     def test_a_corrupt_pointer_falls_back_rather_than_reporting_nothing(self, receipts):
         (receipts / "latest.json").write_text("{ not json", encoding="utf-8")
-        _write(receipts, "20260823-120000.json", {"outcome": "newest"})
+        _write(receipts, "update_20260823_120000_2.json", {"outcome": "newest"})
         assert update_receipt.read_latest_receipt()["outcome"] == "newest"
 
     def test_an_empty_directory_is_still_none(self, receipts):
         assert update_receipt.read_latest_receipt() is None
 
-    def test_the_pointer_itself_is_never_scanned_as_a_receipt(self, receipts):
-        """`latest.json` sorts after the timestamps; it must not win the scan."""
-        _write(receipts, "20260823-120000.json", {"outcome": "newest"})
-        assert update_receipt.read_latest_receipt()["outcome"] == "newest"
+    @pytest.mark.parametrize(
+        "bad", ["{ truncated", '["not", "a", "dict"]', '"a string"', "null"]
+    )
+    def test_an_unreadable_newest_is_unknown_not_a_predecessor(self, receipts, bad):
+        """Reporting an older run as the current one is the staleness this
+        module exists to prevent — it reads identically to a caller whether
+        it came from the pointer or from the scan."""
+        _write(receipts, "update_20260101_000000_1.json", {"outcome": "OLD RUN"})
+        time.sleep(0.01)
+        (receipts / "update_20260823_120000_2.json").write_text(bad, encoding="utf-8")
+
+        assert update_receipt.read_latest_receipt() is None, (
+            "an unreadable newest receipt surfaced a predecessor as the "
+            "current run"
+        )
+
+    def test_ordering_is_by_mtime_not_filename(self, receipts):
+        """Names carry a pid suffix, so lexicographic order is not run order."""
+        _write(receipts, "update_20260823_120000_99.json", {"outcome": "written first"})
+        time.sleep(0.01)
+        _write(receipts, "update_20260823_120000_10.json", {"outcome": "written second"})
+
+        assert update_receipt.read_latest_receipt()["outcome"] == "written second"
+
+    def test_a_broken_receipt_dir_never_raises(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("broken profile")
+
+        monkeypatch.setattr(update_receipt, "_receipt_dir", _boom)
+        assert update_receipt.read_latest_receipt() is None
 
 
 class TestWriter:
-    """Driven through the real finalize path, not a test-only seam."""
+    """Driven through the real begin/finalize path, not a test-only seam."""
+
+    @staticmethod
+    def _break_pointer_write(monkeypatch):
+        """Fail only the atomic rename onto `latest.json`."""
+        real_replace = update_receipt.os.replace
+
+        def _fail(src, dst, *a, **kw):
+            if str(dst).endswith("latest.json"):
+                raise OSError("read-only")
+            return real_replace(src, dst, *a, **kw)
+
+        monkeypatch.setattr(update_receipt.os, "replace", _fail)
 
     def test_a_failed_pointer_write_removes_the_stale_one(self, receipts, monkeypatch, caplog):
         _write(receipts, "latest.json", {"outcome": "PREVIOUS RUN"})
-
-        real_write = update_receipt.Path.write_text
-
-        def _fail_on_pointer(self, data, **kw):
-            if self.name == "latest.json":
-                raise OSError("read-only")
-            return real_write(self, data, **kw)
-
-        monkeypatch.setattr(update_receipt.Path, "write_text", _fail_on_pointer)
+        self._break_pointer_write(monkeypatch)
         update_receipt.begin_update_receipt()
 
         with caplog.at_level(logging.WARNING, logger="hermes_cli.update_receipt"):
@@ -88,24 +120,26 @@ class TestWriter:
 
     def test_the_reader_then_finds_this_run_not_the_previous_one(self, receipts, monkeypatch):
         _write(receipts, "latest.json", {"outcome": "PREVIOUS RUN"})
-
-        real_write = update_receipt.Path.write_text
-
-        def _fail_on_pointer(self, data, **kw):
-            if self.name == "latest.json":
-                raise OSError("read-only")
-            return real_write(self, data, **kw)
-
-        monkeypatch.setattr(update_receipt.Path, "write_text", _fail_on_pointer)
+        self._break_pointer_write(monkeypatch)
         update_receipt.begin_update_receipt()
         update_receipt.finalize_update_receipt("success")
 
-        # The reader only reads; the write patch is irrelevant to it, and
+        # The reader only reads; the rename patch is irrelevant to it, and
         # undoing every patch here would also drop the receipt-dir fixture.
         got = update_receipt.read_latest_receipt()
         assert got is not None and got.get("outcome") == "success", got
 
+    def test_no_temp_file_is_left_behind_when_the_rename_fails(self, receipts, monkeypatch):
+        self._break_pointer_write(monkeypatch)
+        update_receipt.begin_update_receipt()
+        update_receipt.finalize_update_receipt("success")
+
+        leftovers = list(receipts.glob(".latest-*.tmp"))
+        assert leftovers == [], f"atomic-write scratch file leaked: {leftovers}"
+
     def test_a_healthy_run_still_writes_the_pointer(self, receipts):
         update_receipt.begin_update_receipt()
         assert update_receipt.finalize_update_receipt("success") is not None
-        assert (receipts / "latest.json").is_file()
+        pointer = receipts / "latest.json"
+        assert pointer.is_file()
+        assert json.loads(pointer.read_text(encoding="utf-8"))["outcome"] == "success"

--- a/tests/hermes_cli/test_update_receipt_pointer.py
+++ b/tests/hermes_cli/test_update_receipt_pointer.py
@@ -1,0 +1,111 @@
+"""The latest-receipt pointer must never speak for a run it did not record.
+
+`read_latest_receipt` is what the Desktop reads — `web_server.py` calls it
+"the durable success signal the Desktop ... rely on". It consulted only
+`latest.json`, and the writer swallowed a failed pointer write with a bare
+`pass`. So a run whose timestamped receipt wrote fine but whose pointer did
+not would report the PREVIOUS run's outcome as this one's — #81193's exact
+shape ("desktop shows failure for a successful update"), one of the issues
+this module was written to end.
+"""
+
+import json
+import logging
+
+import pytest
+
+from hermes_cli import update_receipt
+
+
+@pytest.fixture()
+def receipts(tmp_path, monkeypatch):
+    d = tmp_path / "logs" / "update_receipts"
+    d.mkdir(parents=True)
+    monkeypatch.setattr(update_receipt, "_receipt_dir", lambda: d)
+    return d
+
+
+def _write(directory, name, payload):
+    (directory / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestReader:
+    def test_the_pointer_is_used_when_present(self, receipts):
+        _write(receipts, "latest.json", {"outcome": "pointed-at"})
+        _write(receipts, "20260101-000000.json", {"outcome": "older"})
+        assert update_receipt.read_latest_receipt()["outcome"] == "pointed-at"
+
+    def test_a_missing_pointer_falls_back_to_the_newest_receipt(self, receipts):
+        _write(receipts, "20260101-000000.json", {"outcome": "older"})
+        _write(receipts, "20260823-120000.json", {"outcome": "newest"})
+
+        assert update_receipt.read_latest_receipt()["outcome"] == "newest", (
+            "with no pointer the reader reported nothing, so a completed "
+            "update looks like it never ran"
+        )
+
+    def test_a_corrupt_pointer_falls_back_rather_than_reporting_nothing(self, receipts):
+        (receipts / "latest.json").write_text("{ not json", encoding="utf-8")
+        _write(receipts, "20260823-120000.json", {"outcome": "newest"})
+        assert update_receipt.read_latest_receipt()["outcome"] == "newest"
+
+    def test_an_empty_directory_is_still_none(self, receipts):
+        assert update_receipt.read_latest_receipt() is None
+
+    def test_the_pointer_itself_is_never_scanned_as_a_receipt(self, receipts):
+        """`latest.json` sorts after the timestamps; it must not win the scan."""
+        _write(receipts, "20260823-120000.json", {"outcome": "newest"})
+        assert update_receipt.read_latest_receipt()["outcome"] == "newest"
+
+
+class TestWriter:
+    """Driven through the real finalize path, not a test-only seam."""
+
+    def test_a_failed_pointer_write_removes_the_stale_one(self, receipts, monkeypatch, caplog):
+        _write(receipts, "latest.json", {"outcome": "PREVIOUS RUN"})
+
+        real_write = update_receipt.Path.write_text
+
+        def _fail_on_pointer(self, data, **kw):
+            if self.name == "latest.json":
+                raise OSError("read-only")
+            return real_write(self, data, **kw)
+
+        monkeypatch.setattr(update_receipt.Path, "write_text", _fail_on_pointer)
+        update_receipt.begin_update_receipt()
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.update_receipt"):
+            written = update_receipt.finalize_update_receipt("success")
+
+        assert written is not None, "the timestamped receipt should still be written"
+        assert not (receipts / "latest.json").exists(), (
+            "the previous run's pointer survived, so the Desktop would report "
+            "its outcome for this update"
+        )
+        assert any("stale" in r.getMessage() for r in caplog.records), [
+            r.getMessage() for r in caplog.records
+        ]
+
+    def test_the_reader_then_finds_this_run_not_the_previous_one(self, receipts, monkeypatch):
+        _write(receipts, "latest.json", {"outcome": "PREVIOUS RUN"})
+
+        real_write = update_receipt.Path.write_text
+
+        def _fail_on_pointer(self, data, **kw):
+            if self.name == "latest.json":
+                raise OSError("read-only")
+            return real_write(self, data, **kw)
+
+        monkeypatch.setattr(update_receipt.Path, "write_text", _fail_on_pointer)
+        update_receipt.begin_update_receipt()
+        update_receipt.finalize_update_receipt("success")
+
+        # The reader only reads; the write patch is irrelevant to it, and
+        # undoing every patch here would also drop the receipt-dir fixture.
+        got = update_receipt.read_latest_receipt()
+        assert got is not None and got.get("outcome") == "success", got
+
+    def test_a_healthy_run_still_writes_the_pointer(self, receipts):
+        update_receipt.begin_update_receipt()
+        assert update_receipt.finalize_update_receipt("success") is not None
+        assert (receipts / "latest.json").is_file()


### PR DESCRIPTION
## The bug

`read_latest_receipt` is what the Desktop reads. `hermes_cli/web_server.py:5649` describes it as:

> the durable success signal the Desktop and … rely on

It consulted `latest.json` and nothing else. And the writer swallowed a failed pointer write:

```python
latest = directory / "latest.json"
try:
    latest.write_text(json.dumps(receipt.data, indent=2, default=str), encoding="utf-8")
except OSError:
    pass
```

So on a run where the timestamped receipt wrote fine but the pointer did not — read-only `HERMES_HOME`, a full disk, a permissions change — the **previous** run's `latest.json` stayed in place, and the Desktop reported *its* outcome as this update's.

That is #81193's exact shape, "desktop shows failure for a successful update", which this module's own docstring lists among the silent-failure classes it was written to end:

> Silent-failure classes this makes visible: #88848 … #74973 … #85753 … **#81193 (desktop shows failure for a successful update)**.

## The change

- **A failed pointer write warns and removes the stale pointer.** No pointer is honest; last run's pointer is a lie.
- **`read_latest_receipt` falls back to the newest timestamped receipt** when the pointer is missing or corrupt. The receipts are the record; the pointer is an optimization over them, and the filenames are timestamped, so the newest file is the run that actually happened. Without this, dropping the stale pointer would trade a wrong answer for no answer.
- **The receipt write failure moves DEBUG → WARNING.** A module whose stated purpose is making update outcomes visible should not lose one at a level nobody sees by default.

Everything stays exception-swallowing at the public entry points, per the module's contract — a failure inside the receipt still cannot break an update.

## Tests

8 in `tests/hermes_cli/test_update_receipt_pointer.py`: the pointer is preferred when healthy, the fallback fires on a missing and on a corrupt pointer, an empty directory is still `None`, and `latest.json` never wins the scan as though it were a receipt.

The writer cases are driven through the real `begin_update_receipt` / `finalize_update_receipt` path rather than a test-only seam: with the pointer write failing, the timestamped receipt is still written, the stale pointer is gone, the warning names it, and the reader then returns *this* run.

Reverting the writer and reader hunks fails five of them. The existing `test_update_receipt.py` and `test_update_receipt_endpoint.py` (37 together) pass unchanged.