### PR TITLE
fix(hindsight): apply configurable recall score floors

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -71,7 +71,7 @@ class _RecallResult:
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
 # Keep in sync with tools/lazy_deps.py ("memory.hindsight") and plugin.yaml.
-_MIN_CLIENT_VERSION = "0.6.1"
+_MIN_CLIENT_VERSION = "0.8.4"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # ``metadata.source`` stamped on retained memories — OPT-IN, empty by default.
@@ -89,6 +89,7 @@ _HINDSIGHT_GLYPH = "👁️"
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
 _VALID_BUDGETS = {"low", "mid", "high"}
+_VALID_RECALL_MIN_SCORE_KEYS = {"semantic", "keyword", "reranker", "final"}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
@@ -111,6 +112,28 @@ def _parse_int_setting(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         logger.warning("Invalid integer Hindsight setting %r; using default %s", value, default)
         return default
+
+
+def _normalize_recall_min_scores(value: Any) -> dict[str, float] | None:
+    """Validate the request-stage floors supported by Hindsight recall."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("recall_min_scores must be a JSON object")
+
+    normalized: dict[str, float] = {}
+    for key, raw_score in value.items():
+        if key not in _VALID_RECALL_MIN_SCORE_KEYS:
+            allowed = ", ".join(sorted(_VALID_RECALL_MIN_SCORE_KEYS))
+            raise ValueError(f"unsupported recall_min_scores key {key!r}; expected one of: {allowed}")
+        try:
+            score = float(raw_score)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"recall_min_scores.{key} must be numeric") from exc
+        if not 0.0 <= score <= 1.0:
+            raise ValueError(f"recall_min_scores.{key} must be between 0 and 1")
+        normalized[key] = score
+    return normalized or None
 
 
 # Env var the embedded daemon manager reads (at import time, as a module-level
@@ -846,6 +869,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._auto_recall = True
         self._recall_sync = False
         self._recall_max_tokens = 4096
+        self._recall_min_scores: dict[str, float] | None = None
         # Default to observation-only recall. Observations are Hindsight's
         # consolidated knowledge layer — deduplicated, evidence-grounded
         # beliefs built from many raw facts, with proof counts and
@@ -1202,6 +1226,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "prefetch_retain_drain_timeout", "description": "Max seconds the background prefetch waits for the retain to become recall-visible (queue drain + server-side completion) before recalling anyway", "default": 10.0},
             {"key": "retain_context", "description": "Context label for retained memories", "default": "conversation between Hermes Agent and the User"},
             {"key": "recall_max_tokens", "description": "Maximum tokens for recall results", "default": 4096},
+            {"key": "recall_min_scores", "description": "Optional Hindsight recall score floors applied to both auto-recall and hindsight_recall (JSON object with semantic, keyword, reranker, or final values from 0 to 1)", "default": None},
             {"key": "recall_max_input_chars", "description": "Maximum input query length for auto-recall", "default": 800},
             {"key": "recall_prompt_preamble", "description": "Custom preamble for recalled memories in context"},
             {"key": "timeout", "description": "API request timeout in seconds", "default": _DEFAULT_TIMEOUT},
@@ -1702,6 +1727,9 @@ class HindsightMemoryProvider(MemoryProvider):
         self._auto_recall = self._config.get("auto_recall", True)
         self._recall_sync = bool(self._config.get("recall_sync", False))
         self._recall_max_tokens = int(self._config.get("recall_max_tokens", 4096))
+        self._recall_min_scores = _normalize_recall_min_scores(
+            self._config.get("recall_min_scores")
+        )
         # Default narrows recall to observation-only; pass an explicit
         # `recall_types` list in config.json to broaden (e.g. include
         # "world" / "experience") or to disable the filter entirely.
@@ -1852,6 +1880,23 @@ class HindsightMemoryProvider(MemoryProvider):
             return True
         return False
 
+    def _build_recall_kwargs(self, query: str) -> dict[str, Any]:
+        """Build the one recall contract shared by prefetch and the tool."""
+        recall_kwargs: dict[str, Any] = {
+            "bank_id": self._bank_id,
+            "query": query,
+            "budget": self._budget,
+            "max_tokens": self._recall_max_tokens,
+        }
+        if self._recall_tags:
+            recall_kwargs["tags"] = self._recall_tags
+            recall_kwargs["tags_match"] = self._recall_tags_match
+        if self._recall_types:
+            recall_kwargs["types"] = self._recall_types
+        if self._recall_min_scores:
+            recall_kwargs["min_scores"] = self._recall_min_scores
+        return recall_kwargs
+
     def _do_recall(self, query: str) -> _RecallResult:
         """Run one recall/reflect for *query*.
 
@@ -1870,15 +1915,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
                 # Reflect synthesizes across many memories -> no discrete count.
                 return _RecallResult(resp.text or "", 0)
-            recall_kwargs: dict = {
-                "bank_id": self._bank_id, "query": query,
-                "budget": self._budget, "max_tokens": self._recall_max_tokens,
-            }
-            if self._recall_tags:
-                recall_kwargs["tags"] = self._recall_tags
-                recall_kwargs["tags_match"] = self._recall_tags_match
-            if self._recall_types:
-                recall_kwargs["types"] = self._recall_types
+            recall_kwargs = self._build_recall_kwargs(query)
             logger.debug("Recall: calling recall (bank=%s, query_len=%d, budget=%s)",
                          self._bank_id, len(query), self._budget)
             resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
@@ -2203,15 +2240,7 @@ class HindsightMemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
-                recall_kwargs: dict = {
-                    "bank_id": self._bank_id, "query": query, "budget": self._budget,
-                    "max_tokens": self._recall_max_tokens,
-                }
-                if self._recall_tags:
-                    recall_kwargs["tags"] = self._recall_tags
-                    recall_kwargs["tags_match"] = self._recall_tags_match
-                if self._recall_types:
-                    recall_kwargs["types"] = self._recall_types
+                recall_kwargs = self._build_recall_kwargs(query)
                 logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
                              self._bank_id, len(query), self._budget)
                 resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.6.1"
+  - "hindsight-client>=0.8.4"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client==0.8.4"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -259,6 +259,7 @@ class TestConfig:
         assert provider._auto_recall is True
         assert provider._retain_every_n_turns == 1
         assert provider._recall_max_tokens == 4096
+        assert provider._recall_min_scores is None
         assert provider._recall_max_input_chars == 800
         assert provider._tags is None
         assert provider._observation_scopes is None
@@ -295,6 +296,7 @@ class TestConfig:
             retain_context="custom-ctx",
             bank_retain_mission="Extract key facts",
             recall_max_tokens=2048,
+            recall_min_scores={"semantic": 0.45, "keyword": 0.5, "final": 0.6},
             recall_types=["world", "experience"],
             recall_prompt_preamble="Custom preamble:",
             recall_max_input_chars=500,
@@ -313,6 +315,11 @@ class TestConfig:
         assert p._retain_context == "custom-ctx"
         assert p._bank_retain_mission == "Extract key facts"
         assert p._recall_max_tokens == 2048
+        assert p._recall_min_scores == {
+            "semantic": 0.45,
+            "keyword": 0.5,
+            "final": 0.6,
+        }
         assert p._recall_types == ["world", "experience"]
         assert p._recall_prompt_preamble == "Custom preamble:"
         assert p._recall_max_input_chars == 500
@@ -440,6 +447,27 @@ class TestPostSetup:
 
 
 class TestToolHandlers:
+    def test_recall_min_scores_apply_to_tool_and_prefetch(self, provider_with_config):
+        floors = {"semantic": 0.45, "keyword": 0.5, "final": 0.6}
+        provider = provider_with_config(recall_min_scores=floors)
+
+        provider.handle_tool_call("hindsight_recall", {"query": "tool query"})
+        assert provider._client.arecall.call_args.kwargs["min_scores"] == floors
+
+        provider._client.arecall.reset_mock()
+        provider.queue_prefetch("prefetch query")
+        assert provider._prefetch_thread is not None
+        provider._prefetch_thread.join(timeout=5.0)
+        assert provider._client.arecall.call_args.kwargs["min_scores"] == floors
+
+    @pytest.mark.parametrize(
+        "value",
+        [{"unknown": 0.5}, {"final": 1.1}, {"semantic": "not-a-number"}],
+    )
+    def test_invalid_recall_min_scores_fail_closed(self, provider_with_config, value):
+        with pytest.raises(ValueError, match="recall_min_scores"):
+            provider_with_config(recall_min_scores=value)
+
     def test_retain_success(self, provider):
         result = json.loads(provider.handle_tool_call(
             "hindsight_retain", {"content": "user likes dark mode"}

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    "memory.hindsight": ("hindsight-client==0.8.4",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the

--- a/uv.lock
+++ b/uv.lock
@@ -1868,7 +1868,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.8.4" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.2.0" },
     { name = "httplib2", marker = "extra == 'google'", specifier = "==0.32.0" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
@@ -1966,7 +1966,7 @@ wheels = [
 
 [[package]]
 name = "hindsight-client"
-version = "0.6.1"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1976,9 +1976,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/26/8b8efa4be21fc3ba12ade3b1353d87f9837ec0d3ec2607e8adbf85bc9c63/hindsight_client-0.6.1.tar.gz", hash = "sha256:314d0bb9e13622e15586ba1586a799726d405b27bc20d78872474b5d6d96cd51", size = 99833, upload-time = "2026-05-08T13:01:23.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/e6/1fe61c4fb97afa1dcd9579b8b0f7cb8de24d567a6e8ed5a84192a57a5db5/hindsight_client-0.8.4.tar.gz", hash = "sha256:7291f1aa0e6bb226cd585d1f216e91078cce0af5aca60c24b90e1a54750f3a76", size = 117909, upload-time = "2026-07-01T11:43:58.987Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/4f/a1d0bc33ef933ecc52e76dc1514163594d25836a5d303c256a61bb61445d/hindsight_client-0.6.1-py3-none-any.whl", hash = "sha256:9fdda176ab50f7cec8d7339c6608c148f0cd9ad7e65d9d76192f2db730bc330a", size = 249379, upload-time = "2026-05-08T13:01:22.035Z" },
+    { url = "https://files.pythonhosted.org/packages/19/b1/4abd57a52d3126e0a3554b558442c7d0972be2f3c5b879b9c215d35d5d7e/hindsight_client-0.8.4-py3-none-any.whl", hash = "sha256:8e352bd90d5c43cccb1bee5023ac8c17fb578398c8220d9b85dd6175e7c40c52", size = 290269, upload-time = "2026-07-01T11:43:57.519Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Make Hindsight recall relevance floors configurable and apply one validated recall contract to synchronous recall, background prefetch, and the explicit hindsight_recall tool.

This ports and updates #71122 onto current main while preserving David Wu as the implementation commit author. The follow-up locks the SDK version that first exposes min_scores in arecall.

## Why

Without request-stage floors, hybrid retrieval can fill the token budget with lexical or graph neighbours that the reranker still considers weak. Hermes currently has no way to pass Hindsight min_scores, and its pinned 0.6.1 client does not support that argument.

## Behavior

- Adds optional `recall_min_scores` with `semantic`, `keyword`, `reranker`, and `final` keys.
- Validates values as numbers in the inclusive 0..1 range and fails closed on invalid config.
- Uses one kwargs builder for the sync, async-prefetch, and tool recall paths.
- Keeps reflect unchanged because that API has no `min_scores` field.
- Updates all dependency declarations and `uv.lock` to `hindsight-client` 0.8.4.

No numeric floor is enabled by default; deployments opt in through normal provider config.

## Verification

- 88 passed: `tests/plugins/memory/test_hindsight_provider.py` and `tests/test_packaging_metadata.py`
- Tested with `hindsight-client` 0.8.4 imports, not a mock-only shim.
- `git diff --check` passes.
