### PR TITLE
fix(desktop): ignore preview subframe load failures

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -282,6 +282,34 @@ describe('PreviewPane console state', () => {
     expect(rendered.container.textContent).not.toContain('machine running your agent')
   })
 
+  it('ignores a failed subframe after the main page has loaded', async () => {
+    const pageUrl = 'https://example.com'
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(<PreviewPane target={{ kind: 'url', label: 'Preview', source: pageUrl, url: pageUrl }} />)
+    })
+
+    const webview = rendered.container.querySelector('webview') as HTMLElement
+
+    act(() => {
+      webview.dispatchEvent(Object.assign(new Event('did-navigate'), { url: pageUrl }))
+      webview.dispatchEvent(new Event('did-stop-loading'))
+      webview.dispatchEvent(
+        Object.assign(new Event('did-fail-load'), {
+          errorCode: -105,
+          errorDescription: 'ERR_NAME_NOT_RESOLVED',
+          isMainFrame: false,
+          validatedURL: 'https://ads.example.invalid/sync.html'
+        })
+      )
+    })
+
+    expect(rendered.container.textContent).not.toContain('ERR_NAME_NOT_RESOLVED')
+    expect(rendered.container.textContent).not.toContain('Preview failed to load')
+    expect(webview.parentElement?.className).not.toContain('opacity-0')
+  })
+
   it('surfaces a rejected navigation as a load error', async () => {
     let rendered!: ReturnType<typeof render>
     await act(async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -765,12 +765,15 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       const detail = event as Event & {
         errorCode?: number
         errorDescription?: string
+        isMainFrame?: boolean
         validatedURL?: string
       }
 
       const errorCode = detail.errorCode
 
-      if (errorCode === -3) {
+      // Electron emits did-fail-load for subframes too. A blocked ad or
+      // tracking iframe must not replace an otherwise healthy top-level page.
+      if (detail.isMainFrame === false || errorCode === -3) {
         return
       }
 


### PR DESCRIPTION
## What does this PR do?

Prevents a failed subframe navigation in the Desktop browser preview from replacing an otherwise healthy top-level page with the full-pane **Preview failed to load** state.

A real-world Windows reproduction loaded a Kleinanzeigen page successfully, then an embedded Index Exchange frame (`js-sec.indexww.com/um/ixmatch.html`) failed DNS resolution with `ERR_NAME_NOT_RESOLVED (-105)`. Electron emitted `did-fail-load` for that child frame, and the preview handler treated it as a failure of the whole page.

Electron includes `isMainFrame` on the [`did-fail-load`](https://www.electronjs.org/docs/latest/api/webview-tag#event-did-fail-load) event. This PR ignores events explicitly marked as subframe failures while preserving the existing behavior for top-level failures and aborted navigations.

## Related Issue

No issue — reproduced directly in Hermes Desktop on Windows 11.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/right-rail/preview-pane.tsx`
  - Read `isMainFrame` from `did-fail-load` events.
  - Return early for explicit subframe failures before logging or replacing the preview.
  - Keep the existing `ERR_ABORTED` handling and all top-level error behavior.
- `apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx`
  - Add a regression test that loads a main page, emits `ERR_NAME_NOT_RESOLVED` for a child frame, and verifies that the main preview remains visible.

## How to Test

1. Open a page in the Desktop browser preview whose child iframe is blocked by DNS or an ad blocker.
2. Confirm the top-level page remains visible when the child frame emits `did-fail-load` with `isMainFrame: false`.
3. Navigate the top-level frame to an unresolvable host and confirm the existing full-pane load error still appears.

## Test Results

- ✅ Regression demonstrated first: the new test failed on the old handler with `Preview failed to load ... ERR_NAME_NOT_RESOLVED`.
- ✅ `npm run test:ui -- src/app/chat/right-rail/preview-pane.test.tsx` — 17/17 passed.
- ✅ `npm run typecheck`
- ✅ Prettier check for both changed files.
- ✅ ESLint for both changed files.
- ✅ `npm run build` — production renderer and Electron bundles built successfully on Windows 11.

The repository-wide suites are not fully green in this Windows checkout for unrelated platform/locale cases (for example, POSIX file-mode assertions and `de-DE` number formatting expectations). None of those failures are in the changed preview test file; the focused suite above is green.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched open and closed issues/PRs for `did-fail-load`, `isMainFrame`, subframe preview failures, and `ERR_NAME_NOT_RESOLVED`; no duplicate was found.
- [x] The PR contains only the preview fix and its regression test.
- [x] I've added a regression test for the bug.
- [x] I've tested on Windows 11.
- [x] Python `pytest` is not applicable to this Desktop TypeScript-only change; the relevant TypeScript/UI checks are listed above.

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing API or configuration change.
- [x] `cli-config.yaml.example`: N/A — no configuration keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow change.
- [x] Cross-platform impact considered — the change uses Electron's documented platform-independent `isMainFrame` event field.
- [x] Tool descriptions/schemas: N/A — no tool contract changed.

## Screenshots / Logs

Before the fix, a blocked child frame replaced the loaded page with:

```text
Preview failed to load
js-sec.indexww.com/um/ixmatch.html (-105)
ERR_NAME_NOT_RESOLVED
```

After the fix, that subframe failure is ignored and the successfully loaded top-level page remains visible.
