### PR TITLE
fix(desktop): stop trusting composer previewUrl as a full-res upload cache

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5049,14 +5049,16 @@ describe('uploadComposerAttachment remote read failures', () => {
   })
 })
 
-describe('uploadComposerAttachment preview reuse', () => {
+describe('uploadComposerAttachment image cache contract', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('reuses the chip previewUrl instead of re-reading the image off disk', async () => {
-    // attachImagePath already read the full file for the thumbnail; submit
-    // must not pay the disk read + IPC round-trip a second time.
+  it('always re-reads the image from disk, even when a stale previewUrl is cached', async () => {
+    // attachImagePath drops `previewUrl` as soon as a thumbnail exists, so a
+    // populated `previewUrl` here does not mean it holds full-resolution
+    // bytes (#93324) — the upload must never trust it and must always read
+    // the on-disk file for the bytes the model receives.
     const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,ZnJvbS1kaXNr')
     Object.defineProperty(window, 'hermesDesktop', {
       configurable: true,
@@ -5077,44 +5079,7 @@ describe('uploadComposerAttachment preview reuse', () => {
         kind: 'image',
         label: 'shot.png',
         path: '/local/shot.png',
-        previewUrl: 'data:image/png;base64,ZnJvbS1wcmV2aWV3'
-      },
-      { remote: true, requestGateway, sessionId: RUNTIME_SESSION_ID }
-    )
-
-    expect(readFileDataUrl).not.toHaveBeenCalled()
-    expect(requestGateway).toHaveBeenCalledWith('image.attach_bytes', {
-      content_base64: 'ZnJvbS1wcmV2aWV3',
-      filename: 'shot.png',
-      session_id: RUNTIME_SESSION_ID
-    })
-    expect(uploaded.path).toBe('/gw/images/shot.png')
-  })
-
-  it('falls back to the disk read when previewUrl is not a base64 data URL', async () => {
-    // A non-data previewUrl (e.g. a gateway media URL) carries no bytes —
-    // the upload must still read the real file.
-    const readFileDataUrl = vi.fn(async () => 'data:image/png;base64,ZnJvbS1kaXNr')
-    Object.defineProperty(window, 'hermesDesktop', {
-      configurable: true,
-      value: { readFileDataUrl }
-    })
-
-    const requestGateway = vi.fn(async (method: string) => {
-      if (method === 'image.attach_bytes') {
-        return { attached: true, path: '/gw/images/shot.png' } as never
-      }
-
-      return {} as never
-    })
-
-    await uploadComposerAttachment(
-      {
-        id: 'image:shot.png',
-        kind: 'image',
-        label: 'shot.png',
-        path: '/local/shot.png',
-        previewUrl: 'https://gateway.example/media/shot.png'
+        previewUrl: 'data:image/png;base64,c3RhbGUtY2FjaGVk'
       },
       { remote: true, requestGateway, sessionId: RUNTIME_SESSION_ID }
     )
@@ -5125,6 +5090,7 @@ describe('uploadComposerAttachment preview reuse', () => {
       filename: 'shot.png',
       session_id: RUNTIME_SESSION_ID
     })
+    expect(uploaded.path).toBe('/gw/images/shot.png')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -138,16 +138,17 @@ export async function uploadComposerAttachment(
 
   // Read bytes/paths ONCE, outside the retry. Only the session-scoped RPC is
   // replayed on recovery — re-reading a multi-MB file to retry a dead session
-  // id would double the disk/IPC cost of every recovered attach. For images,
-  // the chip's previewUrl already holds the full file as a base64 data URL,
-  // so passing it avoids re-reading the same bytes off disk at submit.
+  // id would double the disk/IPC cost of every recovered attach. Images are
+  // always read fresh from disk here: the chip's cached `previewUrl` is
+  // dropped once a thumbnail exists, so it cannot be trusted to hold the
+  // full-resolution bytes the model needs.
   let imagePayload: Awaited<ReturnType<typeof readImageForRemoteAttach>> | null = null
   let fileDataUrl: null | string = null
 
   if (uploadBytes) {
     try {
       if (attachment.kind === 'image') {
-        imagePayload = await readImageForRemoteAttach(path, attachment.previewUrl)
+        imagePayload = await readImageForRemoteAttach(path)
       } else {
         fileDataUrl = await readFileDataUrlForAttach(path)
       }

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -369,24 +369,14 @@ export function imageFilenameFromPath(filePath: string): string {
 // not the gateway's, so read the bytes here and upload them via
 // image.attach_bytes. Returns null when the file can't be read.
 //
-// `cachedDataUrl` is the attachment's `previewUrl` when the composer already
-// read the file for the chip thumbnail — that preview is the FULL file as a
-// base64 data URL (attachmentPreviewDataUrl → readFileDataUrl), not a
-// downscaled copy, so reusing it skips a second disk read + IPC round-trip of
-// the same bytes at submit. Only a `;base64,` data URL qualifies; anything
-// else falls through to the disk read.
+// Always re-reads from disk rather than trusting `attachment.previewUrl` as a
+// cache: once a thumbnail is generated, `attachImagePath` keeps only the
+// bounded (≤512px) `thumbnailUrl` and drops `previewUrl` — so a cached
+// `previewUrl` is never guaranteed to be the full-resolution bytes the model
+// needs, and trusting it here would risk silently uploading a downscaled copy.
 export async function readImageForRemoteAttach(
-  filePath: string,
-  cachedDataUrl?: string
+  filePath: string
 ): Promise<{ contentBase64: string; filename: string } | null> {
-  if (cachedDataUrl?.includes(';base64,')) {
-    const cached = base64FromDataUrl(cachedDataUrl)
-
-    if (cached) {
-      return { contentBase64: cached, filename: imageFilenameFromPath(filePath) }
-    }
-  }
-
   const dataUrl = await window.hermesDesktop?.readFileDataUrl(filePath)
   const contentBase64 = dataUrl ? base64FromDataUrl(dataUrl) : ''
 


### PR DESCRIPTION
## What does this PR do?

Fixes #93324 — a contract mismatch between the two sides of the desktop image-attach pipeline.

**Producer** (`apps/desktop/src/app/chat/hooks/use-composer-actions.ts`, `attachImagePath`): once a thumbnail is generated, it keeps only the bounded (≤512px) `thumbnailUrl` on the composer attachment and drops `previewUrl` entirely. This is intentional — retaining a full-resolution multi-MB base64 string per attachment for the life of the chip serves no purpose, since the lightbox/download and (previously) submit all re-read from disk.

**Consumer** (`apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts` + `utils.ts`, `readImageForRemoteAttach`): assumed `attachment.previewUrl` was "already the full file as a base64 data URL" and reused it to skip a disk read at submit time. That assumption predates a same-day sibling change that made the producer drop `previewUrl` whenever a thumbnail exists — so in normal usage the cache lookup is always a miss, and the fallback disk read masks the false premise. Today the *output* is accidentally correct (full-resolution bytes are always uploaded), but the code is one future change away from a silent, unlogged regression: if `previewUrl` ever ends up holding the retained thumbnail instead of nothing, small (512px) images would be silently sent to the model.

## The fix

Removes the dead cache-reuse path in `readImageForRemoteAttach` and always reads the image fresh from disk for remote/cross-filesystem uploads — matching the producer's actual, documented guarantee ("New local image chips omit this and read `path` only when the lightbox opens", `store/composer.ts`). This eliminates the false contract instead of patching around it, so there's no assumption left to invalidate later.

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts` — `readImageForRemoteAttach` no longer takes a `cachedDataUrl` param; always reads via `window.hermesDesktop.readFileDataUrl`. Comment corrected to state the real invariant.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts` — call site updated; stale comment claiming `previewUrl` holds the full file removed.
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx` — replaced the two tests that asserted the (now-removed) cache-reuse/fallback behavior with one regression test asserting the upload **always** reads from disk, even when a `previewUrl` happens to be populated with stale/different bytes.

## How to Test

Automated coverage (from `apps/desktop`):

```
npx vitest run --project ui src/app/session/hooks/use-prompt-actions/index.test.tsx
 Test Files  1 passed (1)
      Tests  121 passed (121)

npx vitest run --project ui src/app/chat/hooks/use-composer-actions.test.ts
 Test Files  1 passed (1)
      Tests  20 passed (20)

npx tsc -p . --noEmit   # clean

npx eslint src/app/session/hooks/use-prompt-actions/index.ts src/app/session/hooks/use-prompt-actions/utils.ts src/app/session/hooks/use-prompt-actions/index.test.tsx
 (0 errors; 1 pre-existing, unrelated react-hooks/exhaustive-deps warning also present on unmodified main)
```

Proved the new regression test fails without the fix: `git checkout HEAD~1 -- src/app/session/hooks/use-prompt-actions/index.ts src/app/session/hooks/use-prompt-actions/utils.ts` (keeping the new test), reran the suite:

```
FAIL src/app/session/hooks/use-prompt-actions/index.test.tsx > uploadComposerAttachment image cache contract
 > always re-reads the image from disk, even when a stale previewUrl is cached
AssertionError: expected "vi.fn()" to be called with arguments: [ '/local/shot.png' ]
Number of calls: 0
```
then restored the fix and confirmed it passes (shown above).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've considered cross-platform impact — this is a pure TypeScript logic change with no OS-specific behavior

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the misleading inline comments describing the (false) cache contract are corrected
- [ ] N/A: no config keys, README, or tool schema changes

## Disclosure

This change was authored with AI assistance (Claude/Claude Code), with the diagnosis, fix, and test verification reviewed against the actual repository history (including the sibling commit that invalidated the cache's premise) before submission.
