### PR TITLE
fix(cli): stop -Q leaking the reasoning box and tool diffs to stdout

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21300,6 +21300,15 @@ def main(
                 # Quiet mode: suppress banner, spinner, tool previews.
                 # Only print the final response and parseable session info.
                 cli.tool_progress_mode = "off"
+                # -Q is the machine-readable surface, so presentation config
+                # must not leak into captured stdout (#93220): the reasoning
+                # box renders via the callback bound at agent construction
+                # (clear it on the live agent — cli.show_reasoning alone
+                # would not re-evaluate that binding), and the tool renderer
+                # reads agent.tool_progress_mode, so sync the off there too.
+                if cli.agent is not None:
+                    cli.agent.reasoning_callback = None
+                    cli.agent.tool_progress_mode = "off"
                 if cli._ensure_runtime_credentials():
                     effective_query: Any = query
                     if single_query_images or single_query_image_urls:

--- a/tests/test_cli_quiet_leak.py
+++ b/tests/test_cli_quiet_leak.py
@@ -1,0 +1,61 @@
+"""`hermes chat -Q` must not leak presentation output into stdout (#93220).
+
+The quiet single-query branch lives inline in ``cli.py``'s ~21k-line main
+flow (no standalone function to call), so these pin the branch's required
+statements at the source level — the established convention for behavior
+with no runtime mirror (see the install.ps1 source-text tests). Deleting
+either live-agent neutralization reintroduces the leak this fixed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cli as cli_mod
+
+
+def _quiet_branch(source: str) -> str:
+    """Return the source slice of the quiet single-query branch."""
+    anchor = 'if quiet:'
+    start = source.index(
+        '# Quiet mode: suppress banner, spinner, tool previews.'
+    )
+    # The branch runs from its anchor a couple of lines above the comment.
+    anchor_idx = source.rindex(anchor, 0, start)
+    # ...to the next statement at the branch's indent (the credentials
+    # check's body ends before `effective_query` moves on); a generous
+    # 2000-char window covers the whole branch body.
+    return source[anchor_idx:anchor_idx + 2000]
+
+
+def test_quiet_branch_clears_live_agent_reasoning_callback():
+    source = Path(cli_mod.__file__).read_text(encoding="utf-8")
+    branch = _quiet_branch(source)
+    assert "cli.agent.reasoning_callback = None" in branch, (
+        "-Q must clear the reasoning callback on the live agent: the "
+        "callback was bound at agent construction from display.show_reasoning, "
+        "so the Reasoning box keeps rendering into captured stdout without "
+        "this (#93220)."
+    )
+
+
+def test_quiet_branch_syncs_tool_progress_off_to_agent():
+    source = Path(cli_mod.__file__).read_text(encoding="utf-8")
+    branch = _quiet_branch(source)
+    assert "cli.agent.tool_progress_mode = \"off\"" in branch, (
+        "-Q must sync tool_progress_mode to the live agent: the tool "
+        "renderer reads agent.tool_progress_mode (initialized from "
+        "display.tool_progress at construction), so tool diffs keep "
+        "printing into captured stdout without this (#93220)."
+    )
+
+
+def test_quiet_branch_still_sets_cli_side_mode():
+    source = Path(cli_mod.__file__).read_text(encoding="utf-8")
+    branch = _quiet_branch(source)
+    assert 'cli.tool_progress_mode = "off"' in branch
+    # The live-agent neutralizations must come after the cli-side switch,
+    # inside the same quiet branch.
+    assert branch.index('cli.tool_progress_mode = "off"') < branch.index(
+        "cli.agent.reasoning_callback = None"
+    )


### PR DESCRIPTION
## What does this PR do?

Makes `hermes chat -Q` honor its documented contract ("suppress banner, spinner, and tool previews. Only output the final response") instead of leaking the model's reasoning box and tool diffs into captured stdout.

`-Q` is the machine-readable surface that programmatic wrappers (bots, cron, CI) pipe directly to users, yet two presentation paths kept writing to stdout whenever `display.show_reasoning` / `display.tool_progress` were enabled in config (#93220 — a wrapper would deliver the model's private reasoning and complete file diffs downstream):

1. **Reasoning box**: it renders via `agent.reasoning_callback`, which is bound at agent-construction time from `display.show_reasoning`. The quiet branch never touched the live agent's callback, so the `┌─ Reasoning ─┐` box kept rendering on every reasoning-emitting turn.
2. **Tool progress + diffs**: the renderer reads `agent.tool_progress_mode` (initialized from `display.tool_progress` at construction). The branch set the cli-side `tool_progress_mode = "off"` but never synced it to the agent, so tool calls — including full `write_file` diffs — kept printing.

The fix clears both on the live agent inside the quiet branch: `cli.agent.reasoning_callback = None` and `cli.agent.tool_progress_mode = "off"`, right after the existing cli-side switch. Non-quiet behavior is untouched.

## Related Issue

Fixes #93220

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — the quiet single-query branch now also clears the live agent's `reasoning_callback` and syncs `tool_progress_mode = "off"` onto it, with a comment explaining why the cli-side flags alone can't help (construction-time binding / agent-side rendering reads).
- `tests/test_cli_quiet_leak.py` — three source-level regression tests pinning the branch's required statements. The branch lives inline in cli.py's ~21k-line main flow with no standalone function to invoke, so source-text pinning is the established convention here (same as the install.ps1 source-text tests); deleting either neutralization turns the tests red.

## How to Test

`pytest tests/test_cli_quiet_leak.py -q` — should pass (3 tests).

Observed result: with the fix, 3/3 pass. With the cli.py change stashed (fix reverted, tests kept), all 3 fail — the branch no longer contains either live-agent neutralization, which is exactly the leaking configuration.

Manual end-to-end (per the issue): with `display.show_reasoning: true` and `display.tool_progress: all` in config, `hermes chat -Q -q "<prompt that triggers a skill + write_file>" > out.txt` — `out.txt` should contain only the final response and the `session_id:` line, no Reasoning box and no tool diffs.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (construction-time binding rationale in the branch)
- [x] Tests added that prove the fix works
- [x] New and existing unit tests pass locally (3/3)
- [x] Platform: macOS (pure output-path logic, platform-independent)
