### PR TITLE
fix(url_safety): default every SSRF-safe client to an identifying User-Agent

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -12,6 +12,8 @@ from tools.url_safety import (
     normalize_url_for_request,
     redirect_target_from_response,
     create_ssrf_safe_async_client,
+    create_ssrf_safe_client,
+    DEFAULT_USER_AGENT,
     SSRFConnectionBlocked,
     _SSRFGuardedAsyncNetworkBackend,
     _MAX_SSRF_CONNECT_IPS,
@@ -237,6 +239,70 @@ class TestSSRFGuardedHttpxClient:
             )
         finally:
             await client.aclose()
+
+
+class TestDefaultUserAgent:
+    """#93242: every SSRF-safe client should default to an identifying UA,
+    since CDNs with basic bot detection (upload.wikimedia.org confirmed in
+    #89260) 403 httpx's bare default (``python-httpx/x``)."""
+
+    @pytest.mark.asyncio
+    async def test_async_client_defaults_to_identifying_user_agent(self):
+        client = create_ssrf_safe_async_client(timeout=0.01)
+        try:
+            assert client.headers["User-Agent"] == DEFAULT_USER_AGENT
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_async_client_respects_caller_supplied_user_agent(self):
+        client = create_ssrf_safe_async_client(
+            timeout=0.01, headers={"User-Agent": "custom-agent/1.0"}
+        )
+        try:
+            assert client.headers["User-Agent"] == "custom-agent/1.0"
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_async_client_treats_user_agent_case_insensitively(self):
+        """A caller-supplied lowercase ``user-agent`` must not get a second,
+        differently-cased default alongside it."""
+        client = create_ssrf_safe_async_client(
+            timeout=0.01, headers={"user-agent": "custom-agent/1.0"}
+        )
+        try:
+            assert client.headers.get_list("user-agent") == ["custom-agent/1.0"]
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_async_client_does_not_mutate_caller_headers_dict(self):
+        """A caller's own dict must come back unchanged -- otherwise a dict
+        reused across requests would get silently poisoned with a UA the
+        caller never asked to keep around."""
+        caller_headers = {"X-Custom": "value"}
+        client = create_ssrf_safe_async_client(timeout=0.01, headers=caller_headers)
+        try:
+            assert caller_headers == {"X-Custom": "value"}
+        finally:
+            await client.aclose()
+
+    def test_sync_client_defaults_to_identifying_user_agent(self):
+        client = create_ssrf_safe_client(timeout=0.01)
+        try:
+            assert client.headers["User-Agent"] == DEFAULT_USER_AGENT
+        finally:
+            client.close()
+
+    def test_sync_client_respects_caller_supplied_user_agent(self):
+        client = create_ssrf_safe_client(
+            timeout=0.01, headers={"User-Agent": "custom-agent/1.0"}
+        )
+        try:
+            assert client.headers["User-Agent"] == "custom-agent/1.0"
+        finally:
+            client.close()
 
 
 class TestIsBlockedIp:

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -822,6 +822,39 @@ def _install_ssrf_guard_on_client(client: Any) -> None:
     )
 
 
+# Identifying UA for Hermes-owned direct downloads (media caches, platform
+# adapter fallbacks, skill installs, ...). CDNs with basic bot detection —
+# upload.wikimedia.org confirmed in #89260 — 403 the bare httpx default
+# (``python-httpx/x``). Wikimedia's UA policy
+# (meta.wikimedia.org/wiki/User-Agent_policy) asks clients to identify
+# themselves rather than impersonate a browser, so this names the agent
+# instead of spoofing Chrome/Firefox. Applied as a client-level default by
+# both factories below rather than re-typed per call site (#93242) — a
+# caller that needs a different UA still overrides it per-request, since
+# httpx merges request headers over client headers.
+DEFAULT_USER_AGENT = "Mozilla/5.0 (compatible; HermesAgent/1.0)"
+
+
+def _with_default_user_agent(kwargs: dict) -> dict:
+    """Return ``kwargs`` with a client-level ``User-Agent`` default filled in.
+
+    Uses ``httpx.Headers`` rather than plain-dict ``setdefault`` for two
+    reasons: it never mutates a caller-supplied headers object (a dict passed
+    by reference would otherwise be permanently poisoned across requests),
+    and it's case-insensitive plus accepts every form httpx's ``headers=``
+    already accepts (dict, list of tuples, or another ``Headers``) — a plain
+    dict's ``setdefault`` would raise on a list and would miss a caller's
+    lowercase ``"user-agent"``, adding a duplicate header instead of leaving
+    it alone.
+    """
+    import httpx
+
+    headers = httpx.Headers(kwargs.get("headers"))
+    headers.setdefault("User-Agent", DEFAULT_USER_AGENT)
+    kwargs["headers"] = headers
+    return kwargs
+
+
 def create_ssrf_safe_async_client(**kwargs: Any) -> Any:
     """Create an ``httpx.AsyncClient`` with connect-time SSRF validation.
 
@@ -830,19 +863,26 @@ def create_ssrf_safe_async_client(**kwargs: Any) -> Any:
     SNI, and certificate verification.  If httpx routes through a proxy, final
     target resolution is delegated to that configured proxy; treat the proxy as
     a trusted egress boundary.
+
+    Sends ``DEFAULT_USER_AGENT`` by default (see above) unless the caller
+    already set a ``User-Agent``.
     """
     import httpx
 
-    client = httpx.AsyncClient(**kwargs)
+    client = httpx.AsyncClient(**_with_default_user_agent(kwargs))
     _install_ssrf_guard_on_async_client(client)
     return client
 
 
 def create_ssrf_safe_client(**kwargs: Any) -> Any:
-    """Create an ``httpx.Client`` with connect-time SSRF validation."""
+    """Create an ``httpx.Client`` with connect-time SSRF validation.
+
+    Sends ``DEFAULT_USER_AGENT`` by default (see above) unless the caller
+    already set a ``User-Agent``.
+    """
     import httpx
 
-    client = httpx.Client(**kwargs)
+    client = httpx.Client(**_with_default_user_agent(kwargs))
     _install_ssrf_guard_on_client(client)
     return client
 


### PR DESCRIPTION
## What does this PR do?

`create_ssrf_safe_async_client()` and `create_ssrf_safe_client()` in `tools/url_safety.py` were thin passthroughs to `httpx.AsyncClient()`/`httpx.Client()` plus the SSRF connect-time guard — neither set a default `User-Agent`, so any caller that didn't set its own got httpx's bare default (`python-httpx/x.x`). CDNs with basic bot detection (`upload.wikimedia.org` confirmed in #89260) 403 that UA outright while the same URL serves fine to an identifying or browser-like UA. #89262 fixed the one call site with a filed bug report (Telegram's image-download fallback); grepping the other 15+ call sites of these two factories showed most send no UA either — Slack, WeCom, Matrix, QQBot, YuanbaoMedia, `vision_tools`, `flux3_video_tool`, `managed_tool_gateway`, `skills_hub` — exposed to the identical failure class.

Both factories now default to `DEFAULT_USER_AGENT` (`"Mozilla/5.0 (compatible; HermesAgent/1.0)"` — an identifying string per Wikimedia's [UA policy](https://meta.wikimedia.org/wiki/User-Agent_policy), not a browser spoof) via a shared `_with_default_user_agent()` helper, so this fixes the whole class in one place instead of waiting for each call site to get its own bug report.

`managed_tool_gateway.py`'s presigned-URL PUT and `flux3_video_tool.py`'s vendor-CDN GET were flagged in #93242 as needing individual review before folding them into a blanket default. Traced both:
- The PUT's presigned-URL signature only binds whatever was declared as `SignedHeaders` at generation time (here, `Content-Type`/`Content-Length`) — an unsigned extra header like a default UA isn't something S3/R2-style presigned URLs reject.
- The GET is structurally the same public-CDN-download shape as the Telegram bug this whole issue is about.

Neither gives a reason to carve out an exception, so the default applies uniformly to all callers rather than special-casing two of eleven.

## Related Issue

Fixes #93242

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `tools/url_safety.py` — new `DEFAULT_USER_AGENT` constant and `_with_default_user_agent()` helper; both `create_ssrf_safe_async_client()` and `create_ssrf_safe_client()` now apply it via `httpx.Headers` (not a plain-dict `setdefault`) so a caller-supplied headers object is never mutated in place and `"User-Agent"`/`"user-agent"` are treated as the same header rather than risking a duplicate.
- `tests/tools/test_url_safety.py` — new `TestDefaultUserAgent`: both factories default to the identifying UA; a caller-supplied `User-Agent` (any case) is preserved and not duplicated; a caller's own headers dict comes back unmutated.

No call site needed its own code changed — the fix is entirely contained in the two factory functions.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_url_safety.py tests/tools/test_flux3_video_tool.py tests/tools/test_managed_tool_gateway.py tests/tools/test_audio_container.py tests/gateway/test_feishu.py tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_telegram_media_read_timeout.py
# Observed result: 280/280 passed, 18 skipped (canonical CI-parity runner) — every test file that references either factory function directly

ruff check tools/url_safety.py tests/tools/test_url_safety.py
# Observed result: All checks passed!
```

**Fail-on-main check:** with `tools/url_safety.py` reverted to its pre-fix state and the new test class kept, collection fails as expected:
```
ImportError: cannot import name 'DEFAULT_USER_AGENT' from 'tools.url_safety'
```
confirming the new tests exercise functionality that doesn't exist without this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate found; this is the follow-up work #93242 itself tracks
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the tests that reference either modified factory function (`scripts/run_tests.sh` — see above) and they pass; the full suite wasn't run locally, CI covers the rest
- [x] I've added tests for my changes
- [x] Tested on: macOS 15 (Darwin 25.5.0, arm64)

### Documentation & Housekeeping

- [x] N/A — no README/docs changes needed
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] Cross-platform: change is a plain header default on an httpx client, no OS-specific behavior
- [x] N/A — no tool schemas changed

## Interaction with #89262

#89262 (Telegram's fix, separate PR, not yet merged) sets the same `User-Agent` explicitly on its one call site. Whichever of the two PRs merges first, the other stays correct: an explicit per-request header and this client-level default carry the same value, and httpx's per-request-wins-over-client-level merge means neither shadows the other incorrectly.
