### PR TITLE
feat(desktop): official quota chip on the status bar

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -881,13 +881,95 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+OFFICIAL_USAGE_PROVIDERS = ("openai-codex", "anthropic", "openrouter", "nous")
+
+USAGE_PROVIDER_ALIASES = {
+    "codex": "openai-codex",
+    "chatgpt": "openai-codex",
+    "openai": "openai-codex",
+    "claude": "anthropic",
+    "or": "openrouter",
+    "portal": "nous",
+    "grok": "xai-oauth",
+    "xai": "xai-oauth",
+}
+
+UNSUPPORTED_USAGE_REASONS = {
+    "xai-oauth": "no official quota API",
+    "xai": "no official quota API",
+}
+
+
+def normalize_usage_provider(provider: Optional[str]) -> str:
+    cleaned = str(provider or "").strip().lower()
+    return USAGE_PROVIDER_ALIASES.get(cleaned, cleaned)
+
+
+def _fetch_nous_account_usage() -> Optional[AccountUsageSnapshot]:
+    try:
+        from hermes_cli.auth import get_provider_auth_state
+
+        tok = (get_provider_auth_state("nous") or {}).get("access_token")
+        if not (isinstance(tok, str) and tok.strip()):
+            return None
+        from hermes_cli.nous_account import get_nous_portal_account_info
+
+        return build_nous_credits_snapshot(get_nous_portal_account_info(force_fresh=True))
+    except Exception:
+        return None
+
+
+def snapshot_to_dict(snapshot: AccountUsageSnapshot) -> dict[str, Any]:
+    windows = []
+    for window in snapshot.windows:
+        remaining = None
+        if window.used_percent is not None:
+            remaining = max(0, round(100.0 - float(window.used_percent)))
+        windows.append(
+            {
+                "name": window.label,
+                "used_percent": window.used_percent,
+                "remaining_percent": remaining,
+                "reset_at": window.reset_at.isoformat() if window.reset_at else None,
+                "detail": window.detail,
+            }
+        )
+    return {
+        "provider": snapshot.provider,
+        "status": "ok",
+        "plan": snapshot.plan,
+        "source": snapshot.source,
+        "fetched_at": snapshot.fetched_at.isoformat(),
+        "windows": windows,
+        "details": list(snapshot.details),
+    }
+
+
+def compact_account_usage_line(snapshot: AccountUsageSnapshot) -> str:
+    parts: list[str] = []
+    for window in snapshot.windows:
+        if window.used_percent is None:
+            continue
+        remaining = max(0, round(100.0 - float(window.used_percent)))
+        bit = f"{window.label} {remaining}% left"
+        if window.reset_at:
+            rel = _format_reset(window.reset_at)
+            # Drop the local-clock parenthetical for one-line status surfaces.
+            bit += f", resets {rel.split(' (', 1)[0]}"
+        elif window.detail:
+            bit += f" · {window.detail}"
+        parts.append(bit)
+    parts.extend(snapshot.details)
+    return " · ".join(parts)
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
 ) -> Optional[AccountUsageSnapshot]:
-    normalized = str(provider or "").strip().lower()
+    normalized = normalize_usage_provider(provider)
     if normalized in {"", "auto", "custom"}:
         return None
     try:
@@ -897,6 +979,8 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "nous":
+            return _fetch_nous_account_usage()
     except Exception:
         return None
     return None

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -72,23 +72,26 @@ def _parse_dt(value: Any) -> Optional[datetime]:
     return None
 
 
-def _format_reset(dt: Optional[datetime]) -> str:
+def _format_reset(dt: Optional[datetime], *, include_local: bool = True) -> str:
     if not dt:
         return "unknown"
     local_dt = dt.astimezone()
     delta = dt - _utc_now()
     total_seconds = int(delta.total_seconds())
     if total_seconds <= 0:
-        return f"now ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
-    hours, rem = divmod(total_seconds, 3600)
-    minutes = rem // 60
-    if hours >= 24:
-        days, hours = divmod(hours, 24)
-        rel = f"in {days}d {hours}h"
-    elif hours > 0:
-        rel = f"in {hours}h {minutes}m"
+        rel = "now"
     else:
-        rel = f"in {minutes}m"
+        hours, rem = divmod(total_seconds, 3600)
+        minutes = rem // 60
+        if hours >= 24:
+            days, hours = divmod(hours, 24)
+            rel = f"in {days}d {hours}h"
+        elif hours > 0:
+            rel = f"in {hours}h {minutes}m"
+        else:
+            rel = f"in {minutes}m"
+    if not include_local:
+        return rel
     return f"{rel} ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
 
 
@@ -953,9 +956,7 @@ def compact_account_usage_line(snapshot: AccountUsageSnapshot) -> str:
         remaining = max(0, round(100.0 - float(window.used_percent)))
         bit = f"{window.label} {remaining}% left"
         if window.reset_at:
-            rel = _format_reset(window.reset_at)
-            # Drop the local-clock parenthetical for one-line status surfaces.
-            bit += f", resets {rel.split(' (', 1)[0]}"
+            bit += f", resets {_format_reset(window.reset_at, include_local=False)}"
         elif window.detail:
             bit += f" · {window.detail}"
         parts.append(bit)

--- a/apps/desktop/src/api/account-usage.test.ts
+++ b/apps/desktop/src/api/account-usage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatQuotaChip } from './account-usage'
+
+describe('formatQuotaChip', () => {
+  it('joins official remaining percents', () => {
+    const { label, tip } = formatQuotaChip({
+      providers: [
+        {
+          provider: 'openai-codex',
+          status: 'ok',
+          plan: 'Plus',
+          windows: [
+            { name: 'Session', remaining_percent: 0 },
+            { name: 'Weekly', remaining_percent: 60 }
+          ]
+        },
+        {
+          provider: 'anthropic',
+          status: 'ok',
+          windows: [{ name: 'Week', remaining_percent: 8 }]
+        }
+      ]
+    })
+    expect(label).toBe('Codex 0% · Claude 8%')
+    expect(tip).toContain('Codex Plus')
+    expect(tip).toContain('Claude')
+  })
+
+  it('hides unavailable providers', () => {
+    const { label } = formatQuotaChip({
+      providers: [{ provider: 'openrouter', status: 'unavailable' }]
+    })
+    expect(label).toBe('')
+  })
+})

--- a/apps/desktop/src/api/account-usage.test.ts
+++ b/apps/desktop/src/api/account-usage.test.ts
@@ -27,6 +27,21 @@ describe('formatQuotaChip', () => {
     expect(tip).toContain('Claude')
   })
 
+  it('formats reset times relatively', () => {
+    const soon = new Date(Date.now() + 90 * 60 * 1000).toISOString()
+    const { tip } = formatQuotaChip({
+      providers: [
+        {
+          provider: 'openai-codex',
+          status: 'ok',
+          windows: [{ name: 'Session', remaining_percent: 12, reset_at: soon }]
+        }
+      ]
+    })
+    expect(tip).toMatch(/Session 12% in 1h/)
+    expect(tip).not.toMatch(/T\d{2}:/)
+  })
+
   it('hides unavailable providers', () => {
     const { label } = formatQuotaChip({
       providers: [{ provider: 'openrouter', status: 'unavailable' }]

--- a/apps/desktop/src/api/account-usage.ts
+++ b/apps/desktop/src/api/account-usage.ts
@@ -1,0 +1,91 @@
+import { hermesApi, type ProfileScope, profileScoped } from './client'
+
+export interface AccountUsageWindow {
+  name: string
+  used_percent?: number | null
+  remaining_percent?: number | null
+  reset_at?: null | string
+  detail?: null | string
+}
+
+export interface AccountUsageProvider {
+  provider: string
+  status: string
+  plan?: null | string
+  windows?: AccountUsageWindow[]
+  details?: string[]
+  remaining_percent?: number | null
+  reason?: string
+}
+
+export interface AccountUsageResponse {
+  providers?: AccountUsageProvider[]
+  unsupported?: AccountUsageProvider[]
+  status?: string
+  provider?: string
+  reason?: string
+  windows?: AccountUsageWindow[]
+  details?: string[]
+  plan?: null | string
+}
+
+export function getAccountUsage(profile?: ProfileScope, provider?: string): Promise<AccountUsageResponse> {
+  const suffix = provider ? `?provider=${encodeURIComponent(provider)}` : ''
+  return hermesApi<AccountUsageResponse>({
+    ...profileScoped(profile),
+    path: `/api/account-usage${suffix}`
+  })
+}
+
+const LABELS: Record<string, string> = {
+  'openai-codex': 'Codex',
+  anthropic: 'Claude',
+  openrouter: 'OR',
+  nous: 'Nous'
+}
+
+export function formatQuotaChip(payload: AccountUsageResponse | null | undefined): {
+  label: string
+  tip: string
+} {
+  const rows = normalizeProviders(payload)
+  if (!rows.length) return { label: '', tip: '' }
+  const label = rows
+    .map(row => {
+      const remaining = tightestRemaining(row)
+      const name = LABELS[row.provider] || row.provider
+      return remaining == null ? `${name} —` : `${name} ${remaining}%`
+    })
+    .join(' · ')
+  const tip = rows
+    .map(row => {
+      const name = LABELS[row.provider] || row.provider
+      const bits = (row.windows || []).map(window => {
+        const remaining = window.remaining_percent
+        const reset = window.reset_at ? ` ${window.reset_at}` : ''
+        return `${window.name} ${remaining ?? '—'}%${reset}`
+      })
+      return `${name}${row.plan ? ` ${row.plan}` : ''}: ${bits.join(' · ') || row.reason || 'ok'}`
+    })
+    .join('\n')
+  return { label, tip }
+}
+
+function normalizeProviders(payload: AccountUsageResponse | null | undefined): AccountUsageProvider[] {
+  if (!payload) return []
+  if (Array.isArray(payload.providers)) {
+    return payload.providers.filter(row => row.status === 'ok')
+  }
+  if (payload.status === 'ok' && payload.provider) {
+    return [payload as AccountUsageProvider]
+  }
+  return []
+}
+
+function tightestRemaining(row: AccountUsageProvider): null | number {
+  const values = (row.windows || [])
+    .map(window => window.remaining_percent)
+    .filter((value): value is number => typeof value === 'number')
+  if (!values.length) return null
+  return Math.min(...values)
+}

--- a/apps/desktop/src/api/account-usage.ts
+++ b/apps/desktop/src/api/account-usage.ts
@@ -37,6 +37,20 @@ export function getAccountUsage(profile?: ProfileScope, provider?: string): Prom
   })
 }
 
+export function formatResetLabel(iso?: null | string): string {
+  if (!iso) return ''
+  const dt = new Date(iso)
+  if (Number.isNaN(dt.getTime())) return ''
+  const delta = dt.getTime() - Date.now()
+  if (delta <= 0) return 'now'
+  const minutes = Math.round(delta / 60000)
+  if (minutes < 60) return `in ${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `in ${hours}h ${minutes % 60}m`
+  const days = Math.floor(hours / 24)
+  return `in ${days}d ${hours % 24}h`
+}
+
 const LABELS: Record<string, string> = {
   'openai-codex': 'Codex',
   anthropic: 'Claude',
@@ -62,8 +76,8 @@ export function formatQuotaChip(payload: AccountUsageResponse | null | undefined
       const name = LABELS[row.provider] || row.provider
       const bits = (row.windows || []).map(window => {
         const remaining = window.remaining_percent
-        const reset = window.reset_at ? ` ${window.reset_at}` : ''
-        return `${window.name} ${remaining ?? '—'}%${reset}`
+        const reset = formatResetLabel(window.reset_at)
+        return `${window.name} ${remaining ?? '—'}%${reset ? ` ${reset}` : ''}`
       })
       return `${name}${row.plan ? ` ${row.plan}` : ''}: ${bits.join(' · ') || row.reason || 'ok'}`
     })

--- a/apps/desktop/src/app/shell/hooks/use-account-quota-item.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-account-quota-item.tsx
@@ -1,0 +1,40 @@
+import { useStore } from '@nanostores/react'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+
+import { formatQuotaChip, getAccountUsage } from '@/api/account-usage'
+import { useI18n } from '@/i18n'
+import { $activeGatewayProfile } from '@/store/profile'
+
+import type { StatusbarItem } from '../statusbar-controls'
+
+const POLL_MS = 5 * 60 * 1000
+
+export function useAccountQuotaStatusbarItem(): StatusbarItem {
+  const { statusbar: copy } = useI18n()
+  const profile = useStore($activeGatewayProfile)
+  const query = useQuery({
+    queryKey: ['account-usage', profile],
+    queryFn: () => getAccountUsage(profile),
+    refetchInterval: POLL_MS,
+    retry: false,
+    staleTime: POLL_MS
+  })
+  const { label, tip } = formatQuotaChip(query.data)
+  const refetch = query.refetch
+
+  return useMemo<StatusbarItem>(
+    () => ({
+      hidden: !label,
+      id: 'account-quota',
+      label,
+      onSelect: () => {
+        void refetch()
+      },
+      title: tip || undefined,
+      toggleLabel: copy.toggleQuota,
+      variant: 'action'
+    }),
+    [copy.toggleQuota, label, refetch, tip]
+  )
+}

--- a/apps/desktop/src/app/shell/hooks/use-account-quota-item.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-account-quota-item.tsx
@@ -9,6 +9,7 @@ import { $activeGatewayProfile } from '@/store/profile'
 import type { StatusbarItem } from '../statusbar-controls'
 
 const POLL_MS = 5 * 60 * 1000
+const EMPTY_POLL_MS = 30 * 60 * 1000
 
 export function useAccountQuotaStatusbarItem(): StatusbarItem {
   const { statusbar: copy } = useI18n()
@@ -16,7 +17,7 @@ export function useAccountQuotaStatusbarItem(): StatusbarItem {
   const query = useQuery({
     queryKey: ['account-usage', profile],
     queryFn: () => getAccountUsage(profile),
-    refetchInterval: POLL_MS,
+    refetchInterval: current => (formatQuotaChip(current.state.data).label ? POLL_MS : EMPTY_POLL_MS),
     retry: false,
     staleTime: POLL_MS
   })

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router'
 
 import { ConnectionSwitcher } from '@/app/chat/sidebar/connection-switcher'
 import type { CommandCenterSection } from '@/app/command-center'
+import { useAccountQuotaStatusbarItem } from '@/app/shell/hooks/use-account-quota-item'
 import { useApprovalModeStatusbarItem } from '@/app/shell/approval-mode-menu'
 import { ContextUsagePanel } from '@/app/shell/context-usage-panel'
 import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
@@ -268,6 +269,7 @@ export function useStatusbarItems({
   const contextBar = useMemo(() => contextBarLabel(gaugeUsage), [gaugeUsage])
 
   const approvalModeItem = useApprovalModeStatusbarItem(activeGatewayProfile, requestGateway)
+  const quotaItem = useAccountQuotaStatusbarItem()
 
   const gatewayMenuContent = useMemo(
     () => (close: () => void) => (
@@ -464,6 +466,7 @@ export function useStatusbarItems({
         toggleLabel: copy.toggleWorkspace,
         variant: 'menu'
       },
+      quotaItem,
       {
         className: cn(
           agentsOpen && 'bg-accent/55 text-foreground',
@@ -524,6 +527,7 @@ export function useStatusbarItems({
       inferenceStatus?.reason,
       openAgents,
       projectName,
+      quotaItem,
       sessionsShowing,
       subagentsFailed,
       subagentsRunning,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2869,6 +2869,7 @@ export const en: Translations = {
       toggleTerminal: 'Terminal',
       toggleVersion: 'Version & updates',
       toggleWorkspace: 'Workspace',
+      toggleQuota: 'Quota',
       agents: 'Agents',
       closeAgents: 'Close agents',
       openAgents: 'Open agents',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2437,6 +2437,7 @@ export interface Translations {
       toggleTerminal: string
       toggleVersion: string
       toggleWorkspace: string
+      toggleQuota: string
       agents: string
       closeAgents: string
       openAgents: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3034,6 +3034,7 @@ export const zh: Translations = {
       toggleTerminal: '终端',
       toggleVersion: '版本与更新',
       toggleWorkspace: '工作区',
+      toggleQuota: '额度',
       agents: '代理',
       closeAgents: '关闭代理',
       openAgents: '打开代理',

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -525,6 +525,14 @@ def auth_status_command(args) -> None:
         value = status.get(key)
         if value:
             print(f"  {key}: {value}")
+    try:
+        from hermes_cli.usage_cmd import compact_usage_line
+
+        usage_line = compact_usage_line(provider)
+    except Exception:
+        usage_line = None
+    if usage_line:
+        print(f"  usage: {usage_line}")
 
 
 def auth_logout_command(args) -> None:

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -642,6 +642,13 @@ class HermesConsoleEngine:
                 [()],
                 set(),
             ),
+            "usage": (
+                "hermes_cli.subcommands.usage",
+                "build_usage_parser",
+                "cmd_usage",
+                [()],
+                set(),
+            ),
             "security": (
                 "hermes_cli.subcommands.security",
                 "build_security_parser",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -478,6 +478,7 @@ from hermes_cli.subcommands.memory import build_memory_parser
 from hermes_cli.subcommands.acp import build_acp_parser
 from hermes_cli.subcommands.tools import build_tools_parser
 from hermes_cli.subcommands.insights import build_insights_parser
+from hermes_cli.subcommands.usage import build_usage_parser
 from hermes_cli.subcommands.monitoring import build_monitoring_parser
 from hermes_cli.subcommands.skills import build_skills_parser
 from hermes_cli.subcommands.pairing import build_pairing_parser
@@ -12472,6 +12473,13 @@ def cmd_insights(args):
                 pass
 
 
+def cmd_usage(args):
+    """Show official OAuth quota windows."""
+    from hermes_cli.usage_cmd import usage_command
+
+    raise SystemExit(usage_command(args))
+
+
 def cmd_monitoring(args):
     """Gateway monitoring status: health & diagnostics export posture."""
     from hermes_cli.config import load_config
@@ -14043,6 +14051,7 @@ def main():
     # insights command  (parser built in hermes_cli/subcommands/insights.py)
     # =========================================================================
     build_insights_parser(subparsers, cmd_insights=cmd_insights)
+    build_usage_parser(subparsers, cmd_usage=cmd_usage)
     build_monitoring_parser(subparsers, cmd_monitoring=cmd_monitoring)
 
     # =========================================================================

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -27,6 +27,20 @@ from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
+def _maybe_print_usage(provider: str, *, enabled: bool) -> None:
+    """Fail-open quota line for ``hermes status --all``."""
+    if not enabled:
+        return
+    try:
+        from hermes_cli.usage_cmd import compact_usage_line
+
+        line = compact_usage_line(provider)
+    except Exception:
+        return
+    if line:
+        print(f"    Usage:      {line}")
+
+
 def check_mark(ok: bool) -> str:
     if ok:
         return color("✓", Colors.GREEN)
@@ -295,6 +309,7 @@ def show_status(args):
         print(f"    Refresh:    {refresh_label}")
     if nous_error:
         print(f"    Error:      {nous_error}")
+    _maybe_print_usage("nous", enabled=bool(getattr(args, "all", False) and nous_logged_in))
 
     codex_logged_in = bool(codex_status.get("logged_in"))
     print(
@@ -309,6 +324,7 @@ def show_status(args):
         print(f"    Refreshed:  {codex_last_refresh}")
     if codex_status.get("error") and not codex_logged_in:
         print(f"    Error:      {codex_status.get('error')}")
+    _maybe_print_usage("openai-codex", enabled=bool(getattr(args, "all", False) and codex_logged_in))
 
     qwen_logged_in = bool(qwen_status.get("logged_in"))
     print(

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -27,16 +27,35 @@ from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
-def _maybe_print_usage(provider: str, *, enabled: bool) -> None:
-    """Fail-open quota line for ``hermes status --all``."""
-    if not enabled:
-        return
-    try:
-        from hermes_cli.usage_cmd import compact_usage_line
+def _prefetch_usage_lines(enabled: bool) -> dict[str, str]:
+    """Fetch official quota lines in parallel for ``hermes status --all``.
 
-        line = compact_usage_line(provider)
-    except Exception:
-        return
+    Existing provider timeouts stay at 10–15s; running them concurrently
+    keeps ``--all`` from stacking four serial HTTP waits.
+    """
+    if not enabled:
+        return {}
+    from concurrent.futures import ThreadPoolExecutor
+
+    from hermes_cli.usage_cmd import compact_usage_line
+
+    providers = ("nous", "openai-codex", "anthropic", "openrouter")
+    out: dict[str, str] = {}
+    with ThreadPoolExecutor(max_workers=len(providers)) as pool:
+        futures = {pool.submit(compact_usage_line, name): name for name in providers}
+        for future, name in futures.items():
+            try:
+                line = future.result()
+            except Exception:
+                line = None
+            if line:
+                out[name] = line
+    return out
+
+
+def _maybe_print_usage(provider: str, cache: dict[str, str]) -> None:
+    """Fail-open quota line for ``hermes status --all``."""
+    line = cache.get(provider)
     if line:
         print(f"    Usage:      {line}")
 
@@ -181,6 +200,7 @@ def show_status(args):
     # =========================================================================
     print()
     print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))
+    usage_cache = _prefetch_usage_lines(bool(getattr(args, "all", False)))
 
     # Values may be a single env var name (str) or a tuple of alternates (first found wins).
     keys: dict[str, str | tuple[str, ...]] = {
@@ -226,11 +246,14 @@ def show_status(args):
         has_key = bool(value)
         display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
+        if name == "OpenRouter":
+            _maybe_print_usage("openrouter", usage_cache)
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
     anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
+    _maybe_print_usage("anthropic", usage_cache)
 
     # =========================================================================
     # Auth Providers (OAuth)
@@ -309,7 +332,7 @@ def show_status(args):
         print(f"    Refresh:    {refresh_label}")
     if nous_error:
         print(f"    Error:      {nous_error}")
-    _maybe_print_usage("nous", enabled=bool(getattr(args, "all", False) and nous_logged_in))
+    _maybe_print_usage("nous", usage_cache)
 
     codex_logged_in = bool(codex_status.get("logged_in"))
     print(
@@ -324,7 +347,7 @@ def show_status(args):
         print(f"    Refreshed:  {codex_last_refresh}")
     if codex_status.get("error") and not codex_logged_in:
         print(f"    Error:      {codex_status.get('error')}")
-    _maybe_print_usage("openai-codex", enabled=bool(getattr(args, "all", False) and codex_logged_in))
+    _maybe_print_usage("openai-codex", usage_cache)
 
     qwen_logged_in = bool(qwen_status.get("logged_in"))
     print(

--- a/hermes_cli/subcommands/usage.py
+++ b/hermes_cli/subcommands/usage.py
@@ -1,0 +1,27 @@
+"""``hermes usage`` subcommand parser."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_usage_parser(subparsers, *, cmd_usage: Callable) -> None:
+    parser = subparsers.add_parser(
+        "usage",
+        help="Show official OAuth quota windows (Codex, Claude, OpenRouter, Nous)",
+        description=(
+            "Fetch first-party subscription quota windows. "
+            "Does not scrape undocumented endpoints (Grok is unsupported)."
+        ),
+    )
+    parser.add_argument(
+        "provider",
+        nargs="?",
+        help="Provider id or alias (openai-codex, anthropic, openrouter, nous). Omit for all official sources.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print a JSON report (script-friendly)",
+    )
+    parser.set_defaults(func=cmd_usage)

--- a/hermes_cli/usage_cmd.py
+++ b/hermes_cli/usage_cmd.py
@@ -1,0 +1,135 @@
+"""Official OAuth quota surfaces: ``hermes usage`` and compact status lines.
+
+Only providers with a first-party usage endpoint are fetched. Fail-open:
+network/auth errors become ``unavailable`` and never crash the CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from agent.account_usage import (
+    OFFICIAL_USAGE_PROVIDERS,
+    UNSUPPORTED_USAGE_REASONS,
+    compact_account_usage_line,
+    fetch_account_usage,
+    normalize_usage_provider,
+    snapshot_to_dict,
+)
+
+DISPLAY_NAMES = {
+    "openai-codex": "Codex",
+    "anthropic": "Claude",
+    "openrouter": "OpenRouter",
+    "nous": "Nous",
+    "xai-oauth": "Grok",
+    "xai": "Grok",
+}
+
+
+def collect_usage_report(provider: str) -> dict[str, Any]:
+    """Return a JSON-safe report. Never raises."""
+    normalized = normalize_usage_provider(provider)
+    if not normalized:
+        return {"provider": "", "status": "unavailable", "reason": "provider required"}
+    if normalized in UNSUPPORTED_USAGE_REASONS:
+        return {
+            "provider": normalized,
+            "status": "unsupported",
+            "reason": UNSUPPORTED_USAGE_REASONS[normalized],
+        }
+    if normalized not in OFFICIAL_USAGE_PROVIDERS:
+        return {
+            "provider": normalized,
+            "status": "unknown",
+            "reason": "no official quota source",
+        }
+    try:
+        snapshot = fetch_account_usage(normalized)
+    except Exception:
+        snapshot = None
+    if snapshot is None or not snapshot.available:
+        return {
+            "provider": normalized,
+            "status": "unavailable",
+            "reason": "quota endpoint unavailable",
+        }
+    return snapshot_to_dict(snapshot)
+
+
+def compact_usage_line(provider: str) -> Optional[str]:
+    """One-line summary for ``hermes status`` / ``auth status``. None if nothing to show."""
+    normalized = normalize_usage_provider(provider)
+    if normalized in UNSUPPORTED_USAGE_REASONS or normalized not in OFFICIAL_USAGE_PROVIDERS:
+        return None
+    try:
+        snapshot = fetch_account_usage(normalized)
+    except Exception:
+        return None
+    if snapshot is None or not snapshot.available:
+        return None
+    line = compact_account_usage_line(snapshot)
+    return line or None
+
+
+def format_usage_text(report: dict[str, Any]) -> str:
+    provider = str(report.get("provider") or "")
+    name = DISPLAY_NAMES.get(provider, provider or "provider")
+    status = report.get("status")
+    if status == "unsupported":
+        return f"{name}      unsupported ({report.get('reason') or 'no official quota API'})"
+    if status == "unknown":
+        return f"{name}      unknown ({report.get('reason') or 'no official quota source'})"
+    if status != "ok":
+        return f"{name}      unavailable"
+    header = f"📈 Account limits"
+    plan = report.get("plan")
+    lines = [header, f"Provider: {provider} ({plan})" if plan else f"Provider: {provider}"]
+    for window in report.get("windows") or []:
+        remaining = window.get("remaining_percent")
+        used = window.get("used_percent")
+        if remaining is None and used is not None:
+            remaining = max(0, round(100.0 - float(used)))
+            used = max(0, round(float(used)))
+        if remaining is None:
+            base = f"{window.get('name')}: unavailable"
+        else:
+            used_i = max(0, round(float(used))) if used is not None else max(0, 100 - int(remaining))
+            base = f"{window.get('name')}: {int(remaining)}% remaining ({used_i}% used)"
+        reset_at = window.get("reset_at")
+        if reset_at:
+            base += f" • resets {reset_at}"
+        elif window.get("detail"):
+            base += f" • {window['detail']}"
+        lines.append(base)
+    for detail in report.get("details") or []:
+        lines.append(str(detail))
+    return "\n".join(lines)
+
+
+def usage_command(args) -> int:
+    as_json = bool(getattr(args, "json", False))
+    requested = str(getattr(args, "provider", "") or "").strip()
+    if requested:
+        report = collect_usage_report(requested)
+        if as_json:
+            print(json.dumps(report, indent=2))
+        else:
+            print(format_usage_text(report))
+        return 2 if report.get("status") == "unknown" else 0
+
+    official = [collect_usage_report(provider) for provider in OFFICIAL_USAGE_PROVIDERS]
+    grok = {
+        "provider": "xai-oauth",
+        "status": "unsupported",
+        "reason": UNSUPPORTED_USAGE_REASONS["xai-oauth"],
+    }
+    if as_json:
+        print(json.dumps({"providers": official + [grok]}, indent=2))
+        return 0
+    for report in official:
+        if report.get("status") == "ok":
+            print(format_usage_text(report))
+    print(format_usage_text(grok))
+    return 0

--- a/hermes_cli/usage_cmd.py
+++ b/hermes_cli/usage_cmd.py
@@ -133,3 +133,21 @@ def usage_command(args) -> int:
             print(format_usage_text(report))
     print(format_usage_text(grok))
     return 0
+
+
+def account_usage_payload(provider: Optional[str] = None) -> dict[str, Any]:
+    """JSON payload for ``GET /api/account-usage`` and the desktop chip."""
+    requested = str(provider or "").strip()
+    if requested:
+        return collect_usage_report(requested)
+    official = [collect_usage_report(name) for name in OFFICIAL_USAGE_PROVIDERS]
+    return {
+        "providers": [row for row in official if row.get("status") == "ok"],
+        "unsupported": [
+            {
+                "provider": "xai-oauth",
+                "status": "unsupported",
+                "reason": UNSUPPORTED_USAGE_REASONS["xai-oauth"],
+            }
+        ],
+    }

--- a/hermes_cli/usage_cmd.py
+++ b/hermes_cli/usage_cmd.py
@@ -83,7 +83,7 @@ def format_usage_text(report: dict[str, Any]) -> str:
         return f"{name}      unknown ({report.get('reason') or 'no official quota source'})"
     if status != "ok":
         return f"{name}      unavailable"
-    header = f"📈 Account limits"
+    header = "📈 Account limits"
     plan = report.get("plan")
     lines = [header, f"Provider: {provider} ({plan})" if plan else f"Provider: {provider}"]
     for window in report.get("windows") or []:
@@ -128,9 +128,15 @@ def usage_command(args) -> int:
     if as_json:
         print(json.dumps({"providers": official + [grok]}, indent=2))
         return 0
-    for report in official:
-        if report.get("status") == "ok":
+    ok_reports = [report for report in official if report.get("status") == "ok"]
+    if not ok_reports:
+        print("No official quota sources are signed in.")
+        for report in official:
             print(format_usage_text(report))
+        print(format_usage_text(grok))
+        return 0
+    for report in ok_reports:
+        print(format_usage_text(report))
     print(format_usage_text(grok))
     return 0
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15708,6 +15708,9 @@ async def get_account_usage(provider: Optional[str] = None):
 
     Fail-open: missing creds or upstream errors become ``unavailable``.
     SuperGrok is listed as unsupported — there is no first-party quota API.
+
+    Sits on the same ``/api/`` auth gate as ``/api/analytics/*`` (not on
+    the public_paths allowlist).
     """
     from hermes_cli.usage_cmd import account_usage_payload
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15702,6 +15702,18 @@ async def get_usage_analytics(
     return await asyncio.to_thread(_get_usage_analytics, days, profile)
 
 
+@app.get("/api/account-usage")
+async def get_account_usage(provider: Optional[str] = None):
+    """Official OAuth quota windows (Codex / Claude / OpenRouter / Nous).
+
+    Fail-open: missing creds or upstream errors become ``unavailable``.
+    SuperGrok is listed as unsupported — there is no first-party quota API.
+    """
+    from hermes_cli.usage_cmd import account_usage_payload
+
+    return await asyncio.to_thread(account_usage_payload, provider)
+
+
 def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
     """Rich per-model analytics for the Models dashboard page.
 

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -227,3 +227,34 @@ def test_redeem_missing_credentials_reports_unavailable(monkeypatch):
 
     assert result.status == "unavailable"
     assert "hermes auth" in result.message
+
+
+def test_fetch_account_usage_accepts_codex_alias(monkeypatch, codex_usage_payload):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "resolve_codex_runtime_credentials",
+        lambda **kwargs: {"api_key": "alias-token", "base_url": "https://chatgpt.com/backend-api/codex"},
+    )
+    snapshot = account_usage.fetch_account_usage("codex")
+    assert snapshot is not None
+    assert snapshot.provider == "openai-codex"
+    assert calls[0]["headers"]["Authorization"] == "Bearer alias-token"
+
+
+def test_fetch_account_usage_nous_dispatches(monkeypatch):
+    from datetime import datetime, timezone
+
+    expected = account_usage.AccountUsageSnapshot(
+        provider="nous",
+        source="portal-account",
+        fetched_at=datetime.now(timezone.utc),
+        details=("Subscription credits: $1.00",),
+    )
+    monkeypatch.setattr(account_usage, "_fetch_nous_account_usage", lambda: expected)
+    assert account_usage.fetch_account_usage("portal") is expected

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -237,3 +237,31 @@ def test_show_status_reports_gateway_session_last_activity(monkeypatch, capsys, 
     assert "Active:       2 session(s)" in output
     assert "Last activity:" in output
     assert "1m ago" in output
+
+
+def test_show_status_all_prints_codex_usage_line(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status_local", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {"logged_in": True}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.usage_cmd.compact_usage_line",
+        lambda provider: "Session 12% left, resets in 1h" if provider == "openai-codex" else None,
+    )
+
+    status_mod.show_status(SimpleNamespace(all=True, deep=False))
+    output = capsys.readouterr().out
+    assert "Usage:      Session 12% left, resets in 1h" in output

--- a/tests/hermes_cli/test_usage_cmd.py
+++ b/tests/hermes_cli/test_usage_cmd.py
@@ -71,6 +71,19 @@ def test_usage_command_json_single(monkeypatch, capsys):
     assert "xai-oauth" in payload
 
 
+def test_usage_command_empty_install_is_explicit(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.usage_cmd.collect_usage_report",
+        lambda provider: {"provider": provider, "status": "unavailable", "reason": "quota endpoint unavailable"},
+    )
+    code = usage_command(SimpleNamespace(provider="", json=False))
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "No official quota sources are signed in." in out
+    assert "unavailable" in out
+    assert "unsupported" in out
+
+
 def test_usage_command_unknown_exit_code(monkeypatch, capsys):
     monkeypatch.setattr(
         "hermes_cli.usage_cmd.collect_usage_report",

--- a/tests/hermes_cli/test_usage_cmd.py
+++ b/tests/hermes_cli/test_usage_cmd.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+
+from agent.account_usage import (
+    AccountUsageSnapshot,
+    AccountUsageWindow,
+    compact_account_usage_line,
+    normalize_usage_provider,
+    snapshot_to_dict,
+)
+from hermes_cli.usage_cmd import collect_usage_report, format_usage_text, usage_command
+
+
+def test_normalize_usage_provider_aliases():
+    assert normalize_usage_provider("codex") == "openai-codex"
+    assert normalize_usage_provider("claude") == "anthropic"
+    assert normalize_usage_provider("grok") == "xai-oauth"
+
+
+def test_collect_usage_report_grok_is_unsupported():
+    report = collect_usage_report("xai-oauth")
+    assert report["status"] == "unsupported"
+    assert "official" in report["reason"]
+
+
+def test_collect_usage_report_unknown_provider():
+    report = collect_usage_report("gemini")
+    assert report["status"] == "unknown"
+
+
+def test_collect_usage_report_codex_ok(monkeypatch):
+    from datetime import datetime, timezone
+
+    snap = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime(2026, 8, 23, tzinfo=timezone.utc),
+        plan="Plus",
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=100.0,
+                reset_at=datetime(2026, 8, 27, 9, 24, tzinfo=timezone.utc),
+            ),
+            AccountUsageWindow(label="Weekly", used_percent=40.0),
+        ),
+        details=("You have 1 reset banked - use /usage reset to activate",),
+    )
+    monkeypatch.setattr("hermes_cli.usage_cmd.fetch_account_usage", lambda provider: snap)
+    report = collect_usage_report("codex")
+    assert report["status"] == "ok"
+    assert report["plan"] == "Plus"
+    assert report["windows"][0]["remaining_percent"] == 0
+    assert report["windows"][1]["remaining_percent"] == 60
+
+
+def test_collect_usage_report_unavailable_on_none(monkeypatch):
+    monkeypatch.setattr("hermes_cli.usage_cmd.fetch_account_usage", lambda provider: None)
+    report = collect_usage_report("anthropic")
+    assert report["status"] == "unavailable"
+
+
+def test_usage_command_json_single(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.usage_cmd.collect_usage_report",
+        lambda provider: {"provider": "xai-oauth", "status": "unsupported", "reason": "no official quota API"},
+    )
+    code = usage_command(SimpleNamespace(provider="grok", json=True))
+    assert code == 0
+    payload = capsys.readouterr().out
+    assert "unsupported" in payload
+    assert "xai-oauth" in payload
+
+
+def test_usage_command_unknown_exit_code(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.usage_cmd.collect_usage_report",
+        lambda provider: {"provider": "gemini", "status": "unknown", "reason": "no official quota source"},
+    )
+    code = usage_command(SimpleNamespace(provider="gemini", json=False))
+    assert code == 2
+    assert "unknown" in capsys.readouterr().out
+
+
+def test_compact_account_usage_line_omits_local_clock():
+    from datetime import datetime, timezone, timedelta
+
+    snap = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=80.0,
+                reset_at=datetime.now(timezone.utc) + timedelta(hours=2, minutes=10),
+            ),
+        ),
+    )
+    line = compact_account_usage_line(snap)
+    assert "Session 20% left" in line
+    assert "resets in" in line
+    assert "(" not in line
+
+
+def test_snapshot_to_dict_roundtrip():
+    from datetime import datetime, timezone
+
+    snap = AccountUsageSnapshot(
+        provider="openrouter",
+        source="credits_api",
+        fetched_at=datetime(2026, 8, 23, tzinfo=timezone.utc),
+        windows=(AccountUsageWindow(label="API key quota", used_percent=50.0, detail="$25 of $50"),),
+        details=("Credits balance: $7.54",),
+    )
+    data = snapshot_to_dict(snap)
+    assert data["status"] == "ok"
+    assert data["windows"][0]["remaining_percent"] == 50
+    text = format_usage_text(data)
+    assert "OpenRouter" not in text or "openrouter" in text.lower() or "Provider: openrouter" in text
+    assert "50% remaining" in text
+
+
+def test_auth_status_prints_usage_line(monkeypatch, capsys):
+    from hermes_cli import auth_commands
+
+    monkeypatch.setattr(
+        auth_commands.auth_mod,
+        "get_auth_status",
+        lambda provider: {"logged_in": True, "auth_type": "oauth"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.usage_cmd.compact_usage_line",
+        lambda provider: "Session 12% left, resets in 1h 4m",
+    )
+    auth_commands.auth_status_command(SimpleNamespace(provider="openai-codex"))
+    out = capsys.readouterr().out
+    assert "openai-codex: logged in" in out
+    assert "usage: Session 12% left, resets in 1h 4m" in out

--- a/tests/hermes_cli/test_usage_cmd.py
+++ b/tests/hermes_cli/test_usage_cmd.py
@@ -136,3 +136,17 @@ def test_auth_status_prints_usage_line(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "openai-codex: logged in" in out
     assert "usage: Session 12% left, resets in 1h 4m" in out
+
+
+def test_account_usage_payload_lists_ok_providers(monkeypatch):
+    from hermes_cli.usage_cmd import account_usage_payload
+
+    def fake_report(provider):
+        if provider == "openai-codex":
+            return {"provider": provider, "status": "ok", "windows": []}
+        return {"provider": provider, "status": "unavailable"}
+
+    monkeypatch.setattr("hermes_cli.usage_cmd.collect_usage_report", fake_report)
+    payload = account_usage_payload()
+    assert [row["provider"] for row in payload["providers"]] == ["openai-codex"]
+    assert payload["unsupported"][0]["provider"] == "xai-oauth"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -87,6 +87,8 @@ Don't have a subscription yet? Get one at [portal.nousresearch.com/manage-subscr
 The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
 
 If a token refresh fails with a terminal error (HTTP 4xx, `invalid_grant`, revoked grant, etc.), Hermes marks the refresh token as dead and stops replaying it so you don't see a flood of identical auth failures. The next request surfaces a typed re-auth message instead. Run `hermes auth add openai-codex` (or `hermes model` → **ChatGPT or Codex Subscription**) to start a fresh device-code login; the quarantine clears on the next successful exchange.
+
+Check remaining Codex / Claude / OpenRouter / Nous allowance with `hermes usage` (or `hermes status --all`). SuperGrok OAuth has no official quota API, so it is listed as unsupported rather than guessed.
 :::
 
 :::warning

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -90,6 +90,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes pets` | Browse, install, and select [petdex](../user-guide/features/pets.md) animated pets shown across the CLI, TUI, and desktop app. Subcommands: `list`, `install`, `select`, `show`, `off`, `scale`, `remove`, `doctor`. |
 | `hermes sessions` | Browse, export, prune, rename, and delete sessions. |
 | `hermes insights` | Show token/cost/activity analytics. |
+| `hermes usage` | Show official OAuth quota windows (Codex, Claude, OpenRouter, Nous). |
 | `hermes claw` | OpenClaw migration helpers. |
 | `hermes import-agent` | Import a Claude Code (`~/.claude`) or Codex CLI (`~/.codex`) setup. |
 | `hermes dashboard` | Launch the web dashboard for managing config, API keys, and sessions. |
@@ -1550,6 +1551,23 @@ hermes insights [--days N] [--source platform]
 |--------|-------------|
 | `--days <n>` | Analyze the last `n` days (default: 30). |
 | `--source <platform>` | Filter by source such as `cli`, `telegram`, or `discord`. |
+
+## `hermes usage`
+
+```bash
+hermes usage [provider] [--json]
+```
+
+Show first-party subscription quota windows for signed-in OAuth providers.
+
+| Argument | Description |
+|----------|-------------|
+| `provider` | Optional id or alias (`openai-codex` / `codex`, `anthropic` / `claude`, `openrouter`, `nous`). Omit to list official sources. |
+| `--json` | Print a script-friendly JSON report. |
+
+Official sources today: Codex (5h + weekly), Claude OAuth, OpenRouter credits, Nous Portal credits. Providers without a public quota API (including SuperGrok / `xai-oauth`) print `unsupported` instead of a guessed number. Failures are `unavailable` and do not change the exit code, except an unknown provider name exits `2`.
+
+`hermes auth status <provider>` and `hermes status --all` reuse the same snapshot for a one-line summary. This is the official remaining allowance, not the local token totals from `hermes insights` or `/usage` session stats.
 
 ## `hermes claw`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1567,7 +1567,7 @@ Show first-party subscription quota windows for signed-in OAuth providers.
 
 Official sources today: Codex (5h + weekly), Claude OAuth, OpenRouter credits, Nous Portal credits. Providers without a public quota API (including SuperGrok / `xai-oauth`) print `unsupported` instead of a guessed number. Failures are `unavailable` and do not change the exit code, except an unknown provider name exits `2`.
 
-`hermes auth status <provider>` and `hermes status --all` reuse the same snapshot for a one-line summary. This is the official remaining allowance, not the local token totals from `hermes insights` or `/usage` session stats.
+`hermes auth status <provider>` and `hermes status --all` reuse the same snapshot for a one-line summary. The desktop status bar shows the same remaining percents as a compact chip (`Codex 12% · Claude 61%`) via `GET /api/account-usage`. This is the official remaining allowance, not the local token totals from `hermes insights` or `/usage` session stats.
 
 ## `hermes claw`
 


### PR DESCRIPTION
## Summary

Depends on #93282. Review the latest commit after that CLI PR; this one only adds the desktop surface.

- `GET /api/account-usage` — same official snapshot as `hermes usage`
- Compact chip on the desktop footer next to This device / Gateway / workspace: `Codex 0% · Claude 8%`
- Hover shows the windows; click refreshes
- 5-minute cache; fetch happens off the render path; empty/failed payload hides the chip
- No Grok scrape. No TUI/CLI status-bar changes (#44506 / #53375)

## Test plan

- [x] `python3 -m pytest tests/hermes_cli/test_usage_cmd.py tests/agent/test_account_usage.py tests/hermes_cli/test_status.py -q` (28 passed)
- [x] Unit test for `formatQuotaChip`
- [ ] After #93282 is available on a running backend: chip appears for signed-in Codex/Claude/OpenRouter
- [ ] With only SuperGrok signed in, chip stays hidden