### PR TITLE
fix(desktop): gate branch publish on workspace identity like cwd

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.test.ts
@@ -2,6 +2,7 @@ import type { ReadableAtom } from 'nanostores'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/hermes'
+import type * as sessionStore from '@/store/session'
 
 // Workspace-identity gate on the foreground publish (#92888): a background
 // Kanban worker's session.info carries ITS PR-worktree cwd/branch. The cwd
@@ -17,7 +18,7 @@ const { current } = vi.hoisted(() => ({
 }))
 
 vi.mock('@/store/session', async importOriginal => {
-  const actual = await importOriginal<typeof import('@/store/session')>()
+  const actual = await importOriginal<typeof sessionStore>()
 
   return {
     ...actual,

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.test.ts
@@ -1,0 +1,72 @@
+import type { ReadableAtom } from 'nanostores'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+
+// Workspace-identity gate on the foreground publish (#92888): a background
+// Kanban worker's session.info carries ITS PR-worktree cwd/branch. The cwd
+// write was already gated on the event describing the selected session; the
+// branch write was not, so the default chat's coding rail pointed at another
+// session's checkout while the conversation never moved.
+
+const { current } = vi.hoisted(() => ({
+  current: {
+    selectedStoredSessionId: null as null | string,
+    sessions: [] as SessionInfo[]
+  }
+}))
+
+vi.mock('@/store/session', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/store/session')>()
+
+  return {
+    ...actual,
+    $selectedStoredSessionId: { get: () => current.selectedStoredSessionId },
+    $sessions: { get: () => current.sessions }
+  }
+})
+
+import { workspaceIdentityMatchesSelectedSession } from './session-info-gate'
+import type { GateContext } from './session-info-gate'
+
+const ctx = (): GateContext => ({
+  $selectedStoredSessionId: { get: () => current.selectedStoredSessionId } as unknown as ReadableAtom<null | string>,
+  $sessions: { get: () => current.sessions } as unknown as ReadableAtom<SessionInfo[]>
+})
+
+describe('workspace-identity gate for foreground runtime publishes (#92888)', () => {
+  beforeEach(() => {
+    current.selectedStoredSessionId = 'stored-default'
+    current.sessions = [{ id: 'stored-default' } as SessionInfo]
+  })
+
+  it('accepts an event whose stored id IS the selection', () => {
+    expect(workspaceIdentityMatchesSelectedSession('stored-default', ctx())).toBe(true)
+  })
+
+  it('accepts an absent stored id (lazy/not-yet-built session — #71254 contract)', () => {
+    expect(workspaceIdentityMatchesSelectedSession(undefined, ctx())).toBe(true)
+    expect(workspaceIdentityMatchesSelectedSession('', ctx())).toBe(true)
+  })
+
+  it('rejects a DIFFERENT named session (the Kanban worker worktree case)', () => {
+    expect(workspaceIdentityMatchesSelectedSession('worker-pr-worktree', ctx())).toBe(false)
+  })
+
+  it('rejects any named session when the selection is a fresh draft (null)', () => {
+    current.selectedStoredSessionId = null
+
+    // Even the worker's own id must not rehome a draft.
+    expect(workspaceIdentityMatchesSelectedSession('worker-pr-worktree', ctx())).toBe(false)
+  })
+
+  it('still matches across a compression rotation via the lineage', () => {
+    current.selectedStoredSessionId = 'root-id'
+    current.sessions = [
+      { id: 'tip-id', _lineage_root_id: 'root-id' },
+      { id: 'root-id' }
+    ] as unknown as SessionInfo[]
+
+    expect(workspaceIdentityMatchesSelectedSession('tip-id', ctx())).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.ts
@@ -31,6 +31,11 @@ export function workspaceIdentityMatchesSelectedSession(
   const selected = context.$selectedStoredSessionId.get() ?? null
 
   if (!infoStoredSessionId) {
+    // Absent-id publishes stay allowed (#71254). Deliberate, but worth one
+    // debug line: if this class of cross-session leak ever resurfaces via a
+    // lazy path, this is the fastest place to see which event wrote what.
+    console.debug('[session-info] workspace publish allowed on absent stored_session_id')
+
     return true
   }
 
@@ -47,6 +52,13 @@ export function workspaceIdentityMatchesSelectedSession(
 
   // Either id may be the live tip or the lineage root, so ask whether ONE row
   // answers to both rather than assuming which side rotated.
+  //
+  // Cold-start window: $sessions is briefly empty right after boot or a hard
+  // re-home, so a compression-rotated tip's branch update would fail this
+  // lookup and be dropped where the pre-#92888 branch path was unconditional.
+  // The window is one sessions-refresh wide and self-heals on the next
+  // heartbeat (session.info repeats); accepted rather than queued because a
+  // queue would need invalidation on every list mutation to stay honest.
   return context.$sessions
     .get()
     .some(session => sessionMatchesStoredId(session, infoStoredSessionId) && sessionMatchesStoredId(session, selected))

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.ts
@@ -1,0 +1,53 @@
+import type { ReadableAtom } from 'nanostores'
+
+import type { SessionInfo } from '@/hermes'
+import { $selectedStoredSessionId, $sessions, sessionMatchesStoredId } from '@/store/session'
+
+export interface GateContext {
+  $selectedStoredSessionId: ReadableAtom<null | string>
+  $sessions: ReadableAtom<SessionInfo[]>
+}
+
+/**
+ * Whether a `session.info` payload's `stored_session_id` may drive the
+ * FOREGROUND composer's workspace-identifying state (cwd, branch).
+ *
+ * Extracted from handleSessionInfoEvent so the cwd and branch writes share
+ * ONE identity predicate (#92888): the branch write was left unguarded, so a
+ * background Kanban worker's PR-worktree branch rewrote the selected chat's
+ * coding rail.
+ *
+ * Absent is not the same as different: the backend omits the id on a
+ * not-yet-built (`lazy`) session, and refusing there would leave the workspace
+ * marked un-owned for the rest of the conversation (#71254). Matching goes
+ * through the lineage (`sessionMatchesStoredId`) so a compression-rotated tip
+ * and the root a pinned-row selection may hold still read as one conversation.
+ */
+export function workspaceIdentityMatchesSelectedSession(
+  storedSessionId: string | null | undefined,
+  context: GateContext = { $selectedStoredSessionId, $sessions }
+): boolean {
+  const infoStoredSessionId = storedSessionId?.trim() || null
+  const selected = context.$selectedStoredSessionId.get() ?? null
+
+  if (!infoStoredSessionId) {
+    return true
+  }
+
+  // A named session cannot describe a fresh draft. Treating a null selection
+  // as a wildcard let a background tile's `session.info` rehome the draft to
+  // the tile's workspace.
+  if (!selected) {
+    return false
+  }
+
+  if (infoStoredSessionId === selected) {
+    return true
+  }
+
+  // Either id may be the live tip or the lineage root, so ask whether ONE row
+  // answers to both rather than assuming which side rotated.
+  return context.$sessions
+    .get()
+    .some(session => sessionMatchesStoredId(session, infoStoredSessionId) && sessionMatchesStoredId(session, selected))
+}

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -99,10 +99,10 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
 
       // Workspace-identifying fields may reach the foreground composer only
       // when this event's durable stored-session identity matches the
-      // selected conversation (#92888): a background Kanban worker's
-      // session.info carries ITS PR-worktree cwd/branch, and publishing that
-      // unguarded left the default chat's coding rail pointing at another
-      // session's checkout while the conversation never moved.
+      // selected conversation — see workspaceIdentityMatchesSelectedSession
+      // for why (#92888: a background Kanban worker's session.info carries
+      // ITS PR-worktree cwd/branch, and publishing that unguarded left the
+      // default chat's coding rail pointing at another session's checkout).
       const workspaceIdentityMatches = workspaceIdentityMatchesSelectedSession(payload?.stored_session_id)
 
       if (typeof payload?.cwd === 'string' && workspaceIdentityMatches) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -8,7 +8,6 @@ import {
   $currentModel,
   $currentProvider,
   $selectedStoredSessionId,
-  $sessions,
   sessionMatchesStoredId,
   setCurrentBranch,
   setCurrentCwdTransient,
@@ -27,6 +26,7 @@ import { reportInstallMethodWarning } from '@/store/updates'
 import { finalizeInterruptedMessages } from '../../use-prompt-actions/rewind'
 import { hasSessionInfoStatePatch, PRE_TURN_LIVE_SETTLE_GRACE_MS, sessionInfoStatePatch } from '../utils'
 
+import { workspaceIdentityMatchesSelectedSession } from './session-info-gate'
 import type { GatewayEventContext } from './types'
 
 /**
@@ -38,33 +38,10 @@ import type { GatewayEventContext } from './types'
  * marked un-owned for the rest of the conversation. Matching goes through the
  * lineage (`sessionMatchesStoredId`) so a compression-rotated tip and the root
  * a pinned-row selection may hold still read as one conversation.
+ *
+ * (The predicate itself lives in ./session-info-gate so the cwd and branch
+ * foreground publishes share ONE identity check — #92888.)
  */
-function sessionInfoDescribesSelectedSession(storedSessionId: string | undefined): boolean {
-  const infoStoredSessionId = storedSessionId?.trim() || null
-  const selected = $selectedStoredSessionId.get() ?? null
-
-  if (!infoStoredSessionId) {
-    return true
-  }
-
-  // A named session cannot describe a fresh draft. Treating a null selection as
-  // a wildcard let a background tile's `session.info` rehome the draft to the
-  // tile's workspace.
-  if (!selected) {
-    return false
-  }
-
-  if (infoStoredSessionId === selected) {
-    return true
-  }
-
-  // Either id may be the live tip or the lineage root, so ask whether ONE row
-  // answers to both rather than assuming which side rotated.
-  return $sessions
-    .get()
-    .some(session => sessionMatchesStoredId(session, infoStoredSessionId) && sessionMatchesStoredId(session, selected))
-}
-
 /** session.info / session.usage / session.title. */
 export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, explicitSid, isActiveEvent, occurredAt, fromActiveSource } = ctx
@@ -120,7 +97,15 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
       // Active-session model/provider still flows through the session state
       // cache via updateSessionState → syncRuntimeMetadataToView below.
 
-      if (typeof payload?.cwd === 'string' && sessionInfoDescribesSelectedSession(payload.stored_session_id)) {
+      // Workspace-identifying fields may reach the foreground composer only
+      // when this event's durable stored-session identity matches the
+      // selected conversation (#92888): a background Kanban worker's
+      // session.info carries ITS PR-worktree cwd/branch, and publishing that
+      // unguarded left the default chat's coding rail pointing at another
+      // session's checkout while the conversation never moved.
+      const workspaceIdentityMatches = workspaceIdentityMatchesSelectedSession(payload?.stored_session_id)
+
+      if (typeof payload?.cwd === 'string' && workspaceIdentityMatches) {
         // The active session's agent can relocate itself (new repo/worktree
         // via the terminal). When the SAME active session's cwd actually
         // moves, follow it — refresh the project tree + scope so the sidebar
@@ -145,7 +130,7 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
         }
       }
 
-      if (typeof payload?.branch === 'string') {
+      if (typeof payload?.branch === 'string' && workspaceIdentityMatches) {
         setCurrentBranch(payload.branch)
       }
 


### PR DESCRIPTION
## What does this PR do?

A background Kanban worker running in a PR worktree could rewrite the FOREGROUND composer's workspace state while the default chat never moved (#92888): the composer's coding rail / branch flipped to the worker's checkout mid-conversation.

In handleSessionInfoEvent, the foreground cwd write was already guarded by sessionInfoDescribesSelectedSession() — an event may only claim cwd when its durable stored_session_id matches (or lineage-matches) the selected conversation. But setCurrentBranch() right beside it had NO such guard. session.info heartbeats from a worker profile therefore carried the worker's branch straight into the selected chat's composer.

## The fix

- Extracted the identity predicate into session-info-gate.ts (workspaceIdentityMatchesSelectedSession) — one resolver owns each policy, so the cwd and branch publishes now share ONE check.
- The branch write is gated like the cwd write: a foreign stored_session_id can no longer touch either field.
- Behavior otherwise unchanged: absent ids (lazy sessions) still apply (#71254), direct matches still apply, compression-lineage rotation still matches.

Per-session cache updates via updateSessionState are untouched — background/tile state continues to update independently, exactly as the issue's invariant requires.

## Related Issue

Fixes #92888
(#92811 is the roster-spinner fix and is unrelated; #90006 adjacency noted by the reporter.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.ts (new) — workspaceIdentityMatchesSelectedSession(), the shared identity predicate
- apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts — branch publish gated; duplicate predicate removed in favor of the shared gate
- apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info-gate.test.ts (new) — 5 cases: direct match, absent id, foreign worker id, fresh-draft rejection, lineage rotation

## How to Test

1. cd apps/desktop && npx vitest run session-info-gate session-info — 16 passed
2. Repro on main: default chat foreground + a Kanban worker in a PR worktree → worker runtime updates flip the composer's branch to the worktree's. With this branch they don't; opening the worker's own chat still re-homes correctly.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):)
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Targeted tests pass (16/16); tsc clean; eslint clean on touched files
- [x] I've added tests for my changes
- [x] Tested on macOS 26.5 (Apple Silicon)

### Documentation and Housekeeping

- [ ] Documentation updates — or N/A
- [x] cli-config.yaml.example — or N/A
- [ ] CONTRIBUTING.md / AGENTS.md — or N/A
- [x] Cross-platform impact considered — renderer-only TypeScript
- [ ] Tool descriptions/schemas — or N/A