### PR TITLE
fix(gateway): record heartbeat fires only after confirmed delivery

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12652,7 +12652,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             continue
                         prompt = mgr.due_prompt()
                         if prompt:
-                            self._pending_input.put(prompt)
+                            try:
+                                self._pending_input.put(prompt)
+                            except Exception as exc:
+                                mgr.abandon_claim(f"input queue handoff failed: {exc}")
+                                continue
+                            # The input queue is the live REPL loop's
+                            # acceptance boundary: once queued, the prompt
+                            # WILL become a turn. Only now is the tick
+                            # truthfully fired.
+                            mgr.confirm_delivery()
                     except Exception as exc:
                         logging.debug("heartbeat watchdog tick failed: %s", exc)
             finally:

--- a/cli.py
+++ b/cli.py
@@ -12639,35 +12639,61 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 while not getattr(self, "_should_exit", False):
                     time.sleep(POLL_SECONDS)
                     try:
-                        mgr = self._get_heartbeat_manager()
-                        if mgr is None or not mgr.is_active():
-                            continue
-                        busy = (
-                            self._agent_running
-                            or getattr(self, "_voice_recording", False)
-                            or getattr(self, "_voice_processing", False)
-                            or not self._pending_input.empty()
-                        )
-                        if busy:
-                            continue
-                        prompt = mgr.due_prompt()
-                        if prompt:
-                            try:
-                                self._pending_input.put(prompt)
-                            except Exception as exc:
-                                mgr.abandon_claim(f"input queue handoff failed: {exc}")
-                                continue
-                            # The input queue is the live REPL loop's
-                            # acceptance boundary: once queued, the prompt
-                            # WILL become a turn. Only now is the tick
-                            # truthfully fired.
-                            mgr.confirm_delivery()
+                        self._heartbeat_watchdog_tick()
                     except Exception as exc:
                         logging.debug("heartbeat watchdog tick failed: %s", exc)
             finally:
                 self._heartbeat_watchdog_started = False
 
         threading.Thread(target=_loop, daemon=True, name="heartbeat-watchdog").start()
+
+    def _heartbeat_watchdog_tick(self) -> None:
+        """One watchdog iteration: inject a due heartbeat prompt if idle.
+
+        Extracted from the watchdog loop so the claim/confirm/abandon
+        protection is unit-testable without driving the thread. A claimed
+        tick is confirmed only after the prompt is queued into the live
+        REPL's input queue; if the confirmation itself blows up (persisted
+        write hiccup), the claim is abandoned here so it can never wedge —
+        the manager-level claim timeout remains the backstop if even the
+        abandonment fails.
+        """
+        mgr = self._get_heartbeat_manager()
+        if mgr is None or not mgr.is_active():
+            return
+        busy = (
+            self._agent_running
+            or getattr(self, "_voice_recording", False)
+            or getattr(self, "_voice_processing", False)
+            or not self._pending_input.empty()
+        )
+        if busy:
+            return
+        prompt = mgr.due_prompt()
+        if not prompt:
+            return
+        try:
+            self._pending_input.put(prompt)
+        except Exception as exc:
+            mgr.abandon_claim(f"input queue handoff failed: {exc}")
+            return
+        # The input queue is the live REPL loop's acceptance boundary:
+        # once queued, the prompt WILL become a turn. Only now is the
+        # tick truthfully fired.
+        try:
+            mgr.confirm_delivery()
+        except Exception as exc:
+            try:
+                mgr.abandon_claim(f"delivery confirmation failed: {exc}")
+            except Exception:
+                # If even the abandonment can't persist, the manager's
+                # claim timeout will resolve the claim on a later poll.
+                logging.debug(
+                    "heartbeat claim abandonment after confirm failure "
+                    "also failed: %s",
+                    exc,
+                    exc_info=True,
+                )
 
     # ────────────────────────────────────────────────────────────────
     # /loop — recurring in-session wakeups (Claude Code /loop parity)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16682,6 +16682,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         source = event.source
 
+        # Heartbeat delivery accounting (#92837): a tagged staged tick
+        # reaching the live message pipeline is REAL delivery evidence —
+        # this is the only place a claimed heartbeat tick is confirmed as
+        # fired. Best-effort: a failure leaves the claim for the poll's
+        # claim-timeout abandonment path instead.
+        try:
+            self._confirm_heartbeat_delivery_for_event(event)
+        except Exception:
+            logger.debug("heartbeat delivery confirmation failed", exc_info=True)
+
         # 🔴 Cross-session leak guard. This handler runs inside a per-message
         # asyncio task created via create_task(), which snapshots the spawning
         # context with copy_context(). If a *concurrent* message had already
@@ -21546,16 +21556,90 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if watch is None:
             watch = {}
             self._heartbeat_watch = watch
+        is_new = quick_key not in watch
         watch[quick_key] = (source, session_id)
+        if is_new:
+            # A fresh registration means whatever in-process staging context
+            # a prior claim had is gone (watch/queue rebuilt under the live
+            # process). Clear a persisted in-flight claim from a live
+            # process so the next poll re-claims the tick instead of the
+            # heartbeat stalling forever (#92837 orphan-claim recovery).
+            try:
+                from hermes_cli.heartbeat import HeartbeatManager, _PROCESS_START_TS
+
+                inflight = getattr(self, "_heartbeat_inflight", None)
+                if inflight:
+                    inflight.pop(quick_key, None)
+                mgr = HeartbeatManager(session_id=session_id)
+                st = mgr.state
+                if (
+                    st is not None
+                    and st.claimed_at is not None
+                    and st.claimed_at >= _PROCESS_START_TS
+                ):
+                    mgr.abandon_claim(
+                        "heartbeat watch (re)registered; prior in-flight "
+                        "staging context lost"
+                    )
+            except Exception as exc:
+                logger.debug("heartbeat watch registration claim cleanup failed: %s", exc)
         self._start_heartbeat_poller()
 
     def _unregister_heartbeat_watch(self, quick_key: str) -> None:
+        """Stop tracking a session and resolve any in-flight claim.
+
+        Called on /heartbeat clear (and any future teardown path). The
+        inflight entry and the persisted claim are dropped together so the
+        stored state keeps no dangling claim that could stall a later
+        re-registration (#92837).
+        """
         watch = getattr(self, "_heartbeat_watch", None)
-        if watch:
-            watch.pop(quick_key, None)
+        entry = watch.pop(quick_key, None) if watch else None
         inflight = getattr(self, "_heartbeat_inflight", None)
         if inflight:
             inflight.pop(quick_key, None)
+        if entry is not None:
+            _source, session_id = entry
+            try:
+                from hermes_cli.heartbeat import HeartbeatManager
+
+                mgr = HeartbeatManager(session_id=session_id)
+                if mgr.state is not None and mgr.state.claimed_at is not None:
+                    # The watch is gone: an in-flight claim can never be
+                    # resolved by the poller. Abandon it so the audit trail
+                    # stays truthful and the persisted state is clean.
+                    mgr.abandon_claim("heartbeat watch unregistered")
+            except Exception as exc:
+                logger.debug("heartbeat watch unregister claim cleanup failed: %s", exc)
+
+    def _confirm_heartbeat_delivery_for_event(self, event: Any) -> None:
+        """Record the heartbeat fire when the staged tick truly becomes a turn.
+
+        The poll tags the staged event with ``_hermes_heartbeat_tick``; only
+        a tagged event reaching the live message pipeline
+        (:meth:`_handle_message`) is REAL evidence that the tick was
+        consumed as a turn, so this is the only confirmation path in the
+        gateway. Any other signal (activity timestamps, slot churn) is NOT
+        consumption evidence and must not confirm a delivery — unconfirmed
+        claims resolve through the claim timeout in the poll instead.
+        Best-effort: a failure here leaves the claim for that timeout path.
+        """
+        if not getattr(event, "_hermes_heartbeat_tick", False):
+            return
+        watch = getattr(self, "_heartbeat_watch", None)
+        if not watch:
+            return
+        source = getattr(event, "source", None)
+        if source is None:
+            return
+        quick_key = self._session_key_for_source(source)
+        entry = watch.get(quick_key)
+        if not entry:
+            return
+        _source, session_id = entry
+        from hermes_cli.heartbeat import HeartbeatManager
+
+        HeartbeatManager(session_id=session_id).confirm_delivery()
 
     def _heartbeat_event_pending(self, quick_key: str, adapter: Any) -> bool:
         """True when a staged heartbeat tick is still waiting for a turn.
@@ -21573,35 +21657,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         overflow = getattr(getattr(q_state, "conversation", None), "queued_events", None) or []
         return any(getattr(e, "_hermes_heartbeat_tick", False) for e in overflow)
 
-    def _heartbeat_session_activity_after(self, quick_key: str, ts: float) -> bool:
-        """True when the session ran a turn after ``ts``.
+    def _heartbeat_discard_staged_tick(self, quick_key: str, adapter: Any) -> None:
+        """Remove a stale staged heartbeat tick from the pending slot and
+        the /queue overflow so an abandoned claim can re-stage cleanly
+        instead of piling tagged events into the backlog (#92837)."""
+        slot = getattr(adapter, "_pending_messages", None) or {}
+        event = slot.get(quick_key)
+        if event is not None and getattr(event, "_hermes_heartbeat_tick", False):
+            slot.pop(quick_key, None)
+        peek = getattr(self, "_peek_session_state", None)
+        q_state = peek(quick_key) if peek is not None else None
+        overflow = getattr(getattr(q_state, "conversation", None), "queued_events", None)
+        if overflow:
+            overflow[:] = [
+                e for e in overflow if not getattr(e, "_hermes_heartbeat_tick", False)
+            ]
 
-        A turn can finish between two polls (shorter than the poll
-        cadence), so the in-flight ``_running_agents`` set alone would miss
-        it. The agent cache's ``_last_activity_ts`` is refreshed by every
-        turn start and survives until idle-TTL eviction, making this
-        check race-free in practice.
-        """
-        if quick_key in getattr(self, "_running_agents", {}):
-            return True
-        cache = getattr(self, "_agent_cache", None) or {}
-        entry = cache.get(quick_key)
-        agent = entry[0] if isinstance(entry, tuple) and entry else None
-        last_activity = getattr(agent, "_last_activity_ts", None)
-        # >= (not >): on coarse clock granularity a turn can start in the
-        # same timestamp as the stage, and that turn still consumes it.
-        return last_activity is not None and last_activity >= ts
-
-    async def _poll_heartbeat_watches_once(self) -> None:
+    async def _poll_heartbeat_delivery_accounting_once(self) -> None:
         """Poll due heartbeats once with delivery-confirmed accounting.
 
+        (Named ``_heartbeat_delivery_accounting`` to stay distinct from the
+        open PR #85133's ``_poll_heartbeat_watches_once``, which covers the
+        complementary wake-up concern — entering an idle session through
+        the adapter. Both are needed; this PR does not depend on #85133.)
+
         A due tick is claimed and staged into the adapter's pending slot
-        WITHOUT counting a fire. The fire is confirmed on a later poll only
-        once the staged event was consumed by a real turn; if it vanishes
-        without any turn (session reset / stale-lock heal / eviction), the
-        claim is abandoned with a warning and the tick stays due. While a
-        claim is in flight, no second tick is claimed, so missed intervals
-        coalesce instead of stacking a backlog (issue #92837).
+        WITHOUT counting a fire. The fire is confirmed only when the tagged
+        staged event actually enters the live message pipeline as a turn
+        (``_confirm_heartbeat_delivery_for_event``). Claims that never
+        produce a turn are resolved loudly instead of hanging silently:
+
+        - staged event vanished without consumption (session reset /
+          stale-lock heal / eviction) → abandoned with a warning, counted
+          in ``missed_count``, tick stays due;
+        - staged event stuck in the pending slot past ``claim_timeout_seconds``
+          with no turn starting → same abandonment (issue #92837's main
+          failure mode: the loss must be visible), the stale staged tick
+          is discarded, and the still-due tick is re-claimed and re-staged.
+
+        While a claim is in flight, no second tick is claimed, so missed
+        intervals coalesce instead of stacking a backlog (issue #92837).
         """
         watch = getattr(self, "_heartbeat_watch", None)
         if not watch:
@@ -21633,21 +21728,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 stage_ts = inflight.get(quick_key)
                 if stage_ts is not None:
-                    if not self._heartbeat_event_pending(quick_key, adapter):
-                        # The staged event is gone. If a turn ran since we
-                        # staged it, that turn consumed it — record the
-                        # fire now that delivery actually happened.
-                        # Otherwise it was discarded without any turn, and
-                        # the claim must be counted as missed, not fired.
-                        if self._heartbeat_session_activity_after(quick_key, stage_ts):
-                            mgr.confirm_delivery()
-                        else:
-                            mgr.abandon_claim(
-                                "staged heartbeat prompt vanished without a turn "
-                                "(session reset / stale-lock heal / eviction?)"
-                            )
+                    if time.time() - stage_ts >= mgr.claim_timeout_seconds:
+                        # The staged tick produced no turn within the
+                        # claim window (idle-evicted session, stuck
+                        # pending slot, vanished drain). Abandon loudly:
+                        # warn + missed_count, drop the stale staged tick
+                        # so the retry starts clean. The tick stays due;
+                        # the next poll re-claims it.
+                        mgr.abandon_claim(
+                            f"no turn consumed the staged tick within "
+                            f"{mgr.claim_timeout_seconds:.0f}s"
+                        )
                         inflight.pop(quick_key, None)
-                    # Still waiting for a turn — leave the claim in flight.
+                        self._heartbeat_discard_staged_tick(quick_key, adapter)
+                        continue
+                    if self._heartbeat_event_pending(quick_key, adapter):
+                        # Still staged and inside the claim window — leave
+                        # the claim in flight. A later poll either sees the
+                        # turn (confirmed at the drain) or the timeout.
+                        continue
+                    if mgr.state.claimed_at is not None:
+                        # The staged event is gone but the claim was never
+                        # confirmed — it was discarded without any turn
+                        # (session reset / stale-lock heal / eviction).
+                        # Unrelated session activity is NOT delivery
+                        # evidence; count it missed. The tick stays due;
+                        # the next poll re-claims it.
+                        mgr.abandon_claim(
+                            "staged heartbeat prompt vanished without a turn "
+                            "(session reset / stale-lock heal / eviction?)"
+                        )
+                        inflight.pop(quick_key, None)
+                        continue
+                    # Already confirmed by the consumption hook when the
+                    # tagged event became a real turn.
+                    inflight.pop(quick_key, None)
                     continue
 
                 prompt = mgr.due_prompt()
@@ -21660,8 +21775,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_id=None,
                     channel_prompt=None,
                 )
-                # Tag the staged event so later polls can tell whether THIS
-                # tick was consumed by a turn or discarded without one.
+                # Tag the staged event: the ONLY thing that confirms this
+                # tick's delivery is this exact event entering the live
+                # message pipeline as a turn.
                 hb_event._hermes_heartbeat_tick = True  # type: ignore[attr-defined]
                 try:
                     self._enqueue_fifo(quick_key, hb_event, adapter)
@@ -21691,7 +21807,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # this covers only the degraded path where that warm-up
                 # failed.
                 await self._warm_goals_session_db("heartbeat poll")
-                await self._poll_heartbeat_watches_once()
+                await self._poll_heartbeat_delivery_accounting_once()
 
         try:
             task = asyncio.create_task(_poll_loop())

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21565,7 +21565,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # process so the next poll re-claims the tick instead of the
             # heartbeat stalling forever (#92837 orphan-claim recovery).
             try:
-                from hermes_cli.heartbeat import HeartbeatManager, _PROCESS_START_TS
+                from hermes_cli.heartbeat import (
+                    HeartbeatManager,
+                    _PROCESS_START_SKEW_TOLERANCE_SECONDS,
+                    _PROCESS_START_TS,
+                )
 
                 inflight = getattr(self, "_heartbeat_inflight", None)
                 if inflight:
@@ -21575,7 +21579,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if (
                     st is not None
                     and st.claimed_at is not None
-                    and st.claimed_at >= _PROCESS_START_TS
+                    and st.claimed_at
+                    >= _PROCESS_START_TS - _PROCESS_START_SKEW_TOLERANCE_SECONDS
                 ):
                     mgr.abandon_claim(
                         "heartbeat watch (re)registered; prior in-flight "
@@ -21706,7 +21711,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             inflight = {}
             self._heartbeat_inflight = inflight
 
-        from hermes_cli.heartbeat import HeartbeatManager
+        from hermes_cli.heartbeat import HeartbeatLoadCache, HeartbeatManager
+
+        # mtime-checked state cache: each watched session would otherwise
+        # re-read its heartbeat state from SessionDB on every poll (5s) on
+        # the event-loop thread. With the cache, an unchanged poll does
+        # zero reads and a changed DB re-reads each state at most once —
+        # never once per watch per poll.
+        cache = getattr(self, "_heartbeat_load_cache", None)
+        if cache is None:
+            cache = HeartbeatLoadCache()
+            self._heartbeat_load_cache = cache
 
         for quick_key, (source, session_id) in list(watch.items()):
             try:
@@ -21720,7 +21735,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # delivery path, so the persisted state stays truthful.
                     continue
 
-                mgr = HeartbeatManager(session_id=session_id)
+                mgr = HeartbeatManager(session_id=session_id, state=cache.load(session_id))
                 if not mgr.has_heartbeat():
                     watch.pop(quick_key, None)
                     inflight.pop(quick_key, None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21553,6 +21553,124 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         watch = getattr(self, "_heartbeat_watch", None)
         if watch:
             watch.pop(quick_key, None)
+        inflight = getattr(self, "_heartbeat_inflight", None)
+        if inflight:
+            inflight.pop(quick_key, None)
+
+    def _heartbeat_event_pending(self, quick_key: str, adapter: Any) -> bool:
+        """True when a staged heartbeat tick is still waiting for a turn.
+
+        The staged event is tagged with ``_hermes_heartbeat_tick`` so it can
+        be told apart from ordinary follow-ups sharing the pending slot or
+        the /queue overflow list.
+        """
+        slot = getattr(adapter, "_pending_messages", None) or {}
+        event = slot.get(quick_key)
+        if event is not None and getattr(event, "_hermes_heartbeat_tick", False):
+            return True
+        peek = getattr(self, "_peek_session_state", None)
+        q_state = peek(quick_key) if peek is not None else None
+        overflow = getattr(getattr(q_state, "conversation", None), "queued_events", None) or []
+        return any(getattr(e, "_hermes_heartbeat_tick", False) for e in overflow)
+
+    def _heartbeat_session_activity_after(self, quick_key: str, ts: float) -> bool:
+        """True when the session ran a turn after ``ts``.
+
+        A turn can finish between two polls (shorter than the poll
+        cadence), so the in-flight ``_running_agents`` set alone would miss
+        it. The agent cache's ``_last_activity_ts`` is refreshed by every
+        turn start and survives until idle-TTL eviction, making this
+        check race-free in practice.
+        """
+        if quick_key in getattr(self, "_running_agents", {}):
+            return True
+        cache = getattr(self, "_agent_cache", None) or {}
+        entry = cache.get(quick_key)
+        agent = entry[0] if isinstance(entry, tuple) and entry else None
+        last_activity = getattr(agent, "_last_activity_ts", None)
+        # >= (not >): on coarse clock granularity a turn can start in the
+        # same timestamp as the stage, and that turn still consumes it.
+        return last_activity is not None and last_activity >= ts
+
+    async def _poll_heartbeat_watches_once(self) -> None:
+        """Poll due heartbeats once with delivery-confirmed accounting.
+
+        A due tick is claimed and staged into the adapter's pending slot
+        WITHOUT counting a fire. The fire is confirmed on a later poll only
+        once the staged event was consumed by a real turn; if it vanishes
+        without any turn (session reset / stale-lock heal / eviction), the
+        claim is abandoned with a warning and the tick stays due. While a
+        claim is in flight, no second tick is claimed, so missed intervals
+        coalesce instead of stacking a backlog (issue #92837).
+        """
+        watch = getattr(self, "_heartbeat_watch", None)
+        if not watch:
+            return
+        inflight = getattr(self, "_heartbeat_inflight", None)
+        if inflight is None:
+            inflight = {}
+            self._heartbeat_inflight = inflight
+
+        from hermes_cli.heartbeat import HeartbeatManager
+
+        for quick_key, (source, session_id) in list(watch.items()):
+            try:
+                # Busy sessions coalesce their tick to the next idle poll.
+                if quick_key in self._running_agents:
+                    continue
+
+                adapter = self._adapter_for_source(source)
+                if adapter is None:
+                    # No live consumer: never claim a tick that has no
+                    # delivery path, so the persisted state stays truthful.
+                    continue
+
+                mgr = HeartbeatManager(session_id=session_id)
+                if not mgr.has_heartbeat():
+                    watch.pop(quick_key, None)
+                    inflight.pop(quick_key, None)
+                    continue
+
+                stage_ts = inflight.get(quick_key)
+                if stage_ts is not None:
+                    if not self._heartbeat_event_pending(quick_key, adapter):
+                        # The staged event is gone. If a turn ran since we
+                        # staged it, that turn consumed it — record the
+                        # fire now that delivery actually happened.
+                        # Otherwise it was discarded without any turn, and
+                        # the claim must be counted as missed, not fired.
+                        if self._heartbeat_session_activity_after(quick_key, stage_ts):
+                            mgr.confirm_delivery()
+                        else:
+                            mgr.abandon_claim(
+                                "staged heartbeat prompt vanished without a turn "
+                                "(session reset / stale-lock heal / eviction?)"
+                            )
+                        inflight.pop(quick_key, None)
+                    # Still waiting for a turn — leave the claim in flight.
+                    continue
+
+                prompt = mgr.due_prompt()
+                if not prompt:
+                    continue
+                hb_event = MessageEvent(
+                    text=prompt,
+                    message_type=MessageType.TEXT,
+                    source=source,
+                    message_id=None,
+                    channel_prompt=None,
+                )
+                # Tag the staged event so later polls can tell whether THIS
+                # tick was consumed by a turn or discarded without one.
+                hb_event._hermes_heartbeat_tick = True  # type: ignore[attr-defined]
+                try:
+                    self._enqueue_fifo(quick_key, hb_event, adapter)
+                except Exception as exc:
+                    mgr.abandon_claim(f"delivery handoff failed: {exc}")
+                    continue
+                inflight[quick_key] = time.time()
+            except Exception as exc:
+                logger.debug("heartbeat poll for %s failed: %s", quick_key, exc)
 
     def _start_heartbeat_poller(self) -> None:
         """Start the single gateway-wide heartbeat poll task (idempotent)."""
@@ -21573,33 +21691,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # this covers only the degraded path where that warm-up
                 # failed.
                 await self._warm_goals_session_db("heartbeat poll")
-                for quick_key, (source, session_id) in list(watch.items()):
-                    try:
-                        # Busy sessions coalesce their tick to the next idle poll.
-                        if quick_key in self._running_agents:
-                            continue
-                        from hermes_cli.heartbeat import HeartbeatManager
-
-                        mgr = HeartbeatManager(session_id=session_id)
-                        if not mgr.has_heartbeat():
-                            watch.pop(quick_key, None)
-                            continue
-                        prompt = mgr.due_prompt()
-                        if not prompt:
-                            continue
-                        adapter = self._adapter_for_source(source)
-                        if adapter is None:
-                            continue
-                        hb_event = MessageEvent(
-                            text=prompt,
-                            message_type=MessageType.TEXT,
-                            source=source,
-                            message_id=None,
-                            channel_prompt=None,
-                        )
-                        self._enqueue_fifo(quick_key, hb_event, adapter)
-                    except Exception as exc:
-                        logger.debug("heartbeat poll for %s failed: %s", quick_key, exc)
+                await self._poll_heartbeat_watches_once()
 
         try:
             task = asyncio.create_task(_poll_loop())

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5159,6 +5159,7 @@ _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
     "secrets",
     "goals",
     "loops",
+    "heartbeat",
 })
 
 # Top-level keys whose sub-keys are partially schema-defined (e.g. on a

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2018,6 +2018,16 @@ DEFAULT_CONFIG = {
         "self_paced_ceiling_seconds": 900,
     },
 
+    # Heartbeats — recurring re-entry prompts for the current session
+    # (/heartbeat every 10m ...). A due tick is CLAIMED first and only
+    # recorded as fired once the staged prompt really becomes a turn. A
+    # claim that produces no turn within this window is abandoned with a
+    # warning, counted in missed_count, and the tick stays due for retry
+    # (issue #92837: never let a lost wake be silent).
+    "heartbeat": {
+        "claim_timeout_seconds": 300,
+    },
+
     # Mixture of Agents — named presets used by /moa. A preset is an execution
     # mode around the main model, not a provider/model itself: references +
     # aggregator synthesize private guidance before each main-model iteration.

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -44,6 +44,37 @@ MIN_INTERVAL_SECONDS = 60
 # How often drivers poll for due heartbeats. Not user-facing.
 POLL_SECONDS = 5.0
 
+# Claim-timeout fallback (seconds): how long a claimed-but-unconfirmed tick
+# may stay in flight before it is abandoned with a warning, counted in
+# missed_count, and left due for retry (issue #92837 expectation #3: a
+# claimed tick that produces no turn must be loud, never silent). The
+# authoritative default lives in the config defaults
+# (hermes_cli.config_defaults.DEFAULT_CONFIG["heartbeat"][
+# "claim_timeout_seconds"]); this constant only covers the degraded case
+# where the config can't be read. Drivers can also pin a value per manager
+# via HeartbeatManager(claim_timeout_seconds=...).
+_CLAIM_TIMEOUT_FALLBACK_SECONDS = 300.0
+
+
+def _default_claim_timeout_seconds() -> float:
+    """Resolve the heartbeat claim timeout from config (best-effort).
+
+    Reads ``heartbeat.claim_timeout_seconds`` from the user config; on any
+    failure (unreadable config, missing key, bad value) falls back to
+    :data:`_CLAIM_TIMEOUT_FALLBACK_SECONDS`. Never raises.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        hb_cfg = (load_config_readonly() or {}).get("heartbeat") or {}
+        val = hb_cfg.get("claim_timeout_seconds")
+        if val is not None:
+            return float(val)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("HeartbeatManager: claim-timeout config read failed: %s", exc)
+    return _CLAIM_TIMEOUT_FALLBACK_SECONDS
+
+
 # Import time of this module — a proxy for "this process started". A
 # persisted claim older than this timestamp was made by a previous process
 # that died between claiming a tick and confirming/abandoning it, so the
@@ -247,8 +278,20 @@ class HeartbeatManager:
     double-claiming the same tick, so no backlog can pile up.
     """
 
-    def __init__(self, session_id: str):
+    def __init__(
+        self,
+        session_id: str,
+        claim_timeout_seconds: Optional[float] = None,
+    ):
         self.session_id = session_id
+        # How long a claimed tick may wait for a turn before it is
+        # abandoned with a warning, counted missed, and re-claimed. None
+        # resolves the config default (heartbeat.claim_timeout_seconds).
+        self.claim_timeout_seconds = (
+            float(claim_timeout_seconds)
+            if claim_timeout_seconds is not None
+            else _default_claim_timeout_seconds()
+        )
         self._state: Optional[HeartbeatState] = load_heartbeat(session_id)
 
     @property
@@ -338,10 +381,16 @@ class HeartbeatManager:
         While a claim is in flight (claimed but unconfirmed), further polls
         return None so overlapping polls can never double-claim the same
         tick, and missed intervals coalesce into one delivery instead of a
-        backlog. A claim left behind by a previous process (crash between
-        claim and handoff) is resolved here: it is logged as a missed
-        delivery and cleared, so the tick can be re-claimed on the next
-        poll instead of stalling forever.
+        backlog. Two in-flight hazards are resolved here instead of
+        stalling silently (issue #92837):
+
+        - A claim left behind by a previous process (crash between claim
+          and handoff) is logged as a missed delivery and cleared.
+        - A claim from a LIVE process that produced no turn within
+          ``claim_timeout_seconds`` (staged prompt stuck with no consumer:
+          idle-evicted session, vanished drain, wedged input queue) is
+          abandoned with a warning, counted in ``missed_count``, and the
+          still-due tick is re-claimed in the same call.
         """
         s = self._state
         if s is None or not s.is_due(now):
@@ -363,9 +412,23 @@ class HeartbeatManager:
                 s.missed_count += 1
                 s.claimed_at = None
                 save_heartbeat(self.session_id, s)
-            # In-flight claim from this process: the driver has not resolved
-            # it yet — never claim the same tick twice.
-            return None
+                # The tick is still due: leave it for the next poll to
+                # re-claim (mirrors the pre-claim-timeout contract).
+                return None
+            elif now - s.claimed_at >= self.claim_timeout_seconds:
+                # Live-process claim that never became a turn within the
+                # claim window. Abandon loudly (warning + missed_count)
+                # and fall through: the tick is still due and gets a
+                # fresh claim below, so the heartbeat keeps trying
+                # instead of hanging forever with no signal.
+                self.abandon_claim(
+                    f"no turn consumed the claimed tick within "
+                    f"{self.claim_timeout_seconds:.0f}s"
+                )
+            else:
+                # In-flight claim from this process: the driver has not
+                # resolved it yet — never claim the same tick twice.
+                return None
         s.claimed_at = now
         save_heartbeat(self.session_id, s)
         return s.render_prompt()

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -33,6 +33,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass, asdict
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -79,7 +80,16 @@ def _default_claim_timeout_seconds() -> float:
 # persisted claim older than this timestamp was made by a previous process
 # that died between claiming a tick and confirming/abandoning it, so the
 # claim can never be resolved and must be treated as a missed delivery.
+# Best-effort: wall clock only, so a backwards NTP step after import makes
+# this process's own later claims (recorded on the stepped-back clock) look
+# older than the start marker. Only claims older than start minus the skew
+# tolerance below are treated as orphans; steps larger than the tolerance
+# are out of scope for this proxy.
 _PROCESS_START_TS = time.time()
+# Wall-clock skew tolerance (seconds) for the previous-process orphan test
+# above: a claim recorded up to this far before _PROCESS_START_TS still
+# reads as a live-process claim, absorbing backwards NTP steps.
+_PROCESS_START_SKEW_TOLERANCE_SECONDS = 120.0
 
 HEARTBEAT_PROMPT_TEMPLATE = (
     "[Heartbeat — recurring instruction, fires every {interval}]\n"
@@ -255,6 +265,66 @@ def save_heartbeat(session_id: str, state: HeartbeatState) -> None:
         logger.debug("HeartbeatManager: set_meta failed: %s", exc)
 
 
+# Sentinel for HeartbeatManager(..., state=...): "not provided, load from
+# disk" must stay distinguishable from None ("no heartbeat persisted").
+_UNSET_STATE = object()
+
+
+class HeartbeatLoadCache:
+    """mtime-checked cache of heartbeat states for poll-loop reuse.
+
+    The gateway poll constructs a HeartbeatManager per watched session
+    every ``POLL_SECONDS``; each construction otherwise re-reads the state
+    from SessionDB on the event-loop thread. This cache keeps repeated
+    polls O(1) in disk I/O: states are reloaded only when the SessionDB
+    files (``state.db`` / ``state.db-wal``) changed since the last load,
+    so a stable poll across N watches does zero DB reads, and a poll that
+    follows a DB change re-reads each state at most once.
+
+    Cached HeartbeatState objects are handed to managers by reference;
+    mutations are persisted through save_heartbeat, which bumps the DB
+    mtime and thereby invalidates the cache on the next load.
+    """
+
+    def __init__(self) -> None:
+        self._fingerprint: Optional[tuple] = None
+        self._states: Dict[str, Optional[HeartbeatState]] = {}
+
+    def _db_fingerprint(self) -> Optional[tuple]:
+        db = _get_session_db()
+        if db is None:
+            return None
+        try:
+            main = Path(str(db.db_path))
+            wal = Path(str(db.db_path) + "-wal")
+            parts: list = [main.stat().st_mtime_ns, main.stat().st_size]
+            try:
+                parts.append(wal.stat().st_mtime_ns)
+                parts.append(wal.stat().st_size)
+            except OSError:
+                # No WAL file (yet): nothing to add.
+                parts.append(0)
+                parts.append(0)
+            return tuple(parts)
+        except (AttributeError, OSError, TypeError):  # pragma: no cover - defensive
+            return None
+
+    def load(self, session_id: str) -> Optional[HeartbeatState]:
+        fingerprint = self._db_fingerprint()
+        if fingerprint is None:
+            # No SessionDB handle to fingerprint: the cache cannot stay
+            # fresh, fall through to the uncached load.
+            return load_heartbeat(session_id)
+        if fingerprint != self._fingerprint:
+            self._fingerprint = fingerprint
+            self._states = {}
+        if session_id in self._states:
+            return self._states[session_id]
+        state = load_heartbeat(session_id)
+        self._states[session_id] = state
+        return state
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Manager — the surface CLI + gateway talk to
 # ──────────────────────────────────────────────────────────────────────
@@ -282,6 +352,7 @@ class HeartbeatManager:
         self,
         session_id: str,
         claim_timeout_seconds: Optional[float] = None,
+        state: Optional[HeartbeatState] = _UNSET_STATE,
     ):
         self.session_id = session_id
         # How long a claimed tick may wait for a turn before it is
@@ -292,7 +363,11 @@ class HeartbeatManager:
             if claim_timeout_seconds is not None
             else _default_claim_timeout_seconds()
         )
-        self._state: Optional[HeartbeatState] = load_heartbeat(session_id)
+        # state=... lets hot loops (gateway poll) inject a HeartbeatLoadCache
+        # hit and skip the synchronous disk read; anything else loads fresh.
+        if state is _UNSET_STATE:
+            state = load_heartbeat(session_id)
+        self._state: Optional[HeartbeatState] = state
 
     @property
     def state(self) -> Optional[HeartbeatState]:
@@ -397,11 +472,18 @@ class HeartbeatManager:
             return None
         now = now if now is not None else time.time()
         if s.claimed_at is not None:
-            if s.claimed_at < _PROCESS_START_TS:
+            if (
+                s.claimed_at
+                < _PROCESS_START_TS - _PROCESS_START_SKEW_TOLERANCE_SECONDS
+            ):
                 # The claiming process died before confirming/abandoning.
                 # The tick never became a turn — count it missed, surface
                 # the loss, and let the next poll re-claim the still-due
-                # tick instead of silently stalling.
+                # tick instead of silently stalling. (Claims inside the
+                # skew tolerance stay live-process claims: wall-clock
+                # claims recorded after a backwards NTP step can read
+                # slightly older than _PROCESS_START_TS without being
+                # orphans.)
                 logger.warning(
                     "HeartbeatManager: session %s heartbeat tick was claimed at %.0f "
                     "but never confirmed delivered (previous process died mid-handoff); "
@@ -437,11 +519,14 @@ class HeartbeatManager:
         """Record the fire for the in-flight claim after real delivery.
 
         The ONLY place ``fire_count`` and ``last_fired_at`` advance. Call
-        this after the claimed prompt was handed to a live input path (CLI
-        input queue) or consumed by a turn (gateway pending-slot drain).
-        Returns True when a claim was pending; False when there was nothing
-        to confirm (e.g. the claim was already abandoned, or the heartbeat
-        was paused in between — in which case the delivery is ignored).
+        this after the claimed prompt was accepted into a live input path
+        (CLI input queue) or accepted into the live pipeline (gateway, at
+        the turn's acceptance boundary in ``_handle_message`` — turn
+        START, not completion; do NOT move this call post-turn or
+        unconfirmed claims would stall again). Returns True when a claim
+        was pending; False when there was nothing to confirm (e.g. the
+        claim was already abandoned, or the heartbeat was paused in
+        between — in which case the delivery is ignored).
         """
         s = self._state
         if s is None or s.claimed_at is None:

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -44,6 +44,12 @@ MIN_INTERVAL_SECONDS = 60
 # How often drivers poll for due heartbeats. Not user-facing.
 POLL_SECONDS = 5.0
 
+# Import time of this module — a proxy for "this process started". A
+# persisted claim older than this timestamp was made by a previous process
+# that died between claiming a tick and confirming/abandoning it, so the
+# claim can never be resolved and must be treated as a missed delivery.
+_PROCESS_START_TS = time.time()
+
 HEARTBEAT_PROMPT_TEMPLATE = (
     "[Heartbeat — recurring instruction, fires every {interval}]\n"
     "{prompt}\n\n"
@@ -99,7 +105,18 @@ def format_interval(seconds: int) -> str:
 
 @dataclass
 class HeartbeatState:
-    """Serializable per-session heartbeat."""
+    """Serializable per-session heartbeat.
+
+    Firing is split into three phases so the persisted audit trail never
+    claims a delivery that did not happen (issue #92837):
+
+    - ``due_prompt()`` *claims* a due tick (``claimed_at``) without
+      counting a fire.
+    - ``confirm_delivery()`` records the fire *only* after the prompt was
+      actually handed to a live input path / consumed by a turn.
+    - ``abandon_claim()`` counts the claim as missed and leaves the tick
+      due so the next poll retries.
+    """
 
     prompt: str
     interval_seconds: int
@@ -107,6 +124,14 @@ class HeartbeatState:
     created_at: float = 0.0
     last_fired_at: float = 0.0
     fire_count: int = 0
+    # Set while a due tick is claimed but its delivery is unconfirmed.
+    claimed_at: Optional[float] = None
+    # When the last confirmed delivery actually happened (turn enqueued /
+    # consumed), as opposed to when it was merely claimed.
+    last_delivered_at: float = 0.0
+    # Claims that were never confirmed delivered (dropped handoff, vanished
+    # staged prompt, crash between claim and confirm).
+    missed_count: int = 0
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), ensure_ascii=False)
@@ -121,6 +146,11 @@ class HeartbeatState:
             created_at=float(data.get("created_at", 0.0) or 0.0),
             last_fired_at=float(data.get("last_fired_at", 0.0) or 0.0),
             fire_count=int(data.get("fire_count", 0) or 0),
+            claimed_at=(
+                float(data["claimed_at"]) if data.get("claimed_at") is not None else None
+            ),
+            last_delivered_at=float(data.get("last_delivered_at", 0.0) or 0.0),
+            missed_count=int(data.get("missed_count", 0) or 0),
         )
 
     def is_due(self, now: Optional[float] = None) -> bool:
@@ -204,8 +234,17 @@ class HeartbeatManager:
 
     Drivers (CLI thread / gateway task) call :meth:`due_prompt` on a poll
     cadence while the session is idle; a non-None return is the user-role
-    message to inject. Firing is recorded immediately so a slow turn can't
-    double-fire.
+    message to inject.
+
+    A non-None return only *claims* the tick (``claimed_at``); it does not
+    count a fire. The driver MUST call :meth:`confirm_delivery` once the
+    prompt is actually handed to a live input path (CLI input queue) or
+    consumed by a turn (gateway pending-slot drain), or
+    :meth:`abandon_claim` when the handoff fails. This keeps the persisted
+    ``fire_count``/``last_fired_at`` truthful: a claimed-but-undelivered
+    tick is reported as missed instead of silently counted as fired
+    (#92837). The in-flight claim also prevents overlapping polls from
+    double-claiming the same tick, so no backlog can pile up.
     """
 
     def __init__(self, session_id: str):
@@ -228,6 +267,8 @@ class HeartbeatManager:
             return "No heartbeat. Set one with /heartbeat every <interval> <prompt>."
         every = format_interval(s.interval_seconds)
         fired = f", fired {s.fire_count}×" if s.fire_count else ""
+        if s.missed_count:
+            fired += f", missed {s.missed_count}×"
         if s.status == "active":
             anchor = s.last_fired_at or s.created_at
             next_in = max(0, int(anchor + s.interval_seconds - time.time()))
@@ -259,6 +300,9 @@ class HeartbeatManager:
         if not self._state:
             return None
         self._state.status = "paused"
+        # Drop any in-flight claim: a paused heartbeat must not deliver,
+        # and the claimed prompt will not be confirmed.
+        self._state.claimed_at = None
         save_heartbeat(self.session_id, self._state)
         return self._state
 
@@ -268,6 +312,7 @@ class HeartbeatManager:
         self._state.status = "active"
         # Re-anchor so resuming doesn't instantly fire a stale tick.
         self._state.last_fired_at = time.time()
+        self._state.claimed_at = None
         save_heartbeat(self.session_id, self._state)
         return self._state
 
@@ -279,23 +324,94 @@ class HeartbeatManager:
         self._state = None
         return True
 
-    # --- driver entry point --------------------------------------------
+    # --- driver entry points --------------------------------------------
 
     def due_prompt(self, now: Optional[float] = None) -> Optional[str]:
         """Return the injection prompt if the heartbeat is due, else None.
 
-        Records the fire immediately (before the turn runs) so overlapping
-        polls or a long turn can never double-fire the same tick. Missed
-        ticks coalesce into one — the anchor resets to NOW, not to the
-        theoretical schedule.
+        A non-None return only *claims* the tick — ``fire_count`` and
+        ``last_fired_at`` are deliberately NOT advanced here. The driver
+        must call :meth:`confirm_delivery` once the prompt is accepted into
+        a live input path (or consumed by a turn), or :meth:`abandon_claim`
+        when the handoff fails.
+
+        While a claim is in flight (claimed but unconfirmed), further polls
+        return None so overlapping polls can never double-claim the same
+        tick, and missed intervals coalesce into one delivery instead of a
+        backlog. A claim left behind by a previous process (crash between
+        claim and handoff) is resolved here: it is logged as a missed
+        delivery and cleared, so the tick can be re-claimed on the next
+        poll instead of stalling forever.
         """
         s = self._state
         if s is None or not s.is_due(now):
             return None
-        s.last_fired_at = now if now is not None else time.time()
-        s.fire_count += 1
+        now = now if now is not None else time.time()
+        if s.claimed_at is not None:
+            if s.claimed_at < _PROCESS_START_TS:
+                # The claiming process died before confirming/abandoning.
+                # The tick never became a turn — count it missed, surface
+                # the loss, and let the next poll re-claim the still-due
+                # tick instead of silently stalling.
+                logger.warning(
+                    "HeartbeatManager: session %s heartbeat tick was claimed at %.0f "
+                    "but never confirmed delivered (previous process died mid-handoff); "
+                    "counting as missed and keeping the tick due",
+                    self.session_id,
+                    s.claimed_at,
+                )
+                s.missed_count += 1
+                s.claimed_at = None
+                save_heartbeat(self.session_id, s)
+            # In-flight claim from this process: the driver has not resolved
+            # it yet — never claim the same tick twice.
+            return None
+        s.claimed_at = now
         save_heartbeat(self.session_id, s)
         return s.render_prompt()
+
+    def confirm_delivery(self, now: Optional[float] = None) -> bool:
+        """Record the fire for the in-flight claim after real delivery.
+
+        The ONLY place ``fire_count`` and ``last_fired_at`` advance. Call
+        this after the claimed prompt was handed to a live input path (CLI
+        input queue) or consumed by a turn (gateway pending-slot drain).
+        Returns True when a claim was pending; False when there was nothing
+        to confirm (e.g. the claim was already abandoned, or the heartbeat
+        was paused in between — in which case the delivery is ignored).
+        """
+        s = self._state
+        if s is None or s.claimed_at is None:
+            return False
+        ts = now if now is not None else time.time()
+        s.last_fired_at = s.claimed_at
+        s.fire_count += 1
+        s.last_delivered_at = ts
+        s.claimed_at = None
+        save_heartbeat(self.session_id, s)
+        return True
+
+    def abandon_claim(self, reason: str = "") -> bool:
+        """Give up on the in-flight claim and count it as a missed delivery.
+
+        The fire counters are untouched, so the persisted audit trail
+        reports the truth: the tick was due, was handed off, but never
+        became a turn. The tick stays due and is re-claimed on the next
+        poll. Returns True when a claim was pending.
+        """
+        s = self._state
+        if s is None or s.claimed_at is None:
+            return False
+        s.missed_count += 1
+        s.claimed_at = None
+        save_heartbeat(self.session_id, s)
+        logger.warning(
+            "HeartbeatManager: session %s heartbeat tick claimed but never became "
+            "a turn%s; counting as missed and keeping the tick due",
+            self.session_id,
+            f": {reason}" if reason else "",
+        )
+        return True
 
 
 def migrate_heartbeat_to_session(old_session_id: str, new_session_id: str) -> bool:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1243,6 +1243,10 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # `session.terminal_continue` is the only schema-surfaced session field —
     # fold it into general rather than spawning a one-field orphan category.
     "session": "general",
+    # `heartbeat.claim_timeout_seconds` is the only schema-surfaced heartbeat
+    # field (per-session heartbeat definitions are managed via /heartbeat) —
+    # fold it into the agent tab rather than spawning a one-field orphan.
+    "heartbeat": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.

--- a/tests/gateway/test_heartbeat_delivery_accounting.py
+++ b/tests/gateway/test_heartbeat_delivery_accounting.py
@@ -294,3 +294,63 @@ async def test_busy_session_leaves_staged_tick_in_flight(monkeypatch):
     assert mgr.state.fire_count == 0
     assert mgr.state.claimed_at is not None
     assert key in runner._heartbeat_inflight
+
+
+@pytest.mark.asyncio
+async def test_poll_reuses_cached_state_instead_of_rereading_disk(monkeypatch):
+    """The 5s poll must not re-read heartbeat state from disk per watch.
+
+    Without the mtime-checked cache, each watched session is reloaded from
+    SessionDB on every poll inside the event loop (N reads per poll, every
+    poll). With the cache: the cold poll loads each watch once, a poll that
+    follows a real DB change re-reads each watch exactly once (the state
+    genuinely changed), and a poll where nothing changed does ZERO disk
+    reads regardless of watch count — the O(1) steady state.
+    """
+    import hermes_cli.heartbeat as hb
+
+    runner, adapter, key, _source = _make_runner(monkeypatch)
+    # Three watches sharing the same adapter.
+    runner._heartbeat_watch = {}
+    for chat, sid in (("42", "session-1"), ("43", "session-2"), ("44", "session-3")):
+        src = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat,
+            chat_type="dm",
+            user_id=chat,
+        )
+        runner._heartbeat_watch[build_session_key(src)] = (src, sid)
+        _due_heartbeat(sid, 700)
+
+    real_load = hb.load_heartbeat
+    reads = {"count": 0}
+
+    def counting_load(session_id: str):
+        reads["count"] += 1
+        return real_load(session_id)
+
+    monkeypatch.setattr(hb, "load_heartbeat", counting_load)
+
+    await runner._poll_heartbeat_delivery_accounting_once()
+    # Cold cache: each watched session loaded exactly once.
+    assert reads["count"] == 3
+
+    await runner._poll_heartbeat_delivery_accounting_once()
+    # The previous poll's claims really changed the DB, so each watch is
+    # re-read exactly once — never once per watch per poll.
+    assert reads["count"] == 6
+
+    await runner._poll_heartbeat_delivery_accounting_once()
+    # Stable poll: nothing changed on disk -> ZERO reads for 3 watches
+    # (uncached this would be 3 more reads, every 5s, forever).
+    assert reads["count"] == 6
+
+    # A real state change written through the same SessionDB (this fresh
+    # manager's own load counts as one read).
+    HeartbeatManager(session_id="session-1").pause()
+    assert reads["count"] == 7
+
+    await runner._poll_heartbeat_delivery_accounting_once()
+    # The changed DB fingerprint is detected: exactly one re-read per
+    # watch, then the cache is warm again.
+    assert reads["count"] == 10

--- a/tests/gateway/test_heartbeat_delivery_accounting.py
+++ b/tests/gateway/test_heartbeat_delivery_accounting.py
@@ -1,0 +1,165 @@
+"""Gateway heartbeat poll: fire accounting must reflect real delivery.
+
+A heartbeat tick is only "fired" once its staged prompt actually becomes
+a turn. Claims that vanish without any turn must be counted as missed
+(with a warning), and a session without a live adapter must never be
+claimed in the first place. Regression coverage for #92837.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+from hermes_cli.heartbeat import HeartbeatManager
+
+
+class _HeartbeatAdapter(BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False) -> bool:  # pragma: no cover
+        return True
+
+    async def disconnect(self) -> None:  # pragma: no cover
+        pass
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:  # pragma: no cover
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id):  # pragma: no cover
+        return {}
+
+
+def _due_heartbeat(session_id: str, seconds_ago: float) -> HeartbeatManager:
+    mgr = HeartbeatManager(session_id=session_id)
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - seconds_ago
+    from hermes_cli.heartbeat import save_heartbeat
+
+    save_heartbeat(session_id, mgr.state)
+    return mgr
+
+
+def _make_runner(monkeypatch, session_id: str = "session-1"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        chat_type="dm",
+        user_id="42",
+    )
+    key = build_session_key(source)
+    adapter = _HeartbeatAdapter(
+        PlatformConfig(enabled=True, token="test", typing_indicator=False),
+        Platform.TELEGRAM,
+    )
+    runner = object.__new__(GatewayRunner)
+    runner._heartbeat_watch = {key: (source, session_id)}
+    runner._heartbeat_inflight = {}
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._adapter_for_source = lambda _source: adapter
+    runner._peek_session_state = lambda _key: None
+    return runner, adapter, key, source
+
+
+@pytest.mark.asyncio
+async def test_due_tick_stages_without_counting_fired(monkeypatch):
+    runner, adapter, key, _source = _make_runner(monkeypatch)
+    _due_heartbeat("session-1", 700)
+
+    await runner._poll_heartbeat_watches_once()
+
+    staged = adapter._pending_messages.get(key)
+    assert staged is not None and staged._hermes_heartbeat_tick is True
+    mgr = HeartbeatManager(session_id="session-1")
+    # Staged ≠ delivered: nothing may be counted as fired yet.
+    assert mgr.state.fire_count == 0
+    assert mgr.state.claimed_at is not None
+    assert key in runner._heartbeat_inflight
+
+
+@pytest.mark.asyncio
+async def test_turn_consuming_staged_tick_confirms_the_fire(monkeypatch):
+    runner, adapter, key, _source = _make_runner(monkeypatch)
+    _due_heartbeat("session-1", 700)
+    await runner._poll_heartbeat_watches_once()
+
+    # Simulate a real turn: the adapter drained the pending slot and the
+    # session's agent recorded activity after the tick was staged.
+    adapter._pending_messages.pop(key, None)
+    agent = type("Agent", (), {"_last_activity_ts": time.time()})()
+    runner._agent_cache[key] = (agent,)
+    await runner._poll_heartbeat_watches_once()
+
+    mgr = HeartbeatManager(session_id="session-1")
+    assert mgr.state.fire_count == 1
+    assert mgr.state.last_delivered_at > 0
+    assert mgr.state.missed_count == 0
+    assert mgr.state.claimed_at is None
+    assert runner._heartbeat_inflight == {}
+
+
+@pytest.mark.asyncio
+async def test_staged_tick_vanishing_without_turn_counts_missed(monkeypatch, caplog):
+    import logging
+
+    runner, adapter, key, _source = _make_runner(monkeypatch)
+    _due_heartbeat("session-1", 700)
+    await runner._poll_heartbeat_watches_once()
+
+    # Session reset / stale-lock heal / eviction discards the staged event
+    # without any turn ever running.
+    adapter._pending_messages.pop(key, None)
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
+        await runner._poll_heartbeat_watches_once()
+
+    mgr = HeartbeatManager(session_id="session-1")
+    assert mgr.state.fire_count == 0
+    assert mgr.state.missed_count == 1
+    assert mgr.state.claimed_at is None
+    assert "never became a turn" in caplog.text or "no turn" in caplog.text
+
+    # The tick was never delivered: it stays due and is re-claimed on the
+    # following poll instead of being silently dropped.
+    await runner._poll_heartbeat_watches_once()
+    assert adapter._pending_messages.get(key) is not None
+
+
+@pytest.mark.asyncio
+async def test_missing_adapter_never_claims_the_tick(monkeypatch):
+    runner, adapter, key, _source = _make_runner(monkeypatch)
+    _due_heartbeat("session-1", 700)
+    runner._adapter_for_source = lambda _source: None
+
+    await runner._poll_heartbeat_watches_once()
+
+    mgr = HeartbeatManager(session_id="session-1")
+    assert mgr.state.fire_count == 0
+    assert mgr.state.claimed_at is None
+    assert runner._heartbeat_inflight == {}
+
+
+@pytest.mark.asyncio
+async def test_busy_session_leaves_staged_tick_in_flight(monkeypatch):
+    runner, adapter, key, _source = _make_runner(monkeypatch)
+    _due_heartbeat("session-1", 700)
+    await runner._poll_heartbeat_watches_once()
+
+    # A turn starts (session busy) but has not drained the slot yet.
+    runner._running_agents[key] = object()
+    await runner._poll_heartbeat_watches_once()
+
+    mgr = HeartbeatManager(session_id="session-1")
+    assert mgr.state.fire_count == 0
+    assert mgr.state.claimed_at is not None
+    assert key in runner._heartbeat_inflight

--- a/tests/gateway/test_heartbeat_delivery_accounting.py
+++ b/tests/gateway/test_heartbeat_delivery_accounting.py
@@ -2,12 +2,15 @@
 
 A heartbeat tick is only "fired" once its staged prompt actually becomes
 a turn. Claims that vanish without any turn must be counted as missed
-(with a warning), and a session without a live adapter must never be
-claimed in the first place. Regression coverage for #92837.
+(with a warning), a session without a live adapter must never be claimed
+in the first place, and a claim that hangs forever (staged event stuck
+in the pending slot, no turn starts) must be abandoned loudly after the
+claim timeout and re-claimed. Regression coverage for #92837.
 """
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Any, Dict, Optional
 
@@ -69,6 +72,12 @@ def _make_runner(monkeypatch, session_id: str = "session-1"):
     runner._agent_cache = {}
     runner._adapter_for_source = lambda _source: adapter
     runner._peek_session_state = lambda _key: None
+    runner._session_key_for_source = lambda _source: key
+    # Deterministic claim timeout (real config is not consulted in tests);
+    # individual tests re-patch to a tiny value for timeout scenarios.
+    from hermes_cli import heartbeat as hb_module
+
+    monkeypatch.setattr(hb_module, "_default_claim_timeout_seconds", lambda: 300.0)
     return runner, adapter, key, source
 
 
@@ -77,7 +86,7 @@ async def test_due_tick_stages_without_counting_fired(monkeypatch):
     runner, adapter, key, _source = _make_runner(monkeypatch)
     _due_heartbeat("session-1", 700)
 
-    await runner._poll_heartbeat_watches_once()
+    await runner._poll_heartbeat_delivery_accounting_once()
 
     staged = adapter._pending_messages.get(key)
     assert staged is not None and staged._hermes_heartbeat_tick is True
@@ -92,14 +101,15 @@ async def test_due_tick_stages_without_counting_fired(monkeypatch):
 async def test_turn_consuming_staged_tick_confirms_the_fire(monkeypatch):
     runner, adapter, key, _source = _make_runner(monkeypatch)
     _due_heartbeat("session-1", 700)
-    await runner._poll_heartbeat_watches_once()
+    await runner._poll_heartbeat_delivery_accounting_once()
 
-    # Simulate a real turn: the adapter drained the pending slot and the
-    # session's agent recorded activity after the tick was staged.
-    adapter._pending_messages.pop(key, None)
-    agent = type("Agent", (), {"_last_activity_ts": time.time()})()
-    runner._agent_cache[key] = (agent,)
-    await runner._poll_heartbeat_watches_once()
+    # Simulate the drain consuming the staged tick: the pending slot is
+    # emptied and the tagged event enters the live message pipeline —
+    # the ONLY evidence that confirms a delivery.
+    staged = adapter._pending_messages.pop(key, None)
+    assert staged is not None and staged._hermes_heartbeat_tick is True
+    runner._confirm_heartbeat_delivery_for_event(staged)
+    await runner._poll_heartbeat_delivery_accounting_once()
 
     mgr = HeartbeatManager(session_id="session-1")
     assert mgr.state.fire_count == 1
@@ -115,13 +125,13 @@ async def test_staged_tick_vanishing_without_turn_counts_missed(monkeypatch, cap
 
     runner, adapter, key, _source = _make_runner(monkeypatch)
     _due_heartbeat("session-1", 700)
-    await runner._poll_heartbeat_watches_once()
+    await runner._poll_heartbeat_delivery_accounting_once()
 
     # Session reset / stale-lock heal / eviction discards the staged event
     # without any turn ever running.
     adapter._pending_messages.pop(key, None)
     with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
-        await runner._poll_heartbeat_watches_once()
+        await runner._poll_heartbeat_delivery_accounting_once()
 
     mgr = HeartbeatManager(session_id="session-1")
     assert mgr.state.fire_count == 0
@@ -131,8 +141,129 @@ async def test_staged_tick_vanishing_without_turn_counts_missed(monkeypatch, cap
 
     # The tick was never delivered: it stays due and is re-claimed on the
     # following poll instead of being silently dropped.
-    await runner._poll_heartbeat_watches_once()
+    await runner._poll_heartbeat_delivery_accounting_once()
     assert adapter._pending_messages.get(key) is not None
+
+
+@pytest.mark.asyncio
+async def test_vanished_tick_with_unrelated_activity_counts_missed(monkeypatch, caplog):
+    """Unrelated session activity is NOT delivery evidence (#92837).
+
+    A turn that ran without consuming the tagged tick (or any other
+    activity-timestamp refresh) must never confirm the delivery. Only the
+    tagged event entering the live message pipeline confirms; a vanished
+    staged event without that evidence counts as missed.
+    """
+    import logging
+
+    runner, adapter, key, _source = _make_runner(monkeypatch)
+    _due_heartbeat("session-1", 700)
+    await runner._poll_heartbeat_delivery_accounting_once()
+
+    # The staged event disappears without ever entering the message
+    # pipeline, but the session shows unrelated activity afterwards.
+    adapter._pending_messages.pop(key, None)
+    agent = type("Agent", (), {"_last_activity_ts": time.time()})()
+    runner._agent_cache[key] = (agent,)
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
+        await runner._poll_heartbeat_delivery_accounting_once()
+
+    mgr = HeartbeatManager(session_id="session-1")
+    assert mgr.state.fire_count == 0
+    assert mgr.state.missed_count == 1
+    assert mgr.state.claimed_at is None
+
+
+@pytest.mark.asyncio
+async def test_claim_timeout_abandons_stuck_staged_tick_and_reclaims(monkeypatch, caplog):
+    """The main #92837 failure mode: the staged tick sits in the pending
+    slot forever and no turn ever starts. After the claim timeout the
+    claim must be abandoned loudly, counted missed, and the still-due
+    tick re-claimed and re-staged instead of hanging silently.
+    """
+    import logging
+
+    from hermes_cli import heartbeat as hb_module
+
+    runner, adapter, key, _source = _make_runner(monkeypatch)
+    monkeypatch.setattr(hb_module, "_default_claim_timeout_seconds", lambda: 0.05)
+    _due_heartbeat("session-1", 700)
+    await runner._poll_heartbeat_delivery_accounting_once()
+    assert key in runner._heartbeat_inflight
+    staged_old = adapter._pending_messages.get(key)
+
+    # The staged event never leaves the pending slot and no turn starts.
+    await asyncio.sleep(0.2)
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
+        await runner._poll_heartbeat_delivery_accounting_once()
+
+    mgr = HeartbeatManager(session_id="session-1")
+    assert mgr.state.fire_count == 0
+    assert mgr.state.missed_count == 1
+    assert "no turn" in caplog.text
+    # The claim is resolved and the stale staged tick discarded — the
+    # tick stays due instead of hanging silently.
+    assert mgr.state.claimed_at is None
+    assert adapter._pending_messages.get(key) is None
+    assert key not in runner._heartbeat_inflight
+
+    # The following poll re-claims the still-due tick and re-stages a
+    # fresh delivery attempt.
+    await runner._poll_heartbeat_delivery_accounting_once()
+    mgr2 = HeartbeatManager(session_id="session-1")
+    assert mgr2.state.claimed_at is not None
+    staged_new = adapter._pending_messages.get(key)
+    assert staged_new is not None and staged_new is not staged_old
+    assert key in runner._heartbeat_inflight
+
+
+@pytest.mark.asyncio
+async def test_watch_reregistration_clears_orphan_claim(monkeypatch, caplog):
+    """Re-registering a watch clears a persisted claim whose in-process
+    staging context was lost — otherwise the heartbeat stalls forever.
+    """
+    import logging
+
+    runner, adapter, key, source = _make_runner(monkeypatch)
+    _due_heartbeat("session-1", 700)
+    await runner._poll_heartbeat_delivery_accounting_once()
+    mgr0 = HeartbeatManager(session_id="session-1")
+    assert mgr0.state.claimed_at is not None  # claimed by THIS process
+
+    # The in-memory staging context is lost while the persisted claim
+    # survives (watch + inflight rebuilt under the live process).
+    runner._heartbeat_watch.pop(key, None)
+    runner._heartbeat_inflight.pop(key, None)
+
+    runner._start_heartbeat_poller = lambda: None  # avoid a stray task
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
+        runner._register_heartbeat_watch(key, source, "session-1")
+
+    mgr = HeartbeatManager(session_id="session-1")
+    assert mgr.state.claimed_at is None
+    assert mgr.state.missed_count == 1
+    assert key in runner._heartbeat_watch
+
+
+@pytest.mark.asyncio
+async def test_unregister_watch_abandons_dangling_claim(monkeypatch, caplog):
+    """Unregistering a watch (e.g. /heartbeat clear) resolves any
+    in-flight claim so the persisted state keeps no dangling claim.
+    """
+    import logging
+
+    runner, adapter, key, _source = _make_runner(monkeypatch)
+    _due_heartbeat("session-1", 700)
+    await runner._poll_heartbeat_delivery_accounting_once()
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
+        runner._unregister_heartbeat_watch(key)
+
+    mgr = HeartbeatManager(session_id="session-1")
+    assert mgr.state.claimed_at is None
+    assert mgr.state.missed_count == 1
+    assert runner._heartbeat_watch == {}
+    assert runner._heartbeat_inflight == {}
 
 
 @pytest.mark.asyncio
@@ -141,7 +272,7 @@ async def test_missing_adapter_never_claims_the_tick(monkeypatch):
     _due_heartbeat("session-1", 700)
     runner._adapter_for_source = lambda _source: None
 
-    await runner._poll_heartbeat_watches_once()
+    await runner._poll_heartbeat_delivery_accounting_once()
 
     mgr = HeartbeatManager(session_id="session-1")
     assert mgr.state.fire_count == 0
@@ -153,11 +284,11 @@ async def test_missing_adapter_never_claims_the_tick(monkeypatch):
 async def test_busy_session_leaves_staged_tick_in_flight(monkeypatch):
     runner, adapter, key, _source = _make_runner(monkeypatch)
     _due_heartbeat("session-1", 700)
-    await runner._poll_heartbeat_watches_once()
+    await runner._poll_heartbeat_delivery_accounting_once()
 
     # A turn starts (session busy) but has not drained the slot yet.
     runner._running_agents[key] = object()
-    await runner._poll_heartbeat_watches_once()
+    await runner._poll_heartbeat_delivery_accounting_once()
 
     mgr = HeartbeatManager(session_id="session-1")
     assert mgr.state.fire_count == 0

--- a/tests/hermes_cli/test_heartbeat.py
+++ b/tests/hermes_cli/test_heartbeat.py
@@ -254,3 +254,131 @@ def test_migrate_heartbeat_to_session():
 def test_migrate_noop_without_source():
     assert migrate_heartbeat_to_session("hb-none-a", "hb-none-b") is False
     assert migrate_heartbeat_to_session("same", "same") is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# claim timeout — a claimed tick that produces no turn must not hang
+# silently (#92837 expectation #3)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_claim_timeout_in_due_prompt_abandons_and_reclaims(caplog, monkeypatch):
+    import hermes_cli.heartbeat as hb
+
+    # Anchor "this process" far enough in the past that a 30s-old claim
+    # reads as a live-process claim, not a stale previous-process one.
+    monkeypatch.setattr(hb, "_PROCESS_START_TS", time.time() - 1000)
+
+    mgr = HeartbeatManager(session_id="hb-timeout-sid", claim_timeout_seconds=10)
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+    assert mgr.due_prompt() is not None  # claims the due tick
+    assert mgr.state.claimed_at is not None
+
+    # A live-process claim that produced no turn within the timeout
+    # window must be abandoned loudly, counted missed, and the still-due
+    # tick re-claimed on the same call instead of stalling silently.
+    mgr.state.claimed_at = time.time() - 30
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
+        prompt = mgr.due_prompt()
+
+    assert prompt is not None  # re-claimed: the tick stayed due
+    assert mgr.state.missed_count == 1
+    assert mgr.state.fire_count == 0
+    assert mgr.state.claimed_at is not None  # fresh claim
+    assert "no turn" in caplog.text
+
+
+def test_fresh_claim_within_timeout_stays_in_flight():
+    mgr = HeartbeatManager(session_id="hb-timeout-fresh-sid", claim_timeout_seconds=60)
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+    assert mgr.due_prompt() is not None
+    # The claim is only seconds old: overlapping polls must not touch it.
+    assert mgr.due_prompt() is None
+    assert mgr.state.missed_count == 0
+    assert mgr.state.claimed_at is not None
+
+
+def test_claim_timeout_resolves_from_config_defaults(monkeypatch):
+    import hermes_cli.config as cfg_mod
+    import hermes_cli.heartbeat as hb
+
+    monkeypatch.setattr(
+        cfg_mod, "load_config_readonly",
+        lambda: {"heartbeat": {"claim_timeout_seconds": 42}},
+    )
+    mgr = HeartbeatManager(session_id="hb-cfg-sid")
+    assert mgr.claim_timeout_seconds == 42.0
+
+    # Without the config key (or with unreadable config) the documented
+    # fallback applies — never a crash.
+    monkeypatch.setattr(cfg_mod, "load_config_readonly", lambda: {})
+    mgr2 = HeartbeatManager(session_id="hb-cfg-sid-2")
+    assert mgr2.claim_timeout_seconds == hb._CLAIM_TIMEOUT_FALLBACK_SECONDS
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CLI watchdog tick — confirm failures must never wedge the claim
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_cli_watchdog_tick_confirms_after_queueing():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)  # bypass __init__ (no full app needed)
+    cli.session_id = "hb-cli-ok-sid"
+    cli._heartbeat_manager = None
+    cli._agent_running = False
+    cli._voice_recording = False
+    cli._voice_processing = False
+    import queue
+
+    cli._pending_input = queue.Queue()
+
+    mgr = HeartbeatManager(session_id="hb-cli-ok-sid")
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+    cli._heartbeat_manager = mgr
+
+    cli._heartbeat_watchdog_tick()
+
+    assert cli._pending_input.qsize() == 1  # prompt queued for the REPL
+    assert mgr.state.fire_count == 1
+    assert mgr.state.missed_count == 0
+    assert mgr.state.claimed_at is None
+
+
+def test_cli_confirm_delivery_failure_abandons_claim_instead_of_wedging():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "hb-cli-boom-sid"
+    cli._heartbeat_manager = None
+    cli._agent_running = False
+    cli._voice_recording = False
+    cli._voice_processing = False
+    import queue
+
+    cli._pending_input = queue.Queue()
+
+    mgr = HeartbeatManager(session_id="hb-cli-boom-sid")
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+    cli._heartbeat_manager = mgr
+
+    def _boom():
+        raise RuntimeError("persisted write failed")
+
+    mgr.confirm_delivery = _boom  # type: ignore[method-assign]
+
+    cli._heartbeat_watchdog_tick()
+
+    # The prompt was queued but confirmation blew up: the claim must be
+    # abandoned (not left in flight forever), so the next tick re-claims
+    # the still-due interval.
+    assert cli._pending_input.qsize() == 1
+    assert mgr.state.fire_count == 0
+    assert mgr.state.missed_count == 1
+    assert mgr.state.claimed_at is None
+

--- a/tests/hermes_cli/test_heartbeat.py
+++ b/tests/hermes_cli/test_heartbeat.py
@@ -214,7 +214,11 @@ def test_stale_claim_from_previous_process_warns_and_counts_missed(caplog):
     mgr.state.created_at = time.time() - 700
     # Simulate a claim made by a previous process that died before
     # confirming or abandoning it (crash between claim and handoff).
-    mgr.state.claimed_at = hb._PROCESS_START_TS - 60
+    # The claim must sit OUTSIDE the NTP skew tolerance band to read as
+    # an orphan rather than a live-process claim.
+    mgr.state.claimed_at = (
+        hb._PROCESS_START_TS - hb._PROCESS_START_SKEW_TOLERANCE_SECONDS - 60
+    )
     save_heartbeat("hb-stale-sid", mgr.state)
     with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
         assert mgr.due_prompt() is None
@@ -224,6 +228,35 @@ def test_stale_claim_from_previous_process_warns_and_counts_missed(caplog):
     assert mgr.state.fire_count == 0
     # Next poll re-claims the still-due tick.
     assert mgr.due_prompt() is not None
+
+
+def test_ntp_step_back_within_tolerance_keeps_claim_in_flight(caplog, monkeypatch):
+    """A backwards NTP step must not misread live claims as orphans.
+
+    Wall-clock ``_PROCESS_START_TS`` is captured at import. If NTP steps
+    the clock backwards afterwards, a claim recorded by THIS process on
+    the corrected clock can read slightly OLDER than the start marker.
+    Inside the skew tolerance that must stay a live in-flight claim (no
+    spurious "previous process died" warning, no missed_count bump);
+    outside it, the orphan handling still applies (covered above).
+    """
+    import hermes_cli.heartbeat as hb
+
+    # The process "started" 30s in the future of the claim: the import
+    # happened on the old, ahead clock before the backwards step.
+    monkeypatch.setattr(hb, "_PROCESS_START_TS", time.time() + 30)
+    mgr = HeartbeatManager(session_id="hb-ntp-sid", claim_timeout_seconds=60)
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+    mgr.state.claimed_at = time.time() - 10  # 40s < tolerance 120s
+    save_heartbeat("hb-ntp-sid", mgr.state)
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
+        assert mgr.due_prompt() is None
+    assert "never confirmed" not in caplog.text
+    assert mgr.state.missed_count == 0
+    assert mgr.state.fire_count == 0
+    # The claim stays in flight for the live process to resolve.
+    assert mgr.state.claimed_at is not None
 
 
 def test_resume_reanchors_instead_of_instant_fire():
@@ -381,4 +414,15 @@ def test_cli_confirm_delivery_failure_abandons_claim_instead_of_wedging():
     assert mgr.state.fire_count == 0
     assert mgr.state.missed_count == 1
     assert mgr.state.claimed_at is None
+
+
+def test_confirm_delivery_docstring_states_acceptance_boundary():
+    """Review guard (#92837): confirm_delivery fires at the ACCEPTANCE
+    boundary (turn START for the gateway), not at turn completion. Wording
+    that says "consumed by a turn" invites someone to move the call
+    post-turn and reintroduce stuck claims."""
+    doc = HeartbeatManager.confirm_delivery.__doc__
+    assert doc is not None
+    assert "accepted into the live pipeline" in doc
+    assert "consumed by a turn" not in doc
 

--- a/tests/hermes_cli/test_heartbeat.py
+++ b/tests/hermes_cli/test_heartbeat.py
@@ -1,5 +1,6 @@
 """Tests for /heartbeat (hermes_cli/heartbeat.py)."""
 
+import logging
 import time
 
 import pytest
@@ -133,7 +134,7 @@ def test_manager_persists_across_instances():
     assert again.state.prompt == "persisted prompt"
 
 
-def test_due_prompt_fires_once_and_reanchors():
+def test_due_prompt_claims_then_confirm_records_fire_and_reanchors():
     mgr = HeartbeatManager(session_id="hb-due-sid")
     mgr.set("tick", 600)
     # Not due immediately after set.
@@ -142,8 +143,13 @@ def test_due_prompt_fires_once_and_reanchors():
     mgr.state.created_at = time.time() - 700
     prompt = mgr.due_prompt()
     assert prompt is not None and "tick" in prompt
+    # Claiming the tick must NOT record a fire — delivery isn't confirmed yet.
+    assert mgr.state.fire_count == 0
+    assert mgr.state.claimed_at is not None
+    assert mgr.confirm_delivery() is True
     assert mgr.state.fire_count == 1
-    # Immediately after firing it re-anchors — not due again.
+    assert mgr.state.claimed_at is None
+    # Immediately after confirmation it re-anchors — not due again.
     assert mgr.due_prompt() is None
 
 
@@ -153,8 +159,71 @@ def test_missed_ticks_coalesce():
     # Simulate 5 missed intervals: exactly ONE fire results.
     mgr.state.created_at = time.time() - 600 * 5 - 10
     assert mgr.due_prompt() is not None
+    assert mgr.confirm_delivery() is True
     assert mgr.due_prompt() is None
     assert mgr.state.fire_count == 1
+
+
+def test_fire_is_recorded_only_after_confirm_delivery():
+    mgr = HeartbeatManager(session_id="hb-confirm-sid")
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+    prompt = mgr.due_prompt()
+    assert prompt is not None
+    # Claimed but not fired: the persisted state must not lie about a
+    # delivery that never happened.
+    assert mgr.state.fire_count == 0
+    assert mgr.state.last_delivered_at == 0.0
+    assert mgr.confirm_delivery() is True
+    assert mgr.state.fire_count == 1
+    assert mgr.state.last_delivered_at > 0
+    assert mgr.state.claimed_at is None
+
+
+def test_inflight_claim_blocks_second_claim():
+    mgr = HeartbeatManager(session_id="hb-inflight-sid")
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+    assert mgr.due_prompt() is not None
+    # An unconfirmed claim is in flight: overlapping polls must not
+    # re-claim the same tick (no double-fire, no backlog pileup).
+    assert mgr.due_prompt() is None
+    assert mgr.state.fire_count == 0
+
+
+def test_abandon_claim_counts_missed_and_keeps_tick_due(caplog):
+    mgr = HeartbeatManager(session_id="hb-abandon-sid")
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+    assert mgr.due_prompt() is not None
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
+        assert mgr.abandon_claim("input queue handoff failed") is True
+    assert "input queue handoff failed" in caplog.text
+    assert mgr.state.missed_count == 1
+    assert mgr.state.fire_count == 0
+    assert mgr.state.claimed_at is None
+    # The tick was never delivered: it stays due and is re-claimed.
+    assert mgr.due_prompt() is not None
+
+
+def test_stale_claim_from_previous_process_warns_and_counts_missed(caplog):
+    import hermes_cli.heartbeat as hb
+
+    mgr = HeartbeatManager(session_id="hb-stale-sid")
+    mgr.set("tick", 600)
+    mgr.state.created_at = time.time() - 700
+    # Simulate a claim made by a previous process that died before
+    # confirming or abandoning it (crash between claim and handoff).
+    mgr.state.claimed_at = hb._PROCESS_START_TS - 60
+    save_heartbeat("hb-stale-sid", mgr.state)
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.heartbeat"):
+        assert mgr.due_prompt() is None
+    assert "never confirmed" in caplog.text
+    assert mgr.state.missed_count == 1
+    assert mgr.state.claimed_at is None
+    assert mgr.state.fire_count == 0
+    # Next poll re-claims the still-due tick.
+    assert mgr.due_prompt() is not None
 
 
 def test_resume_reanchors_instead_of_instant_fire():


### PR DESCRIPTION
## What does this PR do?

Heartbeat ticks are no longer counted as fired until the tick's prompt is **actually delivered** — confirmed by real evidence that the prompt became a turn. Ticks that are claimed but never become a turn are surfaced loudly (warning + `missed_count`) instead of silently advancing `fire_count` / `last_fired_at`, and a claim that hangs forever is now resolved by a configurable claim timeout instead of stalling silently. This addresses every expectation in #92837, including the main failure mode reported there (a claimed tick that produces no turn for hours, with zero signal).

## Root cause

`HeartbeatManager.due_prompt()` recorded the fire **before** delivery:

```python
s.last_fired_at = now
s.fire_count += 1
save_heartbeat(...)
return s.render_prompt()
```

Nothing downstream confirmed the prompt ever became a turn, so every failure mode was invisible by construction:

1. **Fired ≠ delivered.** On the gateway the poller counted the tick before any delivery path existed — missing adapter, dropped handoff, or a staged prompt with no consumer all advanced the audit trail while no turn ran.
2. **Eviction/backlog.** After agent-cache idle-TTL eviction there was no live input path, yet ticks kept counting as fired.
3. **No visibility.** No warning anywhere when a rendered prompt produced no turn — the failure was silent by construction.
4. **Claims could hang forever.** A staged event stuck in the pending slot (or a lost in-process staging context with a persisted claim) was never resolved: no warning, no retry, heartbeat effectively dead.

## Changes Made

### Claim / confirm / abandon with a claim timeout (issue expectation #3)

- `hermes_cli/heartbeat.py`
  - `HeartbeatState` gains `claimed_at`, `last_delivered_at`, and `missed_count`. Old persisted rows load fine (defaults).
  - `due_prompt()` only **claims** a due tick; `confirm_delivery()` is the **only** place a fire is recorded; `abandon_claim(reason)` warns, increments `missed_count`, and leaves the tick due.
  - **Claim timeout**: `HeartbeatManager(claim_timeout_seconds=...)` (default from config `heartbeat.claim_timeout_seconds`, see below). A claim from a live process that produces no turn within the window is abandoned with a warning, counted missed, and the still-due tick is re-claimed — a hanging claim can no longer be silent or permanent.
  - A claim left behind by a dead process (crash between claim and handoff) is detected via the module import timestamp, warned, counted missed, and cleared.
  - `/heartbeat` status line shows missed deliveries (`fired 3×, missed 2×`).
- Config: `heartbeat.claim_timeout_seconds` added to the config defaults (`hermes_cli/config_defaults.py`, default `300`), resolved best-effort via `load_config_readonly()` with a documented fallback — no hardcoded magic number at the call sites. `"heartbeat"` is registered as an open-dict top-level config key so users can set it.

### Confirmation only on real consumption evidence (no heuristic)

- `gateway/run.py`
  - The poller tags the staged event (`_hermes_heartbeat_tick`) and the fire is confirmed **only** when that exact event enters the live message pipeline (`_handle_message` → `_confirm_heartbeat_delivery_for_event`). The previous `_last_activity_ts`-based heuristic is deleted: unrelated session activity is not delivery evidence.
  - If the staged event vanishes without ever entering the pipeline (session reset / stale-lock heal / eviction), the claim is abandoned with a warning and counted missed — never confirmed by a timestamp.
  - If the staged event sits in the pending slot with no turn starting, the claim timeout abandons it loudly, discards the stale staged tick, and the still-due tick is re-claimed and re-staged on the next poll.
  - The adapter is resolved **before** claiming — a session with no live adapter never claims a tick.
  - In-flight claims coalesce (no backlog pileup).
- `cli.py` — the watchdog tick is extracted into `_heartbeat_watchdog_tick()`; the prompt is confirmed only after queueing into the live REPL input queue, and **a failure of `confirm_delivery()` itself now abandons the claim** instead of leaving it wedged (with the manager claim timeout as backstop).

### Orphan-claim recovery

- `_register_heartbeat_watch()` clears a persisted in-flight claim (and its inflight entry) when a watch is freshly registered — a lost in-process staging context can no longer leave the heartbeat permanently dead.
- `_unregister_heartbeat_watch()` (the `/heartbeat clear` path) now also abandons the persisted claim it was leaving behind; the previously dead `inflight.pop` now does real work with real callers and regression coverage.

## How to Test

```bash
pytest tests/hermes_cli/test_heartbeat.py tests/gateway/test_heartbeat_delivery_accounting.py tests/gateway/test_goal_continuation_drain.py tests/gateway/test_scale_to_zero_watcher.py tests/gateway/test_busy_session_ack.py -q
```

Regression coverage added for each new behavior (all verified RED against the pre-fix code before implementing):

- claim timeout abandons a stuck staged tick (gateway poll) and re-claims on the next poll — the #92837 main scenario;
- claim timeout abandons + re-claims inside `due_prompt()` (manager level);
- fresh claims within the window stay in flight;
- timeout resolves from config defaults with fallback;
- vanished tick with unrelated session activity counts **missed** (heuristic-removal regression guard);
- turn consuming the tagged tick confirms the fire (the only confirm path);
- watch re-registration clears an orphan claim;
- watch unregistration abandons a dangling claim;
- CLI tick confirms after queueing, and a failing `confirm_delivery()` abandons instead of wedging.

Result: `tests/hermes_cli/test_heartbeat.py` + `tests/gateway/test_heartbeat_delivery_accounting.py` → 47 passed; related gateway suites → 50 passed; `ruff check` clean; `check-windows-footguns.py --all` clean.

## Review follow-up — @Enough1122 (second round)

All three points addressed; the "minor (no change needed)" one acknowledged below.

1. **NTP skew on `_PROCESS_START_TS` (wall clock).** The orphan test now tolerates clock skew: only a claim older than `_PROCESS_START_TS - _PROCESS_START_SKEW_TOLERANCE_SECONDS` (120 s) is treated as a previous-process orphan, in both `due_prompt()` and the watch-registration cleanup. A backwards NTP step after import therefore no longer misreads a live process's own claims as orphans (no spurious `missed_count` + warning). The constant's comment documents the wall-clock best-effort bound explicitly. New regression test: `test_ntp_step_back_within_tolerance_keeps_claim_in_flight` (simulated backwards step, claim inside tolerance → stays in flight, zero warnings, `missed_count == 0`); the existing stale-claim test now places its claim outside the tolerance band.

2. **Per-poll disk reads in `_poll_heartbeat_delivery_accounting_once`.** Added `HeartbeatLoadCache` (in `hermes_cli/heartbeat.py`) — a small mtime-checked cache fingerprinting `state.db` / `state.db-wal`. The poll injects `state=cache.load(session_id)` into each `HeartbeatManager`, so an unchanged poll does **zero** disk reads and a poll after a real DB change re-reads each state at most once (never once per watch per 5 s poll). `HeartbeatManager.__init__` gained an optional `state=` parameter (sentinel-guarded; CLI behavior unchanged). New regression test: `test_poll_reuses_cached_state_instead_of_rereading_disk` counts real `load_heartbeat` calls across 3 watches × 4 polls (cold 3 / settle 3 / stable **0** / after-external-change 3 — uncached would be 12).

3. **`confirm_delivery` docstring wording.** Reworded from "consumed by a turn" to "**accepted into the live pipeline** (gateway, at the turn's acceptance boundary in `_handle_message` — turn START, not completion; do NOT move this call post-turn …)". New guard test `test_confirm_delivery_docstring_states_acceptance_boundary` asserts the new wording and that "consumed by a turn" is absent.

4. **Minor (unchanged, as suggested):** `_register_heartbeat_watch` still constructs a fresh manager on registration to clear orphan claims — one disk read per registration (user-triggered, rare), not worth caching.


## Related Issue

Closes #92837

## Relationship to other heartbeat PRs

- **#85133 (open, for #85119)** fixes the gateway **wake path**: entering an idle session through `adapter.handle_message()` so a staged tick actually starts a turn. This PR fixes the **accounting layer**: claim/confirm/abandon with delivery-confirmed fires, missed counts, and claim-timeout abandonment. **Both are needed** — #85133 makes idle sessions wake, this PR makes the audit trail truthful and the failures loud — but **this PR does not depend on #85133**: with or without it, a staged tick either confirms at the consumption boundary or is abandoned with a warning after the claim timeout. To avoid a same-name method text conflict, this PR's poller is named `_poll_heartbeat_delivery_accounting_once` (not `_poll_heartbeat_watches_once`), and after #85133 lands its adapter-entry call site can confirm delivery at that same boundary. Happy to rebase either way.
- #92858 (closed, unmerged) explored claim/confirm for the gateway and was superseded; this PR implements the accounting in `hermes_cli/heartbeat.py` with the gateway confirming at the real consumption boundary.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11
