### PR TITLE
fix(desktop): prevent cross-profile MoA autosaves on profile switch

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -475,6 +475,65 @@ describe('ModelSettings MoA preset editor', () => {
     return { ref1Provider: all.at(-6)!, ref1Model: all.at(-5)! }
   }
 
+  it('cancels a pending MoA autosave when the active profile changes', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+
+    try {
+      await openReferenceEditor()
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Enabled' }))
+
+      await act(async () => {
+        profileSwitchHandler?.()
+      })
+      await vi.advanceTimersByTimeAsync(700)
+
+      expect(saveMoaModels).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores an in-flight MoA save response after the active profile changes', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    let resolveSave: ((value: ReturnType<typeof moaConfig>) => void) | undefined
+    const staleProfileResponse = moaConfig()
+
+    staleProfileResponse.presets.default.enabled = false
+    saveMoaModels.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveSave = resolve
+      })
+    )
+
+    try {
+      await openReferenceEditor()
+
+      fireEvent.click(screen.getByRole('switch', { name: 'Enabled' }))
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(700)
+      })
+      expect(saveMoaModels).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        profileSwitchHandler?.()
+      })
+      await waitFor(() => expect(getMoaModels).toHaveBeenCalledTimes(2))
+      await waitFor(() =>
+        expect(screen.getByRole('switch', { name: 'Enabled' }).getAttribute('data-state')).toBe('checked')
+      )
+
+      await act(async () => {
+        resolveSave?.(staleProfileResponse)
+        await Promise.resolve()
+      })
+
+      expect(screen.getByRole('switch', { name: 'Enabled' }).getAttribute('data-state')).toBe('checked')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('holds the autosave while a slot is half-filled (provider changed, model pending)', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -228,6 +228,11 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
   // so a request in flight when the user switches profiles can't paint profile
   // A's models/providers into profile B (or fire onMainModelChanged for A).
   const profileEpoch = useRef(0)
+  // Debounced MoA writes resolve their target profile when they fire. A profile
+  // switch must therefore cancel pending timers and invalidate in-flight saves
+  // before the ambient active profile changes underneath them.
+  const moaSaveTimer = useRef<number | null>(null)
+  const moaSaveGeneration = useRef(0)
 
   const refresh = useCallback(
     async ({ replaceSelection = false }: { replaceSelection?: boolean } = {}) => {
@@ -289,6 +294,11 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
   // new profile (bumping the epoch first so any in-flight A request is discarded).
   useOnProfileSwitch(() => {
     profileEpoch.current += 1
+    if (moaSaveTimer.current !== null) {
+      window.clearTimeout(moaSaveTimer.current)
+      moaSaveTimer.current = null
+    }
+    moaSaveGeneration.current += 1
     // The panel stays mounted across profile switches, so clear the previous
     // profile's draft selection before loading the new profile's source of
     // truth. Ordinary same-profile refreshes still preserve in-progress edits.
@@ -361,19 +371,15 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
     moaRef.current = moa
   }, [moa])
 
-  const moaSaveTimer = useRef<number | null>(null)
-
   useEffect(
     () => () => {
-      if (moaSaveTimer.current) {
+      if (moaSaveTimer.current !== null) {
         window.clearTimeout(moaSaveTimer.current)
+        moaSaveTimer.current = null
       }
     },
     []
   )
-
-  // Guard against stale save responses overwriting newer state.
-  const moaSaveGeneration = useRef(0)
 
   // Quiet debounced persist for inline MoA edits — mirrors the config page's
   // autosave so slot/aggregator tweaks save themselves, matching the


### PR DESCRIPTION
## What does this PR do?

Desktop Model Settings autosaves MoA preset edits through a debounced timer whose target profile resolves when the timer fires, not when the edit is made. If the user switches profiles while a save is pending or already in flight:

- profile A's queued payload can be written through `saveMoaModels(next, undefined)` into newly active profile B (`undefined` resolves to the ambient active profile at execution time), and
- an in-flight save's response from A can repaint B's UI with A's state.

This fixes both halves of the race.

## Related Issue

No tracking issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`apps/desktop/src/app/settings/model-settings.tsx`:
- Moved `moaSaveTimer` / `moaSaveGeneration` refs above the `useOnProfileSwitch` handler.
- On active-profile switch: cancel any pending MoA save timer, null it, and increment `moaSaveGeneration` before refreshing, so stale in-flight responses are discarded by the existing generation guard.
- Unmount cleanup is now null-safe and resets the timer ref.

`apps/desktop/src/app/settings/model-settings.test.tsx`:
- Regression test: "cancels a pending MoA autosave when the active profile changes" (failed before the fix).
- Regression test: "ignores an in-flight MoA save response after the active profile changes" (failed before the fix; needed generation invalidation, not just timer cancellation).

Normal same-profile debounced autosave behavior is unchanged.

## How to Test

1. Open Model Settings → Mixture of Agents section.
2. Toggle a preset switch, then switch the active profile within the 600ms debounce window → the old profile's payload must not be saved to the new profile.
3. Run the regression tests:
   ```
   cd apps/desktop && npm test -- --run src/app/settings/model-settings.test.tsx -t "active profile changes"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: desktop-only TypeScript change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A ✔ N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A ✔ N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A ✔ N/A
- [x] I've considered cross-platform impact (Windows, macOS) — timer/generation logic is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A ✔ N/A
