### PR TITLE
fix(dashboard): block credential files on fs preview reads

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2169,6 +2169,17 @@ def _fs_regular_file(path: Path) -> tuple[Path, os.stat_result]:
     return target, st
 
 
+def _fs_openable_file(raw_path: str) -> tuple[Path, os.stat_result]:
+    """Resolve a regular file for /api/fs read/download, blocking credential files."""
+    target, st = _fs_regular_file(_fs_path(raw_path))
+    if _is_sensitive_path(target):
+        raise HTTPException(
+            status_code=403,
+            detail="Access to sensitive files is not allowed",
+        )
+    return target, st
+
+
 def _fs_find_git_root(start: Path) -> str | None:
     directory = start
     for _ in range(50):
@@ -2883,7 +2894,7 @@ async def fs_list(path: str):
 
 @app.get("/api/fs/read-text")
 async def fs_read_text(path: str):
-    target, st = _fs_regular_file(_fs_path(path))
+    target, st = _fs_openable_file(path)
     if st.st_size > _FS_TEXT_SOURCE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     bytes_to_read = min(st.st_size, _FS_TEXT_PREVIEW_MAX_BYTES)
@@ -2954,7 +2965,7 @@ async def fs_write_text(payload: FsWriteText):
 
 @app.get("/api/fs/read-data-url")
 async def fs_read_data_url(path: str):
-    target, st = _fs_regular_file(_fs_path(path))
+    target, st = _fs_openable_file(path)
     if st.st_size > _FS_DATA_URL_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     try:
@@ -2968,9 +2979,7 @@ async def fs_read_data_url(path: str):
 
 @app.get("/api/fs/download")
 async def fs_download(path: str):
-    target, _st = _fs_regular_file(_fs_path(path))
-    if _is_sensitive_path(target):
-        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
+    target, _st = _fs_openable_file(path)
     return FileResponse(
         path=str(target),
         media_type=_fs_mime_type(target),

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -77,6 +77,32 @@ def test_fs_download_rejects_sensitive_files(client, tmp_path):
     assert response.status_code == 403
 
 
+@pytest.mark.parametrize("route", ["/api/fs/read-text", "/api/fs/read-data-url", "/api/fs/download"])
+@pytest.mark.parametrize(
+    "relpath",
+    [".env", ".env.local", "config.yaml", "mcp-tokens/server.json", "pairing/code.json"],
+)
+def test_fs_read_routes_reject_sensitive_files(client, tmp_path, route, relpath):
+    target = tmp_path / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("SECRET=1")
+
+    response = client.get(route, params={"path": str(target)})
+
+    assert response.status_code == 403
+    assert "SECRET" not in response.text
+
+
+def test_fs_read_text_returns_plain_file(client, tmp_path):
+    target = tmp_path / "notes.txt"
+    target.write_text("hello")
+
+    response = client.get("/api/fs/read-text", params={"path": str(target)})
+
+    assert response.status_code == 200
+    assert response.json()["text"] == "hello"
+
+
 def test_fs_endpoints_require_auth(tmp_path):
     client = TestClient(web_server.app)
     target = tmp_path / "secret.txt"


### PR DESCRIPTION
## What does this PR do?

`/api/fs/download` already 403s credential files (`.env`, `config.yaml`, `mcp-tokens/`, `pairing/`). `read-text` and `read-data-url` on the same API did not, so an authenticated dashboard or desktop session could read those files as JSON or a data URL.

All three routes now go through one helper that runs `_is_sensitive_path` after resolving the file. A normal project file still reads.

Related: #58724 / #58726 confine hosted/locked roots. That guard is a no-op when `locked_root` is unset, which is the normal local install. This PR is the credential-name check on the preview reads for every install.

## Related Issue

Fixes #93167

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_cli/web_server.py`: add `_fs_openable_file` and use it from `fs_read_text`, `fs_read_data_url`, and `fs_download`
- `tests/hermes_cli/test_web_server_fs.py`: 403 on `.env`, `.env.local`, `config.yaml`, `mcp-tokens/`, and `pairing/` for all three routes; `read-text` still returns a plain file

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/hermes_cli/test_web_server_fs.py -q`
2. Authenticated `GET /api/fs/read-text?path=<tmp>/.env` must be 403 and must not contain the file body
3. Same for `/api/fs/read-data-url` and `/api/fs/download`
4. `GET /api/fs/read-text?path=<tmp>/notes.txt` still returns 200 with the text

Ran on Windows 11 with Python 3.11: 21 passed in `tests/hermes_cli/test_web_server_fs.py`.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

```
=== Summary: 1 files, 21 tests passed, 0 failed ===
```
