### PR TITLE
fix(kanban): don't record a comment/event when block/schedule/unblock is rejected

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2342,8 +2342,6 @@ def _cmd_block(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
             if not kb.block_task(
                 conn,
                 tid,
@@ -2354,6 +2352,8 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 failed.append(tid)
                 print(f"cannot block {tid}", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"BLOCKED: {reason}")
                 # Report where the task actually landed — dependency blocks go
                 # to todo, and a tripped unblock-loop breaker routes to triage.
                 landed = kb.get_task(conn, tid)
@@ -2378,8 +2378,6 @@ def _cmd_schedule(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"SCHEDULED: {reason}")
             if not kb.schedule_task(
                 conn,
                 tid,
@@ -2389,6 +2387,8 @@ def _cmd_schedule(args: argparse.Namespace) -> int:
                 failed.append(tid)
                 print(f"cannot schedule {tid}", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"SCHEDULED: {reason}")
                 print(f"Scheduled {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 
@@ -2405,12 +2405,12 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
-            if reason:
-                kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
             if not kb.unblock_task(conn, tid):
                 failed.append(tid)
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:
+                if reason:
+                    kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
                 print(f"Unblocked {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -167,6 +167,50 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
+# ---------------------------------------------------------------------------
+# rejected state mutations must not leave a note/event behind (issue #93225)
+# ---------------------------------------------------------------------------
+
+
+def test_block_on_triage_task_leaves_no_comment_or_event(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="triage task", triage=True)
+
+    out = kc.run_slash(f"block {tid} not actionable yet")
+    assert "cannot block" in out.lower(), out
+
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+        assert kb.list_comments(conn, tid) == []
+        assert all(e.kind != "commented" for e in kb.list_events(conn, tid))
+
+
+def test_schedule_on_triage_task_leaves_no_comment_or_event(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="triage task", triage=True)
+
+    out = kc.run_slash(f"schedule {tid} wait for input")
+    assert "cannot schedule" in out.lower(), out
+
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+        assert kb.list_comments(conn, tid) == []
+        assert all(e.kind != "commented" for e in kb.list_events(conn, tid))
+
+
+def test_unblock_on_triage_task_leaves_no_comment_or_event(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="triage task", triage=True)
+
+    out = kc.run_slash(f"unblock {tid} --reason 'nevermind'")
+    assert "cannot unblock" in out.lower(), out
+
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+        assert kb.list_comments(conn, tid) == []
+        assert all(e.kind != "commented" for e in kb.list_events(conn, tid))
+
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -211,8 +211,6 @@ def test_unblock_on_triage_task_leaves_no_comment_or_event(kanban_home):
         assert all(e.kind != "commented" for e in kb.list_events(conn, tid))
 
 
-
-
 # ---------------------------------------------------------------------------
 # /kanban specify — slash surface (same entry point CLI + gateway use)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes one specific defect described in #93225: `kanban block`, `kanban
schedule`, and `kanban unblock` recorded the `--reason`/`--reason` note
as a task comment (which also appends a `commented` event) *before*
checking whether the underlying state transition (`kb.block_task`,
`kb.schedule_task`, `kb.unblock_task`) actually succeeded. When the
task wasn't in a state the transition accepts — e.g. running `kanban
block` on a task that's in `triage`, which `block_task` only accepts
from `running`/`ready` — the command printed `cannot block <id>` and
returned a non-zero exit code, but the comment and its event had
already been committed to the task's history. A rejected mutation was
not actually a no-op.

This directly matches the acceptance criterion from #93225: "No
note/event on a rejected state mutation."

**Scope note:** #93225 bundles several other, unrelated capability
requests (atomic triage→ready promotion, exact-task dispatch
selection, worktree-binding validation, a new post-create field
setter, structured run-framed logs). Those are separate, much larger
design questions spanning the dispatcher and worktree binding layers;
this PR only fixes the "stray note/event on a rejected transition" bug
across the three commands that share the pattern (`block`, `schedule`,
`unblock`). It does not close the issue on its own.

## Related Issue

Addresses part of #93225 (see scope note above — not a full fix).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban.py`: in `_cmd_block`, `_cmd_schedule`, and
  `_cmd_unblock`, move the `kb.add_comment(...)` call so it only runs
  after the corresponding transition (`block_task` / `schedule_task` /
  `unblock_task`) reports success, instead of unconditionally before
  the transition is attempted.
- `tests/hermes_cli/test_kanban_cli.py`: add
  `test_block_on_triage_task_leaves_no_comment_or_event`,
  `test_schedule_on_triage_task_leaves_no_comment_or_event`, and
  `test_unblock_on_triage_task_leaves_no_comment_or_event`, each
  creating a `triage` task (a status none of the three transitions
  accept), invoking the CLI command with a reason, and asserting the
  command reports failure while the task ends up with zero comments
  and no `commented` event.

## How to Test

```
python3 -m pytest tests/hermes_cli/test_kanban_cli.py -k "triage_task_leaves_no_comment" -q
```

With the fix (this branch):

```
...                                                                      [100%]
3 passed, 4 deselected in 0.86s
```

Confirmed the new tests fail without the fix — reverted only
`hermes_cli/kanban.py` to `HEAD~1` (keeping the new tests) and re-ran:

```
FAILED tests/hermes_cli/test_kanban_cli.py::test_block_on_triage_task_leaves_no_comment_or_event
  - AssertionError: assert [Comment(id=1, ..., body='BLOCKED: not actionable yet', ...)] == []
FAILED tests/hermes_cli/test_kanban_cli.py::test_schedule_on_triage_task_leaves_no_comment_or_event
  - AssertionError: assert [Comment(id=1, ..., body='SCHEDULED: wait for input', ...)] == []
FAILED tests/hermes_cli/test_kanban_cli.py::test_unblock_on_triage_task_leaves_no_comment_or_event
  - AssertionError: assert [Comment(id=1, ..., body='UNBLOCK: nevermind', ...)] == []
3 failed, 4 deselected in 0.93s
```

Then restored the fix and reran the broader kanban CLI suite plus
related block-kind tests, all passing:

```
python3 -m pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_blocked_sticky.py -q
...........                                                              [100%]
11 passed in 3.44s
```

Also ran the full `-k kanban` slice of `tests/hermes_cli/` on both this
branch and unmodified `upstream/main`: the same 15 tests fail on both
(plugin-discovery/env-isolation flakiness and a missing optional
`acp.schema` module, unrelated to this change), confirming this PR
introduces no regressions.

Lint: `python3 -m ruff check hermes_cli/kanban.py tests/hermes_cli/test_kanban_cli.py` → `All checks passed!`

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(kanban):`)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes

## AI assistance disclosure

This change was written with the assistance of an AI coding agent
(Claude), including the diagnosis, the fix, and the regression tests.
All test output above was actually executed and captured, not
fabricated.
