### PR TITLE
fix(tui): settle execFileNoThrow on timeout even when a daemon holds stdio

### DIFF
--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.test.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.test.ts
@@ -65,19 +65,26 @@ afterEach(() => {
 })
 
 describe.skipIf(onWindows)('execFileNoThrow with daemon-style children', () => {
-  // Skipped because the bug it documents is a forever-hang. Without
-  // resolveOnExit, the 'close' event doesn't fire when the immediate
-  // child has exited but a forked daemon still holds stdio open. Even
-  // SIGTERM at the timeout doesn't help — the daemon survives it. To
-  // verify by hand: remove `it.skip` and watch the test timeout. This
-  // test is here so a reviewer reading the resolveOnExit option knows
-  // *why* every clipboard-tool spawn in osc.ts wires it on.
-  it.skip('(documented hang) without resolveOnExit, await never resolves when daemon inherits stdio', async () => {
+  // Formerly a documented forever-hang: without resolveOnExit, the 'close'
+  // event doesn't fire when the immediate child has exited but a forked
+  // daemon still holds stdio open, and even the SIGTERM at timeout used to
+  // leave the promise unsettled (#93134). The unconditional settle(124) in
+  // the timeout handler now guarantees the await resolves with 124.
+  // The daemon script's sleeper lives 30s so it genuinely outlives the
+  // timeout (and vitest's own 5s test timeout — before the fix this test
+  // fails by timing out, not by asserting).
+  it('settles with code=124 on timeout when a daemon inherits stdio and resolveOnExit is off', async () => {
     const pidFile = join(scriptDir, 'sleeper-skip.pid')
-    const result = await execFileNoThrow(daemonScript, [pidFile], { timeout: 300 })
+    const longDaemonScript = join(scriptDir, 'fake-daemonizer-long.sh')
+    writeFileSync(longDaemonScript, '#!/bin/sh\nsleep 30 &\necho $! > "$1"\nexit 0\n')
+    chmodSync(longDaemonScript, 0o755)
+    const start = Date.now()
+
+    const result = await execFileNoThrow(longDaemonScript, [pidFile], { timeout: 300 })
     trackSleeperPid(pidFile)
 
     expect(result.code).toBe(124)
+    expect(Date.now() - start).toBeLessThan(2000)
   })
 
   it("settles immediately on 'exit' when resolveOnExit is true, regardless of daemon stdio", async () => {

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -69,12 +69,14 @@ export function execFileNoThrow(
           timedOut = true
           child.kill('SIGTERM')
 
-          // When resolving on exit, SIGTERM-ing a child that has already
-          // exited is a no-op and `'exit'` won't fire again — settle here
-          // so the promise doesn't leak. Safe under settled-guard.
-          if (options.resolveOnExit) {
-            settle(124)
-          }
+          // Settle unconditionally: SIGTERM-ing the child does not
+          // guarantee 'close'/'exit' will fire. In the default
+          // (non-resolveOnExit) path a daemonized grandchild that
+          // inherited the stdio pipes keeps them open forever, so
+          // 'close' never fires and the promise leaked (#93134).
+          // The settled-guard makes this a no-op when the child's own
+          // 'exit'/'close' won the race.
+          settle(124)
         }, options.timeout)
       : null
 


### PR DESCRIPTION
## What does this PR do?

Guarantees `execFileNoThrow()`'s returned promise settles on timeout in the default (non-`resolveOnExit`) path, fixing a forever-hang on the TUI clipboard path.

Today the timeout handler only calls `settle(124)` when `resolveOnExit: true`. The default path waits for the child's `'close'` event, which requires **every** inherited stdio handle to close — so when a spawned tool forks a daemonized grandchild that keeps the pipes open (the exact scenario `resolveOnExit` was added for, e.g. `wl-copy`-style double-forks), `'close'` never fires, and the timeout's SIGTERM only reaches the direct child, leaving the grandchild alive and the **promise pending forever**. The production clipboard path (`setClipboard()` → `tmuxLoadBuffer()` → the `osc.ts` spawn that does not pass `resolveOnExit`) hits exactly this shape (#93134). The repo already carried an `it.skip`'d regression test documenting the hang.

The fix: call `settle(124)` unconditionally in the timeout handler. The existing `settled`-guard makes it a no-op when the child's own `'exit'`/`'close'` won the race — normal timeout behavior is byte-for-byte unchanged — and in the daemon case it becomes the only exit, returning the same `124` the `'close'` path would have produced.

## Related Issue

Fixes #93134

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts` — the timeout handler now settles with `124` unconditionally instead of only under `resolveOnExit`; comment explains the daemon-grandchild mechanics.
- `ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.test.ts` — un-skipped the documented-hang regression test and hardened it: the daemon script's sleeper now lives 30s so it genuinely outlives the timeout and vitest's own 5s test timeout (before the fix the test fails by timing out, exactly as the old skip-comment predicted), plus an elapsed bound (<2s) pinning the settle to the timeout, not the sleeper's death.

## How to Test

`cd ui-tui && npx vitest run packages/hermes-ink/src/utils/execFileNoThrow.test.ts` — should pass (5 tests).

Observed result: with the fix, all 5 pass in ~1.3s. With the source change stashed (fix reverted, hardened test kept), the new test fails by hitting vitest's 5s test timeout — the never-settling hang the old `it.skip` documented — while the other 4 tests still pass.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (timeout/grandchild-stdio mechanics in both files)
- [x] Tests added that prove the fix works (un-skipped + hardened regression test)
- [x] New and existing unit tests pass locally (5/5)
- [x] Platform: macOS (POSIX daemonization; suite already `skipIf(onWindows)`)
