### PR TITLE
feat(desktop): optimize Kanban task drawer

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -167,6 +167,11 @@ Sizes: `default`, `xs`, `overlay` (titlebar glyph counts).
 - **`SegmentedControl`** — the choice control for small mutually-exclusive sets
   (color mode, tool-call display, usage period). Replaces radio piles and
   pill rows.
+- **`Tabs`** — use the default `segmented` treatment for compact mode switches.
+  Use `variant="line"` on both `TabsList` and its `TabsTrigger` children for
+  persistent content regions whose views share one panel (for example,
+  overview / timeline / execution). The line variant stays flat and marks the
+  active view with the shared accent underline.
 - **`Switch`** (`size="xs"`) — bare, with `aria-label`. No bordered text wrapper.
 
 ## Layout

--- a/apps/desktop/src/components/ui/tabs.test.tsx
+++ b/apps/desktop/src/components/ui/tabs.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Tabs, TabsList, TabsTrigger } from './tabs'
+
+afterEach(cleanup)
+
+describe('Tabs line variant', () => {
+  it('uses flat chrome and an active underline instead of a segmented surface', () => {
+    render(
+      <Tabs defaultValue="overview">
+        <TabsList aria-label="Task sections" variant="line">
+          <TabsTrigger value="overview" variant="line">
+            Overview
+          </TabsTrigger>
+          <TabsTrigger value="activity" variant="line">
+            Activity
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+    )
+
+    const list = screen.getByRole('tablist', { name: 'Task sections' })
+    const active = screen.getByRole('tab', { name: 'Overview' })
+
+    expect(list.className).toContain('border-b')
+    expect(list.className).toContain('bg-transparent')
+    expect(active.className).toContain('after:bg-(--ui-accent)')
+    expect(active.className).not.toContain('data-[state=active]:shadow-xs')
+  })
+})

--- a/apps/desktop/src/components/ui/tabs.test.tsx
+++ b/apps/desktop/src/components/ui/tabs.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { cleanup } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { Tabs, TabsList, TabsTrigger } from './tabs'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs'
 
 afterEach(cleanup)
 
@@ -28,5 +28,35 @@ describe('Tabs line variant', () => {
     expect(list.className).toContain('bg-transparent')
     expect(active.className).toContain('after:bg-(--ui-accent)')
     expect(active.className).not.toContain('data-[state=active]:shadow-xs')
+  })
+
+  it('keeps force-mounted panels linked to their tabs', () => {
+    render(
+      <Tabs defaultValue="overview">
+        <TabsList aria-label="Task sections" variant="line">
+          <TabsTrigger value="overview" variant="line">
+            Overview
+          </TabsTrigger>
+          <TabsTrigger value="timeline" variant="line">
+            Timeline
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent forceMount value="overview">
+          Overview panel
+        </TabsContent>
+        <TabsContent forceMount value="timeline">
+          Timeline panel
+        </TabsContent>
+      </Tabs>
+    )
+
+    const overview = screen.getByRole('tab', { name: 'Overview' })
+    const timeline = screen.getByRole('tab', { name: 'Timeline' })
+    const panels = screen.getAllByRole('tabpanel', { hidden: true })
+
+    expect(panels).toHaveLength(2)
+    expect(panels.map(panel => panel.id)).toContain(overview.getAttribute('aria-controls'))
+    expect(panels.map(panel => panel.id)).toContain(timeline.getAttribute('aria-controls'))
+    expect(screen.getByText('Timeline panel').getAttribute('data-state')).toBe('inactive')
   })
 })

--- a/apps/desktop/src/components/ui/tabs.tsx
+++ b/apps/desktop/src/components/ui/tabs.tsx
@@ -42,4 +42,8 @@ function TabsTrigger({ className, variant = 'segmented', ...props }: TabsTrigger
   )
 }
 
-export { Tabs, TabsList, TabsTrigger }
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return <TabsPrimitive.Content className={cn('min-h-0 flex-1', className)} data-slot="tabs-content" {...props} />
+}
+
+export { Tabs, TabsContent, TabsList, TabsTrigger }

--- a/apps/desktop/src/components/ui/tabs.tsx
+++ b/apps/desktop/src/components/ui/tabs.tsx
@@ -7,11 +7,18 @@ function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive
   return <TabsPrimitive.Root className={cn('flex flex-col gap-2', className)} data-slot="tabs" {...props} />
 }
 
-function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+type TabsVisualVariant = 'line' | 'segmented'
+
+type TabsListProps = React.ComponentProps<typeof TabsPrimitive.List> & { variant?: TabsVisualVariant }
+type TabsTriggerProps = React.ComponentProps<typeof TabsPrimitive.Trigger> & { variant?: TabsVisualVariant }
+
+function TabsList({ className, variant = 'segmented', ...props }: TabsListProps) {
   return (
     <TabsPrimitive.List
       className={cn(
-        'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+        variant === 'line'
+          ? 'inline-flex h-10 w-full items-stretch justify-start border-b border-(--ui-stroke-tertiary) bg-transparent text-(--ui-text-tertiary)'
+          : 'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
         className
       )}
       data-slot="tabs-list"
@@ -20,11 +27,13 @@ function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimi
   )
 }
 
-function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+function TabsTrigger({ className, variant = 'segmented', ...props }: TabsTriggerProps) {
   return (
     <TabsPrimitive.Trigger
       className={cn(
-        'inline-flex h-7 items-center justify-center gap-1.5 rounded-md px-3 text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:bg-background focus-visible:text-foreground focus-visible:ring-[0.1875rem] focus-visible:ring-ring/35 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-xs [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+        variant === 'line'
+          ? 'relative inline-flex h-10 flex-1 items-center justify-center gap-1.5 px-3 text-xs font-medium whitespace-nowrap transition-colors outline-none after:absolute after:inset-x-3 after:-bottom-px after:h-0.5 after:rounded-t after:bg-transparent focus-visible:bg-background focus-visible:text-foreground focus-visible:ring-[0.1875rem] focus-visible:ring-ring/35 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-foreground data-[state=active]:after:bg-(--ui-accent)'
+          : 'inline-flex h-7 items-center justify-center gap-1.5 rounded-md px-3 text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:bg-background focus-visible:text-foreground focus-visible:ring-[0.1875rem] focus-visible:ring-ring/35 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-xs [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
         className
       )}
       data-slot="tabs-trigger"

--- a/apps/desktop/src/plugins/kanban/drawer-layout.test.ts
+++ b/apps/desktop/src/plugins/kanban/drawer-layout.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { drawerTabStats } from './drawer-layout'
+
+describe('drawer tab stats', () => {
+  it('counts human comments and machine events together in the timeline', () => {
+    expect(
+      drawerTabStats({
+        comments: 3,
+        events: 8,
+        hasLog: false,
+        running: false,
+        runs: 2
+      }).timelineCount
+    ).toBe(11)
+  })
+
+  it('marks execution live only while the task is running', () => {
+    expect(drawerTabStats({ comments: 0, events: 0, hasLog: true, running: true, runs: 1 }).executionLive).toBe(true)
+    expect(drawerTabStats({ comments: 0, events: 0, hasLog: true, running: false, runs: 1 }).executionLive).toBe(false)
+  })
+
+  it('keeps execution discoverable when a log exists without run history', () => {
+    expect(drawerTabStats({ comments: 0, events: 0, hasLog: true, running: false, runs: 0 }).executionCount).toBe(1)
+  })
+
+  it('uses actual run history as the execution count when present', () => {
+    expect(drawerTabStats({ comments: 0, events: 0, hasLog: true, running: false, runs: 4 }).executionCount).toBe(4)
+  })
+})

--- a/apps/desktop/src/plugins/kanban/drawer-layout.ts
+++ b/apps/desktop/src/plugins/kanban/drawer-layout.ts
@@ -1,0 +1,17 @@
+export type DrawerTab = 'execution' | 'overview' | 'timeline'
+
+type DrawerTabStatsInput = {
+  comments: number
+  events: number
+  hasLog: boolean
+  running: boolean
+  runs: number
+}
+
+export function drawerTabStats({ comments, events, hasLog, running, runs }: DrawerTabStatsInput) {
+  return {
+    executionCount: runs || (hasLog ? 1 : 0),
+    executionLive: running,
+    timelineCount: comments + events
+  }
+}

--- a/apps/desktop/src/plugins/kanban/drawer-layout.ts
+++ b/apps/desktop/src/plugins/kanban/drawer-layout.ts
@@ -10,6 +10,8 @@ type DrawerTabStatsInput = {
 
 export function drawerTabStats({ comments, events, hasLog, running, runs }: DrawerTabStatsInput) {
   return {
+    // Older tasks can retain worker output after their run history has been pruned.
+    // Give that output a discoverable Execution badge without claiming it is a run count.
     executionCount: runs || (hasLog ? 1 : 0),
     executionLive: running,
     timelineCount: comments + events

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -809,9 +809,12 @@ export function TaskDrawer({
             <TabsTrigger value="execution" variant="line">
               {k.tabExecution}
               {tabStats.executionLive ? (
-                <span aria-label={k.working} className="text-[0.625rem] text-(--ui-accent)">
-                  ●
-                </span>
+                <>
+                  <span aria-hidden="true" className="text-[0.625rem] text-(--ui-accent)">
+                    ●
+                  </span>
+                  <span className="sr-only">{k.working}</span>
+                </>
               ) : tabStats.executionCount > 0 ? (
                 <span className="text-[0.625rem] font-normal text-(--ui-text-quaternary)">
                   {tabStats.executionCount}

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -367,7 +367,6 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
 
   return (
     <Section
-      variant="drawer"
       action={
         <Button
           aria-label={editing ? k.cancelEdit : k.editDescription}
@@ -382,6 +381,7 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
         </Button>
       }
       label={k.description}
+      variant="drawer"
     >
       {editing ? (
         <div className="flex flex-col gap-1.5">
@@ -429,7 +429,6 @@ function AttachmentsSection({
 
   return (
     <Section
-      variant="drawer"
       action={
         <>
           <input
@@ -458,6 +457,7 @@ function AttachmentsSection({
         </>
       }
       label={k.attachments(attachments.length)}
+      variant="drawer"
     >
       {attachments.length > 0 ? (
         <ul className="flex flex-col gap-1">
@@ -500,7 +500,7 @@ function EstimateSection({ id }: { id: string }) {
   useEffect(() => setResult(null), [id])
 
   return (
-    <Section variant="drawer" label={k.estimate}>
+    <Section label={k.estimate} variant="drawer">
       {result?.ok ? (
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2 text-[0.8125rem]">
@@ -827,7 +827,7 @@ export function TaskDrawer({
           >
             <div className="flex flex-col gap-5 text-sm">
               {currentState && (
-                <Section variant="drawer" label={k.currentState}>
+                <Section label={k.currentState} variant="drawer">
                   <p className="whitespace-pre-wrap text-[0.8125rem] leading-relaxed text-(--ui-text-secondary)">
                     {currentState}
                   </p>
@@ -846,14 +846,14 @@ export function TaskDrawer({
               )}
 
               {task.diagnostics && task.diagnostics.length > 0 && (
-                <Section variant="drawer" label={k.diagnosticsN(task.diagnostics.length)}>
+                <Section label={k.diagnosticsN(task.diagnostics.length)} variant="drawer">
                   <Diagnostics items={task.diagnostics} onReclaim={() => void mutate(() => reclaimTask(task.id))()} />
                 </Section>
               )}
 
               <DescriptionSection body={task.body} onSave={body => void mutate(() => patchTask(task.id, { body }))()} />
 
-              <Section variant="drawer" label={k.details}>
+              <Section label={k.details} variant="drawer">
                 <div className="grid grid-cols-[6rem_minmax(0,1fr)] gap-x-3 gap-y-1.5 text-[0.71rem]">
                   <MetaRow label={k.assignee}>
                     <AssigneeMenu
@@ -888,7 +888,7 @@ export function TaskDrawer({
               <EstimateSection id={task.id} />
 
               {(detail.links.parents.length > 0 || detail.links.children.length > 0) && (
-                <Section variant="drawer" label={k.dependencies}>
+                <Section label={k.dependencies} variant="drawer">
                   {(['parents', 'children'] as const).map(side =>
                     detail.links[side].length > 0 ? (
                       <div className="flex flex-wrap items-center gap-1.5" key={side}>
@@ -932,7 +932,6 @@ export function TaskDrawer({
 
               {detail.comments.length > 0 && (
                 <Section
-                  variant="drawer"
                   action={
                     <Tip label={running ? k.commentsHelpRunning : k.commentsHelp}>
                       <span className="grid size-5 place-items-center rounded text-(--ui-text-quaternary) hover:text-(--ui-text-secondary)">
@@ -941,6 +940,7 @@ export function TaskDrawer({
                     </Tip>
                   }
                   label={k.comments(detail.comments.length)}
+                  variant="drawer"
                 >
                   <ul className="flex flex-col gap-3">
                     {detail.comments.map(comment => (
@@ -962,7 +962,7 @@ export function TaskDrawer({
               )}
 
               {detail.events.length > 0 && (
-                <Section variant="drawer" label={k.activity(detail.events.length)}>
+                <Section label={k.activity(detail.events.length)} variant="drawer">
                   <ul className="relative ml-1 flex flex-col gap-3 border-l border-(--ui-stroke-tertiary) pl-4">
                     {detail.events.map(event => {
                       const { detail: extra, label } = eventText(event, k)
@@ -1000,7 +1000,7 @@ export function TaskDrawer({
               )}
 
               {detail.runs.length > 0 && (
-                <Section variant="drawer" label={k.runs(detail.runs.length)}>
+                <Section label={k.runs(detail.runs.length)} variant="drawer">
                   <ul className="flex flex-col gap-3">
                     {detail.runs.map(run => {
                       const failed = ['crashed', 'failed', 'timed_out', 'gave_up'].includes(run.outcome ?? run.status)
@@ -1042,7 +1042,7 @@ export function TaskDrawer({
               )}
 
               {log?.exists && log.content && (
-                <Section variant="drawer" label={log.truncated ? k.workerLogTail : k.workerLog}>
+                <Section label={log.truncated ? k.workerLogTail : k.workerLog} variant="drawer">
                   <ScrollFade deps={log.content.length} max="24rem">
                     <LogView className="border-0 px-0">{log.content}</LogView>
                   </ScrollFade>

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -21,6 +21,7 @@ import {
   Loader,
   LogView,
   Tabs,
+  TabsContent,
   TabsList,
   TabsTrigger,
   Textarea,
@@ -70,6 +71,7 @@ import {
   type KanbanText,
   lockedReason,
   ScrollFade,
+  Section,
   shortId,
   StatusMenu,
   useDefaultAssignee,
@@ -178,18 +180,6 @@ function MetaRow({ children, label }: { children: ReactNode; label: string }) {
       <span className="text-(--ui-text-quaternary)">{label}</span>
       <span className="min-w-0 truncate text-(--ui-text-secondary)">{children}</span>
     </>
-  )
-}
-
-function DrawerSection({ action, children, label }: { action?: ReactNode; children: ReactNode; label: string }) {
-  return (
-    <section className="flex flex-col gap-2">
-      <div className="flex items-center justify-between gap-3">
-        <h3 className="text-xs font-semibold text-(--ui-text-secondary)">{label}</h3>
-        {action}
-      </div>
-      {children}
-    </section>
   )
 }
 
@@ -376,7 +366,8 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
   const [draft, setDraft] = useState('')
 
   return (
-    <DrawerSection
+    <Section
+      variant="drawer"
       action={
         <Button
           aria-label={editing ? k.cancelEdit : k.editDescription}
@@ -416,7 +407,7 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
       ) : (
         <p className="text-[0.8125rem] text-(--ui-text-quaternary)">{k.noDescription}</p>
       )}
-    </DrawerSection>
+    </Section>
   )
 }
 
@@ -437,7 +428,8 @@ function AttachmentsSection({
   const fileRef = useRef<HTMLInputElement>(null)
 
   return (
-    <DrawerSection
+    <Section
+      variant="drawer"
       action={
         <>
           <input
@@ -479,7 +471,7 @@ function AttachmentsSection({
       ) : (
         <p className="text-[0.75rem] text-(--ui-text-quaternary)">{k.noAttachments}</p>
       )}
-    </DrawerSection>
+    </Section>
   )
 }
 
@@ -508,7 +500,7 @@ function EstimateSection({ id }: { id: string }) {
   useEffect(() => setResult(null), [id])
 
   return (
-    <DrawerSection label={k.estimate}>
+    <Section variant="drawer" label={k.estimate}>
       {result?.ok ? (
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2 text-[0.8125rem]">
@@ -548,7 +540,7 @@ function EstimateSection({ id }: { id: string }) {
           </Tip>
         </div>
       )}
-    </DrawerSection>
+    </Section>
   )
 }
 
@@ -792,8 +784,12 @@ export function TaskDrawer({
         )}
       </header>
 
-      {task && (
-        <Tabs className="gap-0" onValueChange={value => setActiveTab(value as DrawerTab)} value={activeTab}>
+      {task ? (
+        <Tabs
+          className="min-h-0 flex-1 gap-0"
+          onValueChange={value => setActiveTab(value as DrawerTab)}
+          value={activeTab}
+        >
           <TabsList aria-label={k.details} variant="line">
             <TabsTrigger value="overview" variant="line">
               {k.tabOverview}
@@ -822,226 +818,244 @@ export function TaskDrawer({
               ) : null}
             </TabsTrigger>
           </TabsList>
-        </Tabs>
-      )}
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4" data-selectable-text="true">
-        {errorMessage ? (
-          <ErrorState title={errorMessage} />
-        ) : !detail || !task ? (
-          <div className="grid h-32 place-items-center">
-            <Loader type="lemniscate-bloom" />
-          </div>
-        ) : activeTab === 'overview' ? (
-          <div className="flex flex-col gap-5 text-sm">
-            {currentState && (
-              <DrawerSection label={k.currentState}>
-                <p className="whitespace-pre-wrap text-[0.8125rem] leading-relaxed text-(--ui-text-secondary)">
-                  {currentState}
-                </p>
-                {task.result && currentSummary && (
-                  <p className="whitespace-pre-wrap text-[0.75rem] leading-relaxed text-(--ui-text-tertiary)">
-                    {currentSummary}
+          <TabsContent
+            className="overflow-y-auto px-4 py-4 data-[state=inactive]:hidden"
+            data-selectable-text="true"
+            forceMount
+            value="overview"
+          >
+            <div className="flex flex-col gap-5 text-sm">
+              {currentState && (
+                <Section variant="drawer" label={k.currentState}>
+                  <p className="whitespace-pre-wrap text-[0.8125rem] leading-relaxed text-(--ui-text-secondary)">
+                    {currentState}
                   </p>
-                )}
-              </DrawerSection>
-            )}
+                  {task.result && currentSummary && (
+                    <p className="whitespace-pre-wrap text-[0.75rem] leading-relaxed text-(--ui-text-tertiary)">
+                      {currentSummary}
+                    </p>
+                  )}
+                </Section>
+              )}
 
-            {task.status === 'ready' && !task.assignee && !defaultAssignee && (
-              <Callout title={k.readyUnassignedTitle} tone={SEVERITY_TONE.warning}>
-                <p className="text-[0.71rem] leading-relaxed text-(--ui-text-secondary)">{k.readyUnassignedBody}</p>
-              </Callout>
-            )}
+              {task.status === 'ready' && !task.assignee && !defaultAssignee && (
+                <Callout title={k.readyUnassignedTitle} tone={SEVERITY_TONE.warning}>
+                  <p className="text-[0.71rem] leading-relaxed text-(--ui-text-secondary)">{k.readyUnassignedBody}</p>
+                </Callout>
+              )}
 
-            {task.diagnostics && task.diagnostics.length > 0 && (
-              <DrawerSection label={k.diagnosticsN(task.diagnostics.length)}>
-                <Diagnostics items={task.diagnostics} onReclaim={() => void mutate(() => reclaimTask(task.id))()} />
-              </DrawerSection>
-            )}
+              {task.diagnostics && task.diagnostics.length > 0 && (
+                <Section variant="drawer" label={k.diagnosticsN(task.diagnostics.length)}>
+                  <Diagnostics items={task.diagnostics} onReclaim={() => void mutate(() => reclaimTask(task.id))()} />
+                </Section>
+              )}
 
-            <DescriptionSection body={task.body} onSave={body => void mutate(() => patchTask(task.id, { body }))()} />
+              <DescriptionSection body={task.body} onSave={body => void mutate(() => patchTask(task.id, { body }))()} />
 
-            <DrawerSection label={k.details}>
-              <div className="grid grid-cols-[6rem_minmax(0,1fr)] gap-x-3 gap-y-1.5 text-[0.71rem]">
-                <MetaRow label={k.assignee}>
-                  <AssigneeMenu
-                    current={task.assignee}
-                    onReassign={profile => void mutate(() => reassignTask(task.id, profile))()}
-                  />
-                </MetaRow>
-                {typeof task.priority === 'number' && <MetaRow label={k.metaPriority}>{task.priority}</MetaRow>}
-                {task.tenant && <MetaRow label={k.metaTenant}>{task.tenant}</MetaRow>}
-                {task.workspace_path && (
-                  <MetaRow label={k.workspace}>
-                    {task.workspace_kind ? `${task.workspace_kind}: ` : ''}
-                    {task.workspace_path}
+              <Section variant="drawer" label={k.details}>
+                <div className="grid grid-cols-[6rem_minmax(0,1fr)] gap-x-3 gap-y-1.5 text-[0.71rem]">
+                  <MetaRow label={k.assignee}>
+                    <AssigneeMenu
+                      current={task.assignee}
+                      onReassign={profile => void mutate(() => reassignTask(task.id, profile))()}
+                    />
                   </MetaRow>
-                )}
-                <MetaRow label={k.model}>
-                  <ModelOverrideField
-                    onChange={next => void mutate(() => patchTask(task.id, overridePatch(next)))()}
-                    value={{
-                      effort: task.reasoning_effort ?? '',
-                      model: task.model_override ?? '',
-                      provider: task.provider_override ?? ''
-                    }}
-                  />
-                </MetaRow>
-                {task.created_by && <MetaRow label={k.metaCreatedBy}>{task.created_by}</MetaRow>}
-                {ago(task.created_at) && <MetaRow label={k.metaCreated}>{ago(task.created_at)}</MetaRow>}
-                {running && task.worker_pid ? <MetaRow label={k.metaWorkerPid}>{task.worker_pid}</MetaRow> : null}
-              </div>
-            </DrawerSection>
+                  {typeof task.priority === 'number' && <MetaRow label={k.metaPriority}>{task.priority}</MetaRow>}
+                  {task.tenant && <MetaRow label={k.metaTenant}>{task.tenant}</MetaRow>}
+                  {task.workspace_path && (
+                    <MetaRow label={k.workspace}>
+                      {task.workspace_kind ? `${task.workspace_kind}: ` : ''}
+                      {task.workspace_path}
+                    </MetaRow>
+                  )}
+                  <MetaRow label={k.model}>
+                    <ModelOverrideField
+                      onChange={next => void mutate(() => patchTask(task.id, overridePatch(next)))()}
+                      value={{
+                        effort: task.reasoning_effort ?? '',
+                        model: task.model_override ?? '',
+                        provider: task.provider_override ?? ''
+                      }}
+                    />
+                  </MetaRow>
+                  {task.created_by && <MetaRow label={k.metaCreatedBy}>{task.created_by}</MetaRow>}
+                  {ago(task.created_at) && <MetaRow label={k.metaCreated}>{ago(task.created_at)}</MetaRow>}
+                  {running && task.worker_pid ? <MetaRow label={k.metaWorkerPid}>{task.worker_pid}</MetaRow> : null}
+                </div>
+              </Section>
 
-            <EstimateSection id={task.id} />
+              <EstimateSection id={task.id} />
 
-            {(detail.links.parents.length > 0 || detail.links.children.length > 0) && (
-              <DrawerSection label={k.dependencies}>
-                {(['parents', 'children'] as const).map(side =>
-                  detail.links[side].length > 0 ? (
-                    <div className="flex flex-wrap items-center gap-1.5" key={side}>
-                      <span className="text-[0.6875rem] text-(--ui-text-quaternary)">
-                        {side === 'parents' ? k.blockedBy : k.blocks}
-                      </span>
-                      {detail.links[side].map(linked => (
-                        <button
-                          className="rounded bg-(--ui-bg-quaternary) px-1.5 py-0.5 font-mono text-[0.625rem] text-(--ui-text-secondary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
-                          key={linked}
-                          onClick={() => onOpen(linked)}
-                          type="button"
-                        >
-                          {shortId(linked)}
-                        </button>
-                      ))}
-                    </div>
-                  ) : null
-                )}
-              </DrawerSection>
-            )}
-
-            <AttachmentsSection
-              attachments={detail.attachments}
-              onUpload={file => uploadMut.mutate(file)}
-              pending={uploadMut.isPending}
-            />
-          </div>
-        ) : activeTab === 'timeline' ? (
-          <div className="flex flex-col gap-5 text-sm">
-            {tabStats.timelineCount === 0 && (
-              <p className="py-6 text-center text-xs text-(--ui-text-quaternary)">{k.noTimeline}</p>
-            )}
-
-            {detail.comments.length > 0 && (
-              <DrawerSection
-                action={
-                  <Tip label={running ? k.commentsHelpRunning : k.commentsHelp}>
-                    <span className="grid size-5 place-items-center rounded text-(--ui-text-quaternary) hover:text-(--ui-text-secondary)">
-                      <Codicon name="question" size="0.8rem" />
-                    </span>
-                  </Tip>
-                }
-                label={k.comments(detail.comments.length)}
-              >
-                <ul className="flex flex-col gap-3">
-                  {detail.comments.map(comment => (
-                    <li
-                      className="border-b border-(--ui-stroke-tertiary) pb-3 text-[0.75rem] last:border-0 last:pb-0"
-                      key={comment.id}
-                    >
-                      <span className="font-medium text-(--ui-text-secondary)">{comment.author}</span>
-                      <span className="ml-2 text-[0.625rem] text-(--ui-text-quaternary)">
-                        {ago(comment.created_at)}
-                      </span>
-                      <p className="mt-1 whitespace-pre-wrap leading-relaxed text-(--ui-text-tertiary)">
-                        {comment.body}
-                      </p>
-                    </li>
-                  ))}
-                </ul>
-              </DrawerSection>
-            )}
-
-            {detail.events.length > 0 && (
-              <DrawerSection label={k.activity(detail.events.length)}>
-                <ul className="relative ml-1 flex flex-col gap-3 border-l border-(--ui-stroke-tertiary) pl-4">
-                  {detail.events.map(event => {
-                    const { detail: extra, label } = eventText(event, k)
-
-                    return (
-                      <li
-                        className="relative text-[0.6875rem] before:absolute before:top-1.5 before:-left-[1.1875rem] before:size-1.5 before:rounded-full before:bg-(--ui-text-quaternary) before:ring-4 before:ring-(--ui-bg-elevated)"
-                        key={event.id}
-                      >
-                        <div className="flex items-baseline gap-2">
-                          <span className="text-(--ui-text-secondary)">{label}</span>
-                          <span className="ml-auto shrink-0 text-(--ui-text-quaternary)">{ago(event.created_at)}</span>
-                        </div>
-                        {extra && <p className="mt-0.5 text-(--ui-text-quaternary)">{extra}</p>}
-                      </li>
-                    )
-                  })}
-                </ul>
-              </DrawerSection>
-            )}
-          </div>
-        ) : (
-          <div className="flex flex-col gap-5 text-sm">
-            {detail.runs.length === 0 && !(log?.exists && log.content) && (
-              <p className="py-6 text-center text-xs text-(--ui-text-quaternary)">{k.noExecution}</p>
-            )}
-
-            {detail.runs.length > 0 && (
-              <DrawerSection label={k.runs(detail.runs.length)}>
-                <ul className="flex flex-col gap-3">
-                  {detail.runs.map(run => {
-                    const failed = ['crashed', 'failed', 'timed_out', 'gave_up'].includes(run.outcome ?? run.status)
-
-                    return (
-                      <li
-                        className="flex flex-col gap-1 border-b border-(--ui-stroke-tertiary) pb-3 text-[0.71rem] last:border-0 last:pb-0"
-                        key={run.id}
-                      >
-                        <div className="flex items-center gap-2">
-                          <Badge size="xs" variant={failed ? 'destructive' : 'muted'}>
-                            {run.outcome ?? run.status}
-                          </Badge>
-                          {run.profile && <span className="text-(--ui-text-tertiary)">{run.profile}</span>}
-                          {duration(run.started_at, run.ended_at) && (
-                            <span className="text-(--ui-text-quaternary)">
-                              {duration(run.started_at, run.ended_at)}
-                            </span>
-                          )}
-                          <span className="ml-auto shrink-0 text-(--ui-text-quaternary)">
-                            {ago(run.ended_at ?? run.started_at)}
-                          </span>
-                        </div>
-                        {(run.error || run.summary) && (
-                          <p
-                            className={cn(
-                              'line-clamp-3 whitespace-pre-wrap leading-relaxed',
-                              run.error ? 'text-destructive' : 'text-(--ui-text-quaternary)'
-                            )}
+              {(detail.links.parents.length > 0 || detail.links.children.length > 0) && (
+                <Section variant="drawer" label={k.dependencies}>
+                  {(['parents', 'children'] as const).map(side =>
+                    detail.links[side].length > 0 ? (
+                      <div className="flex flex-wrap items-center gap-1.5" key={side}>
+                        <span className="text-[0.6875rem] text-(--ui-text-quaternary)">
+                          {side === 'parents' ? k.blockedBy : k.blocks}
+                        </span>
+                        {detail.links[side].map(linked => (
+                          <button
+                            className="rounded bg-(--ui-bg-quaternary) px-1.5 py-0.5 font-mono text-[0.625rem] text-(--ui-text-secondary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground"
+                            key={linked}
+                            onClick={() => onOpen(linked)}
+                            type="button"
                           >
-                            {run.error ?? run.summary}
-                          </p>
-                        )}
-                      </li>
-                    )
-                  })}
-                </ul>
-              </DrawerSection>
-            )}
+                            {shortId(linked)}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null
+                  )}
+                </Section>
+              )}
 
-            {log?.exists && log.content && (
-              <DrawerSection label={log.truncated ? k.workerLogTail : k.workerLog}>
-                <ScrollFade deps={log.content.length} max="24rem">
-                  <LogView className="border-0 px-0">{log.content}</LogView>
-                </ScrollFade>
-              </DrawerSection>
-            )}
-          </div>
-        )}
-      </div>
+              <AttachmentsSection
+                attachments={detail.attachments}
+                onUpload={file => uploadMut.mutate(file)}
+                pending={uploadMut.isPending}
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent
+            className="overflow-y-auto px-4 py-4 data-[state=inactive]:hidden"
+            data-selectable-text="true"
+            forceMount
+            value="timeline"
+          >
+            <div className="flex flex-col gap-5 text-sm">
+              {tabStats.timelineCount === 0 && (
+                <p className="py-6 text-center text-xs text-(--ui-text-quaternary)">{k.noTimeline}</p>
+              )}
+
+              {detail.comments.length > 0 && (
+                <Section
+                  variant="drawer"
+                  action={
+                    <Tip label={running ? k.commentsHelpRunning : k.commentsHelp}>
+                      <span className="grid size-5 place-items-center rounded text-(--ui-text-quaternary) hover:text-(--ui-text-secondary)">
+                        <Codicon name="question" size="0.8rem" />
+                      </span>
+                    </Tip>
+                  }
+                  label={k.comments(detail.comments.length)}
+                >
+                  <ul className="flex flex-col gap-3">
+                    {detail.comments.map(comment => (
+                      <li
+                        className="border-b border-(--ui-stroke-tertiary) pb-3 text-[0.75rem] last:border-0 last:pb-0"
+                        key={comment.id}
+                      >
+                        <span className="font-medium text-(--ui-text-secondary)">{comment.author}</span>
+                        <span className="ml-2 text-[0.625rem] text-(--ui-text-quaternary)">
+                          {ago(comment.created_at)}
+                        </span>
+                        <p className="mt-1 whitespace-pre-wrap leading-relaxed text-(--ui-text-tertiary)">
+                          {comment.body}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                </Section>
+              )}
+
+              {detail.events.length > 0 && (
+                <Section variant="drawer" label={k.activity(detail.events.length)}>
+                  <ul className="relative ml-1 flex flex-col gap-3 border-l border-(--ui-stroke-tertiary) pl-4">
+                    {detail.events.map(event => {
+                      const { detail: extra, label } = eventText(event, k)
+
+                      return (
+                        <li
+                          className="relative text-[0.6875rem] before:absolute before:top-1.5 before:-left-[1.1875rem] before:size-1.5 before:rounded-full before:bg-(--ui-text-quaternary) before:ring-4 before:ring-(--ui-bg-elevated)"
+                          key={event.id}
+                        >
+                          <div className="flex items-baseline gap-2">
+                            <span className="text-(--ui-text-secondary)">{label}</span>
+                            <span className="ml-auto shrink-0 text-(--ui-text-quaternary)">
+                              {ago(event.created_at)}
+                            </span>
+                          </div>
+                          {extra && <p className="mt-0.5 text-(--ui-text-quaternary)">{extra}</p>}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </Section>
+              )}
+            </div>
+          </TabsContent>
+
+          <TabsContent
+            className="overflow-y-auto px-4 py-4 data-[state=inactive]:hidden"
+            data-selectable-text="true"
+            forceMount
+            value="execution"
+          >
+            <div className="flex flex-col gap-5 text-sm">
+              {detail.runs.length === 0 && !(log?.exists && log.content) && (
+                <p className="py-6 text-center text-xs text-(--ui-text-quaternary)">{k.noExecution}</p>
+              )}
+
+              {detail.runs.length > 0 && (
+                <Section variant="drawer" label={k.runs(detail.runs.length)}>
+                  <ul className="flex flex-col gap-3">
+                    {detail.runs.map(run => {
+                      const failed = ['crashed', 'failed', 'timed_out', 'gave_up'].includes(run.outcome ?? run.status)
+
+                      return (
+                        <li
+                          className="flex flex-col gap-1 border-b border-(--ui-stroke-tertiary) pb-3 text-[0.71rem] last:border-0 last:pb-0"
+                          key={run.id}
+                        >
+                          <div className="flex items-center gap-2">
+                            <Badge size="xs" variant={failed ? 'destructive' : 'muted'}>
+                              {run.outcome ?? run.status}
+                            </Badge>
+                            {run.profile && <span className="text-(--ui-text-tertiary)">{run.profile}</span>}
+                            {duration(run.started_at, run.ended_at) && (
+                              <span className="text-(--ui-text-quaternary)">
+                                {duration(run.started_at, run.ended_at)}
+                              </span>
+                            )}
+                            <span className="ml-auto shrink-0 text-(--ui-text-quaternary)">
+                              {ago(run.ended_at ?? run.started_at)}
+                            </span>
+                          </div>
+                          {(run.error || run.summary) && (
+                            <p
+                              className={cn(
+                                'line-clamp-3 whitespace-pre-wrap leading-relaxed',
+                                run.error ? 'text-destructive' : 'text-(--ui-text-quaternary)'
+                              )}
+                            >
+                              {run.error ?? run.summary}
+                            </p>
+                          )}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </Section>
+              )}
+
+              {log?.exists && log.content && (
+                <Section variant="drawer" label={log.truncated ? k.workerLogTail : k.workerLog}>
+                  <ScrollFade deps={log.content.length} max="24rem">
+                    <LogView className="border-0 px-0">{log.content}</LogView>
+                  </ScrollFade>
+                </Section>
+              )}
+            </div>
+          </TabsContent>
+        </Tabs>
+      ) : (
+        <div className="grid min-h-0 flex-1 place-items-center px-4 py-4">
+          {errorMessage ? <ErrorState title={errorMessage} /> : <Loader type="lemniscate-bloom" />}
+        </div>
+      )}
 
       {detail && task && (
         <footer className="border-t border-(--ui-stroke-tertiary) px-3 py-2.5">

--- a/apps/desktop/src/plugins/kanban/drawer.tsx
+++ b/apps/desktop/src/plugins/kanban/drawer.tsx
@@ -20,6 +20,9 @@ import {
   host,
   Loader,
   LogView,
+  Tabs,
+  TabsList,
+  TabsTrigger,
   Textarea,
   Tip,
   useMutation,
@@ -45,6 +48,7 @@ import {
   taskKey,
   uploadAttachment
 } from './api'
+import { type DrawerTab, drawerTabStats } from './drawer-layout'
 import { ModelOverrideField, overridePatch } from './model-override'
 import {
   type Diagnostic,
@@ -66,7 +70,6 @@ import {
   type KanbanText,
   lockedReason,
   ScrollFade,
-  Section,
   shortId,
   StatusMenu,
   useDefaultAssignee,
@@ -175,6 +178,18 @@ function MetaRow({ children, label }: { children: ReactNode; label: string }) {
       <span className="text-(--ui-text-quaternary)">{label}</span>
       <span className="min-w-0 truncate text-(--ui-text-secondary)">{children}</span>
     </>
+  )
+}
+
+function DrawerSection({ action, children, label }: { action?: ReactNode; children: ReactNode; label: string }) {
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-xs font-semibold text-(--ui-text-secondary)">{label}</h3>
+        {action}
+      </div>
+      {children}
+    </section>
   )
 }
 
@@ -361,7 +376,7 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
   const [draft, setDraft] = useState('')
 
   return (
-    <Section
+    <DrawerSection
       action={
         <Button
           aria-label={editing ? k.cancelEdit : k.editDescription}
@@ -401,7 +416,7 @@ function DescriptionSection({ body, onSave }: { body: null | string | undefined;
       ) : (
         <p className="text-[0.8125rem] text-(--ui-text-quaternary)">{k.noDescription}</p>
       )}
-    </Section>
+    </DrawerSection>
   )
 }
 
@@ -422,7 +437,7 @@ function AttachmentsSection({
   const fileRef = useRef<HTMLInputElement>(null)
 
   return (
-    <Section
+    <DrawerSection
       action={
         <>
           <input
@@ -464,7 +479,7 @@ function AttachmentsSection({
       ) : (
         <p className="text-[0.75rem] text-(--ui-text-quaternary)">{k.noAttachments}</p>
       )}
-    </Section>
+    </DrawerSection>
   )
 }
 
@@ -493,7 +508,7 @@ function EstimateSection({ id }: { id: string }) {
   useEffect(() => setResult(null), [id])
 
   return (
-    <Section label={k.estimate}>
+    <DrawerSection label={k.estimate}>
       {result?.ok ? (
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2 text-[0.8125rem]">
@@ -533,7 +548,7 @@ function EstimateSection({ id }: { id: string }) {
           </Tip>
         </div>
       )}
-    </Section>
+    </DrawerSection>
   )
 }
 
@@ -551,6 +566,7 @@ export function TaskDrawer({
   const k = useKanban()
   const qc = useQueryClient()
   const slug = useValue($boardSlug)
+  const [activeTab, setActiveTab] = useState<DrawerTab>('overview')
 
   // Socket-invalidated (bindApi); the interval is only the socketless heartbeat.
   const { data: detail, error } = useQuery({
@@ -582,6 +598,8 @@ export function TaskDrawer({
 
     return () => window.removeEventListener('keydown', onKey)
   }, [id, onClose])
+
+  useEffect(() => setActiveTab('overview'), [id])
 
   const invalidate = () => {
     void qc.invalidateQueries({ queryKey: taskKey(slug, id!) })
@@ -673,6 +691,17 @@ export function TaskDrawer({
     moveMut.mutate(status)
   }
 
+  const currentSummary = task?.latest_summary && !isAdminSummary(task.latest_summary) ? task.latest_summary : null
+  const currentState = task?.result ?? currentSummary
+
+  const tabStats = drawerTabStats({
+    comments: detail?.comments.length ?? 0,
+    events: detail?.events.length ?? 0,
+    hasLog: !!(log?.exists && log.content),
+    running,
+    runs: detail?.runs.length ?? 0
+  })
+
   return (
     <div className="absolute inset-y-0 right-0 z-20 flex w-[26rem] flex-col border-l border-(--ui-stroke-tertiary) bg-(--ui-bg-elevated) duration-150 ease-out animate-in fade-in slide-in-from-right-4">
       <header className="flex flex-col gap-2 px-4 pt-3.5 pb-3">
@@ -741,50 +770,79 @@ export function TaskDrawer({
           </div>
         </div>
         {task && (
-          <h2 className="text-sm leading-snug font-semibold text-foreground" data-selectable-text="true">
-            {task.title || task.id}
-          </h2>
+          <>
+            <h2 className="text-base leading-snug font-semibold text-foreground" data-selectable-text="true">
+              {task.title || task.id}
+            </h2>
+            <div className="flex min-w-0 items-center gap-1.5 text-[0.6875rem] text-(--ui-text-tertiary)">
+              {task.assignee && (
+                <>
+                  <Avatar name={task.assignee} size="1rem" />
+                  <span className="truncate">{task.assignee}</span>
+                </>
+              )}
+              {typeof task.priority === 'number' && (
+                <span>
+                  · {k.metaPriority} {task.priority}
+                </span>
+              )}
+              {ago(task.created_at) && <span className="ml-auto shrink-0">{ago(task.created_at)}</span>}
+            </div>
+          </>
         )}
       </header>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4" data-selectable-text="true">
+      {task && (
+        <Tabs className="gap-0" onValueChange={value => setActiveTab(value as DrawerTab)} value={activeTab}>
+          <TabsList aria-label={k.details} variant="line">
+            <TabsTrigger value="overview" variant="line">
+              {k.tabOverview}
+            </TabsTrigger>
+            <TabsTrigger value="timeline" variant="line">
+              {k.tabTimeline}
+              {tabStats.timelineCount > 0 && (
+                <span className="text-[0.625rem] font-normal text-(--ui-text-quaternary)">
+                  {tabStats.timelineCount}
+                </span>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="execution" variant="line">
+              {k.tabExecution}
+              {tabStats.executionLive ? (
+                <span aria-label={k.working} className="text-[0.625rem] text-(--ui-accent)">
+                  ●
+                </span>
+              ) : tabStats.executionCount > 0 ? (
+                <span className="text-[0.625rem] font-normal text-(--ui-text-quaternary)">
+                  {tabStats.executionCount}
+                </span>
+              ) : null}
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4" data-selectable-text="true">
         {errorMessage ? (
           <ErrorState title={errorMessage} />
         ) : !detail || !task ? (
           <div className="grid h-32 place-items-center">
             <Loader type="lemniscate-bloom" />
           </div>
-        ) : (
-          <div className="flex flex-col gap-4 text-sm">
-            <div className="grid grid-cols-[6rem_minmax(0,1fr)] gap-x-3 gap-y-1 text-[0.71rem]">
-              <MetaRow label={k.assignee}>
-                <AssigneeMenu
-                  current={task.assignee}
-                  onReassign={profile => void mutate(() => reassignTask(task.id, profile))()}
-                />
-              </MetaRow>
-              {typeof task.priority === 'number' && <MetaRow label={k.metaPriority}>{task.priority}</MetaRow>}
-              {task.tenant && <MetaRow label={k.metaTenant}>{task.tenant}</MetaRow>}
-              {task.workspace_path && (
-                <MetaRow label={k.workspace}>
-                  {task.workspace_kind ? `${task.workspace_kind}: ` : ''}
-                  {task.workspace_path}
-                </MetaRow>
-              )}
-              <MetaRow label={k.model}>
-                <ModelOverrideField
-                  onChange={next => void mutate(() => patchTask(task.id, overridePatch(next)))()}
-                  value={{
-                    effort: task.reasoning_effort ?? '',
-                    model: task.model_override ?? '',
-                    provider: task.provider_override ?? ''
-                  }}
-                />
-              </MetaRow>
-              {task.created_by && <MetaRow label={k.metaCreatedBy}>{task.created_by}</MetaRow>}
-              {ago(task.created_at) && <MetaRow label={k.metaCreated}>{ago(task.created_at)}</MetaRow>}
-              {running && task.worker_pid ? <MetaRow label={k.metaWorkerPid}>{task.worker_pid}</MetaRow> : null}
-            </div>
+        ) : activeTab === 'overview' ? (
+          <div className="flex flex-col gap-5 text-sm">
+            {currentState && (
+              <DrawerSection label={k.currentState}>
+                <p className="whitespace-pre-wrap text-[0.8125rem] leading-relaxed text-(--ui-text-secondary)">
+                  {currentState}
+                </p>
+                {task.result && currentSummary && (
+                  <p className="whitespace-pre-wrap text-[0.75rem] leading-relaxed text-(--ui-text-tertiary)">
+                    {currentSummary}
+                  </p>
+                )}
+              </DrawerSection>
+            )}
 
             {task.status === 'ready' && !task.assignee && !defaultAssignee && (
               <Callout title={k.readyUnassignedTitle} tone={SEVERITY_TONE.warning}>
@@ -793,29 +851,49 @@ export function TaskDrawer({
             )}
 
             {task.diagnostics && task.diagnostics.length > 0 && (
-              <Section label={k.diagnosticsN(task.diagnostics.length)}>
+              <DrawerSection label={k.diagnosticsN(task.diagnostics.length)}>
                 <Diagnostics items={task.diagnostics} onReclaim={() => void mutate(() => reclaimTask(task.id))()} />
-              </Section>
+              </DrawerSection>
             )}
 
             <DescriptionSection body={task.body} onSave={body => void mutate(() => patchTask(task.id, { body }))()} />
 
+            <DrawerSection label={k.details}>
+              <div className="grid grid-cols-[6rem_minmax(0,1fr)] gap-x-3 gap-y-1.5 text-[0.71rem]">
+                <MetaRow label={k.assignee}>
+                  <AssigneeMenu
+                    current={task.assignee}
+                    onReassign={profile => void mutate(() => reassignTask(task.id, profile))()}
+                  />
+                </MetaRow>
+                {typeof task.priority === 'number' && <MetaRow label={k.metaPriority}>{task.priority}</MetaRow>}
+                {task.tenant && <MetaRow label={k.metaTenant}>{task.tenant}</MetaRow>}
+                {task.workspace_path && (
+                  <MetaRow label={k.workspace}>
+                    {task.workspace_kind ? `${task.workspace_kind}: ` : ''}
+                    {task.workspace_path}
+                  </MetaRow>
+                )}
+                <MetaRow label={k.model}>
+                  <ModelOverrideField
+                    onChange={next => void mutate(() => patchTask(task.id, overridePatch(next)))()}
+                    value={{
+                      effort: task.reasoning_effort ?? '',
+                      model: task.model_override ?? '',
+                      provider: task.provider_override ?? ''
+                    }}
+                  />
+                </MetaRow>
+                {task.created_by && <MetaRow label={k.metaCreatedBy}>{task.created_by}</MetaRow>}
+                {ago(task.created_at) && <MetaRow label={k.metaCreated}>{ago(task.created_at)}</MetaRow>}
+                {running && task.worker_pid ? <MetaRow label={k.metaWorkerPid}>{task.worker_pid}</MetaRow> : null}
+              </div>
+            </DrawerSection>
+
             <EstimateSection id={task.id} />
 
-            {task.result && (
-              <Section label={k.result}>
-                <p className="whitespace-pre-wrap text-[0.8125rem] text-(--ui-text-secondary)">{task.result}</p>
-              </Section>
-            )}
-
-            {task.latest_summary && !isAdminSummary(task.latest_summary) && (
-              <Section label={k.latestSummary}>
-                <p className="whitespace-pre-wrap text-[0.8125rem] text-(--ui-text-secondary)">{task.latest_summary}</p>
-              </Section>
-            )}
-
             {(detail.links.parents.length > 0 || detail.links.children.length > 0) && (
-              <Section label={k.dependencies}>
+              <DrawerSection label={k.dependencies}>
                 {(['parents', 'children'] as const).map(side =>
                   detail.links[side].length > 0 ? (
                     <div className="flex flex-wrap items-center gap-1.5" key={side}>
@@ -835,114 +913,7 @@ export function TaskDrawer({
                     </div>
                   ) : null
                 )}
-              </Section>
-            )}
-
-            <Section
-              action={
-                <Tip label={running ? k.commentsHelpRunning : k.commentsHelp}>
-                  <span className="grid size-5 place-items-center rounded text-(--ui-text-quaternary) hover:text-(--ui-text-secondary)">
-                    <Codicon name="question" size="0.8rem" />
-                  </span>
-                </Tip>
-              }
-              label={k.comments(detail.comments.length)}
-            >
-              {detail.comments.length > 0 && (
-                <ul className="flex flex-col gap-2">
-                  {detail.comments.map(comment => (
-                    <li className="text-[0.75rem]" key={comment.id}>
-                      <span className="font-medium text-(--ui-text-secondary)">{comment.author}</span>
-                      <span className="ml-2 text-[0.625rem] text-(--ui-text-quaternary)">
-                        {ago(comment.created_at)}
-                      </span>
-                      <p className="whitespace-pre-wrap text-(--ui-text-tertiary)">{comment.body}</p>
-                    </li>
-                  ))}
-                </ul>
-              )}
-              <CommentComposer
-                onRequeue={body => requeueMut.mutate(body)}
-                onSubmit={body => commentMut.mutate(body)}
-                pending={commentMut.isPending || requeueMut.isPending}
-                running={running}
-              />
-            </Section>
-
-            {detail.events.length > 0 && (
-              <Section label={k.activity(detail.events.length)}>
-                <ScrollFade deps={detail.events.length} max="7rem">
-                  <ul className="flex flex-col gap-1">
-                    {detail.events.map(event => {
-                      const { detail: extra, label } = eventText(event, k)
-
-                      return (
-                        <li className="flex items-baseline gap-2 text-[0.6875rem]" key={event.id}>
-                          <span className="shrink-0 text-(--ui-text-secondary)">{label}</span>
-                          {extra && (
-                            <span
-                              className="min-w-0 truncate text-[0.625rem] text-(--ui-text-quaternary)"
-                              title={extra}
-                            >
-                              {extra}
-                            </span>
-                          )}
-                          <span className="ml-auto shrink-0 text-(--ui-text-quaternary)">{ago(event.created_at)}</span>
-                        </li>
-                      )
-                    })}
-                  </ul>
-                </ScrollFade>
-              </Section>
-            )}
-
-            {detail.runs.length > 0 && (
-              <Section label={k.runs(detail.runs.length)}>
-                <ScrollFade max="11rem">
-                  <ul className="flex flex-col gap-1.5">
-                    {detail.runs.map(run => {
-                      const failed = ['crashed', 'failed', 'timed_out', 'gave_up'].includes(run.outcome ?? run.status)
-
-                      return (
-                        <li className="flex flex-col gap-0.5 text-[0.71rem]" key={run.id}>
-                          <div className="flex items-center gap-2">
-                            <Badge size="xs" variant={failed ? 'destructive' : 'muted'}>
-                              {run.outcome ?? run.status}
-                            </Badge>
-                            {run.profile && <span className="text-(--ui-text-tertiary)">{run.profile}</span>}
-                            {duration(run.started_at, run.ended_at) && (
-                              <span className="text-(--ui-text-quaternary)">
-                                {duration(run.started_at, run.ended_at)}
-                              </span>
-                            )}
-                            <span className="ml-auto shrink-0 text-(--ui-text-quaternary)">
-                              {ago(run.ended_at ?? run.started_at)}
-                            </span>
-                          </div>
-                          {(run.error || run.summary) && (
-                            <p
-                              className={cn(
-                                'line-clamp-2 whitespace-pre-wrap',
-                                run.error ? 'text-destructive' : 'text-(--ui-text-quaternary)'
-                              )}
-                            >
-                              {run.error ?? run.summary}
-                            </p>
-                          )}
-                        </li>
-                      )
-                    })}
-                  </ul>
-                </ScrollFade>
-              </Section>
-            )}
-
-            {log?.exists && log.content && (
-              <Section label={log.truncated ? k.workerLogTail : k.workerLog}>
-                <ScrollFade deps={log.content.length} max="12rem">
-                  <LogView className="border-0 px-0">{log.content}</LogView>
-                </ScrollFade>
-              </Section>
+              </DrawerSection>
             )}
 
             <AttachmentsSection
@@ -951,8 +922,134 @@ export function TaskDrawer({
               pending={uploadMut.isPending}
             />
           </div>
+        ) : activeTab === 'timeline' ? (
+          <div className="flex flex-col gap-5 text-sm">
+            {tabStats.timelineCount === 0 && (
+              <p className="py-6 text-center text-xs text-(--ui-text-quaternary)">{k.noTimeline}</p>
+            )}
+
+            {detail.comments.length > 0 && (
+              <DrawerSection
+                action={
+                  <Tip label={running ? k.commentsHelpRunning : k.commentsHelp}>
+                    <span className="grid size-5 place-items-center rounded text-(--ui-text-quaternary) hover:text-(--ui-text-secondary)">
+                      <Codicon name="question" size="0.8rem" />
+                    </span>
+                  </Tip>
+                }
+                label={k.comments(detail.comments.length)}
+              >
+                <ul className="flex flex-col gap-3">
+                  {detail.comments.map(comment => (
+                    <li
+                      className="border-b border-(--ui-stroke-tertiary) pb-3 text-[0.75rem] last:border-0 last:pb-0"
+                      key={comment.id}
+                    >
+                      <span className="font-medium text-(--ui-text-secondary)">{comment.author}</span>
+                      <span className="ml-2 text-[0.625rem] text-(--ui-text-quaternary)">
+                        {ago(comment.created_at)}
+                      </span>
+                      <p className="mt-1 whitespace-pre-wrap leading-relaxed text-(--ui-text-tertiary)">
+                        {comment.body}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              </DrawerSection>
+            )}
+
+            {detail.events.length > 0 && (
+              <DrawerSection label={k.activity(detail.events.length)}>
+                <ul className="relative ml-1 flex flex-col gap-3 border-l border-(--ui-stroke-tertiary) pl-4">
+                  {detail.events.map(event => {
+                    const { detail: extra, label } = eventText(event, k)
+
+                    return (
+                      <li
+                        className="relative text-[0.6875rem] before:absolute before:top-1.5 before:-left-[1.1875rem] before:size-1.5 before:rounded-full before:bg-(--ui-text-quaternary) before:ring-4 before:ring-(--ui-bg-elevated)"
+                        key={event.id}
+                      >
+                        <div className="flex items-baseline gap-2">
+                          <span className="text-(--ui-text-secondary)">{label}</span>
+                          <span className="ml-auto shrink-0 text-(--ui-text-quaternary)">{ago(event.created_at)}</span>
+                        </div>
+                        {extra && <p className="mt-0.5 text-(--ui-text-quaternary)">{extra}</p>}
+                      </li>
+                    )
+                  })}
+                </ul>
+              </DrawerSection>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-5 text-sm">
+            {detail.runs.length === 0 && !(log?.exists && log.content) && (
+              <p className="py-6 text-center text-xs text-(--ui-text-quaternary)">{k.noExecution}</p>
+            )}
+
+            {detail.runs.length > 0 && (
+              <DrawerSection label={k.runs(detail.runs.length)}>
+                <ul className="flex flex-col gap-3">
+                  {detail.runs.map(run => {
+                    const failed = ['crashed', 'failed', 'timed_out', 'gave_up'].includes(run.outcome ?? run.status)
+
+                    return (
+                      <li
+                        className="flex flex-col gap-1 border-b border-(--ui-stroke-tertiary) pb-3 text-[0.71rem] last:border-0 last:pb-0"
+                        key={run.id}
+                      >
+                        <div className="flex items-center gap-2">
+                          <Badge size="xs" variant={failed ? 'destructive' : 'muted'}>
+                            {run.outcome ?? run.status}
+                          </Badge>
+                          {run.profile && <span className="text-(--ui-text-tertiary)">{run.profile}</span>}
+                          {duration(run.started_at, run.ended_at) && (
+                            <span className="text-(--ui-text-quaternary)">
+                              {duration(run.started_at, run.ended_at)}
+                            </span>
+                          )}
+                          <span className="ml-auto shrink-0 text-(--ui-text-quaternary)">
+                            {ago(run.ended_at ?? run.started_at)}
+                          </span>
+                        </div>
+                        {(run.error || run.summary) && (
+                          <p
+                            className={cn(
+                              'line-clamp-3 whitespace-pre-wrap leading-relaxed',
+                              run.error ? 'text-destructive' : 'text-(--ui-text-quaternary)'
+                            )}
+                          >
+                            {run.error ?? run.summary}
+                          </p>
+                        )}
+                      </li>
+                    )
+                  })}
+                </ul>
+              </DrawerSection>
+            )}
+
+            {log?.exists && log.content && (
+              <DrawerSection label={log.truncated ? k.workerLogTail : k.workerLog}>
+                <ScrollFade deps={log.content.length} max="24rem">
+                  <LogView className="border-0 px-0">{log.content}</LogView>
+                </ScrollFade>
+              </DrawerSection>
+            )}
+          </div>
         )}
       </div>
+
+      {detail && task && (
+        <footer className="border-t border-(--ui-stroke-tertiary) px-3 py-2.5">
+          <CommentComposer
+            onRequeue={body => requeueMut.mutate(body)}
+            onSubmit={body => commentMut.mutate(body)}
+            pending={commentMut.isPending || requeueMut.isPending}
+            running={running}
+          />
+        </footer>
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -118,6 +118,13 @@ type KanbanMessages = {
   evtReprioritized: (priority: string) => string
   someone: string
   // drawer — meta + sections
+  tabOverview: string
+  tabTimeline: string
+  tabExecution: string
+  currentState: string
+  details: string
+  noTimeline: string
+  noExecution: string
   metaPriority: string
   metaTenant: string
   metaCreatedBy: string
@@ -318,6 +325,13 @@ export const en: KanbanMessages = {
   evtArchived: 'archived',
   evtReprioritized: priority => `priority set to ${priority}`,
   someone: 'someone',
+  tabOverview: 'Overview',
+  tabTimeline: 'Timeline',
+  tabExecution: 'Execution',
+  currentState: 'Current state',
+  details: 'Details',
+  noTimeline: 'No comments or activity yet.',
+  noExecution: 'No runs or worker log yet.',
   metaPriority: 'Priority',
   metaTenant: 'Tenant',
   metaCreatedBy: 'Created by',
@@ -519,6 +533,13 @@ const ja: KanbanMessages = {
   evtArchived: 'アーカイブ済み',
   evtReprioritized: priority => `優先度を ${priority} に設定`,
   someone: '誰か',
+  tabOverview: '概要',
+  tabTimeline: '履歴',
+  tabExecution: '実行',
+  currentState: '現在の状況',
+  details: '詳細',
+  noTimeline: 'コメントやアクティビティはまだありません。',
+  noExecution: '実行履歴やワーカーログはまだありません。',
   metaPriority: '優先度',
   metaTenant: 'テナント',
   metaCreatedBy: '作成者',
@@ -719,6 +740,13 @@ const zh: KanbanMessages = {
   evtArchived: '已归档',
   evtReprioritized: priority => `优先级设为 ${priority}`,
   someone: '某人',
+  tabOverview: '概览',
+  tabTimeline: '时间线',
+  tabExecution: '执行',
+  currentState: '当前状态',
+  details: '详细信息',
+  noTimeline: '暂无评论或活动。',
+  noExecution: '暂无运行记录或工作单元日志。',
   metaPriority: '优先级',
   metaTenant: '租户',
   metaCreatedBy: '创建者',
@@ -917,6 +945,13 @@ const zhHant: KanbanMessages = {
   evtArchived: '已封存',
   evtReprioritized: priority => `優先順序設為 ${priority}`,
   someone: '某人',
+  tabOverview: '概覽',
+  tabTimeline: '時間軸',
+  tabExecution: '執行',
+  currentState: '目前狀態',
+  details: '詳細資訊',
+  noTimeline: '尚無留言或活動。',
+  noExecution: '尚無執行記錄或工作單元日誌。',
   metaPriority: '優先順序',
   metaTenant: '租戶',
   metaCreatedBy: '建立者',

--- a/apps/desktop/src/plugins/kanban/ui.tsx
+++ b/apps/desktop/src/plugins/kanban/ui.tsx
@@ -3,6 +3,7 @@
 
 import {
   atom,
+  cn,
   coarseElapsed,
   Codicon,
   DropdownMenu,
@@ -231,11 +232,27 @@ export function StatusMenu({
 // create dialog's Field, and the orchestration panel all read identically.
 export const FIELD_LABEL = 'text-[0.62rem] font-semibold uppercase tracking-[0.14em] text-(--ui-text-quaternary)'
 
-export function Section({ action, children, label }: { action?: ReactNode; children: ReactNode; label: string }) {
+export function Section({
+  action,
+  children,
+  label,
+  variant = 'field'
+}: {
+  action?: ReactNode
+  children: ReactNode
+  label: string
+  variant?: 'drawer' | 'field'
+}) {
+  const isDrawer = variant === 'drawer'
+
   return (
-    <section className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between">
-        <div className={FIELD_LABEL}>{label}</div>
+    <section className={cn('flex flex-col', isDrawer ? 'gap-2' : 'gap-1.5')}>
+      <div className={cn('flex items-center justify-between', isDrawer && 'gap-3')}>
+        {isDrawer ? (
+          <h3 className="text-xs font-semibold text-(--ui-text-secondary)">{label}</h3>
+        ) : (
+          <div className={FIELD_LABEL}>{label}</div>
+        )}
         {action}
       </div>
       {children}

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1294,7 +1294,7 @@ export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 export { Separator } from '@/components/ui/separator'
 export { Skeleton } from '@/components/ui/skeleton'
 export { Switch } from '@/components/ui/switch'
-export { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+export { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 export { Textarea } from '@/components/ui/textarea'
 export { Tip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 export type { GatewayEventListener } from '@/contrib/events'


### PR DESCRIPTION
## Summary

Reworks the Desktop Kanban task drawer from a single long event stream into an operator-focused task record.

- Adds Overview, Timeline, and Execution tabs, keeping status/current state and the task description first.
- Groups comments and activity into Timeline; runs and worker logs into Execution.
- Keeps the comment/requeue composer permanently reachable at the drawer footer.
- Adds a reusable flat line variant to the existing Tabs primitives and tests its behavior.
- Preserves existing task actions, metadata editing, diagnostics, dependencies, attachments, requeueing, and model overrides.

## Validation

- `npm run test:ui -- src/plugins/kanban/drawer-layout.test.ts src/components/ui/tabs.test.tsx src/plugins/kanban/model-override.test.tsx` (14 passed)
- `npm run typecheck`
- ESLint and Prettier checks on all touched TypeScript/TSX files
- `npm run build`
- Manual desktop validation with an isolated Electron user-data copy: opened a live task, switched Overview / Timeline / Execution, and checked a 655px-wide window for overflow and the fixed composer.

The full UI suite has four locale-sensitive failures that reproduce unchanged on current `origin/main`; they are unrelated to this drawer change.

## Platform tested

- Fedora Linux 44 (Workstation Edition), x86_64 — Electron Desktop
