### PR TITLE
chore(tools): remove duplicate computer-use export

### DIFF
--- a/tools/computer_use/__init__.py
+++ b/tools/computer_use/__init__.py
@@ -41,5 +41,4 @@ from tools.computer_use.tool import (  # noqa: F401
     set_approval_callback,
     check_computer_use_requirements,
     get_computer_use_schema,
-    release_computer_use_session,
 )


### PR DESCRIPTION
## Summary

This PR removes a duplicate public re-export from the `computer_use` package initializer.

## Related issue

Fixes #93144

## Root cause

`release_computer_use_session` appeared twice in the same import/re-export tuple in `tools/computer_use/__init__.py`. Both entries referenced the same symbol from `tools.computer_use.tool`, so the duplicate was cosmetic, but it made the public surface harder to audit and could conceal a missing neighboring export during future edits.

## Implementation

- Remove the second `release_computer_use_session` entry.
- Preserve every other existing public re-export.
- Make no changes to computer-use lifecycle behavior, backend selection, permissions, approvals, or session teardown.

## Scope and non-goals

This is a one-line export-list cleanup. It is not a security change and does not modify authentication, authorization, credentials, desktop control, or any security boundary.

## Validation

- `scripts/run_tests.sh tests/computer_use/test_cua_atexit_teardown.py -q` — `3` tests passed.
- `python3 -m ruff check --isolated --select F811 tools/computer_use/__init__.py` — passed.
- Real import check for `release_computer_use_session` and `handle_computer_use` — passed.
- `git diff --check` — passed.

## Hardening review

1. **Premise/root cause:** compared both duplicate entries against `tools.computer_use.tool` and confirmed they were the same symbol.
2. **Failure modes:** checked that the remaining import is still reachable and that no lifecycle implementation code changes.
3. **Regression/simplification:** removed only the duplicate line and validated the package import plus the existing teardown test.

## Follow-up

No behavioral follow-up is required unless a future export-list audit identifies a separate missing symbol.


## Infographic : 

<img width="1672" height="941" alt="hermes-infographic-pr-93213" src="https://github.com/user-attachments/assets/a4d1a772-18cf-44cc-af43-871137bb4b98" />


## Validation update — current base

The canonical computer-use teardown test passed `3` tests. The focused `F811` check and real package import passed. The remote run reports `All required checks pass`.
