### PR TITLE
fix(desktop): isolate Files across registered connections

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -68,6 +68,25 @@ describe('useProjectTree', () => {
     expect(result.current.data).toEqual([])
   })
 
+  it('clears root loading and recovers when a root read rejects', async () => {
+    readDir.mockRejectedValueOnce(new Error('remote request aborted'))
+    readDir.mockResolvedValueOnce(ok([{ name: 'IDEA.md', path: '/remote/IDEA.md', isDirectory: false }]))
+
+    const { result } = renderHook(() => useProjectTree('/remote'))
+
+    await waitFor(() => {
+      expect(result.current.rootError).toBe('remote request aborted')
+      expect(result.current.rootLoading).toBe(false)
+    })
+
+    await act(async () => {
+      await result.current.refreshRoot()
+    })
+
+    expect(result.current.rootError).toBeNull()
+    expect(result.current.data.map(node => node.name)).toEqual(['IDEA.md'])
+  })
+
   it('lazy-loads children on loadChildren and replaces the placeholder', async () => {
     readDir.mockResolvedValueOnce(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
     readDir.mockResolvedValueOnce(
@@ -168,6 +187,29 @@ describe('useProjectTree', () => {
     ])
   })
 
+  it('clears child loading and allows retry when a child read rejects', async () => {
+    readDir.mockResolvedValueOnce(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
+    readDir.mockRejectedValueOnce(new Error('child request aborted'))
+    readDir.mockResolvedValueOnce(ok([{ name: 'index.ts', path: '/p/src/index.ts', isDirectory: false }]))
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+
+    await waitFor(() => expect(result.current.data.length).toBe(1))
+
+    await act(async () => {
+      await result.current.loadChildren('/p/src')
+    })
+
+    expect(result.current.data[0]).toMatchObject({ error: 'child request aborted', loading: false })
+
+    await act(async () => {
+      await result.current.loadChildren('/p/src')
+    })
+
+    expect(result.current.data[0]).toMatchObject({ error: undefined, loading: false })
+    expect(result.current.data[0].children?.map(node => node.name)).toEqual(['index.ts'])
+  })
+
   it('dedupes concurrent loadChildren calls for the same id', async () => {
     readDir.mockResolvedValueOnce(ok([{ name: 'src', path: '/p/src', isDirectory: true }]))
 
@@ -209,6 +251,35 @@ describe('useProjectTree', () => {
 
     expect(result.current.rootError).toBeNull()
     expect(result.current.data.map(n => n.name)).toEqual(['README.md'])
+  })
+
+  it('reloads the same path when the active registered connection changes', async () => {
+    let resolveFirst: ((result: HermesReadDirResult) => void) | undefined
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          resolveFirst = resolve
+        })
+    )
+    readDir.mockResolvedValueOnce(ok([{ name: 'from-b', path: '/shared/from-b', isDirectory: false }]))
+    $connection.set({ baseUrl: 'https://gateway.example', connectionId: 'connection-a', mode: 'local', profile: 'default' } as never)
+
+    const { result } = renderHook(() => useProjectTree('/shared'))
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      $connection.set({
+        baseUrl: 'https://gateway.example',
+        connectionId: 'connection-b',
+        mode: 'local',
+        profile: 'default'
+      } as never)
+      resolveFirst?.(ok([{ name: 'from-a', path: '/shared/from-a', isDirectory: false }]))
+    })
+
+    await waitFor(() => expect(result.current.data.map(node => node.name)).toEqual(['from-b']))
+    expect(readDir).toHaveBeenCalledTimes(2)
   })
 
   it('reloads when cwd changes', async () => {

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesReadDirResult } from '@/global'
 import { $connection } from '@/store/session'
+import { notifyWorkspaceChanged } from '@/store/workspace-events'
 
 import { clearProjectDirCache, readProjectDir } from './ipc'
 import { resetProjectTreeState, useProjectTree } from './use-project-tree'
@@ -66,6 +67,36 @@ describe('useProjectTree', () => {
 
     await waitFor(() => expect(result.current.rootError).toBe('EACCES'))
     expect(result.current.data).toEqual([])
+  })
+
+  it('does not fall back after a failed root read from a superseded connection', async () => {
+    let resolveRootFromA: ((result: HermesReadDirResult) => void) | undefined
+    const sanitizeWorkspaceCwd = vi.fn(async () => ({ cwd: '/fallback', sanitized: true }))
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          resolveRootFromA = resolve
+        })
+    )
+    readDir.mockResolvedValueOnce(ok([{ name: 'from-b', path: '/shared/from-b', isDirectory: false }]))
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { readDir, sanitizeWorkspaceCwd }
+    $connection.set({ baseUrl: 'local-a', connectionId: 'connection-a', mode: 'local', profile: 'default' } as never)
+
+    const { result } = renderHook(() => useProjectTree('/shared'))
+
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      $connection.set({ baseUrl: 'local-b', connectionId: 'connection-b', mode: 'local', profile: 'default' } as never)
+    })
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      resolveRootFromA?.({ entries: [], error: 'ENOENT' })
+    })
+
+    await waitFor(() => expect(result.current.data.map(node => node.name)).toEqual(['from-b']))
+    expect(sanitizeWorkspaceCwd).not.toHaveBeenCalled()
   })
 
   it('clears root loading and recovers when a root read rejects', async () => {
@@ -253,7 +284,83 @@ describe('useProjectTree', () => {
     expect(result.current.data.map(n => n.name)).toEqual(['README.md'])
   })
 
-  it('reloads the same path when the active registered connection changes', async () => {
+  it('discards a stale live refresh after the active registered connection changes', async () => {
+    let resolveRefreshFromA: ((result: HermesReadDirResult) => void) | undefined
+    readDir.mockResolvedValueOnce(ok([{ name: 'from-a', path: '/shared/from-a', isDirectory: false }]))
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          resolveRefreshFromA = resolve
+        })
+    )
+    readDir.mockResolvedValueOnce(ok([{ name: 'from-b', path: '/shared/from-b', isDirectory: false }]))
+    $connection.set({ baseUrl: 'https://gateway.example', connectionId: 'connection-a', mode: 'local', profile: 'default' } as never)
+
+    const { result } = renderHook(() => useProjectTree('/shared'))
+
+    await waitFor(() => expect(result.current.data.map(node => node.name)).toEqual(['from-a']))
+
+    act(() => {
+      notifyWorkspaceChanged()
+    })
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(2))
+
+    act(() => {
+      $connection.set({
+        baseUrl: 'https://gateway.example',
+        connectionId: 'connection-b',
+        mode: 'local',
+        profile: 'default'
+      } as never)
+    })
+    await waitFor(() => expect(result.current.data.map(node => node.name)).toEqual(['from-b']))
+
+    await act(async () => {
+      resolveRefreshFromA?.(ok([{ name: 'stale-a', path: '/shared/stale-a', isDirectory: false }]))
+    })
+
+    expect(result.current.data.map(node => node.name)).toEqual(['from-b'])
+  })
+
+  it('discards a stale child read after the active registered connection changes', async () => {
+    let resolveChildFromA: ((result: HermesReadDirResult) => void) | undefined
+    readDir.mockResolvedValueOnce(ok([{ name: 'src', path: '/shared/src', isDirectory: true }]))
+    readDir.mockImplementationOnce(
+      () =>
+        new Promise<HermesReadDirResult>(resolve => {
+          resolveChildFromA = resolve
+        })
+    )
+    readDir.mockResolvedValueOnce(ok([{ name: 'src', path: '/shared/src', isDirectory: true }]))
+    $connection.set({ baseUrl: 'https://gateway.example', connectionId: 'connection-a', mode: 'local', profile: 'default' } as never)
+
+    const { result } = renderHook(() => useProjectTree('/shared'))
+
+    await waitFor(() => expect(result.current.data[0]?.name).toBe('src'))
+
+    act(() => {
+      void result.current.loadChildren('/shared/src')
+    })
+    await waitFor(() => expect(readDir).toHaveBeenCalledTimes(2))
+
+    act(() => {
+      $connection.set({
+        baseUrl: 'https://gateway.example',
+        connectionId: 'connection-b',
+        mode: 'local',
+        profile: 'default'
+      } as never)
+    })
+    await waitFor(() => expect(result.current.data[0]?.name).toBe('src'))
+
+    await act(async () => {
+      resolveChildFromA?.(ok([{ name: 'from-a', path: '/shared/src/from-a', isDirectory: false }]))
+    })
+
+    expect(result.current.data[0]).not.toMatchObject({ children: [{ name: 'from-a' }] })
+  })
+
+  it('discards a stale root read after the active registered connection changes', async () => {
     let resolveFirst: ((result: HermesReadDirResult) => void) | undefined
     readDir.mockImplementationOnce(
       () =>

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -160,8 +160,8 @@ function clearProjectTree() {
  *  than bricking the tree, display the sanitized workspace fallback (main
  *  prefers the configured default project dir). Local connections only —
  *  remote trees are read through the remote bridge. */
-async function fallbackRootFor(cwd: string): Promise<string | null> {
-  if ($connection.get()?.mode === 'remote') {
+async function fallbackRootFor(cwd: string, sourceIsRemote: boolean): Promise<string | null> {
+  if (sourceIsRemote) {
     return null
   }
 
@@ -180,7 +180,10 @@ async function fallbackRootFor(cwd: string): Promise<string | null> {
   }
 }
 
-async function loadRoot(cwd: string, { force = false }: { force?: boolean } = {}) {
+async function loadRoot(
+  cwd: string,
+  { connectionKey = desktopFsCacheKey(), force = false }: { connectionKey?: string; force?: boolean } = {}
+) {
   if (!cwd) {
     clearProjectTree()
 
@@ -213,6 +216,7 @@ async function loadRoot(cwd: string, { force = false }: { force?: boolean } = {}
     rootLoading: true
   })
 
+  const sourceIsRemote = $connection.get()?.mode === 'remote'
   let resolvedCwd = cwd
   let entries: ProjectTreeEntry[] = []
   let error: string | undefined
@@ -220,8 +224,8 @@ async function loadRoot(cwd: string, { force = false }: { force?: boolean } = {}
   try {
     ;({ entries, error } = await readProjectDir(cwd, cwd))
 
-    if (error) {
-      const fallback = await fallbackRootFor(cwd)
+    if (error && desktopFsCacheKey() === connectionKey) {
+      const fallback = await fallbackRootFor(cwd, sourceIsRemote)
 
       if (fallback) {
         const retry = await readProjectDir(fallback, fallback)
@@ -238,7 +242,7 @@ async function loadRoot(cwd: string, { force = false }: { force?: boolean } = {}
   }
 
   setProjectTree(latest => {
-    if (latest.cwd !== cwd || latest.requestId !== requestId) {
+    if (latest.cwd !== cwd || latest.requestId !== requestId || desktopFsCacheKey() !== connectionKey) {
       return latest
     }
 
@@ -265,10 +269,14 @@ export function resetProjectTreeState() {
 // untouched folders never touch the filesystem or re-render. Falls back to
 // re-reading every loaded dir only when the mutation is opaque (a terminal
 // command / a path we couldn't resolve) — see store/workspace-events.
-async function revalidateTree(cwd: string, change: { dirs: string[]; full: boolean }): Promise<void> {
+async function revalidateTree(
+  cwd: string,
+  change: { dirs: string[]; full: boolean },
+  connectionKey: string
+): Promise<void> {
   const state = $projectTree.get()
 
-  if (!cwd || state.cwd !== cwd || !state.loaded) {
+  if (!cwd || state.cwd !== cwd || !state.loaded || desktopFsCacheKey() !== connectionKey) {
     return
   }
 
@@ -286,7 +294,7 @@ async function revalidateTree(cwd: string, change: { dirs: string[]; full: boole
     const reads = await Promise.all(targets.map(async dir => ({ dir, ...(await readProjectDir(dir, rootPath)) })))
 
     setProjectTree(latest => {
-      if (latest.cwd !== cwd || !latest.loaded) {
+      if (latest.cwd !== cwd || !latest.loaded || desktopFsCacheKey() !== connectionKey) {
         return latest
       }
 
@@ -337,7 +345,9 @@ async function revalidateTree(cwd: string, change: { dirs: string[]; full: boole
 
   const nextData = await reconcile(rootPath, state.data)
 
-  setProjectTree(latest => (latest.cwd === cwd && latest.loaded ? { ...latest, data: nextData } : latest))
+  setProjectTree(latest =>
+    latest.cwd === cwd && latest.loaded && desktopFsCacheKey() === connectionKey ? { ...latest, data: nextData } : latest
+  )
 }
 
 /**
@@ -353,7 +363,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
   const workspaceTick = useStore($workspaceChangeTick)
   const connectionKey = desktopFsCacheKey(connection)
 
-  const refreshRoot = useCallback(() => loadRoot(cwd, { force: true }), [cwd])
+  const refreshRoot = useCallback(() => loadRoot(cwd, { connectionKey, force: true }), [connectionKey, cwd])
 
   const setNodeOpen = useCallback(
     (id: string, open: boolean) => {
@@ -389,14 +399,16 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
 
   const loadChildren = useCallback(
     async (id: string) => {
-      if (!cwd || inflight.has(id)) {
+      const inflightKey = `${connectionKey}:${id}`
+
+      if (!cwd || inflight.has(inflightKey)) {
         return
       }
 
-      inflight.add(id)
+      inflight.add(inflightKey)
 
       setProjectTree(current => {
-        if (current.cwd !== cwd) {
+        if (current.cwd !== cwd || desktopFsCacheKey() !== connectionKey) {
           return current
         }
 
@@ -415,11 +427,11 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       } catch (cause) {
         error = readError(cause)
       } finally {
-        inflight.delete(id)
+        inflight.delete(inflightKey)
       }
 
       setProjectTree(current => {
-        if (current.cwd !== cwd) {
+        if (current.cwd !== cwd || desktopFsCacheKey() !== connectionKey) {
           return current
         }
 
@@ -434,16 +446,16 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
         }
       })
     },
-    [cwd]
+    [connectionKey, cwd]
   )
 
   // Live, non-destructive refresh when the agent touches the tree (skip the
   // very first render: tick 0 is the initial value, not a real change).
   useEffect(() => {
     if (workspaceTick > 0) {
-      void revalidateTree(cwd, consumeWorkspaceChange())
+      void revalidateTree(cwd, consumeWorkspaceChange(), connectionKey)
     }
-  }, [workspaceTick, cwd])
+  }, [connectionKey, cwd, workspaceTick])
 
   useEffect(() => {
     const connectionChanged = lastConnectionKey !== '' && lastConnectionKey !== connectionKey
@@ -451,12 +463,12 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
 
     if (connectionChanged) {
       clearProjectDirCache()
-      void loadRoot(cwd, { force: true })
+      void loadRoot(cwd, { connectionKey, force: true })
 
       return
     }
 
-    void loadRoot(cwd)
+    void loadRoot(cwd, { connectionKey })
   }, [connectionKey, cwd])
 
   // Self-heal: an errored root re-probes every few seconds while the tree is
@@ -467,10 +479,10 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       return
     }
 
-    const timer = window.setTimeout(() => void loadRoot(cwd, { force: true }), ROOT_ERROR_RETRY_MS)
+    const timer = window.setTimeout(() => void loadRoot(cwd, { connectionKey, force: true }), ROOT_ERROR_RETRY_MS)
 
     return () => window.clearTimeout(timer)
-  }, [cwd, state.cwd, state.requestId, state.rootError])
+  }, [connectionKey, cwd, state.cwd, state.requestId, state.rootError])
 
   // While showing the fallback root, quietly re-probe the session's real cwd
   // (a worktree re-created, a checkout restored) and switch back when it
@@ -485,18 +497,20 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
     let cancelled = false
 
     const timer = window.setInterval(() => {
-      void readProjectDir(cwd, cwd).then(({ error }) => {
-        if (!cancelled && !error) {
-          void loadRoot(cwd, { force: true })
-        }
-      })
+      void readProjectDir(cwd, cwd)
+        .then(({ error }) => {
+          if (!cancelled && !error && desktopFsCacheKey() === connectionKey) {
+            void loadRoot(cwd, { connectionKey, force: true })
+          }
+        })
+        .catch(() => undefined)
     }, ROOT_ERROR_RETRY_MS)
 
     return () => {
       cancelled = true
       window.clearInterval(timer)
     }
-  }, [cwd, usingFallback])
+  }, [connectionKey, cwd, usingFallback])
 
   return useMemo(
     () => ({

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { atom } from 'nanostores'
 import { useCallback, useEffect, useMemo } from 'react'
 
+import { desktopFsCacheKey } from '@/lib/desktop-fs'
 import { $connection } from '@/store/session'
 import { $workspaceChangeTick, consumeWorkspaceChange } from '@/store/workspace-events'
 
@@ -86,6 +87,10 @@ function errorChild(parentId: string, error: string | undefined): TreeNode {
     name: `Unable to read (${error || 'read-error'})`,
     placeholder: 'error'
   }
+}
+
+function readError(cause: unknown): string {
+  return cause instanceof Error && cause.message ? cause.message : 'read-error'
 }
 
 export interface UseProjectTreeResult {
@@ -209,20 +214,27 @@ async function loadRoot(cwd: string, { force = false }: { force?: boolean } = {}
   })
 
   let resolvedCwd = cwd
-  let { entries, error } = await readProjectDir(cwd, cwd)
+  let entries: ProjectTreeEntry[] = []
+  let error: string | undefined
 
-  if (error) {
-    const fallback = await fallbackRootFor(cwd)
+  try {
+    ;({ entries, error } = await readProjectDir(cwd, cwd))
 
-    if (fallback) {
-      const retry = await readProjectDir(fallback, fallback)
+    if (error) {
+      const fallback = await fallbackRootFor(cwd)
 
-      if (!retry.error) {
-        resolvedCwd = fallback
-        entries = retry.entries
-        error = undefined
+      if (fallback) {
+        const retry = await readProjectDir(fallback, fallback)
+
+        if (!retry.error) {
+          resolvedCwd = fallback
+          entries = retry.entries
+          error = undefined
+        }
       }
     }
+  } catch (cause) {
+    error = readError(cause)
   }
 
   setProjectTree(latest => {
@@ -339,7 +351,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
   const state = useStore($projectTree)
   const connection = useStore($connection)
   const workspaceTick = useStore($workspaceChangeTick)
-  const connectionKey = `${connection?.mode || 'local'}:${connection?.profile || ''}:${connection?.baseUrl || ''}`
+  const connectionKey = desktopFsCacheKey(connection)
 
   const refreshRoot = useCallback(() => loadRoot(cwd, { force: true }), [cwd])
 
@@ -395,9 +407,16 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       })
 
       const rootPath = $projectTree.get().resolvedCwd || cwd
-      const { entries, error } = await readProjectDir(id, rootPath)
+      let entries: ProjectTreeEntry[] = []
+      let error: string | undefined
 
-      inflight.delete(id)
+      try {
+        ;({ entries, error } = await readProjectDir(id, rootPath))
+      } catch (cause) {
+        error = readError(cause)
+      } finally {
+        inflight.delete(id)
+      }
 
       setProjectTree(current => {
         if (current.cwd !== cwd) {

--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -2,7 +2,12 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesReadDirResult } from '@/global'
-import { $connection, setCurrentCwd } from '@/store/session'
+import {
+  $connection,
+  $selectedStoredSessionId,
+  $workspaceCwdOwner,
+  setCurrentCwd
+} from '@/store/session'
 
 import { resetProjectTreeState } from './files/use-project-tree'
 
@@ -17,6 +22,8 @@ function installBridge() {
 describe('RightSidebarPane', () => {
   beforeEach(() => {
     $connection.set(null)
+    $selectedStoredSessionId.set(null)
+    $workspaceCwdOwner.set(null)
     resetProjectTreeState()
     readDir.mockReset()
     readDir.mockResolvedValue({ entries: [{ isDirectory: false, name: 'README.md', path: '/repo/README.md' }] })
@@ -26,6 +33,8 @@ describe('RightSidebarPane', () => {
   afterEach(() => {
     cleanup()
     $connection.set(null)
+    $selectedStoredSessionId.set(null)
+    $workspaceCwdOwner.set(null)
     setCurrentCwd('')
     resetProjectTreeState()
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
@@ -44,6 +53,17 @@ describe('RightSidebarPane', () => {
 
     // The freeform folder picker is retired.
     expect(screen.queryByRole('button', { name: 'Open folder' })).toBeNull()
+  })
+
+  it('does not read a retained cwd while it belongs to a previous session', async () => {
+    $selectedStoredSessionId.set('new-session')
+    $workspaceCwdOwner.set('previous-session')
+    setCurrentCwd('/home/doug/default-profile-workspace')
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
+    expect(readDir).not.toHaveBeenCalled()
   })
 
   it('shows no tree for a detached chat (no working dir)', async () => {

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -13,7 +13,7 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
-import { $currentCwd } from '@/store/session'
+import { $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
@@ -30,12 +30,14 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
   const currentCwd = useStore($currentCwd).trim()
+  const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const workspaceCwdOwner = useStore($workspaceCwdOwner)
 
-  // The file tree is simply "browse the session's working directory". If the
-  // session has a cwd — a repo, a sibling worktree, or any folder — show it. A
-  // bare/detached chat (resolveNewSessionCwd → '') has none, so it shows the
-  // empty hint instead of whatever dir Hermes happens to run from.
-  const hasWorkspace = Boolean(currentCwd)
+  // A transition intentionally retains the old CWD until the new session
+  // confirms its workspace. Do not issue a filesystem read against that path:
+  // under a gateway switch it may belong to a different remote machine.
+  const hasWorkspace =
+    Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
 
   const {
     collapseAll,

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -180,6 +180,31 @@ describe('desktop filesystem facade', () => {
     expect(desktopFsCacheKey()).not.toBe(mrSmallKey)
   })
 
+  it('prefers registry connection identity over SSH host identity', () => {
+    $connection.set({
+      baseUrl: 'http://127.0.0.1:41001',
+      connectionId: 'connection-a',
+      mode: 'remote',
+      remoteHost: 'operator@remote-box',
+      remoteKind: 'ssh',
+      remoteIdentity: 'operator@remote-box',
+      profile: 'default'
+    } as never)
+    const first = desktopFsCacheKey()
+
+    $connection.set({
+      baseUrl: 'http://127.0.0.1:52002',
+      connectionId: 'connection-b',
+      mode: 'remote',
+      remoteHost: 'operator@remote-box',
+      remoteKind: 'ssh',
+      remoteIdentity: 'operator@remote-box',
+      profile: 'default'
+    } as never)
+
+    expect(desktopFsCacheKey()).not.toBe(first)
+  })
+
   it('keys SSH filesystem caches by stable host identity instead of the forwarded port', () => {
     $connection.set({
       mode: 'remote',

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -144,6 +144,42 @@ describe('desktop filesystem facade', () => {
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: 'remote-docker' })
   })
 
+  it('pins remote filesystem requests to the active registry connection', async () => {
+    $connection.set({ connectionId: 'mr-small', mode: 'remote', profile: 'default' } as never)
+
+    await readDesktopDir('/home/doug/default-profile-workspace')
+    await readDesktopFileText('/home/doug/default-profile-workspace/IDEA.md')
+    await readDesktopFileDataUrl('/home/doug/default-profile-workspace/IDEA.md')
+    await desktopGitRoot('/home/doug/default-profile-workspace')
+    await desktopDefaultCwd()
+    await desktopFileDiff('/home/doug/default-profile-workspace', 'IDEA.md')
+
+    expect(api).toHaveBeenCalledTimes(6)
+
+    for (const [request] of api.mock.calls) {
+      expect(request).toMatchObject({ connectionId: 'mr-small', profile: 'default' })
+    }
+  })
+
+  it('separates filesystem cache keys for registered connections sharing a profile', () => {
+    $connection.set({
+      baseUrl: 'https://gateway.example',
+      connectionId: 'mr-small',
+      mode: 'remote',
+      profile: 'default'
+    } as never)
+    const mrSmallKey = desktopFsCacheKey()
+
+    $connection.set({
+      baseUrl: 'https://gateway.example',
+      connectionId: 'other-default',
+      mode: 'remote',
+      profile: 'default'
+    } as never)
+
+    expect(desktopFsCacheKey()).not.toBe(mrSmallKey)
+  })
+
   it('keys SSH filesystem caches by stable host identity instead of the forwarded port', () => {
     $connection.set({
       mode: 'remote',

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -21,9 +21,9 @@ function connectionCacheKey(connection: HermesConnection | null) {
     return 'local:'
   }
 
-  // A profile belongs to a registry connection, not the whole Desktop. Prefer
-  // the stable registry id so two backends exposing the same profile/path never
-  // share filesystem/gitignore cache entries during a connection switch.
+  // A profile belongs to a registry connection, not the whole Desktop. The
+  // registry id is the isolation boundary, including for SSH connections; the
+  // stable host identity below is only the fallback for legacy connections.
   if (connection.connectionId) {
     return `connection:${connection.connectionId}:${connection.profile || ''}`
   }

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -21,6 +21,13 @@ function connectionCacheKey(connection: HermesConnection | null) {
     return 'local:'
   }
 
+  // A profile belongs to a registry connection, not the whole Desktop. Prefer
+  // the stable registry id so two backends exposing the same profile/path never
+  // share filesystem/gitignore cache entries during a connection switch.
+  if (connection.connectionId) {
+    return `connection:${connection.connectionId}:${connection.profile || ''}`
+  }
+
   const target =
     connection.remoteKind === 'ssh'
       ? connection.remoteIdentity || connection.remoteHost || ''
@@ -58,9 +65,16 @@ function bridge() {
 }
 
 function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
-  return bridge().api<T>(
-    body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
-  )
+  const connectionId = $connection.get()?.connectionId
+
+  const request = {
+    ...(body ? { body, method: 'POST' as const } : {}),
+    ...(connectionId ? { connectionId } : {}),
+    path,
+    profile: desktopFsProfile()
+  }
+
+  return bridge().api<T>(request)
 }
 
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {


### PR DESCRIPTION
## Summary

Fix Desktop Files-panel routing and stale-tree state when multiple registered gateway connections are configured.

- Pin remote filesystem and Git REST calls to the active `connectionId`.
- Scope filesystem/tree cache identity by registered connection.
- Avoid loading a retained CWD until it belongs to the selected session.
- Drop stale root, child, refresh, retry, and fallback results after a connection change.
- Recover tree loading/inflight state when bridge/API reads reject.

## Verification

- `npm run test:ui` — 579 files / 5,559 tests passed
- `npm run typecheck`
- Changed-file ESLint and `git diff --check`
- Packaged macOS Desktop runtime verification with the existing `mr-small` connection and another registered connection:
  - Files displayed correctly across `mr-small` default-project sessions.
  - No `ENOENT` during repeated switching.
  - Normal Desktop quit succeeded.

## Notes

The separate issue where selecting non-default profiles on `mr-small` returns to the local gateway was observed but intentionally left out of this focused Files-panel fix.
