### PR TITLE
feat(api): add lightweight search query rewrite endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7,6 +7,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
+- POST /v1/search/rewrite          — lightweight provider call that rewrites natural language for FTS
 - GET  /v1/capabilities            — machine-readable API capabilities for external UIs
 - GET  /api/sessions               — list client-visible Hermes sessions
 - POST /api/sessions               — create an empty Hermes session
@@ -374,6 +375,27 @@ def _clean_request_string(value: Any) -> Optional[str]:
         return None
     cleaned = value.strip()
     return cleaned or None
+
+
+def _parse_search_rewrite_content(value: Any) -> str:
+    """Extract a bounded FTS query from strict JSON or a cheap-model fallback."""
+    if not isinstance(value, str):
+        return ""
+    candidate = value.strip()
+    if candidate.startswith("```"):
+        candidate = re.sub(r"^```(?:json)?\s*", "", candidate, flags=re.IGNORECASE)
+        candidate = re.sub(r"\s*```$", "", candidate).strip()
+    try:
+        decoded = json.loads(candidate)
+    except (TypeError, ValueError):
+        decoded = None
+    if isinstance(decoded, dict) and isinstance(decoded.get("query"), str):
+        candidate = decoded["query"]
+    else:
+        candidate = re.sub(r"^query\s*:\s*", "", candidate, flags=re.IGNORECASE)
+    candidate = re.sub(r"[\r\n\t]+", " ", candidate)
+    candidate = re.sub(r"\s+", " ", candidate).strip()
+    return candidate[:80]
 
 
 def _request_reasoning_config(model_options: Any) -> Optional[Dict[str, Any]]:
@@ -2216,6 +2238,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/health", self._handle_health),
             ("GET", "/v1/models", self._handle_models),
             ("GET", "/api/model/options", self._handle_model_options),
+            ("POST", "/v1/search/rewrite", self._handle_search_rewrite),
             ("GET", "/v1/capabilities", self._handle_capabilities),
             # Authenticated browser-control surface: POST registration
             # mints a short-lived ticket; the controller then opens the WS with
@@ -3303,6 +3326,166 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=500,
             )
 
+    async def _handle_search_rewrite(self, request: "web.Request") -> "web.Response":
+        """POST /v1/search/rewrite — turn natural language into a tiny FTS query.
+
+        Unlike ``/v1/chat/completions``, this endpoint does not construct an
+        AIAgent, load memories, expose tools, or create a session. It calls the
+        explicitly selected configured provider with a fixed minimal prompt so
+        mobile search can use an inexpensive model without sending the full
+        Hermes system prompt.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(
+                _openai_error("Invalid JSON body.", code="invalid_json"),
+                status=400,
+            )
+        if not isinstance(body, dict):
+            return web.json_response(
+                _openai_error("Request body must be an object.", code="invalid_request"),
+                status=400,
+            )
+
+        query = _clean_request_string(body.get("query"))
+        provider = _clean_request_string(body.get("provider"))
+        model = _clean_request_string(body.get("model"))
+        for field, value in (("query", query), ("provider", provider), ("model", model)):
+            if not value:
+                return web.json_response(
+                    _openai_error(
+                        f"The '{field}' field is required.",
+                        code=f"missing_{field}",
+                    ),
+                    status=400,
+                )
+        if len(query) > 500:
+            return web.json_response(
+                _openai_error(
+                    "The 'query' field must be 500 characters or fewer.",
+                    code="search_rewrite_query_too_long",
+                ),
+                status=400,
+            )
+        if len(provider) > 100 or len(model) > 300:
+            return web.json_response(
+                _openai_error(
+                    "Provider or model identifier is too long.",
+                    code="search_rewrite_model_invalid",
+                ),
+                status=400,
+            )
+
+        client = None
+        try:
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, resolved_model = resolve_provider_client(
+                provider,
+                model=model,
+                async_mode=True,
+            )
+            if client is None or not resolved_model:
+                return web.json_response(
+                    _openai_error(
+                        "The selected provider/model is not configured on this Hermes host.",
+                        code="search_rewrite_provider_unavailable",
+                    ),
+                    status=400,
+                )
+
+            completion_kwargs: Dict[str, Any] = {
+                "model": resolved_model,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "Rewrite the user's request into a short lexical query for "
+                            "searching their chat message history. Return JSON only: "
+                            '{"query":"..."}. Use 1 to 4 distinctive words or one quoted '
+                            "phrase likely to occur verbatim. Preserve names, project names, "
+                            "places, model names, and technical terms. Do not answer, explain, "
+                            "use markdown, wildcards, or boolean operators. Keep it under 80 "
+                            "characters."
+                        ),
+                    },
+                    {"role": "user", "content": query},
+                ],
+                "temperature": 0,
+                # Reasoning models may spend ~100 hidden tokens before emitting
+                # their tiny JSON answer, so 120 can terminate with content=null.
+                "max_tokens": 400,
+            }
+            if "gpt-oss" in resolved_model.lower():
+                completion_kwargs["extra_body"] = {"reasoning_effort": "low"}
+
+            response = await asyncio.wait_for(
+                client.chat.completions.create(**completion_kwargs),
+                timeout=30,
+            )
+            choices = getattr(response, "choices", None) or []
+            message = getattr(choices[0], "message", None) if choices else None
+            content = getattr(message, "content", "") if message is not None else ""
+            rewritten = _parse_search_rewrite_content(content)
+            if not rewritten:
+                return web.json_response(
+                    _openai_error(
+                        "The selected model returned no usable search query.",
+                        code="search_rewrite_empty",
+                    ),
+                    status=502,
+                )
+
+            usage = getattr(response, "usage", None)
+            input_tokens = int(getattr(usage, "prompt_tokens", 0) or 0)
+            output_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+            total_tokens = int(getattr(usage, "total_tokens", 0) or 0)
+            if not total_tokens:
+                total_tokens = input_tokens + output_tokens
+            return web.json_response(
+                {
+                    "query": rewritten,
+                    "provider": provider,
+                    "model": resolved_model,
+                    "usage": {
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "total_tokens": total_tokens,
+                    },
+                }
+            )
+        except asyncio.TimeoutError:
+            return web.json_response(
+                _openai_error(
+                    "The search rewrite model timed out.",
+                    code="search_rewrite_timeout",
+                ),
+                status=504,
+            )
+        except Exception as exc:
+            logger.exception("[%s] POST /v1/search/rewrite failed", self.name)
+            return web.json_response(
+                _openai_error(
+                    f"Search rewrite failed: {_redact_api_error_text(exc)}",
+                    code="search_rewrite_failed",
+                ),
+                status=502,
+            )
+        finally:
+            close = getattr(client, "close", None)
+            if close is not None:
+                try:
+                    result = close()
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception:
+                    logger.debug("Failed to close search rewrite client", exc_info=True)
+
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
         """GET /v1/capabilities — advertise the stable API surface.
 
@@ -3347,6 +3530,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "approval_events": True,
                 "session_resources": True,
                 "model_options": True,
+                "search_rewrite": True,
                 "session_chat": True,
                 "session_chat_streaming": True,
                 "session_fork": True,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -33,6 +33,7 @@ from gateway.platforms.api_server import (
     _IdempotencyCache,
     _derive_chat_session_id,
     _hermes_version,
+    _parse_search_rewrite_content,
     _redact_api_error_text,
     _request_agent_overrides,
     check_api_server_requirements,
@@ -309,6 +310,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_get("/api/model/options", adapter._handle_model_options)
+    app.router.add_post("/v1/search/rewrite", adapter._handle_search_rewrite)
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
     app.router.add_get("/v1/skills", adapter._handle_skills)
     app.router.add_get("/v1/toolsets", adapter._handle_toolsets)
@@ -756,6 +758,165 @@ class TestHealthDetailedEndpoint:
         with patch("tools.process_registry.process_registry.completion_queue.qsize", return_value=0), \
              patch("tools.async_delegation.active_count", return_value=0):
             assert adapter._readiness_work_counts() == (4, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# /v1/search/rewrite endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestSearchRewriteEndpoint:
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            ('```json\n{"query":"RAFT occlusion"}\n```', "RAFT occlusion"),
+            ("query: Hindsight memory", "Hindsight memory"),
+            ('{"query":"  C-MAY   Ethiopia  "}', "C-MAY Ethiopia"),
+        ],
+    )
+    def test_parses_inexpensive_model_output_defensively(self, content, expected):
+        assert _parse_search_rewrite_content(content) == expected
+
+    @pytest.mark.asyncio
+    async def test_requires_api_auth(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/v1/search/rewrite",
+                json={"query": "electric tuk tuk", "provider": "nvidia", "model": "openai/gpt-oss-20b"},
+            )
+        assert response.status == 401
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("payload", "field"),
+        [
+            ({"provider": "nvidia", "model": "openai/gpt-oss-20b"}, "query"),
+            ({"query": "find this", "model": "openai/gpt-oss-20b"}, "provider"),
+            ({"query": "find this", "provider": "nvidia"}, "model"),
+        ],
+    )
+    async def test_rejects_missing_required_fields(self, adapter, payload, field):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post("/v1/search/rewrite", json=payload)
+            body = await response.json()
+        assert response.status == 400
+        assert field in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_runs_a_bare_provider_completion_and_returns_usage(self, adapter):
+        completion = types.SimpleNamespace(
+            choices=[
+                types.SimpleNamespace(
+                    message=types.SimpleNamespace(
+                        content='{"query":"tuk-tuk électrique Ethiopie"}'
+                    )
+                )
+            ],
+            usage=types.SimpleNamespace(
+                prompt_tokens=91,
+                completion_tokens=12,
+                total_tokens=103,
+            ),
+        )
+        create = AsyncMock(return_value=completion)
+        client_mock = types.SimpleNamespace(
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=create)
+            )
+        )
+        app = _create_app(adapter)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(client_mock, "openai/gpt-oss-20b"),
+        ) as resolve:
+            async with TestClient(TestServer(app)) as client:
+                response = await client.post(
+                    "/v1/search/rewrite",
+                    json={
+                        "query": "retrouve le projet de tuk-tuk en Ethiopie",
+                        "provider": "nvidia",
+                        "model": "openai/gpt-oss-20b",
+                    },
+                )
+                body = await response.json()
+
+        assert response.status == 200
+        assert body == {
+            "query": "tuk-tuk électrique Ethiopie",
+            "provider": "nvidia",
+            "model": "openai/gpt-oss-20b",
+            "usage": {
+                "input_tokens": 91,
+                "output_tokens": 12,
+                "total_tokens": 103,
+            },
+        }
+        resolve.assert_called_once_with(
+            "nvidia",
+            model="openai/gpt-oss-20b",
+            async_mode=True,
+        )
+        kwargs = create.call_args.kwargs
+        assert kwargs["model"] == "openai/gpt-oss-20b"
+        assert kwargs["temperature"] == 0
+        assert kwargs["max_tokens"] == 400
+        assert kwargs["extra_body"] == {"reasoning_effort": "low"}
+        assert len(kwargs["messages"]) == 2
+        assert "tools" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_rejects_unavailable_provider_without_fallback(self, adapter):
+        app = _create_app(adapter)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(None, None),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                response = await client.post(
+                    "/v1/search/rewrite",
+                    json={"query": "find it", "provider": "missing", "model": "cheap-model"},
+                )
+                body = await response.json()
+        assert response.status == 400
+        assert body["error"]["code"] == "search_rewrite_provider_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_redacts_provider_errors(self, adapter):
+        secret = "sk-proj-super-secret-value-1234567890"
+        create = AsyncMock(side_effect=RuntimeError(f"provider rejected {secret}"))
+        client_mock = types.SimpleNamespace(
+            chat=types.SimpleNamespace(
+                completions=types.SimpleNamespace(create=create)
+            )
+        )
+        app = _create_app(adapter)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(client_mock, "model"),
+        ):
+            async with TestClient(TestServer(app)) as client:
+                response = await client.post(
+                    "/v1/search/rewrite",
+                    json={"query": "find it", "provider": "provider", "model": "model"},
+                )
+                raw_body = await response.text()
+        assert response.status == 502
+        assert secret not in raw_body
+        assert "search_rewrite_failed" in raw_body
+
+    @pytest.mark.asyncio
+    async def test_rejects_overlong_query_before_provider_call(self, adapter):
+        app = _create_app(adapter)
+        with patch("agent.auxiliary_client.resolve_provider_client") as resolve:
+            async with TestClient(TestServer(app)) as client:
+                response = await client.post(
+                    "/v1/search/rewrite",
+                    json={"query": "x" * 501, "provider": "nvidia", "model": "model"},
+                )
+        assert response.status == 400
+        resolve.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds authenticated `POST /v1/search/rewrite` for clients that need to turn natural-language search into a compact lexical query.

Unlike `/v1/chat/completions`, this endpoint does not build the Hermes agent prompt, load tools or memory, create a session, or persist history. It resolves the configured provider directly and makes one bounded completion.

## API

Request:
```json
{"query":"the tuk-tuk project in Ethiopia","provider":"nvidia","model":"openai/gpt-oss-20b"}
```

Response:
```json
{"query":"tuk-tuk Ethiopia","provider":"nvidia","model":"openai/gpt-oss-20b","usage":{"prompt_tokens":114,"completion_tokens":39,"total_tokens":153}}
```

## Safety and compatibility

- Existing API-key middleware protects the route.
- Query/provider/model are validated and bounded before provider resolution.
- Provider calls have a 30-second timeout.
- Provider errors pass through the existing secret redactor.
- Provider clients are closed in `finally`.
- GPT-OSS receives low reasoning effort; other models do not receive that provider-specific option.
- Capability discovery now advertises `search_rewrite: true`.

## Measured result

Using configured NVIDIA `openai/gpt-oss-20b` for the same rewrite:

- full agent path: 19,780 prompt tokens
- this endpoint: 114 prompt + 39 completion = 153 total tokens

## Tests

- `python -m pytest tests/gateway/test_api_server.py -o 'addopts=' -q` — 120 passed
- `ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py` — passed
- `py_compile` for both changed Python files — passed
- Real NVIDIA provider smoke test — valid JSON query returned

The repository-wide suite currently stops at an unrelated existing Anthropic/MCP assertion after 328 passing tests:
`tests/agent/test_anthropic_mcp_prefix_strip.py::TestAnthropicOAuthOutgoingPrefix::test_oauth_promotes_single_underscore_mcp_server_tool`.

## Client

The companion Android PR uses this endpoint for opt-in AI-assisted full-text session search. Full-text search without AI continues to work against the existing dashboard endpoint.

