### PR TITLE
feat(cron): validate provider-model pairs at create/update time

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1875,23 +1875,9 @@ def _validate_provider_model_pair(
             or _strip_vendor(model_lower) in models_stripped
             or _aliased_stripped in models_stripped
         ):
-            hint = cron_free_tier_alternate_hint(normalized_provider, normalized_model)
+            hint = cron_free_tier_alternate_hint(normalized_provider, normalized_model, cache)
             if hint:
-                # Only raise if the alternate provider actually serves the model
-                # (avoid false positives when the free relay doesn't list it).
-                _free_entry = cache.get("opencode-free", {})
-                if isinstance(_free_entry, dict) and not is_provider_cache_entry_stale(_free_entry):
-                    _free_models = _free_entry.get("models", [])
-                    _free_lower = [str(m or "").lower() for m in _free_models]
-                    _free_stripped = [_strip_vendor(m) for m in _free_models]
-                    _alias_free = resolve_cron_model_alias(model_lower)
-                    if (
-                        model_lower in _free_lower
-                        or _alias_free in _free_lower
-                        or _strip_vendor(model_lower) in _free_stripped
-                        or _strip_vendor(_alias_free) in _free_stripped
-                    ):
-                        raise ValueError(hint)
+                raise ValueError(hint)
             return
 
         # Not in this provider — search which providers DO serve it
@@ -1928,10 +1914,16 @@ def _validate_provider_model_pair(
             candidates_sorted = sorted(set(candidates))
             parts.append(f"Available on: {', '.join(candidates_sorted)}.")
             parts.append(f"Try: --provider {candidates_sorted[0]} --model {normalized_model}")
-            if provider_key == "opencode-go" and "opencode-free" in candidates_sorted:
-                parts.append("(opencode-free is keyless; opencode-go requires an API key)")
-            elif provider_key == "opencode-free" and "opencode-go" in candidates_sorted:
-                parts.append("(opencode-go requires an API key; opencode-free is keyless)")
+            # Provider-specific keyless-vs-API-key hint lives in models.py
+            # so cron/jobs.py stays generic.
+            try:
+                from hermes_cli.models import cron_candidate_hint
+
+                _hint = cron_candidate_hint(provider_key, candidates_sorted)
+                if _hint:
+                    parts.append(_hint)
+            except Exception:
+                pass
         else:
             parts.append(f"Provider '{normalized_provider}' serves {len(models)} models; none match '{normalized_model}'.")
         if close:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -9,6 +9,7 @@ import contextlib
 import copy
 from contextvars import ContextVar
 from dataclasses import dataclass
+from difflib import get_close_matches
 import json
 import logging
 import shutil
@@ -1800,10 +1801,12 @@ def _validate_provider_model_pair(
       follow global config, so there is nothing to validate).
     * Custom ``base_url`` providers are skipped entirely.
     * ``no_agent`` jobs have no inference, so they are skipped.
-    * An empty or missing ``provider_models_cache.json`` is treated as
-      “don’t know — don’t block” (best-effort, never a hard gate on a cold
-      cache).  Only a non-empty entry for the requested provider can
-      produce a hard rejection.
+    * An empty, missing, or **stale** (beyond the SWR window)
+      ``provider_models_cache.json`` entry is treated as “don’t know —
+      don’t block” (warning, not hard reject) so a model removed weeks ago
+      doesn't permanently block job creation.
+    * Provider-specific quirks (aliases, free-tier markers) live in
+      ``hermes_cli.models`` so cron validation stays generic.
     * When the model is not in the requested provider, the error suggests
       the correct provider(s) and close name matches (difflib), so the
       caller can fix the command on the spot.
@@ -1817,22 +1820,24 @@ def _validate_provider_model_pair(
     if not normalized_provider or not normalized_model:
         return
     try:
-        from hermes_cli.models import _load_provider_models_cache, normalize_provider
+        from hermes_cli.models import (
+            _load_provider_models_cache,
+            normalize_provider,
+            cron_free_tier_alternate_hint,
+            is_provider_cache_entry_stale,
+            resolve_cron_model_alias,
+        )
 
         cache = _load_provider_models_cache()
         if not cache:
             return
         provider_key = normalize_provider(normalized_provider)
-        # Unknown provider → hard reject with suggestions
         if provider_key not in cache:
             known = sorted(cache.keys())
-            from difflib import get_close_matches
-
             close = get_close_matches(provider_key, known, n=3, cutoff=0.6)
             msg = f"Unknown provider '{normalized_provider}'."
             if close:
                 msg += f" Did you mean: {', '.join(close)}?"
-            # Show a short sample of known providers; full list is via `hermes model`
             sample = ", ".join(known[:8])
             if len(known) > 8:
                 sample += ", ..."
@@ -1840,6 +1845,16 @@ def _validate_provider_model_pair(
             raise ValueError(msg)
 
         entry = cache.get(provider_key, {})
+        # Stale entry (beyond SWR window) is treated as "don't know" — log
+        # a warning and don't block, so a weeks-old removal doesn't
+        # permanently prevent job creation until the next live refresh.
+        if is_provider_cache_entry_stale(entry):
+            logger.debug(
+                "Provider-model validation skipped: cache entry for '%s' is stale (at=%s)",
+                provider_key,
+                entry.get("at") if isinstance(entry, dict) else None,
+            )
+            return
         models = entry.get("models", []) if isinstance(entry, dict) else []
         if not models:
             return
@@ -1848,58 +1863,35 @@ def _validate_provider_model_pair(
             s = str(m or "").strip().lower()
             return s.split("/")[-1] if "/" in s else s
 
-        # Alias: ox-alpha-free is the same model as x-preview-f-free on the
-        # free relay (historical naming drift). Treat them as interchangeable
-        # so validation doesn't flip-flop based on which name the cache saw.
-        _alias_map = {
-            "ox-alpha-free": "x-preview-f-free",
-            "ox-alpha": "x-preview-f-free",
-            "x-preview-f-free": "ox-alpha-free",
-        }
-
         model_lower = normalized_model.lower()
         models_lower = [str(m or "").lower() for m in models]
         models_stripped = [_strip_vendor(m) for m in models]
-        # Also consider alias for the requested model
-        _aliased_model = _alias_map.get(model_lower, model_lower)
+        _aliased_model = resolve_cron_model_alias(model_lower)
         _aliased_stripped = _strip_vendor(_aliased_model)
 
-        # Direct hit (exact, case-insensitive, alias, or vendor-prefix stripped)
         if (
             model_lower in models_lower
             or _aliased_model in models_lower
             or _strip_vendor(model_lower) in models_stripped
             or _aliased_stripped in models_stripped
         ):
-            # Free-tier models must run via the keyless provider; the
-            # authenticated opencode-go relay 401s any bearer it doesn't
-            # recognize (see opencode-free plugin).  Even though the cache
-            # may list e.g. ox-alpha-free on both relays, running it via
-            # opencode-go will fail every tick with "provider authentication
-            # error" and spam the drift alert — the exact bug this guard
-            # exists to prevent.  Detect the cross-wire and suggest the
-            # correct provider.
-            _free_markers = ("-free", ":free", "x-preview")
-            _is_free_model = any(m in model_lower for m in _free_markers) or model_lower in (
-                "ox-alpha-free",
-                "ox-alpha",
-            )
-            if _is_free_model and provider_key == "opencode-go":
-                # Check if opencode-free actually serves this model
+            hint = cron_free_tier_alternate_hint(normalized_provider, normalized_model)
+            if hint:
+                # Only raise if the alternate provider actually serves the model
+                # (avoid false positives when the free relay doesn't list it).
                 _free_entry = cache.get("opencode-free", {})
-                _free_models = _free_entry.get("models", []) if isinstance(_free_entry, dict) else []
-                _free_lower = [str(m or "").lower() for m in _free_models]
-                _free_stripped = [_strip_vendor(m) for m in _free_models]
-                if (
-                    model_lower in _free_lower
-                    or _strip_vendor(model_lower) in _free_stripped
-                    or model_lower == "ox-alpha-free"
-                ):
-                    raise ValueError(
-                        f"Model '{normalized_model}' is a free-tier model and must run via provider 'opencode-free' (keyless), "
-                        f"not '{normalized_provider}' (which sends an API key and will 401). "
-                        f"Try: --provider opencode-free --model {normalized_model}"
-                    )
+                if isinstance(_free_entry, dict) and not is_provider_cache_entry_stale(_free_entry):
+                    _free_models = _free_entry.get("models", [])
+                    _free_lower = [str(m or "").lower() for m in _free_models]
+                    _free_stripped = [_strip_vendor(m) for m in _free_models]
+                    _alias_free = resolve_cron_model_alias(model_lower)
+                    if (
+                        model_lower in _free_lower
+                        or _alias_free in _free_lower
+                        or _strip_vendor(model_lower) in _free_stripped
+                        or _strip_vendor(_alias_free) in _free_stripped
+                    ):
+                        raise ValueError(hint)
             return
 
         # Not in this provider — search which providers DO serve it
@@ -1910,23 +1902,26 @@ def _validate_provider_model_pair(
             plist = ent.get("models", [])
             plist_lower = [str(m or "").lower() for m in plist]
             plist_stripped = [_strip_vendor(m) for m in plist]
-            if model_lower in plist_lower or _strip_vendor(model_lower) in plist_stripped:
+            # Also consider alias for candidate search
+            if (
+                model_lower in plist_lower
+                or _aliased_model in plist_lower
+                or _strip_vendor(model_lower) in plist_stripped
+                or _aliased_stripped in plist_stripped
+            ):
                 candidates.append(p)
-
-        from difflib import get_close_matches
 
         close = get_close_matches(normalized_model, models, n=3, cutoff=0.6)
         if not close:
-            # Try on stripped forms (handles vendor-prefixed cache entries)
+            # Try on stripped forms (handles vendor-prefixed cache entries).
+            # Build a reverse map that preserves the first original for each
+            # stripped name so duplicate stripped forms don't always map to the
+            # same first entry via .index().
+            _stripped_to_original: dict[str, str] = {}
+            for orig, stripped in zip(models, models_stripped):
+                _stripped_to_original.setdefault(stripped, orig)
             close_stripped = get_close_matches(_strip_vendor(normalized_model), models_stripped, n=3, cutoff=0.6)
-            # Map back to original model names
-            close = []
-            for c in close_stripped:
-                try:
-                    idx = models_stripped.index(c)
-                    close.append(models[idx])
-                except ValueError:
-                    pass
+            close = [_stripped_to_original[c] for c in close_stripped if c in _stripped_to_original]
 
         parts = [f"Model '{normalized_model}' is not available on provider '{normalized_provider}'."]
         if candidates:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1782,6 +1782,173 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def _validate_provider_model_pair(
+    provider: Optional[str],
+    model: Optional[str],
+    base_url: Optional[str],
+    no_agent: bool,
+) -> None:
+    """Validate that a pinned provider+model pair is actually reachable.
+
+    Guards cron creation against the class of bug where a job is pinned to
+    e.g. ``--provider opencode-go --model ox-alpha-free`` but the model is
+    only served on ``opencode-free`` (keyless) — the job would then fail
+    every tick with ``provider authentication error`` and spam the drift
+    alert.  The check is intentionally lenient:
+
+    * Only fires when BOTH provider and model are pinned (single-axis pins
+      follow global config, so there is nothing to validate).
+    * Custom ``base_url`` providers are skipped entirely.
+    * ``no_agent`` jobs have no inference, so they are skipped.
+    * An empty or missing ``provider_models_cache.json`` is treated as
+      “don’t know — don’t block” (best-effort, never a hard gate on a cold
+      cache).  Only a non-empty entry for the requested provider can
+      produce a hard rejection.
+    * When the model is not in the requested provider, the error suggests
+      the correct provider(s) and close name matches (difflib), so the
+      caller can fix the command on the spot.
+    """
+    if bool(no_agent):
+        return
+    if base_url and str(base_url).strip():
+        return
+    normalized_provider = _normalize_job_optional_text(provider)
+    normalized_model = _normalize_job_optional_text(model)
+    if not normalized_provider or not normalized_model:
+        return
+    try:
+        from hermes_cli.models import _load_provider_models_cache, normalize_provider
+
+        cache = _load_provider_models_cache()
+        if not cache:
+            return
+        provider_key = normalize_provider(normalized_provider)
+        # Unknown provider → hard reject with suggestions
+        if provider_key not in cache:
+            known = sorted(cache.keys())
+            from difflib import get_close_matches
+
+            close = get_close_matches(provider_key, known, n=3, cutoff=0.6)
+            msg = f"Unknown provider '{normalized_provider}'."
+            if close:
+                msg += f" Did you mean: {', '.join(close)}?"
+            # Show a short sample of known providers; full list is via `hermes model`
+            sample = ", ".join(known[:8])
+            if len(known) > 8:
+                sample += ", ..."
+            msg += f" Known providers: {sample}."
+            raise ValueError(msg)
+
+        entry = cache.get(provider_key, {})
+        models = entry.get("models", []) if isinstance(entry, dict) else []
+        if not models:
+            return
+
+        def _strip_vendor(m: str) -> str:
+            s = str(m or "").strip().lower()
+            return s.split("/")[-1] if "/" in s else s
+
+        # Alias: ox-alpha-free is the same model as x-preview-f-free on the
+        # free relay (historical naming drift). Treat them as interchangeable
+        # so validation doesn't flip-flop based on which name the cache saw.
+        _alias_map = {
+            "ox-alpha-free": "x-preview-f-free",
+            "ox-alpha": "x-preview-f-free",
+            "x-preview-f-free": "ox-alpha-free",
+        }
+
+        model_lower = normalized_model.lower()
+        models_lower = [str(m or "").lower() for m in models]
+        models_stripped = [_strip_vendor(m) for m in models]
+        # Also consider alias for the requested model
+        _aliased_model = _alias_map.get(model_lower, model_lower)
+        _aliased_stripped = _strip_vendor(_aliased_model)
+
+        # Direct hit (exact, case-insensitive, alias, or vendor-prefix stripped)
+        if (
+            model_lower in models_lower
+            or _aliased_model in models_lower
+            or _strip_vendor(model_lower) in models_stripped
+            or _aliased_stripped in models_stripped
+        ):
+            # Free-tier models must run via the keyless provider; the
+            # authenticated opencode-go relay 401s any bearer it doesn't
+            # recognize (see opencode-free plugin).  Even though the cache
+            # may list e.g. ox-alpha-free on both relays, running it via
+            # opencode-go will fail every tick with "provider authentication
+            # error" and spam the drift alert — the exact bug this guard
+            # exists to prevent.  Detect the cross-wire and suggest the
+            # correct provider.
+            _free_markers = ("-free", ":free", "x-preview")
+            _is_free_model = any(m in model_lower for m in _free_markers) or model_lower in (
+                "ox-alpha-free",
+                "ox-alpha",
+            )
+            if _is_free_model and provider_key == "opencode-go":
+                # Check if opencode-free actually serves this model
+                _free_entry = cache.get("opencode-free", {})
+                _free_models = _free_entry.get("models", []) if isinstance(_free_entry, dict) else []
+                _free_lower = [str(m or "").lower() for m in _free_models]
+                _free_stripped = [_strip_vendor(m) for m in _free_models]
+                if (
+                    model_lower in _free_lower
+                    or _strip_vendor(model_lower) in _free_stripped
+                    or model_lower == "ox-alpha-free"
+                ):
+                    raise ValueError(
+                        f"Model '{normalized_model}' is a free-tier model and must run via provider 'opencode-free' (keyless), "
+                        f"not '{normalized_provider}' (which sends an API key and will 401). "
+                        f"Try: --provider opencode-free --model {normalized_model}"
+                    )
+            return
+
+        # Not in this provider — search which providers DO serve it
+        candidates: list[str] = []
+        for p, ent in cache.items():
+            if not isinstance(ent, dict):
+                continue
+            plist = ent.get("models", [])
+            plist_lower = [str(m or "").lower() for m in plist]
+            plist_stripped = [_strip_vendor(m) for m in plist]
+            if model_lower in plist_lower or _strip_vendor(model_lower) in plist_stripped:
+                candidates.append(p)
+
+        from difflib import get_close_matches
+
+        close = get_close_matches(normalized_model, models, n=3, cutoff=0.6)
+        if not close:
+            # Try on stripped forms (handles vendor-prefixed cache entries)
+            close_stripped = get_close_matches(_strip_vendor(normalized_model), models_stripped, n=3, cutoff=0.6)
+            # Map back to original model names
+            close = []
+            for c in close_stripped:
+                try:
+                    idx = models_stripped.index(c)
+                    close.append(models[idx])
+                except ValueError:
+                    pass
+
+        parts = [f"Model '{normalized_model}' is not available on provider '{normalized_provider}'."]
+        if candidates:
+            candidates_sorted = sorted(set(candidates))
+            parts.append(f"Available on: {', '.join(candidates_sorted)}.")
+            parts.append(f"Try: --provider {candidates_sorted[0]} --model {normalized_model}")
+            if provider_key == "opencode-go" and "opencode-free" in candidates_sorted:
+                parts.append("(opencode-free is keyless; opencode-go requires an API key)")
+            elif provider_key == "opencode-free" and "opencode-go" in candidates_sorted:
+                parts.append("(opencode-go requires an API key; opencode-free is keyless)")
+        else:
+            parts.append(f"Provider '{normalized_provider}' serves {len(models)} models; none match '{normalized_model}'.")
+        if close:
+            parts.append(f"Similar models on '{normalized_provider}': {', '.join(close)}.")
+        raise ValueError(" ".join(parts))
+    except ValueError:
+        raise
+    except Exception:
+        logger.debug("Provider-model validation skipped due to cache error", exc_info=True)
+        return
+
+
 def _validate_job_mode_invariants(
     monitor_script: Optional[str],
     monitor_url: Optional[str],
@@ -1949,6 +2116,12 @@ def create_job(
         normalized_monitor_url,
         normalized_no_agent,
         normalized_script,
+    )
+    _validate_provider_model_pair(
+        normalized_provider,
+        normalized_model,
+        normalized_base_url,
+        normalized_no_agent,
     )
 
     # Normalize context_from: accept str or list of str, store as list or None
@@ -2228,6 +2401,12 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updated["next_run_at"] = updated_next_run
 
             if inference_fields_changed:
+                _validate_provider_model_pair(
+                    updated.get("provider"),
+                    updated.get("model"),
+                    updated.get("base_url"),
+                    bool(updated.get("no_agent")),
+                )
                 provider_snapshot, model_snapshot = _compute_provider_model_snapshots(
                     provider=updated.get("provider"),
                     model=updated.get("model"),

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3573,6 +3573,80 @@ def provider_label(provider: Optional[str]) -> str:
     return _PROVIDER_LABELS.get(normalized, original or "OpenRouter")
 
 
+# ---------------------------------------------------------------------------
+# Cron provider-model validation helpers
+# ---------------------------------------------------------------------------
+# Provider quirks that would otherwise rot in generic cron/jobs.py are
+# centralized here, next to the provider registry they describe. Cron
+# validation stays generic; provider-specific knowledge lives with the
+# provider catalog.
+
+_CRON_MODEL_ALIASES: dict[str, str] = {
+    "ox-alpha-free": "x-preview-f-free",
+    "ox-alpha": "x-preview-f-free",
+    "x-preview-f-free": "ox-alpha-free",
+}
+
+_CRON_FREE_TIER_MARKERS: tuple[str, ...] = ("-free", ":free", "x-preview")
+
+
+def resolve_cron_model_alias(model_id: str) -> str:
+    """Resolve a historical cron model alias to its canonical cache name.
+
+    `ox-alpha-free` and `x-preview-f-free` are the same relay model under
+    two names; the cache may list either. Treat them as interchangeable so
+    validation doesn't flip-flop based on which name was cached.
+    """
+    return _CRON_MODEL_ALIASES.get(str(model_id or "").strip().lower(), str(model_id or "").strip().lower())
+
+
+def is_cron_free_tier_model(model_id: str) -> bool:
+    """Return True if the model is a free-tier variant (keyless relay).
+
+    Free-tier models must run via the keyless `opencode-free` relay; the
+    authenticated `opencode-go` relay 401s any bearer it doesn't recognize.
+    """
+    lower = str(model_id or "").strip().lower()
+    return any(m in lower for m in _CRON_FREE_TIER_MARKERS) or lower in (
+        "ox-alpha-free",
+        "ox-alpha",
+    )
+
+
+def cron_free_tier_alternate_hint(provider: str, model_id: str) -> str | None:
+    """Return a human hint when a free-tier model is pinned to the wrong relay.
+
+    `opencode-go` (authenticated) → `opencode-free` (keyless) is the only
+    cross-wire we currently enforce; other providers are unaffected.
+    """
+    prov = normalize_provider(provider)
+    if prov == "opencode-go" and is_cron_free_tier_model(model_id):
+        return (
+            f"Model '{model_id}' is a free-tier model and must run via provider 'opencode-free' (keyless), "
+            f"not '{provider}' (which sends an API key and will 401). "
+            f"Try: --provider opencode-free --model {model_id}"
+        )
+    return None
+
+
+def is_provider_cache_entry_stale(entry: dict | None) -> bool:
+    """Return True if a provider_models_cache entry is beyond the SWR window.
+
+    Cron validation treats stale entries as \"don't know\" (warning, not hard
+    reject) so a model removed from the cache weeks ago doesn't permanently
+    block job creation until the next live refresh.
+    """
+    if not isinstance(entry, dict):
+        return True
+    at = entry.get("at")
+    if not isinstance(at, (int, float)):
+        return True
+    try:
+        return (time.time() - float(at)) >= _PROVIDER_MODELS_STALE_SERVE_MAX
+    except Exception:
+        return True
+
+
 # Models that support OpenAI Priority Processing (service_tier="priority").
 # See https://openai.com/api-priority-processing/ for the canonical list.
 #

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3613,19 +3613,61 @@ def is_cron_free_tier_model(model_id: str) -> bool:
     )
 
 
-def cron_free_tier_alternate_hint(provider: str, model_id: str) -> str | None:
+def cron_free_tier_alternate_hint(provider: str, model_id: str, cache: dict | None = None) -> str | None:
     """Return a human hint when a free-tier model is pinned to the wrong relay.
 
     `opencode-go` (authenticated) → `opencode-free` (keyless) is the only
-    cross-wire we currently enforce; other providers are unaffected.
+    cross-wire we currently enforce; other providers are unaffected. When
+    `cache` is provided, the hint is only returned if the free relay actually
+    serves the model (and its entry isn't stale) — avoids false positives
+    when the free cache is cold or doesn't list the model.
     """
     prov = normalize_provider(provider)
     if prov == "opencode-go" and is_cron_free_tier_model(model_id):
+        if cache is not None:
+            free_entry = cache.get("opencode-free", {})
+            if not isinstance(free_entry, dict) or is_provider_cache_entry_stale(free_entry):
+                return None
+            # Check if the free relay actually lists the model (alias-aware, vendor-prefix stripped)
+            def _strip(m: str) -> str:
+                s = str(m or "").strip().lower()
+                return s.split("/")[-1] if "/" in s else s
+
+            lower = str(model_id or "").strip().lower()
+            alias = resolve_cron_model_alias(lower)
+            free_models = free_entry.get("models", [])
+            free_lower = [str(m or "").lower() for m in free_models]
+            free_stripped = [_strip(m) for m in free_models]
+            alias_stripped = _strip(alias)
+            if not (
+                lower in free_lower
+                or alias in free_lower
+                or _strip(lower) in free_stripped
+                or alias_stripped in free_stripped
+            ):
+                return None
         return (
             f"Model '{model_id}' is a free-tier model and must run via provider 'opencode-free' (keyless), "
             f"not '{provider}' (which sends an API key and will 401). "
             f"Try: --provider opencode-free --model {model_id}"
         )
+    return None
+
+
+def cron_candidate_hint(provider_key: str, candidates: list[str]) -> str | None:
+    """Return a keyless-vs-API-key hint for the candidate-provider suggestion.
+
+    Centralized here so cron/jobs.py doesn't hardcode provider names. When a
+    model is not on the requested provider but is available elsewhere, and the
+    candidate set spans the keyless/authenticated opencode relays, explain the
+    difference so the user picks the right one.
+    """
+    prov = normalize_provider(provider_key)
+    cand_set = {normalize_provider(c) for c in candidates}
+    if prov == "opencode-go" and "opencode-free" in cand_set:
+        return "(opencode-free is keyless; opencode-go requires an API key)"
+    if prov == "opencode-free" and "opencode-go" in cand_set:
+        return "(opencode-go requires an API key; opencode-free is keyless)"
     return None
 
 

--- a/tests/cron/test_cron_provider_model_guard.py
+++ b/tests/cron/test_cron_provider_model_guard.py
@@ -1,0 +1,132 @@
+"""Tests for cron provider-model validation guard (PR #93132).
+
+Covers the ~165 lines of branching in cron/jobs.py::_validate_provider_model_pair:
+- alias handling (ox-alpha-free ↔ x-preview-f-free)
+- vendor-prefix stripping
+- unknown provider suggestions
+- not-on-provider with candidate search
+- stale/empty cache → don't block
+- free-tier cross-wire (opencode-go + free model → suggest opencode-free)
+"""
+
+import time
+import pytest
+
+from cron.jobs import create_job, update_job, remove_job
+from hermes_cli.models import _load_provider_models_cache, _save_provider_models_cache
+
+
+@pytest.fixture
+def isolated_cache(tmp_path, monkeypatch):
+    """Isolate provider_models_cache to a temp HERMES_HOME so tests don't pollute real cache."""
+    # Patch the cache path to tmp_path
+    import hermes_cli.models as models_mod
+
+    orig_path = models_mod._provider_models_cache_path
+
+    def _tmp_path():
+        return tmp_path / "provider_models_cache.json"
+
+    monkeypatch.setattr(models_mod, "_provider_models_cache_path", _tmp_path)
+    # Also patch cron/jobs.py's import path (it imports from hermes_cli.models at call time, so patching there is enough)
+    yield tmp_path
+    # Cleanup handled by tmp_path fixture
+
+
+def _seed_cache(cache_data):
+    _save_provider_models_cache(cache_data)
+
+
+def test_alias_direct_hit_allows_opencode_free_ox_alpha(isolated_cache):
+    _seed_cache({
+        "opencode-free": {"at": time.time(), "fp": "test", "models": ["x-preview-f-free", "laguna-s-2.1-free"]},
+        "opencode-go": {"at": time.time(), "fp": "test", "models": ["muse-spark-1.2-contributor", "ox-alpha-free"]},
+    })
+    # ox-alpha-free is alias for x-preview-f-free, so opencode-free should allow it
+    job = create_job(prompt="test alias", schedule="every 1h", provider="opencode-free", model="ox-alpha-free")
+    assert job["provider"] == "opencode-free"
+    remove_job(job["id"])
+
+
+def test_unknown_provider_suggests_close_match(isolated_cache):
+    _seed_cache({
+        "opencode-go": {"at": time.time(), "fp": "test", "models": ["muse-spark-1.2-contributor"]},
+        "openai-codex": {"at": time.time(), "fp": "test", "models": ["gpt-5.6-sol"]},
+    })
+    with pytest.raises(ValueError, match="Unknown provider.*Did you mean"):
+        create_job(prompt="test", schedule="every 1h", provider="opencode-goo", model="muse-spark-1.2-contributor")
+
+
+def test_not_on_provider_suggests_correct_provider(isolated_cache):
+    _seed_cache({
+        "opencode-go": {"at": time.time(), "fp": "test", "models": ["muse-spark-1.2-contributor"]},
+        "openai-codex": {"at": time.time(), "fp": "test", "models": ["gpt-5.6-sol", "gpt-5.6-terra"]},
+        "openrouter": {"at": time.time(), "fp": "test", "models": ["openai/gpt-5.6-terra"]},
+    })
+    with pytest.raises(ValueError, match="not available on provider 'opencode-go'.*Available on:.*openai-codex"):
+        create_job(prompt="test", schedule="every 1h", provider="opencode-go", model="gpt-5.6-terra")
+
+
+def test_vendor_prefix_stripping_allows_match(isolated_cache):
+    _seed_cache({
+        "openrouter": {"at": time.time(), "fp": "test", "models": ["openai/gpt-5.6-terra"]},
+    })
+    # Request without vendor prefix should match cache entry with prefix
+    job = create_job(prompt="test", schedule="every 1h", provider="openrouter", model="gpt-5.6-terra")
+    assert job["model"] == "gpt-5.6-terra"
+    remove_job(job["id"])
+
+
+def test_stale_cache_does_not_block(isolated_cache):
+    # Entry older than 7 days (SWR window) should be treated as "don't know"
+    stale_at = time.time() - (8 * 24 * 3600)
+    _seed_cache({
+        "opencode-go": {"at": stale_at, "fp": "test", "models": ["muse-spark-1.2-contributor"]},
+    })
+    # Even though gpt-5.6-terra is not in the stale entry, we should not hard-reject
+    job = create_job(prompt="test stale", schedule="every 1h", provider="opencode-go", model="gpt-5.6-terra")
+    assert job["provider"] == "opencode-go"
+    remove_job(job["id"])
+
+
+def test_empty_cache_does_not_block(isolated_cache):
+    _seed_cache({})
+    job = create_job(prompt="test empty", schedule="every 1h", provider="opencode-go", model="any-model-xyz")
+    assert job["provider"] == "opencode-go"
+    remove_job(job["id"])
+
+
+def test_free_tier_cross_wire_rejects_go_suggests_free(isolated_cache):
+    _seed_cache({
+        "opencode-go": {"at": time.time(), "fp": "test", "models": ["ox-alpha-free", "muse-spark-1.2-contributor"]},
+        "opencode-free": {"at": time.time(), "fp": "test", "models": ["x-preview-f-free", "laguna-s-2.1-free"]},
+    })
+    with pytest.raises(ValueError, match="free-tier model.*must run via provider 'opencode-free'"):
+        create_job(prompt="test", schedule="every 1h", provider="opencode-go", model="ox-alpha-free")
+
+
+def test_single_axis_pin_does_not_validate(isolated_cache):
+    _seed_cache({
+        "opencode-go": {"at": time.time(), "fp": "test", "models": ["muse-spark-1.2-contributor"]},
+    })
+    # Only provider pinned, no model -> should not validate
+    job = create_job(prompt="test", schedule="every 1h", provider="opencode-go", model=None)
+    assert job["provider"] == "opencode-go"
+    remove_job(job["id"])
+    # Only model pinned, no provider -> should not validate
+    job2 = create_job(prompt="test", schedule="every 1h", provider=None, model="gpt-5.6-terra")
+    assert job2["model"] == "gpt-5.6-terra"
+    remove_job(job2["id"])
+
+
+def test_no_agent_and_base_url_skip_validation(isolated_cache):
+    _seed_cache({
+        "opencode-go": {"at": time.time(), "fp": "test", "models": ["muse-spark-1.2-contributor"]},
+    })
+    job = create_job(prompt="test", schedule="every 1h", provider="opencode-go", model="invalid-model-xyz", no_agent=True, script="test.sh")
+    assert job["no_agent"] is True
+    remove_job(job["id"])
+
+    job2 = create_job(prompt="test", schedule="every 1h", provider="opencode-go", model="invalid-model-xyz", base_url="https://my-proxy.example.com/v1")
+    assert job2["base_url"] == "https://my-proxy.example.com/v1"
+    remove_job(job2["id"])


### PR DESCRIPTION
# feat(cron): validate provider-model pairs at create/update time

## Summary

Guards `hermes cron create` / `hermes cron edit` (and the `cronjob` agent tool) against invalid `provider+model` pins that would otherwise fail **every tick** with `provider authentication error` and spam the drift alert.

**Root cause (reported):**  
`Nipas — opencode free loop (d50757d1c660)` was pinned to `--provider opencode-go --model ox-alpha-free`.  
`ox-alpha-free` is only served **keyless** on `opencode-free`; the authenticated `opencode-go` relay 401s any bearer it doesn't recognize. The job failed 3 consecutive runs and spammed `⚠️ provider authentication error`.

**Also guards** the general class: `--provider opencode-go --model gpt-5.6-terra` (model lives on `openai-codex`/`openrouter`), typos like `fake-provider-xyz`, etc.

## Design

New helper `cron/jobs.py::_validate_provider_model_pair()` — **best-effort, never a hard gate on a cold cache**:

- Only fires when **both** `provider` and `model` are pinned (single-axis pins follow global config, nothing to validate).
- **Skips** `no_agent` jobs and custom `base_url` providers.
- Reads the **live** `provider_models_cache.json` populated by `cached_provider_model_ids()` (`/v1/models` per provider, TTL, `fp` fingerprint). An empty/missing cache is treated as "don't know — don't block".
- **Exact, case-insensitive, vendor-prefix stripped** match (`openai/gpt-5.6-terra` ↔ `gpt-5.6-terra`).
- **Alias** `ox-alpha-free ↔ x-preview-f-free` (historical naming drift on the free relay).
- On miss, **searches all providers** for the model and suggests the correct `--provider` (sorted), plus `difflib.get_close_matches` for typos.
- **Free-tier cross-wire**: `*-free`, `:free`, `x-preview` or `ox-alpha-free` pinned to `opencode-go` is rejected even though the cache lists it on both relays — the authenticated relay 401s free models. Suggests `opencode-free` (keyless) with the correct hint.
- Enforced in **both** `create_job` and `update_job` (so the invariant can't be bypassed through the update door), mirroring `_validate_job_mode_invariants`. Raises `ValueError` → surfaced as `Failed to create job: …` (CLI) / `result["error"]` (agent tool) — existing error path, no new plumbing.

## Testing

Manual (live cache, `opencode-go` has 29 models, `openai-codex` has 6):

```bash
hermes cron create --provider opencode-go --model gpt-5.6-terra "every 1h" "test"
# → Failed to create job: Model 'gpt-5.6-terra' is not available on provider 'opencode-go'. Available on: kilocode, openai-codex, openrouter. Try: --provider kilocode --model gpt-5.6-terra Similar models on 'opencode-go': gpt-5.6-luna.

hermes cron create --provider opencode-go --model ox-alpha-free "every 1h" "test"
# → Failed to create job: Model 'ox-alpha-free' is a free-tier model and must run via provider 'opencode-free' (keyless), not 'opencode-go' (which sends an API key and will 401). Try: --provider opencode-free --model ox-alpha-free

hermes cron create --provider opencode-free --model ox-alpha-free "every 1h" "test free"
# → Created job: … (allowed via alias x-preview-f-free)

hermes cron create --provider opencode-go --model muse-spark-1.2-contributor "every 1h" "test valid"
# → Created job: … (allowed)
```

Existing `tests/cron/test_jobs.py` is expected to keep passing — the guard is lenient on empty caches and single-axis pins, and `no_agent`/`base_url` jobs are skipped. No existing test creates a fully-pinned invalid pair against a populated cache.

## Checklist

- [x] No new `HERMES_*` env vars
- [x] No new core model tools
- [x] Error messages are actionable (suggest correct provider + close matches)
- [x] Lenient on cold cache (never blocks when the cache is empty)
- [x] Covered by existing `ValueError` → `Failed to create job` UX (CLI + agent tool)
