### PR TITLE
fix(agent): preserve parallel tool results across ID variants

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -33,7 +33,12 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.timeouts import get_provider_request_timeout
-from agent.message_sanitization import _FULL_ARGS_LOG_BOUND
+from agent.message_sanitization import (
+    _FULL_ARGS_LOG_BOUND,
+    coalesce_tool_call_id,
+    tool_call_id_variants,
+    tool_result_id_variants,
+)
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
@@ -413,7 +418,10 @@ def sanitize_tool_call_arguments(
                     candidate = messages[scan_index]
                     if not isinstance(candidate, dict) or candidate.get("role") != "tool":
                         break
-                    if candidate.get("tool_call_id") == tool_call_id:
+                    if (
+                        tool_result_id_variants(candidate.get("tool_call_id"))
+                        & tool_call_id_variants(tool_call)
+                    ):
                         existing_tool_msg = candidate
                         break
                     scan_index += 1
@@ -688,25 +696,15 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             continue
         collapsed.append(msg)
 
-    # Pass 1: drop stray tool messages that don't follow a known
-    # assistant tool_call_id. Uses a rolling set of known ids refreshed
-    # on each assistant message.
-    #
-    # Both ``id`` AND ``call_id`` are registered for every assistant
-    # tool_call. In the Codex Responses API format the two differ
-    # (``id`` = ``fc_...`` response-item id, ``call_id`` = ``call_...``
-    # the function-call id), and a tool result's ``tool_call_id`` may be
-    # matched against *either* depending on which code path built it
-    # (the OpenAI-compatible path stores ``tc.id``; codex paths store
-    # ``call_id``). Registering only ``id`` — as this pass did before —
-    # made a valid tool result look orphaned whenever the assistant
-    # tool_call carried a distinct ``call_id`` (or only ``call_id``); the
-    # pass then dropped it, leaving the assistant tool_call unanswered and
-    # producing an HTTP 400 on strict providers (DeepSeek, Kimi). Matching
-    # on the *superset* of both keys achieves the same tolerance as
-    # ``_get_tool_call_id_static``'s ``call_id || id`` — a match set must
-    # accept every legitimate reference, not just the canonical one (#58168).
-    known_tool_ids: set = set()
+    # Pass 1: drop stray tool messages that don't follow a known assistant
+    # tool call. A Responses call can have several equivalent spellings
+    # (call_id, id, response_item_id, or a composite ``call|item`` id), so
+    # consume the whole alias group when one spelling is matched. Otherwise a
+    # duplicate result keyed on the sibling alias would survive and be replayed
+    # to strict providers (#66974).
+    known_tool_ids: Dict[str, int] = {}
+    matched_tool_groups: set[int] = set()
+    next_tool_group = 0
     filtered: List[Dict] = []
     for msg in collapsed:
         if not isinstance(msg, dict):
@@ -714,25 +712,33 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
             continue
         role = msg.get("role")
         if role == "assistant":
-            known_tool_ids = set()
+            known_tool_ids = {}
+            matched_tool_groups = set()
             for tc in (msg.get("tool_calls") or []):
                 if not isinstance(tc, dict):
                     continue
-                for key in ("id", "call_id"):
-                    tc_id = tc.get(key)
-                    if tc_id:
-                        known_tool_ids.add(tc_id)
+                variants = tool_call_id_variants(tc)
+                if not variants:
+                    continue
+                group_id = next_tool_group
+                next_tool_group += 1
+                for tc_id in variants:
+                    known_tool_ids.setdefault(tc_id, group_id)
             filtered.append(msg)
         elif role == "tool":
-            tc_id = msg.get("tool_call_id")
-            if tc_id and tc_id in known_tool_ids:
+            result_variants = tool_result_id_variants(msg.get("tool_call_id"))
+            candidate_groups = {
+                known_tool_ids[tc_id]
+                for tc_id in result_variants
+                if tc_id in known_tool_ids
+                and known_tool_ids[tc_id] not in matched_tool_groups
+            }
+            if not result_variants:
                 filtered.append(msg)
-                # Consume the id so a SECOND tool result carrying the same
-                # tool_call_id (duplicate from a retry/crash/session-resume
-                # glitch) falls into the drop branch below instead of being
-                # replayed — strict providers (DeepSeek) reject a duplicate
-                # tool_call_id with HTTP 400 (#58327). Credit: #55436.
-                known_tool_ids.discard(tc_id)
+            elif candidate_groups:
+                group_id = min(candidate_groups)
+                filtered.append(msg)
+                matched_tool_groups.add(group_id)
             else:
                 repairs += 1
         else:
@@ -740,7 +746,8 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 # A user turn closes the tool-result run; subsequent
                 # tool messages without a fresh assistant tool_call
                 # are orphans.
-                known_tool_ids = set()
+                known_tool_ids = {}
+                matched_tool_groups = set()
             filtered.append(msg)
 
     # Pass 2: merge consecutive user messages. Preserves all user input
@@ -3692,53 +3699,75 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             elif isinstance(tc, dict):
                 tc["function"] = {"name": _EMPTY_NAME_SENTINEL, "arguments": "{}"}
 
-    surviving_call_ids: set = set()
+    assistant_call_variants: List[tuple[Any, frozenset[str]]] = []
+    surviving_call_ids: set[str] = set()
     for msg in messages:
-        if msg.get("role") == "assistant":
-            for tc in msg.get("tool_calls") or []:
-                cid = _ra().AIAgent._get_tool_call_id_static(tc)
-                if cid:
-                    surviving_call_ids.add(cid)
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            variants = tool_call_id_variants(tc)
+            if variants:
+                assistant_call_variants.append((tc, variants))
+                surviving_call_ids.update(variants)
 
-    result_call_ids: set = set()
-    for msg in messages:
-        if msg.get("role") == "tool":
-            cid = (msg.get("tool_call_id") or "").strip()
-            if cid:
-                result_call_ids.add(cid)
+    result_entries = [
+        (msg, tool_result_id_variants(msg.get("tool_call_id")))
+        for msg in messages
+        if msg.get("role") == "tool"
+    ]
 
-    # 1. Drop tool results with no matching assistant call
-    orphaned_results = result_call_ids - surviving_call_ids
-    if orphaned_results:
-        messages = [
-            m for m in messages
-            if not (m.get("role") == "tool" and (m.get("tool_call_id") or "").strip() in orphaned_results)
+    # 1. Drop tool results whose complete alias set matches no assistant call.
+    orphaned_result_objects = {
+        id(msg)
+        for msg, variants in result_entries
+        if variants and not (variants & surviving_call_ids)
+    }
+    if orphaned_result_objects:
+        messages = [m for m in messages if id(m) not in orphaned_result_objects]
+        result_entries = [
+            (msg, variants)
+            for msg, variants in result_entries
+            if id(msg) not in orphaned_result_objects
         ]
         _ra().logger.debug(
             "Pre-call sanitizer: removed %d orphaned tool result(s)",
-            len(orphaned_results),
+            len(orphaned_result_objects),
         )
 
-    # 2. Inject stub results for calls whose result was dropped
-    missing_results = surviving_call_ids - result_call_ids
-    if missing_results:
+    # 2. Inject one stub per assistant call with no result on ANY alias.
+    surviving_result_variants = [
+        variants for _, variants in result_entries if variants
+    ]
+    missing_tool_calls = [
+        tc
+        for tc, variants in assistant_call_variants
+        if not any(variants & result_variants for result_variants in surviving_result_variants)
+    ]
+    if missing_tool_calls:
+        missing_tool_call_objects = {id(tc) for tc in missing_tool_calls}
         patched: List[Dict[str, Any]] = []
         for msg in messages:
             patched.append(msg)
             if msg.get("role") == "assistant":
                 for tc in msg.get("tool_calls") or []:
-                    cid = _ra().AIAgent._get_tool_call_id_static(tc)
-                    if cid in missing_results:
-                        patched.append({
-                            "role": "tool",
-                            "name": _ra().AIAgent._get_tool_call_name_static(tc),
-                            "content": "[Result unavailable — see context summary above]",
-                            "tool_call_id": cid,
-                        })
+                    if id(tc) not in missing_tool_call_objects:
+                        continue
+                    cid = coalesce_tool_call_id(tc)
+                    if not cid:
+                        variants = tool_call_id_variants(tc)
+                        cid = sorted(variants)[0] if variants else ""
+                    if not cid:
+                        continue
+                    patched.append({
+                        "role": "tool",
+                        "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                        "content": "[Result unavailable — see context summary above]",
+                        "tool_call_id": cid,
+                    })
         messages = patched
         _ra().logger.debug(
             "Pre-call sanitizer: added %d stub tool result(s)",
-            len(missing_results),
+            len(missing_tool_calls),
         )
 
     # 3. Deduplicate tool_call_ids. Strict providers (DeepSeek) reject a
@@ -3761,8 +3790,11 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # semantics keep both protections intact: a re-emitted result still
     # answers no pending call and is still dropped, while a genuine new call
     # that reuses the id re-arms that id first.
-    seen_assistant_call_ids: set = set()
-    outstanding_call_ids: set = set()
+    seen_assistant_call_ids: set[str] = set()
+    outstanding_call_ids: set[str] = set()
+    outstanding_groups: Dict[int, frozenset[str]] = {}
+    variant_to_group: Dict[str, int] = {}
+    next_group_id = 0
     deduped: List[Dict[str, Any]] = []
     removed_dupes = 0
     for msg in messages:
@@ -3770,13 +3802,18 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
         if role == "assistant" and msg.get("tool_calls"):
             kept_tcs = []
             for tc in msg.get("tool_calls") or []:
-                cid = _ra().AIAgent._get_tool_call_id_static(tc)
-                if cid and cid in seen_assistant_call_ids:
+                variants = tool_call_id_variants(tc)
+                if variants and variants & seen_assistant_call_ids:
                     removed_dupes += 1
                     continue
-                if cid:
-                    seen_assistant_call_ids.add(cid)
-                    outstanding_call_ids.add(cid)
+                if variants:
+                    group_id = next_group_id
+                    next_group_id += 1
+                    outstanding_groups[group_id] = variants
+                    for variant in variants:
+                        seen_assistant_call_ids.add(variant)
+                        outstanding_call_ids.add(variant)
+                        variant_to_group.setdefault(variant, group_id)
                 kept_tcs.append(tc)
             if kept_tcs:
                 msg = {**msg, "tool_calls": kept_tcs}
@@ -3784,16 +3821,25 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
                 msg = {k: v for k, v in msg.items() if k != "tool_calls"}
             deduped.append(msg)
         elif role == "tool":
-            cid = (msg.get("tool_call_id") or "").strip()
-            if cid and cid not in outstanding_call_ids:
+            result_variants = tool_result_id_variants(msg.get("tool_call_id"))
+            candidate_groups = {
+                variant_to_group[variant]
+                for variant in result_variants
+                if variant in variant_to_group
+                and variant in outstanding_call_ids
+            }
+            if result_variants and not candidate_groups:
                 removed_dupes += 1
                 continue
-            if cid:
-                # Answered: this id is no longer outstanding, so a second
-                # result replaying it is still caught above.
-                outstanding_call_ids.discard(cid)
-                # A reused id must be re-armable by the next assistant call.
-                seen_assistant_call_ids.discard(cid)
+            if candidate_groups:
+                group_id = min(candidate_groups)
+                group_variants = outstanding_groups.pop(group_id, frozenset())
+                for variant in group_variants:
+                    outstanding_call_ids.discard(variant)
+                    # A reused id must be re-armable by the next assistant call.
+                    seen_assistant_call_ids.discard(variant)
+                    if variant_to_group.get(variant) == group_id:
+                        variant_to_group.pop(variant, None)
             deduped.append(msg)
         else:
             deduped.append(msg)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -51,6 +51,7 @@ from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
     _repair_tool_call_arguments,
+    coalesce_tool_call_id,
     _sanitize_messages_non_ascii,
     _sanitize_messages_surrogates,
     _sanitize_structure_non_ascii,
@@ -7083,7 +7084,7 @@ def run_conversation(
                         append_message(messages, {
                             "role": "tool",
                             "name": tc.function.name,
-                            "tool_call_id": tc.id,
+                            "tool_call_id": coalesce_tool_call_id(tc),
                             "content": content,
                         })
                     continue
@@ -7187,7 +7188,7 @@ def run_conversation(
                             append_message(messages, {
                                 "role": "tool",
                                 "name": tc.function.name,
-                                "tool_call_id": tc.id,
+                                "tool_call_id": coalesce_tool_call_id(tc),
                                 "content": tool_result,
                             })
                         continue
@@ -7335,7 +7336,7 @@ def run_conversation(
                         append_message(messages, {
                             "role": "tool",
                             "name": tc.function.name,
-                            "tool_call_id": tc.id,
+                            "tool_call_id": coalesce_tool_call_id(tc),
                             "content": _invalid_tool_name_error_content(
                                 tc.function.name, agent.valid_tool_names
                             ),

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -493,6 +493,8 @@ __all__ = [
     # call_id policy owners (F4 consolidation)
     "deterministic_call_id",
     "coalesce_tool_call_id",
+    "tool_call_id_variants",
+    "tool_result_id_variants",
     "uniquify_tool_call_ids",
     # reasoning_content policy owners (F4 consolidation)
     "reasoning_echo_family",
@@ -536,16 +538,72 @@ def deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
     return f"call_{digest}"
 
 
+def _expand_tool_id_variants(values: tuple[Any, ...]) -> frozenset[str]:
+    """Return every wire spelling of one or more tool-call identifiers.
+
+    Responses bridges may expose the pairing id and response-item id
+    separately, or encode both as ``call_id|response_item_id``.  The values
+    are aliases for one call, not distinct calls.  Keeping the expansion in
+    the shared policy module prevents the repair and pre-send paths from
+    drifting apart again.
+    """
+    variants: set[str] = set()
+    for raw in values:
+        if not isinstance(raw, str):
+            continue
+        value = raw.strip()
+        if not value:
+            continue
+        variants.add(value)
+        if "|" in value:
+            for part in value.split("|"):
+                part = part.strip()
+                if part:
+                    variants.add(part)
+    return frozenset(variants)
+
+
+def tool_call_id_variants(tc: Any) -> frozenset[str]:
+    """Return all pairing-id variants carried by a tool-call entry."""
+    if isinstance(tc, dict):
+        values = (
+            tc.get("call_id"),
+            tc.get("id"),
+            tc.get("response_item_id"),
+        )
+    else:
+        values = (
+            getattr(tc, "call_id", None),
+            getattr(tc, "id", None),
+            getattr(tc, "response_item_id", None),
+        )
+    return _expand_tool_id_variants(values)
+
+
+def tool_result_id_variants(tool_call_id: Any) -> frozenset[str]:
+    """Return all matching variants for a role=tool ``tool_call_id``."""
+    return _expand_tool_id_variants((tool_call_id,))
+
+
 def coalesce_tool_call_id(tc: Any) -> str:
     """Extract the effective call ID from a tool_call entry (dict or object).
 
-    Single owner for the ``call_id or id`` coalescing rule: Codex Responses
-    tool calls carry ``call_id`` (authoritative pairing key), Chat
-    Completions ones carry ``id`` only. Returns ``""`` when neither is set.
+    Single owner for the canonical pairing rule: Codex Responses tool calls
+    carry ``call_id`` (authoritative pairing key), Chat Completions ones carry
+    ``id`` only, and bridge ids may encode ``call_id|response_item_id``.
+    Returns ``""`` when neither pairing field is set.
     """
     if isinstance(tc, dict):
-        return (tc.get("call_id", "") or tc.get("id", "") or "").strip()
-    return (getattr(tc, "call_id", "") or getattr(tc, "id", "") or "").strip()
+        values = (tc.get("call_id"), tc.get("id"))
+    else:
+        values = (getattr(tc, "call_id", None), getattr(tc, "id", None))
+    for raw in values:
+        if not isinstance(raw, str):
+            continue
+        value = raw.strip()
+        if value:
+            return value.split("|", 1)[0].strip() or value
+    return ""
 
 
 def uniquify_tool_call_ids(tool_calls: list) -> list:

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -531,6 +531,13 @@ def _trajectory_normalize_msg(msg: Dict[str, Any]) -> Dict[str, Any]:
     return msg
 
 
+def _normalize_tool_call_id(tool_call_id: Any) -> Any:
+    """Normalize a composite bridge id to its canonical call-id half."""
+    if isinstance(tool_call_id, str) and "|" in tool_call_id:
+        return tool_call_id.split("|", 1)[0].strip()
+    return tool_call_id
+
+
 def make_tool_result_message(
     name: str,
     content: Any,
@@ -557,6 +564,10 @@ def make_tool_result_message(
     The outer list itself is rebuilt rather than returned by identity, so
     callers should compare by value, not by ``is``.
     """
+    # Keep the constructor safe for every caller, including replay recovery
+    # paths that do not go through the live executor's canonical-id helper.
+    tool_call_id = _normalize_tool_call_id(tool_call_id)
+
     # Order matters: detect provider-side elision on the RAW content and
     # append the notice first, THEN wrap — so the notice lives inside the
     # untrusted block next to the data it describes, appended exactly once

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -32,6 +32,7 @@ from agent.display import (
     redact_tool_args_for_display as _redact_tool_args_for_display,
     _detect_tool_failure,
 )
+from agent.message_sanitization import coalesce_tool_call_id
 from agent.tool_dispatch_helpers import (
     _NEVER_PARALLEL_TOOLS,
     _is_destructive_command,
@@ -53,6 +54,11 @@ from tools.tool_result_storage import (
 from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context_window
 
 logger = logging.getLogger(__name__)
+
+
+def _pairing_tool_call_id(tool_call: Any) -> str:
+    """Return the canonical id used by the persisted assistant message."""
+    return coalesce_tool_call_id(tool_call)
 
 
 def _record_persisted_path_for_stub(agent, tool_call_id: str, function_result) -> None:
@@ -1100,10 +1106,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 f"[Tool execution cancelled — {tc.function.name} was skipped "
                 "due to user interrupt]"
             )
+            tool_call_id = _pairing_tool_call_id(tc)
             messages.append(make_tool_result_message(
                 tc.function.name,
                 cancelled_result,
-                tc.id,
+                tool_call_id,
                 effect_disposition="none",
             ))
             _emit_terminal_post_tool_call(
@@ -1112,7 +1119,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 function_args={},
                 result=cancelled_result,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tc, "id", "") or "",
+                tool_call_id=tool_call_id,
                 status="cancelled",
                 error_type="user_interrupt",
                 error_message="Tool execution skipped due to user interrupt",
@@ -1322,6 +1329,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # ContextVars are propagated by propagate_context_to_thread() at the
         # submit site below (GHSA-qg5c-hvr5-hjgr, #13617).
         start = time.time()
+        tool_call_id = _pairing_tool_call_id(tool_call)
         blocked = False
         dispatched = False
         start_advanced = False
@@ -1351,7 +1359,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         function_name,
                         next_args,
                         effective_task_id,
-                        tool_call.id,
+                        tool_call_id,
                         messages=messages,
                         pre_tool_block_checked=True,
                         skip_tool_request_middleware=True,
@@ -1364,7 +1372,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     function_name=function_name,
                     function_args=function_args,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     execute=_execute,
                     scope_block=scope_block,
                     display_index=index + 1,
@@ -1398,7 +1406,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     function_name=function_name,
                     function_args=function_args,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     start_time=start,
                     middleware_trace=list(middleware_trace),
                 )
@@ -1425,7 +1433,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     function_args=function_args,
                     result=result,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     duration_ms=int(duration * 1000),
                     middleware_trace=list(middleware_trace),
                 )
@@ -1676,6 +1684,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         parsed_calls
     ):
         r = results[i]
+        tool_call_id = _pairing_tool_call_id(tc)
         blocked = False
         is_error = True
         progress_function_name = name
@@ -1694,7 +1703,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 function_args=args,
                 result=function_result,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tc, "id", "") or "",
+                tool_call_id=tool_call_id,
                 duration_ms=int((timeout_s or 0.0) * 1000),
                 status="timeout",
                 error_type="tool_timeout",
@@ -1712,7 +1721,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     function_args=args,
                     result=function_result,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tc, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     status="cancelled",
                     error_type="keyboard_interrupt",
                     error_message="Tool execution cancelled by user interrupt",
@@ -1726,7 +1735,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     function_args=args,
                     result=function_result,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tc, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     status="error",
                     error_type="thread_missing_result",
                     error_message=function_result,
@@ -1745,7 +1754,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     function_args=function_args,
                     result=function_result,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tc, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     status="error",
                     error_type="invalid_tool_arguments",
                     error_message="Tool arguments must be a valid JSON object",
@@ -1760,7 +1769,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     function_args,
                     function_result,
                     failed=is_error,
-                    tool_call_id=getattr(tc, "id", "") or "",
+                    tool_call_id=tool_call_id,
                 )
 
             if is_error:
@@ -1791,11 +1800,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=name,
-            tool_use_id=tc.id,
+            tool_use_id=tool_call_id,
             env=get_active_env(effective_task_id),
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
-        _record_persisted_path_for_stub(agent, tc.id, function_result)
+        _record_persisted_path_for_stub(agent, tool_call_id, function_result)
 
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
         if subdir_hints:
@@ -1818,7 +1827,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         tool_message = make_tool_result_message(
             name,
             _tool_content,
-            tc.id,
+            tool_call_id,
             effect_disposition=effect_disposition,
         )
         messages.append(tool_message)
@@ -1862,7 +1871,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             try:
                 display_args = _redact_tool_args_for_display(name, args) or args
                 agent.tool_complete_callback(
-                    tc.id, name, display_args, display_function_result,
+                    tool_call_id, name, display_args, display_function_result,
                 )
             except Exception as cb_err:
                 logging.debug("Tool complete callback error: %s", cb_err)
@@ -1878,7 +1887,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     name,
                     None,
                     None,
-                    tool_call_id=tc.id,
+                    tool_call_id=tool_call_id,
                     risk_metadata=risk_metadata,
                 )
             except Exception as cb_err:
@@ -1917,7 +1926,7 @@ def _append_cancelled_tool_results(messages: list, tool_calls, *, reason: str) -
         messages.append(make_tool_result_message(
             name,
             f"[Tool execution cancelled — {name} was skipped due to {reason}]",
-            getattr(tc, "id", "") or "",
+            _pairing_tool_call_id(tc),
             effect_disposition="none",
         ))
 
@@ -1938,6 +1947,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         return _run_sequential_tool_execution_middleware(agent, **kwargs)
 
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
+        tool_call_id = _pairing_tool_call_id(tool_call)
         if getattr(agent, "_incremental_persistence_failed", False):
             return
         # SAFETY: check interrupt BEFORE starting each tool.
@@ -1956,7 +1966,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 messages.append(make_tool_result_message(
                     skipped_name,
                     cancelled_result,
-                    skipped_tc.id,
+                    _pairing_tool_call_id(skipped_tc),
                     effect_disposition="none",
                 ))
                 _emit_terminal_post_tool_call(
@@ -1990,7 +2000,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_args=function_args,
                 result=malformed_args_result,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 status="error",
                 error_type="invalid_tool_arguments",
                 error_message="Tool arguments must be a valid JSON object",
@@ -1999,7 +2009,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 make_tool_result_message(
                     function_name,
                     malformed_args_result,
-                    tool_call.id,
+                    tool_call_id,
                 )
             )
             if not _flush_session_db_after_tool_progress(
@@ -2066,7 +2076,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2091,7 +2101,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2123,7 +2133,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2153,7 +2163,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         next_args,
                         build_metadata=lambda: agent._build_memory_write_metadata(
                             task_id=effective_task_id,
-                            tool_call_id=getattr(tool_call, "id", None),
+                            tool_call_id=tool_call_id,
                         ),
                     )
                 return result
@@ -2162,7 +2172,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2185,7 +2195,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2206,7 +2216,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2227,7 +2237,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2255,7 +2265,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2278,7 +2288,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2297,7 +2307,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2324,7 +2334,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_name=function_name,
                 function_args=function_args,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 execute=_execute,
                 scope_block=_ts_scope_block,
                 display_index=i,
@@ -2383,7 +2393,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name=function_name,
                     function_args=function_args,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     execute=_execute,
                     scope_block=_ts_scope_block,
                     display_index=i,
@@ -2416,7 +2426,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name=function_name,
                     function_args=function_args,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     execute=_execute,
                     scope_block=_ts_scope_block,
                     display_index=i,
@@ -2452,7 +2462,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name=function_name,
                     function_args=function_args,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     execute=_execute,
                     scope_block=_ts_scope_block,
                     display_index=i,
@@ -2487,7 +2497,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             function_name,
                             next_args,
                             effective_task_id,
-                            tool_call_id=tool_call.id,
+                            tool_call_id=tool_call_id,
                             session_id=agent.session_id or "",
                             turn_id=getattr(agent, "_current_turn_id", "") or "",
                             api_request_id=getattr(agent, "_current_api_request_id", "")
@@ -2517,7 +2527,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         function_name=function_name,
                         function_args=function_args,
                         effective_task_id=effective_task_id,
-                        tool_call_id=getattr(tool_call, "id", "") or "",
+                        tool_call_id=tool_call_id,
                         execute=_execute,
                         scope_block=_ts_scope_block,
                         display_index=i,
@@ -2531,7 +2541,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name=function_name,
                     function_args=function_args,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     start_time=tool_start_time,
                     middleware_trace=list(middleware_trace),
                 )
@@ -2569,7 +2579,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             function_name,
                             next_args,
                             effective_task_id,
-                            tool_call_id=tool_call.id,
+                            tool_call_id=tool_call_id,
                             session_id=agent.session_id or "",
                             turn_id=getattr(agent, "_current_turn_id", "") or "",
                             api_request_id=getattr(agent, "_current_api_request_id", "")
@@ -2599,7 +2609,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         function_name=function_name,
                         function_args=function_args,
                         effective_task_id=effective_task_id,
-                        tool_call_id=getattr(tool_call, "id", "") or "",
+                        tool_call_id=tool_call_id,
                         execute=_execute,
                         scope_block=_ts_scope_block,
                         display_index=i,
@@ -2612,7 +2622,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name=function_name,
                     function_args=function_args,
                     effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
+                    tool_call_id=tool_call_id,
                     start_time=tool_start_time,
                     middleware_trace=list(middleware_trace),
                 )
@@ -2667,7 +2677,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_args=function_args,
                 result=function_result,
                 effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
                 duration_ms=int(tool_duration * 1000),
                 middleware_trace=list(middleware_trace),
             )
@@ -2677,7 +2687,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_args,
                 function_result,
                 failed=_is_error_result,
-                tool_call_id=getattr(tool_call, "id", "") or "",
+                tool_call_id=tool_call_id,
             )
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
@@ -2712,11 +2722,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=function_name,
-            tool_use_id=tool_call.id,
+            tool_use_id=tool_call_id,
             env=get_active_env(effective_task_id),
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
-        _record_persisted_path_for_stub(agent, tool_call.id, function_result)
+        _record_persisted_path_for_stub(agent, tool_call_id, function_result)
 
         # Discover subdirectory context files from tool arguments
         subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
@@ -2732,7 +2742,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         tool_message = make_tool_result_message(
             function_name,
             _tool_content,
-            tool_call.id,
+            tool_call_id,
             effect_disposition="unknown" if _execution_timed_out else None,
         )
         messages.append(tool_message)
@@ -2763,7 +2773,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     or function_args
                 )
                 agent.tool_complete_callback(
-                    tool_call.id,
+                    tool_call_id,
                     function_name,
                     display_args,
                     display_function_result,
@@ -2782,7 +2792,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name,
                     None,
                     None,
-                    tool_call_id=tool_call.id,
+                    tool_call_id=tool_call_id,
                     risk_metadata=risk_metadata,
                 )
             except Exception as cb_err:
@@ -2805,7 +2815,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 messages.append(make_tool_result_message(
                     skipped_name,
                     f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
-                    skipped_tc.id,
+                    _pairing_tool_call_id(skipped_tc),
                     effect_disposition="none",
                 ))
                 if not _flush_session_db_after_tool_progress(

--- a/tests/agent/test_tool_dispatch_helpers.py
+++ b/tests/agent/test_tool_dispatch_helpers.py
@@ -142,6 +142,11 @@ class TestMakeToolResultMessage:
 
         assert msg["timestamp"] == 123.5
 
+    def test_composite_tool_call_id_is_normalized_at_constructor_boundary(self):
+        msg = make_tool_result_message("terminal", "ok", "call_abc|fc_def")
+
+        assert msg["tool_call_id"] == "call_abc"
+
     def test_high_risk_message_content_wrapped(self):
         msg = make_tool_result_message("web_extract", SAMPLE_LONG_TEXT, "call_2")
         assert msg["role"] == "tool"

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -169,6 +169,166 @@ def test_repair_keeps_tool_matching_only_call_id():
 
 
 
+def test_repair_keeps_tool_result_keyed_by_response_item_id():
+    """The normalized call id must still pair the raw Responses item id."""
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    messages = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_ABC",
+                "call_id": "call_ABC",
+                "response_item_id": "fc_123",
+                "type": "function",
+                "function": {"name": "x", "arguments": "{}"},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "fc_123", "content": "result"},
+    ]
+
+    repairs = repair_message_sequence(_bare_agent(), messages)
+
+    assert repairs == 0
+    assert messages[-1]["content"] == "result"
+
+
+def test_coalesce_tool_call_id_uses_call_half_of_composite_id():
+    """Raw bridge ids must use their canonical call half for tool results."""
+    from agent.message_sanitization import coalesce_tool_call_id
+
+    assert coalesce_tool_call_id({"id": "call_ABC|fc_123"}) == "call_ABC"
+
+
+def test_sanitize_keeps_parallel_results_keyed_by_responses_id_variant():
+    """A valid parallel Responses batch must not become all unavailable stubs.
+
+    Responses/Codex calls can expose a response-item ``id`` (``fc_*``) and a
+    distinct pairing ``call_id`` (``call_*``). The execution path may key the
+    real result with either variant, but the pre-send sanitizer must recognize
+    both as the same assistant call. This is the minimal reproduction of the
+    reported all-results loss for a larger parallel batch.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    batch_size = 8
+    messages = [
+        {"role": "user", "content": "run the independent calls"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": f"fc_{i}",
+                    "call_id": f"call_{i}",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+                for i in range(batch_size)
+            ],
+        },
+        *[
+            {
+                "role": "tool",
+                "tool_call_id": f"fc_{i}",
+                "content": f"real-result-{i}",
+            }
+            for i in range(batch_size)
+        ],
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    results = [msg for msg in out if msg.get("role") == "tool"]
+    assert [msg["tool_call_id"] for msg in results] == [
+        f"fc_{i}" for i in range(batch_size)
+    ]
+    assert [msg["content"] for msg in results] == [
+        f"real-result-{i}" for i in range(batch_size)
+    ]
+
+
+def test_repair_keeps_two_parallel_calls_answered_by_mixed_variants():
+    """Consuming one alias group must not orphan a different parallel call."""
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    messages = [
+        {"role": "user", "content": "do both"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "call_id": "call_1",
+                    "response_item_id": "fc_1",
+                    "type": "function",
+                    "function": {"name": "x", "arguments": "{}"},
+                },
+                {
+                    "id": "call_2",
+                    "call_id": "call_2",
+                    "response_item_id": "fc_2",
+                    "type": "function",
+                    "function": {"name": "y", "arguments": "{}"},
+                },
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "r1"},
+        {"role": "tool", "tool_call_id": "fc_2", "content": "r2"},
+    ]
+
+    repairs = repair_message_sequence(_bare_agent(), messages)
+
+    assert repairs == 0
+    assert [m["content"] for m in messages if m.get("role") == "tool"] == [
+        "r1", "r2"
+    ]
+
+
+def test_sanitize_consumes_all_responses_id_variants_for_duplicate_result():
+    """A sibling-id replay must not replace the first real result."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "call_ABC",
+                "call_id": "call_ABC",
+                "response_item_id": "fc_123",
+                "type": "function",
+                "function": {"name": "x", "arguments": "{}"},
+            }],
+        },
+        {"role": "tool", "tool_call_id": "fc_123", "content": "real"},
+        {"role": "tool", "tool_call_id": "call_ABC", "content": "replayed"},
+    ]
+
+    out = sanitize_api_messages(messages)
+
+    assert [msg["content"] for msg in out if msg.get("role") == "tool"] == [
+        "real"
+    ]
+
+
+def test_tool_executor_uses_canonical_responses_pairing_id():
+    """The executor must emit the id used by the normalized assistant turn."""
+    from types import SimpleNamespace
+
+    from agent.tool_executor import _pairing_tool_call_id
+
+    assert _pairing_tool_call_id(
+        SimpleNamespace(id="fc_123", call_id="call_ABC")
+    ) == "call_ABC"
+    assert _pairing_tool_call_id(
+        SimpleNamespace(id="call_ABC|fc_123")
+    ) == "call_ABC"
+
+
 # ── repair_message_sequence_with_cursor (#44837) ───────────────────────────
 
 from agent.agent_runtime_helpers import repair_message_sequence_with_cursor


### PR DESCRIPTION
## Summary

Preserve real tool results when a parallel assistant turn uses Responses/Codex-style identifier variants. The runtime now treats `call_id`, `id`, `response_item_id`, and composite `call_id|response_item_id` spellings as aliases of one tool call instead of dropping the real result and injecting `[Result unavailable — see context summary above]`.

Fixes #93251

## Root cause

The production path normalized assistant tool calls to a canonical `call_id` while several execution and recovery paths created `role: tool` messages from the raw SDK `id`. The pre-send repair/sanitizer then compared only one spelling, classified valid results as orphans, removed them, and synthesized an unavailable-result stub. The sharp 3-to-4 boundary was not independently proven as a count-only limit; the current-main reproduction failed for divergent IDs at batch sizes 1 through 8, which explains why enabling provider-side parallel calls exposed the symptom.

## Implementation

- Add one shared identifier-variant policy for assistant calls and tool results.
- Match tool results by alias intersection in `repair_message_sequence()` and `sanitize_api_messages()`.
- Consume every alias in a matched group so a duplicate keyed on a sibling ID cannot be replayed.
- Use the canonical pairing ID across concurrent, sequential, segmented, cancellation, timeout, invalid-call, persistence, callback, and replay paths.
- Normalize composite IDs at the central `make_tool_result_message()` boundary as a final defense.
- Preserve genuinely orphaned-result removal, duplicate protection, constant-ID reuse behavior, strict role/message invariants, and prompt-cache stability.

This deliberately fixes the identity contract instead of imposing an arbitrary parallelism cap. PR #93298 was reviewed as a visible-loss mitigation, but its default cap of 12 would not protect the reported 4–6-call case and would not repair mismatched IDs.

## Hardening review

- GitHub priority: P1 from issue #93251; complexity mapping: difficult; three hardening passes required.
- Pass 1 — premise/root cause: traced assistant construction, concurrent/sequential executors, error paths, message repair, sanitizer, persistence, and replay. Confirmed the old RED reproduction before implementation.
- Pass 2 — failure modes/bottlenecks: covered divergent IDs, composite IDs, missing results, sibling-keyed duplicates, two parallel calls answered by mixed aliases, constant/reused IDs, cancellation, timeout, malformed calls, strict-provider replay, and Windows test-environment limits.
- Pass 3 — simplification/regression: centralized alias expansion, kept the fix at existing message boundaries, inspected #56148, #66974, #63005, #58287, and #93298, and added invariant tests rather than a batch-size snapshot.

## Tests and verification

Focused canonical-wrapper validation:

- `scripts/run_tests.sh tests/agent/test_tool_dispatch_helpers.py tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_agent_guardrails.py tests/run_agent/test_concurrent_interrupt.py tests/run_agent/test_tool_executor_contextvar_propagation.py tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_tool_batch_segmentation.py -k 'not symlink_aliases' -q` — 181 passed.
- `scripts/run_tests.sh tests/agent/test_context_compressor.py -q` — 136 passed.
- `uv run --frozen ruff check` on all changed Python files — passed.
- `uv run --frozen ty check agent/message_sanitization.py` — passed.
- `uv run --frozen ty check agent/tool_dispatch_helpers.py` — passed.
- The focused regression was RED before the fix and GREEN afterward; the final repair test file passes 27 tests.

Known limitations are environmental and unrelated to this change:

- `tests/run_agent/test_run_agent.py`: 274 passed, 1 failed because the optional `anthropic` package is not installed; one existing fixture warning also reports a missing `flush_token_counts()` method.
- The full Windows suite was stopped after unrelated platform failures such as missing `os.chown` and symlink privilege `WinError 1314`; no required remote CI result is being represented as green here.
- Provider-specific live E2E was not run because the issue did not include a preserved authenticated wire payload; the deterministic production-path regression is included instead.

## Related work

- #55626 / #56148: sanitizer matching for alternate tool-call IDs.
- #66974: consume sibling ID variants during sequence repair.
- #63000 / #63005: composite tool-call IDs.
- #58287: compression sanitizer variant matching.
- #93298: visible batch-cap mitigation; this PR fixes the shared identity cause instead.

## Security and compatibility

No credentials, tokens, local machine paths, database dumps, or environment files are included. The change is additive for accepted identifier shapes, keeps true orphan filtering, and does not add a user-facing environment variable or alter tool schemas.

## Infographic

<!-- pr-infographic: generated by scripts/generate_pr_infographic.py; theme=cyberpunk-network-02; roulette=72/100; seed=93251 -->
![PR infographic — preserve parallel tool results across ID variants](https://files.catbox.moe/zvbllc.png)

**Visual theme:** Cyberpunk network — firewall district  
**Why it fits:** api, integration, payload, response, routing, security
