### PR TITLE
fix(review): bound same-model background review replay (in-memory compaction + input budget)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -200,6 +200,21 @@ def cancel_background_review_for_live_turn(agent: Any) -> None:
 # Historical hardcoded iteration budget for the review fork.
 _REVIEW_MAX_ITERATIONS = 16
 
+# Default aggregate INPUT-token budget for one review fork (#93057). The
+# fork's first request replays the full snapshot — a warm prompt-cache read
+# that is cheap and intended (cache parity). After that, detached in-memory
+# compaction bounds each request to roughly the compression threshold, but
+# nothing capped the SUM across the review's tool loop: one production
+# review made 8 requests replaying 1,487,951 input tokens total (four of
+# them at 350k-384k). This budget caps the aggregate; the review tool loop
+# stops before the provider call that would cross it (see
+# ``_review_input_budget_exhausted`` in agent/conversation_loop.py).
+# 2x the historical 300k foreground trigger keeps legitimate reviews
+# comfortable while capping the pathological case. Override with
+# ``auxiliary.background_review.max_input_tokens``; 0 or a negative value
+# disables the cap (unbounded = pre-fix behavior).
+_REVIEW_MAX_INPUT_TOKENS_DEFAULT = 600_000
+
 
 def _background_review_task_config(
     task_cfg: Optional[Dict[str, Any]] = None,
@@ -220,6 +235,26 @@ def _background_review_task_config(
     aux = cfg.get("auxiliary", {}) if isinstance(cfg.get("auxiliary"), dict) else {}
     task = aux.get("background_review", {})
     return task if isinstance(task, dict) else {}
+
+
+def _review_input_token_budget(
+    task_cfg: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Aggregate input-token budget for one review fork (None = unlimited).
+
+    Reads ``auxiliary.background_review.max_input_tokens``; falls back to
+    :data:`_REVIEW_MAX_INPUT_TOKENS_DEFAULT`. ``0`` or a negative value
+    disables the cap explicitly.
+    """
+    task = _background_review_task_config(task_cfg)
+    raw = task.get("max_input_tokens", _REVIEW_MAX_INPUT_TOKENS_DEFAULT)
+    try:
+        budget = int(raw)
+    except (TypeError, ValueError):
+        budget = _REVIEW_MAX_INPUT_TOKENS_DEFAULT
+    if budget <= 0:
+        return None
+    return budget
 
 
 def load_background_review_settings() -> tuple[bool, Dict[str, Any]]:
@@ -1269,17 +1304,61 @@ def _run_review_in_thread(
             # conversation (the review fires every ~10 turns). Leave session
             # finalization to the real owner (CLI close / gateway reset / cron).
             review_agent._end_session_on_close = False
-            # Never let the review fork compress. It shares the parent's
-            # session_id, so if it won a compression race it would rotate the
-            # parent into a NEW child that the gateway never adopts (the fork
-            # is single-lifecycle and dies right after this run_conversation).
-            # The foreground turn would then start from the stale parent and
-            # compress it again, leaving the same parent with two sibling
-            # children (issue #38727). Review also needs full context to
-            # produce a good memory/skill summary — compressing would strip
-            # detail. Both compression triggers in conversation_loop.py gate on
-            # agent.compression_enabled, so this short-circuits both paths.
-            review_agent.compression_enabled = False
+            # DETACHED IN-MEMORY COMPACTION (issue #93057). The fork shares
+            # the parent's session_id (pinned above for prefix-cache parity),
+            # so the historical guard here was ``compression_enabled = False``:
+            # if the fork ran the ordinary compression path it could rotate /
+            # archive the parent's live session — the sibling-session race
+            # behind #38727. But disabling compaction was a proxy for
+            # detachment, and it removed the ONLY bound on the review's
+            # private snapshot: as the review performs tool calls, every
+            # follow-up provider request replayed the snapshot plus the
+            # growing review tool loop (350k-384k input tokens per request in
+            # production, 1.49M total across one 8-request review).
+            #
+            # The fix is detachment, not disablement:
+            #   • Persistence is already off above (_persist_disabled /
+            #     _session_db=None), so the commit site in compress_context
+            #     (``if agent._session_db:``) skips every durable write and
+            #     compaction can only ever rewrite the fork's private
+            #     in-memory transcript.
+            #   • The compressor's OWN session binding still needs severing:
+            #     AIAgent.__init__ bound it to the parent's SessionDB and
+            #     session_id before this function nulled the agent-level
+            #     binding, so durable cooldown/streak/ineffective-count
+            #     writes would otherwise land on the parent's row. Rebinding
+            #     with session_db=None / session_id="" makes every
+            #     compressor persist guard a no-op.
+            #   • Force in-place mode (never rotation) even if the parent's
+            #     config selected rotation, and re-enable compression so the
+            #     trigger gates in conversation_loop.py can fire.
+            _review_compressor = getattr(review_agent, "context_compressor", None)
+            _bind_review_compressor = getattr(
+                _review_compressor, "bind_session_state", None
+            )
+            if callable(_bind_review_compressor):
+                try:
+                    # Plugin/third-party context engines may not accept these
+                    # kwargs; they own their own persistence policy, so a
+                    # failed rebind leaves the pre-existing flags in place
+                    # and must never abort the review (same tolerance as the
+                    # init-time binding in agent_init.py).
+                    _bind_review_compressor(session_db=None, session_id="")
+                except Exception:
+                    logger.debug(
+                        "background-review compressor detachment failed; "
+                        "keeping the engine's existing session binding",
+                        exc_info=True,
+                    )
+            review_agent.compression_in_place = True
+            review_agent.compression_enabled = True
+            # Aggregate input budget: compaction bounds any single request;
+            # this bounds the WHOLE review. Iterations are already capped by
+            # _REVIEW_MAX_ITERATIONS. Checked in agent/conversation_loop.py
+            # via _review_input_budget_exhausted (issue #93057).
+            review_agent._review_input_token_budget = _review_input_token_budget(
+                task_cfg
+            )
 
             # Register this fork on the PARENT's _active_children (the same
             # list interrupt() fans out to for subagent delegation) and

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -202,13 +202,15 @@ _REVIEW_MAX_ITERATIONS = 16
 
 # Default aggregate INPUT-token budget for one review fork (#93057). The
 # fork's first request replays the full snapshot — a warm prompt-cache read
-# that is cheap and intended (cache parity). After that, detached in-memory
-# compaction bounds each request to roughly the compression threshold, but
-# nothing capped the SUM across the review's tool loop: one production
-# review made 8 requests replaying 1,487,951 input tokens total (four of
-# them at 350k-384k). This budget caps the aggregate; the review tool loop
-# stops before the provider call that would cross it (see
-# ``_review_input_budget_exhausted`` in agent/conversation_loop.py).
+# that is cheap and intended (cache parity), which is why both compression
+# gates are deferred until the first provider response arrives
+# (_review_fork_first_request_pending in agent/turn_context.py). After that,
+# detached in-memory compaction bounds each request to roughly the
+# compression threshold, but nothing capped the SUM across the review's tool
+# loop: one production review made 8 requests replaying 1,487,951 input
+# tokens total (four of them at 350k-384k). This budget caps the aggregate;
+# the review tool loop stops before the provider call that would cross it
+# (see ``_review_input_budget_exhausted`` in agent/conversation_loop.py).
 # 2x the historical 300k foreground trigger keeps legitimate reviews
 # comfortable while capping the pathological case. Override with
 # ``auxiliary.background_review.max_input_tokens``; 0 or a negative value
@@ -1330,12 +1332,16 @@ def _run_review_in_thread(
             #     with session_db=None / session_id="" makes every
             #     compressor persist guard a no-op.
             #   • Force in-place mode (never rotation) even if the parent's
-            #     config selected rotation, and re-enable compression so the
-            #     trigger gates in conversation_loop.py can fire.
+            #     config selected rotation, and re-enable compression ONLY
+            #     after the rebind succeeds (fail-closed — see below). While
+            #     enabled, both compression gates stay deferred until the
+            #     fork's first provider response so request #1 replays the
+            #     full snapshot as a warm cache read.
             _review_compressor = getattr(review_agent, "context_compressor", None)
             _bind_review_compressor = getattr(
                 _review_compressor, "bind_session_state", None
             )
+            _review_compression_detached = False
             if callable(_bind_review_compressor):
                 try:
                     # Plugin/third-party context engines may not accept these
@@ -1344,14 +1350,42 @@ def _run_review_in_thread(
                     # and must never abort the review (same tolerance as the
                     # init-time binding in agent_init.py).
                     _bind_review_compressor(session_db=None, session_id="")
+                    _review_compression_detached = True
                 except Exception:
-                    logger.debug(
+                    # FAIL-CLOSED (adversarial review, #93057): if the rebind
+                    # could not sever the engine's session binding, the
+                    # compressor may still point at the parent's
+                    # SessionDB/session_id. Enabling compression in that
+                    # state would let durable cooldown/streak/ineffective-
+                    # count writes land on the parent's row and re-open the
+                    # #38727 sibling race. Keep the historical
+                    # compression_enabled=False behavior instead and warn;
+                    # the review still runs, bounded by the iteration cap
+                    # and the aggregate input budget below.
+                    logger.warning(
                         "background-review compressor detachment failed; "
-                        "keeping the engine's existing session binding",
+                        "keeping compression DISABLED on this review fork "
+                        "(fail-closed, issue #93057 / #38727)",
                         exc_info=True,
                     )
+            # Force in-place mode (never rotation) even if the parent's
+            # config selected rotation. Re-enable compression ONLY after the
+            # compressor's session binding was successfully severed; an
+            # engine without a bind hook keeps the historical disabled
+            # behavior as well.
             review_agent.compression_in_place = True
-            review_agent.compression_enabled = True
+            review_agent.compression_enabled = _review_compression_detached
+            if _review_compression_detached:
+                # Warm-cache parity: the fork's FIRST provider request
+                # replays the parent's full snapshot as a warm prompt-cache
+                # read, so compaction must not rewrite the snapshot before
+                # that first request goes out. Defer both compression gates
+                # until the first provider response arrives (see
+                # _review_fork_first_request_pending in agent/turn_context.py
+                # and the pre-API gate in agent/conversation_loop.py); from
+                # the second request on, the fork's transcript is its own and
+                # compaction bounds it.
+                review_agent._review_defer_compaction_before_first_response = True
             # Aggregate input budget: compaction bounds any single request;
             # this bounds the WHOLE review. Iterations are already capped by
             # _REVIEW_MAX_ITERATIONS. Checked in agent/conversation_loop.py

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -41,6 +41,7 @@ from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_metadata import append_message
 from agent.turn_context import (
     _compression_warrants_another_preflight_pass,
+    _review_fork_first_request_pending,
     build_turn_context,
     compose_user_api_content,
     reanchor_current_turn_user_idx,
@@ -2637,6 +2638,7 @@ def run_conversation(
         )()
         if (
             agent.compression_enabled
+            and not _review_fork_first_request_pending(agent)
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
             and not _preflight_compression_blocked

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -118,6 +118,26 @@ RUN_BUDGET_WRAPUP_NOTICE = (
 )
 
 
+def _review_input_budget_exhausted(agent: Any) -> bool:
+    """True when a detached review fork has replayed its aggregate input budget.
+
+    Only forks carrying an explicit ``_review_input_token_budget`` (the
+    background-review path, #93057) are gated; every other agent returns
+    False and is unaffected. ``session_input_tokens`` accumulates from
+    provider usage after each response, so the check fires at the top of the
+    NEXT tool-loop iteration — the budget-crossing request is admitted and
+    completes (its tool writes land), then the loop stops before any further
+    provider call. This caps the review's total replayed input, complementing
+    the per-request bound provided by detached in-memory compaction and the
+    ``_REVIEW_MAX_ITERATIONS`` iteration cap.
+    """
+    budget = getattr(agent, "_review_input_token_budget", None)
+    if not isinstance(budget, int) or isinstance(budget, bool) or budget <= 0:
+        return False
+    used = getattr(agent, "session_input_tokens", 0)
+    return isinstance(used, int) and not isinstance(used, bool) and used >= budget
+
+
 def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) -> bool:
     """Inject the one-time wall-clock wrap-up notice when past 80% of budget.
 
@@ -1976,6 +1996,21 @@ def run_conversation(
             _turn_exit_reason = "interrupted_by_user"
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
+            break
+
+        # Aggregate input budget for detached auxiliary forks (background
+        # review, #93057): compaction bounds each request; this bounds the
+        # review as a whole. Fires between iterations — the budget-crossing
+        # request completed (its tool writes landed), and the tool loop stops
+        # before the next provider call, mirroring the iteration-budget exit.
+        if _review_input_budget_exhausted(agent):
+            _turn_exit_reason = "review_input_budget_exhausted"
+            if not agent.quiet_mode:
+                agent._safe_print(
+                    f"\n⏹️  Review input budget exhausted "
+                    f"({int(agent.session_input_tokens):,} tokens) — stopping "
+                    f"the review tool loop before the next provider call."
+                )
             break
         
         api_call_count += 1

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -320,6 +320,24 @@ def compression_made_progress(
 _compression_made_progress = compression_made_progress
 
 
+def _review_fork_first_request_pending(agent: Any) -> bool:
+    """Whether a detached review fork has yet to send its first provider request.
+
+    The background-review fork (issue #93057) replays the parent's FULL
+    snapshot on its first provider request as a warm prompt-cache read
+    (same-model cache parity). Compaction must not rewrite the snapshot
+    before that first request goes out — a compacted transcript would miss
+    the parent's cached prefix and turn a cheap cached replay into a cold
+    over-threshold write. Once the first provider response has arrived the
+    fork's tool loop is its own context, and both compression gates resume.
+    Dormant for every agent without the attribute.
+    """
+    return bool(
+        getattr(agent, "_review_defer_compaction_before_first_response", False)
+        and not getattr(agent, "_turn_received_provider_response", False)
+    )
+
+
 def _compression_warrants_another_preflight_pass(
     orig_tokens: int, new_tokens: int, threshold_tokens: int
 ) -> bool:
@@ -879,11 +897,15 @@ def build_turn_context(
     _preflight_compression_blocked = False
     agent._turn_received_provider_response = False
     agent._turn_preflight_display_snapshot = None
-    if agent.compression_enabled and _should_run_preflight_estimate(
-        messages,
-        agent.context_compressor.protect_first_n,
-        agent.context_compressor.protect_last_n,
-        agent.context_compressor.threshold_tokens,
+    if (
+        agent.compression_enabled
+        and not _review_fork_first_request_pending(agent)
+        and _should_run_preflight_estimate(
+            messages,
+            agent.context_compressor.protect_first_n,
+            agent.context_compressor.protect_last_n,
+            agent.context_compressor.threshold_tokens,
+        )
     ):
         _preflight_tokens = estimate_request_tokens_rough(
             messages,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1252,6 +1252,13 @@ DEFAULT_CONFIG = {
             "timeout": 120,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            # Aggregate INPUT-token budget for one review fork (issue #93057).
+            # The fork compacts an oversized snapshot in memory before further
+            # provider calls; this caps the SUM of input tokens replayed
+            # across the whole review tool loop (iterations are separately
+            # capped at 16). The loop stops before the provider call that
+            # would cross the budget. 0 or a negative value = unlimited.
+            "max_input_tokens": 600000,
         },
         "moa_reference": {
             "provider": "auto",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1253,11 +1253,14 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
             # Aggregate INPUT-token budget for one review fork (issue #93057).
-            # The fork compacts an oversized snapshot in memory before further
-            # provider calls; this caps the SUM of input tokens replayed
-            # across the whole review tool loop (iterations are separately
-            # capped at 16). The loop stops before the provider call that
-            # would cross the budget. 0 or a negative value = unlimited.
+            # The fork's FIRST request replays the full snapshot as a warm
+            # prompt-cache read (compaction is deferred until the first
+            # provider response arrives); after that it compacts an oversized
+            # snapshot in memory before further provider calls. This caps the
+            # SUM of input tokens replayed across the whole review tool loop
+            # (iterations are separately capped at 16). The loop stops before
+            # the provider call that would cross the budget. 0 or a negative
+            # value = unlimited.
             "max_input_tokens": 600000,
         },
         "moa_reference": {

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -36,6 +36,7 @@ import sqlite3
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1188,74 +1189,190 @@ def test_real_lock_api_internal_errors_fail_closed_skips_compression(
 
 
 
-def test_review_fork_disables_compression_to_prevent_stale_parent_fork(tmp_path: Path) -> None:
-    """The background-review fork must set ``compression_enabled = False``
-    so it can never compress the parent it shares a session_id with
-    (issue #38727).
+def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> None:
+    """An oversized review snapshot compacts in memory without mutating the parent.
 
-    The per-session compression lock only serialises a SAME-WINDOW concurrent
-    race. It does NOT stop a stale parent from being compressed again in a
-    LATER turn: if ``review_agent`` had won the race, its new child session is
-    never adopted by the gateway (the fork is single-lifecycle and dies right
-    after one ``run_conversation``), so the foreground path would start the
-    next turn from the stale parent and compress it AGAIN — leaving the same
-    parent with two sibling children.
+    Regression for #93057: the fork historically pinned ``compression_enabled =
+    False`` because it shares the parent's session_id (issue #38727). That
+    left the review's private snapshot unbounded — every follow-up request in
+    the review tool loop replayed the whole snapshot (350k-384k input tokens
+    per request in production). The fix detaches the fork's compressor from
+    the parent's SessionDB/session_id and enables in-memory-only compaction.
 
-    The fix makes the review fork never trigger compression at all. Both
-    compression trigger sites in ``agent/conversation_loop.py`` gate on
-    ``agent.compression_enabled`` BEFORE calling ``_compress_context``:
-      • preflight (``if agent.compression_enabled and len(messages) > ...``)
-      • mid-loop  (``if agent.compression_enabled and _compressor.should_compress(...)``)
-    so a fork with the flag cleared never reaches the rotation path.
-
-    This test pins the contract at the source: ``_run_review_in_thread``
-    must set ``review_agent.compression_enabled = False`` on the fork it
-    builds. It calls the real worker synchronously with
-    ``AIAgent.run_conversation`` patched (so no LLM call happens) and
-    captures the constructed review agent to assert the flag.
+    This test drives the REAL ``_run_review_in_thread`` + ``run_conversation``
+    with a threshold-crossing snapshot and asserts:
+      • compression actually fired (a real threshold crossing, not just
+        construction-time flag state);
+      • the outbound provider request carries the compaction summary and none
+        of the middle snapshot turns;
+      • the fork keeps the parent's session_id (prompt-cache parity) but its
+        agent-level AND compressor-level session bindings are detached;
+      • the parent's durable transcript, session row, and child-session graph
+        are byte-for-byte unchanged after the compaction ran.
     """
     import agent.background_review as br
 
-    captured = {}
-
-    def _fake_run_conversation(self, *_a, **_k):
-        captured["compression_enabled"] = self.compression_enabled
-        captured["session_id"] = self.session_id
-        return {"final_response": "", "messages": []}
-
-    parent_sid = "REVIEW_FORK_FLAG_TEST"
+    parent_sid = "REVIEW_FORK_IN_MEMORY_COMPACTION_93057"
 
     db = SessionDB(db_path=tmp_path / "state.db")
     db.create_session(parent_sid, source="discord")
+    db.append_message(parent_sid, role="user", content="durable parent turn")
+    durable_before = db.get_messages(parent_sid)
+    session_row_before = tuple(
+        db._conn.execute(
+            "SELECT id, parent_session_id, ended_at, end_reason FROM sessions WHERE id = ?",
+            (parent_sid,),
+        ).fetchone()
+    )
     parent = _build_agent_with_db(db, parent_sid)
+    parent._cached_system_prompt = "stable parent prompt"
 
-    # The worker does a local ``from run_agent import AIAgent``; patching
-    # the class method covers that import path.
-    from run_agent import AIAgent
+    snapshot = [
+        {
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": f"review turn {i} " + "x" * 200,
+        }
+        for i in range(24)
+    ]
 
-    with patch.object(AIAgent, "run_conversation", _fake_run_conversation):
-        br._run_review_in_thread(
-            parent,
-            [{"role": "user", "content": "hi"}],
-            "review this conversation",
+    captured = {}
+
+    def _final_response():
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    index=0,
+                    message=SimpleNamespace(
+                        role="assistant",
+                        content="review complete",
+                        tool_calls=None,
+                        reasoning_content=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=SimpleNamespace(
+                prompt_tokens=100, completion_tokens=10, total_tokens=110
+            ),
+            model="test/model",
         )
 
-    assert captured, (
-        "_run_review_in_thread never reached run_conversation — the spawn path "
-        "changed; update this test to capture the review AIAgent."
-    )
-    assert captured["session_id"] == parent_sid, (
-        "Review fork should inherit the parent's session_id (shared id is the "
-        "whole reason compression must be disabled)."
-    )
-    assert captured["compression_enabled"] is False, (
-        "FIX REGRESSION: background-review fork did NOT disable compression. "
-        "It shares the parent's session_id, so an enabled fork can rotate the "
-        "parent into an orphan child (issue #38727). The trigger gates in "
-        "conversation_loop.py only short-circuit when compression_enabled is "
-        "False — this flag MUST be cleared on the review fork."
-    )
-    db.close()
+    # The worker does a local ``from run_agent import AIAgent``; patching the
+    # class method covers that import path.
+    from run_agent import AIAgent
+
+    real_run_conversation = AIAgent.run_conversation
+
+    def _run_threshold_crossing_review(self, *args, **kwargs):
+        captured["compression_enabled"] = self.compression_enabled
+        captured["compression_in_place"] = self.compression_in_place
+        captured["session_id"] = self.session_id
+        captured["session_db"] = self._session_db
+        captured["input_budget"] = getattr(
+            self, "_review_input_token_budget", "missing"
+        )
+        captured["compressor_session_db"] = getattr(
+            self.context_compressor, "_session_db", "missing"
+        )
+        captured["compressor_session_id"] = getattr(
+            self.context_compressor, "_session_id", "missing"
+        )
+        # Stub the fork's compressor so compaction output is deterministic
+        # and no aux-LLM call happens; the trigger/commit paths stay real.
+        self.context_compressor.threshold_tokens = 1
+        self.context_compressor.protect_first_n = 1
+        self.context_compressor.protect_last_n = 1
+        self.context_compressor.compress = MagicMock(
+            return_value=[
+                {"role": "user", "content": "[CONTEXT COMPACTION] review summary"},
+                {"role": "assistant", "content": "summary acknowledged"},
+            ]
+        )
+        self.context_compressor.should_compress = MagicMock(
+            side_effect=lambda _tokens: True
+        )
+        self.context_compressor.should_compress_info = MagicMock(
+            return_value=(True, "over threshold")
+        )
+        self.context_compressor.should_compress_preflight = MagicMock(
+            return_value=True
+        )
+        self.context_compressor.should_defer_preflight_to_real_usage = MagicMock(
+            return_value=False
+        )
+        self.context_compressor.get_active_compression_failure_cooldown = MagicMock(
+            return_value=None
+        )
+        self.context_compressor.select_context = MagicMock(return_value=None)
+        self._compression_feasibility_checked = True
+        self.client = MagicMock()
+        self.client.chat.completions.create.side_effect = [_final_response()]
+        self._disable_streaming = True
+        self._use_prompt_caching = False
+
+        result = real_run_conversation(self, *args, **kwargs)
+        captured["compression_calls"] = self.context_compressor.compress.call_count
+        captured["create_calls"] = self.client.chat.completions.create.call_count
+        last_call = self.client.chat.completions.create.call_args
+        captured["outbound"] = (
+            last_call.kwargs.get("messages") if last_call else None
+        )
+        return result
+
+    try:
+        with patch.object(AIAgent, "run_conversation", _run_threshold_crossing_review):
+            br._run_review_in_thread(parent, snapshot, "review this conversation")
+
+        assert captured["compression_calls"] >= 1, (
+            "FIX REGRESSION: the review fork did not compact its oversized "
+            "snapshot. compression_enabled was historically set False on the "
+            "fork, which removed the only bound on the replayed snapshot "
+            "(issue #93057)."
+        )
+        assert captured["create_calls"] >= 1
+        outbound_contents = [
+            str(m.get("content", "")) for m in captured["outbound"]
+        ]
+        assert any(
+            "[CONTEXT COMPACTION] review summary" in text
+            for text in outbound_contents
+        ), f"outbound request did not contain the compaction summary: {outbound_contents!r}"
+        assert not any("review turn 12" in text for text in outbound_contents), (
+            "outbound request still replays the middle of the snapshot — "
+            "the review replayed an unbounded transcript despite compaction"
+        )
+        assert captured["session_id"] == parent_sid, (
+            "Review fork should inherit the parent's session_id for "
+            "prompt-cache parity."
+        )
+        assert captured["session_db"] is None, (
+            "Review fork must keep its agent-level SessionDB detached "
+            "(_session_db=None) so compaction can never persist."
+        )
+        assert captured["compressor_session_db"] is None, (
+            "Review fork's compressor must be detached from the parent "
+            "SessionDB, otherwise durable cooldown/streak writes land on "
+            "the parent's row (issue #93057)."
+        )
+        assert captured["compressor_session_id"] == ""
+        assert captured["compression_enabled"] is True
+        assert captured["compression_in_place"] is True
+        assert isinstance(captured["input_budget"], int) and captured["input_budget"] > 0
+
+        # Parent session must be byte-for-byte unchanged after the review
+        # compacted its private snapshot.
+        assert parent.session_id == parent_sid
+        assert db.get_messages(parent_sid) == durable_before
+        session_row_after = tuple(
+            db._conn.execute(
+                "SELECT id, parent_session_id, ended_at, end_reason FROM sessions WHERE id = ?",
+                (parent_sid,),
+            ).fetchone()
+        )
+        assert session_row_after == session_row_before
+        assert _count_children(db, parent_sid) == 0
+    finally:
+        db.close()
 
 
 # ── Lease-refresher bounded-failure tolerance (salvage follow-up, #54465) ────

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import copy
 import inspect
 import json
+import logging
 import os
 import sqlite3
 import threading
@@ -1190,7 +1191,8 @@ def test_real_lock_api_internal_errors_fail_closed_skips_compression(
 
 
 def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> None:
-    """An oversized review snapshot compacts in memory without mutating the parent.
+    """An oversized review snapshot replays warm on the first request, then
+    compacts in memory before further requests — without mutating the parent.
 
     Regression for #93057: the fork historically pinned ``compression_enabled =
     False`` because it shares the parent's session_id (issue #38727). That
@@ -1200,11 +1202,14 @@ def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> No
     the parent's SessionDB/session_id and enables in-memory-only compaction.
 
     This test drives the REAL ``_run_review_in_thread`` + ``run_conversation``
-    with a threshold-crossing snapshot and asserts:
-      • compression actually fired (a real threshold crossing, not just
-        construction-time flag state);
-      • the outbound provider request carries the compaction summary and none
-        of the middle snapshot turns;
+    with a threshold-crossing snapshot across two provider requests and
+    asserts:
+      • the FIRST request replays the full snapshot untouched (warm
+        prompt-cache parity) — no compaction summary, middle turns present;
+      • compression actually fired before the SECOND request (a real
+        threshold crossing, not just setup-time binding state), and that
+        request carries the compaction summary and none of the middle
+        snapshot turns;
       • the fork keeps the parent's session_id (prompt-cache parity) but its
         agent-level AND compressor-level session bindings are detached;
       • the parent's durable transcript, session row, and child-session graph
@@ -1236,6 +1241,31 @@ def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> No
     ]
 
     captured = {}
+
+    def _tool_response(prompt_tokens: int) -> SimpleNamespace:
+        message = SimpleNamespace(
+            content=None,
+            reasoning_content=None,
+            reasoning=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    type="function",
+                    function=SimpleNamespace(
+                        name="web_search", arguments='{"query": "x"}'
+                    ),
+                )
+            ],
+        )
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+            model="test/model",
+            usage=SimpleNamespace(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=1,
+                total_tokens=prompt_tokens + 1,
+            ),
+        )
 
     def _final_response():
         return SimpleNamespace(
@@ -1271,6 +1301,9 @@ def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> No
         captured["input_budget"] = getattr(
             self, "_review_input_token_budget", "missing"
         )
+        captured["defer_first_request"] = getattr(
+            self, "_review_defer_compaction_before_first_response", "missing"
+        )
         captured["compressor_session_db"] = getattr(
             self.context_compressor, "_session_db", "missing"
         )
@@ -1288,8 +1321,16 @@ def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> No
                 {"role": "assistant", "content": "summary acknowledged"},
             ]
         )
+        # Compress on the first pressure check after the first response, then
+        # stand down so the compacted request proceeds instead of looping.
+        _should_compress_calls = {"count": 0}
+
+        def _should_compress(_tokens):
+            _should_compress_calls["count"] += 1
+            return _should_compress_calls["count"] == 1
+
         self.context_compressor.should_compress = MagicMock(
-            side_effect=lambda _tokens: True
+            side_effect=_should_compress
         )
         self.context_compressor.should_compress_info = MagicMock(
             return_value=(True, "over threshold")
@@ -1306,17 +1347,33 @@ def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> No
         self.context_compressor.select_context = MagicMock(return_value=None)
         self._compression_feasibility_checked = True
         self.client = MagicMock()
-        self.client.chat.completions.create.side_effect = [_final_response()]
+        self.client.chat.completions.create.side_effect = [
+            _tool_response(100),
+            _final_response(),
+        ]
         self._disable_streaming = True
         self._use_prompt_caching = False
 
+        def _fake_execute_tool_calls(assistant_message, messages, *_args):
+            tool_call = assistant_message.tool_calls[0]
+            messages.append(
+                {
+                    "role": "tool",
+                    "name": tool_call.function.name,
+                    "tool_call_id": tool_call.id,
+                    "content": "ok",
+                }
+            )
+
+        self._execute_tool_calls = _fake_execute_tool_calls
+
         result = real_run_conversation(self, *args, **kwargs)
         captured["compression_calls"] = self.context_compressor.compress.call_count
-        captured["create_calls"] = self.client.chat.completions.create.call_count
-        last_call = self.client.chat.completions.create.call_args
-        captured["outbound"] = (
-            last_call.kwargs.get("messages") if last_call else None
-        )
+        create = self.client.chat.completions.create
+        captured["create_calls"] = create.call_count
+        captured["outbound"] = [
+            call.kwargs.get("messages") for call in create.call_args_list
+        ]
         return result
 
     try:
@@ -1329,15 +1386,30 @@ def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> No
             "fork, which removed the only bound on the replayed snapshot "
             "(issue #93057)."
         )
-        assert captured["create_calls"] >= 1
-        outbound_contents = [
-            str(m.get("content", "")) for m in captured["outbound"]
-        ]
+        assert captured["create_calls"] == 2, (
+            f"expected a 2-request review (tool call + final), "
+            f"got {captured['create_calls']}"
+        )
+        first_outbound, second_outbound = captured["outbound"]
+        first_contents = [str(m.get("content", "")) for m in first_outbound]
+        second_contents = [str(m.get("content", "")) for m in second_outbound]
+        # Warm-cache parity: the first request replays the full snapshot
+        # untouched — middle turns present, no compaction summary yet.
+        assert any("review turn 12" in text for text in first_contents), (
+            "the review fork's FIRST request must replay the full snapshot "
+            "(warm prompt-cache read) — compaction must not rewrite it before "
+            "the first provider call"
+        )
+        assert not any(
+            "[CONTEXT COMPACTION]" in text for text in first_contents
+        ), f"first request was compacted prematurely: {first_contents!r}"
+        # The SECOND request carries the compaction summary and none of the
+        # middle snapshot turns.
         assert any(
             "[CONTEXT COMPACTION] review summary" in text
-            for text in outbound_contents
-        ), f"outbound request did not contain the compaction summary: {outbound_contents!r}"
-        assert not any("review turn 12" in text for text in outbound_contents), (
+            for text in second_contents
+        ), f"outbound request did not contain the compaction summary: {second_contents!r}"
+        assert not any("review turn 12" in text for text in second_contents), (
             "outbound request still replays the middle of the snapshot — "
             "the review replayed an unbounded transcript despite compaction"
         )
@@ -1357,6 +1429,7 @@ def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> No
         assert captured["compressor_session_id"] == ""
         assert captured["compression_enabled"] is True
         assert captured["compression_in_place"] is True
+        assert captured["defer_first_request"] is True
         assert isinstance(captured["input_budget"], int) and captured["input_budget"] > 0
 
         # Parent session must be byte-for-byte unchanged after the review
@@ -1371,6 +1444,97 @@ def test_review_fork_compacts_oversized_snapshot_in_memory(tmp_path: Path) -> No
         )
         assert session_row_after == session_row_before
         assert _count_children(db, parent_sid) == 0
+    finally:
+        db.close()
+
+
+def test_review_fork_fails_closed_when_compressor_rebind_raises(
+    tmp_path: Path, caplog
+) -> None:
+    """A failed compressor detachment must keep the fork's compression OFF.
+
+    Regression for the #93057 adversarial review: if ``bind_session_state``
+    cannot sever the engine's binding to the parent's SessionDB/session_id,
+    enabling compression would run it against the parent's live session
+    binding — durable cooldown/streak/ineffective-count writes on the
+    parent's row and the sibling-session race behind #38727 re-opened. The
+    fork must fail CLOSED: keep the historical ``compression_enabled = False``
+    behavior and warn. The review still runs (the iteration cap and the
+    aggregate input budget still bound it).
+    """
+    import agent.background_review as br
+    from agent.context_compressor import ContextCompressor
+
+    parent_sid = "REVIEW_FORK_REBIND_FAIL_CLOSED_93057"
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(parent_sid, source="discord")
+    parent = _build_agent_with_db(db, parent_sid)
+    parent._cached_system_prompt = "stable parent prompt"
+
+    snapshot = [
+        {
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": f"review turn {i}",
+        }
+        for i in range(8)
+    ]
+
+    captured = {}
+
+    def _capture_fork_flags(self, *args, **kwargs):
+        captured["compression_enabled"] = self.compression_enabled
+        captured["compression_in_place"] = self.compression_in_place
+        captured["input_budget"] = getattr(
+            self, "_review_input_token_budget", "missing"
+        )
+        return {
+            "completed": True,
+            "final_response": "review complete",
+            "api_call_count": 0,
+        }
+
+    # The worker does a local ``from run_agent import AIAgent``; patching the
+    # class method covers that import path.
+    from run_agent import AIAgent
+
+    _real_bind = ContextCompressor.bind_session_state
+
+    def _failing_bind(self, session_db=None, session_id=""):
+        # Only the detachment rebind may fail; any other binding passes
+        # through so the fork's construction path stays intact.
+        if session_db is None:
+            raise RuntimeError("detachment boom")
+        return _real_bind(self, session_db, session_id)
+
+    try:
+        with (
+            patch.object(AIAgent, "run_conversation", _capture_fork_flags),
+            patch.object(
+                ContextCompressor, "bind_session_state", _failing_bind
+            ),
+        ):
+            with caplog.at_level(logging.WARNING, logger="agent.background_review"):
+                br._run_review_in_thread(parent, snapshot, "review this conversation")
+
+        assert captured["compression_enabled"] is False, (
+            "FIX REGRESSION: a failed compressor rebind must leave "
+            "compression_enabled False on the review fork (fail-closed). "
+            "Enabling compression with the engine still bound to the "
+            "parent's session re-opens the #38727 race (issue #93057)."
+        )
+        assert any(
+            "detachment failed" in record.message for record in caplog.records
+        ), (
+            "the failed rebind must log a warning so operators can see the "
+            "fork fell back to the pre-fix behavior"
+        )
+        assert (
+            isinstance(captured["input_budget"], int) and captured["input_budget"] > 0
+        ), (
+            "the aggregate input budget must still be armed on the fail-closed "
+            "path — it bounds the review even when compaction stays off"
+        )
     finally:
         db.close()
 

--- a/tests/run_agent/test_background_review_input_budget.py
+++ b/tests/run_agent/test_background_review_input_budget.py
@@ -1,0 +1,239 @@
+"""Regression tests for the background-review aggregate input budget (#93057).
+
+The review fork replays its snapshot on every provider request in its tool
+loop. Detached in-memory compaction bounds any SINGLE request; the aggregate
+input budget (``_review_input_token_budget``, set by
+``_run_review_in_thread`` from ``auxiliary.background_review.max_input_tokens``)
+bounds the WHOLE review: the tool loop stops before the provider call that
+would cross it, mirroring the iteration-budget exit.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _tool_call() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments='{"query": "x"}'),
+    )
+
+
+def _tool_response(prompt_tokens: int) -> SimpleNamespace:
+    message = SimpleNamespace(
+        content=None,
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=[_tool_call()],
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="tool_calls")],
+        model="test/model",
+        usage=SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=1,
+            total_tokens=prompt_tokens + 1,
+        ),
+    )
+
+
+def _final_response() -> SimpleNamespace:
+    message = SimpleNamespace(
+        content="done",
+        reasoning_content=None,
+        reasoning=None,
+        tool_calls=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message, finish_reason="stop")],
+        model="test/model",
+        usage=None,
+    )
+
+
+def _tool_definition() -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "web_search",
+            "description": "Search the web",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def _make_loop_agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[_tool_definition()]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("agent.model_metadata.get_model_context_length", return_value=256_000),
+        patch("agent.context_compressor.get_model_context_length", return_value=256_000),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=10,
+        )
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent._disable_streaming = True
+    agent.tool_delay = 0
+    agent.save_trajectories = False
+    agent.max_compression_attempts = 1
+
+    compressor = MagicMock()
+    compressor.protect_first_n = 3
+    compressor.protect_last_n = 20
+    compressor.threshold_tokens = 999_999_999  # never fire compaction here
+    compressor.context_length = 1_000_000_000
+    compressor.last_prompt_tokens = -1
+    compressor._verify_compaction_cleared_threshold = False
+    compressor.awaiting_real_usage_after_compression = False
+    compressor.should_compress.return_value = False
+    compressor.should_compress_info.return_value = (False, None)
+    compressor.should_compress_preflight.return_value = False
+    compressor.should_defer_preflight_to_real_usage.return_value = False
+    compressor.get_active_compression_failure_cooldown.return_value = None
+    compressor.select_context.return_value = None
+    compressor.get_automatic_compaction_status_message.return_value = ""
+    agent.compression_enabled = False  # isolate the budget behavior under test
+    agent.context_compressor = compressor
+
+    def _fake_execute_tool_calls(assistant_message, messages, *_args):
+        tool_call = assistant_message.tool_calls[0]
+        messages.append(
+            {
+                "role": "tool",
+                "name": tool_call.function.name,
+                "tool_call_id": tool_call.id,
+                "content": "ok",
+            }
+        )
+
+    agent._execute_tool_calls = _fake_execute_tool_calls
+    return agent
+
+
+def _run_with_responses(agent, responses):
+    agent.client.chat.completions.create.side_effect = responses
+    with (
+        patch.object(agent, "_flush_messages_to_session_db", return_value=True),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("do some tool work")
+    return result
+
+
+def test_review_input_budget_stops_tool_loop_before_next_provider_call():
+    """Once a fork's cumulative input crosses its budget, no further provider
+    call is made — the crossing request completes, then the loop stops."""
+    agent = _make_loop_agent()
+    agent._review_input_token_budget = 100_000
+
+    responses = [
+        _tool_response(50_000),
+        _tool_response(50_000),  # cumulative 100_000 -> budget crossed
+        _tool_response(50_000),  # must never be consumed
+        _final_response(),
+    ]
+    result = _run_with_responses(agent, responses)
+
+    create = agent.client.chat.completions.create
+    assert create.call_count == 2, (
+        f"expected the loop to stop after crossing the input budget, "
+        f"but {create.call_count} provider calls were made (budget "
+        f"{agent._review_input_token_budget}, "
+        f"used {agent.session_input_tokens})"
+    )
+    assert agent.session_input_tokens == 100_000
+    assert result["completed"] is False
+
+
+def test_no_budget_attribute_leaves_tool_loop_unbounded():
+    """Agents without ``_review_input_token_budget`` (every normal agent)
+    are unaffected by the gate and consume all scripted responses."""
+    agent = _make_loop_agent()
+
+    responses = [
+        _tool_response(50_000),
+        _tool_response(50_000),
+        _tool_response(50_000),
+        _final_response(),
+    ]
+    result = _run_with_responses(agent, responses)
+
+    assert agent.client.chat.completions.create.call_count == 4
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+
+
+def test_review_input_budget_exhausted_predicate_edge_cases():
+    """The gate only arms for a positive int budget and a real token count."""
+    from agent.conversation_loop import _review_input_budget_exhausted
+
+    class _Agent:
+        pass
+
+    agent = _Agent()
+    assert _review_input_budget_exhausted(agent) is False
+
+    agent._review_input_token_budget = None
+    agent.session_input_tokens = 999_999
+    assert _review_input_budget_exhausted(agent) is False
+
+    agent._review_input_token_budget = 0
+    assert _review_input_budget_exhausted(agent) is False
+
+    agent._review_input_token_budget = -1
+    assert _review_input_budget_exhausted(agent) is False
+
+    agent._review_input_token_budget = "100"
+    assert _review_input_budget_exhausted(agent) is False
+
+    agent._review_input_token_budget = True
+    assert _review_input_budget_exhausted(agent) is False
+
+    agent._review_input_token_budget = 100_000
+    agent.session_input_tokens = 99_999
+    assert _review_input_budget_exhausted(agent) is False
+
+    agent.session_input_tokens = 100_000
+    assert _review_input_budget_exhausted(agent) is True
+
+
+@pytest.mark.parametrize(
+    ("config_value", "expected"),
+    [
+        ({}, 600_000),
+        ({"max_input_tokens": 1_000_000}, 1_000_000),
+        ({"max_input_tokens": 0}, None),
+        ({"max_input_tokens": -5}, None),
+        ({"max_input_tokens": "not-a-number"}, 600_000),
+        ({"max_input_tokens": "300000"}, 300_000),
+    ],
+)
+def test_review_input_token_budget_resolution(config_value, expected):
+    """Config parsing: default, override, explicit disable, garbage fallback."""
+    from agent.background_review import _review_input_token_budget
+
+    assert _review_input_token_budget(config_value) == expected


### PR DESCRIPTION
## Root cause

The background-review fork shares the parent's `session_id` for prompt-cache parity. Because of that shared id, the fork sets `compression_enabled = False` — the historical guard against the sibling-session compression race (#38727), where a fork winning a compression race could rotate/archive the parent's live session into a child the gateway never adopts.

That guard was a proxy for detachment, and it removed the **only** bound on the review's private snapshot. On the same-model path the fork replays the full parent transcript on every provider request in its tool loop, so each follow-up request resends *snapshot + the growing review tool loop*. Production trace on `v2026.8.19-189-g7a54ab22e`: one 8-request review replayed **1,487,951** input tokens (186,217 / 51,957 / 51,400 / 184,487 / 350,015 / 365,665 / 384,240 / 363,970). The configured 300k foreground compression trigger never applied because the fork explicitly disables compression.

## Fix

Detach instead of disable — the direction the issue's acceptance criteria describe:

1. **Rebind the fork's compressor, fail-closed.** `AIAgent.__init__` had bound the compressor to the parent's `SessionDB`/session id before `_run_review_in_thread` nulls the agent-level binding, so durable cooldown/streak/ineffective-count writes would otherwise still land on the parent's row. The fork rebinds with `bind_session_state(session_db=None, session_id="")`, making every compressor persist guard a no-op. **If the rebind raises** (plugin/third-party engine), the fork keeps the historical `compression_enabled = False` behavior and logs a warning — compression is never enabled against a compressor that may still point at the parent's row (that would re-open #38727). The review still runs; the iteration cap and the aggregate budget below still bound it.
2. **Re-enable compression only after successful detachment** (`compression_enabled = True`, `compression_in_place = True`). Persistence stays off (`_persist_disabled=True`, `_session_db=None` — unchanged), so the commit site in `compress_context` (`if agent._session_db:`) skips every durable write: compaction can only ever rewrite the fork's private in-memory transcript. The parent's session id, transcript, compression lock/cooldown state, and child-session graph are untouched. **Warm-cache parity on the first request:** the fork's first provider request replays the full snapshot as a warm prompt-cache read; both compression gates (turn-prologue preflight + pre-API pressure check) are deferred until the first provider response arrives (`_review_fork_first_request_pending` in `agent/turn_context.py`), so compaction only applies from the second request on.
3. **Aggregate input budget** (acceptance criterion 3): compaction bounds any single request; a new `_review_input_token_budget` on the fork bounds the *whole* review. The tool loop stops before the provider call that would cross it (new gate in `agent/conversation_loop.py`, dormant for every agent without the attribute). Default 600,000 input tokens, configurable via `auxiliary.background_review.max_input_tokens` (0 or negative = unlimited); iterations remain capped at the existing 16.

## Budget truncation semantics

When the aggregate budget is exhausted the review tool loop stops **before** the next provider call: the turn exits with `completed=False` and `_turn_exit_reason = "review_input_budget_exhausted"`. Exact behavior on truncation:

- The budget-crossing request is **admitted and completes** — its tool writes have already landed before the gate fires at the top of the next iteration. A truncated review can therefore leave **partial artifacts** (partially written skill files / memory notes from the tool calls it did complete). Those artifacts are not rolled back or cleaned up; they are ordinary tool writes, indistinguishable from a review that legitimately finished early with fewer actions.
- The review never produces its final memory-digest/summary pass when truncated.
- The user-visible self-improvement summary still surfaces every action the truncated review **did** complete (via `summarize_background_review_actions`), so partial progress is reported rather than silently discarded — only the remaining work is dropped.
- The parent's live session is untouched either way (persistence isolation is independent of the budget).
- The stop notice is intentionally not shown to the user (the fork runs with status output suppressed, same as the existing iteration-cap exit); the reason survives in `_turn_exit_reason` for diagnostics.

This mirrors the pre-existing 16-iteration cap: both exits are hard bounds that truncate the review's remaining work, not the work already done.

## Tests

- `tests/agent/test_compression_concurrent_fork.py::test_review_fork_compacts_oversized_snapshot_in_memory` — replaces the old `compression_enabled is False` contract test. Drives the real `_run_review_in_thread` + `run_conversation` with a threshold-crossing snapshot across a two-request review and asserts: the FIRST request replays the full snapshot untouched (warm prompt-cache parity), compaction actually fired before the SECOND request (a real threshold crossing, not setup-time binding state), the second request carries the compaction summary and none of the middle snapshot turns, the fork keeps the parent's `session_id` while its agent-level AND compressor-level session bindings are detached, and the parent's durable transcript / session row / child-session graph are byte-for-byte unchanged after the compaction ran. **Fails on pre-fix code** (verified via sabotage run).
- `tests/agent/test_compression_concurrent_fork.py::test_review_fork_fails_closed_when_compressor_rebind_raises` (new) — a `bind_session_state` that raises leaves the fork with `compression_enabled = False` (fail-closed), logs a warning, and still arms the input budget. **Fails on pre-fix code** (verified via sabotage run).
- `tests/run_agent/test_background_review_input_budget.py` (new) — a budget-crossing review stops before the next provider call (2 calls admitted, the 3rd never sent); agents without the budget attribute are unaffected (4/4 scripted calls consumed); predicate edge cases; config resolution. **Fails on pre-fix code** (verified via sabotage run).
- Locally: 116 tests green across all touched suites (compression concurrent fork, background-review usage/isolation/cache-parity/cost-controls, preflight compression gate/cap, compression budget rearm/refund); `ruff check` clean on all changed files.

## Notes

- **Supersedes #69313.** That PR implements the same narrow detachment core but is stale (no CI checks, no review activity since 2026-08-12). This PR carries the same core, plus the aggregate input budget from the issue's acceptance criteria, the fail-closed rebind guarantee, the warm-cache first-request guarantee, and regression tests that prove the parent DB is untouched *after a compaction actually runs*. Reviewers should evaluate this PR instead; #69313 can be closed as superseded.
- Same-model prompt-cache parity is preserved — including on the first request, which still replays the full snapshot as a cached read; only subsequent requests see the compacted transcript.
- Routed (different-model) reviews are unaffected — they already replay a digest.

Closes #93057
