### PR TITLE
fix(dashboard-auth): sign-in no longer dies when Desktop triggers a plugin re-discovery (#91701, salvage #91741)

### DIFF
--- a/hermes_cli/dashboard_auth/registry.py
+++ b/hermes_cli/dashboard_auth/registry.py
@@ -122,6 +122,44 @@ def list_session_providers() -> List[DashboardAuthProvider]:
     return [p for p in list_providers() if getattr(p, "supports_session", True)]
 
 
+def register_global_provider(provider: DashboardAuthProvider) -> None:
+    """Register a host-owned provider in the process-global slot (upsert).
+
+    The dashboard auth registry is process-global and shared across every
+    profile the dashboard serves from one process, so its providers must
+    outlive any single per-home plugin manager. Unlike ``register_provider``
+    this always targets the global ``_providers`` map (never a per-home
+    overlay) and *replaces* any same-name entry instead of raising, so a
+    forced plugin re-discovery (e.g. after a password change) rotates the
+    provider in place. Pairs with ``unregister_global_provider`` for teardown
+    of the exact object still current (#91701).
+    """
+    assert_protocol_compliance(type(provider))
+    with _lock:
+        _providers[provider.name] = provider
+    _log.info(
+        "dashboard-auth: registered global provider %r (%s)",
+        provider.name, provider.display_name,
+    )
+
+
+def unregister_global_provider(
+    name: str,
+    provider: DashboardAuthProvider,
+) -> bool:
+    """Remove a global provider registration if ``provider`` is still current.
+
+    Identity-conditional so a stale handle (whose provider was already
+    replaced by a later ``register_global_provider``) never clears the live
+    registration.
+    """
+    with _lock:
+        if _providers.get(name) is provider:
+            _providers.pop(name, None)
+            return True
+    return False
+
+
 def clear_providers() -> None:
     """Test-only: drop all registrations."""
     with _lock:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1537,10 +1537,18 @@ class PluginContext:
         kind: str,
         key: str,
         release: Callable[[], None],
+        *,
+        persistent: bool = False,
     ) -> PluginRegistration:
-        """Record host-owned cleanup for a successful registration."""
+        """Record host-owned cleanup for a successful registration.
+
+        ``persistent`` registrations are returned as live handles but kept
+        out of the manager's reverse-order teardown, so a routine per-home
+        manager unload does not dispose them (see
+        :meth:`PluginManager._track_registration`).
+        """
         return self._manager._track_registration(
-            self.manifest, kind, key, release
+            self.manifest, kind, key, release, persistent=persistent
         )
 
     def _track_replacement(
@@ -2382,12 +2390,11 @@ class PluginContext:
         cannot crash the host. Same convention as
         ``register_image_gen_provider``.
         """
-        from hermes_cli.dashboard_auth import (
-            DashboardAuthProvider,
-            register_provider,
+        from hermes_cli.dashboard_auth import DashboardAuthProvider
+        from hermes_cli.dashboard_auth.registry import (
+            register_global_provider,
+            unregister_global_provider,
         )
-        from hermes_cli.dashboard_auth.registry import restore_registration
-        from hermes_cli.dashboard_auth.registry import snapshot_registration
 
         if not isinstance(provider, DashboardAuthProvider):
             logger.warning(
@@ -2397,10 +2404,19 @@ class PluginContext:
             )
             return
         registry_name = provider.name
-        scope = self._manager.scope_key
-        previous = snapshot_registration(registry_name, scope=scope)
+        # The dashboard auth registry is process-global — its lifetime is the
+        # web server, not this per-home plugin manager. A per-home manager is
+        # torn down routinely (profile-scoped dashboard activity, force
+        # re-discovery), and disposing this registration on that teardown
+        # emptied the auth registry for the WHOLE process, permanently
+        # disabling sign-in until restart (#91701). So register it in the
+        # global slot (upsert) and, crucially, keep it OUT of the manager's
+        # reverse-order teardown (``persistent=True``): a per-home unload can
+        # no longer clear it. The handle still disposes explicitly (identity-
+        # conditional), and a forced re-discovery rotates the provider in
+        # place via the upsert.
         try:
-            register_provider(provider, scope=scope)
+            register_global_provider(provider)
         except (TypeError, ValueError) as e:
             logger.warning(
                 "Plugin '%s' failed to register dashboard-auth provider "
@@ -2408,18 +2424,11 @@ class PluginContext:
                 self.manifest.name, getattr(provider, "name", "?"), e,
             )
             return
-        registered = snapshot_registration(registry_name, scope=scope)
-        if registered is not provider:
-            return None
-        handle = self._track_replacement(
+        handle = self._track(
             "dashboard_auth_provider",
             registry_name,
-            slot=("dashboard_auth_provider", scope, registry_name),
-            current=provider,
-            previous=previous,
-            restore=lambda replacement: restore_registration(
-                registry_name, provider, replacement, scope=scope
-            ),
+            lambda: unregister_global_provider(registry_name, provider),
+            persistent=True,
         )
         logger.info(
             "Plugin '%s' registered dashboard-auth provider: %s (%s)",
@@ -3478,8 +3487,18 @@ class PluginManager:
         kind: str,
         key: str,
         release: Callable[[], None],
+        *,
+        persistent: bool = False,
     ) -> PluginRegistration:
-        """Record one successful registration under its canonical plugin key."""
+        """Record one successful registration under its canonical plugin key.
+
+        ``persistent`` registrations (process-global host infrastructure such
+        as dashboard-auth providers, whose lifetime is the server rather than
+        a per-home plugin manager) are still tracked in the ownership ledger
+        for attribution, but are NOT enrolled in ``_registration_order`` — so
+        a routine per-home manager unload cannot dispose them (#91701). The
+        returned handle still releases on explicit ``dispose()``.
+        """
         plugin_key = manifest.key or manifest.name
         registration = PluginRegistration(
             kind=kind,
@@ -3491,7 +3510,8 @@ class PluginManager:
             [disposed]
         )
         self._ownership_ledger.setdefault(plugin_key, []).append(registration)
-        self._registration_order.append(registration)
+        if not persistent:
+            self._registration_order.append(registration)
         return registration
 
     @staticmethod
@@ -5685,6 +5705,18 @@ def _reset_plugin_managers_for_tests() -> None:
                 logger.debug("test plugin-manager unload failed", exc_info=True)
         _plugin_managers_by_home.clear()
         _plugin_manager = None
+    # Dashboard-auth providers are persistent host-owned registrations that
+    # deliberately survive a routine manager unload (#91701), so the "clean
+    # slate" reset must drop the process-global auth registry explicitly —
+    # otherwise a provider auto-registered during one test leaks into the next.
+    try:
+        from hermes_cli.dashboard_auth.registry import (
+            clear_providers as _clear_dashboard_auth_providers,
+        )
+
+        _clear_dashboard_auth_providers()
+    except Exception:
+        logger.debug("dashboard-auth registry clear failed", exc_info=True)
 
 
 def has_enabled_agent_plugin_mcp(raw_config: Mapping[str, Any]) -> bool:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1183,6 +1183,13 @@ class PluginRegistration:
     key: str
     release: Callable[[], None]
     plugin_key: str = ""
+    # Process-global host infrastructure (e.g. dashboard-auth providers) whose
+    # lifetime is the server, not this per-home manager: kept out of
+    # ``_registration_order`` so a routine unload-all cannot dispose it
+    # (#91701), but still disposed by a *targeted* unload (plugin disable/
+    # uninstall) and evicted on force re-discovery when the plugin no longer
+    # re-registers it.
+    persistent: bool = False
     _disposed: bool = field(default=False, init=False, repr=False)
     _on_dispose: Optional[Callable[["PluginRegistration"], None]] = field(
         default=None, init=False, repr=False
@@ -3468,6 +3475,13 @@ class PluginManager:
         # symmetric force-reload lands.
         self._ownership_ledger: Dict[str, List[PluginRegistration]] = {}
         self._registration_order: List[PluginRegistration] = []
+        # Persistent (process-global) registrations that survived an
+        # unload-all. Force re-discovery drains this via
+        # _evict_stale_persistent_registrations(): entries whose plugin
+        # re-registered the same (kind, key) are kept (the upsert rotated
+        # them in place), the rest are disposed so a disabled/removed auth
+        # plugin's provider does not outlive its plugin (#91701 follow-up).
+        self._persistent_carryover: List[PluginRegistration] = []
         # Deferred platform plugins whose client tools were registered at
         # discovery time (see _register_deferred_platform_tools). Keyed by
         # plugin id: the already-imported package module, so materializing the
@@ -3505,6 +3519,7 @@ class PluginManager:
             key=key,
             release=release,
             plugin_key=plugin_key,
+            persistent=persistent,
         )
         registration._on_dispose = lambda disposed: self._forget_registrations(
             [disposed]
@@ -3513,6 +3528,48 @@ class PluginManager:
         if not persistent:
             self._registration_order.append(registration)
         return registration
+
+    def _evict_stale_persistent_registrations(self) -> None:
+        """Dispose carried-over persistent registrations not re-registered.
+
+        Persistent registrations (process-global host infrastructure such as
+        dashboard-auth providers) survive an unload-all by design (#91701);
+        ``_unload_scoped`` parks their handles in ``_persistent_carryover``.
+        After a re-discovery pass, three cases exist for each parked handle:
+
+        - the plugin re-registered the same ``(kind, key)`` → the upsert
+          rotated the entry in place. The old handle is superseded; drop it
+          WITHOUT disposing (a plugin that re-registered the *same object*
+          would otherwise pass the identity check and evict the live entry).
+        - the plugin did not come back (disabled, uninstalled, omitted) →
+          dispose, releasing the process-global registration.
+        - the handle was already disposed elsewhere (targeted unload) → drop.
+        """
+        if not self._persistent_carryover:
+            return
+        parked = self._persistent_carryover
+        self._persistent_carryover = []
+        current = {
+            (registration.kind, registration.key)
+            for owned in self._ownership_ledger.values()
+            for registration in owned
+            if registration.persistent and registration.active
+        }
+        stale = [
+            registration
+            for registration in parked
+            if registration.active
+            and (registration.kind, registration.key) not in current
+        ]
+        for registration in stale:
+            logger.info(
+                "Evicting persistent registration %s/%s: plugin '%s' no "
+                "longer supplies it after re-discovery",
+                registration.kind,
+                registration.key,
+                registration.plugin_key,
+            )
+        self._dispose_registrations(stale)
 
     @staticmethod
     def _remove_identity(values: list, target: Any) -> bool:
@@ -3683,6 +3740,18 @@ class PluginManager:
                 for registration in self._registration_order
                 if registration.plugin_key in target_keys
             ]
+            # Persistent registrations (process-global host infrastructure,
+            # e.g. dashboard-auth providers) are deliberately absent from
+            # _registration_order so an unload-all cannot dispose them
+            # (#91701). A *targeted* unload is different: it is the plugin
+            # disable/uninstall path, and a disabled auth plugin's provider
+            # must NOT stay live process-wide. Gather them from the ledger.
+            registrations.extend(
+                registration
+                for key in target_keys
+                for registration in self._ownership_ledger.get(key, [])
+                if registration.persistent and registration.active
+            )
 
         found = bool(target_keys or registrations)
         self._dispose_registrations(registrations)
@@ -3736,6 +3805,21 @@ class PluginManager:
                                 tool_name,
                                 exc,
                             )
+            # Persistent registrations survive this unload-all by design
+            # (#91701) but must not be orphaned by the ledger clear below:
+            # carry them over so a force re-discovery can evict the ones
+            # whose plugin does not come back (disabled/removed/omitted).
+            carryover_ids = {
+                id(registration) for registration in self._persistent_carryover
+            }
+            self._persistent_carryover.extend(
+                registration
+                for owned in self._ownership_ledger.values()
+                for registration in owned
+                if registration.persistent
+                and registration.active
+                and id(registration) not in carryover_ids
+            )
             self._ownership_ledger.clear()
             self._plugins.clear()
             self._hooks.clear()
@@ -3817,6 +3901,13 @@ class PluginManager:
             self._discovered = True
             try:
                 self._discover_and_load_inner()
+                # Persistent registrations deliberately survived the
+                # unload-all above (#91701). Now that plugins have had their
+                # chance to re-register, dispose the ones whose plugin did
+                # not come back (disabled, removed, or omitted from this
+                # discovery pass) so e.g. a disabled auth plugin's provider
+                # does not stay live process-wide until restart.
+                self._evict_stale_persistent_registrations()
                 # Plugin secret sources register during discover; the initial
                 # load_hermes_dotenv() already ran at import time. Re-pull so the
                 # first process sees plugin backends (tracking #64177).

--- a/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
+++ b/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
@@ -11,7 +11,9 @@ from hermes_cli.dashboard_auth import clear_providers, get_provider
 from hermes_cli.dashboard_auth.base import (
     DashboardAuthProvider, LoginStart, Session,
 )
-from hermes_cli.plugins import PluginContext, PluginManifest
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+from hermes_cli.dashboard_auth import registry as _auth_registry
+from hermes_constants import hermes_home_key
 
 
 class _Stub(DashboardAuthProvider):
@@ -80,3 +82,90 @@ def test_plugin_ctx_silently_ignores_non_provider(caplog):
         and "DashboardAuthProvider" in rec.message
         for rec in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# #91701: a dashboard-auth provider is process-global host infrastructure. A
+# per-home plugin manager is torn down routinely (profile-scoped dashboard
+# activity, force re-discovery); that teardown must NOT empty the auth
+# registry and lock the whole process out of sign-in.
+# ---------------------------------------------------------------------------
+
+
+class _Basic(DashboardAuthProvider):
+    name = "basic"
+    display_name = "Basic"
+
+    def __init__(self, tag: str = "a") -> None:
+        self.tag = tag
+
+    def start_login(self, *, redirect_uri):
+        return LoginStart(redirect_url="x", cookie_payload={})
+
+    def complete_login(self, *, code, state, code_verifier, redirect_uri):
+        return Session("u", "e", "n", "o", "basic", 0, "a", "r")
+
+    def verify_session(self, *, access_token):
+        return None
+
+    def refresh_session(self, *, refresh_token):
+        return None
+
+    def revoke_session(self, *, refresh_token):
+        return None
+
+
+def _real_ctx() -> tuple[PluginManager, PluginContext]:
+    manager = PluginManager(scope_key=hermes_home_key())
+    manifest = PluginManifest(name="basic", version="0.0.1", kind="backend")
+    return manager, PluginContext(manifest=manifest, manager=manager)
+
+
+def test_auth_provider_registers_globally_not_in_home_overlay():
+    """Registered in the process-global slot so every profile scope sees it."""
+    manager, ctx = _real_ctx()
+    ctx.register_dashboard_auth_provider(_Basic())
+    assert "basic" in _auth_registry._providers
+    assert "basic" not in _auth_registry._scoped_providers.get(
+        manager.scope_key, {}
+    )
+    assert [p.name for p in _auth_registry.list_session_providers()] == ["basic"]
+
+
+def test_auth_provider_survives_per_home_manager_unload():
+    """Regression for #91701: routine per-home unload must not disable auth."""
+    manager, ctx = _real_ctx()
+    ctx.register_dashboard_auth_provider(_Basic())
+    assert get_provider("basic") is not None
+
+    # The exact teardown discover_and_load(force=True) / profile-scoped
+    # activity drives; before the fix this emptied the registry permanently.
+    manager.unload()
+
+    assert get_provider("basic") is not None, (
+        "auth provider was disposed by a per-home plugin-manager unload"
+    )
+    assert [p.name for p in _auth_registry.list_session_providers()] == ["basic"]
+
+
+def test_auth_provider_kept_out_of_manager_teardown_order():
+    """Persistent registration is not enrolled in reverse-order teardown."""
+    manager, ctx = _real_ctx()
+    ctx.register_dashboard_auth_provider(_Basic())
+    assert manager._registration_order == []
+    # Still attributed to the plugin for `hermes plugins list`.
+    assert "basic" in manager._ownership_ledger
+
+
+def test_auth_provider_re_register_rotates_in_place():
+    """A forced re-discovery (e.g. password change) upserts the new provider."""
+    manager, ctx = _real_ctx()
+    old = _Basic("old")
+    new = _Basic("new")
+    stale = ctx.register_dashboard_auth_provider(old)
+    ctx.register_dashboard_auth_provider(new)
+    assert get_provider("basic") is new
+
+    # The superseded handle is identity-conditional: disposing it is a no-op.
+    stale.dispose()
+    assert get_provider("basic") is new

--- a/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
+++ b/tests/hermes_cli/test_dashboard_auth_plugin_hook.py
@@ -169,3 +169,89 @@ def test_auth_provider_re_register_rotates_in_place():
     # The superseded handle is identity-conditional: disposing it is a no-op.
     stale.dispose()
     assert get_provider("basic") is new
+
+
+# ---------------------------------------------------------------------------
+# #91701 follow-up: persistence must not outlive the plugin. A targeted
+# unload (plugin disable/uninstall) and a re-discovery that drops the plugin
+# must both release the process-global provider — only the ROUTINE
+# unload-all path keeps it alive.
+# ---------------------------------------------------------------------------
+
+
+def test_targeted_unload_disposes_persistent_auth_provider():
+    """Disabling the auth plugin removes its provider process-wide."""
+    manager, ctx = _real_ctx()
+    ctx.register_dashboard_auth_provider(_Basic())
+    assert get_provider("basic") is not None
+
+    # `hermes plugins disable basic` drives a targeted unload of that plugin.
+    assert manager.unload("basic") is True
+
+    assert get_provider("basic") is None, (
+        "disabled auth plugin's provider stayed registered process-wide"
+    )
+    assert _auth_registry.list_session_providers() == []
+
+
+def test_rediscovery_evicts_provider_when_plugin_gone():
+    """Force re-discovery where the plugin does not come back → evicted."""
+    manager, ctx = _real_ctx()
+    ctx.register_dashboard_auth_provider(_Basic())
+
+    # discover_and_load(force=True) step 1: unload-all parks the handle.
+    manager.unload()
+    assert get_provider("basic") is not None
+
+    # Step 2: discovery ran, plugin did not re-register (disabled/removed).
+    manager._evict_stale_persistent_registrations()
+
+    assert get_provider("basic") is None, (
+        "provider survived a re-discovery its plugin was dropped from"
+    )
+
+
+def test_rediscovery_keeps_provider_when_plugin_returns():
+    """Force re-discovery where the plugin re-registers → new provider live."""
+    manager, ctx = _real_ctx()
+    old = _Basic("old")
+    ctx.register_dashboard_auth_provider(old)
+
+    manager.unload()
+    # Plugin re-registers during discovery (upsert rotates in place).
+    new = _Basic("new")
+    ctx.register_dashboard_auth_provider(new)
+    manager._evict_stale_persistent_registrations()
+
+    assert get_provider("basic") is new
+    # Eviction must be one-shot: the parked list is drained.
+    assert manager._persistent_carryover == []
+
+
+def test_rediscovery_same_object_reregistration_survives_eviction():
+    """A plugin re-registering the SAME provider object must stay live."""
+    manager, ctx = _real_ctx()
+    provider = _Basic("same")
+    ctx.register_dashboard_auth_provider(provider)
+
+    manager.unload()
+    ctx.register_dashboard_auth_provider(provider)
+    manager._evict_stale_persistent_registrations()
+
+    assert get_provider("basic") is provider
+
+
+def test_persistent_dispose_is_idempotent_after_targeted_unload():
+    """A handle disposed by a targeted unload never re-parks or re-releases."""
+    manager, ctx = _real_ctx()
+    ctx.register_dashboard_auth_provider(_Basic())
+
+    manager.unload("basic")   # targeted unload disposes + forgets the handle
+    assert get_provider("basic") is None
+
+    # A later unload-all parks nothing (the handle is gone from the ledger),
+    # and the eviction pass must not raise or double-release.
+    manager.unload()
+    assert manager._persistent_carryover == []
+    manager._evict_stale_persistent_registrations()
+    assert get_provider("basic") is None


### PR DESCRIPTION
## Summary

Basic-auth (and any plugin-provided dashboard-auth provider) no longer vanishes from a running dashboard: a routine per-home plugin-manager unload can no longer empty the process-global auth registry, while plugin disable/uninstall and force re-discovery still revoke providers correctly. Fixes #91701 — long-running non-loopback dashboards silently lost all sign-in within minutes of Desktop's profile-scoped activity, and the only recovery was a restart.

Salvage of #91741 by @rainbowgore with their authorship preserved, plus a follow-up lifecycle commit closing the gap flagged in review.

## Changes

- `hermes_cli/dashboard_auth/registry.py` (contributor commit): `register_global_provider` (process-global upsert) + `unregister_global_provider` (identity-conditional removal).
- `hermes_cli/plugins.py` (contributor commit): dashboard-auth registrations become `persistent=True` — tracked in the ownership ledger for attribution but kept out of `_registration_order`, so an unload-all cannot dispose them.
- `hermes_cli/plugins.py` (follow-up): persistence must not outlive the plugin —
  - targeted `unload(<plugin>)` (the disable/uninstall path) now gathers persistent rows from the ledger and disposes them;
  - unload-all parks live persistent handles in `_persistent_carryover`; `discover_and_load(force=True)` evicts the ones whose plugin did not re-register the same `(kind, key)`, dropping superseded handles without disposal so a same-object re-registration stays live.
- `tests/hermes_cli/test_dashboard_auth_plugin_hook.py`: 4 contributor regression tests + 5 follow-up lifecycle tests.

## Validation

| Check | Result |
|---|---|
| `test_dashboard_auth_*` family (14 files) + plugins + ownership ledger | 211 + 103 passed |
| E2E: real plugin dir, real discovery, force re-discovery, disable + re-discovery | 3/3 pass |
| Sabotage run (new tests against main's code) | 8/11 fail as expected |

## Infographic

![Persistent Auth Provider — holo card](https://v3b.fal.media/files/b/0aa78be1/mcWQI7r57iqzLQTmUwAdl_iI2jV04S.png)
