### PR TITLE
test(desktop): forbid focused Playwright tests in CI

### DIFF
--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
    * per test gives us headroom without masking real hangs. */
   timeout: 90_000,
   retries: process.env.CI ? 1 : 0,
+  forbidOnly: !!process.env.CI,
   /* Each test gets its own worker so the Electron process is fully isolated. */
   fullyParallel: false,
   reporter: reporters,


### PR DESCRIPTION
Fixes #93142

Desktop Playwright CI currently allows committed `test.only` / `describe.only` markers, which can make a partial suite report green.

This keeps local developer behavior unchanged while making CI fail closed on exclusive test markers by setting `forbidOnly: !!process.env.CI` in the shared Playwright config.

Scope:
- one-line Playwright config change
- no E2E behavior changes outside CI
- no unrelated formatting or dependency updates

Validation:
- branch is based on current upstream `main` (`0159b51f2b1cdaa8fcf65d181fc0527692724fae`)
- final diff is exactly 1 file / +1 line
- duplicate check immediately before opening found no existing PR for #93142

I could not run the temporary uncommitted `test.only` smoke test from this connector-only environment; hosted CI should exercise the config on the PR head.