### PR TITLE
feat(model): add minimax/minimax-m2.5 to curated OpenRouter catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -115,6 +115,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("moonshotai/kimi-k3",                     "recommended"),
     # MiniMax
     ("minimax/minimax-m3",                     ""),
+    ("minimax/minimax-m2.5",                   ""),
     # Z-AI
     ("z-ai/glm-5.3",                           ""),
     ("z-ai/glm-5.2",                           "default"),
@@ -293,6 +294,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "moonshotai/kimi-k3",
         # MiniMax
         "minimax/minimax-m3",
+        "minimax/minimax-m2.5",
         # Z-AI
         "z-ai/glm-5.3",
         "z-ai/glm-5.2",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -117,6 +117,10 @@
           "description": ""
         },
         {
+          "id": "minimax/minimax-m2.5",
+          "description": ""
+        },
+        {
           "id": "z-ai/glm-5.3",
           "description": ""
         },
@@ -266,7 +270,10 @@
           "id": "minimax/minimax-m3"
         },
         {
-          "id": "z-ai/glm-5.3"
+          "id": "minimax/minimax-m2.5"
+        },
+        {
+          "id": "z-ai/glm-5.3" 
         },
         {
           "id": "z-ai/glm-5.2",


### PR DESCRIPTION
## Summary

Adds `minimax/minimax-m2.5` (200K context, tools support) to the curated model catalog, alongside the existing `minimax-m3` entry.

## Changes

- **hermes_cli/models.py**: Added to `OPENROUTER_MODELS` and `_PROVIDER_MODELS['nous']`
- **website/static/api/model-catalog.json**: Added to both `openrouter` and `nous` provider blocks

## Verification

- Context length metadata already exists (`minimax` catch-all = 204800)
- `fetch_openrouter_models(force_refresh=True)` confirmed model is reachable on OpenRouter
- All 98 existing model catalog tests pass