### PR TITLE
test(desktop): guard CI and link parked regressions

### DIFF
--- a/apps/desktop/e2e/large-session-resume.spec.ts
+++ b/apps/desktop/e2e/large-session-resume.spec.ts
@@ -199,7 +199,7 @@ test.describe('large session resume', () => {
     // Known RED: a rapid warm resume rebuilds the transcript three times
     // (28 → 53 → 53 DOM additions) instead of the two-paint budget. Keep the
     // regression visible without making unrelated desktop work fail CI.
-    test.fixme(true, 'Fast warm resume has an unresolved third transcript rebuild')
+    test.fixme(true, 'Blocked on #93138: fast warm resume has an unresolved third transcript rebuild')
 
     fixture = await setupSeededDesktop()
     await waitForAppReady(fixture, 120_000)

--- a/apps/desktop/e2e/tile-unread-bug.spec.ts
+++ b/apps/desktop/e2e/tile-unread-bug.spec.ts
@@ -173,7 +173,7 @@ test.describe('sidebar states — tab (hidden) unread is correct', () => {
 // Test 2: SPLIT (visible) — unread dot is WRONG (FAILS until fix)
 // ────────────────────────────────────────────────────────────────────────
 
-test.describe.skip('sidebar states — split (visible) unread bug (RED)', () => {
+test.describe.skip('Blocked on #93141: sidebar states — split (visible) unread bug (RED)', () => {
   test.describe.configure({ mode: 'serial' })
 
   let fixture: MockBackendFixture

--- a/apps/desktop/e2e/warm-resume-jitter.spec.ts
+++ b/apps/desktop/e2e/warm-resume-jitter.spec.ts
@@ -396,7 +396,7 @@ test('tab reactivation preserves the mounted transcript without repainting', asy
 test('warm-route resume after background inference completes (no jitter)', async ({}, testInfo) => {
   test.fixme(
     true,
-    'Warm resume repaints after inference: expected one additive burst, got two ([18,1]).',
+    'Blocked on #93140: warm resume repaints after inference: expected one additive burst, got two ([18,1]).',
   )
 
   const page = fixture!.page

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
   /* Test files live under e2e/ so they never collide with the vitest suite
    * under src/ or the node:test files under electron/. */
   testDir: './e2e',
+  /* A stray `test.only` must never make CI report a partial green run. */
+  forbidOnly: !!process.env.CI,
   /* The desktop app can take a while to bootstrap on cold CI runners — 90 s
    * per test gives us headroom without masking real hangs. */
   timeout: 90_000,


### PR DESCRIPTION
## Summary

This PR hardens the desktop Playwright gate against accidental focused tests and links three intentionally parked RED regressions to dedicated GitHub issues.

## Related issues

Fixes #93142
Refs #93138
Refs #93140
Refs #93141

The three RED issues remain open because this PR adds traceability and prevention only; it does not claim to fix their underlying desktop behavior.

## Root cause

`apps/desktop/playwright.config.ts` did not set `forbidOnly`. A committed `test.only`, `describe.only`, or equivalent could reduce a CI run to one focused test while still producing a successful-looking result.

Separately, three E2E regressions were visible only as source-level `fixme`/`skip` markers:

- `large-session-resume.spec.ts` documents the unresolved third transcript rebuild during fast warm resume;
- `warm-resume-jitter.spec.ts` documents a second paint burst after inference;
- `tile-unread-bug.spec.ts` documents the missing unread indicator for a visible split tile.

Without issue references, these RED cases had no durable ownership or searchable tracking outside the test files.

## Implementation

- Add `forbidOnly: !!process.env.CI` to the shared Playwright configuration.
- Keep local developer behavior unchanged while making CI fail on an exclusive marker.
- Replace the three generic parked-test descriptions with explicit references to issues `#93138`, `#93140`, and `#93141`.
- Preserve the existing test bodies and failure semantics; no RED regression is silently converted to a pass.

## Scope and non-goals

This is desktop test-run integrity and issue traceability. It does not change application runtime behavior, session data, authentication, authorization, credentials, or any security boundary. It does not close or claim to solve the three parked UI regressions.

## Validation

- `npm run typecheck --workspace apps/desktop` — passed for renderer, Electron, and E2E TypeScript projects.
- A temporary uncommitted spec containing `test.only` was run with `CI=1`; Playwright rejected it with `item focused with '.only' is not allowed due to the 'forbidOnly' option`.
- The temporary probe file was removed after the check.
- `git diff --check` — passed.

The local Node runtime is `v22.16.0`, below the repository's declared `>=22.22.0` requirement, so dependency installation used only the non-persistent `engine-strict=false` override. The typecheck and behavioral config probe completed successfully; full desktop E2E execution was not claimed.

The repository's installed Prettier version reports pre-existing formatting differences across these files beyond the changed lines. No broad formatter rewrite was included because it would add unrelated churn.

## Hardening review

1. **Premise/root cause:** confirmed that the current specs contain no active `.only` marker and that the missing `forbidOnly` was preventive configuration debt; traced each parked marker to its exact E2E scenario.
2. **Failure modes:** verified the CI-only guard, preserved local behavior, checked that issue references distinguish prevention from unresolved RED behavior, and avoided falsely closing the parked issues.
3. **Regression/simplification:** used the smallest configuration and string-only changes; did not refactor desktop state or weaken any existing assertion.

## Follow-up

Issues `#93138`, `#93140`, and `#93141` need separate behavioral fixes. This PR only ensures they remain visible, searchable, and protected from accidental focused-test masking.

## Infographic :

<img width="1672" height="941" alt="hermes-infographic-pr-93211" src="https://github.com/user-attachments/assets/c40d0257-e032-4cc8-b0e3-3e0edbd018d0" />


## Validation update — current base

The local TypeScript typecheck passed. A temporary `CI=1` Playwright probe containing `test.only` was rejected by `forbidOnly`, and the temporary file was removed. The four required remote checks report `All required checks pass`.

The three parked desktop regressions remain traceability-only references; this PR does not claim to fix their underlying rendering or unread-state behavior.
