### PR TITLE
fix(desktop): stop persisting ephemeral preview tiles into the layout tree

### DIFF
--- a/apps/desktop/src/app/chat/preview-tile.tsx
+++ b/apps/desktop/src/app/chat/preview-tile.tsx
@@ -13,7 +13,7 @@
 import { useStore } from '@nanostores/react'
 
 import { findGroup } from '@/components/pane-shell/tree/model'
-import { $activeTreeGroup, $layoutTree, revealTreePane, treePanesWithPrefix } from '@/components/pane-shell/tree/store'
+import { $activeTreeGroup, $layoutTree, isEphemeralPane, PREVIEW_TILE_PANE_NAMESPACE, revealTreePane, treePanesWithPrefix } from '@/components/pane-shell/tree/store'
 import { type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { FileTypeIcon } from '@/components/ui/file-type-icon'
 import { ToolIcon } from '@/components/ui/tool-icon'
@@ -153,9 +153,7 @@ function PreviewTabLead({ tabId }: { tabId: string }) {
   return <FileTypeIcon className="opacity-70" path={target.path || target.url} size="0.6875rem" />
 }
 
-const PREVIEW_TILE_PREFIX = 'preview-tile'
-
-const previewPaneId = (tabId: string) => `${PREVIEW_TILE_PREFIX}:${tabId}`
+const previewPaneId = (tabId: string) => `${PREVIEW_TILE_PANE_NAMESPACE}:${tabId}`
 
 /** The pane a NEW preview tile should stack into: another preview tile already
  *  in the tree, else another open tab adopted earlier in the same pass (a
@@ -163,7 +161,7 @@ const previewPaneId = (tabId: string) => `${PREVIEW_TILE_PREFIX}:${tabId}`
  *  `undefined` means this is the first preview — it opens its own zone. */
 function existingPreviewAnchor(tabId: string): string | undefined {
   const own = previewPaneId(tabId)
-  const inTree = treePanesWithPrefix(`${PREVIEW_TILE_PREFIX}:`).find(id => id !== own)
+  const inTree = treePanesWithPrefix(`${PREVIEW_TILE_PANE_NAMESPACE}:`).find(id => id !== own)
 
   if (inTree) {
     return inTree
@@ -173,7 +171,6 @@ function existingPreviewAnchor(tabId: string): string | undefined {
 
   return other ? previewPaneId(other.id) : undefined
 }
-
 /** Keep pane contributions mirroring `$previewTabs`, keep the store's selection
  *  and the tree's active pane agreeing, and front a tile when its tab is
  *  selected. Call once from the root. */
@@ -189,7 +186,7 @@ export function watchPreviewTiles(): void {
     const tabId = $rightRailActiveTabId.get()
 
     if (tabId && targetFor(tabId)) {
-      revealTreePane(`${PREVIEW_TILE_PREFIX}:${tabId}`)
+      revealTreePane(`${PREVIEW_TILE_PANE_NAMESPACE}:${tabId}`)
     }
   }
 
@@ -207,11 +204,13 @@ export function watchPreviewTiles(): void {
     const groupId = $activeTreeGroup.get()
     const active = groupId && tree ? findGroup(tree, groupId)?.active : undefined
 
-    if (!active?.startsWith(`${PREVIEW_TILE_PREFIX}:`)) {
+    // Assert against the tree store's OWN definition — the pane this zone
+    // fronts is a preview tile only if the persisted-copy scrubber agrees.
+    if (!active || !isEphemeralPane(active)) {
       return
     }
 
-    const tabId = active.slice(PREVIEW_TILE_PREFIX.length + 1) as RightRailTabId
+    const tabId = active.slice(PREVIEW_TILE_PANE_NAMESPACE.length + 1) as RightRailTabId
 
     if (targetFor(tabId) && $rightRailActiveTabId.get() !== tabId) {
       selectRightRailTab(tabId)
@@ -229,7 +228,7 @@ const watchPreviewTileMirror = paneMirror<{ id: string }>({
   // shows. Scoping this to `sessions` filtered the pane out of Bot Mode, so
   // `openPreview` ran and the click looked like a no-op.
   key: tab => tab.id,
-  prefix: PREVIEW_TILE_PREFIX,
+  prefix: PREVIEW_TILE_PANE_NAMESPACE,
   // The FIRST preview still opens its own zone docked beside main (identical
   // to route tiles — NOT anchored to the file tree, so ⌘J can't take it
   // along). Every SUBSEQUENT preview stacks into that zone as a center tab:

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -8,6 +8,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as HermesApi from '@/hermes'
 import { queryClient } from '@/lib/query-client'
 
+// Static on purpose: this import pulls the whole SkillsView module graph
+// (CodeEditor & co.). When it lived inside renderSkills(), the FIRST test in
+// the file paid that load inside its own 15s timeout window — enough to time
+// out on a cold/loaded CI host (see the testTimeout note in vitest.config.ts,
+// and the "found multiple elements" cascade that follows any such timeout).
+// At file scope the cost lands in the file-import phase, not in a test window.
+import { SkillsView } from './index'
+
 const getSkills = vi.fn()
 const getToolsets = vi.fn()
 const setSkillEnabled = vi.fn()
@@ -65,7 +73,6 @@ function toolset(overrides: Record<string, unknown> = {}) {
 }
 
 async function renderSkills() {
-  const { SkillsView } = await import('./index')
   let result: ReturnType<typeof render>
   await act(async () => {
     result = render(
@@ -161,7 +168,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       ]
     })
 
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
@@ -207,7 +213,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       }
     ])
 
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
@@ -251,7 +256,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       }
     ])
 
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
@@ -307,7 +311,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
 
     // Embedded mode drives tabs through local state (the route hooks are
     // mocked here), starting on Skills: the picker mounts with the tab.
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
@@ -366,7 +369,6 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
     // the live surface pointed at ITS backend — the reads must carry the
     // (connection, profile) pin, not a bare profile name that would resolve
     // against the ACTIVE gateway (the wrong-machine bug).
-    const { SkillsView } = await import('./index')
     await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>

--- a/apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts
@@ -2,6 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { LayoutNode } from '@/components/pane-shell/tree/model'
 
+// The drift test below imports the preview tile watcher to exercise REAL
+// id minting. Its render/console leaves are never invoked there (the mirror
+// only registers pane contributions), and their component graph is heavy —
+// mock them so this file stays light under parallel full-suite runs.
+vi.mock('@/app/chat/right-rail/preview', () => ({ PreviewTilePane: () => null }))
+vi.mock('@/app/chat/right-rail/preview-console-store', () => ({ forgetPreviewConsole: () => {} }))
+
 // Preview tiles are transient: their panes must never reach the persisted
 // layout tree. A tree saved WITH them bakes splits/weights around tabs the
 // next session may not restore (artifact previews never persist; the Browser
@@ -132,6 +139,55 @@ describe('ephemeral preview panes are scrubbed from the persisted tree', () => {
     }
 
     expect(stored.weights).toEqual([3, 1])
+  })
+
+  it('persisting a preview-free tree never materializes the pane-id list', async () => {
+    const { model, registerFiles, tree } = await setup()
+
+    // Adoption of `files` itself runs `allPaneIds` (dock-anchor lookup) — that
+    // is expected. The assertion covers the EVERY-COMMIT persist that follows:
+    // with no preview tile in the tree it must early-out before building ids.
+    registerFiles()
+
+    const spy = vi.spyOn(model, 'allPaneIds')
+
+    tree.persistTree()
+
+    expect(spy).not.toHaveBeenCalled()
+
+    spy.mockRestore()
+  })
+
+  it('exports the ephemeral predicate and namespace so minting and scrubbing share one definition', async () => {
+    const { tree } = await setup()
+
+    expect(tree.PREVIEW_TILE_PANE_NAMESPACE).toBe('preview-tile')
+    expect(tree.isEphemeralPane(`${tree.PREVIEW_TILE_PANE_NAMESPACE}:file:notes`)).toBe(true)
+    expect(tree.isEphemeralPane('workspace')).toBe(false)
+    expect(tree.isEphemeralPane('route-tile:/skills')).toBe(false)
+  })
+
+  it('pane ids minted by the preview tile mirror satisfy the shared predicate', async () => {
+    const { registry, tree } = await setup()
+
+    const { $previewTabs } = await import('@/store/preview')
+    const { watchPreviewTiles } = await import('@/app/chat/preview-tile')
+
+    watchPreviewTiles()
+
+    $previewTabs.set([
+      {
+        id: 'file:notes',
+        target: { kind: 'file', label: 'notes', source: 'C:/notes.md', url: 'file:///C:/notes.md' }
+      }
+    ])
+
+    const ephemeralPaneIds = registry
+      .getArea('panes')
+      .map(contribution => contribution.id)
+      .filter(id => tree.isEphemeralPane(id))
+
+    expect(ephemeralPaneIds).toEqual(['preview-tile:file:notes'])
   })
 
   it('a stored tree written by an older build heals on load', async () => {

--- a/apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { LayoutNode } from '@/components/pane-shell/tree/model'
+
+// Preview tiles are transient: their panes must never reach the persisted
+// layout tree. A tree saved WITH them bakes splits/weights around tabs the
+// next session may not restore (artifact previews never persist; the Browser
+// tab re-keys to a singleton), so a hand-built pane arrangement re-assembles
+// differently on every boot. `persist()` must scrub them from the STORED copy
+// while the LIVE tree keeps them for the session, and a stored tree written by
+// an older build must heal on load.
+
+const TREE_KEY = 'hermes.desktop.layoutTree.v2'
+
+function storedTree(): LayoutNode | null {
+  const raw = window.localStorage.getItem(TREE_KEY)
+
+  return raw ? (JSON.parse(raw) as LayoutNode) : null
+}
+
+describe('ephemeral preview panes are scrubbed from the persisted tree', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  async function setup() {
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    registry.register({
+      id: 'workspace',
+      area: 'panes',
+      title: 'chat',
+      data: { placement: 'main', uncloseable: true },
+      render: () => null
+    })
+
+    const registerPreview = (id: string, pos: 'center' | 'right' = 'right') =>
+      registry.register({
+        id,
+        area: 'panes',
+        title: 'Preview',
+        data: { placement: 'main', dock: { pane: 'workspace', pos } },
+        render: () => null
+      })
+
+    const registerFiles = () =>
+      registry.register({
+        id: 'files',
+        area: 'panes',
+        title: 'Files',
+        data: { placement: 'side', dock: { pane: 'workspace', pos: 'right' } },
+        render: () => null
+      })
+
+    tree.declareDefaultTree(model.group(['workspace'], { id: 'grp-main' }))
+    tree.watchContributedPanes()
+
+    return { model, registerFiles, registerPreview, registry, tree }
+  }
+
+  it('persistTree() scrubs preview panes from storage but keeps them live', async () => {
+    const { model, registerPreview, tree } = await setup()
+
+    registerPreview('preview-tile:file:notes')
+
+    // Live tree: the pane is docked beside workspace (a real split).
+    const live = tree.$layoutTree.get()!
+
+    expect(live.type).toBe('split')
+    expect(model.allPaneIds(live)).toContain('preview-tile:file:notes')
+
+    tree.persistTree()
+
+    // Stored copy: the split collapses back to the bare workspace group.
+    const stored = storedTree()!
+
+    expect(stored.type).toBe('group')
+    expect(model.allPaneIds(stored)).toEqual(['workspace'])
+
+    // The live tree is untouched — the pane stays for THIS session.
+    expect(model.allPaneIds(tree.$layoutTree.get()!)).toContain('preview-tile:file:notes')
+  })
+
+  it('scrubbing a stacked preview tab does not strand its zone active', async () => {
+    const { model, tree } = await setup()
+
+    // The preview tab IS the active tab of its zone — the scrubbed stored copy
+    // must fall back to a real pane instead of persisting a dangling active id.
+    tree.$layoutTree.set(
+      model.group(['workspace', 'preview-tile:artifact:abc'], { id: 'grp-main', active: 'preview-tile:artifact:abc' })
+    )
+
+    tree.persistTree()
+
+    const stored = storedTree()!
+
+    expect(model.allPaneIds(stored)).toEqual(['workspace'])
+
+    if (stored.type !== 'group') {
+      throw new Error(`expected a group, got ${stored.type}`)
+    }
+
+    expect(stored.active).toBe('workspace')
+
+    // Live tree untouched.
+    expect(model.allPaneIds(tree.$layoutTree.get()!)).toEqual(['workspace', 'preview-tile:artifact:abc'])
+  })
+
+  it('non-ephemeral panes and their weights persist unchanged', async () => {
+    const { model, registerFiles, tree } = await setup()
+
+    registerFiles()
+
+    const root = tree.$layoutTree.get()!
+
+    tree.setTreeSplitWeights(root.id, [3, 1])
+    tree.persistTree()
+
+    const stored = storedTree()!
+
+    expect(model.allPaneIds(stored)).toEqual(['workspace', 'files'])
+
+    if (stored.type !== 'split') {
+      throw new Error(`expected a split, got ${stored.type}`)
+    }
+
+    expect(stored.weights).toEqual([3, 1])
+  })
+
+  it('a stored tree written by an older build heals on load', async () => {
+    // Seed storage the way a pre-fix build would have persisted it: the live
+    // split including a stale artifact preview pane that can never come back.
+    const { model } = await setup()
+
+    window.localStorage.setItem(
+      TREE_KEY,
+      JSON.stringify(
+        model.split('row', [
+          model.group(['workspace'], { id: 'grp-main' }),
+          model.group(['preview-tile:artifact:stale'], { id: 'grp-stale' })
+        ])
+      )
+    )
+
+    // Fresh module state: `$layoutTree` initializes from the seeded storage.
+    vi.resetModules()
+    const tree = await import('@/components/pane-shell/tree/store')
+
+    const booted = tree.$layoutTree.get()!
+
+    // The ghost preview pane is gone before anything renders…
+    expect(model.allPaneIds(booted)).toEqual(['workspace'])
+    expect(booted.type).toBe('group')
+
+    // …and the live session can still open a preview: adoption re-docks it,
+    // and the NEXT persist keeps storage clean.
+    const { registry } = await import('@/contrib/registry')
+
+    registry.register({
+      id: 'preview-tile:url:browser',
+      area: 'panes',
+      title: 'Browser',
+      data: { placement: 'main', dock: { pane: 'workspace', pos: 'right' } },
+      render: () => null
+    })
+    tree.declareDefaultTree(booted)
+    tree.watchContributedPanes()
+
+    expect(model.allPaneIds(tree.$layoutTree.get()!)).toContain('preview-tile:url:browser')
+
+    tree.persistTree()
+    expect(model.allPaneIds(storedTree()!)).not.toContain('preview-tile:url:browser')
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -62,10 +62,28 @@ let defaultTree: LayoutNode | null = null
  * differently on every restart. The LIVE tree keeps them for the session; only
  * the STORED copy is scrubbed, and boot adoption re-docks surviving preview
  * tabs at their remembered share (see `rememberPaneShare`).
+ *
+ * The pane-id namespace preview tiles are MINTED under (`paneMirror` builds
+ * `${prefix}:${key}`) is declared HERE and exported for the minting side, so
+ * the minted id and the ephemeral set are one definition; the predicate below
+ * is exported for the same reason — the minting side asserts against THIS
+ * definition instead of a second copy of the `preview-tile:` literal.
  */
-const EPHEMERAL_PANE_PREFIXES = ['preview-tile:'] as const
+export const PREVIEW_TILE_PANE_NAMESPACE = 'preview-tile'
 
-const isEphemeralPane = (paneId: string): boolean => EPHEMERAL_PANE_PREFIXES.some(prefix => paneId.startsWith(prefix))
+const EPHEMERAL_PANE_PREFIXES = [`${PREVIEW_TILE_PANE_NAMESPACE}:`] as const
+
+export const isEphemeralPane = (paneId: string): boolean =>
+  EPHEMERAL_PANE_PREFIXES.some(prefix => paneId.startsWith(prefix))
+
+/** Depth-first, allocation-free: true the moment any pane id is ephemeral.
+ *  `persist` runs on every commit, and most commits carry no preview tile —
+ *  the no-op path must not materialize the `allPaneIds` array. */
+function containsEphemeralPane(node: LayoutNode): boolean {
+  return node.type === 'group'
+    ? node.panes.some(isEphemeralPane)
+    : node.children.some(containsEphemeralPane)
+}
 
 /** Remove every ephemeral tile pane from a tree COPY (`removePane` rebuilds;
  *  the input is never mutated). Returns the same reference when nothing matches
@@ -74,6 +92,10 @@ const isEphemeralPane = (paneId: string): boolean => EPHEMERAL_PANE_PREFIXES.som
 function scrubEphemeralPanes(tree: LayoutNode | null): LayoutNode | null {
   if (!tree) {
     return null
+  }
+
+  if (!containsEphemeralPane(tree)) {
+    return tree
   }
 
   let next: LayoutNode | null = tree

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -53,19 +53,69 @@ writeKey('hermes.desktop.layoutTree.v1', null)
 
 let defaultTree: LayoutNode | null = null
 
+/**
+ * Panes that must never reach the persisted tree. Preview tiles are transient
+ * by design: their pane set is re-derived from `$previewTabs` on every boot
+ * (artifact and other non-restorable tabs are dropped outright at decode), so
+ * a tree saved with `preview-tile:` panes bakes splits/weights around tabs the
+ * next session may not have — and the user's hand-built arrangement re-assembles
+ * differently on every restart. The LIVE tree keeps them for the session; only
+ * the STORED copy is scrubbed, and boot adoption re-docks surviving preview
+ * tabs at their remembered share (see `rememberPaneShare`).
+ */
+const EPHEMERAL_PANE_PREFIXES = ['preview-tile:'] as const
+
+const isEphemeralPane = (paneId: string): boolean => EPHEMERAL_PANE_PREFIXES.some(prefix => paneId.startsWith(prefix))
+
+/** Remove every ephemeral tile pane from a tree COPY (`removePane` rebuilds;
+ *  the input is never mutated). Returns the same reference when nothing matches
+ *  — `persist` runs on every commit and must not churn allocations — and null
+ *  only for a tree that was nothing but ephemeral panes. */
+function scrubEphemeralPanes(tree: LayoutNode | null): LayoutNode | null {
+  if (!tree) {
+    return null
+  }
+
+  let next: LayoutNode | null = tree
+
+  for (const paneId of allPaneIds(tree)) {
+    if (isEphemeralPane(paneId)) {
+      next = next === null ? null : removePane(next, paneId)
+    }
+  }
+
+  return next
+}
+
 function loadPersisted(): LayoutNode | null {
   const parsed = readJson<unknown>(STORAGE_KEY)
 
   // Canonicalize on load: bring attributes onto the current schema (see
   // migratePersistedTree — the retired `headerHidden` is dropped here) and
-  // re-flatten the structure.
-  return isLayoutNode(parsed) ? normalize(migratePersistedTree(parsed)) : null
+  // re-flatten the structure. Ephemeral tile panes are scrubbed here too, so
+  // trees persisted by older builds (before persist() scrubbed them) heal on
+  // their next boot instead of re-arranging around ghost preview tiles.
+  return isLayoutNode(parsed) ? scrubEphemeralPanes(normalize(migratePersistedTree(parsed))) : null
 }
 
 function persist(tree: LayoutNode | null) {
   // A secondary window (single-chat pop-out) shares the origin's localStorage;
   // writing its stripped-down DEFAULT tree back would wipe the primary's layout.
   if (isSecondaryWindow()) {
+    return
+  }
+
+  if (tree) {
+    const stored = scrubEphemeralPanes(tree)
+
+    // A tree that was nothing but ephemeral panes has no layout worth keeping;
+    // skip the write so the last good persisted tree survives.
+    if (!stored) {
+      return
+    }
+
+    writeJson(STORAGE_KEY, stored)
+
     return
   }
 


### PR DESCRIPTION
## Root cause

Preview tiles register as regular layout-tree panes under the `preview-tile:` namespace (`app/chat/preview-tile.tsx` → `paneMirror` → `registry.register`), and `persist()` in `pane-shell/tree/store.ts` wrote the live tree verbatim to `hermes.desktop.layoutTree.v2`.

The pane set behind those tiles is *not* stable across sessions:

- `store/preview.ts` only restores `file:` / `url:` tabs. Artifact tabs (memory-only registry), `transient` targets, and inline-`dataUrl` HTML are dropped at encode/decode, and URL tabs are re-keyed onto the singleton `url:browser` id.
- So the tree saved at quit can contain `preview-tile:` panes for tabs that the next boot never restores (or restores under a different id set).

On boot those ghost panes occupy splits/weights that then collapse (`removePane`/`normalize`) or get pruned by the mirror's prefix sweep — after the boot tree was already assembled around them — which is why a hand-built arrangement re-assembles differently every restart.

## Fix

- `store.ts` now scrubs `preview-tile:` panes (an extensible `EPHEMERAL_PANE_PREFIXES` list) from the **stored** copy in `persist()`; the live tree keeps them for the session.
- `loadPersisted()` scrubs too, so trees already persisted by older builds heal on their next boot instead of booting with ghost preview tiles.
- Boot behavior is unchanged for surviving tabs: `$previewTabs` restores → the mirror registers panes → `adoptContributedPanes()` docks each beside `workspace` at the share it held when it closed (`rememberPaneShare` / `recalledEdgeWeights`), so re-docking is deterministic and the base layout never moves.

## Evidence

- New regression test `apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts`:
  - red before the fix (a `preview-tile:` pane written by `persistTree()` lands in the stored tree),
  - green after (stored tree collapses back to the persistent panes; live tree untouched),
  - plus cases for stacked (center-docked) preview tabs, non-ephemeral panes persisting with their weights byte-stable, and a stored tree from a pre-fix build healing on load.
- `npx vitest run --project ui src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts` → 4 passed
- `npx vitest run --project ui src/components/pane-shell/tree` → all tree-store suites pass
- `npm run typecheck` in `apps/desktop` → clean

## Review follow-up (Enough1122) — `5d76769`

- `scrubEphemeralPanes` no longer materializes `allPaneIds(tree)` on every commit: a new `containsEphemeralPane` depth-first scan stops at the first ephemeral pane and the scrub early-returns the same tree reference before building any id list. The no-op path (most commits — no preview tile open) is now allocation-free.
- `PREVIEW_TILE_PANE_NAMESPACE` and `isEphemeralPane` are exported from the tree store; `preview-tile.tsx` drops its private `'preview-tile'` literal and now mints ids **and** asserts pane membership against that single shared definition.
- New tests: the preview-free persist path never calls `allPaneIds` (spy assertion); the exported predicate/namespace contract; pane ids minted by the real preview tile mirror satisfy the shared predicate. RED-before/GREEN-after verified, `apps/desktop` typecheck + eslint clean.

Closes #92818
