### PR TITLE
fix(auxiliary): derive Z.ai vision model and endpoint from the live main runtime

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1329,7 +1329,9 @@ def _to_openai_base_url(base_url: str) -> str:
     if url.endswith("/anthropic"):
         # ZAI uses /api/anthropic for the Coding Plan's Anthropic wire.  The
         # matching OpenAI-wire endpoint is /api/coding/paas/v4; /api/paas/v4
-        # is the independently billed general API.
+        # is the independently billed general API.  Covers both Z.AI hosts
+        # (api.z.ai and open.bigmodel.cn — the host pair lives in the zai
+        # plugin's _ZAI_HOSTS; keep this table in sync, see #92817).
         if base_url_host_matches(url, "open.bigmodel.cn") or base_url_host_matches(url, "api.z.ai"):
             rewritten = url[: -len("/anthropic")] + "/coding/paas/v4"
             logger.debug("Auxiliary client: rewrote ZAI base URL %s → %s", url, rewritten)
@@ -7307,10 +7309,31 @@ def _is_zai_host_url(base_url: Optional[str]) -> bool:
 
     Host-anchored (never path-anchored) so a lookalike host or a path
     marker on a gateway URL cannot trigger Z.ai-specific routing.
+
+    Z.AI host facts live in exactly one place: ``_ZAI_HOSTS`` in the zai
+    plugin (plugins/model-providers/zai/__init__.py).  This helper delegates
+    to the registered profile's ``is_zai_host_url()`` so an endpoint added
+    there is picked up here automatically.  The local pair below is only a
+    fallback for contexts where provider plugins are not loaded (e.g. CLI
+    surfaces) — keep it in sync with the plugin (#92817).
     """
     url = str(base_url or "").strip()
     if not url:
         return False
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("zai")
+        if profile is not None:
+            checker = getattr(profile, "is_zai_host_url", None)
+            if callable(checker):
+                return bool(checker(url))
+    except Exception:
+        logger.debug(
+            "Auxiliary client: zai host check via profile unavailable; "
+            "using local host pair",
+            exc_info=True,
+        )
     return base_url_host_matches(url, "api.z.ai") or base_url_host_matches(
         url, "open.bigmodel.cn"
     )
@@ -7519,7 +7542,7 @@ def resolve_vision_provider_client(
                             rpc_base_url = custom_base
                             rpc_api_key = custom_key
                             rpc_api_mode = resolved_api_mode or custom_mode or None
-                if zai_main_base:
+                if zai_main_base and rpc_base_url is None:
                     # Reuse the live Z.ai main endpoint so vision consumes the
                     # same billing pool as the main model.  A Coding Plan key
                     # is rejected by the general API (1113) and the coding
@@ -7528,6 +7551,12 @@ def resolve_vision_provider_client(
                     # endpoint is what actually works (#92817).  The OpenAI
                     # wire is mandatory for Z.ai vision (the Anthropic wire
                     # rejects multimodal calls with error 1210).
+                    #
+                    # Precedence: the guard above means an explicit custom
+                    # vision base_url (set in the custom-provider branch from
+                    # user config, above) wins over the runtime-derived
+                    # endpoint — user-explicit config is never silently
+                    # clobbered by the live Z.ai runtime (#92817 review).
                     rpc_base_url = _to_openai_base_url(zai_main_base)
                     rpc_api_key = runtime.get("api_key") or None
                     if isinstance(rpc_api_key, str):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -998,22 +998,32 @@ def _task_prefers_fast_model(task: Optional[str]) -> bool:
 # When the user's main provider has a dedicated vision/multimodal model that
 # differs from their main chat model, map it here.  The vision auto-detect
 # "exotic provider" branch checks this before falling back to the main model.
+# Providers whose vision default depends on the endpoint (Z.AI's Coding Plan
+# serves glm-4.5v, the general API serves glm-5v-turbo) live in their
+# ProviderProfile's ``default_vision_model()`` hook instead — a static entry
+# here cannot know the caller's billing pool (see #92817).
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "xiaomi": "mimo-v2.5",
-    "zai": "glm-5v-turbo",
 }
 
 
-def _resolve_provider_vision_default(provider: str) -> Optional[str]:
+def _resolve_provider_vision_default(
+    provider: str, *, base_url: Optional[str] = None
+) -> Optional[str]:
     """Return the provider's preferred default vision model id, or None.
 
-    Static entries in :data:`_PROVIDER_VISION_MODELS` win first (xiaomi /
-    zai have dedicated vision-only model names that don't live in any
-    discoverable catalog). Otherwise the provider's :class:`ProviderProfile`
-    gets a chance to supply one via its ``default_vision_model()`` hook —
-    that's where catalog-backed providers (DeepInfra) resolve a live default,
+    Static entries in :data:`_PROVIDER_VISION_MODELS` win first (xiaomi has
+    a dedicated vision-only model name that doesn't live in any discoverable
+    catalog). Otherwise the provider's :class:`ProviderProfile` gets a chance
+    to supply one via its ``default_vision_model()`` hook — that's where
+    catalog-backed providers (DeepInfra) resolve a live default and where
+    endpoint-aware providers (Z.AI) pick the vision model their billing pool
+    actually serves (coding plan → glm-4.5v, general API → glm-5v-turbo),
     keeping the discovery logic inside their plugin instead of a name-check
     branch here.
+
+    ``base_url`` carries the live main-runtime endpoint for endpoint-aware
+    hooks; hooks that predate the parameter ignore it.
     """
     static = _PROVIDER_VISION_MODELS.get(provider)
     if static:
@@ -1026,6 +1036,12 @@ def _resolve_provider_vision_default(provider: str) -> Optional[str]:
     if profile is None:
         return None
     try:
+        if base_url:
+            try:
+                return profile.default_vision_model(base_url=base_url)
+            except TypeError:
+                # Out-of-tree profile predating the base_url parameter.
+                return profile.default_vision_model()
         return profile.default_vision_model()
     except Exception:
         return None
@@ -5540,9 +5556,14 @@ def _try_main_agent_model_fallback(
         return None, None, ""
 
     label = f"main-agent({main_provider})"
+    # Name the endpoint the fallback degraded to: a vision routing miss on
+    # Z.ai surfaces as a confusing 1210 content-type error unless the log
+    # shows which model AND which billing pool the fallback actually used.
+    main_base = _read_main_base_url()
     logger.info(
-        "Auxiliary %s: %s on %s — falling back to main agent model %s (%s)",
+        "Auxiliary %s: %s on %s — falling back to main agent model %s (%s) at %s",
         task or "call", reason, failed_provider, label, resolved_model or main_model,
+        main_base or "default endpoint",
     )
     return client, resolved_model or main_model, label
 
@@ -7281,6 +7302,47 @@ def get_available_vision_backends() -> List[str]:
     return available
 
 
+def _is_zai_host_url(base_url: Optional[str]) -> bool:
+    """True when *base_url* points at a Z.AI / BigModel host.
+
+    Host-anchored (never path-anchored) so a lookalike host or a path
+    marker on a gateway URL cannot trigger Z.ai-specific routing.
+    """
+    url = str(base_url or "").strip()
+    if not url:
+        return False
+    return base_url_host_matches(url, "api.z.ai") or base_url_host_matches(
+        url, "open.bigmodel.cn"
+    )
+
+
+def _zai_main_endpoint_base_url(runtime: Dict[str, Any]) -> Optional[str]:
+    """Return the Z.ai host endpoint of the live main runtime, or None.
+
+    Only meaningful when the main provider IS a zai-family provider — the
+    runtime endpoint of any other provider belongs to a different billing
+    pool and must never be reused.  Falls back to the configured main
+    endpoint only when the runtime records no provider at all (non-gateway
+    callers), so a zai Coding Plan base_url in config still drives vision
+    routing. (#92817)
+    """
+    rt_provider = _normalize_aux_provider(str(runtime.get("provider") or ""))
+    if rt_provider == "zai":
+        base = str(runtime.get("base_url") or "").strip().rstrip("/")
+        if base and _is_zai_host_url(base):
+            return base
+        return None
+    if rt_provider not in {"", "auto"}:
+        # A concrete non-zai main provider is authoritative — never borrow
+        # config state that belongs to a different provider.
+        return None
+    if _normalize_aux_provider((_read_main_provider() or "").strip().lower()) == "zai":
+        base = (_read_main_base_url() or "").strip().rstrip("/")
+        if base and _is_zai_host_url(base):
+            return base
+    return None
+
+
 def resolve_vision_provider_client(
     provider: Optional[str] = None,
     model: Optional[str] = None,
@@ -7332,13 +7394,12 @@ def resolve_vision_provider_client(
     if requested == "auto":
         # Vision auto-detection order:
         #   1. User's main provider + main model (including aggregators).
-        #      _PROVIDER_VISION_MODELS provides per-provider vision model
-        #      overrides when the provider has a dedicated multimodal model
-        #      that differs from the chat model (e.g. xiaomi → mimo-v2-omni,
-        #      zai → glm-5v-turbo). DeepInfra is similar but resolves its
-        #      default vision model live from the catalog (see
-        #      :func:`_resolve_provider_vision_default`). Nous is the
-        #      exception: it has a dedicated strict vision backend with
+        #      Provider-specific vision models come from
+        #      _resolve_provider_vision_default: the xiaomi static entry or
+        #      the ProviderProfile's default_vision_model() hook (DeepInfra
+        #      resolves live from the catalog; Z.AI picks per billing pool —
+        #      coding plan → glm-4.5v, general API → glm-5v-turbo). Nous is
+        #      the exception: it has a dedicated strict vision backend with
         #      tier-aware defaults, so it must not fall through to the
         #      user's text chat model here.
         #   2. OpenRouter (vision-capable aggregator fallback)
@@ -7368,13 +7429,19 @@ def resolve_vision_provider_client(
                 runtime["api_mode"] = ""
         if main_provider and main_provider not in {"auto", "", "moa"}:
             # A provider-specific vision default wins over the user's chat model:
-            # static overrides (xiaomi/zai) and catalog-backed discovery (the
+            # static overrides (xiaomi) and catalog-backed discovery (the
             # DeepInfra profile hook) both yield a *known* vision-capable model,
             # whereas the pinned chat model is usually NOT multimodal (e.g. the
             # DeepSeek-V4-Flash default) and _main_model_supports_vision can't be
-            # trusted to catch that. Only fall back to the chat model when no
-            # provider default is available (catalog unreachable).
-            provider_vision_default = _resolve_provider_vision_default(main_provider)
+            # trusted to catch that. Endpoint-aware providers (Z.AI) resolve the
+            # vision model their billing pool actually serves via the same hook
+            # (coding plan → glm-4.5v, general API → glm-5v-turbo). Only fall
+            # back to the chat model when no provider default is available
+            # (catalog unreachable).
+            zai_main_base = _zai_main_endpoint_base_url(runtime)
+            provider_vision_default = _resolve_provider_vision_default(
+                main_provider, base_url=zai_main_base
+            )
             vision_model = provider_vision_default or main_model
             if main_provider == "nous":
                 # Nous resolves its vision model from the Portal's tier-aware
@@ -7452,6 +7519,20 @@ def resolve_vision_provider_client(
                             rpc_base_url = custom_base
                             rpc_api_key = custom_key
                             rpc_api_mode = resolved_api_mode or custom_mode or None
+                if zai_main_base:
+                    # Reuse the live Z.ai main endpoint so vision consumes the
+                    # same billing pool as the main model.  A Coding Plan key
+                    # is rejected by the general API (1113) and the coding
+                    # endpoint rejects glm-5v-turbo (1311), so pairing the
+                    # endpoint-aware vision model (glm-4.5v) with the runtime
+                    # endpoint is what actually works (#92817).  The OpenAI
+                    # wire is mandatory for Z.ai vision (the Anthropic wire
+                    # rejects multimodal calls with error 1210).
+                    rpc_base_url = _to_openai_base_url(zai_main_base)
+                    rpc_api_key = runtime.get("api_key") or None
+                    if isinstance(rpc_api_key, str):
+                        rpc_api_key = rpc_api_key.strip() or None
+                    rpc_api_mode = "chat_completions"
                 rpc_client, rpc_model = resolve_provider_client(
                     main_provider, vision_model,
                     api_mode=rpc_api_mode,
@@ -7490,15 +7571,42 @@ def resolve_vision_provider_client(
     # The Anthropic wire rejects max_tokens on multimodal calls (error 1210),
     # while the OpenAI wire handles it correctly.
     if requested == "zai" and not resolved_base_url:
+        # When the live main runtime is a Z.ai endpoint, try it FIRST so the
+        # vision call consumes the same billing pool as the main model: a
+        # Coding Plan key is billed from the coding pool, and the general API
+        # answers it with 429 code 1113 (insufficient balance) even though
+        # the key is valid (#92817). The runtime endpoint is rewritten to the
+        # OpenAI wire (e.g. /api/anthropic → /api/coding/paas/v4) and the
+        # general-API list remains as the ordered fallback for
+        # non-subscription keys.
+        zai_main_base = _zai_main_endpoint_base_url(runtime)
         zai_openai_urls = [
             "https://open.bigmodel.cn/api/paas/v4",
             "https://api.z.ai/api/paas/v4",
         ]
-        for _zai_url in zai_openai_urls:
+        zai_urls: List[str] = []
+        runtime_key: Optional[str] = None
+        if zai_main_base:
+            _derived = _to_openai_base_url(zai_main_base)
+            zai_urls.append(_derived)
+            zai_urls.extend(u for u in zai_openai_urls if u != _derived)
+            _rt_key = runtime.get("api_key")
+            if isinstance(_rt_key, str):
+                runtime_key = _rt_key.strip() or None
+        else:
+            zai_urls.extend(zai_openai_urls)
+        for _zai_url in zai_urls:
+            # Without an explicit auxiliary.vision.model, pick the vision
+            # model the endpoint actually serves (glm-4.5v on coding,
+            # glm-5v-turbo on general) instead of the text-only aux default
+            # (glm-4.5-flash), which would always fail with error 1210.
+            effective_model = resolved_model or _resolve_provider_vision_default(
+                "zai", base_url=_zai_url
+            )
             client, final_model = _get_cached_client(
-                requested, resolved_model, async_mode,
+                requested, effective_model, async_mode,
                 base_url=_zai_url,
-                api_key=resolved_api_key or None,
+                api_key=resolved_api_key or runtime_key,
                 api_mode="chat_completions",
                 main_runtime=runtime,
                 is_vision=True,
@@ -7506,7 +7614,8 @@ def resolve_vision_provider_client(
             if client is not None:
                 return _finalize(requested, client, final_model)
         # Fallback: try without explicit base_url (old behavior)
-        client, final_model = _get_cached_client(requested, resolved_model, async_mode,
+        effective_model = resolved_model or _resolve_provider_vision_default("zai")
+        client, final_model = _get_cached_client(requested, effective_model, async_mode,
                                                  api_mode=resolved_api_mode,
                                                  main_runtime=runtime,
                                                  is_vision=True)

--- a/plugins/model-providers/deepinfra/__init__.py
+++ b/plugins/model-providers/deepinfra/__init__.py
@@ -21,7 +21,7 @@ class _DeepInfraProfile(ProviderProfile):
     "deepinfra"`` branch reaching into the catalog helpers).
     """
 
-    def default_vision_model(self):  # type: ignore[override]
+    def default_vision_model(self, base_url=None):  # type: ignore[override]
         """First vision-capable *chat* model from the live catalog, or None.
 
         Key-gated so a box without ``DEEPINFRA_API_KEY`` never pays the

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -41,10 +41,36 @@ from providers.base import ProviderProfile
 
 _GLM_VERSION_RE = re.compile(r"^glm-(\d+)(?:\.(\d+))?")
 
-#: Z.AI / BigModel hosts.  Host-anchored matching so a lookalike host
+#: Z.AI / BigModel hosts — the single source of truth for Z.AI host facts.
+#: The shared aux client does NOT keep its own copy: ``agent.auxiliary_client.
+#: _is_zai_host_url`` delegates to :meth:`ZaiProfile.is_zai_host_url` (its
+#: local host pair is only a fallback for contexts where this plugin is not
+#: loaded).  Add any new Z.AI/BigModel endpoint here so every consumer picks
+#: it up in one edit (#92817).  Host-anchored matching so a lookalike host
 #: (``api.z.ai.evil.example.com``) or a path marker on a gateway URL never
 #: triggers endpoint-specific routing.
 _ZAI_HOSTS = ("api.z.ai", "open.bigmodel.cn")
+
+
+def _is_zai_host_url(base_url: str | None) -> bool:
+    """True when *base_url* points at a Z.AI / BigModel host.
+
+    Host-anchored (never path-anchored) and subdomain-tolerant — mirrors
+    ``utils.base_url_host_matches`` semantics — so a lookalike host
+    (``api.z.ai.evil.example.com``) or a path marker on a gateway URL never
+    matches, while a genuine ``*.api.z.ai`` endpoint still does.  The aux
+    client reaches this through :meth:`ZaiProfile.is_zai_host_url`.
+    """
+    url = str(base_url or "").strip()
+    if not url:
+        return False
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    if not host:
+        return False
+    return any(host == h or host.endswith("." + h) for h in _ZAI_HOSTS)
 
 
 def _is_zai_coding_endpoint(base_url: str | None) -> bool:
@@ -157,6 +183,15 @@ def _glm_5_2_reasoning_effort(
 
 class ZaiProfile(ProviderProfile):
     """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2 reasoning_effort."""
+
+    def is_zai_host_url(self, base_url: str | None = None) -> bool:
+        """Host check delegated from ``agent.auxiliary_client._is_zai_host_url``.
+
+        Public so the shared aux client asks the profile instead of
+        re-deriving Z.AI host facts — when a new Z.AI/BigModel endpoint is
+        added to :data:`_ZAI_HOSTS`, aux picks it up with no change there.
+        """
+        return _is_zai_host_url(base_url)
 
     def default_vision_model(self, base_url: str | None = None) -> str | None:
         """Vision default for the billing pool *base_url* lands on.

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -22,17 +22,53 @@ two enabled levels — ``high`` and ``max`` — on the OpenAI-compatible endpoin
 (per Z.AI / BigModel docs).  Hermes' richer effort scale is collapsed onto
 those two so the user's effort preference actually reaches the model instead
 of being silently dropped.
+
+Vision routing is endpoint-aware: the Coding Plan endpoint serves
+``glm-4.5v`` but not the general API's ``glm-5v-turbo`` (429 code 1311 —
+not in subscription).  :meth:`ZaiProfile.default_vision_model` picks the
+vision default for the billing pool the request actually lands on (issue
+#92817).
 """
 
 from __future__ import annotations
 
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
 _GLM_VERSION_RE = re.compile(r"^glm-(\d+)(?:\.(\d+))?")
+
+#: Z.AI / BigModel hosts.  Host-anchored matching so a lookalike host
+#: (``api.z.ai.evil.example.com``) or a path marker on a gateway URL never
+#: triggers endpoint-specific routing.
+_ZAI_HOSTS = ("api.z.ai", "open.bigmodel.cn")
+
+
+def _is_zai_coding_endpoint(base_url: str | None) -> bool:
+    """True when *base_url* is a Z.AI Coding Plan endpoint.
+
+    Covers the OpenAI-wire form ``/api/coding/paas/v4`` and the
+    Anthropic-wire form ``/api/anthropic`` (whose OpenAI sibling is the
+    coding endpoint — see ``_to_openai_base_url``).  The general API
+    (``/api/paas/v4``) is billed independently and is NOT a coding endpoint.
+    """
+    url = str(base_url or "").strip().rstrip("/")
+    if not url:
+        return False
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except ValueError:
+        return False
+    if host not in _ZAI_HOSTS:
+        return False
+    return (
+        "/coding/" in url
+        or url.endswith("/coding")
+        or url.endswith("/api/anthropic")
+    )
 
 
 def _model_supports_thinking(model: str | None) -> bool:
@@ -121,6 +157,19 @@ def _glm_5_2_reasoning_effort(
 
 class ZaiProfile(ProviderProfile):
     """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2 reasoning_effort."""
+
+    def default_vision_model(self, base_url: str | None = None) -> str | None:
+        """Vision default for the billing pool *base_url* lands on.
+
+        The Coding Plan endpoint (``/api/coding/paas/v4``, or its
+        Anthropic-wire form ``/api/anthropic``) does not serve
+        ``glm-5v-turbo`` — it answers 429 code 1311 ("not in subscription").
+        It serves ``glm-4.5v``, which is included in the plan (measured live,
+        issue #92817).  The general API keeps ``glm-5v-turbo``.
+        """
+        if _is_zai_coding_endpoint(base_url):
+            return "glm-4.5v"
+        return "glm-5v-turbo"
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context

--- a/providers/base.py
+++ b/providers/base.py
@@ -167,13 +167,19 @@ class ProviderProfile:
         """
         return {}, {}
 
-    def default_vision_model(self) -> str | None:
+    def default_vision_model(self, base_url: str | None = None) -> str | None:
         """Return a default vision model id for this provider, or None.
 
         Overrideable hook for providers that discover their vision default at
         runtime (e.g. from a live catalog) rather than pinning one in code.
         Keeps provider-specific vision discovery inside the provider's plugin
         instead of a name-check branch in shared vision resolution.
+
+        ``base_url`` carries the live main-runtime endpoint (when known) so
+        endpoint-aware providers can pick the vision model their billing pool
+        actually serves — e.g. Z.AI's Coding Plan endpoint serves
+        ``glm-4.5v`` but not the general API's ``glm-5v-turbo``. Hooks that
+        predate the parameter simply ignore it.
 
         Default: None (no provider-specific vision model — the caller falls
         back to the user's chat model or the aggregator chain).

--- a/tests/agent/test_auxiliary_explicit_base_anthropic.py
+++ b/tests/agent/test_auxiliary_explicit_base_anthropic.py
@@ -140,3 +140,39 @@ def test_explicit_base_unknown_host_keeps_anthropic_path():
     assert client is not None
     assert not isinstance(client, AnthropicAuxiliaryClient)
     assert _client_base_url(client).rstrip("/").endswith("/proxy/anthropic")
+
+
+# ── Z.AI: /api/anthropic → /api/coding/paas/v4 rewrite table ────────────────
+
+
+_ZAI_ANTHROPIC_REWRITES = [
+    ("https://api.z.ai/api/anthropic", "https://api.z.ai/api/coding/paas/v4"),
+    (
+        "https://open.bigmodel.cn/api/anthropic",
+        "https://open.bigmodel.cn/api/coding/paas/v4",
+    ),
+]
+
+
+@pytest.mark.parametrize("anthropic_url,expected", _ZAI_ANTHROPIC_REWRITES)
+def test_zai_anthropic_wire_rewrites_to_coding_openai_wire(anthropic_url, expected):
+    """Both Z.AI hosts' /api/anthropic form must map to the OpenAI-wire coding
+    endpoint — the billing pool is preserved, never the general /api/paas/v4
+    (#92817 review point 3)."""
+    from agent.auxiliary_client import _to_openai_base_url
+
+    assert _to_openai_base_url(anthropic_url) == expected
+
+
+def test_zai_openai_wire_urls_pass_through_unchanged():
+    """OpenAI-wire Z.AI URLs (general + coding) are not part of the /anthropic
+    rewrite table and must pass through byte-identical."""
+    from agent.auxiliary_client import _to_openai_base_url
+
+    for url in (
+        "https://api.z.ai/api/paas/v4",
+        "https://open.bigmodel.cn/api/paas/v4",
+        "https://api.z.ai/api/coding/paas/v4",
+        "https://open.bigmodel.cn/api/coding/paas/v4",
+    ):
+        assert _to_openai_base_url(url) == url

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -183,7 +183,7 @@ class TestResolveVisionProviderClientModelNormalization:
 
         assert provider == "zai"
         assert client is not None
-        assert model == "glm-5v-turbo"  # zai has dedicated vision model in _PROVIDER_VISION_MODELS
+        assert model == "glm-5v-turbo"  # zai has dedicated vision model via its provider profile
 
 
 class TestVisionPathApiMode:

--- a/tests/agent/test_vision_zai_coding_endpoint_92817.py
+++ b/tests/agent/test_vision_zai_coding_endpoint_92817.py
@@ -171,6 +171,25 @@ class TestVisionAutoZaiEndpointAware:
             == "https://api.z.ai/api/paas/v4"
         )
 
+    def test_bigmodel_coding_runtime_uses_glm45v_on_coding_endpoint(self):
+        """The BigModel CN host routes exactly like api.z.ai in auto mode —
+        both hosts of the pair must drive the same endpoint reuse."""
+        provider, client, model, mock_resolve = self._run_auto(
+            "https://open.bigmodel.cn/api/coding/paas/v4"
+        )
+
+        assert provider == "zai"
+        assert client is not None
+        assert model == "glm-4.5v"
+        assert mock_resolve.call_args.args[1] == "glm-4.5v"
+        kwargs = mock_resolve.call_args.kwargs
+        assert (
+            kwargs.get("explicit_base_url")
+            == "https://open.bigmodel.cn/api/coding/paas/v4"
+        )
+        assert kwargs.get("explicit_api_key") == "zai-runtime-key"
+        assert kwargs.get("api_mode") == "chat_completions"
+
 
 # ── Explicit mode: prepend the main-runtime endpoint ────────────────────────
 
@@ -258,6 +277,27 @@ class TestVisionExplicitZaiEndpointAware:
         assert calls[0]["model"] == "glm-4.5v"
         assert calls[0]["api_mode"] == "chat_completions"
 
+    def test_bigmodel_anthropic_wire_runtime_rewritten_to_coding_openai_wire(self):
+        """Both Z.AI hosts' /api/anthropic form must map to the OpenAI-wire
+        coding endpoint — not just api.z.ai (#92817 review point 3)."""
+        provider, _client, model, calls = self._run_explicit(
+            {
+                "provider": "zai",
+                "model": "glm-5.3",
+                "base_url": "https://open.bigmodel.cn/api/anthropic",
+                "api_key": "zai-runtime-key",
+                "api_mode": "anthropic_messages",
+            }
+        )
+
+        assert provider == "zai"
+        assert model == "glm-4.5v"
+        assert (
+            calls[0]["base_url"] == "https://open.bigmodel.cn/api/coding/paas/v4"
+        )
+        assert calls[0]["model"] == "glm-4.5v"
+        assert calls[0]["api_mode"] == "chat_completions"
+
     def test_non_zai_main_runtime_keeps_general_urls_and_vision_default(self):
         """When main is not zai, the general-API list remains — but the
         model default becomes the vision model, not the text-only aux
@@ -295,6 +335,114 @@ class TestVisionExplicitZaiEndpointAware:
         assert model == "glm-5v-turbo"
         assert calls[0]["base_url"] == "https://api.z.ai/api/coding/paas/v4"
         assert calls[0]["model"] == "glm-5v-turbo"
+
+
+# ── Auto mode: explicit custom vision config wins over the Z.ai runtime ─────
+
+
+class TestVisionAutoCustomPrecedence:
+    def test_explicit_custom_vision_base_wins_over_zai_main_runtime(self):
+        """An explicit custom vision base_url in config is user intent — a
+        Z.ai-family main endpoint must not silently clobber it (#92817 review
+        point 1)."""
+        fake_client = MagicMock(name="custom_vision_client")
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fake_client, None),
+        ) as mock_resolve, patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="custom:zai",
+        ), patch(
+            "agent.auxiliary_client._read_main_model",
+            return_value="glm-5.3",
+        ), patch(
+            "agent.auxiliary_client._read_main_base_url",
+            return_value="https://api.z.ai/api/coding/paas/v4",
+        ), patch(
+            "agent.auxiliary_client._resolve_custom_runtime",
+            return_value=(
+                "https://gateway.example.com/v1",
+                "gateway-key",
+                "chat_completions",
+            ),
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client(
+                main_runtime={}
+            )
+
+        assert provider == "custom:zai"
+        assert client is not None
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs.get("explicit_base_url") == "https://gateway.example.com/v1"
+        assert kwargs.get("explicit_api_key") == "gateway-key"
+        assert kwargs.get("api_mode") == "chat_completions"
+
+
+# ── Host facts live in the zai plugin; aux delegates to the profile ─────────
+
+
+class TestZaiProfileHostCheck:
+    """``ZaiProfile.is_zai_host_url`` — the single source aux delegates to."""
+
+    def test_profile_accepts_both_hosts(self, zai_profile):
+        assert zai_profile.is_zai_host_url("https://api.z.ai/api/paas/v4") is True
+        assert (
+            zai_profile.is_zai_host_url("https://open.bigmodel.cn/api/anthropic")
+            is True
+        )
+
+    def test_profile_rejects_lookalike_and_path_markers(self, zai_profile):
+        assert (
+            zai_profile.is_zai_host_url("https://api.z.ai.evil.example.com/api/paas/v4")
+            is False
+        )
+        assert (
+            zai_profile.is_zai_host_url(
+                "https://gateway.example.com/api.z.ai/api/paas/v4"
+            )
+            is False
+        )
+        assert zai_profile.is_zai_host_url(None) is False
+
+
+class TestAuxZaiHostCheckDelegation:
+    """aux ``_is_zai_host_url`` asks the registered zai profile and only falls
+    back to its local host pair when the plugin is not loaded."""
+
+    def test_aux_accepts_both_hosts(self, zai_profile):
+        from agent.auxiliary_client import _is_zai_host_url
+
+        assert _is_zai_host_url("https://api.z.ai/api/paas/v4") is True
+        assert _is_zai_host_url("https://open.bigmodel.cn/api/anthropic") is True
+
+    def test_aux_rejects_lookalike_and_path_markers(self, zai_profile):
+        from agent.auxiliary_client import _is_zai_host_url
+
+        assert (
+            _is_zai_host_url("https://api.z.ai.evil.example.com/api/paas/v4")
+            is False
+        )
+        assert (
+            _is_zai_host_url(
+                "https://gateway.example.com/api.z.ai/api/paas/v4"
+            )
+            is False
+        )
+        assert _is_zai_host_url("") is False
+        assert _is_zai_host_url(None) is False
+
+    def test_aux_falls_back_to_local_pair_without_profile(self):
+        from agent.auxiliary_client import _is_zai_host_url
+
+        with patch("providers.get_provider_profile", return_value=None):
+            assert _is_zai_host_url("https://api.z.ai/api/paas/v4") is True
+            assert _is_zai_host_url("https://open.bigmodel.cn/api/paas/v4") is True
+            assert _is_zai_host_url("https://api.z.ai.evil.example.com/x") is False
 
 
 # ── Fallback logging names the endpoint it degraded to ──────────────────────

--- a/tests/agent/test_vision_zai_coding_endpoint_92817.py
+++ b/tests/agent/test_vision_zai_coding_endpoint_92817.py
@@ -1,0 +1,328 @@
+"""Regression tests for issue #92817 — Z.ai Coding Plan vision routing.
+
+Before the fix, ``resolve_vision_provider_client`` carried two hardcoded Z.ai
+assumptions that broke vision for every Coding Plan subscriber:
+
+1. **Auto mode**: ``_PROVIDER_VISION_MODELS["zai"] = "glm-5v-turbo"`` — a
+   static, endpoint-blind default. Coding Plan subscriptions do not include
+   glm-5v-turbo, so the call returned ``429 code 1311`` and the chain
+   silently degraded to the text-only main model → ``400 code 1210``
+   (``messages.content.type is invalid``).
+2. **Explicit mode** (``auxiliary.vision.provider: zai`` with no
+   ``base_url``): the fallback URL list pinned vision to the *general* API
+   endpoints, which are billed independently of the Coding Plan → ``429
+   code 1113`` (insufficient balance for a valid plan key) → same 1210.
+
+Measured live with a Coding Plan key (issue table): ``glm-4.5v`` on the
+coding endpoint ``https://api.z.ai/api/coding/paas/v4`` returns 200 OK and
+is included in the plan — the routing just never sent it there.
+
+The fix makes vision routing endpoint-aware:
+
+- the zai provider profile owns its vision default via
+  ``default_vision_model()`` (coding endpoint → ``glm-4.5v``, general API →
+  ``glm-5v-turbo``), replacing the hardcoded dict entry;
+- auto mode reuses the live main-runtime endpoint so vision hits the same
+  billing pool as the main model;
+- explicit-provider mode prepends the main-runtime endpoint (rewriting the
+  Anthropic wire to its OpenAI-wire coding sibling) before the general-API
+  fallback list, and defaults to a vision-capable model instead of the
+  text-only aux default (``glm-4.5-flash``).
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def zai_profile():
+    """Resolve the registered Z.AI profile through the real discovery path."""
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("zai")
+    assert profile is not None, "zai provider profile must be registered"
+    return profile
+
+
+# ── The profile owns the endpoint-aware default ─────────────────────────────
+
+
+class TestZaiProfileVisionDefault:
+    """``default_vision_model()`` picks a model the endpoint actually serves."""
+
+    def test_coding_endpoint_returns_glm45v(self, zai_profile):
+        assert (
+            zai_profile.default_vision_model(
+                "https://api.z.ai/api/coding/paas/v4"
+            )
+            == "glm-4.5v"
+        )
+
+    def test_bigmodel_cn_coding_endpoint_returns_glm45v(self, zai_profile):
+        assert (
+            zai_profile.default_vision_model(
+                "https://open.bigmodel.cn/api/coding/paas/v4"
+            )
+            == "glm-4.5v"
+        )
+
+    def test_anthropic_wire_coding_endpoint_returns_glm45v(self, zai_profile):
+        assert (
+            zai_profile.default_vision_model("https://api.z.ai/api/anthropic")
+            == "glm-4.5v"
+        )
+
+    def test_general_endpoint_keeps_glm5v_turbo(self, zai_profile):
+        assert (
+            zai_profile.default_vision_model("https://api.z.ai/api/paas/v4")
+            == "glm-5v-turbo"
+        )
+
+    def test_no_base_url_keeps_glm5v_turbo(self, zai_profile):
+        assert zai_profile.default_vision_model(None) == "glm-5v-turbo"
+
+    def test_lookalike_host_not_treated_as_zai(self, zai_profile):
+        url = "https://api.z.ai.evil.example.com/api/coding/paas/v4"
+        assert zai_profile.default_vision_model(url) == "glm-5v-turbo"
+
+    def test_path_marker_alone_not_coding(self, zai_profile):
+        url = "https://gateway.example.com/api.z.ai/api/coding/paas/v4"
+        assert zai_profile.default_vision_model(url) == "glm-5v-turbo"
+
+
+class TestResolveProviderVisionDefault:
+    """``_resolve_provider_vision_default`` honours the endpoint context."""
+
+    def test_zai_coding_endpoint(self):
+        from agent.auxiliary_client import _resolve_provider_vision_default
+
+        assert (
+            _resolve_provider_vision_default(
+                "zai", base_url="https://api.z.ai/api/coding/paas/v4"
+            )
+            == "glm-4.5v"
+        )
+
+    def test_zai_general_endpoint(self):
+        from agent.auxiliary_client import _resolve_provider_vision_default
+
+        assert _resolve_provider_vision_default("zai") == "glm-5v-turbo"
+
+
+# ── Auto mode: endpoint-aware model + endpoint reuse ────────────────────────
+
+
+class TestVisionAutoZaiEndpointAware:
+    def _run_auto(self, runtime_base_url):
+        fake_client = MagicMock(name="zai_vision_client")
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fake_client, None),
+        ) as mock_resolve:
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client(
+                main_runtime={
+                    "provider": "zai",
+                    "model": "glm-5.3",
+                    "base_url": runtime_base_url,
+                    "api_key": "zai-runtime-key",
+                    "api_mode": "chat_completions",
+                }
+            )
+        return provider, client, model, mock_resolve
+
+    def test_coding_runtime_uses_glm45v_on_coding_endpoint(self):
+        """Auto vision on a coding-plan main runtime must reuse the runtime
+        endpoint and send the coding-served vision model, not glm-5v-turbo."""
+        provider, client, model, mock_resolve = self._run_auto(
+            "https://api.z.ai/api/coding/paas/v4"
+        )
+
+        assert provider == "zai"
+        assert client is not None
+        assert model == "glm-4.5v"
+        assert mock_resolve.call_args.args[1] == "glm-4.5v"
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs.get("explicit_base_url") == "https://api.z.ai/api/coding/paas/v4"
+        assert kwargs.get("explicit_api_key") == "zai-runtime-key"
+        assert kwargs.get("api_mode") == "chat_completions"
+
+    def test_general_runtime_keeps_glm5v_turbo(self):
+        """General-API users keep glm-5v-turbo (still the static default),
+        but the vision call now reuses the live main endpoint."""
+        provider, _client, model, mock_resolve = self._run_auto(
+            "https://api.z.ai/api/paas/v4"
+        )
+
+        assert provider == "zai"
+        assert model == "glm-5v-turbo"
+        assert mock_resolve.call_args.args[1] == "glm-5v-turbo"
+        assert (
+            mock_resolve.call_args.kwargs.get("explicit_base_url")
+            == "https://api.z.ai/api/paas/v4"
+        )
+
+
+# ── Explicit mode: prepend the main-runtime endpoint ────────────────────────
+
+
+class TestVisionExplicitZaiEndpointAware:
+    def _run_explicit(self, main_runtime, task_model=None, read_main_provider="zai"):
+        fake_client = MagicMock(name="zai_vision_client")
+        calls = []
+
+        def fake_gcc(
+            provider,
+            model,
+            async_mode,
+            base_url=None,
+            api_key=None,
+            api_mode=None,
+            main_runtime=None,
+            is_vision=False,
+            task=None,
+        ):
+            calls.append(
+                {
+                    "provider": provider,
+                    "model": model,
+                    "base_url": base_url,
+                    "api_key": api_key,
+                    "api_mode": api_mode,
+                }
+            )
+            return (fake_client, model)
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("zai", task_model, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client", side_effect=fake_gcc
+        ), patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value=read_main_provider,
+        ):
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client(
+                provider="zai", main_runtime=main_runtime
+            )
+        return provider, client, model, calls
+
+    def test_coding_runtime_prepends_coding_endpoint_with_glm45v(self):
+        """Explicit ``provider: zai`` with no base_url must try the live
+        coding-plan endpoint first — the general API bills the key wrong."""
+        provider, client, model, calls = self._run_explicit(
+            {
+                "provider": "zai",
+                "model": "glm-5.3",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "api_key": "zai-runtime-key",
+                "api_mode": "chat_completions",
+            }
+        )
+
+        assert provider == "zai"
+        assert client is not None
+        assert model == "glm-4.5v"
+        assert calls[0]["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+        assert calls[0]["model"] == "glm-4.5v"
+        assert calls[0]["api_key"] == "zai-runtime-key"
+        assert calls[0]["api_mode"] == "chat_completions"
+
+    def test_anthropic_wire_runtime_rewritten_to_coding_openai_wire(self):
+        """A main runtime on the /api/anthropic wire maps to the OpenAI-wire
+        coding endpoint for vision (max_tokens/1210-safe)."""
+        provider, _client, model, calls = self._run_explicit(
+            {
+                "provider": "zai",
+                "model": "glm-5.3",
+                "base_url": "https://api.z.ai/api/anthropic",
+                "api_key": "zai-runtime-key",
+                "api_mode": "anthropic_messages",
+            }
+        )
+
+        assert provider == "zai"
+        assert model == "glm-4.5v"
+        assert calls[0]["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+        assert calls[0]["model"] == "glm-4.5v"
+        assert calls[0]["api_mode"] == "chat_completions"
+
+    def test_non_zai_main_runtime_keeps_general_urls_and_vision_default(self):
+        """When main is not zai, the general-API list remains — but the
+        model default becomes the vision model, not the text-only aux
+        default (glm-4.5-flash)."""
+        provider, _client, model, calls = self._run_explicit(
+            {
+                "provider": "deepseek",
+                "model": "deepseek-v4",
+                "base_url": "https://api.deepseek.com/v1",
+                "api_key": "ds-key",
+            },
+            read_main_provider="deepseek",
+        )
+
+        assert provider == "zai"
+        assert model == "glm-5v-turbo"
+        assert calls[0]["base_url"] == "https://open.bigmodel.cn/api/paas/v4"
+        assert calls[0]["model"] == "glm-5v-turbo"
+
+    def test_explicit_model_wins_over_endpoint_default(self):
+        """An explicit ``auxiliary.vision.model`` is user intent — keep it
+        even when it differs from the endpoint-aware default."""
+        provider, _client, model, calls = self._run_explicit(
+            {
+                "provider": "zai",
+                "model": "glm-5.3",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "api_key": "zai-runtime-key",
+                "api_mode": "chat_completions",
+            },
+            task_model="glm-5v-turbo",
+        )
+
+        assert provider == "zai"
+        assert model == "glm-5v-turbo"
+        assert calls[0]["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+        assert calls[0]["model"] == "glm-5v-turbo"
+
+
+# ── Fallback logging names the endpoint it degraded to ──────────────────────
+
+
+class TestMainFallbackLogNamesEndpoint:
+    def test_fallback_log_includes_main_endpoint(self, caplog):
+        fake_client = MagicMock(name="main_agent_client")
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="zai"
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="glm-5.3"
+        ), patch(
+            "agent.auxiliary_client._read_main_base_url",
+            return_value="https://api.z.ai/api/coding/paas/v4",
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fake_client, "glm-5.3"),
+        ):
+            from agent.auxiliary_client import _try_main_agent_model_fallback
+
+            with caplog.at_level(logging.INFO, logger="agent.auxiliary_client"):
+                client, model, label = _try_main_agent_model_fallback(
+                    "zai-vision", task="vision", reason="rate limit"
+                )
+
+        assert client is fake_client
+        assert model == "glm-5.3"
+        assert label == "main-agent(zai)"
+        assert "glm-5.3" in caplog.text
+        assert "https://api.z.ai/api/coding/paas/v4" in caplog.text


### PR DESCRIPTION
## Problem

Z.ai users on a **Coding Plan** subscription cannot get working vision routing in either `auto` or explicit-provider mode — both paths silently degrade to the text-only chat model, which rejects the image with `400 code 1210` (`messages.content.type is invalid, allowed values: ['text']`). See #92817.

Two hardcoded assumptions in `agent/auxiliary_client.py` cause this:

1. **`_PROVIDER_VISION_MODELS["zai"] = "glm-5v-turbo"`** — a static, endpoint-blind default. Coding Plan subscriptions do not include glm-5v-turbo (`429 code 1311` — "not in subscription"), so auto mode picks a model the plan can't serve, then falls back to the text-only main model → 1210.
2. **`zai_openai_urls` pins explicit-provider mode to the general API** (`open.bigmodel.cn` / `api.z.ai` `/api/paas/v4`). The general API is billed independently, so a valid Coding Plan key gets `429 code 1113` (insufficient balance) → same fallback → same 1210.

Measured with a real Coding Plan key (issue table): `glm-4.5v` on `https://api.z.ai/api/coding/paas/v4` returns **200 OK** (0.7–4.8 s, correct answers) and is included in the plan — the routing just never sent it there.

## Root cause & fix

A static per-provider default cannot know the caller's billing pool, so this PR moves the Z.ai vision default into the provider directory (the existing `ProviderProfile.default_vision_model()` interface) and makes routing endpoint-aware:

- **`ZaiProfile.default_vision_model(base_url)`** (`plugins/model-providers/zai`) owns the mapping: coding endpoint (`/api/coding/paas/v4`, or the `/api/anthropic` Anthropic wire) → `glm-4.5v`; general API → `glm-5v-turbo`. `ProviderProfile.default_vision_model` gains an optional `base_url` parameter (DeepInfra's hook ignores it); `zai` is removed from the static `_PROVIDER_VISION_MODELS` dict.
- **Auto mode** passes the live main-runtime endpoint to that hook, and — when main is a zai-family provider — reuses the runtime endpoint + key (`/api/anthropic` rewritten to `/api/coding/paas/v4`, `api_mode=chat_completions`) so the vision call lands in the same billing pool as the main model. The endpoint is only ever borrowed when the main provider *is* zai; other providers' runtimes are never touched.
- **Explicit mode** (`auxiliary.vision.provider: zai`, no `base_url`) prepends the derived main-runtime endpoint before the general-API fallback list, and defaults to the endpoint-aware vision model instead of the text-only aux default (`glm-4.5-flash`) — which could only ever fail with 1210. An explicit `auxiliary.vision.model` still wins, and an explicit `auxiliary.vision.base_url` still takes the direct-endpoint branch untouched (the issue's workaround path).
- **Fallback logging** (`_try_main_agent_model_fallback`) now names the endpoint it degraded to, so a plan/billing routing miss no longer presents as a content-type problem.

This is deliberately *not* the static swap of #46054 (which would break general-API users who do have glm-5v-turbo) nor a hardcoded coding-URL prepend with connectivity probes (#55156/#55116) — the runtime endpoint already carries the right answer, so the code reuses it, and the model mapping lives in the provider plugin like DeepInfra's catalog hook.

## Tests

New `tests/agent/test_vision_zai_coding_endpoint_92817.py` (16 tests, real imports, network boundaries mocked):

- profile hook: coding / bigmodel-cn / `/api/anthropic` endpoints → `glm-4.5v`; general / `None` → `glm-5v-turbo`; host-anchored (lookalike hosts and path markers don't trigger).
- auto mode: coding runtime → `glm-4.5v` + runtime endpoint + runtime key + `chat_completions`; general runtime → `glm-5v-turbo` on the live endpoint.
- explicit mode: coding runtime → coding endpoint tried first with `glm-4.5v`; `/api/anthropic` runtime → rewritten to `/api/coding/paas/v4`; non-zai main keeps the general-API list but now uses the vision default instead of `glm-4.5-flash`; explicit model wins.
- fallback log includes the endpoint.

All new tests were **verified to fail on pre-fix code** (sabotage run: fix stashed → 15 failed / 1 passed; fix restored → 16 passed), so they demonstrably bite.

## Verification

- `pytest tests/agent/test_vision_zai_coding_endpoint_92817.py` → **16 passed**
- `pytest tests/agent/test_auxiliary_client.py` → **182 passed**
- `pytest tests/agent/test_auxiliary_main_first.py tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_vision_resolved_args.py tests/agent/test_minimax_auxiliary_url.py tests/plugins/model_providers/test_zai_profile.py` → **90 passed**; 1 pre-existing environment failure (`test_resolve_provider_client_returns_anthropic_client` — the `anthropic` SDK is not installed in the test venv; fails identically without this change)
- `ruff check` on all changed files → clean
- full `tests/agent` sweep (394 files, ~24 min on this Windows box): **4896 passed, 40 skipped, 197 failed**. None of the failures are caused by this change: the vision-adjacent failure (`test_vision_routing_31179.py::test_vision_capable_main_used`, "no Anthropic credentials found") fails identically on pristine `main` (0159b51f2) in a scratch worktree; the other failed families (`test_unsupported_temperature_retry`, codex transports) all pass in isolation on this branch — they are cross-test state pollution in the single-process sweep, plus known environment gaps (no `anthropic` SDK in the venv, Windows npm-path in `tests/agent/lsp`).

## Review follow-up (Enough1122)

All three review points addressed in `6691174`:

1. **Precedence guard (auto mode).** The runtime-reuse block is now `if zai_main_base and rpc_base_url is None:` — an explicit custom vision `base_url` from config (custom-provider branch above it) wins over the runtime-derived Z.ai endpoint, so user-explicit config is never silently clobbered. Comment on the block documents the rule. New adversarial test: `TestVisionAutoCustomPrecedence::test_explicit_custom_vision_base_wins_over_zai_main_runtime` (verified RED pre-fix: the runtime endpoint did overwrite the explicit gateway URL; GREEN post-fix).
2. **Single source of Z.AI host facts.** `agent._is_zai_host_url` now delegates to the registered zai profile's new public `ZaiProfile.is_zai_host_url()`, which derives from the plugin's `_ZAI_HOSTS` — an international endpoint added there is picked up by aux with no second edit. Aux's local host pair remains only as a fallback for contexts where provider plugins are not loaded, and both sites cross-reference each other in comments. Tests: `TestZaiProfileHostCheck` + `TestAuxZaiHostCheckDelegation` (delegation path, lookalike/path-marker rejection, no-profile fallback).
3. **Both hosts' Anthropic-wire rewrite confirmed + now pinned by tests.** `_to_openai_base_url` already mapped both `api.z.ai/api/anthropic` and `open.bigmodel.cn/api/anthropic` to their `/api/coding/paas/v4` sibling (the host check at the top of that branch covers both) — the gap was test coverage, which only exercised api.z.ai. Added: parametrized unit tests `test_zai_anthropic_wire_rewrites_to_coding_openai_wire` (both hosts), passthrough test for OpenAI-wire ZAI URLs, plus auto-mode (`test_bigmodel_coding_runtime_uses_glm45v_on_coding_endpoint`) and explicit-mode (`test_bigmodel_anthropic_wire_runtime_rewritten_to_coding_openai_wire`) bigmodel runtime tests. Byte-identical output verified at runtime.

## Review-fix verification

- `pytest tests/agent/test_vision_zai_coding_endpoint_92817.py tests/agent/test_auxiliary_explicit_base_anthropic.py` → **31 passed** (RED run on pre-fix code: 3 failed / 28 passed — exactly the new precedence + profile-method tests)
- `pytest tests/plugins/model_providers/test_zai_profile.py tests/agent/test_set_runtime_main_custom_provider.py tests/agent/test_minimax_auxiliary_url.py tests/agent/test_auxiliary_named_custom_providers.py tests/run_agent/test_fallback_api_mode_preservation.py` → 83 passed, 2 pre-existing environment failures (anthropic SDK not installed in the test venv — fail identically with the fix stashed)
- `pytest tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py tests/agent/test_vision_resolved_args.py` → 198 passed; 2 pre-existing cross-test pollution failures in `test_auxiliary_main_first` (reproduced identically with the fix stashed); 1 timing-flaky Codex timeout test that passes in isolation
- `ruff check` on all changed files → clean
- Runtime byte-identical checks: `/api/anthropic` rewrites for both hosts and OpenAI-wire passthroughs verified byte-for-byte; precedence scenario verified live (`provider='custom:zai'`, explicit gateway base/key/mode preserved)

Closes #92817
