### PR TITLE
fix(security): exclude credential stores from profile clone-all

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -120,6 +120,8 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
 #   state-snapshots     — quick-backup snapshot trees
 #   checkpoints         — session checkpoint data
 _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
+    ".env",
+    "auth.json",
     "state.db",
     "state.db-wal",
     "state.db-shm",

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -114,6 +114,20 @@ class TestGetProfileDir:
 class TestCreateProfile:
     """Tests for create_profile()."""
 
+    def test_clone_all_excludes_credential_stores(self, profile_env):
+        source = create_profile("source", no_alias=True)
+        (source / ".env").write_text("FAKE_TOKEN=must-not-copy\n")
+        (source / "auth.json").write_text('{"credential_pool":{"fake":[]}}')
+        (source / "config.yaml").write_text("model: test\n")
+
+        target = create_profile(
+            "target", clone_from="source", clone_all=True, no_alias=True
+        )
+
+        assert not (target / "auth.json").exists()
+        assert "FAKE_TOKEN" not in (target / ".env").read_text()
+        assert (target / "config.yaml").exists()
+
 
     def test_seeds_placeholder_env_file(self, profile_env):
         """Fresh profiles get their own .env (owner-only) so channel/env
@@ -1123,5 +1137,4 @@ class TestResolveProfileEnvSpelling:
         # No HERMES_HOME: the platform default root applies (existing contract).
         monkeypatch.delenv("HERMES_HOME", raising=False)
         assert Path(resolve_profile_env("default")) == _get_default_hermes_home()
-
 


### PR DESCRIPTION
## What

- Exclude root-level `.env` and `auth.json` from `profile create --clone-all`.
- Keep cloning non-secret profile data, including `config.yaml`.
- Rely on the existing post-clone bootstrap to create a credential-free placeholder `.env` in the target.

## Why

`--clone-all` currently copies provider OAuth pools and messaging/channel credentials into a new profile. In a real profile clone this seated one agent's Anthropic credential, another agent's Telegram bot token, and a third agent's channel identity in the target profile. Besides crossing profile identity boundaries, a copied bot token can put multiple gateways on the same credential.

This intentionally narrows the behavior introduced by #51719: clone-all remains a full copy for non-secret profile state, but credentials must be seated explicitly in the destination profile.

## Test

```text
scripts/run_tests.sh tests/hermes_cli/test_profiles.py -k test_clone_all_excludes_credential_stores
1 passed, 0 failed
```

The full profile test file on native Windows also reported 51 passes and 6 unrelated existing platform failures (POSIX wrapper expectations, POSIX mode assertions, and symlink privilege requirements). This PR does not modify those tests.