### PR TITLE
fix: profile-flag gateway restart no longer bypasses the lifecycle guard when self-targeting (#78028, salvage #78044)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -31,6 +31,11 @@ stop|restart`` separately refuse to self-target from inside the gateway.
 Blocking cron specs at creation time as well means the agent gets an immediate,
 informative rejection instead of scheduling a job that will only fail
 (silently) when it fires.
+
+The profile-flag form (``hermes -p <profile> gateway restart|stop``, #78028)
+is handled profile-aware: it is blocked only when the named profile is the
+profile running the guard. Sibling-profile restarts are legitimate fleet
+operations and stay allowed.
 """
 
 from __future__ import annotations
@@ -97,12 +102,85 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 _SHELL_LINE_CONTINUATION = re.compile(r"\\\r?\n[ \t]*")
 
 
+# Branch A2 (#78028): the same foot-gun written with an explicit profile
+# selector — `hermes -p <profile> gateway restart|stop` / `--profile <name>`
+# / `--profile=<name>`. The selector token between `hermes` and `gateway`
+# breaks Branch A's literal adjacency. Unlike Branch A this form is NOT
+# unconditionally self-targeting: issued from inside gateway `zeus`,
+# `hermes -p venus gateway restart` operates on a sibling profile's gateway
+# and is a legitimate fleet operation. The pattern captures the named
+# profile so `contains_gateway_lifecycle_command` can block only the
+# self-targeting shape (named profile == the profile running the guard).
+# `start` stays excluded for the same reason as Branch A.
+_PROFILE_FLAG_LIFECYCLE_PATTERN = re.compile(
+    r"(?i)"
+    r"hermes\s+"
+    # Any global flags before the profile selector (each may carry a value).
+    r"(?:-{1,2}\S+(?:\s+\S+)?\s+)*"
+    # The selector itself: `--profile=<name>` or the space-separated
+    # `-p <name>` / `--profile <name>` — exactly the shapes the CLI's
+    # `_apply_profile_override` accepts.
+    r"(?:--profile=([^\s]+)|(?:-p|--profile)\s+([^\s]+))"
+    # Any global flags between the selector and the subcommand.
+    r"(?:\s+-{1,2}\S+(?:\s+\S+)?)*"
+    r"\s+gateway\s+(?:restart|stop)"
+)
+
+
+def _current_profile_name() -> Optional[str]:
+    """Return the name of the profile running the guard, if determinable.
+
+    Prefers the explicit ``HERMES_PROFILE_NAME`` / ``HERMES_PROFILE`` env
+    (set by the profile launcher and kanban worker spawns), falling back to
+    ``hermes_cli.profiles.get_active_profile_name`` (derived from
+    ``HERMES_HOME``, which the gateway process inherits from its launch
+    profile). Returns ``None`` when neither source yields a name.
+    """
+    for env_name in ("HERMES_PROFILE_NAME", "HERMES_PROFILE"):
+        value = os.environ.get(env_name)
+        if value and value.strip():
+            return value.strip()
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name() or None
+    except Exception:
+        return None
+
+
+def _named_profile_is_current(named: str) -> bool:
+    """True when *named* is the profile executing the guard (self-targeting)."""
+    current = _current_profile_name()
+    if not current:
+        # No profile identity available: cannot prove self-targeting, so do
+        # not block — sibling restarts must stay allowed (#78028).
+        return False
+    return named.strip().casefold() == current.strip().casefold()
+
+
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
-    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
+    if _GATEWAY_LIFECYCLE_PATTERN.search(normalized):
+        return True
+    # Profile-flag form (#78028): `hermes -p <profile> gateway restart|stop`
+    # bypasses Branch A because the selector sits between `hermes` and
+    # `gateway`. It is only the same foot-gun when the named profile IS the
+    # profile running the guard — sibling-profile restarts are legitimate
+    # fleet operations and stay allowed.
+    profile_match = _PROFILE_FLAG_LIFECYCLE_PATTERN.search(normalized)
+    if profile_match:
+        named = profile_match.group(1) or profile_match.group(2)
+        if named:
+            # Profile ids cannot contain quotes (hermes_cli.profiles
+            # enforces `^[a-z0-9][a-z0-9_-]{0,63}$`), so a shell-quoted
+            # `-p 'zeus'` compares equal to the bare name.
+            named = named.strip().strip("\"'")
+            if _named_profile_is_current(named):
+                return True
+    return False
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -144,6 +144,85 @@ class TestGatewayLifecyclePattern:
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
 
+class TestProfileFlagGatewayLifecycle:
+    """#78028: `hermes -p <profile> gateway restart|stop` bypasses Branch A's
+    literal adjacency, so it needs its own pattern. It is only the same
+    self-termination foot-gun when the named profile IS the profile running
+    the guard; sibling-profile restarts are legitimate fleet operations and
+    must stay allowed."""
+
+    @pytest.fixture(autouse=True)
+    def _pin_profile_identity(self, monkeypatch):
+        # The ambient test env may carry HERMES_HOME/HERMES_PROFILE; pin the
+        # profile identity explicitly so every assertion is deterministic.
+        monkeypatch.setenv("HERMES_PROFILE", "zeus")
+        monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+
+    @pytest.mark.parametrize("text", [
+        "hermes -p zeus gateway stop",
+        "hermes -p zeus gateway restart",
+        "hermes --profile zeus gateway restart",
+        "hermes --profile zeus gateway stop",
+        "hermes --profile=zeus gateway restart",
+        # Global flags before/after the selector must not hide the shape.
+        "hermes -v -p zeus gateway restart",
+        "hermes -p zeus -v gateway restart",
+        "hermes --debug --profile zeus gateway stop",
+        # Shell quoting of the profile id is equivalent to the bare name.
+        "hermes -p 'zeus' gateway restart",
+        "hermes --profile \"zeus\" gateway stop",
+    ])
+    def test_self_target_blocked(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should block: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        "hermes -p venus gateway stop",
+        "hermes -p venus gateway restart",
+        "hermes --profile venus gateway restart",
+        "hermes --profile=venus gateway stop",
+        "hermes -p venus -v gateway restart",
+    ])
+    def test_sibling_allowed(self, text):
+        assert not _contains_gateway_lifecycle_command(text), f"Should allow: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        "hermes -p zeus gateway start",
+        "hermes -p zeus gateway start --all",
+    ])
+    def test_start_still_allowed(self, text):
+        # `start` is intentionally excluded from the guard, with or without
+        # the profile flag (#30719 rationale).
+        assert not _contains_gateway_lifecycle_command(text), f"Should allow: {text!r}"
+
+    def test_adjacent_form_still_blocked(self):
+        # Branch A remains unconditional — the profile-flag check is an
+        # additional layer, not a replacement.
+        assert _contains_gateway_lifecycle_command("hermes gateway restart")
+        assert _contains_gateway_lifecycle_command("hermes gateway stop")
+
+    def test_hermes_home_derived_profile(self, monkeypatch):
+        # Without HERMES_PROFILE the guard falls back to the HERMES_HOME-
+        # derived profile identity (get_active_profile_name) — the signal the
+        # gateway process itself carries.
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+        import hermes_cli.profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "zeus")
+        assert _contains_gateway_lifecycle_command("hermes -p zeus gateway restart")
+        assert not _contains_gateway_lifecycle_command("hermes -p venus gateway restart")
+
+    def test_no_profile_context_conservative_allow(self, monkeypatch):
+        # With no profile identity the guard cannot prove self-targeting, so
+        # the profile-flag form is allowed rather than over-blocking siblings;
+        # the adjacent form stays blocked unconditionally.
+        import cron.lifecycle_guard as lifecycle_guard
+
+        monkeypatch.setattr(lifecycle_guard, "_current_profile_name", lambda: None)
+        assert not _contains_gateway_lifecycle_command("hermes -p zeus gateway restart")
+        assert _contains_gateway_lifecycle_command("hermes gateway restart")
+
+
 class TestCronCreateLifecycleBlock:
     """Verify cron create rejects gateway lifecycle prompts."""
 


### PR DESCRIPTION
## Summary

`hermes -p <profile> gateway restart|stop` no longer bypasses the gateway lifecycle guard when it targets the guard's own profile — and sibling-profile restarts stay allowed as legitimate fleet operations. Root cause (#78028): Branch A of the lifecycle pattern required literal `hermes gateway` adjacency, so a profile selector between the tokens defeated the matcher entirely; a production field report documented a 6-minute outage because systemd treats an explicit stop as terminal state (`Restart=always` does not recover it).

Salvages PR #78044 by @webtecnica. Closes #78028; also the concern behind PR #91322 (sibling restarts must stay allowed) is handled profile-aware here.

## Changes

- `cron/lifecycle_guard.py` (@webtecnica): new profile-flag pattern (`-p X` / `--profile X` / `--profile=X`, global flags tolerated on either side) that captures the named profile and blocks only when it equals the profile running the guard (`HERMES_PROFILE_NAME`/`HERMES_PROFILE` env, falling back to `get_active_profile_name()`); no identity available → not provably self-targeting → allow
- `tests/hermes_cli/test_gateway_restart_loop.py` (@webtecnica): 20 parametrized cases — self-target shapes blocked, sibling shapes allowed, `start` excluded, quoting/case handled

## Validation

| Case | Before | After |
|---|---|---|
| `hermes -p zeus gateway restart` (from profile zeus) | passed guard → gateway down, no auto-recovery | blocked |
| `sleep 1 && hermes -p zeus gateway restart` (field-report shape) | passed | blocked |
| `hermes -p venus gateway restart` (sibling) | passed | still passes |
| `hermes -p zeus gateway start` | passed | still passes (intentional) |
| canonical `hermes gateway restart` | blocked | still blocked |

All shapes verified live against the real guard on this branch; `tests/hermes_cli/test_gateway_restart_loop.py` 152/152 pass.

## Infographic

![Self-target guard: block self, allow siblings](https://v3b.fal.media/files/b/0aa78c78/zpPEDdv8hjX_kSb3t02of_pEE3zdHz.png)
