### PR TITLE
fix: recover Windows remote serve after update

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -91,23 +91,41 @@ def _scan_dashboard_processes(
                 timeout=10,
                 errors="ignore",
             )
-            if result is None or result.returncode != 0 or result.stdout is None:
-                return []
-            current_cmd = ""
-            for line in result.stdout.split("\n"):
-                line = line.strip()
-                if line.startswith("CommandLine="):
-                    current_cmd = line[len("CommandLine=") :]
-                elif line.startswith("ProcessId="):
-                    pid_str = line[len("ProcessId=") :]
-                    if (
-                        any(p in current_cmd for p in patterns)
-                        and int(pid_str) != self_pid
-                    ):
+            if result is not None and result.returncode == 0 and result.stdout is not None:
+                current_cmd = ""
+                for line in result.stdout.split("\n"):
+                    line = line.strip()
+                    if line.startswith("CommandLine="):
+                        current_cmd = line[len("CommandLine=") :]
+                    elif line.startswith("ProcessId="):
+                        pid_str = line[len("ProcessId=") :]
+                        if (
+                            any(p in current_cmd for p in patterns)
+                            and int(pid_str) != self_pid
+                        ):
+                            try:
+                                dashboard_processes.append((int(pid_str), current_cmd))
+                            except ValueError:
+                                pass
+
+            # WMIC is an optional Windows Feature and is absent by default on
+            # current Windows 11. Fall back to psutil (a core dependency) when
+            # the probe fails or yields no Hermes web-server processes.
+            if not dashboard_processes:
+                try:
+                    import psutil
+
+                    for proc in psutil.process_iter(["pid", "cmdline"]):
                         try:
-                            dashboard_processes.append((int(pid_str), current_cmd))
-                        except ValueError:
-                            pass
+                            pid = int(proc.info.get("pid") or 0)
+                            argv = proc.info.get("cmdline") or []
+                            command = subprocess.list2cmdline([str(arg) for arg in argv])
+                        except (psutil.NoSuchProcess, psutil.AccessDenied, ValueError, TypeError):
+                            continue
+                        if pid != self_pid and any(p in command for p in patterns):
+                            dashboard_processes.append((pid, command))
+                except (ImportError, OSError):
+                    pass
         else:
             # Linux / macOS: scan the process table via ps and match against
             # the same explicit patterns list used on Windows.  Using ps
@@ -312,14 +330,12 @@ def _kill_stale_dashboard_processes(
     Windows: ``taskkill /PID <pid> /F`` since there's no clean SIGTERM
     equivalent for background console apps.
 
-    Manually-started dashboards are not auto-restarted because we don't know
-    the original launch args (--host, --port, --insecure, --tui, --no-open).
-    When ``restart_managed`` is true (the ``hermes update`` path), a detected
-    ``hermes-dashboard.service`` is restarted through systemd; any OTHER
-    killed PID that was supervised by a systemd unit (custom unit names —
-    e.g. a remote backend's ``hermes-serve.service``) has its owning unit
-    restarted after the kill, because systemd treats our SIGTERM as a clean
-    stop and ``Restart=on-failure`` would never fire (#68934).
+    On the update path, fixed-port manually-started backends are respawned
+    from their captured argv on every platform. Ephemeral ``--port 0`` Desktop
+    children remain Desktop-owned and are never resurrected. systemd-managed
+    processes are restarted through their owning unit; this matters because
+    systemd treats our SIGTERM as a clean stop and ``Restart=on-failure`` would
+    never fire (#68934).
 
     *already_restarted_units* names units (no ``.service`` suffix) the
     caller already restarted directly — e.g. ``hermes update``'s systemd
@@ -356,23 +372,25 @@ def _kill_stale_dashboard_processes(
     if not pids:
         return {"matched": [], "killed": [], "failed": []}
 
-    # Before killing, snapshot systemd cgroup info for each PID so we can
-    # restart supervised services after the kill (the cgroup disappears
-    # along with the process).  Only meaningful on Linux, and only when the
-    # caller asked for restarts (the `hermes update` path) — `--stop` must
-    # stay a stop, not a restart.
+    # Before killing, snapshot supervision + argv so update can recover the
+    # exact backend afterward. systemd ownership exists only on POSIX, but
+    # cmdline capture is cross-platform: fixed-port Windows remote serves are
+    # just as persistent as their POSIX counterparts and must survive updates.
     pid_cgroup: dict[int, str | None] = {}
     pid_service: dict[int, str | None] = {}
     pid_cmdline: dict[int, list[str]] = {}
     pid_home: dict[int, str | None] = {}
-    if restart_managed and sys.platform != "win32":
+    if restart_managed:
         for pid in pids:
-            cg_path = _m()._get_pid_cgroup_path(pid)
-            pid_cgroup[pid] = cg_path
-            pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
-            if not pid_service[pid]:
+            if sys.platform != "win32":
+                cg_path = _m()._get_pid_cgroup_path(pid)
+                pid_cgroup[pid] = cg_path
+                pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
+            if not pid_service.get(pid):
                 # Manually-started process: preserve its exact argv so we
-                # can respawn it after the update (#40449, #68934).
+                # can respawn it after the update (#40449). This includes
+                # Windows fixed-port remote serves; port-zero Desktop children
+                # are filtered out by _filter_dashboard_respawn_candidates.
                 # Snapshot HERMES_HOME before the kill so per-profile caps
                 # still work after the process is gone (#78821).
                 cmdline = _m()._dashboard_cmdline_for_pid(pid)
@@ -380,7 +398,7 @@ def _kill_stale_dashboard_processes(
                     pid_cmdline[pid] = cmdline
                     pid_home[pid] = _hermes_home_for_pid(pid)
 
-        if already_restarted_units:
+        if already_restarted_units and sys.platform != "win32":
             # Already handled directly by the caller (e.g. hermes update's
             # systemd fleet-restart loop) — leave these alone instead of
             # killing and re-restarting a process that's already fresh.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8390,11 +8390,16 @@ def _dashboard_cmdline_for_pid(pid: int) -> list[str] | None:
     Linux: reads ``/proc/<pid>/cmdline`` (NUL-separated, lossless).
     macOS: falls back to ``ps -o command=`` + shlex (best effort — quoting
     is reconstructed, but hermes launch commands don't embed exotic args).
-    Windows: returns ``None``; taskkill /F gives no graceful window and the
-    desktop app manages its own backend there.
+    Windows: reads argv through psutil, avoiding optional/deprecated WMIC.
     """
     if sys.platform == "win32":
-        return None
+        try:
+            import psutil
+
+            argv = psutil.Process(pid).cmdline()
+            return [str(part) for part in argv] or None
+        except (psutil.NoSuchProcess, psutil.AccessDenied, OSError, ValueError):
+            return None
     try:
         cmdline_path = f"/proc/{pid}/cmdline"
         if os.path.exists(cmdline_path):

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -108,6 +108,7 @@ class TestFindStaleDashboardPids:
         assert 12345 in pids
 
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="ps-based scan path")
     def test_ps_timeout_returns_empty(self):
         import subprocess as sp
         with patch("subprocess.run", side_effect=sp.TimeoutExpired("ps", 10)):
@@ -227,6 +228,44 @@ class TestKillStaleDashboardWindows:
         assert "✓ stopped PID 12345" in out
         assert "✓ stopped PID 12346" in out
 
+    @pytest.mark.windows_only
+    def test_windows_cmdline_capture_uses_psutil(self):
+        """Windows update recovery preserves argv without relying on WMIC."""
+        live = sys.modules["hermes_cli.main"]
+        argv = [sys.executable, "-m", "hermes_cli.main", "serve", "--port", "9119"]
+        proc = MagicMock()
+        proc.cmdline.return_value = argv
+        with patch("psutil.Process", return_value=proc):
+            assert live._dashboard_cmdline_for_pid(45020) == argv
+
+    @pytest.mark.windows_only
+    def test_update_respawns_fixed_port_manual_serve(self, capsys):
+        """A Windows fixed-port remote backend survives ``hermes update``."""
+        live = sys.modules["hermes_cli.main"]
+        argv = [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "serve",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9119",
+            "--skip-build",
+        ]
+
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[19176]), \
+             patch.object(live, "_dashboard_cmdline_for_pid", return_value=argv), \
+             patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None), \
+             patch.object(live, "_respawn_dashboard_processes", return_value=[]) as respawn, \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        respawn.assert_called_once_with([argv])
+        assert result["unrecovered"] == []
+        assert "when you're ready" not in capsys.readouterr().out
+
 
 class TestBackCompatAlias:
     """``_warn_stale_dashboard_processes`` is kept as an alias for the
@@ -254,6 +293,30 @@ class TestWindowsWmicEncoding:
     """Regression tests for #17049 — the Windows wmic branch must not crash
     `hermes update` on non-UTF-8 system locales (e.g. cp936 on zh-CN).
     """
+
+    def test_missing_wmic_falls_back_to_psutil(self):
+        """Modern Windows without WMIC must still find fixed-port serves."""
+        proc = MagicMock()
+        proc.info = {
+            "pid": 19176,
+            "cmdline": [
+                sys.executable,
+                "-m",
+                "hermes_cli.main",
+                "serve",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "9119",
+            ],
+        }
+        with patch("sys.platform", "win32"), \
+             patch("hermes_cli._subprocess_compat.bounded_probe_run") as probe, \
+             patch("psutil.process_iter", return_value=[proc]):
+            probe.return_value = None
+            matches = _find_stale_dashboard_pids()
+
+        assert matches == [19176]
 
     def test_wmic_routed_through_bounded_probe_run_with_ignore_errors(self):
         """The wmic scan must go through ``bounded_probe_run`` — which owns
@@ -298,7 +361,8 @@ class TestWindowsWmicEncoding:
         an empty scan, not an AttributeError on result.stdout (#87134)."""
         with patch("sys.platform", "win32"), \
              patch("hermes_cli._subprocess_compat.bounded_probe_run",
-                   return_value=None):
+                   return_value=None), \
+             patch("psutil.process_iter", return_value=[]):
             assert _find_stale_dashboard_pids() == []
 
 


### PR DESCRIPTION
## Summary
- fall back to psutil when WMIC is unavailable on modern Windows 11
- capture Windows dashboard/serve argv before update cleanup
- respawn fixed-port remote backends after update while leaving Desktop port-zero children excluded

## Root cause
`hermes update` stops stale web-server processes after replacing the checkout. The Windows path skipped argv capture, so a fixed-port remote `hermes serve` backend was stopped and never relaunched. Process discovery also returned no matches when optional WMIC was absent.

## Verification
- `28 passed, 12 skipped` in `tests/hermes_cli/test_update_stale_dashboard.py`
- live Windows recovery test stopped the fixed-port backend, respawned its captured command, and restored local and Tailscale `/api/status` to HTTP 200 with `overall=ok`
