### PR TITLE
fix(desktop): unify target-session RPC routing — salvage #93301 onto post-#93296 main

### DIFF
--- a/apps/desktop/src/app/contrib/wiring-routing.test.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { findStoredIdForRuntimeId, resolveRoutingSessionId } from './wiring-routing'
+
+describe('findStoredIdForRuntimeId', () => {
+  it('reverse-resolves a runtime id to its stored id', () => {
+    const bindings = new Map([
+      ['stored-a', 'runtime-a'],
+      ['stored-b', 'runtime-b']
+    ])
+
+    expect(findStoredIdForRuntimeId(bindings, 'runtime-b')).toBe('stored-b')
+  })
+
+  it('returns undefined for an unknown runtime id', () => {
+    expect(findStoredIdForRuntimeId(new Map([['stored-a', 'runtime-a']]), 'runtime-x')).toBeUndefined()
+    expect(findStoredIdForRuntimeId(new Map(), 'anything')).toBeUndefined()
+  })
+})
+
+describe('resolveRoutingSessionId', () => {
+  const never = (): string | undefined => undefined
+
+  it('routes by the RPC target session, not the focused tile (the Bot Mode misroute)', () => {
+    // A bot chat is a background tile: focused/selected point at the DEFAULT
+    // chat, but the RPC targets the bot. Routing must follow the RPC's target.
+    const routing = resolveRoutingSessionId({
+      focusedStoredSessionId: 'default-chat',
+      paramSessionId: 'runtime-bot',
+      selectedStoredSessionId: 'default-chat',
+      storedIdForRuntime: runtimeId => (runtimeId === 'runtime-bot' ? 'stored-bot' : undefined)
+    })
+
+    expect(routing).toBe('stored-bot')
+  })
+
+  it('treats an unresolved session_id as already a stored id', () => {
+    // Several RPCs pass stored ids directly; a runtime miss must not drop back
+    // to the focused tile (that reintroduces the misroute).
+    const routing = resolveRoutingSessionId({
+      focusedStoredSessionId: 'default-chat',
+      paramSessionId: 'stored-bot-direct',
+      selectedStoredSessionId: 'default-chat',
+      storedIdForRuntime: never
+    })
+
+    expect(routing).toBe('stored-bot-direct')
+  })
+
+  it('falls back to focused then selected when the RPC carries no session_id', () => {
+    expect(
+      resolveRoutingSessionId({
+        focusedStoredSessionId: 'focused',
+        paramSessionId: undefined,
+        selectedStoredSessionId: 'selected',
+        storedIdForRuntime: never
+      })
+    ).toBe('focused')
+
+    expect(
+      resolveRoutingSessionId({
+        focusedStoredSessionId: null,
+        paramSessionId: undefined,
+        selectedStoredSessionId: 'selected',
+        storedIdForRuntime: never
+      })
+    ).toBe('selected')
+
+    expect(
+      resolveRoutingSessionId({
+        focusedStoredSessionId: null,
+        paramSessionId: undefined,
+        selectedStoredSessionId: null,
+        storedIdForRuntime: never
+      })
+    ).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/contrib/wiring-routing.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure routing helpers for the contrib wiring controller.
+ *
+ * Kept out of wiring.tsx so they can be unit-tested without importing the whole
+ * React/Electron controller module.
+ */
+
+/**
+ * Resolve a runtime session id back to its stored id by reverse-scanning the
+ * stored->runtime binding map — the same ladder use-session-tile-delegate's
+ * `storedSessionIdForRuntime` uses. Returns undefined when the id isn't a known
+ * runtime id, so the caller can treat it as already a stored id.
+ */
+export function findStoredIdForRuntimeId(bindings: Map<string, string>, runtimeId: string): string | undefined {
+  for (const [storedId, mapped] of bindings) {
+    if (mapped === runtimeId) {
+      return storedId
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * The stored session id a session-scoped RPC should route by.
+ *
+ * Route by the session the RPC TARGETS (its `session_id` param), not by the
+ * window's focused tile: `requestGateway` is one shared closure for every
+ * session RPC, so keying off the focused tile sent a non-focused tile's RPC
+ * (a bot chat while another pane is active) to the focused tile's backend — the
+ * Bot Mode misroute. `session_id` is a RUNTIME id while tiles/rows key on the
+ * STORED id, so translate via the state cache, then the reverse binding scan;
+ * an unknown id is already a stored id (several RPCs pass stored ids directly).
+ * With no `session_id` at all (ambient/config calls) fall back to the focused
+ * then selected tile.
+ */
+export function resolveRoutingSessionId(args: {
+  paramSessionId: string | undefined
+  storedIdForRuntime: (runtimeId: string) => string | undefined
+  focusedStoredSessionId: null | string
+  selectedStoredSessionId: null | string
+}): null | string {
+  const { focusedStoredSessionId, paramSessionId, selectedStoredSessionId, storedIdForRuntime } = args
+
+  if (paramSessionId) {
+    return storedIdForRuntime(paramSessionId) ?? paramSessionId
+  }
+
+  return focusedStoredSessionId ?? selectedStoredSessionId
+}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -152,6 +152,7 @@ import { McpInstallDeepLinkDialog } from './mcp-install-deeplink-dialog'
 import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
+import { findStoredIdForRuntimeId, resolveRoutingSessionId } from './wiring-routing'
 
 // Overlay views the controller mounts over the shell — lazy, load on demand.
 // The workspace-route full-page views (skills/messaging/artifacts) are the
@@ -316,10 +317,36 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // too. Fall back to the list-derived profile only when no tile route exists.
   const requestGateway = useCallback(
     <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
-      const paramsSessionId = typeof params?.session_id === 'string' ? params.session_id.trim() : ''
-      const targetStoredSessionId = paramsSessionId ? storedSessionIdForRuntimeId(paramsSessionId) : null
+      // Route each RPC by the session IT targets, not by whatever tile is
+      // focused. `requestGateway` is one shared closure used for every session
+      // RPC in the window; keying the owner off $focusedStoredSessionId sent a
+      // NON-focused tile's RPC (any bot chat while another pane is active) to
+      // the focused tile's backend. That is the Bot Mode bug: a bot's
+      // prompt.submit carried its own session_id but ran on the default backend
+      // (served via ?profile= from the default's state.db), or 4001'd when the
+      // default backend didn't hold the runtime session.
+      //
+      // params.session_id is a RUNTIME id, while tiles and session rows key on
+      // the STORED id, so translate first (state cache, then a reverse scan of
+      // the stored->runtime map, then the persisted tile map — the same ladder
+      // use-session-tile-delegate uses, plus the tile rung that survives a
+      // reload when the state cache is cold). A miss on ALL rungs means the id
+      // is already a stored id (several RPCs pass stored ids directly), so use
+      // it as-is. Only an RPC with no session_id at all (ambient/config calls)
+      // keeps the focused-tile route.
+      const paramSessionId =
+        typeof params?.session_id === 'string' && params.session_id ? params.session_id : undefined
 
-      const routingSessionId = targetStoredSessionId ?? $focusedStoredSessionId.get() ?? selectedStoredSessionIdRef.current
+      const routingSessionId = resolveRoutingSessionId({
+        focusedStoredSessionId: $focusedStoredSessionId.get(),
+        paramSessionId,
+        selectedStoredSessionId: selectedStoredSessionIdRef.current,
+        storedIdForRuntime: runtimeId =>
+          sessionStateByRuntimeIdRef.current.get(runtimeId)?.storedSessionId ??
+          findStoredIdForRuntimeId(runtimeIdByStoredSessionIdRef.current, runtimeId) ??
+          storedSessionIdForRuntimeId(runtimeId) ??
+          undefined
+      })
 
       const owner =
         (routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined) ??
@@ -327,7 +354,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       return requestForSessionProfile<T>(owner, ambientRequestGateway, method, params ?? {}, timeoutMs, signal)
     },
-    [ambientRequestGateway]
+    [ambientRequestGateway, runtimeIdByStoredSessionIdRef, selectedStoredSessionIdRef, sessionStateByRuntimeIdRef]
   )
 
   const { loadMoreMessagingForPlatform, loadMoreSessions, refreshCronJobs, refreshMessagingSessions, refreshSessions } =


### PR DESCRIPTION
## Summary

Salvage of #93301 (@teknium1) onto current main. His branch conflicted with main because my #93296 — implementing the same diagnosis he traced and messaged over — merged first and rewrote the exact `requestGateway` region his commit patches. This PR preserves his commit verbatim (cherry-pick, authorship intact) and resolves the conflict by UNIFYING the two implementations, keeping the strongest parts of each.

## Why merge this when #93296 already landed

Reviewing his implementation head-to-head against what's on main found his version is semantically better on two points — this PR upgrades main to his semantics:

1. **Unresolved-id passthrough (the important one).** Main's merged version falls back to the FOCUSED tile when the id resolves to no tile — but several RPCs pass STORED ids directly, and a session can exist in `$sessions` with no tile binding. His `storedIdForRuntime(id) ?? id` treats an unresolved id as already-stored, which downstream `rememberedSessionProfile` can still resolve to the right profile row. Main's fallback re-introduces a residual misroute on exactly that edge; his passthrough eliminates it.
2. **Richer lookup ladder + testable seam.** His resolution reads the live state cache (`sessionStateByRuntimeIdRef`) and the wiring's own stored→runtime binding map — sources that are warm during live streaming — and extracts the decision into pure, DI-injected helpers (`wiring-routing.ts`), directly unit-testable without the React controller.

The conflict resolution keeps main's one complementary rung: `storedSessionIdForRuntimeId()` (the persisted tile map) as the LAST rung of his ladder — tiles survive window reloads when both in-memory caches are cold, so the full ladder is now: state cache → binding-map reverse scan → persisted tile map → passthrough-as-stored.

## Contents

- `fbd4f0c` (@teknium1, authorship preserved): pure helpers + wiring rewire + 6 tests — conflict resolved as described
- Follow-up commit: ladder comment updated to document the tile rung

## Validation

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| his `wiring-routing.test.ts` + main's `session-states-runtime-map.test.ts` + adjacent | 81 passed |
| full `src/app/contrib/` + `src/store/` sweep | 1163 passed |

Closes #93301 (salvaged here with authorship preserved — the original can't merge due to the #93296 conflict).
