### PR TITLE
fix: lifecycle guard no longer blocks prose or quoted data as gateway commands (#92372, salvage #92443)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -59,7 +59,7 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # `start` is intentionally excluded: starting a gateway from inside a
     # gateway is benign (a no-op or "already running" error), and a
     # legitimate cron job might start a sibling profile's gateway.
-    r"(?:hermes\s+gateway\s+(?:restart|stop))"
+    r"(?:hermes\s+gateway\s+(?:restart|stop)\b)"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.
@@ -77,8 +77,10 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both
     # token orders because real reproductions show both.
-    r"|(?:p?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
-    r"|(?:p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    # Leading \b ensures we match "pkill" or "kill" as whole words, not as
+    # suffixes of other words (e.g. "skill" -> "kill").
+    r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
+    r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
 )
 
 
@@ -177,10 +179,60 @@ _BINARY_SNIFF_BYTES = 4096
 _ReadRemoteScriptFn = Callable[[str], Optional[str]]
 
 
+def _split_logical_lines(text: str) -> list[str]:
+    """Split text on newlines that are not inside quotes.
+
+    A newline inside a quoted string (single or double quotes) is data,
+    not a command separator. Handles escaped quotes within strings.
+    """
+    lines = []
+    current = []
+    in_single = False
+    in_double = False
+    escape = False
+
+    for ch in text:
+        if escape:
+            current.append(ch)
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            current.append(ch)
+            continue
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            current.append(ch)
+            continue
+        if ch == '"' and not in_single:
+            in_double = not in_double
+            current.append(ch)
+            continue
+        if ch == "\n" and not in_single and not in_double:
+            lines.append("".join(current))
+            current = []
+            continue
+        current.append(ch)
+
+    if current:
+        lines.append("".join(current))
+    return lines
+
+
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
-    """Yield shell-tokenized command segments, honoring quotes and comments."""
+    """Yield shell-tokenized command segments, honoring quotes and comments.
+
+    A newline inside a quoted token is data, not a command separator.
+    First split on logical lines (newlines outside quotes), then tokenize
+    each logical line with shlex. If a logical line cannot be tokenized
+    (unbalanced quotes), fall back to per-physical-line tokenization for
+    that logical line.
+    """
     normalized = command.replace("\\\n", "")
-    for line in normalized.splitlines() or [normalized]:
+    logical_lines = _split_logical_lines(normalized)
+
+    for line in logical_lines:
+        # Try to tokenize the logical line as a whole.
         try:
             lexer = shlex.shlex(
                 line,
@@ -191,6 +243,31 @@ def _iter_command_segments(command: str) -> Iterator[list[str]]:
             lexer.commenters = "#"
             tokens = list(lexer)
         except ValueError:
+            # Fall back to per-physical-line tokenization for this logical line.
+            # This handles cases where quotes are unbalanced across lines.
+            for physical_line in line.splitlines():
+                try:
+                    lexer = shlex.shlex(
+                        physical_line,
+                        posix=True,
+                        punctuation_chars=";&|()",
+                    )
+                    lexer.whitespace_split = True
+                    lexer.commenters = "#"
+                    tokens = list(lexer)
+                except ValueError:
+                    continue
+
+                segment: list[str] = []
+                for token in tokens:
+                    if token and set(token) <= _CONTROL_CHARS:
+                        if segment:
+                            yield segment
+                            segment = []
+                        continue
+                    segment.append(token)
+                if segment:
+                    yield segment
             continue
 
         segment: list[str] = []

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -102,9 +102,46 @@ class TestGatewayLifecyclePattern:
         "Monitor the gateway and tell me if a restart is recommended",
         "research how the OpenAI API gateway handles restart after rate limiting",
         "compare AWS API Gateway vs Cloudflare on restart latency",
+        # #92372 Branch A: no trailing boundary meant ordinary prose matched —
+        # "restarted" carries the "restart" prefix and the old pattern ended
+        # exactly there. \b after the verb group fixes it.
+        "echo after the hermes gateway restarted cleanly",
+        "the hermes gateway stopped responding, please investigate",
+        # #92372 Branch D: `p?kill` without a leading \b matched the "kill"
+        # tail of "skill".
+        "hermes skill view gateway-notes && echo hermes gateway docs",
     ])
     def test_safe_commands(self, text):
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        # Trailing-boundary fix must not weaken real commands.
+        "hermes gateway restart",
+        "hermes gateway restart; echo done",
+        "hermes gateway stop && echo stopped",
+    ])
+    def test_boundary_fix_still_blocks_real_commands(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
+    def test_quoted_multiline_payload_tokenizes_as_one_logical_line(self):
+        # #92372: a newline inside a quoted string is data, not a command
+        # separator. A quoted data-file path on its own physical line inside
+        # a multiline construct must not be promoted to command position.
+        text = (
+            'FILES=(\n'
+            '  "/tmp/notes about procedures.txt"\n'
+            ')\n'
+            'echo "${FILES[@]}"'
+        )
+        assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
+
+    def test_unbalanced_quotes_still_scanned_not_waved_through(self):
+        # Fail-closed contract: when the logical line cannot tokenize
+        # (unbalanced quote), the per-physical-line fallback must still SCAN
+        # the content — a lifecycle command alongside an unbalanced quote
+        # must remain blocked, never waved through.
+        text = 'echo "unbalanced\nhermes gateway restart'
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
 
 class TestCronCreateLifecycleBlock:


### PR DESCRIPTION
## Summary

The gateway lifecycle guard no longer blocks ordinary prose or quoted data as if it were a gateway command. Root cause (#92372): Branch A of the lifecycle regex had no trailing word boundary ("the hermes gateway restarted cleanly" matched via the "restart" prefix), and the command tokenizer split on physical lines, destroying quote context — a quoted data-file path on its own line inside a multiline construct was promoted to command position and scanned as a referenced script.

Salvages PR #92443 by @webtecnica (the focused variant, per triage on the PR thread) with regression tests added on top.

Closes #92372.

## Changes

- `cron/lifecycle_guard.py` (@webtecnica): trailing `\b` on Branch A, leading `\b` on Branch D (`p?kill` no longer matches the "kill" tail of "skill"), quote-aware logical-line splitting before shlex tokenization with a fail-closed per-physical-line fallback for unbalanced quotes
- `tests/hermes_cli/test_gateway_restart_loop.py`: regression tests — prose false positives, real commands still blocked, quoted multiline payloads stay whole, unbalanced-quote content still scanned (never waved through)

## Validation

| Case | Before | After |
|---|---|---|
| `echo after the hermes gateway restarted cleanly` | BLOCKED (false positive) | allowed |
| quoted data-file path in multiline bash array | scanned as referenced script | allowed |
| `hermes gateway restart` / `; echo done` chain | blocked | still blocked |
| `launchctl kickstart ... ai.hermes.gateway`, `pkill -f 'hermes gateway run'` | blocked | still blocked |
| unbalanced quote + real lifecycle command | blocked | still blocked (fail-closed fallback verified) |

All shapes verified live against the real guard functions on this branch; `tests/hermes_cli/test_gateway_restart_loop.py` 140/140 pass.

## Infographic

![Command guard: words are not commands](https://v3b.fal.media/files/b/0aa78c6b/EBmNPh9PgD-VsKmLSMX48_CE50f1ot.png)
