### PR TITLE
fix: file paths containing lifecycle words no longer trip the gateway guard (#77173, salvage #77536)

### DIFF
--- a/contributors/emails/hermes@mingjing.dev
+++ b/contributors/emails/hermes@mingjing.dev
@@ -1,0 +1,1 @@
+eaglezzz0522-cloud

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -64,7 +64,13 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # `start` is intentionally excluded: starting a gateway from inside a
     # gateway is benign (a no-op or "already running" error), and a
     # legitimate cron job might start a sibling profile's gateway.
-    r"(?:hermes\s+gateway\s+(?:restart|stop)\b)"
+    # The leading separator class (#77173): `hermes` must sit at command
+    # position — start of text, after whitespace/`;`/`&`/`|`, or inside a
+    # substitution/subshell opener — not be a path component. Without it, a
+    # file path with embedded spaces like `/docs/hermes gateway
+    # restart-notes.md` matched via the `/hermes` tail and hard-blocked an
+    # innocent `cat`.
+    r"(?:(?:^|[\s;&|(`])hermes\s+gateway\s+(?:restart|stop)\b)"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -64,13 +64,13 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # `start` is intentionally excluded: starting a gateway from inside a
     # gateway is benign (a no-op or "already running" error), and a
     # legitimate cron job might start a sibling profile's gateway.
-    # The leading separator class (#77173): `hermes` must sit at command
-    # position — start of text, after whitespace/`;`/`&`/`|`, or inside a
-    # substitution/subshell opener — not be a path component. Without it, a
-    # file path with embedded spaces like `/docs/hermes gateway
-    # restart-notes.md` matched via the `/hermes` tail and hard-blocked an
-    # innocent `cat`.
-    r"(?:(?:^|[\s;&|(`])hermes\s+gateway\s+(?:restart|stop)\b)"
+    # The lookbehind (#77173): `hermes` must not be a path component or a
+    # word tail. Excluding `/`, word chars, `.` and `-` keeps file paths
+    # with embedded spaces (`/docs/hermes gateway restart-notes.md`) from
+    # matching via the `/hermes` tail, while every real command position
+    # (start of text, whitespace, `;`/`&`/`|`, `$(`, backtick, even a
+    # U+FFFD from binary-content decoding) still matches.
+    r"(?:(?<![/\w.\-])hermes\s+gateway\s+(?:restart|stop)\b)"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -160,6 +160,11 @@ class TestGatewayLifecyclePattern:
         # #92372 Branch D: `p?kill` without a leading \b matched the "kill"
         # tail of "skill".
         "hermes skill view gateway-notes && echo hermes gateway docs",
+        # #77173/#77536: a file path with embedded spaces containing the
+        # lifecycle words must not match — `hermes` is a path component
+        # there, not a command.
+        "cat '/docs/hermes gateway restart-notes.md'",
+        "less /home/user/notes/hermes gateway restart runbook.txt",
     ])
     def test_safe_commands(self, text):
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
@@ -169,6 +174,12 @@ class TestGatewayLifecyclePattern:
         "hermes gateway restart",
         "hermes gateway restart; echo done",
         "hermes gateway stop && echo stopped",
+        # #77173 command-position anchor must not weaken separator/subshell
+        # forms either.
+        "true;hermes gateway restart",
+        "true && hermes gateway stop",
+        "echo $(hermes gateway restart)",
+        "echo `hermes gateway restart`",
     ])
     def test_boundary_fix_still_blocks_real_commands(self, text):
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1404,7 +1404,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
             def execute(self, command, **kwargs):
                 calls.append(command)
                 if "head -c" in command and "/remote/workspace/remote.sh" in command:
-                    return {"output": "#!/bin/bash\\nhermes gateway restart\\n", "returncode": 0}
+                    return {"output": "#!/bin/bash\nhermes gateway restart\n", "returncode": 0}
                 return {"output": "", "returncode": 0}
 
         fake_env = _RemoteEnv()


### PR DESCRIPTION
## Summary

A file path with embedded spaces containing the lifecycle words — `/docs/hermes gateway restart-notes.md` — no longer trips the gateway lifecycle guard: Branch A now requires `hermes` to sit at command position via a negative lookbehind (`(?<![/\w.\-])`), so path components can't match while every real command shape (bare, chained, subshell, `$()`, backtick, binary-decoded U+FFFD-adjacent) still blocks.

This is the last live false-positive shape from the #77173 family — the directory and oversized-ELF scanner bugs it reported are already fixed on main (verified live). Salvages PR #77536 by @eaglezzz0522-cloud, reapplied onto the current pattern.

Closes #77173.

## Changes

- `cron/lifecycle_guard.py` (@eaglezzz0522-cloud): negative lookbehind anchoring Branch A at command position
- follow-up commit: lookbehind form (instead of the PR's separator class) so fail-closed binary-content and remote-read scans keep working; fixed a latent test fixture that passed literal `\n` instead of newlines
- `tests/hermes_cli/test_gateway_restart_loop.py`: path false-positive cases + command-position still-blocks cases

## Validation

| Case | Before | After |
|---|---|---|
| `cat '/docs/hermes gateway restart-notes.md'` | BLOCKED (false positive) | allowed |
| `hermes gateway restart` (bare/chained/`$()`/backtick) | blocked | still blocked |
| binary bytes decoding adjacent to CLI name | blocked (fail closed) | still blocked |
| remote `head -c` script read containing lifecycle command | blocked | still blocked |

Sabotage-verified both directions: reverting to the unanchored pattern makes the new safe cases false-block (2/2). 180/180 targeted tests.

## Infographic

![Path or command? The guard now knows](https://v3b.fal.media/files/b/0aa78d62/iv07y6EjcoV0Om4sXZFrl_LWBRIpkn.png)
