### PR TITLE
fix(discord): forward skills approval arguments

### DIFF
--- a/contributors/emails/georges.alkhouri@gmail.com
+++ b/contributors/emails/georges.alkhouri@gmail.com
@@ -1,0 +1,1 @@
+GeorgesAlkhouri

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -306,6 +306,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("skills", "Search, install, inspect, or manage skills",
                "Tools & Skills", cli_only=True,
                gateway_config_gate="skills.write_approval",
+               args_hint="[pending|approve|reject|diff|approval] [id|on|off]",
                subcommands=("search", "browse", "inspect", "install", "audit",
                             "pending", "approve", "reject", "diff", "approval")),
     CommandDef("memory", "Review pending memory writes / toggle the approval gate",

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -204,6 +204,26 @@ async def test_auto_registers_plugin_commands_for_discord(adapter):
 
 
 @pytest.mark.asyncio
+async def test_auto_registered_skills_forwards_write_approval_arguments(adapter):
+    """The Discord /skills command must forward its review arguments."""
+    adapter._run_simple_slash = AsyncMock()
+
+    with patch(
+        "hermes_cli.commands._resolve_config_gates",
+        return_value={"skills"},
+    ):
+        adapter._register_slash_commands()
+
+    skills_cmd = adapter._client.tree.commands["skills"]
+    interaction = SimpleNamespace()
+    await skills_cmd.callback(interaction, args="approve a1b2c3d4")
+
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction, "/skills approve a1b2c3d4"
+    )
+
+
+@pytest.mark.asyncio
 async def test_plugin_command_name_conflict_skipped(adapter):
     """A plugin command that collides with a built-in must not override it."""
     adapter._run_simple_slash = AsyncMock()


### PR DESCRIPTION
## What does this PR do?

Makes Discord forward arguments for the auto-registered `/skills` command. Previously, `/skills approve <id>` was registered without an argument field, so Discord dispatched only `/skills` and left the write pending.

## Related Issue

No exact issue found. Related write-approval UX discussion: #70217.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add the existing optional-argument hint to the `/skills` command definition.
- Add a Discord regression test for `/skills approve a1b2c3d4`.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_discord_slash_commands.py tests/hermes_cli/test_commands.py tests/tools/test_write_approval.py -q`.
2. Confirm all 82 tests pass.
3. In Discord, run `/skills approve <id>` and confirm the pending write is applied instead of merely listed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Targeted suite: 82 passed; full suite is left to PR CI.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon), including the live Discord `/skills approve <id>` flow

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: registry metadata only
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

Targeted suite: **82 passed, 0 failed**.