### PR TITLE
ci(stress): kanban stress/chaos scripts actually execute — nightly workflow + honest conftest/README (#93135)

### DIFF
--- a/.github/workflows/stress-nightly.yml
+++ b/.github/workflows/stress-nightly.yml
@@ -1,0 +1,58 @@
+name: Stress / concurrency (nightly)
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stress-nightly
+  cancel-in-progress: false
+
+jobs:
+  stress:
+    if: github.repository == 'NousResearch/hermes-agent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        script:
+          - test_concurrency.py
+          - test_concurrency_mixed.py
+          - test_concurrency_reclaim_race.py
+          - test_concurrency_parent_gate.py
+          - test_property_fuzzing.py
+          - test_subprocess_e2e.py
+          - test_atypical_scenarios.py
+          - test_benchmarks.py
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          version: '0.9.28'
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        uses: ./.github/actions/retry
+        with:
+          command: uv python install 3.11
+
+      - name: Install dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: uv sync --locked --python 3.11 --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web
+
+      - name: Run stress script
+        run: |
+          set -euo pipefail
+          source .venv/bin/activate
+          python "tests/stress/${{ matrix.script }}"

--- a/tests/stress/README.md
+++ b/tests/stress/README.md
@@ -1,18 +1,21 @@
 # Stress / battle-test suite
 
-Long-running tests that exercise the Kanban kernel under adversarial
-conditions. **Not run by `scripts/run_tests.sh`** because they can
+Long-running scripts that exercise the Kanban kernel under adversarial
+conditions. They are **not run by `scripts/run_tests.sh`** because they can
 take 30+ seconds each and spawn real subprocesses.
 
-Run manually:
+These files are standalone `__main__` programs, not pytest test modules.
+Running `pytest tests/stress/` intentionally collects zero tests. Run the
+scripts directly, or use `.github/workflows/stress-nightly.yml`.
+
+Run manually from the repository root:
 
 ```bash
-./venv/bin/python -m pytest tests/stress/ -v -s
-# or individual files:
-./venv/bin/python tests/stress/test_concurrency.py
-./venv/bin/python tests/stress/test_subprocess_e2e.py
-./venv/bin/python tests/stress/test_property_fuzzing.py
-./venv/bin/python tests/stress/test_benchmarks.py
+source .venv/bin/activate
+python tests/stress/test_concurrency.py
+python tests/stress/test_subprocess_e2e.py
+python tests/stress/test_property_fuzzing.py
+python tests/stress/test_benchmarks.py
 ```
 
 ## What's covered

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -1,37 +1,13 @@
-"""pytest config for the stress/ subdirectory.
+"""Keep standalone stress scripts out of normal pytest collection.
 
-These tests are slow (30s+), spawn subprocesses, and are not run by
-default. Enable via `pytest --run-stress` or by running the scripts
-directly.
-
-The scripts are primarily __main__-executable entry points; pytest
-isn't expected to collect individual test functions from them.
+The files in this directory are ``__main__``-executable programs, not pytest
+modules. The dedicated stress workflow invokes them directly; running pytest
+on this directory intentionally collects no tests.
 """
-import pytest
-
-
-def pytest_collection_modifyitems(config, items):
-    if config.getoption("--run-stress", default=False):
-        return
-    skip_stress = pytest.mark.skip(
-        reason="stress test (opt-in via --run-stress or run script directly)"
-    )
-    for item in items:
-        if "tests/stress" in str(item.fspath):
-            item.add_marker(skip_stress)
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--run-stress",
-        action="store_true",
-        default=False,
-        help="Run the stress/battle-test suite (slow, spawns subprocesses).",
-    )
 
 
 collect_ignore_glob = [
-    # The stress scripts have top-level code and hard-coded paths; they're
-    # meant to run as `python tests/stress/<name>.py`, not as pytest modules.
+    # These scripts have top-level entry points and are run as
+    # `python tests/stress/<name>.py`, not as pytest modules.
     "*.py",
 ]

--- a/tests/stress/test_atypical_scenarios.py
+++ b/tests/stress/test_atypical_scenarios.py
@@ -456,8 +456,8 @@ def _(home, kb):
     conn = kb.connect()
     try:
         tid = kb.create_task(
-            conn, title="bad-workspace", assignee="w",
-            workspace_kind="dir",
+            conn, title="bad-workspace", assignee="default",
+            workspace_kind="worktree",
             workspace_path="/nonexistent/path/that/does/not/exist",
         )
         # Run dispatch_once with a dummy spawn_fn
@@ -466,14 +466,14 @@ def _(home, kb):
         task = kb.get_task(conn, tid)
         # Possible outcomes:
         # - Task back in ready (workspace issue = spawn_failed, retries)
-        # - Task in running (kernel accepted the bogus path and spawned)
+        # - Task in running (the workspace resolver accepted the path)
         # - Task auto-blocked (after N retries, but we only ran 1 tick)
         print(f"  after 1 tick with nonexistent workspace: status={task.status}")
         if task.status == "ready":
             # Expected path: workspace failure led to release
-            spawn_failures = task.spawn_failures
-            print(f"  spawn_failures counter: {spawn_failures}")
-            assert spawn_failures >= 1, "spawn_failures counter didn't increment"
+            consecutive_failures = task.consecutive_failures
+            print(f"  consecutive_failures counter: {consecutive_failures}")
+            assert consecutive_failures >= 1, "consecutive_failures counter didn't increment"
         elif task.status == "running":
             # Workspace not checked before spawn — the worker would hit
             # the bad path itself. Defensible for `dir:` workspaces that
@@ -938,7 +938,7 @@ def _(home, kb):
 @scenario("parent_in_different_status_states")
 def _(home, kb):
     """recompute_ready promotes a todo child only if ALL parents are
-    in 'done'. Verify against parents in every non-done state."""
+    terminal ('done' or 'archived'). Verify every other parent state."""
     kb.init_db()
     conn = kb.connect()
     try:
@@ -961,8 +961,9 @@ def _(home, kb):
             (p_running, "todo"),
             (p_blocked, "todo"),
             (p_triage, "todo"),
-            (p_archived, "todo"),  # archived != done!
-            (p_done, "ready"),     # only done parent unblocks child
+            # archived is terminal for dependency resolution.
+            (p_archived, "ready"),
+            (p_done, "ready"),
         ]:
             child = kb.create_task(
                 conn, title=f"child-of-{parent}", assignee="w", parents=[parent],
@@ -973,7 +974,7 @@ def _(home, kb):
                 f"child of {parent} ({kb.get_task(conn, parent).status}): "
                 f"expected {expected}, got {actual}"
             )
-        print("  child promotion correctly gated on parent.status == 'done'")
+        print("  child promotion correctly gated on terminal parent status")
     finally:
         conn.close()
 

--- a/tests/stress/test_subprocess_e2e.py
+++ b/tests/stress/test_subprocess_e2e.py
@@ -12,6 +12,7 @@ This validates the IPC + lifecycle story that mocks can't:
 
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -35,7 +36,9 @@ def make_spawn_fn(home: str):
             "PYTHONPATH": WT,
             "HERMES_KANBAN_TASK": task.id,
             "HERMES_KANBAN_WORKSPACE": workspace,
-            "PATH": f"{os.path.dirname(PY)}:{os.environ.get('PATH','')}",
+            "PATH": os.pathsep.join(
+                [os.path.dirname(PY), os.environ.get("PATH", "")]
+            ),
         }
         log_f = open(log_path, "ab")
         proc = subprocess.Popen(
@@ -52,6 +55,10 @@ def make_spawn_fn(home: str):
 
 
 def main():
+    if os.name == "nt":
+        print("SKIP: test_subprocess_e2e requires a POSIX shell shim")
+        return
+
     home = tempfile.mkdtemp(prefix="hermes_e2e_")
     os.environ["HERMES_HOME"] = home
     os.environ["HOME"] = home
@@ -68,7 +75,13 @@ def main():
 exec {PY} -m hermes_cli.main "$@"
 """)
     os.chmod(shim_path, 0o755)
-    os.environ["PATH"] = f"{shim_dir}:{os.environ.get('PATH','')}"
+    os.environ["PATH"] = os.pathsep.join([shim_dir, os.environ.get("PATH", "")])
+    resolved_hermes = shutil.which("hermes")
+    if not resolved_hermes or Path(resolved_hermes).resolve() != Path(shim_path).resolve():
+        raise RuntimeError(
+            "test_subprocess_e2e resolved the wrong hermes executable: "
+            f"expected {shim_path!r}, got {resolved_hermes!r}"
+        )
 
     kb.init_db()
     conn = kb.connect()


### PR DESCRIPTION
## Summary
The kanban stress/chaos scripts under `tests/stress/` are now actually executed: a dedicated nightly/manual workflow runs them as the standalone programs they are, and the conftest/README stop advertising a `--run-stress` pytest flag that could never collect anything (`collect_ignore_glob = ["*.py"]` made it a permanent no-op).

Fixes #93135 (and sibling facets #93136, #93137 per the original PR).

## Changes
- `.github/workflows/stress-nightly.yml` (new): nightly + manual matrix running each stress script directly; failures fail the job; stays out of the normal PR lane.
- `tests/stress/conftest.py`, `tests/stress/README.md`: remove the dead `--run-stress` path, document the real invocation.
- `tests/stress/test_atypical_scenarios.py`, `tests/stress/test_subprocess_e2e.py`: script-mode fixes so they run standalone. Salvaged from #93210 by @JoaoMarcos44 (joaomarcos).

## Validation
Author verified the subprocess-E2E and main scenario scripts locally; the property-fuzzing/benchmark/atypical runs exceed local timeouts and are explicitly gated on the first nightly workflow run — reviewer note: watch the first scheduled run before trusting the whole matrix. Workflow YAML validated; not in the PR-blocking lane, so a red nightly can't block merges.

## Infographic

![Stress scripts finally run](https://v3b.fal.media/files/b/0aa78e0e/dYvzei5QscYpSz4XOp3JM_gXED0OMN.png)
