### PR TITLE
feat(discord): register slash command aliases from COMMAND_REGISTRY

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6066,24 +6066,27 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not _is_gateway_available(cmd_def, config_overrides):
                     continue
                 # Discord command names: lowercase, hyphens OK, max 32 chars.
-                discord_name = cmd_def.name.lower()[:32]
-                if discord_name in already_registered:
-                    continue
-                if len(already_registered) >= slot_cap:
-                    dropped_over_cap += 1
-                    continue
-                auto_cmd = _build_auto_slash_command(
-                    cmd_def.name,
-                    cmd_def.description,
-                    cmd_def.args_hint,
-                )
-                try:
-                    tree.add_command(auto_cmd)
-                    already_registered.add(discord_name)
-                except Exception:
-                    # Silently skip commands that fail registration (e.g.
-                    # name conflict with a subcommand group).
-                    pass
+                # Register aliases too; gateway users should get the same
+                # command picker as CLI users (for example /compact).
+                for command_name in (cmd_def.name, *cmd_def.aliases):
+                    discord_name = command_name.lower()[:32]
+                    if discord_name in already_registered:
+                        continue
+                    if len(already_registered) >= slot_cap:
+                        dropped_over_cap += 1
+                        continue
+                    auto_cmd = _build_auto_slash_command(
+                        command_name,
+                        cmd_def.description,
+                        cmd_def.args_hint,
+                    )
+                    try:
+                        tree.add_command(auto_cmd)
+                        already_registered.add(discord_name)
+                    except Exception:
+                        # Silently skip commands that fail registration (e.g.
+                        # name conflict with a subcommand group).
+                        pass
 
             logger.debug(
                 "Discord auto-registered %d commands from COMMAND_REGISTRY",

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -204,6 +204,21 @@ async def test_auto_registers_plugin_commands_for_discord(adapter):
 
 
 @pytest.mark.asyncio
+async def test_auto_registers_builtin_aliases_for_discord(adapter):
+    """Aliases from COMMAND_REGISTRY should appear as Discord slash commands."""
+    adapter._run_simple_slash = AsyncMock()
+
+    adapter._register_slash_commands()
+
+    compact_cmd = adapter._client.tree.commands["compact"]
+    interaction = SimpleNamespace()
+    await compact_cmd.callback(interaction, args="here 3")
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction, "/compact here 3"
+    )
+
+
+@pytest.mark.asyncio
 async def test_plugin_command_name_conflict_skipped(adapter):
     """A plugin command that collides with a built-in must not override it."""
     adapter._run_simple_slash = AsyncMock()


### PR DESCRIPTION
Previously only the primary command name was registered as a Discord slash command. This change also registers any aliases defined in COMMAND_REGISTRY, so Discord users can access the same command shortcuts as CLI users (e.g. /compact in addition to /compact_mode).

- Loop over cmd_def.name + cmd_def.aliases when building auto slash commands
- Added test verifying alias registration and callback invocation