### PR TITLE
fix(bot-mode): scope DM temp-dir mode enforcement to POSIX ownership

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -577,11 +577,12 @@ def test_dm_dir_is_private_and_uid_scoped_on_posix(tmp_path, monkeypatch):
 
     if hasattr(os, "getuid"):
         assert dm_dir.name == f"{bot_mode_dm._DM_DIR_NAME}-{os.getuid()}"
+        assert dm_dir.stat().st_mode & 0o777 == 0o700
     else:
         assert dm_dir.name == bot_mode_dm._DM_DIR_NAME
-    assert dm_dir.stat().st_mode & 0o777 == 0o700
 
 
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX ownership contract")
 def test_dm_dir_repairs_restrictive_owner_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
     uid = os.getuid() if hasattr(os, "getuid") else None

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -444,7 +444,10 @@ def _dm_dir() -> Path:
         raise PermissionError(f"DM temp path is not a directory: {path}")
     if uid is not None and info.st_uid != uid:
         raise PermissionError(f"DM temp directory is owned by another user: {path}")
-    if stat.S_IMODE(info.st_mode) != 0o700:
+    # Windows has no POSIX mode bits: stat() always reports directories as
+    # 0o777 regardless of chmod, so this enforcement only means something
+    # where os.getuid (and thus real ownership) exists.
+    if uid is not None and stat.S_IMODE(info.st_mode) != 0o700:
         path.chmod(0o700)
     return path
 


### PR DESCRIPTION
## What

Windows has no POSIX mode bits: `os.stat()` reports every directory as `0o777` regardless of `chmod`, so the `0o700` enforcement added in 08742d0e32 ("isolate DM tempfiles per user") can never succeed there — two of that commit's own new tests fail on every Windows box.

`_dm_dir()` already branches on `os.getuid()` being available for the ownership check; this extends the same guard to the mode check/repair, and marks the owner-mode-repair test POSIX-only, matching the existing symlink test's `skipif`.

## Why

This isn't a hypothetical — it reproduces immediately on a real Windows dev box with the project's own test suite, in code that landed in the current active bot-mode DM-isolation work.

## Test plan

`.venv/Scripts/python.exe -m pytest tests/tools/test_bot_mode_dm.py -q` on Windows:

- **Before:** `3 failed, 35 passed, 1 skipped` (2 of the 3 failures are this bug: `test_dm_dir_is_private_and_uid_scoped_on_posix`, `test_dm_dir_repairs_restrictive_owner_mode`; the 3rd, `test_real_delivery_command_round_trip[True]`, is a pre-existing unrelated unicode/subprocess issue from a different commit, untouched here)
- **After:** `1 failed, 36 passed, 2 skipped` (only the unrelated pre-existing failure remains)

Also ran `tests/tools/test_bot_dm_payload_cache.py` (the only other suite exercising `_dm_dir`): 5/5 pass.

Platforms tested: Windows 11. Not run on POSIX — the change only narrows an existing POSIX-only branch's condition (`uid is not None`), so it cannot alter POSIX behavior since `os.getuid()` is always non-`None` there.