### PR TITLE
fix(tui): settle tmux clipboard load on direct child exit

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
@@ -201,7 +201,10 @@ export async function tmuxLoadBuffer(text: string): Promise<boolean> {
   const { code } = await execFileNoThrow('tmux', args, {
     input: text,
     useCwd: false,
-    timeout: 2000
+    timeout: 2000,
+    // tmux may daemonize a server while retaining the inherited stdio pipes;
+    // only the child exit code is needed for this call site.
+    resolveOnExit: true
   })
 
   return code === 0


### PR DESCRIPTION
## Summary

Completes the remaining production call-site hardening from #93134 without duplicating the first contributor's shared timeout fix in #93148.

- pass `resolveOnExit: true` to `tmuxLoadBuffer()`'s `execFileNoThrow('tmux', ...)` call;
- document why the direct child's exit code is authoritative for this write-only command.

## Why this remains necessary after #93148

#93148 correctly makes the shared timeout handler terminal in both completion modes and reactivates the daemonized-grandchild regression. It does not change `tmuxLoadBuffer()`, which still uses the default `close`-based mode.

A successful `tmux load-buffer` may start or hand work to a tmux server while a descendant retains inherited stdio. In that shape, waiting for `close` can outlive the direct child's successful exit. After #93148 the call is bounded, but it can still wait the full two-second timeout and return synthetic code `124`, incorrectly reporting that a successful buffer load failed. `resolveOnExit: true` preserves the real direct-child exit code immediately.

## Merge order

1. #93148 — shared timeout settlement plus active regression.
2. This PR — tmux-specific successful-exit semantics.

## Caller audit

The daemonizing native clipboard probe/copy paths already use `resolveOnExit: true`. Output-consuming callers retain the default `close` behavior so their stdout/stderr capture remains complete. `tmuxLoadBuffer()` is the remaining write-only production call site where direct exit is the correct terminal event.

## Provenance and validation

- Branch parent is exact upstream main `981101239a064c020a9d18fc3b1060ae306934ed`.
- The call-site change is the already-reviewed portion of closed duplicate #93209; `JoaoMarcos44` is retained as co-author on the commit.
- Scope is one file and one `execFileNoThrow()` invocation.

Completes the remaining acceptance criterion in #93134 after #93148 lands.