### PR TITLE
fix(cli): guard the post-update fleet check against PID reuse

### DIFF
--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -391,6 +391,12 @@ def collect_fleet_versions(
                 # stop, startup failure, stale record from a long-dead
                 # gateway) keeps the historical no-row behavior so the
                 # feature's rollout can't false-positive.
+                #
+                # ``_pre_restart`` is a bare set of PIDs, not (pid, start_time)
+                # pairs, so a recycled PID from gateway A landing in B's stale
+                # record could still mislabel B as down if A's PID happened to
+                # be in the pre-restart snapshot — inherent to the snapshot's
+                # data model, not something this guard can fix on its own.
                 gw_state = record.get("gateway_state")
                 if (
                     pid in _pre_restart

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -320,7 +320,7 @@ def collect_fleet_versions(
         expected_sha = None
 
     try:
-        from gateway.status import _pid_exists, read_runtime_status
+        from gateway.status import read_runtime_status, runtime_status_pid_is_live
         from hermes_cli.profiles import (
             _get_default_hermes_home,
             _get_profiles_root,
@@ -382,13 +382,15 @@ def collect_fleet_versions(
                 pid = int(pid)
             except (TypeError, ValueError):
                 continue
-            if not _pid_exists(pid):
-                # Dead PID: a DOWN row only when this exact pid was alive at
-                # update start AND the record still claims a running state —
-                # "the restart phase stopped it and nothing came back."
-                # Everything else (clean stop, startup failure, stale record
-                # from a long-dead gateway) keeps the historical no-row
-                # behavior so the feature's rollout can't false-positive.
+            if not runtime_status_pid_is_live(record):
+                # Dead PID (or a live PID recycled by an unrelated process
+                # during the update's own churn — #93258): a DOWN row only
+                # when this exact pid was alive at update start AND the
+                # record still claims a running state — "the restart phase
+                # stopped it and nothing came back." Everything else (clean
+                # stop, startup failure, stale record from a long-dead
+                # gateway) keeps the historical no-row behavior so the
+                # feature's rollout can't false-positive.
                 gw_state = record.get("gateway_state")
                 if (
                     pid in _pre_restart

--- a/tests/hermes_cli/test_fleet_matrix_down_state.py
+++ b/tests/hermes_cli/test_fleet_matrix_down_state.py
@@ -71,6 +71,30 @@ def test_cleanly_stopped_gateway_is_not_down(monkeypatch, tmp_path):
         assert ur.collect_fleet_versions(pre_restart_pids=[_DEAD_PID]) == []
 
 
+def test_recycled_pid_is_not_reported_stale(monkeypatch, tmp_path):
+    """A dead gateway's PID reused by an unrelated process (#93258) must not
+    be reported STALE just because *some* process now answers to that PID.
+    """
+    from gateway.status import _get_process_start_time
+
+    reused_pid = os.getpid()
+    wrong_start_time = (_get_process_start_time(reused_pid) or 0) + 12345
+    _setup(
+        monkeypatch,
+        tmp_path,
+        {
+            "pid": reused_pid,
+            "start_time": wrong_start_time,
+            "gateway_state": "running",
+            "code_sha": "OLDSHA",
+            "kind": "hermes-gateway",
+        },
+    )
+    fleet = ur.collect_fleet_versions(pre_restart_pids=[reused_pid])
+    assert len(fleet) == 1
+    assert fleet[0]["state"] == "down"
+
+
 def test_live_gateway_rows_unchanged(monkeypatch, tmp_path):
     """The live-pid path is untouched by the down-state addition."""
     _setup(

--- a/tests/hermes_cli/test_fleet_matrix_down_state.py
+++ b/tests/hermes_cli/test_fleet_matrix_down_state.py
@@ -95,6 +95,27 @@ def test_recycled_pid_is_not_reported_stale(monkeypatch, tmp_path):
     assert fleet[0]["state"] == "down"
 
 
+def test_matching_start_time_is_still_live(monkeypatch, tmp_path):
+    """A record whose start_time matches the live process is not recycled."""
+    from gateway.status import _get_process_start_time
+
+    pid = os.getpid()
+    _setup(
+        monkeypatch,
+        tmp_path,
+        {
+            "pid": pid,
+            "start_time": _get_process_start_time(pid),
+            "gateway_state": "running",
+            "code_sha": "HEADSHA",
+            "kind": "hermes-gateway",
+        },
+    )
+    fleet = ur.collect_fleet_versions(pre_restart_pids=[pid])
+    assert len(fleet) == 1
+    assert fleet[0]["state"] == "current"
+
+
 def test_live_gateway_rows_unchanged(monkeypatch, tmp_path):
     """The live-pid path is untouched by the down-state addition."""
     _setup(


### PR DESCRIPTION
## Summary

Fixes #93258 — `hermes update --yes` on Windows exited 1 with a false
`✗ joao_pessoal (pid 40652) @ b2c4f1f3 — STALE (pre-update code)` row
even though PID 40652 was already gone (it exited cleanly during the
pause phase, well before the fleet check ran).

## Root cause

`collect_fleet_versions()`'s `gateway_state.json` fallback path (used
whenever the profile's control socket isn't reachable yet, e.g. right
after a restart) only called `_pid_exists(pid)` to decide whether the
recorded PID was still the gateway. `_pid_exists` answers "does *some*
process have this PID right now?" — it does not check that it's the
*same* process the record describes.

On Windows, `hermes update` pauses gateways, then spends several
minutes on git fetch / npm / vite / python reinstall before restarting
them. That churn spawns and reaps a lot of short-lived PIDs, so a
paused gateway's now-free PID can be recycled by one of those unrelated
processes before the profile's `gateway_state.json` record is
refreshed. When that happens, `_pid_exists(old_pid)` returns `True` for
the wrong process, so the code falls through to the stale `code_sha`
comparison and reports `STALE` for a gateway that's actually long gone.

The codebase already has the right primitive for this exact problem —
`gateway.status.runtime_status_pid_is_live()`, a `(pid, start_time)`
PID-reuse guard used elsewhere (e.g. `hermes_cli/gateway.py`'s runtime
health summary) — but `collect_fleet_versions()` wasn't using it.

## Fix

Swap the bare `_pid_exists(pid)` check for
`runtime_status_pid_is_live(record)`. A recycled PID now falls into the
same path a genuinely-dead PID already takes: a `DOWN` row if it was
alive when the update started and the record still claims a running
state, or no row at all otherwise (existing rollout-safety rules,
unchanged). Either way it's never reported `STALE`.

This only touches the JSON-fallback path; the primary control-socket
identity check (#92091) already avoids PID-based heuristics entirely
and is untouched.

## Test plan

Added `test_recycled_pid_is_not_reported_stale` to
`tests/hermes_cli/test_fleet_matrix_down_state.py`, which simulates a
dead gateway's PID being reused by the current test process (same PID,
mismatched `start_time`) and asserts the fleet entry is `down`, not
`stale`.

Confirmed the new test fails without the fix:

```
$ git checkout HEAD~1 -- hermes_cli/update_receipt.py
$ python3 -m pytest tests/hermes_cli/test_fleet_matrix_down_state.py::test_recycled_pid_is_not_reported_stale -q
FAILED ... AssertionError: assert 'stale' == 'down'
$ git checkout HEAD -- hermes_cli/update_receipt.py
```

And passes with it, along with the rest of the suite:

```
$ python3 scripts/run_tests_parallel.py tests/hermes_cli/test_fleet_matrix_down_state.py tests/hermes_cli/test_update_receipt.py tests/gateway/test_status.py -q
=== Summary: 3 files, 96 tests passed, 0 failed, 2 skipped (100% complete) in 2.3s (8 workers) ===

$ python3 -m pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_inventory.py tests/hermes_cli/test_update_receipt_endpoint.py tests/gateway/test_control_socket.py -q
71 passed, 1 warning in 42.70s
```

`ruff check` on both changed files passes clean.

## Disclosure

This patch was drafted with AI assistance (an autonomous coding agent),
with the diff and test run reviewed before pushing.
