### PR TITLE
fix(cli): count behind-upstream locally before trusting the compare API

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -301,9 +301,23 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         )
         if ancestor.returncode == 0:
             return 0
-        # Genuinely behind (or diverged). Recover the exact count via the
-        # GitHub compare API; a local-only HEAD 404s there, which safely
-        # degrades to the honest no-count sentinel — never a fabricated 1.
+        # Genuinely behind (or diverged). Prefer the exact LOCAL count when
+        # the objects are present: rev-list from the merge base counts only
+        # the commits strictly after it, which stays correct for a merge
+        # commit whose second parent is an old upstream snapshot — the
+        # GitHub compare API inflates the count there by reporting the total
+        # divergence between the two tips (#93146).
+        merge_base = _git_stdout(["merge-base", "HEAD", upstream_rev], cwd=repo_dir)
+        if merge_base:
+            counted_str = _git_stdout(
+                ["rev-list", "--count", f"{merge_base}..{upstream_rev}"],
+                cwd=repo_dir,
+            )
+            if counted_str and counted_str.strip().isdigit():
+                return int(counted_str.strip())
+        # Local objects unavailable (never fetched) — fall back to the GitHub
+        # compare API; a local-only HEAD 404s there, which safely degrades to
+        # the honest no-count sentinel — never a fabricated 1.
         counted = _github_compare_behind(head_rev, upstream_rev)
         return counted if counted is not None else UPDATE_AVAILABLE_NO_COUNT
 

--- a/tests/hermes_cli/test_banner_git_state.py
+++ b/tests/hermes_cli/test_banner_git_state.py
@@ -87,6 +87,8 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
             return "b" * 40
+        if args == ["merge-base", "HEAD", "a" * 40]:
+            return None  # upstream objects not fetched locally -> API fallback
         raise AssertionError(f"unexpected git call: {args}")
 
     with (
@@ -99,6 +101,48 @@ def test_check_via_local_git_ssh_fastpath_genuinely_behind(tmp_path):
         behind = banner._check_via_local_git(repo_dir)
 
     assert behind == 3
+
+
+def test_check_via_local_git_ssh_prefers_local_count_over_compare_api(tmp_path):
+    """#93146: when the local repo has the upstream objects, the exact local
+    rev-list count wins over the GitHub compare API — the API inflates the
+    count for a merge commit whose second parent is an old upstream snapshot
+    (reported 1567 where the merge-base-anchored count is 5)."""
+    from unittest.mock import MagicMock
+
+    from hermes_cli import banner
+
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".git").mkdir(parents=True)
+    upstream_tip = "a" * 40
+
+    def fake_git_stdout(args, *, cwd, timeout=5):
+        if args == ["remote", "get-url", "origin"]:
+            return "git@github.com:NousResearch/hermes-agent.git"
+        if args == ["rev-parse", "HEAD"]:
+            return "b" * 40
+        if args == ["merge-base", "HEAD", upstream_tip]:
+            return "c" * 40  # old upstream snapshot merged as 2nd parent
+        if args == ["rev-list", "--count", f"{'c' * 40}..{upstream_tip}"]:
+            return "5"
+        raise AssertionError(f"unexpected git call: {args}")
+
+    with (
+        patch.object(banner, "_git_stdout", side_effect=fake_git_stdout),
+        patch.object(banner, "_upstream_main_sha", return_value=upstream_tip),
+        # not an ancestor: the merge's 2nd parent is an OLD upstream tip
+        patch.object(banner.subprocess, "run", return_value=MagicMock(returncode=1)),
+        # The API would report the inflated total divergence (1567 in the
+        # report) — the local count must win without consulting it.
+        patch.object(
+            banner,
+            "_github_compare_behind",
+            side_effect=AssertionError("local count must win over the compare API"),
+        ),
+    ):
+        behind = banner._check_via_local_git(repo_dir)
+
+    assert behind == 5
 
 
 def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
@@ -115,6 +159,8 @@ def test_check_via_local_git_ssh_fastpath_offline_keeps_sentinel(tmp_path):
             return "git@github.com:NousResearch/hermes-agent.git"
         if args == ["rev-parse", "HEAD"]:
             return "b" * 40
+        if args == ["merge-base", "HEAD", "a" * 40]:
+            return None  # upstream objects not fetched locally -> API fallback
         raise AssertionError(f"unexpected git call: {args}")
 
     with (


### PR DESCRIPTION
## What does this PR do?

Fixes an inflated "commits behind upstream" count in the update banner's SSH fast path when HEAD is a merge commit whose second parent is an old upstream snapshot — the standard fork-reconcile shape.

`_check_via_local_git()` decides "genuinely behind" via `git merge-base --is-ancestor <upstream> HEAD`; when that fails it asks the GitHub compare API for the exact count. But for a merge with an old upstream parent, the fresh upstream tip is not an ancestor of HEAD, so the API is consulted — and it returns the **total divergence between the two tips**, not the commits strictly after the merge base. #93146 observed **1567** reported where `git rev-list --count <merge-base>..<upstream>` is **5**.

The fix prefers the exact local count whenever the objects are present: `git merge-base HEAD <upstream>` then `git rev-list --count <merge-base>..<upstream>` — anchored at the merge base, it stays correct for the merge-parent shape. Only when the local repo lacks the upstream objects (never fetched) does the code fall back to the compare API and, failing that, the honest no-count sentinel — both paths unchanged.

## Related Issue

Fixes #93146

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/banner.py` — in `_check_via_local_git()`'s SSH branch, after the not-an-ancestor check, try the local `merge-base` + `rev-list --count` before consulting `_github_compare_behind`; on missing local objects (`merge-base` fails/empty) keep the existing API → sentinel chain untouched.
- `tests/hermes_cli/test_banner_git_state.py` — new regression test replaying the report's shape: merge-base resolves to the old upstream snapshot, local count is 5, and the compare API is asserted to not even be consulted. The two existing SSH-path tests gained a `merge-base -> None` branch in their fakes so they keep exercising the API-fallback semantics they were written for.

## How to Test

`pytest tests/hermes_cli/test_banner_git_state.py -q` — should pass (6 tests).

Observed result: with the fix, all 6 pass. With the banner.py change stashed (fix reverted, new test kept), `test_check_via_local_git_ssh_prefers_local_count_over_compare_api` fails by reaching the compare-API mock (which asserts it must not be called), while the other 5 still pass — the exact behavior split the fix intends.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (merge-base anchoring rationale at the new branch)
- [x] Tests added that prove the fix works
- [x] New and existing unit tests pass locally (test_banner_git_state 6/6; test_banner 8 pass + 1 pre-existing prompt_toolkit env failure reproduced identically on unpatched main)
- [x] Platform: macOS (pure git/CLI logic, platform-independent)
