### PR TITLE
fix(tools): sanitize colon-bearing session ids in docker mount paths

### DIFF
--- a/tests/tools/test_docker_mount_colon_ids.py
+++ b/tests/tools/test_docker_mount_colon_ids.py
@@ -1,0 +1,109 @@
+"""Regression tests for #92414/#93044 — colon-bearing session ids must not
+reach Docker `-v` mount specs.
+
+Docker's short `-v host:container[:mode]` syntax splits on ':'. Session ids
+like `session:agent:main:telegram:dm:<id>` therefore made every sandboxed
+tool call fail with exit 125 ("invalid mode: /root") when
+``terminal.container_persistent`` is enabled, because the raw id was used as
+a bind-mount host-path component. Container labels were already sanitized;
+the mount path was not.
+
+The fix routes the persistent-sandbox path component through the same
+sanitizer used for labels, so one safe form derives both.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def docker_env_cls(monkeypatch, tmp_path):
+    """Import tools.environments.docker with HERMES_HOME pointed at tmp."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setattr(sys, "path", [str(REPO_ROOT)] + sys.path)
+    import importlib
+
+    if "hermes_constants" in sys.modules:
+        importlib.reload(sys.modules["hermes_constants"])
+    else:
+        __import__("hermes_constants")
+    mod = importlib.import_module("tools.environments.docker")
+    return mod.DockerEnvironment, mod._sanitize_label_value
+
+
+COLON_ID = "session:agent:main:telegram:dm:12345"
+
+
+def _capture_mounts(docker_env_cls, task_id):
+    """Build a DockerEnvironment with subprocess.run intercepted; return
+    (env, list of -v spec strings)."""
+    mod = sys.modules["tools.environments.docker"]
+    captured: list[list] = []
+
+    class FakeCompleted:
+        def __init__(self, out: bytes = b""):
+            self.stdout = out
+            self.returncode = 0
+
+    def fake_run(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args")
+        captured.append(list(cmd or []))
+        if any(x == "ps" for x in (cmd or [])):
+            return FakeCompleted(b"")
+        return FakeCompleted(b"fake-container-id\n")
+
+    orig_run = mod.subprocess.run
+    mod.subprocess.run = fake_run
+    try:
+        env = docker_env_cls(
+            image="ubuntu:24.04", task_id=task_id, persistent_filesystem=True,
+        )
+    finally:
+        mod.subprocess.run = orig_run
+
+    mounts = []
+    for cmd in captured:
+        for i, c in enumerate(cmd):
+            if c == "-v":
+                mounts.append(cmd[i + 1])
+    return env, mounts
+
+
+def test_colon_session_id_produces_parsable_mounts(docker_env_cls):
+    """THE bug: a colon-bearing id must never leak into a -v host path."""
+    DockerEnvironment, _ = docker_env_cls
+    env, mounts = _capture_mounts(DockerEnvironment, COLON_ID)
+    assert mounts, "expected at least one -v mount"
+    colon_hosts = [m for m in mounts if ":" in m.split(":")[0]]
+    assert colon_hosts == [], (
+        f"-v host paths contain colons — unparseable by docker: {colon_hosts}"
+    )
+
+
+def test_sanitized_id_matches_label_form(docker_env_cls):
+    """Path component and label should derive from the same sanitized form."""
+    DockerEnvironment, sanitize = docker_env_cls
+    env, _mounts = _capture_mounts(DockerEnvironment, COLON_ID)
+    assert ":" not in env._home_dir
+    expected_fragment = sanitize(COLON_ID)
+    assert expected_fragment in env._home_dir, (
+        f"sandbox path {env._home_dir!r} does not contain the sanitized "
+        f"id fragment {expected_fragment!r}"
+    )
+
+
+def test_plain_task_id_path_unchanged(docker_env_cls, tmp_path):
+    """Ids without colons keep working; no behavior change for them."""
+    DockerEnvironment, _ = docker_env_cls
+    env, mounts = _capture_mounts(DockerEnvironment, "default")
+    assert ":" not in Path(env._home_dir).name
+    assert any(m.endswith(":/root") for m in mounts), (
+        "persistent home mount missing"
+    )

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -980,7 +980,13 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            # Issue #92414: task ids like "session:agent:main:telegram:dm:<id>"
+            # contain colons, and Docker's short `-v host:container[:mode]`
+            # syntax splits on ':'. A raw id in the host path makes the mount
+            # spec unparseable (exit 125, "invalid mode: /root"). Sanitize the
+            # path component the same way container labels are sanitized so
+            # both derive from one safe form.
+            sandbox = get_sandbox_dir() / "docker" / _sanitize_label_value(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([


### PR DESCRIPTION
Fixes #92414
Fixes #93044 (same root cause, marked duplicate)

## Summary

Session ids containing colons — the default for Telegram DM sessions (`session:agent:main:telegram:dm:<id>`) and TUI task keys (`session:<session_key>`) — were used verbatim as the Docker sandbox's bind-mount host-path component. Docker's short `-v host:container[:mode]` syntax splits on `:`, so every sandboxed tool call failed with exit 125, `"invalid mode: /root"`.

Container labels were already sanitized via `_sanitize_label_value()`; the mount path was not. This routes the persistent-sandbox path component through the same sanitizer, so the label and the path derive from one safe form.

## Changes

| File | Change |
|------|--------|
| `tools/environments/docker.py` | Persistent sandbox path uses `_sanitize_label_value(task_id)` instead of the raw id |
| `tests/tools/test_docker_mount_colon_ids.py` | New regression tests: colon-id produces parsable mounts, path matches label form, plain ids unchanged |

## How to test

```bash
pytest tests/tools/test_docker_mount_colon_ids.py -v   # 3 passed
```

Structural repro of the bug (pre-fix): build a `DockerEnvironment` with `task_id="session:agent:main:telegram:dm:12345"`, `persistent_filesystem=True` → `_home_dir` contains raw colons → `-v /…/session:agent:…:/root` is unparseable.

## Verification

```
pytest tests/tools/test_docker_mount_colon_ids.py -v      → 3 passed
pytest tests/tools/ -q -k "docker or sandbox"             → 230 passed, 4 failed*
```

*The 4 failures are pre-existing on clean `main` and unrelated to this diff: they are all in `test_daytona_environment.py`, failing with `ImportError: Feature 'terminal.daytona' unavailable: lazy installs disabled` — the `daytona` package is not installed in this environment. Verified identical on unmodified `origin/main`.

Tested on Pop!_OS 24.04, Python 3.11.
