### PR TITLE
fix(gateway): preserve session key in background tasks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22738,6 +22738,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_name=source.chat_name,
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
+                    gateway_session_key=self._session_key_for_source(source),
                     session_db=getattr(self._session_db, "_db", self._session_db),
                     # Reload from disk — do not reuse the startup snapshot (#60955).
                     fallback_model=self._refresh_fallback_model(),

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -167,6 +167,7 @@ class TestRunBackgroundTask:
         assert agent_kwargs["checkpoint_max_snapshots"] == 8
         assert agent_kwargs["checkpoint_max_total_size_mb"] == 222
         assert agent_kwargs["checkpoint_max_file_size_mb"] == 3
+        assert agent_kwargs["gateway_session_key"] == runner._session_key_for_source(source)
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
 


### PR DESCRIPTION
## Summary
- pass the originating gateway session key into `/background` agents
- prevent background memory providers from falling back to the global Honcho session
- add a regression assertion for the agent constructor

## Test plan
- `uv run --extra dev pytest tests/gateway/test_background_command.py -q -o 'addopts='`\n- Result: 7 passed