### PR TITLE
fix(update): feed Windows gateway relaunch outcome into fleet reconciliation

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5469,6 +5469,20 @@ def _resume_windows_gateways_after_update(token: dict | None) -> None:
                 exc,
             )
 
+    # Surface the outcome on the token (#91277 Phase 2 plan-vs-execution
+    # reconciliation): the git-based update path's fleet reconciliation
+    # cross-checks every planned runtime against restarted_services /
+    # relaunched_profiles / externally_supervised_profiles / killed_pids —
+    # bookkeeping this Windows-specific pause/resume never fed, so a
+    # correctly-paused-and-relaunched Windows gateway was reported
+    # "unaccounted" (loud warning + exit 1) even though the restart
+    # succeeded. The caller merges this into the shared
+    # relaunched_profiles list before reconciliation runs. A profile whose
+    # relaunch genuinely failed is deliberately left off this list — it
+    # must still surface as unaccounted so the user is told to restart it
+    # manually (Windows has no watcher to recover a failed relaunch).
+    token["relaunched_profiles"] = relaunched
+
     # Respawn unmapped gateways (no profile→PID-file mapping, e.g. a Scheduled
     # Task) by replaying the argv we snapshotted before force-killing them.
     unmapped_relaunched = 0
@@ -8245,6 +8259,28 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 pass
 
         _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+        if _windows_gateway_resume:
+            # Feed Windows's own pause/resume outcome into the same
+            # relaunched_profiles bookkeeping the systemd/launchd restart
+            # phase populates, so the #91277 Phase 2 reconciliation below
+            # does not report a correctly-relaunched Windows gateway as
+            # "unaccounted" (a runtime the plan saw but no bookkeeping
+            # mentions — the reconciliation's blind-spot tripwire). A
+            # profile whose relaunch genuinely failed is intentionally
+            # left out of the token's list, so it still surfaces there.
+            # Best-effort: the restart-phase try/except above may have
+            # raised before relaunched_profiles was initialized, so this
+            # must never itself abort the update.
+            try:
+                for _win_profile in _windows_gateway_resume.get("relaunched_profiles") or []:
+                    if _win_profile not in relaunched_profiles:
+                        relaunched_profiles.append(_win_profile)
+            except Exception as _win_reconcile_exc:
+                logger.debug(
+                    "Could not merge Windows relaunch outcome into fleet "
+                    "reconciliation bookkeeping: %s",
+                    _win_reconcile_exc,
+                )
 
         # Warn if legacy Hermes gateway unit files are still installed.
         # When both hermes.service (from a pre-rename install) and the

--- a/tests/hermes_cli/test_windows_update_restart_reconciliation.py
+++ b/tests/hermes_cli/test_windows_update_restart_reconciliation.py
@@ -1,0 +1,145 @@
+"""Regression: Windows gateway pause/resume must feed the #91277 Phase 2
+plan-vs-execution reconciliation, not report a correctly-relaunched Windows
+gateway as "unaccounted".
+
+``_pause_windows_gateways_for_update`` / ``_resume_windows_gateways_after_update``
+are Windows's own gateway restart mechanism — separate from the
+systemd/launchd restart phase in ``_cmd_update_impl`` that populates
+``restarted_services`` / ``relaunched_profiles`` / ``killed_pids`` /
+``externally_supervised_profiles``. Before this fix, a Windows gateway that
+was correctly paused and relaunched left no trace in that bookkeeping, so
+``match_runtime_outcomes`` classified it "unaccounted" — the plan saw it and
+NO bookkeeping mentions it — and ``report_unaccounted_runtimes`` escalated
+that into ``sys.exit(1)`` even though the update (and the restart) succeeded.
+
+``_resume_windows_gateways_after_update`` now writes the profiles it
+successfully relaunched onto ``token["relaunched_profiles"]``; the update
+command merges that into the shared ``relaunched_profiles`` list before
+reconciliation runs (mirrored here directly, since driving the full
+``_cmd_update_impl`` end to end is impractical).
+"""
+
+from unittest.mock import patch
+
+import hermes_cli.gateway as gateway
+import hermes_cli.main as hm
+from hermes_cli.update_cmd import _resume_windows_gateways_after_update
+from hermes_cli.update_inventory import (
+    RuntimeRecord,
+    UpdatePlan,
+    match_runtime_outcomes,
+    report_unaccounted_runtimes,
+)
+
+
+def _token(profiles: dict) -> dict:
+    return {
+        "resume_needed": True,
+        "profiles": profiles,
+        "unmapped_pids": [],
+        "unmapped": [],
+    }
+
+
+def test_resume_records_successfully_relaunched_profiles_on_the_token(monkeypatch):
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+    monkeypatch.setattr(hm, "_refresh_windows_gateway_launchers", lambda: None)
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: True
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", lambda *_a: True
+    )
+
+    token = _token({"default": 1111, "work": 2222})
+    with patch("builtins.print"):
+        _resume_windows_gateways_after_update(token)
+
+    assert sorted(token["relaunched_profiles"]) == ["default", "work"]
+
+
+def test_resume_omits_profiles_whose_relaunch_failed(monkeypatch):
+    """A profile whose relaunch genuinely fails must NOT be marked
+    'relaunched' — it needs to keep surfacing as unaccounted so the user is
+    told to restart it manually (Windows has no watcher to recover it)."""
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+    monkeypatch.setattr(hm, "_refresh_windows_gateway_launchers", lambda: None)
+
+    def _relaunch(profile, _old_pid):
+        return profile == "default"  # "work" fails to relaunch
+
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", _relaunch
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", lambda *_a: True
+    )
+
+    token = _token({"default": 1111, "work": 2222})
+    with patch("builtins.print"):
+        _resume_windows_gateways_after_update(token)
+
+    assert token["relaunched_profiles"] == ["default"]
+
+
+def test_merged_windows_relaunch_resolves_as_restarted_not_unaccounted(monkeypatch):
+    """End-to-end shape of the actual fix: the token's relaunched_profiles,
+    merged into the shared list _cmd_update_impl passes to
+    match_runtime_outcomes, must turn a Windows gateway's plan row from
+    'unaccounted' (loud warning + exit 1) into 'restarted' (clean)."""
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+    monkeypatch.setattr(hm, "_refresh_windows_gateway_launchers", lambda: None)
+    monkeypatch.setattr(
+        gateway, "launch_detached_profile_gateway_restart", lambda *_a: True
+    )
+    monkeypatch.setattr(
+        gateway, "launch_detached_gateway_restart_by_cmdline", lambda *_a: True
+    )
+
+    old_pid = 4242
+    token = _token({"default": old_pid})
+    with patch("builtins.print"):
+        _resume_windows_gateways_after_update(token)
+
+    # collect_runtime_inventory() would have recorded the pre-update PID —
+    # the plan is built BEFORE the pause/relaunch, so it still names the old
+    # pid even though a fresh process now owns the port.
+    plan = UpdatePlan()
+    plan.runtimes = [
+        RuntimeRecord(
+            kind="gateway", profile="default", pid=old_pid, supervisor="manual",
+            restart_via="manual",
+        )
+    ]
+
+    # Without the merge (the pre-fix state): unaccounted, escalates.
+    pre_fix_outcomes = match_runtime_outcomes(
+        plan, restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert pre_fix_outcomes[0]["outcome"] == "unaccounted"
+    assert report_unaccounted_runtimes(pre_fix_outcomes) is True
+
+    # With the merge _cmd_update_impl now performs: restarted, clean.
+    relaunched_profiles: list = []
+    for profile in token.get("relaunched_profiles") or []:
+        if profile not in relaunched_profiles:
+            relaunched_profiles.append(profile)
+
+    post_fix_outcomes = match_runtime_outcomes(
+        plan, restarted_services=[], relaunched_profiles=relaunched_profiles,
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    assert post_fix_outcomes[0]["outcome"] == "restarted"
+    assert report_unaccounted_runtimes(post_fix_outcomes) is False
+
+
+def test_resume_with_no_relaunched_profiles_key_does_not_crash_the_merge():
+    """A token from an early-return path (e.g. cold-start, no profiles) may
+    never gain a 'relaunched_profiles' key at all — the merge in
+    _cmd_update_impl must tolerate that (.get(...) or [])."""
+    token = {"resume_needed": False}
+    relaunched_profiles: list = []
+    for profile in token.get("relaunched_profiles") or []:
+        relaunched_profiles.append(profile)
+    assert relaunched_profiles == []


### PR DESCRIPTION
## What

`#91277` Phase 2's plan-vs-execution reconciliation (`match_runtime_outcomes` in `hermes_cli/update_inventory.py`) cross-checks every runtime `collect_runtime_inventory()` saw against the restart phase's bookkeeping — `restarted_services` / `relaunched_profiles` / `externally_supervised_profiles` / `killed_pids`. That inventory collection is cross-platform (control-socket / PID-file based, no platform gate), so it includes Windows gateways too — but Windows's own separate pause/resume mechanism (`_pause_windows_gateways_for_update` / `_resume_windows_gateways_after_update`) never wrote into any of that shared bookkeeping.

## Why this matters

A Windows gateway that was correctly stopped and relaunched during `hermes update` was still classified `"unaccounted"` by the reconciliation — the plan saw it and no bookkeeping mentions it, the exact "silent miss" class the reconciliation was built to catch. `report_unaccounted_runtimes()` escalates that into `sys.exit(1)` (unconditionally — not gated to `gateway_mode`; in `gateway_mode` it additionally writes `.update_exit_code = "1"`).

Net effect: every successful `hermes update` on Windows with a gateway running reports itself as failed.

Traced end to end on current `main`:
- `collect_runtime_inventory()` records Windows gateways via `identify_gateway()` (control socket) / `read_runtime_status()` / `_pid_exists()` — none of these are platform-gated.
- `_pause_windows_gateways_for_update()` / `_resume_windows_gateways_after_update()` are a structurally separate mechanism, called at several points earlier in `_cmd_update_impl`, and never touch `restarted_services` / `relaunched_profiles` / `externally_supervised_profiles` / `killed_pids`.
- The fleet-restart section that *does* populate those four variables (`restarted_services: list = []` / `killed_pids: set = set()` at the top, `relaunched_profiles = []` / `externally_supervised_profiles = []` / `failed_or_stale_units = []` inside the restart try block) runs on every platform, but nothing inside it applies to Windows — on Windows these all stay empty.
- `match_runtime_outcomes()` therefore has nothing to match a Windows profile against and falls through to `"unaccounted"`.

## Fix

`_resume_windows_gateways_after_update()` now records the profiles it successfully relaunched onto the resume token (`token["relaunched_profiles"]`). `_cmd_update_impl` merges that into the shared `relaunched_profiles` list right after the resume call, before reconciliation runs — the same list `match_runtime_outcomes` already checks first (`r.profile in relaunched`).

A profile whose relaunch genuinely fails is **deliberately** left off this list, so it still surfaces as `"unaccounted"` with the loud warning — Windows has no watcher to recover a failed relaunch, so escalating that case is the correct, intended behavior; only the false-positive (successful relaunch reported as a miss) is being fixed.

The merge is wrapped in its own `try/except` (best-effort, `logger.debug` on failure) — the restart-phase try block that initializes `relaunched_profiles` can itself raise before reaching that line on an earlier failure, and this must never turn into a crash on top of that.

## Testing

- New `tests/hermes_cli/test_windows_update_restart_reconciliation.py`:
  - `_resume_windows_gateways_after_update` records exactly the profiles that successfully relaunch, omitting ones that fail.
  - An end-to-end-shaped test reproduces the actual bug: the same `RuntimeRecord` resolves `"unaccounted"` (escalates) without the merge and `"restarted"` (clean) with it — mirroring precisely what `_cmd_update_impl` now does.
  - A defensive test confirms the merge tolerates a token that never gained a `relaunched_profiles` key (early-return paths like cold-start).
- Mutation-verified: with the production fix reverted, 3 of the 4 new tests fail (`KeyError: 'relaunched_profiles'` on the token, and the reconciliation outcome staying `"unaccounted"`).
- Full `tests/hermes_cli/test_cmd_update.py`, `test_restart_plan_reconciliation.py`, `test_update_gateway_restart_fallback.py`, `test_gateway_external_supervisor.py`, `test_windows_gateway_cold_start_desktop_lifecycle.py`, plus 7 other update-related test files (113 tests) — all pass except one pre-existing test-order-pollution failure (`test_ledger_live_serve_with_live_spawner_owns_lifecycle`, confirmed to fail identically with this change stashed out, in the same batch).
- `ruff check` clean on both changed files.
- Verified purely via source-level trace + unit tests (this environment is not Windows) — the traversal above was walked function-by-function against current `main`, not assumed from the commit message.

## Note on overlapping in-flight work

Two large, unmerged PRs from the same #91277 epic touch `hermes_cli/update_cmd.py` / `hermes_cli/update_inventory.py` broadly: #92545 (Phase 3, baked-image refusal) and #93042 (Phase 4, fleet UX — +3064/-196 in `update_cmd.py` alone). Checked both branches directly: neither implements this fix (no `relaunched_profiles` write on the Windows resume token in either), and `match_runtime_outcomes`'s signature is untouched in #92545. Given #93042's size, some textual conflict on eventual merge is likely, but there is no semantic overlap — this is a small, self-contained fix to a real, currently-reachable false-positive.