### PR TITLE
feat(models): add Inkling free models to OpenRouter catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -134,6 +134,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
     ("stealth/ox-alpha",                       "free"),  # "Ox Alpha" stealth reasoning model — 1M ctx
+    ("thinkingmachines/inkling:free",          "free"),
+    ("thinkingmachines/inkling-small:free",    "free"),
     ("openrouter/elephant-alpha",              "free"),
     ("z-ai/glm-5.2:free",                      "free"),
     ("poolside/laguna-s-2.1:free",             "free"),

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-21T20:49:36Z",
+  "updated_at": "2026-08-23T21:41:06Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -155,6 +155,14 @@
         },
         {
           "id": "stealth/ox-alpha",
+          "description": "free"
+        },
+        {
+          "id": "thinkingmachines/inkling:free",
+          "description": "free"
+        },
+        {
+          "id": "thinkingmachines/inkling-small:free",
           "description": "free"
         },
         {


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
`thinkingmachines/Inkling:free` and `thinkingmachines/Inkling-Small:free` - new free tier of Thinking Machines Lab's Inkling OSS models -- show up in OpenRouter's picker.

I'm new to the project— this is following the same pattern as #91284, which added ox-alpha, as well as Nvidia's nemotron-3-ultra free tier in the same list.



## Type of Change

<!-- Check the one that applies. -->

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Added two entries to `hermes_cli/models.py`
- Reran generation script (for static model-catalog.json, `scripts/build_model_catalog.py`) and tests

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run pytest tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_models.py -q
2. Connect Hermes to OpenRouter.
3. Open the model picker and confirm both Inkling routes appear under the free tier.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: **macOS**

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

After re-seeding the cache in `~/.hermes/cache`, I got it to appear!

<img width="703" height="220" alt="image" src="https://github.com/user-attachments/assets/e61154c8-ae79-482d-9858-8324baa45d6c" />

<img width="1004" height="582" alt="image" src="https://github.com/user-attachments/assets/bddd4924-355d-4d45-aaca-771f50c1b4f7" />


```python
.venv/bin/python -c 'from pathlib import Path; from hermes_cli.model_catalog import seed_cache_from_checkout; assert seed_cache_from_checkout(Path.cwd())'
```
