### PR TITLE
fix(hermes-bots): never double-space when inserting a group mention at a word boundary

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -11678,7 +11678,11 @@ function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...inputPr
     }
 
     const caret = inputRef.current?.selectionStart ?? value.length
-    const next = `${value.slice(0, token.start)}@${handle} ${value.slice(caret)}`
+    // Separator-aware: insert exactly one space after the handle, unless the
+    // remainder already starts with whitespace — never double-space at a word
+    // boundary (e.g. "hello @herin  world" when the caret sits mid-sentence).
+    const separator = /^\s/.test(value.slice(caret)) ? '' : ' '
+    const next = `${value.slice(0, token.start)}@${handle}${separator}${value.slice(caret)}`
     onChange(next)
     setToken(null)
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-mention-composer.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-mention-composer.test.mjs
@@ -32,8 +32,10 @@ test('popover offers @everyone/@all and inserts parser-compatible strings', () =
     source.indexOf('function GroupChatWorkspace')
   )
   assert.ok(component.includes("['everyone', 'all']"), 'quick picks for the room-wide broadcast')
-  // Insertion writes exactly "@handle " — the shape parseGroupChatMentions resolves.
-  assert.ok(component.includes('`${value.slice(0, token.start)}@${handle} ${value.slice(caret)}`'))
+  // Insertion writes exactly "@handle " — the shape parseGroupChatMentions resolves —
+  // but never double-spaces when the remainder already starts with whitespace.
+  assert.ok(component.includes('`${value.slice(0, token.start)}@${handle}${separator}${value.slice(caret)}`'))
+  assert.ok(component.includes("const separator = /^\\s/.test(value.slice(caret)) ? '' : ' '"), 'separator-aware insertion at word boundaries')
   // Member handles come from the same botHandle used by the parser.
   assert.ok(component.includes('botHandle(member.name, member)'))
   // mousedown insertion must preventDefault so the input keeps focus.
@@ -66,4 +68,31 @@ test('mentionTokenAt finds the active @-token at the caret', () => {
   assert.equal(fn('plain text', 10), null)
   // Caret before the @ is not inside the token.
   assert.equal(fn('hey @al', 3), null)
+})
+
+test('insert never double-spaces at a word boundary (regression)', () => {
+  // Extract the insert() body and run it with scripted closure values so the
+  // separator logic is exercised for real, not just source-matched.
+  const start = source.indexOf('function GroupMentionInput')
+  const end = source.indexOf('function GroupChatWorkspace')
+  const component = source.slice(start, end)
+
+  const insertBody = component.slice(
+    component.indexOf('const insert = handle => {'),
+    component.indexOf('\n  }\n', component.indexOf('requestAnimationFrame')) + 4
+  )
+  const ctx = {
+    inputRef: { current: { selectionStart: 7 } },
+    token: { start: 6, query: '' },
+    value: 'hello @ world',
+    onChange: v => {
+      ctx.__next = v
+    },
+    setToken: () => undefined,
+    requestAnimationFrame: () => undefined
+  }
+  vm.createContext(ctx)
+  vm.runInContext(insertBody + '\nthis.__insert = insert', ctx)
+  ctx.__insert('herin')
+  assert.equal(ctx.__next, 'hello @herin world', 'single space at word boundary, no double space')
 })


### PR DESCRIPTION
## Problem

Inserting a group @mention mid-sentence produces a double space. `GroupMentionInput.insert` always writes `@handle ` + `value.slice(caret)`, so when the caret is followed by whitespace (the common mid-sentence case) the result is `hello @herin  world`.

## Repro

In a Bot Mode group composer, type `hello ` then place the caret after the space and pick a member from the @-popover → the composer shows `hello @herin  world` (two spaces).

## Fix

Separator-aware insertion: emit exactly one space after the handle, unless the remainder already starts with whitespace. The `@handle ` shape `parseGroupChatMentions` resolves is preserved (parser matches `@[a-z0-9][a-z0-9._-]*` and ignores trailing whitespace), so mention resolution is unaffected.

## Tests

- Updated the source-shape assertion in `group-mention-composer.test.mjs` that previously asserted the buggy template literal.
- Added an executable regression test that runs the `insert` body with a scripted `inputRef` (word-boundary case) — verified **RED on revert** (buggy code fails both tests).
- Full plugin suite: **527/527 pass**.