### PR TITLE
fix(telegram): retry bounded flood waits

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2996,6 +2996,11 @@ class BasePlatformAdapter(ABC):
     # never see these calls.
     supports_status_text: bool = False
 
+    # Cumulative server-directed sleep budget for one _send_with_retry()
+    # delivery. None preserves the existing unlimited behavior. Regular
+    # exponential backoff does not draw from this adapter-specific budget.
+    retry_after_sleep_budget_secs: Optional[float] = None
+
     def set_status_text(self, chat_id: str, text: Optional[str]) -> None:
         """Set or clear (``None``) the live working-state phrase for a chat.
 
@@ -5695,9 +5700,27 @@ class BasePlatformAdapter(ABC):
             # Honor server-requested retry_after (e.g. Telegram FloodWait)
             # when present — it is authoritative over our backoff schedule.
             server_retry_after = result.retry_after
+            retry_after_spent = 0.0
             for attempt in range(1, max_retries + 1):
                 if server_retry_after is not None:
-                    delay = server_retry_after + random.uniform(0, 1)
+                    raw_wait = float(server_retry_after)
+                    budget = self.retry_after_sleep_budget_secs
+                    remaining = max(0.0, budget - retry_after_spent) if budget is not None else None
+                    if remaining is not None and raw_wait > remaining:
+                        logger.error(
+                            "[%s] Server-directed retry_after %.1fs would exceed the "
+                            "%.1fs sleep budget (%.1fs already spent) — giving up: %s",
+                            self.name,
+                            raw_wait,
+                            budget,
+                            retry_after_spent,
+                            error_str,
+                        )
+                        return result
+                    delay = raw_wait + random.uniform(0, 1)
+                    if remaining is not None:
+                        delay = min(delay, remaining)
+                    retry_after_spent += delay
                     server_retry_after = None  # only honor once per send
                 else:
                     delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -221,11 +221,15 @@ _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 
 # Max seconds a send/edit coroutine may sleep inline on a Telegram
 # flood-control RetryAfter. Longer server penalties fail closed with a
-# ``flood_control:{wait}`` SendResult so the caller's retry machinery
-# (delivery ledger, streaming fallback) owns the wait instead of the
-# coroutine pinning its worker — a 97-minute penalty on the boot path
-# froze inbound on every platform (#91969).
+# ``flood_control:{wait}`` SendResult so the caller's bounded retry machinery
+# owns moderate waits instead of this coroutine. Very large penalties remain
+# non-retryable — a 97-minute wait on the boot path froze inbound on every
+# platform (#91969).
 _FLOOD_INLINE_WAIT_CAP_SECS = 5.0
+# Moderate penalties can be handed to BasePlatformAdapter's bounded retry
+# loop. Larger waits still fail closed: sleeping a multi-minute/hour server
+# penalty in a delivery task can pin gateway work just like the inline path.
+_FLOOD_CALLER_RETRY_CAP_SECS = 60.0
 
 
 def _flood_cap_result(wait: float) -> "SendResult":
@@ -233,6 +237,8 @@ def _flood_cap_result(wait: float) -> "SendResult":
     return SendResult(
         success=False,
         error=f"flood_control:{wait}",
+        error_kind="rate_limited",
+        retryable=wait <= _FLOOD_CALLER_RETRY_CAP_SECS,
         retry_after=float(wait),
     )
 
@@ -622,6 +628,10 @@ class TelegramAdapter(BasePlatformAdapter):
     # non-durable preview. Commit empty-tail fallbacks as a fresh final message
     # instead of trusting the preview as completed delivery.
     RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK: bool = True
+
+    # Bound the total caller-side sleep for consecutive moderate Telegram
+    # cooldowns while preserving the per-wait fail-closed cap above.
+    retry_after_sleep_budget_secs: Optional[float] = _FLOOD_CALLER_RETRY_CAP_SECS
 
     # Adaptive text-batch ingress: short messages need a tighter delay so the
     # first token reaches the agent fast.  Numbers tuned for "feels instant":

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -206,3 +206,21 @@ class TestSendWithRetryAfter:
         second_sleep = mock_sleep.call_args_list[1][0][0]
         assert second_sleep >= 29.0  # 30 - 1 (max jitter)
 
+    @pytest.mark.asyncio
+    async def test_retry_after_budget_is_unlimited_by_default(self):
+        """Adapters that do not opt in preserve consecutive retry_after waits."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="rate limited once", retryable=True, retry_after=35.0),
+            SendResult(success=False, error="rate limited twice", retryable=True, retry_after=35.0),
+            SendResult(success=True, message_id="ok"),
+        ]
+
+        with (
+            patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("gateway.platforms.base.random.uniform", return_value=0.0),
+        ):
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2)
+
+        assert result.success
+        assert [call.args[0] for call in mock_sleep.await_args_list] == [35.0, 35.0]

--- a/tests/gateway/test_telegram_send_path_health.py
+++ b/tests/gateway/test_telegram_send_path_health.py
@@ -5,6 +5,7 @@ can enter a wedged state where ``bot.send_message()`` returns a valid Message
 but nothing reaches the recipient.  ``_send_path_degraded`` short-circuits
 ``send()`` so cron's live-adapter branch falls through to standalone HTTP.
 """
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -54,18 +55,58 @@ async def test_send_long_flood_fails_closed_without_inline_sleep(monkeypatch):
 
     assert result.success is False
     assert result.error == "flood_control:5827.0"
+    assert result.error_kind == "rate_limited"
     assert result.retry_after == 5827.0
     assert result.retryable is False
     sleep.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_send_short_flood_still_retries_inline(monkeypatch):
+async def test_send_moderate_flood_defers_to_bounded_caller_retry(monkeypatch):
+    """A normal Telegram cooldown is retryable without sleeping in send()."""
+    adapter = _make_adapter()
+    adapter._rich_send_disabled = True
+    adapter._bot.send_message = AsyncMock(side_effect=_FloodError(35.0))
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert result.error == "flood_control:35.0"
+    assert result.error_kind == "rate_limited"
+    assert result.retry_after == 35.0
+    assert result.retryable is True
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_bounded_delivery_retry_honors_moderate_telegram_cooldown(monkeypatch):
+    """The real send wrapper delivers once Telegram's normal cooldown ends."""
+    adapter = _make_adapter()
+    adapter._rich_send_disabled = True
+    delivered = MagicMock(message_id=77)
+    adapter._bot.send_message = AsyncMock(side_effect=[_FloodError(35.0), delivered])
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.platforms.base.asyncio.sleep", sleep)
+    monkeypatch.setattr("gateway.platforms.base.random.uniform", lambda *_args: 0.0)
+
+    result = await adapter._send_with_retry("123", "hello")
+
+    assert result.success is True
+    assert result.message_id == "77"
+    assert adapter._bot.send_message.await_count == 2
+    sleep.assert_awaited_once_with(35.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wait", [2.0, 5.0])
+async def test_send_short_flood_still_retries_inline(monkeypatch, wait):
     """Waits of a few seconds keep the existing inline retry."""
     adapter = _make_adapter()
     adapter._rich_send_disabled = True
     ok = MagicMock(message_id=7)
-    adapter._bot.send_message = AsyncMock(side_effect=[_FloodError(2.0), ok])
+    adapter._bot.send_message = AsyncMock(side_effect=[_FloodError(wait), ok])
     sleep = AsyncMock()
     monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
 
@@ -73,6 +114,69 @@ async def test_send_short_flood_still_retries_inline(monkeypatch):
 
     assert result.success is True
     assert result.message_id == "7"
-    sleep.assert_awaited_once_with(2.0)
+    sleep.assert_awaited_once_with(wait)
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("wait", "retryable"),
+    [(5.1, True), (60.0, True), (60.1, False)],
+)
+async def test_send_caller_retry_boundaries_fail_closed_without_inline_sleep(
+    monkeypatch, wait, retryable
+):
+    """Values around both boundaries keep the inline/caller split exact."""
+    adapter = _make_adapter()
+    adapter._rich_send_disabled = True
+    adapter._bot.send_message = AsyncMock(side_effect=_FloodError(wait))
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert result.error == f"flood_control:{wait}"
+    assert result.error_kind == "rate_limited"
+    assert result.retry_after == wait
+    assert result.retryable is retryable
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retry_after_budget_honors_exact_60_and_clips_jitter(monkeypatch):
+    """The exact cap gets one full caller retry without exceeding its budget."""
+    adapter = _make_adapter()
+    adapter._rich_send_disabled = True
+    delivered = MagicMock(message_id=78)
+    adapter._bot.send_message = AsyncMock(side_effect=[_FloodError(60.0), delivered])
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.platforms.base.asyncio.sleep", sleep)
+    monkeypatch.setattr("gateway.platforms.base.random.uniform", lambda *_args: 0.7)
+
+    result = await adapter._send_with_retry("123", "hello")
+
+    assert result.success is True
+    assert result.message_id == "78"
+    assert adapter._bot.send_message.await_count == 2
+    sleep.assert_awaited_once_with(60.0)
+
+
+@pytest.mark.asyncio
+async def test_retry_after_budget_refuses_a_second_full_penalty(monkeypatch):
+    """Consecutive moderate penalties cannot stack beyond one 60s budget."""
+    adapter = _make_adapter()
+    adapter._rich_send_disabled = True
+    adapter._bot.send_message = AsyncMock(
+        side_effect=[_FloodError(35.0), _FloodError(35.0)]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.platforms.base.asyncio.sleep", sleep)
+    monkeypatch.setattr("gateway.platforms.base.random.uniform", lambda *_args: 0.0)
+
+    result = await adapter._send_with_retry("123", "hello")
+
+    assert result.success is False
+    assert result.error == "flood_control:35.0"
+    assert result.retryable is True
+    assert adapter._bot.send_message.await_count == 2
+    sleep.assert_awaited_once_with(35.0)


### PR DESCRIPTION
## Bound Telegram Cooldowns Without Dropping A Completed Reply

This PR gives Telegram a strict **60-second cumulative server-directed sleep budget per delivery**. It preserves the existing short inline retry and prevents repeated moderate penalties from holding a gateway worker for minutes.

**Still conflicted; not a current-main repair.** Main now handles part of the original bug: moderate waits retry without plaintext fallback, and waits over 60 seconds return without sleeping. The cumulative budget remains missing, so this PR is not fully superseded.

## Intended Behavior

- Up to 5 seconds: preserve Telegram's inline retry.
- Over 5 through 60 seconds: honor the cooldown in the shared delivery wrapper.
- Over 60 seconds: return without a long wait.
- Repeated moderate penalties: refuse a wait that exceeds the remaining 60-second budget; clip jitter inward at the exact boundary.

The budget is adapter opt-in. Other adapters keep their existing behavior, and ordinary exponential backoff does not consume this budget. Shared chat cooldowns, restart persistence and native-media retry are outside scope.

## Validation Boundaries

- Original head `45c4c8dcc5`: **24 focused shared-retry and Telegram send-health tests passed**, including 5.0/5.1/60.0/60.1 boundaries, 35+35 and exact-60 budgeting. Ruff, diff checks and selected exact-head CI passed.
- September 6 read-only check against main `cd658b6a46`: **25 existing tests passed**; separate real-adapter probes had **7 passes and 2 failures**. The remaining failures scheduled 60.7 seconds for a 60-second penalty and 70 seconds for two 35-second penalties.
- All four original files conflict with that main pin; no current-main resolution commit is claimed. The useful salvage target is the cumulative budget and exact-boundary tests, while preserving main's newer error classification and long-wait refusal.

These are separate revisions/selections, not a combined test total or live Telegram UAT. The original authored commit is preserved unchanged.

## How To Test

Through `scripts/run_tests.sh`, exercise the real Telegram adapter/shared wrapper with fake transport errors and sleep: confirm a moderate retry preserves the reply, a long penalty does not sleep, exact-60 clips jitter, and a second 35-second wait is refused. Run the non-opted-in adapter control separately.

## Related Work

#91969 established the no-long-inline-sleep boundary; #89962 tracks broader flood-control recovery. #93440 concerns polling-recovery delays and #64145 native-media sends. Neither is treated as proof that this cumulative-budget contract is complete.

## Type Of Change

- [x] Bug fix
- [x] Tests
