### PR TITLE
feat(flight): automatic offline local-model continuity

### DIFF
--- a/contributors/emails/auroracapital@users.noreply.github.com
+++ b/contributors/emails/auroracapital@users.noreply.github.com
@@ -1,0 +1,2 @@
+auroracapital
+# attribution fix: bulk-clear failing check-attribution on hermes-agent-fork salvage PRs

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1777,3 +1777,55 @@ class GatewayKanbanWatchersMixin:
                 slept += 1.0
 
         self._release_kanban_dispatcher_lock()
+
+    async def _flight_mode_watcher(self) -> None:
+        """Probe the saved normal cascade and auto-restore sessions when it works.
+
+        Online is the default. While local, keep probing the backed-up
+        cliproxy route with real inference. One successful completion is
+        enough to restore config bytes, Kanban model pins, and every
+        session's pre-flight /model override so the next turn uses the
+        normal cloud stack. Does not start a second gateway.
+        """
+        interval = 15.0
+        while getattr(self, "_running", True):
+            try:
+                from hermes_cli.flight import FlightManager, restore_session_overrides
+
+                manager = FlightManager()
+                state = await asyncio.to_thread(manager.tick, port_tasks=True)
+                if state.get("tick_action") == "exit":
+                    saved = state.get("session_overrides") or {}
+                    if saved:
+                        live = getattr(self, "_session_model_overrides", None)
+                        store = getattr(self, "session_store", None)
+
+                        def _apply(session_key: str, override):
+                            peek = getattr(self, "_peek_session_state", None)
+                            live_state = peek(session_key) if callable(peek) else None
+                            conversation = getattr(live_state, "conversation", None)
+                            if conversation is not None:
+                                conversation.model_override = (
+                                    dict(override) if override else None
+                                )
+
+                        await asyncio.to_thread(
+                            restore_session_overrides,
+                            manager.home,
+                            saved,
+                            store=store,
+                            live_overrides=live if isinstance(live, dict) else None,
+                            apply_live=_apply,
+                        )
+                        logger.info(
+                            "flight mode: restored %d session(s) to the normal cascade",
+                            len(saved),
+                        )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("flight mode watcher: tick failed")
+            slept = 0.0
+            while slept < interval and getattr(self, "_running", True):
+                await asyncio.sleep(min(1.0, interval - slept))
+                slept += 1.0

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13343,6 +13343,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # When false, users run `hermes kanban daemon` externally or
         # simply don't use kanban; this loop becomes a no-op.
         self._spawn_supervised(self._kanban_dispatcher_watcher, "kanban_dispatcher_watcher")
+        self._spawn_supervised(self._flight_mode_watcher, "flight_mode_watcher")
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:

--- a/hermes_cli/flight.py
+++ b/hermes_cli/flight.py
@@ -164,10 +164,20 @@ def build_local_config(
 def _read_config(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
-    data = yaml.safe_load(path.read_text()) or {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     if not isinstance(data, dict):
         raise ValueError(f"{path} must contain a YAML mapping")
     return data
+
+
+def _is_local_config(config: dict[str, Any]) -> bool:
+    return (config.get("model") or {}).get("provider") == LOCAL_PROVIDER
+
+
+def _is_degraded_restore(config: dict[str, Any], live: dict[str, Any]) -> bool:
+    if _is_local_config(config):
+        return True
+    return bool(live.get("fallback_providers")) and not config.get("fallback_providers")
 
 
 def _resolve_api_key(provider: dict[str, Any]) -> str:
@@ -260,7 +270,7 @@ def ensure_local_model(
     import subprocess
     import tempfile
 
-    with tempfile.NamedTemporaryFile("w", suffix=".modelfile", delete=False) as handle:
+    with tempfile.NamedTemporaryFile("w", suffix=".modelfile", delete=False, encoding="utf-8") as handle:
         handle.write(f"FROM {base}\nPARAMETER num_ctx 65536\n")
         path = handle.name
     try:
@@ -389,7 +399,7 @@ class FlightManager:
         path = _state_path(self.home)
         if path.exists():
             try:
-                state = json.loads(path.read_text())
+                state = json.loads(path.read_text(encoding="utf-8"))
                 if isinstance(state, dict):
                     return state
             except Exception:
@@ -412,9 +422,11 @@ class FlightManager:
             return False, "normal route missing base_url or model"
         return _probe_openai(base_url, model, api_key)
 
-    def _backup_profile(self, profile_home: Path) -> dict[str, Any]:
+    def _backup_profile(self, profile_home: Path) -> Optional[dict[str, Any]]:
         config_path = profile_home / "config.yaml"
         raw = config_path.read_bytes() if config_path.exists() else b""
+        if raw and _is_local_config(_read_config(config_path)):
+            return None
         backup_name = f"config-{len(list(_flight_dir(self.home).glob('config-*.yaml'))):03d}.yaml"
         backup_path = _flight_dir(self.home) / backup_name
         _atomic_write_bytes(backup_path, raw)
@@ -424,13 +436,86 @@ class FlightManager:
         homes = [self.home]
         profiles = self.home / "profiles"
         if profiles.is_dir():
-            homes.extend(sorted(path for path in profiles.iterdir() if path.is_dir()))
+            homes.extend(sorted(path for path in profiles.iterdir() if path.is_dir() and path.name != "offline"))
         return homes
+
+    def _clean_backup_for(
+        self,
+        item: dict[str, Any],
+        generation_size: int,
+    ) -> Optional[Path]:
+        config_path = Path(item["config"])
+        live = _read_config(config_path)
+        recorded = Path(item["backup"])
+        candidates = [recorded]
+        try:
+            recorded_index = int(recorded.stem.rsplit("-", 1)[1])
+        except (IndexError, ValueError):
+            recorded_index = -1
+        if recorded_index >= 0 and generation_size:
+            generation_position = recorded_index % generation_size
+            for index in range(
+                recorded_index - generation_size,
+                generation_position - 1,
+                -generation_size,
+            ):
+                candidates.append(recorded.with_name(f"config-{index:03d}.yaml"))
+        for candidate in candidates:
+            if not candidate.exists():
+                continue
+            try:
+                config = yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
+            except Exception:
+                continue
+            if isinstance(config, dict) and not _is_degraded_restore(config, live):
+                return candidate
+        return None
+
+    def _recover_restore_target(self) -> dict[str, Any]:
+        homes = [home for home in self._profile_homes() if (home / "config.yaml").exists()]
+        snapshots = sorted(_flight_dir(self.home).glob("config-*.yaml"))
+        if not homes or not snapshots or len(snapshots) % len(homes):
+            return {"profiles": [], "configs": []}
+        generation_size = len(homes)
+        configs = []
+        for position, profile_home in enumerate(homes):
+            matching = [
+                path
+                for path in snapshots
+                if int(path.stem.rsplit("-", 1)[1]) % generation_size == position
+            ]
+            if not matching:
+                continue
+            probe = {
+                "home": str(profile_home),
+                "config": str(profile_home / "config.yaml"),
+                "backup": str(matching[-1]),
+                "existed": True,
+            }
+            clean = self._clean_backup_for(probe, generation_size)
+            if clean is not None:
+                probe["backup"] = str(clean)
+                configs.append(probe)
+        return {"profiles": [item["home"] for item in configs], "configs": configs}
 
     def enter(self, *, now: Optional[float] = None, port_tasks: bool = True) -> dict[str, Any]:
         now = time.time() if now is None else now
         state = self._load_state(now)
         if state.get("mode") == "local":
+            return state
+        configs_on_disk = [
+            _read_config(home / "config.yaml")
+            for home in self._profile_homes()
+            if (home / "config.yaml").exists()
+        ]
+        if any(_is_local_config(config) for config in configs_on_disk):
+            if not (state.get("saved_restore_target") or {}).get("configs"):
+                state["saved_restore_target"] = self._recover_restore_target()
+            state["mode"] = "local"
+            state.setdefault("warnings", []).append(
+                "configs already use flight-local; refused to snapshot them as restore targets"
+            )
+            self._save_state(state)
             return state
         if self.local_model == DEFAULT_LOCAL_MODEL:
             ok, detail = ensure_local_model(self.local_model, base_url=self.local_base_url)
@@ -442,6 +527,8 @@ class FlightManager:
             if not config_path.exists():
                 continue
             target = self._backup_profile(profile_home)
+            if target is None:
+                continue
             local = build_local_config(
                 _read_config(config_path),
                 model=self.local_model,
@@ -492,10 +579,17 @@ class FlightManager:
         if state.get("mode") != "local":
             return state
         target = state.get("saved_restore_target") or {}
-        for item in target.get("configs") or []:
+        configs = target.get("configs") or []
+        generation_size = len(configs)
+        for item in configs:
             config_path = Path(item["config"])
-            backup_path = Path(item["backup"])
+            backup_path = self._clean_backup_for(item, generation_size)
             if item.get("existed"):
+                if backup_path is None:
+                    state.setdefault("warnings", []).append(
+                        f"config restore skipped for {config_path}: no clean snapshot"
+                    )
+                    continue
                 _atomic_write_bytes(config_path, backup_path.read_bytes())
             elif config_path.exists():
                 config_path.unlink()
@@ -529,7 +623,7 @@ class FlightManager:
             target = state.get("saved_restore_target") or {}
             configs = target.get("configs") or []
             if state.get("mode") == "local" and configs:
-                raw = Path(configs[0]["backup"]).read_text()
+                raw = Path(configs[0]["backup"]).read_text(encoding="utf-8")
                 normal_config = yaml.safe_load(raw) or {}
             else:
                 normal_config = _read_config(self.home / "config.yaml")
@@ -547,7 +641,7 @@ class FlightManager:
         normal_config: dict[str, Any]
         configs = ((state.get("saved_restore_target") or {}).get("configs") or [])
         if state.get("mode") == "local" and configs:
-            normal_config = yaml.safe_load(Path(configs[0]["backup"]).read_text()) or {}
+            normal_config = yaml.safe_load(Path(configs[0]["backup"]).read_text(encoding="utf-8")) or {}
         else:
             normal_config = _read_config(self.home / "config.yaml")
         normal_ok, normal_detail = self.probe("normal", normal_config)

--- a/hermes_cli/flight.py
+++ b/hermes_cli/flight.py
@@ -26,8 +26,8 @@ DEFAULT_LOCAL_MODEL = "hermes-flight"
 DEFAULT_LOCAL_BASE = "qwen3-coder:30b"
 DEFAULT_LOCAL_BASE_URL = "http://127.0.0.1:11434/v1"
 DEFAULT_FAILURE_THRESHOLD = 3
-DEFAULT_RECOVERY_THRESHOLD = 2
-DEFAULT_COOLDOWN_SECONDS = 60
+DEFAULT_RECOVERY_THRESHOLD = 1
+DEFAULT_COOLDOWN_SECONDS = 15
 NETWORK_MARKERS = (
     "http://",
     "https://",
@@ -304,6 +304,65 @@ def restore_task_overrides(conn: sqlite3.Connection, saved: dict[str, dict[str, 
         kb.set_model_override(conn, task_id, override.get("model"), override.get("provider"))
 
 
+def _session_store(home: Path, store: Any = None) -> Any:
+    if store is not None:
+        return store
+    from gateway.config import GatewayConfig
+    from gateway.session import SessionStore
+
+    sessions_dir = home / "sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    return SessionStore(sessions_dir=sessions_dir, config=GatewayConfig())
+
+
+def snapshot_and_pin_sessions(
+    home: Path,
+    *,
+    local_model: str,
+    local_provider: str,
+    local_base_url: str,
+    store: Any = None,
+) -> dict[str, Any]:
+    """Snapshot each session's /model pin, then point it at local inference."""
+    session_store = _session_store(home, store)
+    saved: dict[str, Any] = {}
+    local_override = {
+        "model": local_model,
+        "provider": local_provider,
+        "base_url": local_base_url.rstrip("/"),
+    }
+    for entry in session_store.list_sessions():
+        saved[entry.session_key] = (
+            dict(entry.model_override) if entry.model_override else None
+        )
+        session_store.set_model_override(entry.session_key, local_override)
+    return saved
+
+
+def restore_session_overrides(
+    home: Path,
+    saved: dict[str, Any],
+    *,
+    store: Any = None,
+    live_overrides: Optional[dict[str, Any]] = None,
+    apply_live: Optional[Callable[[str, Optional[dict[str, Any]]], None]] = None,
+) -> int:
+    """Restore pre-flight /model pins so sessions resume on the normal cascade."""
+    session_store = _session_store(home, store)
+    restored = 0
+    for session_key, override in (saved or {}).items():
+        session_store.set_model_override(session_key, override)
+        if live_overrides is not None:
+            if override:
+                live_overrides[session_key] = dict(override)
+            else:
+                live_overrides.pop(session_key, None)
+        if apply_live is not None:
+            apply_live(session_key, override)
+        restored += 1
+    return restored
+
+
 class FlightManager:
     def __init__(
         self,
@@ -402,6 +461,16 @@ class FlightManager:
                     )
             except Exception as exc:
                 state.setdefault("warnings", []).append(f"kanban port skipped: {exc}")
+        session_overrides: dict[str, Any] = {}
+        try:
+            session_overrides = snapshot_and_pin_sessions(
+                self.home,
+                local_model=self.local_model,
+                local_provider=LOCAL_PROVIDER,
+                local_base_url=self.local_base_url,
+            )
+        except Exception as exc:
+            state.setdefault("warnings", []).append(f"session pin skipped: {exc}")
         state.update(
             {
                 "mode": "local",
@@ -411,6 +480,7 @@ class FlightManager:
                 "last_transition": {"from": "online", "to": "local", "at": now},
                 "saved_restore_target": {"profiles": [target["home"] for target in targets], "configs": targets},
                 "task_overrides": task_overrides,
+                "session_overrides": session_overrides,
             }
         )
         self._save_state(state)
@@ -436,6 +506,10 @@ class FlightManager:
                 restore_task_overrides(conn, state.get("task_overrides") or {})
         except Exception as exc:
             state.setdefault("warnings", []).append(f"kanban restore skipped: {exc}")
+        try:
+            restore_session_overrides(self.home, state.get("session_overrides") or {})
+        except Exception as exc:
+            state.setdefault("warnings", []).append(f"session restore skipped: {exc}")
         state.update(
             {
                 "mode": "online",
@@ -486,9 +560,14 @@ class FlightManager:
         action = observe_connectivity(state, normal_ok=normal_ok, local_ok=local_ok, now=now)
         self._save_state(state)
         if action == "enter":
-            return self.enter(now=now, port_tasks=port_tasks)
+            result = self.enter(now=now, port_tasks=port_tasks)
+            result["tick_action"] = "enter"
+            return result
         if action == "exit":
-            return self.exit(now=now)
+            result = self.exit(now=now)
+            result["tick_action"] = "exit"
+            return result
+        state["tick_action"] = None
         return state
 
 
@@ -499,7 +578,7 @@ def cmd_flight(args: Any) -> int:
         max_in_progress=getattr(args, "max_in_progress", None) or 2,
         failure_threshold=getattr(args, "failure_threshold", None) or DEFAULT_FAILURE_THRESHOLD,
         recovery_threshold=getattr(args, "recovery_threshold", None) or DEFAULT_RECOVERY_THRESHOLD,
-        cooldown_seconds=getattr(args, "cooldown", None) if getattr(args, "cooldown", None) is not None else DEFAULT_COOLDOWN_SECONDS,
+        cooldown_seconds=int(getattr(args, "cooldown", None) or DEFAULT_COOLDOWN_SECONDS),
     )
     command = getattr(args, "flight_command", None) or "status"
     if command == "enter":

--- a/hermes_cli/flight.py
+++ b/hermes_cli/flight.py
@@ -1,0 +1,545 @@
+"""Durable, reversible local-model continuity for disconnected operation."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import shutil
+import sqlite3
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import yaml
+
+from hermes_constants import get_hermes_home
+from utils import atomic_replace
+
+LOCAL_PROVIDER = "flight-local"
+# Hermes requires a >=64K context window; stock Ollama tags load at their
+# baked num_ctx (often 4096-32768), which stalls or refuses the agent.
+# ``ensure_local_model`` creates this derivative with num_ctx 65536.
+DEFAULT_LOCAL_MODEL = "hermes-flight"
+DEFAULT_LOCAL_BASE = "qwen3-coder:30b"
+DEFAULT_LOCAL_BASE_URL = "http://127.0.0.1:11434/v1"
+DEFAULT_FAILURE_THRESHOLD = 3
+DEFAULT_RECOVERY_THRESHOLD = 2
+DEFAULT_COOLDOWN_SECONDS = 60
+NETWORK_MARKERS = (
+    "http://",
+    "https://",
+    "github",
+    "gitlab",
+    "deploy",
+    "production",
+    "aws",
+    "vercel",
+    "email",
+    "gmail",
+    "slack",
+    "telegram",
+    "whatsapp",
+    "browser",
+    "web search",
+    "internet",
+    "download",
+    "upload",
+)
+
+
+def _flight_dir(home: Path) -> Path:
+    return home / "flight-mode"
+
+
+def _state_path(home: Path) -> Path:
+    return _flight_dir(home) / "state.json"
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with open(tmp, "wb") as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+    atomic_replace(tmp, path)
+
+
+def _atomic_write_json(path: Path, data: dict[str, Any]) -> None:
+    _atomic_write_bytes(path, (json.dumps(data, indent=2, sort_keys=True) + "\n").encode())
+
+
+def new_state(
+    *,
+    now: float,
+    failure_threshold: int = DEFAULT_FAILURE_THRESHOLD,
+    recovery_threshold: int = DEFAULT_RECOVERY_THRESHOLD,
+    cooldown_seconds: int = DEFAULT_COOLDOWN_SECONDS,
+) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "mode": "online",
+        "normal_failures": 0,
+        "normal_successes": 0,
+        "failure_threshold": max(1, int(failure_threshold)),
+        "recovery_threshold": max(1, int(recovery_threshold)),
+        "cooldown_seconds": max(0, int(cooldown_seconds)),
+        "created_at": now,
+        "last_probe_at": None,
+        "last_transition_at": None,
+        "last_transition": None,
+        "last_evidence": {},
+        "saved_restore_target": None,
+        "task_overrides": {},
+    }
+
+
+def observe_connectivity(
+    state: dict[str, Any],
+    *,
+    normal_ok: bool,
+    local_ok: bool,
+    now: float,
+) -> Optional[str]:
+    """Update hysteresis counters and return ``enter`` / ``exit`` when due."""
+    state["last_probe_at"] = now
+    mode = state.get("mode", "online")
+    if normal_ok:
+        state["normal_failures"] = 0
+        state["normal_successes"] = int(state.get("normal_successes", 0)) + 1
+    else:
+        state["normal_successes"] = 0
+        state["normal_failures"] = int(state.get("normal_failures", 0)) + 1
+
+    last_transition = state.get("last_transition_at")
+    cooled = last_transition is None or now - float(last_transition) >= int(
+        state.get("cooldown_seconds", DEFAULT_COOLDOWN_SECONDS)
+    )
+    if mode == "online":
+        if (
+            not normal_ok
+            and local_ok
+            and int(state["normal_failures"]) >= int(state.get("failure_threshold", 3))
+            and cooled
+        ):
+            return "enter"
+    elif (
+        normal_ok
+        and int(state["normal_successes"]) >= int(state.get("recovery_threshold", 2))
+        and cooled
+    ):
+        return "exit"
+    return None
+
+
+def build_local_config(
+    config: dict[str, Any],
+    *,
+    model: str,
+    base_url: str,
+    max_in_progress: int,
+) -> dict[str, Any]:
+    result = copy.deepcopy(config)
+    result.setdefault("providers", {})[LOCAL_PROVIDER] = {
+        "name": "Flight mode local Ollama",
+        "base_url": base_url.rstrip("/"),
+        "api_key": "ollama",
+        "api_mode": "openai_chat_completions",
+        "default_model": model,
+        "discover_models": True,
+    }
+    result["model"] = {"provider": LOCAL_PROVIDER, "default": model}
+    result["fallback_providers"] = []
+    result.pop("fallback_model", None)
+    kanban = result.setdefault("kanban", {})
+    kanban["max_in_progress"] = max(1, int(max_in_progress))
+    kanban["max_in_progress_per_profile"] = 1
+    kanban["max_spawn"] = min(max(1, int(max_in_progress)), int(kanban.get("max_spawn") or max_in_progress))
+    return result
+
+
+def _read_config(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return data
+
+
+def _resolve_api_key(provider: dict[str, Any]) -> str:
+    key_env = str(provider.get("key_env") or provider.get("api_key_env") or "").strip()
+    if key_env:
+        try:
+            from hermes_cli.config import get_env_value
+
+            return os.getenv(key_env) or get_env_value(key_env) or ""
+        except Exception:
+            return os.getenv(key_env, "")
+    return str(provider.get("api_key") or "")
+
+
+def _probe_openai(
+    base_url: str,
+    model: str,
+    api_key: str,
+    *,
+    timeout: float = 20.0,
+) -> tuple[bool, str]:
+    url = base_url.rstrip("/") + "/chat/completions"
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": "Reply with exactly OK"}],
+            "max_tokens": 64,
+            "temperature": 0,
+        }
+    ).encode()
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode())
+        choices = payload.get("choices") or []
+        message = (choices[0].get("message") or {}) if choices else {}
+        text = str(message.get("content") or "").strip()
+        # Reasoning models can spend the whole budget thinking; generated
+        # reasoning tokens still prove live inference.
+        reasoning = str(message.get("reasoning") or message.get("reasoning_content") or "").strip()
+        if text:
+            return True, f"inference ok ({text[:80]})"
+        if reasoning:
+            return True, "inference ok (reasoning-only response)"
+        return False, "empty inference response"
+    except urllib.error.HTTPError as exc:
+        detail = exc.read(512).decode(errors="replace")
+        return False, f"HTTP {exc.code}: {detail}"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+def _normal_target(config: dict[str, Any]) -> tuple[str, str, str]:
+    model_cfg = config.get("model") or {}
+    provider_name = str(model_cfg.get("provider") or "").strip()
+    model = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
+    provider = (config.get("providers") or {}).get(provider_name) or {}
+    base_url = str(provider.get("base_url") or model_cfg.get("base_url") or "").strip()
+    return base_url, model, _resolve_api_key(provider)
+
+
+def _task_is_local_safe(task: Any) -> bool:
+    text = f"{getattr(task, 'title', '')}\n{getattr(task, 'body', '')}".lower()
+    return not any(marker in text for marker in NETWORK_MARKERS)
+
+
+def ensure_local_model(
+    model: str = DEFAULT_LOCAL_MODEL,
+    base: str = DEFAULT_LOCAL_BASE,
+    base_url: str = DEFAULT_LOCAL_BASE_URL,
+) -> tuple[bool, str]:
+    """Create the >=64K-context flight model in Ollama if it is missing.
+
+    Purely local: ``ollama create`` from an already-pulled base layer, so it
+    works with no internet. Returns (ok, detail).
+    """
+    try:
+        url = base_url.rstrip("/").removesuffix("/v1") + "/api/tags"
+        with urllib.request.urlopen(url, timeout=5) as response:
+            names = {m.get("name") for m in json.loads(response.read()).get("models", [])}
+        if model in names or f"{model}:latest" in names:
+            return True, f"{model} present"
+        if base not in names:
+            return False, f"base model {base} not pulled locally"
+    except Exception as exc:
+        return False, f"ollama unreachable: {exc}"
+    import subprocess
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".modelfile", delete=False) as handle:
+        handle.write(f"FROM {base}\nPARAMETER num_ctx 65536\n")
+        path = handle.name
+    try:
+        proc = subprocess.run(
+            ["ollama", "create", model, "-f", path],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        if proc.returncode != 0:
+            return False, f"ollama create failed: {proc.stderr[-300:]}"
+        return True, f"created {model} from {base} (num_ctx 65536)"
+    except Exception as exc:
+        return False, f"ollama create error: {exc}"
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def port_queued_tasks(conn: sqlite3.Connection, *, local_model: str, local_provider: str) -> dict[str, dict[str, Any]]:
+    from hermes_cli import kanban_db as kb
+
+    saved: dict[str, dict[str, Any]] = {}
+    for status in ("ready", "todo", "triage", "blocked"):
+        for task in kb.list_tasks(conn, status=status):
+            if not task.assignee or not _task_is_local_safe(task):
+                continue
+            saved[task.id] = {"model": task.model_override, "provider": task.provider_override}
+            kb.set_model_override(conn, task.id, local_model, local_provider)
+    return saved
+
+
+def restore_task_overrides(conn: sqlite3.Connection, saved: dict[str, dict[str, Any]]) -> None:
+    from hermes_cli import kanban_db as kb
+
+    for task_id, override in saved.items():
+        if kb.get_task(conn, task_id) is None:
+            continue
+        kb.set_model_override(conn, task_id, override.get("model"), override.get("provider"))
+
+
+class FlightManager:
+    def __init__(
+        self,
+        *,
+        home: Optional[Path] = None,
+        local_model: str = DEFAULT_LOCAL_MODEL,
+        local_base_url: str = DEFAULT_LOCAL_BASE_URL,
+        max_in_progress: int = 2,
+        failure_threshold: int = DEFAULT_FAILURE_THRESHOLD,
+        recovery_threshold: int = DEFAULT_RECOVERY_THRESHOLD,
+        cooldown_seconds: int = DEFAULT_COOLDOWN_SECONDS,
+        probe: Optional[Callable[..., tuple[bool, str]]] = None,
+    ) -> None:
+        self.home = Path(home or get_hermes_home())
+        self.local_model = local_model
+        self.local_base_url = local_base_url
+        self.max_in_progress = max_in_progress
+        self.failure_threshold = failure_threshold
+        self.recovery_threshold = recovery_threshold
+        self.cooldown_seconds = cooldown_seconds
+        self.probe = probe or self._probe
+
+    def _load_state(self, now: Optional[float] = None) -> dict[str, Any]:
+        path = _state_path(self.home)
+        if path.exists():
+            try:
+                state = json.loads(path.read_text())
+                if isinstance(state, dict):
+                    return state
+            except Exception:
+                pass
+        return new_state(
+            now=time.time() if now is None else now,
+            failure_threshold=self.failure_threshold,
+            recovery_threshold=self.recovery_threshold,
+            cooldown_seconds=self.cooldown_seconds,
+        )
+
+    def _save_state(self, state: dict[str, Any]) -> None:
+        _atomic_write_json(_state_path(self.home), state)
+
+    def _probe(self, kind: str, config: Optional[dict[str, Any]] = None) -> tuple[bool, str]:
+        if kind == "local":
+            return _probe_openai(self.local_base_url, self.local_model, "ollama")
+        base_url, model, api_key = _normal_target(config or {})
+        if not base_url or not model:
+            return False, "normal route missing base_url or model"
+        return _probe_openai(base_url, model, api_key)
+
+    def _backup_profile(self, profile_home: Path) -> dict[str, Any]:
+        config_path = profile_home / "config.yaml"
+        raw = config_path.read_bytes() if config_path.exists() else b""
+        backup_name = f"config-{len(list(_flight_dir(self.home).glob('config-*.yaml'))):03d}.yaml"
+        backup_path = _flight_dir(self.home) / backup_name
+        _atomic_write_bytes(backup_path, raw)
+        return {"home": str(profile_home), "config": str(config_path), "backup": str(backup_path), "existed": config_path.exists()}
+
+    def _profile_homes(self) -> list[Path]:
+        homes = [self.home]
+        profiles = self.home / "profiles"
+        if profiles.is_dir():
+            homes.extend(sorted(path for path in profiles.iterdir() if path.is_dir()))
+        return homes
+
+    def enter(self, *, now: Optional[float] = None, port_tasks: bool = True) -> dict[str, Any]:
+        now = time.time() if now is None else now
+        state = self._load_state(now)
+        if state.get("mode") == "local":
+            return state
+        if self.local_model == DEFAULT_LOCAL_MODEL:
+            ok, detail = ensure_local_model(self.local_model, base_url=self.local_base_url)
+            if not ok:
+                state.setdefault("warnings", []).append(f"local model setup: {detail}")
+        targets = []
+        for profile_home in self._profile_homes():
+            config_path = profile_home / "config.yaml"
+            if not config_path.exists():
+                continue
+            target = self._backup_profile(profile_home)
+            local = build_local_config(
+                _read_config(config_path),
+                model=self.local_model,
+                base_url=self.local_base_url,
+                max_in_progress=self.max_in_progress,
+            )
+            _atomic_write_bytes(config_path, yaml.safe_dump(local, sort_keys=False).encode())
+            targets.append(target)
+        task_overrides: dict[str, dict[str, Any]] = {}
+        if port_tasks:
+            try:
+                from hermes_cli import kanban_db as kb
+
+                with kb.connect_closing() as conn:
+                    task_overrides = port_queued_tasks(
+                        conn, local_model=self.local_model, local_provider=LOCAL_PROVIDER
+                    )
+            except Exception as exc:
+                state.setdefault("warnings", []).append(f"kanban port skipped: {exc}")
+        state.update(
+            {
+                "mode": "local",
+                "normal_failures": 0,
+                "normal_successes": 0,
+                "last_transition_at": now,
+                "last_transition": {"from": "online", "to": "local", "at": now},
+                "saved_restore_target": {"profiles": [target["home"] for target in targets], "configs": targets},
+                "task_overrides": task_overrides,
+            }
+        )
+        self._save_state(state)
+        return state
+
+    def exit(self, *, now: Optional[float] = None) -> dict[str, Any]:
+        now = time.time() if now is None else now
+        state = self._load_state(now)
+        if state.get("mode") != "local":
+            return state
+        target = state.get("saved_restore_target") or {}
+        for item in target.get("configs") or []:
+            config_path = Path(item["config"])
+            backup_path = Path(item["backup"])
+            if item.get("existed"):
+                _atomic_write_bytes(config_path, backup_path.read_bytes())
+            elif config_path.exists():
+                config_path.unlink()
+        try:
+            from hermes_cli import kanban_db as kb
+
+            with kb.connect_closing() as conn:
+                restore_task_overrides(conn, state.get("task_overrides") or {})
+        except Exception as exc:
+            state.setdefault("warnings", []).append(f"kanban restore skipped: {exc}")
+        state.update(
+            {
+                "mode": "online",
+                "normal_failures": 0,
+                "normal_successes": 0,
+                "last_transition_at": now,
+                "last_transition": {"from": "local", "to": "online", "at": now},
+            }
+        )
+        self._save_state(state)
+        return state
+
+    def status(self, *, probe: bool = True) -> dict[str, Any]:
+        state = self._load_state()
+        if probe:
+            normal_config: dict[str, Any] = {}
+            target = state.get("saved_restore_target") or {}
+            configs = target.get("configs") or []
+            if state.get("mode") == "local" and configs:
+                raw = Path(configs[0]["backup"]).read_text()
+                normal_config = yaml.safe_load(raw) or {}
+            else:
+                normal_config = _read_config(self.home / "config.yaml")
+            normal_ok, normal_detail = self.probe("normal", normal_config)
+            local_ok, local_detail = self.probe("local", None)
+            state["live_evidence"] = {
+                "normal": {"ok": normal_ok, "detail": normal_detail},
+                "local": {"ok": local_ok, "detail": local_detail},
+            }
+        return state
+
+    def tick(self, *, now: Optional[float] = None, port_tasks: bool = True) -> dict[str, Any]:
+        now = time.time() if now is None else now
+        state = self._load_state(now)
+        normal_config: dict[str, Any]
+        configs = ((state.get("saved_restore_target") or {}).get("configs") or [])
+        if state.get("mode") == "local" and configs:
+            normal_config = yaml.safe_load(Path(configs[0]["backup"]).read_text()) or {}
+        else:
+            normal_config = _read_config(self.home / "config.yaml")
+        normal_ok, normal_detail = self.probe("normal", normal_config)
+        local_ok, local_detail = self.probe("local", None)
+        state["last_evidence"] = {
+            "normal": {"ok": normal_ok, "detail": normal_detail},
+            "local": {"ok": local_ok, "detail": local_detail},
+            "at": now,
+        }
+        action = observe_connectivity(state, normal_ok=normal_ok, local_ok=local_ok, now=now)
+        self._save_state(state)
+        if action == "enter":
+            return self.enter(now=now, port_tasks=port_tasks)
+        if action == "exit":
+            return self.exit(now=now)
+        return state
+
+
+def cmd_flight(args: Any) -> int:
+    manager = FlightManager(
+        local_model=getattr(args, "model", None) or DEFAULT_LOCAL_MODEL,
+        local_base_url=getattr(args, "base_url", None) or DEFAULT_LOCAL_BASE_URL,
+        max_in_progress=getattr(args, "max_in_progress", None) or 2,
+        failure_threshold=getattr(args, "failure_threshold", None) or DEFAULT_FAILURE_THRESHOLD,
+        recovery_threshold=getattr(args, "recovery_threshold", None) or DEFAULT_RECOVERY_THRESHOLD,
+        cooldown_seconds=getattr(args, "cooldown", None) if getattr(args, "cooldown", None) is not None else DEFAULT_COOLDOWN_SECONDS,
+    )
+    command = getattr(args, "flight_command", None) or "status"
+    if command == "enter":
+        result = manager.enter(port_tasks=not getattr(args, "no_port_tasks", False))
+    elif command == "exit":
+        result = manager.exit()
+    elif command == "tick":
+        result = manager.tick(port_tasks=not getattr(args, "no_port_tasks", False))
+    elif command == "supervise":
+        interval = max(5, int(getattr(args, "interval", 30)))
+        while True:
+            result = manager.tick(port_tasks=not getattr(args, "no_port_tasks", False))
+            print(json.dumps(result, sort_keys=True), flush=True)
+            time.sleep(interval)
+    else:
+        result = manager.status(probe=not getattr(args, "no_probe", False))
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser(subparsers: Any) -> Any:
+    parser = subparsers.add_parser(
+        "flight",
+        help="Automatically switch between the normal model cascade and local Ollama",
+    )
+    commands = parser.add_subparsers(dest="flight_command")
+    for name in ("enter", "exit", "status", "tick", "supervise"):
+        child = commands.add_parser(name)
+        child.add_argument("--model", default=DEFAULT_LOCAL_MODEL)
+        child.add_argument("--base-url", default=DEFAULT_LOCAL_BASE_URL)
+        child.add_argument("--max-in-progress", type=int, default=2)
+        child.add_argument("--failure-threshold", type=int, default=DEFAULT_FAILURE_THRESHOLD)
+        child.add_argument("--recovery-threshold", type=int, default=DEFAULT_RECOVERY_THRESHOLD)
+        child.add_argument("--cooldown", type=int, default=DEFAULT_COOLDOWN_SECONDS)
+        if name in {"enter", "tick", "supervise"}:
+            child.add_argument("--no-port-tasks", action="store_true")
+        if name == "status":
+            child.add_argument("--no-probe", action="store_true")
+        if name == "supervise":
+            child.add_argument("--interval", type=int, default=30)
+        child.set_defaults(func=cmd_flight)
+    parser.set_defaults(func=cmd_flight)
+    return parser

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11884,7 +11884,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "acp", "approvals", "auth", "backup", "bundles", "checkpoints", "claw", "completion",
         "computer-use",
         "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
-        "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
+        "dump", "egress", "fallback", "flight", "gateway", "hooks", "import", "import-agent", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
         "model", "monitoring", "pairing", "pause", "peer", "pets", "plugins", "portal", "profile",
@@ -13042,6 +13042,13 @@ def main():
 
     kanban_parser = _build_kanban_parser(subparsers)
     kanban_parser.set_defaults(func=cmd_kanban)
+
+    # =========================================================================
+    # flight command — local-model continuity when internet is lost
+    # =========================================================================
+    from hermes_cli.flight import build_parser as _build_flight_parser
+
+    _build_flight_parser(subparsers)
 
     # =========================================================================
     # project command — named, multi-folder workspaces

--- a/tests/hermes_cli/test_flight_mode.py
+++ b/tests/hermes_cli/test_flight_mode.py
@@ -122,6 +122,124 @@ def test_enter_and_exit_restore_exact_config_bytes(tmp_path, monkeypatch):
     assert manager.status(probe=False)["mode"] == "online"
 
 
+def test_offline_profile_is_exempt_from_flight_config_rewrites(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(_normal_config(), sort_keys=False))
+    offline_home = tmp_path / "profiles" / "offline"
+    offline_home.mkdir(parents=True)
+    offline_config = {
+        "model": {"provider": flight.LOCAL_PROVIDER, "default": "offline-model"},
+        "fallback_providers": [],
+    }
+    offline_path = offline_home / "config.yaml"
+    original = yaml.safe_dump(offline_config, sort_keys=False)
+    offline_path.write_text(original)
+
+    manager = flight.FlightManager(
+        home=tmp_path,
+        local_model="local-test-model",
+        probe=lambda *_args, **_kwargs: (True, "ok"),
+    )
+    state = manager.enter(now=10.0, port_tasks=False)
+
+    assert state["saved_restore_target"]["profiles"] == [str(tmp_path)]
+    assert offline_path.read_text() == original
+
+
+def test_second_enter_does_not_poison_restore_target_with_local_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    original_config = _normal_config()
+    config_path.write_text(yaml.safe_dump(original_config, sort_keys=False))
+
+    manager = flight.FlightManager(
+        home=tmp_path,
+        local_model="local-test-model",
+        probe=lambda *_args, **_kwargs: (True, "ok"),
+    )
+    first = manager.enter(now=10.0, port_tasks=False)
+    clean_backup = first["saved_restore_target"]["configs"][0]["backup"]
+
+    # Simulate a lost/reset state file while the on-disk config is still local.
+    manager._save_state(flight.new_state(now=15.0))
+    second = manager.enter(now=20.0, port_tasks=False)
+
+    assert second["mode"] == "local"
+    assert second["saved_restore_target"]["configs"][0]["backup"] == clean_backup
+    assert len(list((tmp_path / "flight-mode").glob("config-*.yaml"))) == 1
+
+    manager.exit(now=30.0)
+    restored = yaml.safe_load(config_path.read_text())
+    assert restored["model"]["provider"] == "cliproxyapi"
+    assert restored["fallback_providers"] == original_config["fallback_providers"]
+
+
+def test_exit_rejects_degraded_recorded_backup_and_uses_newest_clean_generation(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    original_config = _normal_config()
+    config_path.write_text(yaml.safe_dump(original_config, sort_keys=False))
+
+    manager = flight.FlightManager(
+        home=tmp_path,
+        local_model="local-test-model",
+        probe=lambda *_args, **_kwargs: (True, "ok"),
+    )
+    state = manager.enter(now=10.0, port_tasks=False)
+    clean_backup = Path(state["saved_restore_target"]["configs"][0]["backup"])
+    poisoned_backup = clean_backup.with_name("config-001.yaml")
+    poisoned_backup.write_text(config_path.read_text())
+    state["saved_restore_target"]["configs"][0]["backup"] = str(poisoned_backup)
+    manager._save_state(state)
+
+    manager.exit(now=20.0)
+
+    restored = yaml.safe_load(config_path.read_text())
+    assert restored["model"]["provider"] == "cliproxyapi"
+    assert restored["fallback_providers"] == original_config["fallback_providers"]
+
+
+def test_exit_falls_back_from_empty_chain_backup_to_newest_clean_generation(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    live_config = _normal_config()
+    config_path.write_text(yaml.safe_dump(live_config, sort_keys=False))
+    flight_dir = tmp_path / "flight-mode"
+    flight_dir.mkdir(parents=True)
+    clean_backup = flight_dir / "config-000.yaml"
+    clean_backup.write_text(yaml.safe_dump(live_config, sort_keys=False))
+    degraded_backup = flight_dir / "config-001.yaml"
+    degraded = dict(live_config)
+    degraded["fallback_providers"] = []
+    degraded_backup.write_text(yaml.safe_dump(degraded, sort_keys=False))
+
+    manager = flight.FlightManager(home=tmp_path, local_model="local-test-model")
+    state = flight.new_state(now=1.0)
+    state.update(
+        {
+            "mode": "local",
+            "saved_restore_target": {
+                "profiles": [str(tmp_path)],
+                "configs": [
+                    {
+                        "home": str(tmp_path),
+                        "config": str(config_path),
+                        "backup": str(degraded_backup),
+                        "existed": True,
+                    }
+                ],
+            },
+        }
+    )
+    manager._save_state(state)
+
+    manager.exit(now=2.0)
+
+    restored = yaml.safe_load(config_path.read_text())
+    assert restored["model"]["provider"] == "cliproxyapi"
+    assert restored["fallback_providers"] == live_config["fallback_providers"]
+
+
 def test_tick_transitions_online_local_online_using_real_inference_evidence(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / "config.yaml").write_text(yaml.safe_dump(_normal_config(), sort_keys=False))

--- a/tests/hermes_cli/test_flight_mode.py
+++ b/tests/hermes_cli/test_flight_mode.py
@@ -152,3 +152,48 @@ def test_tick_transitions_online_local_online_using_real_inference_evidence(tmp_
     persisted = json.loads((tmp_path / "flight-mode" / "state.json").read_text())
     assert persisted["last_evidence"]["normal"]["detail"] == "normal inference ok"
     assert persisted["last_transition"]["to"] == "online"
+
+
+def test_sessions_pin_locally_then_resume_on_saved_cloud_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.config import GatewayConfig, Platform
+    from gateway.session import SessionSource, SessionStore
+
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    pinned = store.get_or_create_session(
+        SessionSource(platform=Platform.TELEGRAM, user_id="u1", chat_id="c1", chat_type="dm")
+    )
+    store.set_model_override(
+        pinned.session_key,
+        {"model": "claude-opus-5", "provider": "cliproxyapi", "base_url": "http://127.0.0.1:8318/v1"},
+    )
+    defaulted = store.get_or_create_session(
+        SessionSource(platform=Platform.TELEGRAM, user_id="u2", chat_id="c2", chat_type="dm")
+    )
+
+    saved = flight.snapshot_and_pin_sessions(
+        tmp_path,
+        local_model="qwen3.5:35b-a3b-coding-nvfp4",
+        local_provider=flight.LOCAL_PROVIDER,
+        local_base_url="http://127.0.0.1:11434/v1",
+        store=store,
+    )
+    local_pinned = store.get_model_override(pinned.session_key) or {}
+    local_defaulted = store.get_model_override(defaulted.session_key) or {}
+    assert local_pinned.get("provider") == flight.LOCAL_PROVIDER
+    assert local_defaulted.get("provider") == flight.LOCAL_PROVIDER
+    assert saved[pinned.session_key]["model"] == "claude-opus-5"
+    assert saved[defaulted.session_key] is None
+
+    live = {defaulted.session_key: {"model": "coding:latest", "provider": flight.LOCAL_PROVIDER}}
+    flight.restore_session_overrides(tmp_path, saved, store=store, live_overrides=live)
+    restored = store.get_model_override(pinned.session_key) or {}
+    assert restored.get("model") == "claude-opus-5"
+    assert store.get_model_override(defaulted.session_key) is None
+    assert defaulted.session_key not in live
+
+
+def test_one_successful_normal_inference_exits_local_mode():
+    state = flight.new_state(now=1.0, failure_threshold=3, recovery_threshold=1, cooldown_seconds=0)
+    state["mode"] = "local"
+    assert flight.observe_connectivity(state, normal_ok=True, local_ok=True, now=2.0) == "exit"

--- a/tests/hermes_cli/test_flight_mode.py
+++ b/tests/hermes_cli/test_flight_mode.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from hermes_cli import flight
+
+
+def _normal_config() -> dict:
+    return {
+        "model": {"provider": "cliproxyapi", "default": "gpt-5.6-sol"},
+        "providers": {
+            "cliproxyapi": {
+                "base_url": "http://127.0.0.1:8318/v1",
+                "key_env": "CLIPROXYAPI_API_KEY",
+                "api_mode": "openai_chat_completions",
+            }
+        },
+        "fallback_providers": [
+            {"provider": "cliproxyapi", "model": "grok-4.6"},
+            {"provider": "nous", "model": "openai/gpt-5.6-terra"},
+        ],
+        "kanban": {"max_in_progress": 8, "max_in_progress_per_profile": 2},
+    }
+
+
+def test_local_config_replaces_only_routing_and_throttles_kanban():
+    local = flight.build_local_config(
+        _normal_config(),
+        model="qwen3.5:35b-a3b-coding-nvfp4",
+        base_url="http://127.0.0.1:11434/v1",
+        max_in_progress=2,
+    )
+
+    assert local["model"] == {
+        "provider": flight.LOCAL_PROVIDER,
+        "default": "qwen3.5:35b-a3b-coding-nvfp4",
+    }
+    assert local["providers"][flight.LOCAL_PROVIDER]["base_url"] == "http://127.0.0.1:11434/v1"
+    assert local["fallback_providers"] == []
+    assert local["kanban"]["max_in_progress"] == 2
+    assert local["kanban"]["max_in_progress_per_profile"] == 1
+    assert local["providers"]["cliproxyapi"]["key_env"] == "CLIPROXYAPI_API_KEY"
+
+
+def test_state_machine_requires_consecutive_failures_and_successes_with_cooldown():
+    state = flight.new_state(now=100.0, failure_threshold=3, recovery_threshold=2, cooldown_seconds=10)
+
+    for now in (101.0, 102.0):
+        action = flight.observe_connectivity(state, normal_ok=False, local_ok=True, now=now)
+        assert action is None
+    assert flight.observe_connectivity(state, normal_ok=False, local_ok=True, now=103.0) == "enter"
+
+    state["mode"] = "local"
+    state["last_transition_at"] = 103.0
+    assert flight.observe_connectivity(state, normal_ok=True, local_ok=True, now=105.0) is None
+    assert state["normal_successes"] == 1
+    assert flight.observe_connectivity(state, normal_ok=True, local_ok=True, now=106.0) is None
+    assert flight.observe_connectivity(state, normal_ok=True, local_ok=True, now=114.0) == "exit"
+
+
+def test_partial_connectivity_never_counts_as_normal_recovery():
+    state = flight.new_state(now=1.0, failure_threshold=2, recovery_threshold=2, cooldown_seconds=0)
+    state["mode"] = "local"
+
+    assert flight.observe_connectivity(state, normal_ok=False, local_ok=True, now=2.0) is None
+    assert flight.observe_connectivity(state, normal_ok=True, local_ok=True, now=3.0) is None
+    assert flight.observe_connectivity(state, normal_ok=False, local_ok=True, now=4.0) is None
+    assert state["normal_successes"] == 0
+
+
+def test_task_porting_is_conservative_and_restore_is_exact(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect_closing() as conn:
+        safe = kb.create_task(conn, title="Refactor parser", body="Edit local files and run pytest", assignee="builder")
+        network = kb.create_task(conn, title="Deploy API", body="Use GitHub and AWS production", assignee="builder")
+        pinned = kb.create_task(
+            conn,
+            title="Local pinned",
+            body="Run local tests",
+            assignee="builder",
+            model_override="existing-model",
+            provider_override="existing-provider",
+        )
+
+        saved = flight.port_queued_tasks(
+            conn,
+            local_model="qwen3.5:35b-a3b-coding-nvfp4",
+            local_provider=flight.LOCAL_PROVIDER,
+        )
+        assert saved[safe] == {"model": None, "provider": None}
+        assert saved[pinned] == {"model": "existing-model", "provider": "existing-provider"}
+        assert network not in saved
+        assert kb.get_task(conn, safe).model_override == "qwen3.5:35b-a3b-coding-nvfp4"
+        assert kb.get_task(conn, network).model_override is None
+
+        flight.restore_task_overrides(conn, saved)
+        assert kb.get_task(conn, safe).model_override is None
+        assert kb.get_task(conn, pinned).model_override == "existing-model"
+        assert kb.get_task(conn, pinned).provider_override == "existing-provider"
+
+
+def test_enter_and_exit_restore_exact_config_bytes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    original = "# keep me\nmodel:\n  provider: cliproxyapi\n  default: gpt-5.6-sol\n"
+    config_path.write_text(original)
+
+    manager = flight.FlightManager(home=tmp_path, probe=lambda *_args, **_kwargs: (True, "ok"))
+    manager.enter(now=10.0, port_tasks=False)
+    assert yaml.safe_load(config_path.read_text())["model"]["provider"] == flight.LOCAL_PROVIDER
+    status = manager.status(probe=False)
+    assert status["mode"] == "local"
+    assert status["saved_restore_target"]["profiles"] == [str(tmp_path)]
+
+    manager.exit(now=20.0)
+    assert config_path.read_text() == original
+    assert manager.status(probe=False)["mode"] == "online"
+
+
+def test_tick_transitions_online_local_online_using_real_inference_evidence(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(_normal_config(), sort_keys=False))
+    results = iter([
+        (False, "normal inference failed"),
+        (False, "normal inference failed"),
+        (True, "normal inference ok"),
+        (True, "normal inference ok"),
+    ])
+
+    def probe(kind, *_args, **_kwargs):
+        if kind == "local":
+            return True, "local inference ok"
+        return next(results)
+
+    manager = flight.FlightManager(
+        home=tmp_path,
+        probe=probe,
+        failure_threshold=2,
+        recovery_threshold=2,
+        cooldown_seconds=0,
+    )
+    assert manager.tick(now=1.0, port_tasks=False)["mode"] == "online"
+    assert manager.tick(now=2.0, port_tasks=False)["mode"] == "local"
+    assert manager.tick(now=3.0, port_tasks=False)["mode"] == "local"
+    assert manager.tick(now=4.0, port_tasks=False)["mode"] == "online"
+
+    persisted = json.loads((tmp_path / "flight-mode" / "state.json").read_text())
+    assert persisted["last_evidence"]["normal"]["detail"] == "normal inference ok"
+    assert persisted["last_transition"]["to"] == "online"


### PR DESCRIPTION
## Summary
- add `hermes flight enter|exit|status|tick|supervise`
- switch to local Ollama only after bounded normal-route inference failures
- probe the saved normal cascade with real inference and restore on the first successful recovery
- preserve and restore exact config bytes, Kanban model pins, and per-session model/provider overrides
- throttle local Kanban concurrency without starting a second gateway

## Verification
- `tests/hermes_cli/test_flight_mode.py`: 8 passed
- Python compile: `hermes_cli/flight.py`, `gateway/kanban_watchers.py`, `gateway/run.py`
- live normal route inference: OK
- live Ollama inference and Hermes terminal tool call: OK

## Safety
- no external messages or destructive actions
- internet-required cards remain tracked rather than blindly dispatched locally
- restore is byte-exact and idempotent