### PR TITLE
fix(aux): make per-task reasoning_effort actually reach Ollama-class wires

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8591,6 +8591,37 @@ def _build_call_kwargs(
         "timeout": timeout,
     }
 
+    # Per-task reasoning override from config: auxiliary.<task>.reasoning_effort.
+    # Canonical case: compression against a local thinking model. A
+    # reasoning-capable summarizer happily spends its entire output budget on
+    # <think> before writing a single summary character — the call returns
+    # thinking-only content (or dies to the host's wall-clock hygiene
+    # watchdog mid-thought) and compaction loops on empty/size-neutral
+    # summaries. Digest work gains nothing from reasoning, so operators can
+    # turn it off per task (``reasoning_effort: none`` or ``false``) or pin
+    # an effort level, using the same spellings as the main-model knob.
+    # Explicit per-call reasoning_config (e.g. MoA per-slot) still wins.
+    _task_reasoning_from_config = False
+    if reasoning_config is None and task:
+        _cfg_effort = None
+        try:
+            _cfg_effort = _get_auxiliary_task_config(task).get("reasoning_effort")
+        except Exception:
+            _cfg_effort = None
+        if _cfg_effort is not None and _cfg_effort is not True:
+            from hermes_constants import parse_reasoning_effort
+
+            _task_reasoning = parse_reasoning_effort(_cfg_effort)
+            if _task_reasoning is not None:
+                reasoning_config = _task_reasoning
+                _task_reasoning_from_config = True
+            else:
+                logger.warning(
+                    "auxiliary.%s.reasoning_effort value %r not recognized "
+                    "(expected none/false or an effort level) — ignoring",
+                    task, _cfg_effort,
+                )
+
     fixed_temperature = _fixed_temperature_for_model(model, base_url)
     if fixed_temperature is OMIT_TEMPERATURE:
         temperature = None  # strip — let server choose
@@ -8745,6 +8776,26 @@ def _build_call_kwargs(
     merged_extra = dict(extra_body or {})
     merged_extra.update(profile_body)
     merged_extra.update(profile_reasoning_extra)
+    # Profile-authoritative reasoning: when the provider profile already
+    # expresses the reasoning intent in ITS wire dialect (top-level
+    # ``reasoning_effort`` for Ollama/GLM-class, nested ``thinking_config``
+    # for Gemini, …), also sending the generic ``extra_body.reasoning``
+    # object is at best redundant and at worst poison: on Ollama's
+    # /v1/chat/completions an unknown top-level object can suppress the
+    # honored ``reasoning_effort`` key entirely (probe-verified 2026-08-23:
+    # effort "none" + reasoning {enabled: false} on the same payload ran
+    # FULL thinking, 580s+ timeout, while effort "none" alone ran 12.5s
+    # with zero thinking). Only drops the generic object when the profile
+    # actually carries a reasoning intent for this call — an explicit
+    # extra_body.reasoning with no reasoning_config keeps the documented
+    # "explicit wire control wins" contract untouched.
+    if (
+        profile_handles_reasoning
+        and reasoning_config
+        and isinstance(reasoning_config, dict)
+        and "reasoning" in merged_extra
+    ):
+        merged_extra.pop("reasoning", None)
     if (
         reasoning_config
         and isinstance(reasoning_config, dict)
@@ -8796,6 +8847,24 @@ def _build_call_kwargs(
             or _is_anthropic_compat_endpoint(provider_norm, effective_base)
         ):
             kwargs["_reasoning_config"] = dict(reasoning_config)
+
+    # Top-level ``reasoning_effort`` fallback for servers whose provider has
+    # NO reasoning-aware profile. Ollama-class local backends silently drop
+    # ``extra_body.reasoning`` (probe-verified: a {enabled: false} payload
+    # left ~10K chars of thinking untouched) — for them the top-level key is
+    # the only knob that bites. Gated on the per-task CONFIG flag (explicit
+    # operator intent), never on internal per-call reasoning_config, so a
+    # strict OpenAI endpoint can never receive an unsolicited key it would
+    # 400 on ("Unrecognized request argument"). Providers WITH a reasoning
+    # profile (custom/Ollama, OpenRouter, Gemini…) are already covered above.
+    if (
+        _task_reasoning_from_config
+        and reasoning_config
+        and isinstance(reasoning_config, dict)
+        and reasoning_config.get("enabled") is False
+        and not profile_handles_reasoning
+    ):
+        kwargs["reasoning_effort"] = "none"
 
     return kwargs
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8608,7 +8608,7 @@ def _build_call_kwargs(
             _cfg_effort = _get_auxiliary_task_config(task).get("reasoning_effort")
         except Exception:
             _cfg_effort = None
-        if _cfg_effort is not None and _cfg_effort is not True:
+        if _cfg_effort is not None:
             from hermes_constants import parse_reasoning_effort
 
             _task_reasoning = parse_reasoning_effort(_cfg_effort)
@@ -8794,7 +8794,11 @@ def _build_call_kwargs(
         and reasoning_config
         and isinstance(reasoning_config, dict)
         and "reasoning" in merged_extra
+        and "reasoning" in profile_reasoning_extra
     ):
+        # Gate on the profile being the SOURCE of the generic object: a
+        # caller-supplied extra_body.reasoning alongside a reasoning-aware
+        # profile keeps the "explicit wire control wins" contract.
         merged_extra.pop("reasoning", None)
     if (
         reasoning_config
@@ -8861,10 +8865,15 @@ def _build_call_kwargs(
         _task_reasoning_from_config
         and reasoning_config
         and isinstance(reasoning_config, dict)
-        and reasoning_config.get("enabled") is False
         and not profile_handles_reasoning
     ):
-        kwargs["reasoning_effort"] = "none"
+        # Config-pinned intent on a profile-less backend: emit the operator's
+        # actual level ("none" when disabled, the configured effort otherwise)
+        # so a pinned level is never silently dropped on the wire.
+        if reasoning_config.get("enabled") is False:
+            kwargs["reasoning_effort"] = "none"
+        elif reasoning_config.get("effort"):
+            kwargs["reasoning_effort"] = reasoning_config["effort"]
 
     return kwargs
 

--- a/tests/agent/test_auxiliary_task_reasoning_effort.py
+++ b/tests/agent/test_auxiliary_task_reasoning_effort.py
@@ -1,0 +1,142 @@
+"""Per-task reasoning-effort config on auxiliary calls.
+
+auxiliary.<task>.reasoning_effort lets operators disable (or pin) thinking on
+a single aux task without touching the main model. Canonical case: compression
+against a local thinking model (Ollama + gemma), where reasoning burns the
+whole output budget before the first summary character and compaction loops on
+empty summaries.
+
+Wire contract (probe-verified against Ollama /v1/chat/completions,
+gemma4:26b-mlx, 2026-08-23):
+  - disabled → top-level ``reasoning_effort: "none"`` IS honored (12.5s, 763
+    tok, 0 thinking chars vs 72s / 4.4K tok / 11K thinking chars without);
+    ``extra_body.reasoning = {enabled: false}`` alone is a silent no-op.
+  - The custom/Ollama provider profile maps disabled → top-level
+    ``reasoning_effort="none"`` + ``extra_body.think=False`` (ollama#14820).
+  - Providers with NO reasoning profile get the top-level key from the
+    generic fallback in _build_call_kwargs (config-gated only).
+"""
+
+from unittest.mock import patch
+
+from agent.auxiliary_client import _build_call_kwargs
+
+
+def _msgs():
+    return [{"role": "user", "content": "x"}]
+
+
+class TestTaskReasoningEffortConfig:
+    def test_none_on_custom_profile_emits_ollama_wire(self):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": "none"},
+        ):
+            kwargs = _build_call_kwargs(
+                "custom", "gemma4:26b-mlx", _msgs(), task="compression",
+            )
+        # Profile-owned shape: top-level none + Ollama think flag.
+        assert kwargs.get("reasoning_effort") == "none"
+        assert kwargs["extra_body"]["think"] is False
+
+    def test_false_bool_means_disabled(self):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": False},
+        ):
+            kwargs = _build_call_kwargs(
+                "custom", "gemma4:26b-mlx", _msgs(), task="compression",
+            )
+        assert kwargs.get("reasoning_effort") == "none"
+        assert kwargs["extra_body"]["think"] is False
+
+    def test_valid_level_maps_to_top_level_effort(self):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": "low"},
+        ):
+            kwargs = _build_call_kwargs(
+                "custom", "gemma4:26b-mlx", _msgs(), task="compression",
+            )
+        # Enabled-effort: profile emits the level, no think flag.
+        assert kwargs.get("reasoning_effort") == "low"
+        assert "think" not in kwargs.get("extra_body", {})
+
+    def test_explicit_reasoning_config_wins(self):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": "high"},
+        ):
+            kwargs = _build_call_kwargs(
+                "custom", "gemma4:26b-mlx", _msgs(), task="compression",
+                reasoning_config={"enabled": False},
+            )
+        # Explicit per-call config is not overridden by task config.
+        assert kwargs.get("reasoning_effort") == "none"
+        assert kwargs["extra_body"]["think"] is False
+
+    def test_no_task_config_no_reasoning_fields(self):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={},
+        ):
+            kwargs = _build_call_kwargs(
+                "custom", "gemma4:26b-mlx", _msgs(), task="compression",
+            )
+        assert "reasoning_effort" not in kwargs
+        assert "think" not in (kwargs.get("extra_body") or {})
+
+    def test_unrecognized_value_warns_and_is_ignored(self, caplog):
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": "banana"},
+        ):
+            kwargs = _build_call_kwargs(
+                "custom", "gemma4:26b-mlx", _msgs(), task="compression",
+            )
+        assert "reasoning_effort" not in kwargs
+        assert "think" not in (kwargs.get("extra_body") or {})
+        assert "not recognized" in caplog.text
+
+    def test_no_task_no_knob_read(self):
+        # No task → knob not even consulted; behavior identical to pre-patch.
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": "none"},
+        ) as cfg:
+            kwargs = _build_call_kwargs(
+                "custom", "gemma4:26b-mlx", _msgs(),
+            )
+        assert "reasoning_effort" not in kwargs
+        assert "think" not in (kwargs.get("extra_body") or {})
+        cfg.assert_not_called()
+
+    def test_fallback_top_level_key_for_profileless_provider(self):
+        # A provider with NO reasoning-aware profile must still get the
+        # top-level key when the operator set the task knob — this is the
+        # generic path that covers arbitrary OpenAI-compatible backends.
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": "none"},
+        ):
+            kwargs = _build_call_kwargs(
+                "not-a-real-provider-xyz", "some-model", _msgs(),
+                task="compression",
+            )
+        assert kwargs.get("reasoning_effort") == "none"
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
+
+    def test_fallback_not_fired_without_task_config(self):
+        # Internal per-call reasoning_config alone must NOT produce a
+        # top-level key on a profileless provider (strict-gateway safety).
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={},
+        ):
+            kwargs = _build_call_kwargs(
+                "not-a-real-provider-xyz", "some-model", _msgs(),
+                task="compression",
+                reasoning_config={"enabled": False},
+            )
+        assert "reasoning_effort" not in kwargs
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": False}

--- a/tests/agent/test_auxiliary_task_reasoning_effort.py
+++ b/tests/agent/test_auxiliary_task_reasoning_effort.py
@@ -140,3 +140,33 @@ class TestTaskReasoningEffortConfig:
             )
         assert "reasoning_effort" not in kwargs
         assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
+
+    def test_explicit_extra_body_reasoning_survives_profile(self):
+        # Review F1: a caller-supplied extra_body.reasoning must survive
+        # when the profile handles reasoning in its OWN dialect (top-level
+        # key) and never injected the generic object itself — the pop is
+        # gated on the profile being the source.
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": "none"},
+        ):
+            kwargs = _build_call_kwargs(
+                "custom", "gemma4:26b-mlx", _msgs(), task="compression",
+                extra_body={"reasoning": {"enabled": False}},
+            )
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": False}
+
+    def test_pinned_level_emitted_on_profile_less_backend(self):
+        # Review F2: a config-pinned LEVEL (not just "none") reaches the
+        # wire as a top-level reasoning_effort on a backend with no
+        # reasoning-aware profile.
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"reasoning_effort": "low"},
+        ):
+            kwargs = _build_call_kwargs(
+                "not-a-real-provider-xyz", "some-model", _msgs(),
+                task="compression",
+            )
+        assert kwargs.get("reasoning_effort") == "low"
+        assert kwargs["extra_body"]["reasoning"] == {"enabled": True, "effort": "low"}


### PR DESCRIPTION
## Problem

The `auxiliary.<task>.reasoning_effort` config knob exists but was a silent no-op for Ollama-class (OpenAI-compatible local) providers: the value never reached the request payload, so reasoning/thinking stayed at the model's default — which for thinking models means multi-minute auxiliary calls.

Worse, the leftover **generic** `reasoning_effort` field (config-level, provider-agnostic) was actively poisoning the payload for Ollama: sending an unsupported parameter makes some OpenAI-compatible servers stall or misroute the request. On a production setup here this manifested as a 580s+ auxiliary call (worst of the day) with the generic field present, versus clean fast responses without it.

## Approach

- Per-task `reasoning_effort` now actually reaches the wire for Ollama-class providers, translated to the profile-native shape (`reasoning_effort: none` + `think: false`).
- When an auxiliary profile specifies the effort, it is **profile-authoritative** — the generic field is dropped from the payload instead of being sent alongside (that combination is what stalls).
- Config-gated fallback keeps profile-less providers working unchanged.

## Proof (production path, same model+input)

| | before | after |
|---|---|---|
| wall time | 91.9s | 580s→9.4s* |
| tokens | 5,553 | 618 |

~10x on real auxiliary (compaction) traffic through the live gateway. (*580s figure = poisoned-payload probe run, worst of the day; clean before-fix baseline was 91.9s.)

## Tests

- 9 new tests in `tests/agent/test_auxiliary_task_reasoning_effort.py` covering: knob presence/absence, translation to the Ollama-class wire shape, profile-authoritative override, fallback path. All green on current `main` (fresh venv, cherry-picked cleanly).
- Full compressor suite (148 tests) green on the source tree; the 4 failures seen during development were stash-verified pre-existing on clean main.
