### PR TITLE
fix(bot-mode): resurrect canonical Bot Chat archived by recoverable reasons on reopen (#92687)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4258,6 +4258,31 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         if title_filter:
             sessions = [s for s in sessions if (s.get("title") or "").strip() == title_filter]
+            if not sessions:
+                # Recoverable-archive resurrection (#92687): a canonical Bot
+                # Chat archived by the ws-orphan reaper / older agent cleanup
+                # is invisible to list_sessions_rich (include_archived=False),
+                # which would fail `hermes peer dm` resolution and mint
+                # transient sessions — same accident the tui_gateway lookups
+                # heal. Resurrect and re-list; deliberate archives stay put.
+                try:
+                    from tools.bot_mode_probe import BOT_CHAT_TITLE
+
+                    stale = db.get_session_by_title(title_filter) if title_filter == BOT_CHAT_TITLE else None
+                    if stale and stale.get("archived") and db.unarchive_recoverable_session(stale["id"]):
+                        sessions = await asyncio.to_thread(db.list_sessions_rich,
+                            source=source,
+                            limit=limit,
+                            offset=offset,
+                            include_children=include_children,
+                            order_by_last_active=True,
+                            include_pinned=True,
+                            search_query=title_filter,
+                            include_hidden=include_hidden,
+                        )
+                        sessions = [s for s in sessions if (s.get("title") or "").strip() == title_filter]
+                except Exception:
+                    pass  # resolution degrades to today's no-row behavior
         # Back-filled pins arrive PAST the limit, so counting them would report
         # another page that doesn't exist. Only the recency window decides.
         windowed = sum(1 for s in sessions if not s.get("pinned"))

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8829,6 +8829,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
+    # Accidental end reasons that recovery treats as resumable (see
+    # find_latest_gateway_session_for_peer and promote_to_session_reset,
+    # whose SQL literals must stay in sync with this tuple, and
+    # docs/session-lifecycle.md "recoverable accidental reasons").
+    RECOVERABLE_END_REASONS = ("agent_close", "ws_orphan_reap")
+
+    def unarchive_recoverable_session(self, session_id: str) -> bool:
+        """Un-archive a session that was archived by a recoverable accident.
+
+        Registry-style lookups (Bot Mode's canonical "Bot Chat") use this to
+        resurrect a row the ws-orphan reaper (``ws_orphan_reap``) or older
+        agent cleanup (``agent_close``) archived: those ends are accidents,
+        not user intent, so the identity-scoped canonical chat must survive
+        them (#92687). Sessions archived with no end_reason or an explicit
+        boundary reason (user archived deliberately, ``session_reset``, …)
+        are left untouched — returns ``False`` for those, ``True`` only when
+        the row was archived for a recoverable reason and is now un-archived
+        (whole compression lineage, via :meth:`set_session_archived`).
+        """
+        if not session_id:
+            return False
+        try:
+            row = self.get_session(session_id)
+        except Exception:
+            return False
+        if not row or not row.get("archived"):
+            return False
+        if (row.get("end_reason") or "") not in self.RECOVERABLE_END_REASONS:
+            return False
+        return self.set_session_archived(session_id, False)
+
     def set_session_pinned(self, session_id: str, pinned: bool) -> bool:
         """Pin or unpin a session (and its whole compression lineage).
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -65,6 +65,8 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _LISTABLE_CHILD_SQL,
     _PREVIEW_ELIGIBLE_SQL,
     _PREVIEW_RAW_SELECT,
+    _RECOVERABLE_END_REASONS,
+    _RECOVERABLE_END_REASONS_SQL,
     _RESET_END_REASONS,
     _RESET_END_REASONS_SQL,
     _ephemeral_child_sql,
@@ -5747,7 +5749,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash
                 WHERE s.session_key = ?
                   AND s.source = ?
-                  AND (s.ended_at IS NULL OR s.end_reason IN ('agent_close', 'ws_orphan_reap'))
+                  AND (s.ended_at IS NULL OR s.end_reason IN ({_RECOVERABLE_END_REASONS_SQL}))
                   AND NOT EXISTS (
                       SELECT 1 FROM sessions b
                       WHERE b.session_key = s.session_key
@@ -5786,7 +5788,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND COALESCE(s.chat_id, '') = COALESCE(?, '')
                   AND COALESCE(s.chat_type, '') = COALESCE(?, '')
                   AND COALESCE(s.thread_id, '') = COALESCE(?, '')
-                  AND (s.ended_at IS NULL OR s.end_reason IN ('agent_close', 'ws_orphan_reap'))
+                  AND (s.ended_at IS NULL OR s.end_reason IN ({_RECOVERABLE_END_REASONS_SQL}))
                   AND (COALESCE(s.message_count, 0) > 0 OR EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = s.id LIMIT 1
                   ))
@@ -6422,7 +6424,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             cursor = conn.execute(
                 "UPDATE sessions SET ended_at = ?, end_reason = ? "
                 "WHERE id = ? AND (ended_at IS NULL "
-                "OR end_reason IN ('agent_close', 'ws_orphan_reap'))",
+                f"OR end_reason IN ({_RECOVERABLE_END_REASONS_SQL}))",
                 (now, reason, session_id),
             )
             return cursor.rowcount
@@ -8829,11 +8831,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
-    # Accidental end reasons that recovery treats as resumable (see
-    # find_latest_gateway_session_for_peer and promote_to_session_reset,
-    # whose SQL literals must stay in sync with this tuple, and
-    # docs/session-lifecycle.md "recoverable accidental reasons").
-    RECOVERABLE_END_REASONS = ("agent_close", "ws_orphan_reap")
+    # Accidental end reasons that recovery treats as resumable. Single source
+    # of truth: hermes_state_common._RECOVERABLE_END_REASONS, interpolated
+    # into find_latest_gateway_session_for_peer / promote_to_session_reset
+    # SQL — literals cannot drift (docs/session-lifecycle.md "recoverable
+    # accidental reasons").
+    RECOVERABLE_END_REASONS = _RECOVERABLE_END_REASONS
 
     def unarchive_recoverable_session(self, session_id: str) -> bool:
         """Un-archive a session that was archived by a recoverable accident.
@@ -8856,9 +8859,34 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return False
         if not row or not row.get("archived"):
             return False
-        if (row.get("end_reason") or "") not in self.RECOVERABLE_END_REASONS:
+        # A compressed lineage's registry row keeps end_reason='compression';
+        # the accidental stamp lives on the live TIP. Judge recoverability at
+        # the tip (== the row itself when uncompressed).
+        tip = row
+        try:
+            tip_id = self.resolve_resume_session_id(session_id) or session_id
+            if tip_id != session_id:
+                tip = self.get_session(tip_id) or row
+        except Exception:
+            tip_id = session_id
+        if (tip.get("end_reason") or "") not in self.RECOVERABLE_END_REASONS:
             return False
-        return self.set_session_archived(session_id, False)
+        if not self.set_session_archived(session_id, False):
+            return False
+
+        # Clear the accidental end stamp: the session is live again, and a
+        # surviving ws_orphan_reap/agent_close reason would make a LATER
+        # deliberate archive (which never writes end_reason) auto-resurrect
+        # on the next lookup — permanently overriding user intent.
+        def _clear_end(conn):
+            conn.execute(
+                "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
+                (tip["id"],),
+            )
+            return 1
+
+        self._execute_write(_clear_end)
+        return True
 
     def set_session_pinned(self, session_id: str, pinned: bool) -> bool:
         """Pin or unpin a session (and its whole compression lineage).

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -200,6 +200,13 @@ _RESET_END_REASONS = (
 )
 _RESET_END_REASONS_SQL = ", ".join(f"'{reason}'" for reason in _RESET_END_REASONS)
 
+# Accidental end reasons that recovery treats as resumable (see
+# docs/session-lifecycle.md "recoverable accidental reasons"). Interpolated
+# into the recovery SQL below AND exposed as SessionDB.RECOVERABLE_END_REASONS
+# so the tuple is the single source of truth — literals cannot drift.
+_RECOVERABLE_END_REASONS = ("agent_close", "ws_orphan_reap")
+_RECOVERABLE_END_REASONS_SQL = ", ".join(f"'{reason}'" for reason in _RECOVERABLE_END_REASONS)
+
 
 def _legacy_reset_child_sql(alias: str, reasons_sql: str) -> str:
     """Pre-marker reset-continuation heuristic.

--- a/tests/tui_gateway/test_profiles_list_canonical_session.py
+++ b/tests/tui_gateway/test_profiles_list_canonical_session.py
@@ -11,7 +11,9 @@ pin-verification contract is REMOVED (pointers dangle; names cannot).
 Contract under test:
 - Every profile row (with include_sessions on) carries ``canonical_session``:
   a summary dict when a "Bot Chat" row exists, ``None`` when it does not
-  (no row, denied internal source, archived).
+  (no row, denied internal source, deliberately archived; a row archived by
+  a recoverable accident — ws_orphan_reap/agent_close — is resurrected,
+  #92687).
 - Summary keys: ``id`` (the durable registry row), ``resolved_id`` (live
   compression tip; equal to ``id`` when uncompressed), ``root_title``,
   ``title``, ``preview`` (newest user/assistant text at the tip),
@@ -45,7 +47,7 @@ def _db(profile_dir):
 
 
 def _add_session(db, sid, *, source="cli", title="", ts, text, hidden=False,
-                 parent=None, end_reason=None):
+                 parent=None, end_reason=None, archived=False):
     """Create one session with a single user message at an exact timestamp."""
     db.create_session(sid, source, parent_session_id=parent)
     db.append_message(sid, "user", text, timestamp=ts)
@@ -58,6 +60,9 @@ def _add_session(db, sid, *, source="cli", title="", ts, text, hidden=False,
                 "UPDATE sessions SET ended_at = ?, end_reason = ? WHERE id = ?",
                 (ts + 1, end_reason, sid),
             )
+        if archived:
+            db._conn.execute(
+                "UPDATE sessions SET archived = 1 WHERE id = ?", (sid,))
     if hidden:
         db.set_session_hidden(sid, True)
 
@@ -154,6 +159,115 @@ def test_canonical_session_resolves_compression_tip(home):
     assert canonical["root_title"] == "Bot Chat"
     assert canonical["title"] == "Bot Chat (continued)"
     assert "post-compression content" in canonical["preview"]
+
+
+# ---------------------------------------------------------------------------
+# Recoverable-archive resurrection (#92687)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("reason", ["ws_orphan_reap", "agent_close"])
+def test_canonical_session_archived_by_recoverable_reason_is_resurrected(home, reason):
+    # The ws-orphan reaper (and older agent cleanup) archives by ACCIDENT —
+    # the canonical forever-chat must come back with the SAME id, un-archived.
+    db = _db(home)
+    _add_session(db, "reaped1", title="Bot Chat", ts=1000,
+                 text="surviving forever chat", hidden=True,
+                 end_reason=reason, archived=True)
+    db.close()
+
+    row = _row(_profiles({}), "default")
+
+    canonical = row["canonical_session"]
+    assert canonical is not None
+    assert canonical["id"] == "reaped1"
+    assert "surviving forever chat" in canonical["preview"]
+
+    # The archive flag was durably cleared, not just masked for this call.
+    db = _db(home)
+    try:
+        assert not db.get_session("reaped1")["archived"]
+    finally:
+        db.close()
+
+
+def test_canonical_session_deliberately_archived_stays_archived(home):
+    # No recoverable end_reason ⇒ the user retired it on purpose: absent.
+    db = _db(home)
+    _add_session(db, "retired1", title="Bot Chat", ts=1000,
+                 text="deliberately retired", hidden=True, archived=True)
+    db.close()
+
+    row = _row(_profiles({}), "default")
+    assert row["canonical_session"] is None
+
+    db = _db(home)
+    try:
+        assert db.get_session("retired1")["archived"]
+    finally:
+        db.close()
+
+
+def test_canonical_session_archived_with_explicit_boundary_stays_archived(home):
+    # Explicit boundary reasons (session_reset) are not recoverable either.
+    db = _db(home)
+    _add_session(db, "reset1", title="Bot Chat", ts=1000,
+                 text="reset boundary", hidden=True,
+                 end_reason="session_reset", archived=True)
+    db.close()
+
+    row = _row(_profiles({}), "default")
+    assert row["canonical_session"] is None
+
+
+def test_non_canonical_archived_session_untouched_by_resurrection(home):
+    # Ordinary sessions keep today's behavior exactly: an archived
+    # non-canonical row stays archived even with a recoverable reason.
+    db = _db(home)
+    _add_session(db, "plain1", title="Scratch", ts=1000, text="scratch",
+                 end_reason="ws_orphan_reap", archived=True)
+    _add_session(db, "chat1", title="Bot Chat", ts=2000, text="forever")
+    db.close()
+
+    row = _row(_profiles({}), "default")
+    assert row["canonical_session"]["id"] == "chat1"
+
+    db = _db(home)
+    try:
+        assert db.get_session("plain1")["archived"]
+    finally:
+        db.close()
+
+
+def test_session_list_title_lookup_resurrects_recoverable_bot_chat(home, monkeypatch):
+    # The exact-title registry lookup (session.list title=) — the desktop's
+    # click-open path — must also resurrect instead of returning no rows.
+    db = _db(home)
+    _add_session(db, "reaped2", title="Bot Chat", ts=1000,
+                 text="click target", hidden=True,
+                 end_reason="ws_orphan_reap", archived=True)
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+
+    envelope = srv._methods["session.list"](1, {"title": "Bot Chat"})
+    sessions = envelope["result"]["sessions"]
+    assert len(sessions) == 1
+    assert sessions[0]["id"] == "reaped2"
+
+    # The archive flag was durably cleared.
+    assert not db.get_session("reaped2")["archived"]
+    db.close()
+
+
+def test_session_list_title_lookup_keeps_deliberate_archive_hidden(home, monkeypatch):
+    db = _db(home)
+    _add_session(db, "retired2", title="Bot Chat", ts=1000,
+                 text="retired", hidden=True, archived=True)
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+
+    envelope = srv._methods["session.list"](1, {"title": "Bot Chat"})
+    assert envelope["result"]["sessions"] == []
+    assert db.get_session("retired2")["archived"]
+    db.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tui_gateway/test_profiles_list_canonical_session.py
+++ b/tests/tui_gateway/test_profiles_list_canonical_session.py
@@ -183,10 +183,44 @@ def test_canonical_session_archived_by_recoverable_reason_is_resurrected(home, r
     assert canonical["id"] == "reaped1"
     assert "surviving forever chat" in canonical["preview"]
 
-    # The archive flag was durably cleared, not just masked for this call.
+    # Idempotence: a second listing resolves the same row again (the stale
+    # end stamp was cleared, nothing re-hides or re-resurrects in a loop).
+    again = _row(_profiles({}), "default")["canonical_session"]
+    assert again is not None and again["id"] == "reaped1"
+
+    # The archive flag was durably cleared, not just masked for this call —
+    # and the accidental end stamp went with it.
     db = _db(home)
     try:
-        assert not db.get_session("reaped1")["archived"]
+        fresh = db.get_session("reaped1")
+        assert not fresh["archived"]
+        assert fresh["end_reason"] is None
+    finally:
+        db.close()
+
+
+def test_resurrection_unarchives_the_whole_compression_lineage(home):
+    # unarchive_recoverable_session promises lineage-wide un-archive via
+    # set_session_archived: a compressed canonical chat (root + tip both
+    # archived by the reaper) must fully resurrect, resolved to the tip.
+    db = _db(home)
+    _add_session(db, "root1", title="Bot Chat", ts=1000,
+                 text="pre-compression", hidden=True,
+                 end_reason="compression", archived=True)
+    _add_session(db, "tip1", ts=2000, text="post-compression content",
+                 parent="root1", end_reason="ws_orphan_reap", archived=True)
+    db.close()
+
+    row = _row(_profiles({}), "default")
+    canonical = row["canonical_session"]
+    assert canonical is not None
+    assert canonical["id"] == "root1"
+    assert canonical["resolved_id"] == "tip1"
+
+    db = _db(home)
+    try:
+        assert not db.get_session("root1")["archived"]
+        assert not db.get_session("tip1")["archived"]
     finally:
         db.close()
 
@@ -268,6 +302,32 @@ def test_session_list_title_lookup_keeps_deliberate_archive_hidden(home, monkeyp
     assert envelope["result"]["sessions"] == []
     assert db.get_session("retired2")["archived"]
     db.close()
+
+
+def test_deliberate_archive_after_resurrection_stays_archived(home):
+    # Resurrection must clear the accidental end stamp: if ws_orphan_reap
+    # survived on the row, a LATER deliberate archive (which writes no
+    # end_reason) would auto-resurrect on the next lookup — permanently
+    # overriding user intent.
+    db = _db(home)
+    _add_session(db, "cycle1", title="Bot Chat", ts=1000,
+                 text="reaped then retired", hidden=True,
+                 end_reason="ws_orphan_reap", archived=True)
+    db.close()
+
+    # First lookup resurrects (accidental archive).
+    row = _row(_profiles({}), "default")
+    assert row["canonical_session"] is not None
+
+    # User now deliberately archives the resurrected row.
+    db = _db(home)
+    assert db.get_session("cycle1")["end_reason"] is None  # stamp cleared
+    db.set_session_archived("cycle1", True)
+    db.close()
+
+    # Second lookup must respect the deliberate archive.
+    row = _row(_profiles({}), "default")
+    assert row["canonical_session"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -99,7 +99,17 @@ def _(rid, params: dict) -> dict:
                 if (row.get("source") or "").strip().lower() in deny:
                     return None
                 if row.get("archived"):
-                    return None
+                    # An archived canonical row usually means the user
+                    # deliberately retired it — report absent. But the
+                    # ws-orphan reaper / older agent cleanup can archive it
+                    # by accident (end_reason ws_orphan_reap / agent_close):
+                    # the canonical chat is identity-scoped (the bot's
+                    # forever conversation), so an accidental archive is
+                    # user-visible amnesia. Resurrect those — un-archive and
+                    # keep resolving — reusing the same recoverable-reason
+                    # set as gateway stale-route recovery (#92687).
+                    if not db.unarchive_recoverable_session(session_id):
+                        return None
                 try:
                     tip = db.resolve_resume_session_id(session_id) or session_id
                 except Exception:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -192,6 +192,16 @@ def _(rid, params: dict) -> dict:
             title_lookup = str(params.get("title") or "").strip()
             if title_lookup:
                 row = db.get_session_by_title(title_lookup)
+                if row and row.get("archived") and title_lookup == "Bot Chat":
+                    # The canonical Bot Chat is identity-scoped: an archive
+                    # stamped by the ws-orphan reaper or older agent cleanup
+                    # (ws_orphan_reap / agent_close) is an accident, not user
+                    # intent, and hiding the row here makes the desktop mint
+                    # transient replacements forever (#92687). Resurrect it —
+                    # same recoverable-reason set as stale-route recovery.
+                    # Deliberate archives (no/explicit end_reason) still hide.
+                    if db.unarchive_recoverable_session(row["id"]):
+                        row = db.get_session_by_title(title_lookup)
                 if (
                     not row
                     or row.get("archived")

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -192,16 +192,22 @@ def _(rid, params: dict) -> dict:
             title_lookup = str(params.get("title") or "").strip()
             if title_lookup:
                 row = db.get_session_by_title(title_lookup)
-                if row and row.get("archived") and title_lookup == "Bot Chat":
-                    # The canonical Bot Chat is identity-scoped: an archive
-                    # stamped by the ws-orphan reaper or older agent cleanup
-                    # (ws_orphan_reap / agent_close) is an accident, not user
-                    # intent, and hiding the row here makes the desktop mint
-                    # transient replacements forever (#92687). Resurrect it —
-                    # same recoverable-reason set as stale-route recovery.
-                    # Deliberate archives (no/explicit end_reason) still hide.
-                    if db.unarchive_recoverable_session(row["id"]):
-                        row = db.get_session_by_title(title_lookup)
+                if row and row.get("archived"):
+                    from tools.bot_mode_probe import BOT_CHAT_TITLE
+
+                    if title_lookup == BOT_CHAT_TITLE:
+                        # The canonical Bot Chat is identity-scoped: an archive
+                        # stamped by the ws-orphan reaper or older agent cleanup
+                        # (ws_orphan_reap / agent_close) is an accident, not user
+                        # intent, and hiding the row here makes the desktop mint
+                        # transient replacements forever (#92687). Resurrect it —
+                        # same recoverable-reason set as stale-route recovery.
+                        # Deliberate archives (no/explicit end_reason) still hide.
+                        # Re-fetch by ID: title has no DB-level UNIQUE, so a
+                        # title re-query could grab a different (still-archived)
+                        # duplicate row.
+                        if db.unarchive_recoverable_session(row["id"]):
+                            row = db.get_session(row["id"])
                 if (
                     not row
                     or row.get("archived")


### PR DESCRIPTION
## Summary

The canonical Bot Chat archived by an *accidental* reason (`ws_orphan_reap`, `agent_close`) is now resurrected by the canonical-session lookups instead of the desktop getting no-row and minting a transient session on every click. Fixes #92687.

Root cause (full trace on the issue): both desktop-facing lookups treat any archived row as gone — `_canonical_session_row()` (`tui_gateway/methods_profiles.py:101`, the `profiles.list` canonical_session resolver) and the `session.list` exact-title lookup (`tui_gateway/methods_session.py:195`, the click-open path). The transcript is intact on disk the whole time; the codebase even already classifies `ws_orphan_reap`/`agent_close` as recoverable accidental reasons (`find_latest_gateway_session_for_peer`, `promote_to_session_reset`, docs/session-lifecycle.md) — the lookups just never consulted that machinery.

## Changes

- `hermes_state.py`: the recoverable set is now exposed as `SessionDB.RECOVERABLE_END_REASONS` (same two reasons, single source of truth); new `unarchive_recoverable_session()` clears the archived flag via the existing lineage-wide `set_session_archived` path — deliberate archives (no end_reason, or explicit boundaries like `session_reset`) return `False` and stay archived.
- `tui_gateway/methods_profiles.py`: `_canonical_session_row()`'s archived branch attempts resurrection and continues resolving on success.
- `tui_gateway/methods_session.py`: the exact-title lookup resurrects an archived "Bot Chat" row the same way; other titles untouched.

Note: review verified no reaper-exemption has landed on main (the #93077 idea), so this resurrection path is load-bearing for FUTURE accidental archives too, not just pre-existing rows. If an exemption ships later, this remains the healing layer for every other accidental-archival source.

## Validation

| Suite | Result |
|---|---|
| test_profiles_list_canonical_session.py (7 new tests: recoverable resurrection ×2, deliberate archive stays, explicit boundary stays, non-canonical untouched, session.list resurrect + deliberate-hidden) + test_bot_relay_methods.py + test_session_hidden_rpc.py | 23 passed |
| session-lifecycle files for the touched module (expiry-finalized, compression-watermark) | 21 passed |
| ruff on changed files | clean |

No existing test pinned the buggy behavior (the archived case lived only in a module docstring, updated).

