### PR TITLE
fix: isolate foreground terminal workers from gateway cgroup

### DIFF
--- a/tests/tools/test_local_foreground_systemd_scope.py
+++ b/tests/tools/test_local_foreground_systemd_scope.py
@@ -1,0 +1,145 @@
+"""Foreground local commands must not share the gateway cgroup."""
+
+import signal
+from unittest.mock import MagicMock
+
+from tools.environments.local import LocalEnvironment
+
+
+def _bare_local_environment(tmp_path):
+    env = object.__new__(LocalEnvironment)
+    env.env = {}
+    env.cwd = str(tmp_path)
+    return env
+
+
+def test_gateway_foreground_command_uses_bounded_systemd_scope(monkeypatch, tmp_path):
+    env = _bare_local_environment(tmp_path)
+    proc = MagicMock(pid=12345)
+    popen = MagicMock(return_value=proc)
+
+    monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+    monkeypatch.setattr("tools.environments.local._find_bash", lambda: "/bin/bash")
+    monkeypatch.setattr("tools.environments.local._make_run_env", lambda value: value)
+    monkeypatch.setattr("tools.environments.local.os.getpgid", lambda pid: pid)
+    monkeypatch.setattr("tools.environments.local.subprocess.Popen", popen)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+    monkeypatch.setattr(
+        "tools.process_registry._is_supervised_gateway_process", lambda: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry._systemd_run_user_scope_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry._worker_memory_max_bytes", lambda: 4 * 1024**3
+    )
+
+    result = env._run_bash("printf ready")
+
+    argv = popen.call_args.args[0]
+    assert argv[:5] == [
+        "/usr/bin/systemd-run",
+        "--user",
+        "--scope",
+        "--quiet",
+        "--unit",
+    ]
+    assert argv[5].startswith("hermes-worker-foreground-")
+    assert "MemoryMax=4294967296" in argv
+    assert "OOMPolicy=kill" in argv
+    assert argv[-4:] == ["--", "/bin/bash", "-c", "printf ready"]
+    assert getattr(result, "_hermes_systemd_unit") == f"{argv[5]}.scope"
+    assert popen.call_args.kwargs["start_new_session"] is True
+
+
+def test_kill_foreground_scope_stops_cgroup_before_process_group(monkeypatch, tmp_path):
+    env = _bare_local_environment(tmp_path)
+    proc = MagicMock(pid=12345)
+    setattr(proc, "_hermes_systemd_unit", "hermes-worker-foreground-test.scope")
+    stopped = []
+    killpg = MagicMock()
+
+    monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+    monkeypatch.setattr(
+        "tools.process_registry._stop_systemd_unit",
+        lambda unit: stopped.append(unit) or True,
+    )
+    monkeypatch.setattr("tools.environments.local.os.killpg", killpg)
+
+    env._kill_process(proc)
+
+    assert stopped == ["hermes-worker-foreground-test.scope"]
+    killpg.assert_not_called()
+
+
+def test_non_gateway_foreground_command_keeps_direct_shell_spawn(monkeypatch, tmp_path):
+    env = _bare_local_environment(tmp_path)
+    proc = MagicMock(pid=12345)
+    popen = MagicMock(return_value=proc)
+
+    monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+    monkeypatch.setattr("tools.environments.local._find_bash", lambda: "/bin/bash")
+    monkeypatch.setattr("tools.environments.local._make_run_env", lambda value: value)
+    monkeypatch.setattr("tools.environments.local.os.getpgid", lambda pid: pid)
+    monkeypatch.setattr("tools.environments.local.subprocess.Popen", popen)
+    monkeypatch.setattr(
+        "tools.process_registry._is_supervised_gateway_process", lambda: False
+    )
+
+    result = env._run_bash("printf ready")
+
+    assert popen.call_args.args[0] == ["/bin/bash", "-c", "printf ready"]
+    assert "_hermes_systemd_unit" not in vars(result)
+
+
+def test_scope_builder_fallback_does_not_record_nonexistent_unit(monkeypatch, tmp_path):
+    env = _bare_local_environment(tmp_path)
+    proc = MagicMock(pid=12345)
+    popen = MagicMock(return_value=proc)
+
+    monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+    monkeypatch.setattr("tools.environments.local._find_bash", lambda: "/bin/bash")
+    monkeypatch.setattr("tools.environments.local._make_run_env", lambda value: value)
+    monkeypatch.setattr("tools.environments.local.os.getpgid", lambda pid: pid)
+    monkeypatch.setattr("tools.environments.local.subprocess.Popen", popen)
+    monkeypatch.setattr(
+        "tools.process_registry._is_supervised_gateway_process", lambda: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry._systemd_run_user_scope_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "tools.process_registry._build_systemd_scope_argv",
+        lambda argv, *, unit_suffix: argv,
+    )
+
+    result = env._run_bash("printf ready")
+
+    assert popen.call_args.args[0] == ["/bin/bash", "-c", "printf ready"]
+    assert "_hermes_systemd_unit" not in vars(result)
+
+
+def test_failed_scope_stop_falls_back_to_process_group(monkeypatch, tmp_path):
+    env = _bare_local_environment(tmp_path)
+    proc = MagicMock(pid=12345)
+    setattr(proc, "_hermes_systemd_unit", "hermes-worker-foreground-test.scope")
+    stopped = []
+    killpg_calls = []
+
+    def fake_killpg(pgid, sig):
+        killpg_calls.append((pgid, sig))
+        if sig == 0:
+            raise ProcessLookupError
+
+    monkeypatch.setattr("tools.environments.local._IS_WINDOWS", False)
+    monkeypatch.setattr(
+        "tools.process_registry._stop_systemd_unit",
+        lambda unit: stopped.append(unit) or False,
+    )
+    monkeypatch.setattr("tools.environments.local.os.getpgid", lambda pid: 67890)
+    monkeypatch.setattr("tools.environments.local.os.killpg", fake_killpg)
+
+    env._kill_process(proc)
+
+    assert stopped == ["hermes-worker-foreground-test.scope"]
+    assert killpg_calls == [(67890, signal.SIGTERM), (67890, 0)]

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1958,6 +1958,62 @@ class TestSystemdCgroupIsolation:
 
         assert session.systemd_unit == ""
 
+    def test_pipe_scope_builder_fallback_does_not_record_unit(
+        self, registry, monkeypatch, _gateway_identity
+    ):
+        """A vanished systemd-run must leave pipe cleanup on the PID group."""
+        fake_popen, captured = self._fake_popen_capture()
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "tools.process_registry._build_systemd_scope_argv",
+            lambda argv, *, unit_suffix: argv,
+        )
+
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            session = registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert captured["argv"] == [
+            "/bin/bash", "-lic", "set +m; echo hello",
+        ]
+        assert session.systemd_unit == ""
+
+    def test_pty_scope_builder_fallback_does_not_record_unit(
+        self, registry, monkeypatch, _gateway_identity
+    ):
+        """A vanished systemd-run must leave PTY cleanup on the PID group."""
+        from ptyprocess import PtyProcess
+
+        fake_pty = MagicMock(pid=4321)
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "tools.process_registry._systemd_run_user_scope_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "tools.process_registry._build_systemd_scope_argv",
+            lambda argv, *, unit_suffix: argv,
+        )
+
+        with (
+            patch.object(PtyProcess, "spawn", return_value=fake_pty) as pty_spawn,
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            session = registry.spawn_local("codex", cwd="/tmp", use_pty=True)
+
+        assert pty_spawn.call_args.args[0] == [
+            "/bin/bash", "-lic", "set +m; codex",
+        ]
+        assert session.systemd_unit == ""
+
     def test_systemd_post_spawn_failure_never_kills_gateway_process_group(
         self, registry, monkeypatch, _gateway_identity
     ):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -1794,6 +1795,33 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
+        # A supervised gateway must keep foreground executors out of its own
+        # memory cgroup, just as ProcessRegistry does for background commands.
+        # Import lazily: process_registry imports LocalEnvironment at module
+        # load time, so a top-level import here would create a cycle.
+        systemd_unit = None
+        if not _IS_WINDOWS:
+            try:
+                from tools.process_registry import (
+                    _build_systemd_scope_argv,
+                    _is_supervised_gateway_process,
+                    _systemd_run_user_scope_available,
+                )
+
+                if (
+                    _is_supervised_gateway_process()
+                    and _systemd_run_user_scope_available()
+                ):
+                    suffix = f"foreground-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+                    scoped_args = _build_systemd_scope_argv(
+                        args, unit_suffix=suffix
+                    )
+                    if scoped_args is not args:
+                        args = scoped_args
+                        systemd_unit = f"hermes-worker-{suffix}.scope"
+            except Exception as exc:
+                logger.debug("Foreground systemd scope setup failed: %s", exc)
+
         # Recover when the cwd has been deleted out from under us — usually by
         # a previous tool call that ran ``rm -rf`` on its own working dir
         # (issue #17558).  Popen would otherwise raise FileNotFoundError on
@@ -1841,6 +1869,8 @@ class LocalEnvironment(BaseEnvironment):
                 proc._hermes_pgid = os.getpgid(proc.pid)
             except ProcessLookupError:
                 pass
+            if systemd_unit:
+                setattr(proc, "_hermes_systemd_unit", systemd_unit)
 
         if stdin_data is not None:
             _pipe_stdin(proc, stdin_data)
@@ -1892,6 +1922,24 @@ class LocalEnvironment(BaseEnvironment):
                 except (subprocess.TimeoutExpired, OSError):
                     pass
             else:
+                systemd_unit = getattr(proc, "_hermes_systemd_unit", None)
+                if systemd_unit:
+                    try:
+                        from tools.process_registry import _stop_systemd_unit
+
+                        if _stop_systemd_unit(systemd_unit):
+                            try:
+                                proc.wait(timeout=0.2)
+                            except (subprocess.TimeoutExpired, OSError):
+                                pass
+                            return
+                    except Exception as exc:
+                        logger.debug(
+                            "Foreground systemd scope cleanup failed for %s: %s",
+                            systemd_unit,
+                            exc,
+                        )
+
                 try:
                     pgid = os.getpgid(proc.pid)
                 except ProcessLookupError:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1032,12 +1032,14 @@ class ProcessRegistry:
                 )
 
                 if pty_use_systemd_scope:
-                    pty_argv = _build_systemd_scope_argv(
+                    scoped_pty_argv = _build_systemd_scope_argv(
                         pty_argv,
                         unit_suffix=session.id,
                     )
-                    session.systemd_unit = f"hermes-worker-{session.id}.scope"
-                    pty_scope_attempted = True
+                    if scoped_pty_argv is not pty_argv:
+                        pty_argv = scoped_pty_argv
+                        session.systemd_unit = f"hermes-worker-{session.id}.scope"
+                        pty_scope_attempted = True
                 elif pty_in_supervised_gateway:
                     logger.debug(
                         "PTY background executor not isolated in a "
@@ -1112,11 +1114,15 @@ class ProcessRegistry:
             unit_suffix = (
                 f"{session.id}-pipe-fallback" if pty_scope_attempted else session.id
             )
-            spawn_argv = _build_systemd_scope_argv(
+            scoped_spawn_argv = _build_systemd_scope_argv(
                 shell_argv,
                 unit_suffix=unit_suffix,
             )
-            session.systemd_unit = f"hermes-worker-{unit_suffix}.scope"
+            if scoped_spawn_argv is not shell_argv:
+                spawn_argv = scoped_spawn_argv
+                session.systemd_unit = f"hermes-worker-{unit_suffix}.scope"
+            else:
+                spawn_argv = shell_argv
             # CRITICAL (#70716 regression): systemd-run --scope does NOT give
             # the worker a new session — the invoked process keeps the
             # parent's session and inherits its controlling terminal.  From an


### PR DESCRIPTION
## Summary
- run supervised-gateway foreground local terminal commands in the same bounded transient systemd scopes already used by background workers
- stop the recorded scope before process-group fallback on timeout or interruption
- avoid recording nonexistent scope metadata if `systemd-run` disappears after the cached availability probe across foreground, background pipe, and PTY paths

## Why
Foreground terminal work could remain inside `hermes-gateway.service`, so a memory-heavy build or persistent child could push the messaging control plane into `MemoryHigh` throttling or its hard cgroup limit even though background workers were isolated.

## Verification
- `scripts/run_tests.sh -j 2 tests/tools/test_local_foreground_systemd_scope.py tests/tools/test_process_registry.py` — 93 passed, 4 skipped
- broader local terminal/process-registry regression selection — 451 passed, 23 skipped
- `ruff check` on changed production/tests — passed
- real Linux integration probe observed the command under `hermes-worker-foreground-*.scope`
- independent fail-closed review passed after two TOCTOU review/fix cycles

Windows-specific tests remain on the repository CI lane.