### PR TITLE
fix(desktop): surface failed bot group turns in Activity

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -479,6 +479,32 @@ function currentGroupActivity(group) {
   return ($groupActivity.get()[group] || {}).events?.filter(event => (event.epoch || 0) === epoch) || []
 }
 
+/** Keep unresolved terminal alerts visible in the collapsed row even after the
+ *  turn settles. A later successful reply clears alerts for that member only.
+ *  Input is already scoped to the current epoch. */
+function groupActivitySummary(events) {
+  const current = Array.isArray(events) ? events : []
+  const resolvedMembers = new Set()
+
+  for (let i = current.length - 1; i >= 0; i--) {
+    const event = current[i]
+
+    if (event.kind === 'replied' || event.kind === 'delivered') {
+      resolvedMembers.add(event.member)
+      continue
+    }
+
+    if (
+      (event.kind === 'failed' || event.kind === 'timed-out') &&
+      !resolvedMembers.has(event.member)
+    ) {
+      return event
+    }
+  }
+
+  return current.length ? current[current.length - 1] : null
+}
+
 /** Human label for one activity event, used by the collapsed summary and
  *  the expanded rows. */
 function groupActivityLabel(event) {
@@ -11915,11 +11941,12 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
       title: (b.remoteSource ? '' : allMeta[b.name]?.title) || b.title || ''
     }))
 
-  // Activity disclosure: quiet, collapsed by default. The collapsed row shows
-  // the latest event; expanding lists the current run's events newest-first.
-  // Events are epoch-tagged, so a superseded run's history drops out of view.
+  // Activity disclosure: quiet, collapsed by default. The collapsed row keeps
+  // a current-run failure/timeout visible over the later settled event;
+  // expanding lists the current run's events newest-first. Events are
+  // epoch-tagged, so a superseded run's history drops out of view.
   const activityEvents = currentGroupActivity(group)
-  const latestActivity = activityEvents.length ? activityEvents[activityEvents.length - 1] : null
+  const latestActivity = groupActivitySummary(activityEvents)
   const activityPanel = jsxs('div', {
     className: 'border-b border-(--ui-stroke-secondary)',
     children: [
@@ -11939,7 +11966,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
           jsx('span', { className: 'shrink-0 font-medium', children: 'Activity' }),
           latestActivity
             ? jsx('span', {
-                className: 'min-w-0 flex-1 truncate',
+                className: cn('min-w-0 flex-1 truncate', groupActivityTone(latestActivity.kind)),
                 children: `${groupActivityLabel(latestActivity)} · ${relativeTime(latestActivity.at)}`
               })
             : null

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
@@ -98,7 +98,7 @@ function load(turnScript = () => '(pass)') {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__ga = { sendToGroupChat, recordGroupActivity, currentGroupActivity, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, GROUP_ACTIVITY_LIMIT };\n'
+      '\nglobalThis.__ga = { sendToGroupChat, recordGroupActivity, currentGroupActivity, groupActivitySummary: typeof groupActivitySummary === "function" ? groupActivitySummary : undefined, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, GROUP_ACTIVITY_LIMIT };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -151,11 +151,65 @@ test('a failed member turn records failed instead of a phantom reply', async () 
     return '(pass)'
   })
 
-  gc.sendToGroupChat('Flaky', MEMBERS, 'anyone around?')
+  gc.sendToGroupChat('Flaky', MEMBERS, '@builder anyone around?')
   await drain(gc, 'Flaky')
 
   const events = feed(gc, 'Flaky')
   assert.equal(events.some(e => e.kind === 'failed' && e.member === 'builder'), true)
+  assert.equal(gc.groupActivitySummary(events).kind, 'failed')
+  assert.deepEqual(gc.calls.map(call => call.profile), ['builder'])
+})
+
+test('collapsed summary keeps a current-epoch failure visible after settling', () => {
+  const gc = load()
+  gc.updateGroupChat('Flaky', room => ({ ...room, log: [], epoch: 7 }))
+  gc.recordGroupActivity('Flaky', { kind: 'failed', member: 'builder' })
+  gc.recordGroupActivity('Flaky', { kind: 'settled', member: null })
+
+  assert.equal(typeof gc.groupActivitySummary, 'function')
+  assert.equal(gc.groupActivitySummary(gc.currentGroupActivity('Flaky')).kind, 'failed')
+})
+
+test('collapsed summary keeps a current-epoch timeout visible after settling', () => {
+  const gc = load()
+  gc.updateGroupChat('Slow', room => ({ ...room, log: [], epoch: 9 }))
+  gc.recordGroupActivity('Slow', { kind: 'timed-out', member: 'research' })
+  gc.recordGroupActivity('Slow', { kind: 'settled', member: null })
+
+  assert.equal(gc.groupActivitySummary(gc.currentGroupActivity('Slow')).kind, 'timed-out')
+})
+
+test('collapsed summary clears a member timeout after its late reply is delivered', () => {
+  const gc = load()
+  const events = [
+    { kind: 'timed-out', member: 'research' },
+    { kind: 'settled', member: null },
+    { kind: 'delivered', member: 'research' }
+  ]
+
+  assert.equal(gc.groupActivitySummary(events).kind, 'delivered')
+})
+
+test('another member reply does not clear an unresolved timeout', () => {
+  const gc = load()
+  const events = [
+    { kind: 'timed-out', member: 'research' },
+    { kind: 'replied', member: 'builder' },
+    { kind: 'settled', member: null }
+  ]
+
+  const summary = gc.groupActivitySummary(events)
+  assert.equal(summary.kind, 'timed-out')
+  assert.equal(summary.member, 'research')
+})
+
+test('collapsed summary uses the latest event when the turn has no alert', () => {
+  const gc = load()
+  gc.updateGroupChat('Fine', room => ({ ...room, log: [], epoch: 11 }))
+  gc.recordGroupActivity('Fine', { kind: 'replied', member: 'research' })
+  gc.recordGroupActivity('Fine', { kind: 'settled', member: null })
+
+  assert.equal(gc.groupActivitySummary(gc.currentGroupActivity('Fine')).kind, 'settled')
 })
 
 test('a newer send interrupts the previous run and records cancelled in the CURRENT epoch', async () => {
@@ -260,6 +314,10 @@ test('source contract: the workspace mounts a quiet, collapsed-by-default disclo
   const panel = pluginSource.slice(pluginSource.indexOf('// Activity disclosure:'), pluginSource.indexOf('const submit = () => {'))
   assert.doesNotMatch(panel, /autoFocus/)
   assert.doesNotMatch(panel, /autoScroll|scrollIntoView/)
+  // A terminal alert stays visible and destructive in the collapsed summary
+  // instead of being replaced by the final settled event.
+  assert.match(panel, /const latestActivity = groupActivitySummary\(activityEvents\)/)
+  assert.match(panel, /groupActivityTone\(latestActivity\.kind\)/)
   // Truthful event vocabulary is wired.
   assert.match(pluginSource, /'timed-out': 'took too long'/)
   assert.match(pluginSource, /cancelled: 'turn interrupted by a newer message'/)


### PR DESCRIPTION
## Summary
- keep current-epoch failed and timed-out Bot Mode member turns visible in the collapsed Activity row after settlement
- clear a bot’s stale failure only when that same bot later delivers a reply
- prevent unrelated member replies from hiding another member’s unresolved failure

## Verification
- `node --test apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs` (498 passed)
- `node --check apps/desktop/src/plugins/hermes-bots/plugin.js`
- `node --check apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs`
- `git diff --check origin/main...HEAD`

## Non-goals
- no automatic retry, replay, or resubmission of group turns
- no changes to room metadata, sync schemas, archive handling, or room topology