### PR TITLE
fix(gateway): never bind a routing key to a delegate subagent session (#92859)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3603,9 +3603,17 @@ class SessionStore:
             try:
                 target_row = db.get_session(target_session_id)
             except Exception:
-                logger.debug(
-                    "switch_session subagent pre-check failed for %s",
-                    target_session_id, exc_info=True,
+                # Fail OPEN: a SQLite hiccup must not break /resume or CLI
+                # handoff for every user. But this is precisely the shape that
+                # silently reintroduces #92859 — the lookup fails, the row
+                # reads as non-subagent, and the bind proceeds — so it is
+                # logged at warning, not debug, to leave a trace in the record
+                # when a hijack slips through this path.
+                logger.warning(
+                    "switch_session subagent pre-check failed for %s; "
+                    "allowing the bind (fail-open). A delegate row could be "
+                    "bound to routing key %s if this recurs (#92859).",
+                    target_session_id, session_key, exc_info=True,
                 )
                 target_row = None
             if is_internal_subagent_row(target_row):

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -18,7 +18,7 @@ import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -1209,6 +1209,33 @@ def build_session_key(
         key_parts.append(str(participant_id))
 
     return ":".join(str(part) for part in key_parts)
+
+
+def is_internal_subagent_row(row: Optional[Dict[str, Any]]) -> bool:
+    """True when a sessions row is a delegate/subagent execution transcript.
+
+    Subagent sessions are internal execution records, never conversations a
+    human can address: ``delegate_tool`` creates them with
+    ``platform="subagent"`` and stamps the durable
+    ``model_config._delegate_from`` marker (#92859). Either signal alone is
+    enough — the marker survives a later ``record_gateway_session_peer``
+    overwriting ``source`` with the platform name, which is exactly what a
+    hijacked child row looks like after the fact.
+    """
+    if not row:
+        return False
+    if str(row.get("source") or "") == "subagent":
+        return True
+    raw = row.get("model_config")
+    if not raw:
+        return False
+    try:
+        cfg = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(cfg, dict):
+        return False
+    return bool(str(cfg.get("_delegate_from") or "").strip())
 
 
 class _SessionFlight:
@@ -3557,9 +3584,38 @@ class SessionStore:
         generating a fresh session ID, re-uses ``target_session_id`` so the
         old transcript is loaded on the next message. If the target session was
         previously ended, re-open it so gateway resume semantics match the CLI.
+
+        Refuses outright when ``target_session_id`` is a delegate/subagent
+        execution transcript (#92859). Those rows are internal — a human
+        cannot address one — so binding a platform routing key to one both
+        hijacks the chat (the user's next message lands in a leaf subagent
+        with no conversation context) and ends the real conversation at the
+        un-resurrectable ``session_switch`` boundary, which then makes the
+        delegation's own completion undeliverable. This is the sink for every
+        caller (async-completion pinning, /resume, CLI handoff, Telegram topic
+        rebinding), so no future call site can reintroduce the hijack.
         """
         db_end_session_id = None
         new_entry = None
+
+        if self._db is not None and target_session_id:
+            db = cast(Any, self._db)
+            try:
+                target_row = db.get_session(target_session_id)
+            except Exception:
+                logger.debug(
+                    "switch_session subagent pre-check failed for %s",
+                    target_session_id, exc_info=True,
+                )
+                target_row = None
+            if is_internal_subagent_row(target_row):
+                logger.warning(
+                    "Refusing to bind gateway routing key %s to delegate "
+                    "subagent session %s: subagent transcripts are internal "
+                    "and are never route owners (#92859).",
+                    session_key, target_session_id,
+                )
+                return None
 
         with self._lock:
             self._ensure_loaded_locked()

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -38,6 +38,7 @@ from gateway.session import (
     AsyncSessionStore,
     SessionSource,
     build_session_key,
+    is_internal_subagent_row,
     is_shared_multi_user_session,
 )
 from hermes_cli.config import atomic_config_write, cfg_get, clear_model_endpoint_credentials
@@ -5193,6 +5194,24 @@ class GatewaySlashCommandsMixin:
 
         # Clear any running agent for this session key
         self._release_running_agent_state(session_key)
+
+        # A delegate/subagent transcript is an internal execution record, not a
+        # conversation (#92859). switch_session() refuses it outright, which
+        # would surface here as the generic "Failed to switch session." Detect
+        # it first so an explicit `/resume <subagent id>` explains itself
+        # instead of looking like a transient failure. Mirrors the guard's own
+        # fail-open posture: if the row can't be read, fall through and let
+        # switch_session decide.
+        if self._session_db:
+            try:
+                target_row = await self._session_db.get_session(target_id)
+            except Exception:
+                logger.debug(
+                    "resume subagent pre-check failed for %s", target_id, exc_info=True
+                )
+                target_row = None
+            if is_internal_subagent_row(target_row):
+                return t("gateway.resume.blocked_subagent", name=name)
 
         # Switch the session entry to point at the old session
         new_entry = await self.async_session_store.switch_session(session_key, target_id)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -63,6 +63,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _FTS_CJK_TRIGGERS,
     _FTS_TRIGGERS,
     _LISTABLE_CHILD_SQL,
+    _NOT_SUBAGENT_ROW_SQL,
     _PREVIEW_ELIGIBLE_SQL,
     _PREVIEW_RAW_SELECT,
     _RECOVERABLE_END_REASONS,
@@ -6600,6 +6601,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 WHERE s.session_key = ?
                   AND s.source = ?
                   AND (s.ended_at IS NULL OR s.end_reason IN ({_RECOVERABLE_END_REASONS_SQL}))
+                  AND {_NOT_SUBAGENT_ROW_SQL.format(a='s')}
                   AND NOT EXISTS (
                       SELECT 1 FROM sessions b
                       WHERE b.session_key = s.session_key
@@ -6639,6 +6641,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND COALESCE(s.chat_type, '') = COALESCE(?, '')
                   AND COALESCE(s.thread_id, '') = COALESCE(?, '')
                   AND (s.ended_at IS NULL OR s.end_reason IN ({_RECOVERABLE_END_REASONS_SQL}))
+                  AND {_NOT_SUBAGENT_ROW_SQL.format(a='s')}
                   AND (COALESCE(s.message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = s.id LIMIT 1
                   ))

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -196,9 +196,20 @@ _COMPRESSION_CHILD_SQL = (
 # overwritten with the platform name by ``record_gateway_session_peer``.
 # Interpolated (not bound) so it can be embedded in the peer-recovery
 # queries alongside the other f-string predicates in this module.
+#
+# ``NULLIF(TRIM(...), '')`` keeps this predicate equivalent to the Python
+# detector ``gateway.session.is_internal_subagent_row``, which treats a blank
+# marker as absent via ``str(...).strip()``. TRIM matches ``.strip()`` for the
+# whitespace-only case and NULLIF collapses the empty result to NULL. Without
+# both, a row carrying ``_delegate_from: ""`` (or ``"  "``) would be refused a
+# route bind by the Python guard yet still be returned by restart recovery
+# here — one invariant, two answers. Nothing writes a blank marker today; this
+# keeps the halves from drifting if anything ever does.
 _NOT_SUBAGENT_ROW_SQL = (
     "(COALESCE({a}.source, '') != 'subagent'"
-    " AND json_extract(COALESCE({a}.model_config, '{{}}'), '$._delegate_from')"
+    " AND NULLIF(TRIM("
+    "COALESCE(json_extract(COALESCE({a}.model_config, '{{}}'),"
+    " '$._delegate_from'), '')), '')"
     " IS NULL)"
 )
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -189,6 +189,20 @@ _COMPRESSION_CHILD_SQL = (
 )
 
 
+# A delegate/subagent execution transcript is never a gateway route owner
+# (#92859). ``delegate_tool`` creates these rows with ``source='subagent'``
+# and the durable ``model_config._delegate_from`` marker; either signal is
+# enough, because a row that already got hijacked has had its ``source``
+# overwritten with the platform name by ``record_gateway_session_peer``.
+# Interpolated (not bound) so it can be embedded in the peer-recovery
+# queries alongside the other f-string predicates in this module.
+_NOT_SUBAGENT_ROW_SQL = (
+    "(COALESCE({a}.source, '') != 'subagent'"
+    " AND json_extract(COALESCE({a}.model_config, '{{}}'), '$._delegate_from')"
+    " IS NULL)"
+)
+
+
 _RESET_END_REASONS = (
     "session_reset",
     # switch_session() never creates a child row, but pre-marker DBs can hold

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -292,6 +292,7 @@ gateway:
     not_found:             "No session found matching '**{name}**'.\nUse `/resume` with no arguments to see available sessions."
     already_on:            "📌 Already on session **{name}**."
     switch_failed:         "Failed to switch session."
+    blocked_subagent:      "⚠️ /resume blocked: '**{name}**' is an internal subagent transcript, not a conversation. Delegate runs are execution records owned by the session that spawned them — resume that session instead."
     resumed_one:           "↻ Resumed session **{title}** ({count} message). Conversation restored."
     resumed_many:          "↻ Resumed session **{title}** ({count} messages). Conversation restored."
     resumed_no_count:      "↻ Resumed session **{title}**. Conversation restored."

--- a/tests/gateway/test_subagent_route_bind_guard.py
+++ b/tests/gateway/test_subagent_route_bind_guard.py
@@ -1,0 +1,218 @@
+"""A delegate subagent transcript can never own a gateway routing key (#92859).
+
+Reported failure: a ``delegate_task`` batch dispatched from a Discord DM ended
+with the DM's routing key bound to one of the *spawned children*. That bind
+went through ``SessionStore.switch_session()``, which promotes the outgoing
+session to the un-resurrectable ``session_switch`` boundary — so the human
+parent was killed mid-batch, every in-flight delegation from that parent was
+then classified ``terminal`` and dropped, and the user's next DM was routed
+into a leaf subagent with no knowledge of the conversation.
+
+Two invariants are pinned here, both against real ``SessionDB`` rows:
+
+1. ``switch_session()`` — the single sink every route rebind funnels through
+   (async-completion pinning, /resume, CLI handoff, Telegram topic rebinding)
+   — refuses a delegate/subagent target and leaves the incumbent route and
+   its session row untouched.
+2. ``find_latest_gateway_session_for_peer()`` — the restart-recovery path —
+   never returns a subagent row, so a route that was hijacked before this fix
+   (or by any other means) is not re-adopted after a gateway restart.
+"""
+
+import json
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore, is_internal_subagent_row
+
+
+@pytest.fixture
+def store_and_db(tmp_path):
+    from unittest.mock import patch
+
+    from hermes_state import SessionDB
+
+    config = GatewayConfig()
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    store._db = db
+    store._loaded = True
+    try:
+        yield store, db
+    finally:
+        db.close()
+
+
+def _dm_source():
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="1540910309580214372",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="karan",
+    )
+
+
+class TestSwitchSessionRefusesSubagentTargets:
+    def test_delegate_child_cannot_take_over_its_parents_route(self, store_and_db):
+        """The exact reported sequence: parent DM, live child, rebind attempt."""
+        store, db = store_and_db
+        parent_entry = store.get_or_create_session(_dm_source())
+        parent_id = parent_entry.session_id
+
+        # A subagent child exactly as delegate_tool creates it: platform
+        # source 'subagent', durable _delegate_from marker, no routing key.
+        db.create_session(
+            "child_leaf",
+            source="subagent",
+            parent_session_id=parent_id,
+            model_config={"_delegate_from": parent_id},
+        )
+
+        switched = store.switch_session(parent_entry.session_key, "child_leaf")
+
+        assert switched is None, "a subagent row must never become a route owner"
+        # The route still points at the human conversation...
+        assert (
+            store.get_or_create_session(_dm_source()).session_id == parent_id
+        )
+        # ...and, decisively, the parent was NOT ended at the hard
+        # session_switch boundary, which is what made the batch's own
+        # completion undeliverable in the incident.
+        parent_row = db.get_session(parent_id)
+        assert parent_row["ended_at"] is None
+        assert parent_row["end_reason"] is None
+        # The child never acquired the routing key.
+        assert not db.get_session("child_leaf")["session_key"]
+
+    def test_refusal_holds_for_nested_and_already_hijacked_rows(self, store_and_db):
+        """Provenance, not the parent edge, decides — two harder shapes.
+
+        ``parent_session_id == current route`` is not the invariant: a
+        grandchild's parent edge points at another child, and a row hijacked
+        before this fix has had ``source`` overwritten with the platform name
+        by ``record_gateway_session_peer``. Both must still be refused.
+        """
+        store, db = store_and_db
+        parent_entry = store.get_or_create_session(_dm_source())
+        parent_id = parent_entry.session_id
+
+        db.create_session(
+            "child_leaf", source="subagent", parent_session_id=parent_id,
+            model_config={"_delegate_from": parent_id},
+        )
+        # Grandchild: parent edge is the CHILD, not the routed session.
+        db.create_session(
+            "grandchild", source="subagent", parent_session_id="child_leaf",
+            model_config={"_delegate_from": "child_leaf"},
+        )
+        # A row that was already hijacked once: source is now the platform,
+        # only the _delegate_from marker still betrays what it is (this is
+        # the literal shape of session 20260823_041917_519cdb on the
+        # reporter's machine).
+        db.create_session(
+            "rehijack", source="discord", parent_session_id=parent_id,
+            model_config={"_delegate_from": parent_id},
+        )
+
+        for target in ("grandchild", "rehijack"):
+            assert store.switch_session(parent_entry.session_key, target) is None
+            assert db.get_session(parent_id)["ended_at"] is None
+
+    def test_real_gateway_session_still_switches(self, store_and_db):
+        """The guard must not break /resume — the feature switch_session exists for."""
+        store, db = store_and_db
+        parent_entry = store.get_or_create_session(_dm_source())
+        parent_id = parent_entry.session_id
+
+        db.create_session("older_convo", source="discord", user_id="user-1")
+        db.end_session("older_convo", end_reason="user_exit")
+
+        switched = store.switch_session(parent_entry.session_key, "older_convo")
+
+        assert switched is not None
+        assert switched.session_id == "older_convo"
+        assert db.get_session("older_convo")["ended_at"] is None
+        assert db.get_session(parent_id)["end_reason"] == "session_switch"
+
+
+class TestPeerRecoveryExcludesSubagentRows:
+    def test_hijacked_child_is_not_re_adopted_after_restart(self, store_and_db):
+        """Restart recovery must prefer the real conversation, not the child.
+
+        The incident left a subagent row carrying the DM's routing key and
+        still open, ranked *above* the real parent by recency. Recovery would
+        hand the chat straight back to the subagent on the next restart.
+        """
+        store, db = store_and_db
+        key = "agent:main:discord:dm:1540910309580214372"
+
+        db.create_session(
+            "real_convo", source="discord", session_key=key,
+            user_id="user-1", chat_id="1540910309580214372", chat_type="dm",
+        )
+        db.append_message(session_id="real_convo", role="user", content="hi")
+        # Hijacked child: same key, newer, holds messages too.
+        db.create_session(
+            "hijacked_child", source="discord", session_key=key,
+            user_id="user-1", chat_id="1540910309580214372", chat_type="dm",
+            parent_session_id="real_convo",
+            model_config={"_delegate_from": "real_convo"},
+        )
+        db.append_message(session_id="hijacked_child", role="user", content="task")
+
+        recovered = db.find_latest_gateway_session_for_peer(
+            source="discord", session_key=key, user_id="user-1",
+            chat_id="1540910309580214372", chat_type="dm",
+        )
+
+        assert recovered is not None
+        assert recovered["id"] == "real_convo"
+
+    def test_peer_tuple_fallback_also_excludes_subagent_rows(self, store_and_db):
+        """The keyless fallback query needs the same fence, not just the keyed one."""
+        store, db = store_and_db
+        db.create_session(
+            "subagent_only", source="discord", user_id="user-1",
+            chat_id="1540910309580214372", chat_type="dm",
+            model_config={"_delegate_from": "some_parent"},
+        )
+        db.append_message(session_id="subagent_only", role="user", content="task")
+
+        recovered = db.find_latest_gateway_session_for_peer(
+            source="discord", session_key="agent:main:discord:dm:no-such-key",
+            user_id="user-1", chat_id="1540910309580214372", chat_type="dm",
+        )
+
+        assert recovered is None
+
+
+class TestIsInternalSubagentRow:
+    @pytest.mark.parametrize(
+        "row",
+        [
+            {"source": "subagent"},
+            {"source": "discord", "model_config": {"_delegate_from": "p"}},
+            {"source": "discord", "model_config": json.dumps({"_delegate_from": "p"})},
+        ],
+    )
+    def test_detects_subagent_rows(self, row):
+        assert is_internal_subagent_row(row) is True
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            None,
+            {},
+            {"source": "discord"},
+            {"source": "discord", "model_config": "not json"},
+            {"source": "discord", "model_config": json.dumps(["not", "a", "dict"])},
+            {"source": "discord", "model_config": {"_delegate_from": ""}},
+            # A /branch child is a real, user-addressable conversation.
+            {"source": "discord", "model_config": {"_branched_from": "p"}},
+        ],
+    )
+    def test_leaves_real_sessions_alone(self, row):
+        assert is_internal_subagent_row(row) is False

--- a/tests/gateway/test_subagent_route_bind_guard.py
+++ b/tests/gateway/test_subagent_route_bind_guard.py
@@ -218,6 +218,88 @@ class TestIsInternalSubagentRow:
         assert is_internal_subagent_row(row) is False
 
 
+class TestDetectorHalvesAgree:
+    """The Python guard and the SQL fence must answer identically (#93208 review).
+
+    Subagent-ness has two homes: ``is_internal_subagent_row`` gates
+    ``switch_session``, and ``_NOT_SUBAGENT_ROW_SQL`` fences restart recovery.
+    The prior revision disagreed on a blank ``_delegate_from``: Python treated
+    ``""`` as absent (``.strip()``) while the SQL used a bare ``IS NULL``,
+    under which an empty string is NOT null. The same row was therefore
+    refused a route bind but still returned by recovery — one invariant with
+    two answers, and the residual case the per-half tests cannot catch because
+    each only pins its own side.
+
+    These cases drive BOTH halves over the same rows and assert they agree.
+    """
+
+    @pytest.mark.parametrize(
+        "marker,is_subagent",
+        [
+            ("real_parent", True),   # a genuine delegate marker
+            ("", False),             # blank -> not a delegate, both halves
+            ("   ", False),          # whitespace-only -> .strip() / TRIM
+        ],
+    )
+    def test_blank_marker_treated_identically_by_both_halves(
+        self, store_and_db, marker, is_subagent
+    ):
+        store, db = store_and_db
+        key = "agent:main:discord:dm:1540910309580214372"
+
+        db.create_session(
+            "probe", source="discord", session_key=key,
+            user_id="user-1", chat_id="1540910309580214372", chat_type="dm",
+            model_config={"_delegate_from": marker},
+        )
+        db.append_message(session_id="probe", role="user", content="hi")
+
+        # Half 1 — the Python detector used by switch_session().
+        python_says = is_internal_subagent_row(db.get_session("probe"))
+
+        # Half 2 — the SQL fence used by restart recovery. A row it considers
+        # a subagent is excluded, so "not recovered" == "SQL says subagent".
+        recovered = db.find_latest_gateway_session_for_peer(
+            source="discord", session_key=key, user_id="user-1",
+            chat_id="1540910309580214372", chat_type="dm",
+        )
+        sql_says = recovered is None
+
+        assert python_says is is_subagent
+        assert sql_says is is_subagent
+        assert python_says == sql_says, (
+            "the Python guard and the SQL fence disagree on "
+            f"_delegate_from={marker!r}: switch_session and restart recovery "
+            "would classify the same row differently"
+        )
+
+
+class TestResumeRefusalIsExplained:
+    """A refused bind must not read as a transient failure (#93208 review).
+
+    ``switch_session`` returning ``None`` is surfaced by /resume as the generic
+    "Failed to switch session." For a user who pastes a subagent id explicitly
+    that is misleading — nothing failed, the target is simply not a
+    conversation. All four other callers tolerate ``None`` correctly (CLI
+    handoff raises, async-completion pinning logs and drops the injection,
+    Telegram topic rebinding keeps the incumbent entry), so /resume is the one
+    path that needed a specific message.
+    """
+
+    def test_locale_string_exists_and_names_the_reason(self):
+        import yaml
+        from pathlib import Path
+
+        locales = Path(__file__).resolve().parents[2] / "locales" / "en.yaml"
+        data = yaml.safe_load(locales.read_text(encoding="utf-8"))
+        msg = data["gateway"]["resume"]["blocked_subagent"]
+
+        assert "{name}" in msg, "must interpolate the requested target"
+        # It has to tell the user WHY, not just that something failed.
+        assert "subagent" in msg.lower()
+        assert msg != data["gateway"]["resume"]["switch_failed"]
+
+
 class TestGuardSurvivesSessionGenerationChanges:
     """The #92872 review's case 1: a compression rotation must not reopen this.
 

--- a/tests/gateway/test_subagent_route_bind_guard.py
+++ b/tests/gateway/test_subagent_route_bind_guard.py
@@ -216,3 +216,64 @@ class TestIsInternalSubagentRow:
     )
     def test_leaves_real_sessions_alone(self, row):
         assert is_internal_subagent_row(row) is False
+
+
+class TestGuardSurvivesSessionGenerationChanges:
+    """The #92872 review's case 1: a compression rotation must not reopen this.
+
+    Merged #69312 makes compression a logical continuation that can advance the
+    gateway route from parent ``P`` to live tip ``P2`` while a delegation
+    spawned by ``P`` is still running. Any guard keyed on
+    ``child.parent_session_id == <currently routed id>`` stops firing at that
+    point, because the child still points at ``P`` while the route is on
+    ``P2``. This guard reads the *target's* provenance and never the parent
+    edge, so the route generation is irrelevant — pinned here so a future
+    refactor cannot quietly reintroduce the edge comparison.
+    """
+
+    def test_child_cannot_take_the_route_after_its_parent_compressed(
+        self, store_and_db
+    ):
+        store, db = store_and_db
+        entry = store.get_or_create_session(_dm_source())
+        p_id = entry.session_id
+
+        # C is spawned by P while P is still the routed session.
+        db.create_session(
+            "child_leaf", source="subagent", parent_session_id=p_id,
+            model_config={"_delegate_from": p_id},
+        )
+        # P then compresses; the route legitimately advances to tip P2.
+        db.end_session(p_id, "compression")
+        db.create_session("p2_tip", source="discord", parent_session_id=p_id)
+        assert store.switch_session(entry.session_key, "p2_tip") is not None
+        assert store.get_or_create_session(_dm_source()).session_id == "p2_tip"
+
+        # Now the completion stamped C arrives. C.parent_session_id is P, and
+        # the route is P2 — a parent-edge guard would not fire here.
+        assert store.switch_session(entry.session_key, "child_leaf") is None
+
+        assert store.get_or_create_session(_dm_source()).session_id == "p2_tip"
+        assert db.get_session("p2_tip")["ended_at"] is None
+
+    def test_grandchild_after_compression_is_also_refused(self, store_and_db):
+        """Both review objections composed: nested provenance + rotated route."""
+        store, db = store_and_db
+        entry = store.get_or_create_session(_dm_source())
+        p_id = entry.session_id
+
+        db.create_session(
+            "child_leaf", source="subagent", parent_session_id=p_id,
+            model_config={"_delegate_from": p_id},
+        )
+        db.create_session(
+            "grandchild", source="subagent", parent_session_id="child_leaf",
+            model_config={"_delegate_from": "child_leaf"},
+        )
+        db.end_session(p_id, "compression")
+        db.create_session("p2_tip", source="discord", parent_session_id=p_id)
+        store.switch_session(entry.session_key, "p2_tip")
+
+        assert store.switch_session(entry.session_key, "grandchild") is None
+        assert store.get_or_create_session(_dm_source()).session_id == "p2_tip"
+        assert db.get_session("p2_tip")["ended_at"] is None


### PR DESCRIPTION
## Related issue

Fixes #92859.

## Summary

A `delegate_task` batch dispatched from a Discord DM ended with the DM's routing key bound to one of the **spawned children**. That bind went through `SessionStore.switch_session()`, which promotes the outgoing session to the un-resurrectable `session_switch` boundary — so the human parent was killed while its own children were still running, every in-flight delegation from that parent was then classified `terminal` and dropped, and the user's next DM was routed into a leaf subagent that knew nothing about the conversation.

Reproduced three times on the reporter's machine (twice *after* the issue was filed). 4/4 batches whose `origin_session` was a gateway routing key were dropped; the only batch that ever reached the user had a plain session id as its origin.

## Root cause and where the guard goes

The report's own suggested invariant — *"a session with a non-empty `parent_session_id` should never be bindable to a gateway routing key"* — is right in spirit but wrong in predicate: compression continuations also carry `parent_session_id` and legitimately continue the route. The stable signal is **delegate provenance**, which `delegate_tool` already writes durably at creation (`source='subagent'` + `model_config._delegate_from`, `tools/delegate_tool.py:2024`).

The guard is placed at the **sink**, not at a caller. `switch_session()` is the single funnel every route rebind passes through — async-completion pinning (`gateway/run.py:16357`), `/resume`, CLI handoff (`:13777`), Telegram topic rebinding (`:19127`) — so refusing there closes the class rather than the one observed call path, and no future call site can reintroduce the hijack.

Provenance rather than the parent edge, deliberately:

- a **grandchild's** `parent_session_id` points at another child, not at the routed session;
- a row that has **already been hijacked once** has had its `source` overwritten with the platform name by `record_gateway_session_peer` — that is the literal shape of `20260823_041917_519cdb` in the report (`source='discord'`, but `_delegate_from` still set). Either signal alone is therefore sufficient.

## Restart recovery gets the same fence

`find_latest_gateway_session_for_peer()` ranked the hijacked child **above** the real conversation on recency, so a gateway restart would have handed the chat straight back to the subagent even after the bind path was fixed. Both its keyed query and its peer-tuple fallback now exclude subagent rows.

`create_session` already refused to let delegate children *inherit* a routing key at creation (`hermes_state.py:5218` — "must NOT inherit routing keys, or peer recovery could repoint gateway traffic into a subagent's session"). This PR extends that existing, deliberate rule to the two paths that could grant one **afterwards**.

## Relationship to the other open PRs

- **#92620** (`_delegate_from` provenance walk in `_resolve_async_delegation_session`) — same family, complementary rather than overlapping: it canonicalizes the *completion resolver's* pinned id; this PR refuses the *bind* itself and also fences restart recovery. They compose cleanly — with this PR the resolver's `switch_session` call can no longer land on a child even if the walk is bypassed.
- **#92872** (closed) — guarded on `pinned_row.parent_session_id == prior_session_id`, which its own blocking review correctly noted is not a stable invariant (compression can advance the route off that exact row). This PR does not use the parent edge at all.

## Testing

`tests/gateway/test_subagent_route_bind_guard.py` — 15 tests against real `SessionDB` rows, not mocks:

- the exact reported sequence: parent DM + live child + rebind attempt → refused, **and the parent is not ended** (the assertion that pins the delivery-drop consequence, not just the routing symptom);
- the two harder shapes a parent-edge predicate misses (nested grandchild, already-hijacked row);
- `/resume` to a real prior conversation still switches — the feature `switch_session` exists for;
- restart recovery prefers the real conversation over a hijacked child, on both the keyed query and the peer-tuple fallback;
- `is_internal_subagent_row` detection matrix, including a `/branch` child (a real, user-addressable conversation) staying out of scope.

```
scripts/run_tests.sh tests/gateway/test_subagent_route_bind_guard.py -q
→ 15 tests passed, 0 failed
```

**Sabotage-verified.** Disabling the `switch_session` guard and removing the SQL fence:

```
→ 4 failed, 11 passed
```

The 4 failures are exactly the behavioral tests; the 11 detection/regression tests stay green, so each test is bound to the code it claims to pin.

Wider suite:

```
scripts/run_tests.sh tests/gateway/ tests/state/ -q
→ 695 files, 6207 passed, 6 failed, 40 skipped
```

The 6 failures reproduce identically on unmodified `origin/main` (`test_scale_to_zero`, `test_shutdown_forensics`, `test_systemd_notify`, `test_wecom_callback` — macOS-local baseline, untouched by this diff).

## Risk

Refusal is fail-closed and logged at WARNING with the routing key and target id, so the failure mode becomes greppable instead of a silent DM hijack. For a normal session there is no behavior change: a real gateway row has neither `source='subagent'` nor `_delegate_from`, and the `/resume` regression test pins that.
