### PR TITLE
fix(tools): pass single_query_deny_message to the ssh-config write approval gate

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -1000,3 +1000,36 @@ class TestNotFoundCache:
         assert _check_not_found_cache("read", "/tmp/never-exists-notify", tid) is None, (
             "notify_other_tool_call must clear cached misses"
         )
+
+
+class TestSSHConfigWriteGateSingleQuery:
+    """Regression: the ssh-config write guard must pass
+    single_query_deny_message to _run_approval_gate (required kwarg since
+    1596148ff). Missing it raises TypeError instead of routing through the
+    approval flow — see issue #93201."""
+
+    def test_gate_call_passes_single_query_deny_message(self):
+        import inspect as _inspect
+        import re as _re
+        import tools.file_tools as ft
+
+        src = _inspect.getsource(ft)
+        idx = src.find("_approval._run_approval_gate(")
+        assert idx != -1, "ssh_config_write gate call not found"
+        block = src[idx:idx + 900]
+        assert "pattern_key=\"ssh_config_write\"" in block
+
+        from tools.approval import _run_approval_gate
+        required = [
+            name for name, param in _inspect.signature(
+                _run_approval_gate).parameters.items()
+            if param.kind == _inspect.Parameter.KEYWORD_ONLY
+            and param.default is _inspect.Parameter.empty
+        ]
+        missing = [k for k in required if not _re.search(
+            rf"\b{k}\s*=", block)]
+        assert missing == [], (
+            f"_run_approval_gate call at ssh_config_write gate is missing "
+            f"required kwargs {missing}; it would raise TypeError instead "
+            f"of showing an approval prompt"
+        )

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1008,6 +1008,11 @@ def _check_approval_required_write(paths: list[str],
         display_target=f"<write to {display_targets}>",
         cron_deny_message=blocked.format(
             why="requires approval but this cron session denies it."),
+        single_query_deny_message=blocked.format(
+            why="requires approval but single-query (-q) sessions run "
+                "without a user present to approve it. To allow flagged "
+                "actions in single-query mode, set approvals.single_query_mode: "
+                "approve in config.yaml."),
         autoapprove_log_prefix="ssh_config_write",
         fail_closed_when_no_human=True,
         no_human_block_message=blocked.format(


### PR DESCRIPTION
## What does this PR do?

Fixes a guaranteed `TypeError` on every approval-gated write to an SSH client config file.

Commit 1596148ff ("fix(approval): deterministic approvals.single_query_mode for -q sessions") made `single_query_deny_message` a **required** keyword-only parameter of `_run_approval_gate()` and updated its two callers inside `tools/approval.py` — but missed the third caller: the SSH-config write guard in `tools/file_tools.py` (`_check_approval_required_write`, `pattern_key="ssh_config_write"`).

Any `write_file`/patch touching `~/.ssh/config` therefore raised:

```
TypeError: _run_approval_gate() missing 1 required keyword-only argument: single_query_deny_message
```

instead of routing through the human-approval flow — i.e. the fail-closed security guard fails closed *by crashing*, breaking legitimate approval prompts on every install since 1596148ff.

## Changes

- Pass `single_query_deny_message` at the missed call site, with a `-q`-specific deny message pointing operators at `approvals.single_query_mode: approve`.
- Add a regression test (`TestSSHConfigWriteGateSingleQuery`) asserting the gate call passes **every** required keyword-only arg of `_run_approval_gate`. Verified it fails on unpatched `main` (9811012) and passes with this fix.

## Relation to existing PRs

This supersedes the functional part of #87735 (same one-site fix) and #93203 (closed as duplicate). Per the review on #87735, this PR additionally includes the regression test that reviewer suggested — none of the prior PRs pinned the call site against future signature changes.

Fixes #93201
