### PR TITLE
fix(gateway): never deliver the "(empty)" terminal sentinel to Telegram

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4010,6 +4010,32 @@ import weakref as _weakref
 _gateway_runner_ref: _weakref.ref = lambda: None
 
 
+def _is_empty_agent_sentinel(text: Any) -> bool:
+    """Return True when *text* is an empty agent reply, not user-facing content.
+
+    Covers three shapes the agent produces when a turn yields no answer:
+
+    * ``None`` / ``""`` / whitespace-only — the response is blank;
+    * the bare ``"(empty)"`` terminal sentinel — set by
+      ``agent/conversation_loop.py`` when the retry/fallback chain (nudge,
+      prefill, empty-retry, provider fallback) is exhausted (#92924);
+    * whitespace-padded variants of the sentinel, which escape every
+      exact-equality comparison and were delivered verbatim to chat surfaces.
+
+    The canonical sentinel lives in ``agent.anthropic_adapter``; importing it
+    lazily keeps gateway startup cheap and avoids a module-load cycle.
+    """
+    if not isinstance(text, str):
+        if text is None:
+            return True
+        text = str(text)
+    try:
+        from agent.anthropic_adapter import _EMPTY_TEXT_PLACEHOLDER
+    except Exception:
+        _EMPTY_TEXT_PLACEHOLDER = "(empty)"
+    return text.strip() in ("", _EMPTY_TEXT_PLACEHOLDER)
+
+
 def _normalize_empty_agent_response(
     agent_result: dict,
     response: str,
@@ -4022,13 +4048,19 @@ def _normalize_empty_agent_response(
     the case where the agent did work (api_calls > 0) but returned no text.
     Fix for #18765.
 
+    Also treats the agent's ``"(empty)"`` terminal sentinel (and its
+    whitespace-padded variants) as empty so the bare placeholder is never
+    delivered to a chat surface (#92924): when all retries are exhausted the
+    user gets the same friendly fallback as a blank response, mirroring the
+    WeChat adapter's silent empty-chunk filtering.
+
     Also surfaces a retry hint when the agent never ran at all
     (api_calls == 0) for a non-interrupted, non-failed turn -- this is the
     silent-drop pattern observed after ``/stop`` where the next user
     message hits a stale generation token and returns an empty result,
     leaving the platform with nothing to send. (#31884)
     """
-    if response:
+    if response and not _is_empty_agent_sentinel(response):
         return response
 
     if agent_result.get("failed"):
@@ -6456,7 +6488,7 @@ class TurnRunner:
                 and result.get("completed") is not False
             ):
                 _fr = result.get("final_response")
-                if isinstance(_fr, str) and _fr.strip() and _fr != "(empty)":
+                if isinstance(_fr, str) and _fr.strip() and not _is_empty_agent_sentinel(_fr):
                     _final_for_stream = _fr
             if _final_for_stream is not None:
                 # Duck-type safe: test doubles / older consumers may expose a
@@ -20443,7 +20475,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # produce visible content after exhausting all retries (nudge,
             # prefill, empty-retry, fallback).  Sending the raw sentinel
             # looks like a bug; a short explanation is more helpful.
-            if response == "(empty)" and not _intentional_silence:
+            # Compare stripped text (#92924): whitespace-padded sentinel
+            # variants must not slip past the exact-equality check.
+            if (
+                isinstance(response, str)
+                and not _intentional_silence
+                and _is_empty_agent_sentinel(response)
+                and str(response).strip() != ""
+            ):
                 response = (
                     "⚠️ The model returned no response after processing tool "
                     "results. This can happen with some models — try again or "
@@ -29908,7 +29947,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _sc = stream_consumer_holder[0]
         if isinstance(response, dict) and not response.get("failed"):
             _final = response.get("final_response") or ""
-            _is_empty_sentinel = not _final or _final == "(empty)"
+            _is_empty_sentinel = _is_empty_agent_sentinel(_final)
             # response_previewed means the interim_assistant_callback already
             # saw the final text, but only suppress the normal send if that
             # exact final text was delivered. Unrelated commentary/progress

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4031,7 +4031,11 @@ def _is_empty_agent_sentinel(text: Any) -> bool:
         text = str(text)
     try:
         from agent.anthropic_adapter import _EMPTY_TEXT_PLACEHOLDER
-    except Exception:
+    except ImportError:
+        # Only the standalone/test edge (``agent`` package not importable)
+        # degrades to the literal.  Narrow on purpose: a syntax error or
+        # other genuine breakage in agent.anthropic_adapter must surface
+        # loudly, not silently pin the fallback literal forever (#92924).
         _EMPTY_TEXT_PLACEHOLDER = "(empty)"
     return text.strip() in ("", _EMPTY_TEXT_PLACEHOLDER)
 
@@ -20477,6 +20481,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # looks like a bug; a short explanation is more helpful.
             # Compare stripped text (#92924): whitespace-padded sentinel
             # variants must not slip past the exact-equality check.
+            # The `str(response).strip() != ""` clause deliberately lets a
+            # whitespace-only reply bypass this explainer: that case is
+            # normalized by _normalize_empty_agent_response() below, which
+            # has its own friendly fallback for blank responses.  Only the
+            # non-blank sentinel (incl. padded variants) gets this
+            # tool-results message; this asymmetry is intentional.
             if (
                 isinstance(response, str)
                 and not _intentional_silence

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5219,7 +5219,13 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="send_path_degraded", retryable=True)
 
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
-        if not content or not content.strip():
+        # Also skip the agent's "(empty)" terminal sentinel (#92924): the
+        # gateway converts it to a friendly fallback on the normal delivery
+        # path, but direct callers (status bubbles, pushes, queued sends) can
+        # still hand us the raw placeholder — never render it to a user.
+        if not content or not content.strip() or (
+            isinstance(content, str) and content.strip() == "(empty)"
+        ):
             return SendResult(success=True, message_id=None)
         
         try:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -38,6 +38,23 @@ def _redact_telegram_error_text(error: object) -> str:
         return "<telegram error redacted>"
 
 
+def _empty_agent_sentinel_text() -> str:
+    """The agent's terminal ``"(empty)"`` sentinel, from its single source.
+
+    The canonical constant is ``agent.anthropic_adapter._EMPTY_TEXT_PLACEHOLDER``
+    — the same source the gateway's ``_is_empty_agent_sentinel`` classifier
+    imports — so the adapter guard can never drift from the gateway's
+    comparison (#92924). Imported lazily, matching the adapter's other
+    ``agent.*`` imports and the gateway's lazy import; the literal is only a
+    defensive fallback for standalone/test use.
+    """
+    try:
+        from agent.anthropic_adapter import _EMPTY_TEXT_PLACEHOLDER
+        return _EMPTY_TEXT_PLACEHOLDER
+    except Exception:
+        return "(empty)"
+
+
 def _scoped_gate_env(name: str, default: str = "") -> str:
     """Read a TELEGRAM_*/GATEWAY_* authorization gate env var per-profile.
 
@@ -5222,9 +5239,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # Also skip the agent's "(empty)" terminal sentinel (#92924): the
         # gateway converts it to a friendly fallback on the normal delivery
         # path, but direct callers (status bubbles, pushes, queued sends) can
-        # still hand us the raw placeholder — never render it to a user.
+        # still hand us the raw placeholder. The sentinel value comes from the
+        # same canonical constant the gateway compares against, so this guard
+        # and the gateway's classifier cannot drift apart.
         if not content or not content.strip() or (
-            isinstance(content, str) and content.strip() == "(empty)"
+            isinstance(content, str) and content.strip() == _empty_agent_sentinel_text()
         ):
             return SendResult(success=True, message_id=None)
         

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -51,7 +51,11 @@ def _empty_agent_sentinel_text() -> str:
     try:
         from agent.anthropic_adapter import _EMPTY_TEXT_PLACEHOLDER
         return _EMPTY_TEXT_PLACEHOLDER
-    except Exception:
+    except ImportError:
+        # Standalone/test-use fallback only.  Narrow on purpose: genuine
+        # breakage in agent.anthropic_adapter (e.g. a syntax error) must
+        # raise loudly instead of silently pinning the literal and drifting
+        # from the gateway's classifier (#92924).
         return "(empty)"
 
 

--- a/tests/gateway/test_normalize_empty_agent_response.py
+++ b/tests/gateway/test_normalize_empty_agent_response.py
@@ -8,6 +8,8 @@ They must also never see 'The request failed: None' when the gateway result
 dict carries an explicit ``error: None``.
 """
 
+import sys
+
 import pytest
 
 from gateway.run import _normalize_empty_agent_response
@@ -189,4 +191,47 @@ class TestIsEmptyAgentSentinelHelper:
         is_sentinel = self._helper()
         for value in ("hello", "(empty) but also words", "(emptyish)", "0", 123):
             assert not is_sentinel(value), repr(value)
+
+    @staticmethod
+    def _install_fake_agent_package(monkeypatch, tmp_path, anthropic_adapter_source):
+        """Make `agent.anthropic_adapter` resolve to a fake, in-test module."""
+        agent_dir = tmp_path / "agent"
+        agent_dir.mkdir()
+        (agent_dir / "__init__.py").write_text("", encoding="utf-8")
+        (agent_dir / "anthropic_adapter.py").write_text(
+            anthropic_adapter_source, encoding="utf-8"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.delitem(sys.modules, "agent.anthropic_adapter", raising=False)
+        monkeypatch.delitem(sys.modules, "agent", raising=False)
+
+    def test_import_error_falls_back_to_literal(self, monkeypatch, tmp_path):
+        """Standalone/test edge still degrades gracefully on ImportError.
+
+        With the sentinel constant absent from the (fake) module, the lazy
+        ``from ... import`` raises ImportError and the classifier must fall
+        back to the ``"(empty)"`` literal (#92924 review: narrow to
+        ImportError, keep the standalone edge working).
+        """
+        is_sentinel = self._helper()
+        self._install_fake_agent_package(
+            monkeypatch, tmp_path, "# no _EMPTY_TEXT_PLACEHOLDER here\n"
+        )
+        assert is_sentinel("(empty)")
+        assert is_sentinel("   \n")
+        assert not is_sentinel("real answer")
+
+    def test_syntax_error_in_anthropic_adapter_surfaces(self, monkeypatch, tmp_path):
+        """A genuine breakage in agent.anthropic_adapter must NOT be swallowed.
+
+        A syntax error is not an ImportError, so the narrowed handler must let
+        it propagate instead of silently pinning the fallback literal forever
+        (#92924 review: real bugs surface loudly).
+        """
+        is_sentinel = self._helper()
+        self._install_fake_agent_package(
+            monkeypatch, tmp_path, "def broken(:\n"
+        )
+        with pytest.raises(SyntaxError):
+            is_sentinel("(empty)")
 

--- a/tests/gateway/test_normalize_empty_agent_response.py
+++ b/tests/gateway/test_normalize_empty_agent_response.py
@@ -126,3 +126,67 @@ class TestGenericFailureRegression:
 
         assert "context window" in response
         assert "/compact" in response
+
+
+class TestEmptySentinelNormalizedToFriendlyFallback:
+    """The agent's '(empty)' terminal sentinel (conversation_loop.py sets
+    final_response='(empty)' after the retry/fallback chain is exhausted)
+    must never be delivered to a chat surface verbatim (#92924). It is a
+    user-facing failure signal, so ``_normalize_empty_agent_response`` must
+    treat it — and whitespace-padded variants of it — as an empty response
+    and substitute the friendly fallback, exactly like a blank response."""
+
+    def test_bare_empty_sentinel_becomes_friendly_fallback(self):
+        agent_result = {"api_calls": 2}
+        response = _normalize_empty_agent_response(agent_result, "(empty)", history_len=10)
+        assert response != "(empty)"
+        assert "no response was generated" in response
+
+    def test_whitespace_padded_sentinel_becomes_friendly_fallback(self):
+        agent_result = {"api_calls": 2}
+        for padded in ("(empty)\n", " (empty) ", "(empty)\n\n"):
+            response = _normalize_empty_agent_response(agent_result, padded, history_len=10)
+            assert response != padded
+            assert "(empty)" not in response
+            assert "no response was generated" in response
+
+    def test_whitespace_only_response_becomes_friendly_fallback(self):
+        agent_result = {"api_calls": 3}
+        response = _normalize_empty_agent_response(agent_result, "   \n  ", history_len=10)
+        assert response.strip()
+        assert "no response was generated" in response
+
+    def test_sentinel_with_zero_api_calls_never_reaches_user(self):
+        agent_result = {"api_calls": 0}
+        response = _normalize_empty_agent_response(agent_result, "(empty)", history_len=10)
+        assert response != "(empty)"
+        assert "wasn't processed" in response
+
+    def test_failed_turn_with_sentinel_uses_failure_message(self):
+        agent_result = {"api_calls": 2, "failed": True, "error": "provider exploded"}
+        response = _normalize_empty_agent_response(agent_result, "(empty)", history_len=10)
+        assert "(empty)" not in response
+        assert "The request failed: provider exploded" in response
+
+    def test_real_text_still_passes_through(self):
+        agent_result = {"api_calls": 1}
+        assert _normalize_empty_agent_response(agent_result, "real answer", history_len=10) == "real answer"
+
+
+class TestIsEmptyAgentSentinelHelper:
+    """The shared sentinel classifier used by the gateway delivery chain."""
+
+    def _helper(self):
+        from gateway.run import _is_empty_agent_sentinel
+        return _is_empty_agent_sentinel
+
+    def test_recognizes_sentinel_variants(self):
+        is_sentinel = self._helper()
+        for value in (None, "", "   ", "\n", "(empty)", "(empty)\n", " (empty) "):
+            assert is_sentinel(value), repr(value)
+
+    def test_rejects_real_content(self):
+        is_sentinel = self._helper()
+        for value in ("hello", "(empty) but also words", "(emptyish)", "0", 123):
+            assert not is_sentinel(value), repr(value)
+

--- a/tests/gateway/test_telegram_empty_sentinel_guard.py
+++ b/tests/gateway/test_telegram_empty_sentinel_guard.py
@@ -56,3 +56,32 @@ def test_send_still_delivers_real_content():
     result = asyncio.run(adapter.send(chat_id="123", content="real answer"))
     assert result.success is True
     assert bot.send_message.await_count >= 1
+
+
+def test_sentinel_guard_follows_canonical_constant(monkeypatch):
+    """The adapter must not hardcode the sentinel literal.
+
+    The guard reads ``agent.anthropic_adapter._EMPTY_TEXT_PLACEHOLDER`` at
+    call time — the same single source the gateway's classifier imports. If
+    someone re-hardcodes ``"(empty)"`` in the adapter, this test fails
+    because the re-hardcoded guard would send ``(nil)`` to the Bot API
+    instead of skipping it (#92924 review: single-source the sentinel).
+    """
+    import agent.anthropic_adapter as anthropic_adapter
+
+    monkeypatch.setattr(anthropic_adapter, "_EMPTY_TEXT_PLACEHOLDER", "(nil)")
+    adapter, bot = _make_adapter()
+    result = asyncio.run(adapter.send(chat_id="123", content="(nil)"))
+    assert result.success is True
+    assert result.message_id is None
+    assert bot.send_message.await_count == 0
+
+
+def test_sentinel_guard_matches_gateway_classifier():
+    """Adapter guard and gateway classifier must agree on the sentinel value."""
+    from gateway.run import _is_empty_agent_sentinel
+    from plugins.platforms.telegram.adapter import _empty_agent_sentinel_text
+
+    sentinel = _empty_agent_sentinel_text()
+    assert sentinel
+    assert _is_empty_agent_sentinel(sentinel)

--- a/tests/gateway/test_telegram_empty_sentinel_guard.py
+++ b/tests/gateway/test_telegram_empty_sentinel_guard.py
@@ -10,6 +10,7 @@ send it, mirroring the existing whitespace-only skip.
 """
 
 import asyncio
+import sys
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -85,3 +86,46 @@ def test_sentinel_guard_matches_gateway_classifier():
     sentinel = _empty_agent_sentinel_text()
     assert sentinel
     assert _is_empty_agent_sentinel(sentinel)
+
+
+def _install_fake_agent_package(monkeypatch, tmp_path, anthropic_adapter_source):
+    """Make `agent.anthropic_adapter` resolve to a fake, in-test module."""
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    (agent_dir / "__init__.py").write_text("", encoding="utf-8")
+    (agent_dir / "anthropic_adapter.py").write_text(
+        anthropic_adapter_source, encoding="utf-8"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, "agent.anthropic_adapter", raising=False)
+    monkeypatch.delitem(sys.modules, "agent", raising=False)
+
+
+def test_adapter_sentinel_text_import_error_falls_back_to_literal(monkeypatch, tmp_path):
+    """Standalone/test edge still degrades gracefully on ImportError.
+
+    With the sentinel constant absent from the (fake) module, the lazy
+    ``from ... import`` raises ImportError and the adapter helper must fall
+    back to the ``"(empty)"`` literal (#92924 review: narrow to ImportError,
+    keep the standalone edge working).
+    """
+    from plugins.platforms.telegram.adapter import _empty_agent_sentinel_text
+
+    _install_fake_agent_package(
+        monkeypatch, tmp_path, "# no _EMPTY_TEXT_PLACEHOLDER here\n"
+    )
+    assert _empty_agent_sentinel_text() == "(empty)"
+
+
+def test_adapter_sentinel_text_syntax_error_surfaces(monkeypatch, tmp_path):
+    """A genuine breakage in agent.anthropic_adapter must NOT be swallowed.
+
+    A syntax error is not an ImportError, so the narrowed handler must let it
+    propagate instead of silently pinning the fallback literal forever
+    (#92924 review: real bugs surface loudly).
+    """
+    from plugins.platforms.telegram.adapter import _empty_agent_sentinel_text
+
+    _install_fake_agent_package(monkeypatch, tmp_path, "def broken(:\n")
+    with pytest.raises(SyntaxError):
+        _empty_agent_sentinel_text()

--- a/tests/gateway/test_telegram_empty_sentinel_guard.py
+++ b/tests/gateway/test_telegram_empty_sentinel_guard.py
@@ -1,0 +1,58 @@
+"""Regression tests for the Telegram adapter's empty-response sentinel guard (#92924).
+
+The agent's ``(empty)`` terminal sentinel means the model produced no visible
+content after the retry/fallback chain was exhausted. The gateway converts the
+exact sentinel to a friendly message on the normal delivery path, but any path
+that hands the raw sentinel (or a whitespace-padded variant of it) straight to
+``TelegramAdapter.send()`` — status bubbles, direct pushes, queued delivery —
+would render the literal ``(empty)`` text to the user. The adapter must never
+send it, mirroring the existing whitespace-only skip.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter():
+    cfg = PlatformConfig(enabled=True, token="fake-token", extra={})
+    adapter = TelegramAdapter(cfg)
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=456))
+    bot.send_chat_action = AsyncMock()
+    adapter._bot = bot
+    # Force the legacy (non-rich) send path.
+    adapter._rich_messages_enabled = False
+    return adapter, bot
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "(empty)",
+        "(empty)\n",
+        " (empty) ",
+        "(empty)\n\n",
+        "   ",
+        "\n",
+    ],
+)
+def test_send_skips_empty_sentinel_without_network_call(content):
+    """The bare sentinel and its whitespace variants must never be sent."""
+    adapter, bot = _make_adapter()
+    result = asyncio.run(adapter.send(chat_id="123", content=content))
+    assert result.success is True
+    assert result.message_id is None
+    assert bot.send_message.await_count == 0
+
+
+def test_send_still_delivers_real_content():
+    """The guard must not eat genuine replies."""
+    adapter, bot = _make_adapter()
+    result = asyncio.run(adapter.send(chat_id="123", content="real answer"))
+    assert result.success is True
+    assert bot.send_message.await_count >= 1


### PR DESCRIPTION
## Problem

Fixes #92924 — Telegram channels show a bare `(empty)` message when the model returns a null/empty response (e.g. right after switching models on the Nous portal), while WeChat appears to handle the same failure silently.

## Retry behavior is already aligned — the issue's premise, checked against the code

The adversarial question is whether empty results bypass the retry ladder (which would make this PR a cosmetic band-aid). They do not. The ladder exists in the shared agent layer, runs identically for every platform (Telegram and WeChat included), and `"(empty)"` is strictly a **post-exhaustion artifact**:

- **Post-tool-call empty nudge** — `agent/conversation_loop.py:7652-7684`: an empty reply right after tool results re-prompts the model once (`_post_tool_empty_retried`).
- **Thinking-prefill continuation** — `agent/conversation_loop.py:7701-7718`: reasoning-only replies are prefilled and continued (×2).
- **Empty-content retry ladder** — `agent/conversation_loop.py:7761-7815`: truly empty replies retry up to `DEFAULT_EMPTY_RETRY_BUDGET = 3` (`agent/empty_response_guard.py:56`) with jittered backoff (5s→60s), with a cost-aware budget reduction for high-cost requests.
- **Deterministic-empty guard** — `agent/conversation_loop.py:7817-7829`: consecutive zero-output completions deliberately skip the remaining paid retries (NS-503, to stop re-billing input tokens for a model that provably returns nothing).
- **Provider fallback chain** — `agent/conversation_loop.py:7837-7870`: before giving up, the next provider in the fallback chain is activated.
- **Only then** `final_response = "(empty)"` — `agent/conversation_loop.py:7948`. There is no code path that sets the sentinel without running (or deliberately cutting short) the ladder first.

So "Telegram should retry like WeChat" is already true: WeChat has no empty-response retry at the adapter layer either. Its `_send_text_chunk_locked` retries are transport-level (session-expired −14 / rate-limit −2; `gateway/platforms/weixin.py:1822-1865`) — unrelated to a model returning null. Both platforms ride the same agent-layer ladder, and the PR's new Telegram boundary guard mirrors WeChat's empty-chunk send filter.

**Why the reporter saw an immediate `(empty)`, then.** After switching models, a newly-selected model frequently returns consecutive zero-output completions while the provider warms up; the deterministic-empty guard then *intentionally* skips the remaining retries to avoid re-billing, so exhaustion — and the sentinel — arrives fast. That looks like "no retry attempted" but is the cost-protection path. The reason it was rendered as the literal `(empty)` instead of the friendly fallback is the display-layer gap this PR closes (below): the gateway compared the sentinel with exact equality, so whitespace-padded variants, the truthy pass-through in `_normalize_empty_agent_response`, and direct adapter callers all leaked it verbatim. A pre-fix build could also show it if the reporter predates the gateway conversion.

## Root cause (display layer)

The gateway owns the user-facing conversion, but every guard in the delivery chain compared the sentinel with **exact equality on the raw string**:

- `gateway/run.py` `response == "(empty)"` (final-reply conversion) — misses `"(empty)\n"`, `" (empty) "` etc.
- `gateway/run.py` `_fr != "(empty)"` (stream-finalize payload) — a padded variant was adopted as the authoritative streamed final and sealed on screen.
- `gateway/run.py` `_final == "(empty)"` (duplicate-send suppression) — a padded variant could suppress the corrective friendly send after streaming.
- `_normalize_empty_agent_response` — `if response: return response` passed the sentinel straight through: it is a truthy 7-char string, so the documented empty-response catch-all never fired.

The Telegram adapter (`plugins/platforms/telegram/adapter.py`) skips whitespace-only text but had **no sentinel guard at all**, so direct callers (status bubbles, pushes, queued sends) could render the raw placeholder. By contrast, `gateway/platforms/weixin.py` filters empty chunks at the send boundary — the asymmetry the reporter observed.

## Fix

Class-level fix at the gateway chokepoint plus defense-in-depth at the Telegram boundary:

1. **`gateway/run.py`** — new shared helper `_is_empty_agent_sentinel(text)` that recognizes `None`/blank/whitespace-only text and the `(empty)` sentinel **after stripping** (canonical constant imported from `agent.anthropic_adapter._EMPTY_TEXT_PLACEHOLDER`, with a literal fallback).
   - `_normalize_empty_agent_response` now routes sentinel variants into the existing friendly fallbacks ("⚠️ Processing completed but no response was generated…", the zero-api-calls retry hint, or the failure message) instead of echoing the placeholder.
   - All three exact-equality sentinel checks (final-reply conversion, stream-finalize adoption, duplicate-send suppression) now use the stripped comparison.
2. **`plugins/platforms/telegram/adapter.py`** — `send()` extends the existing empty-content skip to the bare sentinel (strip-compared), mirroring the WeChat adapter's silent empty-chunk filtering. The sentinel value is **not hardcoded**: `_empty_agent_sentinel_text()` imports the same canonical `agent.anthropic_adapter._EMPTY_TEXT_PLACEHOLDER` the gateway classifier uses, so the two guards cannot drift apart (review: single-source the constant; regression-tested by monkeypatching the canonical constant and asserting the adapter guard follows it). This closes the known direct-caller paths into the Telegram text-send boundary — it is not a claim that no future outbound surface (e.g. a new media-caption path in another adapter) could ever carry the string.

This preserves existing behavior byte-for-byte for the exact `"(empty)"` string on the normal path (it still gets the specific "model returned no response after processing tool results" wording) while closing the whitespace-variant and direct-caller gaps.

## Verification

- **Pre-fix red**: the new regression tests fail on `origin/main` — 11 failures, including proof that `TelegramAdapter.send("(empty)")` currently hits the Bot API (`message_id` returned).
- **Post-fix green**: `tests/gateway/test_normalize_empty_agent_response.py` (7 new cases + helper suite) and `tests/gateway/test_telegram_empty_sentinel_guard.py` (sentinel skip + real-content passthrough + single-source constant tests) — see CI.
- **Single-source bite test**: monkeypatching `agent.anthropic_adapter._EMPTY_TEXT_PLACEHOLDER` to `(nil)` makes the adapter skip `(nil)` — proof the guard reads the canonical constant instead of a hardcoded literal.
- **Sabotage run**: reverting both fix seams re-breaks 9 of the new tests, confirming they bite.
- Related suites pass: `test_duplicate_reply_suppression.py`, `test_tool_response_drop_recovery.py`, `test_send_error_classification.py`, `test_update_streaming.py` (one pre-existing Windows-env failure in `test_spawns_with_gateway_flag` also fails on clean `origin/main` — unrelated).

## Out of scope / ruled out

- **No new retry loop was added** — the adversarial hypothesis of an empty-result retry gap was checked against `agent/conversation_loop.py` and rejected: empty results cannot reach the `"(empty)"` terminal without passing (or being deliberately cut short by) the ladder at the lines cited above. The issue's own wording made adapter-side retries optional ("optionally show…"), and duplicating the agent-layer ladder in the adapter would double-charge retried turns.
- A model *streaming* the literal `(empty)` text as deltas is not filtered token-by-token (a streaming state machine for that would be over-engineering): the terminal conversion plus the final-payload reconciliation corrects it at turn end.
- WeChat (`weixin.py`) already drops empty chunks at its send boundary — no change needed there.

Closes #92924

## Review round 2 fixes (Enough1122)

### 1. Lazy-import fallbacks narrowed to `except ImportError`

Both fallbacks previously caught bare `except Exception`, which could swallow a genuine breakage in `agent.anthropic_adapter` (e.g. a syntax error) and silently pin the fallback literal forever — the exact drift the single-source design exists to prevent.

- `gateway/run.py` `_is_empty_agent_sentinel`: `except Exception` → `except ImportError`, with a comment stating only the standalone/test edge (agent package not importable / constant missing) degrades to the literal.
- `plugins/platforms/telegram/adapter.py` `_empty_agent_sentinel_text`: same narrowing + comment.

Real bugs now surface loudly; only the standalone/test edge degrades gracefully.

### 2. Whitespace-only asymmetry documented

Added a comment at the `str(response).strip() != ""` clause in `_handle_message_with_agent`: a whitespace-only reply deliberately bypasses the "no response after processing tool results" explainer and is normalized by `_normalize_empty_agent_response()` below, which has its own friendly blank-response fallback. Only the non-blank sentinel (incl. padded variants) gets the tool-results message. The asymmetry is intentional.

### Regression tests added

- `tests/gateway/test_normalize_empty_agent_response.py`:
  - `test_import_error_falls_back_to_literal` — ImportError still degrades to the `"(empty)"` literal (standalone edge preserved).
  - `test_syntax_error_in_anthropic_adapter_surfaces` — a syntax error in `agent.anthropic_adapter` propagates (not swallowed).
- `tests/gateway/test_telegram_empty_sentinel_guard.py`:
  - `test_adapter_sentinel_text_import_error_falls_back_to_literal`
  - `test_adapter_sentinel_text_syntax_error_surfaces`

Verified RED → GREEN: with the fix stashed (pre-fix `except Exception`), both `*_surfaces` tests FAIL (`DID NOT RAISE SyntaxError`); with the fix, all 28 tests in the two files pass, and the broader Telegram regression (`tests/gateway/test_telegram_*.py` + related tools tests) passes 588/588. A live sabotage check (real syntax error appended to `agent/anthropic_adapter.py`) confirmed both fallback paths raise loudly, then the file was restored.

### Follow-up (tracked, not in this PR)

The adapter-level sentinel guard exists only for Telegram. Other platforms' direct-send paths (status bubbles / pushes) can still receive raw sentinels. Tracked as a follow-up; out of scope for this PR.
