### PR TITLE
fix(gateway): log why home-channel startup notifications are skipped (#93122)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24472,10 +24472,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for platform, platform_cfg in self.config.platforms.items():
             home = platform_cfg.home_channel
             if not home or not home.chat_id:
+                logger.info(
+                    "Home-channel startup notification skipped: %s has no configured home channel",
+                    platform.value,
+                )
                 continue
 
             transport = resolve_delivery_transport(platform, self.config, self.adapters)
             if transport is None:
+                logger.info(
+                    "Home-channel startup notification skipped: %s home channel %s has no live delivery transport",
+                    platform.value,
+                    home.chat_id,
+                )
                 continue
 
             if not platform_cfg.gateway_restart_notification:

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -413,3 +413,57 @@ async def test_shutdown_notifications_are_fully_muted_when_flag_disabled():
     adapter.send.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_home_channel_startup_notification_logs_when_no_home_channel(
+    tmp_path, monkeypatch, caplog
+):
+    """A platform with no configured home channel logs why it is skipped.
+
+    Regression for #93122: the two early skip branches in
+    ``_send_home_channel_startup_notifications`` were silent, so a missing
+    home channel was indistinguishable from a delivery failure.
+    """
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    # TELEGRAM is configured but has NO home_channel -> first silent branch.
+    runner.config.platforms[Platform.TELEGRAM].home_channel = None
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    with caplog.at_level("INFO", logger="gateway.run"):
+        delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    adapter.send.assert_not_called()
+    assert any("telegram" in rec.message and "home channel" in rec.message.lower()
+               for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_home_channel_startup_notification_logs_when_no_transport(
+    tmp_path, monkeypatch, caplog
+):
+    """A platform with a home channel but no live transport logs why.
+
+    Regression for #93122: when resolve_delivery_transport() returns None the
+    old code skipped silently, hiding the failure.
+    """
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="parent-42",
+        name="Ops",
+    )
+    # No live adapter for TELEGRAM -> resolve_delivery_transport returns None.
+    runner.adapters = {}
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    with caplog.at_level("INFO", logger="gateway.run"):
+        delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    adapter.send.assert_not_called()
+    assert any("telegram" in rec.message and "transport" in rec.message.lower()
+               for rec in caplog.records)


### PR DESCRIPTION
## Problem

Closes #93122

`_send_home_channel_startup_notifications` (gateway/run.py) has two skip
branches that exit **silently**:

1. platform has no configured home channel (`if not home or not home.chat_id`)
2. `resolve_delivery_transport()` returns no live transport

Only the third skip branch — `gateway_restart_notification=false` — logs a
reason. So when a Photon (iMessage) home-channel "♻️ Gateway online"
notification never fires and no "suppressed" line appears, an operator cannot
tell whether the home channel was misconfigured, the transport failed to
resolve, or something else. The reporter reproduced this across a dozen
restarts with zero log output.

## Fix

Add a `logger.info` line to each of the two silent branches, naming the
platform and (for branch 2) the home-channel `chat_id` that had no live
transport. This mirrors the existing `gateway_restart_notification=false`
log, turning an undiagnosable production issue into a two-minute diagnosis.
Logging only — no control-flow or delivery-behavior change.

## Regression test (RED → GREEN)

Two new tests in `tests/gateway/test_restart_notification.py`, one per silent
branch:

- **RED** (before fix): both fail — no diagnostic log record is emitted
  (`assert False` on the log-content check).

```
tests/gateway/test_restart_notification.py:... AssertionError
FAILED test_..._logs_when_no_home_channel
FAILED test_..._logs_when_no_transport
2 failed, 12 deselected in 0.46s
```

- **GREEN** (after fix):

```
tests/gateway/test_restart_notification.py .................. [100%]
14 passed in 0.59s
```

Both new tests assert `delivered == set()` and that no send was attempted,
then verify a log record naming the platform and reason exists.

## Scope / verification

- `gateway/run.py` +9 lines; test file +54 lines (2 files, 63 insertions).
- Full `tests/gateway/` suite: **6073 passed**. The 49 failures are all in
  unrelated modules (telegram/wecom/whatsapp/pidfile/discord etc.) and fail
  identically on pristine `upstream/main` with this minimal test env — they
  are pre-existing missing-optional-dependency failures, not regressions.
- Cross-lineage skeptic review (claude) independently confirmed the tests
  are genuine (reverting the source hunk makes them fail) and approved.
