### PR TITLE
fix(test): native hermes shim for Windows stress e2e (#93136)

### DIFF
--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,0 +1,2 @@
+smfworks
+# SMF Works contributor

--- a/tests/cron/hermes_checkout_shim.py
+++ b/tests/cron/hermes_checkout_shim.py
@@ -1,0 +1,55 @@
+"""Install a checkout-local `hermes` launcher for stress e2e (#93136).
+
+The previous harness wrote an extensionless POSIX shim and joined PATH with
+``:``. On native Windows that silently resolved to the user-installed
+``hermes.EXE`` instead of the worktree under test.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+
+def prepend_shim_to_path(shim_dir: Path | str, path: str | None = None) -> str:
+    """Join *shim_dir* onto PATH using this OS's path separator."""
+    existing = os.environ.get("PATH", "") if path is None else path
+    prefix = str(shim_dir)
+    if not existing:
+        return prefix
+    return f"{prefix}{os.pathsep}{existing}"
+
+
+def install_checkout_hermes_shim(shim_dir: Path | str, *, python_exe: str) -> Path:
+    """Write a native launcher that execs ``python -m hermes_cli.main``."""
+    dest = Path(shim_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    if os.name == "nt":
+        launcher = dest / "hermes.cmd"
+        launcher.write_text(
+            f'@echo off\r\n"{python_exe}" -m hermes_cli.main %*\r\n',
+            encoding="utf-8",
+        )
+    else:
+        launcher = dest / "hermes"
+        launcher.write_text(
+            f'#!/bin/sh\nexec "{python_exe}" -m hermes_cli.main "$@"\n',
+            encoding="utf-8",
+        )
+        launcher.chmod(0o755)
+    return launcher
+
+
+def assert_which_is_shim(shim_dir: Path | str) -> Path:
+    """Fail closed if ``hermes`` on PATH is not the checkout shim."""
+    resolved = shutil.which("hermes")
+    if resolved is None:
+        raise RuntimeError("hermes shim is not resolvable on PATH")
+    resolved_path = Path(resolved).resolve()
+    expected_dir = Path(shim_dir).resolve()
+    if resolved_path.parent != expected_dir:
+        raise RuntimeError(
+            f"hermes resolved to {resolved_path}, not the checkout shim in {expected_dir}"
+        )
+    return resolved_path

--- a/tests/cron/test_hermes_checkout_shim.py
+++ b/tests/cron/test_hermes_checkout_shim.py
@@ -1,0 +1,48 @@
+"""#93136: stress e2e must never resolve `hermes` to a globally installed binary."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.cron.hermes_checkout_shim import (
+    assert_which_is_shim,
+    install_checkout_hermes_shim,
+    prepend_shim_to_path,
+)
+
+
+def test_path_join_uses_os_pathsep():
+    shim = Path("C:/tmp/shim") if os.name == "nt" else Path("/tmp/shim")
+    joined = prepend_shim_to_path(shim, "elsewhere")
+    assert joined.split(os.pathsep)[0] == str(shim)
+    assert os.pathsep in joined or joined == str(shim)
+
+
+def test_install_shim_is_what_which_resolves(tmp_path, monkeypatch):
+    shim_dir = tmp_path / "bin"
+    install_checkout_hermes_shim(shim_dir, python_exe="python")
+    monkeypatch.setenv("PATH", prepend_shim_to_path(shim_dir, os.environ.get("PATH", "")))
+    resolved = shutil.which("hermes")
+    assert resolved is not None
+    assert_which_is_shim(shim_dir)
+    assert Path(resolved).resolve().parent == shim_dir.resolve()
+
+
+def test_assert_which_is_shim_rejects_foreign_binary(tmp_path, monkeypatch):
+    shim_dir = tmp_path / "bin"
+    foreign = tmp_path / "other"
+    foreign.mkdir()
+    if os.name == "nt":
+        (foreign / "hermes.cmd").write_text("@echo off\r\n", encoding="utf-8")
+    else:
+        launcher = foreign / "hermes"
+        launcher.write_text("#!/bin/sh\n", encoding="utf-8")
+        launcher.chmod(0o755)
+    install_checkout_hermes_shim(shim_dir, python_exe="python")
+    monkeypatch.setenv("PATH", f"{foreign}{os.pathsep}{shim_dir}")
+    with pytest.raises(RuntimeError, match="not the checkout shim"):
+        assert_which_is_shim(shim_dir)

--- a/tests/stress/test_subprocess_e2e.py
+++ b/tests/stress/test_subprocess_e2e.py
@@ -17,6 +17,12 @@ import sys
 import tempfile
 import time
 
+from tests.cron.hermes_checkout_shim import (
+    assert_which_is_shim,
+    install_checkout_hermes_shim,
+    prepend_shim_to_path,
+)
+
 WT = str(Path(__file__).resolve().parents[2])
 FAKE_WORKER = str(Path(__file__).parent / "_fake_worker.py")
 PY = sys.executable
@@ -35,7 +41,7 @@ def make_spawn_fn(home: str):
             "PYTHONPATH": WT,
             "HERMES_KANBAN_TASK": task.id,
             "HERMES_KANBAN_WORKSPACE": workspace,
-            "PATH": f"{os.path.dirname(PY)}:{os.environ.get('PATH','')}",
+            "PATH": prepend_shim_to_path(os.path.dirname(PY), os.environ.get("PATH", "")),
         }
         log_f = open(log_path, "ab")
         proc = subprocess.Popen(
@@ -62,13 +68,9 @@ def main():
     # hermes_cli.main. We do this by putting a shim on PATH.
     shim_dir = os.path.join(home, "bin")
     os.makedirs(shim_dir, exist_ok=True)
-    shim_path = os.path.join(shim_dir, "hermes")
-    with open(shim_path, "w") as f:
-        f.write(f"""#!/bin/sh
-exec {PY} -m hermes_cli.main "$@"
-""")
-    os.chmod(shim_path, 0o755)
-    os.environ["PATH"] = f"{shim_dir}:{os.environ.get('PATH','')}"
+    install_checkout_hermes_shim(shim_dir, python_exe=PY)
+    os.environ["PATH"] = prepend_shim_to_path(shim_dir, os.environ.get("PATH", ""))
+    assert_which_is_shim(shim_dir)
 
     kb.init_db()
     conn = kb.connect()


### PR DESCRIPTION
## Summary

`tests/stress/test_subprocess_e2e.py` built PATH with `:` and wrote an extensionless POSIX `hermes` shim. On native Windows that does not override the installed `hermes.EXE`, so the harness silently exercised the wrong binary (tasks stuck in `running`, zero heartbeats).

- Native launcher: `hermes.cmd` on Windows, POSIX shim elsewhere
- PATH joined with `os.pathsep`
- Fail-closed: `shutil.which(\"hermes\")` must resolve inside the shim directory

The e2e script itself stays opt-in (`--run-stress`). The new helper tests run in default CI.

## Test Plan

- [x] `pytest tests/cron/test_hermes_checkout_shim.py` — 3 passed
- [x] ruff clean

Closes #93136