### PR TITLE
fix(desktop): completed /goal chip no longer sticks to the composer

### DIFF
--- a/apps/desktop/src/store/goals.test.ts
+++ b/apps/desktop/src/store/goals.test.ts
@@ -78,4 +78,33 @@ describe('goal store', () => {
 
     clearSessionGoal('s1')
   })
+
+  it('does not resurrect a done goal on hydration', () => {
+    // `/goal status` reports "✓ Goal done" forever after completion (the DB
+    // keeps terminal state). Hydrating that on session open must not bring
+    // the completed chip back — Bot Mode's single endless session would show
+    // it for the rest of time.
+    applyGoalStatusText('s1', '✓ Goal done (12/20 turns): ship the feature', { hydrate: true })
+
+    expect($goalsBySession.get().s1).toBeUndefined()
+  })
+
+  it('hydration drops a lingering done chip already on screen', () => {
+    vi.useFakeTimers()
+
+    applyGoalStatusText('s1', '✓ Goal achieved: tests pass')
+    applyGoalStatusText('s1', '✓ Goal done (12/20 turns): tests pass', { hydrate: true })
+
+    expect($goalsBySession.get().s1).toBeUndefined()
+  })
+
+  it('hydration still surfaces non-terminal goals', () => {
+    applyGoalStatusText('s1', '⊙ Goal (active, 3/20 turns): ship the feature', { hydrate: true })
+
+    expect($goalsBySession.get().s1).toMatchObject({ status: 'active', title: 'ship the feature' })
+
+    applyGoalStatusText('s2', '⏸ Goal (paused, 20/20 turns): other work', { hydrate: true })
+
+    expect($goalsBySession.get().s2).toMatchObject({ status: 'paused', title: 'other work' })
+  })
 })

--- a/apps/desktop/src/store/goals.ts
+++ b/apps/desktop/src/store/goals.ts
@@ -134,7 +134,7 @@ function nextGoalFromText(text: string, previous?: SessionGoal): SessionGoal | n
   return undefined
 }
 
-export function applyGoalStatusText(sid: string, text: string) {
+export function applyGoalStatusText(sid: string, text: string, opts?: { hydrate?: boolean }) {
   if (!sid) {
     return
   }
@@ -144,6 +144,18 @@ export function applyGoalStatusText(sid: string, text: string) {
   if (next === null) {
     clearSessionGoal(sid)
   } else if (next) {
+    // A done goal is terminal state in the backend DB — it stays "done"
+    // forever (only /goal clear or a new goal replaces it). The 8s linger is
+    // for the LIVE completion moment; re-hydrating "✓ Goal done" on every
+    // mount would resurrect the chip indefinitely. Bot Mode is the worst
+    // case: one endless session means the completed layover would never go
+    // away. On hydration, a terminal goal is the same as no goal.
+    if (opts?.hydrate && next.status === 'done') {
+      clearSessionGoal(sid)
+
+      return
+    }
+
     setSessionGoal(sid, next)
   }
 }
@@ -157,7 +169,8 @@ export async function refreshSessionGoal(sid: string): Promise<void> {
 
   try {
     const result = await gateway.request<{ output?: string }>('slash.exec', { command: 'goal status', session_id: sid })
-    applyGoalStatusText(sid, result?.output ?? '')
+
+    applyGoalStatusText(sid, result?.output ?? '', { hydrate: true })
   } catch {
     // Best-effort: older gateways or detached sessions simply won't hydrate it.
   }


### PR DESCRIPTION
## Summary
The "✓ Goal done" chip above the desktop composer no longer sticks forever. Root cause: a finished goal stays `status=done` in the backend DB permanently, and the status stack re-hydrates the indicator from `/goal status` on every mount — so the done chip was recreated endlessly, bypassing the 8-second linger meant for the live completion moment. In Bot Mode (one endless session) the completed overlay never went away.

## Changes
- `apps/desktop/src/store/goals.ts`: `applyGoalStatusText` gains a `hydrate` flag; during hydration a terminal (done) goal is treated as no goal (and any lingering done chip is dropped). Live events keep the 8s linger.
- `apps/desktop/src/store/goals.test.ts`: 3 new tests — done goal not resurrected on hydration, hydration drops an on-screen done chip, non-terminal goals still hydrate.

## Validation
| | Before | After |
|---|---|---|
| Hydrate "✓ Goal done" on session open | chip appears, never clears | no chip |
| Live "✓ Goal achieved" event | 8s linger then clear | unchanged |
| Hydrate active/paused goal | chip shown | unchanged |

vitest: 14/14 passing (goals + goal-indicator suites). eslint + `tsc --noEmit` clean.

## Infographic

![Completed goal chip no longer sticks](https://v3b.fal.media/files/b/0aa78bd7/zkyalx-XLZeY2FLh_yZcD_PIRdFcw5.png)
