### PR TITLE
perf(bluebubbles): move attachment reads off the event loop

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -16,6 +16,7 @@ import re
 import uuid
 from collections import OrderedDict
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -599,7 +600,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         """Send a file attachment via BlueBubbles multipart upload."""
         if not self.client:
             return SendResult(success=False, error="Not connected")
-        if not os.path.isfile(file_path):
+        if not await asyncio.to_thread(os.path.isfile, file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
 
         guid = await self._resolve_chat_guid(chat_id)
@@ -608,23 +609,26 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         fname = filename or os.path.basename(file_path)
         try:
-            with open(file_path, "rb") as f:
-                files = {"attachment": (fname, f, "application/octet-stream")}
-                data: Dict[str, str] = {
-                    "chatGuid": guid,
-                    "name": fname,
-                    "tempGuid": uuid.uuid4().hex,
-                }
-                if is_audio_message:
-                    data["isAudioMessage"] = "true"
-                res = await self.client.post(
-                    self._api_url("/api/v1/message/attachment"),
-                    files=files,
-                    data=data,
-                    timeout=120,
-                )
-                res.raise_for_status()
-                result = res.json()
+            # httpx's async multipart iterator reads file-like objects through
+            # a synchronous chunk generator. Read the file off the event-loop
+            # thread before handing bytes to the client.
+            payload = await asyncio.to_thread(Path(file_path).read_bytes)
+            files = {"attachment": (fname, payload, "application/octet-stream")}
+            data: Dict[str, str] = {
+                "chatGuid": guid,
+                "name": fname,
+                "tempGuid": uuid.uuid4().hex,
+            }
+            if is_audio_message:
+                data["isAudioMessage"] = "true"
+            res = await self.client.post(
+                self._api_url("/api/v1/message/attachment"),
+                files=files,
+                data=data,
+                timeout=120,
+            )
+            res.raise_for_status()
+            result = res.json()
 
             if caption:
                 await self.send(chat_id, caption)

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -274,6 +274,47 @@ class TestBlueBubblesAttachmentDownload:
         assert result == "/tmp/test_image.png"
 
 
+class TestBlueBubblesAttachmentSend:
+    @pytest.mark.asyncio
+    async def test_attachment_payload_is_read_before_async_upload(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+        file_path = tmp_path / "payload.bin"
+        payload = b"attachment-payload"
+        file_path.write_bytes(payload)
+
+        captured = {}
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;+;chat-guid"
+
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"status": 200, "data": {"guid": "message-guid"}}
+
+        class MockClient:
+            async def post(self, url, *, files, data, timeout):
+                captured.update(url=url, files=files, data=data, timeout=timeout)
+                return MockResponse()
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        adapter.client = MockClient()
+
+        result = await adapter._send_attachment(
+            "target", str(file_path), filename="payload.bin"
+        )
+
+        assert result.success is True
+        assert captured["files"]["attachment"] == (
+            "payload.bin",
+            payload,
+            "application/octet-stream",
+        )
+        assert captured["data"]["chatGuid"] == "iMessage;+;chat-guid"
+
+
 # ---------------------------------------------------------------------------
 # Webhook registration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR moves BlueBubbles outbound attachment filesystem work off the shared async gateway event loop while preserving the existing multipart contract.

## Related issue

Fixes #93143

## Root cause

`BlueBubblesAdapter._send_attachment()` is an async coroutine, but it called `os.path.isfile()` and opened the attachment with synchronous file I/O before passing the handle to `httpx.AsyncClient.post()`.

In the installed `httpx` behavior, the async multipart path iterates file-like inputs through a synchronous chunk generator. A slow local filesystem or network-mounted path can therefore occupy the event-loop thread while the upload is prepared/read, delaying unrelated gateway work.

The impact is workload-dependent. This PR does not claim that every local-disk upload blocks for the entire transfer or that all platforms become unavailable; it removes the avoidable synchronous file operations from the coroutine's event-loop path.

## Implementation

- Run the existence check through `asyncio.to_thread()`.
- Read the file with `Path.read_bytes()` through `asyncio.to_thread()`.
- Pass the resulting bytes to httpx multipart instead of a synchronous file object.
- Preserve the filename, `application/octet-stream` content type, chat GUID, audio flag, timeout, response parsing, caption behavior, and `SendResult` handling.
- Add an async regression test that captures the upload payload and verifies the exact bytes and metadata.

## Trade-off

The implementation buffers the attachment in memory before the HTTP call. This is the smallest safe change for the current contract and avoids synchronous chunk reads on the event loop. If very large attachments or streaming memory limits become a separate requirement, they should be addressed with a dedicated async streaming abstraction rather than reintroducing a synchronous file handle.

## Scope and non-goals

This is a gateway performance change only. It does not change BlueBubbles redirect validation, authentication, authorization, passwords, credentials, or any security boundary. It does not alter inbound attachment handling or other platform adapters.

## Validation

- `scripts/run_tests.sh tests/gateway/test_bluebubbles.py -q` — `19` tests passed.
- `.venv/Scripts/ruff.exe check --isolated --select ASYNC230,ASYNC240 gateway/platforms/bluebubbles.py` — passed.
- Real import check for `BlueBubblesAdapter` — passed.
- `git diff --check` — passed.

A repository-wide ASYNC230/ASYNC240 scan still reports existing violations in unrelated gateway/platform files; the changed BlueBubbles file passes the restricted check and those unrelated findings were not folded into this PR.

## Hardening review

1. **Premise/root cause:** traced the file path from `_send_attachment()` into httpx multipart behavior and confirmed the synchronous file object was the shared boundary.
2. **Failure modes/bottlenecks:** preserved missing-file behavior and response handling, considered TOCTOU and memory buffering, and checked that the async client receives immutable bytes rather than an open handle.
3. **Regression/simplification:** kept the change local to one adapter, added a deterministic payload test, and avoided a speculative async file-streaming abstraction.

## Follow-up

Large-file streaming can be evaluated separately if production attachment sizes justify it. This PR intentionally chooses bounded implementation scope and explicit memory trade-off.

## Infographic : 

<img width="1672" height="941" alt="hermes-infographic-pr-93212" src="https://github.com/user-attachments/assets/1c98831a-c5bf-4815-a3af-ee4271f06fb2" />


## Validation update — current base

The canonical BlueBubbles test command passed `19` tests. The changed adapter passed the focused async lint rules and a real import check. The remote run reports `All required checks pass`.

The implementation keeps the explicit memory trade-off: attachment bytes are buffered off the event-loop thread rather than introducing a speculative async streaming abstraction.
