### PR TITLE
fix(desktop): reuse migrated primary SSH backend

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -30,6 +30,7 @@ import {
   removeConnection,
   resolvedConnectionId,
   resolveRegistryLocalRoute,
+  reuseMatchingPrimarySshBackend,
   setConnectionLaunchMode,
   setLastUsedConnection,
   setPrimaryConnection,
@@ -55,6 +56,148 @@ test('labelSlug kebab-cases and never returns empty for non-empty input', () => 
   assert.equal(labelSlug('Work Laptop'), 'work-laptop')
   assert.equal(labelSlug('Spark Box #2'), 'spark-box-2')
   assert.equal(labelSlug('!!!'), 'connection')
+})
+
+test('matching primary/default SSH route reuses the existing descriptor once', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)
+
+  const descriptor = {
+    mode: 'remote' as const,
+    remoteKind: 'ssh' as const,
+    ssh: {
+      effectiveConfigFingerprint: 'same-effective-config',
+      host: 'build-host',
+      keyPath: '~/.ssh/id_ed25519',
+      remoteProfile: 'default',
+      user: 'alice'
+    }
+  }
+
+  let ensureCalls = 0
+  let fingerprintCalls = 0
+
+  assert.equal(source?.kind, 'ssh')
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({
+      connectionId: registry.primary,
+      effectiveFingerprint: async () => {
+        fingerprintCalls += 1
+
+        return 'same-effective-config'
+      },
+      ensurePrimary: async () => {
+        ensureCalls += 1
+
+        return descriptor
+      },
+      profile: 'default',
+      registry,
+      source: source!
+    }),
+    descriptor
+  )
+  assert.equal(ensureCalls, 1)
+  assert.equal(fingerprintCalls, 1)
+})
+
+test('non-default or non-primary SSH routes do not resolve the primary backend', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)!
+  let ensureCalls = 0
+
+  const opts = {
+    effectiveFingerprint: async () => 'same',
+    ensurePrimary: async () => {
+      ensureCalls += 1
+
+      return { mode: 'remote' as const, remoteKind: 'ssh' as const }
+    },
+    registry,
+    source
+  }
+
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({ ...opts, connectionId: registry.primary, profile: 'researcher' }),
+    null
+  )
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({ ...opts, connectionId: LOCAL_CONNECTION_ID, profile: 'default' }),
+    null
+  )
+  assert.equal(ensureCalls, 0)
+})
+
+test('primary SSH reuse rejects a descriptor with different effective dialing config', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)!
+
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({
+      connectionId: registry.primary,
+      effectiveFingerprint: async () => 'registry-config',
+      ensurePrimary: async () => ({
+        mode: 'remote',
+        remoteKind: 'ssh',
+        ssh: {
+          effectiveConfigFingerprint: 'active-config',
+          host: 'other-host',
+          remoteProfile: ''
+        }
+      }),
+      profile: 'default',
+      registry,
+      source
+    }),
+    null
+  )
+})
+
+test('primary SSH reuse rejects a descriptor with a different remote Hermes path', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', remoteHermesPath: '/srv/hermes', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)!
+
+  assert.equal(
+    await reuseMatchingPrimarySshBackend({
+      connectionId: registry.primary,
+      effectiveFingerprint: async () => 'same-effective-config',
+      ensurePrimary: async () => ({
+        mode: 'remote',
+        remoteKind: 'ssh',
+        ssh: {
+          effectiveConfigFingerprint: 'same-effective-config',
+          host: 'build-host',
+          remoteHermesPath: '/opt/hermes',
+          remoteProfile: '',
+          user: 'alice'
+        }
+      }),
+      profile: 'default',
+      registry,
+      source
+    }),
+    null
+  )
 })
 
 test('resolvedConnectionId identifies local and migrated remote descriptors', () => {

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -58,6 +58,42 @@ test('labelSlug kebab-cases and never returns empty for non-empty input', () => 
   assert.equal(labelSlug('!!!'), 'connection')
 })
 
+test('registry SSH fingerprint failures name the connection and ssh -G step', async () => {
+  const registry = migrateV1ToRegistry({
+    mode: 'ssh',
+    remote: { mode: 'ssh', host: 'build-host', user: 'alice' },
+    profiles: {}
+  })
+
+  const source = registry.connections.find(connection => connection.id === registry.primary)!
+
+  const cause = new Error('spawn ssh ENOENT')
+
+  source.label = 'Build box'
+
+  await assert.rejects(
+    reuseMatchingPrimarySshBackend({
+      connectionId: registry.primary,
+      effectiveFingerprint: async () => {
+        throw cause
+      },
+      ensurePrimary: async () => ({ mode: 'remote', remoteKind: 'ssh' }),
+      profile: 'default',
+      registry,
+      source
+    }),
+    error => {
+      assert.equal(
+        (error as Error).message,
+        `Could not resolve effective SSH config for connection "Build box" (${source.id}) via ssh -G: spawn ssh ENOENT`
+      )
+      assert.equal((error as Error).cause, cause)
+
+      return true
+    }
+  )
+})
+
 test('matching primary/default SSH route reuses the existing descriptor once', async () => {
   const registry = migrateV1ToRegistry({
     mode: 'ssh',

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -185,6 +185,7 @@ export interface RegistryLocalRoute {
 }
 
 export interface ResolvedConnectionSshDescriptor {
+  effectiveConfigFingerprint?: string
   host?: string
   keyPath?: string
   port?: number
@@ -331,6 +332,53 @@ export function resolvedConnectionId(
   }
 
   return matchingConnectionId(registry, route, 'unique') ?? null
+}
+
+export interface ReuseMatchingPrimarySshBackendOptions {
+  connectionId: null | string | undefined
+  effectiveFingerprint: (source: RegistryConnection) => Promise<string>
+  ensurePrimary: () => Promise<ResolvedConnectionDescriptor>
+  profile: null | string | undefined
+  registry: ConnectionRegistry
+  source: RegistryConnection
+}
+
+/**
+ * Reuse the already-booted v1 window SSH backend only when its actual dialing
+ * identity matches the registry primary. Guards run before either async
+ * dependency so secondary profiles and sources never bootstrap the primary.
+ */
+export async function reuseMatchingPrimarySshBackend({
+  connectionId,
+  effectiveFingerprint,
+  ensurePrimary,
+  profile,
+  registry,
+  source
+}: ReuseMatchingPrimarySshBackendOptions): Promise<null | ResolvedConnectionDescriptor> {
+  const id = String(connectionId ?? '').trim()
+  const profileKey = String(profile ?? '').trim() || 'default'
+
+  if (profileKey !== 'default' || !id || id !== registry.primary || source.id !== id || source.kind !== 'ssh') {
+    return null
+  }
+
+  const sourceFingerprint = String(await effectiveFingerprint(source)).trim()
+  const descriptor = await ensurePrimary()
+  const activeSsh = descriptor.mode === 'remote' && descriptor.remoteKind === 'ssh' ? descriptor.ssh : null
+  const rootProfile = (value: unknown) => String(value || '').trim() || 'default'
+
+  if (
+    !sourceFingerprint ||
+    !activeSsh ||
+    sourceFingerprint !== String(activeSsh.effectiveConfigFingerprint || '').trim() ||
+    String(source.remoteHermesPath || '').trim() !== String(activeSsh.remoteHermesPath || '').trim() ||
+    rootProfile(source.remoteProfile) !== rootProfile(activeSsh.remoteProfile)
+  ) {
+    return null
+  }
+
+  return descriptor
 }
 
 function normalizedSshTarget(route: { host?: unknown; port?: unknown; user?: unknown }): null | string {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -344,9 +344,13 @@ export interface ReuseMatchingPrimarySshBackendOptions {
 }
 
 /**
- * Reuse the already-booted v1 window SSH backend only when its actual dialing
- * identity matches the registry primary. Guards run before either async
- * dependency so secondary profiles and sources never bootstrap the primary.
+ * Reuse the v1 window SSH backend only when its actual dialing identity matches
+ * the registry primary. Resolving that descriptor may boot the primary; a
+ * mismatch returns null without reusing it so the caller continues with its
+ * separately scoped registry backend. A matching descriptor is returned
+ * unchanged and the caller may re-stamp routing fields such as profile and
+ * connectionId. Guards run before either async dependency so secondary
+ * profiles and sources never bootstrap the primary.
  */
 export async function reuseMatchingPrimarySshBackend({
   connectionId,
@@ -363,7 +367,19 @@ export async function reuseMatchingPrimarySshBackend({
     return null
   }
 
-  const sourceFingerprint = String(await effectiveFingerprint(source)).trim()
+  let sourceFingerprint
+
+  try {
+    sourceFingerprint = String(await effectiveFingerprint(source)).trim()
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause)
+
+    throw new Error(
+      `Could not resolve effective SSH config for connection "${source.label}" (${source.id}) via ssh -G: ${detail}`,
+      { cause }
+    )
+  }
+
   const descriptor = await ensurePrimary()
   const activeSsh = descriptor.mode === 'remote' && descriptor.remoteKind === 'ssh' ? descriptor.ssh : null
   const rootProfile = (value: unknown) => String(value || '').trim() || 'default'

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -109,6 +109,7 @@ import {
   removeConnection,
   resolvedConnectionId,
   resolveRegistryLocalRoute,
+  reuseMatchingPrimarySshBackend,
   setConnectionLaunchMode,
   setLastUsedConnection,
   setPrimaryConnection,
@@ -9230,7 +9231,7 @@ async function reachablePreviewUrl(rawUrl: string): Promise<string> {
   }
 }
 
-function effectiveSshConfigFingerprint(sshConfig) {
+async function effectiveSshConfigFingerprint(sshConfig) {
   const ssh =
     process.platform === 'win32'
       ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'OpenSSH', 'ssh.exe')
@@ -9247,14 +9248,14 @@ function effectiveSshConfigFingerprint(sshConfig) {
   }
 
   args.push('--', sshConfig.user ? `${sshConfig.user}@${sshConfig.host}` : sshConfig.host)
-  const output = execFileSync(ssh, args, { encoding: 'utf8', timeout: 10_000, windowsHide: true })
+  const output = await execText(ssh, args, { timeout: 10_000 })
 
   return crypto.createHash('sha256').update(output).digest('hex')
 }
 
-async function bootstrapSshConnection(profile, sshConfig, reuseToken, source) {
+async function bootstrapSshConnection(profile, sshConfig, reuseToken, source, resolvedEffectiveFingerprint?) {
   const scope = sshScopeKey(profile)
-  const effectiveConfigFingerprint = effectiveSshConfigFingerprint(sshConfig)
+  const effectiveConfigFingerprint = resolvedEffectiveFingerprint || (await effectiveSshConfigFingerprint(sshConfig))
   const resolvedConfig = { ...sshConfig, effectiveConfigFingerprint }
   const fingerprint = sshConfigFingerprint(scope, resolvedConfig)
 
@@ -9396,7 +9397,19 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
     result.ownershipId
   )
 
-  return { ...connection, remoteHermesVersion: result.hermesVersion || '' }
+  return {
+    ...connection,
+    remoteHermesVersion: result.hermesVersion || '',
+    ssh: {
+      effectiveConfigFingerprint: sshConfig.effectiveConfigFingerprint,
+      host: sshConfig.host,
+      keyPath: sshConfig.keyPath,
+      port: sshConfig.port,
+      remoteHermesPath: sshConfig.remoteHermesPath,
+      remoteProfile: sshConfig.remoteProfile,
+      user: sshConfig.user
+    }
+  }
 }
 
 function persistSshConnectionToken(profile, source, token) {
@@ -10030,6 +10043,64 @@ async function ensureRegistryBackend(connectionId, profile) {
     throw new Error(`No connection with id "${id}".`)
   }
 
+  const profileKey = String(profile ?? '').trim() || 'default'
+  let resolvedRegistrySshConfig
+  let registryEffectiveFingerprintPromise: null | Promise<string> = null
+
+  const resolveRegistrySshConfig = () => {
+    if (source.kind !== 'ssh') {
+      return null
+    }
+
+    if (!resolvedRegistrySshConfig) {
+      resolvedRegistrySshConfig = normalizeSshConfig({
+        mode: 'ssh',
+        host: source.host,
+        user: source.user,
+        port: source.port,
+        keyPath: source.keyPath,
+        remoteHermesPath: source.remoteHermesPath,
+        remoteProfile: source.remoteProfile || (profileKey === 'default' ? '' : profileKey)
+      })
+    }
+
+    return resolvedRegistrySshConfig
+  }
+
+  const resolveRegistryEffectiveFingerprint = () => {
+    if (!registryEffectiveFingerprintPromise) {
+      const sshConfig = resolveRegistrySshConfig()
+
+      registryEffectiveFingerprintPromise = sshConfig
+        ? effectiveSshConfigFingerprint(sshConfig)
+        : Promise.reject(new Error(`SSH connection "${source.label}" has no host configured.`))
+    }
+
+    return registryEffectiveFingerprintPromise
+  }
+
+  // The v2 registry is migrated from (but intentionally coexists with) the
+  // v1 primary connection config. Reuse the already-booted primary descriptor
+  // when both identities match; otherwise a default-profile registry request
+  // opens a second SSH dashboard under a different scope and the competing
+  // lifecycle probes repeatedly tear down each other's tunnel.
+  const primary = await reuseMatchingPrimarySshBackend({
+    connectionId: id,
+    effectiveFingerprint: resolveRegistryEffectiveFingerprint,
+    ensurePrimary: () => ensureBackend(profile),
+    profile,
+    registry,
+    source
+  })
+
+  if (primary) {
+    return {
+      ...primary,
+      profile: profileKey,
+      connectionId: id
+    }
+  }
+
   if (source.kind === 'local') {
     // The registry's 'local' entry means THIS machine's runtime — always.
     // ensureBackend() follows the v1 routing table, which resolves to a
@@ -10040,8 +10111,6 @@ async function ensureRegistryBackend(connectionId, profile) {
     // the v1 route is genuinely local; otherwise spawn/reuse a forced-local
     // child pooled under the composite 'conn:local::<profile>' key so it
     // can't collide with the v1 remote descriptor cached at the bare key.
-    const profileKey = String(profile ?? '').trim() || 'default'
-
     profileDeletionGate.assertCanStart(profileKey)
 
     const localRoute = resolveRegistryLocalRoute(profileKey, {
@@ -10122,7 +10191,14 @@ async function ensureRegistryBackend(connectionId, profile) {
     remoteBaseUrl: null
   }
 
-  entry.connectionPromise = connectRegistryBackend(source, profile, key, entry).catch(error => {
+  entry.connectionPromise = connectRegistryBackend(
+    source,
+    profile,
+    key,
+    entry,
+    resolveRegistrySshConfig(),
+    source.kind === 'ssh' ? resolveRegistryEffectiveFingerprint() : null
+  ).catch(error => {
     if (backendPool.get(key) === entry) {
       backendPool.delete(key)
     }
@@ -10138,7 +10214,14 @@ async function ensureRegistryBackend(connectionId, profile) {
 // Dial a non-local registry connection for one profile. Never spawns a local
 // child (entry.process stays null — stopPoolBackend/evict already tolerate
 // that shape from remote per-profile overrides).
-async function connectRegistryBackend(source, profile, key, poolEntry) {
+async function connectRegistryBackend(
+  source,
+  profile,
+  key,
+  poolEntry,
+  resolvedSshConfig?,
+  resolvedEffectiveFingerprint?: null | Promise<string>
+) {
   const profileKey = String(profile ?? '').trim() || 'default'
 
   if (source.kind === 'ssh') {
@@ -10146,15 +10229,7 @@ async function connectRegistryBackend(source, profile, key, poolEntry) {
     // pair owns its own tunnel + remote dashboard; the profile that re-homes
     // the REMOTE process is the entry's remoteProfile or the requested one —
     // never the composite string.
-    const sshConfig = normalizeSshConfig({
-      mode: 'ssh',
-      host: source.host,
-      user: source.user,
-      port: source.port,
-      keyPath: source.keyPath,
-      remoteHermesPath: source.remoteHermesPath,
-      remoteProfile: source.remoteProfile || (profileKey === 'default' ? '' : profileKey)
-    })
+    const sshConfig = resolvedSshConfig
 
     if (!sshConfig) {
       throw new Error(`SSH connection "${source.label}" has no host configured.`)
@@ -10164,7 +10239,8 @@ async function connectRegistryBackend(source, profile, key, poolEntry) {
       key,
       sshConfig,
       decryptDesktopSecret(source.token),
-      `registry:${source.id}`
+      `registry:${source.id}`,
+      resolvedEffectiveFingerprint ? await resolvedEffectiveFingerprint : undefined
     )
 
     poolEntry.remoteBaseUrl = connection.baseUrl

--- a/apps/desktop/electron/primary-backend-startup.test.ts
+++ b/apps/desktop/electron/primary-backend-startup.test.ts
@@ -70,6 +70,7 @@ test('primary remote descriptor preserves the effective SSH dialing identity', (
   )
 
   assert.equal(connection.ssh, ssh)
+  assert.equal(connection.ssh?.effectiveConfigFingerprint, 'effective-config')
 })
 
 test('primary remote descriptor keeps legacy unregistered routes unqualified', () => {

--- a/apps/desktop/electron/primary-backend-startup.test.ts
+++ b/apps/desktop/electron/primary-backend-startup.test.ts
@@ -48,6 +48,30 @@ test('primary remote descriptor preserves a resolved registry connection id', ()
   assert.equal(connection.isFullscreen, false)
 })
 
+test('primary remote descriptor preserves the effective SSH dialing identity', () => {
+  const ssh = {
+    effectiveConfigFingerprint: 'effective-config',
+    host: 'build-host',
+    remoteHermesPath: '/srv/hermes',
+    remoteProfile: 'default',
+    user: 'alice'
+  }
+
+  const connection = createPrimaryRemoteConnection(
+    {
+      baseUrl: 'http://127.0.0.1:49152',
+      remoteKind: 'ssh',
+      ssh,
+      token: 'secret',
+      wsUrl: 'ws://127.0.0.1:49152/api/ws'
+    },
+    [],
+    {}
+  )
+
+  assert.equal(connection.ssh, ssh)
+})
+
 test('primary remote descriptor keeps legacy unregistered routes unqualified', () => {
   const connection = createPrimaryRemoteConnection(
     {

--- a/apps/desktop/electron/primary-backend-startup.ts
+++ b/apps/desktop/electron/primary-backend-startup.ts
@@ -20,6 +20,15 @@ interface ResolvedPrimaryRemote {
   remoteHost?: string
   remoteKind?: 'cloud' | 'ssh' | 'url'
   source?: string
+  ssh?: {
+    effectiveConfigFingerprint?: string
+    host?: string
+    keyPath?: string
+    port?: number
+    remoteHermesPath?: string
+    remoteProfile?: string
+    user?: string
+  }
   token: unknown
   wsUrl: string
 }
@@ -43,6 +52,7 @@ export function createPrimaryRemoteConnection<State extends object>(
     remoteKind: remote.remoteKind,
     remoteHermesVersion: remote.remoteHermesVersion,
     ...(remote.connectionId ? { connectionId: remote.connectionId } : {}),
+    ...(remote.ssh ? { ssh: remote.ssh } : {}),
     token: remote.token,
     wsUrl: remote.wsUrl,
     logs,


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop from bootstrapping the same migrated primary SSH backend twice.

Desktop intentionally keeps the legacy `connection.json` route after importing it into the v2 `connections.json` registry. The window backend still resolves through the v1 route, while a registry-scoped request for the same primary/default agent previously opened a second SSH backend under `conn:<id>::default`. The two lifecycle owners then produced reconnect churn and repeated liveness failures.

This change reuses the already-booted primary descriptor only when the registry request targets the primary/default route and the descriptor's actual SSH dialing identity matches. It resolves `ssh -G` asynchronously, treats an empty remote profile and `default` as the same root profile, checks the remote Hermes path, and keeps non-default profiles isolated.

## Related Issue

No existing issue found; reproduced after a Desktop self-update on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/connection-registry.ts`
  - Add the primary/default reuse invariant.
  - Compare migrated SSH routes by effective dialing configuration.
  - Normalize empty/`default` remote-profile identity while preserving named-profile isolation.
- `apps/desktop/electron/main.ts`
  - Reuse the v1 window backend for a matching v2 primary/default registry request instead of opening a second SSH lifecycle.
- `apps/desktop/electron/primary-backend-startup.ts`
  - Preserve the actual SSH dialing identity on the primary descriptor so reuse cannot infer ownership from global configuration.
- `apps/desktop/electron/connection-registry.test.ts`
  - Cover matching and mismatched primary descriptors, non-default profiles, non-primary routes, effective SSH configuration equality, and remote-profile differences.
- `apps/desktop/electron/primary-backend-startup.test.ts`
  - Cover preservation of the SSH dialing identity through primary startup.

## How to Test

1. Run the focused registry tests:
   ```bash
   cd apps/desktop
   npm test -- --run electron/connection-registry.test.ts electron/primary-backend-startup.test.ts
   ```
   Expected: `78 passed` across the two focused files.
2. Run type checking and the Electron project suite:
   ```bash
   npm run typecheck
   npm run test:desktop:platforms
   ```
   Expected: typecheck passes; `1607 passed, 3 skipped`.
3. Runtime reproduction:
   - Configure a primary SSH gateway in legacy `connection.json` and allow Desktop to migrate it into `connections.json`.
   - Launch Desktop and request the registry-scoped primary/default agent.
   - Before this fix, `desktop.log` shows two isolated dashboard spawns followed by paired pooled/cached liveness failures.
   - With this fix, exactly one isolated remote dashboard is spawned and its forwarded `/api/status` remains HTTP 200 beyond the previous failure window.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed PRs/issues to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A: Desktop TypeScript-only change; Electron tests below were run)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] Documentation changes are N/A; behavior and rationale are documented in code and tests
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact was considered; the fix reuses the existing platform-aware effective SSH configuration resolver
- [x] Tool descriptions/schemas are N/A

## Screenshots / Logs

Before the fix, a fresh launch opened two control masters and spawned two remote dashboards for the same default route, then logged paired failures:

```text
Pooled remote backend for profile "conn:<id>::default" failed liveness probe
Cached remote Hermes backend failed liveness probe
```

After the fix on Ubuntu Linux:

```text
remote_dashboards_spawned=1
liveness_failures=0
boot_failures=0
GET http://127.0.0.1:<forwarded-port>/api/status -> 200
```

The repaired tunnel remained healthy for more than three minutes, beyond the former ~20-second failure window. Static secret/injection scan and `git diff --check` were clean.
