### PR TITLE
feat(models): add Inkling free models to OpenRouter catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -134,6 +134,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
     ("stealth/ox-alpha",                       "free"),  # "Ox Alpha" stealth reasoning model — 1M ctx
+    ("thinkingmachines/inkling:free",          "free"),
+    ("thinkingmachines/inkling-small:free",    "free"),
     ("openrouter/elephant-alpha",              "free"),
     ("z-ai/glm-5.2:free",                      "free"),
     ("poolside/laguna-s-2.1:free",             "free"),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-21T20:49:36Z",
+  "updated_at": "2026-08-23T21:41:06Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -155,6 +155,14 @@
         },
         {
           "id": "stealth/ox-alpha",
+          "description": "free"
+        },
+        {
+          "id": "thinkingmachines/inkling:free",
+          "description": "free"
+        },
+        {
+          "id": "thinkingmachines/inkling-small:free",
           "description": "free"
         },
         {


### PR DESCRIPTION
## Summary

Adds OpenRouter’s free Thinking Machines Inkling routes to Hermes’ curated model picker:

- `thinkingmachines/inkling:free`
- `thinkingmachines/inkling-small:free`

Both routes are live in OpenRouter’s `/api/v1/models`, priced at zero for input and output, and advertise tool-calling support. This is related to #67726, which adds the separate paid `thinkingmachines/inkling` route; OpenRouter exposes the `:free` routes as distinct model IDs, so they require their own curated entries.

## Changes

- Added both routes to the `OPENROUTER_MODELS` free tier in `hermes_cli/models.py`
- Regenerated `website/static/api/model-catalog.json` with `scripts/build_model_catalog.py`

No context or reasoning-timeout override is needed: both free routes publish a 262,144-token context window through OpenRouter’s live catalog.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_models.py -q` — 98 passed
- Seeded a temporary Hermes catalog cache from the generated manifest and exercised `fetch_openrouter_models(force_refresh=True)` against OpenRouter’s live API; both routes survived the real tool-support/free-pricing picker filter
- `git diff --check` — clean

Tested on macOS.