### PR TITLE
fix(update): defer Windows runtime repair when the updater holds the venv

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1108,6 +1108,76 @@ def _windows_runtime_holders() -> tuple[bool, str]:
     return False, ""
 
 
+def _windows_runtime_self_lock(live: Path) -> tuple[bool, str]:
+    """Detect the one holder the generic scan above is blind to: THIS process.
+
+    ``_detect_venv_python_processes`` excludes the calling process and its
+    ancestors on purpose — a CLI ``hermes update`` itself runs from the
+    venv python — which is correct for the dependency-sync path, where only
+    a *loaded* ``.pyd`` image blocks the rewrite and a fresh child process
+    dodges it.  For the whole-venv park rename that exemption is fatal:
+    Windows keeps the image of any executable a running process was started
+    from mapped until that process exits, so a directory containing the
+    updater's own ``python.exe`` (or a waiting ``hermes.exe`` launcher
+    ancestor) can never be renamed from inside the updater.  The retry loop
+    in ``_cut_over_candidate`` cannot help against that — the lock is
+    structural, not transient (#93032).
+
+    No-op off Windows: POSIX renames work fine while this process maps
+    files from the renamed tree (open FDs and mmaps keep inodes alive).
+    """
+    if platform.system() != "Windows":
+        return False, ""
+    try:
+        live_res = str(live.resolve()).lower().rstrip(os.sep) + os.sep
+    except OSError:
+        live_res = str(live).lower().rstrip(os.sep) + os.sep
+
+    def _under_live(path_value: str | None) -> bool:
+        if not path_value:
+            return False
+        try:
+            resolved = str(Path(path_value).resolve()).lower()
+        except (OSError, ValueError):
+            resolved = str(path_value).lower()
+        return resolved.startswith(live_res)
+
+    try:
+        exe = sys.executable
+    except Exception:
+        exe = None
+    if _under_live(exe):
+        return True, (
+            f"the updater itself runs from the live venv it must replace "
+            f"({exe}); Windows cannot rename a directory while a process "
+            "executes from inside it"
+        )
+    # Belt-and-braces: the venv\Scripts\hermes.exe launcher stays mapped
+    # while it waits for this child, so an ancestor started from the venv
+    # blocks the rename too.
+    try:
+        import psutil
+
+        try:
+            parents = psutil.Process().parents()
+        except Exception:
+            parents = []
+        for anc in parents:
+            try:
+                anc_exe = anc.exe()
+            except Exception:
+                continue
+            if _under_live(anc_exe):
+                return True, (
+                    f"ancestor process PID {anc.pid} runs from the live venv "
+                    f"({anc_exe}); Windows cannot rename a directory while a "
+                    "process executes from inside it"
+                )
+    except Exception:
+        pass
+    return False, ""
+
+
 def _uv_version_string(uv_bin: str) -> str:
     """Return ``uv --version`` output, or ``""`` when it cannot be read."""
     try:
@@ -1273,6 +1343,34 @@ def repair_vulnerable_runtime(
         return RuntimeRepairResult(
             "skipped",
             detail,
+            sqlite_before=current.sqlite_version_string,
+        )
+
+    self_locked, self_detail = _windows_runtime_self_lock(live)
+    if self_locked:
+        # Structural, not transient: this process maps the live venv's own
+        # executable, so the park rename fails the same way on every run and
+        # no number of retries converges. Defer BEFORE provisioning — a
+        # candidate staged for a cutover that can never run only leaks an
+        # incomplete generation (#93032).
+        print(f"  ⚠ SQLite runtime repair deferred: {self_detail}.")
+        print(
+            "    Retrying `hermes update` from inside this venv cannot help: "
+            "the mapped executable is released only when this process exits."
+        )
+        print(
+            "    To complete the repair, run the updater from an interpreter "
+            "that lives outside this venv, e.g.:"
+        )
+        print(f"      cd {root}")
+        print("      <system Python> -m hermes_cli.main update")
+        print(
+            "    Sessions stay protected meanwhile: Hermes keeps databases "
+            "out of WAL mode on this SQLite build."
+        )
+        return RuntimeRepairResult(
+            "skipped",
+            self_detail,
             sqlite_before=current.sqlite_version_string,
         )
 

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -1354,3 +1354,148 @@ class TestVenvPythonUpdateBoundary:
         expected = Path("/opt/hermes/venv/Scripts/python.exe") \
             if sys.platform == "win32" else Path("/opt/hermes/venv/bin/python")
         assert _venv_python(Path("/opt/hermes/venv")) == expected
+
+
+
+class TestWindowsRuntimeSelfLock:
+    """The repair pre-flight must see the ONE holder the generic scan hides:
+    the updater itself (#93032).
+
+    A CLI ``hermes update`` runs from the venv's own python, and
+    ``_detect_venv_python_processes`` excludes the calling process and its
+    ancestors on purpose (correct for the dependency-sync path).  For the
+    whole-venv park rename that exemption is fatal on Windows: a directory
+    containing an executable mapped by a running process cannot be renamed,
+    so the cutover retries burn out against a lock that cannot be released
+    while the updater lives.  The repair must detect the self-lock and defer
+    with honest guidance instead of provisioning a candidate for a doomed
+    rename.
+    """
+
+    def _checkout(self, tmp_path):
+        root, live, sentinel = _make_runtime_install(tmp_path)
+        # Windows-layout interpreter so sys.executable can point inside the
+        # live venv on any host (the detector only string-compares paths).
+        scripts_python = live / "Scripts" / "python.exe"
+        scripts_python.parent.mkdir(parents=True, exist_ok=True)
+        scripts_python.write_text("live interpreter", encoding="utf-8")
+        return root, live, sentinel, scripts_python
+
+    def test_self_lock_defers_repair_before_provisioning(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Regression for #93032: pre-fix, the repair walks straight into the
+        doomed rename (provisioning + cutover) whenever the updater itself
+        maps the live venv; the park then fails with WinError 5 and the user
+        gets the misleading 'next update will retry' message forever."""
+        from hermes_cli import managed_uv
+        from hermes_cli.managed_uv import repair_vulnerable_runtime
+
+        root, live, sentinel, scripts_python = self._checkout(tmp_path)
+        current = _runtime_info(scripts_python, (3, 50, 4))
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(sys, "executable", str(scripts_python))
+
+        with patch(
+                 "hermes_cli.managed_uv._windows_runtime_holders",
+                 return_value=(False, ""),
+             ), \
+             patch(
+                 "hermes_cli.managed_uv.probe_sqlite_runtime",
+                 return_value=current,
+             ), \
+             patch(
+                 "hermes_cli.managed_uv._install_safe_python_generation"
+             ) as mock_install:
+            result = repair_vulnerable_runtime("uv", project_root=root)
+
+        assert result.status == "skipped"
+        assert "live venv" in result.detail
+        mock_install.assert_not_called(), (
+            "a self-locked updater must not provision a candidate it can "
+            "never cut over"
+        )
+        assert sentinel.read_text(encoding="utf-8") == "live"
+        assert not (root / ".hermes-runtime").exists()
+
+        out = capsys.readouterr().out
+        assert "SQLite runtime repair deferred" in out
+        assert "will retry" not in out, (
+            "the structural self-lock must not promise that retrying helps"
+        )
+        assert "outside" in out, "the deferral must point at an escape hatch"
+
+    def test_non_self_locked_repair_proceeds(self, tmp_path, monkeypatch):
+        """The guard must fail OPEN when the updater runs from outside the
+        venv — an always-firing deferral would recreate the never-converging
+        loop this fix removes (#86735 class)."""
+        from hermes_cli import managed_uv
+        from hermes_cli.managed_uv import repair_vulnerable_runtime
+
+        root, live, sentinel, scripts_python = self._checkout(tmp_path)
+        current = _runtime_info(scripts_python, (3, 50, 4))
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(
+            sys, "executable", str(tmp_path / "outside" / "python.exe")
+        )
+
+        with patch(
+                 "hermes_cli.managed_uv._windows_runtime_holders",
+                 return_value=(False, ""),
+             ), \
+             patch(
+                 "hermes_cli.managed_uv.probe_sqlite_runtime",
+                 return_value=current,
+             ), \
+             patch(
+                 "hermes_cli.managed_uv._install_safe_python_generation",
+                 return_value=None,
+             ) as mock_install:
+            result = repair_vulnerable_runtime("uv", project_root=root)
+
+        assert result.status == "failed"
+        assert "provision" in result.detail
+        mock_install.assert_called_once()
+        assert sentinel.read_text(encoding="utf-8") == "live"
+
+    def test_self_lock_is_a_noop_off_windows(self, tmp_path, monkeypatch):
+        """POSIX renames work while the updater maps the venv, so the guard
+        must stay Windows-only."""
+        from hermes_cli import managed_uv
+
+        root, live, sentinel, scripts_python = self._checkout(tmp_path)
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(sys, "executable", str(scripts_python))
+
+        locked, detail = managed_uv._windows_runtime_self_lock(live)
+        assert (locked, detail) == (False, "")
+
+    def test_venv_launcher_ancestor_is_a_self_lock(self, tmp_path, monkeypatch):
+        r"""The venv\Scripts\hermes.exe shim stays mapped while it waits for
+        this child — an ancestor running from the venv blocks the rename too."""
+        from hermes_cli import managed_uv
+
+        root, live, sentinel, scripts_python = self._checkout(tmp_path)
+        monkeypatch.setattr(managed_uv.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(
+            sys, "executable", str(tmp_path / "outside" / "python.exe")
+        )
+
+        class _FakeProc:
+            def __init__(self, pid, exe):
+                self.pid = pid
+                self._exe = exe
+
+            def exe(self):
+                return self._exe
+
+        fake_psutil = SimpleNamespace(
+            Process=lambda: SimpleNamespace(
+                parents=lambda: [_FakeProc(999, str(scripts_python))],
+            ),
+        )
+        with patch.dict(sys.modules, {"psutil": fake_psutil}):
+            locked, detail = managed_uv._windows_runtime_self_lock(live)
+
+        assert locked
+        assert "999" in detail

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -1411,7 +1411,7 @@ class TestWindowsRuntimeSelfLock:
 
         assert result.status == "skipped"
         assert "live venv" in result.detail
-        mock_install.assert_not_called(), (
+        assert mock_install.call_count == 0, (
             "a self-locked updater must not provision a candidate it can "
             "never cut over"
         )


### PR DESCRIPTION
## What does this PR do?

On Windows, `hermes update` launched from the install's own venv (the standard layout) can never complete the managed-runtime repair. The cutover must rename `venv` → `venv.stale.runtime-<token>`, but Windows refuses to rename a directory containing an executable mapped by a running process — and the updater itself is executing `venv\Scripts\python.exe` (with the `venv\Scripts\hermes.exe` launcher still mapped as its parent). The pre-flight holder scan (`_windows_runtime_holders` → `_detect_venv_python_processes`) deliberately excludes the calling process and its ancestors, so the guard reports "no holders", the repair provisions a whole new runtime generation, and then `_rename_with_retry` burns its 5 retries against a lock that cannot be released while the updater lives. The failure is non-fatal, so `hermes update` retries forever without converging — while the misleading "The next `hermes update` will retry" text implies it will.

This PR adds a Windows self-lock pre-flight that is checked **before provisioning**:

- New `_windows_runtime_self_lock(live)` in `hermes_cli/managed_uv.py` detects the one holder the generic scan is blind to — the calling process itself (`sys.executable` under the live venv) or a launcher ancestor (`venv\Scripts\hermes.exe`) started from the venv.
- `repair_vulnerable_runtime` defers with an actionable message instead of staging a candidate for a doomed cutover: it names the mapped executable, explains that retrying from inside the venv cannot converge, and points at the escape hatch (run the updater from an interpreter outside the venv).
- The deferral returns `skipped` (like the existing holders guard), so no caller contract changes, and happens before provisioning — the incomplete `generation-*` leftovers the reporter observed are no longer produced.
- POSIX is untouched: renaming a tree while this process maps files from it works fine there, and the detector is a no-op off Windows.

This mirrors the existing `_defer_update_for_self_lock()` pattern used by the dependency-sync path, which already bails out cleanly when the updater itself holds the lock.

## Root cause

1. `repair_vulnerable_runtime()` provisions a fixed runtime, then `_cut_over_candidate()` parks the live venv via `_rename_with_retry(live, backup)` — any `OSError` becomes `"could not park the existing venv"`.
2. On Windows a directory containing an executable mapped by a running process cannot be renamed; `hermes update` runs from `venv\Scripts\python.exe` / `hermes.exe`, so the rename always fails with `ERROR_ACCESS_DENIED` and the retries can never help while the process lives.
3. The pre-flight guard `_windows_runtime_holders()` delegates to `_detect_venv_python_processes()`, which explicitly excludes the calling process and its ancestors (`skip.add(os.getpid())`) — correct for the dependency-sync path (a fresh child process doesn't map the `.pyd` files), but it makes the guard blind to exactly the holder that matters for a whole-venv rename.
4. Same Windows lock family as #23327 / #38789, whose fixes (rename `hermes.exe` before install, detect venv python workers) cover only the dependency-sync path. The runtime-repair cutover had no equivalent self-lock handling.

## Evidence

- Repro on Windows 11: with `sys.executable` pointed inside the live venv and no other holders, the pre-fix repair walks straight into provisioning and cutover (regression test was red against the pre-fix code — see the sabotage check below), matching the reporter's `could not park the existing venv: [WinError 5]` and the two observed consecutive failures.
- Empirical check on this Windows 11 dev machine: `_windows_runtime_self_lock(<our real venv>)` → `True` with detail naming `...\Scripts\python.exe`; an unrelated venv → `False`.
- Sabotage run: with the guard neutralized (`self_locked, self_detail = False, ""`), `test_self_lock_defers_repair_before_provisioning` FAILS (repair proceeds to provisioning); with the fix restored it passes — the regression test bites.
- `venv.rollback-bak-*` from the report is not produced by any current code (grep: zero references; leftover of older updater releases), and the incomplete `generation-*` class stops being produced by this bug because the deferral happens before provisioning. No cleanup sweep added — out of scope.

## Test plan

- New `TestWindowsRuntimeSelfLock` (4 tests, host-independent via mocks, run on Windows locally and on POSIX CI):
  - self-locked updater → `skipped` deferral, no provisioning, no `.hermes-runtime` dir, output has actionable guidance and no "will retry";
  - non-self-locked updater → repair proceeds (guard fails open, no always-defer loop);
  - detector is a no-op off Windows;
  - a `venv\Scripts` launcher ancestor is detected as a self-lock.
- `pytest tests/hermes_cli/test_managed_uv.py` — 26 passed; the 7 failures on this Windows host are pre-existing Windows-layout failures of POSIX-oriented tests (verified identical at origin/main, untouched by this diff).
- `pytest tests/hermes_cli/test_scan_venv_blockers.py tests/hermes_cli/test_update_orphan_backend_reap.py` — 47 passed.
- `pytest tests/hermes_cli/test_update_self_lock.py tests/hermes_cli/test_update_shim_self_lock.py tests/hermes_cli/test_update_venv_health.py tests/hermes_cli/test_update_secret_import_lock.py` — 55 passed.
- `ruff check` on both files — clean.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related

- #23327, #38789 (same Windows lock family, dependency-sync path)
- PR #23353 / #23408, PR #39037 (the pip/sync-path fixes)
- #88836 (open PR taking the alternative cutover approach — repointing `pyvenv.cfg` instead of renaming; this PR's deferral is complementary: it stops the doomed rename and gives honest guidance, while #88836 would actually complete the repair on Windows)

## Review round 1 — Enough1122 feedback (2026-08-24)

1. **Assertion-message idiom — fixed.** `test_self_lock_defers_repair_before_provisioning` used `mock_install.assert_not_called(), ("…")`: a bare tuple expression whose parenthetical never becomes a failure message. Now `assert mock_install.call_count == 0, ("a self-locked updater must not provision a candidate it can never cut over")`. Verified both directions with the guard forced to fail: the old form raises only the bare mock error (`Expected '_install_safe_python_generation' to not have been called. Called 1 times.`), the new form surfaces the message. Unforced, the test passes as before.
2. **psutil unconditional import — no change.** Agreed with the review: it is the module's only psutil import and it sits inside the existing fail-open `try/except Exception` wrapper (`managed_uv.py:1078-1097`), so a missing psutil skips the ancestor scan instead of failing the repair. Left as-is.
3. **Escape-hatch `cd {root}` — no change, verified.** The printed `root` is `Path(project_root) if project_root is not None else _PROJECT_ROOT`, with `_PROJECT_ROOT = Path(__file__).resolve().parents[1]` — the checkout containing `hermes_cli/`, not the HERMES_HOME data dir. Neither production call site (`managed_uv.py:232`, `:369`) passes `project_root`, so the printed directory always contains `hermes_cli/`. `hermes_cli/main.py` registers the `update` subcommand and runs `main()` under `if __name__ == "__main__"`, so `<system Python> -m hermes_cli.main update` resolves the package from the printed cwd. Guidance stands as written.

Closes #93032

