### PR TITLE
fix: preserve OpenRouter reasoning_details on stream reassembly

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9153,6 +9153,7 @@ class _ChatStreamAccumulator:
         self._total_ceiling = total_ceiling
         self.content_parts: List[str] = []
         self.reasoning_parts: List[str] = []
+        self.reasoning_details_acc: List[Any] = []
         self.tool_calls_acc: Dict[int, Dict[str, Any]] = {}
         self.finish_reason = None
         self.usage = None
@@ -9191,6 +9192,10 @@ class _ChatStreamAccumulator:
         )
         if reasoning_piece and isinstance(reasoning_piece, str):
             self.reasoning_parts.append(reasoning_piece)
+        from agent.chat_completion_helpers import coerce_stream_reasoning_details
+        details = coerce_stream_reasoning_details(delta)
+        if details:
+            self.reasoning_details_acc.extend(details)
         for tc in (getattr(delta, "tool_calls", None) or []):
             idx = getattr(tc, "index", 0) or 0
             acc = self.tool_calls_acc.setdefault(
@@ -9224,6 +9229,7 @@ class _ChatStreamAccumulator:
             content="".join(self.content_parts),
             tool_calls=tool_calls,
             reasoning="".join(self.reasoning_parts) or None,
+            reasoning_details=self.reasoning_details_acc or None,
         )
         choice = SimpleNamespace(
             index=0,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -54,6 +54,37 @@ _PROVIDER_STREAM_ERROR_FINISH_REASONS = {"error", "error_finish"}
 _PROVIDER_STREAM_SSE_FIELDS = {"event", "data", "id", "retry"}
 _PROVIDER_STREAM_ERROR_TEXT_LIMIT = 4096
 
+
+def coerce_stream_reasoning_details(delta: Any) -> list[Any]:
+    """Normalize OpenRouter ``delta.reasoning_details`` from a stream chunk.
+
+    OpenAI SDK 2.24+ keeps unknown ChoiceDelta fields in ``model_extra``.
+    The stream assembler historically read only ``reasoning`` /
+    ``reasoning_content``, so a details-only OpenRouter turn looked empty
+    and conversation_loop empty-retried. Do not promote details to visible
+    content — only preserve the structured field.
+    """
+    rd = getattr(delta, "reasoning_details", None)
+    if rd is None:
+        extra = getattr(delta, "model_extra", None) or {}
+        if isinstance(extra, dict):
+            rd = extra.get("reasoning_details")
+    if not rd:
+        return []
+    items = rd if isinstance(rd, list) else [rd]
+    out: list[Any] = []
+    for item in items:
+        if hasattr(item, "model_dump"):
+            try:
+                item = item.model_dump()
+            except Exception:
+                pass
+        if isinstance(item, dict):
+            out.append(item)
+        elif item is not None:
+            out.append({"value": item})
+    return out
+
 # When the fallback chain is fully exhausted on a non-rate-limit failure
 # (e.g. every provider returns a non-retryable client error like HTTP 400),
 # arm a short cooldown so the NEXT turn's restore_primary_runtime stays gated
@@ -3897,6 +3928,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         model_name = None
         role = "assistant"
         reasoning_parts: list = []
+        reasoning_details_acc: list = []
         usage_obj = None
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -4143,6 +4175,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 _fire_first_delta()
                 agent._fire_reasoning_delta(reasoning_text)
 
+            details = coerce_stream_reasoning_details(delta)
+            if details:
+                reasoning_details_acc.extend(details)
+                _fire_first_delta()
+
             # Accumulate text content — fire callback only when no tool calls
             delta_content = getattr(delta, "content", None)
             if delta_content:
@@ -4366,6 +4403,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             finish_reason is None
             and not content_parts
             and not reasoning_parts
+            and not reasoning_details_acc
             and not tool_calls_acc
         ):
             raise EmptyStreamError(
@@ -4452,6 +4490,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             content=full_content,
             tool_calls=mock_tool_calls,
             reasoning_content=full_reasoning,
+            reasoning_details=reasoning_details_acc or None,
         )
         mock_choice = SimpleNamespace(
             index=0,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3274,6 +3274,7 @@ def cleanup_task_resources(agent, task_id: str) -> None:
 def _build_partial_stream_stub(
     role, full_content, full_reasoning, model_name, usage_obj, *,
     dropped_tool_names=None,
+    reasoning_details=None,
 ):
     """Build a partial-stream-stub response for mid-stream drop scenarios.
 
@@ -3288,6 +3289,7 @@ def _build_partial_stream_stub(
         content=full_content,
         tool_calls=None,
         reasoning_content=full_reasoning,
+        reasoning_details=reasoning_details or None,
     )
     mock_choice = SimpleNamespace(
         index=0,
@@ -4448,6 +4450,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "".join(reasoning_parts) or None,
                 model_name, usage_obj,
                 dropped_tool_names=_dropped_names or None,
+                reasoning_details=reasoning_details_acc or None,
             )
 
         # Text-only stream drop: the upstream closed the connection (or the
@@ -4469,6 +4472,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 role, full_content,
                 "".join(reasoning_parts) or None,
                 model_name, usage_obj,
+                reasoning_details=reasoning_details_acc or None,
             )
 
         effective_finish_reason = finish_reason or "stop"

--- a/tests/agent/test_reasoning_details_stream.py
+++ b/tests/agent/test_reasoning_details_stream.py
@@ -12,7 +12,7 @@ from agent.chat_completion_helpers import coerce_stream_reasoning_details
 from agent.transports.chat_completions import ChatCompletionsTransport
 
 
-def _chunk(*, content=None, reasoning=None, reasoning_content=None, reasoning_details=None, finish=None):
+def _chunk(*, content=None, reasoning=None, reasoning_content=None, reasoning_details=None, finish=None, tool_calls=None):
     extra = {}
     if reasoning_details is not None:
         extra["reasoning_details"] = reasoning_details
@@ -21,7 +21,7 @@ def _chunk(*, content=None, reasoning=None, reasoning_content=None, reasoning_de
         reasoning=reasoning,
         reasoning_content=reasoning_content,
         reasoning_details=reasoning_details,
-        tool_calls=[],
+        tool_calls=tool_calls or [],
         model_extra=extra,
     )
     choice = SimpleNamespace(delta=delta, finish_reason=finish)
@@ -81,3 +81,37 @@ def test_details_not_promoted_to_content():
     acc.feed(_chunk(finish="stop"))
     msg = acc.finish().choices[0].message
     assert "secret cot" not in (msg.content or "")
+
+
+def test_details_then_tool_call_keeps_tools_and_details():
+    acc = _ChatStreamAccumulator(model="glm-4.7")
+    acc.feed(_chunk(reasoning_details=[{"type": "reasoning.summary", "summary": "plan tool"}]))
+    tc = SimpleNamespace(
+        index=0,
+        id="call_1",
+        function=SimpleNamespace(name="terminal", arguments='{"command":"true"}'),
+    )
+    acc.feed(_chunk(tool_calls=[tc]))
+    acc.feed(_chunk(finish="tool_calls"))
+    msg = acc.finish().choices[0].message
+    assert msg.reasoning_details == [{"type": "reasoning.summary", "summary": "plan tool"}]
+    assert msg.tool_calls is not None
+    assert msg.tool_calls[0].id == "call_1"
+    assert msg.tool_calls[0].function.name == "terminal"
+    assert "plan tool" not in (msg.content or "")
+
+
+def test_partial_stub_preserves_details():
+    from agent.chat_completion_helpers import _build_partial_stream_stub
+    stub = _build_partial_stream_stub(
+        "assistant",
+        None,
+        None,
+        "glm-4.7",
+        None,
+        reasoning_details=[{"type": "reasoning.summary", "summary": "mid drop"}],
+    )
+    assert stub.choices[0].message.reasoning_details == [
+        {"type": "reasoning.summary", "summary": "mid drop"}
+    ]
+    assert not (stub.choices[0].message.content or "")

--- a/tests/agent/test_reasoning_details_stream.py
+++ b/tests/agent/test_reasoning_details_stream.py
@@ -1,0 +1,83 @@
+"""Regression: OpenRouter reasoning_details must survive stream reassembly.
+
+task-15963 / P0 H1. Details-only streams used to look empty and trip
+conversation_loop empty-retry. Later content must still be kept.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.auxiliary_client import _ChatStreamAccumulator
+from agent.chat_completion_helpers import coerce_stream_reasoning_details
+from agent.transports.chat_completions import ChatCompletionsTransport
+
+
+def _chunk(*, content=None, reasoning=None, reasoning_content=None, reasoning_details=None, finish=None):
+    extra = {}
+    if reasoning_details is not None:
+        extra["reasoning_details"] = reasoning_details
+    delta = SimpleNamespace(
+        content=content,
+        reasoning=reasoning,
+        reasoning_content=reasoning_content,
+        reasoning_details=reasoning_details,
+        tool_calls=[],
+        model_extra=extra,
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=finish)
+    return SimpleNamespace(id="c1", model="openrouter/z-ai/glm-4.7", choices=[choice], usage=None)
+
+
+def test_coerce_reads_model_extra_when_attr_missing():
+    delta = SimpleNamespace(
+        content=None,
+        model_extra={"reasoning_details": [{"type": "reasoning.summary", "summary": "think"}]},
+    )
+    got = coerce_stream_reasoning_details(delta)
+    assert got == [{"type": "reasoning.summary", "summary": "think"}]
+
+
+def test_accumulator_details_then_content_keeps_content():
+    acc = _ChatStreamAccumulator(model="glm-4.7")
+    acc.feed(_chunk(reasoning_details=[{"type": "reasoning.summary", "summary": "think first"}]))
+    acc.feed(_chunk(content="OK"))
+    acc.feed(_chunk(finish="stop"))
+    msg = acc.finish().choices[0].message
+    assert msg.content == "OK"
+    assert msg.reasoning_details == [{"type": "reasoning.summary", "summary": "think first"}]
+
+
+def test_accumulator_details_only_is_structured_not_empty():
+    acc = _ChatStreamAccumulator(model="glm-4.7")
+    acc.feed(_chunk(reasoning_details=[{"type": "reasoning.summary", "summary": "only think"}]))
+    acc.feed(_chunk(finish="stop"))
+    msg = acc.finish().choices[0].message
+    assert msg.content == ""
+    assert msg.reasoning is None
+    assert msg.reasoning_details == [{"type": "reasoning.summary", "summary": "only think"}]
+    nr = ChatCompletionsTransport().normalize_response(
+        SimpleNamespace(
+            choices=[SimpleNamespace(message=msg, finish_reason="stop")],
+            usage=None,
+        )
+    )
+    assert nr.reasoning_details == [{"type": "reasoning.summary", "summary": "only think"}]
+    assert bool(nr.reasoning_details)
+    assert not (nr.content or "").strip()
+
+
+def test_accumulator_reasoning_content_only_still_works():
+    acc = _ChatStreamAccumulator(model="glm-4.7")
+    acc.feed(_chunk(reasoning_content="structured think only"))
+    acc.feed(_chunk(finish="stop"))
+    msg = acc.finish().choices[0].message
+    assert msg.reasoning == "structured think only"
+    assert msg.reasoning_details is None
+
+
+def test_details_not_promoted_to_content():
+    acc = _ChatStreamAccumulator(model="glm-4.7")
+    acc.feed(_chunk(reasoning_details=[{"type": "reasoning.summary", "summary": "secret cot"}]))
+    acc.feed(_chunk(finish="stop"))
+    msg = acc.finish().choices[0].message
+    assert "secret cot" not in (msg.content or "")


### PR DESCRIPTION
## What
Stream assemblers now keep OpenRouter `delta.reasoning_details` (including OpenAI SDK `model_extra`). Details-only turns are structured, not empty. Later content and tool_calls stay intact. Details are not promoted to visible content.

## Why
OpenRouter reasoning models emit `reasoning_details` first. Hermes 0.20+ read only `reasoning` / `reasoning_content`, rebuilt a mock without `reasoning_details`, and conversation_loop empty-retried with "Model returned no content after all retries."

## Tests
`tests/agent/test_reasoning_details_stream.py` — 7 passed:
- details-then-content keeps both
- details-only is structured / not empty
- details-then-tool_calls keeps tools + details
- details not flattened into content
- partial-stream stub preserves details

## Pin
Head replayed onto current `main` (`981101239`). Lab pin is this PR head.

Fixes CHIMI P0 / task-15963 H1.