### PR TITLE
fix(tools): isolate _pip_install's uv env from third-party UV_PYTHON vars

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -876,7 +876,6 @@ def _pip_install(
     (or the last failure for the caller to inspect).
     """
     venv_root = Path(sys.executable).parent.parent
-    uv_env = {**os.environ, "VIRTUAL_ENV": str(venv_root)}
 
     # Managed uv first: $HERMES_HOME/bin is never on PATH, so a bare which()
     # misses the uv Hermes installed and prefers a system one when both exist.
@@ -884,7 +883,14 @@ def _pip_install(
     # where installing uv is in scope — and tier 2 is a pip that the Windows
     # installer's `uv venv` does not seed, so failing to find uv here is the
     # difference between a working post-setup hook and "No module named pip".
-    from hermes_cli.managed_uv import ensure_uv
+    from hermes_cli.managed_uv import ensure_uv, managed_python_env
+
+    # Official managed_python_env() isolation so a third-party
+    # UV_PYTHON / UV_PYTHON_INSTALL_DIR cannot steer this install into an
+    # unintended interpreter (same class as the update-path fix); then point
+    # VIRTUAL_ENV at this install's venv.
+    uv_env = managed_python_env()
+    uv_env["VIRTUAL_ENV"] = str(venv_root)
 
     uv_bin = ensure_uv()
     if uv_bin:

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -18,6 +18,7 @@ from hermes_cli.tools_config import (
     _configure_provider,
     _reconfigure_provider,
     _get_platform_tools,
+    _pip_install,
     _platform_toolset_summary,
     _reconfigure_tool,
     _run_post_setup,
@@ -1219,3 +1220,62 @@ def test_explicit_plugin_toolset_admitted_against_real_a2a_plugin(monkeypatch):
         f"plugin-provided 'a2a' toolset dropped by _get_platform_tools "
         f"(Layer 2 of #81163); enabled={sorted(enabled)}"
     )
+
+
+class TestPipInstallUvEnvIsolation:
+    """Regression: _pip_install's uv tier must build its env via
+    managed_python_env(), the same third-party UV_PYTHON /
+    UV_PYTHON_INSTALL_DIR isolation the update path uses (sibling of the
+    uv-env-hijack class fixed in hermes_cli/update_cmd.py). Before the fix,
+    _pip_install built its uv env as a bare ``{**os.environ, "VIRTUAL_ENV":
+    ...}``, so a third-party UV_PYTHON / UV_PYTHON_INSTALL_DIR on the host
+    could steer a post-setup install (faster-whisper, piper-tts, ddgs,
+    langfuse) into an unintended interpreter.
+    """
+
+    def test_uv_install_env_drops_third_party_uv_python_vars(self, monkeypatch, tmp_path):
+        """A poisoned UV_PYTHON / UV_PYTHON_INSTALL_DIR on os.environ must not
+        reach the uv subprocess env; VIRTUAL_ENV must point at this venv."""
+        import os
+        import sys
+        from pathlib import Path
+
+        poisoned_dir = str(tmp_path / "hijacker" / "python")
+        poisoned_python = str(tmp_path / "hijacker" / "python" / "python.exe")
+        monkeypatch.setenv("UV_PYTHON_INSTALL_DIR", poisoned_dir)
+        monkeypatch.setenv("UV_PYTHON", poisoned_python)
+        monkeypatch.setenv("UV_SYSTEM_PYTHON", "1")
+
+        captured = {}
+
+        def _fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("hermes_cli.managed_uv.ensure_uv", return_value="/fake/bin/uv"), \
+             patch("subprocess.run", side_effect=_fake_run):
+            _pip_install(["some-package"])
+
+        assert captured["cmd"][0] == "/fake/bin/uv"
+        env = captured["env"]
+        assert env is not None, "uv tier must pass an explicit env=, not inherit os.environ implicitly"
+
+        # The poisoned values must not survive into the uv subprocess env.
+        assert env.get("UV_PYTHON_INSTALL_DIR") != poisoned_dir
+        assert "hijacker" not in (env.get("UV_PYTHON_INSTALL_DIR") or "")
+        assert env.get("UV_PYTHON") is None
+        assert env.get("UV_SYSTEM_PYTHON") is None
+
+        # Managed-env pins are set (same contract as managed_python_env()).
+        assert env.get("UV_MANAGED_PYTHON") == "1"
+        assert env.get("UV_NO_CONFIG") == "1"
+
+        # VIRTUAL_ENV still points at this install's venv (sys.executable's
+        # parent.parent), unlike the third-party VIRTUAL_ENV in os.environ.
+        expected_venv_root = str(Path(sys.executable).parent.parent)
+        assert env.get("VIRTUAL_ENV") == expected_venv_root
+
+        # Sanity: the poisoned values really were on os.environ (guards the
+        # test itself against a no-op monkeypatch).
+        assert os.environ.get("UV_PYTHON_INSTALL_DIR") == poisoned_dir


### PR DESCRIPTION
## What

`_pip_install` (the shared installer `_run_post_setup` calls for faster-whisper, piper-tts, ddgs, and langfuse) built its uv-tier subprocess env as a bare `{**os.environ, "VIRTUAL_ENV": ...}`, without the `managed_python_env()` isolation the update path uses.

## Why

Today's update-path fixes (three sites in `hermes_cli/update_cmd.py`) eliminated this exact pattern because a third-party `UV_PYTHON` / `UV_PYTHON_INSTALL_DIR` / `UV_SYSTEM_PYTHON` on the host can steer `uv pip install` into an unintended interpreter. `tools_config.py::_pip_install` has the identical raw-environ construction and is a fourth, unaddressed site of the same class — there's no design barrier stopping the fix here (the function already imports from `hermes_cli.managed_uv`), it was simply missed by today's sweep since it lives in a different file.

Reachable via 5 real call sites in `_run_post_setup`: enabling faster-whisper, the wheel-based STT fallback, piper-tts, ddgs (web search), and langfuse (tracing) via `hermes tools enable <feature>`.

## How

Same fix as the update path: build the env via `managed_python_env()` (drops third-party `UV_PYTHON*`/`VIRTUAL_ENV`/`PYTHONPATH`, pins `UV_MANAGED_PYTHON=1` + `UV_NO_CONFIG=1`), then re-point `VIRTUAL_ENV` at this install's venv.

## Testing

- New regression test poisons `os.environ` with a fake `UV_PYTHON_INSTALL_DIR`/`UV_PYTHON`/`UV_SYSTEM_PYTHON`, captures the actual `env=` kwarg passed to the uv subprocess, and asserts the poisoned values do not survive while `VIRTUAL_ENV` still points at the real venv.
- Mutation-verified: with the fix reverted, the same test fails — the poisoned `UV_PYTHON_INSTALL_DIR` leaks through into the captured env unchanged.
- Full `tests/hermes_cli/test_tools_config.py` (52 tests) passes.
- Two failures in `tests/tools/test_web_tools_config.py::TestParallelClientConfig` are pre-existing (confirmed unrelated: same failures with this change stashed out — a `parallel-web` package/lazy-install environment issue).
- `ruff check` clean on both changed files.

Fixes: none filed (found via sibling-gap scan of today's UV-env-isolation sweep).