### PR TITLE
fix(computer-use): one truthful existing-profile grant contract with exact rebind guidance

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -329,6 +329,93 @@ def _cua_grant_existing_profile() -> bool:
     return bool(_computer_use_cfg().get("grant_existing_profile", False))
 
 
+# Driver refusal codes that mean "the existing browser profile needs human
+# consent before DevTools access". A stale launch grant makes every one of
+# these unsatisfiable until the session is rebound (#93068).
+_CONSENT_REFUSAL_CODES = frozenset({"browser_consent_required"})
+
+
+def _is_consent_refusal(payload: Dict[str, Any]) -> bool:
+    """True when a refused driver payload is about existing-profile consent.
+
+    The refusal code is the primary signal (``browser_consent_required``),
+    but the driver also emits verify-ladder refusals whose message names the
+    Chrome remote-debugging consent sheet (e.g. ``browser_wrong_target_refused``
+    — "no exact Chrome remote-debugging consent sheet appeared"). Under a
+    stale launch grant those are equally unsatisfiable, so the consent term in
+    the message matches too. Never matches successful payloads.
+    """
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("ok") is True or payload.get("status") == "ok":
+        return False
+    code = payload.get("code")
+    if isinstance(code, str) and code:
+        lowered = code.lower()
+        if lowered in _CONSENT_REFUSAL_CODES or "consent" in lowered:
+            return True
+    message = payload.get("message")
+    return isinstance(message, str) and "consent" in message.lower()
+
+
+def _annotate_browser_harness_hint(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Annotate driver guidance that names a helper absent from the PATH.
+
+    cua-driver refusal text can recommend ``browser-harness mac-approve``
+    while that command is not a standalone binary on the user's shell PATH —
+    it ships inside the cua-driver install. Name where it lives instead of
+    letting the passthrough imply a bare command exists (#93068).
+    """
+    if not isinstance(payload, dict):
+        return payload
+    message = payload.get("message")
+    if not isinstance(message, str) or "browser-harness" not in message:
+        return payload
+    annotated = dict(payload)
+    annotated["message"] = (
+        message
+        + " (Note: `browser-harness` is not a standalone command on your "
+        "shell PATH — it is part of the cua-driver install. Run "
+        "`hermes computer-use status` to locate the installed driver binary "
+        "and invoke the helper through it.)"
+    )
+    return annotated
+
+
+def _stale_grant_refusal(
+    payload: Dict[str, Any],
+    *,
+    bound_grant: bool,
+    granted_now: bool,
+) -> Dict[str, Any]:
+    """Rewrite consent-family refusals into the one actionable blocker.
+
+    When the config now carries ``computer_use.grant_existing_profile`` but
+    the backend was created before it existed, the running driver can never
+    honor the grant: it was launched without ``--grant existing-profile``
+    and no amount of accepting Chrome consent prompts will change that. The
+    only correct action is binding a fresh session, and the refusal says so
+    exactly once instead of looping between a successful config write and a
+    repeating driver refusal (#93068).
+    """
+    if bound_grant or not granted_now or not _is_consent_refusal(payload):
+        return payload
+    return {
+        "ok": False,
+        "status": "refused",
+        "code": "browser_existing_profile_grant_stale",
+        "message": (
+            "computer_use.grant_existing_profile is enabled now, but this "
+            "computer-use session was started before it was set. The grant "
+            "is handed to the cua-driver runtime at launch and cannot take "
+            "effect mid-session. Start a new Hermes session (or restart the "
+            "agent) and retry — the driver will relaunch with the grant and "
+            "no repeated Chrome consent prompts will be needed."
+        ),
+        "driver_refusal": payload,
+    }
+
+
 def _manifest_is_mode_independent(path: str) -> bool:
     """True when this capability manifest may accompany any permission mode.
 
@@ -2739,6 +2826,13 @@ class CuaDriverBackend(ComputerUseBackend):
         if permission_mode not in {"standard", "bounded", "unrestricted"}:
             raise ValueError(f"unsupported cua-driver permission mode: {permission_mode}")
         self.permission_mode = permission_mode
+        # The existing-profile grant is handed to the driver at launch
+        # (`--grant existing-profile`) and is immutable for the life of this
+        # backend. Remember what was in effect at bind time so a mid-session
+        # `hermes config set computer_use.grant_existing_profile true` that
+        # cannot reach the running driver is detected and reported instead of
+        # looping on consent refusals (#93068).
+        self._grant_existing_profile_at_bind = _cua_grant_existing_profile()
         if permission_mode == "unrestricted":
             # Carry the manifest into unrestricted too. It is optional here
             # (unlike bounded), but when the user declared one it still caps
@@ -3946,6 +4040,65 @@ class CuaDriverBackend(ComputerUseBackend):
         # property. It is a standalone native focus operation, not a
         # session-scoped input action.
         return self._action("bring_to_front", args, inject_session=False)
+
+    # ── Typed browser (cua-driver 0.9 contract) ───────────────────
+    def _postprocess_browser_refusal(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize driver browser refusals into one actionable contract.
+
+        Two recovery-path defects share a root cause (#93068):
+
+        * a mid-session ``hermes config set computer_use.grant_existing_profile
+          true`` writes a value the running driver can never see (the grant is
+          baked into the launch args at bind time), so consent refusals loop
+          forever unless the refusal states the rebind action; and
+        * driver guidance naming ``browser-harness mac-approve`` recommends a
+          helper that is not on the user's PATH, so the passthrough says where
+          it lives.
+        """
+        payload = _annotate_browser_harness_hint(payload)
+        bound_grant = bool(getattr(self, "_grant_existing_profile_at_bind", False))
+        try:
+            granted_now = _cua_grant_existing_profile()
+        except Exception:
+            granted_now = False
+        return _stale_grant_refusal(
+            payload, bound_grant=bound_grant, granted_now=granted_now
+        )
+
+    def typed_browser_state(self, **kwargs: Any) -> Dict[str, Any]:
+        """Exact-bind a native browser window or read fresh semantic state."""
+        return self._postprocess_browser_refusal(
+            self._browser_route().observe(**kwargs)
+        )
+
+    def typed_browser_prepare(self, **kwargs: Any) -> Dict[str, Any]:
+        """Prepare an explicitly approved driver-owned browser profile.
+
+        The authorization inputs are resolved here, from config and this
+        backend's immutable mode — never from model-supplied kwargs.
+        """
+        kwargs.pop("grant_existing_profile", None)
+        kwargs.pop("permission_mode", None)
+        result = self._browser_route().prepare(
+            grant_existing_profile=_cua_grant_existing_profile(),
+            permission_mode=self.permission_mode,
+            **kwargs,
+        )
+        # The stale-grant rewrite is scoped to existing-profile attachment;
+        # an isolated launch must never be rewritten into profile advice.
+        if kwargs.get("profile_mode") != "existing_profile":
+            return _annotate_browser_harness_hint(result)
+        return self._postprocess_browser_refusal(result)
+
+    def typed_browser_action(
+        self,
+        driver_tool: str,
+        *,
+        tab_id: Optional[str] = None,
+        args: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Run one namespaced typed-browser mutation in this exact route."""
+        return self._browser_route().mutate(driver_tool, tab_id=tab_id, args=args)
 
     # ── Pointer + display introspection ─────────────────────────────
 

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -391,12 +391,12 @@ def _stale_grant_refusal(
     """Rewrite consent-family refusals into the one actionable blocker.
 
     When the config now carries ``computer_use.grant_existing_profile`` but
-    the backend was created before it existed, the running driver can never
-    honor the grant: it was launched without ``--grant existing-profile``
-    and no amount of accepting Chrome consent prompts will change that. The
-    only correct action is binding a fresh session, and the refusal says so
-    exactly once instead of looping between a successful config write and a
-    repeating driver refusal (#93068).
+    the running driver was launched before it existed, that runtime can
+    never honor the grant: it was launched without ``--grant
+    existing-profile`` and no amount of accepting Chrome consent prompts
+    will change that. The only correct action is binding a fresh session,
+    and the refusal says so exactly once instead of looping between a
+    successful config write and a repeating driver refusal (#93068).
     """
     if bound_grant or not granted_now or not _is_consent_refusal(payload):
         return payload
@@ -1807,6 +1807,10 @@ class _CuaDriverSession:
         # receives it. Select and own a private endpoint so an existing
         # default daemon cannot reject or silently miss the requested grant.
         self._owned_standard_runtime_socket: Optional[str] = None
+        # The existing-profile grant baked into THIS runtime's launch args,
+        # re-read by start() at every launch (lazy first start and each
+        # post-reset relaunch). None = this session has never launched.
+        self._grant_existing_profile_at_launch: Optional[bool] = None
         self._transport_generation = 0
         self._transport_reset_callback: Optional[Any] = None
 
@@ -1850,9 +1854,14 @@ class _CuaDriverSession:
                 child_env = self._embedded_daemon.child_env()
             else:
                 command, args = _resolve_mcp_invocation(driver_cmd)
+                # Bake the grant start() recorded for this exact launch —
+                # never re-read config here, or the bake could diverge from
+                # the snapshot refusal rewriting compares against (#93068).
                 args, owned_socket = _standard_runtime_launch_args(
                     args,
-                    grant_existing_profile=_cua_grant_existing_profile(),
+                    grant_existing_profile=bool(
+                        self._grant_existing_profile_at_launch
+                    ),
                     platform=sys.platform,
                     socket_path=self._owned_standard_runtime_socket,
                 )
@@ -1965,6 +1974,13 @@ class _CuaDriverSession:
         with self._lock:
             if self._started:
                 return
+            # Re-read the existing-profile grant at THIS launch. The runtime
+            # honors only what is baked into its launch args, and every
+            # launch — the lazy first one and each post-reset relaunch —
+            # passes through here. The snapshot therefore always describes
+            # the runtime in flight, never a bind-time value the user may
+            # have changed since (#93068).
+            self._grant_existing_profile_at_launch = _cua_grant_existing_profile()
             # A previous transport may have died without taking down its
             # private app daemon. Stop that exact endpoint before relaunching
             # with --grant; grants cannot modify an already-running runtime.
@@ -2827,12 +2843,15 @@ class CuaDriverBackend(ComputerUseBackend):
             raise ValueError(f"unsupported cua-driver permission mode: {permission_mode}")
         self.permission_mode = permission_mode
         # The existing-profile grant is handed to the driver at launch
-        # (`--grant existing-profile`) and is immutable for the life of this
-        # backend. Remember what was in effect at bind time so a mid-session
-        # `hermes config set computer_use.grant_existing_profile true` that
-        # cannot reach the running driver is detected and reported instead of
-        # looping on consent refusals (#93068).
-        self._grant_existing_profile_at_bind = _cua_grant_existing_profile()
+        # (`--grant existing-profile`) and is immutable for the life of that
+        # runtime. The grant is NOT snapshotted here: the runtime launches
+        # lazily (first driver call) and re-launches on transport resets,
+        # and each launch re-reads the config in _CuaDriverSession.start()
+        # (recorded as `_grant_existing_profile_at_launch`). Reading it at
+        # bind time would drift from the launch args in both windows and
+        # misreport a mid-session `hermes config set` as "restart the
+        # session" even when the launched runtime already has the grant
+        # (#93068).
         if permission_mode == "unrestricted":
             # Carry the manifest into unrestricted too. It is optional here
             # (unlike bounded), but when the user declared one it still caps
@@ -4049,20 +4068,33 @@ class CuaDriverBackend(ComputerUseBackend):
 
         * a mid-session ``hermes config set computer_use.grant_existing_profile
           true`` writes a value the running driver can never see (the grant is
-          baked into the launch args at bind time), so consent refusals loop
+          baked into the launch args at launch time), so consent refusals loop
           forever unless the refusal states the rebind action; and
         * driver guidance naming ``browser-harness mac-approve`` recommends a
           helper that is not on the user's PATH, so the passthrough says where
           it lives.
+
+        The launch-grant comparison reads ``_grant_existing_profile_at_launch``
+        — recorded by ``_CuaDriverSession.start()`` at every launch — so the
+        rewrite fires only when the runtime in flight demonstrably launched
+        without the grant. Before any launch (lazy-start window) and after a
+        relaunch that baked the grant (transfer-reset window), the refusal
+        passes through untouched.
         """
         payload = _annotate_browser_harness_hint(payload)
-        bound_grant = bool(getattr(self, "_grant_existing_profile_at_bind", False))
+        session = getattr(self, "_session", None)
+        bound_grant = getattr(session, "_grant_existing_profile_at_launch", None)
+        if bound_grant is None:
+            # This backend's runtime has not launched yet; the (re)launch
+            # re-reads the grant at start(), so a stale-grant verdict would
+            # be premature. Host-side refusals pass through as-is.
+            return payload
         try:
             granted_now = _cua_grant_existing_profile()
         except Exception:
             granted_now = False
         return _stale_grant_refusal(
-            payload, bound_grant=bound_grant, granted_now=granted_now
+            payload, bound_grant=bool(bound_grant), granted_now=granted_now
         )
 
     def typed_browser_state(self, **kwargs: Any) -> Dict[str, Any]:

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -221,11 +221,18 @@ _CUA_TELEMETRY_ENV_VAR = "CUA_DRIVER_RS_TELEMETRY_ENABLED"
 
 
 def _computer_use_cfg() -> Dict[str, Any]:
-    """The ``computer_use`` config block, or ``{}`` when config is unreadable."""
-    try:
-        from hermes_cli.config import load_config
+    """The ``computer_use`` config block, or ``{}`` when config is unreadable.
 
-        return (load_config() or {}).get("computer_use") or {}
+    Read-only fast path: several consumers sit on hot paths (the typed-browser
+    refusal postprocess reads ``grant_existing_profile`` on every typed call),
+    so this uses ``load_config_readonly`` — hermes_cli's stat-keyed cache
+    without the whole-config deepcopy. Callers must never mutate the returned
+    block.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        return (load_config_readonly() or {}).get("computer_use") or {}
     except Exception:
         return {}
 
@@ -334,6 +341,14 @@ def _cua_grant_existing_profile() -> bool:
 # these unsatisfiable until the session is rebound (#93068).
 _CONSENT_REFUSAL_CODES = frozenset({"browser_consent_required"})
 
+# Known driver prose for the verify-ladder consent refusal: the refusal code
+# (``browser_wrong_target_refused``) carries no consent term, so the message
+# must be matched — but only the driver's own phrasing. A generic refusal
+# whose prose happens to mention consent (an OS permissions dialog, a system
+# prompt) is NOT consent-family: rewriting it would discard the driver's
+# actual instructions (#93068 review).
+_CONSENT_MESSAGE_PHRASES = frozenset({"remote-debugging consent", "consent sheet"})
+
 
 def _is_consent_refusal(payload: Dict[str, Any]) -> bool:
     """True when a refused driver payload is about existing-profile consent.
@@ -342,8 +357,10 @@ def _is_consent_refusal(payload: Dict[str, Any]) -> bool:
     but the driver also emits verify-ladder refusals whose message names the
     Chrome remote-debugging consent sheet (e.g. ``browser_wrong_target_refused``
     — "no exact Chrome remote-debugging consent sheet appeared"). Under a
-    stale launch grant those are equally unsatisfiable, so the consent term in
-    the message matches too. Never matches successful payloads.
+    stale launch grant those are equally unsatisfiable, so the known consent
+    phrases in the message match too. Never matches successful payloads, and
+    never matches prose that merely mentions consent without the driver's
+    phrasing.
     """
     if not isinstance(payload, dict):
         return False
@@ -355,7 +372,12 @@ def _is_consent_refusal(payload: Dict[str, Any]) -> bool:
         if lowered in _CONSENT_REFUSAL_CODES or "consent" in lowered:
             return True
     message = payload.get("message")
-    return isinstance(message, str) and "consent" in message.lower()
+    if not isinstance(message, str):
+        return False
+    lowered_message = message.lower()
+    return any(
+        phrase in lowered_message for phrase in _CONSENT_MESSAGE_PHRASES
+    )
 
 
 def _annotate_browser_harness_hint(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -367,6 +389,10 @@ def _annotate_browser_harness_hint(payload: Dict[str, Any]) -> Dict[str, Any]:
     letting the passthrough imply a bare command exists (#93068).
     """
     if not isinstance(payload, dict):
+        return payload
+    # Mirror `_is_consent_refusal`: success results are never guidance, even
+    # when their message happens to quote the helper name (#93068 review).
+    if payload.get("ok") is True or payload.get("status") == "ok":
         return payload
     message = payload.get("message")
     if not isinstance(message, str) or "browser-harness" not in message:

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -128,6 +128,13 @@ Hermes then launches the cua-driver runtime with the trusted-launcher grant
 existing-profile attachment fails closed; driver-owned isolated profiles work
 either way and are what the agent prefers.
 
+The grant is a launch setting: if you set it while Hermes is already running,
+it binds only when the computer-use session restarts. The running session
+keeps its launch-time grant, and both the refusal messages and a
+`browser_existing_profile_grant_stale` result say exactly that — start a new
+session (or restart the agent) after changing the key, and the attach will
+work without repeated Chrome consent prompts.
+
 ### Bounded mode for repeatable automation
 
 For recurring browser automation (cron jobs, scheduled research against an


### PR DESCRIPTION
## Root cause

`computer_use.grant_existing_profile` is enforced by two different reads that drift apart mid-session:

1. **Host-side floor** — `CuaTypedBrowserRoute.prepare` reads `_cua_grant_existing_profile()` on every call (fresh `load_config()`), so `hermes config set computer_use.grant_existing_profile true` immediately lets the request past the floor.
2. **Driver launch grant** — the same key is baked into the cua-driver launch args once, at backend bind time (`--grant existing-profile` in `_standard_runtime_launch_args`), and the backend is cached per Hermes session.

When the user enables the grant mid-session, path 1 passes but the running driver was launched without the grant, so its daemon authorization coordinator keeps refusing with `browser_consent_required` (state bind) or verify-ladder refusals naming the Chrome remote-debugging consent sheet (prepare). Nothing in that loop ever says that a config write that "succeeds" cannot reach the running driver — the only fix is rebinding the session. A third path, `browser_exec`/`browser-harness mac-approve` guidance, passes through driver text that names a helper which is not on the user's PATH.

(The third issue item — `hermes computer-use browser-approve --help` advertising the removed upstream token path — no longer reproduces on main: the command was removed in a403fe6f9 and tests assert its absence.)

## Fix

One truthful, tool-enforced contract across both paths:

- `CuaDriverBackend` no longer snapshots the grant at bind time. The snapshot lives where the launch args are baked: `_CuaDriverSession.start()` re-reads `computer_use.grant_existing_profile` on **every** launch — the lazy first start and each post-transport-reset relaunch — and records it as `_grant_existing_profile_at_launch`; `_lifecycle_coro` bakes `--grant existing-profile` from that same value, so the recorded grant and the launch args can never diverge.
- `typed_browser_state` / `typed_browser_prepare` post-process driver refusals: when a consent-family refusal arrives (code `browser_consent_required`, any code containing `consent`, or a message naming the Chrome remote-debugging consent sheet) **and** the config now grants existing-profile **but** the runtime in flight demonstrably launched without the grant, the refusal is rewritten to a single actionable blocker `browser_existing_profile_grant_stale`: "start a new Hermes session (or restart the agent)" — with the original driver refusal preserved under `driver_refusal`. Before any launch has happened (lazy-start window) the rewrite is skipped: the upcoming launch re-reads the config and picks the grant up, so a consent refusal there is the legitimate consent flow, never "restart the session".
- The rewrite is scoped to `existing_profile` prepares only; isolated launches are never rewritten.
- The host-side floor refusal (`browser_existing_profile_not_granted`) now states the immutability contract up front: a mid-run `config set` binds only when the session restarts.
- Driver guidance that names `browser-harness` is annotated: the helper ships inside the cua-driver install, not as a bare PATH command, and `hermes computer-use status` locates the driver binary.
- Docs (`website/docs/user-guide/features/computer-use.md`) document the launch-setting contract and the `browser_existing_profile_grant_stale` outcome.

## Evidence

Pre-fix (RED), the new behavioral regression tests fail against unmodified code; post-fix (GREEN):

- `tests/tools/test_computer_use_browser_authorization.py` (+12 tests, 53 total) — mid-session grant enablement reports the rebind action on both `cua_browser_state` and `cua_browser_prepare`; consent refusals pass through untouched when the grant was bound at launch / is still off / is an isolated launch / is a non-consent refusal; the floor refusal names the rebind action; `browser-harness` guidance is annotated with its location; **plus the adversarial-review windows**: the launch snapshot re-reads config at every `start()` (lazy first start and post-reset relaunch), a refusal before any launch passes through instead of being rewritten, and both end-to-end windows (grant enabled before first launch, grant enabled across a transport reset) pass the consent refusal through because the launched runtime demonstrably has the grant.
- Full computer-use suites: 115 passed (`test_computer_use_browser_authorization`, `test_computer_use_cua_0_9`, `test_computer_use_cua_0_10_permissions`, `test_computer_use_browser_contract_020`); 300 passed / 2 skipped / 2 pre-existing environment failures in the wider `tests/tools/test_computer_use*` sweep (both fail identically on clean `0159b51f2b` on this Windows host); `tests/computer_use/` 39 passed / 4 skipped / 2 pre-existing WSL-path environment failures (also identical on clean base).

## Scope caveat

The macOS E2E acceptance criterion (existing Chrome → grant → exact consent sheet → authenticated read) cannot be executed from this Windows dev host; this PR fixes everything static and provable regardless of platform, per the claim comment on the issue. The `browser_exec` isolated-vs-existing default overlap is left to #89143.

Closes #93068


## Review round 2 (Enough1122) — addressed in d177223455

All three findings fixed, each with a regression test added RED-first:

1. **Success payloads are no longer annotated.** `_annotate_browser_harness_hint` now returns early when `payload.get("ok") is True or payload.get("status") == "ok"`, mirroring `_is_consent_refusal`'s guard — a success result quoting the helper name is never rewritten as guidance. Test: `test_browser_harness_hint_never_annotates_success_payloads`.
2. **Message-substring arm narrowed to the driver's known phrasing.** `_is_consent_refusal` no longer matches any message containing "consent". The message arm matches only the driver's verify-ladder wording (`"remote-debugging consent"`, `"consent sheet"` — the exact text of `browser_wrong_target_refused`); the code arm keeps the enumerated codes. Under a stale grant, refusals whose prose merely mentions consent (OS permissions dialog, system prompt) now pass through with the driver's actual instructions intact at the top level. Tests: `test_consent_mention_without_known_driver_phrase_is_not_a_consent_refusal`, `test_stale_grant_rewrite_skips_consent_mentioning_prose`, guard rail `test_verify_ladder_consent_sheet_phrase_still_matches`.
3. **Hot-path grant read no longer deepcopies the config.** `_computer_use_cfg()` now reads through `hermes_cli.config.load_config_readonly()` (stat-keyed cache, no deepcopy) instead of `load_config()`. Freshness is preserved — the cache invalidates on config-file (mtime, size) change, so the mid-session `hermes config set` detection this PR relies on still works — but each typed browser call no longer pays the whole-config deepcopy. Test: `test_grant_read_skips_deepcopy_on_the_typed_browser_hot_path` (asserts `load_config` is never called on that path).

Verification: the 4 new behavioral tests fail against the previous revision (stash-revert RED check) and pass now; `test_computer_use_browser_authorization.py` + `test_computer_use_cua_0_9.py` + `test_computer_use_cua_0_10_permissions.py` = **115 passed**. Full `tests/tools/test_computer_use*` sweep: 305 passed / 2 skipped / 2 pre-existing environment failures (verified identical on clean parent 6af95ca664 on this Windows host). User-facing strings verified byte-identical to the parent revision (sha256 comparison of the annotation note and the stale-grant rewrite message).
