### PR TITLE
feat(desktop): submit clarify choices in one click

### DIFF
--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -537,12 +537,21 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           }
 
           if (includesBlockingClarifyTrigger(parsed.messages)) {
-            if (stream) {
-              streamScriptedTurn(res, model, BLOCKING_CLARIFY_TURN)
-            } else {
-              nonStreamingScriptedTurn(res, model, BLOCKING_CLARIFY_TURN)
+            // The trigger remains in history after the user answers. Emit the
+            // blocking prompt only before its tool result, then let the resumed
+            // turn fall through to the normal canned response.
+            const hasToolResult =
+              Array.isArray(parsed.messages) &&
+              parsed.messages.some((message: { role?: string }) => message?.role === 'tool')
+
+            if (!hasToolResult) {
+              if (stream) {
+                streamScriptedTurn(res, model, BLOCKING_CLARIFY_TURN)
+              } else {
+                nonStreamingScriptedTurn(res, model, BLOCKING_CLARIFY_TURN)
+              }
+              return
             }
-            return
           }
 
           if (isQueueStopTrigger) {

--- a/apps/desktop/e2e/one-click-clarify.spec.ts
+++ b/apps/desktop/e2e/one-click-clarify.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * E2E single-select clarify test — one choice click must answer and resume the
+ * turn without a redundant Continue action.
+ */
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { BLOCKING_CLARIFY_QUESTION, BLOCKING_CLARIFY_TRIGGER } from './mock-server'
+import { expect, test } from './test'
+
+let fixture: MockBackendFixture | null = null
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture!, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('single-select clarify submits and settles on the first click', async () => {
+  const page = fixture!.page
+  const composer = page.locator('[contenteditable="true"]').first()
+
+  await composer.waitFor({ state: 'visible', timeout: 10_000 })
+  await composer.click()
+  await composer.type(BLOCKING_CLARIFY_TRIGGER, { delay: 20 })
+  await page.keyboard.press('Enter')
+
+  const card = page.locator('form[data-clarify-choices]')
+
+  await card.getByText(BLOCKING_CLARIFY_QUESTION).waitFor({ state: 'visible', timeout: 60_000 })
+  await expect(card.getByRole('button', { name: /Continue/ })).toHaveCount(0)
+  await card.getByRole('button', { name: /Yes/ }).click()
+
+  const settled = page.locator('[data-clarify-settled]')
+
+  await settled.waitFor({ state: 'visible', timeout: 30_000 })
+  await expect(settled.getByText(BLOCKING_CLARIFY_QUESTION)).toBeVisible()
+  await expect(settled.locator('[data-clarify-answer]')).toHaveText('Yes')
+  await expect(page.locator('form[data-clarify-choices]')).toHaveCount(0)
+})

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -117,22 +117,65 @@ describe('ClarifyTool choice selection', () => {
     })
   })
 
-  it('keeps single-select replacement and plain-string submission', async () => {
+  it('submits a single-select choice on the first click without Continue', async () => {
     const request = renderLiveClarify()
     const staging = screen.getByRole('button', { name: /staging/ })
-    const production = screen.getByRole('button', { name: /production/ })
+
+    expect(screen.queryByRole('button', { name: /Continue/ })).toBeNull()
+    fireEvent.click(staging)
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'staging',
+        request_id: 'request-1'
+      })
+    })
+  })
+
+  it('suppresses a duplicate single-select response from rapid clicks', async () => {
+    const request = renderLiveClarify()
+    const staging = screen.getByRole('button', { name: /staging/ })
 
     fireEvent.click(staging)
-    fireEvent.click(production)
+    fireEvent.click(staging)
 
-    expect(staging.getAttribute('aria-pressed')).toBe('false')
-    expect(production.getAttribute('aria-pressed')).toBe('true')
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1)
+    })
+  })
 
+  it('restores a single-select card when sending the answer fails', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('offline'))
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      multiSelect: false,
+      question: 'Which deployment target?',
+      requestId: 'request-1',
+      sessionId: 'session-1'
+    })
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /staging/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledTimes(1)
+      expect((screen.getByRole('button', { name: /staging/ }) as HTMLButtonElement).disabled).toBe(false)
+    })
+  })
+
+  it('keeps Continue for a typed Other answer', async () => {
+    const request = renderLiveClarify()
+    const other = screen.getByPlaceholderText(/Other/)
+
+    fireEvent.change(other, { target: { value: 'canary' } })
     fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
 
     await waitFor(() => {
       expect(request).toHaveBeenCalledWith('clarify.respond', {
-        answer: 'production',
+        answer: 'canary',
         request_id: 'request-1'
       })
     })
@@ -309,15 +352,17 @@ describe('ClarifyTool keyboard navigation', () => {
     expect(other.closest('label')?.getAttribute('data-highlighted')).toBe('true')
   })
 
-  it('selects by number and confirms the answer with Enter', async () => {
+  it.each([
+    ['2', 'production'],
+    ['a', 'staging']
+  ])('submits a single-select answer directly with shortcut %s', async (key, answer) => {
     const request = renderLiveClarify()
 
-    fireEvent.keyDown(window, { key: '2' })
-    fireEvent.keyDown(window, { key: 'Enter' })
+    fireEvent.keyDown(window, { key })
 
     await waitFor(() => {
       expect(request).toHaveBeenCalledWith('clarify.respond', {
-        answer: 'production',
+        answer,
         request_id: 'request-1'
       })
     })
@@ -390,7 +435,6 @@ describe('ClarifyTool recommended option', () => {
     expect(recommended.querySelector('.text-\\(--ui-text-tertiary\\)')?.textContent).toBe('(Recommended)')
 
     fireEvent.click(recommended)
-    fireEvent.keyDown(window, { key: 'Enter' })
 
     // The decorated string goes back verbatim; the tool strips the label before
     // the agent ever sees the answer.

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -33,6 +33,7 @@ import {
   normalizeChoices,
   RECOMMENDED_LABEL,
   sessionClarifyRequest,
+  setClarifyRequest,
   warnDroppedChoices
 } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
@@ -432,6 +433,7 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
   // trailing index (=== choices.length) is the "Other" free-text row.
   const [activeIndex, setActiveIndex] = useState(0)
   const [otherFocused, setOtherFocused] = useState(false)
+  const submittingRef = useRef(false)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
   // Race: tool.start fires a tick before clarify.request, so request_id
@@ -443,6 +445,10 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
 
   const respond = useCallback(
     async (answer: string) => {
+      if (submittingRef.current) {
+        return
+      }
+
       if (!ready || !matchingRequest) {
         notifyError(new Error(copy.notReady), copy.sendFailed)
 
@@ -455,7 +461,12 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
         return
       }
 
+      submittingRef.current = true
       setSubmitting(true)
+      // The answer is already decided. Clear first so the live card cannot be
+      // clicked again while the RPC is in flight or linger beside its settled
+      // tool row. Restore the exact request if delivery fails.
+      clearClarifyRequest(matchingRequest.requestId, matchingRequest.sessionId)
 
       try {
         await gateway.request<{ ok?: boolean }>('clarify.respond', {
@@ -463,10 +474,11 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
           answer
         })
         triggerHaptic('submit')
-        clearClarifyRequest(matchingRequest.requestId, matchingRequest.sessionId)
         // tool.complete lands next → ClarifyToolSettled.
       } catch (error) {
         notifyError(error, copy.sendFailed)
+        setClarifyRequest(matchingRequest)
+        submittingRef.current = false
         setSubmitting(false)
       }
     },
@@ -474,9 +486,8 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
   )
 
   const trimmedDraft = draft.trim()
-  // The answer is whichever input is active: a picked choice, or typed text.
-  // Picking a choice no longer fires immediately — it selects, then the user
-  // confirms with Continue (or Enter from the field).
+  // The answer is whichever input is active: a staged multi-select choice, a
+  // failed single-select retry, or typed text.
 
   const selectedAnswer = multiSelect
     ? selectedChoices.length > 0
@@ -490,16 +501,20 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
     (choice: string, index: number) => {
       // Picking a choice and typing are mutually exclusive answers.
       setDraft('')
-      setSelectedChoices(selected => {
-        if (!multiSelect) {
-          return [choice]
-        }
+      setActiveIndex(index)
 
+      if (!multiSelect) {
+        setSelectedChoices([choice])
+        void respond(choice)
+
+        return
+      }
+
+      setSelectedChoices(selected => {
         return selected.includes(choice) ? selected.filter(value => value !== choice) : [...selected, choice]
       })
-      setActiveIndex(index)
     },
-    [multiSelect]
+    [multiSelect, respond]
   )
 
   // Keep the cursor in range when the choice set changes (never past "Other").
@@ -582,8 +597,9 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
     [submitAnswer]
   )
 
-  // Arrow keys move a visual cursor, 1-9 and A/B/C… pick directly, and Enter
-  // confirms the current answer (or acts on the highlighted row). Stands down
+  // Arrow keys move a visual cursor, 1-9 and A/B/C… answer a single-select
+  // immediately (or stage a multi-select), and Enter acts on the highlighted
+  // row. Stands down
   // whenever a focusable control (a field, a choice button, the action bar) is
   // focused, so it never eats keystrokes meant for the composer, the Other box,
   // or a button the user tabbed to.
@@ -768,18 +784,20 @@ function ClarifyToolSinglePending({ fromArgs, request }: { fromArgs: ClarifyArgs
         <Button disabled={submitting} onClick={() => void respond('')} size="xs" type="button" variant="text">
           {copy.skip}
         </Button>
-        <Button disabled={submitting || !pendingAnswer} size="xs" type="submit">
-          {submitting ? (
-            <Loader2 className="size-3 animate-spin" />
-          ) : (
-            <>
-              {copy.continueLabel}
-              <span aria-hidden className="ml-0.5 text-[0.625rem] opacity-70">
-                ⏎
-              </span>
-            </>
-          )}
-        </Button>
+        {!hasChoices || multiSelect || Boolean(trimmedDraft) ? (
+          <Button disabled={submitting || !pendingAnswer} size="xs" type="submit">
+            {submitting ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <>
+                {copy.continueLabel}
+                <span aria-hidden className="ml-0.5 text-[0.625rem] opacity-70">
+                  ⏎
+                </span>
+              </>
+            )}
+          </Button>
+        ) : null}
       </div>
     </form>
   )


### PR DESCRIPTION
## Summary

- submit single-select Clarify choices on the first click or direct keyboard shortcut
- keep explicit confirmation for multi-select and typed Other answers
- suppress rapid duplicate responses and restore the card if delivery fails
- add a real Desktop E2E covering click → tool result → resumed turn

## Verification

- `npx vitest run --project ui src/components/assistant-ui/clarify-tool.test.tsx` — 31 passed
- `npx npm@11.8.0 --workspace apps/desktop run typecheck` — passed
- targeted ESLint — no errors
- `npx playwright test e2e/one-click-clarify.spec.ts` — passed
- `npx playwright test e2e/batch-clarify.spec.ts` — passed
- Desktop production build — passed
