### PR TITLE
fix(state): keep malformed schemas from disabling session persistence

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -875,7 +875,7 @@ def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
     for _ in range(4):
         try:
             row = conn.execute("PRAGMA journal_mode").fetchone()
-        except sqlite3.OperationalError as exc:
+        except sqlite3.DatabaseError as exc:
             last_exc = exc
             if "disk i/o error" not in str(exc).lower():
                 return None
@@ -1334,7 +1334,7 @@ def _apply_delete_for_wal_reset_bug(
     actual = ""
     try:
         actual = _set_journal_mode_no_wait(conn, "DELETE")
-    except sqlite3.OperationalError as exc:
+    except sqlite3.DatabaseError as exc:
         if require_delete:
             raise
         lowered = str(exc).lower()

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -104,6 +104,86 @@ class TestApplyWalWalResetGate:
         finally:
             conn.close()
 
+    def test_malformed_schema_probe_is_indeterminate_without_downgrade(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state, "is_sqlite_wal_reset_vulnerable", lambda version_info=None: True
+        )
+        path = tmp_path / "malformed.db"
+        seed = sqlite3.connect(str(path))
+        seed.execute("CREATE TABLE messages_fts(x)")
+        seed.execute("PRAGMA writable_schema=ON")
+        seed.execute(
+            """
+            INSERT INTO sqlite_master(type, name, tbl_name, rootpage, sql)
+            SELECT type, name, tbl_name, rootpage, sql
+            FROM sqlite_master
+            WHERE name = 'messages_fts'
+            """
+        )
+        seed.commit()
+        seed.close()
+
+        class _TrackDeleteConnection(sqlite3.Connection):
+            delete_attempts = 0
+
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                if "journal_mode=delete" in sql.lower().replace(" ", ""):
+                    self.delete_attempts += 1
+                return super().execute(sql, *args, **kwargs)
+
+        conn = sqlite3.connect(str(path), factory=_TrackDeleteConnection)
+        try:
+            assert apply_wal_with_fallback(conn, db_label="malformed.db") == "wal"
+            assert conn.delete_attempts == 0
+        finally:
+            conn.close()
+
+    def test_automatic_delete_database_error_is_best_effort(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state, "is_sqlite_wal_reset_vulnerable", lambda version_info=None: True
+        )
+
+        class _DeleteDatabaseErrorConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                if "journal_mode=delete" in sql.lower().replace(" ", ""):
+                    raise sqlite3.DatabaseError("malformed database schema")
+                return super().execute(sql, *args, **kwargs)
+
+        conn = sqlite3.connect(
+            str(tmp_path / "automatic.db"), factory=_DeleteDatabaseErrorConnection
+        )
+        try:
+            assert apply_wal_with_fallback(conn, db_label="automatic.db") == "delete"
+        finally:
+            conn.close()
+
+    def test_configured_delete_database_error_still_raises(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            hermes_state, "is_sqlite_wal_reset_vulnerable", lambda version_info=None: True
+        )
+        monkeypatch.setattr(hermes_state, "resolve_journal_mode", lambda: "delete")
+
+        class _DeleteDatabaseErrorConnection(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                if "journal_mode=delete" in sql.lower().replace(" ", ""):
+                    raise sqlite3.DatabaseError("malformed database schema")
+                return super().execute(sql, *args, **kwargs)
+
+        conn = sqlite3.connect(
+            str(tmp_path / "configured.db"), factory=_DeleteDatabaseErrorConnection
+        )
+        try:
+            with pytest.raises(sqlite3.DatabaseError, match="malformed database schema"):
+                apply_wal_with_fallback(conn, db_label="configured.db")
+        finally:
+            conn.close()
+
 
 
     def test_warning_deduped_per_label(self, tmp_path, monkeypatch, caplog):


### PR DESCRIPTION
## What does this PR do?

Prevents malformed SQLite schemas from escaping the vulnerable-runtime WAL compatibility path and disabling session persistence during database initialization. The automatic path remains best-effort, while an unreadable journal mode stays indeterminate so Hermes never forces a downgrade it cannot prove safe.

### Symptom

Opening a database with a duplicated `messages_fts` schema row raises `sqlite3.DatabaseError: malformed database schema (messages_fts) - table messages_fts already exists` from `PRAGMA journal_mode` before session persistence is available.

### Impact

Affected session stores can fail initialization instead of reaching the existing recovery and persistence lifecycle. The blast radius is limited to databases that enter the vulnerable-runtime journal fallback with a malformed schema.

### Bug Cause

**Trigger:** `hermes_state.py` in `_on_disk_journal_mode()` and `_apply_delete_for_wal_reset_bug()` when SQLite raises the `sqlite3.DatabaseError` base class.

**Causal chain:**
1. A vulnerable SQLite runtime opens a database whose schema is malformed.
2. The journal-mode read or automatic DELETE attempt raises `sqlite3.DatabaseError`, but both best-effort handlers catch only its narrower `sqlite3.OperationalError` subclass.
3. The broader exception escapes and can abort `SessionDB` initialization.

**Why it is wrong:** SQLite uses the broader `DatabaseError` class for malformed-schema failures, so the compatibility boundary did not cover the full database-error family it is intended to contain.

**Working sibling / contrast:** `OperationalError` failures already stay inside this boundary, and explicit configured DELETE requests already re-raise instead of silently accepting an unverified mode.

**Ruled out:** This is not a schema-repair failure. A deterministic duplicated `sqlite_master` row fails directly at the journal-mode probe before schema repair can run.

### Fix

Catch `sqlite3.DatabaseError` at both automatic compatibility boundaries. Probe failures now flow into the existing indeterminate no-downgrade branch; automatic DELETE failures remain best-effort; configured DELETE still re-raises the original database error.

## Related Issue

Closes #93087

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` - widen the journal-mode read and automatic DELETE compatibility boundaries to `sqlite3.DatabaseError`.
- `tests/test_sqlite_wal_reset_gate.py` - cover a real malformed-schema probe, automatic DELETE failure, and configured DELETE failure.

## How to Test

1. Create a database with a duplicated `messages_fts` row in `sqlite_master`, reopen it, and force the vulnerable-runtime branch.
2. Verify the mode is treated as indeterminate and no DELETE switch is attempted.
3. Run:

```bash
scripts/run_tests.sh tests/test_sqlite_wal_reset_gate.py -q
scripts/run_tests.sh tests/test_hermes_state_wal_fallback.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant test files and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A
- [x] I've considered cross-platform impact; this uses the standard `sqlite3.DatabaseError` hierarchy
- [x] Tool descriptions or schemas update: N/A

## Screenshots / Logs

N/A - covered by deterministic SQLite regression tests.
