### PR TITLE
fix(state): serialize cross-process FTS rebuild with file lock (fixes recurring DB corruption)

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -33,6 +33,59 @@ from hermes_state_common import (
 # keep that logger identity so log filtering/capture behavior is unchanged.
 logger = logging.getLogger("hermes_state")
 
+
+try:  # POSIX-only; used for cross-process FTS rebuild serialization
+    import fcntl
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover - non-POSIX fallback
+    _HAS_FCNTL = False
+
+_FTS_REBUILD_LOCK_TIMEOUT = 30.0
+
+
+def _acquire_fts_rebuild_lock(db_path) -> Optional[int]:
+    """Exclusive flock on <db_path>.fts_rebuild.lock. Returns fd or None."""
+    if not _HAS_FCNTL:
+        return None
+    try:
+        lock_path = f"{db_path}.fts_rebuild.lock"
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return fd
+        except OSError:
+            pass
+        deadline = time.monotonic() + _FTS_REBUILD_LOCK_TIMEOUT
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return fd
+            except OSError:
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "FTS rebuild lock held by another process beyond "
+                        "%ds timeout; proceeding (SQLite writer lock is the "
+                        "final backstop)", int(_FTS_REBUILD_LOCK_TIMEOUT))
+                    os.close(fd)
+                    return None
+                time.sleep(0.1)
+    except OSError as exc:
+        logger.warning("FTS rebuild lock unavailable (%s); proceeding", exc)
+        return None
+
+
+def _release_fts_rebuild_lock(fd: int) -> None:
+    if not _HAS_FCNTL:
+        return
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        pass
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
 # Characters FTS5's query grammar rejects outside a quoted phrase. Anything
 # missing from this set reaches MATCH raw and raises, which the execute site
 # swallows into zero results — the failure this strip step exists to prevent.
@@ -2404,21 +2457,30 @@ class SessionSearchMixin:
         Returns the number of FTS indexes that were rebuilt.
         """
         rebuilt = 0
-        with self._lock:
-            for tbl in self._FTS_TABLES:
-                if not self._fts_table_exists(tbl):
-                    continue
-                try:
-                    self._conn.execute(
-                        f"INSERT INTO {tbl}({tbl}) VALUES('rebuild')"
-                    )
-                    self._conn.commit()
-                    rebuilt += 1
-                except sqlite3.OperationalError as exc:
-                    self._conn.rollback()
-                    logger.warning(
-                        "FTS rebuild failed for %s: %s", tbl, exc
-                    )
+        lock_fd = None
+        if _HAS_FCNTL:
+            db_path = getattr(self, "db_path", None)
+            if db_path is not None:
+                lock_fd = _acquire_fts_rebuild_lock(db_path)
+        try:
+            with self._lock:
+                for tbl in self._FTS_TABLES:
+                    if not self._fts_table_exists(tbl):
+                        continue
+                    try:
+                        self._conn.execute(
+                            f"INSERT INTO {tbl}({tbl}) VALUES('rebuild')"
+                        )
+                        self._conn.commit()
+                        rebuilt += 1
+                    except sqlite3.OperationalError as exc:
+                        self._conn.rollback()
+                        logger.warning(
+                            "FTS rebuild failed for %s: %s", tbl, exc
+                        )
+        finally:
+            if lock_fd is not None:
+                _release_fts_rebuild_lock(lock_fd)
         return rebuilt
 
     def _merge_fts_incrementally(


### PR DESCRIPTION
## Problem

`rebuild_fts()` in `hermes_state_search.py` only holds an **in-instance** threading lock (`with self._lock`). When two Hermes processes run against the same `$HERMES_HOME` (e.g. `gateway run` + `hermes serve`/desktop) and both detect FTS corruption, **both execute the rebuild on the same database file in parallel**. The concurrent rebuilds collide on write and structurally corrupt `state.db`.

## Real-world impact (twice in production, documented)

- **2026-08-15** and **2026-08-23**: identical corruption signature (`file is not a database` / `database disk image is malformed`), each time triggered by the dual-writer FTS rebuild race.
- The 2026-08-23 incident: gateway's one-shot in-place FTS rebuild on an already-corrupt DB **clobbered the `sessions` b-tree** (garbage rowids containing raw FTS index bytes). Required a full page-level salvage: 5,507 messages recovered row-by-row, 4 sessions rebuilt from message metadata.
- Both times the root cause was the same: a locally-applied cross-process lock fix was **lost during a Hermes update** (the file gets overwritten by upstream versions without the patch).

## Fix

Acquire an exclusive `fcntl.flock` on `<db_path>.fts_rebuild.lock` before running the FTS rebuild, with a bounded 30s wait:

- `_HAS_FCNTL` guard → no-op on non-POSIX platforms (Windows falls back to current behavior; SQLite writer lock remains the backstop)
- `_acquire_fts_rebuild_lock(db_path)` / `_release_fts_rebuild_lock(fd)` module-level helpers
- `rebuild_fts()` wraps its body: file lock acquired before the instance lock, released in `finally`
- On lock timeout, proceeds with a warning (SQLite's own writer lock is the final backstop) — no deadlock risk

No behavioral change to the FTS rebuild loop itself. `py_compile` clean.

## Verification

- Applied in production since 2026-08-15 (re-applied 2026-08-23 after update): no corruption recurrence while the patch is present
- Both corruption incidents occurred exactly when the patch was absent (after code updates overwrote the file)
