### PR TITLE
fix(desktop): restore batch clarify cards on session re-activation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -11,7 +11,6 @@ import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
-import { normalizeChoices, setClarifyRequest } from '@/store/clarify'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import { openGatewayForAgent, openGatewayForProfile, requestGatewayForAgent } from '@/store/gateway'
@@ -100,6 +99,7 @@ import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE }
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
 
+import { restorePendingClarifyForTest } from './restore-pending-clarify'
 import {
   appendLiveSessionProjection,
   applyRuntimeInfo,
@@ -266,23 +266,7 @@ function restorePendingClarify(response: SessionResumeResponse, sessionId: strin
   // Same replay class as pending_approval: the clarify.request event was
   // emitted while this client's transport was detached, so without the resume
   // snapshot the question stays invisible until it times out server-side.
-  const pending = response.pending_clarify
-
-  if (!pending || typeof pending.request_id !== 'string' || typeof pending.question !== 'string') {
-    return false
-  }
-
-  const choices = normalizeChoices(pending.choices)
-
-  setClarifyRequest({
-    choices: choices.length > 0 ? choices : null,
-    multiSelect: pending.multi_select === true,
-    question: pending.question,
-    requestId: pending.request_id,
-    sessionId
-  })
-
-  return true
+  return restorePendingClarifyForTest(response, sessionId)
 }
 
 function normalizeNewChatWorkspaceTarget(target: NewChatWorkspaceTarget): NewChatWorkspaceTarget {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
@@ -1,17 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type * as clarifyStore from '@/store/clarify'
+
 const { setClarifyRequestMock } = vi.hoisted(() => ({ setClarifyRequestMock: vi.fn() }))
 
 vi.mock('@/store/clarify', async importOriginal => {
-  const actual = await importOriginal<typeof import('@/store/clarify')>()
+  const actual = await importOriginal<typeof clarifyStore>()
 
   return {
     ...actual,
     setClarifyRequest: setClarifyRequestMock
   }
 })
-
-import type { SessionResumeResponse } from '@/types/hermes'
 
 import { restorePendingClarifyForTest } from './restore-pending-clarify'
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { setClarifyRequestMock } = vi.hoisted(() => ({ setClarifyRequestMock: vi.fn() }))
+
+vi.mock('@/store/clarify', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/clarify')>()
+
+  return {
+    ...actual,
+    setClarifyRequest: setClarifyRequestMock
+  }
+})
+
+import type { SessionResumeResponse } from '@/types/hermes'
+
+import { restorePendingClarifyForTest } from './restore-pending-clarify'
+
+const base = {
+  message_count: 0,
+  messages: [],
+  resumed: 'live'
+}
+
+describe('restorePendingClarify — batch replay (#92916)', () => {
+  beforeEach(() => {
+    setClarifyRequestMock.mockClear()
+  })
+
+  it('restores a BATCH clarify snapshot (questions, no top-level question)', () => {
+    const ok = restorePendingClarifyForTest(
+      {
+        ...base,
+        pending_clarify: {
+          request_id: 'rid1',
+          questions: [
+            { choices: ['Yes', 'No'], multi_select: false, qid: 'q0', question: 'Proceed?' },
+            { qid: 'q1', question: 'Which region?' }
+          ]
+        }
+      },
+      'sess-1'
+    )
+
+    expect(ok).toBe(true)
+    expect(setClarifyRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        multiSelect: false,
+        question: '',
+        requestId: 'rid1',
+        sessionId: 'sess-1',
+        questions: [
+          { choices: ['Yes', 'No'], multiSelect: false, qid: 'q0', question: 'Proceed?' },
+          { multiSelect: false, qid: 'q1', question: 'Which region?', choices: null }
+        ]
+      })
+    )
+  })
+
+  it('carries server-locked answers into the replayed batch card', () => {
+    restorePendingClarifyForTest(
+      {
+        ...base,
+        pending_clarify: {
+          answers: { q0: 'Yes', junk: 42 },
+          request_id: 'rid2',
+          questions: [{ qid: 'q0', question: 'Proceed?' }]
+        }
+      },
+      'sess-2'
+    )
+
+    expect(setClarifyRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ lockedAnswers: { q0: 'Yes' }, requestId: 'rid2' })
+    )
+  })
+
+  it('still restores the SINGLE-question form', () => {
+    const ok = restorePendingClarifyForTest(
+      {
+        ...base,
+        pending_clarify: {
+          choices: ['A', 'B'],
+          multi_select: true,
+          question: 'Pick one',
+          request_id: 'rid3'
+        }
+      },
+      'sess-3'
+    )
+
+    expect(ok).toBe(true)
+    expect(setClarifyRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        choices: ['A', 'B'],
+        multiSelect: true,
+        question: 'Pick one',
+        requestId: 'rid3'
+      })
+    )
+  })
+
+  it('rejects a payload with neither form (no request restored)', () => {
+    const ok = restorePendingClarifyForTest(
+      {
+        ...base,
+        pending_clarify: { request_id: 'rid4' }
+      },
+      'sess-4'
+    )
+
+    expect(ok).toBe(false)
+    expect(setClarifyRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a payload with no request id', () => {
+    const ok = restorePendingClarifyForTest(
+      {
+        ...base,
+        pending_clarify: { question: 'Orphaned prompt' }
+      },
+      'sess-5'
+    )
+
+    expect(ok).toBe(false)
+    expect(setClarifyRequestMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/restore-pending-clarify.ts
@@ -1,0 +1,63 @@
+import { normalizeChoices, normalizeQuestions, setClarifyRequest } from '@/store/clarify'
+import type { SessionResumeResponse } from '@/types/hermes'
+
+/**
+ * Restore a pending clarify from a resume/activate snapshot onto `sessionId`.
+ *
+ * The snapshot mirrors the live clarify.request wire shape: single-question
+ * payloads carry `question`/`choices`/`multi_select`; batch (multi-question)
+ * ones carry `questions` (+ any answers already locked server-side) and no
+ * top-level `question`. Accepting only the single form left batch cards
+ * invisible after every session switch-and-return (#92916).
+ *
+ * Returns whether a request was restored.
+ */
+export function restorePendingClarifyForTest(
+  response: Pick<SessionResumeResponse, 'pending_clarify'>,
+  sessionId: string
+): boolean {
+  const pending = response.pending_clarify
+
+  if (!pending || typeof pending.request_id !== 'string') {
+    return false
+  }
+
+  const questions = normalizeQuestions(pending.questions)
+
+  if (questions.length > 0) {
+    setClarifyRequest({
+      choices: null,
+      lockedAnswers:
+        pending.answers && typeof pending.answers === 'object'
+          ? Object.fromEntries(
+              Object.entries(pending.answers as Record<string, unknown>).filter(
+                (entry): entry is [string, string] => typeof entry[1] === 'string'
+              )
+            )
+          : undefined,
+      multiSelect: false,
+      question: '',
+      questions,
+      requestId: pending.request_id,
+      sessionId
+    })
+
+    return true
+  }
+
+  if (typeof pending.question !== 'string') {
+    return false
+  }
+
+  const choices = normalizeChoices(pending.choices)
+
+  setClarifyRequest({
+    choices: choices.length > 0 ? choices : null,
+    multiSelect: pending.multi_select === true,
+    question: pending.question,
+    requestId: pending.request_id,
+    sessionId
+  })
+
+  return true
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -663,10 +663,21 @@ export interface SessionResumeResponse {
   // The clarify question still blocking this session, if any. Same replay
   // class as pending_approval: emitted-while-detached prompts are restored
   // from the resume snapshot instead of being lost until server-side timeout.
+  // Mirrors the live clarify.request wire shape: single-question payloads
+  // carry `question`/`choices`/`multi_select`; batch (multi-question) ones
+  // carry `questions` (+ `answers` already locked server-side) and no
+  // top-level `question`.
   pending_clarify?: {
+    answers?: Record<string, unknown>
     choices?: null | string[]
     multi_select?: boolean
     question?: string
+    questions?: Array<{
+      choices?: null | string[]
+      multi_select?: boolean
+      qid?: string
+      question?: string
+    }>
     request_id?: string
   }
   info?: SessionRuntimeInfo


### PR DESCRIPTION
## What does this PR do?

A pending batch (multi-question) clarify card disappeared when the user switched to another session and back. The chat transcript still showed the clarify tool call, but there was no card to answer, and the tool eventually resolved with empty user_response values for every question (#92916).

Root cause: on re-activation the backend correctly replays the pending prompt — _live_session_payload attaches pending_clarify (via _pending_clarify_request_payload) to the session.activate snapshot, and the desktop's useSessionActions calls restorePendingClarify on it. But that function required typeof pending.question === 'string', while a BATCH payload mirrors the live clarify.request wire shape (_clarify_block emits one form or the other): it carries questions[] and NO top-level question. The type guard rejected every batch snapshot, so the card never mounted.

## The fix

Extract the restore into a hook-free module (restore-pending-clarify.ts) and accept both wire forms:

- single-question: question + choices + multi_select, as before
- batch: questions via normalizeQuestions(), with server-locked answers carried through as lockedAnswers (same replay contract the live event uses)

Also extends SessionResumeResponse.pending_clarify with the questions/answers fields so the type matches what _pending_clarify_request_payload actually emits.

## Related Issue

Fixes #92916

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. cd apps/desktop && npx vitest run restore-pending-clarify — 5 passed
2. Repro on main: have the agent call clarify with multiple questions; switch to another session and back → the card is gone. With this branch the full multi-question form restores with its per-question state.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):)
- [x] I searched existing PRs to make sure this isn't a duplicate (#90053 covers a different clarify defect — hydration of pending snapshots on cold mount — and touches different logic)
- [x] My PR contains only changes related to this fix
- [x] Targeted tests pass; tsc clean; eslint clean on touched files
- [x] I've added tests for my changes
- [x] Tested on macOS 26.5 (Apple Silicon)

### Documentation and Housekeeping

- [ ] Documentation updates — or N/A
- [x] cli-config.yaml.example — or N/A
- [ ] CONTRIBUTING.md / AGENTS.md — or N/A
- [x] Cross-platform impact considered — renderer-only TypeScript, no platform-specific paths
- [ ] Tool descriptions/schemas — or N/A