### PR TITLE
fix(tools): deny oversized tool-call batches visibly instead of losing every result

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -44,6 +44,139 @@ logger = logging.getLogger(__name__)
 # When any of these appear in a batch, we fall back to sequential execution.
 _NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
 
+
+# ──────────────────────────────────────────────────────────────────────
+# Per-message tool-call cap (#93251)
+#
+# A single assistant message can carry an arbitrarily large parallel tool
+# batch, and an oversized batch must fail VISIBLY per denied call rather
+# than silently losing work.  ``tools.max_tool_calls_per_batch`` in
+# config.yaml sets the hard cap; overflow calls receive a per-call denial
+# tool result (recoverable — the model can re-issue them next turn) instead
+# of being executed into whatever failure an oversized batch produces.
+# Non-secret behavioral setting ⇒ config.yaml, not an env var.
+# ──────────────────────────────────────────────────────────────────────
+_DEFAULT_MAX_TOOL_CALLS_PER_BATCH = 12
+_MAX_TOOL_CALLS_PER_BATCH_KEY = "tools.max_tool_calls_per_batch"
+
+
+def resolve_max_tool_calls_per_batch() -> int:
+    """Return the per-assistant-message tool-call cap.
+
+    Reads ``tools.max_tool_calls_per_batch`` from config.yaml; falls back to
+    ``_DEFAULT_MAX_TOOL_CALLS_PER_BATCH`` when unset or invalid.  Clamped to
+    at least 1 — a cap of 0 would deny every tool call, which is a
+    misconfiguration, not a feature.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        tools_cfg = cfg.get("tools") if isinstance(cfg, dict) else None
+        value = (
+            tools_cfg.get("max_tool_calls_per_batch")
+            if isinstance(tools_cfg, dict)
+            else None
+        )
+    except Exception:
+        value = None
+
+    if value is None:
+        return _DEFAULT_MAX_TOOL_CALLS_PER_BATCH
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_TOOL_CALLS_PER_BATCH
+    return max(1, limit)
+
+
+def split_batch_overflow(tool_calls, limit: int) -> tuple[list, list]:
+    """Split a tool-call batch into ``(admitted, denied)`` under ``limit``."""
+    calls = list(tool_calls or [])
+    if len(calls) <= limit:
+        return calls, []
+    return calls[:limit], calls[limit:]
+
+
+def make_denied_tool_call_message(
+    tool_name: str,
+    tool_call_id: str,
+    *,
+    allowed: int,
+    attempted: int,
+) -> dict:
+    """Build the visible per-call denial result for an overflow call (#93251).
+
+    The text must tell the model three things: the call did NOT run, why,
+    and how to recover (re-issue within the cap next turn).  Paired to the
+    original ``tool_call_id`` so provider-side tool_use/tool_result pairing
+    stays intact.
+
+    Built directly rather than through :func:`make_tool_result_message`:
+    this result is authored by Hermes itself, not produced by the named
+    tool, so it must NOT receive that function's untrusted-data framing or
+    attacker-content risk scan — those apply to tool OUTPUT, and a denial
+    carries none.
+    """
+    content = (
+        f"[Tool call denied: batch cap exceeded — this assistant turn issued "
+        f"{attempted} tool calls but at most {allowed} are executed per turn "
+        f"({_MAX_TOOL_CALLS_PER_BATCH_KEY}). This call was NOT run and had no "
+        f"effect. Re-issue it in your next turn, keeping the total within the "
+        f"{allowed}-call cap.]"
+    )
+    return stamp_message_timestamp({
+        "role": "tool",
+        "name": tool_name,
+        "tool_name": tool_name,
+        "content": content,
+        "tool_call_id": tool_call_id,
+        "effect_disposition": "none",
+    })
+
+
+def append_denied_batch_results(agent, messages: list, denied_calls, *, limit: int) -> None:
+    """Append visible denial results for overflow calls and persist them.
+
+    Mirrors the executor interrupt paths: every denied ``tool_call_id`` gets
+    exactly one result message so the canonical transcript keeps strict
+    call/result pairing, followed by the incremental SessionDB flush so a
+    crash/resume never replays a denied call as unanswered.  Best-effort UI
+    status per denial — the model-facing result is the source of truth.
+    """
+    if not denied_calls:
+        return
+    attempted = limit + len(denied_calls)
+    emit_status = getattr(agent, "_emit_status", None)
+    for tc in denied_calls:
+        name = getattr(getattr(tc, "function", None), "name", "") or "tool"
+        messages.append(make_denied_tool_call_message(
+            name,
+            getattr(tc, "id", "") or "",
+            allowed=limit,
+            attempted=attempted,
+        ))
+        if callable(emit_status):
+            try:
+                emit_status(
+                    f"⚠️ Tool '{name}' denied: batch cap of {limit} tool calls "
+                    f"reached — not executed"
+                )
+            except Exception:
+                pass
+    flush = getattr(agent, "_flush_messages_to_session_db", None)
+    if flush is not None:
+        try:
+            if flush(messages, None) is False:
+                agent._incremental_persistence_failed = True
+                if getattr(agent, "_last_persistence_error_cause", None) is None:
+                    agent._last_persistence_error_cause = "unknown"
+        except Exception as exc:
+            agent._incremental_persistence_failed = True
+            from hermes_state import classify_persistence_error
+            agent._last_persistence_error_cause = classify_persistence_error(exc)
+
+
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({
     "ha_get_state",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -267,6 +267,53 @@ def _max_workers_for_tool_batch(runnable_calls) -> int:
     return min(len(runnable_calls), max_workers)
 
 
+def _deny_overflow_calls(agent, assistant_message, messages: list) -> frozenset:
+    """Backstop for the per-message tool-call cap (#93251).
+
+    ``AIAgent._execute_tool_calls`` — the single dispatch point — truncates an
+    oversized batch before any executor runs.  These module-level executors
+    are also callable directly (segmented dispatch passes SimpleNamespace
+    wrappers; host code and older plugins may too), so re-check at executor
+    entry and deny the overflow visibly rather than executing into whatever
+    failure an oversized batch produces.
+
+    Returns the set of denied call ids.  When the executor's
+    ``assistant_message.tool_calls`` cannot be truncated in place
+    (read-only wrapper), the caller must skip these ids in its execution
+    loop — the denial results are already appended here.
+    """
+    from agent.tool_dispatch_helpers import (
+        append_denied_batch_results,
+        resolve_max_tool_calls_per_batch,
+        split_batch_overflow,
+    )
+
+    limit = resolve_max_tool_calls_per_batch()
+    admitted_calls, denied_calls = split_batch_overflow(
+        getattr(assistant_message, "tool_calls", None), limit,
+    )
+    if not denied_calls:
+        return frozenset()
+    logger.warning(
+        "Tool batch cap backstop: %d call(s) reached the executor "
+        "un-truncated; denying %d overflow call(s) "
+        "(tools.max_tool_calls_per_batch=%d)",
+        len(admitted_calls) + len(denied_calls), len(denied_calls), limit,
+    )
+    try:
+        assistant_message.tool_calls = admitted_calls
+    except AttributeError:
+        # Read-only wrapper (e.g. a frozen dataclass): leave it untouched.
+        # The returned denied-id set makes the executor skip those calls;
+        # pre-API sanitizers additionally drop any result whose call_id no
+        # longer pairs with an executed call.
+        pass
+    append_denied_batch_results(agent, messages, denied_calls, limit=limit)
+    return frozenset(
+        getattr(tc, "id", "") or "" for tc in denied_calls
+    )
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so patches like ``run_agent._set_interrupt`` work."""
     import run_agent
@@ -1077,7 +1124,18 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     and /steer injection — used when this call is one segment of a larger
     mixed batch and the segmented dispatcher owns the turn-end work.
     """
-    tool_calls = assistant_message.tool_calls
+    _denied_call_ids = _deny_overflow_calls(agent, assistant_message, messages)
+    if getattr(agent, "_incremental_persistence_failed", False):
+        # Denial results could not be made canonical — the same fail-closed
+        # rule the caller applies around every other incremental flush.
+        return
+
+    def _is_denied(tc) -> bool:
+        return (getattr(tc, "id", "") or "") in _denied_call_ids
+
+    tool_calls = [
+        tc for tc in assistant_message.tool_calls if not _is_denied(tc)
+    ]
     num_tools = len(tool_calls)
 
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
@@ -1880,6 +1938,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     # Keep /steer pending until the final post-budget drain below.  The model
     # cannot observe a partial batch, while an early drain can be discarded
     # when aggregate budget enforcement replaces that tool result.
+    # NOTE: `parsed_calls`/`tool_calls` already exclude denied overflow calls
+    # (#93251), whose results sit EARLIER in `messages` — so this tail slice
+    # covers exactly this batch's own results, never a denial notice.
     num_tools = len(parsed_calls)
     if finalize and num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
@@ -1929,9 +1990,16 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     def _run_agent_tool_execution_middleware(agent, **kwargs):
         return _run_sequential_tool_execution_middleware(agent, **kwargs)
 
+    _denied_call_ids = _deny_overflow_calls(agent, assistant_message, messages)
+
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         if getattr(agent, "_incremental_persistence_failed", False):
             return
+        # Denied overflow call (#93251): its visible denial result was
+        # already appended by the backstop. Skip it here so an untruncated
+        # (read-only) assistant message can never re-dispatch one.
+        if (getattr(tool_call, "id", "") or "") in _denied_call_ids:
+            continue
         # SAFETY: check interrupt BEFORE starting each tool.
         # If the user sent "stop" during a previous tool's execution,
         # do NOT start any more tools -- skip them all immediately.
@@ -2793,6 +2861,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             remaining = len(assistant_message.tool_calls) - i
             agent._vprint(f"{agent.log_prefix}⚡ Interrupt: skipping {remaining} remaining tool call(s)", force=True)
             for skipped_tc in assistant_message.tool_calls[i:]:
+                if (getattr(skipped_tc, "id", "") or "") in _denied_call_ids:
+                    continue  # already answered by the cap backstop
                 skipped_name = skipped_tc.function.name
                 messages.append(make_tool_result_message(
                     skipped_name,
@@ -2812,7 +2882,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # Keep /steer pending until the final post-budget drain below.  The model
     # only receives this batch after all calls finish, and an early drain can
     # be discarded when aggregate budget enforcement replaces a tool result.
-    num_tools_seq = len(assistant_message.tool_calls)
+    # Denied overflow results (#93251) sit BEFORE this executor's own results
+    # in `messages`, so the tail slice must skip them — otherwise the cap /
+    # steer would rewrite denial notices instead of real tool outputs.
+    num_tools_seq = len(assistant_message.tool_calls) - len(_denied_call_ids)
     if finalize and num_tools_seq > 0:
         enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)
 
@@ -2854,6 +2927,21 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _active_env = get_active_env(effective_task_id)
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
+
+    # Batch cap (#93251): enforce ONCE for the whole batch here, then strip
+    # denied ids from the plan so no segment can ever run them. Matters when
+    # host code calls this executor directly — the AIAgent dispatcher already
+    # truncated before planning.
+    _denied_call_ids = _deny_overflow_calls(agent, assistant_message, messages)
+    if getattr(agent, "_incremental_persistence_failed", False):
+        return
+    if _denied_call_ids:
+        segments = [
+            (kind, [tc for tc in calls
+                    if (getattr(tc, "id", "") or "") not in _denied_call_ids])
+            for kind, calls in segments
+        ]
+        segments = [(kind, calls) for kind, calls in segments if calls]
 
     for kind, calls in segments:
         if getattr(agent, "_incremental_persistence_failed", False):

--- a/run_agent.py
+++ b/run_agent.py
@@ -8330,21 +8330,51 @@ class AIAgent:
         original single-path dispatch; mixed batches execute segment by
         segment in emission order so safe subsets still run concurrently
         while side-effect ordering is preserved.
+
+        Batch cap (#93251): calls beyond ``tools.max_tool_calls_per_batch``
+        are denied with a visible per-call result instead of being executed
+        into whatever failure an oversized batch produces. Denial happens
+        HERE — the single dispatch point for every execution shape
+        (sequential, concurrent, segmented) — so the cap holds regardless of
+        how the admitted prefix is scheduled, and the overflow is truncated
+        before any segment planning so denied ids can never be dispatched.
         """
-        tool_calls = assistant_message.tool_calls
+        total_requested = len(assistant_message.tool_calls)
+        from agent.tool_dispatch_helpers import (
+            _plan_tool_batch_segments,
+            append_denied_batch_results,
+            resolve_max_tool_calls_per_batch,
+            split_batch_overflow,
+        )
+
+        limit = resolve_max_tool_calls_per_batch()
+        admitted_calls, denied_calls = split_batch_overflow(
+            assistant_message.tool_calls, limit,
+        )
+        if denied_calls:
+            logger.warning(
+                "Tool batch cap: %d call(s) requested, executing first %d and "
+                "denying %d (tools.max_tool_calls_per_batch=%d)",
+                total_requested, len(admitted_calls), len(denied_calls), limit,
+            )
+            assistant_message.tool_calls = admitted_calls
+            append_denied_batch_results(
+                self, messages, denied_calls, limit=limit,
+            )
+            if getattr(self, "_incremental_persistence_failed", False):
+                return
 
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
         try:
-            if len(tool_calls) <= 1:
+            if len(assistant_message.tool_calls) <= 1:
                 return self._execute_tool_calls_sequential(
                     assistant_message, messages, effective_task_id, api_call_count
                 )
 
-            from agent.tool_dispatch_helpers import _plan_tool_batch_segments
             _active_env = get_active_env(effective_task_id)
             _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
-            segments = _plan_tool_batch_segments(tool_calls, execution_cwd=_exec_cwd)
+            segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
             if len(segments) == 1:
                 kind = segments[0][0]

--- a/tests/run_agent/test_tool_batch_cap.py
+++ b/tests/run_agent/test_tool_batch_cap.py
@@ -1,0 +1,535 @@
+"""Behavior-contract tests for the per-message tool-call batch cap (#93251).
+
+An assistant turn can request an arbitrarily large parallel tool batch, and
+when such a batch fails, EVERY result in it was lost ("Result unavailable"
+for all N calls — #93251).  The fix denies overflow calls VISIBLY, per call,
+at the single dispatch point: ``tools.max_tool_calls_per_batch`` caps how
+many calls one assistant message may execute; the rest receive a denial
+tool result (recoverable — re-issue next turn) instead of being executed
+into whatever failure an oversized batch produces.
+
+Contracts pinned here:
+
+1. Every requested ``tool_call_id`` ends up with EXACTLY ONE result —
+   admitted calls get real results, overflow calls get visible denials.
+   This is the anti-silent-loss invariant itself.
+2. Denied calls are NEVER dispatched — no side effects, no invocation.
+3. The cap applies at the single dispatch point (sequential, concurrent,
+   and segmented shapes all flow through it) AND as an entry backstop on
+   the module-level executors that host code can call directly.
+4. Denials are Hermes-authored runtime notices: plain text, never wrapped
+   in the untrusted-data framing reserved for external tool output.
+5. Config round-trip: ``tools.max_tool_calls_per_batch`` wins when valid;
+   unset/invalid falls back to the default; values < 1 clamp to 1 (a cap
+   of 0 would deny every call — misconfiguration, not feature).
+6. Persistence fail-closed: if the incremental SessionDB flush of denial
+   results reports failure, the turn stops rather than continuing from
+   state that exists only in memory.
+
+Mirrors the stub conventions of test_start_order_gate.py /
+test_concurrent_interrupt.py.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir(exist_ok=True)
+
+
+CAP = 4
+
+
+def _load_config_with(cap):
+    return {"tools": {"max_tool_calls_per_batch": cap}}
+
+
+def _make_agent(request=None):
+    """Minimal AIAgent-like stub able to run the real executor paths."""
+    import run_agent as _ra
+
+    class _Stub:
+        _interrupt_requested = False
+        _interrupt_message = None
+        _execution_thread_id = None
+        _interrupt_thread_signal_pending = False
+        log_prefix = ""
+        quiet_mode = True
+        verbose_logging = False
+        log_prefix_chars = 200
+        tool_progress_mode = "off"
+        _checkpoint_mgr = MagicMock(enabled=False)
+        tool_progress_callback = None
+        tool_start_callback = None
+        tool_complete_callback = None
+        valid_tool_names = set()
+        session_id = ""
+        _current_turn_id = ""
+        _current_api_request_id = ""
+        _todo_store = MagicMock()
+        _memory_store = MagicMock()
+        _session_db = None
+        enabled_toolsets = None
+        disabled_toolsets = None
+        _current_tool = None
+        _print_fn = print
+
+        def __init__(self):
+            self.status_log = []
+            self.flushed_snapshots = []
+            self.dispatched_ids = []
+            self._tool_worker_threads = set()
+            self._tool_worker_threads_lock = __import__("threading").Lock()
+            self._active_children = []
+            self._active_children_lock = __import__("threading").Lock()
+
+        def _emit_status(self, message):
+            self.status_log.append(message)
+
+        def _flush_messages_to_session_db(self, messages, conversation_history=None):
+            self.flushed_snapshots.append(list(messages))
+            return True
+
+        def _touch_activity(self, desc):
+            pass
+
+        def _vprint(self, msg, force=False):
+            pass
+
+        def _safe_print(self, msg):
+            pass
+
+        def _should_emit_quiet_tool_messages(self):
+            return False
+
+        def _should_start_quiet_spinner(self):
+            return False
+
+        def _has_stream_consumers(self):
+            return False
+
+        def _tool_result_content_for_active_model(self, name, result):
+            return result
+
+        def _record_file_mutation_result(self, *a, **kw):
+            pass
+
+        def _apply_pending_steer_to_tool_results(self, *a, **kw):
+            pass
+
+        def _invoke_tool(self, name, args, task_id, call_id, **kw):
+            # Concurrent-path dispatch funnel (tool_executor._execute).
+            self.dispatched_ids.append(call_id)
+            return json.dumps({"ok": name})
+
+        def _record_sequential_dispatch(self, *args, **kwargs):
+            # Sequential path funnel: run_agent.handle_function_call is the
+            # module-level dispatcher the sequential executor routes through;
+            # recording here keeps the dispatch ledger executor-agnostic.
+            tool_call_id = kwargs.get("tool_call_id")
+            self.dispatched_ids.append(tool_call_id)
+            return json.dumps({"ok": "dispatched"})
+
+    stub = _Stub()
+    from agent.tool_executor import (
+        execute_tool_calls_concurrent,
+        execute_tool_calls_sequential,
+    )
+
+    stub._context_engine_tool_names = set()
+    stub._memory_manager = None
+    stub._subdirectory_hints = MagicMock()
+    stub._subdirectory_hints.check_tool_call = lambda *a, **kw: None
+    stub._append_guardrail_observation = lambda name, result, *a, **kw: result
+    stub._guardrail_block_result = lambda d: json.dumps({"error": "blocked"})
+    stub._tool_guardrails = MagicMock()
+    stub._tool_guardrails.before_call = lambda name, args: MagicMock(allows_execution=True)
+    # The sequential executor dispatches through the module-level funnel in
+    # run_agent; route it at the stub so tests observe real dispatches.
+    _hf_patch = patch(
+        "run_agent.handle_function_call",
+        side_effect=stub._record_sequential_dispatch,
+    )
+    _hf_patch.start()
+    if request is not None:
+        request.addfinalizer(_hf_patch.stop)
+    stub._execute_tool_calls = _ra.AIAgent._execute_tool_calls.__get__(stub)
+    stub._execute_tool_calls_concurrent = (
+        lambda *a, **kw: execute_tool_calls_concurrent(stub, *a, **kw)
+    )
+    stub._execute_tool_calls_sequential = (
+        lambda *a, **kw: execute_tool_calls_sequential(stub, *a, **kw)
+    )
+    return stub
+
+
+def _tc(name="web_search", args=None, call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{name}_{id(object()):x}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=json.dumps(args or {})),
+    )
+
+
+def _oversized_batch(n=14):
+    return [
+        _tc("web_search", {"query": f"q{i}"}, call_id=f"ov_{i}")
+        for i in range(n)
+    ]
+
+
+def _result_ids(messages):
+    return [m.get("tool_call_id") for m in messages if m.get("role") == "tool"]
+
+
+# ---------------------------------------------------------------------------
+# Contract 1 + 2: every id answered exactly once; denied ids never dispatched
+# ---------------------------------------------------------------------------
+
+class TestOversizedBatchDeniesOverflow:
+    def test_every_call_id_gets_exactly_one_result(self):
+        agent = _make_agent()
+        calls = _oversized_batch(14)
+        assistant_message = SimpleNamespace(tool_calls=list(calls))
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(CAP),
+        ):
+            agent._execute_tool_calls(assistant_message, [], "task-cap")
+
+        # The executors append onto the list passed in by the caller; the
+        # denial flush snapshots capture the canonical transcript state.
+        transcript = agent.flushed_snapshots[-1]
+        ids = _result_ids(transcript)
+        assert sorted(ids) == sorted(c.id for c in calls), (
+            "silent loss regression: every requested tool_call_id must get "
+            "exactly one result (real or visible denial)"
+        )
+        assert len(ids) == len(set(ids)), "a tool_call_id was answered twice"
+
+    def test_overflow_calls_are_never_dispatched(self):
+        agent = _make_agent()
+        calls = _oversized_batch(14)
+        assistant_message = SimpleNamespace(tool_calls=list(calls))
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(CAP),
+        ):
+            agent._execute_tool_calls(assistant_message, [], "task-cap")
+
+        admitted = {c.id for c in calls[:CAP]}
+        denied = {c.id for c in calls[CAP:]}
+        assert set(agent.dispatched_ids) == admitted
+        assert not (denied & set(agent.dispatched_ids)), (
+            "denied calls must not execute — a denial is a visible refusal, "
+            "not a silent drop and not an execution"
+        )
+
+    def test_denial_text_is_visible_actionable_and_unframed(self):
+        agent = _make_agent()
+        calls = _oversized_batch(6)
+        assistant_message = SimpleNamespace(tool_calls=list(calls))
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(2),
+        ):
+            agent._execute_tool_calls(assistant_message, [], "task-cap")
+
+        transcript = agent.flushed_snapshots[-1]
+        denials = [
+            m for m in transcript
+            if m.get("role") == "tool" and m.get("tool_call_id") in {c.id for c in calls[2:]}
+        ]
+        assert len(denials) == 4
+        for m in denials:
+            text = m["content"]
+            assert "NOT run" in text
+            assert "tools.max_tool_calls_per_batch" in text
+            assert "Re-issue" in text
+            assert m.get("effect_disposition") == "none"
+            # Hermes-authored notice, not external tool output: even a
+            # web_search denial must not carry the injection-defense framing.
+            assert "<untrusted_tool_result>" not in text
+
+    def test_user_sees_a_status_per_denial(self):
+        agent = _make_agent()
+        assistant_message = SimpleNamespace(tool_calls=_oversized_batch(6))
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(CAP),
+        ):
+            agent._execute_tool_calls(assistant_message, [], "task-cap")
+
+        assert len(agent.status_log) >= 2
+        assert any("web_search" in s and "cap" in s.lower() for s in agent.status_log)
+
+
+# ---------------------------------------------------------------------------
+# Contract 3: the cap holds across every execution shape
+# ---------------------------------------------------------------------------
+
+class TestCapAcrossExecutionShapes:
+    def test_under_limit_batch_runs_wholly_untouched(self):
+        agent = _make_agent()
+        calls = _oversized_batch(3)  # < CAP
+        original_ids = [c.id for c in calls]
+        assistant_message = SimpleNamespace(tool_calls=list(calls))
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(CAP),
+        ):
+            agent._execute_tool_calls(assistant_message, [], "task-under")
+
+        assert [c.id for c in assistant_message.tool_calls] == original_ids
+        assert set(agent.dispatched_ids) == set(original_ids)
+        transcript = agent.flushed_snapshots[-1]
+        assert all("denied" not in m["content"] for m in transcript)
+
+    def test_single_call_path_still_works_at_cap_edge(self):
+        agent = _make_agent()
+        solo = [_tc("web_search", {}, call_id="solo_1")]
+        assistant_message = SimpleNamespace(tool_calls=list(solo))
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(1),  # cap == batch size
+        ):
+            agent._execute_tool_calls(assistant_message, [], "task-solo")
+
+        assert agent.dispatched_ids == ["solo_1"]
+        transcript = agent.flushed_snapshots[-1]
+        assert _result_ids(transcript) == ["solo_1"]
+
+    def test_segmented_mixed_batch_keeps_admitted_emission_order(self):
+        """Mixed safe/barrier batches truncate BEFORE segment planning, so the
+        admitted prefix keeps the model's emission order across segments."""
+        agent = _make_agent()
+        calls = [
+            _tc("web_search", {}, call_id="r1"),
+            _tc("web_search", {}, call_id="r2"),
+            _tc("read_file", {"path": "a.py"}, call_id="r3"),
+            _tc("terminal", {"command": "echo hi"}, call_id="b1"),  # barrier
+            _tc("web_search", {}, call_id="r4"),
+            _tc("web_search", {}, call_id="r5"),
+        ]
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(CAP),
+        ):
+            agent._execute_tool_calls(SimpleNamespace(tool_calls=calls), [], "task-mixed")
+
+        # First four were admitted, the rest denied.
+        assert set(agent.dispatched_ids) == {"r1", "r2", "r3", "b1"}
+        # Denials land BEFORE the admitted results (same shape as the
+        # invalid-tool-name path in conversation_loop): they are persisted
+        # before any admitted call runs, so even a process-killing tool
+        # (terminal restart) leaves denied ids answered in the store.
+        transcript = agent.flushed_snapshots[-1]
+        assert _result_ids(transcript) == ["r4", "r5", "r1", "r2", "r3", "b1"]
+
+
+class TestDirectExecutorBackstop:
+    def test_module_level_concurrent_executor_rejects_oversized_batch(self):
+        """Host code can call the module-level executors directly, bypassing
+        AIAgent._execute_tool_calls — the backstop must deny there too."""
+        from agent.tool_executor import execute_tool_calls_concurrent
+
+        agent = _make_agent()
+        calls = _oversized_batch(9)
+        assistant_message = SimpleNamespace(tool_calls=list(calls))
+        messages: list = []
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(CAP),
+        ):
+            execute_tool_calls_concurrent(
+                agent, assistant_message, messages, "task-backstop",
+            )
+
+        assert set(agent.dispatched_ids) == {c.id for c in calls[:CAP]}
+        assert sorted(_result_ids(messages)) == sorted(c.id for c in calls)
+        assert [c.id for c in assistant_message.tool_calls] == [
+            c.id for c in calls[:CAP]
+        ], "executor backstop must truncate so denied ids cannot be re-run"
+
+    def test_module_level_sequential_executor_rejects_oversized_batch(self):
+        from agent.tool_executor import execute_tool_calls_sequential
+
+        agent = _make_agent()
+        calls = _oversized_batch(7)
+        assistant_message = SimpleNamespace(tool_calls=list(calls))
+        messages: list = []
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(2),
+        ):
+            execute_tool_calls_sequential(
+                agent, assistant_message, messages, "task-backstop-seq",
+            )
+
+        assert set(agent.dispatched_ids) == {c.id for c in calls[:2]}
+        assert sorted(_result_ids(messages)) == sorted(c.id for c in calls)
+
+    def test_concurrent_backstop_fails_closed_when_denial_flush_fails(self):
+        """If denial persistence fails at the backstop, admitted calls must
+        NOT run from in-memory-only state (same rule as the caller)."""
+        from agent.tool_executor import execute_tool_calls_concurrent
+
+        agent = _make_agent()
+        agent._flush_messages_to_session_db = lambda *a, **kw: False
+        calls = _oversized_batch(6)
+        assistant_message = SimpleNamespace(tool_calls=list(calls))
+        messages: list = []
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(CAP),
+        ):
+            execute_tool_calls_concurrent(
+                agent, assistant_message, messages, "task-backstop-flush",
+            )
+
+        assert getattr(agent, "_incremental_persistence_failed") is True
+        assert agent.dispatched_ids == [], (
+            "no tool may run when the canonical store rejected the denial flush"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Contract 5: config resolution
+# ---------------------------------------------------------------------------
+
+class TestCapResolution:
+    def test_unset_config_falls_back_to_default(self):
+        from agent.tool_dispatch_helpers import (
+            _DEFAULT_MAX_TOOL_CALLS_PER_BATCH,
+            resolve_max_tool_calls_per_batch,
+        )
+
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert resolve_max_tool_calls_per_batch() == _DEFAULT_MAX_TOOL_CALLS_PER_BATCH
+
+    def test_valid_config_wins(self):
+        from agent.tool_dispatch_helpers import resolve_max_tool_calls_per_batch
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"tools": {"max_tool_calls_per_batch": 2}},
+        ):
+            assert resolve_max_tool_calls_per_batch() == 2
+
+    def test_invalid_config_falls_back_to_default(self):
+        from agent.tool_dispatch_helpers import (
+            _DEFAULT_MAX_TOOL_CALLS_PER_BATCH,
+            resolve_max_tool_calls_per_batch,
+        )
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"tools": {"max_tool_calls_per_batch": "lots"}},
+        ):
+            assert resolve_max_tool_calls_per_batch() == _DEFAULT_MAX_TOOL_CALLS_PER_BATCH
+
+    def test_zero_or_negative_clamps_to_one(self):
+        from agent.tool_dispatch_helpers import resolve_max_tool_calls_per_batch
+
+        for bad in (0, -3):
+            with patch(
+                "hermes_cli.config.load_config",
+                return_value={"tools": {"max_tool_calls_per_batch": bad}},
+            ):
+                assert resolve_max_tool_calls_per_batch() == 1
+
+
+# ---------------------------------------------------------------------------
+# Contract 6: persistence of denials is canonical, fail-closed
+# ---------------------------------------------------------------------------
+
+class TestDenialPersistence:
+    def test_denials_are_flushed_before_any_execution(self):
+        agent = _make_agent()
+        assistant_message = SimpleNamespace(tool_calls=_oversized_batch(6))
+        seen_sizes = []
+
+        original_flush = agent._flush_messages_to_session_db
+
+        def _recording_flush(messages, conversation_history=None):
+            seen_sizes.append(len(_result_ids(messages)))
+            return original_flush(messages, conversation_history)
+
+        agent._flush_messages_to_session_db = _recording_flush
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value=_load_config_with(CAP),
+        ):
+            agent._execute_tool_calls(assistant_message, [], "task-flush")
+
+        # The first flush snapshot must already contain all 2 denial results —
+        # persisted BEFORE the admitted calls ran, so a crash mid-batch never
+        # leaves denied ids unanswered in the canonical store.
+        assert seen_sizes[0] == 2
+
+    def test_flush_failure_sets_fail_closed_flag(self):
+        from agent.tool_dispatch_helpers import append_denied_batch_results
+
+        agent = SimpleNamespace(
+            _emit_status=lambda m: None,
+            _flush_messages_to_session_db=lambda *a, **kw: False,
+        )
+        messages: list = []
+        denied = _oversized_batch(2)
+
+        append_denied_batch_results(agent, messages, denied, limit=CAP)
+
+        assert getattr(agent, "_incremental_persistence_failed") is True
+        assert getattr(agent, "_last_persistence_error_cause") == "unknown"
+
+    def test_flush_exception_classifies_and_flags(self):
+        from agent.tool_dispatch_helpers import append_denied_batch_results
+
+        def _boom(*a, **kw):
+            raise RuntimeError("db locked")
+
+        agent = SimpleNamespace(_emit_status=lambda m: None, _flush_messages_to_session_db=_boom)
+        messages: list = []
+
+        append_denied_batch_results(agent, messages, _oversized_batch(1), limit=CAP)
+
+        assert getattr(agent, "_incremental_persistence_failed") is True
+        cause = getattr(agent, "_last_persistence_error_cause")
+        assert cause and cause != "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Split primitive
+# ---------------------------------------------------------------------------
+
+class TestSplitBatchOverflow:
+    def test_split_preserves_emission_order(self):
+        from agent.tool_dispatch_helpers import split_batch_overflow
+
+        calls = [SimpleNamespace(id=f"c{i}") for i in range(5)]
+        admitted, denied = split_batch_overflow(calls, 3)
+        assert [c.id for c in admitted] == ["c0", "c1", "c2"]
+        assert [c.id for c in denied] == ["c3", "c4"]
+
+    def test_split_none_and_empty_are_safe(self):
+        from agent.tool_dispatch_helpers import split_batch_overflow
+
+        assert split_batch_overflow(None, 4) == ([], [])
+        assert split_batch_overflow([], 4) == ([], [])


### PR DESCRIPTION
## Summary

A single assistant message can request an arbitrarily large parallel tool batch. When such a batch fails, the runtime loses **every** result in it: each call comes back as `[Result unavailable — see context summary above]` (the pre-call sanitizer stub), so the whole turn's work is gone. The reporter documented a dose-response pattern across sessions, models, and providers — batches of 1–3 deliver reliably, batches of ≥ 4 lost all results on every occurrence (#93251).

This adds the enforcement layer the issue requests: `tools.max_tool_calls_per_batch` (config.yaml, default 12) caps how many calls one assistant message may execute. Overflow calls receive a **visible per-call denial** instead of being executed into whatever failure an oversized batch produces. A denial is recoverable — the model re-issues within the cap next turn; today's silent loss is not.

## Design

* **Single enforcement point** at `AIAgent._execute_tool_calls` (the one place every execution shape flows through). Overflow is truncated *before* segment planning (`_plan_tool_batch_segments`), so denied ids can never be dispatched.
* **Entry backstop on all three module-level executors** (`execute_tool_calls_concurrent`, `execute_tool_calls_sequential`, `execute_tool_calls_segmented`) that host code can call directly, bypassing the dispatcher. The backstop is idempotent with the dispatcher (no-op when nothing overflows). The sequential loop additionally skips denied ids and segmented strips them from its plan, so even read-only assistant wrappers cannot re-run a denied call.
* **Denial results pair to the original `tool_call_id`** with no effect, and are flushed incrementally **before any admitted call runs** — even a process-killing tool (`terminal` restart) leaves denied ids answered in state.db. Flush failure is fail-closed: no admitted call executes from in-memory-only state (same rule as every other incremental flush).
* **Denials are Hermes-authored notices**: plain text naming the cap key and the recovery path, deliberately *not* wrapped in the untrusted-data framing that `make_tool_result_message` reserves for external tool output.
* **Budget enforcement / steer injection tail-slices count only this batch's own results** (denials sit earlier in `messages`), so the aggregate budget and `/steer` markers keep rewriting real outputs.

Config-only by repo convention — a behavioral setting in `config.yaml`, not a new `HERMES_*` env var.

## Tests

New `tests/run_agent/test_tool_batch_cap.py` pins behavior contracts (not snapshots):

1. Every requested `tool_call_id` gets **exactly one** result — real for admitted calls, visible denial for overflow (the anti-silent-loss invariant itself).
2. Denied ids are **never dispatched** — no side effects, no invocation, across dispatcher, backstops, and segmented plans.
3. Denials are actionable ("NOT run", cap key named, "Re-issue" recovery) and carry `effect_disposition: none`; a `web_search` denial carries **no** `<untrusted_tool_result>` framing.
4. Under-cap batches run wholly untouched; cap == batch size edge works; mixed safe/barrier batches truncate before planning with denials persisted first.
5. Config resolution: valid value wins; unset/invalid falls back to default; `0`/negative clamps to 1 (a cap of 0 would deny everything — misconfiguration, not feature).
6. Persistence of denials is canonical and fail-closed (flush-before-execution ordering asserted; `False` return and exceptions both set `_incremental_persistence_failed`).

All suites green: new tests 19 passed; neighbors `test_run_agent.py` (275), `test_tool_batch_segmentation.py` + `test_start_order_gate.py` + `test_image_generate_parallel.py` + `test_concurrent_interrupt.py` (40+1 skip), `test_tool_activity_heartbeat.py` + `test_tool_call_guardrail_runtime.py` + `test_tool_call_incremental_persistence.py` + `test_message_sanitization_policy.py` (84).

Fixes #93251