### PR TITLE
fix(desktop): verify the gateway RPC bridge at backend boot; actionable repair for a dead IPC bridge

### DIFF
--- a/apps/desktop/electron/gateway-rpc-probe.test.ts
+++ b/apps/desktop/electron/gateway-rpc-probe.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for electron/gateway-rpc-probe.ts.
+ *
+ * Run with: vitest run --project electron electron/gateway-rpc-probe.test.ts
+ * (Wired into npm test:desktop:platforms in package.json.)
+ *
+ * The probe drives one JSON-RPC round-trip over a real WebSocket so boot can
+ * tell "the gateway answers requests" from "the upgrade was accepted but the
+ * dispatcher is dead" (#92927: a half-updated backend boots HTTP/WS-reachable
+ * yet renders an empty shell). Here we inject a fake socket to replay each
+ * outcome deterministically.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { probeGatewayRpc } from './gateway-rpc-probe'
+
+// Minimal WebSocket double: records listeners synchronously and exposes emit()
+// plus a sent-frames log so tests can replay the server's side.
+function makeFakeWs(): { FakeWs: new (url: string) => any; instances: any[] } {
+  const instances: any[] = []
+
+  class FakeWs {
+    url: string
+    closed = false
+    sent: string[] = []
+    listeners: Record<string, any[]> = {}
+    constructor(url: string) {
+      this.url = url
+      this.listeners = {}
+      this.closed = false
+      instances.push(this)
+    }
+    addEventListener(type: string, fn: any) {
+      ;(this.listeners[type] ||= []).push(fn)
+    }
+    send(data: string) {
+      this.sent.push(data)
+    }
+    close() {
+      this.closed = true
+    }
+    emit(type: string, event?: any) {
+      for (const fn of this.listeners[type] || []) {
+        fn(event)
+      }
+    }
+  }
+
+  return { FakeWs, instances }
+}
+
+const FAST = { connectTimeoutMs: 1_000, replyTimeoutMs: 1_000 }
+
+function replyWithId(id: string, extra: Record<string, unknown> = {}) {
+  return { data: JSON.stringify({ jsonrpc: '2.0', id, ...extra }) }
+}
+
+test('probe sends one JSON-RPC request on open and resolves on a result with the matching id', async () => {
+  const { FakeWs, instances } = makeFakeWs()
+
+  const promise = probeGatewayRpc('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    method: 'session.list',
+    requestId: 'probe-1'
+  })
+
+  instances[0].emit('open')
+  assert.equal(instances[0].sent.length, 1)
+
+  const sent = JSON.parse(instances[0].sent[0])
+  assert.equal(sent.jsonrpc, '2.0')
+  assert.equal(sent.id, 'probe-1')
+  assert.equal(sent.method, 'session.list')
+
+  instances[0].emit('message', replyWithId('probe-1', { result: { sessions: [] } }))
+  const result = await promise
+  assert.deepEqual(result, { ok: true })
+  assert.equal(instances[0].closed, true)
+})
+
+test('probe resolves ok on a JSON-RPC ERROR reply with the matching id (dispatcher round-trips)', async () => {
+  const { FakeWs, instances } = makeFakeWs()
+  const promise = probeGatewayRpc('ws://host/api/ws?token=t', { WebSocketImpl: FakeWs, requestId: 'probe-1' })
+
+  instances[0].emit('open')
+  // Unknown method on an older gateway: still a real dispatcher reply.
+  instances[0].emit('message', replyWithId('probe-1', { error: { code: -32601, message: 'unknown method' } }))
+  const result = await promise
+  assert.deepEqual(result, { ok: true })
+})
+
+test('probe ignores gateway events and replies to other ids while waiting', async () => {
+  const { FakeWs, instances } = makeFakeWs()
+
+  const promise = probeGatewayRpc('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    requestId: 'probe-1',
+    ...FAST
+  })
+
+  instances[0].emit('open')
+  instances[0].emit('message', { data: JSON.stringify({ method: 'event', params: { type: 'gateway.ready' } }) })
+  instances[0].emit('message', replyWithId('someone-else', { result: {} }))
+  instances[0].emit('message', replyWithId('probe-1', { result: 'pong' }))
+  const result = await promise
+  assert.deepEqual(result, { ok: true })
+})
+
+test('probe does NOT resolve on events or replies whose id does not match — only our round-trip counts', async () => {
+  const { FakeWs, instances } = makeFakeWs()
+
+  const promise = probeGatewayRpc('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    requestId: 'probe-1',
+    ...FAST
+  })
+
+  instances[0].emit('open')
+  // A chatty gateway: ready event + a reply to someone else's request. If the
+  // probe accepted ANY frame it would resolve here and never notice that ITS
+  // request went unanswered — the exact half-broken-backend state #92927 is
+  // about. It must keep waiting and fail when the socket closes unreplied.
+  instances[0].emit('message', { data: JSON.stringify({ method: 'event', params: { type: 'gateway.ready' } }) })
+  instances[0].emit('message', replyWithId('someone-else', { result: {} }))
+  instances[0].emit('close', { code: 1000 })
+  const result = await promise
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /before replying/)
+})
+
+test('probe fails when the gateway closes after open without replying', async () => {
+  const { FakeWs, instances } = makeFakeWs()
+  const promise = probeGatewayRpc('ws://host/api/ws?token=t', { WebSocketImpl: FakeWs, method: 'session.list', ...FAST })
+
+  instances[0].emit('open')
+  instances[0].emit('close', { code: 1006 })
+  const result = await promise
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /before replying to "session.list"/)
+  assert.match(result.reason, /1006/)
+})
+
+test('probe fails on the reply timeout when the upgrade is accepted but no reply ever comes', async () => {
+  const { FakeWs, instances } = makeFakeWs()
+
+  const promise = probeGatewayRpc('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    method: 'session.list',
+    connectTimeoutMs: 1_000,
+    replyTimeoutMs: 20
+  })
+
+  instances[0].emit('open')
+  const result = await promise
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /Timed out after 20ms waiting for a JSON-RPC reply/)
+})
+
+test('probe times out when the socket never opens', async () => {
+  const { FakeWs } = makeFakeWs()
+
+  const result = await probeGatewayRpc('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    connectTimeoutMs: 20,
+    replyTimeoutMs: 1_000
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /Timed out after 20ms waiting for the WebSocket to open/)
+})
+
+test('probe fails gracefully when the constructor throws', async () => {
+  class ThrowingWs {
+    constructor() {
+      throw new Error('boom')
+    }
+  }
+
+  const result = await probeGatewayRpc('ws://host/api/ws?token=t', { WebSocketImpl: ThrowingWs })
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /boom/)
+})
+
+test('probe fails when WebSocket is unavailable in the runtime', async () => {
+  const result = await probeGatewayRpc('ws://host/api/ws?token=t', {})
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /not available/)
+})

--- a/apps/desktop/electron/gateway-rpc-probe.test.ts
+++ b/apps/desktop/electron/gateway-rpc-probe.test.ts
@@ -159,6 +159,27 @@ test('probe fails on the reply timeout when the upgrade is accepted but no reply
   assert.match(result.reason, /Timed out after 20ms waiting for a JSON-RPC reply/)
 })
 
+test('probe disarms the connect timer on open: a reply arriving after the connect timeout has elapsed still counts', async () => {
+  const { FakeWs, instances } = makeFakeWs()
+
+  const promise = probeGatewayRpc('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    requestId: 'probe-1',
+    connectTimeoutMs: 20,
+    replyTimeoutMs: 1_000
+  })
+
+  instances[0].emit('open')
+  // The socket opened well before the connect timeout; the reply is just
+  // slow (startup import storm). The connect timer must be disarmed at
+  // open — otherwise a healthy reply is misreported as "Timed out waiting
+  // for the WebSocket to open" even though the upgrade was accepted.
+  await new Promise(resolve => setTimeout(resolve, 40))
+  instances[0].emit('message', replyWithId('probe-1', { result: { sessions: [] } }))
+  const result = await promise
+  assert.deepEqual(result, { ok: true })
+})
+
 test('probe times out when the socket never opens', async () => {
   const { FakeWs } = makeFakeWs()
 

--- a/apps/desktop/electron/gateway-rpc-probe.test.ts
+++ b/apps/desktop/electron/gateway-rpc-probe.test.ts
@@ -13,9 +13,14 @@
 
 import assert from 'node:assert/strict'
 
-import { test } from 'vitest'
+import { describe, test } from 'vitest'
 
-import { probeGatewayRpc } from './gateway-rpc-probe'
+import {
+  probeGatewayRpc,
+  rpcProbeBootError,
+  RPC_PROBE_FAILED_ERROR_CODE,
+  RPC_PROBE_UNAVAILABLE_ERROR_CODE
+} from './gateway-rpc-probe'
 
 // Minimal WebSocket double: records listeners synchronously and exposes emit()
 // plus a sent-frames log so tests can replay the server's side.
@@ -205,8 +210,51 @@ test('probe fails gracefully when the constructor throws', async () => {
   assert.match(result.reason, /boom/)
 })
 
-test('probe fails when WebSocket is unavailable in the runtime', async () => {
+test('probe fails with a distinct code when WebSocket is unavailable in the runtime', async () => {
   const result = await probeGatewayRpc('ws://host/api/ws?token=t', {})
   assert.equal(result.ok, false)
   assert.match(result.reason, /not available/)
+  // The call sites must be able to tell a CAPABILITY problem from a torn
+  // install — the unavailable case never gets the `hermes update` advice.
+  assert.equal(result.code, 'websocket-unavailable')
+})
+
+describe('rpcProbeBootError (#92927 review: distinct capability message, single-source copy)', () => {
+  test('a missing WebSocket is a capability message with its own code — never torn-install repair advice', () => {
+    const error = rpcProbeBootError('Local Hermes backend', {
+      ok: false,
+      code: 'websocket-unavailable',
+      reason: 'WebSocket is not available in this runtime.'
+    })
+
+    assert.equal(error.code, RPC_PROBE_UNAVAILABLE_ERROR_CODE)
+    assert.match(error.message, /cannot open a WebSocket/)
+    assert.ok(!error.message.includes('interrupted update'))
+    assert.ok(!error.message.includes('force-build'))
+    assert.ok(!error.message.includes('hermes update'))
+  })
+
+  test('a dead dispatcher carries the shared torn-install guidance with the stable failed code', () => {
+    const error = rpcProbeBootError('Hermes backend for profile "default"', {
+      ok: false,
+      reason: 'Timed out after 8000ms waiting for a JSON-RPC reply to "session.list".'
+    })
+
+    assert.equal(error.code, RPC_PROBE_FAILED_ERROR_CODE)
+    assert.match(error.message, /profile "default"/)
+    assert.match(error.message, /JSON-RPC gateway did not answer/)
+    assert.match(error.message, /interrupted update/)
+    assert.match(error.message, /hermes desktop --force-build/)
+  })
+
+  test('both backend labels build byte-identical guidance from the single constant', () => {
+    const pool = rpcProbeBootError('Hermes backend for profile "work"', { ok: false, reason: 'x' })
+    const primary = rpcProbeBootError('Local Hermes backend', { ok: false, reason: 'x' })
+
+    const guidanceOf = (error: Error) =>
+      error.message.slice(error.message.indexOf('The install may be broken'))
+
+    assert.equal(guidanceOf(pool), guidanceOf(primary))
+    assert.match(guidanceOf(pool), /^The install may be broken by an interrupted update/)
+  })
 })

--- a/apps/desktop/electron/gateway-rpc-probe.test.ts
+++ b/apps/desktop/electron/gateway-rpc-probe.test.ts
@@ -17,9 +17,9 @@ import { describe, test } from 'vitest'
 
 import {
   probeGatewayRpc,
-  rpcProbeBootError,
   RPC_PROBE_FAILED_ERROR_CODE,
-  RPC_PROBE_UNAVAILABLE_ERROR_CODE
+  RPC_PROBE_UNAVAILABLE_ERROR_CODE,
+  rpcProbeBootError
 } from './gateway-rpc-probe'
 
 // Minimal WebSocket double: records listeners synchronously and exposes emit()

--- a/apps/desktop/electron/gateway-rpc-probe.ts
+++ b/apps/desktop/electron/gateway-rpc-probe.ts
@@ -144,6 +144,13 @@ function probeGatewayRpc(wsUrl: string, options: GatewayRpcProbeOptions = {}): P
       }
 
       opened = true
+      // The socket opened: the connect deadline has done its job. Disarm it
+      // so a slow reply (or a grace window longer than connectTimeoutMs)
+      // can't be misreported as a connect timeout on an open connection.
+      if (connectTimer !== null) {
+        clearTimeout(connectTimer)
+        connectTimer = null
+      }
       sendRequest()
     }
 

--- a/apps/desktop/electron/gateway-rpc-probe.ts
+++ b/apps/desktop/electron/gateway-rpc-probe.ts
@@ -1,0 +1,228 @@
+/**
+ * JSON-RPC round-trip validation for the desktop's local backend boot.
+ *
+ * `probeGatewayWebSocket` proves the /api/ws upgrade is ACCEPTED — but a
+ * backend left half-updated by an interrupted `hermes update` (Windows venv
+ * lock aborts the swap mid-flight, #92927) can still accept the upgrade while
+ * its JSON-RPC dispatcher is dead. Boot then declares `backend.ready` off
+ * HTTP+WS readiness alone and the renderer boots into a silent shell: empty
+ * BOTS pane, `window.hermesDesktop is undefined` in the served dashboard, no
+ * error surfaced.
+ *
+ * This probe performs the one round-trip the ENTIRE desktop surface depends
+ * on — a JSON-RPC request and a reply carrying our id. The reply may be a
+ * result OR a JSON-RPC error (e.g. -32601 for an unknown method): both prove
+ * the dispatcher processed the request, so this stays valid across older
+ * gateways without depending on any specific method's availability.
+ *
+ * The `WebSocketImpl` is injectable so unit tests can drive the handshake
+ * without a real socket; in production the caller passes the Node/Electron
+ * global `WebSocket`, exactly like gateway-ws-probe.ts.
+ */
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000
+// Generous for a local backend: the first dispatch after spawn can contend
+// with the startup import storm, and this probe's false-positive (failing a
+// healthy boot) is far worse than its false-negative.
+const DEFAULT_REPLY_TIMEOUT_MS = 8_000
+
+// A string id is unambiguous and JSON-RPC servers MUST echo ids verbatim.
+const PROBE_REQUEST_ID = 'desktop-boot-rpc-probe'
+
+export interface GatewayRpcProbeOptions {
+  WebSocketImpl?: any
+  connectTimeoutMs?: number
+  replyTimeoutMs?: number
+  method?: string
+  params?: Record<string, unknown>
+  requestId?: string
+}
+
+interface ProbeResult {
+  ok: boolean
+  reason?: string
+}
+
+/**
+ * Open `wsUrl`, send one JSON-RPC request, and require a reply frame whose
+ * `id` matches ours (result or JSON-RPC error both qualify).
+ */
+function probeGatewayRpc(wsUrl: string, options: GatewayRpcProbeOptions = {}): Promise<ProbeResult> {
+  const WebSocketImpl = options.WebSocketImpl
+  const connectTimeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS
+  const replyTimeoutMs = options.replyTimeoutMs ?? DEFAULT_REPLY_TIMEOUT_MS
+  const method = options.method ?? 'session.list'
+  const params = options.params ?? {}
+  const requestId = options.requestId ?? PROBE_REQUEST_ID
+
+  if (typeof WebSocketImpl !== 'function') {
+    return Promise.resolve({
+      ok: false,
+      reason: 'WebSocket is not available in this runtime.'
+    })
+  }
+
+  return new Promise<ProbeResult>(resolve => {
+    let settled = false
+    let opened = false
+    let connectTimer: ReturnType<typeof setTimeout> | null = null
+    let replyTimer: ReturnType<typeof setTimeout> | null = null
+    let socket: any
+
+    const clearTimers = () => {
+      if (connectTimer !== null) {
+        clearTimeout(connectTimer)
+        connectTimer = null
+      }
+
+      if (replyTimer !== null) {
+        clearTimeout(replyTimer)
+        replyTimer = null
+      }
+    }
+
+    const finish = (result: ProbeResult) => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      clearTimers()
+
+      try {
+        socket?.close?.()
+      } catch {
+        // ignore — best effort teardown
+      }
+
+      resolve(result)
+    }
+
+    try {
+      socket = new WebSocketImpl(wsUrl)
+    } catch (error) {
+      finish({
+        ok: false,
+        reason: error instanceof Error ? error.message : String(error)
+      })
+
+      return
+    }
+
+    const sendRequest = () => {
+      try {
+        socket.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: requestId,
+            method,
+            params
+          })
+        )
+      } catch (error) {
+        finish({
+          ok: false,
+          reason: error instanceof Error ? error.message : String(error)
+        })
+
+        return
+      }
+
+      // The dispatcher's reply (any frame carrying our id) is the whole
+      // contract; nothing else may end the wait.
+      replyTimer = setTimeout(() => {
+        finish({
+          ok: false,
+          reason: `Timed out after ${replyTimeoutMs}ms waiting for a JSON-RPC reply to "${method}".`
+        })
+      }, replyTimeoutMs)
+    }
+
+    const onOpen = () => {
+      if (settled) {
+        return
+      }
+
+      opened = true
+      sendRequest()
+    }
+
+    const onMessage = (event: any) => {
+      if (settled) {
+        return
+      }
+
+      let frame: any
+
+      try {
+        frame = JSON.parse(typeof event?.data === 'string' ? event.data : String(event?.data ?? ''))
+      } catch {
+        return
+      }
+
+      // Events (`gateway.ready`, `session.info`, …) carry no id and replies to
+      // other requests carry someone else's id — neither proves OUR round-trip.
+      if (frame?.id === requestId) {
+        finish({ ok: true })
+      }
+    }
+
+    const onError = (event: any) => {
+      finish({
+        ok: false,
+        reason:
+          (event instanceof Error ? event.message : event?.error?.message || event?.message) ||
+          'WebSocket connection failed.'
+      })
+    }
+
+    const onClose = (event: any) => {
+      if (settled) {
+        return
+      }
+
+      if (opened) {
+        finish({
+          ok: false,
+          reason: `The gateway closed the WebSocket before replying to "${method}" (code ${event?.code ?? 'unknown'}).`
+        })
+
+        return
+      }
+
+      finish({
+        ok: false,
+        reason: 'The gateway closed the WebSocket before it opened.'
+      })
+    }
+
+    addListener(socket, 'open', onOpen)
+    addListener(socket, 'message', onMessage)
+    addListener(socket, 'error', onError)
+    addListener(socket, 'close', onClose)
+
+    if (connectTimeoutMs > 0) {
+      connectTimer = setTimeout(() => {
+        finish({
+          ok: false,
+          reason: `Timed out after ${connectTimeoutMs}ms waiting for the WebSocket to open.`
+        })
+      }, connectTimeoutMs)
+    }
+  })
+}
+
+function addListener(socket: any, type: string, handler: (event: any) => void) {
+  if (typeof socket.addEventListener === 'function') {
+    socket.addEventListener(type, handler)
+
+    return
+  }
+
+  // The `ws` package's EventEmitter shape, same courtesy as gateway-ws-probe.
+  if (typeof socket.on === 'function') {
+    socket.on(type, handler)
+  }
+}
+
+export { DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_REPLY_TIMEOUT_MS, PROBE_REQUEST_ID, probeGatewayRpc }

--- a/apps/desktop/electron/gateway-rpc-probe.ts
+++ b/apps/desktop/electron/gateway-rpc-probe.ts
@@ -41,6 +41,12 @@ export interface GatewayRpcProbeOptions {
 interface ProbeResult {
   ok: boolean
   reason?: string
+  /**
+   * Machine-readable failure class. `websocket-unavailable` marks a
+   * CAPABILITY problem (the runtime has no WebSocket constructor), which must
+   * never be reported as a torn install — see rpcProbeBootError().
+   */
+  code?: 'websocket-unavailable'
 }
 
 /**
@@ -58,6 +64,7 @@ function probeGatewayRpc(wsUrl: string, options: GatewayRpcProbeOptions = {}): P
   if (typeof WebSocketImpl !== 'function') {
     return Promise.resolve({
       ok: false,
+      code: 'websocket-unavailable',
       reason: 'WebSocket is not available in this runtime.'
     })
   }
@@ -232,4 +239,54 @@ function addListener(socket: any, type: string, handler: (event: any) => void) {
   }
 }
 
-export { DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_REPLY_TIMEOUT_MS, PROBE_REQUEST_ID, probeGatewayRpc }
+// Stable failure codes attached to the boot error (and carried to the
+// renderer as DesktopBootProgress.errorCode, see src/global.d.ts) so the
+// recovery overlay can key on the code instead of string-matching the
+// message — the same structured-classification pattern as
+// isCloudBackendDown (#85335).
+export const RPC_PROBE_FAILED_ERROR_CODE = 'gateway.rpc-probe-failed'
+export const RPC_PROBE_UNAVAILABLE_ERROR_CODE = 'gateway.rpc-unavailable'
+
+// SINGLE SOURCE for the repair guidance both local boot paths surface when
+// the backend is reachable but its JSON-RPC dispatcher never answered
+// (#92927: an interrupted `hermes update` can leave the dispatcher dead while
+// HTTP/WS readiness still passes). Both call sites in main.ts build their
+// boot error through rpcProbeBootError() so this copy cannot drift between
+// the pool-spawn boot and the primary boot.
+const TORN_INSTALL_REPAIR_GUIDANCE =
+  'The install may be broken by an interrupted update — repair with: hermes desktop --force-build, or re-run: hermes update'
+
+/**
+ * Build the boot error for a failed gateway RPC probe. One message shape for
+ * every failure (reachable backend, dead dispatcher), except the
+ * `websocket-unavailable` case: a missing WebSocket constructor is a
+ * CAPABILITY problem, not a torn install, so it gets a distinct message and
+ * a distinct stable code — no `hermes update` advice for a problem the
+ * updater cannot fix.
+ */
+export function rpcProbeBootError(backendLabel: string, probe: ProbeResult): Error & { code: string } {
+  if (probe.code === 'websocket-unavailable') {
+    const error = new Error(
+      `${backendLabel} is reachable but this runtime cannot open a WebSocket to verify its JSON-RPC gateway (${probe.reason ?? 'WebSocket is not available in this runtime.'}).`
+    ) as Error & { code: string }
+    error.code = RPC_PROBE_UNAVAILABLE_ERROR_CODE
+
+    return error
+  }
+
+  const error = new Error(
+    `${backendLabel} is reachable but its JSON-RPC gateway did not answer (${probe.reason ?? 'no reply received'}). ` +
+      TORN_INSTALL_REPAIR_GUIDANCE
+  ) as Error & { code: string }
+  error.code = RPC_PROBE_FAILED_ERROR_CODE
+
+  return error
+}
+
+export {
+  DEFAULT_CONNECT_TIMEOUT_MS,
+  DEFAULT_REPLY_TIMEOUT_MS,
+  PROBE_REQUEST_ID,
+  probeGatewayRpc,
+  type ProbeResult
+}

--- a/apps/desktop/electron/gateway-ws-probe.test.ts
+++ b/apps/desktop/electron/gateway-ws-probe.test.ts
@@ -116,6 +116,24 @@ test('probe times out when the socket never opens', async () => {
   assert.match(result.reason, /Timed out/)
 })
 
+test('probe disarms the connect timer on open: the grace window may outlast connectTimeoutMs', async () => {
+  const { FakeWs, instances } = makeFakeWs()
+
+  const promise = probeGatewayWebSocket('ws://host/api/ws?token=t', {
+    WebSocketImpl: FakeWs,
+    connectTimeoutMs: 20,
+    readyGraceMs: 60
+  })
+
+  instances[0].emit('open')
+  // The upgrade was accepted; only the post-upgrade grace window remains.
+  // The connect timer must be disarmed at open — otherwise a slow-but-fine
+  // handshake is misreported as "Timed out waiting for the WebSocket to
+  // open" when the grace window outlasts the connect timeout.
+  const result = await promise
+  assert.deepEqual(result, { ok: true })
+})
+
 test('probe fails gracefully when the constructor throws', async () => {
   class ThrowingWs {
     constructor() {

--- a/apps/desktop/electron/gateway-ws-probe.ts
+++ b/apps/desktop/electron/gateway-ws-probe.ts
@@ -120,6 +120,13 @@ function probeGatewayWebSocket<T>(
       }
 
       opened = true
+      // The socket opened: the connect deadline has done its job. Disarm it
+      // so the post-upgrade grace window (or a slow frame) can't be cut
+      // short by a connect timer that outlives the handshake it guarded.
+      if (connectTimer !== null) {
+        clearTimeout(connectTimer)
+        connectTimer = null
+      }
       // Upgrade accepted. Give the server a brief window to reject the
       // credential post-handshake (early close) before declaring success.
       graceTimer = setTimeout(() => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -201,6 +201,7 @@ import {
 } from './gateway-file-download'
 import { startGatewaysAfterUpdateAbort, stopGatewayBeforeUpdate } from './gateway-stop-before-update'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
+import { probeGatewayRpc } from './gateway-rpc-probe'
 import { registerGitIpc } from './git-ipc'
 import { clearStaleGitLocks } from './gitlock'
 import { readAndConsumeHandoffResult } from './handoff-result'
@@ -12731,6 +12732,20 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
     )
   }
 
+  // #92927: HTTP + WS-token readiness is not enough. A backend left half-updated
+  // by an interrupted `hermes update` (Windows venv lock, updater exit 2) still
+  // accepts the WS upgrade while its JSON-RPC dispatcher is dead — declaring it
+  // ready boots the renderer into a silent empty shell (dead BOTS pane, no
+  // bridge). Require the one round-trip every desktop surface depends on.
+  const rpcProbe = await probeGatewayRpc(wsUrl, { WebSocketImpl: globalThis.WebSocket })
+
+  if (!rpcProbe.ok) {
+    throw new Error(
+      `Hermes backend for profile "${profile}" is reachable but its JSON-RPC gateway did not answer (${rpcProbe.reason}). ` +
+        'The install may be broken by an interrupted update — repair with: hermes desktop --force-build, or re-run: hermes update'
+    )
+  }
+
   return {
     baseUrl,
     mode: 'local',
@@ -13192,6 +13207,20 @@ async function startHermes() {
     if (!wsProbe.ok) {
       throw new Error(
         `Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws) rejected the session token: ${wsProbe.reason}`
+      )
+    }
+
+    // #92927: same degraded-install guard as the pool spawn — a torn update can
+    // leave the backend HTTP/WS-reachable with a dead JSON-RPC dispatcher, and
+    // boot would silently proceed into the empty-shell state the issue reports
+    // (empty BOTS pane, "Desktop IPC bridge is unavailable"). Require one RPC
+    // round-trip so this boot fails into the recovery overlay instead.
+    const rpcProbe = await probeGatewayRpc(wsUrl, { WebSocketImpl: globalThis.WebSocket })
+
+    if (!rpcProbe.ok) {
+      throw new Error(
+        `Local Hermes backend is reachable but its JSON-RPC gateway did not answer (${rpcProbe.reason}). ` +
+          'The install may be broken by an interrupted update — repair with: hermes desktop --force-build, or re-run: hermes update'
       )
     }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -201,7 +201,7 @@ import {
 } from './gateway-file-download'
 import { startGatewaysAfterUpdateAbort, stopGatewayBeforeUpdate } from './gateway-stop-before-update'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
-import { probeGatewayRpc } from './gateway-rpc-probe'
+import { probeGatewayRpc, rpcProbeBootError } from './gateway-rpc-probe'
 import { registerGitIpc } from './git-ipc'
 import { clearStaleGitLocks } from './gitlock'
 import { readAndConsumeHandoffResult } from './handoff-result'
@@ -1665,6 +1665,9 @@ let nativeThemeListenerInstalled = false
 
 let bootProgressState = {
   error: null,
+  // Stable failure code (see DesktopBootProgress.errorCode); null until a
+  // classified failure publishes one.
+  errorCode: null,
   fakeMode: BOOT_FAKE_MODE,
   isCloudBackendDown: false,
   message: 'Waiting to start Hermes backend',
@@ -2236,6 +2239,9 @@ function updateBootProgress(update, options: { allowDecrease?: boolean } = {}) {
     ...bootProgressState,
     ...update,
     error: update.error === undefined ? bootProgressState.error : update.error,
+    // Rides with `error` exactly like `retryable` below: preserved by updates
+    // that don't carry it, cleared by updates that pass an explicit value.
+    errorCode: update.errorCode === undefined ? bootProgressState.errorCode : update.errorCode,
     fakeMode: BOOT_FAKE_MODE || Boolean(update.fakeMode),
     progress: nextProgress,
     // `retryable` rides with `error`: it survives updates that preserve the
@@ -2260,7 +2266,9 @@ async function advanceBootProgress(phase, message, progress) {
     message,
     progress,
     running: true,
-    error: null
+    error: null,
+    // Clear the failure code alongside the error so a new attempt starts clean.
+    errorCode: null
   })
 
   if (BOOT_FAKE_MODE) {
@@ -12740,10 +12748,10 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   const rpcProbe = await probeGatewayRpc(wsUrl, { WebSocketImpl: globalThis.WebSocket })
 
   if (!rpcProbe.ok) {
-    throw new Error(
-      `Hermes backend for profile "${profile}" is reachable but its JSON-RPC gateway did not answer (${rpcProbe.reason}). ` +
-        'The install may be broken by an interrupted update — repair with: hermes desktop --force-build, or re-run: hermes update'
-    )
+    // Single-source error builder (gateway-rpc-probe.ts): the torn-install
+    // guidance lives in one place for both boots, and the unavailable-runtime
+    // case gets a distinct capability message instead of repair advice.
+    throw rpcProbeBootError(`Hermes backend for profile "${profile}"`, rpcProbe)
   }
 
   return {
@@ -13218,10 +13226,8 @@ async function startHermes() {
     const rpcProbe = await probeGatewayRpc(wsUrl, { WebSocketImpl: globalThis.WebSocket })
 
     if (!rpcProbe.ok) {
-      throw new Error(
-        `Local Hermes backend is reachable but its JSON-RPC gateway did not answer (${rpcProbe.reason}). ` +
-          'The install may be broken by an interrupted update — repair with: hermes desktop --force-build, or re-run: hermes update'
-      )
+      // Same single-source error builder as the pool spawn above.
+      throw rpcProbeBootError('Local Hermes backend', rpcProbe)
     }
 
     updateBootProgress({
@@ -13275,6 +13281,12 @@ async function startHermes() {
     // only consumes the structured result (#85335).
     const isCloudBackendDown = Boolean(error && typeof error === 'object' && (error as any).isCloudBackendDown === true)
 
+    // Same structured-classification pattern for the gateway RPC probe
+    // (#92927): rpcProbeBootError attaches a stable code, which the overlay
+    // keys on for the localized repair guidance.
+    const errorCode =
+      error && typeof error === 'object' && typeof (error as any).code === 'string' ? (error as any).code : undefined
+
     const statusCode = Number(
       error && typeof error === 'object' && Number.isInteger((error as any).statusCode)
         ? (error as any).statusCode
@@ -13309,6 +13321,7 @@ async function startHermes() {
     updateBootProgress(
       {
         error: message,
+        errorCode,
         isCloudBackendDown: isCloudBackendDown || undefined,
         message: `Desktop boot failed: ${message}`,
         phase: 'backend.error',

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -199,9 +199,9 @@ import {
   resolveGatewayFileBackend,
   writeBufferToFile
 } from './gateway-file-download'
+import { probeGatewayRpc, rpcProbeBootError } from './gateway-rpc-probe'
 import { startGatewaysAfterUpdateAbort, stopGatewayBeforeUpdate } from './gateway-stop-before-update'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
-import { probeGatewayRpc, rpcProbeBootError } from './gateway-rpc-probe'
 import { registerGitIpc } from './git-ipc'
 import { clearStaleGitLocks } from './gitlock'
 import { readAndConsumeHandoffResult } from './handoff-result'

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -1784,3 +1784,67 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect($gatewayState.get()).toBe('open')
   })
 })
+
+describe('useGatewayBoot dead IPC bridge (#92927)', () => {
+  const RETRY_KEY = 'hermes.desktop.ipc-bridge-reload-attempt'
+
+  function removeBridge() {
+    delete (window as { hermesDesktop?: unknown }).hermesDesktop
+  }
+
+  function stubReload() {
+    const reload = vi.fn()
+    // jsdom's Location#reload is non-configurable, so shadow window.location
+    // itself instead of redefining the method.
+    const location = { ...window.location, reload }
+    Object.defineProperty(window, 'location', { configurable: true, value: location })
+
+    return reload
+  }
+
+  beforeEach(() => {
+    window.localStorage.removeItem(RETRY_KEY)
+  })
+
+  it('re-arms the bridge once with a reload when window.hermesDesktop never loaded', async () => {
+    removeBridge()
+    const reload = stubReload()
+
+    render(<Harness />)
+    await flushAsync()
+
+    // One bounded re-arm attempt — the only lever a bridgeless renderer has —
+    // then stop: no boot error yet, the reload will re-run preload.
+    expect(reload).toHaveBeenCalledTimes(1)
+    expect(window.localStorage.getItem(RETRY_KEY)).toBe('1')
+    expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('fails boot with the ipc-bridge kind when the reload re-arm was already spent', async () => {
+    window.localStorage.setItem(RETRY_KEY, '1')
+    removeBridge()
+    const reload = stubReload()
+
+    render(<Harness />)
+    await flushAsync()
+
+    // Second consecutive dead bridge: terminal, surfaced as the distinct
+    // ipc-bridge failure so the recovery overlay can show repair copy instead
+    // of bridge-dependent dead-end buttons.
+    expect(reload).not.toHaveBeenCalled()
+    expect($desktopBoot.get().error).toContain('IPC bridge')
+    expect($desktopBoot.get().errorKind).toBe('ipc-bridge')
+  })
+
+  it('clears the re-arm ledger once a boot completes with the bridge armed', async () => {
+    window.localStorage.setItem(RETRY_KEY, '1')
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop()
+
+    render(<Harness />)
+    await flushAsync()
+    await advanceBackoff()
+
+    expect($desktopBoot.get().error).toBeNull()
+    expect(window.localStorage.getItem(RETRY_KEY)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -144,6 +144,19 @@ export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'c
 // so the first dead boot re-arms once via reload; a second consecutive dead
 // boot is terminal and surfaces the ipc-bridge failure kind. The key is
 // cleared as soon as any boot runs with the bridge present.
+//
+// Ledger scoping: `localStorage` is shared per-origin, so every renderer
+// window reads the SAME key — two windows booting concurrently against a
+// dead bridge share this ledger, and the second one can observe the first's
+// spent re-arm and go straight to the terminal failure without spending a
+// reload of its own. That is deliberate rather than a race to fix: the
+// desktop boots a single window (helper windows only open after the primary
+// boot has a live bridge), both windows run the same bundle/preload against
+// the same backend, and the terminal overlay's Retry IS a plain reload — so
+// a window that lands terminal still has a one-click path to the re-arm. We
+// deliberately keep the ledger in localStorage (not sessionStorage or a
+// per-window key) so it survives app restarts: a persistently torn bundle
+// must not be made to waste a reload on every launch.
 export const IPC_BRIDGE_RELOAD_ATTEMPT_KEY = 'hermes.desktop.ipc-bridge-reload-attempt'
 
 interface GatewayBootOptions {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -137,6 +137,15 @@ export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'c
   return connection.mode === 'local' ? 'local' : null
 }
 
+// Ledger key for the bounded dead-bridge re-arm (#92927). An interrupted
+// `hermes update` can leave the app bundle torn so the preload never arms:
+// `window.hermesDesktop` is undefined and the renderer has no IPC bridge.
+// The ONLY lever a bridgeless renderer has is a reload (it re-runs preload),
+// so the first dead boot re-arms once via reload; a second consecutive dead
+// boot is terminal and surfaces the ipc-bridge failure kind. The key is
+// cleared as soon as any boot runs with the bridge present.
+export const IPC_BRIDGE_RELOAD_ATTEMPT_KEY = 'hermes.desktop.ipc-bridge-reload-attempt'
+
 interface GatewayBootOptions {
   beforeConnectionSwitch: () => void
   handleGatewayEvent: (event: RpcEvent) => void
@@ -193,7 +202,22 @@ export function useGatewayBoot({
     }
 
     if (!desktop) {
-      failDesktopBoot('Desktop IPC bridge is unavailable.')
+      // #92927: a torn bundle (interrupted update) leaves preload un-armed, so
+      // the IPC bridge never binds. Re-arm once via reload — the only lever a
+      // bridgeless renderer has; a second consecutive dead boot is terminal
+      // and the overlay surfaces the actionable repair copy.
+      try {
+        if (!window.localStorage.getItem(IPC_BRIDGE_RELOAD_ATTEMPT_KEY)) {
+          window.localStorage.setItem(IPC_BRIDGE_RELOAD_ATTEMPT_KEY, '1')
+          window.location.reload()
+
+          return () => void (cancelled = true)
+        }
+      } catch {
+        // Storage or reload unavailable — fall through to the terminal failure.
+      }
+
+      failDesktopBoot(translateNow('boot.errors.ipcBridgeUnavailable'), 'ipc-bridge')
       setSessionsLoading(false)
 
       return () => void (cancelled = true)
@@ -207,6 +231,14 @@ export function useGatewayBoot({
       beforeConnectionSwitch: () => callbacksRef.current.beforeConnectionSwitch(),
       refreshSessions: shouldPublish => callbacksRef.current.refreshSessions(shouldPublish)
     })
+
+    // The bridge armed for this boot: any previous dead-bridge episode is
+    // resolved, so the one-shot re-arm ledger is spent and can be dropped.
+    try {
+      window.localStorage.removeItem(IPC_BRIDGE_RELOAD_ATTEMPT_KEY)
+    } catch {
+      // Storage unavailable — nothing to clear.
+    }
 
     // --- Reconnect-after-sleep machinery -------------------------------------
     // macOS sleep silently drops the renderer's WebSocket. The backend Python

--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -89,17 +89,26 @@ async function renderMessaging() {
 }
 
 describe('MessagingView profile scope', () => {
-  it('follows the active profile instead of targeting primary when there is no override', async () => {
-    const { $settingsScopeOverride } = await import('@/store/settings-scope')
+  // First test in the file pays jsdom env init + the settings-scope/index module
+  // transform, which tripped vitest's 15s testTimeout under CI load (2026-09-07,
+  // run 34150907291). The widen deadline absorbs the cold start; the body itself
+  // is still synchronous after the dynamic imports resolve. Same pattern as
+  // store/session-unread-tile.test.ts's cold-start budget.
+  it(
+    'follows the active profile instead of targeting primary when there is no override',
+    { timeout: 30_000 },
+    async () => {
+      const { $settingsScopeOverride } = await import('@/store/settings-scope')
 
-    $settingsScopeOverride.set(null)
-    getMessagingPlatforms.mockResolvedValue({ platforms: [platform()] })
+      $settingsScopeOverride.set(null)
+      getMessagingPlatforms.mockResolvedValue({ platforms: [platform()] })
 
-    await renderMessaging()
+      await renderMessaging()
 
-    await waitFor(() => expect(getMessagingPlatforms).toHaveBeenCalledWith(undefined))
-    expect(getPairing).toHaveBeenCalledWith(undefined)
-  })
+      await waitFor(() => expect(getMessagingPlatforms).toHaveBeenCalledWith(undefined))
+      expect(getPairing).toHaveBeenCalledWith(undefined)
+    }
+  )
 })
 
 describe('MessagingView setup-guide link', () => {

--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -255,4 +255,59 @@ describe('BootFailureOverlay', () => {
     expect(screen.queryByRole('button', { name: /gateway settings/i })).toBeNull()
     expect(screen.queryByRole('button', { name: /open logs/i })).toBeNull()
   })
+
+  it('rpc-probe failure (#92927): keys the torn-install hint on the stable errorCode', () => {
+    $desktopBoot.set({
+      error: 'Local Hermes backend is reachable but its JSON-RPC gateway did not answer (Timed out after 8000ms waiting for a JSON-RPC reply to "session.list".).',
+      errorCode: 'gateway.rpc-probe-failed',
+      fakeMode: false,
+      message: 'boot failed',
+      phase: 'renderer.error',
+      progress: 40,
+      running: false,
+      timestamp: Date.now(),
+      visible: true
+    })
+
+    render(<BootFailureOverlay />)
+
+    // The localized torn-install guidance replaces the generic repair hint,
+    // keyed on the stable code (not string-matching the message).
+    expect(screen.getByText(/repair it from a terminal/i)).toBeTruthy()
+    expect(screen.getByText(/hermes desktop --force-build/i)).toBeTruthy()
+    // The bridge is alive here, so the full local recovery set stays.
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /repair install/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /gateway settings/i })).toBeTruthy()
+  })
+
+  it('rpc-probe unavailable (#92927): keys the capability hint on the stable errorCode', () => {
+    $desktopBoot.set({
+      error: 'Local Hermes backend is reachable but this runtime cannot open a WebSocket to verify its JSON-RPC gateway.',
+      errorCode: 'gateway.rpc-unavailable',
+      fakeMode: false,
+      message: 'boot failed',
+      phase: 'renderer.error',
+      progress: 40,
+      running: false,
+      timestamp: Date.now(),
+      visible: true
+    })
+
+    render(<BootFailureOverlay />)
+
+    // A capability problem, not a broken install: the hint says so, and the
+    // torn-install repair commands must NOT appear.
+    expect(screen.getByText(/missing WebSocket support/i)).toBeTruthy()
+    expect(screen.queryByText(/hermes desktop --force-build/i)).toBeNull()
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy()
+  })
+
+  it('a generic local failure without an errorCode keeps the generic repair hint', () => {
+    render(<BootFailureOverlay />)
+
+    expect(screen.getByText(/re-runs the installer/i)).toBeTruthy()
+    expect(screen.queryByText(/repair it from a terminal/i)).toBeNull()
+    expect(screen.queryByText(/missing WebSocket support/i)).toBeNull()
+  })
 })

--- a/apps/desktop/src/components/boot-failure-overlay.test.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.test.tsx
@@ -227,4 +227,32 @@ describe('BootFailureOverlay', () => {
       restore()
     }
   })
+
+  it('ipc-bridge failure (#92927): honest repair copy, no bridge-dependent dead-end actions', () => {
+    $desktopBoot.set({
+      error: 'Desktop IPC bridge is unavailable.',
+      errorKind: 'ipc-bridge',
+      fakeMode: false,
+      message: 'boot failed',
+      phase: 'renderer.error',
+      progress: 6,
+      running: false,
+      timestamp: Date.now(),
+      visible: true
+    })
+
+    render(<BootFailureOverlay />)
+
+    // The ipc-specific title and repair guidance replace the generic
+    // "background gateway didn't come up" copy.
+    expect(screen.getByRole('heading', { name: /Desktop IPC bridge is unavailable/i })).toBeTruthy()
+    expect(screen.getByText(/hermes desktop --force-build/i)).toBeTruthy()
+    // Reload is the only action that works without the bridge; Repair,
+    // Gateway settings and Open logs all round-trip through
+    // window.hermesDesktop and would be silent no-ops here.
+    expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /repair/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /gateway settings/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /open logs/i })).toBeNull()
+  })
 })

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -288,6 +288,16 @@ export function BootFailureOverlay() {
   // that works bridgeless) and say what actually repairs the install.
   const ipcBridgeDown = boot.errorKind === 'ipc-bridge'
 
+  // A reachable backend whose JSON-RPC dispatcher never answered (#92927) —
+  // or a runtime that cannot open the verifying WebSocket. main classifies
+  // these and attaches a stable code (see DesktopBootProgress.errorCode), so
+  // the overlay keys on the code instead of string-matching the message —
+  // the same pattern as isCloudBackendDown. Both are local failures: the
+  // full local recovery set stays, only the hint carries the specific
+  // localized guidance.
+  const rpcProbeFailed = boot.errorCode === 'gateway.rpc-probe-failed'
+  const rpcProbeUnavailable = boot.errorCode === 'gateway.rpc-unavailable'
+
   if (ipcBridgeDown) {
     actions = [retryAction]
     hint = copy.ipcBridgeHint
@@ -347,7 +357,7 @@ export function BootFailureOverlay() {
       },
       { ...settingsAction, variant: 'ghost' }
     ]
-    hint = copy.repairHint
+    hint = rpcProbeFailed ? copy.rpcProbeFailedHint : rpcProbeUnavailable ? copy.rpcProbeUnavailableHint : copy.repairHint
   }
 
   if (view === 'connect') {

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -281,7 +281,17 @@ export function BootFailureOverlay() {
   // guidance instead of the generic remote-failure copy (#85335).
   const cloudDown = Boolean(boot.isCloudBackendDown)
 
-  if (remoteReauth) {
+  // A dead IPC bridge (#92927: preload never armed after a torn update) makes
+  // every recovery action that round-trips through window.hermesDesktop a
+  // silent no-op — Repair, Gateway settings, Open logs. The overlay must not
+  // offer dead ends: keep only Retry (a plain window reload, the one action
+  // that works bridgeless) and say what actually repairs the install.
+  const ipcBridgeDown = boot.errorKind === 'ipc-bridge'
+
+  if (ipcBridgeDown) {
+    actions = [retryAction]
+    hint = copy.ipcBridgeHint
+  } else if (remoteReauth) {
     actions = [
       {
         key: 'signin',
@@ -381,10 +391,22 @@ export function BootFailureOverlay() {
           <ErrorIcon className="mt-0.5" size="1.25rem" />
           <div>
             <h2 className="text-[0.9375rem] font-semibold tracking-tight">
-              {remoteReauth ? copy.remoteTitle : cloudDown ? copy.cloudDownTitle : copy.title}
+              {ipcBridgeDown
+                ? copy.ipcBridgeTitle
+                : remoteReauth
+                  ? copy.remoteTitle
+                  : cloudDown
+                    ? copy.cloudDownTitle
+                    : copy.title}
             </h2>
             <p className="mt-1 text-[0.8125rem] leading-5 text-(--ui-text-tertiary)">
-              {remoteReauth ? copy.remoteDescription : cloudDown ? copy.cloudDownDescription : copy.description}
+              {ipcBridgeDown
+                ? copy.ipcBridgeDescription
+                : remoteReauth
+                  ? copy.remoteDescription
+                  : cloudDown
+                    ? copy.cloudDownDescription
+                    : copy.description}
             </p>
           </div>
         </div>
@@ -402,10 +424,12 @@ export function BootFailureOverlay() {
                   {action.label}
                 </Button>
               ))}
-              <Button onClick={openLogs} variant="ghost">
-                <FileText />
-                {copy.openLogs}
-              </Button>
+              {ipcBridgeDown ? null : (
+                <Button onClick={openLogs} variant="ghost">
+                  <FileText />
+                  {copy.openLogs}
+                </Button>
+              )}
             </div>
             <p className="text-xs text-muted-foreground">{hint}</p>
           </div>

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1123,6 +1123,15 @@ export interface DesktopCloudAgentSignInResult {
 
 export interface DesktopBootProgress {
   error: string | null
+  /**
+   * Stable machine-readable failure code carried by `error` (main-process
+   * classification; see electron/gateway-rpc-probe.ts). 'gateway.rpc-probe-failed'
+   * = the backend is reachable but its JSON-RPC dispatcher never answered
+   * (usually a torn update, #92927); 'gateway.rpc-unavailable' = the runtime
+   * cannot open a WebSocket to verify it (a capability problem, not a broken
+   * install). Absent for renderer-side failures and legacy errors.
+   */
+  errorCode?: string | null
   fakeMode: boolean
   /** True when the boot failure is a Nous Cloud agent that is down (HTTP 502/503/504). */
   isCloudBackendDown?: boolean

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -155,6 +155,10 @@ export const ar = defineLocale({
         'فشل تحميل جسر IPC لسطح المكتب — عادةً ما تكون حزمة التطبيق تالفة بسبب تحديث متقطع. أعد تشغيل Hermes؛ وإن استمر ذلك، فأصلح التثبيت.',
       ipcBridgeHint:
         'أعد تشغيل Hermes (إعادة المحاولة تعيد تحميل النافذة). إذا ظل الجسر غير متاح، فأصلح التثبيت من الطرفية: شغّل hermes desktop --force-build أو أعد تشغيل hermes update.',
+      rpcProbeFailedHint:
+        'قد يكون التثبيت تالفًا بسبب تحديث متقطع — أصلحه من الطرفية: شغّل hermes desktop --force-build أو أعد تشغيل hermes update.',
+      rpcProbeUnavailableHint:
+        'لا يمكن لبيئة التشغيل هذه فتح WebSocket للتحقق من الخادم الخلفي. أعد تشغيل Hermes؛ إذا استمرت المشكلة، فإن بيئة التشغيل تفتقر إلى دعم WebSocket.',
       remoteSignInHint: signInLabel =>
         `يسجّل الخروج من جلسة المتصفح البعيدة المحفوظة، ثم يفتح ${signInLabel}. استخدم البوابة المحلية للتبديل إلى الخلفية المضمنة.`,
       signOutAndSignIn: 'تسجيل الخروج وإعادة تسجيل الدخول',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -150,6 +150,11 @@ export const ar = defineLocale({
       cloudDownDiscord: 'الحصول على مساعدة عبر Discord',
       openLogs: 'فتح السجلات',
       repairHint: 'يعيد الإصلاح تشغيل المثبت وقد يستغرق بضع دقائق على جهاز جديد.',
+      ipcBridgeTitle: 'جسر IPC لسطح المكتب غير متاح',
+      ipcBridgeDescription:
+        'فشل تحميل جسر IPC لسطح المكتب — عادةً ما تكون حزمة التطبيق تالفة بسبب تحديث متقطع. أعد تشغيل Hermes؛ وإن استمر ذلك، فأصلح التثبيت.',
+      ipcBridgeHint:
+        'أعد تشغيل Hermes (إعادة المحاولة تعيد تحميل النافذة). إذا ظل الجسر غير متاح، فأصلح التثبيت من الطرفية: شغّل hermes desktop --force-build أو أعد تشغيل hermes update.',
       remoteSignInHint: signInLabel =>
         `يسجّل الخروج من جلسة المتصفح البعيدة المحفوظة، ثم يفتح ${signInLabel}. استخدم البوابة المحلية للتبديل إلى الخلفية المضمنة.`,
       signOutAndSignIn: 'تسجيل الخروج وإعادة تسجيل الدخول',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -139,6 +139,10 @@ export const en: Translations = {
         "The desktop's IPC bridge failed to load — usually the app bundle was left torn by an interrupted update. Restart Hermes; if it persists, repair the install.",
       ipcBridgeHint:
         'Restart Hermes (Retry reloads the window). If the bridge is still unavailable, repair the install from a terminal: run hermes desktop --force-build, or re-run hermes update.',
+      rpcProbeFailedHint:
+        'The install may be broken by an interrupted update — repair it from a terminal: run hermes desktop --force-build, or re-run hermes update.',
+      rpcProbeUnavailableHint:
+        'This runtime cannot open a WebSocket to verify the backend. Restart Hermes; if it persists, the runtime is missing WebSocket support.',
       remoteSignInHint: signInLabel =>
         `Signs out of the saved remote browser session, then opens ${signInLabel}. Use local gateway to switch to the bundled backend instead.`,
       signOutAndSignIn: 'Sign out & sign in',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -134,6 +134,11 @@ export const en: Translations = {
       back: 'Back',
       openLogs: 'Open logs',
       repairHint: 'Repair re-runs the installer and can take a few minutes on a fresh machine.',
+      ipcBridgeTitle: 'Desktop IPC bridge is unavailable',
+      ipcBridgeDescription:
+        "The desktop's IPC bridge failed to load — usually the app bundle was left torn by an interrupted update. Restart Hermes; if it persists, repair the install.",
+      ipcBridgeHint:
+        'Restart Hermes (Retry reloads the window). If the bridge is still unavailable, repair the install from a terminal: run hermes desktop --force-build, or re-run hermes update.',
       remoteSignInHint: signInLabel =>
         `Signs out of the saved remote browser session, then opens ${signInLabel}. Use local gateway to switch to the bundled backend instead.`,
       signOutAndSignIn: 'Sign out & sign in',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -133,6 +133,11 @@ export const ja = defineLocale({
       back: '戻る',
       openLogs: 'ログを開く',
       repairHint: '修復はインストーラーを再実行します。新しいマシンでは数分かかる場合があります。',
+      ipcBridgeTitle: 'デスクトップIPCブリッジを利用できません',
+      ipcBridgeDescription:
+        'デスクトップのIPCブリッジを読み込めませんでした。通常は、中断された更新によりアプリバンドルが破損しています。Hermesを再起動してください。それでも解決しない場合は、インストールを修復してください。',
+      ipcBridgeHint:
+        'Hermesを再起動してください（再試行でウィンドウを再読み込みします）。それでもブリッジを利用できない場合は、ターミナルから修復してください：hermes desktop --force-build を実行するか、hermes update を再実行します。',
       remoteSignInHint: signInLabel =>
         `保存済みのリモートブラウザセッションからサインアウトし、${signInLabel}を開きます。代わりにバンドルされたバックエンドに切り替えるには「ローカルゲートウェイを使用」を選択してください。`,
       signOutAndSignIn: 'サインアウトして再サインイン',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -138,6 +138,10 @@ export const ja = defineLocale({
         'デスクトップのIPCブリッジを読み込めませんでした。通常は、中断された更新によりアプリバンドルが破損しています。Hermesを再起動してください。それでも解決しない場合は、インストールを修復してください。',
       ipcBridgeHint:
         'Hermesを再起動してください（再試行でウィンドウを再読み込みします）。それでもブリッジを利用できない場合は、ターミナルから修復してください：hermes desktop --force-build を実行するか、hermes update を再実行します。',
+      rpcProbeFailedHint:
+        'インストールが中断された更新で壊れている可能性があります——ターミナルから修復してください：hermes desktop --force-build を実行するか、hermes update を再実行してください。',
+      rpcProbeUnavailableHint:
+        'このランタイムはバックエンドを検証するための WebSocket を開けません。Hermes を再起動してください。それでも続く場合は、ランタイムに WebSocket サポートがありません。',
       remoteSignInHint: signInLabel =>
         `保存済みのリモートブラウザセッションからサインアウトし、${signInLabel}を開きます。代わりにバンドルされたバックエンドに切り替えるには「ローカルゲートウェイを使用」を選択してください。`,
       signOutAndSignIn: 'サインアウトして再サインイン',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -178,6 +178,9 @@ export interface Translations {
       back: string
       openLogs: string
       repairHint: string
+      ipcBridgeTitle: string
+      ipcBridgeDescription: string
+      ipcBridgeHint: string
       remoteSignInHint: (signInLabel: string) => string
       signOutAndSignIn: string
       remoteFailureHint: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -181,6 +181,8 @@ export interface Translations {
       ipcBridgeTitle: string
       ipcBridgeDescription: string
       ipcBridgeHint: string
+      rpcProbeFailedHint: string
+      rpcProbeUnavailableHint: string
       remoteSignInHint: (signInLabel: string) => string
       signOutAndSignIn: string
       remoteFailureHint: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -134,6 +134,8 @@ export const zhHant = defineLocale({
       ipcBridgeTitle: '桌面 IPC 橋接不可用',
       ipcBridgeDescription: '桌面 IPC 橋接載入失敗——通常是中斷的更新導致應用程式套件損壞。請重新啟動 Hermes；若仍失敗，請修復安裝。',
       ipcBridgeHint: '重新啟動 Hermes（重試會重新載入視窗）。若橋接仍不可用，請在終端機中修復安裝：執行 hermes desktop --force-build，或重新執行 hermes update。',
+      rpcProbeFailedHint: '安裝可能因更新中斷而損壞——請在終端機中修復：執行 hermes desktop --force-build，或重新執行 hermes update。',
+      rpcProbeUnavailableHint: '目前執行環境無法開啟 WebSocket 以驗證後端。請重新啟動 Hermes；若問題持續，表示執行環境缺少 WebSocket 支援。',
       remoteSignInHint: signInLabel =>
         `先登出已儲存的遠端瀏覽器工作階段，然後開啟${signInLabel}。使用本機閘道可切換至內建後端。`,
       signOutAndSignIn: '登出並重新登入',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -131,6 +131,9 @@ export const zhHant = defineLocale({
       back: '返回',
       openLogs: '開啟記錄',
       repairHint: '修復會重新執行安裝程式，在新機器上可能需要幾分鐘。',
+      ipcBridgeTitle: '桌面 IPC 橋接不可用',
+      ipcBridgeDescription: '桌面 IPC 橋接載入失敗——通常是中斷的更新導致應用程式套件損壞。請重新啟動 Hermes；若仍失敗，請修復安裝。',
+      ipcBridgeHint: '重新啟動 Hermes（重試會重新載入視窗）。若橋接仍不可用，請在終端機中修復安裝：執行 hermes desktop --force-build，或重新執行 hermes update。',
       remoteSignInHint: signInLabel =>
         `先登出已儲存的遠端瀏覽器工作階段，然後開啟${signInLabel}。使用本機閘道可切換至內建後端。`,
       signOutAndSignIn: '登出並重新登入',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -131,6 +131,9 @@ export const zh: Translations = {
       back: '返回',
       openLogs: '打开日志',
       repairHint: '修复会重新运行安装器，在新机器上可能需要几分钟。',
+      ipcBridgeTitle: '桌面 IPC 桥接不可用',
+      ipcBridgeDescription: '桌面 IPC 桥接加载失败——通常是因为中断的更新导致应用包损坏。请重启 Hermes；若仍失败，请修复安装。',
+      ipcBridgeHint: '重启 Hermes（重试会重新加载窗口）。若桥接仍不可用，请在终端中修复安装：运行 hermes desktop --force-build，或重新运行 hermes update。',
       remoteSignInHint: signInLabel =>
         `先退出已保存的远程浏览器会话，然后打开${signInLabel}。也可以使用本地网关切换到随应用提供的后端。`,
       signOutAndSignIn: '退出并重新登录',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -134,6 +134,8 @@ export const zh: Translations = {
       ipcBridgeTitle: '桌面 IPC 桥接不可用',
       ipcBridgeDescription: '桌面 IPC 桥接加载失败——通常是因为中断的更新导致应用包损坏。请重启 Hermes；若仍失败，请修复安装。',
       ipcBridgeHint: '重启 Hermes（重试会重新加载窗口）。若桥接仍不可用，请在终端中修复安装：运行 hermes desktop --force-build，或重新运行 hermes update。',
+      rpcProbeFailedHint: '安装可能因更新中断而损坏——请在终端中修复：运行 hermes desktop --force-build，或重新运行 hermes update。',
+      rpcProbeUnavailableHint: '当前运行时无法打开 WebSocket 以验证后端。请重启 Hermes；若问题持续，说明运行时缺少 WebSocket 支持。',
       remoteSignInHint: signInLabel =>
         `先退出已保存的远程浏览器会话，然后打开${signInLabel}。也可以使用本地网关切换到随应用提供的后端。`,
       signOutAndSignIn: '退出并重新登录',

--- a/apps/desktop/src/store/boot.test.ts
+++ b/apps/desktop/src/store/boot.test.ts
@@ -13,6 +13,83 @@ import {
 // bridge-dependent dead ends (Repair / Settings / Open logs all round-trip
 // through window.hermesDesktop) and instead show the actionable repair copy.
 
+describe('boot store errorCode (#92927)', () => {
+  it('applyDesktopBootProgress carries the stable main-process errorCode', () => {
+    applyDesktopBootProgress({
+      error: 'Local Hermes backend is reachable but its JSON-RPC gateway did not answer.',
+      errorCode: 'gateway.rpc-probe-failed',
+      fakeMode: false,
+      message: 'Desktop boot failed',
+      phase: 'backend.error',
+      progress: 90,
+      running: false,
+      timestamp: Date.now()
+    })
+
+    expect($desktopBoot.get().errorCode).toBe('gateway.rpc-probe-failed')
+  })
+
+  it('a running progress update cannot clobber a latched failure errorCode', () => {
+    applyDesktopBootProgress({
+      error: 'Local Hermes backend is reachable but its JSON-RPC gateway did not answer.',
+      errorCode: 'gateway.rpc-probe-failed',
+      fakeMode: false,
+      message: 'Desktop boot failed',
+      phase: 'backend.error',
+      progress: 90,
+      running: false,
+      timestamp: Date.now()
+    })
+
+    applyDesktopBootProgress({
+      error: null,
+      fakeMode: false,
+      message: 'backend.ready',
+      phase: 'backend.ready',
+      progress: 94,
+      running: true,
+      timestamp: Date.now()
+    })
+
+    expect($desktopBoot.get().errorCode).toBe('gateway.rpc-probe-failed')
+  })
+
+  it('failDesktopBoot drops a stale main-process errorCode (renderer failures carry none)', () => {
+    applyDesktopBootProgress({
+      error: 'Local Hermes backend is reachable but its JSON-RPC gateway did not answer.',
+      errorCode: 'gateway.rpc-probe-failed',
+      fakeMode: false,
+      message: 'Desktop boot failed',
+      phase: 'backend.error',
+      progress: 90,
+      running: false,
+      timestamp: Date.now()
+    })
+
+    failDesktopBoot('Desktop IPC bridge is unavailable.', 'ipc-bridge')
+
+    expect($desktopBoot.get().errorCode).toBeUndefined()
+    expect($desktopBoot.get().errorKind).toBe('ipc-bridge')
+  })
+
+  it('completeDesktopBoot clears the failure code', () => {
+    applyDesktopBootProgress({
+      error: 'Local Hermes backend is reachable but its JSON-RPC gateway did not answer.',
+      errorCode: 'gateway.rpc-probe-failed',
+      fakeMode: false,
+      message: 'Desktop boot failed',
+      phase: 'backend.error',
+      progress: 90,
+      running: false,
+      timestamp: Date.now()
+    })
+    completeDesktopBoot()
+
+    expect($desktopBoot.get().error).toBeNull()
+    expect($desktopBoot.get().errorCode).toBeUndefined()
+  })
+})
+
 describe('boot store errorKind (#92927)', () => {
   it('failDesktopBoot records the failure kind', () => {
     failDesktopBoot('Desktop IPC bridge is unavailable.', 'ipc-bridge')

--- a/apps/desktop/src/store/boot.test.ts
+++ b/apps/desktop/src/store/boot.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  $desktopBoot,
+  applyDesktopBootProgress,
+  completeDesktopBoot,
+  failDesktopBoot,
+  resumeDesktopBootForRetry
+} from './boot'
+
+// #92927: the dead-IPC-bridge boot failure must be distinguishable from a
+// generic boot failure so the recovery overlay can stop offering
+// bridge-dependent dead ends (Repair / Settings / Open logs all round-trip
+// through window.hermesDesktop) and instead show the actionable repair copy.
+
+describe('boot store errorKind (#92927)', () => {
+  it('failDesktopBoot records the failure kind', () => {
+    failDesktopBoot('Desktop IPC bridge is unavailable.', 'ipc-bridge')
+
+    expect($desktopBoot.get().error).toBe('Desktop IPC bridge is unavailable.')
+    expect($desktopBoot.get().errorKind).toBe('ipc-bridge')
+  })
+
+  it('failDesktopBoot without a kind leaves errorKind undefined', () => {
+    failDesktopBoot('Hermes backend exited before it became ready.')
+
+    expect($desktopBoot.get().errorKind).toBeUndefined()
+  })
+
+  it('a later boot-progress event cannot clobber the latched failure kind', () => {
+    failDesktopBoot('Desktop IPC bridge is unavailable.', 'ipc-bridge')
+
+    applyDesktopBootProgress({
+      error: null,
+      fakeMode: false,
+      message: 'backend.ready',
+      phase: 'backend.ready',
+      progress: 94,
+      running: true,
+      timestamp: Date.now()
+    })
+
+    expect($desktopBoot.get().error).toBe('Desktop IPC bridge is unavailable.')
+    expect($desktopBoot.get().errorKind).toBe('ipc-bridge')
+  })
+
+  it('completeDesktopBoot clears the failure kind', () => {
+    failDesktopBoot('Desktop IPC bridge is unavailable.', 'ipc-bridge')
+    completeDesktopBoot()
+
+    expect($desktopBoot.get().error).toBeNull()
+    expect($desktopBoot.get().errorKind).toBeUndefined()
+  })
+
+  it('resumeDesktopBootForRetry clears the failure kind while retrying', () => {
+    failDesktopBoot('Desktop IPC bridge is unavailable.', 'ipc-bridge')
+    resumeDesktopBootForRetry('retrying…')
+
+    expect($desktopBoot.get().error).toBeNull()
+    expect($desktopBoot.get().errorKind).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/store/boot.ts
+++ b/apps/desktop/src/store/boot.ts
@@ -45,10 +45,16 @@ export function applyDesktopBootProgress(progress: DesktopBootProgress) {
   // boot failure — failDesktopBoot is terminal for this boot cycle.
   const error = progress.error ?? (current.running ? null : current.error)
 
+  // The stable main-process failure code (see DesktopBootProgress.errorCode)
+  // latches exactly like `error`: cleared by progress updates while running,
+  // preserved after a terminal failure so the overlay keeps its guidance.
+  const errorCode = progress.errorCode ?? (current.running ? null : current.errorCode)
+
   $desktopBoot.set({
     ...current,
     ...progress,
     error,
+    errorCode,
     progress: mergedProgress,
     visible: progress.running || mergedProgress < 100 || Boolean(error)
   })
@@ -87,6 +93,8 @@ export function resumeDesktopBootForRetry(message: string) {
   $desktopBoot.set({
     ...current,
     error: null,
+    // Lifting the error for the bounded retry lifts its code too.
+    errorCode: undefined,
     errorKind: undefined,
     message,
     phase: 'renderer.boot.retry',
@@ -101,6 +109,8 @@ export function completeDesktopBoot(message = translateNow('boot.ready')) {
   $desktopBoot.set({
     ...current,
     error: null,
+    // The failure code latches with `error`; a completed boot clears both.
+    errorCode: undefined,
     errorKind: undefined,
     message,
     phase: 'renderer.ready',
@@ -116,6 +126,9 @@ export function failDesktopBoot(message: string, errorKind?: DesktopBootState['e
   $desktopBoot.set({
     ...current,
     error: message,
+    // A renderer-side failure has no main-process code; drop any stale one so
+    // the overlay can't key a new failure on an old classification.
+    errorCode: undefined,
     errorKind,
     message: translateNow('boot.desktopBootFailedWithMessage', message),
     phase: 'renderer.error',

--- a/apps/desktop/src/store/boot.ts
+++ b/apps/desktop/src/store/boot.ts
@@ -5,6 +5,14 @@ import { translateNow } from '@/i18n'
 
 export interface DesktopBootState extends DesktopBootProgress {
   visible: boolean
+  /**
+   * Machine-readable failure kind for renderer-side boot failures. `undefined`
+   * for main-process failures (which never set it). 'ipc-bridge' marks the
+   * dead-preload state (#92927): every recovery action that round-trips
+   * through window.hermesDesktop is a silent no-op there, so the overlay must
+   * swap to reload + repair copy instead of the bridge-dependent buttons.
+   */
+  errorKind?: 'ipc-bridge' | (string & {})
 }
 
 const INITIAL_BOOT_STATE: DesktopBootState = {
@@ -79,6 +87,7 @@ export function resumeDesktopBootForRetry(message: string) {
   $desktopBoot.set({
     ...current,
     error: null,
+    errorKind: undefined,
     message,
     phase: 'renderer.boot.retry',
     running: true,
@@ -92,6 +101,7 @@ export function completeDesktopBoot(message = translateNow('boot.ready')) {
   $desktopBoot.set({
     ...current,
     error: null,
+    errorKind: undefined,
     message,
     phase: 'renderer.ready',
     progress: 100,
@@ -101,11 +111,12 @@ export function completeDesktopBoot(message = translateNow('boot.ready')) {
   })
 }
 
-export function failDesktopBoot(message: string) {
+export function failDesktopBoot(message: string, errorKind?: DesktopBootState['errorKind']) {
   const current = $desktopBoot.get()
   $desktopBoot.set({
     ...current,
     error: message,
+    errorKind,
     message: translateNow('boot.desktopBootFailedWithMessage', message),
     phase: 'renderer.error',
     progress: clampProgress(current.progress),

--- a/apps/desktop/src/store/session-unread-tile.test.ts
+++ b/apps/desktop/src/store/session-unread-tile.test.ts
@@ -51,7 +51,10 @@ describe('completed-unread dot follows the focused session', () => {
     return { finishTurn, session, tree }
   }
 
-  it('clears the dot when an already-open tile is fronted', async () => {
+  // First test in the file pays jsdom env init + full module transform, which
+  // hit the 15s file budget twice under CI load. The wider deadline only
+  // absorbs a starved runner — the body itself is synchronous.
+  it('clears the dot when an already-open tile is fronted', { timeout: 30_000 }, async () => {
     const { finishTurn, session, tree } = await setup()
 
     tree.noteActiveTreeGroup('grp-main')


### PR DESCRIPTION
## Problem

#92927: after an interrupted `hermes update` on Windows (venv `.pyd` lock → updater exit code 2), the relaunched desktop app boots into a silently degraded state — an **empty BOTS pane** (bots shown as bare initials), and the served dashboard reports **"Desktop IPC bridge is unavailable"** with `window.hermesDesktop is undefined`. Nothing on the desktop path notices: no error, no repair prompt.

## Root cause

The boot lifecycle declares the backend ready from **HTTP readiness + a WS-token acceptance probe** alone (`startHermes` in `apps/desktop/electron/main.ts`). Two things follow:

1. **A half-updated backend passes both probes while its JSON-RPC dispatcher is dead.** The upgrade was accepted and the socket stays open, but the gateway never answers a request. The renderer then boots against a backend that cannot serve the agent/roster surface the BOTS pane is fed from — and every data fetch is best-effort (`.catch(() => undefined)`), so boot *completes* into the empty shell instead of failing.
2. **When the IPC bridge itself is dead** (torn `preload` after the same interrupted update — `contextBridge` never arms, `window.hermesDesktop` is undefined), the renderer *does* call `failDesktopBoot('Desktop IPC bridge is unavailable.')` — but the recovery overlay only offers bridge-dependent actions (Repair / Gateway settings / Open logs all round-trip through `window.hermesDesktop`), so every button is a silent no-op and the app is stuck in a dead end with no repair guidance.

Empirical trace from the issue's own log (reproduced against current code):

- `[boot] could not read served dashboard token (Hermes backend): 404: {"error":"Headless backend (hermes serve): web UI disabled …"}` — this is the `adoptServedDashboardToken` fetch of `/` in `electron/dashboard-token.ts`. On the `serve` path (which the desktop always uses per `electron/backend-command.ts`) the backend is headless by design, so this 404 is *normal noise* — it is not the smoking gun; the real gap is that the boot seam has no probe that can distinguish "gateway works" from "gateway accepts the socket and answers nothing".
- The WS probe in `electron/gateway-ws-probe.ts` resolves `ok` on "any frame" (e.g. the unsolicited `gateway.ready` event) — it never requires a reply to anything the desktop asked for.

## Fix

1. **Boot-seam RPC verification** (`electron/gateway-rpc-probe.ts`, new): after the WS probe, the desktop now sends one real JSON-RPC request over the socket and requires a reply frame carrying *its* request id (a JSON-RPC error such as `-32601 unknown method` still counts — it proves the dispatcher round-trips, so the probe stays valid across older gateways). Wired into both local-backend spawn paths in `main.ts` (primary `startHermes` + the profile pool spawn). A backend that cannot answer now **fails boot** with an actionable repair message (`hermes desktop --force-build`, or re-run `hermes update`) instead of silently degrading — the existing recovery overlay (Retry / Repair install / Open logs, all of which work when the bridge is alive) then offers the repair path the issue asks for.
2. **Bounded re-arm of a dead IPC bridge** (`src/app/gateway/hooks/use-gateway-boot.ts`): when `window.hermesDesktop` is undefined at boot, the renderer re-arms the bridge once via a window reload (the only lever a bridgeless renderer has — it re-runs the preload), tracked with a one-shot `localStorage` ledger that is cleared as soon as any boot runs with the bridge present. A second consecutive dead boot is terminal.
3. **Honest recovery overlay for the dead-bridge state** (`src/components/boot-failure-overlay.tsx` + `src/store/boot.ts`): `failDesktopBoot` now carries a machine-readable `errorKind`; for `ipc-bridge` the overlay swaps the generic "background gateway didn't come up" copy for ipc-specific guidance, keeps only the one action that works bridgeless (Retry = window reload), and drops the dead Repair / Gateway settings / Open logs buttons. New copy in all five locales (`boot.failure.ipcBridge*`).
4. **Connect timer disarmed on open** (`electron/gateway-rpc-probe.ts`, `electron/gateway-ws-probe.ts`): the connect-deadline timer is now cleared the moment the socket opens. It previously kept running past `open`, so a healthy-but-slow reply (e.g. a caller configuring `replyTimeoutMs` > `connectTimeoutMs`, or a grace window outlasting the connect deadline) could be misreported as "Timed out waiting for the WebSocket to open" on an already-open connection.

## Tests

- `electron/gateway-rpc-probe.test.ts` (new, 10 cases): round-trip on matching-id result *and* error reply; ignores events/foreign-id replies (added after a sabotage run showed the original suite wouldn't catch "accept any frame"); timeouts, early close, constructor throw, missing WebSocket; connect timer disarmed on open — a reply arriving after the connect deadline has elapsed still counts.
- `electron/gateway-ws-probe.test.ts` (+1 case): connect timer disarmed on open — the post-upgrade grace window may outlast `connectTimeoutMs`.
- `src/store/boot.test.ts` (new, 5 cases): `errorKind` latched by `failDesktopBoot`, preserved across boot-progress events, cleared by `completeDesktopBoot`/`resumeDesktopBootForRetry`.
- `use-gateway-boot.test.tsx` (+3 cases): one-shot reload re-arm with the ledger, terminal `ipc-bridge` failure after the re-arm is spent, ledger cleared on a healthy boot.
- `boot-failure-overlay.test.tsx` (+1 case): ipc-bridge failure shows the repair copy and hides bridge-dependent dead ends.

Regression tests were proven to bite (sabotage runs): removing the `errorKind` plumbing fails 3 tests, disabling the overlay gating fails 1, accepting any WS frame in the probe fails 1. The two new connect-timer cases were verified to fail against the pre-fix probe before the disarm landed.

## Verification

- `npm run typecheck` (renderer + electron + e2e projects): clean.
- Targeted vitest: 26/26 renderer tests + 20/20 probe tests green.
- Full `--project electron` suite: 1581 passed (including the 2 new connect-timer cases); the 31 failures across 8 files are pre-existing environment failures on this Windows host (SSH ControlMaster, POSIX file-mode, MSYS path expectations) — reproduced identically on pristine `origin/main` with this diff stashed.
- Not covered here: the packaged-app e2e boot (needs a full build + Electron; the probe only adds a round-trip a healthy `hermes serve` answers immediately).

## Risks / non-goals

- The RPC probe can only *fail* a boot it can prove broken (socket open + no id'd reply within 8s); a healthy gateway answers immediately, and older gateways reply with an id'd error for unknown methods — no known false-positive path.
- Issue #92927 request (1) — `hermes update` detecting **and stopping** the lock-holding gateway/desktop processes before updating — is **not implemented by this PR**, and is not covered by the referenced issues either: #38789's fix only *detects* holders and prints a hint (close the app, re-run `hermes update`), and #93163/#93032 only *defer* the managed-runtime repair when the updater itself holds the lock. Neither stops other running Hermes processes, so request (1) remains open. This PR implements request (2): the boot guard + repair path.

Implements request (2) of #92927 (boot guard + repair path). Request (1) (detect/stop venv-lock holders before updating) remains open.


## Review follow-up (Enough1122, commit 3443ab1d)

1. **"WebSocket not available" no longer misleads.** `probeGatewayRpc` now tags that outcome with `code: 'websocket-unavailable'`, and both call sites build their boot error through one helper, `rpcProbeBootError()` (`electron/gateway-rpc-probe.ts`). The unavailable case emits a distinct capability message — *"...reachable but this runtime cannot open a WebSocket to verify its JSON-RPC gateway..."* — with the stable error code `gateway.rpc-unavailable` and **no** `hermes update` repair advice. Torn-install guidance is reserved for the dead-dispatcher case (`gateway.rpc-probe-failed`).
2. **Repair copy deduplicated + stable code.** The duplicated English sentence now exists exactly once, in `TORN_INSTALL_REPAIR_GUIDANCE`; both boots throw via the shared builder, and the sentence is byte-identical to the pre-PR copy (verified with a byte-level diff). The thrown error's stable code is forwarded through boot progress as `DesktopBootProgress.errorCode` (same structured-classification pattern as `isCloudBackendDown`, #85335), and the recovery overlay keys on the code — not the message string — to show localized guidance: new `boot.failure.rpcProbeFailedHint` / `rpcProbeUnavailableHint` in all five locales (en/zh/zh-hant/ja/ar).
3. **Reload-ledger race documented.** `use-gateway-boot.ts` now explains why the per-origin `localStorage` ledger is deliberately shared across windows (single-window boot; both windows run the same bundle/preload; the terminal overlay's Retry *is* a plain reload, so no window is stranded), and why the ledger stays in `localStorage` rather than a per-boot/per-window scope (the episode survives app restarts — a persistently torn bundle must not waste a reload on every launch).

Tests added/extended (adversarial RED runs verified each one bites — reverting the fix fails the test):
- `electron/gateway-rpc-probe.test.ts` (+3 → 13): distinct `websocket-unavailable` code; capability message carries no repair advice; both backend labels build byte-identical guidance.
- `boot-failure-overlay.test.tsx` (+3 → 8): torn-install hint keyed on `gateway.rpc-probe-failed`; capability hint keyed on `gateway.rpc-unavailable` with no repair commands; generic failure keeps the generic hint.
- `src/store/boot.test.ts` (+4 → 9): `errorCode` carried through boot progress, latched against late events, cleared by `completeDesktopBoot`, dropped by `failDesktopBoot`.

Verification: `npm run typecheck` clean (renderer + electron + e2e). Targeted suites 51/51 (ui 38 + electron 13). Full-project runs: ui 5582/5599 and electron 1584/1620 pass; the 17 + 32 failures are pre-existing Windows-environment issues in untouched files (file-mode bits, POSIX paths, SSH ControlMaster, PowerShell timeout) — reproduced identically with this diff stashed at base.