### PR TITLE
fix(agent): honor prompt_caching for custom providers (salvage #92785)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2291,29 +2291,67 @@ def anthropic_prompt_cache_policy(
         and (eff_provider == "anthropic" or base_url_hostname(eff_base_url) == "api.anthropic.com")
     )
 
-    # A custom Anthropic-compatible route may use a bare model alias that is
-    # canonicalized only after Hermes sends the request. In that case model
-    # spelling cannot prove cache support. Honor an exact route+model
-    # capability declaration instead; explicit false is authoritative too.
-    # This preserves the runtime model id (and therefore request/cache keys)
-    # while avoiding unsafe alias-name guesses.
+    # A configured route may use an arbitrary provider name and model alias
+    # that are canonicalized only after Hermes sends the request. Honor its
+    # existing per-model ``prompt_caching`` capability instead of guessing
+    # support from either spelling. Explicit false is authoritative too.
     #
-    # Also consulted for a LiteLLM route on the OpenAI wire: that grant is
-    # inferred from the provider/host name, so an operator who explicitly
-    # declares prompt_caching for the route+model must still win over the
-    # inference — in either direction. Narrowed to the routes the LiteLLM
-    # branch below can actually grant (chat_completions + Claude): the lookup
-    # calls get_compatible_custom_providers, which rebuilds its normalized
-    # view on every call (~1.5ms uncached), and this function runs per
-    # request destination. Widening it unconditionally regressed the
-    # non-declaring common case ~200x (7.5us -> 1528us).
+    # The declaration only controls the two transports handled by this marker
+    # planner. Responses and Bedrock use separate caching protocols and must
+    # not receive Anthropic-style cache_control fields.
     custom_prompt_caching = None
+    _supports_anthropic_cache_markers = eff_api_mode in {
+        "anthropic_messages",
+        "chat_completions",
+    }
     _litellm_openai_wire = (
         eff_api_mode == "chat_completions"
         and is_claude
         and _is_litellm_route(provider_lower, eff_base_url)
     )
-    if is_anthropic_wire or _litellm_openai_wire:
+    _custom_providers = getattr(agent, "_custom_providers", None)
+    _route_may_be_custom = False
+    if _custom_providers:
+        # The normalized list is already attached after agent initialization.
+        # Use cheap runtime identity signals before calling the capability
+        # helper so an unrelated configured provider does not put every
+        # built-in chat-completions request on the route-normalization path.
+        _provider_ids = {provider_lower}
+        if provider_lower.startswith("custom:"):
+            _provider_ids.add(provider_lower.removeprefix("custom:"))
+        for _entry in _custom_providers:
+            if not isinstance(_entry, dict):
+                continue
+            _entry_ids = {
+                str(_entry.get("name") or "").strip().lower(),
+                str(_entry.get("provider_key") or "").strip().lower(),
+            }
+            if _provider_ids & (_entry_ids - {""}) or (
+                eff_base_url
+                and str(_entry.get("base_url") or "") == eff_base_url
+            ):
+                _route_may_be_custom = True
+                break
+    elif _custom_providers is None:
+        # During early agent initialization the normalized custom-provider list
+        # is not attached yet. Avoid rebuilding it for ordinary built-in routes,
+        # while still recognizing arbitrary config keys and built-in-name
+        # overrides that point at a different endpoint.
+        try:
+            from hermes_cli.providers import get_provider
+
+            _provider_def = get_provider(eff_provider)
+            _route_may_be_custom = _provider_def is None or (
+                bool(_provider_def.base_url)
+                and base_url_hostname(_provider_def.base_url)
+                != base_url_hostname(eff_base_url)
+            )
+        except Exception:
+            _route_may_be_custom = provider_lower.startswith("custom:")
+
+    if _supports_anthropic_cache_markers and (
+        is_anthropic_wire or _litellm_openai_wire or _route_may_be_custom
+    ):
         try:
             from hermes_cli.config import get_custom_provider_model_capability
 
@@ -2321,7 +2359,7 @@ def anthropic_prompt_cache_policy(
                 model=eff_model,
                 base_url=eff_base_url,
                 capability="prompt_caching",
-                custom_providers=getattr(agent, "_custom_providers", None),
+                custom_providers=_custom_providers,
             )
         except Exception as _cap_exc:
             logger.debug(
@@ -2329,10 +2367,9 @@ def anthropic_prompt_cache_policy(
                 _cap_exc,
             )
     if custom_prompt_caching is not None:
-        # Layout follows the transport, not the declaration: the native
-        # inner-block form is only honored on the Anthropic Messages wire
-        # (see the LiteLLM OpenAI-wire branch below for why a top-level
-        # marker is dropped or 400s on chat_completions).
+        # Layout follows the transport, not the declaration: native Messages
+        # uses inner-block markers; OpenAI-compatible chat uses the envelope
+        # layout already emitted for OpenRouter and LiteLLM.
         return custom_prompt_caching, custom_prompt_caching and is_anthropic_wire
 
     # MiniMax-M3 rides MiniMax's server-side automatic prefix cache on the

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2311,46 +2311,68 @@ def anthropic_prompt_cache_policy(
     )
     _custom_providers = getattr(agent, "_custom_providers", None)
     _route_may_be_custom = False
-    if _custom_providers:
+    if not _supports_anthropic_cache_markers:
+        # Responses/Bedrock never consume the declaration — skip the
+        # identity probe entirely for those transports.
+        pass
+    elif _custom_providers:
         # The normalized list is already attached after agent initialization.
         # Use cheap runtime identity signals before calling the capability
         # helper so an unrelated configured provider does not put every
         # built-in chat-completions request on the route-normalization path.
+        #
+        # Identity must match the authoritative helper's semantics:
+        # get_custom_provider_model_capability compares base URLs via
+        # normalize_route_base_url, and runtime provider ids go through
+        # custom_provider_aliases (space→hyphen, custom: prefix variants).
+        # A raw-string gate here would silently drop declarations whose
+        # config spelling differs only in host case / trailing slash.
+        from hermes_cli.providers import custom_provider_aliases
+        from hermes_cli.route_identity import normalize_route_base_url
+
         _provider_ids = {provider_lower}
         if provider_lower.startswith("custom:"):
             _provider_ids.add(provider_lower.removeprefix("custom:"))
-        from hermes_cli.route_identity import normalize_route_base_url
-
-        _runtime_route_url = normalize_route_base_url(eff_base_url)
+        _eff_url_normalized = normalize_route_base_url(eff_base_url)
         for _entry in _custom_providers:
             if not isinstance(_entry, dict):
                 continue
-            _entry_ids = {
-                str(_entry.get("name") or "").strip().lower(),
-                str(_entry.get("provider_key") or "").strip().lower(),
-            }
-            if _provider_ids & (_entry_ids - {""}) or (
-                _runtime_route_url
+            _entry_ids = custom_provider_aliases(
+                str(_entry.get("name") or ""),
+                str(_entry.get("provider_key") or ""),
+            )
+            if _provider_ids & _entry_ids or (
+                _eff_url_normalized
                 and normalize_route_base_url(_entry.get("base_url"))
-                == _runtime_route_url
+                == _eff_url_normalized
             ):
                 _route_may_be_custom = True
                 break
     elif _custom_providers is None:
-        # During early agent initialization the normalized custom-provider list
-        # is not attached yet. Avoid rebuilding it for ordinary built-in routes,
+        # None = the list is not attached yet (early agent initialization or
+        # a blank_cache_policy_stub destination); an attached empty list means
+        # the agent initialized with no custom providers and correctly never
+        # matches. Avoid rebuilding the list for ordinary built-in routes,
         # while still recognizing arbitrary config keys and built-in-name
         # overrides that point at a different endpoint.
         try:
             from hermes_cli.providers import get_provider
 
-            _provider_def = get_provider(eff_provider)
+            # allow_network=False: this runs per request destination; a cold
+            # models.dev cache must not trigger a foreground registry fetch
+            # from the send path. A catalog miss (None) degrades to the
+            # conservative side (route may be custom → capability lookup).
+            _provider_def = get_provider(eff_provider, allow_network=False)
             _route_may_be_custom = _provider_def is None or (
                 bool(_provider_def.base_url)
                 and base_url_hostname(_provider_def.base_url)
                 != base_url_hostname(eff_base_url)
             )
-        except Exception:
+        except Exception as _pd_exc:
+            logger.debug(
+                "provider lookup failed during cache-policy pre-gate: %s",
+                _pd_exc,
+            )
             _route_may_be_custom = provider_lower.startswith("custom:")
 
     if _supports_anthropic_cache_markers and (

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2319,6 +2319,9 @@ def anthropic_prompt_cache_policy(
         _provider_ids = {provider_lower}
         if provider_lower.startswith("custom:"):
             _provider_ids.add(provider_lower.removeprefix("custom:"))
+        from hermes_cli.route_identity import normalize_route_base_url
+
+        _runtime_route_url = normalize_route_base_url(eff_base_url)
         for _entry in _custom_providers:
             if not isinstance(_entry, dict):
                 continue
@@ -2327,8 +2330,9 @@ def anthropic_prompt_cache_policy(
                 str(_entry.get("provider_key") or "").strip().lower(),
             }
             if _provider_ids & (_entry_ids - {""}) or (
-                eff_base_url
-                and str(_entry.get("base_url") or "") == eff_base_url
+                _runtime_route_url
+                and normalize_route_base_url(_entry.get("base_url"))
+                == _runtime_route_url
             ):
                 _route_may_be_custom = True
                 break

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -294,6 +294,99 @@ class TestThirdPartyAnthropicGateway:
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
 
+class TestCustomProviderOpenAIWireCapability:
+    """Explicit model capability works without provider, host, or family guesses."""
+
+    @staticmethod
+    def _configured_agent(*, enabled: bool, api_mode: str = "chat_completions"):
+        agent = _make_agent(
+            provider="custom:edge-router",
+            base_url="https://models.example.net/v1",
+            api_mode=api_mode,
+            model="vendor-agnostic-model",
+        )
+        agent._custom_providers = [
+            {
+                "name": "edge-router",
+                "base_url": "https://models.example.net/v1",
+                "models": {
+                    "vendor-agnostic-model": {"prompt_caching": enabled},
+                },
+            }
+        ]
+        return agent
+
+    def test_explicit_true_enables_envelope_layout_on_chat_completions(self):
+        agent = self._configured_agent(enabled=True)
+
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_explicit_false_disables_markers_on_chat_completions(self):
+        agent = self._configured_agent(enabled=False)
+
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_undeclared_chat_completions_route_stays_conservative(self):
+        agent = self._configured_agent(enabled=True)
+        agent._custom_providers[0]["models"]["vendor-agnostic-model"] = {
+            "context_length": 131072,
+        }
+
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_unrelated_custom_route_skips_capability_lookup(self, monkeypatch):
+        agent = self._configured_agent(enabled=True)
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "openai/gpt-5.4"
+
+        def unexpected_lookup(**_kwargs):
+            pytest.fail("unrelated built-in route performed custom capability lookup")
+
+        monkeypatch.setattr(
+            "hermes_cli.config.get_custom_provider_model_capability",
+            unexpected_lookup,
+        )
+
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    @pytest.mark.parametrize("api_mode", ["codex_responses", "bedrock_converse"])
+    def test_explicit_true_does_not_cross_into_other_wire_protocols(self, api_mode):
+        agent = self._configured_agent(enabled=True, api_mode=api_mode)
+
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_modern_providers_yaml_is_honored_during_early_init(
+        self, tmp_path, monkeypatch
+    ):
+        import textwrap
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            textwrap.dedent(
+                """
+                providers:
+                  edge-router:
+                    api: https://models.example.net/v1
+                    transport: openai_chat
+                    models:
+                      vendor-agnostic-model:
+                        prompt_caching: true
+                """
+            )
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        agent = _make_agent(
+            provider="edge-router",
+            base_url="https://models.example.net/v1",
+            api_mode="chat_completions",
+            model="vendor-agnostic-model",
+        )
+
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+
 class TestMiniMaxAnthropicWire:
     """MiniMax's own model family on its Anthropic-compatible endpoint.
 

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -326,6 +326,13 @@ class TestCustomProviderOpenAIWireCapability:
 
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
+    def test_equivalent_base_url_spelling_reaches_capability_lookup(self):
+        agent = self._configured_agent(enabled=True)
+        agent.provider = "unrelated-runtime-alias"
+        agent._custom_providers[0]["base_url"] = "HTTPS://models.example.net/v1/"
+
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
     def test_undeclared_chat_completions_route_stays_conservative(self):
         agent = self._configured_agent(enabled=True)
         agent._custom_providers[0]["models"]["vendor-agnostic-model"] = {

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -28,6 +28,11 @@ def _make_agent(
     agent.api_mode = api_mode
     agent.model = model
     agent._base_url_lower = (base_url or "").lower()
+    # Post-init reality for agents without custom providers: an attached
+    # empty list. Keeps built-in-route tests hermetic — the policy's
+    # None-branch would otherwise consult the models.dev catalog and, on a
+    # miss, fall back to reading the developer's real config.yaml.
+    agent._custom_providers = []
     agent.client = MagicMock()
     agent.quiet_mode = True
     return agent
@@ -288,6 +293,7 @@ class TestThirdPartyAnthropicGateway:
         )
         # No agent._custom_providers — exercises the config fallback the
         # init-time call (agent_init before the snapshot assignment) hits.
+        del agent._custom_providers
         assert agent._anthropic_prompt_cache_policy() == (True, True)
 
         agent.model = "opus"
@@ -363,6 +369,69 @@ class TestCustomProviderOpenAIWireCapability:
 
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
+    def test_gate_matches_declaration_despite_url_spelling_drift(self):
+        """The pre-gate must use the same URL identity semantics as the
+        authoritative capability matcher (normalize_route_base_url): a
+        declaration whose config spelling differs only by host case or
+        trailing slash must still be honored, even when the provider name
+        gives the gate no help."""
+        agent = self._configured_agent(enabled=True)
+        agent.provider = "some-unrelated-alias"
+        agent.base_url = "https://Models.Example.NET/v1/"
+        agent._base_url_lower = agent.base_url.lower()
+
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_gate_matches_declaration_via_spaced_legacy_name(self):
+        """Legacy entries with spaced display names ('My Gateway') must match
+        the runtime 'custom:my-gateway' identity (custom_provider_aliases
+        semantics). Combined with URL spelling drift, the raw pre-gate
+        dropped this declaration on both legs."""
+        agent = _make_agent(
+            provider="custom:my-gateway",
+            base_url="https://GW.example.net/v1/",
+            api_mode="chat_completions",
+            model="alias-model",
+        )
+        agent._custom_providers = [
+            {
+                "name": "My Gateway",
+                "base_url": "https://gw.example.net/v1",
+                "models": {"alias-model": {"prompt_caching": True}},
+            }
+        ]
+
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+
+    def test_early_init_probe_never_fetches_catalog_from_network(
+        self, monkeypatch
+    ):
+        """The None-branch provider probe runs per request destination and
+        must stay off the network: get_provider must be called with
+        allow_network=False so a cold models.dev cache cannot trigger a
+        foreground registry download from the send path."""
+        import hermes_cli.providers as _providers
+
+        seen: list = []
+        real_get_provider = _providers.get_provider
+
+        def recording_get_provider(name, **kwargs):
+            seen.append(kwargs.get("allow_network"))
+            return real_get_provider(name, **kwargs)
+
+        monkeypatch.setattr(_providers, "get_provider", recording_get_provider)
+        agent = _make_agent(
+            provider="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        del agent._custom_providers  # early-init shape: attr not attached yet
+
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+        assert seen, "None-branch did not consult the provider catalog"
+        assert all(v is False for v in seen)
+
     def test_modern_providers_yaml_is_honored_during_early_init(
         self, tmp_path, monkeypatch
     ):
@@ -390,6 +459,9 @@ class TestCustomProviderOpenAIWireCapability:
             api_mode="chat_completions",
             model="vendor-agnostic-model",
         )
+        # Early init: the normalized custom-provider list is not attached
+        # yet, so the policy must recognize the route from config itself.
+        del agent._custom_providers
 
         assert agent._anthropic_prompt_cache_policy() == (True, False)
 

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -197,15 +197,15 @@ providers:
 
 With discovery off, the model picker (`hermes model`, `/model`) shows the configured list instead of a live probe.
 
-For an Anthropic-compatible gateway that resolves a bare model alias only
-after receiving the request, opt the alias into native prompt-cache markers
-with the per-model `prompt_caching` capability:
+For a gateway that resolves a bare model alias only after receiving the
+request, opt the alias into prompt-cache markers with the per-model
+`prompt_caching` capability:
 
 ```yaml
 providers:
-  anthropic-proxy:
-    api: https://gateway.example.com/anthropic
-    transport: anthropic_messages
+  model-proxy:
+    api: https://gateway.example.com/v1
+    transport: openai_chat  # or anthropic_messages
     models:
       fable:
         context_length: 1000000
@@ -213,9 +213,12 @@ providers:
 ```
 
 Hermes matches this declaration to the exact provider route and runtime model
-id, without rewriting the alias. Set `prompt_caching: false` to explicitly
-disable cache markers for a model; when omitted, Hermes keeps its normal
-provider and model capability detection.
+id, without rewriting the alias or inferring support from its provider name,
+host, or model family. The marker layout follows the configured transport:
+`openai_chat` uses the OpenAI-compatible envelope layout and
+`anthropic_messages` uses the native inner-block layout. Set
+`prompt_caching: false` to explicitly disable cache markers for a model; when
+omitted, Hermes keeps its normal provider and model capability detection.
 
 :::note Legacy format
 Older configs used a top-level `custom_providers:` list (with `base_url` instead of `api`). It still works and is auto-migrated to the `providers:` dict on `hermes update` (config v12).


### PR DESCRIPTION
## Summary

Custom `openai_chat` routes can now opt in/out of prompt-cache markers via the per-model `prompt_caching` capability — previously the declaration was only consulted on the Anthropic wire and LiteLLM-Claude routes, leaving custom gateways with runtime-resolved model aliases unable to enable caching without renaming their provider or model.

Salvage of #92785 by @dagbs — **both** of their commits cherry-picked with authorship preserved (the original feature commit and the v2 `normalize custom provider route identity` follow-up they pushed in response to review), plus a follow-up commit fixing the remaining review findings.

## Changes

**Salvaged from #92785 (@dagbs, 2 commits):**
- `agent/agent_runtime_helpers.py`: per-model `prompt_caching` declaration is authoritative for custom routes on both supported transports; layout follows the transport (envelope for `openai_chat`, inner-block for `anthropic_messages`); Responses/Bedrock excluded; explicit `false` wins over OpenRouter/LiteLLM inference; undeclared routes stay conservative.
- v2: entry-side URL normalization in the pre-gate + regression test.
- Regression coverage for opt-in/opt-out, undeclared routes, early init from modern `providers:` config, transport isolation.
- Docs: `website/docs/user-guide/configuring-models.md`.

**Follow-up fixes (review findings):**
- Pre-gate identity fully aligned with the authoritative capability matcher: base URLs via `normalize_route_base_url` on **both** sides (runtime and entry), provider ids via `custom_provider_aliases` (spaced legacy display names like `My Gateway` now match runtime `custom:my-gateway`). The raw comparisons silently dropped declarations whose spelling differed only by host case or trailing slash (proven empirically).
- `get_provider(..., allow_network=False)` in the early-init/stub branch: the policy runs per request destination (MoA aggregator, auxiliary replans, early agent init) and a cold models.dev cache triggered a measured **~450 ms foreground registry fetch from the send path**. A catalog miss degrades to the conservative side.
- Identity probe skipped entirely on Responses/Bedrock transports (result was computed then discarded).
- The silent `except Exception` provider-lookup fallback now debug-logs, matching the sibling handler.
- Test hermeticity: `_make_agent` defaults `_custom_providers = []` (post-init reality) so built-in-route tests can't fall through to the models.dev catalog and the developer's real config.yaml; early-init tests delete the attribute explicitly.
- Three new regression tests pin the runtime-side URL-drift, spaced-legacy-name, and no-network contracts — all three fail on the unsalvaged base (mutation-checked). dagbs's v2 entry-side drift test kept; the two drift tests cover opposite legs of the normalization symmetry.

## Validation

| | Result |
|---|---|
| PR test file (83 = 79 original + 1 v2 + 3 new) + adjacent cache suites | 146 pass |
| Mutation check (new guards on unfixed base) | 3/3 fail as required |
| E2E (real imports, temp HERMES_HOME): declared true/false, both drift legs, spaced name, builtin fast path, Bedrock exclusion, stub path | all pass; `get_provider` called with `allow_network=False` only |
| No-regression sweep: no undeclared config changes its `(should_cache, layout)` tuple vs main; `_custom_providers == []` fast path unchanged | verified |
| ruff on changed files | clean |
| ty on changed file | diagnostics byte-identical to origin/main (pre-existing) |

## Credit

Based on #92785 by @dagbs — both commits cherry-picked with authorship preserved.

Closes #92785
