### PR TITLE
feat(mcp-catalog): add Grafana Cloud MCP server

### DIFF
--- a/optional-mcps/grafana/manifest.yaml
+++ b/optional-mcps/grafana/manifest.yaml
@@ -1,0 +1,46 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: grafana
+description: >-
+  Query metrics, logs, dashboards, alerts, and incidents from Grafana Cloud.
+source: https://grafana.com/docs/grafana-cloud/ai-tools/mcp-servers/cloud-mcp/
+
+# Grafana Cloud's hosted remote MCP (URL-only — Hermes never spawns a local
+# process for this entry). Native OAuth 2.1 + Dynamic Client Registration over
+# Streamable HTTP; Hermes's MCP client + mcp_oauth_manager handle discovery,
+# PKCE, token exchange, and refresh. OAuth is user-scoped to your Grafana RBAC.
+#
+# Note: this is the *hosted* Grafana Cloud MCP server, not the self-run OSS
+# `mcp-grafana` binary (which authenticates with a service account token and
+# supports self-hosted Grafana). Self-hosted users should configure that
+# manually per https://github.com/grafana/mcp-grafana.
+transport:
+  type: http
+  url: https://mcp.grafana.com/mcp
+
+auth:
+  type: oauth
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - grafana
+    - promql
+    - logql
+    - observability
+    - dashboard
+  hosts:
+    - grafana.net
+    - grafana.com
+
+post_install: |
+  On first connection Hermes opens a browser to authorize with Grafana Cloud
+  (or run `hermes mcp login grafana`). During authorization you'll enter your
+  Grafana Cloud stack URL (https://<your-stack>.grafana.net) and choose read
+  or read+write access, then approve. Restart the session so tools load.
+
+  Requires a hosted Grafana Cloud stack and the "Assistant Cloud MCP User"
+  role (Editor or higher has it by default). Self-hosted Grafana isn't
+  supported by this endpoint — use the OSS mcp-grafana server instead.


### PR DESCRIPTION
## Summary

Adds a Nous-approved MCP catalog entry for the **Grafana Cloud MCP server** (`optional-mcps/grafana/manifest.yaml`), so users can `hermes mcp install grafana` and get one-click access to Grafana Cloud observability tools.

Grafana Cloud ships a vendor-hosted remote MCP server at `https://mcp.grafana.com/mcp` using Streamable HTTP + native OAuth 2.1 with Dynamic Client Registration — the exact transport/auth shape Hermes' MCP client + `mcp_oauth_manager` already handle. This mirrors the existing `datadog` and `sentry` catalog entries.

## What it exposes

Tools for Prometheus (PromQL), Loki (LogQL), Tempo, Pyroscope, dashboards, folders, datasources, alerting, incidents, and Grafana Assistant investigations. Full list: https://grafana.com/docs/grafana-cloud/ai-tools/mcp-servers/cloud-mcp/

## Manifest

- `manifest_version: 1`
- `transport.type: http`, `url: https://mcp.grafana.com/mcp`
- `auth.type: oauth` (native MCP OAuth — browser flow on first connect, user-scoped to Grafana RBAC)
- No `default_enabled` filter — install-time checklist starts fully checked, users prune.

## Notes

- This is the **hosted Grafana Cloud** MCP, not the self-run OSS `mcp-grafana` binary (service-account-token auth, supports self-hosted Grafana). The `post_install` note points self-hosted users to the OSS server.
- Only Streamable HTTP is supported by the endpoint (no SSE), which matches Hermes' HTTP MCP client.

## Test plan

- [ ] `hermes mcp catalog` lists `grafana`
- [ ] `hermes mcp install grafana` writes the HTTP + `auth: oauth` block to `mcp_servers.grafana`
- [ ] `hermes mcp login grafana` completes the OAuth browser flow against a Grafana Cloud stack
- [ ] Grafana tools appear (`mcp_grafana_*`) after session restart
