### PR TITLE
fix(browser): floor browser-use CLI subprocess PATH with sane system dirs

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -123,6 +123,60 @@ class TestSubprocessEnvironment:
         assert "PYTHONHOME" not in env
         assert env["KEEP_ME"] == "yes"
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX PATH-floor semantics")
+    def test_subprocess_env_floors_version_manager_only_path(self, monkeypatch):
+        """Profile workers (kanban bots, cron) can inherit a PATH of only
+        version-manager dirs (observed in the wild: one nvm dir repeated
+        7x). The uv browser-use trampoline resolves dirname/realpath
+        through PATH, so /usr/bin must be guaranteed or the CLI dies
+        'realpath: not found' (exit 127) before its Python starts."""
+        import sys
+        from types import ModuleType
+
+        browser_tool = ModuleType("tools.browser_tool")
+        browser_tool._build_browser_env = lambda: {
+            "PATH": os.pathsep.join(
+                ["/home/u/.nvm/versions/node/v24.18.0/bin"] * 7
+            ),
+        }
+        monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
+
+        env = bu_cli._base_subprocess_env()
+
+        parts = env["PATH"].split(os.pathsep)
+        assert "/usr/bin" in parts
+        assert "/bin" in parts
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX PATH-floor semantics")
+    def test_floor_preserves_existing_entries_and_order(self):
+        """The floor only adds dirs — never drops or reorders what the
+        caller's environment already had."""
+        original = "/opt/toolchain/bin:/usr/bin:/snap/bin"
+        merged = bu_cli._floor_subprocess_path(original).split(os.pathsep)
+
+        assert set(original.split(os.pathsep)) <= set(merged)
+        positions = [merged.index(p) for p in original.split(os.pathsep)]
+        assert positions == sorted(positions)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX PATH-floor semantics")
+    def test_floor_survives_missing_sibling_helper(self, monkeypatch):
+        """If browser_tool stops exporting _merge_browser_path, the floor
+        degrades to appending FHS bin dirs instead of vanishing."""
+        import sys
+        from types import ModuleType
+
+        browser_tool = ModuleType("tools.browser_tool")
+        browser_tool._build_browser_env = lambda: {
+            "PATH": "/home/u/.nvm/versions/node/v24.18.0/bin"
+        }
+        monkeypatch.setitem(sys.modules, "tools.browser_tool", browser_tool)
+
+        env = bu_cli._base_subprocess_env()
+
+        parts = env["PATH"].split(os.pathsep)
+        assert "/usr/bin" in parts
+        assert "/home/u/.nvm/versions/node/v24.18.0/bin" in parts
+
 
 class TestToolSurfaceSwap:
     def test_legacy_browser_tools_hidden_in_cli_mode(self, monkeypatch):

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -118,8 +118,49 @@ def _base_subprocess_env() -> dict:
     # needs Hermes's import path.
     env.pop("PYTHONPATH", None)
     env.pop("PYTHONHOME", None)
+    # Same class of hazard, PATH flavor: profile-spawned workers (kanban
+    # bots, cron jobs) can hand down a PATH of only version-manager dirs,
+    # which kills the uv trampoline before the CLI's Python starts. Floor
+    # the PATH so coreutils are always reachable (see below).
+    env["PATH"] = _floor_subprocess_path(env.get("PATH", ""))
     env.setdefault("ANONYMIZED_TELEMETRY", "false")
     return env
+
+
+def _floor_subprocess_path(path: str) -> str:
+    """Guarantee core system dirs survive onto the CLI subprocess PATH.
+
+    Profile workers can inherit a PATH holding only version-manager dirs
+    (observed: the nvm node dir repeated 7x, nothing else). That is fatal
+    for the uv-installed browser-use binary: its POSIX sh trampoline
+    resolves ``dirname``/``realpath`` through PATH, so without /usr/bin it
+    dies with ``realpath: not found … exec: /python: not found`` (exit
+    127) before its own Python ever starts. Reuses browser_tool's
+    ``_merge_browser_path`` floor — same hazard, same sane-dir list — and
+    falls back to appending FHS bin dirs if that import is unavailable.
+    Windows .cmd shims don't trampoline through PATH, so no-op there.
+    """
+    if os.name == "nt":
+        return path
+    try:
+        from tools.browser_tool import _merge_browser_path
+
+        return _merge_browser_path(path or "")
+    except Exception:
+        pass
+    parts = [p for p in (path or "").split(os.pathsep) if p]
+    existing = set(parts)
+    for directory in (
+        "/usr/local/sbin",
+        "/usr/local/bin",
+        "/usr/sbin",
+        "/usr/bin",
+        "/sbin",
+        "/bin",
+    ):
+        if directory not in existing and os.path.isdir(directory):
+            parts.append(directory)
+    return os.pathsep.join(parts)
 
 
 def _read_browser_cfg() -> dict:


### PR DESCRIPTION
Fixes #93115

## Summary

`browser_exec` dies with exit 127 (`realpath: not found … exec: /python: not found`) whenever a Hermes process inherits a PATH of only version-manager dirs — observed in the wild from kanban/cron profile workers carrying one nvm dir repeated 7x. The uv-installed `browser-use` entry point is a POSIX sh trampoline that resolves `dirname`/`realpath` through PATH at invocation time, so it fails before its own Python starts.

The agent-browser backend already defends against exactly this hazard via `tools/browser_tool.py::_merge_browser_path()`; this change gives the browser-use backend the same floor.

## What changed

- `tools/browser_use_cli.py`
  - `_base_subprocess_env()` now floors the child PATH through a new `_floor_subprocess_path()` helper.
  - The helper delegates to `browser_tool._merge_browser_path()` (same sane-dir list, never drops or reorders existing entries) and degrades to appending FHS bin dirs if that import is ever unavailable.
  - Windows is a no-op — `.cmd` shims don't trampoline through PATH.
  - PYTHONPATH/PYTHONHOME stripping (#83427 family) was the previous env-hygiene layer here; this is the same class of hazard, PATH flavor.
- `tests/tools/test_browser_use_cli.py`
  - `test_subprocess_env_floors_version_manager_only_path` — the observed-in-the-wild case (nvm-only ×7) must yield `/usr/bin` + `/bin`.
  - `test_floor_preserves_existing_entries_and_order` — floor only adds; existing entries keep relative order.
  - `test_floor_survives_missing_sibling_helper` — degraded fallback still guarantees `/usr/bin`.

## Test plan

- [x] `pytest tests/tools/test_browser_use_cli.py -o 'addopts=' -q` → 95 passed
- [x] Neighbors green: `test_browser_use_session_expiry.py`, `test_browser_homebrew_paths.py` → 32 passed
- [x] Real-subprocess E2E against upstream HEAD: worker process started with `env -i HOME=… PATH=<nvm-dir>` → `_find_cli()` resolves the managed uvx path → `_base_subprocess_env()` child PATH contains `/usr/bin` → `uvx browser-use --version` exits 0 printing `0.1.9`; control run without the floor reproduces exit 127 byte-for-byte with the field report.

## Notes for reviewers

- The floor deliberately reuses `_merge_browser_path()` rather than duplicating its list — if the sane-dir set changes for agent-browser, browser-use follows. The try/except keeps this file independent of that module's internals in tests (existing pattern in this suite stubs `tools.browser_tool`).
- Scope is one spawn seam (`_base_subprocess_env`) — every browser-use CLI launch goes through it, including the uvx zero-install fallback resolved by `_find_cli()`.