### PR TITLE
fix(gateway): restore session history after transient database failure

### DIFF
--- a/gateway/readiness.py
+++ b/gateway/readiness.py
@@ -86,6 +86,20 @@ def _probe_gateway(runtime_status: dict[str, Any]) -> dict[str, Any]:
     return _check(status, state=state, connected_platforms=connected, platforms=configured)
 
 
+def _probe_session_store(
+    runtime_status: dict[str, Any], state_db_probe: dict[str, Any]
+) -> dict[str, Any]:
+    """Report the running gateway cache state, not an independent reopen."""
+    runtime_store = runtime_status.get("session_store")
+    if isinstance(runtime_store, dict):
+        state = str(runtime_store.get("status") or "unknown")
+        if state in {"ok", "unavailable", "retrying"}:
+            return _check(state)
+    # Older gateways do not publish a cache state. Preserve their readiness
+    # behavior until their process restarts onto a version that does.
+    return _check("ok" if state_db_probe.get("status") == "ok" else "unavailable")
+
+
 def collect_runtime_readiness(
     *,
     configured_model: str,
@@ -102,8 +116,10 @@ def collect_runtime_readiness(
     """
     home = get_hermes_home()
     runtime = runtime_status if isinstance(runtime_status, dict) else {}
+    state_db_probe = _probe_state_db(home)
     checks = {
-        "state_db": _probe_state_db(home),
+        "state_db": state_db_probe,
+        "session_store": _probe_session_store(runtime, state_db_probe),
         "config": _probe_config(home),
         "model": _check("ok" if str(configured_model or "").strip() else "degraded"),
         "disk": _probe_disk(home),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7146,6 +7146,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._session_db_pinned: Any = _SESSION_DB_UNPINNED
         self._session_db_handles: Dict[Path, Any] = {}
         self._session_db_handles_lock = threading.Lock()
+        from gateway.session_db_recovery import RecoverableHandleCache
+
+        self._session_db_handle_cache = RecoverableHandleCache(
+            handles=self._session_db_handles,
+            lock=self._session_db_handles_lock,
+        )
         try:
             self._open_session_db_for_active_scope(raise_on_error=True)
         except Exception as e:
@@ -7271,29 +7277,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         search on a multiplexed gateway read the *serving profile's* store
         rather than the root one.
 
-        One ``AsyncSessionDB`` is cached per resolved path under a lock, so
+        One ``AsyncSessionDB`` is cached per resolved path, so
         the wrapper identity is stable per profile (callers compare and stash
-        it) and two profiles never share a handle.  A construction failure is
-        cached as ``None`` for that path so a broken store degrades once, not
-        per command; ``raise_on_error=True`` (construction-time priming)
-        propagates the failure instead so ``__init__`` can record
-        ``_session_db_init_error`` for the #88235 broadcast.
+        it) and two profiles never share a handle. A construction failure
+        enters bounded backoff; one caller retries after the deadline while
+        concurrent callers continue to see the unavailable fallback.
+        ``raise_on_error=True`` (construction-time priming) propagates the
+        failure after recording that recoverable state so ``__init__`` can
+        record ``_session_db_init_error`` for the #88235 broadcast.
         """
         from hermes_state import AsyncSessionDB, SessionDB, _default_db_path
+        from gateway.session_db_recovery import RecoverableHandleCache
 
         path = Path(_default_db_path())
-        with self._session_db_handles_lock:
-            if path in self._session_db_handles:
-                return self._session_db_handles[path]
-            db = None
+        cache = getattr(self, "_session_db_handle_cache", None)
+        if cache is None:
+            # Compatibility for lightweight test runners built with
+            # object.__new__ rather than GatewayRunner.__init__.
+            cache = RecoverableHandleCache(
+                handles=self._session_db_handles,
+                lock=self._session_db_handles_lock,
+            )
+            self._session_db_handle_cache = cache
+
+        def _open():
             try:
-                db = AsyncSessionDB(SessionDB())
-            except Exception as e:
-                if raise_on_error:
-                    raise
-                logger.warning("SQLite session store not available: %s", e)
-            self._session_db_handles[path] = db
-            return db
+                return AsyncSessionDB(SessionDB())
+            except Exception as exc:
+                logger.warning("SQLite session store not available: %s", exc)
+                raise
+
+        def _recovered() -> None:
+            self._session_db_init_error = None
+            logger.info("SQLite session store recovered")
+
+        return cache.get(
+            path,
+            _open,
+            raise_on_error=raise_on_error,
+            on_recovered=_recovered,
+        )
 
     @property
     def _session_db(self) -> Any:
@@ -7320,17 +7343,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``SessionStore.close_all_db_handles``.  Handles are drained under the
         lock and closed outside it; a pinned handle is the pinner's to close.
         """
-        with self._session_db_handles_lock:
-            handles = [db for db in self._session_db_handles.values() if db is not None]
-            self._session_db_handles.clear()
-        for db in handles:
+        def _close(db) -> None:
             inner = getattr(db, "_db", db)
             if inner is None or not hasattr(inner, "close"):
-                continue
+                return
             try:
                 inner.close()
             except Exception as exc:
                 logger.debug("SessionDB close error during handle sweep: %s", exc)
+
+        self._session_db_handle_cache.close_all(_close)
 
     def _wire_teams_pipeline_runtime(self) -> None:
         """Bind the Teams meeting pipeline runtime to Graph webhook ingress.
@@ -24562,7 +24584,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "2. Salvage with: sqlite3 ~/.hermes/state.db \".recover\" "
                 "(then replace state.db)\n"
                 "3. Restore from a backup in ~/.hermes/backups/\n"
-                f"Error: {error}"
+                "Run `hermes doctor` for sanitized diagnostics."
             )
         else:
             message = (

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1256,6 +1256,10 @@ class SessionStore:
         self.config = config
         self._entries: Dict[str, SessionEntry] = {}
         self._loaded = False
+        # A fallback-only initial load must be reconciled with state.db after
+        # the handle recovers, before a whole-index save can replace DB rows.
+        self._routing_db_loaded = False
+        self._routing_fallback_baseline: Optional[Dict[str, Any]] = None
         self._lock = threading.Lock()
         # Serialize whole-index persistence without holding ``_lock`` across
         # SQLite / fsync. Each writer snapshots the latest state only after
@@ -1456,6 +1460,7 @@ class SessionStore:
         the DB doesn't have, then persisted to the DB on the next _save).
         """
         if self._loaded:
+            self._reconcile_recovered_routing_locked()
             return
 
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
@@ -1464,6 +1469,7 @@ class SessionStore:
         # partially-initialized stores without __init__ (same pattern as
         # _prune_stale_sessions_locked).
         db_had_entries = False
+        db_load_succeeded = False
         _db = getattr(self, "_db", None)
         if _db:
             loader = getattr(_db, "load_gateway_routing_entries", None)
@@ -1479,6 +1485,7 @@ class SessionStore:
                                 "Skipping invalid routing entry %r: %s", key, e
                             )
                     db_had_entries = bool(self._entries)
+                    db_load_succeeded = True
                 except Exception as e:
                     logger.warning(
                         "gateway.session: state.db routing load failed: %s", e
@@ -1528,6 +1535,12 @@ class SessionStore:
                 print(f"[gateway] Warning: Failed to load sessions: {e}")
 
         self._loaded = True
+        self._routing_db_loaded = db_load_succeeded
+        self._routing_fallback_baseline = (
+            None
+            if db_load_succeeded
+            else {key: entry.to_dict() for key, entry in self._entries.items()}
+        )
 
         # Prune any sessions.json entries that point to sessions already ended
         # in state.db. A hard gateway crash (exit code 1) skips the graceful
@@ -1641,8 +1654,52 @@ class SessionStore:
         self._routing_generation = getattr(self, "_routing_generation", 0) + 1
         return self._routing_generation
 
+    def _reconcile_recovered_routing_locked(self) -> None:
+        """Merge authoritative rows after a fallback-only startup load."""
+        baseline = getattr(self, "_routing_fallback_baseline", None)
+        if getattr(self, "_routing_db_loaded", False) or baseline is None:
+            return
+
+        db = getattr(self, "_db", None)
+        loader = getattr(db, "load_gateway_routing_entries", None) if db else None
+        if not callable(loader):
+            return
+        try:
+            durable = loader(scope=self._routing_scope())
+        except Exception as exc:
+            logger.warning(
+                "gateway.session: recovered state.db routing load failed: %s", exc
+            )
+            return
+
+        current = {key: entry.to_dict() for key, entry in self._entries.items()}
+        for key, entry_json in durable.items():
+            try:
+                entry_data = json.loads(entry_json)
+                if not isinstance(entry_data, dict):
+                    continue
+                durable_entry = SessionEntry.from_dict(entry_data)
+            except (ValueError, KeyError, TypeError) as exc:
+                logger.warning("Skipping invalid routing entry %r: %s", key, exc)
+                continue
+
+            if key not in baseline:
+                # A key created while on fallback wins over a DB-only key;
+                # otherwise restore the authoritative row that fallback never saw.
+                self._entries.setdefault(key, durable_entry)
+            elif key not in current:
+                # The key was loaded from fallback and deliberately removed.
+                continue
+            elif current[key] == baseline[key]:
+                # Unchanged fallback data yields to the authoritative DB copy.
+                self._entries[key] = durable_entry
+
+        self._routing_db_loaded = True
+        self._routing_fallback_baseline = None
+
     def _snapshot_routing_locked(self) -> tuple[Dict[str, Any], int]:
         """Capture immutable routing data and a monotonic generation."""
+        self._reconcile_recovered_routing_locked()
         return (
             {key: entry.to_dict() for key, entry in self._entries.items()},
             self._next_routing_generation_locked(),

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1315,6 +1315,12 @@ class SessionStore:
         self._db_pinned = _DB_UNPINNED
         self._db_handles: Dict[Path, Any] = {}
         self._db_handles_lock = threading.Lock()
+        from gateway.session_db_recovery import RecoverableHandleCache
+
+        self._db_handle_cache = RecoverableHandleCache(
+            handles=self._db_handles,
+            lock=self._db_handles_lock,
+        )
         self._open_session_db_for_active_scope()
 
     def _open_session_db_for_active_scope(self):
@@ -1329,23 +1335,16 @@ class SessionStore:
 
         Handles are cached per resolved path, so a hot inbound path opens
         SQLite once per profile rather than once per message, and two
-        profiles never share a handle.  Construction is done under the lock
-        so a concurrent first message on the same profile cannot open (and
-        then leak) a second handle for the same path.
-
-        A construction failure is cached as ``None`` for that path, matching
-        the previous behavior where a failed startup left ``_db`` None for
-        the life of the store and callers fell back to JSONL.
+        profiles never share a handle. Failed opens enter a bounded backoff;
+        once it expires, one caller reopens while concurrent callers keep
+        using the JSONL fallback.
         """
         from hermes_state import SessionDB, _default_db_path
 
         path = Path(_default_db_path())
-        with self._db_handles_lock:
-            if path in self._db_handles:
-                return self._db_handles[path]
-            db = None
+        def _open():
             try:
-                db = SessionDB()
+                return SessionDB()
             except RuntimeError as e:
                 if "live-system guard" in str(e):
                     # Test-isolation guard fired: a pytest-context process
@@ -1355,10 +1354,18 @@ class SessionStore:
                     # guard must fire again on the next attempt.
                     raise
                 print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+                raise
             except Exception as e:
                 print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
-            self._db_handles[path] = db
-            return db
+                raise
+
+        return self._db_handle_cache.get(
+            path,
+            _open,
+            non_cacheable=lambda exc: (
+                isinstance(exc, RuntimeError) and "live-system guard" in str(exc)
+            ),
+        )
 
     @property
     def _db(self):
@@ -1399,14 +1406,13 @@ class SessionStore:
         handle (``store._db = fake``) is deliberately not closed here — the
         pinner owns its lifecycle.
         """
-        with self._db_handles_lock:
-            handles = [db for db in self._db_handles.values() if db is not None]
-            self._db_handles.clear()
-        for db in handles:
+        def _close(db) -> None:
             try:
                 db.close()
             except Exception as exc:
                 logger.debug("SessionDB close error during handle sweep: %s", exc)
+
+        self._db_handle_cache.close_all(_close)
 
     def _has_active_processes_safe(self, session_key: str, *, context: str) -> bool:
         """Return whether a session has active work, failing closed on registry errors."""

--- a/gateway/session_db_recovery.py
+++ b/gateway/session_db_recovery.py
@@ -1,0 +1,159 @@
+"""Recoverable per-path SessionDB handle caches for the gateway."""
+
+from __future__ import annotations
+
+import threading
+import time
+import weakref
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+_INITIAL_RETRY_DELAY_SECONDS = 1.0
+_MAX_RETRY_DELAY_SECONDS = 60.0
+
+
+@dataclass
+class _Unavailable:
+    failures: int = 0
+    next_retry_at: float = 0.0
+    in_flight: bool = False
+
+
+class _HealthSource:
+    pass
+
+
+_health_lock = threading.Lock()
+_health_states: weakref.WeakKeyDictionary[_HealthSource, dict[Path, str]] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _publish_health(source: _HealthSource, path: Path, state: str) -> None:
+    """Publish one privacy-safe aggregate for every live gateway DB cache."""
+    with _health_lock:
+        states = _health_states.setdefault(source, {})
+        states[path] = state
+        all_states = [value for item in _health_states.values() for value in item.values()]
+        if "retrying" in all_states:
+            aggregate = "retrying"
+        elif "unavailable" in all_states:
+            aggregate = "unavailable"
+        else:
+            aggregate = "ok"
+
+    try:
+        from gateway.status import write_runtime_status
+
+        write_runtime_status(session_store={"status": aggregate})
+    except Exception:
+        # Runtime health is diagnostic only; persistence must not depend on it.
+        pass
+
+
+class RecoverableHandleCache:
+    """Cache handles by path while allowing failed opens to heal in-process."""
+
+    def __init__(
+        self,
+        *,
+        handles: dict[Path, Any] | None = None,
+        lock: threading.Lock | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        initial_retry_delay: float = _INITIAL_RETRY_DELAY_SECONDS,
+        max_retry_delay: float = _MAX_RETRY_DELAY_SECONDS,
+    ) -> None:
+        self.handles = handles if handles is not None else {}
+        self.lock = lock if lock is not None else threading.Lock()
+        self._clock = clock
+        self._initial_retry_delay = max(0.0, float(initial_retry_delay))
+        self._max_retry_delay = max(
+            self._initial_retry_delay, float(max_retry_delay)
+        )
+        self._unavailable: dict[Path, _Unavailable] = {}
+        self._health_source = _HealthSource()
+
+    def get(
+        self,
+        path: Path,
+        opener: Callable[[], Any],
+        *,
+        raise_on_error: bool = False,
+        on_recovered: Callable[[], None] | None = None,
+        non_cacheable: Callable[[Exception], bool] | None = None,
+    ) -> Any:
+        """Return a cached handle or make one bounded, single-flight open attempt."""
+        path = Path(path)
+        with self.lock:
+            if path in self.handles:
+                return self.handles[path]
+
+            unavailable = self._unavailable.setdefault(path, _Unavailable())
+            now = self._clock()
+            if unavailable.in_flight or now < unavailable.next_retry_at:
+                return None
+            unavailable.in_flight = True
+            was_unavailable = unavailable.failures > 0
+
+        if was_unavailable:
+            _publish_health(self._health_source, path, "retrying")
+
+        try:
+            handle = opener()
+        except Exception as exc:
+            if non_cacheable is not None and non_cacheable(exc):
+                with self.lock:
+                    self._unavailable.pop(path, None)
+                raise
+            with self.lock:
+                unavailable = self._unavailable[path]
+                unavailable.failures += 1
+                delay = min(
+                    self._initial_retry_delay
+                    * (2 ** min(unavailable.failures - 1, 30)),
+                    self._max_retry_delay,
+                )
+                unavailable.next_retry_at = self._clock() + delay
+                unavailable.in_flight = False
+            _publish_health(self._health_source, path, "unavailable")
+            if raise_on_error:
+                raise
+            return None
+
+        with self.lock:
+            self.handles[path] = handle
+            self._unavailable.pop(path, None)
+        _publish_health(self._health_source, path, "ok")
+        if was_unavailable and on_recovered is not None:
+            on_recovered()
+        return handle
+
+    def close_all(self, close: Callable[[Any], None]) -> None:
+        """Drain cached handles under the lock and close them outside it."""
+        with self.lock:
+            handles = list(self.handles.values())
+            paths = set(self.handles) | set(self._unavailable)
+            self.handles.clear()
+            self._unavailable.clear()
+        for handle in handles:
+            try:
+                close(handle)
+            except Exception:
+                pass
+        with _health_lock:
+            states = _health_states.get(self._health_source)
+            if states is not None:
+                for path in paths:
+                    states.pop(path, None)
+
+    def status_for(self, path: Path) -> str:
+        """Return a sanitized state for tests and internal diagnostics."""
+        with self.lock:
+            if Path(path) in self.handles:
+                return "ok"
+            unavailable = self._unavailable.get(Path(path))
+            if unavailable is None:
+                return "unknown"
+            return "retrying" if unavailable.in_flight else "unavailable"

--- a/gateway/session_db_recovery.py
+++ b/gateway/session_db_recovery.py
@@ -74,6 +74,8 @@ class RecoverableHandleCache:
         )
         self._unavailable: dict[Path, _Unavailable] = {}
         self._health_source = _HealthSource()
+        self._generation = 0
+        self._close_rejected: Callable[[Any], None] | None = None
 
     def get(
         self,
@@ -96,6 +98,7 @@ class RecoverableHandleCache:
                 return None
             unavailable.in_flight = True
             was_unavailable = unavailable.failures > 0
+            generation = self._generation
 
         if was_unavailable:
             _publish_health(self._health_source, path, "retrying")
@@ -105,26 +108,51 @@ class RecoverableHandleCache:
         except Exception as exc:
             if non_cacheable is not None and non_cacheable(exc):
                 with self.lock:
-                    self._unavailable.pop(path, None)
+                    if (
+                        generation == self._generation
+                        and self._unavailable.get(path) is unavailable
+                    ):
+                        self._unavailable.pop(path, None)
                 raise
             with self.lock:
-                unavailable = self._unavailable[path]
-                unavailable.failures += 1
-                delay = min(
-                    self._initial_retry_delay
-                    * (2 ** min(unavailable.failures - 1, 30)),
-                    self._max_retry_delay,
-                )
-                unavailable.next_retry_at = self._clock() + delay
-                unavailable.in_flight = False
+                current = self._unavailable.get(path)
+                stale = generation != self._generation or current is not unavailable
+                if not stale:
+                    unavailable.failures += 1
+                    delay = min(
+                        self._initial_retry_delay
+                        * (2 ** min(unavailable.failures - 1, 30)),
+                        self._max_retry_delay,
+                    )
+                    unavailable.next_retry_at = self._clock() + delay
+                    unavailable.in_flight = False
+            if stale:
+                if raise_on_error:
+                    raise
+                return None
             _publish_health(self._health_source, path, "unavailable")
             if raise_on_error:
                 raise
             return None
 
         with self.lock:
-            self.handles[path] = handle
-            self._unavailable.pop(path, None)
+            stale = (
+                generation != self._generation
+                or self._unavailable.get(path) is not unavailable
+            )
+            if stale:
+                close_rejected = self._close_rejected
+            else:
+                self.handles[path] = handle
+                self._unavailable.pop(path, None)
+                close_rejected = None
+        if stale:
+            if close_rejected is not None:
+                try:
+                    close_rejected(handle)
+                except Exception:
+                    pass
+            return None
         _publish_health(self._health_source, path, "ok")
         if was_unavailable and on_recovered is not None:
             on_recovered()
@@ -133,6 +161,8 @@ class RecoverableHandleCache:
     def close_all(self, close: Callable[[Any], None]) -> None:
         """Drain cached handles under the lock and close them outside it."""
         with self.lock:
+            self._generation += 1
+            self._close_rejected = close
             handles = list(self.handles.values())
             paths = set(self.handles) | set(self._unavailable)
             self.handles.clear()

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -669,6 +669,7 @@ def _build_runtime_status_record() -> dict[str, Any]:
         "restart_requested": False,
         "active_agents": 0,
         "platforms": {},
+        "session_store": {"status": "unknown"},
         "updated_at": _utc_now_iso(),
     })
     payload.update(_get_code_identity_fields())
@@ -1072,6 +1073,7 @@ def write_runtime_status(
     needs_attention: Any = _UNSET,
     retrying_since: Any = _UNSET,
     served_profiles: Any = _UNSET,
+    session_store: Any = _UNSET,
     clear_profile_platforms: bool = False,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
@@ -1117,6 +1119,13 @@ def write_runtime_status(
         # for a single-profile gateway. Lets `hermes status` show per-profile
         # coverage without a second probe.
         payload["served_profiles"] = list(served_profiles or [])
+    if session_store is not _UNSET:
+        state = "unknown"
+        if isinstance(session_store, dict):
+            candidate = str(session_store.get("status") or "unknown")
+            if candidate in {"ok", "unavailable", "retrying", "unknown"}:
+                state = candidate
+        payload["session_store"] = {"status": state}
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -31,6 +31,7 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
 
     assert result["status"] == "ok"
     assert result["checks"]["state_db"]["status"] == "ok"
+    assert result["checks"]["session_store"]["status"] == "ok"
     assert result["checks"]["config"]["status"] == "ok"
     assert result["checks"]["model"]["status"] == "ok"
     assert result["checks"]["gateway"]["status"] == "ok"
@@ -57,5 +58,38 @@ def test_collect_runtime_readiness_degrades_on_invalid_config_and_stopped_gatewa
     assert result["checks"]["gateway"]["status"] == "degraded"
     # Readiness is diagnostic data, not an exception or a destructive repair.
     assert (home / "config.yaml").read_text(encoding="utf-8") == "model: [unterminated"
+
+
+def test_readiness_uses_running_session_store_state_over_independent_probe(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    with sqlite3.connect(home / "state.db") as conn:
+        conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    unavailable = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "platforms": {},
+            "session_store": {"status": "unavailable"},
+        },
+    )
+
+    assert unavailable["checks"]["state_db"]["status"] == "ok"
+    assert unavailable["checks"]["session_store"] == {"status": "unavailable"}
+    assert unavailable["status"] == "degraded"
+
+    recovered = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "platforms": {},
+            "session_store": {"status": "ok"},
+        },
+    )
+    assert recovered["checks"]["session_store"] == {"status": "ok"}
 
 

--- a/tests/gateway/test_session_db_recovery.py
+++ b/tests/gateway/test_session_db_recovery.py
@@ -1,0 +1,198 @@
+"""Regression coverage for recoverable gateway SessionDB opens (#93088)."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+from gateway.session_db_recovery import RecoverableHandleCache
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_failed_open_obeys_backoff_then_recovers() -> None:
+    clock = _Clock()
+    cache = RecoverableHandleCache(clock=clock, initial_retry_delay=2, max_retry_delay=8)
+    path = Path("profile/state.db")
+    handle = object()
+    calls = 0
+
+    def opener():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("private/path/state.db is unavailable")
+        return handle
+
+    assert cache.get(path, opener) is None
+    assert cache.status_for(path) == "unavailable"
+    clock.now = 1.99
+    assert cache.get(path, opener) is None
+    assert calls == 1
+
+    clock.now = 2.0
+    assert cache.get(path, opener) is handle
+    assert cache.get(path, opener) is handle
+    assert calls == 2
+    assert cache.status_for(path) == "ok"
+
+
+def test_retry_is_single_flight_for_concurrent_callers() -> None:
+    clock = _Clock()
+    cache = RecoverableHandleCache(clock=clock, initial_retry_delay=1, max_retry_delay=8)
+    path = Path("profile/state.db")
+    entered = threading.Event()
+    release = threading.Event()
+    handle = object()
+    calls = 0
+
+    def opener():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("first open fails")
+        entered.set()
+        assert release.wait(timeout=5)
+        return handle
+
+    assert cache.get(path, opener) is None
+    clock.now = 1.0
+    result: list[object] = []
+    thread = threading.Thread(target=lambda: result.append(cache.get(path, opener)))
+    thread.start()
+    assert entered.wait(timeout=5)
+
+    # The opener runs outside the state lock. Other callers observe in-flight
+    # and keep using the fallback rather than opening or blocking behind it.
+    assert cache.get(path, opener) is None
+    assert calls == 2
+    assert cache.status_for(path) == "retrying"
+
+    release.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert result == [handle]
+    assert cache.get(path, opener) is handle
+    assert calls == 2
+
+
+def test_runtime_health_is_sanitized_and_recovers() -> None:
+    clock = _Clock()
+    cache = RecoverableHandleCache(clock=clock, initial_retry_delay=1)
+    path = Path("secret/profile/state.db")
+    writes: list[dict] = []
+    calls = 0
+
+    def opener():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("database disk image is malformed at secret/profile/state.db")
+        return object()
+
+    with patch("gateway.status.write_runtime_status", side_effect=lambda **kw: writes.append(kw)):
+        assert cache.get(path, opener) is None
+        clock.now = 1.0
+        assert cache.get(path, opener) is not None
+
+    assert writes[-1] == {"session_store": {"status": "ok"}}
+    serialized = repr(writes)
+    assert "secret/profile" not in serialized
+    assert "malformed" not in serialized
+
+
+def test_session_store_and_runner_reopen_after_failed_construction(monkeypatch, tmp_path) -> None:
+    import hermes_state
+    from gateway.run import GatewayRunner, _SESSION_DB_UNPINNED
+    from gateway.session import SessionStore, _DB_UNPINNED
+
+    db_path = tmp_path / "state.db"
+    clock = _Clock()
+    opened: list[object] = []
+
+    def fail_once_session_db():
+        if not opened:
+            opened.append(None)
+            raise OSError("temporary open failure")
+        handle = object()
+        opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(hermes_state, "SessionDB", fail_once_session_db)
+    monkeypatch.setattr(hermes_state, "_default_db_path", lambda: db_path)
+
+    store = object.__new__(SessionStore)
+    store._db_pinned = _DB_UNPINNED
+    store._db_handles = {}
+    store._db_handles_lock = threading.Lock()
+    store._db_handle_cache = RecoverableHandleCache(
+        handles=store._db_handles,
+        lock=store._db_handles_lock,
+        clock=clock,
+        initial_retry_delay=1,
+    )
+    assert store._db is None
+    assert store._db is None
+    assert len(opened) == 1
+    clock.now = 1.0
+    assert store._db is opened[-1]
+
+    runner_opened: list[object] = []
+
+    def runner_fail_once():
+        if not runner_opened:
+            runner_opened.append(None)
+            raise OSError("temporary open failure")
+        handle = object()
+        runner_opened.append(handle)
+        return handle
+
+    monkeypatch.setattr(hermes_state, "SessionDB", runner_fail_once)
+    monkeypatch.setattr(hermes_state, "AsyncSessionDB", lambda db: ("async", db))
+    runner = object.__new__(GatewayRunner)
+    runner._session_db_pinned = _SESSION_DB_UNPINNED
+    runner._session_db_init_error = "temporary open failure"
+    runner._session_db_handles = {}
+    runner._session_db_handles_lock = threading.Lock()
+    runner._session_db_handle_cache = RecoverableHandleCache(
+        handles=runner._session_db_handles,
+        lock=runner._session_db_handles_lock,
+        clock=clock,
+        initial_retry_delay=1,
+    )
+    assert runner._session_db is None
+    assert runner._session_db is None
+    assert len(runner_opened) == 1
+    clock.now = 2.0
+    assert runner._session_db == ("async", runner_opened[-1])
+    assert runner._session_db_init_error is None
+
+
+def test_non_cacheable_guard_is_retried_immediately() -> None:
+    cache = RecoverableHandleCache()
+    path = Path("state.db")
+    calls = 0
+
+    def opener():
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("live-system guard")
+
+    for _ in range(2):
+        try:
+            cache.get(
+                path,
+                opener,
+                non_cacheable=lambda exc: "live-system guard" in str(exc),
+            )
+        except RuntimeError:
+            pass
+    assert calls == 2
+    assert cache.status_for(path) == "unknown"

--- a/tests/gateway/test_session_db_recovery.py
+++ b/tests/gateway/test_session_db_recovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import threading
 from pathlib import Path
 from unittest.mock import patch
@@ -196,3 +197,161 @@ def test_non_cacheable_guard_is_retried_immediately() -> None:
             pass
     assert calls == 2
     assert cache.status_for(path) == "unknown"
+
+
+def test_close_all_rejects_and_closes_inflight_success() -> None:
+    cache = RecoverableHandleCache()
+    path = Path("state.db")
+    entered = threading.Event()
+    release = threading.Event()
+    handle = object()
+    closed: list[object] = []
+    result: list[object | None] = []
+
+    def opener():
+        entered.set()
+        assert release.wait(timeout=5)
+        return handle
+
+    thread = threading.Thread(target=lambda: result.append(cache.get(path, opener)))
+    thread.start()
+    assert entered.wait(timeout=5)
+    cache.close_all(closed.append)
+    release.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert result == [None]
+    assert closed == [handle]
+    assert cache.status_for(path) == "unknown"
+
+
+def test_close_all_preserves_inflight_failure() -> None:
+    cache = RecoverableHandleCache()
+    path = Path("state.db")
+    entered = threading.Event()
+    release = threading.Event()
+    errors: list[BaseException] = []
+    failure = OSError("original open failure")
+
+    def opener():
+        entered.set()
+        assert release.wait(timeout=5)
+        raise failure
+
+    def run() -> None:
+        try:
+            cache.get(path, opener, raise_on_error=True)
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    assert entered.wait(timeout=5)
+    cache.close_all(lambda handle: None)
+    release.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert errors == [failure]
+    assert cache.status_for(path) == "unknown"
+
+
+def test_recovered_db_rows_survive_fallback_structural_save(monkeypatch, tmp_path) -> None:
+    import hermes_state
+    from gateway.config import GatewayConfig, Platform
+    from gateway.session import SessionEntry, SessionSource, SessionStore, _now
+
+    db_path = tmp_path / "state.db"
+    sessions_dir = tmp_path / "sessions"
+    scope = str(sessions_dir.resolve())
+    now = _now()
+    durable = SessionEntry(
+        session_key="agent:main:telegram:dm:durable",
+        session_id="durable-session",
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        created_at=now,
+        updated_at=now,
+        origin=SessionSource(platform=Platform.TELEGRAM, chat_id="durable"),
+    )
+    deleted = SessionEntry(
+        session_key="agent:main:telegram:dm:deleted",
+        session_id="deleted-session",
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        created_at=now,
+        updated_at=now,
+        origin=SessionSource(platform=Platform.TELEGRAM, chat_id="deleted"),
+    )
+    changed = SessionEntry(
+        session_key="agent:main:telegram:dm:changed",
+        session_id="changed-before-recovery",
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        created_at=now,
+        updated_at=now,
+        origin=SessionSource(platform=Platform.TELEGRAM, chat_id="changed"),
+    )
+    database = hermes_state.SessionDB(db_path=db_path)
+    for entry in (durable, deleted, changed):
+        database.save_gateway_routing_entry(
+            entry.session_key,
+            json.dumps(entry.to_dict()),
+            scope=scope,
+        )
+    database.close()
+    sessions_dir.mkdir()
+    (sessions_dir / "sessions.json").write_text(
+        json.dumps(
+            {
+                deleted.session_key: deleted.to_dict(),
+                changed.session_key: changed.to_dict(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    real_session_db = hermes_state.SessionDB
+    calls = 0
+
+    def fail_once_session_db(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("temporary open failure")
+        return real_session_db(db_path=db_path)
+
+    monkeypatch.setattr(hermes_state, "SessionDB", fail_once_session_db)
+    monkeypatch.setattr(hermes_state, "_default_db_path", lambda: db_path)
+    store = SessionStore(
+        sessions_dir,
+        GatewayConfig(sessions_dir=sessions_dir, write_sessions_json=False),
+    )
+    store._ensure_loaded()
+    store._db_handle_cache._unavailable[db_path].next_retry_at = 0
+
+    current = SessionEntry(
+        session_key="agent:main:telegram:dm:current",
+        session_id="current-session",
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        created_at=now,
+        updated_at=now,
+        origin=SessionSource(platform=Platform.TELEGRAM, chat_id="current"),
+    )
+    with store._lock:
+        store._entries.pop(deleted.session_key)
+        store._entries[changed.session_key].session_id = "changed-during-fallback"
+        store._entries[current.session_key] = current
+        store._save()
+
+    rows = store._db.load_gateway_routing_entries(scope=scope)
+    assert set(rows) == {durable.session_key, changed.session_key, current.session_key}
+    assert store._entries[durable.session_key].session_id == durable.session_id
+    assert (
+        json.loads(rows[changed.session_key])["session_id"]
+        == "changed-during-fallback"
+    )
+    assert store._entries[current.session_key].session_id == current.session_id
+    store.close_all_db_handles()

--- a/tests/gateway/test_session_db_recovery.py
+++ b/tests/gateway/test_session_db_recovery.py
@@ -205,6 +205,7 @@ def test_close_all_rejects_and_closes_inflight_success() -> None:
     entered = threading.Event()
     release = threading.Event()
     handle = object()
+    replacement = object()
     closed: list[object] = []
     result: list[object | None] = []
 
@@ -217,13 +218,14 @@ def test_close_all_rejects_and_closes_inflight_success() -> None:
     thread.start()
     assert entered.wait(timeout=5)
     cache.close_all(closed.append)
+    assert cache.get(path, lambda: replacement) is replacement
     release.set()
     thread.join(timeout=5)
 
     assert not thread.is_alive()
     assert result == [None]
     assert closed == [handle]
-    assert cache.status_for(path) == "unknown"
+    assert cache.get(path, lambda: object()) is replacement
 
 
 def test_close_all_preserves_inflight_failure() -> None:
@@ -233,6 +235,7 @@ def test_close_all_preserves_inflight_failure() -> None:
     release = threading.Event()
     errors: list[BaseException] = []
     failure = OSError("original open failure")
+    replacement = object()
 
     def opener():
         entered.set()
@@ -249,12 +252,13 @@ def test_close_all_preserves_inflight_failure() -> None:
     thread.start()
     assert entered.wait(timeout=5)
     cache.close_all(lambda handle: None)
+    assert cache.get(path, lambda: replacement) is replacement
     release.set()
     thread.join(timeout=5)
 
     assert not thread.is_alive()
     assert errors == [failure]
-    assert cache.status_for(path) == "unknown"
+    assert cache.get(path, lambda: object()) is replacement
 
 
 def test_recovered_db_rows_survive_fallback_structural_save(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## What does this PR do?

A gateway that fails to open a profile's `state.db` can now recover session persistence, `/resume`, history, and search without a process restart. Failed opens enter a bounded per-path retry state, and one caller performs each due reopen while concurrent callers continue using the existing fallback.

### Symptom

After one `SessionDB` construction failure, the running gateway continues returning a cached unavailable result even after the filesystem or database becomes usable again.

### Impact

Affected gateway profiles lose DB-backed session operations for the rest of the process lifetime. Operators must restart the gateway to restore persistence and history access.

### Bug Cause

**Trigger:** `gateway/session.py::_open_session_db_for_active_scope` and `gateway/run.py::_open_session_db_for_active_scope` cache a failed constructor result per resolved profile path.

**Causal chain:**
1. A transient lock, mount, permission, I/O, or database-open failure makes `SessionDB()` raise.
2. Both gateway caches retain an unavailable result with no recovery transition.
3. Later session-store and history operations never reopen the repaired store, while an independent readiness probe may still report that the file is readable.

**Why it is wrong:** A long-running gateway treats a transient construction failure as a permanent process-lifetime disable.

**Working sibling / contrast:** Successfully opened per-profile handles already remain stable and isolated by resolved path; the fix preserves that identity contract while making only failed opens recoverable.

**Ruled out:** Automatic database repair is not required for this failure class. A deterministic constructor-fails-once test reproduces the negative-cache behavior without mutating the database.

### Fix

- Add a shared recoverable per-path handle cache with capped exponential backoff and single-flight reopen attempts.
- Keep explicit `store._db = None` and `runner._session_db = None` pins authoritative.
- Clear the runner's initialization error after successful recovery and publish only sanitized `ok`, `unavailable`, or `retrying` runtime health.
- Make detailed readiness prefer the running gateway cache state over an independent SQLite probe.
- Remove raw SQLite exception text from the corruption warning delivered to home channels.

## Related Issue

Closes #93088

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session_db_recovery.py` - add bounded, privacy-safe, single-flight handle recovery.
- `gateway/session.py` - recover `SessionStore` handles per active profile path.
- `gateway/run.py` - recover runner handles, clear degraded initialization state, and sanitize user notifications.
- `gateway/status.py` and `gateway/readiness.py` - expose and consume the live session-store state.
- `tests/gateway/test_session_db_recovery.py` and `tests/gateway/test_readiness.py` - cover fails-once recovery, backoff, concurrency, profile cache behavior, status privacy, and readiness transitions.

## How to Test

1. Make the first `SessionDB()` construction fail and allow the next construction to succeed.
2. Verify accesses before the retry deadline do not reopen, concurrent due accesses create one handle, and later DB-backed access returns that handle.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_session_db_recovery.py tests/gateway/test_readiness.py tests/gateway/test_multiplex_session_db_profile_scope.py tests/hermes_state/test_live_db_isolation_guard.py tests/gateway/test_status.py -k 'session_db_recovery or readiness or multiplex_session_db_profile_scope or live_db_isolation_guard or write_runtime_status' -q
```

Result: 29 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant repository test entry and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant behavior is documented in code and docstrings
- [x] Config example update is N/A because no config keys changed
- [x] Contributor guide update is N/A because no public workflow changed
- [x] I've considered cross-platform impact; the implementation uses Python threading, monotonic time, and pathlib
- [x] Tool description/schema update is N/A because no model tool changed

## Screenshots / Logs

N/A - deterministic automated coverage exercises the recovery and readiness transitions.
