### PR TITLE
fix(browser): recover Camofox stale tabs on HTTP 410 Gone

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -381,6 +381,156 @@ class TestCamofoxVisionConfig:
 
 
 # ---------------------------------------------------------------------------
+# Stale tab 404/410 cleanup — sibling ops clear tab_id so navigate recovers
+# (#54729 follow-up + #80276). No blind action replay.
+# ---------------------------------------------------------------------------
+
+
+def _mock_stale_response(status_code: int):
+    """Build a requests.Response that raises HTTPError for stale-tab codes."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {}
+    resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+    return resp
+
+
+class TestStaleTabCleanup:
+    """404 GC and 410 post-restart must clear cached tab_id on sibling ops."""
+
+    def _setup_session(self, mock_post, monkeypatch, task_id):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(
+            json_data={"tabId": "stale-tab", "url": "https://x.com"}
+        )
+        camofox_navigate("https://x.com", task_id=task_id)
+
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_snapshot_clears_tab_on_404(self, mock_post, mock_get, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_snap")
+        mock_get.return_value = _mock_stale_response(404)
+        result = json.loads(camofox_snapshot(task_id="stale_snap"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_snap")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_snapshot_clears_tab_on_410(self, mock_post, mock_get, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_snap_410")
+        mock_get.return_value = _mock_stale_response(410)
+        result = json.loads(camofox_snapshot(task_id="stale_snap_410"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_snap_410")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_click_clears_tab_on_410(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_click")
+        mock_post.return_value = _mock_stale_response(410)
+        result = json.loads(camofox_click("e1", task_id="stale_click"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_click")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_type_clears_tab_on_404(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_type")
+        mock_post.return_value = _mock_stale_response(404)
+        result = json.loads(camofox_type("e1", "hello", task_id="stale_type"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_type")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_scroll_clears_tab_on_404(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_scroll")
+        mock_post.return_value = _mock_stale_response(404)
+        result = json.loads(camofox_scroll("down", task_id="stale_scroll"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_scroll")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_back_clears_tab_on_404(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_back")
+        mock_post.return_value = _mock_stale_response(404)
+        result = json.loads(camofox_back(task_id="stale_back"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_back")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_press_clears_tab_on_404(self, mock_post, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_press")
+        mock_post.return_value = _mock_stale_response(404)
+        result = json.loads(camofox_press("Enter", task_id="stale_press"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_press")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_get_images_clears_tab_on_404(self, mock_post, mock_get, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_img")
+        mock_get.return_value = _mock_stale_response(404)
+        result = json.loads(camofox_get_images(task_id="stale_img"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_img")["tab_id"] is None
+
+    @patch("tools.browser_camofox._get_raw")
+    @patch("tools.browser_camofox.requests.post")
+    def test_vision_clears_tab_on_410(self, mock_post, mock_get_raw, monkeypatch):
+        self._setup_session(mock_post, monkeypatch, "stale_vis")
+        mock_get_raw.side_effect = requests.HTTPError(
+            response=MagicMock(status_code=410),
+        )
+        result = json.loads(camofox_vision("what?", task_id="stale_vis"))
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_vis")["tab_id"] is None
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_non_stale_error_keeps_tab_id(self, mock_post, monkeypatch):
+        """A 500 must NOT clear tab_id — only 404/410 trigger cleanup."""
+        self._setup_session(mock_post, monkeypatch, "stale_500")
+        mock_post.return_value = _mock_stale_response(500)
+        result = json.loads(camofox_click("e1", task_id="stale_500"))
+        assert result["success"] is False
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_500")["tab_id"] == "stale-tab"
+
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_navigate_recovers_after_sibling_clears_tab(self, mock_post, mock_get, monkeypatch):
+        """After click clears a stale tab, navigate creates a fresh one."""
+        self._setup_session(mock_post, monkeypatch, "stale_recover")
+        mock_post.return_value = _mock_stale_response(410)
+        camofox_click("e1", task_id="stale_recover")
+
+        mock_post.return_value = _mock_response(
+            json_data={"tabId": "fresh-tab", "url": "https://y.com"}
+        )
+        mock_get.return_value = _mock_response(json_data={"snapshot": "", "refsCount": 0})
+        result = json.loads(camofox_navigate("https://y.com", task_id="stale_recover"))
+        assert result["success"] is True
+        assert result["url"] == "https://y.com"
+        from tools.browser_camofox import _get_session
+        assert _get_session("stale_recover")["tab_id"] == "fresh-tab"
+
+
+# ---------------------------------------------------------------------------
 # Routing integration — verify browser_tool routes to camofox
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -1,6 +1,8 @@
 """Tests for the Camofox browser backend."""
 
 import json
+
+import requests
 from unittest.mock import MagicMock, patch
 
 
@@ -112,6 +114,47 @@ class TestCamofoxNavigate:
         result = json.loads(camofox_navigate("https://example.com", task_id="t_err"))
         assert result["success"] is False
         assert "Cannot connect" in result["error"]
+
+    def test_stale_tab_410_recreates_tab(self, monkeypatch):
+        """HTTP 410 Gone after camofox-browser restart must recover like 404 (#80276)."""
+        import tools.browser_camofox as mod
+
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        with mod._sessions_lock:
+            mod._sessions["t_410"] = {
+                "user_id": "hermes_test",
+                "tab_id": "dead-tab",
+                "session_key": "task_t_410",
+                "managed": False,
+                "adopt_existing_tab": False,
+            }
+
+        gone = requests.HTTPError("410 Gone")
+        gone.response = MagicMock(status_code=410)
+        navigate_calls: list[str] = []
+
+        def _post_side_effect(path, body=None, **kwargs):
+            navigate_calls.append(path)
+            if path == "/tabs/dead-tab/navigate":
+                raise gone
+            return {"ok": True, "url": (body or {}).get("url", "")}
+
+        def _ensure_tab(task_id, url="about:blank"):
+            session = mod._get_session(task_id)
+            session["tab_id"] = "fresh-tab"
+            return session
+
+        with patch.object(mod, "_post", side_effect=_post_side_effect), \
+             patch.object(mod, "_get", return_value={"snapshot": "", "refsCount": 0}), \
+             patch.object(mod, "_ensure_tab", side_effect=_ensure_tab) as mock_ensure:
+            result = json.loads(camofox_navigate("https://example.com/next", task_id="t_410"))
+
+        assert result["success"] is True
+        assert "/tabs/dead-tab/navigate" in navigate_calls
+        mock_ensure.assert_called()
+        with mod._sessions_lock:
+            assert mod._sessions["t_410"]["tab_id"] == "fresh-tab"
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -150,10 +150,44 @@ class TestCamofoxNavigate:
             result = json.loads(camofox_navigate("https://example.com/next", task_id="t_410"))
 
         assert result["success"] is True
-        assert "/tabs/dead-tab/navigate" in navigate_calls
+        assert navigate_calls[0] == "/tabs/dead-tab/navigate"
+        assert navigate_calls[1] == "/tabs/fresh-tab/navigate"
+        assert result["url"] == "https://example.com/next"
         mock_ensure.assert_called()
         with mod._sessions_lock:
             assert mod._sessions["t_410"]["tab_id"] == "fresh-tab"
+
+    def test_navigate_posts_to_adopted_tab(self, monkeypatch):
+        """Adopted tabs must receive the requested /navigate, not a synthesized URL."""
+        import tools.browser_camofox as mod
+
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        with mod._sessions_lock:
+            mod._sessions["t_adopt"] = {
+                "user_id": "hermes_test",
+                "tab_id": "adopted-tab",
+                "session_key": "task_t_adopt",
+                "managed": True,
+                "adopt_existing_tab": True,
+            }
+
+        posts: list[tuple[str, str]] = []
+
+        def _post_side_effect(path, body=None, **kwargs):
+            posts.append((path, (body or {}).get("url", "")))
+            return {"ok": True, "url": (body or {}).get("url", ""), "title": "live"}
+
+        with patch.object(mod, "_post", side_effect=_post_side_effect), \
+             patch.object(mod, "_get", return_value={"snapshot": "", "refsCount": 0}), \
+             patch.object(mod, "_ensure_tab") as mock_ensure:
+            result = json.loads(
+                camofox_navigate("https://example.com/target", task_id="t_adopt")
+            )
+
+        mock_ensure.assert_not_called()
+        assert posts == [("/tabs/adopted-tab/navigate", "https://example.com/target")]
+        assert result["success"] is True
+        assert result["url"] == "https://example.com/target"
 
 
 
@@ -528,6 +562,130 @@ class TestStaleTabCleanup:
         assert result["url"] == "https://y.com"
         from tools.browser_camofox import _get_session
         assert _get_session("stale_recover")["tab_id"] == "fresh-tab"
+
+    @patch("tools.browser_camofox.requests.get")
+    @patch("tools.browser_camofox.requests.post")
+    def test_bonus_snapshot_410_clears_tab_after_successful_navigate(
+        self, mock_post, mock_get, monkeypatch
+    ):
+        """Post-navigation bonus snapshot must invalidate a tab that dies mid-call."""
+        mock_get.return_value = _mock_response(json_data={"snapshot": "", "refsCount": 0})
+        self._setup_session(mock_post, monkeypatch, "bonus_snap")
+        mock_post.return_value = _mock_response(
+            json_data={"ok": True, "url": "https://y.com", "title": ""}
+        )
+        mock_get.return_value = _mock_stale_response(410)
+        result = json.loads(camofox_navigate("https://y.com", task_id="bonus_snap"))
+        assert result["success"] is True
+        from tools.browser_camofox import _get_session
+        assert _get_session("bonus_snap")["tab_id"] is None
+
+    @patch("tools.browser_camofox._get")
+    @patch("tools.browser_camofox._get_raw")
+    @patch("tools.browser_camofox.requests.post")
+    def test_vision_annotation_snapshot_410_clears_tab(
+        self, mock_post, mock_get_raw, mock_get, monkeypatch, tmp_path
+    ):
+        mock_get.return_value = {"snapshot": "", "refsCount": 0}
+        self._setup_session(mock_post, monkeypatch, "vis_ann")
+        mock_get_raw.return_value = MagicMock(content=b"\x89PNG\r\n\x1a\nfake")
+        mock_get.side_effect = requests.HTTPError(
+            response=MagicMock(status_code=410, json=lambda: {}),
+        )
+        llm = MagicMock()
+        llm.choices = [MagicMock(message=MagicMock(content="ok"))]
+        with patch("hermes_constants.get_hermes_home", return_value=tmp_path), \
+             patch("agent.auxiliary_client.call_llm", return_value=llm), \
+             patch("agent.redact.redact_sensitive_text", side_effect=lambda s: s):
+            result = json.loads(
+                camofox_vision("what?", annotate=True, task_id="vis_ann")
+            )
+        assert result["success"] is True
+        from tools.browser_camofox import _get_session
+        assert _get_session("vis_ann")["tab_id"] is None
+
+
+class TestCamofoxEvalStaleVsCapability:
+    def _session(self, monkeypatch, task_id="eval_t"):
+        import tools.browser_camofox as mod
+
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        session = {
+            "user_id": "hermes_test",
+            "tab_id": "eval-tab",
+            "session_key": f"task_{task_id}",
+            "managed": False,
+            "adopt_existing_tab": False,
+        }
+        with mod._sessions_lock:
+            mod._sessions[task_id] = session
+        return session
+
+    def test_eval_410_clears_tab_and_asks_navigate(self, monkeypatch):
+        from tools.browser_tool import _camofox_eval
+        import tools.browser_camofox as mod
+
+        session = self._session(monkeypatch)
+        gone = requests.HTTPError("410 Gone")
+        gone.response = MagicMock(status_code=410, json=lambda: {"recovery": "create_new_tab"})
+
+        with patch.object(mod, "_ensure_tab", return_value=session), \
+             patch.object(mod, "_post", side_effect=gone):
+            result = json.loads(_camofox_eval("1+1", task_id="eval_t"))
+
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        assert session["tab_id"] is None
+
+    def test_eval_404_without_tab_payload_is_capability(self, monkeypatch):
+        from tools.browser_tool import _camofox_eval
+        import tools.browser_camofox as mod
+
+        session = self._session(monkeypatch, "eval_cap")
+        missing = requests.HTTPError("404")
+        missing.response = MagicMock(status_code=404, json=lambda: {}, text="Not Found")
+
+        with patch.object(mod, "_ensure_tab", return_value=session), \
+             patch.object(mod, "_post", side_effect=missing):
+            result = json.loads(_camofox_eval("1+1", task_id="eval_cap"))
+
+        assert result["success"] is False
+        assert "not supported" in result["error"]
+        assert session["tab_id"] == "eval-tab"
+
+    def test_eval_404_tab_missing_payload_is_stale(self, monkeypatch):
+        from tools.browser_tool import _camofox_eval
+        import tools.browser_camofox as mod
+
+        session = self._session(monkeypatch, "eval_miss")
+        missing = requests.HTTPError("404")
+        missing.response = MagicMock(
+            status_code=404,
+            json=lambda: {"code": "tab_destroyed", "recovery": "create_new_tab"},
+            text="tab destroyed",
+        )
+
+        with patch.object(mod, "_ensure_tab", return_value=session), \
+             patch.object(mod, "_post", side_effect=missing):
+            result = json.loads(_camofox_eval("1+1", task_id="eval_miss"))
+
+        assert result["success"] is False
+        assert "browser_navigate" in result["error"]
+        assert session["tab_id"] is None
+
+    def test_ssrf_probe_410_clears_tab(self, monkeypatch):
+        from tools.browser_tool import _camofox_current_page_private_url
+        import tools.browser_camofox as mod
+
+        session = self._session(monkeypatch, "probe_t")
+        gone = requests.HTTPError("410 Gone")
+        gone.response = MagicMock(status_code=410, json=lambda: {})
+
+        with patch.object(mod, "_post", side_effect=gone):
+            assert _camofox_current_page_private_url(
+                "eval-tab", "hermes_test", session=session
+            ) is None
+        assert session["tab_id"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -301,6 +301,7 @@ class TestConfiguredCamofoxIdentity:
         with mod._sessions_lock:
             assert "task-1" not in mod._sessions
 
+
 class TestVncUrlDiscovery:
     """VNC URL is derived from the Camofox health endpoint."""
 

--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -102,9 +102,22 @@ class TestManagedPersistenceMode:
         requests_seen = []
 
         def _capture_post(url, json=None, timeout=None, headers=None):
-            requests_seen.append(json)
+            requests_seen.append((url, json))
+            if url.endswith("/tabs"):
+                tab_count = sum(
+                    1 for request_url, _ in requests_seen if request_url.endswith("/tabs")
+                )
+                return _mock_response(
+                    json_data={
+                        "tabId": f"tab-{tab_count}",
+                        "url": "https://example.com",
+                    }
+                )
             return _mock_response(
-                json_data={"tabId": f"tab-{len(requests_seen)}", "url": "https://example.com"}
+                json_data={
+                    "url": (json or {}).get("url", ""),
+                    "title": "live",
+                }
             )
 
         with (
@@ -118,9 +131,25 @@ class TestManagedPersistenceMode:
 
         assert first["success"] is True
         assert second["success"] is True
-        tab_requests = [req for req in requests_seen if "userId" in req]
+        tab_requests = [
+            body for request_url, body in requests_seen if request_url.endswith("/tabs")
+        ]
+        navigate_requests = [
+            (request_url, body)
+            for request_url, body in requests_seen
+            if request_url.endswith("/navigate")
+        ]
         assert len(tab_requests) == 2
+        assert len(navigate_requests) == 2
         assert tab_requests[0]["userId"] == tab_requests[1]["userId"]
+        assert [request_url for request_url, _ in navigate_requests] == [
+            "http://localhost:9377/tabs/tab-1/navigate",
+            "http://localhost:9377/tabs/tab-2/navigate",
+        ]
+        assert all(
+            body["userId"] == tab_requests[0]["userId"]
+            for _, body in navigate_requests
+        )
 
 
 class TestConfiguredCamofoxIdentity:
@@ -156,22 +185,36 @@ class TestConfiguredCamofoxIdentity:
                 patch("tools.browser_camofox.load_config", return_value=config),
                 patch(
                     "tools.browser_camofox.requests.post",
-                    return_value=_mock_response(json_data={"tabId": "scoped-tab"}),
+                    side_effect=[
+                        _mock_response(json_data={"tabId": "scoped-tab"}),
+                        _mock_response(
+                            json_data={
+                                "url": "https://example.com",
+                                "title": "live",
+                            }
+                        ),
+                    ],
                 ) as mock_post,
             ):
                 result = json.loads(
                     camofox_navigate("https://example.com", task_id="scoped-precedence")
                 )
-                request_url = mock_post.call_args.args[0]
-                request_body = mock_post.call_args.kwargs["json"]
+                create_call, navigate_call = mock_post.call_args_list
         finally:
             secret_scope.reset_secret_scope(token)
             secret_scope.set_multiplex_active(False)
 
         assert result["success"] is True
-        assert request_url == "https://secondary.example/tabs"
-        assert request_body["userId"] == "secondary-scope-user"
-        assert request_body["listItemId"] == "secondary-scope-session"
+        assert create_call.args[0] == "https://secondary.example/tabs"
+        assert create_call.kwargs["json"]["userId"] == "secondary-scope-user"
+        assert create_call.kwargs["json"]["listItemId"] == "secondary-scope-session"
+        assert navigate_call.args[0] == (
+            "https://secondary.example/tabs/scoped-tab/navigate"
+        )
+        assert navigate_call.kwargs["json"] == {
+            "userId": "secondary-scope-user",
+            "url": "https://example.com",
+        }
 
     def test_multiplex_scope_miss_uses_profile_config_not_process_env(
         self, tmp_path, monkeypatch
@@ -257,7 +300,6 @@ class TestConfiguredCamofoxIdentity:
         import tools.browser_camofox as mod
         with mod._sessions_lock:
             assert "task-1" not in mod._sessions
-
 
 class TestVncUrlDiscovery:
     """VNC URL is derived from the Camofox health endpoint."""

--- a/tests/tools/test_browser_camofox_private_page_guard.py
+++ b/tests/tools/test_browser_camofox_private_page_guard.py
@@ -31,7 +31,9 @@ def _block_active(monkeypatch):
 
     monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
     monkeypatch.setattr(
-        browser_tool, "_camofox_current_page_private_url", lambda tab_id, user_id: PRIVATE_URL
+        browser_tool,
+        "_camofox_current_page_private_url",
+        lambda tab_id, user_id, session=None: PRIVATE_URL,
     )
 
 
@@ -41,7 +43,7 @@ def _block_inactive_guard(monkeypatch):
 
     monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: False)
 
-    def fail_probe(tab_id, user_id):
+    def fail_probe(tab_id, user_id, session=None):
         raise AssertionError("must not probe page URL when the SSRF guard is inactive")
 
     monkeypatch.setattr(browser_tool, "_camofox_current_page_private_url", fail_probe)
@@ -52,7 +54,9 @@ def _public_page(monkeypatch):
 
     monkeypatch.setattr(browser_tool, "_eval_ssrf_guard_active", lambda task_id: True)
     monkeypatch.setattr(
-        browser_tool, "_camofox_current_page_private_url", lambda tab_id, user_id: None
+        browser_tool,
+        "_camofox_current_page_private_url",
+        lambda tab_id, user_id, session=None: None,
     )
 
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -507,6 +507,33 @@ def _delete(path: str, body: dict = None, timeout: Optional[int] = None) -> dict
     return resp.json()
 
 
+
+# Stale-tab recovery (#54729 follow-up + #80276):
+# - 404: tab GC'd by Camofox idle cleanup
+# - 410 Gone: tab died with a previous camofox-browser process (container restart)
+# Navigate can recreate a tab (has a target URL). Sibling ops only clear the
+# cached id so the next browser_navigate is not stuck on a dead tab_id.
+_STALE_TAB_STATUSES = (404, 410)
+_STALE_TAB_ERROR = (
+    "Browser tab was garbage-collected by the Camofox server. "
+    "Call browser_navigate to open a new tab."
+)
+
+
+def _clear_stale_tab(session: Dict[str, Any], exc: requests.HTTPError) -> bool:
+    """If *exc* is a stale-tab 404/410, clear session tab_id and return True."""
+    if exc.response is not None and exc.response.status_code in _STALE_TAB_STATUSES:
+        logger.warning(
+            "Camofox tab %s returned %s — tab is gone (GC or server restart). "
+            "Clearing cached tab_id.",
+            session.get("tab_id"),
+            exc.response.status_code,
+        )
+        session["tab_id"] = None
+        return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Tool implementations
 # ---------------------------------------------------------------------------
@@ -521,7 +548,7 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             session = _ensure_tab(task_id, browser_url)
             data = {"ok": True, "url": browser_url}
         else:
-            # Navigate existing tab — recover from stale tab 404
+            # Navigate existing tab — recover from stale tab 404/410
             try:
                 data = _post(
                     f"/tabs/{session['tab_id']}/navigate",
@@ -529,18 +556,7 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                     timeout=60,
                 )
             except requests.HTTPError as e:
-                # 404: tab GC'd by Camofox. 410 Gone: tab died with a previous
-                # server/container process (common after camofox-browser restart).
-                # Either way the cached tab_id is unusable — clear and recreate
-                # (#80276).
-                if e.response is not None and e.response.status_code in (404, 410):
-                    logger.warning(
-                        "Camofox tab %s returned %s — tab was garbage collected. "
-                        "Creating a fresh tab.",
-                        session["tab_id"],
-                        e.response.status_code,
-                    )
-                    session["tab_id"] = None
+                if _clear_stale_tab(session, e):
                     session = _ensure_tab(task_id, browser_url)
                     data = {"ok": True, "url": browser_url}
                 else:
@@ -643,10 +659,15 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
         if blocked:
             return blocked
 
-        data = _get(
-            f"/tabs/{session['tab_id']}/snapshot",
-            params={"userId": session["user_id"]},
-        )
+        try:
+            data = _get(
+                f"/tabs/{session['tab_id']}/snapshot",
+                params={"userId": session["user_id"]},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
 
         snapshot = data.get("snapshot", "")
         refs_count = data.get("refsCount", 0)
@@ -687,10 +708,15 @@ def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
         # Strip @ prefix if present (our tool convention)
         clean_ref = ref.lstrip("@")
 
-        data = _post(
-            f"/tabs/{session['tab_id']}/click",
-            {"userId": session["user_id"], "ref": clean_ref},
-        )
+        try:
+            data = _post(
+                f"/tabs/{session['tab_id']}/click",
+                {"userId": session["user_id"], "ref": clean_ref},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         return json.dumps({
             "success": True,
             "clicked": clean_ref,
@@ -713,10 +739,15 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
 
         clean_ref = ref.lstrip("@")
 
-        _post(
-            f"/tabs/{session['tab_id']}/type",
-            {"userId": session["user_id"], "ref": clean_ref, "text": text},
-        )
+        try:
+            _post(
+                f"/tabs/{session['tab_id']}/type",
+                {"userId": session["user_id"], "ref": clean_ref, "text": text},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         from agent.display import (
             redact_browser_typed_text_for_display,
             redact_tool_args_for_display,
@@ -748,10 +779,15 @@ def camofox_scroll(direction: str, task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
-        _post(
-            f"/tabs/{session['tab_id']}/scroll",
-            {"userId": session["user_id"], "direction": direction},
-        )
+        try:
+            _post(
+                f"/tabs/{session['tab_id']}/scroll",
+                {"userId": session["user_id"], "direction": direction},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         return json.dumps({"success": True, "scrolled": direction})
     except Exception as e:
         return tool_error(str(e), success=False)
@@ -764,10 +800,15 @@ def camofox_back(task_id: Optional[str] = None) -> str:
         if not session["tab_id"]:
             return tool_error("No browser session. Call browser_navigate first.", success=False)
 
-        data = _post(
-            f"/tabs/{session['tab_id']}/back",
-            {"userId": session["user_id"]},
-        )
+        try:
+            data = _post(
+                f"/tabs/{session['tab_id']}/back",
+                {"userId": session["user_id"]},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         return json.dumps({"success": True, "url": data.get("url", "")})
     except Exception as e:
         return tool_error(str(e), success=False)
@@ -784,10 +825,15 @@ def camofox_press(key: str, task_id: Optional[str] = None) -> str:
         if blocked:
             return blocked
 
-        _post(
-            f"/tabs/{session['tab_id']}/press",
-            {"userId": session["user_id"], "key": key},
-        )
+        try:
+            _post(
+                f"/tabs/{session['tab_id']}/press",
+                {"userId": session["user_id"], "key": key},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         return json.dumps({"success": True, "pressed": key})
     except Exception as e:
         return tool_error(str(e), success=False)
@@ -825,10 +871,15 @@ def camofox_get_images(task_id: Optional[str] = None) -> str:
 
         import re
 
-        data = _get(
-            f"/tabs/{session['tab_id']}/snapshot",
-            params={"userId": session["user_id"]},
-        )
+        try:
+            data = _get(
+                f"/tabs/{session['tab_id']}/snapshot",
+                params={"userId": session["user_id"]},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
         snapshot = data.get("snapshot", "")
 
         # Parse img elements from the accessibility tree.
@@ -872,10 +923,15 @@ def camofox_vision(question: str, annotate: bool = False,
             return blocked
 
         # Get screenshot as binary PNG
-        resp = _get_raw(
-            f"/tabs/{session['tab_id']}/screenshot",
-            params={"userId": session["user_id"]},
-        )
+        try:
+            resp = _get_raw(
+                f"/tabs/{session['tab_id']}/screenshot",
+                params={"userId": session["user_id"]},
+            )
+        except requests.HTTPError as e:
+            if _clear_stale_tab(session, e):
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            raise
 
         # Save screenshot to cache
         from hermes_constants import get_hermes_home

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -508,11 +508,14 @@ def _delete(path: str, body: dict = None, timeout: Optional[int] = None) -> dict
 
 
 
-# Stale-tab recovery (#54729 follow-up + #80276):
-# - 404: tab GC'd by Camofox idle cleanup
-# - 410 Gone: tab died with a previous camofox-browser process (container restart)
-# Navigate can recreate a tab (has a target URL). Sibling ops only clear the
-# cached id so the next browser_navigate is not stuck on a dead tab_id.
+# Camofox reports a cached tab as gone with two status codes (same client
+# action — forget tab_id):
+# - 404: idle GC, or an id this server never issued
+# - 410 Gone: tab_destroyed / page_crashed / browser_restarted (camofox
+#   server.js; body includes recovery: "create_new_tab"). After a browser
+#   restart every cached tab_id is stale at once.
+# Navigate recreates a tab (has a target URL). Sibling ops only clear the
+# cached id so the next browser_navigate is not stuck.
 _STALE_TAB_STATUSES = (404, 410)
 _STALE_TAB_ERROR = (
     "Browser tab was garbage-collected by the Camofox server. "

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -529,11 +529,16 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                     timeout=60,
                 )
             except requests.HTTPError as e:
-                if e.response is not None and e.response.status_code == 404:
+                # 404: tab GC'd by Camofox. 410 Gone: tab died with a previous
+                # server/container process (common after camofox-browser restart).
+                # Either way the cached tab_id is unusable — clear and recreate
+                # (#80276).
+                if e.response is not None and e.response.status_code in (404, 410):
                     logger.warning(
-                        "Camofox tab %s returned 404 — tab was garbage collected. "
+                        "Camofox tab %s returned %s — tab was garbage collected. "
                         "Creating a fresh tab.",
                         session["tab_id"],
+                        e.response.status_code,
                     )
                     session["tab_id"] = None
                     session = _ensure_tab(task_id, browser_url)

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -510,31 +510,129 @@ def _delete(path: str, body: dict = None, timeout: Optional[int] = None) -> dict
 
 # Camofox reports a cached tab as gone with two status codes (same client
 # action — forget tab_id):
-# - 404: idle GC, or an id this server never issued
+# - 404: idle GC, or an id this server never issued (mandatory tab endpoints)
 # - 410 Gone: tab_destroyed / page_crashed / browser_restarted (camofox
 #   server.js; body includes recovery: "create_new_tab"). After a browser
 #   restart every cached tab_id is stale at once.
-# Navigate recreates a tab (has a target URL). Sibling ops only clear the
-# cached id so the next browser_navigate is not stuck.
+# Navigate POSTs /navigate to the resolved tab (has a target URL). Sibling
+# ops only clear the cached id so the next browser_navigate is not stuck.
+# /evaluate is optional: 404 without a tab-missing payload is "route not
+# found" on older servers (capability), not a stale tab.
 _STALE_TAB_STATUSES = (404, 410)
 _STALE_TAB_ERROR = (
     "Browser tab was garbage-collected by the Camofox server. "
     "Call browser_navigate to open a new tab."
 )
+_EVAL_CAPABILITY_ERROR = (
+    "JavaScript evaluation is not supported by this Camofox server. "
+    "Use browser_snapshot or browser_vision to inspect page state."
+)
+_TAB_MISSING_CODES = frozenset({
+    "tab_destroyed",
+    "page_crashed",
+    "tab_timeout",
+    "tab_not_found",
+    "unknown_tab",
+    "tab_gone",
+})
 
 
-def _clear_stale_tab(session: Dict[str, Any], exc: requests.HTTPError) -> bool:
-    """If *exc* is a stale-tab 404/410, clear session tab_id and return True."""
-    if exc.response is not None and exc.response.status_code in _STALE_TAB_STATUSES:
-        logger.warning(
-            "Camofox tab %s returned %s — tab is gone (GC or server restart). "
-            "Clearing cached tab_id.",
-            session.get("tab_id"),
-            exc.response.status_code,
-        )
-        session["tab_id"] = None
+def _http_error_payload(exc: BaseException) -> Dict[str, Any]:
+    resp = getattr(exc, "response", None)
+    if resp is None:
+        return {}
+    try:
+        data = resp.json()
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _payload_says_tab_missing(exc: BaseException) -> bool:
+    payload = _http_error_payload(exc)
+    if payload.get("recovery") == "create_new_tab":
         return True
-    return False
+    code = str(payload.get("code") or "")
+    if code in _TAB_MISSING_CODES:
+        return True
+    parts = [
+        payload.get("error"),
+        payload.get("message"),
+        payload.get("code"),
+    ]
+    resp = getattr(exc, "response", None)
+    if resp is not None and not any(parts):
+        try:
+            parts.append(resp.text)
+        except Exception:
+            pass
+    text = " ".join(str(p) for p in parts if p).lower()
+    return any(
+        token in text
+        for token in (
+            "tab not found",
+            "unknown tab",
+            "tab destroyed",
+            "no such tab",
+            "tab_destroyed",
+            "page_crashed",
+        )
+    )
+
+
+def classify_camofox_http_error(exc: BaseException, *, endpoint: str = "mandatory") -> str:
+    """Classify a Camofox HTTPError: ``stale``, ``capability``, or ``other``.
+
+    ``endpoint="evaluate"`` treats bare 404/405/501 as missing capability
+    unless the body says the tab itself is gone. Mandatory tab endpoints
+    treat every 404 as stale.
+    """
+    resp = getattr(exc, "response", None)
+    if not isinstance(exc, requests.HTTPError) or resp is None:
+        return "other"
+    try:
+        status = int(resp.status_code)
+    except (TypeError, ValueError):
+        return "other"
+    if status == 410:
+        return "stale"
+    if endpoint == "evaluate":
+        if status in (405, 501):
+            return "capability"
+        if status == 404:
+            return "stale" if _payload_says_tab_missing(exc) else "capability"
+        return "other"
+    if status == 404:
+        return "stale"
+    return "other"
+
+
+def _clear_stale_tab(
+    session: Dict[str, Any],
+    exc: BaseException,
+    *,
+    endpoint: str = "mandatory",
+) -> bool:
+    """If *exc* is a stale-tab error, clear session tab_id and return True."""
+    if classify_camofox_http_error(exc, endpoint=endpoint) != "stale":
+        return False
+    logger.warning(
+        "Camofox tab %s returned %s — tab is gone (GC or server restart). "
+        "Clearing cached tab_id.",
+        session.get("tab_id"),
+        getattr(getattr(exc, "response", None), "status_code", "?"),
+    )
+    session["tab_id"] = None
+    return True
+
+
+def _post_tab_navigate(session: Dict[str, Any], browser_url: str) -> dict:
+    """POST the target URL to the resolved tab. Never synthesize success."""
+    return _post(
+        f"/tabs/{session['tab_id']}/navigate",
+        {"userId": session["user_id"], "url": browser_url},
+        timeout=60,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -547,23 +645,17 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
         browser_url, rewrite_info = _rewrite_loopback_url_for_camofox(url)
         session = _get_session(task_id)
         if not session["tab_id"]:
-            # Create tab with the target URL directly
+            # Create or adopt a tab. Adoption can attach to an already-open
+            # tab that is not at *browser_url*, so success always comes from
+            # a real /navigate (or a retry after stale-tab recovery).
             session = _ensure_tab(task_id, browser_url)
-            data = {"ok": True, "url": browser_url}
-        else:
-            # Navigate existing tab — recover from stale tab 404/410
-            try:
-                data = _post(
-                    f"/tabs/{session['tab_id']}/navigate",
-                    {"userId": session["user_id"], "url": browser_url},
-                    timeout=60,
-                )
-            except requests.HTTPError as e:
-                if _clear_stale_tab(session, e):
-                    session = _ensure_tab(task_id, browser_url)
-                    data = {"ok": True, "url": browser_url}
-                else:
-                    raise
+        try:
+            data = _post_tab_navigate(session, browser_url)
+        except requests.HTTPError as e:
+            if not _clear_stale_tab(session, e):
+                raise
+            session = _ensure_tab(task_id, browser_url)
+            data = _post_tab_navigate(session, browser_url)
         result = {
             "success": True,
             "url": data.get("url", browser_url),
@@ -599,6 +691,8 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                 snapshot_text = _truncate_snapshot(snapshot_text)
             result["snapshot"] = snapshot_text
             result["element_count"] = snap_data.get("refsCount", 0)
+        except requests.HTTPError as e:
+            _clear_stale_tab(session, e)
         except Exception:
             pass  # Navigation succeeded; snapshot is a bonus
 
@@ -637,7 +731,9 @@ def _camofox_private_page_block(session: Dict[str, Any], task_id: Optional[str],
 
     if not _eval_ssrf_guard_active(task_id or "default"):
         return None
-    blocked_url = _camofox_current_page_private_url(session["tab_id"], session["user_id"])
+    blocked_url = _camofox_current_page_private_url(
+        session["tab_id"], session["user_id"], session=session
+    )
     if not blocked_url:
         return None
     return json.dumps({
@@ -957,6 +1053,8 @@ def camofox_vision(question: str, annotate: bool = False,
                     params={"userId": session["user_id"]},
                 )
                 annotation_context = f"\n\nAccessibility tree (element refs for interaction):\n{snap_data.get('snapshot', '')[:3000]}"
+            except requests.HTTPError as e:
+                _clear_stale_tab(session, e)
             except Exception:
                 pass
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4344,7 +4344,11 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False, default=str)
 
 
-def _camofox_current_page_private_url(tab_id: str, user_id: str) -> Optional[str]:
+def _camofox_current_page_private_url(
+    tab_id: str,
+    user_id: str,
+    session: Optional[dict] = None,
+) -> Optional[str]:
     """Return the Camofox page URL when it targets a private/internal address.
 
     Camofox analogue of ``_current_page_private_url`` (evaluate endpoint instead
@@ -4352,6 +4356,9 @@ def _camofox_current_page_private_url(tab_id: str, user_id: str) -> Optional[str
     can't be determined, or the probe errors (fail-open on probe failure,
     matching the snapshot/vision guards — do not change to fail-closed without
     also changing the sibling).
+
+    A stale-tab HTTP error still clears *session* when provided so a dead
+    tab_id is not kept after the probe swallows the exception.
     """
     try:
         from tools.browser_camofox import _post
@@ -4365,18 +4372,44 @@ def _camofox_current_page_private_url(tab_id: str, user_id: str) -> Optional[str
         if current_url and (_is_always_blocked_url(current_url) or not _is_safe_url(current_url)):
             return current_url
     except Exception as exc:
+        if session is not None:
+            from tools.browser_camofox import _clear_stale_tab
+
+            _clear_stale_tab(session, exc, endpoint="evaluate")
         logger.debug("_camofox_current_page_private_url: probe failed (%s)", exc)
     return None
 
 
 def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
     """Evaluate JS via Camofox's /tabs/{tab_id}/evaluate endpoint (if available)."""
-    from tools.browser_camofox import _ensure_tab, _post
+    from tools.browser_camofox import (
+        _EVAL_CAPABILITY_ERROR,
+        _STALE_TAB_ERROR,
+        _clear_stale_tab,
+        _ensure_tab,
+        _post,
+        classify_camofox_http_error,
+    )
     try:
         tab_info = _ensure_tab(task_id or "default")
         tab_id = tab_info.get("tab_id") or tab_info.get("id")
         user_id = tab_info["user_id"]
-        resp = _post(f"/tabs/{tab_id}/evaluate", body={"expression": expression, "userId": user_id})
+        try:
+            resp = _post(
+                f"/tabs/{tab_id}/evaluate",
+                body={"expression": expression, "userId": user_id},
+            )
+        except Exception as e:
+            kind = classify_camofox_http_error(e, endpoint="evaluate")
+            if kind == "stale":
+                _clear_stale_tab(tab_info, e, endpoint="evaluate")
+                return tool_error(_STALE_TAB_ERROR, success=False)
+            if kind == "capability":
+                return json.dumps({
+                    "success": False,
+                    "error": _EVAL_CAPABILITY_ERROR,
+                })
+            raise
 
         # Camofox returns the result in a JSON envelope
         raw_result = resp.get("result") if isinstance(resp, dict) else resp
@@ -4388,7 +4421,9 @@ def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
                 pass
 
         if _eval_ssrf_guard_active(task_id or "default"):
-            _blocked_url = _camofox_current_page_private_url(tab_id, user_id)
+            _blocked_url = _camofox_current_page_private_url(
+                tab_id, user_id, session=tab_info
+            )
             if _blocked_url:
                 return json.dumps({
                     "success": False,
@@ -4405,15 +4440,13 @@ def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
             "result_type": type(parsed).__name__,
         }, ensure_ascii=False, default=str)
     except Exception as e:
-        error_msg = str(e)
-        # Graceful degradation — server may not support eval
-        if any(code in error_msg for code in ("404", "405", "501")):
+        kind = classify_camofox_http_error(e, endpoint="evaluate")
+        if kind == "capability":
             return json.dumps({
                 "success": False,
-                "error": "JavaScript evaluation is not supported by this Camofox server. "
-                         "Use browser_snapshot or browser_vision to inspect page state.",
+                "error": _EVAL_CAPABILITY_ERROR,
             })
-        return tool_error(error_msg, success=False)
+        return tool_error(str(e), success=False)
 
 
 def _maybe_start_recording(task_id: str):


### PR DESCRIPTION
## Landing transaction for #80298

This branch carries exact head `2b9e91fe` from #80298 verbatim, preserving @686f6c61's four commits, and adds one test-only repair commit before integrating current `main` (`96df9525`).

### Exact-head CI repair

CI run `32662268254` failed only `Python tests / Run tests` because two persistence tests still modeled navigation as a single `POST /tabs` transaction:

- `test_navigate_reuses_identity_after_close` classified every body containing `userId` as a tab-creation request, so the newly required `POST /tabs/{tab_id}/navigate` calls were double-counted.
- `test_multiplex_scope_identity_wins_over_process_env_and_config` inspected the final POST and expected it to be `/tabs`; after the landing amendment, the final POST is correctly `/tabs/scoped-tab/navigate`.

The repair does not weaken the new behavior. It strengthens the contract by asserting:

- exactly two tab creations and two explicit navigations across close/reopen;
- stable managed identity across both transaction stages;
- multiplex-scoped server URL and identity on both create and navigate.

The 14 commits added to `main` after #80298's rebase do not touch any of the five Camofox files, so the current-main integration is conflict-free.

Production behavior remains the selected landing design: `navigate` may recreate and explicitly navigate because it owns a complete target URL; sibling operations clear stale identity and require `browser_navigate` rather than replaying against an unknown replacement page.

Fixes #80276.

Supersedes #80298 as the writable landing vehicle only; the original contributor commits and attribution are retained in this branch history.