### PR TITLE
fix(tui): settle execFileNoThrow timeouts unconditionally

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
@@ -201,7 +201,10 @@ export async function tmuxLoadBuffer(text: string): Promise<boolean> {
   const { code } = await execFileNoThrow('tmux', args, {
     input: text,
     useCwd: false,
-    timeout: 2000
+    timeout: 2000,
+    // tmux may daemonize a server while retaining the inherited stdio pipes;
+    // only the child exit code is needed for this call site.
+    resolveOnExit: true
   })
 
   return code === 0

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.test.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.test.ts
@@ -65,19 +65,16 @@ afterEach(() => {
 })
 
 describe.skipIf(onWindows)('execFileNoThrow with daemon-style children', () => {
-  // Skipped because the bug it documents is a forever-hang. Without
-  // resolveOnExit, the 'close' event doesn't fire when the immediate
-  // child has exited but a forked daemon still holds stdio open. Even
-  // SIGTERM at the timeout doesn't help — the daemon survives it. To
-  // verify by hand: remove `it.skip` and watch the test timeout. This
-  // test is here so a reviewer reading the resolveOnExit option knows
-  // *why* every clipboard-tool spawn in osc.ts wires it on.
-  it.skip('(documented hang) without resolveOnExit, await never resolves when daemon inherits stdio', async () => {
-    const pidFile = join(scriptDir, 'sleeper-skip.pid')
+  // Regression guard: a daemon that inherits stdio must not make the
+  // default close-based mode ignore its declared timeout.
+  it('settles on timeout when a daemon inherits stdio without resolveOnExit', async () => {
+    const pidFile = join(scriptDir, 'sleeper-default.pid')
+    const start = Date.now()
     const result = await execFileNoThrow(daemonScript, [pidFile], { timeout: 300 })
     trackSleeperPid(pidFile)
 
     expect(result.code).toBe(124)
+    expect(Date.now() - start).toBeLessThan(1500)
   })
 
   it("settles immediately on 'exit' when resolveOnExit is true, regardless of daemon stdio", async () => {

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -69,12 +69,12 @@ export function execFileNoThrow(
           timedOut = true
           child.kill('SIGTERM')
 
-          // When resolving on exit, SIGTERM-ing a child that has already
-          // exited is a no-op and `'exit'` won't fire again — settle here
-          // so the promise doesn't leak. Safe under settled-guard.
-          if (options.resolveOnExit) {
-            settle(124)
-          }
+          // Settle in both modes. In resolveOnExit mode the child may already
+          // be gone, so SIGTERM is a no-op and 'exit' will not fire again. In
+          // the default mode a grandchild that inherited the stdio pipes can
+          // keep 'close' from firing forever. The settled guard makes this
+          // safe when a later process event also arrives.
+          settle(124)
         }, options.timeout)
       : null
 


### PR DESCRIPTION
## Summary

This PR fixes a TUI process-lifecycle bug in `execFileNoThrow()` that could leave an awaited Promise pending indefinitely when a daemonized grandchild inherited the child stdio pipes.

## Related issue

Fixes #93134

## Root cause

`execFileNoThrow()` supports two completion modes:

- the default mode waits for Node's `close` event, which waits for the stdio streams to close;
- `resolveOnExit: true` settles from the child `exit` event and is intended for tools that daemonize.

The timeout handler called `settle(124)` only in the `resolveOnExit` branch. If the immediate child exited but a grandchild retained the inherited pipes, the default mode waited for `close` forever. The timeout then sent `SIGTERM` to a child that had already exited, so no later event necessarily settled the Promise.

The production call path was `setClipboard()` → `tmuxLoadBuffer()` → `execFileNoThrow('tmux', ...)`. `tmuxLoadBuffer()` did not request exit-based resolution even though it only consumes the exit code.

## Implementation

- Make the timeout handler call `settle(124)` in both completion modes.
- Add `resolveOnExit: true` to the `tmuxLoadBuffer()` call site.
- Reactivate the previously skipped daemon-child regression and assert that the default mode settles within a bounded time.
- Preserve the existing settled guard so timer and process events cannot double-resolve the Promise.

## Scope and non-goals

This is limited to TUI child-process lifecycle handling and the tmux clipboard call site. It does not change clipboard payloads, authentication, authorization, credentials, sandboxing, or any security boundary. It does not attempt to kill arbitrary grandchildren; it ensures the caller's Promise cannot leak after the declared timeout.

## Validation

### Runtime reproduction

A Windows runtime harness imported the changed `execFileNoThrow()` implementation and created a child that daemonized a grandchild with inherited stdio:

- default mode: `WITHOUT resolveOnExit -> 124 after 522ms`
- exit mode: `WITH resolveOnExit -> 0 after 162ms`

The first result proves the timeout now settles the default path; the second preserves the existing successful exit behavior.

### Focused checks

- `npm exec --workspace ui-tui -- vitest run packages/hermes-ink/src/utils/execFileNoThrow.test.ts`
  - the file was discovered successfully;
  - its POSIX-only daemon tests are skipped on native Windows by design.
- `npm run typecheck --workspace ui-tui` — passed.
- `git diff --check` — passed.

The POSIX-only Vitest cases were not presented as executed on Windows. The runtime reproduction above exercised the changed function directly on this host.

## Hardening review

1. **Premise/root cause:** traced all non-test `execFileNoThrow()` callers and confirmed the tmux path was the only production caller without `resolveOnExit`.
2. **Failure modes:** checked child exit before timeout, timeout before child exit, inherited stdio, non-zero child exit, and timer/exit races; the existing `settled` guard remains authoritative.
3. **Regression/simplification:** kept the fix at the shared timeout boundary, added the call-site option only where output is not consumed, and converted the documented hang into an active regression guard.

## Limitations

The repository's daemon-child fixture uses POSIX shell behavior and remains platform-gated on Windows. The cross-platform runtime harness was used to validate the changed Promise lifecycle on this host.

## Validation update — current base

The current-base runtime reproduction remains:

- default mode settles with code `124` after the declared timeout;
- `resolveOnExit` mode preserves the normal child exit code.

The TUI TypeScript typecheck passed, the POSIX-only Vitest fixture is explicitly skipped on native Windows, and the remote GitHub run reports `All required checks pass`.
