### PR TITLE
fix(sessions): reconnect no longer strands or storms sessions — reap loop broken, owner-routed RPCs (8 salvages, #91276 cluster)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -250,6 +250,7 @@ import {
   fetchPrimaryProfileSessions,
   fetchRegistrySessionRows,
   fetchRemoteProfileSessions,
+  findRemoteOwnerProfileForSession,
   mergeProfileSessionWindow,
   type RegistrySessionSource,
   spliceRegistrySessionRows
@@ -13483,10 +13484,21 @@ async function interceptSessionRequestForRemote(request) {
   //  - global remote mode: ONE backend serves every profile via ?profile=, so
   //    route there and KEEP the profile param so it opens the right state.db.
   if (/^\/api\/sessions\/[^/]+(\/messages)?$/.test(pathname)) {
-    const profile = (searchParams.get('profile') || request.profile || '').trim()
+    let profile = (searchParams.get('profile') || request.profile || '').trim()
 
     if (!profile) {
-      return undefined
+      // No explicit owner hint (#85834). The list endpoints above already know
+      // which remote profile owns each row (remoteSessionList tags s.profile),
+      // but a caller without a hint used to fall straight through to the LOCAL
+      // backend and 404 on its state.db even though the session lives on a
+      // remote. Consult the same remote lists to find the owner; only fall
+      // through when the id is genuinely unknown remotely.
+      const sessionId = decodeURIComponent(pathname.split('/')[3] || '')
+      profile = (await remoteOwnerProfileForSession(sessionId)) || ''
+
+      if (!profile) {
+        return undefined
+      }
     }
 
     // Preserve every non-profile query param (limit/offset/order pagination —
@@ -13543,6 +13555,39 @@ async function remoteSessionList(profile, searchParams) {
   }
 
   return { ...(data as any), sessions: rowsOf(data) }
+}
+
+// #85834: find which remote profile owns a session id when the caller gave no
+// profile hint (pure lookup lives in profile-session-routing.ts). Results are
+// memoized briefly so a burst of hint-less reads (transcript + messages)
+// costs one sweep across the configured remotes.
+const remoteOwnerBySessionId = new Map<string, { at: number; profile: null | string }>()
+const REMOTE_OWNER_CACHE_TTL_MS = 30_000
+
+async function remoteOwnerProfileForSession(sessionId: string) {
+  if (!sessionId) {
+    return null
+  }
+
+  const remoteProfiles = configuredRemoteProfileNames()
+
+  if (remoteProfiles.length === 0) {
+    return null
+  }
+
+  const cached = remoteOwnerBySessionId.get(sessionId)
+
+  if (cached && Date.now() - cached.at < REMOTE_OWNER_CACHE_TTL_MS) {
+    return cached.profile
+  }
+
+  const owner = await findRemoteOwnerProfileForSession(sessionId, remoteProfiles, (profile, params) =>
+    remoteSessionList(profile, params)
+  ).catch(() => null)
+
+  remoteOwnerBySessionId.set(sessionId, { at: Date.now(), profile: owner })
+
+  return owner
 }
 
 // Resolve one /api/profiles/sessions slice with remote profiles spliced in —

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -7,6 +7,7 @@ import {
   fetchPrimaryProfileSessions,
   fetchRegistrySessionRows,
   fetchRemoteProfileSessions,
+  findRemoteOwnerProfileForSession,
   mergeProfileSessionWindow,
   spliceRegistrySessionRows
 } from './profile-session-routing'
@@ -373,4 +374,44 @@ test('splice: registry rows dedupe by id and extend per-profile totals', () => {
   assert.equal(totals['hermes-claude'], 1)
   assert.equal(totals.default, 2) // untagged registry row counts under default
   assert.equal(totals.work, 1) // deduped row does not double-count
+})
+
+test('finds the remote owner profile for a hint-less session read (#85834)', async () => {
+  const owner = await findRemoteOwnerProfileForSession('sess-remote', ['vps-a', 'vps-b'], async profile => {
+    if (profile === 'vps-b') {
+      return { sessions: [{ id: 'sess-remote' }] } as never
+    }
+
+    return { sessions: [{ id: 'other' }] } as never
+  })
+
+  assert.equal(owner, 'vps-b')
+})
+
+test('remote owner lookup matches a compression lineage root id too', async () => {
+  const owner = await findRemoteOwnerProfileForSession('root-1', ['vps-a'], async () => {
+    return { sessions: [{ id: 'tip-2', _lineage_root_id: 'root-1' }] } as never
+  })
+
+  assert.equal(owner, 'vps-a')
+})
+
+test('remote owner lookup returns null when no remote lists the id or remotes fail', async () => {
+  const missing = await findRemoteOwnerProfileForSession('sess-x', ['vps-a'], async () => {
+    return { sessions: [{ id: 'other' }] } as never
+  })
+
+  assert.equal(missing, null)
+
+  const dead = await findRemoteOwnerProfileForSession('sess-x', ['vps-a'], async () => {
+    throw new Error('remote unavailable')
+  })
+
+  assert.equal(dead, null)
+
+  const noRemotes = await findRemoteOwnerProfileForSession('sess-x', [], async () => {
+    throw new Error('never called')
+  })
+
+  assert.equal(noRemotes, null)
 })

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -374,3 +374,36 @@ export async function fetchRemoteProfileSessions(
     offset: requestedOffset
   }
 }
+
+/**
+ * #85834: which remote profile owns `sessionId`, when a /api/sessions/{id}
+ * caller supplied no profile hint. Reads the same per-remote lists the list
+ * endpoints splice into the sidebar (each fetch is per-profile, so a hit IS
+ * the owner). Dead remotes contribute nothing; returns null when no remote
+ * lists the id — the intercept then falls through to the local backend
+ * exactly as before.
+ */
+export async function findRemoteOwnerProfileForSession(
+  sessionId: string,
+  remoteProfiles: readonly string[],
+  listForProfile: (profile: string, searchParams: URLSearchParams) => Promise<SessionListResponse | null>
+): Promise<null | string> {
+  if (!sessionId || remoteProfiles.length === 0) {
+    return null
+  }
+
+  const params = new URLSearchParams()
+  params.set('limit', '200')
+  params.set('offset', '0')
+
+  const matches = await Promise.all(
+    remoteProfiles.map(async profile => {
+      const list = await listForProfile(profile, params).catch(() => null)
+      const rows = Array.isArray(list?.sessions) ? (list.sessions as Array<Record<string, unknown>>) : []
+
+      return rows.some(row => row?.id === sessionId || row?._lineage_root_id === sessionId) ? profile : null
+    })
+  )
+
+  return matches.find(profile => profile !== null) ?? null
+}

--- a/apps/desktop/src/app/chat/session-tile.test.ts
+++ b/apps/desktop/src/app/chat/session-tile.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { sessionTileResumeFailure } from './session-tile'
+
+describe('sessionTileResumeFailure', () => {
+  it('keeps a confirmed durable session retryable instead of repeating a stale 404', () => {
+    expect(sessionTileResumeFailure('session not found', true, true)).toBe('Session is still available — retry resuming it.')
+  })
+
+  it('fails safe on an inconclusive durable lookup', () => {
+    expect(sessionTileResumeFailure('404', false, true)).toBe('Session unavailable — you can retry resuming it.')
+  })
+
+  it('does not overwrite a tile that rebound while the lookup was pending', () => {
+    expect(sessionTileResumeFailure('session not found', true, false)).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -53,7 +53,6 @@ import {
   $sessionTileDelegateRevision,
   $sessionTiles,
   closeSessionTile,
-  discardSessionTile,
   patchSessionTile,
   type SessionTile,
   sessionTileDelegate,
@@ -265,6 +264,10 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const delegateRevision = useStore($sessionTileDelegateRevision)
   const resumingRef = useRef(false)
   const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
+  const storedSessionStillExists = useCallback(
+    () => $sessions.get().some(s => sessionMatchesStoredId(s, storedSessionId)),
+    [storedSessionId]
+  )
 
   // A tab-strip "+"/⌘T tab is created UNLISTED — its session stays out of
   // $sessions (no sidebar clutter) until it's actually used, so the tab shows
@@ -277,7 +280,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const hasMessages = useStore(view.$messagesEmpty) === false
 
   useEffect(() => {
-    const alreadyListed = () => $sessions.get().some(s => sessionMatchesStoredId(s, storedSessionId))
+    const alreadyListed = storedSessionStillExists
 
     if (!runtimeId || !hasMessages || alreadyListed()) {
       return
@@ -311,7 +314,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
         window.clearTimeout(timer)
       }
     }
-  }, [hasMessages, ownerRoute, runtimeId, storedSessionId])
+  }, [hasMessages, ownerRoute, runtimeId, storedSessionId, storedSessionStillExists])
 
   // Same gating as the primary's route resume (use-route-resume): never fire
   // session.resume before the gateway is OPEN. Persisted tiles mount at boot
@@ -334,22 +337,29 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
     delegate
       .resumeTile(storedSessionId)
       .then(id => patchSessionTile(storedSessionId, { error: undefined, runtimeId: id }))
-      .catch((err: unknown) => {
+      .catch(async (err: unknown) => {
         const message = err instanceof Error ? err.message : String(err)
 
-        // A gone session (404 / "Session not found") is terminal — a stale or
-        // cross-profile persisted tile. Discard it instead of latching an error
-        // that re-retries on every reconnect (the "Session not found" spam).
-        if (/session not found|\b404\b/i.test(message)) {
-          discardSessionTile(storedSessionId)
-        } else {
+        if (!/session not found|\b404\b/i.test(message)) {
+          patchSessionTile(storedSessionId, { error: message })
+          return
+        }
+
+        // A recents page is not authoritative, and resolveStoredSession()
+        // intentionally treats transient probe failures like a miss. Await it
+        // before releasing this resume attempt, then fail safe: a tile may be
+        // retried by the user, but must never be deleted on an inconclusive
+        // reconnect-time lookup.
+        await resolveStoredSession(storedSessionId, ownerRoute).catch(() => undefined)
+        const current = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
+        if (current && !current.runtimeId) {
           patchSessionTile(storedSessionId, { error: message })
         }
       })
       .finally(() => {
         resumingRef.current = false
       })
-  }, [delegateRevision, gatewayOpen, runtimeId, storedSessionId, tile?.error])
+  }, [delegateRevision, gatewayOpen, ownerRoute, runtimeId, storedSessionId, tile?.error])
 
   // The gateway (re)opening invalidates any latched error — it likely came
   // from a not-yet-open gateway or the previous connection. Clearing it

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -76,6 +76,26 @@ import { ChatView } from '.'
 
 const NO_MESSAGES: ChatMessage[] = []
 
+export function sessionTileResumeFailure(
+  message: string,
+  durableSessionFound: boolean | undefined,
+  tileStillUnbound: boolean
+): string | undefined {
+  if (!tileStillUnbound) {
+    return undefined
+  }
+
+  if (!/session not found|\b404\b/i.test(message)) {
+    return message
+  }
+
+  if (durableSessionFound) {
+    return 'Session is still available — retry resuming it.'
+  }
+
+  return 'Session unavailable — you can retry resuming it.'
+}
+
 /** The tile's SessionView: the same atom shape the primary chat renders
  *  from, computed from this session's slice of `$sessionStates`. */
 function buildTileView(storedSessionId: string): SessionView {
@@ -264,6 +284,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
   const delegateRevision = useStore($sessionTileDelegateRevision)
   const resumingRef = useRef(false)
   const view = useMemo(() => buildTileView(storedSessionId), [storedSessionId])
+
   const storedSessionStillExists = useCallback(
     () => $sessions.get().some(s => sessionMatchesStoredId(s, storedSessionId)),
     [storedSessionId]
@@ -342,6 +363,7 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
 
         if (!/session not found|\b404\b/i.test(message)) {
           patchSessionTile(storedSessionId, { error: message })
+
           return
         }
 
@@ -350,10 +372,12 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
         // before releasing this resume attempt, then fail safe: a tile may be
         // retried by the user, but must never be deleted on an inconclusive
         // reconnect-time lookup.
-        await resolveStoredSession(storedSessionId, ownerRoute).catch(() => undefined)
+        const durableSession = await resolveStoredSession(storedSessionId, ownerRoute).catch(() => undefined)
         const current = $sessionTiles.get().find(candidate => candidate.storedSessionId === storedSessionId)
-        if (current && !current.runtimeId) {
-          patchSessionTile(storedSessionId, { error: message })
+        const error = sessionTileResumeFailure(message, Boolean(durableSession), Boolean(current && !current.runtimeId))
+
+        if (error) {
+          patchSessionTile(storedSessionId, { error })
         }
       })
       .finally(() => {

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -107,19 +107,29 @@ describe('useSessionTileDelegate resumeTile', () => {
   it('resolves and carries a default-profile session explicitly', async () => {
     setSessions([row({ id: 'stored-y', profile: 'default' })])
 
-    const requestGateway = vi.fn(async (method: string) =>
-      method === 'session.resume' ? ({ session_id: 'runtime-2' } as never) : ({} as never)
-    )
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    // #92961: a known owner is ALWAYS routed through the profile router —
+    // even 'default' — never dispatched on the ambient socket.
+    vi.mocked(requestGatewayForProfile).mockResolvedValueOnce({ session_id: 'runtime-2' } as never)
 
     renderTile(requestGateway)
-    await sessionTileDelegate()!.resumeTile('stored-y')
+    const runtimeId = await sessionTileDelegate()!.resumeTile('stored-y')
 
-    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
-      session_id: 'stored-y',
-      cols: 96,
-      profile: 'default',
-      omit_messages: true
-    })
+    expect(runtimeId).toBe('runtime-2')
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'default',
+      'session.resume',
+      {
+        session_id: 'stored-y',
+        cols: 96,
+        profile: 'default',
+        omit_messages: true
+      },
+      undefined,
+      undefined
+    )
+    expect(requestGateway).not.toHaveBeenCalled()
   })
 
   it('routes a Bot tile prefetch and resume through its exact connection owner', async () => {
@@ -174,20 +184,26 @@ describe('useSessionTileDelegate resumeTile', () => {
     const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-b', 'runtime-dead']]) }
     const sessionStateByRuntimeIdRef = { current: new Map([['runtime-dead', staleState]]) }
 
-    const requestGateway = vi.fn(async (method: string) =>
-      method === 'session.resume' ? ({ session_id: 'runtime-fresh' } as never) : ({} as never)
-    )
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    vi.mocked(requestGatewayForProfile).mockResolvedValueOnce({ session_id: 'runtime-fresh' } as never)
 
     renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
     const runtimeId = await sessionTileDelegate()!.resumeTile('stored-b')
 
     expect(runtimeId).toBe('runtime-fresh')
-    expect(requestGateway).toHaveBeenCalledWith('session.resume', {
-      session_id: 'stored-b',
-      cols: 96,
-      profile: 'default',
-      omit_messages: true
-    })
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'default',
+      'session.resume',
+      {
+        session_id: 'stored-b',
+        cols: 96,
+        profile: 'default',
+        omit_messages: true
+      },
+      undefined,
+      undefined
+    )
   })
 
   it('invalidateRuntimeBindings clears the stored→runtime map so tiles re-resume after reconnect', async () => {
@@ -197,9 +213,9 @@ describe('useSessionTileDelegate resumeTile', () => {
     const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-c', 'runtime-dead']]) }
     const sessionStateByRuntimeIdRef = { current: new Map([['runtime-dead', liveState]]) }
 
-    const requestGateway = vi.fn(async (method: string) =>
-      method === 'session.resume' ? ({ session_id: 'runtime-fresh' } as never) : ({} as never)
-    )
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    vi.mocked(requestGatewayForProfile).mockResolvedValueOnce({ session_id: 'runtime-fresh' } as never)
 
     renderTile(requestGateway, { runtimeIdByStoredSessionIdRef, sessionStateByRuntimeIdRef })
 

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -8,6 +8,7 @@ import { publishSessionState, sessionTileOwnerRoute, setSessionTileDelegate } fr
 import type { SessionResumeResponse } from '@/types/hermes'
 
 import type { usePromptActions } from '../../session/hooks/use-prompt-actions'
+import { singleFlightSessionResume } from '../../session/hooks/use-prompt-actions/single-flight-resume'
 import { markSessionRecentlyInterrupted, withSessionNotFoundResume } from '../../session/hooks/use-prompt-actions/utils'
 import { resolveSessionProfile } from '../../session/hooks/use-session-actions/utils'
 import type { useSessionStateCache } from '../../session/hooks/use-session-state-cache'
@@ -176,12 +177,14 @@ export function useSessionTileDelegate({
 
         const [prefetch, resumed] = await Promise.all([
           getLatestSessionMessages(storedSessionId, restScope).catch(() => null),
-          requestForSessionProfile<SessionResumeResponse>(owner, requestGateway, 'session.resume', {
-            session_id: storedSessionId,
-            cols: 96,
-            omit_messages: true,
-            ...(owner ? { profile: typeof owner === 'string' ? owner : owner.profile } : {})
-          })
+          singleFlightSessionResume(storedSessionId, () =>
+            requestForSessionProfile<SessionResumeResponse>(owner, requestGateway, 'session.resume', {
+              session_id: storedSessionId,
+              cols: 96,
+              omit_messages: true,
+              ...(owner ? { profile: typeof owner === 'string' ? owner : owner.profile } : {})
+            })
+          )
         ])
 
         const runtimeId = resumed?.session_id

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -14,6 +14,7 @@ import { type CSSProperties, lazy, type ReactNode, Suspense, useCallback, useEff
 import { useLocation, useNavigate } from 'react-router'
 
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
+import { resolveSessionProfile } from '@/app/session/hooks/use-session-actions/utils'
 import { formatRefValue } from '@/components/assistant-ui/directive-text'
 import { BootFailureOverlay } from '@/components/boot-failure-overlay'
 import { ConfirmHost } from '@/components/confirm-host'
@@ -71,14 +72,14 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
-  rememberedSessionProfile,
+  knownSessionProfile,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
   setBusy,
   setMessages
 } from '@/store/session'
-import { requestForSessionProfile } from '@/store/session-request-router'
+import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
@@ -315,8 +316,16 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // "session not found" / hang. The tile route is per-session, survives
   // relaunch, and needs no list membership, so it fixes an already-open chat
   // too. Fall back to the list-derived profile only when no tile route exists.
+  // Session-scoped RPCs route to the backend that OWNS the session — its
+  // profile's own local gateway — never to whatever is "active" (active is
+  // presentation only). Resolve the owner from, in order: the tile's persisted
+  // route (bot chats carry an exact connectionId+profile), the known session
+  // profile (row or open-time hint), then a cross-profile REST probe that
+  // stamps ownership for a hidden/unlisted session. Only a request with NO
+  // session at all (a fresh draft, global chrome) falls to the ambient socket.
+  // The probe result is cached as an owner hint so the next call is sync.
   const requestGateway = useCallback(
-    <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
+    async <T,>(method: string, params?: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
       // Route each RPC by the session IT targets, not by whatever tile is
       // focused. `requestGateway` is one shared closure used for every session
       // RPC in the window; keying the owner off $focusedStoredSessionId sent a
@@ -348,9 +357,22 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           undefined
       })
 
-      const owner =
+      let owner: SessionOwnerScope =
         (routingSessionId ? sessionTileOwnerRoute(routingSessionId) : undefined) ??
-        rememberedSessionProfile($sessions.get(), routingSessionId, $activeGatewayProfile.get())
+        knownSessionProfile($sessions.get(), routingSessionId)
+
+      if (!owner && routingSessionId) {
+        // Unknown owner for a REAL session: probe across profiles (REST, not the
+        // gateway socket, so no recursion) rather than defaulting to active. A
+        // hit stamps ownership + caches a hint; a miss leaves owner undefined
+        // and the request falls to ambient, exactly as an unroutable session did
+        // before — but only after we tried, never as a silent active fallback.
+        const probed = await resolveSessionProfile(routingSessionId)
+
+        if (probed) {
+          owner = probed
+        }
+      }
 
       return requestForSessionProfile<T>(owner, ambientRequestGateway, method, params ?? {}, timeoutMs, signal)
     },

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -24,6 +24,7 @@ import { primaryRuntimeConnectionId, useGatewayBoot } from './use-gateway-boot'
 
 type Listener = (ev: unknown) => void
 let connectionApplied: null | (() => void) = null
+let powerResume: null | (() => void) = null
 
 describe('primaryRuntimeConnectionId', () => {
   it('uses the registry identity when the primary connection has one', () => {
@@ -151,7 +152,13 @@ function fakeDesktop() {
         connectionApplied = null
       }
     }),
-    onPowerResume: vi.fn(() => () => undefined),
+    onPowerResume: vi.fn(callback => {
+      powerResume = callback
+
+      return () => {
+        powerResume = null
+      }
+    }),
     revalidateConnection: vi.fn(async () => ({ ok: true, rebuilt: false })),
     onWindowStateChanged: vi.fn(() => () => undefined),
     touchBackend: vi.fn(async () => undefined),
@@ -198,6 +205,7 @@ beforeEach(() => {
   FakeWebSocket.mode = 'open'
   FakeWebSocket.instances = []
   connectionApplied = null
+  powerResume = null
   ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
   ;(window as { hermesDesktop?: unknown }).hermesDesktop = fakeDesktop()
   $gatewayState.set('idle')
@@ -482,6 +490,32 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     const lastCall = desktop.getConnection.mock.calls.at(-1) ?? []
     expect(lastCall.length === 0 || lastCall[0] == null || lastCall[0] === '').toBe(true)
     expect(desktop.getGatewayWsUrl).toHaveBeenCalledTimes(2)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    expect($gatewayState.get()).toBe('open')
+  })
+
+  it('power resume force-redials a half-open primary socket that still reports OPEN', async () => {
+    const desktop = fakeDesktop()
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    const staleSocket = FakeWebSocket.instances[0]
+
+    expect(staleSocket.readyState).toBe(FakeWebSocket.OPEN)
+    expect($gatewayState.get()).toBe('open')
+    expect(powerResume).not.toBeNull()
+
+    // macOS can discard the TCP connection during sleep without updating the
+    // renderer WebSocket object. Leave readyState OPEN and emit only resume.
+    act(() => powerResume?.())
+    await flushAsync()
+    await flushAsync()
+
+    expect(staleSocket.readyState).toBe(FakeWebSocket.CLOSED)
+    expect(desktop.revalidateConnection).toHaveBeenCalledOnce()
     expect(FakeWebSocket.instances).toHaveLength(2)
     expect($gatewayState.get()).toBe('open')
   })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -334,7 +334,7 @@ export function useGatewayBoot({
       }, delay)
     }
 
-    const reconnectNow = async () => {
+    const reconnectNow = async ({ forceOpenSocket = false }: { forceOpenSocket?: boolean } = {}) => {
       if (cancelled || !bootCompleted || $gatewaySwitching.get()) {
         return
       }
@@ -343,7 +343,17 @@ export function useGatewayBoot({
       reconnectAttempt = 0
       reconnectFailingSince = null
       escalated = false
-      reconnectSecondaryGateways()
+      reconnectSecondaryGateways({ forceOpenSockets: forceOpenSocket })
+
+      // Browser WebSocket state can remain OPEN after sleep even though the OS
+      // discarded the underlying TCP connection. Strong recovery signals must
+      // retire that half-open socket before the normal reconnect path can run.
+      if (forceOpenSocket && gatewayOpen()) {
+        gateway.close()
+        // close() publishes `closed`, which schedules the regular backoff.
+        // This path reconnects immediately, so remove that redundant timer.
+        clearReconnectTimer()
+      }
 
       if (!gatewayOpen()) {
         await attemptReconnect()
@@ -583,9 +593,10 @@ export function useGatewayBoot({
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
     // window regaining focus/visibility. Each nudges an immediate reconnect.
-    const offPowerResume = desktop.onPowerResume?.(() => void reconnectNow())
+    const forceReconnectNow = () => reconnectNow({ forceOpenSocket: true })
+    const offPowerResume = desktop.onPowerResume?.(() => void forceReconnectNow())
     const offConnectionApplied = desktop.onConnectionApplied?.(() => void softSwitch())
-    const offGatewayReconnect = registerGatewayReconnect(reconnectNow)
+    const offGatewayReconnect = registerGatewayReconnect(forceReconnectNow)
 
     // Registry lifecycle: a removed connection's secondaries must close NOW
     // (remote/cloud have no local process whose death would drop the socket —
@@ -599,7 +610,7 @@ export function useGatewayBoot({
       disposeSecondariesForConnection(payload.connectionId, { redial: payload.reason === 'updated' })
     })
 
-    const onOnline = () => void reconnectNow()
+    const onOnline = () => void forceReconnectNow()
 
     const onVisible = () => {
       if (document.visibilityState === 'visible') {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -4708,6 +4708,78 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
     ])
   })
 
+  it('keeps an explicit background queue target isolated from foreground routed recovery (#90428)', async () => {
+    const FOREGROUND_STORED_ID = 'stored-foreground-b'
+    const FOREGROUND_RUNTIME_ID = 'rt-foreground-b'
+    const QUEUED_STORED_ID = 'stored-queued-c'
+    const QUEUED_RUNTIME_ID = 'rt-queued-c-recovered'
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const stateWrites: { sessionId: string; storedSessionId: null | string | undefined }[] = []
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: FOREGROUND_STORED_ID }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: FOREGROUND_RUNTIME_ID }
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([[FOREGROUND_STORED_ID, FOREGROUND_RUNTIME_ID]])
+    }
+
+    const resumeStoredSession = vi.fn(async () => undefined)
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.resume') {
+        expect(params?.session_id).toBe(QUEUED_STORED_ID)
+
+        return { session_id: QUEUED_RUNTIME_ID } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={FOREGROUND_RUNTIME_ID}
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => FOREGROUND_STORED_ID}
+        getRouteToken={() => `/${FOREGROUND_STORED_ID}::`}
+        getRuntimeIdForStoredSession={storedId => runtimeIdByStoredSessionIdRef.current.get(storedId) ?? null}
+        onReady={h => (handle = h)}
+        onUpdateState={(sessionId, storedSessionId) => stateWrites.push({ sessionId, storedSessionId })}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        resumeStoredSession={resumeStoredSession}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={FOREGROUND_STORED_ID}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    expect(
+      await handle!.submitText('queued prompt for C', {
+        fromQueue: true,
+        sessionId: null,
+        storedSessionId: QUEUED_STORED_ID
+      })
+    ).toBe(true)
+    expect(resumeStoredSession).not.toHaveBeenCalled()
+    expect(calls).toEqual([
+      {
+        method: 'session.resume',
+        params: { session_id: QUEUED_STORED_ID, source: 'desktop', omit_messages: true }
+      },
+      {
+        method: 'prompt.submit',
+        params: { session_id: QUEUED_RUNTIME_ID, text: 'queued prompt for C', queued: true }
+      }
+    ])
+    expect(stateWrites.some(write => write.sessionId === FOREGROUND_RUNTIME_ID)).toBe(false)
+    expect(selectedStoredSessionIdRef.current).toBe(FOREGROUND_STORED_ID)
+    expect(activeSessionIdRef.current).toBe(FOREGROUND_RUNTIME_ID)
+    expect(runtimeIdByStoredSessionIdRef.current).toEqual(new Map([[FOREGROUND_STORED_ID, FOREGROUND_RUNTIME_ID]]))
+  })
+
   it('still aborts when the user genuinely moves to a different chat mid-submit', async () => {
     // The churn tolerance must not weaken the real guard: selection AND route
     // moving to another actual chat is a user switch and must abort.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -4652,6 +4652,62 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
     })
   })
 
+  it('submits once through authoritative recovery when routed resume publication lags (#90428)', async () => {
+    const staleStoredId = 'stored-previous-selection'
+    const staleRuntimeId = 'rt-previous-selection'
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: staleStoredId }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: staleRuntimeId }
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([[staleStoredId, staleRuntimeId]])
+    }
+
+    const resumeStoredSession = vi.fn(async () => undefined)
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.resume') {
+        return { session_id: RESUMED_RUNTIME_ID } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        activeSessionId={staleRuntimeId}
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => STORED_ID}
+        getRouteToken={() => `/${STORED_ID}::`}
+        getRuntimeIdForStoredSession={storedId => runtimeIdByStoredSessionIdRef.current.get(storedId) ?? null}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        resumeStoredSession={resumeStoredSession}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId={staleStoredId}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    expect(await handle!.submitText('deliver despite lagging local publication')).toBe(true)
+    expect(resumeStoredSession).toHaveBeenCalledOnce()
+    expect(calls).toEqual([
+      {
+        method: 'session.resume',
+        params: { session_id: STORED_ID, source: 'desktop', omit_messages: true }
+      },
+      {
+        method: 'prompt.submit',
+        params: { session_id: RESUMED_RUNTIME_ID, text: 'deliver despite lagging local publication' }
+      }
+    ])
+  })
+
   it('still aborts when the user genuinely moves to a different chat mid-submit', async () => {
     // The churn tolerance must not weaken the real guard: selection AND route
     // moving to another actual chat is a user switch and must abort.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -4715,14 +4715,24 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
     const QUEUED_RUNTIME_ID = 'rt-queued-c-recovered'
     const calls: { method: string; params?: Record<string, unknown> }[] = []
     const stateWrites: { sessionId: string; storedSessionId: null | string | undefined }[] = []
+    // Load-bearing shape (per #91357 review): foreground B must actually NEED
+    // routed recovery — no active runtime and an empty ownership cache — so the
+    // formerly broken foreground-recovery branch is genuinely reachable. With a
+    // pre-bound B this fixture passed even on the broken head.
     const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: FOREGROUND_STORED_ID }
-    const activeSessionIdRef: MutableRefObject<string | null> = { current: FOREGROUND_RUNTIME_ID }
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: null }
 
     const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
-      current: new Map([[FOREGROUND_STORED_ID, FOREGROUND_RUNTIME_ID]])
+      current: new Map()
     }
 
-    const resumeStoredSession = vi.fn(async () => undefined)
+    // A high-level resume of B FULLY publishes B's runtime + ownership cache:
+    // if the explicit-target guard ever regresses, the submit would adopt B's
+    // recovered runtime and the assertions below catch the mis-delivery.
+    const resumeStoredSession = vi.fn(async () => {
+      activeSessionIdRef.current = FOREGROUND_RUNTIME_ID
+      runtimeIdByStoredSessionIdRef.current.set(FOREGROUND_STORED_ID, FOREGROUND_RUNTIME_ID)
+    })
 
     const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       calls.push({ method, params })
@@ -4739,7 +4749,7 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
     let handle: HarnessHandle | null = null
     render(
       <Harness
-        activeSessionId={FOREGROUND_RUNTIME_ID}
+        activeSessionId={null}
         activeSessionIdRef={activeSessionIdRef}
         getRoutedStoredSessionId={() => FOREGROUND_STORED_ID}
         getRouteToken={() => `/${FOREGROUND_STORED_ID}::`}
@@ -4763,6 +4773,7 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
         storedSessionId: QUEUED_STORED_ID
       })
     ).toBe(true)
+    // No high-level resume of B: the explicit queue target C is authoritative.
     expect(resumeStoredSession).not.toHaveBeenCalled()
     expect(calls).toEqual([
       {
@@ -4774,10 +4785,12 @@ describe('usePromptActions busy-gateway churn tolerance (#64327)', () => {
         params: { session_id: QUEUED_RUNTIME_ID, text: 'queued prompt for C', queued: true }
       }
     ])
+    // No prompt or state write ever touches B, and no foreground
+    // selection/cache mutation leaks out of the background drain.
     expect(stateWrites.some(write => write.sessionId === FOREGROUND_RUNTIME_ID)).toBe(false)
     expect(selectedStoredSessionIdRef.current).toBe(FOREGROUND_STORED_ID)
-    expect(activeSessionIdRef.current).toBe(FOREGROUND_RUNTIME_ID)
-    expect(runtimeIdByStoredSessionIdRef.current).toEqual(new Map([[FOREGROUND_STORED_ID, FOREGROUND_RUNTIME_ID]]))
+    expect(activeSessionIdRef.current).toBeNull()
+    expect(runtimeIdByStoredSessionIdRef.current).toEqual(new Map())
   })
 
   it('still aborts when the user genuinely moves to a different chat mid-submit', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -29,9 +29,17 @@ import { dropSessionState, publishSessionState } from '@/store/session-states'
 import { $wakeWord, resetWakeWordState } from '@/store/wake-word'
 import type { SessionInfo } from '@/types/hermes'
 
+import { clearSingleFlightSessionResumeState } from './single-flight-resume'
 import type { SubmitTextOptions } from './utils'
 
 import { uploadComposerAttachment, usePromptActions } from '.'
+
+// Suites in this file reuse the same stored-id constants. The module-level
+// single-flight resume map (and drift-recovery cache) would otherwise leak a
+// never-settling in-flight promise from one test into the next.
+beforeEach(() => {
+  clearSingleFlightSessionResumeState()
+})
 
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/resolve-target-session.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/resolve-target-session.ts
@@ -1,5 +1,6 @@
 import { resolveSessionProfile } from '../use-session-actions/utils'
 
+import { singleFlightSessionResume, takeRecoveredRuntime } from './single-flight-resume'
 import type { GatewayRequest } from './utils'
 
 /**
@@ -89,12 +90,22 @@ export async function resolveTargetSessionId(deps: ResolveTargetSessionDeps): Pr
 
   if (storedTarget) {
     try {
-      const profile = await resolveSessionProfile(storedTarget)
+      // Reuse a runtime an aborted recovery already minted for this stored
+      // session; otherwise resume once, shared across concurrent callers.
+      const cachedRuntimeId = takeRecoveredRuntime(storedTarget)
 
-      const resumed = await requestGateway<{ session_id?: string }>('session.resume', {
-        session_id: storedTarget,
-        source: 'desktop',
-        ...(profile ? { profile } : {})
+      if (cachedRuntimeId) {
+        return cachedRuntimeId
+      }
+
+      const resumed = await singleFlightSessionResume(storedTarget, async () => {
+        const profile = await resolveSessionProfile(storedTarget)
+
+        return requestGateway<{ session_id?: string }>('session.resume', {
+          session_id: storedTarget,
+          source: 'desktop',
+          ...(profile ? { profile } : {})
+        })
       })
 
       return resumed?.session_id || null

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clearSingleFlightSessionResumeState,
+  registerRecoveredRuntime,
+  singleFlightSessionResume,
+  takeRecoveredRuntime
+} from './single-flight-resume'
+import { resumeStoredRuntimeSession, SessionRecoveryAborted, withSessionNotFoundResume } from './utils'
+
+afterEach(() => {
+  clearSingleFlightSessionResumeState()
+  vi.restoreAllMocks()
+})
+
+describe('singleFlightSessionResume', () => {
+  it('two concurrent resume callers for the same stored id produce ONE session.resume RPC', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      expect(method).toBe('session.resume')
+      // Yield so both callers are in flight before either resolves.
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      return { session_id: 'rt-fresh' }
+    })
+
+    const deps = { requestGateway: requestGateway as never, resolveProfile: async () => undefined }
+
+    const [a, b] = await Promise.all([
+      resumeStoredRuntimeSession('stored-a', deps),
+      resumeStoredRuntimeSession('stored-a', deps)
+    ])
+
+    expect(a).toBe('rt-fresh')
+    expect(b).toBe('rt-fresh')
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+  })
+
+  it('different stored ids still resume independently', async () => {
+    const requestGateway = vi.fn(async (_method: string, params?: Record<string, unknown>) => {
+      await new Promise(resolve => setTimeout(resolve, 5))
+
+      return { session_id: `rt-${String(params?.session_id)}` }
+    })
+
+    const deps = { requestGateway: requestGateway as never, resolveProfile: async () => undefined }
+
+    const [a, b] = await Promise.all([
+      resumeStoredRuntimeSession('stored-a', deps),
+      resumeStoredRuntimeSession('stored-b', deps)
+    ])
+
+    expect(a).toBe('rt-stored-a')
+    expect(b).toBe('rt-stored-b')
+    expect(requestGateway).toHaveBeenCalledTimes(2)
+  })
+
+  it('a rejected flight is not cached: the next caller retries', async () => {
+    const run = vi
+      .fn<() => Promise<{ session_id: string }>>()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ session_id: 'rt-second' })
+
+    await expect(singleFlightSessionResume('stored-a', run)).rejects.toThrow('boom')
+    await expect(singleFlightSessionResume('stored-a', run)).resolves.toEqual({ session_id: 'rt-second' })
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('drift-abort recovered-runtime cache', () => {
+  it('drift-abort does not strand the recovered runtime — it is registered in the cache', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return { session_id: 'rt-recovered' }
+      }
+
+      throw new Error('unexpected call')
+    })
+
+    const call = vi.fn(async (liveId: string) => {
+      if (liveId === 'rt-dead') {
+        throw new Error('session not found: rt-dead')
+      }
+
+      return 'ok'
+    })
+
+    await expect(
+      withSessionNotFoundResume('rt-dead', 'stored-a', call, {
+        requestGateway: requestGateway as never,
+        resolveProfile: async () => undefined,
+        driftReason: () => 'user switched away'
+      })
+    ).rejects.toThrow(SessionRecoveryAborted)
+
+    // The freshly-minted runtime is NOT abandoned: the next action reuses it.
+    expect(takeRecoveredRuntime('stored-a')).toBe('rt-recovered')
+    // Take-semantics: consumed exactly once.
+    expect(takeRecoveredRuntime('stored-a')).toBeUndefined()
+  })
+
+  it('a later non-drifted recovery adopts the cached runtime instead of resuming again', async () => {
+    registerRecoveredRuntime('stored-a', 'rt-cached')
+
+    const requestGateway = vi.fn(async () => {
+      throw new Error('session.resume must not be called when a cached runtime exists')
+    })
+
+    const onRecovered = vi.fn()
+
+    const call = vi.fn(async (liveId: string) => {
+      if (liveId === 'rt-dead') {
+        throw new Error('session not found: rt-dead')
+      }
+
+      return `ran-on-${liveId}`
+    })
+
+    const outcome = await withSessionNotFoundResume('rt-dead', 'stored-a', call, {
+      requestGateway: requestGateway as never,
+      resolveProfile: async () => undefined,
+      onRecovered
+    })
+
+    expect(outcome).toEqual({ recovered: true, result: 'ran-on-rt-cached', sessionId: 'rt-cached' })
+    expect(onRecovered).toHaveBeenCalledWith('rt-cached')
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('takeRecoveredRuntime skips a cached id the caller already knows is dead', () => {
+    registerRecoveredRuntime('stored-a', 'rt-dead')
+
+    expect(takeRecoveredRuntime('stored-a', 'rt-dead')).toBeUndefined()
+    expect(takeRecoveredRuntime('stored-a')).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
@@ -22,11 +22,16 @@ export function singleFlightSessionResume<T>(storedSessionId: string, run: () =>
     return existing as Promise<T>
   }
 
-  const flight = run().finally(() => {
-    if (_inFlightResumeByStoredSessionId.get(storedSessionId) === flight) {
-      _inFlightResumeByStoredSessionId.delete(storedSessionId)
-    }
-  })
+  // Promise.resolve().then(run) tolerates run() being synchronous, returning a
+  // bare value, or throwing synchronously (test doubles and legacy callers do
+  // all three) — a raw run().finally() would crash on a non-promise return.
+  const flight = Promise.resolve()
+    .then(run)
+    .finally(() => {
+      if (_inFlightResumeByStoredSessionId.get(storedSessionId) === flight) {
+        _inFlightResumeByStoredSessionId.delete(storedSessionId)
+      }
+    })
 
   _inFlightResumeByStoredSessionId.set(storedSessionId, flight)
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
@@ -1,0 +1,77 @@
+/**
+ * Single-flight guard for `session.resume`, keyed by STORED session id.
+ *
+ * After sleep/wake or a reconnect, many independent surfaces discover the same
+ * dead runtime at once — submit recovery, slash/rewind recovery, tile resumes,
+ * the route resolver — and each used to fire its own `session.resume` for the
+ * same durable conversation. The gateway happily mints a runtime per call and
+ * the losers become orphans for the reaper (#91276 storm).
+ *
+ * Module-level so EVERY call site in the window shares one in-flight promise
+ * per stored id, no matter which hook instance it lives in. All participating
+ * callers resolve to a `session.resume`-shaped response (an object carrying
+ * `session_id`); joiners receive whatever the winning call returns.
+ */
+
+const _inFlightResumeByStoredSessionId = new Map<string, Promise<unknown>>()
+
+export function singleFlightSessionResume<T>(storedSessionId: string, run: () => Promise<T>): Promise<T> {
+  const existing = _inFlightResumeByStoredSessionId.get(storedSessionId)
+
+  if (existing) {
+    return existing as Promise<T>
+  }
+
+  const flight = run().finally(() => {
+    if (_inFlightResumeByStoredSessionId.get(storedSessionId) === flight) {
+      _inFlightResumeByStoredSessionId.delete(storedSessionId)
+    }
+  })
+
+  _inFlightResumeByStoredSessionId.set(storedSessionId, flight)
+
+  return flight
+}
+
+/**
+ * Adopt-or-reuse cache for recovered runtimes a drift-abort walked away from.
+ *
+ * A recovery resume can succeed while the caller's drift check says the user
+ * moved on (SessionRecoveryAborted). The freshly-minted runtime is REAL and
+ * registered on the gateway; abandoning the id client-side strands it for the
+ * orphan reaper AND makes the next action for the same stored session mint yet
+ * another runtime. When adoption (rebinding the caller's runtime ref via
+ * onRecovered/onRuntimeRecovered) is wrong — the user is elsewhere — record it
+ * here so the next resume-shaped action reuses it instead of re-minting.
+ */
+const _recoveredRuntimeByStoredSessionId = new Map<string, string>()
+
+export function registerRecoveredRuntime(storedSessionId: string, runtimeId: string): void {
+  if (storedSessionId && runtimeId) {
+    _recoveredRuntimeByStoredSessionId.set(storedSessionId, runtimeId)
+  }
+}
+
+/**
+ * Consume a previously-abandoned recovered runtime for this stored session.
+ * Take-semantics: the entry is removed so a dead cached id can only cost one
+ * bounded retry, never a loop. `deadRuntimeId` skips (and drops) the entry
+ * when the caller already knows that exact runtime is dead.
+ */
+export function takeRecoveredRuntime(storedSessionId: string, deadRuntimeId?: null | string): string | undefined {
+  const cached = _recoveredRuntimeByStoredSessionId.get(storedSessionId)
+
+  if (cached === undefined) {
+    return undefined
+  }
+
+  _recoveredRuntimeByStoredSessionId.delete(storedSessionId)
+
+  return deadRuntimeId && cached === deadRuntimeId ? undefined : cached
+}
+
+/** Test seam: reset all module-level single-flight/recovery state. */
+export function clearSingleFlightSessionResumeState(): void {
+  _inFlightResumeByStoredSessionId.clear()
+  _recoveredRuntimeByStoredSessionId.clear()
+}

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -527,7 +527,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         scope.setMessages(current => [...current, buildUserMessage()])
       }
 
-      if (!sessionId && routedStoredSessionId && routedSessionNeedsResume) {
+      if (!options?.storedSessionId && !sessionId && routedStoredSessionId && routedSessionNeedsResume) {
         // The URL still names a durable conversation, but a profile
         // swap/reconnect left its volatile session binding incomplete or
         // cross-wired. Run the full profile-aware resume path. Creating here

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -206,9 +206,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // Queue drains carry their source session explicitly. A background drain
       // must never inherit the currently selected session after the user moves
       // to another chat.
-      const targetStoredSessionId = options?.storedSessionId ?? selectedStoredSessionIdRef.current
+      let targetStoredSessionId = options?.storedSessionId ?? selectedStoredSessionIdRef.current
 
-      const targetStartedInCurrentView =
+      let targetStartedInCurrentView =
         !targetStoredSessionId || targetStoredSessionId === selectedStoredSessionIdRef.current
 
       // A queued/background drain whose runtime binding was reaped must NOT
@@ -275,9 +275,24 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           startingActiveSessionId !== routedRuntimeId)
       )
 
+      // For an ordinary foreground submit, the durable route is the authority
+      // when renderer selection publication is stale after reconnect. Pin the
+      // operation to that route before any recovery; explicit queue/tile targets
+      // remain authoritative and never inherit the foreground route.
+      if (!options?.storedSessionId && routedSessionNeedsResume && routedStoredSessionId) {
+        targetStoredSessionId = routedStoredSessionId
+        targetStartedInCurrentView = true
+      }
+
       let startingStoredSessionId = routedSessionNeedsResume
         ? routedStoredSessionId
         : (selectedStoredSessionId ?? routedStoredSessionId)
+
+      // Selection publishes independently from the durable route. Keep its
+      // entry snapshot as the drift baseline instead of rewriting history to
+      // the routed target: an already-stale ref is not evidence that the user
+      // switched chats while this submit was in flight.
+      let startingSelectedStoredSessionId = selectedStoredSessionId
 
       let startingRouteToken = getRouteToken()
 
@@ -296,7 +311,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           ? sessionContextDrift({
               startRouteToken: startingRouteToken,
               nowRouteToken: getRouteToken(),
-              startSelectedStoredId: startingStoredSessionId,
+              startSelectedStoredId: startingSelectedStoredSessionId,
               nowSelectedStoredId: selectedStoredSessionIdRef.current,
               submitTargetStoredId: startingStoredSessionId,
               composerScope: options?.composerScope,
@@ -534,20 +549,20 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         const recoveredRuntimeId = activeSessionIdRef.current
         const validatedRuntimeId = getRuntimeIdForStoredSession(routedStoredSessionId)
 
-        // Recovery only succeeded when both sides of the cache agree that the
-        // live runtime belongs to the durable routed session. A failed profile
-        // swap may leave the previous profile's runtime active, while a recycled
-        // runtime id may leave a cross-wired stored-session mapping.
+        // Adopt the high-level resume only after its renderer-side ownership
+        // publications agree. Those refs/caches update independently, so a
+        // successful resume can legitimately return before they settle. That
+        // is not a failed recovery and not evidence of navigation: leave the
+        // runtime unresolved and let the direct, profile-aware session.resume
+        // rung below return an authoritative id for this exact durable target.
         if (
-          !recoveredRuntimeId ||
-          recoveredRuntimeId !== validatedRuntimeId ||
-          selectedStoredSessionIdRef.current !== routedStoredSessionId
+          recoveredRuntimeId &&
+          recoveredRuntimeId === validatedRuntimeId &&
+          selectedStoredSessionIdRef.current === routedStoredSessionId
         ) {
-          return abortForSessionSwitch(null)
+          sessionId = recoveredRuntimeId
+          seedOptimistic(sessionId)
         }
-
-        sessionId = recoveredRuntimeId
-        seedOptimistic(sessionId)
       }
 
       if (!sessionId && targetStoredSessionId) {
@@ -657,6 +672,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         // Re-pin the baseline to the created chat for the rest of the
         // pipeline; the closures (seedOptimistic et al) see the new value.
         startingStoredSessionId = selectedStoredSessionIdRef.current
+        startingSelectedStoredSessionId = selectedStoredSessionIdRef.current
         startingRouteToken = getRouteToken()
 
         seedOptimistic(sessionId)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -37,6 +37,7 @@ import { sessionContextDrift } from '../session-context-drift'
 import { resolveSessionProfile } from '../use-session-actions/utils'
 
 import { finalizeInterruptedMessages } from './rewind'
+import { registerRecoveredRuntime, singleFlightSessionResume, takeRecoveredRuntime } from './single-flight-resume'
 import {
   acquireSubmitInFlight,
   type GatewayRequest,
@@ -543,6 +544,15 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         if (routedResumeDrift) {
           console.warn('[submit-drift-abort]', routedResumeDrift, { phase: 'post-routed-resume' })
 
+          // The high-level resume may have already published a fresh runtime
+          // for this durable session. Don't strand it: record it so the next
+          // action targeting this stored session reuses it (#91276).
+          const publishedRuntimeId = getRuntimeIdForStoredSession(routedStoredSessionId)
+
+          if (publishedRuntimeId) {
+            registerRecoveredRuntime(routedStoredSessionId, publishedRuntimeId)
+          }
+
           return abortForSessionSwitch(null)
         }
 
@@ -573,19 +583,33 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         try {
           // Re-register on the session's OWNING profile — resuming on whichever
           // profile is live would fork the conversation into the wrong DB (#67603).
-          const resumeProfile = await resolveSessionProfile(targetStoredSessionId)
+          // A runtime a previous drift-aborted recovery already minted for this
+          // exact stored session is reused instead of resuming again.
+          const cachedRuntimeId = takeRecoveredRuntime(targetStoredSessionId)
 
-          const resumed = await requestGateway<{ session_id: string }>('session.resume', {
-            session_id: targetStoredSessionId,
-            source: 'desktop',
-            omit_messages: true,
-            ...(resumeProfile ? { profile: resumeProfile } : {})
-          })
+          const resumed = cachedRuntimeId
+            ? { session_id: cachedRuntimeId }
+            : await singleFlightSessionResume(targetStoredSessionId, async () => {
+                const resumeProfile = await resolveSessionProfile(targetStoredSessionId)
+
+                return requestGateway<{ session_id: string }>('session.resume', {
+                  session_id: targetStoredSessionId,
+                  source: 'desktop',
+                  omit_messages: true,
+                  ...(resumeProfile ? { profile: resumeProfile } : {})
+                })
+              })
 
           const resumeDrift = sessionDriftReason()
 
           if (resumeDrift) {
             console.warn('[submit-drift-abort]', resumeDrift, { phase: 'post-resume' })
+
+            // Keep the freshly-bound runtime findable for the next action on
+            // this stored session instead of stranding it for the reaper.
+            if (resumed?.session_id) {
+              registerRecoveredRuntime(targetStoredSessionId, resumed.session_id)
+            }
 
             return abortForSessionSwitch(sessionId)
           }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -6,6 +6,8 @@ import { type CommandsCatalogLike, filterDesktopCommandsCatalog } from '@/lib/de
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import type { ComposerAttachment } from '@/store/composer'
 
+import { registerRecoveredRuntime, singleFlightSessionResume, takeRecoveredRuntime } from './single-flight-resume'
+
 export type GatewayRequest = <T>(method: string, params?: Record<string, unknown>, timeoutMs?: number) => Promise<T>
 
 export function delay(ms: number): Promise<void> {
@@ -113,14 +115,20 @@ export async function resumeStoredRuntimeSession(
   storedSessionId: string,
   deps: SessionRecoveryDeps
 ): Promise<null | string> {
-  const resolveProfile = deps.resolveProfile ?? defaultResolveProfile
-  const profile = await resolveProfile(storedSessionId)
+  // Single-flight per stored id: after a reconnect many surfaces discover the
+  // same dead runtime at once, and each independent session.resume mints a new
+  // runtime — every loser is an orphan for the reaper. Sharing one in-flight
+  // promise makes concurrent recoveries converge on ONE runtime.
+  const resumed = await singleFlightSessionResume(storedSessionId, async () => {
+    const resolveProfile = deps.resolveProfile ?? defaultResolveProfile
+    const profile = await resolveProfile(storedSessionId)
 
-  const resumed = await deps.requestGateway<{ session_id: string }>('session.resume', {
-    session_id: storedSessionId,
-    source: 'desktop',
-    omit_messages: true,
-    ...(profile ? { profile } : {})
+    return deps.requestGateway<{ session_id: string }>('session.resume', {
+      session_id: storedSessionId,
+      source: 'desktop',
+      omit_messages: true,
+      ...(profile ? { profile } : {})
+    })
   })
 
   return resumed?.session_id ?? null
@@ -163,6 +171,33 @@ export async function withSessionNotFoundResume<T>(
       throw err
     }
 
+    // A previous recovery for this stored session already minted a runtime
+    // that its caller drift-aborted away from. Reuse it before resuming
+    // again — re-minting would strand yet another runtime for the reaper.
+    const cachedRecoveredId = takeRecoveredRuntime(storedSessionId, sessionId)
+
+    if (cachedRecoveredId) {
+      const cachedDrift = deps.driftReason?.()
+
+      if (cachedDrift) {
+        // Still drifted: keep the runtime findable for whoever acts next.
+        registerRecoveredRuntime(storedSessionId, cachedRecoveredId)
+        throw new SessionRecoveryAborted(cachedDrift, cachedRecoveredId)
+      }
+
+      try {
+        deps.onRecovered?.(cachedRecoveredId)
+
+        return { recovered: true, result: await call(cachedRecoveredId), sessionId: cachedRecoveredId }
+      } catch (cachedErr) {
+        // The cached runtime died in the meantime; fall through to a fresh
+        // resume only for the same stale-session class, otherwise surface it.
+        if (!isSessionNotFoundError(cachedErr)) {
+          throw cachedErr
+        }
+      }
+    }
+
     let recoveredId: null | string
 
     try {
@@ -178,6 +213,11 @@ export async function withSessionNotFoundResume<T>(
     const drift = deps.driftReason?.()
 
     if (drift) {
+      // Do NOT abandon the freshly-minted runtime: adoption is wrong here
+      // (the user moved on), so record it in the stored->runtime recovery
+      // cache. The next action targeting this stored session reuses it
+      // instead of minting another orphan (#91276).
+      registerRecoveredRuntime(storedSessionId, recoveredId)
       throw new SessionRecoveryAborted(drift, recoveredId)
     }
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -99,6 +99,7 @@ import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, Usag
 import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
+import { singleFlightSessionResume } from '../use-prompt-actions/single-flight-resume'
 
 import {
   appendLiveSessionProjection,
@@ -1196,21 +1197,23 @@ export function useSessionActions({
 
         let resumeRuntimeBaselineMessages: ChatMessage[] = []
 
-        const resumePromise = requestForSession<SessionResumeResponse>('session.resume', {
-          session_id: storedSessionId,
-          cols: 96,
-          source: 'desktop',
-          defer_history: !watchWindow,
-          // REST is the transcript authority for Desktop. Avoid duplicating a
-          // potentially huge compression lineage in the WebSocket response.
-          // Watch windows attach lazily (live mirror). Every other cold resume
-          // gets the gateway's default deferred build: the RPC returns the
-          // transcript immediately instead of blocking the switch on _make_agent
-          // (MCP discovery / prompt build), and the agent pre-warms in the
-          // background while the prefetch above paints the transcript.
-          ...(watchWindow ? { lazy: true } : { omit_messages: true }),
-          ...(sessionProfile ? { profile: sessionProfile } : {})
-        }).then(resumed => {
+        const resumePromise = singleFlightSessionResume(storedSessionId, () =>
+          requestForSession<SessionResumeResponse>('session.resume', {
+            session_id: storedSessionId,
+            cols: 96,
+            source: 'desktop',
+            defer_history: !watchWindow,
+            // REST is the transcript authority for Desktop. Avoid duplicating a
+            // potentially huge compression lineage in the WebSocket response.
+            // Watch windows attach lazily (live mirror). Every other cold resume
+            // gets the gateway's default deferred build: the RPC returns the
+            // transcript immediately instead of blocking the switch on _make_agent
+            // (MCP discovery / prompt build), and the agent pre-warms in the
+            // background while the prefetch above paints the transcript.
+            ...(watchWindow ? { lazy: true } : { omit_messages: true }),
+            ...(sessionProfile ? { profile: sessionProfile } : {})
+          })
+        ).then(resumed => {
           resumeRuntimeBaselineMessages =
             sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.messages ?? resumeRuntimeBaselineMessages
 

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -28,6 +28,7 @@ import {
   sessionApprovalInlineVisible,
   sessionApprovalRequest
 } from '@/store/prompts'
+import { requestForOwnedSession } from '@/store/session-states'
 
 import type { ToolPart } from './fallback-model'
 
@@ -143,11 +144,22 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       setSubmitting(choice)
 
       try {
-        await gateway.request<{ resolved?: boolean }>('approval.respond', {
-          choice,
-          request_id: request.requestId,
-          session_id: request.sessionId ?? undefined
-        })
+        // Route through the session's OWNER (tile route → known profile);
+        // ambient only when no owner is known. The ambient socket follows
+        // foreground focus, and for a cross-profile session it points at a
+        // backend that never held this approval (#91684 client half).
+        await requestForOwnedSession<{ resolved?: boolean }>(
+          request.sessionId,
+          // Bound (not wrapped) so the ambient fallback keeps the exact
+          // 2-arg call shape gateway.request callers assert on.
+          gateway.request.bind(gateway) as typeof gateway.request,
+          'approval.respond',
+          {
+            choice,
+            request_id: request.requestId,
+            session_id: request.sessionId ?? undefined
+          }
+        )
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')
         clearApprovalRequest(request.sessionId, request.requestId)
         void replayPendingApproval(gateway, request.sessionId).catch(() => undefined)

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -246,6 +246,29 @@ describe('retireLocalProfileGateways', () => {
   })
 })
 
+describe('reconnectSecondaryGateways', () => {
+  it('force-redials an open secondary whose transport may be half-open after wake', async () => {
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      descriptorFor(connectionId, profile)
+    )
+
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('homelab', 'default')
+    expect(gatewayMocks.connect).toHaveBeenCalledTimes(1)
+    expect(gatewayMocks.instances[0].connectionState).toBe('open')
+
+    reconnectSecondaryGateways({ forceOpenSockets: true })
+
+    await vi.waitFor(() => {
+      expect(gatewayMocks.connect).toHaveBeenCalledTimes(2)
+    })
+    expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
+    expect(getConnectionFor).toHaveBeenCalledTimes(2)
+    expect(gatewayMocks.instances[0].connectionState).toBe('open')
+  })
+})
+
 describe('reconnect fail-stop on a removed connection', () => {
   it('evicts the entry instead of retrying when the registry no longer knows the id', async () => {
     const getConnectionFor = vi

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -886,11 +886,20 @@ export async function ensureActiveGatewayOpen(): Promise<HermesGateway | null> {
 // activation before reporting the gateway as unavailable.
 const ACTIVE_GATEWAY_OPEN_WAIT_MS = 8_000
 
-// Wake signal (sleep/network/visibility): nudge every live secondary back open.
-export function reconnectSecondaryGateways(): void {
+// Recovery signal: nudge every live secondary back open. Power-resume/network
+// signals can force sockets that still report open to retire before redialing.
+export function reconnectSecondaryGateways({ forceOpenSockets = false }: { forceOpenSockets?: boolean } = {}): void {
   for (const entry of g.secondaries.values()) {
-    if (!entry.wantOpen || isOpen(entry.gateway)) {
+    if (!entry.wantOpen) {
       continue
+    }
+
+    if (isOpen(entry.gateway)) {
+      if (!forceOpenSockets) {
+        continue
+      }
+
+      entry.gateway.close()
     }
 
     entry.reconnectAttempt = 0

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -7,6 +7,7 @@ import { $gateway } from './gateway'
 import { withinNativeNotifyBaseline } from './notify-baseline'
 import { clearApprovalRequest } from './prompts'
 import { $activeSessionId } from './session'
+import { requestForOwnedSession } from './session-states'
 
 export type { HermesOpenTarget }
 
@@ -359,7 +360,18 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
   }
 
   try {
-    await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
+    // Route through the session's OWNER (tile route → known profile); the
+    // ambient socket follows foreground focus and, for a background approval
+    // raised by a cross-profile session, points at a backend that never held
+    // the approval (#91684 client half). Ambient only when no owner is known.
+    await requestForOwnedSession(
+      sessionId,
+      // Bound (not wrapped) so the ambient fallback keeps the exact 2-arg
+      // call shape gateway.request callers assert on.
+      gateway.request.bind(gateway) as typeof gateway.request,
+      'approval.respond',
+      { choice, session_id: sessionId ?? undefined }
+    )
     clearApprovalRequest(sessionId)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.

--- a/apps/desktop/src/store/session-request-router.test.ts
+++ b/apps/desktop/src/store/session-request-router.test.ts
@@ -128,18 +128,26 @@ describe('$activeGatewayRoute (registry-owned active profile)', () => {
 })
 
 describe('sessionRpcNeedsProfileRoute', () => {
-  it('routes ambient when the owner is unknown or already active', () => {
-    expect(sessionRpcNeedsProfileRoute(null, 'default')).toBe(false)
-    expect(sessionRpcNeedsProfileRoute('', 'default')).toBe(false)
-    expect(sessionRpcNeedsProfileRoute('   ', 'loki')).toBe(false)
-    expect(sessionRpcNeedsProfileRoute('loki', 'loki')).toBe(false)
-    expect(sessionRpcNeedsProfileRoute('default', 'default')).toBe(false)
+  it('routes ambient ONLY when the owner is unknown (no session / global chrome)', () => {
+    expect(sessionRpcNeedsProfileRoute(null)).toBe(false)
+    expect(sessionRpcNeedsProfileRoute(undefined)).toBe(false)
+    expect(sessionRpcNeedsProfileRoute('')).toBe(false)
+    expect(sessionRpcNeedsProfileRoute('   ')).toBe(false)
   })
 
-  it('pins to the owning profile when the active route diverges', () => {
-    expect(sessionRpcNeedsProfileRoute('loki', 'default')).toBe(true)
-    expect(sessionRpcNeedsProfileRoute('default', 'loki')).toBe(true)
-    expect(sessionRpcNeedsProfileRoute('loki', 'hulk')).toBe(true)
+  it('pins a KNOWN owner to its own profile regardless of what is active', () => {
+    // No active-profile comparison exists anymore: "active" is presentation
+    // state, never a routing authority. A known owner ALWAYS routes to its own
+    // profile — even when it happens to equal whatever is currently active,
+    // gatewayForProfile collapses that back to the primary socket (no cost).
+    expect(sessionRpcNeedsProfileRoute('loki')).toBe(true)
+    expect(sessionRpcNeedsProfileRoute('default')).toBe(true)
+    expect(sessionRpcNeedsProfileRoute('hulk')).toBe(true)
+  })
+
+  it('pins a route owner with a connectionId', () => {
+    expect(sessionRpcNeedsProfileRoute({ connectionId: 'local', profile: 'developer' })).toBe(true)
+    expect(sessionRpcNeedsProfileRoute({ connectionId: '', profile: 'developer' })).toBe(false)
   })
 })
 
@@ -303,11 +311,10 @@ describe('requestForSessionProfile', () => {
     )
   })
 
-  it('keeps the ambient dispatcher when the active route already serves the owner', async () => {
+  it('routes an owner that IS the primary profile onto the primary socket (no active comparison)', async () => {
     const primary = makePrimary()
-    setPrimaryGateway(primary as never, 'default')
+    setPrimaryGateway(primary as never, 'loki')
     installDesktop()
-    await ensureGatewayForProfile('loki')
 
     const ambient = vi.fn(async (method: string, params?: Record<string, unknown>) => ({
       ambient: true,
@@ -315,10 +322,21 @@ describe('requestForSessionProfile', () => {
       params
     }))
 
-    const result = await requestForSessionProfile('loki', ambient as never, 'session.activate', { session_id: 'rt-1' })
+    // Owner 'loki' equals the PRIMARY profile. There is no active-profile
+    // comparison anymore, but gatewayForProfile collapses a primary-profile
+    // owner back to the primary socket — so no secondary is spun up. The
+    // ambient fn isn't used (routing goes through requestGatewayForProfile),
+    // but the request still lands on the one primary gateway.
+    const result = await requestForSessionProfile<{ method: string; params: Record<string, unknown> }>(
+      'loki',
+      ambient as never,
+      'session.activate',
+      { session_id: 'rt-1' }
+    )
 
-    expect(ambient).toHaveBeenCalledWith('session.activate', { session_id: 'rt-1' })
-    expect(result).toEqual({ ambient: true, method: 'session.activate', params: { session_id: 'rt-1' } })
+    expect(secondaryGateways).toHaveLength(0)
+    expect(primary.request).toHaveBeenCalledWith('session.activate', { session_id: 'rt-1' })
+    expect(result).toEqual({ method: 'session.activate', params: { session_id: 'rt-1' } })
   })
 
   it('keeps the ambient dispatcher for sessions with no owning profile', async () => {

--- a/apps/desktop/src/store/session-request-router.ts
+++ b/apps/desktop/src/store/session-request-router.ts
@@ -1,9 +1,4 @@
-import {
-  activeGatewayConnectionId,
-  activeGatewayProfileKey,
-  requestGatewayForAgent,
-  requestGatewayForProfile
-} from '@/store/gateway'
+import { requestGatewayForAgent, requestGatewayForProfile } from '@/store/gateway'
 
 export interface SessionProfileRoute {
   connectionId: string
@@ -15,17 +10,22 @@ export interface SessionProfileRoute {
 export type SessionOwnerScope = undefined | null | string | SessionProfileRoute
 
 // ── Session-scoped RPC routing (the #89206 class) ───────────────────────────
-// A session-scoped RPC (session.resume / session.activate / session.usage)
-// only means anything on the backend that OWNS the session's profile. The
-// ambient "active gateway" is a moving target: between the profile-swap await
-// and the RPC dispatch, a concurrent switch, an idle-reap eviction, a failed
-// dial, or a connection edit can re-point the active route at another
-// backend. Dispatching on it anyway lands the RPC on a backend that has never
-// heard of the session — it 404s or times out, the renderer burns its bounded
-// retries, and the user sees "retries gave up" while the session's own
-// backend is healthy (blank Bot Chats, dead wake-ups; local pool and SSH
-// alike). These helpers make the owning profile, resolved at REQUEST time,
-// the routing authority.
+// A session-scoped RPC (session.resume / session.activate / session.usage /
+// prompt.submit) only means anything on the backend that OWNS the session's
+// profile. A session's profile is a PROPERTY OF THE SESSION, not of whatever
+// the window is currently showing. The "active gateway" is a moving target
+// (a concurrent switch, an idle-reap eviction, a failed dial, or a connection
+// edit re-points it) AND, for a hidden/unlisted session, it is simply the
+// WRONG backend — one that never owned the session. Dispatching there 404s or
+// times out while the session's own backend is healthy (blank Bot Chats, dead
+// wake-ups; local pool and SSH alike).
+//
+// So: a KNOWN owner is always routed to its own profile's socket — there is no
+// "same as active, so use ambient" shortcut, because "active" carries no
+// routing authority. Only a genuinely UNKNOWN owner (a fresh draft with no
+// session yet, or truly global chrome) falls to the ambient dispatcher, and
+// callers are expected to resolve the owner (cross-profile probe) before they
+// reach that case for a real session.
 
 const normKey = (profile: null | string | undefined): string => (profile ?? '').trim() || 'default'
 
@@ -41,16 +41,15 @@ function routeParams(route: SessionProfileRoute, params: Record<string, unknown>
 }
 
 /**
- * True when a session-scoped RPC must be pinned to `ownerProfile`'s own
- * socket because the active gateway currently serves a different profile.
- * A null/empty owner means the session's profile is unknown — route ambient
- * (the pre-multi-profile behavior) rather than guessing.
+ * True when a session-scoped RPC must be pinned to `ownerProfile`'s own socket.
+ *
+ * A KNOWN owner (route or profile name) always needs its own socket: the
+ * session belongs to that profile regardless of what the window is showing.
+ * There is deliberately NO comparison against the active profile — "active" is
+ * presentation state, never a routing authority. Only a null/empty owner (a
+ * fresh draft with no session, or global chrome) routes ambient.
  */
-export function sessionRpcNeedsProfileRoute(
-  ownerProfile: SessionOwnerScope | undefined,
-  activeProfile: string = activeGatewayProfileKey(),
-  activeConnectionId: null | string = activeGatewayConnectionId()
-): boolean {
+export function sessionRpcNeedsProfileRoute(ownerProfile: SessionOwnerScope | undefined): boolean {
   if (isRoute(ownerProfile)) {
     // A descriptor is an immutable ownership claim. Even an explicitly local
     // route must not collapse to the ambient request: another connection can
@@ -58,11 +57,7 @@ export function sessionRpcNeedsProfileRoute(
     return Boolean(ownerProfile.connectionId.trim())
   }
 
-  if (ownerProfile == null || !String(ownerProfile).trim()) {
-    return false
-  }
-
-  return normKey(ownerProfile) !== normKey(activeProfile)
+  return ownerProfile != null && Boolean(String(ownerProfile).trim())
 }
 
 /**

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -4,7 +4,7 @@ import type { ClientSessionState } from '@/app/types'
 import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { $activeGatewayProfile } from '@/store/profile'
-import { $selectedStoredSessionId } from '@/store/session'
+import { $selectedStoredSessionId, setSessions } from '@/store/session'
 import type { SessionTile } from '@/store/session-states'
 import {
   $sessionStates,
@@ -12,12 +12,14 @@ import {
   blankDraftTile,
   focusedSessionNeedsRoute,
   focusOpenSession,
+  knownOwnerForSession,
   markSelectionRestore,
   nextSessionTileForWorkspace,
   openSessionTile,
   orderTilesByTree,
   patchSessionTile,
   releaseSessionTranscript,
+  requestForOwnedSession,
   resetTileRuntimeBindings,
   selectionHomesToWorkspace,
   type SessionTileDelegate,
@@ -573,5 +575,55 @@ describe('sessionTileOwnerRoute', () => {
     $sessionTiles.set([])
 
     expect(sessionTileOwnerRoute('missing')).toBeUndefined()
+  })
+})
+
+describe('knownOwnerForSession / requestForOwnedSession (#91684 client half)', () => {
+  beforeEach(() => {
+    // Earlier suites leave profile-scoped tile buckets behind; pin the profile
+    // BEFORE seeding tiles so the bucket subscriber cannot clobber the seed.
+    $activeGatewayProfile.set('default')
+    $sessionTiles.set([])
+  })
+  afterEach(() => {
+    $sessionTiles.set([])
+    setSessions([])
+  })
+
+  it('resolves the tile owner route first, translating a runtime id to its stored id', () => {
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: 'conn-a', profile: 'work' },
+        runtimeId: 'rt-1',
+        storedSessionId: 'stored-1'
+      }
+    ])
+
+    expect(knownOwnerForSession('rt-1')).toEqual({ connectionId: 'conn-a', profile: 'work' })
+    expect(knownOwnerForSession('stored-1')).toEqual({ connectionId: 'conn-a', profile: 'work' })
+  })
+
+  it('falls back to the session row profile when no tile route exists', () => {
+    setSessions([{ id: 'stored-2', profile: 'loki' } as never])
+
+    expect(knownOwnerForSession('stored-2')).toBe('loki')
+  })
+
+  it('returns undefined (ambient) when no owner is known, and for null ids', () => {
+    expect(knownOwnerForSession('unknown-session')).toBeUndefined()
+    expect(knownOwnerForSession(null)).toBeUndefined()
+    expect(knownOwnerForSession(undefined)).toBeUndefined()
+  })
+
+  it('requestForOwnedSession dispatches ambient with the exact 2-arg shape when no owner is known', async () => {
+    const ambient = vi.fn(async (method: string, params?: Record<string, unknown>) => ({ method, params }))
+
+    await requestForOwnedSession('unknown-session', ambient as never, 'approval.respond', {
+      choice: 'once',
+      session_id: 'unknown-session'
+    })
+
+    expect(ambient).toHaveBeenCalledTimes(1)
+    expect(ambient.mock.calls[0]).toEqual(['approval.respond', { choice: 'once', session_id: 'unknown-session' }])
   })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -42,13 +42,14 @@ import {
   $selectedStoredSessionId,
   $sessions,
   clearReadBaseline,
+  knownSessionProfile,
   lineageAliases,
   markSessionRead,
   sessionMatchesStoredId,
   setActiveSessionStoredIdRotation,
   setSessions
 } from './session'
-import type { SessionProfileRoute } from './session-request-router'
+import { requestForSessionProfile, type SessionOwnerScope, type SessionProfileRoute } from './session-request-router'
 import { ackStoredSessionId, markSessionUnreadFinished } from './session-unread'
 import { isSecondaryWindow } from './windows'
 
@@ -736,6 +737,45 @@ export function patchSessionTile(storedSessionId: string, patch: Partial<Session
 
 export function sessionTileOwnerRoute(storedSessionId: string): SessionProfileRoute | undefined {
   return $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.ownerRoute
+}
+
+/**
+ * Sync owner resolution for a session id that may be a RUNTIME or a STORED id.
+ * Tile route first (exact connectionId+profile, survives relaunch), then the
+ * known session profile (row or open-time hint). Returns undefined when no
+ * owner is known — the caller falls back to ambient, never to "active".
+ */
+export function knownOwnerForSession(sessionId: null | string | undefined): SessionOwnerScope {
+  if (!sessionId) {
+    return undefined
+  }
+
+  const storedSessionId = storedSessionIdForRuntimeId(sessionId) ?? sessionId
+
+  return sessionTileOwnerRoute(storedSessionId) ?? knownSessionProfile($sessions.get(), storedSessionId)
+}
+
+/**
+ * Dispatch a session-scoped RPC through the OWNER of `sessionId` (tile route →
+ * known profile), falling back to the ambient dispatcher only when no owner is
+ * known. This is the client half of #91684: approval.respond (and siblings)
+ * sent on the ambient socket land on whatever backend is active, which for a
+ * cross-profile session is a backend that never held the approval.
+ */
+export function requestForOwnedSession<T>(
+  sessionId: null | string | undefined,
+  ambientRequest: <R>(
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ) => Promise<R>,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs?: number,
+  signal?: AbortSignal
+): Promise<T> {
+  return requestForSessionProfile<T>(knownOwnerForSession(sessionId), ambientRequest, method, params, timeoutMs, signal)
 }
 
 /** Resolve a session id THAT MAY BE A RUNTIME ID to the stored id its tile

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -30,6 +30,7 @@ import {
   getRememberedRoute,
   getRememberedSessionId,
   getSessionOwnerHint,
+  knownSessionProfile,
   mergeSessionPage,
   rememberedSessionProfile,
   resolveComposerSessionKey,
@@ -947,5 +948,27 @@ describe('rememberedSessionProfile', () => {
   it('normalizes a blank active profile to default', () => {
     expect(rememberedSessionProfile([], null, '')).toBe('default')
     expect(rememberedSessionProfile([], null, null)).toBe('default')
+  })
+})
+
+describe('knownSessionProfile', () => {
+  it('returns the row owner when the session is listed', () => {
+    const sessions = [session({ id: 'stored-1', profile: 'ai-engineer' })]
+
+    expect(knownSessionProfile(sessions, 'stored-1')).toBe('ai-engineer')
+  })
+
+  it('returns the owner hint for a hidden session absent from the list', () => {
+    setSessionOwnerHint('hidden-bot-chat', { connectionId: 'local', mode: 'local', profile: 'developer' })
+
+    expect(knownSessionProfile([], 'hidden-bot-chat')).toBe('developer')
+  })
+
+  it('returns undefined for an unknown session — NEVER falls back to active', () => {
+    // This is the whole point of the no-active-fallback architecture: an
+    // unresolved owner must be undefined so the caller does a cross-profile
+    // probe, not silently route the RPC to whatever profile is on screen.
+    expect(knownSessionProfile([], 'totally-unknown')).toBeUndefined()
+    expect(knownSessionProfile([], null)).toBeUndefined()
   })
 })

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -117,42 +117,50 @@ export function sessionBelongsToProfile(
 }
 
 /**
- * The profile a routed session belongs to, for keying the remembered id.
+ * The profile that owns a session, from SYNC known sources only: the session
+ * row (the cross-profile aggregator tags each row) then the owner hint recorded
+ * at open time. Returns undefined when neither knows — the caller must resolve
+ * it (cross-profile probe) rather than fall back to whatever is active, because
+ * "active" is presentation state and never a routing authority. Hidden sessions
+ * (Bot Mode's canonical "Bot Chat") never appear in the row list, so the hint is
+ * often the only sync source.
+ */
+export function knownSessionProfile(
+  sessions: readonly SessionInfo[],
+  sessionId: null | string
+): string | undefined {
+  if (!sessionId) {
+    return undefined
+  }
+
+  const owner = sessions.find(session => sessionMatchesStoredId(session, sessionId))?.profile?.trim()
+
+  if (owner) {
+    return owner
+  }
+
+  const hint = getSessionOwnerHint(sessionId)
+
+  return (hint?.targetProfile ?? hint?.profile)?.trim() || undefined
+}
+
+/**
+ * The profile a routed session belongs to, for keying the remembered id and
+ * other PRESENTATION uses (which profile's sidebar/navigation this session sits
+ * under). Falls back to the active gateway profile when the owner is unknown.
  *
- * Prefer the owning profile recorded on the session row (the cross-profile
- * aggregator tags each row), so the session is remembered under ITS profile
- * even while a different one is live. Falls back to the active gateway profile
- * for a session not yet in the in-memory list.
+ * Do NOT use this to ROUTE a session-scoped RPC: the active-profile fallback is
+ * exactly what sends a hidden/unlisted session's RPC to a backend that never
+ * owned it. Routing must use `knownSessionProfile` + a cross-profile probe and
+ * surface an error instead of falling back. This remains for the navigation
+ * keying it was written for.
  */
 export function rememberedSessionProfile(
   sessions: readonly SessionInfo[],
   sessionId: null | string,
   activeProfile: null | string
 ): string {
-  if (sessionId) {
-    const owner = sessions.find(session => sessionMatchesStoredId(session, sessionId))?.profile?.trim()
-
-    if (owner) {
-      return owner
-    }
-
-    // Hidden / plugin-owned sessions (Bot Mode's canonical "Bot Chat" rows are
-    // born hidden) never appear in the sidebar list, so the row lookup above
-    // misses for them whenever the aggregator page replaced the in-memory row.
-    // Falling straight through to the ACTIVE profile routed their session RPCs
-    // at a backend that never owned the session — prompt.submit answered 4001
-    // "session not found" while the bot's own backend sat healthy. The open
-    // path records an owner hint for exactly this; honor it before falling
-    // back to the active profile.
-    const hint = getSessionOwnerHint(sessionId)
-    const hinted = (hint?.targetProfile ?? hint?.profile)?.trim()
-
-    if (hinted) {
-      return hinted
-    }
-  }
-
-  return (activeProfile ?? '').trim() || 'default'
+  return knownSessionProfile(sessions, sessionId) ?? ((activeProfile ?? '').trim() || 'default')
 }
 
 // The last non-overlay route (a page like /skills, or a session route), so a

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1557,6 +1557,18 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
+        # WebSocket keepalive for the dashboard/desktop web server (#79635).
+        # Applied to NON-loopback binds only: loopback always disables the
+        # protocol ping (see hermes_cli/web_server.py — an event-loop stall
+        # must never kill a healthy local connection). Values are seconds.
+        "ws_ping_interval": 20.0,
+        "ws_ping_timeout": 20.0,
+        # Grace window (seconds) before a WS-orphaned gateway session is
+        # interrupted/reaped after its client disconnects (#79635). The
+        # HERMES_TUI_WS_ORPHAN_REAP_GRACE_S env var remains an internal
+        # override for backward compatibility. 0 disables the reap
+        # (park forever).
+        "ws_orphan_reap_grace_s": 20.0,
         # OAuth gate configuration (engaged when ``--host`` is set and
         # ``--insecure`` is not). The bundled Nous Portal plugin reads
         # both keys at startup; they are the canonical surface for these

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19316,6 +19316,20 @@ def start_server(
     # ping at 20/20 to detect it promptly and stay under the tunnel's idle
     # window.
     _is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    # Non-loopback ping cadence is config-driven (dashboard.ws_ping_interval /
+    # dashboard.ws_ping_timeout, #79635); the 20/20 defaults keep the
+    # Cloudflare-Tunnel-friendly behaviour when unset or invalid.
+    try:
+        _dash_cfg = load_config().get("dashboard") or {}
+    except Exception:
+        _dash_cfg = {}
+
+    def _ws_ping_setting(key: str, default: float = 20.0) -> float:
+        try:
+            return float(_dash_cfg.get(key, default))
+        except (TypeError, ValueError):
+            return default
+
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning",
         # proxy_headers defaults to False so _ws_client_is_allowed sees
@@ -19330,8 +19344,8 @@ def start_server(
         # disables the protocol ping (None) so an event-loop stall can never
         # trigger a false disconnect; a genuinely dead local client is still
         # reaped via the WebSocketDisconnect → disconnect/reap path.
-        ws_ping_interval=None if _is_loopback else 20.0,
-        ws_ping_timeout=None if _is_loopback else 20.0,
+        ws_ping_interval=None if _is_loopback else _ws_ping_setting("ws_ping_interval"),
+        ws_ping_timeout=None if _is_loopback else _ws_ping_setting("ws_ping_timeout"),
         ws_max_size=_DESKTOP_ATTACHMENT_WS_MAX_BYTES,
     )
     server = uvicorn.Server(config)

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -204,7 +204,14 @@ _RESET_END_REASONS_SQL = ", ".join(f"'{reason}'" for reason in _RESET_END_REASON
 # docs/session-lifecycle.md "recoverable accidental reasons"). Interpolated
 # into the recovery SQL below AND exposed as SessionDB.RECOVERABLE_END_REASONS
 # so the tuple is the single source of truth — literals cannot drift.
-_RECOVERABLE_END_REASONS = ("agent_close", "ws_orphan_reap")
+_RECOVERABLE_END_REASONS = (
+    "agent_close",
+    "ws_orphan_reap",
+    # A stale sentinel-parked runtime quietly superseded by a fresh
+    # session.resume of the same stored session (no reclaimed broadcast);
+    # the stored session stays resumable like any accidental end.
+    "superseded_by_resume",
+)
 _RECOVERABLE_END_REASONS_SQL = ", ".join(f"'{reason}'" for reason in _RECOVERABLE_END_REASONS)
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5218,6 +5218,202 @@ def test_ws_orphan_reap_spares_reattached_session(monkeypatch):
     assert server._ws_session_is_orphaned(done) is False
 
 
+def test_resume_rebind_cancels_pending_ws_orphan_reap(monkeypatch):
+    """Re-binding a live transport via _live_session_payload must cancel the
+    pending ws-orphan reap Timer (storm killer, part 1)."""
+    cancelled = []
+
+    class _Timer:
+        def __init__(self, _delay, fn):
+            self.fn = fn
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            cancelled.append(self)
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    session = _session(transport=server._detached_ws_transport, running=False)
+    server._sessions["cancel-sid"] = session
+
+    try:
+        server._schedule_ws_orphan_reap("cancel-sid")
+        assert "cancel-sid" in server._pending_ws_reaps
+
+        server._live_session_payload("cancel-sid", session, transport=_LiveTransport())
+
+        assert "cancel-sid" not in server._pending_ws_reaps
+        assert len(cancelled) == 1
+    finally:
+        server._sessions.pop("cancel-sid", None)
+        server._pending_ws_reaps.pop("cancel-sid", None)
+
+
+def test_claim_or_reuse_live_winner_cancels_pending_reap(monkeypatch):
+    """A resume that reuses the live winner cancels the winner's pending reap."""
+    cancelled = []
+
+    class _Timer:
+        def __init__(self, _delay, fn):
+            self.fn = fn
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            cancelled.append(self)
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    agent = types.SimpleNamespace(session_id="stored-claim")
+    winner = _session(
+        agent=agent,
+        session_key="stored-claim",
+        transport=server._detached_ws_transport,
+        running=False,
+    )
+    server._sessions["winner-sid"] = winner
+
+    try:
+        server._schedule_ws_orphan_reap("winner-sid")
+        assert "winner-sid" in server._pending_ws_reaps
+
+        live = server._claim_or_reuse_live(
+            "fresh-sid", "stored-claim", _session(), None
+        )
+
+        assert live == ("winner-sid", winner)
+        assert "winner-sid" not in server._pending_ws_reaps
+        assert len(cancelled) == 1
+    finally:
+        server._sessions.pop("winner-sid", None)
+        server._sessions.pop("fresh-sid", None)
+        server._pending_ws_reaps.pop("winner-sid", None)
+
+
+def test_superseded_runtime_finalized_without_reclaimed_broadcast(monkeypatch):
+    """When a resume mints a fresh runtime for a stored id whose prior runtime
+    is sentinel-parked, the old record is finalized quietly with end_reason
+    superseded_by_resume — no session.reclaimed broadcast, and its pending
+    reap Timer is cancelled (storm killer, part 2)."""
+    cancelled = []
+    broadcasts = []
+    torn_down = []
+
+    class _Timer:
+        def __init__(self, _delay, fn):
+            self.fn = fn
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            cancelled.append(self)
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(
+        server,
+        "_broadcast_global_event",
+        lambda event, payload=None: broadcasts.append((event, payload)),
+    )
+    monkeypatch.setattr(
+        server,
+        "_teardown_popped_session",
+        lambda popped, *, end_reason: torn_down.append((popped, end_reason)) or True,
+    )
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _s: None)
+
+    old_agent = types.SimpleNamespace(session_id="stored-super")
+    old = _session(
+        agent=old_agent,
+        session_key="stored-super",
+        transport=server._detached_ws_transport,
+        running=False,
+    )
+    server._sessions["old-sid"] = old
+    fresh = _session(session_key="stored-super")
+
+    try:
+        server._schedule_ws_orphan_reap("old-sid")
+        assert "old-sid" in server._pending_ws_reaps
+
+        # The old runtime looks live to _find_live_session_by_key, so make it
+        # invisible the way a real mint path would (its client is gone and the
+        # resume slow path only mints after the fast path found no live match:
+        # mark it finalized-for-lookup via a different stored key is wrong —
+        # instead simulate the mint race by removing it from lookup).
+        old["_finalized"] = False
+        monkeypatch.setattr(server, "_find_live_session_by_key", lambda _k: None)
+
+        result = server._claim_or_reuse_live("new-sid", "stored-super", fresh, None)
+
+        assert result is None
+        assert server._sessions.get("new-sid") is fresh
+        assert "old-sid" not in server._sessions
+        assert "old-sid" not in server._pending_ws_reaps
+        assert len(cancelled) == 1
+        assert torn_down == [(old, "superseded_by_resume")]
+        assert broadcasts == []  # no session.reclaimed storm
+    finally:
+        server._sessions.pop("old-sid", None)
+        server._sessions.pop("new-sid", None)
+        server._pending_ws_reaps.pop("old-sid", None)
+        server._pending_ws_reaps.pop("new-sid", None)
+
+
+def test_superseded_by_resume_is_recoverable_end_reason():
+    from hermes_state_common import _RECOVERABLE_END_REASONS
+
+    assert "superseded_by_resume" in _RECOVERABLE_END_REASONS
+    # And quiet: it must NOT trigger the session.reclaimed broadcast.
+    assert "superseded_by_resume" not in server._RECLAIM_END_REASONS
+
+
+def test_ws_orphan_reap_still_fires_when_never_resumed(monkeypatch):
+    """Nobody re-resumes: the reap fires normally and unregisters its Timer."""
+    callbacks = []
+    torn_down = []
+
+    class _Timer:
+        def __init__(self, _delay, fn):
+            callbacks.append(fn)
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            return None
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(
+        server,
+        "_teardown_popped_session",
+        lambda popped, *, end_reason: torn_down.append((popped, end_reason)) or True,
+    )
+    session = _session(transport=server._detached_ws_transport, running=False)
+    server._sessions["lonely-sid"] = session
+
+    try:
+        server._schedule_ws_orphan_reap("lonely-sid")
+        assert "lonely-sid" in server._pending_ws_reaps
+        callbacks.pop(0)()
+
+        assert "lonely-sid" not in server._sessions
+        assert "lonely-sid" not in server._pending_ws_reaps
+        assert torn_down == [(session, "ws_orphan_reap")]
+    finally:
+        server._sessions.pop("lonely-sid", None)
+        server._pending_ws_reaps.pop("lonely-sid", None)
+
+
 def test_ws_orphan_reap_spares_detached_session_with_running_async_delegation(monkeypatch):
     """A detached desktop session with live background delegation is parked.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4585,6 +4585,279 @@ def test_session_close_settles_active_turn_before_teardown(monkeypatch):
     assert response["result"] == {"closed": True}
 
 
+def test_ws_orphan_reap_interrupts_isolated_turn_then_reaps(monkeypatch):
+    callbacks = []
+    interrupted = []
+    torn_down = []
+
+    class _Timer:
+        def __init__(self, _delay, callback):
+            callbacks.append(callback)
+            self.daemon = False
+
+        def start(self):
+            return None
+
+    class _Supervisor:
+        def interrupt(self, sid, *, request_id=None):
+            interrupted.append((sid, request_id))
+
+    session = _session(
+        agent=None,
+        agent_ready=threading.Event(),
+        transport=server._detached_ws_transport,
+        running=True,
+        _compute_host_active=True,
+        history=[{"role": "assistant", "content": "partial"}],
+        queued_prompt={"text": "must not run"},
+    )
+    server._sessions["isolated-sid"] = session
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+    )
+    monkeypatch.setattr(
+        server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor()
+    )
+    monkeypatch.setattr(
+        server,
+        "_teardown_popped_session",
+        lambda claimed, *, end_reason: torn_down.append((claimed, end_reason)) or True,
+    )
+
+    try:
+        server._schedule_ws_orphan_reap("isolated-sid")
+        callbacks.pop(0)()
+
+        assert interrupted == [("isolated-sid", "client-gone-isolated-sid")]
+        assert session["_turn_cancel_requested"] is True
+        assert session["queued_prompt"] is None
+        assert session["history"] == [{"role": "assistant", "content": "partial"}]
+        assert len(callbacks) == 1
+
+        callbacks.pop(0)()
+
+        assert interrupted == [("isolated-sid", "client-gone-isolated-sid")]
+        assert len(callbacks) == 1
+
+        session["running"] = False
+        callbacks.pop(0)()
+
+        assert "isolated-sid" not in server._sessions
+        assert torn_down == [(session, "ws_orphan_reap")]
+    finally:
+        server._sessions.pop("isolated-sid", None)
+
+
+def test_ws_orphan_reap_spares_turn_reattached_within_grace(monkeypatch):
+    callbacks = []
+    interrupted = []
+
+    class _Timer:
+        def __init__(self, _delay, callback):
+            callbacks.append(callback)
+
+        def start(self):
+            return None
+
+    class _LiveThread:
+        def is_alive(self):
+            return True
+
+    class _LiveTransport:
+        def write(self, *_args, **_kwargs):
+            return True
+
+    disconnecting_transport = _LiveTransport()
+    session = _session(
+        agent=types.SimpleNamespace(
+            interrupt=lambda: interrupted.append("interrupted")
+        ),
+        transport=disconnecting_transport,
+        running=True,
+        _run_thread=_LiveThread(),
+    )
+    server._sessions["reattached-sid"] = session
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    try:
+        server._close_sessions_for_transport(disconnecting_transport)
+        assert session["transport"] is server._detached_ws_transport
+
+        session["transport"] = _LiveTransport()
+        callbacks.pop(0)()
+
+        assert interrupted == []
+        assert "reattached-sid" in server._sessions
+        assert callbacks == []
+    finally:
+        server._sessions.pop("reattached-sid", None)
+
+
+def test_session_resume_does_not_rebind_after_client_gone_interrupt_claim(monkeypatch):
+    class _DB:
+        def get_session(self, session_id):
+            assert session_id == "stored-sid"
+            return {"id": session_id, "cwd": "/tmp"}
+
+        def resolve_resume_session_id(self, session_id):
+            return session_id
+
+    live_transport = object()
+    session = _session(
+        session_key="stored-sid",
+        transport=server._detached_ws_transport,
+        running=True,
+        _client_gone_interrupt_requested=True,
+    )
+    server._sessions["live-sid"] = session
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "current_transport", lambda: live_transport)
+
+    try:
+        response = server.handle_request(
+            {
+                "id": "resume-after-claim",
+                "method": "session.resume",
+                "params": {"session_id": "stored-sid"},
+            }
+        )
+
+        assert response is not None
+        assert response["error"]["code"] == 4009
+        assert response["error"]["message"] == "session disconnect interrupt settling"
+        assert session["transport"] is server._detached_ws_transport
+    finally:
+        server._sessions.pop("live-sid", None)
+
+
+def test_ws_orphan_reap_defers_running_turn_for_active_delegation(monkeypatch):
+    callbacks = []
+    interrupted = []
+    delegation_active = iter((True, False, False))
+
+    class _Timer:
+        def __init__(self, _delay, callback):
+            callbacks.append(callback)
+
+        def start(self):
+            return None
+
+    class _LiveThread:
+        def is_alive(self):
+            return True
+
+    def _interrupt():
+        interrupted.append("interrupted")
+        session["running"] = False
+
+    session = _session(
+        agent=types.SimpleNamespace(interrupt=_interrupt),
+        transport=server._detached_ws_transport,
+        running=True,
+        _run_thread=_LiveThread(),
+    )
+    server._sessions["delegating-turn"] = session
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(
+        server,
+        "_session_has_active_delegations",
+        lambda *_args, **_kwargs: next(delegation_active),
+    )
+    monkeypatch.setattr(server, "_teardown_popped_session", lambda *_args, **_kwargs: True)
+
+    try:
+        server._schedule_ws_orphan_reap("delegating-turn")
+        callbacks.pop(0)()
+
+        assert interrupted == []
+        assert len(callbacks) == 1
+
+        callbacks.pop(0)()
+
+        assert interrupted == ["interrupted"]
+        assert len(callbacks) == 1
+
+        callbacks.pop(0)()
+        assert "delegating-turn" not in server._sessions
+    finally:
+        server._sessions.pop("delegating-turn", None)
+
+
+def test_ws_orphan_reap_interrupts_in_process_turn(monkeypatch):
+    callbacks = []
+    interrupted = []
+
+    class _Timer:
+        def __init__(self, _delay, callback):
+            callbacks.append(callback)
+
+        def start(self):
+            return None
+
+    class _LiveThread:
+        def is_alive(self):
+            return True
+
+    def _interrupt():
+        interrupted.append("interrupted")
+        session["running"] = False
+
+    session = _session(
+        agent=types.SimpleNamespace(interrupt=_interrupt),
+        transport=server._detached_ws_transport,
+        running=True,
+        _run_thread=_LiveThread(),
+    )
+    server._sessions["inline-sid"] = session
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    try:
+        server._schedule_ws_orphan_reap("inline-sid")
+        callbacks.pop(0)()
+
+        assert interrupted == ["interrupted"]
+        assert session["_turn_cancel_requested"] is True
+        assert len(callbacks) == 1
+    finally:
+        server._sessions.pop("inline-sid", None)
+
+
+def test_ws_disconnect_running_sidecar_still_closes_without_orphan_timer(monkeypatch):
+    closed = []
+    scheduled = []
+    transport = object()
+    server._sessions["sidecar-sid"] = _session(
+        transport=transport,
+        running=True,
+        close_on_disconnect=True,
+    )
+    monkeypatch.setattr(
+        server,
+        "_close_session_by_id",
+        lambda sid, *, end_reason: closed.append((sid, end_reason)) or True,
+    )
+    monkeypatch.setattr(
+        server, "_schedule_ws_orphan_reap", lambda sid: scheduled.append(sid)
+    )
+
+    try:
+        reaped, detached = server._close_sessions_for_transport(transport)
+
+        assert (reaped, detached) == (1, 0)
+        assert closed == [("sidecar-sid", "ws_disconnect")]
+        assert scheduled == []
+    finally:
+        server._sessions.pop("sidecar-sid", None)
+
+
 def test_ws_orphan_reap_closes_worker_when_session_stays_detached(monkeypatch):
     """A detached WS session past its grace window has its slash_worker closed.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5110,6 +5110,90 @@ def test_finalize_session_closes_slash_worker(monkeypatch):
     assert closed["count"] == 1
 
 
+def test_close_transport_rebinds_session_to_remaining_viewer(monkeypatch):
+    """Closing a pop-out window's transport must re-bind the session to a
+    still-open window instead of stranding it on the drop sentinel (#83716)."""
+    reap_calls = []
+    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    main = _LiveTransport()
+    popout = _LiveTransport()
+    session = _session(transport=popout, running=False)
+    session["viewers"] = {main: 100.0, popout: 200.0}
+    server._sessions["multi-sid"] = session
+
+    reaped, detached = server._close_sessions_for_transport(popout)
+
+    assert reaped == 0 and detached == 0
+    assert session["transport"] is main
+    assert "multi-sid" not in reap_calls
+    assert server._ws_session_is_orphaned(session) is False
+
+
+def test_close_transport_detaches_when_no_viewers_remain(monkeypatch):
+    """The last viewer closing still lands the session on the drop sentinel
+    and schedules the grace reap (unchanged single-window behavior)."""
+    reap_calls = []
+    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    only = _LiveTransport()
+    session = _session(transport=only, running=False)
+    session["viewers"] = {only: 100.0}
+    server._sessions["solo-sid"] = session
+
+    reaped, detached = server._close_sessions_for_transport(only)
+
+    assert reaped == 0 and detached == 1
+    assert session["transport"] is server._detached_ws_transport
+    assert reap_calls == ["solo-sid"]
+
+
+def test_close_transport_skips_dead_remaining_viewers(monkeypatch):
+    """A viewer whose socket is already dead must not win the re-bind."""
+    reap_calls = []
+    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    dead = _LiveTransport()
+    dead._closed = True
+    owner = _LiveTransport()
+    session = _session(transport=owner, running=False)
+    session["viewers"] = {dead: 100.0, owner: 200.0}
+    server._sessions["dead-viewer-sid"] = session
+
+    reaped, detached = server._close_sessions_for_transport(owner)
+
+    assert detached == 1
+    assert session["transport"] is server._detached_ws_transport
+    assert reap_calls == ["dead-viewer-sid"]
+
+
+def test_live_session_payload_registers_transport_as_viewer():
+    """Resume/activate through _live_session_payload must register the caller
+    as a viewer so the disconnect path has something to re-bind to (#83716)."""
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    t = _LiveTransport()
+    session = _session(transport=server._detached_ws_transport, running=False)
+    server._live_session_payload("viewer-sid", session, transport=t)
+
+    assert session["transport"] is t
+    assert t in session.get("viewers", {})
+
+
 def test_ws_orphan_reap_spares_reattached_session(monkeypatch):
     """A session that rebinds a live transport is NOT considered orphaned."""
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4660,6 +4660,52 @@ def test_ws_orphan_reap_releases_resume_lock_before_slow_teardown(monkeypatch):
     assert not thread.is_alive()
 
 
+def test_ws_orphan_reap_reschedules_while_mid_turn_then_reaps(monkeypatch):
+    """A detached session that is still running must keep the reap timer (#85578)."""
+    callbacks = []
+    torn_down = []
+
+    class _Timer:
+        def __init__(self, _delay, callback):
+            callbacks.append(callback)
+            self.daemon = False
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(
+        server,
+        "_teardown_session",
+        lambda session, *, end_reason="tui_close": torn_down.append(
+            (session, end_reason)
+        ),
+    )
+    live = _session(
+        transport=server._detached_ws_transport,
+        running=True,
+    )
+    server._sessions["midturn-sid"] = live
+
+    try:
+        server._schedule_ws_orphan_reap("midturn-sid")
+        callbacks.pop(0)()
+
+        assert "midturn-sid" in server._sessions
+        assert len(callbacks) == 1
+        assert torn_down == []
+
+        live["running"] = False
+        callbacks.pop(0)()
+
+        assert "midturn-sid" not in server._sessions
+        assert len(torn_down) == 1
+        assert torn_down[0][1] == "ws_orphan_reap"
+    finally:
+        server._sessions.pop("midturn-sid", None)
+
+
 def test_ws_orphan_reap_waits_for_active_delegation_then_reaps(monkeypatch):
     from tools import async_delegation
 

--- a/tests/test_ws_keepalive_config.py
+++ b/tests/test_ws_keepalive_config.py
@@ -1,0 +1,92 @@
+"""Config propagation tests for the WS keepalive + orphan-reap grace knobs (#79635)."""
+
+import textwrap
+
+import pytest
+
+
+@pytest.fixture()
+def _temp_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_TUI_WS_ORPHAN_REAP_GRACE_S", raising=False)
+    return home
+
+
+def _write_config(home, body: str) -> None:
+    (home / "config.yaml").write_text(textwrap.dedent(body))
+
+
+def test_dashboard_ws_defaults_present(_temp_home):
+    from hermes_cli.config import load_config
+
+    _write_config(_temp_home, "model:\n  default: test-model\n")
+    cfg = load_config()
+    dash = cfg.get("dashboard") or {}
+    assert dash.get("ws_ping_interval") == 20.0
+    assert dash.get("ws_ping_timeout") == 20.0
+    assert dash.get("ws_orphan_reap_grace_s") == 20.0
+
+
+def test_dashboard_ws_values_propagate_from_yaml(_temp_home):
+    from hermes_cli.config import load_config
+
+    _write_config(
+        _temp_home,
+        """
+        dashboard:
+          ws_ping_interval: 45.5
+          ws_ping_timeout: 10
+          ws_orphan_reap_grace_s: 90
+        """,
+    )
+    cfg = load_config()
+    dash = cfg["dashboard"]
+    assert dash["ws_ping_interval"] == 45.5
+    assert dash["ws_ping_timeout"] == 10
+    assert dash["ws_orphan_reap_grace_s"] == 90
+    # Deep-merge: sibling defaults survive a partial user section.
+    assert dash.get("theme") == "default"
+
+
+def test_ws_orphan_reap_grace_reads_config(_temp_home):
+    from tui_gateway import server
+
+    _write_config(
+        _temp_home,
+        """
+        dashboard:
+          ws_orphan_reap_grace_s: 33
+        """,
+    )
+    assert server._resolve_ws_orphan_reap_grace() == 33.0
+
+
+def test_ws_orphan_reap_grace_env_var_overrides_config(_temp_home, monkeypatch):
+    from tui_gateway import server
+
+    _write_config(
+        _temp_home,
+        """
+        dashboard:
+          ws_orphan_reap_grace_s: 33
+        """,
+    )
+    monkeypatch.setenv("HERMES_TUI_WS_ORPHAN_REAP_GRACE_S", "7")
+    assert server._resolve_ws_orphan_reap_grace() == 7.0
+
+
+def test_ws_orphan_reap_grace_invalid_values_fall_back(_temp_home, monkeypatch):
+    from tui_gateway import server
+
+    _write_config(
+        _temp_home,
+        """
+        dashboard:
+          ws_orphan_reap_grace_s: not-a-number
+        """,
+    )
+    assert server._resolve_ws_orphan_reap_grace() == 20.0
+    monkeypatch.setenv("HERMES_TUI_WS_ORPHAN_REAP_GRACE_S", "-5")
+    assert server._resolve_ws_orphan_reap_grace() == 0.0

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -618,6 +618,86 @@ def test_approval_response_correlates_request_id(server, monkeypatch):
     assert calls == [("agent-1", "once", {"resolve_all": False, "request_id": "req-1"})]
 
 
+def test_approval_respond_falls_back_to_request_id_lookup(server, monkeypatch):
+    """A stale live sid must not 4001 an approval answer when the request_id
+    resolves to a live session (durable-identity fallback, #91684)."""
+    from tools import approval
+
+    live = {"session_key": "agent-live", "history": []}
+    server._sessions["ui-live"] = live
+    calls = []
+    monkeypatch.setattr(
+        approval,
+        "list_gateway_approvals",
+        lambda key: [{"request_id": "req-91684"}] if key == "agent-live" else [],
+    )
+    monkeypatch.setattr(
+        approval,
+        "resolve_gateway_approval",
+        lambda key, choice, **kwargs: calls.append((key, choice, kwargs)) or 1,
+    )
+
+    response = server.handle_request(
+        {
+            "id": "r-fallback",
+            "method": "approval.respond",
+            "params": {
+                "session_id": "gone-sid",
+                "request_id": "req-91684",
+                "choice": "once",
+            },
+        }
+    )
+
+    assert response["result"] == {"resolved": 1}
+    assert calls == [
+        ("agent-live", "once", {"resolve_all": False, "request_id": "req-91684"})
+    ]
+
+
+def test_approval_respond_falls_back_to_stored_session_id(server, monkeypatch):
+    """session_id holding a STORED id maps to the live runtime record."""
+    from tools import approval
+
+    live = {"session_key": "stored-91684", "history": []}
+    server._sessions["ui-stored"] = live
+    calls = []
+    monkeypatch.setattr(approval, "list_gateway_approvals", lambda key: [])
+    monkeypatch.setattr(
+        approval,
+        "resolve_gateway_approval",
+        lambda key, choice, **kwargs: calls.append((key, choice, kwargs)) or 1,
+    )
+
+    response = server.handle_request(
+        {
+            "id": "r-stored",
+            "method": "approval.respond",
+            "params": {"session_id": "stored-91684", "choice": "deny"},
+        }
+    )
+
+    assert response["result"] == {"resolved": 1}
+    assert calls == [
+        ("stored-91684", "deny", {"resolve_all": False, "request_id": None})
+    ]
+
+
+def test_approval_respond_4001_when_nothing_resolves(server, monkeypatch):
+    from tools import approval
+
+    monkeypatch.setattr(approval, "list_gateway_approvals", lambda key: [])
+    response = server.handle_request(
+        {
+            "id": "r-nope",
+            "method": "approval.respond",
+            "params": {"session_id": "nope", "request_id": "req-x", "choice": "once"},
+        }
+    )
+
+    assert response["error"]["code"] == 4001
+
+
 def test_clear_pending(server):
     ev = threading.Event()
     # _pending values are (sid, Event) tuples

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -159,7 +159,14 @@ def test_resume_closes_profile_db_on_live_session_fast_path(profile_dbs, monkeyp
         return db
 
     monkeypatch.setattr("hermes_state.SessionDB", _factory)
-    monkeypatch.setattr(server, "_find_live_session_by_key", lambda _key: ("live-sid", {}))
+    live_session = {}
+    with server._sessions_lock:
+        server._sessions["live-sid"] = live_session
+    monkeypatch.setattr(
+        server,
+        "_find_live_session_by_key",
+        lambda _key: ("live-sid", live_session),
+    )
     monkeypatch.setattr(
         server,
         "_live_session_payload",

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1518,11 +1518,64 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5004, str(e))
 
 
+def _approval_respond_session_fallback(params: dict):
+    """Durable-identity fallback for ``approval.respond`` (#91684).
+
+    The desktop can answer an approval prompt with a stale live sid (its
+    runtime record was re-minted after a reconnect while the prompt stayed
+    on screen). Before failing with 4001, try resolving the target session:
+
+    1. by the approval ``request_id`` — unique across sessions — scanning
+       every live session's pending gateway approvals;
+    2. by treating ``session_id`` as a STORED session id and mapping it to
+       the live runtime record for that stored id.
+
+    Returns the live session record or None.
+    """
+    request_id = str(params.get("request_id") or "")
+    if request_id:
+        try:
+            from tools.approval import list_gateway_approvals
+
+            with _sessions_lock:
+                live = list(_sessions.items())
+            for sid, session in live:
+                key = str(session.get("session_key") or "")
+                if not key:
+                    continue
+                for pending in list_gateway_approvals(key):
+                    if str(pending.get("request_id") or "") == request_id:
+                        return session
+        except Exception:
+            logger.debug(
+                "approval.respond request_id fallback failed", exc_info=True
+            )
+    target = str(params.get("session_id") or "")
+    if target:
+        try:
+            live = _find_live_session_by_key(target)
+            if live is not None:
+                return live[1]
+        except Exception:
+            logger.debug(
+                "approval.respond stored-id fallback failed", exc_info=True
+            )
+    return None
+
+
 @method("approval.respond")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
-        return err
+        # Session-not-found (4001) only: the client may hold a stale live
+        # sid for a session whose runtime was re-minted after a reconnect.
+        # Resolve by durable identity before failing (#91684).
+        code = (err.get("error") or {}).get("code")
+        if code != 4001:
+            return err
+        session = _approval_respond_session_fallback(params)
+        if session is None:
+            return err
     try:
         from tools.approval import resolve_gateway_approval
 
@@ -1558,6 +1611,7 @@ def register(server) -> None:
         _coerce_truncate_int,
         _reconcile_client_ordinal,
         _pending_reaction_notes,
+        _approval_respond_session_fallback,
     ):
         setattr(
             server,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -552,11 +552,23 @@ def _(rid, params: dict) -> dict:
                 payload["status"] = "streaming"
             return payload
 
+        def _reuse_live_response(sid: str, session: dict) -> dict:
+            # The helper owns the resume lock because slow-path claim races can
+            # discover a live winner and return it after releasing their own lock.
+            # Keeping the client-gone check and transport rebind in one critical
+            # section makes grace expiry atomic across every reuse path.
+            with _session_resume_lock:
+                if _sessions.get(sid) is not session:
+                    return _err(rid, 4007, "session no longer live; retry resume")
+                if session.get("_client_gone_interrupt_requested"):
+                    return _err(rid, 4009, "session disconnect interrupt settling")
+                return _ok(rid, _reuse_live_payload(sid, session))
+
         # Fast path: if the session is already live, reuse it under the lock.
         with _session_resume_lock:
             live = _find_live_session_by_key(target)
-            if live is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+        if live is not None:
+            return _reuse_live_response(*live)
 
         # Lazy/watch resume: register the live session WITHOUT building an agent.
         # Used by the desktop's subagent windows — the child runs inside the
@@ -597,7 +609,7 @@ def _(rid, params: dict) -> dict:
                 lazy=True,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
             # A delegated child mid-run emits no session events of its own — report
             # its liveness from the relay registry so the window shows a busy turn.
             child_running = _child_run_active(target)
@@ -668,7 +680,7 @@ def _(rid, params: dict) -> dict:
             record["resume_hydrating"] = True
             record["resume_message_count"] = int(found.get("message_count") or 0)
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
 
             _schedule_resume_hydration(sid, target, db, close_db=owns_db)
             # The hydration worker now owns a profile-scoped handle and closes it
@@ -761,7 +773,7 @@ def _(rid, params: dict) -> dict:
                 resume_runtime_overrides=overrides or None,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
-                return _ok(rid, _reuse_live_payload(*live))
+                return _reuse_live_response(*live)
 
             _schedule_agent_build(sid)
             _schedule_session_cap_enforcement()  # trim detached idle sessions over the cap
@@ -871,17 +883,7 @@ def _(rid, params: dict) -> dict:
                     pass
                 if lease is not None:
                     lease.release()
-                other_sid, other_session = live
-                payload = _live_session_payload(
-                    other_sid,
-                    other_session,
-                    cols=cols,
-                    touch=True,
-                    transport=current_transport() or _stdio_transport,
-                    omit_messages=omit_messages,
-                )
-                payload["resumed"] = target
-                return _ok(rid, payload)
+                return _reuse_live_response(*live)
             try:
                 init_home_token = (
                     set_hermes_home_override(str(profile_home))
@@ -3250,67 +3252,15 @@ def _(rid, params: dict) -> dict:
         return err
     if _session_uses_compute_host(session):
         sid = str(params.get("session_id") or "")
-        if session.get("running"):
-            try:
-                _get_compute_host_supervisor().interrupt(sid, request_id=f"interrupt-{rid}")
-            except Exception as exc:
-                return _err(rid, 5019, f"compute-host interrupt failed: {exc}")
-        with session["history_lock"]:
-            session["_turn_cancel_requested"] = True
-            session["queued_prompt"] = None
-            session.pop("queued_prompts", None)
-            session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
-        _clear_pending(sid)
         try:
-            from tools.approval import resolve_gateway_approval
-
-            resolve_gateway_approval(session["session_key"], "deny", resolve_all=True)
-        except Exception:
-            pass
+            _interrupt_session_turn(sid, session, request_id=f"interrupt-{rid}")
+        except Exception as exc:
+            return _err(rid, 5019, f"compute-host interrupt failed: {exc}")
         return _ok(rid, {"status": "interrupted", "turn_isolation": True})
     session, err = _sess(params, rid)
     if err:
         return err
-    # Safety net: if the turn's run thread is already gone but `running` stayed
-    # stuck (a crash/desync that skipped the run loop's `finally`), force-clear it
-    # so the session can't be permanently bricked at 4009 "session busy" — every
-    # send/restore/resume would otherwise reject until a full backend restart.
-    # Always tell the agent to interrupt when the session claims a run is active:
-    # stale flags are cleared below, and fresh turns clear the interrupt flag at
-    # entry. This keeps a stale/missing thread handle from making Stop a no-op.
-    run_thread = session.get("_run_thread")
-    run_thread_alive = run_thread is not None and run_thread.is_alive()
-    should_interrupt = bool(session.get("running"))
-    with session["history_lock"]:
-        session["_turn_cancel_requested"] = True
-        session["queued_prompt"] = None
-        session.pop("queued_prompts", None)
-        session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
-    if should_interrupt:
-        from agent.interrupt_compat import request_hard_interrupt
-
-        request_hard_interrupt(session["agent"])
-    if not run_thread_alive:
-        with session["history_lock"]:
-            if session.get("running"):
-                session["running"] = False
-                _clear_inflight_turn(session)
-
-    # Stop = stop the TURN (cooperative interrupt above also kills the in-flight
-    # foreground subprocess). Background processes the agent started (dev servers,
-    # watchers) are intentionally left running — kill those individually with the
-    # "x" on the task row (process.kill). Don't reap them here.
-    # Scope the pending-prompt release to THIS session.  A global
-    # _clear_pending() would collaterally cancel clarify/sudo/secret
-    # prompts on unrelated sessions sharing the same tui_gateway
-    # process, silently resolving them to empty strings.
-    _clear_pending(params.get("session_id", ""))
-    try:
-        from tools.approval import resolve_gateway_approval
-
-        resolve_gateway_approval(session["session_key"], "deny", resolve_all=True)
-    except Exception:
-        pass
+    _interrupt_session_turn(str(params.get("session_id") or ""), session)
     return _ok(rid, {"status": "interrupted"})
 
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -562,6 +562,12 @@ def _(rid, params: dict) -> dict:
                     return _err(rid, 4007, "session no longer live; retry resume")
                 if session.get("_client_gone_interrupt_requested"):
                     return _err(rid, 4009, "session disconnect interrupt settling")
+                # This resume reattaches the live record: cancel any pending
+                # ws-orphan reap timer armed while the client was detached
+                # (storm killer — _live_session_payload's rebind also cancels,
+                # but only when a transport is passed; cancel unconditionally
+                # here so the fast path can never race the reap Timer).
+                _cancel_ws_orphan_reap(sid)
                 return _ok(rid, _reuse_live_payload(sid, session))
 
         # Fast path: if the session is already live, reuse it under the lock.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1164,9 +1164,21 @@ def _schedule_ws_orphan_reap(sid: str) -> None:
         session = None
         with _session_resume_lock:
             current = _sessions.get(sid)
-            if not _ws_session_is_orphaned(current):
+            # Mid-turn detached sessions are not yet orphaned (_running
+            # short-circuits _ws_session_is_orphaned). If we return here
+            # the single Timer is gone and the session is immortal until
+            # the 6h TTL — which also skips running (#85578). Reschedule
+            # like the active-delegation branch below.
+            if (
+                current
+                and not current.get("_finalized")
+                and current.get("running")
+                and current.get("transport") is _detached_ws_transport
+            ):
+                reschedule = True
+            elif not _ws_session_is_orphaned(current):
                 return
-            if _session_has_active_delegations(sid, current):
+            elif _session_has_active_delegations(sid, current):
                 reschedule = True
             else:
                 session = _pop_session_by_id(sid)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1206,6 +1206,34 @@ def _session_has_active_delegations(sid: str, session: dict | None = None) -> bo
         return True
 
 
+# One pending WS-orphan reap Timer per live sid. Registered by
+# _schedule_ws_orphan_reap, popped when its _reap fires, and cancelled by
+# _cancel_ws_orphan_reap from every resume/reuse/transport-rebind path. Without
+# this cancellation the reap could fire against an already-reattached session,
+# broadcast session.reclaimed, and trigger the client's auto-re-resume — a
+# reap->broadcast->resume feedback storm. Guarded by _sessions_lock.
+_pending_ws_reaps: dict[str, threading.Timer] = {}
+
+
+def _cancel_ws_orphan_reap(sid: str) -> None:
+    """Cancel a pending WS-orphan reap for ``sid`` (client came back).
+
+    Called from every path that re-binds a live transport onto the session:
+    the session.resume fast-path reuse, _claim_or_reuse_live winners, and the
+    _live_session_payload transport rebind. Cancelling here (rather than
+    relying on the reap's own orphan re-check) removes the window where a
+    fired-but-not-yet-run Timer races the resume, and stops dead Timers from
+    accumulating for sessions that reconnect frequently.
+    """
+    with _sessions_lock:
+        timer = _pending_ws_reaps.pop(sid, None)
+    if timer is not None:
+        try:
+            timer.cancel()
+        except Exception:
+            pass
+
+
 def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
     """After a grace window, reap session ``sid`` iff it's still orphaned.
 
@@ -1231,6 +1259,11 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
         interrupt_session = None
         session = None
         with _session_resume_lock:
+            # This Timer is running: drop its registration so a concurrent
+            # _cancel_ws_orphan_reap doesn't cancel a dead Timer object while
+            # a rescheduled one (registered below) is the live owner.
+            with _sessions_lock:
+                _pending_ws_reaps.pop(sid, None)
             current = _sessions.get(sid)
             if current is None or not _ws_session_is_detached(current):
                 return
@@ -1298,6 +1331,14 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
         _reap,
     )
     timer.daemon = True
+    with _sessions_lock:
+        prior = _pending_ws_reaps.pop(sid, None)
+        _pending_ws_reaps[sid] = timer
+    if prior is not None:
+        try:
+            prior.cancel()
+        except Exception:
+            pass
     timer.start()
 
 
@@ -8883,11 +8924,74 @@ def _claim_or_reuse_live(
         if live is not None:
             if lease is not None:
                 lease.release()
+            # The winner is being reattached by this resume: any pending
+            # ws-orphan reap for it must not fire against the reclaimed
+            # client (storm killer — see _cancel_ws_orphan_reap).
+            _cancel_ws_orphan_reap(live[0])
             return live
         with _sessions_lock:
             _sessions[sid] = record
             _register_session_cwd(_sessions[sid])
+        # A fresh runtime was minted for this stored session id: the new sid
+        # has no pending reap, but a PRIOR runtime for the same stored id may
+        # still be sentinel-parked with a reap Timer armed. Cancel + finalize
+        # those quietly so the reap doesn't later broadcast session.reclaimed
+        # for a session the client just re-resumed (auto-re-resume storm).
+        _cancel_ws_orphan_reap(sid)
+        stale = _claim_parked_runtimes(session_key, keep_sid=sid)
+    # Slow finalization work stays OUTSIDE _session_resume_lock (see
+    # _pop_session_by_id) — the stale records are already claimed above.
+    _finalize_superseded_runtimes(stale)
     return None
+
+
+def _claim_parked_runtimes(
+    session_key: str, *, keep_sid: str
+) -> list[tuple[str, dict]]:
+    """Claim sentinel-parked stale runtimes of ``session_key`` for supersession.
+
+    When a resume mints a fresh runtime for stored session id ``session_key``,
+    any older runtime record for the same stored id that is still parked on
+    the detached-WS sentinel is superseded: its pending orphan-reap Timer is
+    cancelled and the record is atomically popped from ``_sessions`` here
+    (under the caller's _session_resume_lock), then finalized by
+    :func:`_finalize_superseded_runtimes` after the lock is released.
+    """
+    stale: list[tuple[str, dict]] = []
+    with _sessions_lock:
+        candidates = [
+            (old_sid, old)
+            for old_sid, old in list(_sessions.items())
+            if old_sid != keep_sid
+            and not old.get("_finalized")
+            and _session_lookup_key(old, fallback=old_sid) == session_key
+            and old.get("transport") is _detached_ws_transport
+        ]
+    for old_sid, _old in candidates:
+        _cancel_ws_orphan_reap(old_sid)
+        popped = _pop_session_by_id(old_sid)
+        if popped is not None:
+            stale.append((old_sid, popped))
+    return stale
+
+
+def _finalize_superseded_runtimes(stale: list[tuple[str, dict]]) -> None:
+    """Quietly finalize runtimes claimed by :func:`_claim_parked_runtimes`.
+
+    Ends them with end_reason ``superseded_by_resume`` — deliberately NOT in
+    _RECLAIM_END_REASONS, so no ``session.reclaimed`` broadcast fires (that
+    broadcast triggers client auto-re-resume and fed the
+    reap->broadcast->resume feedback loop). ``superseded_by_resume`` IS in
+    hermes_state_common._RECOVERABLE_END_REASONS so canonical Bot Chat
+    resurrection still applies to the stored session.
+    """
+    for old_sid, popped in stale:
+        try:
+            _teardown_popped_session(popped, end_reason="superseded_by_resume")
+        except Exception:
+            logger.exception(
+                "superseded runtime teardown failed sid=%s", old_sid
+            )
 
 
 def _schedule_agent_build(sid: str, delay: float = 0.05) -> None:
@@ -9183,6 +9287,10 @@ def _live_session_payload(
             # stranding it on the drop sentinel (#83716).
             viewers = session.setdefault("viewers", {})
             viewers[transport] = time.time()
+            if transport is not _detached_ws_transport:
+                # A live transport rebind means the client is back — any
+                # pending ws-orphan reap must not fire (storm killer).
+                _cancel_ws_orphan_reap(sid)
         if touch:
             session["last_active"] = time.time()
         in_memory_history = list(session.get("display_history_prefix") or []) + list(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1329,6 +1329,22 @@ def _close_sessions_for_transport(
             # Point detached sessions at the drop sentinel (NOT real stdio) so
             # _ws_session_is_orphaned recognizes them and the grace-reap can
             # actually fire; a standalone `hermes --tui` keeps real _stdio.
+            # UNLESS another window still shows the session: multi-window
+            # pop-outs all register as viewers, so on disconnect re-bind the
+            # session to the most recent surviving viewer instead of
+            # stranding the original window on the sentinel (#83716).
+            viewers = session.get("viewers")
+            if viewers:
+                viewers.pop(transport, None)
+            remaining = [
+                (ts, v)
+                for v, ts in (viewers or {}).items()
+                if v is not transport and not _transport_is_dead(v)
+            ]
+            if remaining:
+                remaining.sort(key=lambda kv: kv[0])
+                session["transport"] = remaining[-1][1]
+                continue
             session["transport"] = _detached_ws_transport
             session.pop("_client_gone_interrupt_requested", None)
             detached += 1
@@ -9160,6 +9176,13 @@ def _live_session_payload(
             session["cols"] = cols
         if transport is not None:
             session["transport"] = transport
+            # Track every transport that has shown this session (multi-window:
+            # pop-out windows each resume the same sid). The last viewer
+            # becomes the transport on the disconnect path so closing a
+            # pop-out re-binds the session to a still-open window instead of
+            # stranding it on the drop sentinel (#83716).
+            viewers = session.setdefault("viewers", {})
+            viewers[transport] = time.time()
         if touch:
             session["last_active"] = time.time()
         in_memory_history = list(session.get("display_history_prefix") or []) + list(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -177,8 +177,8 @@ _SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
 # ``session.create`` (new sid + a fresh _SlashWorker via _deferred_build) and
 # never reattaches the OLD sid, so the old session's slash-worker subprocess
 # lingers forever — one leaked python process per refresh (#38591 fallout).
-# After this grace window, an orphaned (transport-detached, not-running) WS
-# session is reaped: its _SlashWorker is closed and the session finalized.
+# After this grace window, an orphaned WS session is interrupted if it is still
+# running, then reaped once the normal turn-finalization path settles.
 # Set to 0 to disable (park forever, pre-fix behaviour).
 try:
     _ws_orphan_reap_grace = float(
@@ -187,6 +187,7 @@ try:
 except (ValueError, TypeError):
     _ws_orphan_reap_grace = 20.0
 _WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
+_WS_ORPHAN_INTERRUPT_REAP_POLL_S = 1.0
 _TURN_SETTLE_BEFORE_CLOSE_SECONDS = 5.0
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
@@ -1050,6 +1051,15 @@ def _close_session_by_id(
     return _teardown_popped_session(session, end_reason=end_reason)
 
 
+def _ws_session_is_detached(session: dict | None) -> bool:
+    """True if a live session is still bound to the disconnected-WS sentinel."""
+    return bool(
+        session
+        and not session.get("_finalized")
+        and session.get("transport") is _detached_ws_transport
+    )
+
+
 def _ws_session_is_orphaned(session: dict | None) -> bool:
     """True if a WS session has no live transport and no in-flight turn.
 
@@ -1057,11 +1067,61 @@ def _ws_session_is_orphaned(session: dict | None) -> bool:
     ``_detached_ws_transport``. A session left on that transport (and not
     mid-turn) is genuinely orphaned and safe to reap.
     """
-    if not session or session.get("_finalized"):
-        return False
-    if session.get("running"):
-        return False
-    return session.get("transport") is _detached_ws_transport
+    return bool(
+        _ws_session_is_detached(session)
+        and session is not None
+        and not session.get("running")
+    )
+
+
+def _interrupt_session_turn(
+    sid: str, session: dict, *, request_id: str | None = None
+) -> bool:
+    """Apply the shared ``session.interrupt`` contract to one claimed session.
+
+    Returns whether the interrupt used the compute-host control channel. The WS
+    orphan reaper calls this same helper after its reconnect grace expires, so a
+    dead client gets the same partial-history and queued-prompt semantics as an
+    explicit user interrupt.
+    """
+    use_compute_host = _session_uses_compute_host(session)
+    should_interrupt = bool(session.get("running"))
+    run_thread_alive = False
+
+    if use_compute_host:
+        if should_interrupt:
+            _get_compute_host_supervisor().interrupt(sid, request_id=request_id)
+    else:
+        run_thread = session.get("_run_thread")
+        run_thread_alive = run_thread is not None and run_thread.is_alive()
+
+    with session["history_lock"]:
+        session["_turn_cancel_requested"] = True
+        session["queued_prompt"] = None
+        session.pop("queued_prompts", None)
+        session["_queued_prompt_generation"] = int(
+            session.get("_queued_prompt_generation", 0)
+        ) + 1
+
+    if not use_compute_host:
+        if should_interrupt:
+            from agent.interrupt_compat import request_hard_interrupt
+
+            request_hard_interrupt(session.get("agent"))
+        if not run_thread_alive:
+            with session["history_lock"]:
+                if session.get("running"):
+                    session["running"] = False
+                    _clear_inflight_turn(session)
+
+    _clear_pending(sid)
+    try:
+        from tools.approval import resolve_gateway_approval
+
+        resolve_gateway_approval(session["session_key"], "deny", resolve_all=True)
+    except Exception:
+        pass
+    return use_compute_host
 
 
 def _session_owns_durable_lifecycle(session_id: str | None) -> bool:
@@ -1139,7 +1199,7 @@ def _session_has_active_delegations(sid: str, session: dict | None = None) -> bo
         return True
 
 
-def _schedule_ws_orphan_reap(sid: str) -> None:
+def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
     """After a grace window, reap session ``sid`` iff it's still orphaned.
 
     Called from the WS-disconnect path. The grace window lets a transient
@@ -1160,34 +1220,60 @@ def _schedule_ws_orphan_reap(sid: str) -> None:
         # mutual exclusion against _init_session / _close_session_by_id, which
         # guard with _sessions_lock). _sessions_lock is an RLock and the global
         # ordering is always resume_lock -> sessions_lock, so nesting is safe.
-        reschedule = False
+        reschedule_delay = None
+        interrupt_session = None
         session = None
         with _session_resume_lock:
             current = _sessions.get(sid)
-            # Mid-turn detached sessions are not yet orphaned (_running
-            # short-circuits _ws_session_is_orphaned). If we return here
-            # the single Timer is gone and the session is immortal until
-            # the 6h TTL — which also skips running (#85578). Reschedule
-            # like the active-delegation branch below.
-            if (
-                current
-                and not current.get("_finalized")
-                and current.get("running")
-                and current.get("transport") is _detached_ws_transport
-            ):
-                reschedule = True
-            elif not _ws_session_is_orphaned(current):
+            if current is None or not _ws_session_is_detached(current):
                 return
-            elif _session_has_active_delegations(sid, current):
-                reschedule = True
+            if _session_has_active_delegations(sid, current):
+                reschedule_delay = _WS_ORPHAN_REAP_GRACE_S
+            elif current.get("running"):
+                # Mid-turn detached sessions must never drop the single
+                # Timer (#85578): after the reconnect grace the turn is
+                # interrupted once, then the reap keeps polling until the
+                # normal turn-finalization path settles.
+                if not current.get("_client_gone_interrupt_requested"):
+                    current["_client_gone_interrupt_requested"] = True
+                    interrupt_session = current
+                reschedule_delay = _WS_ORPHAN_INTERRUPT_REAP_POLL_S
             else:
                 session = _pop_session_by_id(sid)
-        if reschedule:
-            _schedule_ws_orphan_reap(sid)
+
+        if interrupt_session is not None:
+            try:
+                isolated = _interrupt_session_turn(
+                    sid,
+                    interrupt_session,
+                    request_id=f"client-gone-{sid}",
+                )
+                logger.info(
+                    "client_gone sid=%s action=interrupt turn_isolation=%s",
+                    sid,
+                    isolated,
+                )
+            except Exception:
+                logger.exception("client_gone interrupt failed sid=%s", sid)
+                with _sessions_lock:
+                    if _sessions.get(sid) is interrupt_session:
+                        interrupt_session.pop(
+                            "_client_gone_interrupt_requested", None
+                        )
+
+        if reschedule_delay is not None:
+            _schedule_ws_orphan_reap(sid, delay_s=reschedule_delay)
             return
+        if session is not None and session.get(
+            "_client_gone_interrupt_requested"
+        ):
+            logger.info("client_gone sid=%s action=reap", sid)
         _teardown_popped_session(session, end_reason="ws_orphan_reap")
 
-    timer = threading.Timer(_WS_ORPHAN_REAP_GRACE_S, _reap)
+    timer = threading.Timer(
+        _WS_ORPHAN_REAP_GRACE_S if delay_s is None else max(0.0, delay_s),
+        _reap,
+    )
     timer.daemon = True
     timer.start()
 
@@ -1221,6 +1307,7 @@ def _close_sessions_for_transport(
             # _ws_session_is_orphaned recognizes them and the grace-reap can
             # actually fire; a standalone `hermes --tui` keeps real _stdio.
             session["transport"] = _detached_ws_transport
+            session.pop("_client_gone_interrupt_requested", None)
             detached += 1
             try:
                 _schedule_ws_orphan_reap(sid)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -180,13 +180,31 @@ _SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
 # After this grace window, an orphaned WS session is interrupted if it is still
 # running, then reaped once the normal turn-finalization path settles.
 # Set to 0 to disable (park forever, pre-fix behaviour).
-try:
-    _ws_orphan_reap_grace = float(
-        os.environ.get("HERMES_TUI_WS_ORPHAN_REAP_GRACE_S") or "20"
-    )
-except (ValueError, TypeError):
-    _ws_orphan_reap_grace = 20.0
-_WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
+def _resolve_ws_orphan_reap_grace() -> float:
+    """Resolve the WS-orphan reap grace window (seconds).
+
+    Config-driven via ``dashboard.ws_orphan_reap_grace_s`` (#79635); the
+    ``HERMES_TUI_WS_ORPHAN_REAP_GRACE_S`` env var is kept as an internal
+    override for backward compatibility and wins when set.
+    """
+    raw = os.environ.get("HERMES_TUI_WS_ORPHAN_REAP_GRACE_S")
+    if raw is None or not str(raw).strip():
+        try:
+            from hermes_cli.config import load_config
+
+            raw = (load_config().get("dashboard") or {}).get(
+                "ws_orphan_reap_grace_s"
+            )
+        except Exception:
+            raw = None
+    try:
+        grace = float(raw) if raw is not None else 20.0
+    except (ValueError, TypeError):
+        grace = 20.0
+    return max(0.0, grace)
+
+
+_WS_ORPHAN_REAP_GRACE_S = _resolve_ws_orphan_reap_grace()
 _WS_ORPHAN_INTERRUPT_REAP_POLL_S = 1.0
 # Total budget for the interrupt-then-reap poll chain. If an interrupted turn
 # never settles (agent thread hung in a syscall, supervisor lost), each 1s poll

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -188,6 +188,13 @@ except (ValueError, TypeError):
     _ws_orphan_reap_grace = 20.0
 _WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
 _WS_ORPHAN_INTERRUPT_REAP_POLL_S = 1.0
+# Total budget for the interrupt-then-reap poll chain. If an interrupted turn
+# never settles (agent thread hung in a syscall, supervisor lost), each 1s poll
+# would otherwise reschedule forever — trading the old leak-one-worker bug for
+# leak-one-session-plus-timer-chain (review finding, PR #90373). After this
+# many polls we log loudly and force-reap, mirroring the pre-existing
+# stuck-`running` safety net's role of breaking the deadlock.
+_WS_ORPHAN_INTERRUPT_REAP_MAX_POLLS = 60
 _TURN_SETTLE_BEFORE_CLOSE_SECONDS = 5.0
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
@@ -1234,10 +1241,26 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
                 # Timer (#85578): after the reconnect grace the turn is
                 # interrupted once, then the reap keeps polling until the
                 # normal turn-finalization path settles.
-                if not current.get("_client_gone_interrupt_requested"):
-                    current["_client_gone_interrupt_requested"] = True
-                    interrupt_session = current
-                reschedule_delay = _WS_ORPHAN_INTERRUPT_REAP_POLL_S
+                polls = int(current.get("_client_gone_interrupt_polls") or 0) + 1
+                current["_client_gone_interrupt_polls"] = polls
+                if polls > _WS_ORPHAN_INTERRUPT_REAP_MAX_POLLS:
+                    # The interrupted turn never settled inside the budget —
+                    # force-reap rather than parking the session + a timer
+                    # chain forever. Loud by design: this only fires when a
+                    # turn is genuinely stuck past interrupt.
+                    logger.error(
+                        "client_gone sid=%s: turn did not settle after %d "
+                        "interrupt polls (%.0fs) — force-reaping detached "
+                        "session",
+                        sid, polls - 1,
+                        (polls - 1) * _WS_ORPHAN_INTERRUPT_REAP_POLL_S,
+                    )
+                    session = _pop_session_by_id(sid)
+                else:
+                    if not current.get("_client_gone_interrupt_requested"):
+                        current["_client_gone_interrupt_requested"] = True
+                        interrupt_session = current
+                    reschedule_delay = _WS_ORPHAN_INTERRUPT_REAP_POLL_S
             else:
                 session = _pop_session_by_id(sid)
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2608,9 +2608,14 @@ dashboard:
   drain_auth:                 # Drain-control service-credential gate (dashboard_auth/drain plugin)
     scope: "drain"            # capability label on the verified principal
     min_secret_chars: 43      # entropy bar (url-safe-b64 chars; 43 ≈ 256 bits)
+  ws_ping_interval: 20.0      # Non-loopback WebSocket keepalive ping interval (seconds)
+  ws_ping_timeout: 20.0       # Non-loopback WebSocket keepalive pong timeout (seconds)
+  ws_orphan_reap_grace_s: 20.0 # Grace before a WS-detached session is reaped (seconds)
 ```
 
 - `theme` — dashboard visual theme.
 - `show_token_analytics` — off by default. The Analytics page and token/cost figures are a **local lower-bound estimate** (they exclude auxiliary calls, retries, fallbacks, and cache writes), so they can read far below the provider bill. Set `true` only if you understand they're not billing.
 - `public_url` — when set, this is the complete authority (scheme + host + optional path prefix) the OAuth `redirect_uri` is built from. Set it for deploys behind reverse proxies that don't reliably forward `X-Forwarded-*` headers. Leave empty to use proxy-header reconstruction.
 - `oauth` / `basic_auth` / `drain_auth` — auth provider config read by the bundled dashboard-auth plugins. The drain secret itself is **not** set here; it's provisioned via the `HERMES_DASHBOARD_DRAIN_SECRET` env var. See [Web Dashboard](/user-guide/features/web-dashboard) for full auth setup.
+- `ws_ping_interval` / `ws_ping_timeout` — WebSocket keepalive tuning for non-loopback binds (loopback connections never ping). Raise these on high-latency links (Tailscale, distant SSH tunnels) where the 20 s defaults can manufacture spurious 1006 disconnects.
+- `ws_orphan_reap_grace_s` — how long a WS-detached session waits before the orphan reaper collects it. Raise alongside the keepalive values if clients reconnect slowly. (`HERMES_TUI_WS_ORPHAN_REAP_GRACE_S` remains as an internal override.)


### PR DESCRIPTION
# Session-not-found cluster: consolidated fix

## Summary
Desktop sessions now survive gateway restarts, sleep/wake, and WS drops end to end: the #91276 reap storm can no longer occur (resume cancels the pending reap and stale runtimes are superseded quietly instead of re-broadcast), a live tab always converges back onto its stored session, and session-scoped RPCs — including approvals — always reach the owning gateway. Resolves the verified "session not found after reconnect" bug family in one PR, salvaging 8 open PRs from 6 contributors with authorship preserved plus maintainer storm-killer/routing commits.

## Root cause (storm, #91276)
The gateway judged orphanhood per-socket: any WS drop sentinel-parked every session on that socket and reaped after 20s even though the client was already back on a new socket. Each auto-re-resume minted a fresh runtime id bound to the new socket; the reap broadcast triggered the next re-resume — a feedback loop reclaiming every ~2min, never converging. The renderer amplified it: no single-flight on session.resume, and drift-abort paths abandoned successfully-minted runtimes to the reaper.

## Changes — gateway (tui_gateway, hermes_cli)
- Storm killer (maintainer): every resume/reuse/rebind path cancels the pending WS-orphan reap for its runtime AND for sentinel-parked prior runtimes of the same stored id; superseded runtimes are finalized quietly (`end_reason=superseded_by_resume`, recoverable, no `session.reclaimed` broadcast) — breaking the reap→broadcast→re-resume loop.
- Salvage #85598 (@686f6c61): reaper reschedules for detached mid-turn sessions instead of dropping its Timer (fixes immortal sessions, #85578).
- Salvage #90373 (@Kyzcreig, both commits): still-detached running turns are interrupted after grace instead of burning compute forever; bounded poll chain; 4009 settling guard kept.
- Salvage #86039 (@ayushnangia): viewer registry — pop-out window close rebinds the session to a surviving window instead of sentinel-parking it (fixes #83716).
- Config-driven WS keepalive + reap grace (#79635): `dashboard.ws_ping_interval` / `ws_ping_timeout` / `ws_orphan_reap_grace_s` in config.yaml (env var kept as internal override); docs updated in the same PR.
- approval.respond resolves by request_id / stored-id before failing 4001 (server half of #91684).

## Changes — desktop (apps/desktop)
- Salvage #89092 (@yu-xin-c): power-resume/online/manual-reconnect force-close apparently-open (half-open) sockets and redial (fixes #89083 sleep/wake dead app).
- Salvage #91333 (@wz-heng): a tile is never discarded on a stale 404 without durable-absence confirmation.
- Our #92961: active gateway is never a session-RPC routing authority (plugin-host requestGateway resolves the owner).
- Salvage #91357 (@enwaiax) + maintainer follow-up: routed submits deliver to the recovered runtime instead of a silent drop (fixes #90428); explicit queued targets never inherit foreground recovery, with a load-bearing regression fixture (the review blocker).
- Single-flight session.resume per stored id across all resume call sites + adopt-or-reuse on drift-abort — the renderer half of the storm fix.
- approval.respond routes through the session's owner, not the ambient socket (client half of #91684).
- Electron REST intercept resolves the owning remote profile before a hint-less `/api/sessions/{id}` read falls through to the local DB (fixes #85834).

## Validation
| Suite | Result |
|---|---|
| Gateway: test_tui_gateway_server + ws_keepalive_config + protocol + resume_db_ownership (combined branch) | 684 passed |
| Storm-killer unit tests (cancel-on-resume, quiet supersede, normal reap preserved) | 5/5 |
| Desktop focused vitest, 9 touched test files (combined branch) | 308 passed |
| Desktop full builder run (14 files) | 445 passed |
| tsc `--noEmit` | clean |
| eslint changed files | 0 errors (1 pre-existing warning, verified on merge-base) |
| ruff changed python files | clean |
| Attribution audit | all mapped |

## Resolves / supersedes
Fixes #91276, #90428, #89083, #85578, #83716, #79635, #91684, #85834. Salvages (to close with credit): #85598, #90373, #86039, #89092, #91333, #91357, #92961 (ours). Related close-outs handled post-merge: #92832 (already fixed on main), #75756/#79229 (dupes, fixed by c1305b645), #68947 (superseded by e35c2f60), #93077 disposition per #93217.

## Infographic

![Session recovery after reconnect](https://v3b.fal.media/files/b/0aa78e29/OBZa-YfrVC8mbvsFbAAZK_9r8f97w0.png)
