### PR TITLE
fix(kanban): surface undeclared scratch content destroyed on completion

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6106,6 +6106,12 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
             import shutil
             wp = Path(row["workspace_path"])
             if wp.is_dir() and _is_managed_scratch_path(wp):
+                # Same surfacing contract as the direct-completion path:
+                # this second rmtree destroys undeclared parent content
+                # just as silently as the first one did before #93164 —
+                # the deferred sweep is the exact case the feature exists
+                # to cover (flagged by the #93709 review).
+                _warn_and_event_discarded_scratch_content(conn, parent_id, wp)
                 shutil.rmtree(wp, ignore_errors=True)
                 _log.debug("Deferred cleanup: removed parent %s scratch workspace: %s", parent_id, wp)
     except Exception:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5933,6 +5933,7 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
             # completion would unconditionally ``shutil.rmtree`` that path
             # and silently delete the user's source data.
             if _is_managed_scratch_path(wp):
+                _warn_and_event_discarded_scratch_content(conn, task_id, wp)
                 shutil.rmtree(wp, ignore_errors=True)
                 _log.debug("Removed scratch workspace: %s", wp)
             else:
@@ -5949,6 +5950,52 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
         # tasks now have all children done — their deferred cleanup can
         # proceed (#33774).
         _try_cleanup_parent_workspaces(conn, task_id)
+    except Exception:
+        pass  # best-effort — never block completion
+
+
+def _warn_and_event_discarded_scratch_content(
+    conn: sqlite3.Connection, task_id: str, wp: Path
+) -> None:
+    """Surface non-trivial files a worker left in a scratch workspace (#93164).
+
+    Declared artifacts are copied to the board's attachment store before
+    cleanup (#63619); anything else in the dir was destroyed with no trace
+    anywhere. Keep the loss visible instead: a WARNING naming a bounded
+    sample plus a ``workspace_discarded_content`` task event, so the board
+    retains what was destroyed. Leftovers under 1KB stay silent — empty
+    scaffolding and ephemeral bookkeeping files would otherwise flag every
+    completion. Best-effort, same contract as the cleanup around it.
+    """
+    try:
+        files = [
+            (f.relative_to(wp).as_posix(), f.stat().st_size)
+            for f in wp.rglob("*")
+            if f.is_file()
+        ]
+    except OSError:
+        return
+    if not files:
+        return
+    total = sum(size for _, size in files)
+    if total < 1024:
+        return
+    sample = sorted(files, key=lambda item: -item[1])[:10]
+    payload = {
+        "path": str(wp),
+        "total_bytes": total,
+        "file_count": len(files),
+        "sample": [{"file": name, "bytes": size} for name, size in sample],
+    }
+    _log.warning(
+        "Task %s: scratch workspace %s still held %d file(s), %d bytes of "
+        "undeclared content (not listed in kanban_complete artifacts); "
+        "removing anyway. Largest: %s",
+        task_id, wp, len(files), total,
+        ", ".join(f"{name} ({size}B)" for name, size in sample[:5]),
+    )
+    try:
+        _append_event(conn, task_id, "workspace_discarded_content", payload)
     except Exception:
         pass  # best-effort — never block completion
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -613,6 +613,55 @@ def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
 
 
 
+def test_undeclared_scratch_content_warns_and_events(kanban_home):
+    """#93164: files not declared in kanban_complete(artifacts) used to be
+    destroyed silently. Non-trivial leftovers now leave a task event."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="render chart")
+        task = kb.get_task(conn, t)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, t, ws)
+        undeclared = ws / "deliverable.txt"
+        undeclared.write_bytes(b"x" * 4096)  # >1KB: non-trivial
+
+        assert kb.complete_task(conn, t, result="ok")
+
+        events = [
+            e for e in kb.list_events(conn, t)
+            if e.kind == "workspace_discarded_content"
+        ]
+
+    assert not ws.exists(), "scratch workspace is still cleaned up"
+    assert len(events) == 1
+    payload = events[0].payload
+    assert payload["file_count"] == 1
+    assert payload["total_bytes"] == 4096
+    assert payload["sample"][0]["file"] == "deliverable.txt"
+
+
+
+def test_small_scratch_leftovers_stay_silent(kanban_home):
+    """Empty scaffolding / sub-1KB bookkeeping files don't flag every
+    completion — only non-trivial content emits the discarded event."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="quick note")
+        task = kb.get_task(conn, t)
+        ws = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, t, ws)
+        (ws / "scaffold.tmp").write_bytes(b"x" * 10)  # <1KB: trivial
+
+        assert kb.complete_task(conn, t, result="ok")
+
+        events = [
+            e for e in kb.list_events(conn, t)
+            if e.kind == "workspace_discarded_content"
+        ]
+
+    assert not ws.exists(), "scratch workspace is still cleaned up"
+    assert events == []
+
+
+
 
 # ---------------------------------------------------------------------------
 # Deferred scratch cleanup for parent/child handoff (#33774)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -701,6 +701,46 @@ def test_dir_child_completion_unblocks_deferred_scratch_parent(kanban_home, tmp_
     assert child_dir.exists(), "Non-scratch 'dir' child workspace is never deleted"
 
 
+def test_deferred_parent_cleanup_also_signals(kanban_home, tmp_path, caplog):
+    """The deferred parent-sweep rmtree emits the same discarded-content
+    signal as the direct-completion path (#93164 review on #93709): a
+    parent whose cleanup waited on children would otherwise destroy its
+    undeclared files silently on the second rmtree path."""
+    import logging
+
+    child_dir = tmp_path / "persistent-child"
+    child_dir.mkdir()
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="scratch parent")
+        child = kb.create_task(
+            conn, title="dir child", workspace_kind="dir",
+            workspace_path=str(child_dir),
+        )
+        kb.link_tasks(conn, parent, child)
+        parent_ws = kb.resolve_workspace(kb.get_task(conn, parent))
+        kb.set_workspace_path(conn, parent, parent_ws)
+        (parent_ws / "undeclared.md").write_text("q" * 2048)  # over the 1KB floor
+
+        with caplog.at_level(logging.WARNING, logger=kb._log.name):
+            kb.complete_task(conn, parent, result="handoff")  # deferred
+            assert "undeclared.md" not in caplog.text, (
+                "parent still deferred: no signal yet"
+            )
+            kb.complete_task(conn, child, result="built")     # triggers sweep
+
+        assert "undeclared.md" in caplog.text, (
+            "deferred sweep must surface the content it destroys"
+        )
+        events = [
+            e for e in kb.list_events(conn, parent)
+            if e.kind == "workspace_discarded_content"
+        ]
+        assert events, "the parent's board event must be appended too"
+        assert events[0].payload["file_count"] == 1
+
+    assert not parent_ws.exists()
+
+
 
 
 def test_is_managed_scratch_path_rejects_kanban_metadata_subtrees(kanban_home):


### PR DESCRIPTION
## What does this PR do?

Makes the destruction of undeclared scratch-workspace content visible instead of silent.

`complete_task` → `_cleanup_workspace` unconditionally `shutil.rmtree`s a scratch workspace after the completion commit. Declared artifacts are safe — they are copied to the board's attachment store first (#63619) — but any file the worker wrote and did **not** list in `kanban_complete(artifacts=[...])` was destroyed silently: no warning, no trace on the board, and the only copy gone. This bites LLM workers that believe the summary is enough and forget the path (#93164, observed in production).

This implements the report's minimal ask: before removing a managed scratch dir, scan it for non-trivial content and, when found, emit a WARNING naming a bounded sample and append a `workspace_discarded_content` task event (path, total bytes, file count, sample) so the board retains what was destroyed. Leftovers under 1KB total stay silent — empty scaffolding and sub-KB bookkeeping files would otherwise flag every completion. The removal itself, the containment guard (#28818), and the deferred-parent-cleanup semantics (#33774) are unchanged.

## Related Issue

Fixes #93164

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` — new `_warn_and_event_discarded_scratch_content()` helper (rglob scan, 1KB threshold, bounded 10-file sample, WARNING + `_append_event`); `_cleanup_workspace()` calls it right before the managed-scratch `rmtree`. Best-effort like the cleanup around it — a scan or event failure never blocks completion.
- `tests/hermes_cli/test_kanban_db.py` — two regressions following the existing scratch-artifacts test pattern: a >1KB undeclared file produces exactly one `workspace_discarded_content` event with the right payload (and the workspace is still removed); a sub-1KB leftover produces no event.

## How to Test

`pytest tests/hermes_cli/test_kanban_db.py -q` — should pass (32 passed, 1 skipped).

Observed result: with the fix, all pass. With the kanban_db.py change stashed (fix reverted, tests kept), `test_undeclared_scratch_content_warns_and_events` fails (no event on main — the silent-destruction behavior) while `test_small_scratch_leftovers_stay_silent` still passes by design.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (threshold rationale and #63619/#28818/#33774 boundary notes in the helper docstring)
- [x] Tests added that prove the fix works
- [x] New and existing unit tests pass locally (32 passed, 1 skipped)
- [x] Platform: macOS (pure sqlite + filesystem logic, platform-independent)
