### PR TITLE
fix(auth): avoid duplicate MiniMax OAuth pool entries

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -8700,7 +8700,7 @@ def _minimax_save_auth_state(auth_state: Dict[str, Any]) -> None:
 
 def _minimax_oauth_login(
     *, region: str = "global", open_browser: bool = True,
-    timeout_seconds: float = 15.0,
+    timeout_seconds: float = 15.0, label: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Run MiniMax OAuth flow, persist tokens, return auth state dict."""
     pconfig = PROVIDER_REGISTRY["minimax-oauth"]
@@ -8773,6 +8773,8 @@ def _minimax_oauth_login(
         "expires_at": datetime.fromtimestamp(expires_at_unix, tz=timezone.utc).isoformat(),
         "expires_in": expires_in_s,
     }
+    if label:
+        auth_state["label"] = label
 
     _minimax_save_auth_state(auth_state)
     print("\u2713 MiniMax OAuth login successful.")

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -409,26 +409,19 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "minimax-oauth":
-        creds = auth_mod._minimax_oauth_login(
+        requested_label = (getattr(args, "label", None) or "").strip()
+        auth_mod._minimax_oauth_login(
             open_browser=not getattr(args, "no_browser", False),
             timeout_seconds=getattr(args, "timeout", None) or 15.0,
+            label=requested_label or None,
         )
-        label = (getattr(args, "label", None) or "").strip() or label_from_token(
-            creds["access_token"],
-            _oauth_default_label(provider, len(pool.entries()) + 1),
+        pool = load_pool(provider)
+        entry = next(
+            (item for item in pool.entries() if item.source == "oauth"),
+            None,
         )
-        entry = PooledCredential(
-            provider=provider,
-            id=uuid.uuid4().hex[:6],
-            label=label,
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source=f"{SOURCE_MANUAL}:minimax_oauth",
-            access_token=creds["access_token"],
-            refresh_token=creds.get("refresh_token"),
-            base_url=creds.get("inference_base_url"),
-        )
-        pool.add_entry(entry)
+        if entry is None:
+            raise SystemExit("MiniMax login succeeded but the OAuth pool was not seeded.")
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
         return
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -228,6 +228,65 @@ def test_auth_add_nous_oauth_honors_custom_label(tmp_path, monkeypatch):
     assert payload["providers"]["nous"]["label"] == "my-nous"
 
 
+def test_auth_add_minimax_oauth_reuses_canonical_seeded_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    states = iter(
+        [
+            {
+                "provider": "minimax-oauth",
+                "access_token": "first-access-token",
+                "refresh_token": "first-refresh-token",
+                "inference_base_url": "https://api.minimax.io/anthropic",
+            },
+            {
+                "provider": "minimax-oauth",
+                "access_token": "second-access-token",
+                "refresh_token": "second-refresh-token",
+                "inference_base_url": "https://api.minimax.io/anthropic",
+            },
+        ]
+    )
+
+    def _fake_login(*, label=None, **_kwargs):
+        from hermes_cli.auth import _minimax_save_auth_state
+
+        state = next(states)
+        if label:
+            state["label"] = label
+        _minimax_save_auth_state(state)
+        return state
+
+    monkeypatch.setattr("hermes_cli.auth._minimax_oauth_login", _fake_login)
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "minimax-oauth"
+        auth_type = "oauth"
+        api_key = None
+        label = "primary-minimax"
+        no_browser = False
+        timeout = None
+
+    auth_add_command(_Args())
+    first_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    first_entry = first_payload["credential_pool"]["minimax-oauth"][0]
+
+    auth_add_command(_Args())
+    final_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = final_payload["credential_pool"]["minimax-oauth"]
+
+    assert len(entries) == 1
+    assert entries[0]["source"] == "oauth"
+    assert entries[0]["id"] == first_entry["id"]
+    assert entries[0]["priority"] == first_entry["priority"] == 0
+    assert entries[0]["access_token"] == "second-access-token"
+    assert entries[0]["refresh_token"] == "second-refresh-token"
+    assert entries[0]["label"] == "primary-minimax"
+    assert not any(item["source"] == "manual:minimax_oauth" for item in entries)
+
+
 def test_auth_add_codex_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch):
     """Two ``hermes auth add openai-codex`` runs for different ChatGPT
     accounts must produce two independent pool entries with distinct tokens.


### PR DESCRIPTION
## What

- Treat the singleton `providers.minimax-oauth` state as the canonical result of a MiniMax login.
- Reload the seeded `oauth` pool row after login instead of appending a second `manual:minimax_oauth` row.
- Preserve an optional user label in the singleton state so re-seeding retains it.

## Why

One `hermes auth add minimax-oauth` currently writes the same login twice under different sources. On a later re-auth, only the seeded `oauth` row refreshes while the older manual row stays ahead of it, creating a stale wrong-first credential.

This change is deliberately scoped to the double-write from a single MiniMax login. It does **not** change Hermes' intentional general behavior where repeated `auth add` can create multiple accounts, and it does not introduce a default-replacement or `--add-fallback` policy.

## Test

```text
scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py tests/test_minimax_oauth.py
34 passed, 0 failed
```

The regression calls the MiniMax add path twice and verifies one `oauth` row remains, its ID and priority are preserved, token material updates, and no `manual:minimax_oauth` row is created.