### PR TITLE
fix(agent): tool results survive divergent id/call_id variants at all four pairing sites (#93251, salvages #56148 #58287 #66974 #91768)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3826,6 +3826,14 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # that reuses the id re-arms that id first.
     seen_assistant_call_ids: set = set()
     outstanding_call_ids: set = set()
+    # Variant → full variant-set of the tool_call it belongs to, so answering
+    # or deduping one variant consumes its siblings too. A Codex/Responses
+    # tool_call registers BOTH ``id`` (fc_...) and ``call_id`` (call_...)
+    # (#55626/#58168); tracking only the coalesced id here made a result
+    # keyed on the OTHER variant look like it answered no outstanding call,
+    # so this pass deleted the very result step 2's variant-aware matching
+    # had just preserved (issue #93251 — whole parallel batches vanished).
+    dedup_id_siblings: Dict[str, set] = {}
     deduped: List[Dict[str, Any]] = []
     removed_dupes = 0
     for msg in messages:
@@ -3833,13 +3841,14 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         if role == "assistant" and msg.get("tool_calls"):
             kept_tcs = []
             for tc in msg.get("tool_calls") or []:
-                cid = _ra().AIAgent._get_tool_call_id_static(tc)
-                if cid and cid in seen_assistant_call_ids:
+                variants = _tool_call_id_variants(tc)
+                if variants and variants & seen_assistant_call_ids:
                     removed_dupes += 1
                     continue
-                if cid:
+                for cid in variants:
                     seen_assistant_call_ids.add(cid)
                     outstanding_call_ids.add(cid)
+                    dedup_id_siblings[cid] = variants
                 kept_tcs.append(tc)
             if kept_tcs:
                 msg = {**msg, "tool_calls": kept_tcs}
@@ -3852,11 +3861,13 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 removed_dupes += 1
                 continue
             if cid:
-                # Answered: this id is no longer outstanding, so a second
-                # result replaying it is still caught above.
-                outstanding_call_ids.discard(cid)
-                # A reused id must be re-armable by the next assistant call.
-                seen_assistant_call_ids.discard(cid)
+                # Answered: consume EVERY variant of the matched call so a
+                # second result replaying either sibling is still caught
+                # above, and the ids are re-armable by the next assistant
+                # call that reuses them.
+                for sibling in dedup_id_siblings.get(cid, {cid}):
+                    outstanding_call_ids.discard(sibling)
+                    seen_assistant_call_ids.discard(sibling)
             deduped.append(msg)
         else:
             deduped.append(msg)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -720,9 +720,19 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             known_tool_ids = set()
             tool_id_siblings = {}
             for tc in (msg.get("tool_calls") or []):
-                if not isinstance(tc, dict):
-                    continue
-                variants = {tc.get(key) for key in ("id", "call_id") if tc.get(key)}
+                # Mirror ``_get_tool_call_id_static``'s dict-or-object
+                # tolerance: SDK tool_call objects (e.g. an unserialized
+                # ``ChatCompletionMessageToolCall``) reach this pass on
+                # host-fed / pre-serialization histories just as often as
+                # plain dicts. Skipping non-dict entries left
+                # ``known_tool_ids`` empty for such messages, so the
+                # following legitimate ``tool`` result was misclassified
+                # as orphaned and silently dropped.
+                variants = set()
+                for key in ("id", "call_id"):
+                    tc_id = tc.get(key) if isinstance(tc, dict) else getattr(tc, key, None)
+                    if tc_id:
+                        variants.add(tc_id)
                 for tc_id in variants:
                     known_tool_ids.add(tc_id)
                     tool_id_siblings[tc_id] = variants

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3456,6 +3456,25 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     return None
 
 
+def _tool_call_id_variants(tc: Any) -> set:
+    """Return every id a tool result might legitimately match this tool_call on.
+
+    A tool_call can carry both ``call_id`` and ``id`` with different values
+    (Responses-API / codex flows), and different code paths key the matching
+    ``role="tool"`` result's ``tool_call_id`` off one or the other. Returning
+    all non-empty variants lets the sanitizer treat a result matching ANY of
+    them as paired, so a valid result is never falsely orphaned and dropped.
+    """
+    variants: set = set()
+    if isinstance(tc, dict):
+        candidates = (tc.get("call_id"), tc.get("id"))
+    else:
+        candidates = (getattr(tc, "call_id", None), getattr(tc, "id", None))
+    for c in candidates:
+        if isinstance(c, str) and c.strip():
+            variants.add(c.strip())
+    return variants
+
 
 # Placeholder substituted for an empty non-final message that would otherwise
 # make the provider reject the whole request. Kept identical to the stub-
@@ -3696,8 +3715,18 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     for msg in messages:
         if msg.get("role") == "assistant":
             for tc in msg.get("tool_calls") or []:
-                cid = _ra().AIAgent._get_tool_call_id_static(tc)
-                if cid:
+                # A tool_call may carry BOTH ``call_id`` and ``id`` with
+                # DIFFERENT values (e.g. Responses-API / codex tool calls,
+                # where ``id`` is a ``fc_...`` response-item id distinct from
+                # the ``call_...`` id). ``_get_tool_call_id_static`` returns
+                # only the preferred one (``call_id``), but a tool result
+                # keyed on the OTHER id would then look orphaned and get
+                # dropped + replaced with a bogus "[Result unavailable]"
+                # stub — silently eating a perfectly valid tool result
+                # (#55626). Register EVERY id variant so a result matching
+                # any of them survives. This is purely additive: it can only
+                # prevent false drops, never introduce new ones.
+                for cid in _tool_call_id_variants(tc):
                     surviving_call_ids.add(cid)
 
     result_call_ids: set = set()
@@ -3719,26 +3748,37 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             len(orphaned_results),
         )
 
-    # 2. Inject stub results for calls whose result was dropped
-    missing_results = surviving_call_ids - result_call_ids
-    if missing_results:
-        patched: List[Dict[str, Any]] = []
-        for msg in messages:
-            patched.append(msg)
-            if msg.get("role") == "assistant":
-                for tc in msg.get("tool_calls") or []:
-                    cid = _ra().AIAgent._get_tool_call_id_static(tc)
-                    if cid in missing_results:
-                        patched.append({
-                            "role": "tool",
-                            "name": _ra().AIAgent._get_tool_call_name_static(tc),
-                            "content": "[Result unavailable — see context summary above]",
-                            "tool_call_id": cid,
-                        })
+    # 2. Inject stub results for calls whose result was dropped.
+    #    A call is "answered" when ANY of its id variants (call_id/id) has a
+    #    matching result, so a call answered via its ``id`` (fc_...) is not
+    #    mistaken for unanswered just because its distinct ``call_id`` has no
+    #    result of its own (#55626).
+    stub_count = 0
+    patched: List[Dict[str, Any]] = []
+    for msg in messages:
+        patched.append(msg)
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                variants = _tool_call_id_variants(tc)
+                if not variants:
+                    continue
+                if variants & result_call_ids:
+                    continue  # already answered on some id variant
+                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                if not cid:
+                    continue
+                patched.append({
+                    "role": "tool",
+                    "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                    "content": "[Result unavailable — see context summary above]",
+                    "tool_call_id": cid,
+                })
+                stub_count += 1
+    if stub_count:
         messages = patched
         _ra().logger.debug(
             "Pre-call sanitizer: added %d stub tool result(s)",
-            len(missing_results),
+            stub_count,
         )
 
     # 3. Deduplicate tool_call_ids. Strict providers (DeepSeek) reject a

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -707,6 +707,9 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     # ``_get_tool_call_id_static``'s ``call_id || id`` — a match set must
     # accept every legitimate reference, not just the canonical one (#58168).
     known_tool_ids: set = set()
+    # Maps every registered id variant back to the full variant set of the
+    # tool_call it came from, so consuming one variant consumes its siblings.
+    tool_id_siblings: Dict[str, set] = {}
     filtered: List[Dict] = []
     for msg in collapsed:
         if not isinstance(msg, dict):
@@ -715,13 +718,14 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         role = msg.get("role")
         if role == "assistant":
             known_tool_ids = set()
+            tool_id_siblings = {}
             for tc in (msg.get("tool_calls") or []):
                 if not isinstance(tc, dict):
                     continue
-                for key in ("id", "call_id"):
-                    tc_id = tc.get(key)
-                    if tc_id:
-                        known_tool_ids.add(tc_id)
+                variants = {tc.get(key) for key in ("id", "call_id") if tc.get(key)}
+                for tc_id in variants:
+                    known_tool_ids.add(tc_id)
+                    tool_id_siblings[tc_id] = variants
             filtered.append(msg)
         elif role == "tool":
             tc_id = msg.get("tool_call_id")
@@ -732,7 +736,16 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 # glitch) falls into the drop branch below instead of being
                 # replayed — strict providers (DeepSeek) reject a duplicate
                 # tool_call_id with HTTP 400 (#58327). Credit: #55436.
-                known_tool_ids.discard(tc_id)
+                #
+                # Consume EVERY variant of the matched call, not just the one
+                # this result referenced. A Codex/Responses tool_call registers
+                # both ``id`` (``fc_...``) and ``call_id`` (``call_...``) above
+                # (#58168), so discarding only the matched key leaves its
+                # sibling live — and a duplicate result keyed on that sibling
+                # sails straight through this guard, re-creating the very 400
+                # the consume step exists to prevent.
+                for sibling in tool_id_siblings.get(tc_id, {tc_id}):
+                    known_tool_ids.discard(sibling)
             else:
                 repairs += 1
         else:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5688,10 +5688,33 @@ This compaction should PRIORITISE preserving all information related to the focu
 
     @staticmethod
     def _get_tool_call_id(tc) -> str:
-        """Extract the call ID from a tool_call entry (dict or SimpleNamespace)."""
+        """Extract the canonical call ID from a tool_call entry (dict or
+        SimpleNamespace), for logging/display only. Matching logic must use
+        :meth:`_tool_call_id_variants` instead — see its docstring."""
         if isinstance(tc, dict):
             return tc.get("call_id", "") or tc.get("id", "") or ""
         return getattr(tc, "call_id", "") or getattr(tc, "id", "") or ""
+
+    @staticmethod
+    def _tool_call_id_variants(tc) -> set:
+        """Return every id variant a tool result might reference *tc* by.
+
+        A tool result's ``tool_call_id`` may be keyed on either ``id`` or
+        ``call_id`` depending on which code path built it — in the Codex
+        Responses API format they are distinct (``id`` is the ``fc_...``
+        response-item id, ``call_id`` is the ``call_...`` function-call id).
+        Matching on a single value (the old ``call_id || id`` precedence)
+        misclassified a genuinely matching pair as orphaned whenever the
+        result used the field that precedence didn't pick, dropping BOTH the
+        valid result and its tool_call. Registering the superset of both ids
+        is the same fix #58168 applied to ``repair_message_sequence``'s
+        known-id set.
+        """
+        if isinstance(tc, dict):
+            get = tc.get
+        else:
+            get = lambda key: getattr(tc, key, None)
+        return {v for v in (get("id"), get("call_id")) if v}
 
     def _sanitize_tool_pairs(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Fix orphaned tool_call / tool_result pairs after compression.
@@ -5719,9 +5742,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         for msg in messages:
             if msg.get("role") == "assistant":
                 for tc in msg.get("tool_calls") or []:
-                    cid = self._get_tool_call_id(tc)
-                    if cid:
-                        surviving_call_ids.add(cid)
+                    surviving_call_ids |= self._tool_call_id_variants(tc)
 
         result_call_ids: set = set()
         for msg in messages:
@@ -5744,8 +5765,11 @@ This compaction should PRIORITISE preserving all information related to the focu
         #    were dropped.  Stripping is preferred over inserting stub results
         #    because stubs can be dropped by downstream repair_message_sequence
         #    when call_id != id (Codex Responses API format), re-exposing orphans.
-        missing_results = surviving_call_ids - result_call_ids
-        if missing_results:
+        #    A tool_call survives if ANY of its id variants still has a
+        #    matching result — checking only one variant per side is exactly
+        #    the mismatch this method exists to avoid.
+        stripped_count = 0
+        if surviving_call_ids - result_call_ids:
             # --- In-flight tool chain protection (issue #79278) -------------
             # A strip here must distinguish a *pending* tool_call (the model's
             # live request whose result the executor has not yet appended) from
@@ -5790,8 +5814,9 @@ This compaction should PRIORITISE preserving all information related to the focu
                 tcs = msg.get("tool_calls")
                 if not tcs:
                     continue
-                kept = [tc for tc in tcs if self._get_tool_call_id(tc) not in missing_results]
+                kept = [tc for tc in tcs if self._tool_call_id_variants(tc) & result_call_ids]
                 if len(kept) != len(tcs):
+                    stripped_count += len(tcs) - len(kept)
                     if kept:
                         msg["tool_calls"] = kept
                     else:
@@ -5801,10 +5826,10 @@ This compaction should PRIORITISE preserving all information related to the focu
                         content = msg.get("content")
                         if not content or (isinstance(content, str) and not content.strip()):
                             msg["content"] = "(tool call removed)"
-            if not self.quiet_mode:
+            if stripped_count and not self.quiet_mode:
                 logger.info(
                     "Compression sanitizer: stripped %d orphaned tool_call(s) from assistant messages",
-                    len(missing_results),
+                    stripped_count,
                 )
 
         return messages

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2514,7 +2514,9 @@ class TestSanitizerStripsOrphanedToolCalls:
         """Negative control: registering both id and call_id must not
         over-relax orphan detection. A genuinely orphaned tool_call (no
         result matching either id variant) is still stripped, while a valid
-        dual-id pair in the same window survives."""
+        dual-id pair in the same window survives. A trailing user turn keeps
+        the assistant message out of the in-flight protection window (#79278),
+        which intentionally preserves a still-pending trailing call."""
         msgs = [
             {
                 "role": "assistant",
@@ -2535,6 +2537,7 @@ class TestSanitizerStripsOrphanedToolCalls:
                 ],
             },
             {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            {"role": "user", "content": "next question"},
         ]
 
         sanitized = compressor._sanitize_tool_pairs(msgs)

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2477,6 +2477,72 @@ class TestSanitizerStripsOrphanedToolCalls:
         assert not asst.get("tool_calls")
         # No stub tool messages (which would have call_id != id mismatch)
 
+    def test_sanitizer_keeps_valid_pair_matching_on_id_not_call_id(self, compressor):
+        """A genuinely matching Codex-format pair must survive when the
+        result's tool_call_id matches ``id`` rather than ``call_id`` (#58168
+        class). ``_get_tool_call_id``'s ``call_id || id`` precedence picks
+        ``call_id`` first, so building the known-id set from a single value
+        per tool_call misclassified this valid pair as orphaned on BOTH
+        sides — dropping the result AND stripping the tool_call, even though
+        neither was actually orphaned."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "fc_777",
+                        "call_id": "call_777",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "fc_777", "content": "result"},
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        asst = next(m for m in sanitized if m.get("role") == "assistant")
+        assert asst.get("tool_calls"), "valid tool_call must not be stripped"
+        assert asst["tool_calls"][0]["id"] == "fc_777"
+        tool_msgs = [m for m in sanitized if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1, "valid tool result must not be dropped as orphaned"
+        assert tool_msgs[0]["tool_call_id"] == "fc_777"
+
+    def test_sanitizer_still_drops_genuine_orphan_with_dual_ids(self, compressor):
+        """Negative control: registering both id and call_id must not
+        over-relax orphan detection. A genuinely orphaned tool_call (no
+        result matching either id variant) is still stripped, while a valid
+        dual-id pair in the same window survives."""
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "fc_1",
+                        "call_id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    },
+                    {
+                        "id": "fc_2",
+                        "call_id": "call_2",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+        ]
+
+        sanitized = compressor._sanitize_tool_pairs(msgs)
+
+        asst = next(m for m in sanitized if m.get("role") == "assistant")
+        surviving_ids = {tc["id"] for tc in asst.get("tool_calls") or []}
+        assert surviving_ids == {"fc_1"}
+
 
 class TestSanitizerPreservesInFlightToolChain:
     """Issue #79278: an in-flight tool call chain must survive compression.

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -503,6 +503,44 @@ def test_repair_drops_stale_empty_tool_calls_on_merged_assistant():
     assert "second" in assistants[0]["content"]
 
 
+def test_repair_keeps_tool_result_when_tool_calls_are_sdk_objects():
+    """repair_message_sequence must not drop a valid tool result just because
+    the assistant's ``tool_calls`` entries are unserialized SDK objects
+    (e.g. ``ChatCompletionMessageToolCall``) instead of plain dicts.
+
+    Host-fed / pre-serialization histories (gateway multi-queue replay,
+    session resume) can carry SDK tool_call objects into this pass. The
+    dict-only ``tc.get(key)`` lookup previously left ``known_tool_ids``
+    empty for such messages, so the id-matching pass below misclassified
+    the legitimate tool result as an orphan and silently deleted it —
+    corrupting the persisted history and leaving the assistant's
+    tool_calls unanswered (itself a strict-provider HTTP 400 trigger)."""
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    class SDKToolCall:
+        def __init__(self, call_id):
+            self.id = call_id
+            self.call_id = None
+            self.function = type("F", (), {"name": "read_file", "arguments": "{}"})()
+
+    messages = [
+        {"role": "user", "content": "read the file"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [SDKToolCall("call_1")],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "file contents"},
+    ]
+    agent = type("Agent", (), {})()
+    repair_message_sequence(agent, messages)
+
+    roles = [m.get("role") for m in messages]
+    assert "tool" in roles, "legitimate tool result was dropped as a false orphan"
+    tool_msg = next(m for m in messages if m.get("role") == "tool")
+    assert tool_msg["content"] == "file contents"
+
+
 
 
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -654,3 +654,84 @@ def test_repair_keeps_both_results_for_two_codex_calls_mixed_keys():
 
     assert repairs == 0
     assert [m["content"] for m in messages if m.get("role") == "tool"] == ["r1", "r2"]
+
+
+def test_sanitize_dedup_pass_keeps_batch_results_keyed_on_divergent_id():
+    """The step-3 dedup pass must not delete real results whose tool_call_id
+    matches the non-coalesced id variant.
+
+    A parallel batch of Codex/Responses-style tool_calls carries divergent
+    ``id`` (fc_...) and ``call_id`` (call_...). Step 2's variant-aware
+    matching preserves results keyed on either variant, but the dedup pass
+    tracked only the coalesced (call_id||id) value in
+    ``outstanding_call_ids`` — so every result keyed on ``id`` looked like it
+    answered no outstanding call and was deleted wholesale. Whole parallel
+    batches vanished with no stub at all (#93251, #55626 class).
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": f"fc_{i}", "call_id": f"call_{i}", "type": "function",
+             "function": {"name": "terminal", "arguments": "{}"}}
+            for i in range(4)
+        ]},
+    ] + [
+        {"role": "tool", "tool_call_id": f"fc_{i}", "content": f"REAL {i}"}
+        for i in range(4)
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    tool_msgs = [m for m in out if m.get("role") == "tool"]
+    assert [m["content"] for m in tool_msgs] == [
+        "REAL 0", "REAL 1", "REAL 2", "REAL 3",
+    ], "real batch results must survive the dedup pass"
+    assert not any("Result unavailable" in m["content"] for m in tool_msgs)
+
+
+def test_sanitize_dedup_pass_still_drops_result_replayed_on_sibling_id():
+    """Variant-aware dedup must still drop a SECOND result for an
+    already-answered call even when the replay uses the OTHER id variant
+    (strict providers 400 on duplicate tool_call_id)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "fc_1", "call_id": "call_1", "type": "function",
+             "function": {"name": "f", "arguments": "{}"}},
+        ]},
+        {"role": "tool", "tool_call_id": "fc_1", "content": "first"},
+        {"role": "tool", "tool_call_id": "call_1", "content": "sibling replay"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    tool_msgs = [m for m in out if m.get("role") == "tool"]
+    assert [m["content"] for m in tool_msgs] == ["first"]
+
+
+def test_sanitize_dedup_pass_rearms_constant_llamacpp_id():
+    """llama.cpp emits one constant id for every call; a fresh assistant call
+    re-arms the id so the second round's result still survives (#58327
+    outstanding-call semantics must be preserved by the variant-set change)."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "call_K", "type": "function",
+             "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_K", "content": "round1"},
+        {"role": "assistant", "content": "", "tool_calls": [
+            {"id": "call_K", "type": "function",
+             "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_K", "content": "round2"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    tool_msgs = [m for m in out if m.get("role") == "tool"]
+    assert [m["content"] for m in tool_msgs] == ["round1", "round2"]

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -563,3 +563,56 @@ def test_sanitize_dedup_drops_tool_calls_key_when_all_removed():
     assert "tool_calls" not in assistant2
     # Content should be preserved
     assert assistant2["content"] == "retrying"
+
+
+def test_repair_drops_duplicate_tool_result_keyed_on_sibling_id():
+    """A duplicate result must be dropped even when it uses the OTHER id variant.
+
+    A Codex/Responses ``tool_call`` carries both ``id`` (``fc_...``) and
+    ``call_id`` (``call_...``); both are registered so a result keyed on either
+    is recognised (#58168). The duplicate guard (#58327) consumed only the id
+    the first result referenced, leaving its sibling live — so a second result
+    keyed on that sibling sailed through and two tool messages were replayed
+    for a single call, re-creating the HTTP 400 the guard exists to prevent.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "fc_1", "call_id": "call_1", "type": "function",
+                         "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "first"},
+        {"role": "tool", "tool_call_id": "fc_1", "content": "duplicate"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 1
+    tool_msgs = [m for m in messages if m.get("role") == "tool"]
+    assert [m["content"] for m in tool_msgs] == ["first"]
+
+
+def test_repair_keeps_both_results_for_two_codex_calls_mixed_keys():
+    """Consuming a call's sibling ids must not orphan a *different* call.
+
+    Two parallel Codex tool_calls answered via different id variants
+    (one by ``call_id``, one by ``id``) are both legitimate and must survive.
+    """
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [
+             {"id": "fc_1", "call_id": "call_1", "type": "function",
+              "function": {"name": "f", "arguments": "{}"}},
+             {"id": "fc_2", "call_id": "call_2", "type": "function",
+              "function": {"name": "g", "arguments": "{}"}},
+         ]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "r1"},
+        {"role": "tool", "tool_call_id": "fc_2", "content": "r2"},
+    ]
+
+    repairs = AIAgent._repair_message_sequence(agent, messages)
+
+    assert repairs == 0
+    assert [m["content"] for m in messages if m.get("role") == "tool"] == ["r1", "r2"]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2848,6 +2848,51 @@ class TestHandleMaxIterations:
             "call_123"
         ]
 
+    def test_api_sanitizer_matches_responses_id_when_result_keyed_on_id(self, agent):
+        """Inverse of the call_id case: a tool_call carries BOTH ``id`` (fc_...)
+        and a distinct ``call_id``, but the matching result is keyed on ``id``.
+        The sanitizer preferred ``call_id`` only, so it treated the valid
+        result as orphaned, dropped it, and injected a bogus
+        '[Result unavailable ...]' stub — silently eating a real tool result
+        (e.g. mnemosyne_recall / cronjob list). The result must survive intact.
+        (#55626)"""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "fc_456",
+                        "call_id": "call_456",
+                        "type": "function",
+                        "function": {"name": "mnemosyne_recall", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "fc_456", "content": '{"results": [1, 2]}'},
+        ]
+
+        sanitized = agent._sanitize_api_messages(messages)
+
+        tool_msgs = [m for m in sanitized if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "fc_456"
+        assert tool_msgs[0]["content"] == '{"results": [1, 2]}'
+        assert "Result unavailable" not in tool_msgs[0]["content"]
+
+    def test_api_sanitizer_still_drops_genuinely_orphaned_result(self, agent):
+        """The id-variant matching must not weaken orphan removal: a tool result
+        whose tool_call_id matches NO assistant tool_call (neither call_id nor
+        id) is still dropped. (#55626 regression guard)"""
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "tool_call_id": "call_nomatch", "content": "orphan"},
+        ]
+
+        sanitized = agent._sanitize_api_messages(messages)
+
+        assert all(m.get("role") != "tool" for m in sanitized)
+
     def test_api_sanitizer_repairs_tool_call_with_empty_function_name(self, agent):
         """A tool_call with id but empty function.name makes the Responses-API
         adapter drop the function_call while keeping its function_call_output,


### PR DESCRIPTION
## Summary
Parallel tool batches no longer lose their results: every pairing pass (pre-call sanitizer, dedup, sequence repair, compression sanitizer) now matches tool results against BOTH id variants a tool_call can carry (`id` = `fc_...`, `call_id` = `call_...`). Previously each pass keyed on a single coalesced id, so results keyed on the other variant were dropped as orphans and replaced with `[Result unavailable]` stubs — or deleted outright by the dedup pass with no stub at all. This is the mechanism behind #93251 (P1, whole >=4-call batches lost), #55626, and the #63000 class.

Salvages four contributor fixes onto current main with authorship preserved, plus one follow-up closing the remaining gap.

## Changes
- `agent/agent_runtime_helpers.py` — `sanitize_api_messages` registers every id variant when pairing (salvage of #56148, @Bartok9); step-3 dedup pass tracks the full variant set and consumes siblings when a call is answered (follow-up — without it, step 3 deleted the very results step 2 had just preserved); `repair_message_sequence` consumes sibling ids on duplicate results (salvage of #66974, @Frowtek) and tolerates SDK tool_call objects (salvage of #91768, @JoaoMarcos44).
- `agent/context_compressor.py` — `_sanitize_tool_pairs` variant-aware on both sides (salvage of #58287, @srojk34), merged with the in-flight tool chain protection (#79278) that landed after that PR was opened.
- Tests: contributors' regression tests from all four PRs, plus new dedup-pass coverage (divergent-id batch survival, sibling-replay still dropped, llama.cpp constant-id re-arm preserved).

## Validation
| Scenario (live, current main) | Before | After |
|---|---|---|
| Batch of 4, results keyed on `id` (fc_) | 4/4 real results deleted, 0 stubs | 4/4 delivered |
| Batches 1–8, either id variant | lost when variant mismatched | all delivered |
| Compressor: valid dual-id pair | result dropped + call stripped | pair survives |
| Repair: SDK tool_call objects | result dropped as orphan | survives |
| Duplicate result on sibling id | replayed (strict-provider 400) | dropped |
| Genuine orphans / llama.cpp constant-id re-arm | — | behavior preserved |

Sabotage-verified: new dedup tests fail with the old single-id tracking. Targeted suites: 442 passed (`test_message_sequence_repair.py`, `test_run_agent.py`, `test_context_compressor.py`).

Fixes #93251. Fixes #55626. Fixes #63000.

## Infographic

![Tool results recovered — one call two ids, four sites fixed](https://v3b.fal.media/files/b/0aa78d63/zKPn6rk8qDjpkh2DR1N7Q_YZnWvscp.png)
