### PR TITLE
fix(cron): linger for notify_on_complete background processes in `run`

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -6,6 +6,7 @@ pause/resume/run/remove, status, and tick.
 """
 
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -527,6 +528,27 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
     finally:
         if _stateless_reset is not None:
             _stateless_reset()
+    if action == "run":
+        # Same one-shot exit class as #90879 (fixed for `hermes chat -q/-Q`
+        # in cli.py and `-z` in hermes_cli/oneshot.py): this CLI process
+        # exits as soon as this function returns, and the stateless
+        # declaration above makes the job's agent turn execute inline in
+        # THIS process — so a terminal(background=true,
+        # notify_on_complete=true) job dispatch (e.g. a Bot Mode handoff
+        # reply, or a plain long-running background command) still holds a
+        # stdout pipe owned by this dying process and is destroyed a few
+        # seconds later, its completion never delivered. Linger (bounded by
+        # terminal.oneshot_completion_wait_seconds) exactly like the other
+        # two one-shot exit paths. Cheap no-op when nothing is pending
+        # (including the rare case where the run above was dispatched to
+        # the gateway daemon's background worker instead of executing
+        # inline — that work lives in a different process's registry).
+        try:
+            from tools.process_registry import process_registry
+
+            process_registry.wait_for_pending_completions(None)
+        except Exception:
+            logging.debug("cron run background completion wait failed", exc_info=True)
     if not result.get("success"):
         print(color(f"Failed to {action} job: {result.get('error', 'unknown error')}", Colors.RED))
         return 1

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -383,3 +383,113 @@ class TestCronRunBackgroundDispatch:
         assert rc == 0
         assert "Running in background (delegation del-xyz)." in out
         assert "failed" not in out.lower()
+
+
+class TestCronRunNotifyOnCompleteLinger:
+    """`hermes cron run` is a one-shot CLI process (#90879 class, same as
+    `hermes chat -q/-Q` and `-z`): it exits as soon as this command returns,
+    so a job whose agent turn spawns a
+    terminal(background=true, notify_on_complete=true) job (a Bot Mode
+    handoff reply, or any bounded background command) would have that
+    delivery destroyed a few seconds later unless the parent lingers for it
+    first, exactly like the other two one-shot exit paths.
+    """
+
+    def _run_cmd(self, capsys):
+        rc = cron_command(Namespace(cron_command="run", job_id="job-1"))
+        return rc, capsys.readouterr().out
+
+    def test_run_action_lingers_for_pending_completions(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job": {
+                    "id": "job-1", "name": "Watchdog",
+                    "executed": True, "execution_success": True,
+                },
+            },
+        )
+        calls = []
+        monkeypatch.setattr(
+            "tools.process_registry.process_registry.wait_for_pending_completions",
+            lambda task_id: calls.append(task_id) or {"waited": [], "completed": [], "timed_out": []},
+        )
+
+        rc, out = self._run_cmd(capsys)
+
+        assert rc == 0
+        assert calls == [None], (
+            "hermes cron run must linger on the whole registry (task_id=None), "
+            "the same as cli.py's one-shot exit path"
+        )
+
+    def test_run_action_lingers_even_on_a_synchronous_failure(self, monkeypatch, capsys):
+        """A job whose turn dispatches a background reply and THEN fails must
+        still linger — the background work was already spawned."""
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job": {
+                    "id": "job-1", "name": "Watchdog",
+                    "executed": True, "execution_success": False,
+                },
+            },
+        )
+        calls = []
+        monkeypatch.setattr(
+            "tools.process_registry.process_registry.wait_for_pending_completions",
+            lambda task_id: calls.append(task_id) or {"waited": [], "completed": [], "timed_out": []},
+        )
+
+        self._run_cmd(capsys)
+
+        assert calls == [None]
+
+    def test_non_run_action_does_not_linger(self, monkeypatch, capsys):
+        """Only 'run' actually executes an agent turn; pause/resume/etc. must
+        not pay for a registry wait they have no need for."""
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {"success": True, "job": {"id": "job-1", "name": "Watchdog"}},
+        )
+        calls = []
+        monkeypatch.setattr(
+            "tools.process_registry.process_registry.wait_for_pending_completions",
+            lambda task_id: calls.append(task_id) or {"waited": [], "completed": [], "timed_out": []},
+        )
+
+        cron_command(Namespace(cron_command="pause", job_id="job-1"))
+
+        assert calls == []
+
+    def test_linger_failure_does_not_break_the_run_report(self, monkeypatch, capsys):
+        """The linger is best-effort: a raising registry must not turn a
+        successful run report into a crash."""
+        monkeypatch.setattr(
+            cron_cli,
+            "_cron_api",
+            lambda **kwargs: {
+                "success": True,
+                "job": {
+                    "id": "job-1", "name": "Watchdog",
+                    "executed": True, "execution_success": True,
+                },
+            },
+        )
+
+        def _boom(_task_id):
+            raise RuntimeError("registry unavailable")
+
+        monkeypatch.setattr(
+            "tools.process_registry.process_registry.wait_for_pending_completions", _boom
+        )
+
+        rc, out = self._run_cmd(capsys)
+
+        assert rc == 0
+        assert "Ran now: succeeded." in out


### PR DESCRIPTION
## What

`hermes cron run <job_id>` is a third one-shot CLI exit path in the same class as `#90879` (fixed today for `hermes chat -q/-Q` in `cli.py` and `-z` in `hermes_cli/oneshot.py`): the process exits as soon as the command returns.

## Why

The `"run"` branch of `_job_action` in `hermes_cli/cron.py` already declares the delivery channel stateless before calling `_cron_api(action="run", ...)` — its own comment says this: *"One-shot CLI: this process exits as soon as the command returns"*. That declaration forces `async_delivery_supported()` to return `False`, so the job's agent turn executes **synchronously, inline, in this same process** (`tools/cronjob_tools.py::_execute_job_now` → `run_one_job`), rather than being dispatched to a gateway daemon.

If that turn dispatches a `terminal(background=true, notify_on_complete=true)` job — a Bot Mode handoff reply, or any bounded background command — the child still holds a stdout pipe owned by this process. The CLI process returns and exits right after `_job_action` returns, destroying the delivery a few seconds later. Its completion is never delivered — the exact symptom today's fix (`process_registry.wait_for_pending_completions`, landed as *"class-wide, not DM-specific"*) already targets. It just wasn't wired into this third exit path — only `cli.py` (`-q`/`-Q`) and `hermes_cli/oneshot.py` (`-z`) call it.

Traced directly: `grep`-ing all callers of `wait_for_pending_completions` before this change shows exactly those two call sites; `hermes_cli/cron.py` has none.

## Fix

Call `process_registry.wait_for_pending_completions(None)` from the `"run"` branch of `_job_action`, right after `_cron_api` returns and before the function returns — scoped to `"run"` (the only action that executes an agent turn), and placed so it covers a run that dispatches background work and then ultimately fails, not just a clean success. Best-effort, wrapped in `try/except` with a debug log, matching the other two call sites exactly. A no-op in the (rare, edge-case) scenario where the stateless declaration failed and the run was instead dispatched to the gateway daemon's background worker — that work lives in a different process's registry, so there is nothing to wait on here.

## Testing

- New `TestCronRunNotifyOnCompleteLinger` in `tests/hermes_cli/test_cron.py`, following the existing `TestCronRunBackgroundDispatch` class's mocking conventions:
  - The linger fires (`task_id=None`, the whole registry) for a successful `run`.
  - The linger also fires when the synchronous run ultimately reports failure (background work may already have been dispatched before the failure).
  - Other actions (e.g. `pause`) do not pay for the registry wait.
  - A raising registry does not break the run report (best-effort).
- Mutation-verified: with the production fix reverted, the two success/failure linger tests fail (`calls == []` instead of `[None]`) — the fix genuinely changes behavior.
- Full `tests/hermes_cli/test_cron.py` (18 tests), `tests/cron/` (873 tests, 1 pre-existing unrelated skip), and `tests/tools/test_oneshot_completion_linger.py` (18 tests, the linger mechanism's own suite) — all pass.
- `ruff check` clean on both changed files.

## Competing PRs

Checked `#90905` and `#90954` (both reference `#90879`) — neither touches `hermes_cli/cron.py` or `tools/cronjob_tools.py`. Both operate at a different layer: in-process notification-poller ownership when the addressed session isn't the one currently polling, not this process-exit linger. No overlap.