### PR TITLE
test(desktop): assert the isDisabled flip-back actually notifies

### DIFF
--- a/apps/desktop/src/lib/incremental-runtime-adapter-notify.test.ts
+++ b/apps/desktop/src/lib/incremental-runtime-adapter-notify.test.ts
@@ -130,7 +130,11 @@ describe('IncrementalExternalStoreThreadRuntimeCore adapter swap notifications',
     expect(notifications).toBeGreaterThan(0)
 
     // And flipping back also notifies — but an unchanged repeat stays silent.
+    const beforeFlipBack = notifications
     core.setAdapter(adapterWith(repo, { isDisabled: false }))
+
+    expect(notifications).toBeGreaterThan(beforeFlipBack)
+
     const afterFlipBack = notifications
 
     core.setAdapter(adapterWith(repo, { isDisabled: false }))


### PR DESCRIPTION
## Summary
The isDisabled guard test added in #93080 documented "flipping back also notifies" but never asserted it — a regression making the true→false transition silent (e.g. gating `disabledChanged` on truthiness) would still pass.

## Changes
- `apps/desktop/src/lib/incremental-runtime-adapter-notify.test.ts`: capture `beforeFlipBack` and assert the flip-back setAdapter call notifies (+4 lines).

## Validation
| | Before | After |
|---|---|---|
| `disabledChanged = newDisabled && ...` mutation | 5/5 pass (hole) | 1 failed (caught) |
| unmutated suite | 5/5 pass | 5/5 pass |

Follow-up from the post-merge /simplify-code pass on #93080.
