### PR TITLE
fix(tui): continue goals after iteration cap

### DIFF
--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -170,6 +170,52 @@ def _compression_failure():
     }
 
 
+def _max_iterations_fallback(final_response="fallback summary"):
+    return {
+        "final_response": final_response,
+        "completed": False,
+        "failed": False,
+        "turn_exit_reason": "max_iterations_reached(3/3)",
+    }
+
+
+@pytest.mark.parametrize(
+    ("result", "status", "raw", "expected"),
+    [
+        (_max_iterations_fallback(), "complete", "fallback summary", True),
+        (
+            {
+                "completed": True,
+                "failed": False,
+                "turn_exit_reason": "text_response(finish_reason=stop)",
+            },
+            "complete",
+            "normal response",
+            True,
+        ),
+        (
+            {**_max_iterations_fallback(), "failed": True},
+            "complete",
+            "fallback summary",
+            False,
+        ),
+        (
+            {**_max_iterations_fallback(), "turn_exit_reason": "budget_exhausted"},
+            "complete",
+            "fallback summary",
+            False,
+        ),
+        (_max_iterations_fallback(), "error", "fallback summary", False),
+        (_max_iterations_fallback(), "interrupted", "fallback summary", False),
+        (_max_iterations_fallback(), "complete", "   ", False),
+    ],
+)
+def test_successful_goal_turn_accepts_only_valid_completion_outcomes(
+    server, result, status, raw, expected
+):
+    assert server._is_successful_goal_turn(result, status, raw) is expected
+
+
 # ── command.dispatch /goal ────────────────────────────────────────────
 
 
@@ -251,6 +297,57 @@ def test_pending_input_commands_includes_goal(server):
     """Guard: _PENDING_INPUT_COMMANDS must list 'goal' — removing it would
     silently re-break the TUI."""
     assert "goal" in server._PENDING_INPUT_COMMANDS
+
+
+def test_iteration_limit_fallback_is_judged_and_can_continue(
+    server, turn_env, monkeypatch
+):
+    from hermes_cli.goals import GoalManager
+
+    session_key = "goal-iteration-limit-fallback"
+    mgr = GoalManager(session_key)
+    mgr.set("finish the current task")
+    continuation = mgr.next_continuation_prompt()
+    seen_prompts = []
+    judged = []
+    results = iter([
+        _max_iterations_fallback(),
+        {
+            "final_response": "finished normally",
+            "completed": True,
+            "failed": False,
+            "turn_exit_reason": "text_response(finish_reason=stop)",
+        },
+    ])
+
+    def run_conversation(message, **_kwargs):
+        seen_prompts.append(message)
+        return next(results)
+
+    def evaluate(self, response, **_kwargs):
+        judged.append(response)
+        if len(judged) == 1:
+            return {
+                "message": "",
+                "should_continue": True,
+                "continuation_prompt": continuation,
+            }
+        return {"message": "", "should_continue": False}
+
+    monkeypatch.setattr(GoalManager, "evaluate_after_turn", evaluate)
+    agent = types.SimpleNamespace(
+        session_id=session_key,
+        run_conversation=run_conversation,
+        clear_interrupt=lambda: None,
+    )
+    session = _turn_session(agent, session_key)
+
+    server._run_prompt_submit("rid", "sid", session, "initial work")
+
+    assert seen_prompts == ["initial work", continuation]
+    assert judged == ["fallback summary", "finished normally"]
+    completes = [p for event, _sid, p in turn_env if event == "message.complete"]
+    assert [p["status"] for p in completes] == ["complete", "complete"]
 
 
 # ── active-goal recovery after compression exhaustion ───────────────

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10615,12 +10615,25 @@ _GOAL_COMPRESSION_RECOVERY_LIMIT = 1
 
 def _is_successful_goal_turn(result: Any, status: str, raw: Any) -> bool:
     """Return whether a turn produced a real response the goal judge can use."""
+    turn_exit_reason = (
+        result.get("turn_exit_reason") if isinstance(result, dict) else None
+    )
+    iteration_limit_fallback = (
+        isinstance(result, dict)
+        and result.get("completed") is False
+        and isinstance(turn_exit_reason, str)
+        and turn_exit_reason.startswith("max_iterations_reached(")
+    )
     return bool(
         status == "complete"
         and isinstance(raw, str)
         and raw.strip()
-        and not (isinstance(result, dict) and result.get("failed"))
-        and not (isinstance(result, dict) and result.get("completed") is False)
+        and (not isinstance(result, dict) or result.get("failed") is not True)
+        and (
+            not isinstance(result, dict)
+            or result.get("completed") is not False
+            or iteration_limit_fallback
+        )
     )
 
 


### PR DESCRIPTION
## Rationale

An active TUI `/goal` can be stranded when an agent reaches its per-turn
iteration limit. Hermes may still produce a usable final summary, but the TUI
treats every `completed=False` result as ineligible for the post-turn goal
judge, so it never schedules the next goal turn.

This fixes the active-goal continuation path. It does not make a bare session
resume issue work automatically or change configured iteration limits; a new
user turn retains its normal fresh turn budget.

## Summary

- Allow cap-bound turns with a nonempty final response and a
  `max_iterations_reached(...)` exit reason to reach the goal judge.
- Preserve exclusion for errors, interruptions, empty replies, compression
  exhaustion, and other budget outcomes.
- Add regression coverage for the capped-turn continuation path.

## Test Plan

- [x] `scripts/run_tests.sh tests/tui_gateway/test_goal_command.py -q` — 20 passed
- [x] `git diff --check`
- [x] Upstream CI required checks passed
