### PR TITLE
fix(auth): make credential removals durable across stale writers

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -100,6 +100,13 @@ _TERMINAL_AUTH_REASONS = frozenset({
 # write-side sync (``_save_codex_tokens`` etc.) clears the status.
 DEAD_MANUAL_PRUNE_TTL_SECONDS = 24 * 60 * 60  # 24 hours
 
+_FILE_BACKED_SINGLETON_SOURCES = frozenset({
+    ("minimax-oauth", "oauth"),
+    ("nous", "device_code"),
+    ("openai-codex", "device_code"),
+    ("xai-oauth", "device_code"),
+})
+
 AUTH_TYPE_OAUTH = "oauth"
 AUTH_TYPE_API_KEY = "api_key"
 
@@ -3041,6 +3048,7 @@ def _prune_stale_seeded_entries(
         return (
             is_borrowed_credential_source(entry.source, entry.provider)
             or entry.source == "hermes_pkce"
+            or (entry.provider, entry.source) in _FILE_BACKED_SINGLETON_SOURCES
         )
 
     retained = [

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1749,6 +1749,16 @@ def write_credential_pool(
     removed = {rid for rid in (removed_ids or ()) if rid}
     with _auth_store_lock():
         auth_store = _load_auth_store()
+        tombstones = auth_store.get("credential_pool_removed_ids")
+        if not isinstance(tombstones, dict):
+            tombstones = {}
+            auth_store["credential_pool_removed_ids"] = tombstones
+        provider_tombstones = {
+            str(item) for item in tombstones.get(provider_id, []) if item
+        }
+        provider_tombstones.update(str(item) for item in removed)
+        if provider_tombstones:
+            tombstones[provider_id] = sorted(provider_tombstones)
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
             pool = {}
@@ -1757,6 +1767,8 @@ def write_credential_pool(
             sanitize_borrowed_credential_payload(entry, provider_id)
             if isinstance(entry, dict) else entry
             for entry in entries
+            if not isinstance(entry, dict)
+            or entry.get("id") not in provider_tombstones
         ]
         existing = pool.get(provider_id)
         existing_list = existing if isinstance(existing, list) else []
@@ -1782,7 +1794,11 @@ def write_credential_pool(
             if not isinstance(disk_entry, dict):
                 continue
             disk_id = disk_entry.get("id")
-            if not disk_id or disk_id in new_ids or disk_id in removed:
+            if (
+                not disk_id
+                or disk_id in new_ids
+                or disk_id in provider_tombstones
+            ):
                 continue
             merged.append(sanitize_borrowed_credential_payload(disk_entry, provider_id))
         pool[provider_id] = merged

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -929,6 +929,37 @@ def test_write_credential_pool_preserves_known_provider_owned_oauth_state(tmp_pa
     assert persisted["agent_key"] == f"agent-{sentinel}"
 
 
+@pytest.mark.parametrize(
+    ("provider", "source"),
+    [
+        ("minimax-oauth", "oauth"),
+        ("nous", "device_code"),
+        ("openai-codex", "device_code"),
+        ("xai-oauth", "device_code"),
+    ],
+)
+def test_prune_stale_file_backed_singleton_entries(provider, source):
+    from agent.credential_pool import (
+        PooledCredential,
+        _prune_stale_seeded_entries,
+    )
+
+    entries = [
+        PooledCredential(
+            provider=provider,
+            id="stale-file-backed",
+            label="stale",
+            auth_type="oauth",
+            priority=0,
+            source=source,
+            access_token="stale-access-token",
+        )
+    ]
+
+    assert _prune_stale_seeded_entries(entries, set()) is True
+    assert entries == []
+
+
 
 def test_load_pool_prefers_dotenv_over_stale_os_environ(tmp_path, monkeypatch):
     """Regression for #18254: stale OPENROUTER_API_KEY in os.environ (inherited

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -288,3 +288,26 @@ def test_write_pool_never_merges_cooldown_onto_reauthed_entry(classic_env):
     assert persisted["access_token"] == "sk-new"
     assert persisted.get("last_status") != "exhausted"
     assert persisted.get("last_error_code") is None
+
+
+def test_write_pool_tombstone_blocks_stale_snapshot_resurrection(classic_env):
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    removed = _pool_entry(id="removed-id", label="removed")
+    retained = _pool_entry(id="retained-id", label="retained", priority=1)
+    write_credential_pool("anthropic", [removed, retained])
+    stale_snapshot = read_credential_pool("anthropic")
+
+    write_credential_pool(
+        "anthropic",
+        [retained],
+        removed_ids={"removed-id"},
+    )
+    write_credential_pool("anthropic", stale_snapshot)
+
+    data = json.loads((classic_env / "auth.json").read_text())
+    final_ids = {
+        entry["id"] for entry in data["credential_pool"]["anthropic"]
+    }
+    assert final_ids == {"retained-id"}
+    assert data["credential_pool_removed_ids"]["anthropic"] == ["removed-id"]


### PR DESCRIPTION
## What

- Persist per-provider credential removal tombstones in `auth.json`.
- Filter tombstoned IDs from both caller snapshots and the concurrent on-disk merge.
- Make file-backed singleton rows prunable when their backing state is absent for MiniMax, Nous, Codex, and xAI OAuth.

## Why

`removed_ids` currently protects only the write that performs a removal. A later process holding an older in-memory snapshot can submit the removed row as normal input and resurrect it. Persistent tombstones preserve the concurrency merge without allowing that silent reversal.

There is a second silent failure in `_prune_stale_seeded_entries()`: its comment and control flow say file-backed singleton rows disappear when their backing file/state is gone, but `agent/credential_persistence.py` classifies MiniMax `oauth` plus Nous/Codex/xAI `device_code` sources as persistable. That makes `is_borrowed_credential_source()` false and defeats the advertised prune. This PR explicitly identifies those file-backed singleton sources as prunable and relies on the tombstone path to keep the removal durable.

## Test

```text
scripts/run_tests.sh tests/hermes_cli/test_auth_profile_fallback.py tests/agent/test_credential_pool.py
71 passed, 0 failed
```

Coverage includes a stale snapshot attempting to restore a removed ID and all four file-backed singleton source pairs with absent backing state.