### PR TITLE
fix(delegate): retain partial output on timeout

### DIFF
--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -41,6 +41,7 @@ class _StubChild:
         hang_seconds: float = 5.0,
         subagent_id: str = "sa-0-stubabc",
         tool_schema=None,
+        stream_text: str = "",
     ):
         self._subagent_id = subagent_id
         self._delegate_depth = 1
@@ -64,6 +65,7 @@ class _StubChild:
         self._api_call_count = api_call_count
         self._hang = threading.Event()
         self._hang_seconds = hang_seconds
+        self._stream_text = stream_text
 
     def get_activity_summary(self):
         return {
@@ -74,6 +76,8 @@ class _StubChild:
         }
 
     def run_conversation(self, user_message, task_id=None, stream_callback=None):
+        if stream_callback and self._stream_text:
+            stream_callback(self._stream_text)
         self._hang.wait(self._hang_seconds)
         return {"final_response": "", "completed": False, "api_calls": self._api_call_count}
 
@@ -210,6 +214,18 @@ class TestRunSingleChildTimeoutDump:
         assert "without making any API call" in result["error"]
         assert "Diagnostic:" in result["error"]
         assert str(dump_path) in result["error"]
+
+    def test_timeout_preserves_streamed_partial_summary(self, hermes_home, monkeypatch):
+        child = _StubChild(
+            api_call_count=1,
+            hang_seconds=10.0,
+            stream_text="Useful partial finding before the slow tool call.",
+        )
+
+        result = self._invoke_with_short_timeout(child, monkeypatch)
+
+        assert result["status"] == "timeout"
+        assert result["summary"] == "Useful partial finding before the slow tool call."
 
 
     # ── explicit timeout metadata (#51690, salvaged from PR #60378) ────

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2772,11 +2772,22 @@ def _run_single_child(
         # Python stack (see #14726 — 0-API-call hangs are opaque without it).
         _worker_thread_holder: Dict[str, Optional[threading.Thread]] = {"t": None}
 
+        # Keep a bounded copy of streamed answer text so a timeout returns the
+        # child's useful work instead of replacing it with ``summary: None``.
+        _partial_text_parts: List[str] = []
+        _partial_text_limit = 12_000
+
         def _relay_child_text(delta: str) -> None:
             # Forward the child's streamed reply text up the progress relay so
             # gateway watch windows mirror it live (subagent.text → message.delta).
             # Inert under CLI/TUI: their progress handlers ignore non-tool events.
-            if not delta or not child_progress_cb:
+            if not delta:
+                return
+            _partial_text_parts.append(delta)
+            _partial_text = "".join(_partial_text_parts)
+            if len(_partial_text) > _partial_text_limit:
+                _partial_text_parts[:] = [_partial_text[-_partial_text_limit:]]
+            if not child_progress_cb:
                 return
             try:
                 child_progress_cb("subagent.text", preview=delta)
@@ -2818,6 +2829,7 @@ def _run_single_child(
 
             is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
             duration = round(time.monotonic() - child_start, 2)
+            partial_summary = "".join(_partial_text_parts).strip()
             logger.warning(
                 "Subagent %d %s after %.1fs",
                 task_index,
@@ -2864,7 +2876,7 @@ def _run_single_child(
                         ),
                         status="timeout" if is_timeout else "error",
                         duration_seconds=duration,
-                        summary="",
+                        summary=partial_summary,
                     )
                 except Exception:
                     pass
@@ -2894,7 +2906,7 @@ def _run_single_child(
             _error_entry = {
                 "task_index": task_index,
                 "status": "timeout" if is_timeout else "error",
-                "summary": None,
+                "summary": partial_summary or None,
                 "error": _err,
                 "exit_reason": "timeout" if is_timeout else "error",
                 "api_calls": child_api_calls,


### PR DESCRIPTION
## Summary
- retain a bounded 12,000-character copy of streamed child output
- include useful partial work in timeout/error summaries instead of returning `None`
- add regression coverage for a child that streams before timing out

## Test plan
- `uv run --extra dev pytest tests/tools/test_delegate_subagent_timeout_diagnostic.py -q -o 'addopts='`\n- Result: 5 passed