### PR TITLE
feat(mcp): add EnvelopeBudget catalog entry

### DIFF
--- a/optional-mcps/envelopebudget/manifest.yaml
+++ b/optional-mcps/envelopebudget/manifest.yaml
@@ -4,16 +4,17 @@ manifest_version: 1
 
 name: envelopebudget
 description: >-
-  Read-only access to authorized EnvelopeBudget budgets, transactions,
-  envelope balances, spending, cashflow, and AI categorization reviews.
+  Read-only-by-default access to authorized EnvelopeBudget budgets,
+  transactions, envelope balances, spending, cashflow, and optional
+  explicitly scoped categorization workflows.
 source: https://github.com/envelope-budget/envelopebudget-mcp
 
-# Official vendor-hosted Streamable HTTP server. Version 1 is deliberately
-# read-only and uses a user-created EnvelopeBudget developer key.
+# Official vendor-hosted Streamable HTTP server. API keys are read-only by
+# default; categorization writes require separate user-selected scopes.
 transport:
   type: http
   url: https://envelopebudget.com/mcp
-  version: "1.0.0"
+  version: "1.2.0"
 
 auth:
   type: api_key
@@ -48,8 +49,12 @@ post_install: |
   Create a dedicated, expiring key at
   https://envelopebudget.com/developer/api-keys before installation.
 
-  EnvelopeBudget MCP v1 is read-only. It cannot create or update
-  transactions, move funds, start AI jobs, record consent, or approve
-  suggestions. Delete or rotate the developer key to disconnect Hermes.
+  This catalog enables only the 11 read-only tools by default. The live v1.2
+  server also advertises three write tools, but they require separate API-key
+  scopes and are intentionally not enabled by this catalog entry. Direct
+  categorization cannot create transactions, change amounts, dates, payees,
+  memos, or accounts, or move envelope funds.
+
+  Delete or rotate the developer key to disconnect Hermes.
 
   Start a new Hermes session after installation so the tools load.

--- a/optional-mcps/envelopebudget/manifest.yaml
+++ b/optional-mcps/envelopebudget/manifest.yaml
@@ -1,0 +1,55 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: envelopebudget
+description: >-
+  Read-only access to authorized EnvelopeBudget budgets, transactions,
+  envelope balances, spending, cashflow, and AI categorization reviews.
+source: https://github.com/envelope-budget/envelopebudget-mcp
+
+# Official vendor-hosted Streamable HTTP server. Version 1 is deliberately
+# read-only and uses a user-created EnvelopeBudget developer key.
+transport:
+  type: http
+  url: https://envelopebudget.com/mcp
+  version: "1.0.0"
+
+auth:
+  type: api_key
+  env:
+    - name: MCP_ENVELOPEBUDGET_API_KEY
+      prompt: "EnvelopeBudget developer API key (Developer → API Keys)"
+      required: true
+      secret: true
+
+tools:
+  default_enabled:
+    - list_budgets
+    - get_budget_overview
+    - list_accounts
+    - list_envelopes
+    - search_transactions
+    - get_transaction
+    - get_spending_summary
+    - get_cashflow_summary
+    - get_ai_categorization_disclosure
+    - list_ai_categorization_jobs
+    - get_ai_categorization_review
+
+suggest:
+  keywords:
+    - envelopebudget
+    - envelope budget
+  hosts:
+    - envelopebudget.com
+
+post_install: |
+  Create a dedicated, expiring key at
+  https://envelopebudget.com/developer/api-keys before installation.
+
+  EnvelopeBudget MCP v1 is read-only. It cannot create or update
+  transactions, move funds, start AI jobs, record consent, or approve
+  suggestions. Delete or rotate the developer key to disconnect Hermes.
+
+  Start a new Hermes session after installation so the tools load.


### PR DESCRIPTION
## Summary

Add the official EnvelopeBudget remote MCP server to the reviewed Hermes catalog.

- hosted Streamable HTTP endpoint: `https://envelopebudget.com/mcp`
- active official Registry entry: `com.envelopebudget/mcp` v1.2.0
- API-key setup through the catalog's existing `http + api_key` path
- secret stored as `MCP_ENVELOPEBUDGET_API_KEY`; generated config keeps only the Bearer interpolation
- all 11 read-only tools enabled by default
- three write tools remain intentionally disabled by default and require separate EnvelopeBudget API-key scopes
- composer suggestions for `EnvelopeBudget` and `envelopebudget.com`
- source and security documentation: https://github.com/envelope-budget/envelopebudget-mcp

## Safety

EnvelopeBudget keys are read-only by default. The live server advertises 14 tools, but this catalog enables only the 11 read tools. Provider-suggestion and direct transaction-categorization tools require separate user-selected key scopes. Direct categorization uses signed stale-state tokens, idempotency, durable attribution, and batch Undo; it cannot create transactions, change amounts/dates/payees/memos/accounts, or move envelope funds.

## Verification

- manifest parsed through `hermes_cli.mcp_catalog._parse_manifest`
- generated HTTP config uses `Authorization: Bearer ${MCP_ENVELOPEBUDGET_API_KEY}`
- exactly 11 default tools
- live production v1.2 reports 14 tools
- public production assignment, idempotency, conflict, audit, balances, Undo, and zero-fixture cleanup passed
- Registry v1.2.0 is active and latest
