### PR TITLE
fix(auth): upsert OAuth credentials by stable account subject

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -169,6 +169,7 @@ _EXTRA_KEYS = frozenset({
     "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
     "agent_key_obtained_at", "tls", "secret_source", "secret_fingerprint",
+    "account_subject",
     # Classified failure semantics for the last exhaustion, as decided by
     # agent/error_classifier.py. The raw HTTP status is not enough to size a
     # cooldown: providers return 403 for both an edge throttle (transient,
@@ -177,6 +178,18 @@ _EXTRA_KEYS = frozenset({
     # 60s transient cooldown.
     "failure_reason",
 })
+
+
+def _oauth_account_subject(provider: str, token: str) -> Optional[str]:
+    """Return a stable provider-scoped account id proven by OAuth claims."""
+    claims = _decode_jwt_claims(token)
+    nested = claims.get("https://api.openai.com/auth")
+    if isinstance(nested, dict):
+        account_id = nested.get("chatgpt_account_id")
+        if isinstance(account_id, str) and account_id.strip():
+            return account_id.strip()
+    subject = claims.get("sub")
+    return subject.strip() if isinstance(subject, str) and subject.strip() else None
 
 
 def _normalize_pool_auth_type(provider: str, token: Any, auth_type: Any) -> str:
@@ -224,6 +237,10 @@ class PooledCredential:
             self.access_token,
             self.auth_type,
         )
+        if self.auth_type == AUTH_TYPE_OAUTH and not self.extra.get("account_subject"):
+            subject = _oauth_account_subject(self.provider, self.access_token)
+            if subject:
+                self.extra["account_subject"] = subject
 
     def __getattr__(self, name: str):
         if name in _EXTRA_KEYS:
@@ -2399,6 +2416,35 @@ class CredentialPool:
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
         with self._lock:
+            subject = entry.account_subject if entry.auth_type == AUTH_TYPE_OAUTH else None
+            matching_indices = [
+                idx
+                for idx, existing in enumerate(self._entries)
+                if subject
+                and existing.auth_type == AUTH_TYPE_OAUTH
+                and existing.account_subject == subject
+            ]
+            if matching_indices:
+                existing_idx = matching_indices[0]
+                existing = self._entries[existing_idx]
+                removed_ids = [
+                    self._entries[idx].id for idx in matching_indices[1:]
+                ]
+                replacement = replace(
+                    entry,
+                    id=existing.id,
+                    priority=existing.priority,
+                )
+                self._entries[existing_idx] = replacement
+                duplicate_indices = set(matching_indices[1:])
+                if duplicate_indices:
+                    self._entries = [
+                        item
+                        for idx, item in enumerate(self._entries)
+                        if idx not in duplicate_indices
+                    ]
+                self._persist(removed_ids=removed_ids)
+                return replacement
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
             self._persist()
@@ -2406,9 +2452,19 @@ class CredentialPool:
 
 
 def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, payload: Dict[str, Any]) -> bool:
+    incoming_subject = payload.get("account_subject") or _oauth_account_subject(
+        provider, payload.get("access_token", "")
+    )
+    if incoming_subject:
+        payload["account_subject"] = incoming_subject
     matching_indices = []
     for idx, entry in enumerate(entries):
-        if entry.source == source:
+        same_account = (
+            incoming_subject
+            and entry.auth_type == AUTH_TYPE_OAUTH
+            and entry.account_subject == incoming_subject
+        )
+        if entry.source == source or same_account:
             matching_indices.append(idx)
 
     existing_idx = matching_indices[0] if matching_indices else None

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -24,6 +24,107 @@ def _jwt_with_claims(claims: dict) -> str:
     return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
 
 
+def test_oauth_account_subject_prefers_provider_account_id():
+    from agent.credential_pool import _oauth_account_subject
+
+    token = _jwt_with_claims(
+        {
+            "sub": "login-subject",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "account-123",
+            },
+        }
+    )
+
+    assert _oauth_account_subject("openai-codex", token) == "account-123"
+
+
+def test_add_entry_replaces_same_oauth_account_in_place(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "credential_pool": {}})
+
+    from agent.credential_pool import CredentialPool, PooledCredential
+
+    first = PooledCredential(
+        provider="openai-codex",
+        id="stable-id",
+        label="first",
+        auth_type="oauth",
+        priority=0,
+        source="device_code",
+        access_token=_jwt_with_claims({"sub": "same-account"}),
+        refresh_token="first-refresh",
+    )
+    duplicate = PooledCredential(
+        provider="openai-codex",
+        id="duplicate-id",
+        label="duplicate",
+        auth_type="oauth",
+        priority=1,
+        source="manual:device_code",
+        access_token=_jwt_with_claims({"sub": "same-account"}),
+        refresh_token="duplicate-refresh",
+    )
+    pool = CredentialPool("openai-codex", [first, duplicate])
+    replacement = PooledCredential(
+        provider="openai-codex",
+        id="new-id",
+        label="reauthenticated",
+        auth_type="oauth",
+        priority=99,
+        source="manual:device_code",
+        access_token=_jwt_with_claims({"sub": "same-account"}),
+        refresh_token="fresh-refresh",
+    )
+
+    added = pool.add_entry(replacement)
+
+    assert added.id == "stable-id"
+    assert added.priority == 0
+    assert added.refresh_token == "fresh-refresh"
+    assert [entry.id for entry in pool.entries()] == ["stable-id"]
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert [
+        entry["id"]
+        for entry in persisted["credential_pool"]["openai-codex"]
+    ] == ["stable-id"]
+
+
+def test_upsert_matches_same_oauth_account_across_sources():
+    from agent.credential_pool import PooledCredential, _upsert_entry
+
+    original = PooledCredential(
+        provider="openai-codex",
+        id="stable-id",
+        label="original",
+        auth_type="oauth",
+        priority=3,
+        source="device_code",
+        access_token=_jwt_with_claims({"sub": "same-account"}),
+        refresh_token="old-refresh",
+    )
+    entries = [original]
+
+    changed = _upsert_entry(
+        entries,
+        "openai-codex",
+        "manual:device_code",
+        {
+            "auth_type": "oauth",
+            "source": "manual:device_code",
+            "access_token": _jwt_with_claims({"sub": "same-account"}),
+            "refresh_token": "new-refresh",
+        },
+    )
+
+    assert changed is True
+    assert len(entries) == 1
+    assert entries[0].id == "stable-id"
+    assert entries[0].priority == 3
+    assert entries[0].source == "manual:device_code"
+    assert entries[0].refresh_token == "new-refresh"
+
+
 
 
 


### PR DESCRIPTION
## What

- Derive a stable provider-scoped OAuth account subject from proven JWT claims (`chatgpt_account_id` when present, otherwise `sub`).
- Persist that subject as credential metadata.
- Replace same-account OAuth rows in place across source-name changes while preserving the stable ID and priority; distinct account subjects still append normally.

## Why

Source strings describe how a credential entered Hermes, not which account it belongs to. The same OAuth account can appear under multiple source names and survive as duplicate rows that later diverge after refresh. Matching on provider plus a proven account subject fixes that class without relying on labels, email alone, or rotating token fingerprints.

This preserves Hermes' intentional multi-account behavior: different proven subjects remain separate rows.

**MiniMax is not covered by this PR.** Its persisted OAuth response does not contain a stable account subject, so it still requires the separate MiniMax singleton/double-write correction in the rank 2 PR.

## Test

```text
scripts/run_tests.sh tests/agent/test_credential_pool.py
62 passed, 0 failed
```

Coverage verifies provider account-ID precedence, same-account replacement with ID/priority preservation, duplicate removal, and cross-source upsert.