### PR TITLE
fix(cli): count scalar include/exclude filters in mcp list

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -716,15 +716,28 @@ def cmd_mcp_list(args=None):
         else:
             transport = "?"
 
-        # Tool count
+        # Tool count — mirror _normalize_name_filter's accepted shapes: the
+        # sanctioned config writer stores a scalar string for a single-tool
+        # include, and registration enforces it, so counting only lists would
+        # display "all" while exactly one tool is live (#93313).
         tools_cfg = cfg.get("tools", {})
         if isinstance(tools_cfg, dict):
             include = tools_cfg.get("include")
             exclude = tools_cfg.get("exclude")
-            if include and isinstance(include, list):
-                tools_str = f"{len(include)} selected"
-            elif exclude and isinstance(exclude, list):
-                tools_str = f"-{len(exclude)} excluded"
+
+            def _filter_len(value: Any) -> int:
+                if isinstance(value, str):
+                    return 1
+                if isinstance(value, (list, tuple, set)):
+                    return len(value)
+                return 0
+
+            include_n = _filter_len(include)
+            exclude_n = _filter_len(exclude)
+            if include_n:
+                tools_str = f"{include_n} selected"
+            elif exclude_n:
+                tools_str = f"-{exclude_n} excluded"
             else:
                 tools_str = "all"
         else:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -737,7 +737,11 @@ def cmd_mcp_list(args=None):
             if include_n:
                 tools_str = f"{include_n} selected"
             elif exclude_n:
-                tools_str = f"-{exclude_n} excluded"
+                # Offline list has no served tool list, so this counts
+                # configured patterns, not tools actually blocked — say
+                # "patterns" so the number can't be read as an effect
+                # count (#98067).
+                tools_str = f"{exclude_n} pattern{'s' if exclude_n != 1 else ''}"
             else:
                 tools_str = "all"
         else:

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -108,6 +108,7 @@ class TestMcpList:
         assert "ink" in out
         assert "github" in out
         assert "2 selected" in out  # ink has 2 in include
+        assert "all" in out  # github has no tools block: default filter renders "all"
         assert "disabled" in out  # github is disabled
 
     def test_list_enabled_default_true(self, tmp_path, capsys):

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -140,21 +140,61 @@ class TestMcpList:
         assert "1 selected" in out
         assert "all" not in out
 
-    def test_list_scalar_exclude_shows_one_excluded(self, tmp_path, capsys):
-        """Scalar exclude mirrors the same normalization shape (#93313)."""
-        _seed_config(tmp_path, {
-            "ink": {
-                "url": "https://mcp.ml.ink/mcp",
-                "enabled": True,
-                "tools": {"exclude": "debug_tool"},
+    def test_list_scalar_exclude_counts_as_one_pattern(self, tmp_path, capsys):
+        """#93313: scalar exclude mirrors the same normalization shape —
+        one configured pattern. #98067: an exclude count must say
+        "patterns", never imply a blocked-tool count."""
+        _seed_config(
+            tmp_path,
+            {
+                "ink": {
+                    "url": "https://mcp.ml.ink/mcp",
+                    "enabled": True,
+                    "tools": {"exclude": "debug_tool"},
+                },
             },
-        })
+        )
         from hermes_cli.mcp_config import cmd_mcp_list
 
         cmd_mcp_list()
         out = capsys.readouterr().out
-        assert "-1 excluded" in out
+        assert "1 pattern" in out
+        assert "1 patterns" not in out
         assert "all" not in out
+        assert "excluded" not in out
+
+    def test_list_exclude_counts_patterns_not_tools(self, tmp_path, capsys):
+        """#98067: offline list can't know blocked-tool counts; a 9-pattern
+        config that matches nothing must not read as "9 tools excluded"."""
+        _seed_config(
+            tmp_path,
+            {
+                "betterstack": {
+                    "url": "https://mcp.betterstack.com",
+                    "enabled": True,
+                    "tools": {
+                        "exclude": [
+                            "execute_query",
+                            "Execute query",
+                            "search_documentation",
+                            "*instructions*",
+                            "create_cloud_connection",
+                            "*team_member*",
+                            "monitors",
+                            "docs",
+                            "*radar*",
+                        ]
+                    },
+                },
+            },
+        )
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "betterstack" in out
+        assert "9 patterns" in out
+        assert "excluded" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -122,6 +122,39 @@ class TestMcpList:
         assert "myserver" in out
         assert "enabled" in out
 
+    def test_list_scalar_include_shows_one_selected(self, tmp_path, capsys):
+        """#93313: a scalar-string include is enforced at registration (a
+        one-tool filter) — the list display must not claim "all"."""
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "enabled": True,
+                "tools": {"include": "create_service"},
+            },
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "1 selected" in out
+        assert "all" not in out
+
+    def test_list_scalar_exclude_shows_one_excluded(self, tmp_path, capsys):
+        """Scalar exclude mirrors the same normalization shape (#93313)."""
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "enabled": True,
+                "tools": {"exclude": "debug_tool"},
+            },
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "-1 excluded" in out
+        assert "all" not in out
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_remove


### PR DESCRIPTION
## What does this PR do?

Fixes two defects in the same `cmd_mcp_list` tool-count display block:

**1. Scalar filters displayed "all" (#93313).** The sanctioned config writer (`hermes config set mcp_servers.<name>.tools.include <tool>`) stores a scalar, and registration enforces it — `_normalize_name_filter()` in `tools/mcp_tool.py` accepts a bare string as a one-entry filter. But the display formatter only counted list-shaped filters, so a scalar include fell through to `else` and displayed **"all"** while exactly one tool was live. The fix mirrors `_normalize_name_filter`'s accepted shapes (`str` / `list` / `tuple` / `set`) when counting for display: a scalar counts as one entry.

**2. Exclude counts read as effect counts (#98067).** `hermes mcp list` is an offline config dump with no served tool list, so for exclude filters it printed `-{len(exclude)} excluded` — that counts configured *patterns*, not tools actually blocked. A real-world config with 9 exclude patterns where 7 patterns match nothing and only 5 of 111 tools are blocked still displayed `-9 excluded`, in the permissive direction, exactly when a user is verifying that a security-motivated filter took effect. The exclude branch now says what the number is: `{n} pattern(s)` (e.g. `9 patterns`). The live blocked-tool count belongs to the online commands (`mcp test` / `mcp configure`), which do see the served tool list.

Both are display-only (registration/enforcement is correct); no machine consumes this table's wording, so rephrasing carries no compatibility risk.

## Related Issue

Fixes #93313
Fixes #98067

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_config.py` — the tool-count block in `cmd_mcp_list`'s row formatter normalizes the filter shape before counting (scalar → 1, sequence → `len`), and the exclude branch now renders `{n} pattern(s)` instead of `-{n} excluded`; comments tie the shapes to `_normalize_name_filter`'s contract and the wording to the offline-list constraint.
- `tests/hermes_cli/test_mcp_config.py` — regressions in the existing `TestMcpList` pattern (`_seed_config` + `cmd_mcp_list` + capsys): a scalar include shows `1 selected` (not `all`); a scalar exclude shows `1 pattern` (not `all`, no "excluded"); a 9-pattern exclude config reproducing #98067's observed case shows `9 patterns` with no "excluded" anywhere; plus a pin that a no-tools-block default renders `all`.

## How to Test

`pytest tests/hermes_cli/test_mcp_config.py -q` — should pass (41 tests).

Observed result: all 41 pass at head. Reverting only the `mcp_config.py` wording (keeping tests): the #98067 tests fail with `-9 excluded` in the output; reverting only the shape normalization: the scalar tests fail with the row printing `all` — exactly the two display/behavior mismatches the issues report.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (shape-mirroring rationale + offline-count constraint at the formatter)
- [x] Tests added that prove the fix works
- [x] New and existing unit tests pass locally (41/41)
- [x] Platform: macOS (pure display logic, platform-independent)
