### PR TITLE
Fix DeepSeek V4 tool-call truncation via default_max_tokens

### DIFF
--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -16,6 +16,18 @@ Moonshot wire shape that DeepSeek's OpenAI-compat endpoint expects:
 Non-thinking models (``deepseek-v3-*`` variants) are left as no-ops so we
 don't perturb the V3 wire format.
 
+The V4 models are reasoning models, and this profile deliberately omits
+``reasoning_effort`` when the user hasn't set one so DeepSeek applies its
+server default (currently *high*).  DeepSeek's OpenAI-compat endpoint in turn
+defaults to a low ``max_tokens`` when the field is omitted — so thinking
+tokens exhaust the completion budget and tool calls are truncated
+(``finish_reason="length"``), which the agent then refuses as an incomplete
+tool call.  ``default_max_tokens=65536`` gives an ample output budget so tool
+calls complete, matching the ``qwen-oauth`` profile's fix for the same
+reasoning-model failure mode (well within V4's 384k output limit and 1M
+context; the ephemeral "max_tokens too large given prompt" path still caps it
+safely against very large prompts).
+
 The legacy aliases ``deepseek-chat`` / ``deepseek-reasoner`` were retired on
 2026-07-24.  Use ``deepseek-v4-flash`` or ``deepseek-v4-pro``; Hermes remaps
 the retired IDs in ``hermes_cli.model_normalize``.
@@ -106,6 +118,10 @@ deepseek = DeepSeekProfile(
     ),
     base_url="https://api.deepseek.com/v1",
     default_aux_model="deepseek-v4-flash",
+    # V4 reasoning models truncate tool calls when max_tokens is omitted —
+    # thinking tokens exhaust DeepSeek's low default cap. Send an ample
+    # budget, mirroring the qwen-oauth profile. See module docstring.
+    default_max_tokens=65536,
 )
 
 register_provider(deepseek)

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -219,5 +219,38 @@ class TestQwenProfile:
         assert "metadata" not in eb
 
 
+class TestDeepSeekProfile:
+    def test_registered(self):
+        p = get_provider_profile("deepseek")
+        assert p is not None
+        assert p.name == "deepseek"
+        assert "deepseek.com" in p.base_url
+
+    def test_default_max_tokens(self):
+        # V4 reasoning models truncate tool calls when max_tokens is omitted;
+        # the profile ships an ample default budget (mirrors qwen-oauth).
+        p = get_provider_profile("deepseek")
+        assert p.default_max_tokens == 65536
+        assert p.get_max_tokens("deepseek-v4-flash") == 65536
+
+    def test_v4_enables_thinking_wire_shape(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="deepseek-v4-flash",
+        )
+        assert eb["thinking"] == {"type": "enabled"}
+        assert tl["reasoning_effort"] == "high"
+
+    def test_v3_is_noop(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="deepseek-v3-0324",
+        )
+        assert eb == {}
+        assert tl == {}
+
+
 
 


### PR DESCRIPTION
## What

Set `default_max_tokens=65536` on the DeepSeek provider profile so V4 tool calls stop truncating.

Fixes #93156.

## Why

DeepSeek V4 (`deepseek-v4-flash` / `-pro`) are reasoning models. The profile intentionally omits `reasoning_effort` when the user hasn't set one, so DeepSeek applies its server default (**high**). But the profile sets no `default_max_tokens`, and in `agent/transports/chat_completions.py` `build_kwargs` the output-cap priority is `ephemeral > user > profile_default > anthropic`. For DeepSeek (OpenAI-compatible, non-Anthropic) with no user `max_tokens` and no profile default, **nothing is sent** — DeepSeek's low default cap applies, high reasoning eats it, and tool calls truncate (`finish_reason="length"`). Hermes then refuses the incomplete tool call, which reliably breaks subagent / `delegate_task` runs that emit large tool-call bodies.

This is the same reasoning-model failure mode already fixed for **`qwen-oauth`** (`default_max_tokens=65536`). DeepSeek is the direct analog and just lacks it.

## Change

- `plugins/model-providers/deepseek/__init__.py`: add `default_max_tokens=65536` (+ docstring/inline explanation).
- `tests/providers/test_provider_profiles.py`: add `TestDeepSeekProfile` — asserts the default cap and `get_max_tokens("deepseek-v4-flash") == 65536`, plus the existing V4-enabled / V3-noop thinking wire shape.

## Notes

- `65536` matches `qwen-oauth` and is well within V4's 384k output limit and 1M context. The ephemeral "max_tokens too large given prompt" path (`parse_available_output_tokens_from_error` + `_ephemeral_max_output_tokens`) still caps it safely against very large prompts.
- No change to V3 models (`get_max_tokens` returns the static field for all models; V3 wire shape is already a no-op and stays that way — covered by the new test).

## Testing

- `TestDeepSeekProfile` (4 assertions) passes.
- Verified end-to-end on `deepseek-v4-flash`: before, a subagent writing a file truncates with `finish_reason="length"` and is abandoned; after sending an explicit `max_tokens`, the same multi-step coding workload (file reads/edits, running Python) completes with no truncation warnings.
- Confirmed `reasoning_effort: low` alone is **not** a sufficient workaround (large tool bodies still exceed the low default cap).
