### PR TITLE
fix(desktop): make remote profile badges legible

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -1281,7 +1281,7 @@ function ProfileSquare({
                     {remoteHost && (
                       <span
                         aria-hidden="true"
-                        className="absolute -right-0.5 -top-0.5 grid size-2 place-items-center rounded-full bg-(--ui-panel-background)"
+                        className="absolute -right-0.5 -top-0.5 grid size-3 place-items-center rounded-full border border-(--ui-stroke-secondary) bg-(--ui-panel-background) text-(--ui-accent)"
                         data-slot="profile-remote-badge"
                       >
                         <Codicon name="globe" size="0.5rem" />


### PR DESCRIPTION
## What does this PR do?

Makes the existing remote-override globe on profile squares readable at normal
Desktop scale.

The current 8px badge renders the globe at the same 8px size, which collapses
into an ambiguous corner speck. This keeps the same meaning, host-aware
tooltip, accessible profile label, and interaction; it only uses a 12px
token-colored badge with a shared stroke and an 8px globe. The original
half-step corner offset is preserved so the badge has breathing room without
being clipped by the profile strip.

## Screenshot

<img width="260" height="42" alt="Remote profile override badge on the profile strip" src="https://github.com/user-attachments/assets/82cf8060-8753-48c4-8c94-7bbe96e6ceec" />

## Related work

- Follow-up to merged #89719, which introduced the registered-gateway/profile
  rail. Routing and switching behavior are unchanged.
- #72767 asks for broader per-session profile identity. This is a narrow visual
  fix, not that complete design.
- #93348 changes the same rail for opt-in profile grouping. Its current head
  conflicts with the refactored rail; if it lands, it should preserve this
  badge token and accessible label during rebase.

## Type of change

- [x] UI bug fix

## Validation

Current-main head `c08954e828` on `24e54b55f5`:

- Profile rail and connection-switcher behavior: **18 passed** on the
  equivalent pre-rebase tree
- Desktop typecheck on this exact head: passed
- ESLint on the changed file: passed
- `git diff --check`: passed
- One one-line, safe-to-cherry-pick commit

No backend, persistence, routing, or profile semantics change. All selected
exact-head GitHub checks pass.
