### PR TITLE
feat(skills): add optional gbr phone-pairing skill

### DIFF
--- a/optional-skills/mcp/DESCRIPTION.md
+++ b/optional-skills/mcp/DESCRIPTION.md
@@ -2,4 +2,4 @@
 
 Skills for building, testing, and deploying MCP (Model Context Protocol) servers.
 
-- `gbr`: pair a phone spectator to this Hermes host (`gbr-agent` + loopback `:8788` / `gbr-mcp`).
+- `gbr`: pair a phone spectator to this Hermes host (`gbr-agent` + stdio `gbr-mcp`; `:8788` is Bot API REST).

--- a/optional-skills/mcp/DESCRIPTION.md
+++ b/optional-skills/mcp/DESCRIPTION.md
@@ -1,3 +1,5 @@
 # MCP
 
 Skills for building, testing, and deploying MCP (Model Context Protocol) servers.
+
+- `gbr`: pair a phone with Build Remote Agent (`gbr-agent` + loopback `:8788` / `gbr-mcp`).

--- a/optional-skills/mcp/DESCRIPTION.md
+++ b/optional-skills/mcp/DESCRIPTION.md
@@ -2,4 +2,4 @@
 
 Skills for building, testing, and deploying MCP (Model Context Protocol) servers.
 
-- `gbr`: pair a phone with Build Remote Agent (`gbr-agent` + loopback `:8788` / `gbr-mcp`).
+- `gbr`: pair a phone spectator to this Hermes host (`gbr-agent` + loopback `:8788` / `gbr-mcp`).

--- a/optional-skills/mcp/gbr/SKILL.md
+++ b/optional-skills/mcp/gbr/SKILL.md
@@ -10,8 +10,6 @@ metadata:
     tags: [MCP, Mobile, Pairing]
     related_skills: [hermes-agent]
     homepage: https://grokbuildremote.com/
-prerequisites:
-  commands: [gbr-agent]
 ---
 
 # GBR Skill
@@ -33,21 +31,22 @@ Do not use for:
 
 ## Prerequisites
 
-- `gbr-agent` v0.6.0 or newer on PATH. Prefer a pinned GitHub Release binary from https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0 (assets `gbr-agent-<os>-<arch>`). The website `install.sh` is mutable; do not treat it as a pin.
+- `gbr-agent` ≥0.6.0 on PATH. Prefer a pinned GitHub Release binary from https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0 (assets `gbr-agent-<os>-<arch>`). The website `install.sh` is mutable; do not treat it as a pin.
+- `node` on PATH when attaching via stdio `gbr-mcp` on the Hermes box. HTTP attach does not need Node.
 - Phone app: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
 - Attach is only `http://127.0.0.1:8788` (after `gbr-agent run` on this same host) or stdio `gbr-mcp`.
-- MCP setup is on the Hermes box, not on a remote GBR host. HTTP loopback works only when `gbr-agent run` is local to Hermes. Stdio `gbr-mcp` needs Node on the Hermes box.
+- MCP setup is on the Hermes box, not on a remote GBR host. HTTP loopback works only when `gbr-agent run` is local to Hermes.
 
-Register MCP through `terminal` after the binary or `gbr-mcp` is present:
+Register MCP through `terminal` after the binary or `gbr-mcp` is present (`hermes mcp add` takes `--url` or `--command`/`--args`, not a `--` URL remainder):
 
 ```
-terminal(command="hermes mcp add gbr -- http://127.0.0.1:8788")
+terminal(command="hermes mcp add gbr --url http://127.0.0.1:8788")
 ```
 
 or stdio:
 
 ```
-terminal(command="hermes mcp add gbr -- stdio -- node ./bin/gbr-mcp.js")
+terminal(command="hermes mcp add gbr --command node --args ./bin/gbr-mcp.js")
 ```
 
 Equivalent `~/.hermes/config.yaml` (HTTP, same host):
@@ -66,9 +65,14 @@ Invoke host commands through the `terminal` tool. Do not substitute a fourth pai
 terminal(command="gbr-agent version")
 terminal(command="gbr-agent pair", pty=true, timeout=180)
 terminal(command="gbr-agent run", background=true)
+terminal(command="hermes mcp add gbr --url http://127.0.0.1:8788")
 ```
 
-`gbr-agent pair` prints an 8-char code and opens a browser QR. The phone scans the QR or types that code. Then keep `gbr-agent run` running.
+`gbr-agent pair` prints an 8-char code and opens a browser QR. The phone scans the QR or types that code. Then keep `gbr-agent run` running. Stdio attach instead of HTTP:
+
+```
+terminal(command="hermes mcp add gbr --command node --args ./bin/gbr-mcp.js")
+```
 
 ## Quick Reference
 
@@ -79,8 +83,8 @@ terminal(command="gbr-agent run", background=true)
 | `gbr-agent run` | Serve loopback `http://127.0.0.1:8788` |
 | `gbr-agent doctor` | Prove install and pair health |
 | `gbr-agent status` | List local session |
-| `hermes mcp add gbr -- http://127.0.0.1:8788` | HTTP attach (same host) |
-| `hermes mcp add gbr -- stdio -- node ./bin/gbr-mcp.js` | Stdio `gbr-mcp` on the Hermes box |
+| `hermes mcp add gbr --url http://127.0.0.1:8788` | HTTP attach (same host) |
+| `hermes mcp add gbr --command node --args ./bin/gbr-mcp.js` | Stdio `gbr-mcp` on the Hermes box |
 
 ## Procedure
 
@@ -88,8 +92,9 @@ terminal(command="gbr-agent run", background=true)
 2. On the phone, open Build Remote Agent → Connect.
 3. On the host, invoke `gbr-agent pair` through `terminal` (`pty=true`). Done when a QR page is open **and** an 8-char code is printed.
 4. Phone scans the QR **or** types the 8-char code. Done when the phone shows this host as paired.
-5. Invoke `gbr-agent run` through `terminal` (`background=true`). Done when the process stays up and loopback `http://127.0.0.1:8788` is the attach URL (or stdio `gbr-mcp` is registered on the Hermes box).
-6. Phone spectates and may veto; it does not drive the Hermes tool loop.
+5. Invoke `gbr-agent run` through `terminal` (`background=true`). Done when the process stays up and loopback `http://127.0.0.1:8788` is the attach URL.
+6. On the Hermes box, register MCP through `terminal`: `hermes mcp add gbr --url http://127.0.0.1:8788` (same host) or `hermes mcp add gbr --command node --args ./bin/gbr-mcp.js` (stdio `gbr-mcp`). Done when `hermes mcp list` shows `gbr`.
+7. Phone spectates and may veto; it does not drive the Hermes tool loop.
 
 ## Pitfalls
 

--- a/optional-skills/mcp/gbr/SKILL.md
+++ b/optional-skills/mcp/gbr/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: gbr
+description: >
+  Pair a phone running Build Remote Agent to Hermes. Requires gbr-agent run on
+  the host. Attach via Bot API 127.0.0.1:8788 or hermes mcp add gbr (stdio gbr-mcp).
+  Use when the user wants a mobile spectator / inject into this Hermes session.
+version: 1.0.0
+author: community
+license: MIT
+platforms: [linux, macos, windows]
+compatibility: Requires gbr-agent ≥ 0.6.0 on the host. Loopback only. No mailbox keys in this file.
+metadata:
+  hermes:
+    tags: [MCP, Mobile, Pairing, Tools]
+    homepage: https://grokbuildremote.com/
+    product: "Build Remote Agent"
+  version: "0.6.1"
+prerequisites:
+  commands: [node, gbr-agent]
+---
+
+# Build Remote Agent — pairing device
+
+One adapter. Protocol `gbr/1`. No fourth pair protocol.
+
+Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
+
+Hermes messaging channels (Telegram, WhatsApp, …) are not `gbr/1`. The phone
+app spectates the **desktop** Hermes session through the host Bot API / MCP.
+
+This skill is optional (not bundled). Install with `hermes skills install` from
+this path, or copy to `~/.hermes/skills/`.
+
+## Pair (unchanged)
+
+1. Phone: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
+2. PC: `gbr-agent pair` — browser QR **and** printed 8-char code.
+3. Phone scans QR **or** types the 8-char code.
+4. PC: `gbr-agent run` (keep it running).
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Unpair on the phone before a new mailbox. Force-close is not enough.
+
+## Attach (only these)
+
+| How | Where |
+|-----|--------|
+| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
+| MCP | `gbr-mcp` stdio (same JSON as Bot API) |
+
+Phone is spectator + veto, not orchestrator.
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+curl -sS -X POST http://127.0.0.1:8788/v1/inject \
+  -H 'Content-Type: application/json' \
+  -d '{"session_id":"SESSION","text":"hello","submit":true}'
+```
+
+## Hermes MCP
+
+```bash
+git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
+cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
+node bin/gbr-mcp.js --diagnose
+
+# stdio (works even if you only have gbr-mcp on this box)
+hermes mcp add gbr -- stdio -- node ./bin/gbr-mcp.js
+
+# HTTP only if gbr-agent run is already on this same host:
+# hermes mcp add gbr -- http://127.0.0.1:8788
+```
+
+Equivalent `~/.hermes/config.yaml` (never put mailbox keys here):
+
+```yaml
+mcp_servers:
+  gbr:
+    command: "node"
+    args: ["/absolute/path/to/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+```
+
+Remote bots: phone **Settings → Bot API** copies relay URL + mailbox id + key. Never commit the key.
+
+## Loop
+
+diagnose → open/attach → lock → inject → wait idle → harvest excerpt → iterate or close
+
+Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md

--- a/optional-skills/mcp/gbr/SKILL.md
+++ b/optional-skills/mcp/gbr/SKILL.md
@@ -1,95 +1,111 @@
 ---
 name: gbr
-description: >
-  Pair a phone running Build Remote Agent to Hermes. Requires gbr-agent run on
-  the host. Attach via Bot API 127.0.0.1:8788 or hermes mcp add gbr (stdio gbr-mcp).
-  Use when the user wants a mobile spectator / inject into this Hermes session.
+description: Pair a phone spectator to this Hermes host session.
 version: 1.0.0
-author: community
+author: David Rad (LinespottingPrivate), Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
-compatibility: Requires gbr-agent ≥ 0.6.0 on the host. Loopback only. No mailbox keys in this file.
 metadata:
   hermes:
-    tags: [MCP, Mobile, Pairing, Tools]
+    tags: [MCP, Mobile, Pairing]
+    related_skills: [hermes-agent]
     homepage: https://grokbuildremote.com/
-    product: "Build Remote Agent"
-  version: "0.6.1"
 prerequisites:
-  commands: [node, gbr-agent]
+  commands: [gbr-agent]
 ---
 
-# Build Remote Agent — pairing device
+# GBR Skill
 
-One adapter. Protocol `gbr/1`. No fourth pair protocol.
+Pair a phone running Build Remote Agent as a spectator (and veto) on this Hermes host session. Protocol is `gbr/1` only: phone app, `gbr-agent pair` (QR and printed 8-char code), then `gbr-agent run`. This skill does not make the phone the orchestrator, does not treat Hermes chat channels as the pair path, and does not require Hermes to run on a GBR host — MCP add stays on the Hermes box.
 
 Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.
 
-Hermes messaging channels (Telegram, WhatsApp, …) are not `gbr/1`. The phone
-app spectates the **desktop** Hermes session through the host Bot API / MCP.
+## When to Use
 
-This skill is optional (not bundled). Install with `hermes skills install` from
-this path, or copy to `~/.hermes/skills/`.
+- The user wants a phone to spectate or veto this Hermes host session.
+- The user asks to pair Build Remote Agent / `gbr-agent` with Hermes.
 
-## Pair (unchanged)
+Do not use for:
 
-1. Phone: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
-2. PC: `gbr-agent pair` — browser QR **and** printed 8-char code.
-3. Phone scans QR **or** types the 8-char code.
-4. PC: `gbr-agent run` (keep it running).
+- Making the phone the orchestrator
+- Pairing through Hermes messaging (Telegram, WhatsApp, Discord, …)
+- Any fourth pair protocol beyond phone app + `gbr-agent pair` + `gbr-agent run`
 
-```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash   # Windows: irm https://grokbuildremote.com/install.ps1 | iex
-gbr-agent version    # need v0.6.0+
-gbr-agent pair && gbr-agent run
+## Prerequisites
+
+- `gbr-agent` v0.6.0 or newer on PATH. Prefer a pinned GitHub Release binary from https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0 (assets `gbr-agent-<os>-<arch>`). The website `install.sh` is mutable; do not treat it as a pin.
+- Phone app: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
+- Attach is only `http://127.0.0.1:8788` (after `gbr-agent run` on this same host) or stdio `gbr-mcp`.
+- MCP setup is on the Hermes box, not on a remote GBR host. HTTP loopback works only when `gbr-agent run` is local to Hermes. Stdio `gbr-mcp` needs Node on the Hermes box.
+
+Register MCP through `terminal` after the binary or `gbr-mcp` is present:
+
+```
+terminal(command="hermes mcp add gbr -- http://127.0.0.1:8788")
 ```
 
-Unpair on the phone before a new mailbox. Force-close is not enough.
+or stdio:
 
-## Attach (only these)
-
-| How | Where |
-|-----|--------|
-| Bot API | `http://127.0.0.1:8788` after `gbr-agent run` |
-| MCP | `gbr-mcp` stdio (same JSON as Bot API) |
-
-Phone is spectator + veto, not orchestrator.
-
-```bash
-curl -sS http://127.0.0.1:8788/health
-curl -sS http://127.0.0.1:8788/v1/sessions
-curl -sS -X POST http://127.0.0.1:8788/v1/inject \
-  -H 'Content-Type: application/json' \
-  -d '{"session_id":"SESSION","text":"hello","submit":true}'
+```
+terminal(command="hermes mcp add gbr -- stdio -- node ./bin/gbr-mcp.js")
 ```
 
-## Hermes MCP
-
-```bash
-git clone https://github.com/LinespottingOrg/GrokBuildRemote-Agents.git
-cd GrokBuildRemote-Agents/mcp/gbr-mcp && npm install
-node bin/gbr-mcp.js --diagnose
-
-# stdio (works even if you only have gbr-mcp on this box)
-hermes mcp add gbr -- stdio -- node ./bin/gbr-mcp.js
-
-# HTTP only if gbr-agent run is already on this same host:
-# hermes mcp add gbr -- http://127.0.0.1:8788
-```
-
-Equivalent `~/.hermes/config.yaml` (never put mailbox keys here):
+Equivalent `~/.hermes/config.yaml` (HTTP, same host):
 
 ```yaml
 mcp_servers:
   gbr:
-    command: "node"
-    args: ["/absolute/path/to/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js"]
+    url: "http://127.0.0.1:8788"
 ```
 
-Remote bots: phone **Settings → Bot API** copies relay URL + mailbox id + key. Never commit the key.
+## How to Run
 
-## Loop
+Invoke host commands through the `terminal` tool. Do not substitute a fourth pair path.
 
-diagnose → open/attach → lock → inject → wait idle → harvest excerpt → iterate or close
+```
+terminal(command="gbr-agent version")
+terminal(command="gbr-agent pair", pty=true, timeout=180)
+terminal(command="gbr-agent run", background=true)
+```
 
-Docs: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/BOT-API.md
+`gbr-agent pair` prints an 8-char code and opens a browser QR. The phone scans the QR or types that code. Then keep `gbr-agent run` running.
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `gbr-agent version` | Confirm v0.6.0+ |
+| `gbr-agent pair` | QR **and** printed 8-char code |
+| `gbr-agent run` | Serve loopback `http://127.0.0.1:8788` |
+| `gbr-agent doctor` | Prove install and pair health |
+| `gbr-agent status` | List local session |
+| `hermes mcp add gbr -- http://127.0.0.1:8788` | HTTP attach (same host) |
+| `hermes mcp add gbr -- stdio -- node ./bin/gbr-mcp.js` | Stdio `gbr-mcp` on the Hermes box |
+
+## Procedure
+
+1. Confirm `gbr-agent version` reports v0.6.0 or newer via `terminal`. Done when stdout includes `v0.6` or higher.
+2. On the phone, open Build Remote Agent → Connect.
+3. On the host, invoke `gbr-agent pair` through `terminal` (`pty=true`). Done when a QR page is open **and** an 8-char code is printed.
+4. Phone scans the QR **or** types the 8-char code. Done when the phone shows this host as paired.
+5. Invoke `gbr-agent run` through `terminal` (`background=true`). Done when the process stays up and loopback `http://127.0.0.1:8788` is the attach URL (or stdio `gbr-mcp` is registered on the Hermes box).
+6. Phone spectates and may veto; it does not drive the Hermes tool loop.
+
+## Pitfalls
+
+- Unpair on the phone before pairing a new host. Force-close is not enough.
+- Website `install.sh` / `install.ps1` can change without a tag; pin GitHub Release v0.6.0+.
+- `http://127.0.0.1:8788` is loopback. It is not reachable if Hermes is on another machine — use stdio `gbr-mcp` on the Hermes box instead.
+- Hermes messaging channels are not `gbr/1`.
+- Do not invent a fourth pair protocol.
+- Phone is spectator + veto, not orchestrator.
+
+## Verification
+
+One command, through `terminal`:
+
+```
+terminal(command="gbr-agent doctor")
+```
+
+Done when `gbr-agent doctor` exits 0.

--- a/optional-skills/mcp/gbr/SKILL.md
+++ b/optional-skills/mcp/gbr/SKILL.md
@@ -28,34 +28,33 @@ Do not use for:
 - Making the phone the orchestrator
 - Pairing through Hermes messaging (Telegram, WhatsApp, Discord, …)
 - Any fourth pair protocol beyond phone app + `gbr-agent pair` + `gbr-agent run`
+- Registering `http://127.0.0.1:8788` as a Hermes MCP `--url` (that port is Bot API REST, not MCP)
 
 ## Prerequisites
 
 - `gbr-agent` ≥0.6.0 on PATH. Prefer a pinned GitHub Release binary from https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0 (assets `gbr-agent-<os>-<arch>`). The website `install.sh` is mutable; do not treat it as a pin.
-- `node` on PATH when attaching via stdio `gbr-mcp` on the Hermes box. HTTP attach does not need Node.
+- `node` on PATH. Hermes MCP attach is **stdio `gbr-mcp` only**.
+- Clone `mcp/gbr-mcp` from that same tagged Agents repo (`npm install` in `mcp/gbr-mcp`). There is no npm package.
 - Phone app: [Build Remote Agent](https://grokbuildremote.com/) → Connect.
-- Attach is only `http://127.0.0.1:8788` (after `gbr-agent run` on this same host) or stdio `gbr-mcp`.
-- MCP setup is on the Hermes box, not on a remote GBR host. HTTP loopback works only when `gbr-agent run` is local to Hermes.
+- `gbr-agent run` serves Bot API REST at `http://127.0.0.1:8788` on this host. That URL is not an MCP endpoint.
+- MCP setup is on the Hermes box. `gbr-mcp` then talks HTTP to local `:8788`.
 
-Register MCP through `terminal` after the binary or `gbr-mcp` is present (`hermes mcp add` takes `--url` or `--command`/`--args`, not a `--` URL remainder):
-
-```
-terminal(command="hermes mcp add gbr --url http://127.0.0.1:8788")
-```
-
-or stdio:
+Register MCP through `terminal` after `gbr-mcp` is present (`hermes mcp add` takes `--command` / `--args`, not a `--` remainder, and not `--url` against `:8788`):
 
 ```
-terminal(command="hermes mcp add gbr --command node --args ./bin/gbr-mcp.js")
+terminal(command="hermes mcp add gbr --command node --args mcp/gbr-mcp/bin/gbr-mcp.js")
 ```
 
-Equivalent `~/.hermes/config.yaml` (HTTP, same host):
+Equivalent `~/.hermes/config.yaml` (stdio):
 
 ```yaml
 mcp_servers:
   gbr:
-    url: "http://127.0.0.1:8788"
+    command: node
+    args: ["mcp/gbr-mcp/bin/gbr-mcp.js"]
 ```
+
+Use an absolute path to `bin/gbr-mcp.js` if the working directory is not the Agents clone. Then `hermes mcp test gbr` (new chat to load tools).
 
 ## How to Run
 
@@ -65,14 +64,10 @@ Invoke host commands through the `terminal` tool. Do not substitute a fourth pai
 terminal(command="gbr-agent version")
 terminal(command="gbr-agent pair", pty=true, timeout=180)
 terminal(command="gbr-agent run", background=true)
-terminal(command="hermes mcp add gbr --url http://127.0.0.1:8788")
+terminal(command="hermes mcp add gbr --command node --args mcp/gbr-mcp/bin/gbr-mcp.js")
 ```
 
-`gbr-agent pair` prints an 8-char code and opens a browser QR. The phone scans the QR or types that code. Then keep `gbr-agent run` running. Stdio attach instead of HTTP:
-
-```
-terminal(command="hermes mcp add gbr --command node --args ./bin/gbr-mcp.js")
-```
+`gbr-agent pair` prints an 8-char code and opens a browser QR. The phone scans the QR or types that code. Then keep `gbr-agent run` running so Bot API REST is on loopback `:8788`. Hermes talks to that API **through stdio `gbr-mcp`**, not as MCP HTTP.
 
 ## Quick Reference
 
@@ -80,11 +75,11 @@ terminal(command="hermes mcp add gbr --command node --args ./bin/gbr-mcp.js")
 |---------|---------|
 | `gbr-agent version` | Confirm v0.6.0+ |
 | `gbr-agent pair` | QR **and** printed 8-char code |
-| `gbr-agent run` | Serve loopback `http://127.0.0.1:8788` |
+| `gbr-agent run` | Serve Bot API REST `http://127.0.0.1:8788` |
 | `gbr-agent doctor` | Prove install and pair health |
 | `gbr-agent status` | List local session |
-| `hermes mcp add gbr --url http://127.0.0.1:8788` | HTTP attach (same host) |
-| `hermes mcp add gbr --command node --args ./bin/gbr-mcp.js` | Stdio `gbr-mcp` on the Hermes box |
+| `hermes mcp add gbr --command node --args mcp/gbr-mcp/bin/gbr-mcp.js` | Stdio `gbr-mcp` on the Hermes box |
+| `hermes mcp test gbr` | Handshake; expect 13 tools |
 
 ## Procedure
 
@@ -92,15 +87,16 @@ terminal(command="hermes mcp add gbr --command node --args ./bin/gbr-mcp.js")
 2. On the phone, open Build Remote Agent → Connect.
 3. On the host, invoke `gbr-agent pair` through `terminal` (`pty=true`). Done when a QR page is open **and** an 8-char code is printed.
 4. Phone scans the QR **or** types the 8-char code. Done when the phone shows this host as paired.
-5. Invoke `gbr-agent run` through `terminal` (`background=true`). Done when the process stays up and loopback `http://127.0.0.1:8788` is the attach URL.
-6. On the Hermes box, register MCP through `terminal`: `hermes mcp add gbr --url http://127.0.0.1:8788` (same host) or `hermes mcp add gbr --command node --args ./bin/gbr-mcp.js` (stdio `gbr-mcp`). Done when `hermes mcp list` shows `gbr`.
+5. Invoke `gbr-agent run` through `terminal` (`background=true`). Done when the process stays up and loopback `http://127.0.0.1:8788` answers Bot API REST (`/v1/status`).
+6. On the Hermes box, register MCP through `terminal`: `hermes mcp add gbr --command node --args mcp/gbr-mcp/bin/gbr-mcp.js`. Done when `hermes mcp list` shows `gbr` and `hermes mcp test gbr` reports tools.
 7. Phone spectates and may veto; it does not drive the Hermes tool loop.
 
 ## Pitfalls
 
 - Unpair on the phone before pairing a new host. Force-close is not enough.
 - Website `install.sh` / `install.ps1` can change without a tag; pin GitHub Release v0.6.0+.
-- `http://127.0.0.1:8788` is loopback. It is not reachable if Hermes is on another machine — use stdio `gbr-mcp` on the Hermes box instead.
+- Do not `hermes mcp add gbr --url http://127.0.0.1:8788`. That port is Bot API REST. MCP handshake fails. Use stdio `gbr-mcp`.
+- `http://127.0.0.1:8788` is loopback. If `gbr-agent run` is on another machine, stdio `gbr-mcp` must still run next to that agent (or use the agent's documented relay), not a remote Hermes `--url` to `:8788`.
 - Hermes messaging channels are not `gbr/1`.
 - Do not invent a fourth pair protocol.
 - Phone is spectator + veto, not orchestrator.

--- a/tests/skills/test_gbr_skill.py
+++ b/tests/skills/test_gbr_skill.py
@@ -1,0 +1,130 @@
+"""Tests for the optional gbr phone-pairing skill.
+
+Stdlib + pytest + unittest.mock only. No live network.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL_MD = REPO / "optional-skills" / "mcp" / "gbr" / "SKILL.md"
+DESCRIPTION_MD = REPO / "optional-skills" / "mcp" / "DESCRIPTION.md"
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
+
+FORBIDDEN = (
+    "mailbox key",
+    "mailbox keys",
+    "x-gbr-key",
+    "device.json",
+)
+
+MARKETING = re.compile(
+    r"\b(powerful|comprehensive|seamless|advanced)\b",
+    re.I,
+)
+
+
+def _skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_skill_lives_under_optional_mcp_not_bundled_or_plugins():
+    assert SKILL_MD.is_file()
+    rel = SKILL_MD.relative_to(REPO).as_posix()
+    assert rel == "optional-skills/mcp/gbr/SKILL.md"
+    assert not (REPO / "skills" / "mcp" / "gbr" / "SKILL.md").exists()
+    assert not (REPO / "plugins" / "gbr").exists()
+
+
+def test_description_hardline_single_line():
+    text = _skill_text()
+    m = re.search(r"^description: (.*)$", text, re.MULTILINE)
+    assert m, "description must be a single YAML line, not a folded block"
+    desc = m.group(1)
+    assert len(desc) <= 60, (desc, len(desc))
+    assert desc.endswith(".")
+    assert not desc.startswith(">")
+    assert "gbr" not in desc.lower()
+    assert not MARKETING.search(desc)
+
+
+def test_frontmatter_author_credits_human_first():
+    text = _skill_text()
+    m = re.search(r"^author: (.*)$", text, re.MULTILINE)
+    assert m, "author field missing"
+    author = m.group(1).strip()
+    lead = author.split(",")[0].strip()
+    assert lead != "community"
+    assert lead != "Hermes Agent"
+    assert "David Rad" in lead
+    assert "LinespottingPrivate" in lead
+
+
+def test_required_sections_in_order():
+    text = _skill_text()
+    assert re.search(r"^# GBR Skill\s*$", text, re.MULTILINE)
+    positions = []
+    for heading in REQUIRED_SECTIONS:
+        idx = text.find(heading)
+        assert idx != -1, f"missing section {heading}"
+        positions.append(idx)
+    assert positions == sorted(positions)
+
+
+def test_how_to_run_uses_terminal_tool():
+    text = _skill_text()
+    how = text.split("## How to Run", 1)[1].split("## ", 1)[0]
+    assert "`terminal`" in how
+    assert "gbr-agent pair" in how
+    assert "gbr-agent run" in how
+
+
+def test_verification_is_one_gbr_agent_command():
+    text = _skill_text()
+    verify = text.split("## Verification", 1)[1]
+    assert "gbr-agent doctor" in verify
+    assert "curl" not in verify.lower()
+
+
+def test_no_secrets_or_host_key_material():
+    blob = _skill_text().lower()
+    for needle in FORBIDDEN:
+        assert needle not in blob, f"forbidden {needle!r} in SKILL.md"
+
+
+def test_no_curl_grep_cat_prose_and_no_folded_description():
+    text = _skill_text()
+    assert "description: >" not in text
+    assert re.search(r"\bcurl\b", text, re.I) is None
+    # Word-level: do not instruct the agent to grep/cat host files.
+    assert re.search(r"(?i)(?<!/)(?<!\w)grep(?!\w)", text) is None
+    assert re.search(r"(?i)(?<!/)(?<!\w)cat(?!\w)", text) is None
+
+
+def test_attach_only_loopback_or_stdio_and_spectator_role():
+    text = _skill_text()
+    assert "http://127.0.0.1:8788" in text
+    assert "gbr-mcp" in text
+    assert "spectator" in text.lower()
+    assert "not orchestrator" in text.lower()
+    assert "Linespotting AB" in text
+    assert "not affiliated with xai or spacex" in text.lower()
+    assert "fourth pair" in text.lower()
+    assert "install.sh" in text and "mutable" in text.lower()
+
+
+def test_description_index_one_liner():
+    index = DESCRIPTION_MD.read_text(encoding="utf-8")
+    assert "`gbr`:" in index
+    gbr_lines = [ln for ln in index.splitlines() if "`gbr`" in ln]
+    assert len(gbr_lines) == 1

--- a/tests/skills/test_gbr_skill.py
+++ b/tests/skills/test_gbr_skill.py
@@ -87,6 +87,8 @@ def test_how_to_run_uses_terminal_tool():
     assert "`terminal`" in how
     assert "gbr-agent pair" in how
     assert "gbr-agent run" in how
+    assert "hermes mcp add gbr --command node --args" in how
+    assert "hermes mcp add gbr --url" not in how
 
 
 def test_verification_is_one_gbr_agent_command():
@@ -117,10 +119,11 @@ def test_attach_only_loopback_or_stdio_and_spectator_role():
     assert "gbr-mcp" in text
     assert "spectator" in text.lower()
     assert "not orchestrator" in text.lower()
-    # Real CLI: hermes mcp add NAME --url|--command|--args (not Claude-style -- remainder).
-    assert "hermes mcp add gbr --url http://127.0.0.1:8788" in text
-    assert "hermes mcp add gbr --command node --args ./bin/gbr-mcp.js" in text
+    # Real CLI: hermes mcp add NAME --command/--args. :8788 is Bot API REST, not MCP HTTP.
+    assert "hermes mcp add gbr --command node --args mcp/gbr-mcp/bin/gbr-mcp.js" in text
+    assert "hermes mcp add gbr --url http://127.0.0.1:8788" not in text
     assert "hermes mcp add gbr -- " not in text
+    assert "Bot API REST" in text
 
 
 def test_description_index_one_liner():

--- a/tests/skills/test_gbr_skill.py
+++ b/tests/skills/test_gbr_skill.py
@@ -117,10 +117,10 @@ def test_attach_only_loopback_or_stdio_and_spectator_role():
     assert "gbr-mcp" in text
     assert "spectator" in text.lower()
     assert "not orchestrator" in text.lower()
-    assert "Linespotting AB" in text
-    assert "not affiliated with xai or spacex" in text.lower()
-    assert "fourth pair" in text.lower()
-    assert "install.sh" in text and "mutable" in text.lower()
+    # Real CLI: hermes mcp add NAME --url|--command|--args (not Claude-style -- remainder).
+    assert "hermes mcp add gbr --url http://127.0.0.1:8788" in text
+    assert "hermes mcp add gbr --command node --args ./bin/gbr-mcp.js" in text
+    assert "hermes mcp add gbr -- " not in text
 
 
 def test_description_index_one_liner():


### PR DESCRIPTION
## What

Optional skill (`optional-skills/mcp/gbr/`) so a phone can spectate (and veto) this Hermes host session. Not bundled. Not a `plugins/` product integration.

HARDLINE fixes in this update:
- `description` is a single line, 51 characters, one sentence, ends with a period (no YAML `>` fold)
- Body uses modern section order: When to Use, Prerequisites, How to Run (`terminal`), Quick Reference, Procedure, Pitfalls, Verification
- `author` credits David Rad (LinespottingPrivate) first
- Tests at `tests/skills/test_gbr_skill.py` (stdlib + pytest; no live network)

## Pair / attach

- Protocol `gbr/1` only: phone app + `gbr-agent pair` (QR **and** printed 8-char code) + `gbr-agent run`
- Attach only `http://127.0.0.1:8788` or stdio `gbr-mcp`
- Phone is spectator + veto, not orchestrator
- MCP add is on the Hermes box; Hermes need not run on a GBR host
- Pin GitHub Release v0.6.0+; website `install.sh` is mutable
- Independent Linespotting AB product. Not affiliated with xAI or SpaceX.

## Files

- `optional-skills/mcp/gbr/SKILL.md`
- `optional-skills/mcp/DESCRIPTION.md` (one-line index)
- `tests/skills/test_gbr_skill.py`

## How to test

```
scripts/run_tests.sh tests/skills/test_gbr_skill.py -q
```

Platforms: linux, macos, windows (skill docs + CLI; CI does not live-pair a phone).