### PR TITLE
fix(curator): report pin failures instead of false success and surface pinned unmanaged skills

### DIFF
--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -295,7 +295,13 @@ def _cmd_pin(args) -> int:
             "(only agent-created skills participate in curation)"
         )
         return 1
-    skill_usage.set_pinned(args.skill, True)
+    if not skill_usage.set_pinned(args.skill, True):
+        print(
+            f"curator: could not pin '{args.skill}' — the skill is not "
+            "curation-eligible (protected built-in or external). "
+            f"`hermes curator status` shows why a skill is unmanaged."
+        )
+        return 1
     print(f"curator: pinned '{args.skill}' (will bypass auto-transitions)")
     return 0
 

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -299,7 +299,7 @@ def _cmd_pin(args) -> int:
         print(
             f"curator: could not pin '{args.skill}' — the skill is not "
             "curation-eligible (protected built-in or external). "
-            f"`hermes curator status` shows why a skill is unmanaged."
+            "`hermes curator list-unmanaged` shows which skills the curator tracks."
         )
         return 1
     print(f"curator: pinned '{args.skill}' (will bypass auto-transitions)")
@@ -314,7 +314,12 @@ def _cmd_unpin(args) -> int:
             "there's nothing to unpin (curator only tracks agent-created skills)"
         )
         return 1
-    skill_usage.set_pinned(args.skill, False)
+    if not skill_usage.set_pinned(args.skill, False):
+        print(
+            f"curator: could not unpin '{args.skill}' — the skill is not "
+            "curation-eligible (protected built-in or external)."
+        )
+        return 1
     print(f"curator: unpinned '{args.skill}'")
     return 0
 

--- a/tests/hermes_cli/test_curator_pin_visibility.py
+++ b/tests/hermes_cli/test_curator_pin_visibility.py
@@ -1,0 +1,193 @@
+"""Regression tests for issue #92993 — `curator pin` false success + invisible pin.
+
+Two stacked defects, each with its own failing assertion:
+
+1. **False success (write-path).** `_cmd_pin` gates on `is_agent_created()`
+   and then prints "pinned" unconditionally, but `set_pinned()` routes through
+   `_mutate(require_curation_eligible=True)`, which silently no-ops when
+   `is_curation_eligible()` is False. A skill can pass the first gate and fail
+   the second; the user sees "pinned" while nothing was written. The CLI must
+   detect the failed write and exit nonzero with a clear error.
+
+2. **Invisible pin (visibility).** `curator status` reads pins from
+   `curated_report()`, which only iterates `list_agent_created_skill_names()` —
+   and that list requires the `created_by: agent` management marker. A skill
+   that IS curation-eligible but carries no marker (pre-provenance record,
+   foreground-created) never appears as a row, so its pin is silently absent
+   from the status output even when successfully written.
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+from argparse import Namespace
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_skill(skills_dir: Path, name: str):
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: x\n---\n", encoding="utf-8",
+    )
+    return d
+
+
+class _Args:
+    def __init__(self, skill: str):
+        self.skill = skill
+
+
+@pytest.fixture
+def pin_env(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with freshly reloaded modules (same pattern as
+    tests/agent/test_curator.py::curator_env but scoped for the CLI layer)."""
+    home = tmp_path / ".hermes"
+    skills = home / "skills"
+    skills.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    from tools import skill_usage
+    importlib.reload(skill_usage)
+    # curator module reads config through its own loader; keep defaults.
+    from agent import curator
+    importlib.reload(curator)
+    monkeypatch.setattr(curator, "_load_config", lambda: {})
+    monkeypatch.setattr(skill_usage, "_prune_builtins_enabled", lambda: False)
+    from hermes_cli import curator as curator_cli
+    importlib.reload(curator_cli)
+
+    yield {
+        "home": home,
+        "skills": skills,
+        "usage": skill_usage,
+        "cli": curator_cli,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — pin must fail loudly when the write does not land
+# ---------------------------------------------------------------------------
+
+
+def test_pin_fails_loudly_when_write_does_not_land(pin_env, capsys):
+    """A skill that passes `is_agent_created()` but fails
+    `is_curation_eligible()` must produce a NONZERO exit and an explanatory
+    error — not a success message over a silent no-write.
+
+    Real trigger: PROTECTED_BUILTIN_SKILLS blocks by NAME. A user's own skill
+    literally named ``plan`` is not in the bundled manifest, so
+    ``is_agent_created()`` says True — but ``is_protected_builtin()`` makes it
+    ineligible, and ``set_pinned()`` silently no-ops through
+    ``_mutate(require_curation_eligible=True)``."""
+    env = pin_env
+    name = "plan"  # collides with the protected built-in name
+
+    _make_skill(env["skills"], name)
+
+    # Sanity: the two gates genuinely disagree for this skill.
+    assert env["usage"].is_agent_created(name) is True
+    assert env["usage"].is_curation_eligible(name) is False
+
+    cli = env["cli"]
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli._cmd_pin(_Args(name))
+    out = buf.getvalue()
+
+    # The bug: rc == 0 with "pinned" printed although nothing was written.
+    assert rc != 0, (
+        f"_cmd_pin reported success (rc=0, output={out!r}) for a skill whose "
+        "pin write silently did not land — this is the false-success defect."
+    )
+    # Record on disk must NOT claim a pin.
+    rec = env["usage"].get_record(name)
+    assert not rec.get("pinned"), "usage record claims pinned=true despite failed eligibility"
+    # Error output must explain the refusal, not just fail quietly.
+    assert "pin" in out.lower(), "refusal must mention the pin outcome"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — successful pin on eligible-but-unmanaged skill must be VISIBLE
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_eligible_unmanaged_skill_visible_in_status(pin_env):
+    """A curation-ELIGIBLE skill without the created_by marker (foreground-
+    created / pre-provenance) can be pinned successfully — and once pinned,
+    it MUST surface in `curator status` output. Before the fix it vanishes:
+    curated_report() skips it because list_agent_created_skill_names()
+    requires the management marker."""
+    env = pin_env
+    usage = env["usage"]
+    cli = env["cli"]
+
+    _make_skill(env["skills"], "legacy-skill")
+    # No mark_agent_created() call — deliberately unmanaged-but-eligible.
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli._cmd_pin(_Args("legacy-skill"))
+    out = buf.getvalue()
+
+    # The pin itself should succeed for an eligible skill...
+    if rc == 0:
+        rec = usage.get_record("legacy-skill")
+        assert rec.get("pinned") is True, "eligible skill pin wrote nothing despite rc=0"
+
+        # ...and then status MUST show it. This is the visibility half.
+        buf2 = io.StringIO()
+        with redirect_stdout(buf2):
+            status_rc = cli._cmd_status(Namespace())
+        assert status_rc == 0
+        status = buf2.getvalue()
+        assert "legacy-skill" in status and "pinned" in status.lower(), (
+            "pin landed on disk but the skill is absent from `curator status` "
+            "— the invisible-pin defect."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — regression guard: normal managed pin still works end to end
+# ---------------------------------------------------------------------------
+
+
+def test_pin_managed_skill_end_to_end(pin_env):
+    """The happy path must stay green: a properly adopted (managed) skill
+    pins, reports success, and shows in status. Guards against fixing the
+    two defects by breaking legitimate pins."""
+    env = pin_env
+    usage = env["usage"]
+    cli = env["cli"]
+
+    _make_skill(env["skills"], "managed-skill")
+    usage.mark_agent_created("managed-skill")
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = cli._cmd_pin(_Args("managed-skill"))
+    assert rc == 0, "managed skill pin must succeed"
+    assert "pinned" in buf.getvalue().lower()
+
+    assert usage.get_record("managed-skill").get("pinned") is True
+
+    buf2 = io.StringIO()
+    with redirect_stdout(buf2):
+        assert cli._cmd_status(Namespace()) == 0
+    status = buf2.getvalue()
+    assert "managed-skill" in status
+    assert "pinned" in status.lower(), (
+        "managed+pinned skill missing from the pinned list in status output"
+    )

--- a/tests/hermes_cli/test_curator_pin_visibility.py
+++ b/tests/hermes_cli/test_curator_pin_visibility.py
@@ -142,21 +142,23 @@ def test_pinned_eligible_unmanaged_skill_visible_in_status(pin_env):
         rc = cli._cmd_pin(_Args("legacy-skill"))
     out = buf.getvalue()
 
-    # The pin itself should succeed for an eligible skill...
-    if rc == 0:
-        rec = usage.get_record("legacy-skill")
-        assert rec.get("pinned") is True, "eligible skill pin wrote nothing despite rc=0"
+    # The pin MUST succeed for an eligible skill — unconditional, so a
+    # regression that flips pin to failure fails here instead of silently
+    # skipping the visibility assertions below.
+    assert rc == 0, f"eligible-skill pin must succeed (got rc={rc}): {out.strip()}"
+    rec = usage.get_record("legacy-skill")
+    assert rec.get("pinned") is True, "eligible skill pin wrote nothing despite rc=0"
 
-        # ...and then status MUST show it. This is the visibility half.
-        buf2 = io.StringIO()
-        with redirect_stdout(buf2):
-            status_rc = cli._cmd_status(Namespace())
-        assert status_rc == 0
-        status = buf2.getvalue()
-        assert "legacy-skill" in status and "pinned" in status.lower(), (
-            "pin landed on disk but the skill is absent from `curator status` "
-            "— the invisible-pin defect."
-        )
+    # ...and then status MUST show it. This is the visibility half.
+    buf2 = io.StringIO()
+    with redirect_stdout(buf2):
+        status_rc = cli._cmd_status(Namespace())
+    assert status_rc == 0
+    status = buf2.getvalue()
+    assert "legacy-skill" in status and "pinned" in status.lower(), (
+        "pin landed on disk but the skill is absent from `curator status` "
+        "— the invisible-pin defect."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -1024,10 +1024,14 @@ def set_state(skill_name: str, state: str) -> None:
         _emit_skill_lifecycle(skill_name, action, record=facts)
 
 
-def set_pinned(skill_name: str, pinned: bool) -> None:
-    def _apply(rec: Dict[str, Any]) -> None:
+def set_pinned(skill_name: str, pinned: bool) -> bool:
+    """Set/clear the pin flag. Returns False when the write did not land
+    (skill not curation-eligible), True on success — so callers can report
+    failure instead of a false success (issue #92993)."""
+    def _apply(rec: Dict[str, Any]) -> Any:
         rec["pinned"] = bool(pinned)
-    _mutate(skill_name, _apply, require_curation_eligible=True)
+        return True  # non-None sentinel: _mutate propagates the mutator result
+    return bool(_mutate(skill_name, _apply, require_curation_eligible=True))
 
 
 def set_sync(skill_name: str, sync: bool) -> None:
@@ -1296,7 +1300,14 @@ def curated_report() -> List[Dict[str, Any]]:
     """
     data = load_usage()
     rows: List[Dict[str, Any]] = []
-    for name in list_agent_created_skill_names():
+    names = set(list_agent_created_skill_names())
+    # Issue #92993: a successfully pinned skill must be visible in the report
+    # even when it lacks the created_by marker (eligible-but-unmanaged), or
+    # its pin silently vanishes from `curator status`.
+    for name, rec in data.items():
+        if isinstance(rec, dict) and rec.get("pinned") and is_curation_eligible(name):
+            names.add(name)
+    for name in sorted(names):
         raw = data.get(name)
         persisted = isinstance(raw, dict)
         rec: Dict[str, Any] = raw if isinstance(raw, dict) else _empty_record()

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -1303,9 +1303,16 @@ def curated_report() -> List[Dict[str, Any]]:
     names = set(list_agent_created_skill_names())
     # Issue #92993: a successfully pinned skill must be visible in the report
     # even when it lacks the created_by marker (eligible-but-unmanaged), or
-    # its pin silently vanishes from `curator status`.
+    # its pin silently vanishes from `curator status`. The local-dir guard
+    # keeps stale records for deleted skill dirs from rendering as ghost rows;
+    # `curator unpin` is the cleanup path for those.
     for name, rec in data.items():
-        if isinstance(rec, dict) and rec.get("pinned") and is_curation_eligible(name):
+        if (
+            isinstance(rec, dict)
+            and rec.get("pinned")
+            and is_curation_eligible(name)
+            and _find_skill_dir(name) is not None
+        ):
             names.add(name)
     for name in sorted(names):
         raw = data.get(name)


### PR DESCRIPTION
Fixes #92993

## Summary

`hermes curator pin <skill>` reported success even when the underlying write never landed, and pins on curation-eligible-but-unmanaged skills never appeared in `curator status`. This fixes both behavioral defects.

Related: #93002 addresses the *messaging* half of the same issue (what the command says on the unmanaged path). This PR fixes the *behavioral* half it does not cover. Whichever lands second will need a small rebase in `_cmd_pin`; both together close #92993 completely.

## Changes

| File | Change |
|------|--------|
| `tools/skill_usage.py` | `set_pinned()` now returns `bool`: True when the write landed, False when `_mutate` no-opped (skill not curation-eligible) or the save failed |
| `hermes_cli/curator.py` | `_cmd_pin` checks that return and exits 1 with an explanation instead of printing a false "pinned" |
| `tools/skill_usage.py` | `curated_report()` also surfaces records that carry `pinned: true` and pass `is_curation_eligible()`, even without the `created_by: agent` marker — a successful pin can no longer vanish from `curator status` |

## How to test

```bash
# 1. Unmanaged skill: pin must now be visible
mkdir -p ~/.hermes/skills/my-skill && printf -- '---\nname: my-skill\ndescription: x\n---\n' > ~/.hermes/skills/my-skill/SKILL.md
hermes curator list-unmanaged            # my-skill listed as (no marker)
hermes curator pin my-skill              # pinned
hermes curator status | grep my-skill    # NOW listed under "pinned" (was absent before)

# 2. Refusal path: protected/external skills exit 1 instead of false success
hermes curator pin ""                    # exit 1
```

## Verification

```
pytest tests/hermes_cli/test_curator_pin_visibility.py -v   → 3 passed
pytest tests/hermes_cli/test_curator_status.py \
       tests/hermes_cli/test_curator_usage.py -q            → 5 passed
pytest tests/agent/test_curator.py -q                       → 28 passed
pytest tests/hermes_cli/test_curator_archive_prune.py \
       tests/agent/test_curator_reports.py -q               → 5 passed
```

Plus real-CLI end-to-end runs against an isolated `HERMES_HOME`: pin → record written (`pinned: true` on disk) and visible in status; unpin roundtrip; refusal paths exit nonzero.

Tested on Pop!_OS 24.04, Python 3.11.
