### PR TITLE
feat(bot-mode): push-notified relay drain with poll backstop (#93091)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1388,6 +1388,10 @@ let relayRosterBusy = false
 let relayDrainBusy = false
 let relayPushUnsub = null
 let relayPushDebounceTimer = null
+// A push landing while a drain is ALREADY running would be lost forever —
+// the gateway signature is monotone (one event per new envelope, never
+// re-broadcast) — so remember it and re-schedule after the drain finishes.
+let relayDrainRerun = false
 
 /** One representative route per reachable connection id. */
 async function relayConnections() {
@@ -1514,7 +1518,16 @@ async function syncRelayRosters() {
  *  connection's own socket; the reply (or error) is posted back to the
  *  sender gateway for its waiter. */
 async function drainRelayOutboxes() {
-  if (relayDisposed || relayDrainBusy) {
+  if (relayDisposed) {
+    return
+  }
+
+  if (relayDrainBusy) {
+    // A push signal raced an in-flight drain. The gateway never re-sends it
+    // (monotone signature), so without this flag the envelope would wait out
+    // the full poll interval — exactly the latency the push path removes.
+    relayDrainRerun = true
+
     return
   }
 
@@ -1582,6 +1595,13 @@ async function drainRelayOutboxes() {
     }
   } finally {
     relayDrainBusy = false
+
+    if (relayDrainRerun && !relayDisposed) {
+      // Envelopes signaled mid-drain: schedule one follow-up pass (debounced)
+      // instead of leaving them to the interval poll.
+      relayDrainRerun = false
+      scheduleRelayPushDrain()
+    }
   }
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1651,6 +1651,9 @@ function startBotRelay() {
 
 function stopBotRelay() {
   relayDisposed = true
+  // A rerun remembered mid-drain must not leak into the next start —
+  // it would fire one stale drain after restart.
+  relayDrainRerun = false
 
   if (relayRosterTimer !== null) {
     clearInterval(relayRosterTimer)

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1376,11 +1376,18 @@ function handleSessionsGatewayTransition() {
 // relay degrades to whatever subset of connections supports it.
 const RELAY_ROSTER_INTERVAL_MS = 60_000
 const RELAY_DRAIN_INTERVAL_MS = 4_000
+// Push path (#93091): the gateway broadcasts `bot_relay.outbox.pending` when
+// an envelope lands on disk; a burst of signals inside this window collapses
+// to ONE drain. The interval poll above stays as the backstop for older
+// backends (and connections whose events don't reach the tap).
+const RELAY_PUSH_DEBOUNCE_MS = 250
 let relayDisposed = false
 let relayRosterTimer = null
 let relayDrainTimer = null
 let relayRosterBusy = false
 let relayDrainBusy = false
+let relayPushUnsub = null
+let relayPushDebounceTimer = null
 
 /** One representative route per reachable connection id. */
 async function relayConnections() {
@@ -1578,6 +1585,23 @@ async function drainRelayOutboxes() {
   }
 }
 
+/** Push-notified drain (#93091): collapse a burst of pending signals into
+ *  one drain call ~RELAY_PUSH_DEBOUNCE_MS after the first signal. */
+function scheduleRelayPushDrain() {
+  if (relayDisposed || typeof setTimeout !== 'function') {
+    return
+  }
+
+  if (relayPushDebounceTimer !== null) {
+    return
+  }
+
+  relayPushDebounceTimer = setTimeout(() => {
+    relayPushDebounceTimer = null
+    void drainRelayOutboxes()
+  }, RELAY_PUSH_DEBOUNCE_MS)
+}
+
 function startBotRelay() {
   relayDisposed = false
 
@@ -1595,6 +1619,14 @@ function startBotRelay() {
   if (relayDrainTimer === null) {
     relayDrainTimer = setInterval(() => void drainRelayOutboxes(), RELAY_DRAIN_INTERVAL_MS)
   }
+
+  // Push path: the gateway change watcher broadcasts when an envelope hits
+  // the outbox; drain immediately (debounced) instead of waiting the poll
+  // out. Feature-detected — older shells have no host.onEvent — and the 4s
+  // poll above stays untouched as the backstop either way.
+  if (relayPushUnsub === null && typeof host.onEvent === 'function') {
+    relayPushUnsub = host.onEvent('bot_relay.outbox.pending', () => scheduleRelayPushDrain())
+  }
 }
 
 function stopBotRelay() {
@@ -1608,6 +1640,20 @@ function stopBotRelay() {
   if (relayDrainTimer !== null) {
     clearInterval(relayDrainTimer)
     relayDrainTimer = null
+  }
+
+  if (relayPushDebounceTimer !== null) {
+    clearTimeout(relayPushDebounceTimer)
+    relayPushDebounceTimer = null
+  }
+
+  if (relayPushUnsub !== null) {
+    try {
+      relayPushUnsub()
+    } catch {
+      // Disposer from an older shell shape — never break teardown.
+    }
+    relayPushUnsub = null
   }
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/relay-push-drain.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/relay-push-drain.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Push-notified relay drain (#93091, motivated by #92760 slow replies): the
+// gateway broadcasts `bot_relay.outbox.pending` when an envelope lands in the
+// outbox; the plugin drains immediately instead of waiting out the 4s poll.
+// Contracts:
+// - a burst of signals inside RELAY_PUSH_DEBOUNCE_MS collapses to ONE drain;
+// - after the debounce fires, a later signal schedules a fresh drain;
+// - the subscription is feature-detected (host.onEvent) and disposed, and the
+//   4s interval poll remains untouched as the backstop.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadScheduler() {
+  const start = pluginSource.indexOf('function scheduleRelayPushDrain(')
+  const end = pluginSource.indexOf('function startBotRelay(', start)
+  assert.ok(start > 0, 'plugin defines scheduleRelayPushDrain')
+  assert.ok(end > start, 'scheduler has a stable source boundary')
+
+  const context = {
+    setTimeout,
+    clearTimeout,
+    relayDisposed: false,
+    relayPushDebounceTimer: null,
+    RELAY_PUSH_DEBOUNCE_MS: 50, // shrunk from 250ms to keep the test fast
+    drainCalls: 0
+  }
+  vm.createContext(context)
+  vm.runInContext(
+    `async function drainRelayOutboxes() { drainCalls += 1 }\n${pluginSource.slice(start, end)}\nglobalThis.scheduleRelayPushDrain = scheduleRelayPushDrain`,
+    context
+  )
+  return context
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+test('a burst of pending signals collapses to one drain', async () => {
+  const ctx = loadScheduler()
+
+  for (let i = 0; i < 6; i += 1) {
+    ctx.scheduleRelayPushDrain()
+  }
+
+  assert.equal(ctx.drainCalls, 0, 'drain waits for the debounce window')
+  await sleep(120)
+  assert.equal(ctx.drainCalls, 1, 'six signals inside the window → one drain')
+})
+
+test('a signal after the window fires a fresh drain', async () => {
+  const ctx = loadScheduler()
+
+  ctx.scheduleRelayPushDrain()
+  await sleep(120)
+  assert.equal(ctx.drainCalls, 1)
+
+  ctx.scheduleRelayPushDrain()
+  ctx.scheduleRelayPushDrain()
+  await sleep(120)
+  assert.equal(ctx.drainCalls, 2)
+})
+
+test('a disposed relay never schedules a drain', async () => {
+  const ctx = loadScheduler()
+  ctx.relayDisposed = true
+
+  ctx.scheduleRelayPushDrain()
+  await sleep(120)
+  assert.equal(ctx.drainCalls, 0)
+})
+
+test('subscription is feature-detected, disposed, and the poll backstop stays', () => {
+  const start = pluginSource.indexOf("host.onEvent('bot_relay.outbox.pending'")
+  assert.ok(start > 0, 'plugin subscribes to bot_relay.outbox.pending')
+  const block = pluginSource.slice(start - 400, start + 400)
+  assert.match(block, /typeof host\.onEvent === 'function'/)
+  assert.match(pluginSource, /relayPushUnsub\(\)/)
+  // The 4s interval poll is untouched — push is an accelerator, not a
+  // replacement (older backends never emit the event).
+  assert.match(pluginSource, /RELAY_DRAIN_INTERVAL_MS = 4_000/)
+  assert.match(pluginSource, /setInterval\(\(\) => void drainRelayOutboxes\(\), RELAY_DRAIN_INTERVAL_MS\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/relay-push-drain.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/relay-push-drain.test.mjs
@@ -83,3 +83,20 @@ test('subscription is feature-detected, disposed, and the poll backstop stays', 
   assert.match(pluginSource, /RELAY_DRAIN_INTERVAL_MS = 4_000/)
   assert.match(pluginSource, /setInterval\(\(\) => void drainRelayOutboxes\(\), RELAY_DRAIN_INTERVAL_MS\)/)
 })
+
+test('a push racing an in-flight drain schedules a follow-up pass instead of dropping', () => {
+  // The gateway signature is monotone — one event per new envelope, never
+  // re-broadcast — so a push swallowed by the relayDrainBusy early-return
+  // would strand its envelope until the poll. The rerun flag re-schedules.
+  const drain = pluginSource.slice(
+    pluginSource.indexOf('async function drainRelayOutboxes'),
+    pluginSource.indexOf('function scheduleRelayPushDrain')
+  )
+  assert.match(drain, /if \(relayDrainBusy\) \{/)
+  assert.match(drain, /relayDrainRerun = true/)
+  // finally block: after busy clears, a remembered push re-schedules once.
+  const finallyBlock = drain.slice(drain.indexOf('} finally {'))
+  assert.match(finallyBlock, /relayDrainBusy = false/)
+  assert.match(finallyBlock, /relayDrainRerun && !relayDisposed/)
+  assert.match(finallyBlock, /scheduleRelayPushDrain\(\)/)
+})

--- a/tests/tui_gateway/test_change_watcher.py
+++ b/tests/tui_gateway/test_change_watcher.py
@@ -24,6 +24,7 @@ def watcher_home(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_change_sigs", {})
     monkeypatch.setattr(server, "_change_checked_at", {})
     monkeypatch.setattr(server, "_change_broadcast_at", {})
+    monkeypatch.setattr(server, "_bot_relay_outbox_seen", 0)
 
     events = []
     monkeypatch.setattr(
@@ -175,6 +176,46 @@ def test_renderable_pet_broadcasts_meta_payload(watcher_home, monkeypatch):
     assert payload["enabled"] is True
     assert payload["slug"] == "boba"
     assert payload["spritesheetRevision"]
+
+
+def test_enqueued_envelope_broadcasts_outbox_pending(watcher_home):
+    """A cross-connection envelope written by the agent process must reach the
+    Desktop's push-triggered drain on its own signal (#93091) — the drain poll
+    is the backstop, not the transport."""
+    home, events = watcher_home
+    outbox = home / "bot_relay" / "outbox"
+    outbox.mkdir(parents=True)
+    server._broadcast_watched_changes(now=0.0)
+
+    (outbox / ("a" * 32 + ".json")).write_text('{"id": "' + "a" * 32 + '"}')
+    server._broadcast_watched_changes(now=10.0)
+
+    assert ("bot_relay.outbox.pending", {}) in events
+
+
+def test_drained_outbox_does_not_rebroadcast_pending(watcher_home):
+    """Signature is monotone: a drain empties outbox/ (rename → claimed/), and
+    that emptying must NOT look like a change — only new envelopes fire."""
+    home, events = watcher_home
+    outbox = home / "bot_relay" / "outbox"
+    outbox.mkdir(parents=True)
+    envelope = outbox / ("b" * 32 + ".json")
+    envelope.write_text("{}")
+    server._broadcast_watched_changes(now=0.0)
+
+    envelope.unlink()  # the Desktop drained it
+    server._broadcast_watched_changes(now=10.0)
+    server._broadcast_watched_changes(now=20.0)
+
+    assert not [e for e in events if e[0] == "bot_relay.outbox.pending"]
+
+
+def test_no_outbox_dir_never_fires_pending(watcher_home):
+    home, events = watcher_home
+    server._broadcast_watched_changes(now=0.0)
+    server._broadcast_watched_changes(now=10.0)
+
+    assert not [e for e in events if e[0] == "bot_relay.outbox.pending"]
 
 
 def test_broken_probe_never_kills_the_pass(watcher_home, monkeypatch):

--- a/tests/tui_gateway/test_change_watcher.py
+++ b/tests/tui_gateway/test_change_watcher.py
@@ -7,6 +7,7 @@ once, the sessions floor coalesces a write burst but keeps its trailing edge,
 and the pet signature only moves for a *renderable* pet.
 """
 
+import os
 import time
 
 import pytest
@@ -208,6 +209,33 @@ def test_drained_outbox_does_not_rebroadcast_pending(watcher_home):
     server._broadcast_watched_changes(now=20.0)
 
     assert not [e for e in events if e[0] == "bot_relay.outbox.pending"]
+
+
+def test_new_envelope_after_drain_fires_pending_again(watcher_home):
+    """The other half of the monotone contract: the watermark must not eat
+    GENUINELY new envelopes. write → drain → write-newer fires twice."""
+    home, events = watcher_home
+    outbox = home / "bot_relay" / "outbox"
+    outbox.mkdir(parents=True)
+    first = outbox / ("c" * 32 + ".json")
+    first.write_text("{}")
+    server._broadcast_watched_changes(now=0.0)
+    first.write_text("{}")  # make the first sighting a change, not a seed
+    server._broadcast_watched_changes(now=10.0)
+
+    first.unlink()  # the Desktop drained it
+    server._broadcast_watched_changes(now=20.0)
+
+    second = outbox / ("d" * 32 + ".json")
+    second.write_text("{}")
+    now_ns = time.time_ns()
+    os.utime(second, ns=(now_ns, now_ns))  # strictly newer than the watermark
+    server._broadcast_watched_changes(now=30.0)
+
+    assert [e for e in events if e[0] == "bot_relay.outbox.pending"] == [
+        ("bot_relay.outbox.pending", {}),
+        ("bot_relay.outbox.pending", {}),
+    ]
 
 
 def test_no_outbox_dir_never_fires_pending(watcher_home):

--- a/tests/tui_gateway/test_change_watcher.py
+++ b/tests/tui_gateway/test_change_watcher.py
@@ -221,6 +221,8 @@ def test_new_envelope_after_drain_fires_pending_again(watcher_home):
     first.write_text("{}")
     server._broadcast_watched_changes(now=0.0)
     first.write_text("{}")  # make the first sighting a change, not a seed
+    bump_ns = first.stat().st_mtime_ns + 1_000_000
+    os.utime(first, ns=(bump_ns, bump_ns))  # strictly newer, FS-independent
     server._broadcast_watched_changes(now=10.0)
 
     first.unlink()  # the Desktop drained it
@@ -228,8 +230,8 @@ def test_new_envelope_after_drain_fires_pending_again(watcher_home):
 
     second = outbox / ("d" * 32 + ".json")
     second.write_text("{}")
-    now_ns = time.time_ns()
-    os.utime(second, ns=(now_ns, now_ns))  # strictly newer than the watermark
+    newer_ns = bump_ns + 1_000_000  # strictly beyond the watermark
+    os.utime(second, ns=(newer_ns, newer_ns))
     server._broadcast_watched_changes(now=30.0)
 
     assert [e for e in events if e[0] == "bot_relay.outbox.pending"] == [

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3936,6 +3936,42 @@ def _pairing_sig():
     return sig
 
 
+# Newest outbox-envelope mtime the watcher has EVER seen (monotone). A drain
+# empties the outbox (rename → claimed/), and letting the signature fall back
+# to None on empty would fire a spurious pending event right after every
+# drain — so the signature only moves forward, on genuinely new envelopes.
+_bot_relay_outbox_seen = 0
+
+
+def _bot_relay_outbox_sig():
+    """Newest mtime across pending bot-relay outbox envelopes (monotone).
+
+    Envelopes are written by the AGENT process (``message_agent`` →
+    ``tools.bot_relay.enqueue_envelope``) — a different process that never
+    touches this gateway's transports — so the files are the only shared
+    signal, exactly like the pairing store. The Desktop reacts to
+    ``bot_relay.outbox.pending`` with an immediate (debounced) drain instead
+    of waiting out its poll interval (#93091, motivated by #92760).
+    """
+    global _bot_relay_outbox_seen
+    home = _watcher_home()
+    root = home.parent.parent if home.parent.name == "profiles" else home
+    newest = 0
+    try:
+        for entry in (root / "bot_relay" / "outbox").iterdir():
+            if not entry.name.endswith(".json"):
+                continue
+            try:
+                newest = max(newest, entry.stat().st_mtime_ns)
+            except OSError:
+                continue
+    except OSError:
+        pass
+    if newest > _bot_relay_outbox_seen:
+        _bot_relay_outbox_seen = newest
+    return _bot_relay_outbox_seen or None
+
+
 # Watched change signals: event → (check interval, signature fn, payload fn).
 # Signatures are stat/dict-lookup cheap, same bar as the skin watcher; the
 # check interval keeps the pricier probes (pet resolves the active sheet off
@@ -3946,6 +3982,9 @@ _CHANGE_WATCHES: dict[str, tuple[float, Any, Any]] = {
     "sessions.changed": (0.5, _sessions_sig, lambda: {}),
     "platforms.changed": (2.0, _platforms_sig, lambda: {}),
     "pairing.changed": (2.0, _pairing_sig, lambda: {}),
+    # Cross-connection DM latency: 1s check so a queued envelope reaches the
+    # Desktop's push-triggered drain fast; the Desktop's poll stays backstop.
+    "bot_relay.outbox.pending": (1.0, _bot_relay_outbox_sig, lambda: {}),
 }
 
 # state.db moves on every message append during a streaming turn, and the


### PR DESCRIPTION
## Summary

Bot-relay delivery is now push-notified instead of pure-polling: the gateway signals the Desktop the moment an envelope lands in the outbox, and the Desktop drains immediately (debounced). The existing interval poll stays as a backstop, so nothing regresses when the push path isn't available. Cuts worst-case per-hop delivery latency from ~4s (poll only) to ~1.25s (1s gateway change-watcher check + 250ms debounce) — the transport half of #92760's "bots reply slowly". The signal rides the existing change-watcher, so no new event mechanism and no watcher thread.

## Changes

- `tui_gateway/server.py` (+39): emits a `bot_relay.outbox.pending` change-watcher event when the outbox gains an envelope, reusing the gateway's existing change-notification channel toward connected clients (no new event mechanism).
- `apps/desktop/src/plugins/hermes-bots/plugin.js` (+46): subscribes to the signal; on receipt runs `drainRelayOutboxes()` behind a ~250ms debounce (bursts collapse to one drain). The `RELAY_DRAIN_INTERVAL_MS` poll timer is unchanged as backstop.
- Tests: `tests/tui_gateway/test_change_watcher.py` (+41) covers signal-on-enqueue / no-signal-otherwise; new `relay-push-drain.test.mjs` covers the debounce (N signals in <250ms ⇒ one drain).

## Validation

| Check | Result |
|---|---|
| tests/tui_gateway/test_change_watcher.py | 14 passed |
| full hermes-bots plugin suite (node --test, incl. new file) | 485 passed, 0 failed |
| node --check plugin.js | clean |
| ruff on changed py files | clean |

Part of #93091; pairs with the leader-routing item (item 4) — this fixes transport latency, that fixes fan-out.
