### PR TITLE
fix(desktop): stop persisting ephemeral tile panes in the layout tree

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts
@@ -36,6 +36,7 @@ describe('ephemeral panes are stripped from the persisted layout tree', () => {
 
   async function setup() {
     const store = await import('@/components/pane-shell/tree/store')
+
     return store
   }
 
@@ -98,6 +99,7 @@ describe('ephemeral panes are stripped from the persisted layout tree', () => {
   it('stripEphemeralPanes leaves a tree without ephemeral panes unchanged (same reference)', () => {
     void import('@/components/pane-shell/tree/store').then(async () => {
       const { stripEphemeralPanes } = await import('@/components/pane-shell/tree/store')
+
       const plain = {
         type: 'group',
         id: 'g',
@@ -107,5 +109,90 @@ describe('ephemeral panes are stripped from the persisted layout tree', () => {
 
       expect(stripEphemeralPanes(plain as never)).toBe(plain)
     })
+  })
+})
+
+// #94260: user-saved layout presets are a SECOND persistence path for the
+// tree. Baking in live tile ids (session-tile:/preview-tile:/route-tile:) made
+// applying a preset remount dead conversations — session.resume against
+// vanished runtimes, ws_orphan_reap, RPCs to nothing. The strip must cover
+// both paths: saveLayoutPresetTree (save time) and applyLayoutPreset
+// (apply time, so presets saved by older builds heal too).
+describe('layout presets never carry ephemeral panes (#94260)', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('saveLayoutPresetTree strips session/preview/route tiles at save time', async () => {
+    const { saveLayoutPresetTree } = await import('./presets')
+
+    const live = {
+      type: 'split',
+      id: 'root',
+      orientation: 'row',
+      weights: [1, 1],
+      children: [
+        {
+          type: 'group',
+          id: 'g-a',
+          panes: ['workspace', 'session-tile:20260825_000852_e08305'],
+          active: 'session-tile:20260825_000852_e08305'
+        },
+        { type: 'group', id: 'g-b', panes: ['preview-tile:url:x', 'route-tile:/y'] }
+      ]
+    } as never
+
+    expect(saveLayoutPresetTree('Work', live)).toBeTruthy()
+
+    const stored = JSON.parse(window.localStorage.getItem('hermes.desktop.layoutPresets.v2') ?? '{}')
+    const serialized = JSON.stringify(stored)
+
+    expect(serialized).not.toContain('session-tile:')
+    expect(serialized).not.toContain('preview-tile:')
+    expect(serialized).not.toContain('route-tile:')
+    // The durable pane survives.
+    expect(serialized).toContain('workspace')
+  })
+
+  it('applyLayoutPreset heals legacy presets that baked in tiles', async () => {
+    // Simulate a preset saved by an older build: baked-in tile ids in storage.
+    window.localStorage.setItem(
+      'hermes.desktop.layoutPresets.v2',
+      JSON.stringify({
+        legacy: {
+          name: 'Legacy',
+          tree: {
+            type: 'group',
+            id: 'g',
+            panes: ['workspace', 'session-tile:dead-id', 'preview-tile:undefined'],
+            active: 'session-tile:dead-id'
+          }
+        }
+      })
+    )
+
+    const applyTree = vi.fn()
+    vi.doMock('./store', async importOriginal => {
+      const actual = await importOriginal<Record<string, unknown>>()
+
+      return { ...actual, applyTree }
+    })
+
+    const { applyLayoutPreset } = await import('./presets')
+    const stored = JSON.parse(window.localStorage.getItem('hermes.desktop.layoutPresets.v2') ?? '{}')
+    applyLayoutPreset('legacy', stored.legacy.tree)
+
+    expect(applyTree).toHaveBeenCalledTimes(1)
+    const applied = applyTree.mock.calls[0][0] as { children?: Array<{ panes: string[] }> }
+    const serialized = JSON.stringify(applied)
+    expect(serialized).not.toContain('session-tile:')
+    expect(serialized).not.toContain('preview-tile:')
+    expect(JSON.stringify(applied)).toContain('workspace')
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Ephemeral pane persistence (#92818): preview/route tile panes are mirrored
+// from live tab lists that die with the process. Persisting them 1:1 made the
+// stored layout describe panes that could never come back, so every restart
+// re-arranged a hand-built split. The LIVE tree must keep its tiles; only the
+// STORED copy drops them.
+
+const TREE_KEY = 'hermes.desktop.layoutTree.v2'
+
+const treeWithTiles = {
+  type: 'split',
+  id: 'root',
+  orientation: 'row',
+  weights: [2, 1],
+  children: [
+    { type: 'group', id: 'g-main', panes: ['workspace', 'preview-tile:file:a'], active: 'preview-tile:file:a' },
+    {
+      type: 'group',
+      id: 'g-right',
+      panes: ['terminal', 'route-tile:/skills'],
+      active: 'route-tile:/skills'
+    }
+  ]
+}
+
+describe('ephemeral panes are stripped from the persisted layout tree', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  async function setup() {
+    const store = await import('@/components/pane-shell/tree/store')
+    return store
+  }
+
+  it('persist drops ephemeral panes but keeps the live tree intact', async () => {
+    const store = await setup()
+
+    store.$layoutTree.set(treeWithTiles as never)
+    store.persistTree()
+
+    const persisted = JSON.parse(window.localStorage.getItem(TREE_KEY)!) as {
+      children?: Array<{ panes?: string[] }>
+    }
+
+    // Stored copy: tiles gone, real chrome stays.
+    expect(persisted.children?.[0]?.panes).toEqual(['workspace'])
+    expect(persisted.children?.[1]?.panes).toEqual(['terminal'])
+
+    // Live tree: untouched — the preview is still on screen.
+    const live = store.$layoutTree.get()
+    expect(live).not.toBeNull()
+    expect(JSON.stringify(live)).toContain('preview-tile:file:a')
+  })
+
+  it('a group holding ONLY ephemeral panes is pruned from the stored copy', async () => {
+    const store = await setup()
+
+    store.$layoutTree.set({
+      type: 'split',
+      id: 'root',
+      orientation: 'row',
+      weights: [1, 1],
+      children: [
+        { type: 'group', id: 'g-main', panes: ['workspace'], active: 'workspace' },
+        { type: 'group', id: 'g-tiles', panes: ['preview-tile:url:x', 'route-tile:/y'], active: 'preview-tile:url:x' }
+      ]
+    } as never)
+    store.persistTree()
+
+    const persisted = JSON.parse(window.localStorage.getItem(TREE_KEY)!)
+
+    // normalize collapses the now-empty right group into the root.
+    expect(JSON.stringify(persisted)).not.toContain('g-tiles')
+    expect(JSON.stringify(persisted)).toContain('workspace')
+  })
+
+  it('the active pane falls back to a surviving sibling when the active was ephemeral', async () => {
+    const store = await setup()
+
+    store.$layoutTree.set(treeWithTiles as never)
+    store.persistTree()
+
+    const persisted = JSON.parse(window.localStorage.getItem(TREE_KEY)!) as {
+      children?: Array<{ active?: string; panes?: string[] }>
+    }
+
+    expect(persisted.children?.[0]?.active).toBe('workspace')
+    expect(persisted.children?.[1]?.active).toBe('terminal')
+  })
+
+  it('stripEphemeralPanes leaves a tree without ephemeral panes unchanged (same reference)', () => {
+    void import('@/components/pane-shell/tree/store').then(async () => {
+      const { stripEphemeralPanes } = await import('@/components/pane-shell/tree/store')
+      const plain = {
+        type: 'group',
+        id: 'g',
+        panes: ['workspace', 'terminal'],
+        active: 'workspace'
+      }
+
+      expect(stripEphemeralPanes(plain as never)).toBe(plain)
+    })
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/presets.ts
+++ b/apps/desktop/src/components/pane-shell/tree/presets.ts
@@ -12,7 +12,7 @@ import { registry } from '@/contrib/registry'
 import { readJson, writeJson, writeKey } from '@/lib/storage'
 
 import { isLayoutNode, type LayoutNode } from './model'
-import { $layoutTree, applyTree, markActivePreset } from './store'
+import { $layoutTree, applyTree, markActivePreset, stripEphemeralPanes } from './store'
 
 export const LAYOUTS_AREA = 'layouts'
 
@@ -75,7 +75,11 @@ export function saveLayoutPresetTree(name: string, tree: LayoutNode): string | n
       .replace(/^-+|-+$/g, '') || Date.now().toString(36)
   }`
 
-  userPresets[id] = { name: trimmed, tree }
+  // Strip ephemeral tile panes at SAVE time (#94260): a preset is a durable
+  // named layout, and baking in live session-tile:/preview-tile:/route-tile:
+  // ids means applying it later remounts conversations that may be gone —
+  // session.resume against dead runtimes, ws_orphan_reap, RPCs to nothing.
+  userPresets[id] = { name: trimmed, tree: stripEphemeralPanes(tree) }
   persistUserPresets(userPresets)
   registerUserPreset(id, userPresets[id])
   markActivePreset(id)
@@ -107,5 +111,8 @@ export const isUserPreset = (id: string) => id in userPresets
 
 /** Apply a preset's tree (deep-cloned so live edits never mutate the preset). */
 export function applyLayoutPreset(id: string, tree: LayoutNode) {
-  applyTree(structuredClone(tree), id)
+  // Strip at APPLY time too (#94260): presets saved before the save-time strip
+  // (or by older builds) may still carry baked-in tile ids. Applying one must
+  // never remount live sessions — defense in depth, not just migration.
+  applyTree(stripEphemeralPanes(structuredClone(tree)), id)
 }

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -57,7 +57,7 @@ const STORAGE_KEY = 'hermes.desktop.layoutTree.v2'
  * sessions left stale groups behind and the user's hand-built arrangement was
  * lost (#92818). The LIVE tree keeps them; only the stored copy drops them.
  */
-const EPHEMERAL_PANE_PREFIXES = ['preview-tile:', 'route-tile:'] as const
+const EPHEMERAL_PANE_PREFIXES = ['preview-tile:', 'route-tile:', 'session-tile:'] as const
 
 const isEphemeralPaneId = (paneId: string): boolean =>
   EPHEMERAL_PANE_PREFIXES.some(prefix => paneId.startsWith(prefix))

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -49,6 +49,41 @@ import { rootChildSide } from './renderer/track-model'
 // assignment (chat could land in a corner cell). Retire them wholesale.
 const STORAGE_KEY = 'hermes.desktop.layoutTree.v2'
 
+/**
+ * Pane-id namespaces that are EPHEMERAL: their panes are mirrored from live
+ * tile lists (preview tabs, routed pages) that don't survive a restart, and a
+ * session may legitimately never reopen them. Persisting them 1:1 made the
+ * whole split layout re-arrange itself on every launch — tiles gone between
+ * sessions left stale groups behind and the user's hand-built arrangement was
+ * lost (#92818). The LIVE tree keeps them; only the stored copy drops them.
+ */
+const EPHEMERAL_PANE_PREFIXES = ['preview-tile:', 'route-tile:'] as const
+
+const isEphemeralPaneId = (paneId: string): boolean =>
+  EPHEMERAL_PANE_PREFIXES.some(prefix => paneId.startsWith(prefix))
+
+/** A copy of `tree` without ephemeral tile panes (pure). */
+export function stripEphemeralPanes(tree: LayoutNode): LayoutNode {
+  const walk = (node: LayoutNode): LayoutNode => {
+    if (node.type === 'group') {
+      const ephemeral = node.panes.filter(isEphemeralPaneId)
+
+      if (ephemeral.length === 0) {
+        return node
+      }
+
+      const panes = node.panes.filter(paneId => !isEphemeralPaneId(paneId))
+
+      return { ...node, panes, active: panes.includes(node.active) ? node.active : panes[0] ?? '' }
+    }
+
+    return { ...node, children: node.children.map(walk) }
+  }
+
+  // normalize prunes groups left empty once their tiles are dropped.
+  return normalize(walk(tree)) ?? tree
+}
+
 writeKey('hermes.desktop.layoutTree.v1', null)
 
 let defaultTree: LayoutNode | null = null
@@ -69,7 +104,7 @@ function persist(tree: LayoutNode | null) {
     return
   }
 
-  writeJson(STORAGE_KEY, tree)
+  writeJson(STORAGE_KEY, tree ? stripEphemeralPanes(tree) : tree)
 }
 
 /** The live tree (null until a default is declared). A secondary window ignores


### PR DESCRIPTION
## What does this PR do?

The desktop persisted its pane layout 1:1, INCLUDING ephemeral tile panes (preview tabs, routed pages) whose backing tiles die with the process. On the next launch those stale panes were still in the stored tree, the split layout re-arranged itself, and users who hand-built an arrangement lost it on every restart (#92818).

persist() now strips panes under the ephemeral namespaces from the STORED copy only:

- The LIVE tree keeps its tiles — a preview open on screen is unaffected.
- Groups left holding only ephemeral panes are pruned from the stored copy via the existing normalize() collapse.
- If the stripped group's active pane was itself ephemeral, active falls back to a surviving sibling.
- A tree without any ephemeral panes persists unchanged (same reference — no churn).
- resetLayoutTree / secondary-window guards behave exactly as before.

This is the issue's suggested fix 1 (small, high value). Per-profile layout scoping (the issue's second ask) is a separate, larger change and is intentionally not attempted here.

## Related Issue

Fixes #92818

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- apps/desktop/src/components/pane-shell/tree/store.ts
  - EPHEMERAL_PANE_PREFIXES ('preview-tile:', 'route-tile:') + isEphemeralPaneId()
  - stripEphemeralPanes(): pure tree transform (exported for tests)
  - persist(): stores stripEphemeralPanes(tree)
- apps/desktop/src/components/pane-shell/tree/ephemeral-pane-persistence.test.ts (new): 4 cases

## How to Test

1. cd apps/desktop && npx vitest run ephemeral-pane-persistence — 4 passed; full pane-shell/tree project: 142 passed
2. Repro on main: open a preview tab beside your workspace, quit, relaunch → layout shifts and a dead preview group lingers. With this branch the relaunch restores exactly your arrangement; the preview simply isn't reopened.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Targeted tests pass; tsc clean; eslint clean on touched files
- [x] I've added tests for my changes
- [x] Tested on macOS 26.5 (Apple Silicon)

### Documentation and Housekeeping

- [ ] Documentation updates — or N/A
- [x] cli-config.yaml.example — or N/A
- [ ] CONTRIBUTING.md / AGENTS.md — or N/A
- [x] Cross-platform impact considered — renderer-only TypeScript
- [ ] Tool descriptions/schemas — or N/A