### PR TITLE
fix(desktop): keep the venv interpreter in Exec= and fail the hermes launcher with an actionable error when deps are missing

### DIFF
--- a/hermes
+++ b/hermes
@@ -4,8 +4,59 @@ Hermes Agent CLI launcher.
 
 This wrapper should behave like the installed `hermes` command, including
 subcommands such as `gateway`, `cron`, and `doctor`.
+
+When the interpreter running this script has none of Hermes' dependencies
+installed — a bare uv-managed CPython, or a generated .desktop ``Exec=``
+whose interpreter escaped the install venv — it fails with an actionable
+diagnostic instead of a bare ``ModuleNotFoundError`` (#92882, #90292,
+#91504, #80439).
 """
 
+import sys
+from pathlib import Path
+
+
+def _find_install_venv_python(checkout: Path) -> str | None:
+    """The install venv's interpreter next to this checkout, if it exists."""
+    windows = sys.platform == "win32"
+    python_name = "python.exe" if windows else "python"
+    for name in ("venv", ".venv"):
+        venv_dir = checkout / name
+        if not (venv_dir / "pyvenv.cfg").is_file():
+            continue
+        python = venv_dir / ("Scripts" if windows else "bin") / python_name
+        if python.is_file():
+            return str(python)
+    return None
+
+
+def _report_launcher_failure(missing: str) -> None:
+    """Print which interpreter ran, which module is missing, and the fix."""
+    script = Path(__file__).resolve()
+    lines = [
+        "hermes: cannot start under this Python interpreter.",
+        f"  running interpreter: {sys.executable}",
+        f"  missing dependency:  {missing}",
+        "  Hermes' dependencies live in the install venv, which this "
+        "interpreter does not use.",
+    ]
+    expected = _find_install_venv_python(script.parent)
+    if expected:
+        lines.append(f"  expected interpreter: {expected}")
+        lines.append(f"  fix: {expected} {script} " + " ".join(sys.argv[1:]))
+    else:
+        lines.append(
+            "  fix: run this script with the venv Python Hermes was installed "
+            "into (e.g. <checkout>/venv/bin/python), or reinstall Hermes' "
+            "dependencies into this interpreter."
+        )
+    sys.stderr.write("\n".join(lines) + "\n")
+
+
 if __name__ == "__main__":
-    from hermes_cli.main import main
+    try:
+        from hermes_cli.main import main
+    except ModuleNotFoundError as exc:
+        _report_launcher_failure(getattr(exc, "name", "") or str(exc))
+        sys.exit(1)
     main()

--- a/hermes
+++ b/hermes
@@ -9,7 +9,9 @@ When the interpreter running this script has none of Hermes' dependencies
 installed — a bare uv-managed CPython, or a generated .desktop ``Exec=``
 whose interpreter escaped the install venv — it fails with an actionable
 diagnostic instead of a bare ``ModuleNotFoundError`` (#92882, #90292,
-#91504, #80439).
+#91504, #80439). An import failure for a ``hermes_cli.*`` module raised
+from inside the package itself is reported as an internal error, never as
+a missing dependency.
 """
 
 import sys
@@ -30,9 +32,58 @@ def _find_install_venv_python(checkout: Path) -> str | None:
     return None
 
 
-def _report_launcher_failure(missing: str) -> None:
-    """Print which interpreter ran, which module is missing, and the fix."""
+def _classify_import_failure(
+    exc: ModuleNotFoundError, pkg_dir: Path | None = None
+) -> tuple[str, bool]:
+    """Split a launcher import failure into (missing_module, is_internal_bug).
+
+    A missing third-party dependency (``yaml``, ``dotenv``, ...) is an
+    install problem and gets the venv fix. A ``ModuleNotFoundError`` for a
+    ``hermes_cli.*`` module raised from a file *inside* the package is the
+    package failing to import its own code — an internal bug that must not
+    be misreported as a missing dependency.
+    """
+    missing = getattr(exc, "name", "") or str(exc)
+    if not (missing == "hermes_cli" or missing.startswith("hermes_cli.")):
+        return missing, False
+    if pkg_dir is None:
+        pkg_dir = Path(__file__).resolve().parent / "hermes_cli"
+    pkg_dir = Path(pkg_dir).resolve()
+    tb = exc.__traceback__
+    frame = None
+    while tb is not None:
+        frame = tb.tb_frame
+        tb = tb.tb_next
+    if frame is None:
+        return missing, False
+    try:
+        origin = Path(frame.f_code.co_filename).resolve()
+    except OSError:
+        return missing, False
+    return missing, origin.is_relative_to(pkg_dir)
+
+
+def _report_launcher_failure(
+    missing: str, internal: bool = False, exc: BaseException | None = None
+) -> None:
+    """Print which interpreter ran, what failed, and the fix."""
     script = Path(__file__).resolve()
+    if internal:
+        lines = [
+            f"hermes: hermes_cli failed to import its own module '{missing}'.",
+            "  This is an internal error in the checkout, not an install problem.",
+            f"  running interpreter: {sys.executable}",
+            f"  missing module:      {missing}",
+            "  fix: the failing import lives inside hermes_cli itself; "
+            "inspect the traceback below for a typo'd or removed module, "
+            "or reinstall/refresh this checkout.",
+        ]
+        sys.stderr.write("\n".join(lines) + "\n")
+        if exc is not None:
+            import traceback
+
+            traceback.print_exception(exc, file=sys.stderr)
+        return
     lines = [
         "hermes: cannot start under this Python interpreter.",
         f"  running interpreter: {sys.executable}",
@@ -57,6 +108,7 @@ if __name__ == "__main__":
     try:
         from hermes_cli.main import main
     except ModuleNotFoundError as exc:
-        _report_launcher_failure(getattr(exc, "name", "") or str(exc))
+        missing, internal = _classify_import_failure(exc)
+        _report_launcher_failure(missing, internal=internal, exc=exc)
         sys.exit(1)
     main()

--- a/hermes
+++ b/hermes
@@ -14,6 +14,7 @@ from inside the package itself is reported as an internal error, never as
 a missing dependency.
 """
 
+import shlex
 import sys
 from pathlib import Path
 
@@ -39,17 +40,34 @@ def _classify_import_failure(
 
     A missing third-party dependency (``yaml``, ``dotenv``, ...) is an
     install problem and gets the venv fix. A ``ModuleNotFoundError`` for a
-    ``hermes_cli.*`` module raised from a file *inside* the package is the
-    package failing to import its own code — an internal bug that must not
-    be misreported as a missing dependency.
+    ``hermes_cli.*`` module whose original import site is a file *inside*
+    the package is the package failing to import its own code — an internal
+    bug that must not be misreported as a missing dependency. The original
+    import site is the innermost frame of the deepest traceback in the
+    ``__cause__`` chain, so a failure re-raised via ``raise ... from err``
+    is attributed to its real origin, not to whatever re-raised it.
     """
-    missing = getattr(exc, "name", "") or str(exc)
+    name = getattr(exc, "name", "")
+    if name:
+        missing = name
+    else:
+        message = str(exc)
+        prefix = "No module named "
+        if message.startswith(prefix):
+            missing = message[len(prefix) :].strip("'\"")
+        else:
+            missing = message
     if not (missing == "hermes_cli" or missing.startswith("hermes_cli.")):
         return missing, False
     if pkg_dir is None:
         pkg_dir = Path(__file__).resolve().parent / "hermes_cli"
     pkg_dir = Path(pkg_dir).resolve()
-    tb = exc.__traceback__
+    cause: BaseException | None = exc
+    tb = None
+    while cause is not None:
+        if cause.__traceback__ is not None:
+            tb = cause.__traceback__
+        cause = cause.__cause__
     frame = None
     while tb is not None:
         frame = tb.tb_frame
@@ -94,7 +112,7 @@ def _report_launcher_failure(
     expected = _find_install_venv_python(script.parent)
     if expected:
         lines.append(f"  expected interpreter: {expected}")
-        lines.append(f"  fix: {expected} {script} " + " ".join(sys.argv[1:]))
+        lines.append(f"  fix: {expected} {script} " + shlex.join(sys.argv[1:]))
     else:
         lines.append(
             "  fix: run this script with the venv Python Hermes was installed "

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -9,7 +9,11 @@ Two values must be absolute for the entry to work:
 
   - ``Exec`` — the launcher runs without shell ``PATH`` customizations, so
     a bare ``hermes desktop`` fails when hermes lives in ``~/.local/bin``
-    or a venv. Resolve the real binary and write its full path.
+    or a venv. Resolve the real binary and write its full path. When an
+    interpreter is written (``sys.executable``), keep it VERBATIM: on
+    POSIX a venv's ``bin/python`` is a symlink to the base interpreter,
+    and resolving it would point ``Exec`` at an interpreter with none of
+    Hermes' dependencies (#92882).
   - ``Icon`` — an unqualified icon name needs an indexed icon theme. The
     spec allows an absolute path instead, so point at the app icon in the
     checkout. Do not copy the icon: ``Exec`` already depends on that tree.
@@ -63,6 +67,13 @@ def resolve_exec_command() -> str:
     Prefer the real ``hermes`` executable (argv[0] or PATH). When Hermes
     runs as a module with no launcher installed, use the current
     interpreter, also absolute.
+
+    The interpreter is written as ``sys.executable`` VERBATIM — never
+    ``resolve()``-d. On POSIX a venv's ``bin/python`` is a symlink to the
+    base interpreter, so resolving it walks straight out of the venv and
+    pins ``Exec=`` to an interpreter with none of Hermes' dependencies
+    (#92882). Keeping the symlink path lets CPython detect the venv via
+    the ``pyvenv.cfg`` next to it, so the venv's deps stay active.
     """
     from hermes_cli.relaunch import resolve_hermes_bin
 
@@ -77,12 +88,12 @@ def resolve_exec_command() -> str:
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # venv one), so prefix it explicitly — verbatim, per the docstring.
+            argv = [sys.executable, str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [sys.executable, "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 

--- a/tests/hermes_cli/test_launcher.py
+++ b/tests/hermes_cli/test_launcher.py
@@ -2,6 +2,7 @@
 
 import builtins
 import runpy
+import shlex
 import subprocess
 import sys
 import types
@@ -151,6 +152,110 @@ def test_classify_hermes_cli_name_from_outside_is_not_internal(tmp_path):
     missing, internal = classify(exc, pkg_dir=pkg_dir)
     assert missing == "hermes_cli.definitely_missing_submodule"
     assert internal is False
+
+
+def test_classify_attributes_re_raised_import_to_cause_chain(tmp_path):
+    """An import failure re-raised via `raise ... from err` keeps the original
+    import site on `__cause__`. Classification must use the deepest traceback
+    in that chain — here a frame inside hermes_cli — not the innermost frame
+    of the re-raise site (which lives outside the package and would wrongly
+    demote an internal bug to a missing dependency)."""
+    classify = _launcher_namespace()["_classify_import_failure"]
+    pkg_dir = tmp_path / "hermes_cli"
+
+    inner = tmp_path / "hermes_cli" / "broken.py"
+    inner.parent.mkdir(parents=True, exist_ok=True)
+    inner.write_text("import hermes_cli.definitely_missing_submodule\n")
+
+    outer = tmp_path / "re_raise_site.py"  # deliberately outside the package
+    outer_code = (
+        "import builtins\n"
+        "try:\n"
+        f"    exec(compile({inner.read_text()!r}, {str(inner)!r}, 'exec'),"
+        " {'__builtins__': builtins.__dict__})\n"
+        "except ModuleNotFoundError as err:\n"
+        "    raise ModuleNotFoundError(err.name) from err\n"
+    )
+    try:
+        exec(
+            compile(outer_code, str(outer), "exec"),
+            {"__builtins__": builtins.__dict__},
+        )
+    except ModuleNotFoundError as exc:
+        wrapped = exc
+    else:
+        raise AssertionError("expected a re-raised ModuleNotFoundError")
+
+    assert wrapped.__cause__ is not None
+    missing, internal = classify(wrapped, pkg_dir=pkg_dir)
+    assert missing == "hermes_cli.definitely_missing_submodule"
+    assert internal is True
+
+
+def test_classify_normalizes_unnamed_module_error_to_module_token():
+    """When `exc.name` is empty, the raw `No module named 'x'` message must be
+    normalized to just the module token so the `missing dependency:` report
+    field stays machine-greppable."""
+    classify = _launcher_namespace()["_classify_import_failure"]
+
+    exc = ModuleNotFoundError("No module named 'definitely_missing_dependency'")
+    assert exc.name is None
+
+    missing, internal = classify(exc)
+    assert missing == "definitely_missing_dependency"
+    assert internal is False
+
+
+def test_report_launcher_failure_missing_dependency_field_is_bare_token(capsys):
+    """The `missing dependency:` field must carry just the module token, never
+    the whole `No module named 'x'` sentence."""
+    ns = _launcher_namespace()
+    globs = ns["_report_launcher_failure"].__globals__
+    globs["_find_install_venv_python"] = lambda checkout: None
+
+    exc = ModuleNotFoundError("No module named 'definitely_missing_dependency'")
+    missing, internal = ns["_classify_import_failure"](exc)
+    ns["_report_launcher_failure"](missing, internal=internal)
+
+    err = capsys.readouterr().err
+    assert "missing dependency:  definitely_missing_dependency" in err
+    assert "missing dependency:  No module named" not in err
+
+
+def test_report_launcher_failure_fix_command_is_shell_quoted(monkeypatch, capsys):
+    """argv entries containing spaces must be shell-quoted in the suggested
+    fix so the printed command copy-pastes correctly (`--model "a b"` must
+    not flatten into `--model a b`)."""
+    ns = _launcher_namespace()
+    ns["_report_launcher_failure"].__globals__["_find_install_venv_python"] = (
+        lambda checkout: "/opt/hermes/venv/bin/python"
+    )
+    monkeypatch.setattr(
+        sys, "argv", [str(_launcher()), "gateway", "run", "--model", "a b"]
+    )
+
+    ns["_report_launcher_failure"]("yaml")
+
+    err = capsys.readouterr().err
+    fix_lines = [line for line in err.splitlines() if line.startswith("  fix:")]
+    assert len(fix_lines) == 1
+    command = fix_lines[0][len("  fix:") :].strip()
+    expected_prefix = f"/opt/hermes/venv/bin/python {_launcher()} "
+    assert command.startswith(expected_prefix)
+    assert command[len(expected_prefix) :] == shlex.join([
+        "gateway",
+        "run",
+        "--model",
+        "a b",
+    ])
+    # The argv portion must round-trip through a POSIX shell: 'a b' stays one
+    # argument, not two.
+    assert shlex.split(command[len(expected_prefix) :]) == [
+        "gateway",
+        "run",
+        "--model",
+        "a b",
+    ]
 
 
 def test_report_launcher_failure_distinguishes_internal_bug(capsys):

--- a/tests/hermes_cli/test_launcher.py
+++ b/tests/hermes_cli/test_launcher.py
@@ -1,6 +1,7 @@
 """Tests for the top-level `./hermes` launcher script."""
 
 import runpy
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -40,3 +41,41 @@ def test_launcher_delegates_to_argparse_entrypoint(monkeypatch):
     runpy.run_path(str(launcher_path), run_name="__main__")
 
     assert called == ["hermes_cli.main"]
+
+
+def _launcher() -> Path:
+    return Path(__file__).resolve().parents[2] / "hermes"
+
+
+def test_launcher_fails_actionably_when_deps_are_missing():
+    """Running under an interpreter with none of Hermes' dependencies — a
+    bare uv-managed CPython, or a generated .desktop Exec= whose interpreter
+    escaped the install venv — must name the running interpreter and the fix,
+    never a bare `ModuleNotFoundError` traceback (#92882, #90292, #91504)."""
+    result = subprocess.run(
+        [sys.executable, "-S", str(_launcher()), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode != 0
+    assert "Traceback" not in result.stderr
+    assert "ModuleNotFoundError" not in result.stderr
+    assert "hermes:" in result.stderr
+    assert sys.executable in result.stderr
+    assert "venv" in result.stderr.lower()
+
+
+def test_launcher_still_runs_cli_when_deps_are_present():
+    """The import guard must not change the healthy path: with dependencies
+    installed, `./hermes --help` still exits 0 and prints usage."""
+    result = subprocess.run(
+        [sys.executable, str(_launcher()), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0
+    assert "usage" in (result.stdout + result.stderr).lower()

--- a/tests/hermes_cli/test_launcher.py
+++ b/tests/hermes_cli/test_launcher.py
@@ -1,5 +1,6 @@
 """Tests for the top-level `./hermes` launcher script."""
 
+import builtins
 import runpy
 import subprocess
 import sys
@@ -79,3 +80,116 @@ def test_launcher_still_runs_cli_when_deps_are_present():
 
     assert result.returncode == 0
     assert "usage" in (result.stdout + result.stderr).lower()
+
+
+def _launcher_namespace() -> dict:
+    """The launcher's module namespace without running its `__main__` block."""
+    return runpy.run_path(str(_launcher()))
+
+
+def _import_failure_from(tmp_path: Path, rel_path: str, code: str):
+    """`exec` `code` from a temp file so the raised `ModuleNotFoundError`'s
+    innermost traceback frame is that file — mirroring a real import
+    statement living there."""
+    file = tmp_path / rel_path
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text(code)
+    try:
+        exec(compile(code, str(file), "exec"), {"__builtins__": builtins.__dict__})
+    except ModuleNotFoundError as exc:
+        return exc
+    raise AssertionError(f"expected {code!r} to raise ModuleNotFoundError")
+
+
+def test_classify_flags_hermes_cli_internal_import_as_bug(tmp_path):
+    """A `ModuleNotFoundError` for a `hermes_cli.*` submodule raised from a
+    file *inside* the package is an internal bug — the package failing to
+    import its own code — not a missing dependency."""
+    classify = _launcher_namespace()["_classify_import_failure"]
+    pkg_dir = tmp_path / "hermes_cli"
+
+    exc = _import_failure_from(
+        tmp_path,
+        "hermes_cli/broken.py",
+        "import hermes_cli.definitely_missing_submodule",
+    )
+
+    missing, internal = classify(exc, pkg_dir=pkg_dir)
+    assert missing == "hermes_cli.definitely_missing_submodule"
+    assert internal is True
+
+
+def test_classify_reports_missing_third_party_dep(tmp_path):
+    """A missing external module (yaml, dotenv, ...) is a missing dependency
+    even when the failing import statement sits inside hermes_cli."""
+    classify = _launcher_namespace()["_classify_import_failure"]
+    pkg_dir = tmp_path / "hermes_cli"
+
+    exc = _import_failure_from(
+        tmp_path,
+        "hermes_cli/config.py",
+        "import definitely_missing_dependency",
+    )
+
+    missing, internal = classify(exc, pkg_dir=pkg_dir)
+    assert missing == "definitely_missing_dependency"
+    assert internal is False
+
+
+def test_classify_hermes_cli_name_from_outside_is_not_internal(tmp_path):
+    """The same `hermes_cli.*`-named failure raised from *outside* the
+    package (e.g. the launcher itself) is not an internal bug."""
+    classify = _launcher_namespace()["_classify_import_failure"]
+    pkg_dir = tmp_path / "hermes_cli"
+
+    exc = _import_failure_from(
+        tmp_path,
+        "outside.py",
+        "import hermes_cli.definitely_missing_submodule",
+    )
+
+    missing, internal = classify(exc, pkg_dir=pkg_dir)
+    assert missing == "hermes_cli.definitely_missing_submodule"
+    assert internal is False
+
+
+def test_report_launcher_failure_distinguishes_internal_bug(capsys):
+    """The internal-bug report must say 'internal error', never claim a
+    missing dependency or suggest the venv fix."""
+    report = _launcher_namespace()["_report_launcher_failure"]
+    exc = ModuleNotFoundError("No module named 'hermes_cli.typo'")
+    exc.name = "hermes_cli.typo"
+
+    report("hermes_cli.typo", internal=True, exc=exc)
+
+    err = capsys.readouterr().err
+    assert "hermes_cli.typo" in err
+    assert "internal error" in err.lower()
+    assert "missing dependency" not in err.lower()
+
+
+def test_launcher_flags_internal_import_bug_not_missing_deps(tmp_path):
+    """End-to-end: a checkout whose hermes_cli imports its own missing
+    submodule must exit with an 'internal error' diagnostic and the real
+    traceback — it must never be misreported as a missing dependency."""
+    checkout = tmp_path / "checkout"
+    pkg = checkout / "hermes_cli"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    (pkg / "main.py").write_text(
+        "import hermes_cli.definitely_missing_submodule\ndef main():\n    pass\n"
+    )
+    script = checkout / "hermes"
+    script.write_text(_launcher().read_text())
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode != 0
+    assert "internal error" in result.stderr.lower()
+    assert "missing dependency" not in result.stderr.lower()
+    assert "hermes_cli.definitely_missing_submodule" in result.stderr

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import stat
 from pathlib import Path
 
@@ -93,6 +94,9 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
 # interpreter when the DE spawns the .desktop entry → ModuleNotFoundError,
 # silent (Terminal=false). The Exec line must prefix sys.executable for any
 # resolved bin that is a python script escaping the running venv.
+# #92882: the prefixed interpreter must be sys.executable VERBATIM — never
+# resolve()-d — because on POSIX a venv's bin/python is a symlink to the base
+# interpreter and resolve() would walk Exec= straight out of the venv.
 def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_home, monkeypatch):
     import sys
 
@@ -107,10 +111,72 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
-    assert exec_line.split(" ")[0].strip('"') == interpreter
-    assert str(hermes_bin) in exec_line
-    assert exec_line.endswith("desktop")
+    # shlex parses the spec quoting (backslash-escapes inside double quotes),
+    # so the comparison is correct on hosts whose paths need quoting too.
+    tokens = shlex.split(exec_line)
+    assert tokens[0] == sys.executable
+    assert tokens[1] == str(Path(hermes_bin).resolve())
+    assert tokens[-1] == "desktop"
+
+
+def _make_venv_symlink(tmp_path: Path) -> tuple[Path, Path]:
+    """A POSIX-venv ``bin/python`` symlink and its (bare) base interpreter."""
+    base_python = tmp_path / "base" / "python3.11"
+    base_python.parent.mkdir()
+    base_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    venv_python = tmp_path / "venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(base_python)
+    return venv_python, base_python
+
+
+# #92882: on POSIX a venv's bin/python is a symlink to the base interpreter.
+# resolve() follows it out of the venv, so an Exec= built from
+# Path(sys.executable).resolve() pins the entry to an interpreter with none
+# of Hermes' deps — the exact ModuleNotFoundError from the issue. Exec must
+# keep the symlink path verbatim: the kernel follows it to the base binary,
+# but CPython detects the venv via the pyvenv.cfg next to the symlink, so
+# the venv's dependencies stay active.
+@pytest.mark.require_symlinks
+def test_exec_fallback_keeps_venv_interpreter_symlink_verbatim(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    venv_python, base_python = _make_venv_symlink(tmp_path)
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: None)
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    first = shlex.split(exec_line)[0]
+    assert first == str(venv_python)
+    assert str(base_python) not in exec_line
+    assert exec_line.endswith("-m hermes_cli.main desktop")
+
+
+@pytest.mark.require_symlinks
+def test_exec_prefix_keeps_venv_interpreter_symlink_verbatim(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    venv_python, base_python = _make_venv_symlink(tmp_path)
+
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text("#!/usr/bin/env python3\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    tokens = shlex.split(exec_line)
+    assert tokens[0] == str(venv_python)
+    assert str(base_python) not in exec_line
+    assert tokens[1] == str(Path(hermes_bin).resolve())
+    assert tokens[-1] == "desktop"
 
 
 def test_exec_leaves_shell_wrapper_launchers_alone(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Problem

`hermes desktop` — and the generated `~/.local/share/applications/hermes.desktop` — die at import time with a bare `ModuleNotFoundError: No module named 'yaml'` (or `'dotenv'`) whenever the interpreter that ends up running the `hermes` entry script is not the install venv: a uv-managed CPython invoked directly, or an `Exec=` whose interpreter escaped the venv.

## Root cause

1. `hermes_cli/linux_desktop_entry.py::resolve_exec_command()` composed the `Exec=` interpreter from `Path(sys.executable).resolve()`. On POSIX a venv's `bin/python` is a **symlink** to the base interpreter, so `.resolve()` follows it straight out of the venv and pins `Exec=` to an interpreter with none of Hermes' dependencies. Both tracebacks in the issue go through exactly this (`config.py` → `import yaml`, `env_loader.py` → `import dotenv` — different import depths, same escaped-venv interpreter).
2. The repo's `hermes` entry script does a bare `from hermes_cli.main import main`, so any invocation under a dep-less interpreter (the issue's step 2: `<uv-cpython> ~/.hermes/hermes-agent/hermes desktop`) surfaces as an opaque import traceback with no hint about which interpreter ran or where the deps live.

## Fix

1. `resolve_exec_command()` now writes `sys.executable` **verbatim** — never `resolve()`-d — in both the `-m hermes_cli.main` fallback and the env-shebang-prefix branches. Keeping the symlink path is correct: the kernel follows it to the base binary, but CPython detects the venv via the `pyvenv.cfg` next to the symlink, so the venv's dependencies stay active.
2. The `hermes` launcher catches an import-time `ModuleNotFoundError` and exits 1 with an actionable diagnostic: the running interpreter (`sys.executable`), the missing module, and — when discoverable next to the checkout (`venv`/`.venv` + `pyvenv.cfg`) — the expected venv interpreter and the exact command to re-run. A `ModuleNotFoundError` for a `hermes_cli.*` module raised from a file **inside** the package is classified as an internal error (reported with the real traceback, never as a missing dependency), so the launcher guard cannot mask an import bug in `hermes_cli` itself.

## Re-review fixes (Enough1122 nits)

1. **Shell-quoted suggested fix command** — `_report_launcher_failure` renders the re-run command with `shlex.join(sys.argv[1:])` instead of `" ".join(...)`, so `hermes gateway run --model "a b"` comes out as `... --model 'a b'` and copy-pastes verbatim instead of flattening into two arguments.
2. **`raise ... from err` attribution** — `_classify_import_failure` classifies by the innermost frame of the **deepest traceback in the `__cause__` chain**, so an import failure re-raised via `raise ... from err` is attributed to its original import site rather than to whatever re-raised it (which could sit outside the package and demote an internal bug to a "missing dependency"). The contract is pinned in the docstring.
3. **Machine-greppable missing-dependency field** — when `exc.name` is empty, the whole `No module named 'x'` sentence used to land in the `missing dependency:` field; it is now normalized to the bare module token `x`.

New regression tests for this round (RED pre-fix, GREEN with the patch):

- `test_report_launcher_failure_fix_command_is_shell_quoted` — argv entries with spaces must be shell-quoted in the suggested fix and round-trip through a POSIX shell.
- `test_classify_attributes_re_raised_import_to_cause_chain` — a `raise ... from err`-wrapped import failure whose re-raise site is outside `hermes_cli` is still classified as internal via the `__cause__` chain.
- `test_classify_normalizes_unnamed_module_error_to_module_token` — `No module named 'x'` with empty `exc.name` normalizes to `x`.
- `test_report_launcher_failure_missing_dependency_field_is_bare_token` — the report field carries only the module token.

## Evidence / regression tests (RED pre-fix, GREEN with this patch)

- `test_exec_fallback_keeps_venv_interpreter_symlink_verbatim` — builds a real venv-`bin/python` symlink over a bare base interpreter; asserts the `Exec=` first token stays the symlink path and the base interpreter never appears. Pre-fix it pinned `Exec=` to `.../base/python3.11` (exactly the issue's mechanism).
- `test_exec_prefix_keeps_venv_interpreter_symlink_verbatim` — same for the env-shebang-prefix branch.
- `test_launcher_fails_actionably_when_deps_are_missing` — runs `./hermes` under `python -S` (site-packages stripped). Pre-fix stderr is the issue's exact `Traceback ... No module named 'yaml'` (same `main.py:723`); post-fix it names the running interpreter + missing module + fix, with no `Traceback` and no `ModuleNotFoundError`.
- `test_classify_flags_hermes_cli_internal_import_as_bug` / `test_classify_reports_missing_third_party_dep` / `test_classify_hermes_cli_name_from_outside_is_not_internal` — the import-failure classifier: a `hermes_cli.*` module missing from inside the package is an internal bug; a missing external module (yaml, dotenv, …) is a dependency problem even when the failing import sits inside `hermes_cli`; the same `hermes_cli.*` failure raised from outside the package is not internal.
- `test_report_launcher_failure_distinguishes_internal_bug` — the internal-bug report says "internal error", never "missing dependency".
- `test_launcher_flags_internal_import_bug_not_missing_deps` — end-to-end: a checkout whose `hermes_cli` imports its own missing submodule exits 1 with the internal-error diagnostic + real traceback, and is never misreported as a missing dependency.
- `test_launcher_still_runs_cli_when_deps_are_present` — `./hermes --help` still exits 0 with deps installed; the guard does not change the healthy path.
- `test_exec_prefixes_interpreter_for_env_shebang_python_script` updated to the verbatim-interpreter contract (`#90292` coverage stays intact).

Local runs: `pytest tests/hermes_cli/test_launcher.py` → **12 passed** (8 baseline + 4 new); `ruff check` / `ruff format --check` clean on the touched files. RED-before/GREEN-after re-verified for this round: with the launcher fixes reverted to the previous head, exactly the 4 new tests fail; with the fixes restored, all 12 pass. A handful of failures in `test_linux_desktop_entry.py` / `test_relaunch.py` / `test_gui_command.py` on the local Windows box (spec backslash-escaping in raw string comparisons, `S_IXUSR`, POSIX `execvp` contract, missing npm/Electron toolchain) fail identically on pristine `main` and are untouched by this diff — they pass on the Linux/macOS CI lanes where they run.

## Ruled out (same class, sibling sites)

- `_needs_interpreter()` keeps `.resolve()` for shebang classification: it only decides whether to PREFIX with the now-verbatim `sys.executable`, so it cannot itself escape the venv. The one case it misses is a shebang hand-written to the resolved base interpreter, which no pip/uv tooling produces.
- Repo-wide sweep: every other `sys.executable` launch-composition site (cron scheduler, gateway run, kanban dispatch) already uses it verbatim.

## Related — overlap with sibling PRs, stated plainly

- The **`Exec=` half** of this PR (keeping the venv interpreter verbatim in the generated .desktop entry) is **synonymous with open #92090** and overlaps #92122 / #92516 / #92278 / #92790 / #92285 (all unmerged). It is kept here because the issue's `Exec=` traceback goes through exactly this path — but I am happy to rebase onto whichever sibling PR lands first and drop this half, or have maintainers merge per-half.
- The **launcher diagnostic half is unique to this PR**: none of the sibling PRs touch the `hermes` entry script, so only this PR covers the direct-invocation path (issue step 2).

Closes #92882
