### PR TITLE
fix(stt): tolerate truncated audio recordings instead of failing transcription

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1502,6 +1502,41 @@ def _validate_audio_file_size(audio_path: Path) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _remux_with_ffmpeg(file_path: str) -> Optional[str]:
+    """Best-effort recovery of a truncated audio container via ffmpeg.
+
+    Returns a path to a remuxed 16 kHz mono WAV on success, else None.
+    Uses shutil.which so any ffmpeg on PATH works (no hard dependency).
+    """
+    import shutil as _shutil
+    ffmpeg = _shutil.which("ffmpeg")
+    if not ffmpeg:
+        return None
+    tmp = tempfile.NamedTemporaryFile(
+        prefix="hermes-audio-recover-", suffix=".wav", delete=False
+    )
+    tmp.close()
+    try:
+        proc = subprocess.run(
+            [
+                ffmpeg, "-y", "-err_detect", "ignore_err",
+                "-i", file_path, "-vn", "-ar", "16000", "-ac", "1", tmp.name,
+            ],
+            capture_output=True,
+            timeout=120,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        os.unlink(tmp.name)
+        return None
+    if proc.returncode == 0 and os.path.getsize(tmp.name) > 44:
+        return tmp.name
+    try:
+        os.unlink(tmp.name)
+    except OSError:
+        pass
+    return None
+
+
 def _validate_audio_source_file(
     file_path: str,
     *,
@@ -1977,8 +2012,30 @@ def _transcribe_local(
             transcribe_kwargs["initial_prompt"] = prompt
 
         try:
-            segments, info = model.transcribe(file_path, **transcribe_kwargs)
-            transcript = _join_confident_segments(segments, local_config)
+            try:
+                segments, info = model.transcribe(file_path, **transcribe_kwargs)
+                transcript = _join_confident_segments(segments, local_config)
+            except (EOFError, OSError, ValueError) as exc:
+                # Truncated/empty recordings (e.g. the desktop voice recorder
+                # stopped before flushing the WebM container) surface here as
+                # ``av.error.EOFError [Errno 541478725] End of file`` or
+                # ``OSError(5, 'I/O error')``. Try an ffmpeg remux first; if
+                # even ffmpeg cannot read it, treat as silence so live voice
+                # loops re-listen instead of showing a failure toast.
+                recovered = _remux_with_ffmpeg(file_path)
+                if not recovered:
+                    logger.warning(
+                        "Audio %s is truncated/unreadable (%s) — treating as silence.",
+                        Path(file_path).name, exc,
+                    )
+                    return {
+                        "success": True,
+                        "transcript": "",
+                        "no_speech": True,
+                    }
+                logger.info("Retrying transcription via ffmpeg remux after decode error: %s", exc)
+                segments, info = model.transcribe(recovered, **transcribe_kwargs)
+                transcript = _join_confident_segments(segments, local_config)
         except Exception as exc:
             # CUDA runtime libs sometimes only fail at dlopen-on-first-use,
             # AFTER the model loaded successfully.  Evict the broken cached


### PR DESCRIPTION
## Problem

Desktop voice recordings (WebM via MediaRecorder) can end up **truncated** when the recorder stops before flushing the container. faster-whisper surfaces this as:

```
av.error.EOFError: [Errno 541478725] End of file: '...\Temp\hermes-desktop-voice-*.webm'
```

which bubbled all the way up as a user-facing **"Voice transcription failed"** error toast. Reproduced on Windows by truncating a valid WebM at various offsets — cuts inside the first cluster reproduce this exact error signature at `av.open`.

## Fix

Two-layer tolerance in `_transcribe_local()`:

1. On `EOFError`/`OSError`/`ValueError` from `model.transcribe()`, retry through an **ffmpeg remux** (`-err_detect ignore_err` → 16 kHz mono WAV), which recovers decodable truncations. ffmpeg is resolved via `shutil.which` — no hard dependency.
2. If even ffmpeg cannot read the file, treat it as **silence** (`success=True, transcript="", no_speech=True`) so live voice loops quietly re-listen instead of surfacing a failure toast on every empty recording.

## Testing

Verified against synthetic truncated WebMs (generated with PyAV + Opus):

| Scenario | Before | After |
|---|---|---|
| WebM truncated inside first cluster (user's exact failure) | ❌ `Local transcription failed` | ✅ treated as silence |
| WebM truncated but decodable | ❌ error | ✅ recovered via ffmpeg remux |
| Valid file | ✅ | ✅ (no regression) |

Also confirmed end-to-end through `transcribe_recording()` (the desktop `/api/audio/transcribe` path).