### PR TITLE
fix(desktop): route session RPCs by their own target session, not the focused tile

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -79,7 +79,7 @@ import {
   setMessages
 } from '@/store/session'
 import { requestForSessionProfile } from '@/store/session-request-router'
-import { $focusedStoredSessionId, sessionTileOwnerRoute } from '@/store/session-states'
+import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isHudWindow } from '@/store/windows'
@@ -296,20 +296,30 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // When chrome stays on the launch backend (Bot Mode / all-profiles
   // navigation), session-owned RPCs still have to hit the session's backend.
   //
+  // Route by the SESSION THIS RPC TARGETS first: a session-scoped RPC carries
+  // its target in params.session_id, and dispatching it by the WINDOW's
+  // focused tile instead sends a background bot's prompt.submit to whichever
+  // backend the focused pane happens to own — the bot then runs on the
+  // default backend (its store, its logs), or 4001s when default doesn't
+  // hold the session. params.session_id is a RUNTIME id while tile routes
+  // key on the STORED id, so translate via the tile map before resolving.
+  // Only when the RPC names no session (config reads, list refreshes, cron)
+  // does the focused-tile key apply — those are genuinely window-ambient.
+  //
   // A bot chat is a persisted TILE that already records the EXACT owning route
   // (connectionId + profile) it was opened with — the same authoritative owner
-  // Sessions mode reads off the session row. Prefer it, keyed on the FOCUSED
-  // stored id: a tile is never $selectedStoredSessionId (that stays the primary
-  // pane), so routing off `selected` would send the bot's RPC to the primary's
-  // profile. The canonical Bot Chat is also hidden, so it never appears in
-  // $sessions and rememberedSessionProfile's row lookup misses and falls back to
-  // the ACTIVE profile — the Bot Mode "session not found" / hang. The tile route
-  // is per-session, survives relaunch, and needs no list membership, so it fixes
-  // an already-open chat too. Fall back to the list-derived profile (keyed on
-  // the same focused id) only when no tile route exists.
+  // Sessions mode reads off the session row. Prefer it. The canonical Bot Chat
+  // is hidden, so it never appears in $sessions and rememberedSessionProfile's
+  // row lookup misses and falls back to the ACTIVE profile — the Bot Mode
+  // "session not found" / hang. The tile route is per-session, survives
+  // relaunch, and needs no list membership, so it fixes an already-open chat
+  // too. Fall back to the list-derived profile only when no tile route exists.
   const requestGateway = useCallback(
     <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
-      const routingSessionId = $focusedStoredSessionId.get() ?? selectedStoredSessionIdRef.current
+      const paramsSessionId = typeof params?.session_id === 'string' ? params.session_id.trim() : ''
+      const targetStoredSessionId = paramsSessionId ? storedSessionIdForRuntimeId(paramsSessionId) : null
+
+      const routingSessionId = targetStoredSessionId ?? $focusedStoredSessionId.get() ?? selectedStoredSessionIdRef.current
 
       const owner =
         (routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined) ??

--- a/apps/desktop/src/store/session-states-runtime-map.test.ts
+++ b/apps/desktop/src/store/session-states-runtime-map.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $sessionTiles, storedSessionIdForRuntimeId } from '@/store/session-states'
+
+// #92687-adjacent Bot Mode misroute: a session RPC (prompt.submit et al.)
+// carries its target as a RUNTIME id, while tile owner routes key on the
+// STORED id. requestGateway (contrib/wiring) routes by the RPC's own target
+// session — which requires this translation. Before the fix it routed by the
+// WINDOW's focused tile, so a background bot chat's submit dispatched on
+// whatever backend the focused pane owned: the bot ran on the default
+// backend, or 4001'd when default didn't hold the session.
+
+describe('storedSessionIdForRuntimeId', () => {
+  afterEach(() => {
+    $sessionTiles.set([])
+  })
+
+  it('maps a runtime id to the stored id of the tile bound to it', () => {
+    $sessionTiles.set([
+      { runtimeId: 'rt-default', storedSessionId: 'stored-default' },
+      { runtimeId: 'rt-developer', storedSessionId: 'stored-developer' }
+    ])
+
+    expect(storedSessionIdForRuntimeId('rt-developer')).toBe('stored-developer')
+    expect(storedSessionIdForRuntimeId('rt-default')).toBe('stored-default')
+  })
+
+  it('passes a stored id through unchanged (callers may hold either identity)', () => {
+    $sessionTiles.set([{ runtimeId: 'rt-a', storedSessionId: 'stored-a' }])
+
+    expect(storedSessionIdForRuntimeId('stored-a')).toBe('stored-a')
+  })
+
+  it('returns null for an unknown id so the caller falls back to ambient routing', () => {
+    $sessionTiles.set([{ runtimeId: 'rt-a', storedSessionId: 'stored-a' }])
+
+    expect(storedSessionIdForRuntimeId('rt-unknown')).toBeNull()
+    expect(storedSessionIdForRuntimeId('')).toBeNull()
+  })
+
+  it('ignores tiles with no runtime binding instead of matching undefined ids', () => {
+    // A drafted/never-resumed tile has no runtimeId. Looking up an undefined-ish
+    // id must not accidentally claim that tile.
+    $sessionTiles.set([{ storedSessionId: 'stored-unbound' }, { runtimeId: 'rt-b', storedSessionId: 'stored-b' }])
+
+    expect(storedSessionIdForRuntimeId('rt-b')).toBe('stored-b')
+    expect(storedSessionIdForRuntimeId('undefined')).toBeNull()
+  })
+
+  it('prefers the stored-id identity when one tile is stored-matched and another is runtime-matched', () => {
+    // Pathological but possible after a stale rebind: some other tile's dead
+    // runtimeId equals a live tile's storedSessionId. The stored-id claim is
+    // authoritative (durable identity wins).
+    $sessionTiles.set([
+      { runtimeId: 'collision', storedSessionId: 'stored-other' },
+      { runtimeId: 'rt-live', storedSessionId: 'collision' }
+    ])
+
+    expect(storedSessionIdForRuntimeId('collision')).toBe('collision')
+  })
+})

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -738,6 +738,34 @@ export function sessionTileOwnerRoute(storedSessionId: string): SessionProfileRo
   return $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.ownerRoute
 }
 
+/** Resolve a session id THAT MAY BE A RUNTIME ID to the stored id its tile
+ *  keys on. Session-scoped RPC params carry the runtime id, while tile owner
+ *  routes (and everything else durable) key on the stored id — so routing an
+ *  RPC by its own target session needs this translation first (#93080 /
+ *  Bot Mode misroute). Ids that match a tile's stored id pass through, so
+ *  callers can hand in either identity. Unknown ids return null: the caller
+ *  falls back to its ambient routing rather than guessing. */
+export function storedSessionIdForRuntimeId(sessionId: string): null | string {
+  const tiles = $sessionTiles.get()
+
+  // Stored-id claims are authoritative (durable identity): check them all
+  // before any runtime binding, so a stale tile whose dead runtimeId collides
+  // with a live tile's stored id cannot hijack the lookup.
+  for (const tile of tiles) {
+    if (tile.storedSessionId === sessionId) {
+      return tile.storedSessionId
+    }
+  }
+
+  for (const tile of tiles) {
+    if (tile.runtimeId && tile.runtimeId === sessionId) {
+      return tile.storedSessionId
+    }
+  }
+
+  return null
+}
+
 export function setSessionTileWorkspaceScope(storedSessionId: string, scope: SessionTileWorkspaceScope): boolean {
   const tile = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
   const workspaceOwnerKey = scope.workspaceMode === 'bots' ? scope.workspaceOwnerKey : undefined


### PR DESCRIPTION
## Summary

Session-scoped RPCs from the desktop now dispatch on the backend that owns the SESSION THE RPC TARGETS, not the backend of whichever tile happens to hold window focus. This is the root cause of the Bot Mode "session not found" (4001) / bot-runs-on-wrong-backend class: a background bot chat's `prompt.submit` carried the bot's `session_id` but was routed by `$focusedStoredSessionId`, so it executed on the focused pane's backend — the profile bot ran on the **default** backend (sessions created in the default store, the profile's own logs empty), or 4001'd whenever default didn't hold the session.

## Credit

Root cause isolated by @teknium1 through live multi-layer tracing: Developer-bot `prompt.submit` (session c93770) executing in root `logs/agent.log` while `profiles/developer/logs/` stayed empty at send time, completing only when the default backend happened to hold the session — placing the misroute downstream of the tile-owner-route fix, in the routing-key choice itself. This PR implements exactly that diagnosis.

## Changes

- `apps/desktop/src/app/contrib/wiring.tsx` — `requestGateway` routes by `params.session_id` first (translated runtime→stored), falling back to the focused-tile key only for RPCs that name no session (config reads, list refreshes, cron — genuinely window-ambient).
- `apps/desktop/src/store/session-states.ts` — new `storedSessionIdForRuntimeId()`: tiles already carry both identities (`runtimeId` + `storedSessionId`); the lookup checks stored-id claims before runtime bindings so a stale tile's dead `runtimeId` can never hijack a live tile's identity, and unknown ids return null (caller falls back to ambient, never guesses).
- `apps/desktop/src/store/session-states-runtime-map.test.ts` — 5 regression tests: runtime→stored mapping, stored-id passthrough, unknown-id null fallback, unbound-tile immunity, and the stored-beats-runtime collision case.

Identity note (per the desktop guide's "Identity is not incidental"): the translation happens at the routing boundary — the runtime id never leaks inward as a routing key.

## Validation

| Suite | Result |
|---|---|
| new regression file + session-states + profile-routing | 76 passed |
| full `src/store/` + `src/app/contrib/` (ui project) | 1158 passed / 106 files |

Fixes the live repro from Teknium's Developer-profile setup; complements #93080 (dual-venv boot + adapter-notify) and #93217 (canonical Bot Chat resurrection) — three distinct failure modes that all presented as "bot chats on non-default profiles are broken."
