### PR TITLE
fix: gateway uninstall and execute_code payloads no longer bypass the lifecycle guard (salvage #20489, #68289)

### DIFF
--- a/contributors/emails/szsyyk@163.com
+++ b/contributors/emails/szsyyk@163.com
@@ -1,0 +1,1 @@
+arcimun

--- a/contributors/emails/szsyyk@163.com
+++ b/contributors/emails/szsyyk@163.com
@@ -1,1 +1,1 @@
-arcimun
+KeaneYan

--- a/contributors/emails/trayhartred@gmail.com
+++ b/contributors/emails/trayhartred@gmail.com
@@ -1,0 +1,1 @@
+arcimun

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -27,7 +27,7 @@ This is a defence-in-depth layer.  ``tools/terminal_tool.py`` blocks direct
 commands and shell scripts they reference when ``_HERMES_GATEWAY=1``. It also
 rejects ``launchctl submit`` in gateway sessions because launchd treats that
 primitive as a persistent KeepAlive job, not a one-shot task. ``hermes gateway
-stop|restart`` separately refuse to self-target from inside the gateway.
+stop|restart|uninstall`` separately refuse to self-target from inside the gateway.
 Blocking cron specs at creation time as well means the agent gets an immediate,
 informative rejection instead of scheduling a job that will only fail
 (silently) when it fires.
@@ -60,7 +60,8 @@ class GatewayLifecycleBlocked(ValueError):
 # actual shell-command-shaped strings, not on prose.
 _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"(?i)"
-    # Branch A: `hermes gateway restart|stop` — the canonical foot-gun.
+    # Branch A: destructive `hermes gateway` operations.
+    # The destructive operations are restart, stop, and uninstall.
     # `start` is intentionally excluded: starting a gateway from inside a
     # gateway is benign (a no-op or "already running" error), and a
     # legitimate cron job might start a sibling profile's gateway.
@@ -70,7 +71,7 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # matching via the `/hermes` tail, while every real command position
     # (start of text, whitespace, `;`/`&`/`|`, `$(`, backtick, even a
     # U+FFFD from binary-content decoding) still matches.
-    r"(?:(?<![/\w.\-])hermes\s+gateway\s+(?:restart|stop)\b)"
+    r"(?:(?<![/\w.\-])hermes\s+gateway\s+(?:restart|stop|uninstall)\b)"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -115,6 +115,12 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 # across genuinely separate lines.
 _SHELL_LINE_CONTINUATION = re.compile(r"\\\r?\n[ \t]*")
 
+# Python argv-list punctuation (#68289): `subprocess.run(["launchctl",
+# "bootout", ...])` separates the words the OS will exec with brackets and
+# commas rather than spaces. Stripped before the token-join re-scan only —
+# never from the raw text, so prose stays governed by the primary pattern.
+_ARGV_LIST_PUNCTUATION = re.compile(r"[\[\],]+")
+
 
 # Branch A2 (#78028): the same foot-gun written with an explicit profile
 # selector — `hermes -p <profile> gateway restart|stop` / `--profile <name>`
@@ -252,10 +258,17 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
     # Token-aware second pass (#80269): re-run the pattern on shell-tokenized
     # segments where quotes/escapes are resolved, closing splice bypasses
     # like `kick"start"`. Runs after the profile-flag check so both passes
-    # apply independently.
+    # apply independently. Tokens are additionally re-joined with Python
+    # argv-list punctuation ([ ] ,) stripped (#68289): the same command
+    # reaches this guard as `subprocess.run(["launchctl", "bootout", ...])`
+    # from execute_code, where commas and brackets — not spaces — separate
+    # the argv words the OS will actually see.
     for segment in _iter_command_segments(normalized):
         joined = " ".join(segment)
         if joined and _GATEWAY_LIFECYCLE_PATTERN.search(joined):
+            return True
+        stripped = _ARGV_LIST_PUNCTUATION.sub(" ", joined)
+        if stripped != joined and _GATEWAY_LIFECYCLE_PATTERN.search(stripped):
             return True
     # Order-independent launchctl pass (#77083): a shell loop can build the
     # gateway label from a variable defined in an earlier `;`-separated

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7935,6 +7935,20 @@ def _gateway_command_inner(args):
             sys.exit(1)
 
     elif subcmd == "uninstall":
+        # Uninstall stops the managed service before removing it. Gate on
+        # PID-file ownership like stop/restart (#92560): the env marker is
+        # inherited by every descendant, and CLI sessions spawned under the
+        # gateway tree must stay able to manage it.
+        from tools.process_registry import _is_supervised_gateway_process
+
+        if _is_supervised_gateway_process():
+            print_error(
+                "Refusing to uninstall the gateway from inside the gateway process.\n"
+                "This command was blocked to prevent the gateway from terminating itself.\n"
+                "Use `hermes gateway uninstall` from a shell outside the running gateway."
+            )
+            sys.exit(1)
+
         if is_managed():
             managed_error("uninstall gateway service")
             return

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -232,6 +232,24 @@ class TestGatewayLifecyclePattern:
         text = 'echo "unbalanced\nhermes gateway restart'
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
+    @pytest.mark.parametrize("text", [
+        # #68289: execute_code payloads carry the argv as a Python list —
+        # brackets/commas separate the words the OS will exec.
+        'import subprocess\nsubprocess.run(["launchctl", "bootout", "gui/501/ai.hermes.gateway"])',
+        'subprocess.run(["hermes", "gateway", "restart"])',
+        'os.system("launchctl kickstart -k gui/501/ai.hermes.gateway")',
+    ])
+    def test_python_argv_list_forms_blocked(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        # Argv-punctuation stripping must not create prose false positives.
+        'print("checking gateway restart docs")',
+        'data = ["hermes", "notes"]  # unrelated list',
+    ])
+    def test_python_argv_stripping_stays_narrow(self, text):
+        assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
+
 
 class TestProfileFlagGatewayLifecycle:
     """#78028: `hermes -p <profile> gateway restart|stop` bypasses Branch A's
@@ -416,7 +434,10 @@ class TestGatewaySelfTargetingGuard:
         assert exc_info.value.code == 1
 
     def test_uninstall_refuses_inside_gateway(self, monkeypatch):
-        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        from tools import process_registry
+        monkeypatch.setattr(
+            process_registry, "_is_supervised_gateway_process", lambda: True
+        )
         from hermes_cli.gateway import gateway_command
 
         args = Namespace(gateway_command="uninstall", system=False)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -28,6 +28,7 @@ class TestGatewayLifecyclePattern:
     @pytest.mark.parametrize("text", [
         "hermes gateway restart",
         "hermes gateway stop",
+        "hermes gateway uninstall",
         "hermes  gateway  restart",         # double spaces
         "Hermez Gateway Restart".lower().replace("z", "s"),  # case handled
         "HERMES GATEWAY RESTART",           # uppercase
@@ -43,6 +44,7 @@ class TestGatewayLifecyclePattern:
         "launchctl submit -l hermes-gateway-restart-helper -- /bin/sh helper.sh",
         # bootstrap loads an arbitrary plist — same laundering shape.
         "launchctl bootstrap gui/501 ~/Library/LaunchAgents/ai.hermes.gateway.restart-once.plist",
+        "launchctl bootout gui/501/ai.hermes.gateway",
         # The exact reported shape: split across shell line-continuations
         # (`\` immediately followed by a newline). `[^\n]*` alone can't span
         # that, so the verb and the gateway-label token land on different
@@ -400,7 +402,7 @@ class TestCronCreateLifecycleBlock:
 # ---------------------------------------------------------------------------
 
 class TestGatewaySelfTargetingGuard:
-    """Verify hermes gateway stop/restart refuse when _HERMES_GATEWAY=1."""
+    """Verify destructive gateway commands refuse inside the gateway."""
 
     def test_stop_refuses_inside_gateway(self, monkeypatch):
         from tools import process_registry
@@ -409,6 +411,15 @@ class TestGatewaySelfTargetingGuard:
         )
         from hermes_cli.gateway import gateway_command
         args = Namespace(gateway_command="stop", all=False, system=False)
+        with pytest.raises(SystemExit) as exc_info:
+            gateway_command(args)
+        assert exc_info.value.code == 1
+
+    def test_uninstall_refuses_inside_gateway(self, monkeypatch):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        from hermes_cli.gateway import gateway_command
+
+        args = Namespace(gateway_command="uninstall", system=False)
         with pytest.raises(SystemExit) as exc_info:
             gateway_command(args)
         assert exc_info.value.code == 1
@@ -476,7 +487,9 @@ class TestTerminalToolGatewayLifecycleGuard:
         "systemctl --user restart hermes-gateway",
         "systemctl stop hermes-gateway.service",
         "hermes gateway restart",
+        "hermes gateway uninstall",
         "launchctl kickstart gui/501/ai.hermes.gateway",
+        "launchctl bootout gui/501/ai.hermes.gateway",
         # #62891 exact reported shape and its bootstrap sibling.
         "launchctl submit -l ai.hermes.gateway-hard-restart-no-photon-notice -- /bin/sh ~/.hermes/scripts/hard_restart_gateway_no_photon_notice.sh",
         "launchctl submit -l com.foo -- /path/gateway",

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1286,6 +1286,23 @@ def execute_code(
             "terminal(command=...) instead."
         )
 
+    # Hard-block gateway-lifecycle commands, mirroring the terminal_tool
+    # guard (#68289): without this, execute_code is a straight bypass — the
+    # terminal() path refuses `launchctl bootout ai.hermes.gateway`, but the
+    # identical command inside `os.system(...)` / `subprocess.run([...])`
+    # here sailed through and SIGTERM'd the gateway mid-task. Gated on
+    # PID-file ownership, not the inherited env marker (#92560).
+    from tools.process_registry import _is_supervised_gateway_process
+    if _is_supervised_gateway_process():
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command
+        if contains_gateway_lifecycle_command(code):
+            return tool_error(
+                "Blocked: cannot restart or stop the gateway from inside the "
+                "gateway process. The gateway would kill this script before "
+                "it could complete (SIGTERM propagates to child processes). "
+                "Run the lifecycle command from a shell outside the gateway."
+            )
+
     # Dispatch: remote backends use file-based RPC, local uses UDS
     from tools.terminal_tool import _get_env_config, _docker_has_host_access
     _env_config = _get_env_config()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2870,7 +2870,7 @@ def terminal_tool(
         session_key = get_current_session_key(default="") or (task_id or "")
 
         # Hard-block: gateway lifecycle commands (systemctl/launchctl/hermes
-        # restart|stop targeting hermes-gateway) must never run inside the
+        # restart|stop|uninstall targeting hermes-gateway) must never run inside the
         # gateway process itself. The restart would SIGTERM the gateway, which
         # kills this very subprocess before it can complete — the service may
         # never restart. This mirrors the `hermes gateway restart` guard in
@@ -2978,8 +2978,8 @@ def terminal_tool(
                     "output": "",
                     "exit_code": 1,
                     "error": (
-                        "Blocked: command or referenced script cannot restart or stop "
-                        "the gateway from inside the gateway process. The gateway would "
+                        "Blocked: command or referenced script cannot restart, stop, or "
+                        "uninstall the gateway from inside the gateway process. The gateway would "
                         "kill this command before it could complete (SIGTERM propagates "
                         "to child processes). Run `hermes gateway restart` from a "
                         "separate shell outside the running gateway."


### PR DESCRIPTION
## Summary

Two remaining gateway-lifecycle guard bypass surfaces are closed. (1) `hermes gateway uninstall` — which stops the service before removing it — now refuses to self-target, in both the CLI and the shared guard pattern. (2) `execute_code` gets the same lifecycle guard as the terminal tool: Python payloads like `subprocess.run(["launchctl", "bootout", "gui/.../ai.hermes.gateway"])` sailed through because execute_code had no guard at all AND argv-list punctuation (brackets/commas) hid the command words from the shell-shaped pattern.

Salvages PR #20489 by @KeaneYan (uninstall, adapted to the #92560 ownership gate) and the execute_code half of PR #68289 by @arcimun (adapted likewise; its Branch B verb additions already landed via #93297).

## Changes

- `hermes_cli/gateway.py` (@KeaneYan): uninstall self-target refusal, gated on `_is_supervised_gateway_process()`
- `cron/lifecycle_guard.py` (@KeaneYan): `uninstall` added to Branch A verbs
- `tools/code_execution_tool.py` (@arcimun): lifecycle guard mirroring terminal_tool, ownership-gated
- `cron/lifecycle_guard.py` (@arcimun): argv-list punctuation stripped in the token-join re-scan
- Tests: uninstall refusal (ownership-mocked like siblings), argv-list blocked shapes, prose-safety negatives

## Validation

| Case | Before | After |
|---|---|---|
| `hermes gateway uninstall` from supervised gateway | ran (service stops, gateway dies) | blocked |
| `subprocess.run(["launchctl","bootout",".../ai.hermes.gateway"])` via execute_code | ran | blocked |
| `subprocess.run(["hermes","gateway","restart"])` | passed pattern | blocked |
| `print("checking gateway restart docs")` in code | allowed | still allowed |
| CLI session (env inherited, no PID ownership) running uninstall | — | allowed (ownership gate) |

All shapes live-verified against the real guard; 184/184 restart-loop tests + 283 pass across restart-loop + code-execution suites.

## Infographic

![Every door, same lock](https://v3b.fal.media/files/b/0aa78da9/auLIXdMvgkFVq7MSx8JxB_vlNaZrH3.png)
