### PR TITLE
feat(stt): support cuda:<index> device selection for local whisper

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1779,7 +1779,25 @@ def _load_local_whisper_model(model_name: str, device: str = "auto", compute_typ
         )
         return WhisperModel(model_name, device="cpu", compute_type="int8")
 
+    # ``cuda:<index>`` selects a specific GPU.  ctranslate2 rejects the
+    # index embedded in the device string ("unsupported device cuda:3");
+    # faster-whisper exposes it via the separate ``device_index`` arg.
+    device_index: Optional[int] = None
+    if isinstance(device, str) and device.startswith("cuda:"):
+        try:
+            device_index = int(device.rsplit(":", 1)[1])
+        except ValueError:
+            raise ValueError(
+                f"Invalid STT device {device!r} — use 'cuda' or 'cuda:<index>'"
+            ) from None
+        device = "cuda"
+
     try:
+        if device_index is not None:
+            return WhisperModel(
+                model_name, device=device, device_index=device_index,
+                compute_type=compute_type,
+            )
         return WhisperModel(model_name, device=device, compute_type=compute_type)
     except Exception as exc:
         if not _looks_like_cuda_lib_error(exc):


### PR DESCRIPTION
## Summary

Local whisper STT (`stt.local`) could not target a specific GPU: `stt.local.device` only accepted `auto`/`cpu`/`cuda`, and ctranslate2 rejects a device index embedded in the device string (`"unsupported device cuda:3"`). On multi-GPU hosts `auto` always resolves to GPU 0, which hangs indefinitely when GPU 0 is saturated by another workload (e.g. a local inference server) — the transcript never returns and the desktop app eventually times out on the whole backend connection.

## Changes

- `tools/transcription_tools.py` — `_load_local_whisper_model` now parses a `cuda:<index>` device value and passes the index through faster-whisper's separate `device_index` argument (the form ctranslate2 actually accepts).
- Invalid indices (`cuda:abc`) raise a clear `ValueError` naming the expected syntax, instead of a cryptic ctranslate2 error.
- `cuda`, `cpu` and `auto` behave exactly as before; the existing CPU fallback on CUDA library errors still applies.

## Verification

- `bash scripts/run_tests.sh tests/tools/test_transcription_tools.py tests/tools/test_pre_transcription_hook.py` → 72 passed, 0 failed, 2 skipped.
- Live E2E on a 4x RTX PRO 6000 host with `stt.local.device: cuda:3` / `float16` / `language: pl`: medium model transcribed a 11.9 s clip in ~2.6 s; nvidia-smi showed VRAM rising only on GPU 3 during decode (GPUs 0-2 unchanged).
