### PR TITLE
fix(desktop): boot-time source restore keeps the All-profiles preference (#93197)

### DIFF
--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -253,4 +253,27 @@ describe('selectConnection', () => {
     expect($pendingConnectionId.get()).toBeNull()
     expect(setLastUsed).not.toHaveBeenCalled()
   })
+
+  it('boot-time restore leaves "All profiles" browse mode on (#93197)', async () => {
+    // Fresh boot: nothing active yet, registry restores last-used. The
+    // persisted showAllProfiles=true must survive the silent restore.
+    list.mockResolvedValueOnce({ ...registry, lastUsed: 'homelab', launchMode: 'last-used' })
+    $showAllProfiles.set(true)
+
+    await initializeConnectionsRegistry()
+
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect($showAllProfiles.get()).toBe(true)
+  })
+
+  it('a user-initiated source switch still collapses "All profiles"', async () => {
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'local', mode: 'local' })
+    $showAllProfiles.set(true)
+
+    await selectConnection('homelab')
+
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect($showAllProfiles.get()).toBe(false)
+  })
 })

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -158,6 +158,12 @@ export async function selectConnection(connectionId: string): Promise<void> {
     return
   }
 
+  // A user-initiated source switch collapses "All profiles" browse mode: the
+  // picker is a concrete-source action. The silent boot-time restore (below,
+  // from initializeConnectionsRegistry) is not — it must leave the persisted
+  // browse-mode preference alone so it survives restart (#93197).
+  const restoreOnBoot = pendingTarget === null && $activeConnectionId.get() === null
+
   const currentConnectionId = $activeConnectionId.get()
   const currentProfile = normalizeProfileKey($activeGatewayProfile.get())
   const targetProfile = normalizeProfileKey($lastProfileByConnection.get()[connectionId] ?? 'default')
@@ -207,7 +213,9 @@ export async function selectConnection(connectionId: string): Promise<void> {
     if (revision === switchRevision) {
       await rememberConnection(connectionId)
       wipeSessionListsForGatewaySwitch()
-      $showAllProfiles.set(false)
+      if (!restoreOnBoot) {
+        $showAllProfiles.set(false)
+      }
       $newChatProfile.set(targetProfile)
       requestFreshSession()
       await refreshActiveProfile()


### PR DESCRIPTION
## Summary

The "Show all profiles" browse-mode toggle is persisted to localStorage, but every restart it was silently force-collapsed. `initializeConnectionsRegistry` restores the last-used source at boot via `selectConnection`, whose post-activation path unconditionally ran `$showAllProfiles.set(false)` — so a user who enables the unified view loses it on every relaunch.

That collapse is correct for a **user-initiated** switch (picking a concrete source is a concrete-scope action). The silent boot-time restore is not a user action, and must not mutate the persisted preference.

## Fix

Gate both reset sites in `selectConnection` on the fresh-boot state (`pendingTarget === null && $activeConnectionId === null`). Boot restore now leaves the flag alone; every real user switch still collapses browse mode.

## Testing

- New regression: boot-time restore leaves `showAllProfiles=true` intact
- New regression: user-initiated source switch still collapses it
- Full existing `connections.test.ts` suite (15 tests) green; renderer tsc + eslint clean

Fixes #93197