### PR TITLE
fix(desktop): show full-resolution attachments in sent bubble and lightbox

### DIFF
--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -10,6 +10,7 @@ import type { I18nContextValue } from '@/i18n'
 import { extractEmbeddedImages } from '@/lib/embedded-images'
 import { openLink } from '@/lib/external-link'
 import { triggerHaptic } from '@/lib/haptics'
+import { downscaleDataUrlForPreview, FALLBACK_PLACEHOLDER } from '@/lib/image-resize'
 import { gatewayMediaDataUrl, isRemoteGateway } from '@/lib/media'
 import { useSessionLinkTitle } from '@/lib/session-link-title'
 import { parseSessionRefValue, sessionRefFallbackLabel } from '@/lib/session-refs'
@@ -401,7 +402,12 @@ export const DirectiveText: TextMessagePartComponent = ({ text }: TextMessagePar
  * across initial send and refresh. */
 const DirectiveImage: FC<{ id: string; label: string }> = ({ id, label }) => {
   const isUrl = /^(?:https?|data):/i.test(id)
+  // `src` is the bounded thumbnail painted inline; `zoomSrc` is the full-
+  // resolution source the lightbox and download use. Keeping inline bounded is
+  // what lets the in-flight bubble render an `@image:<path>` ref without the
+  // multi-image paint freeze the 512px cap exists to prevent (#93204).
   const [src, setSrc] = useState<string | null>(isUrl ? id : null)
+  const [zoomSrc, setZoomSrc] = useState<string | null>(isUrl ? id : null)
   const [failed, setFailed] = useState(false)
 
   useEffect(() => {
@@ -417,7 +423,23 @@ const DirectiveImage: FC<{ id: string; label: string }> = ({ id, label }) => {
       window.hermesDesktop && isRemoteGateway() ? gatewayMediaDataUrl(id) : window.hermesDesktop?.readFileDataUrl(id)
 
     void Promise.resolve(load)
-      .then(url => alive && url && setSrc(url))
+      .then(async url => {
+        if (!alive || !url) {
+          return
+        }
+
+        // Full resolution powers the click-to-zoom lightbox and Save; the inline
+        // <img> gets a bounded thumbnail so a turn full of screenshots does not
+        // hand Chromium multi-MB paint sources.
+        setZoomSrc(url)
+        const thumbnail = await downscaleDataUrlForPreview(url)
+
+        if (!alive) {
+          return
+        }
+
+        setSrc(thumbnail && thumbnail !== FALLBACK_PLACEHOLDER ? thumbnail : url)
+      })
       .catch(() => alive && setFailed(true))
 
     return () => {
@@ -445,6 +467,7 @@ const DirectiveImage: FC<{ id: string; label: string }> = ({ id, label }) => {
       draggable={false}
       slot="aui_directive-image"
       src={src}
+      zoomSrc={zoomSrc ?? undefined}
     />
   )
 }

--- a/apps/desktop/src/components/chat/zoomable-image.test.tsx
+++ b/apps/desktop/src/components/chat/zoomable-image.test.tsx
@@ -1,0 +1,62 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n/context'
+
+import { ZoomableImage } from './zoomable-image'
+
+// A bounded thumbnail (what the composer/optimistic bubble paints inline) and
+// the full-resolution source (what the lightbox should enlarge). Issue #93204:
+// clicking a freshly sent image enlarged the 512px thumbnail instead of the
+// original.
+const THUMB = 'data:image/png;base64,dGh1bWJuYWls'
+const FULL = 'data:image/png;base64,ZnVsbHJlc29sdXRpb24='
+
+async function renderWithI18n(ui: React.ReactNode) {
+  let result: ReturnType<typeof render>
+  await act(async () => {
+    result = render(
+      <I18nProvider configClient={{ getConfig: async () => ({}), saveConfig: async () => ({ ok: true }) }}>
+        {ui}
+      </I18nProvider>
+    )
+  })
+
+  return result!
+}
+
+describe('ZoomableImage zoomSrc', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('paints the bounded src inline but enlarges the full-resolution zoomSrc (#93204)', async () => {
+    await renderWithI18n(<ZoomableImage alt="shot" src={THUMB} zoomSrc={FULL} />)
+
+    // Inline stays the cheap thumbnail — no multi-MB paint.
+    const inline = screen.getByAltText('shot') as HTMLImageElement
+    expect(inline.getAttribute('src')).toBe(THUMB)
+
+    // Click to zoom: the lightbox must show the original, not the thumbnail.
+    fireEvent.click(inline)
+
+    await waitFor(() => {
+      const full = screen.getAllByAltText('shot').find(img => img.getAttribute('src') === FULL)
+      expect(full).toBeDefined()
+    })
+
+    expect(screen.queryAllByAltText('shot').some(img => img.getAttribute('src') === THUMB)).toBe(true)
+  })
+
+  it('falls back to src for the lightbox when no zoomSrc is given', async () => {
+    await renderWithI18n(<ZoomableImage alt="shot" src={THUMB} />)
+
+    fireEvent.click(screen.getByAltText('shot'))
+
+    await waitFor(() => {
+      // Both inline and lightbox use src — backward compatible with callers that
+      // pass a single source.
+      expect(screen.getAllByAltText('shot').every(img => img.getAttribute('src') === THUMB)).toBe(true)
+    })
+  })
+})

--- a/apps/desktop/src/components/chat/zoomable-image.tsx
+++ b/apps/desktop/src/components/chat/zoomable-image.tsx
@@ -11,6 +11,11 @@ import { cn } from '@/lib/utils'
 export interface ZoomableImageProps extends ComponentProps<'img'> {
   containerClassName?: string
   slot?: string
+  /** Full-resolution source for the lightbox and download. When set, the inline
+   * `<img>` keeps its bounded `src` (avoiding heavy inline paints) while the
+   * zoom view and Save action use the original — so a click-to-zoom shows real
+   * detail instead of an upscaled thumbnail. Defaults to `src`. */
+  zoomSrc?: string
 }
 
 export interface ImageActionCopy {
@@ -18,10 +23,13 @@ export interface ImageActionCopy {
   savingImage: string
 }
 
-export function ZoomableImage({ className, containerClassName, src, alt, slot, ...props }: ZoomableImageProps) {
+export function ZoomableImage({ className, containerClassName, src, zoomSrc, alt, slot, ...props }: ZoomableImageProps) {
   const { t } = useI18n()
   const copy = t.desktop
-  const { download, saving } = useImageDownload(src)
+  // The lightbox and Save action prefer the full-resolution source; the inline
+  // thumbnail (`src`) stays the cheap paint.
+  const fullSrc = zoomSrc || src || ''
+  const { download, saving } = useImageDownload(fullSrc)
   const [lightboxOpen, setLightboxOpen] = useState(false)
   const canOpen = Boolean(src)
 
@@ -52,7 +60,7 @@ export function ZoomableImage({ className, containerClassName, src, alt, slot, .
           onOpenChange={setLightboxOpen}
           open={lightboxOpen}
           saving={saving}
-          src={src}
+          src={fullSrc}
         />
       )}
     </>

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -24,33 +24,56 @@ function attachment(overrides: Partial<ComposerAttachment> & Pick<ComposerAttach
 }
 
 describe('optimisticAttachmentRef', () => {
-  it('renders an image from its in-hand base64 preview (no @image: path ref)', () => {
+  it('renders a path-backed image through the same @image: ref as a reloaded turn (#93204)', () => {
     const ref = optimisticAttachmentRef(attachment({ kind: 'image', detail: '/tmp/shot.png', previewUrl: DATA_URL }))
 
-    // The raw data URL flows through extractEmbeddedImages → inline thumbnail,
-    // dodging the remote /api/media 403 an @image:<localpath> ref would hit.
-    expect(ref).toBe(DATA_URL)
+    // DirectiveImage paints a bounded thumbnail inline and hands the full file
+    // to the lightbox, so the in-flight bubble matches the reloaded turn instead
+    // of freezing on a 512px thumbnail. Remote gateways resolve the same path
+    // over the authenticated media API (no /api/media 403).
+    expect(ref).toBe('@image:/tmp/shot.png')
   })
 
-  it('prefers the downscaled thumbnail for the display ref when present', () => {
+  it('prefers the path ref even when a downscaled thumbnail is present (#93204)', () => {
     const ref = optimisticAttachmentRef(
-      attachment({ kind: 'image', detail: '/tmp/shot.png', previewUrl: DATA_URL, thumbnailUrl: THUMB_URL })
+      attachment({ kind: 'image', path: '/tmp/shot.png', previewUrl: DATA_URL, thumbnailUrl: THUMB_URL })
     )
 
-    // The bubble is display-only; full bytes are read on demand and for upload.
-    expect(ref).toBe(THUMB_URL)
+    // The thumbnail no longer caps fidelity: the path lets the lightbox load the
+    // original. Full bytes are read on demand and for upload.
+    expect(ref).toBe('@image:/tmp/shot.png')
   })
 
-  it('does not render a full path-backed image while its bounded thumbnail is pending', () => {
-    expect(optimisticAttachmentRef(attachment({ kind: 'image', detail: '/tmp/shot.png' }))).toBeNull()
+  it('emits the path ref for a freshly attached image before its thumbnail resolves (#93204)', () => {
+    // Previously this returned null (waiting on the resize); now the path drives
+    // an @image: ref that DirectiveImage renders bounded-inline immediately.
+    expect(optimisticAttachmentRef(attachment({ kind: 'image', detail: '/tmp/shot.png' }))).toBe('@image:/tmp/shot.png')
   })
 
-  it('does not use a path fallback for a non-data preview url', () => {
+  it('emits the path ref regardless of a non-data preview url (#93204)', () => {
     const ref = optimisticAttachmentRef(
       attachment({ kind: 'image', detail: '/tmp/shot.png', previewUrl: 'https://example.com/x.png' })
     )
 
-    expect(ref).toBeNull()
+    expect(ref).toBe('@image:/tmp/shot.png')
+  })
+
+  it('falls back to the bounded thumbnail for a path-less pasted image', () => {
+    // No filesystem path to rehydrate from (raw clipboard bytes): keep the
+    // inline thumbnail so the bubble still renders something.
+    const ref = optimisticAttachmentRef(attachment({ kind: 'image', previewUrl: DATA_URL, thumbnailUrl: THUMB_URL }))
+
+    expect(ref).toBe(THUMB_URL)
+  })
+
+  it('falls back to a data preview url when a path-less image has no thumbnail', () => {
+    const ref = optimisticAttachmentRef(attachment({ kind: 'image', previewUrl: DATA_URL }))
+
+    expect(ref).toBe(DATA_URL)
+  })
+
+  it('returns null for a path-less image with no renderable inline source', () => {
+    expect(optimisticAttachmentRef(attachment({ kind: 'image', previewUrl: 'https://example.com/x.png' }))).toBeNull()
   })
 
   it('passes non-image attachments straight through to attachmentDisplayText', () => {

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -257,9 +257,23 @@ export function optimisticAttachmentRef(attachment: ComposerAttachment): string 
   }
 
   if (attachment.kind === 'image') {
+    // Prefer a filesystem-backed `@image:<path>` ref so the in-flight bubble
+    // renders through the same DirectiveImage path as a reloaded turn. That
+    // component shows a bounded thumbnail inline (no full-resolution paint, so
+    // the multi-image send freeze this design guards against does not return)
+    // and hands the full-resolution file to the lightbox/download — fixing the
+    // live-vs-reload fidelity gap where a sent screenshot stayed 512px until a
+    // session reload rehydrated it (#93204). Remote gateways resolve the same
+    // path over the authenticated media API, so no /api/media 403.
+    const pathRef = attachment.path || attachment.detail
+
+    if (pathRef) {
+      return `@image:${formatRefValue(pathRef)}`
+    }
+
     if (attachment.thumbnailUrl?.startsWith('data:')) {
-      // The pill and the in-flight bubble render the bounded thumbnail. Full
-      // bytes are read separately for lightbox/download and model upload.
+      // No path to rehydrate from (e.g. pasted bytes): render the bounded
+      // thumbnail inline. Full bytes remain available for the model upload.
       return attachment.thumbnailUrl
     }
 
@@ -269,10 +283,9 @@ export function optimisticAttachmentRef(attachment: ComposerAttachment): string 
       return attachment.previewUrl
     }
 
-    // A newly attached image has no thumbnail while its queued resize is still
-    // pending. Do not fall through to @image:<path>: the optimistic bubble would
-    // fetch and paint the full source, recreating the freeze if Send wins the
-    // race. The model upload remains path/byte based and is unaffected.
+    // A newly attached image with no path and no thumbnail yet: the queued
+    // resize is still pending. Render nothing rather than paint the full source
+    // and recreate the freeze if Send wins the race.
     return null
   }
 

--- a/apps/desktop/src/lib/image-resize.ts
+++ b/apps/desktop/src/lib/image-resize.ts
@@ -16,7 +16,7 @@
  */
 
 /** 1×1 transparent PNG — fail closed so the pill never receives the original. */
-const FALLBACK_PLACEHOLDER =
+export const FALLBACK_PLACEHOLDER =
   'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+GkZcAAAAASUVORK5CYII='
 
 // Composer pills render at 32 CSS pixels. A 512px source stays sharp on


### PR DESCRIPTION
## What does this PR do?

Attached images in the Electron desktop chat rendered at a 512px thumbnail everywhere in the live conversation — the sent message bubble and the click-to-zoom lightbox — and only became sharp after switching sessions and back, which rehydrates the turn from the full file on disk. Live rendering and reloaded rendering disagreed on fidelity.

The 512px downscale exists on purpose: assigning multi-MB screenshots to `<img>` elements makes Chromium build very large paint operations, so a bounded thumbnail is the right thing to paint *inline*. The problem is that the in-flight bubble had no way to reach the original for the lightbox, so click-to-zoom just enlarged the thumbnail.

This change makes the in-flight bubble render through the same code path as a reloaded turn: a bounded thumbnail is still painted inline (the anti-freeze guarantee is preserved), while the full-resolution file is handed to the on-demand lightbox and download. Raising the downscale cap was intentionally avoided, since that would reintroduce the paint pressure the cap protects against.

## Related Issue

Fixes #93204

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/chat-runtime.ts` — `optimisticAttachmentRef` now emits an `@image:<path>` ref for images that have a filesystem path, so the in-flight bubble renders through `DirectiveImage` exactly like a reloaded turn. Path-less pasted images fall back to the bounded thumbnail as before.
- `apps/desktop/src/components/assistant-ui/directive-text.tsx` — `DirectiveImage` paints a bounded thumbnail inline (via the existing downscale helper) and passes the full-resolution source to the lightbox/download, keeping inline paints cheap.
- `apps/desktop/src/components/chat/zoomable-image.tsx` — added an optional `zoomSrc` used by the lightbox and Save action; the inline `<img>` keeps its bounded `src`. Backward compatible — existing callers are unaffected.
- `apps/desktop/src/lib/image-resize.ts` — exported the fallback placeholder constant so `DirectiveImage` can detect a failed downscale and fall back to the full source.
- `apps/desktop/src/lib/chat-runtime.test.ts` — updated `optimisticAttachmentRef` coverage for the path-backed ref and the path-less fallbacks.
- `apps/desktop/src/components/chat/zoomable-image.test.tsx` — new coverage asserting the inline `<img>` uses the bounded source while the lightbox enlarges the full-resolution `zoomSrc`.

## How to Test

1. Take a screenshot wider than ~1024px (any HiDPI display qualifies).
2. Paste it into the composer and send it.
3. The image in the sent bubble is sharp, and clicking it opens the full-resolution original in the lightbox — no longer an upscaled 512px copy.
4. Switch to another session and back: the image still renders sharp, matching the live render.

Automated coverage (from `apps/desktop`):

```
vitest run --project ui src/lib/chat-runtime.test.ts src/lib/image-resize.test.ts src/components/chat/zoomable-image.test.tsx
 Test Files  3 passed (3)
      Tests  49 passed (49)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The fix is display-only. The bounded thumbnail is still painted inline; the lightbox and Save action now use the full-resolution file read from disk (local) or the authenticated media API (remote gateway), matching how a reloaded turn already rendered.
