### PR TITLE
fix(bot-mode): rotate user-terminated group sessions

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6413,8 +6413,15 @@ async function ensureGroupChatSession(group, member) {
   const key = groupMemberKey(member)
   const known = room.sessions && room.sessions[key]
 
+  // `true` is a poison sentinel: the prior turn persisted a user prompt but
+  // produced no assistant reply. Resuming that session would append a second
+  // user role and violate the model/provider alternation contract. Skip both
+  // stored-id and title lookup once, create a fresh hidden plumbing session,
+  // then replace the sentinel with its real stored id below.
+  const resumeTargets = known === true ? [] : [known, title]
+
   // Try resuming what we know (stored sid first, then title lookup).
-  for (const target of [known, title]) {
+  for (const target of resumeTargets) {
     if (!target || target === true) {
       continue
     }
@@ -6461,6 +6468,18 @@ async function ensureGroupChatSession(group, member) {
   }
 
   return { runtime: created?.session_id || null, stored }
+}
+
+/** Mark a member's plumbing session unusable after a turn persisted a user
+ * message without a matching assistant message. The next turn rotates to a
+ * fresh hidden session instead of violating role alternation. */
+function invalidateGroupChatSession(group, member) {
+  const key = groupMemberKey(member)
+
+  updateGroupChat(group, room => {
+    room.sessions = { ...(room.sessions || {}), [key]: true }
+    return room
+  })
 }
 
 const GROUP_TURN_TIMEOUT_MS = 180000
@@ -6717,7 +6736,10 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
     const done = !busy && !awaitingUser
 
     if (messages.length > before && done) {
-      for (let i = messages.length - 1; i >= 0; i--) {
+      // Only this turn's suffix can satisfy this turn. Scanning older history
+      // can mistake a previous assistant reply for a failed user-only submit,
+      // repost stale text, and leave the session user-terminated.
+      for (let i = messages.length - 1; i >= before; i--) {
         const msg = messages[i]
 
         if (msg?.role === 'assistant') {
@@ -6739,6 +6761,7 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
       }
 
       recordGroupActivity(group, { kind: 'passed', member: member.name, thread })
+      invalidateGroupChatSession(group, member)
 
       return null
     }
@@ -6816,7 +6839,10 @@ async function harvestStrandedGroupReply(group, member) {
     return
   }
 
-  for (let i = messages.length - 1; i >= 0; i--) {
+  // The stranded baseline is the exact message count before the timed-out
+  // submit. Older assistants belong to earlier turns and must never satisfy
+  // or be redelivered as this stranded result.
+  for (let i = messages.length - 1; i >= strandedBefore; i--) {
     const msg = messages[i]
 
     if (msg?.role === 'assistant') {
@@ -6844,6 +6870,11 @@ async function harvestStrandedGroupReply(group, member) {
       return
     }
   }
+
+  // The stranded turn completed with new persisted messages but no assistant
+  // response. Rotate before the next prompt rather than resuming a session
+  // whose last durable role is user.
+  invalidateGroupChatSession(group, member)
 }
 
 /** Drive one bounded round-robin turn for ONE THREAD. Serial — one member at
@@ -6935,6 +6966,7 @@ async function runGroupChatRounds(group, members, thread) {
           reply = await runGroupChatMemberTurn(group, member, prompt, thread, deltaImages)
         } catch {
           recordGroupActivity(group, { kind: 'failed', member: member.name, thread })
+          invalidateGroupChatSession(group, member)
           reply = null // a failed turn is a pass, never a room error
         }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -8,7 +8,7 @@ const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf
 /** Load the plugin in a vm with a scripted cli.exec so member turns are
  *  deterministic. `turnScript(profile, prompt)` returns the member's reply
  *  text (or throws to simulate a failed turn). */
-function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false } = {}) {
+function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approvalUntilResumeCall, conflictOnce = false, deferredTimers = false, omitAssistantOnCalls = [] } = {}) {
   const values = new Map()
   const atom = initial => {
     const slot = { get: () => values.get(slot), set: value => {
@@ -170,7 +170,9 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
             title: session.title
           })
           const reply = turnScript(session.profile, params.text, calls.length, session)
-          session.messages.push({ role: 'assistant', content: reply })
+          if (!omitAssistantOnCalls.includes(calls.length)) {
+            session.messages.push({ role: 'assistant', content: reply })
+          }
           return {}
         }
         if (method === 'clarify.respond') {
@@ -311,6 +313,56 @@ test('failed member turn is a pass, not a room error', async () => {
 
   const log = roomLog(gc, 'Flaky')
   assert.equal(log.length, 1) // just the user message; no error entries
+})
+
+test('a user-only failed member session is rotated before the next group turn', async () => {
+  let attempt = 0
+  const gc = load(() => {
+    attempt += 1
+    if (attempt === 1) {
+      throw new Error('provider failed after persisting the user prompt')
+    }
+    return '(pass)'
+  })
+  const member = [{ name: 'research', title: '' }]
+
+  gc.sendToGroupChat('Retry', member, 'first')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Retry || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  gc.sendToGroupChat('Retry', member, 'second')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().Retry || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  assert.equal(gc.sessions.size, 2, 'the poisoned user-only session must not be resumed')
+  for (const session of gc.sessions.values()) {
+    for (let i = 1; i < session.messages.length; i++) {
+      assert.notEqual(session.messages[i - 1].role, session.messages[i].role, 'stored roles must alternate')
+    }
+  }
+})
+
+test('a non-throwing user-only turn ignores old assistants and rotates before retry', async () => {
+  const gc = load(() => '(pass)', { omitAssistantOnCalls: [2] })
+  const member = [{ name: 'research', title: '' }]
+
+  gc.sendToGroupChat('History', member, 'healthy first turn')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().History || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  gc.sendToGroupChat('History', member, 'provider stores only this user turn')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().History || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  assert.equal(gc.$groupChats.get().History.sessions.research, true, 'user-only completion poisons the session')
+
+  gc.sendToGroupChat('History', member, 'retry on a fresh session')
+  for (let i = 0; i < 200 && (gc.$groupChats.get().History || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  assert.equal(gc.sessions.size, 2, 'retry rotates instead of resuming the user-terminated session')
 })
 
 test('delta injection: a second user send only feeds members the NEW messages', async () => {
@@ -1399,6 +1451,33 @@ test('stranded harvest: a timed-out turn whose reply landed late posts into the 
   assert.equal(log[0].from.name, 'research')
   assert.match(log[0].text, /delivered late/)
   assert.equal(gc.$groupChats.get().Late.stranded.research, undefined, 'marker consumed')
+})
+
+test('stranded harvest ignores old assistants and poisons a completed user-only session', async () => {
+  const gc = load(() => '(pass)')
+
+  gc.updateGroupChat('LateFail', room => {
+    room.stranded = { research: 2 }
+    room.sessions = { research: 'sid-research' }
+    return room
+  })
+  gc.sessions.set('sid-research', {
+    stored: 'sid-research',
+    runtime: 'rt-research',
+    profile: 'research',
+    title: 'Group: LateFail',
+    messages: [
+      { role: 'user', content: 'healthy prior prompt' },
+      { role: 'assistant', content: 'healthy prior reply must not be redelivered' },
+      { role: 'user', content: 'timed-out prompt that later ended without an assistant' }
+    ]
+  })
+
+  await gc.harvestStrandedGroupReply('LateFail', { name: 'research', title: '' })
+
+  assert.equal(roomLog(gc, 'LateFail').length, 0, 'an old assistant is never reposted as the stranded result')
+  assert.equal(gc.$groupChats.get().LateFail.stranded.research, undefined, 'completed marker is consumed')
+  assert.equal(gc.$groupChats.get().LateFail.sessions.research, true, 'user-only stranded completion poisons the session')
 })
 
 test('stranded + still busy: the round loop never re-submits into a member whose harvest just confirmed they are still running', async () => {


### PR DESCRIPTION
## Status — design review blocked

This draft is retained as a reproduction and test artifact, **not a merge candidate**. Three implementation review cycles and an independent architecture review found that correct recovery must be reconciled with #92870 and #90933 and requires submit quarantine/idempotency, attempt and reload fencing, atomic exactly-once late delivery, stale clarify/approval fencing, explicit watermark rules, and a cross-renderer single-writer contract. The local implementation cycle has stopped; do not merge this head.

## Summary

- rotate a Bot Mode group member session when a failed turn leaves new durable messages but no new assistant reply
- restrict normal and stranded assistant lookup to the exact post-submit message suffix
- prevent stale prior assistants from being reused or reposted as the current turn

## Problem

A production-adjacent Desktop group run reproduced this durable sequence after a provider failure and retry:

```text
user → user → assistant
```

The first failed turn persisted its user prompt without an assistant response. The next group turn resumed that user-terminated session. Two full-history scans also allowed an older assistant reply to satisfy or be redelivered for the failed turn.

That violates Hermes's strict role-alternation invariant and can replay stale room content.

## Approach

A user-only completion marks the room's member-session pointer with a one-use poison sentinel. The next turn skips stored-id and title resume, creates a fresh hidden plumbing session, and replaces the sentinel with the new stored ID.

Both normal polling and stranded harvesting now inspect only messages at or after their captured pre-submit baseline. Older assistants cannot satisfy a newer turn.

Historical sessions are preserved; nothing is deleted or rewritten.

## Tests

RED was observed before implementation for all three regression classes:

- thrown failure after the user prompt was persisted
- non-throwing user-only completion in an established session with older assistant history
- stranded user-only completion with an older assistant that must not be redelivered

Current verification:

- `node --test src/plugins/hermes-bots/tests/group-chat.test.mjs src/plugins/hermes-bots/tests/roster-groups.test.mjs` — 99/99 passed
- `npm run typecheck` — passed
- repository `npm run lint` — passes with existing warnings; the configured ESLint ignore rules exclude `plugin.js`, so no direct lint claim is made for that file
- `git diff --check origin/main...HEAD` — passed
- exact-head review: **rejected**; the three demonstrated regressions have real pre-fix bite, but broader concurrency, supersession, reload, clarification/approval, and exactly-once contracts remain unresolved

The retained head is evidence only. The rejected follow-up correction and architecture reviews are not included in this commit.

## Related work

- #92870 fixes a distinct sibling failure: transient `session.resume` errors must not fork an otherwise valid group session. This PR handles sessions that really did persist a new user message but completed without a new assistant.
- #90933 changes timed-out-turn background delivery. Its stranded-harvest implementation should retain this PR's suffix-bounded assistant selection and user-only poisoning behavior when reconciled.

## Risk and rollback

The change is limited to hidden Bot Mode group plumbing sessions. Rollback is reverting this commit. Existing sessions and room history are never deleted.