### PR TITLE
fix(vision): handle HEIC clipboard images locally

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -592,10 +592,10 @@ _UNIVERSALLY_SUPPORTED_MIMES = frozenset({
 })
 
 
-def _transcode_to_png(raw: bytes) -> Optional[bytes]:
-    """Decode arbitrary image bytes with Pillow and re-encode as PNG.
+def _transcode_to_supported_format(raw: bytes) -> Optional[tuple[bytes, str]]:
+    """Decode arbitrary image bytes with Pillow and re-encode to JPEG/PNG.
 
-    Returns None if Pillow isn't installed or can't decode the input
+    Returns (bytes, mime) tuple or None if Pillow isn't installed or can't decode the input
     (rare formats, corrupted bytes, missing optional decoder plugin for
     HEIC/AVIF, or vector formats like SVG). Caller falls back to skipping
     the image so the rest of the turn still works.
@@ -625,21 +625,30 @@ def _transcode_to_png(raw: bytes) -> Optional[bytes]:
         import pillow_avif  # type: ignore  # noqa: F401  -- registers AVIF on import
     except Exception:
         pass
+    # Strategy: if opaque (no alpha), transcode to JPEG (quality 85) to avoid
+    # massive PNG explosion on camera photos (e.g. 48MP iPhone HEIC -> 30MB+ PNG).
+    # If transparent or exotic palette, transcode to PNG.
     try:
         from io import BytesIO
 
         with Image.open(BytesIO(raw)) as im:
-            # Pick an output mode PNG can serialise. Anything other than
-            # the standard set gets normalised to RGBA so transparency is
-            # preserved where the source had it.
-            if im.mode not in {"RGB", "RGBA", "L", "LA", "P"}:
-                im = im.convert("RGBA")
+            has_alpha = im.mode in ("RGBA", "LA", "PA") or (
+                im.mode == "P" and "transparency" in im.info
+            )
             buf = BytesIO()
-            im.save(buf, format="PNG", optimize=False)
-            return buf.getvalue()
+            if has_alpha:
+                if im.mode not in {"RGB", "RGBA", "L", "LA", "P"}:
+                    im = im.convert("RGBA")
+                im.save(buf, format="PNG", optimize=False)
+                return buf.getvalue(), "image/png"
+            else:
+                if im.mode not in {"RGB", "L"}:
+                    im = im.convert("RGB")
+                im.save(buf, format="JPEG", quality=85)
+                return buf.getvalue(), "image/jpeg"
     except Exception as exc:
         logger.info(
-            "image_routing: Pillow could not transcode image to PNG -- %s", exc
+            "image_routing: Pillow could not transcode image -- %s", exc
         )
         return None
 
@@ -710,21 +719,22 @@ def _file_to_data_url(path: Path) -> Optional[str]:
         return None
     mime = _guess_mime(path, raw=raw)
     if mime not in _UNIVERSALLY_SUPPORTED_MIMES:
-        transcoded = _transcode_to_png(raw)
-        if transcoded is None:
+        transcode_res = _transcode_to_supported_format(raw)
+        if transcode_res is None:
             logger.warning(
                 "image_routing: %s is %s which is not accepted by all major "
-                "vision providers and could not be transcoded to PNG; "
+                "vision providers and could not be transcoded; "
                 "skipping this attachment.",
                 path, mime,
             )
             return None
+        transcoded, out_mime = transcode_res
         logger.info(
-            "image_routing: transcoded %s (%s) -> image/png for provider compatibility",
-            path.name, mime,
+            "image_routing: transcoded %s (%s) -> %s for provider compatibility",
+            path.name, mime, out_mime,
         )
         raw = transcoded
-        mime = "image/png"
+        mime = out_mime
     b64 = base64.b64encode(raw).decode("ascii")
     return f"data:{mime};base64,{b64}"
 

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -555,16 +555,13 @@ def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
     # BMP: "BM"
     if raw.startswith(b"BM"):
         return "image/bmp"
-    # ISO-BMFF family (HEIC/HEIF/AVIF): bytes 4..8 == 'ftyp', major brand at 8..12
-    if len(raw) >= 12 and raw[4:8] == b"ftyp":
-        brand = raw[8:12]
-        if brand in {b"avif", b"avis"}:
-            return "image/avif"
-        if brand in {
-            b"heic", b"heix", b"hevc", b"hevx",
-            b"mif1", b"msf1", b"heim", b"heis",
-        }:
-            return "image/heic"
+    # ISO-BMFF family (HEIC/HEIF/AVIF): scan ftyp brands
+    from tools.image_formats import sniff_isobmff_image_brand
+    isobmff_brand = sniff_isobmff_image_brand(raw)
+    if isobmff_brand == "avif":
+        return "image/avif"
+    if isobmff_brand == "heic":
+        return "image/heic"
     # TIFF: II*\0 (little-endian) or MM\0* (big-endian)
     if raw[:4] in {b"II*\x00", b"MM\x00*"}:
         return "image/tiff"

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2479,22 +2479,6 @@ _CHAT_IMAGE_ALLOWED_EXTENSIONS = frozenset({
     ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp",
     ".heic", ".heif", ".avif",
 })
-_CHAT_IMAGE_ISOBMFF_BRANDS = frozenset({
-    # HEIF/HEIC brands. ``mif1``/``msf1`` are generic HEIF brands and may
-    # appear as the major brand even when a compatible brand identifies HEIC.
-    b"heic", b"heix", b"hevc", b"hevx", b"heim", b"heis",
-    b"mif1", b"msf1",
-    # AVIF is also an ISO-BMFF image and is handled by the same local
-    # Pillow/pillow-heif normalization path before the provider call.
-    b"avif", b"avis",
-})
-_CHAT_IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
-    (b"\x89PNG\r\n\x1a\n", ".png"),
-    (b"\xff\xd8\xff", ".jpg"),
-    (b"GIF87a", ".gif"),
-    (b"GIF89a", ".gif"),
-    (b"BM", ".bmp"),
-)
 
 
 def _sanitize_chat_image_filename(filename: str | None) -> str:
@@ -2505,25 +2489,8 @@ def _sanitize_chat_image_filename(filename: str | None) -> str:
 
 
 def _chat_image_extension(data: bytes) -> str | None:
-    head = data[:16]
-    if head.startswith(b"RIFF") and head[8:12] == b"WEBP":
-        return ".webp"
-    # HEIC/HEIF/AVIF are ISO Base Media File Format images. Do not trust the
-    # browser filename: iOS/WebUI can hand us HEIC bytes named ``.jpg``.
-    # Check the major brand and aligned compatible-brand slots in the ftyp
-    # box, since some cameras use the generic ``mif1`` major brand.
-    if len(data) >= 12 and data[4:8] == b"ftyp":
-        brands = {
-            data[offset:offset + 4]
-            for offset in range(8, min(len(data), 128) - 3, 4)
-        }
-        for brand in brands:
-            if brand in _CHAT_IMAGE_ISOBMFF_BRANDS:
-                return ".avif" if brand in {b"avif", b"avis"} else ".heic"
-    for sig, ext in _CHAT_IMAGE_MAGIC:
-        if head.startswith(sig):
-            return ext
-    return None
+    from tools.image_formats import sniff_image_extension
+    return sniff_image_extension(data)
 
 
 def _decode_chat_image_upload(payload: ChatImageUpload) -> tuple[bytes, str, str]:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2475,7 +2475,19 @@ def _decode_data_url(data_url: str) -> tuple[bytes, str]:
 
 
 _CHAT_IMAGE_UPLOAD_MAX_BYTES = 25 * 1024 * 1024
-_CHAT_IMAGE_ALLOWED_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"})
+_CHAT_IMAGE_ALLOWED_EXTENSIONS = frozenset({
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp",
+    ".heic", ".heif", ".avif",
+})
+_CHAT_IMAGE_ISOBMFF_BRANDS = frozenset({
+    # HEIF/HEIC brands. ``mif1``/``msf1`` are generic HEIF brands and may
+    # appear as the major brand even when a compatible brand identifies HEIC.
+    b"heic", b"heix", b"hevc", b"hevx", b"heim", b"heis",
+    b"mif1", b"msf1",
+    # AVIF is also an ISO-BMFF image and is handled by the same local
+    # Pillow/pillow-heif normalization path before the provider call.
+    b"avif", b"avis",
+})
 _CHAT_IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
     (b"\x89PNG\r\n\x1a\n", ".png"),
     (b"\xff\xd8\xff", ".jpg"),
@@ -2496,6 +2508,18 @@ def _chat_image_extension(data: bytes) -> str | None:
     head = data[:16]
     if head.startswith(b"RIFF") and head[8:12] == b"WEBP":
         return ".webp"
+    # HEIC/HEIF/AVIF are ISO Base Media File Format images. Do not trust the
+    # browser filename: iOS/WebUI can hand us HEIC bytes named ``.jpg``.
+    # Check the major brand and aligned compatible-brand slots in the ftyp
+    # box, since some cameras use the generic ``mif1`` major brand.
+    if len(data) >= 12 and data[4:8] == b"ftyp":
+        brands = {
+            data[offset:offset + 4]
+            for offset in range(8, min(len(data), 128) - 3, 4)
+        }
+        for brand in brands:
+            if brand in _CHAT_IMAGE_ISOBMFF_BRANDS:
+                return ".avif" if brand in {b"avif", b"avis"} else ".heic"
     for sig, ext in _CHAT_IMAGE_MAGIC:
         if head.startswith(sig):
             return ext

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -392,9 +392,9 @@ class TestFormatCompatibility:
         assert _sniff_mime_from_bytes(b'<svg xmlns="http://www.w3.org/2000/svg"/>') == "image/svg+xml"
         assert _sniff_mime_from_bytes(b'<?xml version="1.0"?><svg/>') == "image/svg+xml"
 
-    def test_bmp_transcoded_to_png(self, tmp_path: Path):
-        """BMP file should land as image/png in the data URL, not image/bmp,
-        because not every provider (Anthropic) accepts BMP."""
+    def test_bmp_transcoded_to_jpeg_when_opaque(self, tmp_path: Path):
+        """Opaque BMP file should land as image/jpeg in the data URL,
+        because it is universally accepted and more compact than PNG."""
         import pytest
         Image = pytest.importorskip("PIL.Image", reason="Pillow not installed; transcode is best-effort")
         from agent.image_routing import _file_to_data_url
@@ -403,9 +403,26 @@ class TestFormatCompatibility:
         Image.new("RGB", (4, 4), (255, 0, 0)).save(img_path, format="BMP")
         url = _file_to_data_url(img_path)
         assert url is not None
-        assert url.startswith("data:image/png;base64,"), (
-            f"BMP must be transcoded to PNG for cross-provider compatibility, got: {url[:60]}"
+        assert url.startswith("data:image/jpeg;base64,"), (
+            f"Opaque BMP must be transcoded to JPEG for cross-provider compatibility and size, got: {url[:60]}"
         )
+
+    def test_bmp_transcoded_to_png_when_transparent(self, tmp_path: Path):
+        """BMP/RGBA file with transparency should land as image/png in the data URL."""
+        import pytest
+        Image = pytest.importorskip("PIL.Image", reason="Pillow not installed; transcode is best-effort")
+        from agent.image_routing import _file_to_data_url
+
+        img_path = tmp_path / "scan_alpha.png"
+        # Create a non-universal format or simulate alpha transcode
+        from agent.image_routing import _transcode_to_supported_format
+        import io
+        buf = io.BytesIO()
+        Image.new("RGBA", (4, 4), (255, 0, 0, 128)).save(buf, format="PNG")
+        res = _transcode_to_supported_format(buf.getvalue())
+        assert res is not None
+        _, out_mime = res
+        assert out_mime == "image/png"
 
 
     def test_png_passes_through_no_transcode(self, tmp_path: Path):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1037,7 +1037,18 @@ class TestWebServerEndpoints:
 
     # ── POST /api/chat/image-upload (browser clipboard/drop images) ─────
 
+    def test_chat_image_sniffs_heic_bytes_over_misleading_filename(self):
+        from hermes_cli.web_server import _chat_image_extension
 
+        # ISO-BMFF with a generic HEIF major brand and HEIC compatible brand.
+        heic = b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00heic" + b"\x00" * 32
+        assert _chat_image_extension(heic) == ".heic"
+
+    def test_chat_image_sniffs_avif_bytes(self):
+        from hermes_cli.web_server import _chat_image_extension
+
+        avif = b"\x00\x00\x00\x18ftypavif\x00\x00\x00\x00" + b"\x00" * 32
+        assert _chat_image_extension(avif) == ".avif"
 
 
 

--- a/tests/tools/test_image_formats.py
+++ b/tests/tools/test_image_formats.py
@@ -1,0 +1,78 @@
+"""Unit tests for tools.image_formats shared sniffer."""
+
+import pytest
+from tools.image_formats import (
+    sniff_isobmff_image_brand,
+    sniff_image_mime,
+    sniff_image_extension,
+    HEIC_ISOBMFF_BRANDS,
+    AVIF_ISOBMFF_BRANDS,
+)
+
+
+def test_raster_magic_sniffing():
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    assert sniff_image_mime(png) == "image/png"
+    assert sniff_image_extension(png) == ".png"
+
+    jpg = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+    assert sniff_image_mime(jpg) == "image/jpeg"
+    assert sniff_image_extension(jpg) == ".jpg"
+
+    gif = b"GIF89a" + b"\x00" * 32
+    assert sniff_image_mime(gif) == "image/gif"
+    assert sniff_image_extension(gif) == ".gif"
+
+    bmp = b"BM" + b"\x00" * 32
+    assert sniff_image_mime(bmp) == "image/bmp"
+    assert sniff_image_extension(bmp) == ".bmp"
+
+    webp = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 32
+    assert sniff_image_mime(webp) == "image/webp"
+    assert sniff_image_extension(webp) == ".webp"
+
+
+def test_isobmff_heic_direct_major_brand():
+    heic = b"\x00\x00\x00\x18ftypheic\x00\x00\x00\x00" + b"\x00" * 32
+    assert sniff_isobmff_image_brand(heic) == "heic"
+    assert sniff_image_mime(heic) == "image/heic"
+    assert sniff_image_extension(heic) == ".heic"
+
+
+def test_isobmff_heic_compatible_brand_in_mif1():
+    # Major brand mif1, compatible brand heic at offset 16
+    data = b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00heic" + b"\x00" * 32
+    assert sniff_isobmff_image_brand(data) == "heic"
+    assert sniff_image_mime(data) == "image/heic"
+    assert sniff_image_extension(data) == ".heic"
+
+
+def test_isobmff_avif_direct_major_brand():
+    avif = b"\x00\x00\x00\x18ftypavif\x00\x00\x00\x00" + b"\x00" * 32
+    assert sniff_isobmff_image_brand(avif) == "avif"
+    assert sniff_image_mime(avif) == "image/avif"
+    assert sniff_image_extension(avif) == ".avif"
+
+
+def test_isobmff_avif_compatible_brand_in_mif1():
+    # Major brand mif1, compatible brand avif at offset 16
+    data = b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00avif" + b"\x00" * 32
+    assert sniff_isobmff_image_brand(data) == "avif"
+    assert sniff_image_mime(data) == "image/avif"
+    assert sniff_image_extension(data) == ".avif"
+
+
+def test_isobmff_brand_beyond_32_bytes():
+    # Brand located at offset 48 (past 32-byte header window, within scan_limit 128)
+    padding = b"\x00\x00\x00\x00" * 9
+    data = b"\x00\x00\x00\x40ftypmif1" + padding + b"hevc" + b"\x00" * 32
+    assert sniff_isobmff_image_brand(data) == "heic"
+    assert sniff_image_mime(data) == "image/heic"
+    assert sniff_image_extension(data) == ".heic"
+
+
+def test_non_image_and_empty():
+    assert sniff_image_mime(b"") is None
+    assert sniff_image_extension(b"") is None
+    assert sniff_isobmff_image_brand(b"") is None
+    assert sniff_image_mime(b"hello world plaintext") is None

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -17,6 +17,7 @@ import pytest
 
 PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
 JPEG = b"\xff\xd8\xff" + b"\x00" * 64
+HEIC = b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00heic" + b"\x00" * 64
 
 
 def _reload(monkeypatch, hermes_home: Path):
@@ -56,6 +57,17 @@ class TestDataUrl:
         with pytest.raises(isrc.NotAnImage):
             await isrc.resolve_image_source(
                 f"data:text/plain;base64,{b64}", isrc.ResolveContext())
+
+    @pytest.mark.asyncio
+    async def test_heic_magic_is_detected_even_with_wrong_filename(self, tmp_path, monkeypatch):
+        """Clipboard/WebUI may label HEIC bytes as .jpg; bytes are authoritative."""
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        img = tmp_path / "screenshot.jpg"
+        img.write_bytes(HEIC)
+        res = await isrc.resolve_image_source(str(img), isrc.ResolveContext())
+        assert res.mime == "image/heic"
+        assert res.data == HEIC
 
 
 class TestLocalBackend:

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -344,6 +344,40 @@ class TestSvgNormalization:
         assert path is None
         assert "rasterizer" in err
 
+    def test_opaque_image_normalizes_to_jpeg(self, tmp_path, monkeypatch):
+        """Opaque images (like HEIC/BMP camera photos) normalize to JPEG, not PNG,
+        to prevent massive size inflation and HTTP 413s."""
+        import pytest
+        Image = pytest.importorskip("PIL.Image")
+        from tools import vision_tools as vt
+        _reload(monkeypatch, tmp_path / "hermes")
+        bmp = tmp_path / "photo.bmp"
+        Image.new("RGB", (100, 100), (0, 128, 255)).save(bmp, format="BMP")
+        path, mime, err = vt._normalize_to_supported_image(bmp, "image/bmp")
+        assert err is None
+        assert mime == "image/jpeg"
+        assert path.suffix == ".jpg"
+        assert path.exists()
+        path.unlink()
+
+    def test_alpha_image_normalizes_to_png(self, tmp_path, monkeypatch):
+        """Images with transparency preserve alpha by normalizing to PNG."""
+        import pytest
+        Image = pytest.importorskip("PIL.Image")
+        from tools import vision_tools as vt
+        _reload(monkeypatch, tmp_path / "hermes")
+        # Save a BMP with RGBA or create an uncompressed format with alpha
+        from unittest.mock import patch
+        img_path = tmp_path / "transparent.bmp"
+        Image.new("RGBA", (100, 100), (0, 128, 255, 128)).save(img_path, format="PNG")
+        # Pass non-standard mime to trigger normalization
+        path, mime, err = vt._normalize_to_supported_image(img_path, "image/x-custom")
+        assert err is None
+        assert mime == "image/png"
+        assert path.suffix == ".png"
+        assert path.exists()
+        path.unlink()
+
 
 class TestLazySandboxBringUp:
     """Issue #62825: under a non-local backend, the FIRST vision_analyze of a

--- a/tools/image_formats.py
+++ b/tools/image_formats.py
@@ -1,0 +1,107 @@
+"""Shared magic-byte image format and container sniffing.
+
+Provides authoritative byte-level image sniffing for WebUI uploads, vision tools,
+and agent image routing. Prevents table drift across the codebase.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# ISO-BMFF brands that indicate HEIC/HEIF or AVIF still images.
+# ``mif1`` and ``msf1`` are generic HEIF brands and may appear as the major brand
+# even when a compatible brand identifies HEIC.
+HEIC_ISOBMFF_BRANDS = frozenset({
+    b"heic", b"heix", b"hevc", b"hevx", b"heim", b"heis",
+    b"mif1", b"msf1",
+})
+
+AVIF_ISOBMFF_BRANDS = frozenset({
+    b"avif", b"avis",
+})
+
+ALL_ISOBMFF_IMAGE_BRANDS = HEIC_ISOBMFF_BRANDS | AVIF_ISOBMFF_BRANDS
+
+# Common raster magic signatures: (signature, mime_type, extension)
+_COMMON_IMAGE_SIGNATURES: tuple[tuple[bytes, str, str], ...] = (
+    (b"\x89PNG\r\n\x1a\n", "image/png", ".png"),
+    (b"\xff\xd8\xff", "image/jpeg", ".jpg"),
+    (b"GIF87a", "image/gif", ".gif"),
+    (b"GIF89a", "image/gif", ".gif"),
+    (b"BM", "image/bmp", ".bmp"),
+)
+
+
+def sniff_isobmff_image_brand(data: bytes, scan_limit: int = 128) -> Optional[str]:
+    """Sniff ISO-BMFF brand from image bytes.
+
+    Returns "avif", "heic", or None if no recognized still-image brand is found.
+    Scans the major brand (offset 8) and aligned compatible-brand slots up to `scan_limit`.
+    """
+    if len(data) < 12 or data[4:8] != b"ftyp":
+        return None
+
+    # Brands are 4-byte aligned tokens starting after the 8-byte box header.
+    limit = min(len(data), scan_limit)
+    brands = {
+        data[offset:offset + 4]
+        for offset in range(8, limit - 3, 4)
+    }
+
+    # AVIF check first (or check specific brand sets)
+    for brand in brands:
+        if brand in AVIF_ISOBMFF_BRANDS:
+            return "avif"
+    for brand in brands:
+        if brand in HEIC_ISOBMFF_BRANDS:
+            return "heic"
+
+    return None
+
+
+def sniff_image_mime(data: bytes) -> Optional[str]:
+    """Sniff image MIME type from raw magic bytes.
+
+    Returns MIME string (e.g. "image/png", "image/heic", "image/avif") or None.
+    """
+    if not data:
+        return None
+
+    for sig, mime, _ in _COMMON_IMAGE_SIGNATURES:
+        if data.startswith(sig):
+            return mime
+
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+
+    isobmff_brand = sniff_isobmff_image_brand(data)
+    if isobmff_brand == "avif":
+        return "image/avif"
+    if isobmff_brand == "heic":
+        return "image/heic"
+
+    return None
+
+
+def sniff_image_extension(data: bytes) -> Optional[str]:
+    """Sniff image file extension from raw magic bytes.
+
+    Returns extension string (e.g. ".png", ".heic", ".avif") or None.
+    """
+    if not data:
+        return None
+
+    for sig, _, ext in _COMMON_IMAGE_SIGNATURES:
+        if data.startswith(sig):
+            return ext
+
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return ".webp"
+
+    isobmff_brand = sniff_isobmff_image_brand(data)
+    if isobmff_brand == "avif":
+        return ".avif"
+    if isobmff_brand == "heic":
+        return ".heic"
+
+    return None

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -236,6 +236,11 @@ def _media_cache_roots() -> list:
         home / "video_cache",
         home / "temp_vision_images",
         home / "temp_video_files",
+        # WebUI uploads are agent-managed inbound media, just like gateway
+        # image caches.  They are bind-mounted into the WebUI container and
+        # must remain host-readable when the terminal backend is SSH/Docker;
+        # otherwise vision incorrectly falls through to the sandbox path.
+        home / "webui" / "attachments",
     ]
 
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -281,12 +281,11 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "starlette==1.3.1",  # CVE-2026-48710 (BadHost) — keep lazy-install in sync with pyproject [web]
         "python-multipart==0.0.32",  # FastAPI UploadFile/Form for streaming uploads (NS-501)
     ),
-    # Vision image-resize recovery (Pillow). Pillow is now a CORE dependency
-    # (pyproject `dependencies`), so this entry is a belt-and-suspenders fallback
-    # for stripped/source-build installs that somehow dropped it. The vision
-    # call site uses prompt=False so it can never raise a blocking input()
-    # prompt mid-session (#40490).
-    "tool.vision": ("Pillow==12.3.0",),
+    # Vision image normalization/resizing. Pillow is now a CORE dependency
+    # (pyproject `dependencies`); pillow-heif is lazy because only HEIC/HEIF/
+    # AVIF inputs need its native codec. Vision calls use prompt=False so a
+    # missing codec can never raise a blocking input() prompt mid-session.
+    "tool.vision": ("Pillow==12.3.0", "pillow-heif==1.5.0"),
     # Document-to-Markdown extraction for read_file (firecrawl-anydoc, Rust
     # core, imports as `anydoc`). Widens read_file's auto-extraction beyond
     # the stdlib .ipynb/.docx/.xlsx to PDF, legacy Office (.doc/.ppt/.xls),

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -371,14 +371,30 @@ def _normalize_to_supported_image(
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(image_path) as _img:
-            if _img.mode not in ("RGB", "RGBA", "L"):
-                _img = _img.convert("RGBA")
-            _img.save(out_path, format="PNG")
+            # Re-encode opaque images as JPEG (quality 85) to avoid blowing up
+            # camera photos (e.g. 48MP iPhone HEIC -> 30MB+ PNG -> 413 error).
+            # Keep PNG for images with alpha transparency.
+            has_alpha = _img.mode in ("RGBA", "LA", "PA") or (
+                _img.mode == "P" and "transparency" in _img.info
+            )
+            if has_alpha:
+                if _img.mode not in ("RGB", "RGBA", "L"):
+                    _img = _img.convert("RGBA")
+                out_path = out_dir / f"converted_{uuid.uuid4()}.png"
+                _img.save(out_path, format="PNG")
+                out_mime = "image/png"
+            else:
+                if _img.mode not in ("RGB", "L"):
+                    _img = _img.convert("RGB")
+                out_path = out_dir / f"converted_{uuid.uuid4()}.jpg"
+                _img.save(out_path, format="JPEG", quality=85)
+                out_mime = "image/jpeg"
+
         if out_path.exists() and out_path.stat().st_size > 0:
-            return out_path, "image/png", None
+            return out_path, out_mime, None
     except Exception as _exc:
-        logger.warning("Failed to normalize %s image to PNG: %s",
-                       detected_mime, _exc)
+        logger.warning("Failed to normalize %s image to %s: %s",
+                       detected_mime, out_mime if 'out_mime' in locals() else 'PNG/JPEG', _exc)
     return (
         None,
         None,

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -260,6 +260,20 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
         return "image/bmp"
     if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
         return "image/webp"
+    # ISO-BMFF image containers used by iPhones and other mobile cameras.
+    # WebUI may preserve the upload bytes while assigning a .jpg filename.
+    if len(header) >= 12 and header[4:8] == b"ftyp":
+        brands = {
+            header[offset:offset + 4]
+            for offset in range(8, len(header) - 3, 4)
+        }
+        if brands & {
+            b"heic", b"heix", b"hevc", b"hevx",
+            b"mif1", b"msf1", b"heim", b"heis",
+        }:
+            return "image/heic"
+        if brands & {b"avif", b"avis"}:
+            return "image/avif"
     return None
 
 
@@ -358,7 +372,22 @@ def _normalize_to_supported_image(
             "(`pip install cairosvg`) — then re-run vision_analyze on the PNG.",
         )
 
-    # Other non-supported raster formats (BMP, TIFF, ...): re-encode via Pillow.
+    # Register HEIF support before Pillow opens an iPhone image. WebUI uploads
+    # may carry HEIC bytes under a .jpg filename. The codec is lazy-installed
+    # only when needed, so ordinary PNG/JPEG vision calls do not incur a setup
+    # cost; prompt=False prevents an interactive install prompt mid-session.
+    if detected_mime in {"image/heic", "image/avif"}:
+        try:
+            import pillow_heif  # type: ignore
+            pillow_heif.register_heif_opener()
+        except Exception:
+            try:
+                from tools.lazy_deps import ensure as _ensure_dep
+                _ensure_dep("tool.vision", prompt=False)
+                import pillow_heif  # type: ignore
+                pillow_heif.register_heif_opener()
+            except Exception:
+                pass
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(image_path) as _img:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -249,32 +249,8 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
     SVG, which has no magic bytes. The resolver special-cases SVG (sniffs
     ``<svg``) and passes it through for rasterization at the call sites.
     """
-    header = data[:64]
-    if header.startswith(b"\x89PNG\r\n\x1a\n"):
-        return "image/png"
-    if header.startswith(b"\xff\xd8\xff"):
-        return "image/jpeg"
-    if header.startswith((b"GIF87a", b"GIF89a")):
-        return "image/gif"
-    if header.startswith(b"BM"):
-        return "image/bmp"
-    if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
-        return "image/webp"
-    # ISO-BMFF image containers used by iPhones and other mobile cameras.
-    # WebUI may preserve the upload bytes while assigning a .jpg filename.
-    if len(header) >= 12 and header[4:8] == b"ftyp":
-        brands = {
-            header[offset:offset + 4]
-            for offset in range(8, len(header) - 3, 4)
-        }
-        if brands & {
-            b"heic", b"heix", b"hevc", b"hevx",
-            b"mif1", b"msf1", b"heim", b"heis",
-        }:
-            return "image/heic"
-        if brands & {b"avif", b"avis"}:
-            return "image/avif"
-    return None
+    from tools.image_formats import sniff_image_mime
+    return sniff_image_mime(data)
 
 
 # Media types the major vision providers (Anthropic in particular) accept for
@@ -372,10 +348,10 @@ def _normalize_to_supported_image(
             "(`pip install cairosvg`) — then re-run vision_analyze on the PNG.",
         )
 
-    # Register HEIF support before Pillow opens an iPhone image. WebUI uploads
-    # may carry HEIC bytes under a .jpg filename. The codec is lazy-installed
-    # only when needed, so ordinary PNG/JPEG vision calls do not incur a setup
-    # cost; prompt=False prevents an interactive install prompt mid-session.
+    # Register HEIF/AVIF support before Pillow opens an iPhone or modern mobile image.
+    # WebUI uploads may carry HEIC bytes under a .jpg filename. The codec is
+    # lazy-installed only when needed, so ordinary PNG/JPEG vision calls do not incur
+    # a setup cost; prompt=False prevents an interactive install prompt mid-session.
     if detected_mime in {"image/heic", "image/avif"}:
         try:
             import pillow_heif  # type: ignore
@@ -386,8 +362,12 @@ def _normalize_to_supported_image(
                 _ensure_dep("tool.vision", prompt=False)
                 import pillow_heif  # type: ignore
                 pillow_heif.register_heif_opener()
-            except Exception:
-                pass
+            except Exception as _codec_err:
+                logger.warning(
+                    "Detected %s image but failed to initialize pillow-heif codec: %s. "
+                    "Install with `pip install pillow-heif` for HEIC/AVIF image support.",
+                    detected_mime, _codec_err,
+                )
     try:
         from PIL import Image as _PILImage
         with _PILImage.open(image_path) as _img:

--- a/web/src/lib/chatImagePaste.ts
+++ b/web/src/lib/chatImagePaste.ts
@@ -8,6 +8,12 @@ const IMAGE_MIME_EXT: Record<string, string> = {
   "image/gif": "gif",
   "image/webp": "webp",
   "image/bmp": "bmp",
+  // iOS screenshots/clipboard payloads are often HEIC bytes with a misleading
+  // .jpg filename. Keep the actual MIME in the data URL; the server sniffs
+  // magic bytes and the vision path normalizes locally before the API call.
+  "image/heic": "heic",
+  "image/heif": "heif",
+  "image/avif": "avif",
 };
 
 // Anthropic caps a single vision image at ~25 MB; reject earlier client-side


### PR DESCRIPTION
## Summary

Fix WebUI clipboard uploads from iOS/macOS when the browser supplies HEIC bytes while the filename or MIME label says JPEG.

- Detect HEIC/HEIF/AVIF from ISO-BMFF magic bytes instead of trusting the filename.
- Accept these formats in the WebUI chat image-upload endpoint.
- Preserve the actual format through the browser upload path.
- Normalize HEIC/HEIF/AVIF to PNG locally with Pillow/pillow-heif before embedding the image in a vision request, so unsupported media types never reach the provider API.
- Keep `pillow-heif` lazy-installed only when an HEIC-family image is actually encountered.
- Allow WebUI attachment paths through the existing non-local backend media-cache boundary.

## Reproduction

A pasted screenshot was stored as `image_*.jpg`, but `file` identified the bytes as:

```text
ISO Media, HEIF Image HEVC Main or Main Still Picture Profile
```

Previously this reached the vision normalization path as an unsupported format and produced the provider-facing conversion error.

## Test plan

- `scripts/run_tests.sh tests/tools/test_image_source.py tests/tools/test_vision_tools.py tests/hermes_cli/test_web_server.py tests/tools/test_lazy_deps.py`
  - 285 passed, 1 skipped on Linux
- `npm run build --workspace web`
  - passed
- Manual end-to-end check with a real WebUI attachment:
  - detected MIME: `image/heic`
  - upload extension: `.heic`
  - normalized provider MIME: `image/png`
