### PR TITLE
fix: preserve terminal cwd and delegation failure identity

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -161,11 +161,27 @@ class _BatchAbandoned(BaseException):
     """
 
 
+class _DuplicateToolArgumentKey(ValueError):
+    """Raised when model-emitted JSON would silently discard an earlier key."""
+
+
+def _reject_duplicate_argument_keys(pairs: list[tuple[str, Any]]) -> dict:
+    parsed: dict = {}
+    for key, value in pairs:
+        if key in parsed:
+            raise _DuplicateToolArgumentKey(key)
+        parsed[key] = value
+    return parsed
+
+
 def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
-    """Parse model-emitted arguments without repairing or coercing them."""
+    """Parse model-emitted arguments without repairing or losing fields."""
     try:
-        arguments = json.loads(raw_arguments)
-    except (json.JSONDecodeError, TypeError):
+        arguments = json.loads(
+            raw_arguments,
+            object_pairs_hook=_reject_duplicate_argument_keys,
+        )
+    except (json.JSONDecodeError, TypeError, _DuplicateToolArgumentKey):
         arguments = None
     if isinstance(arguments, dict):
         return arguments, None

--- a/tests/run_agent/test_malformed_tool_arguments.py
+++ b/tests/run_agent/test_malformed_tool_arguments.py
@@ -55,6 +55,10 @@ def _tool_call(call_id: str, arguments: str):
         pytest.param("[]", id="list"),
         pytest.param("", id="empty"),
         pytest.param('{"query": "cut off', id="truncated"),
+        pytest.param(
+            '{"query": "silently lost", "query": "last value wins"}',
+            id="duplicate-key",
+        ),
     ],
 )
 def test_malformed_arguments_are_rejected_without_blocking_valid_sibling(

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -618,9 +618,81 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert evt.get("is_batch") is True
     assert len(evt["results"]) == 1
     assert evt["results"][0]["summary"] == "done: the real task"
+    assert evt["model"] == "m"
     text = format_process_notification(evt)
     assert text is not None
     assert "the real task" in text
+
+
+def test_background_batch_reports_effective_inherited_model(monkeypatch):
+    """Blank dispatch overrides must not render as ``Model: ?``.
+
+    The child result already carries the effective inherited model; the batch
+    completion envelope should promote that value when every child agrees.
+    """
+    combined = {
+        "results": [
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "done",
+                "model": "effective-model",
+                "exit_reason": "completed",
+            }
+        ],
+        "total_duration_seconds": 1.0,
+    }
+    result = ad.dispatch_async_delegation_batch(
+        goals=["inherit model"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="",
+        runner=lambda: combined,
+        max_async_children=1,
+    )
+    evt = _drain_for(result["delegation_id"], timeout=5.0)
+
+    assert evt is not None
+    assert evt["model"] == "effective-model"
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "Model: effective-model" in text
+
+
+def test_background_timeout_batch_reports_child_model(monkeypatch):
+    combined = {
+        "results": [
+            {
+                "task_index": 0,
+                "status": "timeout",
+                "summary": None,
+                "error": "timed out",
+                "model": "inherited-model",
+                "exit_reason": "timeout",
+            }
+        ],
+        "total_duration_seconds": 1.0,
+    }
+    result = ad.dispatch_async_delegation_batch(
+        goals=["timeout"],
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model=None,
+        session_key="",
+        runner=lambda: combined,
+        max_async_children=1,
+    )
+    evt = _drain_for(result["delegation_id"], timeout=5.0)
+
+    assert evt is not None
+    assert evt["model"] == "inherited-model"
+    text = format_process_notification(evt)
+    assert text is not None
+    assert "Model: inherited-model" in text
+    assert "Model: ?" not in text
 
 
 def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -259,6 +259,112 @@ class TestRunSingleChildSchemaValidation:
         assert len(child.calls) == 1
         assert entry.get("schema_valid") is False
 
+    def test_nonempty_api_failure_skips_schema_retry_and_keeps_terminal_cause(self):
+        """Transport error prose is not a candidate structured response.
+
+        A failed child can return a non-empty user-facing error.  Treating that
+        prose as invalid schema used to fire a second provider call, then label
+        the result ``completed`` / ``max_iterations`` instead of the real API
+        failure.
+        """
+        child = _StubChild(["unused"])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        child.calls = []
+
+        def failed_call(user_message, task_id=None, **_kwargs):
+            child.calls.append(user_message)
+            return {
+                "final_response": "API call failed after 3 retries: HTTP 429",
+                "completed": False,
+                "failed": True,
+                "error": "HTTP 429 rate limit",
+                "failure_reason": "rate_limited",
+                "api_calls": 3,
+                "messages": [],
+            }
+
+        child.run_conversation = failed_call
+        entry = _run(child)
+
+        assert entry["status"] == "failed"
+        assert entry["exit_reason"] == "rate_limited"
+        assert entry["truncated"] is False
+        assert entry["error"] == "HTTP 429 rate limit"
+        assert len(child.calls) == 1
+        assert entry["schema_valid"] is False
+        assert entry.get("schema_retries", 0) == 0
+
+    def test_schema_retry_api_failure_replaces_first_turn_terminal_state(self):
+        """A failed correction turn is terminal, not a successful first turn.
+
+        The first response can be a healthy-but-schema-invalid completion. If
+        the one bounded correction call then fails at the provider boundary,
+        its failure fields must replace the first turn's completed state.
+        """
+        child = _StubChild(["unused"])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        child.calls = []
+
+        responses = iter(
+            [
+                {
+                    "final_response": "not json",
+                    "completed": True,
+                    "api_calls": 1,
+                    "messages": [],
+                },
+                {
+                    "final_response": "API call failed after 3 retries: HTTP 429",
+                    "completed": False,
+                    "failed": True,
+                    "error": "HTTP 429 rate limit",
+                    "failure_reason": "rate_limited",
+                    "turn_exit_reason": "provider_error",
+                    "api_calls": 3,
+                    "messages": [],
+                },
+            ]
+        )
+
+        def sequenced_call(user_message, task_id=None, **_kwargs):
+            child.calls.append(user_message)
+            return next(responses)
+
+        child.run_conversation = sequenced_call
+        entry = _run(child)
+
+        assert entry["status"] == "failed"
+        assert entry["exit_reason"] == "rate_limited"
+        assert entry["error"] == "HTTP 429 rate limit"
+        assert entry["summary"] == "API call failed after 3 retries: HTTP 429"
+        assert entry["api_calls"] == 4
+        assert entry["schema_retries"] == 1
+        assert entry["schema_valid"] is False
+        assert len(child.calls) == 2
+
+    def test_real_iteration_exhaustion_keeps_truncated_completed_summary(self):
+        child = _StubChild(["unused"])
+        child.calls = []
+
+        def exhausted_call(user_message, task_id=None, **_kwargs):
+            child.calls.append(user_message)
+            return {
+                "final_response": "Partial but usable summary",
+                "completed": False,
+                "failed": False,
+                "turn_exit_reason": "max_iterations_reached(5/5)",
+                "api_calls": 5,
+                "messages": [],
+            }
+
+        child.run_conversation = exhausted_call
+        entry = _run(child)
+
+        assert entry["status"] == "completed"
+        assert entry["exit_reason"] == "max_iterations"
+        assert entry["truncated"] is True
+        assert len(child.calls) == 1
+
 
 # ---------------------------------------------------------------------------
 # delegate_task dispatch-time schema handling

--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -201,6 +201,7 @@ class TestRunSingleChildTimeoutDump:
 
         assert result["status"] == "timeout"
         assert result["api_calls"] == 0
+        assert result["model"] == "test/model"
         assert result["diagnostic_path"] is not None
         dump_path = Path(result["diagnostic_path"])
         assert dump_path.is_file()
@@ -235,6 +236,7 @@ class TestRunSingleChildTimeoutDump:
         )
 
         assert result["status"] == "error"
+        assert result["model"] == "test/model"
         assert result["timeout_seconds"] is None
         assert result["timed_out_after_seconds"] is None
         assert result["timeout_phase"] is None

--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -134,6 +134,68 @@ class TestRunBashCwdRecovery:
         assert env.cwd == str(tmp_path)
         assert not any("missing on disk" in rec.message for rec in caplog.records)
 
+    def test_recovered_cwd_is_used_by_wrapped_command(self, tmp_path):
+        """The shell wrapper must not re-cd into the deleted directory.
+
+        ``_run_bash`` historically repaired only ``Popen(cwd=...)`` after
+        ``_wrap_command`` had already embedded the stale path.  The process
+        started successfully, then the wrapper exited 126 before the user's
+        command ran — exactly what happens after a lander removes its own git
+        worktree.
+        """
+        wedged = tmp_path / "landed-worktree"
+        wedged.mkdir()
+        env = LocalEnvironment(cwd=str(wedged), timeout=10)
+        try:
+            shutil.rmtree(wedged)
+            result = env.execute("printf 'COMMAND_RAN\\n'; pwd")
+        finally:
+            env.cleanup()
+
+        assert result["returncode"] == 0
+        assert "COMMAND_RAN" in result["output"]
+        assert str(tmp_path) in result["output"]
+        assert env.cwd == str(tmp_path)
+
+    def test_missing_explicit_cwd_fails_instead_of_running_in_parent(self, tmp_path):
+        """Recovery is for stale session state, never caller input.
+
+        Silently running a destructive command in the nearest surviving parent
+        when its explicit workdir is absent is worse than the original failure.
+        """
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            missing = tmp_path / "explicit-does-not-exist"
+            result = env.execute("printf 'MUST_NOT_RUN\\n'", cwd=str(missing))
+        finally:
+            env.cleanup()
+
+        assert result["returncode"] != 0
+        assert "MUST_NOT_RUN" not in result["output"]
+        assert env.cwd == str(tmp_path)
+
+    def test_explicit_tilde_keeps_existing_shell_semantics(self, tmp_path):
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            result = env.execute("pwd", cwd="~")
+        finally:
+            env.cleanup()
+
+        assert result["returncode"] == 0
+        assert os.path.realpath(result["output"].strip()) == os.path.realpath(os.path.expanduser("~"))
+
+    def test_explicit_relative_cwd_resolves_below_session_cwd(self, tmp_path):
+        child = tmp_path / "child"
+        child.mkdir()
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+        try:
+            result = env.execute("pwd", cwd="child")
+        finally:
+            env.cleanup()
+
+        assert result["returncode"] == 0
+        assert os.path.realpath(result["output"].strip()) == os.path.realpath(child)
+
 
 class TestUpdateCwdRejectsMissingPaths:
     """``_update_cwd`` must not propagate a deleted path back into ``self.cwd``."""

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -1174,6 +1174,18 @@ def _push_batch_completion_event(
 
     dispatched_at = event_record.get("dispatched_at") or time.time()
     completed_at = event_record.get("completed_at") or time.time()
+    results = combined.get("results") or []
+    event_model = event_record.get("model")
+    if not event_model:
+        effective_models = {
+            str(result.get("model"))
+            for result in results
+            if isinstance(result, dict) and result.get("model")
+        }
+        if len(effective_models) == 1:
+            event_model = next(iter(effective_models))
+        elif len(effective_models) > 1:
+            event_model = "mixed"
     evt = {
         "type": "async_delegation",
         "delegation_id": event_record.get("delegation_id"),
@@ -1186,12 +1198,12 @@ def _push_batch_completion_event(
         "context": event_record.get("context"),
         "toolsets": event_record.get("toolsets"),
         "role": event_record.get("role"),
-        "model": event_record.get("model"),
+        "model": event_model,
         "status": status,
         "is_batch": True,
         # The full per-task results list — the formatter renders a
         # consolidated multi-task block from this.
-        "results": combined.get("results") or [],
+        "results": results,
         # Per-task live transcript log paths (cache/delegation/live/...).
         # They persist after completion and double as the full-fidelity
         # operational record of each child's run.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2896,6 +2896,11 @@ def _run_single_child(
                 "status": "timeout" if is_timeout else "error",
                 "summary": None,
                 "error": _err,
+                "model": (
+                    getattr(child, "model", None)
+                    if isinstance(getattr(child, "model", None), str)
+                    else None
+                ),
                 "exit_reason": "timeout" if is_timeout else "error",
                 "api_calls": child_api_calls,
                 "duration_seconds": duration,
@@ -2946,6 +2951,7 @@ def _run_single_child(
                 not _schema_valid
                 and _first_text.strip()
                 and not result.get("interrupted", False)
+                and result.get("failed") is not True
             ):
                 # Exactly one retry turn, carrying the validation errors
                 # verbatim (no schema re-paste — the child already holds
@@ -2974,6 +2980,19 @@ def _run_single_child(
                         ) + int(_retry_result.get("api_calls", 0) or 0)
                     except (TypeError, ValueError):
                         pass
+                    # The correction turn is the terminal turn. Preserve its
+                    # success/failure semantics rather than keeping the first
+                    # (schema-invalid) completion flags and merely swapping text.
+                    for _terminal_field in (
+                        "completed",
+                        "failed",
+                        "interrupted",
+                        "error",
+                        "failure_reason",
+                        "turn_exit_reason",
+                    ):
+                        if _terminal_field in _retry_result:
+                            result[_terminal_field] = _retry_result[_terminal_field]
                     _retry_messages = _retry_result.get("messages")
                     if isinstance(_retry_messages, list) and isinstance(
                         result.get("messages"), list
@@ -3010,6 +3029,13 @@ def _run_single_child(
         summary = result.get("final_response") or ""
         completed = result.get("completed", False)
         interrupted = result.get("interrupted", False)
+        failed = result.get("failed") is True
+        turn_exit_reason = str(result.get("turn_exit_reason") or "")
+        iteration_exhausted = (
+            not completed
+            and not failed
+            and turn_exit_reason.startswith("max_iterations_reached(")
+        )
         api_calls = result.get("api_calls", 0)
 
         # The child emits the literal "(empty)" sentinel (see run_agent.py) when
@@ -3021,10 +3047,15 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
-        elif summary and not _empty_sentinel:
+        elif failed:
+            status = "failed"
+        elif completed and summary and not _empty_sentinel:
+            status = "completed"
+        elif iteration_exhausted and summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
-            # exit_reason ("completed" vs "max_iterations") already
-            # tells the parent *how* the task ended.
+            # The explicit max-iteration turn reason tells the parent *how*
+            # the task ended without conflating transport/content-policy
+            # failures that also return non-empty user-facing prose.
             status = "completed"
         else:
             status = "failed"
@@ -3070,10 +3101,18 @@ def _run_single_child(
         # Determine exit reason
         if interrupted:
             exit_reason = "interrupted"
+        elif failed:
+            exit_reason = (
+                result.get("failure_reason")
+                or turn_exit_reason
+                or "error"
+            )
         elif completed:
             exit_reason = "completed"
-        else:
+        elif iteration_exhausted:
             exit_reason = "max_iterations"
+        else:
+            exit_reason = turn_exit_reason or "incomplete"
 
         # Extract token counts (safe for mock objects)
         _input_tokens = getattr(child, "session_prompt_tokens", 0)
@@ -3279,6 +3318,11 @@ def _run_single_child(
             "status": "error",
             "summary": None,
             "error": str(exc),
+            "model": (
+                getattr(child, "model", None)
+                if isinstance(getattr(child, "model", None), str)
+                else None
+            ),
             "api_calls": 0,
             "duration_seconds": duration,
             "_child_role": getattr(child, "_delegate_role", None),

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -848,6 +848,16 @@ class BaseEnvironment(ABC):
         """
         return shlex.quote(path)
 
+    def _resolve_execution_cwd(self, cwd: str) -> str:
+        """Return the cwd embedded in the command wrapper.
+
+        Remote backends must resolve paths inside their own filesystem, so the
+        base implementation is deliberately a no-op.  LocalEnvironment
+        overrides this hook to repair a directory deleted by an earlier tool
+        call before both the wrapper's ``cd`` and ``Popen(cwd=...)`` are built.
+        """
+        return cwd
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
@@ -1428,7 +1438,10 @@ class BaseEnvironment(ABC):
             from tools.terminal_tool import _rewrite_compound_background
             exec_command = _rewrite_compound_background(exec_command)
         effective_timeout = timeout or self.timeout
-        effective_cwd = cwd or self.cwd
+        # Recovery applies only to stale session state.  An explicit caller
+        # cwd keeps its original shell semantics (including relative paths and
+        # ``~``) and must fail rather than silently run in a surviving parent.
+        effective_cwd = cwd or self._resolve_execution_cwd(self.cwd)
 
         # Merge sudo stdin with caller stdin
         if sudo_stdin is not None and stdin_data is not None:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1777,6 +1777,29 @@ class LocalEnvironment(BaseEnvironment):
         """Rewrite native/mixed Windows paths before quoting for Git Bash."""
         return _quote_bash_path(path)
 
+    def _resolve_execution_cwd(self, cwd: str) -> str:
+        """Repair a stale local cwd before the shell wrapper embeds its ``cd``.
+
+        ``_run_bash`` also guards ``Popen(cwd=...)`` as a final safety net, but
+        that is too late for the command string: ``BaseEnvironment.execute``
+        has already wrapped the stale path by then.  Resolve it at the shared
+        pre-wrap hook and update the persistent cwd when the stale value was
+        this environment's own session directory.
+        """
+        safe_cwd = _resolve_safe_cwd(cwd)
+        if safe_cwd != cwd:
+            normalized = _msys_to_windows_path(cwd) if _IS_WINDOWS else cwd
+            if safe_cwd != normalized:
+                logger.warning(
+                    "LocalEnvironment cwd %r is missing on disk; "
+                    "falling back to %r so terminal commands keep working.",
+                    cwd,
+                    safe_cwd,
+                )
+            if cwd == self.cwd:
+                self.cwd = safe_cwd
+        return safe_cwd
+
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:


### PR DESCRIPTION
## Summary

- Repair a deleted local session cwd before both the wrapped shell `cd` and `Popen(cwd=...)`, while preserving explicit missing/relative/tilde cwd semantics.
- Reject duplicate model-emitted JSON tool-argument keys instead of silently discarding earlier values.
- Preserve delegated API/transport failures and their terminal cause; do not schema-retry error prose or relabel it max-iterations.
- Surface the effective child model on normal, timeout, and error async-batch completion instead of `Model: ?`.

## Why

A long-running multi-agent foreman session exposed all four defects in one lineage: a lander retired the caller's worktree and wedged later commands; duplicate `command` keys silently changed a tool action; rate-limited children were reported completed/truncated; inherited-model error banners rendered unknown.

## Verification

- Focused regressions: 78 passed
- Affected delegation/cwd/terminal/guardrail pack: 359 passed, 22 skipped
- Python compileall: clean
- `git diff --check`: clean
- Independent read-only exact-worktree review: PASS on base `3eb761c51`; no blocking correctness issue

## Safety

The cwd recovery applies only to stale persisted session state. Explicit caller workdirs keep prior shell behavior and fail rather than executing in a surviving parent.
