### PR TITLE
fix(skills): resolve bundled script paths through HERMES_HOME (#93152)

### DIFF
--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,0 +1,2 @@
+smfworks
+# SMF Works contributor

--- a/skills/productivity/maps/SKILL.md
+++ b/skills/productivity/maps/SKILL.md
@@ -39,12 +39,12 @@ functionality is covered by the `nearby` command below, with the same
 
 Python 3.8+ (stdlib only — no pip installs needed).
 
-Script path: `~/.hermes/skills/maps/scripts/maps_client.py`
+Script path: `${HERMES_HOME:-$HOME/.hermes}/skills/productivity/maps/scripts/maps_client.py`
 
 ## Commands
 
 ```bash
-MAPS=~/.hermes/skills/maps/scripts/maps_client.py
+MAPS="${HERMES_HOME:-$HOME/.hermes}/skills/productivity/maps/scripts/maps_client.py"
 ```
 
 ### search — Geocode a place name
@@ -187,9 +187,9 @@ current.
 ## Verification
 
 ```bash
-python ~/.hermes/skills/maps/scripts/maps_client.py search "Statue of Liberty"
+python "${HERMES_HOME:-$HOME/.hermes}/skills/productivity/maps/scripts/maps_client.py" search "Statue of Liberty"
 # Should return lat ~40.689, lon ~-74.044
 
-python ~/.hermes/skills/maps/scripts/maps_client.py nearby --near "Times Square" --category restaurant --limit 3
+python "${HERMES_HOME:-$HOME/.hermes}/skills/productivity/maps/scripts/maps_client.py" nearby --near "Times Square" --category restaurant --limit 3
 # Should return a list of restaurants within ~500m of Times Square
 ```

--- a/skills/research/grounded-citations/SKILL.md
+++ b/skills/research/grounded-citations/SKILL.md
@@ -56,7 +56,7 @@ Override per task with `--ledger <path>` or `HERMES_CITATION_LEDGER`.
 ## How to Run
 
 ```bash
-S=~/.hermes/skills/research/grounded-citations/scripts/sources.py
+S="${HERMES_HOME:-$HOME/.hermes}/skills/research/grounded-citations/scripts/sources.py"
 
 python "$S" reset                                  # start a clean ledger
 python "$S" add https://example.com/a --title "A"  # prints: [1]

--- a/tests/skills/test_bundled_skill_executable_paths.py
+++ b/tests/skills/test_bundled_skill_executable_paths.py
@@ -1,0 +1,28 @@
+"""Bundled SKILL.md must not hardcode ~/.hermes for executable script paths (#93152)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SKILLS = REPO / "skills"
+
+# Copied-and-run assignment: S=~/.hermes/skills/...
+_ASSIGN = re.compile(r"(?m)^[A-Za-z_][A-Za-z0-9_]*=(?:['\"])?~/\.hermes/skills/")
+# Copied-and-run invocation: python ~/.hermes/skills/...
+_INVOKE = re.compile(
+    r"(?m)(?:^|[\s`])(?:python3?|bash|uv)\s+(?:['\"])?~/\.hermes/skills/"
+)
+
+
+def test_bundled_skill_md_does_not_hardcode_default_home_for_scripts():
+    offenders: list[str] = []
+    for skill_md in SKILLS.rglob("SKILL.md"):
+        text = skill_md.read_text(encoding="utf-8")
+        if _ASSIGN.search(text) or _INVOKE.search(text):
+            offenders.append(str(skill_md.relative_to(REPO).as_posix()))
+    assert offenders == [], (
+        "SKILL.md documents a ~/.hermes executable path; use "
+        "${HERMES_HOME:-$HOME/.hermes} instead: " + ", ".join(offenders)
+    )


### PR DESCRIPTION
## Summary

Two bundled `SKILL.md` files told the agent to execute `~/.hermes/skills/...` verbatim. That path does not exist when `HERMES_HOME` is a profile (or any non-default home). Each miss costs a turn (`python3: can't open file ...`).

- `skills/research/grounded-citations/SKILL.md` — `sources.py`
- `skills/productivity/maps/SKILL.md` — `maps_client.py` (also used the wrong relative path `skills/maps/`; the bundled tree is `skills/productivity/maps/`)

Both now use `${HERMES_HOME:-$HOME/.hermes}` plus the real bundled relative path, matching the rest of the skill tree.

A regression test scans every bundled `SKILL.md` for assignment/invocation of `~/.hermes/skills/` so the class does not come back.

## Test Plan

- [x] `pytest tests/skills/test_bundled_skill_executable_paths.py` — 1 passed (failed on unfixed SKILL.md first)
- [x] ruff clean

Closes #93152