### PR TITLE
feat(gateway): expose cron run history and output over HTTP

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3609,6 +3609,51 @@ def save_job_output(job_id: str, output: str):
     return output_file
 
 
+# Matches the filename stem written by ``save_job_output`` above.
+_OUTPUT_TIMESTAMP_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}-[0-9]{2}-[0-9]{2}")
+
+
+def list_job_outputs(job_id: str) -> List[str]:
+    """Return a job's saved run-output timestamps, newest first."""
+    try:
+        job_output_dir = _job_output_dir(job_id)
+    except ValueError:
+        return []
+    try:
+        files = sorted(
+            (f for f in job_output_dir.glob("*.md") if f.is_file()),
+            key=lambda f: f.name,
+            reverse=True,
+        )
+    except OSError:
+        return []
+    return [f.stem for f in files]
+
+
+def read_job_output(job_id: str, timestamp: Optional[str] = None) -> Optional[str]:
+    """Read one saved run's output text; the latest run if *timestamp* is None.
+
+    *timestamp* must match a filename stem produced by ``save_job_output``
+    (rejecting anything else keeps this off the same path-escape surface
+    ``_job_output_dir`` guards against).
+    """
+    if timestamp is None:
+        outputs = list_job_outputs(job_id)
+        if not outputs:
+            return None
+        timestamp = outputs[0]
+    elif not _OUTPUT_TIMESTAMP_RE.fullmatch(timestamp):
+        return None
+    try:
+        job_output_dir = _job_output_dir(job_id)
+    except ValueError:
+        return None
+    try:
+        return (job_output_dir / f"{timestamp}.md").read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
 # =============================================================================
 # Skill reference rewriting (curator integration)
 # =============================================================================

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -49,6 +49,7 @@ import itertools
 import json
 from contextlib import contextmanager, nullcontext, suppress
 from contextvars import ContextVar
+from datetime import datetime
 from functools import wraps
 import logging
 import os
@@ -6824,7 +6825,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 limit = int(limit_raw) if limit_raw is not None else 50
             except ValueError:
                 return web.json_response({"error": "limit must be an integer"}, status=400)
+            limit = max(1, min(limit, 500))
             before = request.query.get("before") or None
+            if before is not None:
+                try:
+                    datetime.fromisoformat(before)
+                except ValueError:
+                    return web.json_response({"error": "before must be an ISO-format timestamp"}, status=400)
             executions = _cron_list_executions(
                 job_id=job_id, limit=limit, before_claimed_at=before,
             )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1418,7 +1418,9 @@ try:
         pause_job as _cron_pause,
         resume_job as _cron_resume,
         trigger_job as _cron_trigger,
+        read_job_output as _cron_read_output,
     )
+    from cron.executions import list_executions as _cron_list_executions
     from cron.scheduler import (
         CronSchedulerRegistrationError as _CronSchedulerRegistrationError,
         create_job_with_scheduler_registration as _cron_create,
@@ -1433,6 +1435,8 @@ except ImportError:
     _cron_pause = None
     _cron_resume = None
     _cron_trigger = None
+    _cron_read_output = None
+    _cron_list_executions = None
 
     class _CronSchedulerRegistrationError(RuntimeError):
         pass
@@ -2264,6 +2268,9 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/jobs/{job_id}/pause", self._handle_pause_job),
             ("POST", "/api/jobs/{job_id}/resume", self._handle_resume_job),
             ("POST", "/api/jobs/{job_id}/run", self._handle_run_job),
+            ("GET", "/api/jobs/{job_id}/executions", self._handle_list_job_executions),
+            ("GET", "/api/jobs/{job_id}/output", self._handle_get_job_output),
+            ("GET", "/api/jobs/{job_id}/output/{timestamp}", self._handle_get_job_output),
             ("POST", "/v1/runs", self._handle_runs),
             ("GET", "/v1/runs/{run_id}", self._handle_get_run),
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
@@ -6794,6 +6801,57 @@ class APIServerAdapter(BasePlatformAdapter):
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
+        except Exception as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=500)
+
+    async def _handle_list_job_executions(self, request: "web.Request") -> "web.Response":
+        """GET /api/jobs/{job_id}/executions?limit=&before= — durable run history."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        cron_err = self._check_jobs_available()
+        if cron_err:
+            return cron_err
+        job_id, id_err = self._check_job_id(request)
+        if id_err:
+            return id_err
+        try:
+            job = _cron_get(job_id)
+            if not job:
+                return web.json_response({"error": "Job not found"}, status=404)
+            limit_raw = request.query.get("limit")
+            try:
+                limit = int(limit_raw) if limit_raw is not None else 50
+            except ValueError:
+                return web.json_response({"error": "limit must be an integer"}, status=400)
+            before = request.query.get("before") or None
+            executions = _cron_list_executions(
+                job_id=job_id, limit=limit, before_claimed_at=before,
+            )
+            return web.json_response({"executions": executions})
+        except Exception as e:
+            return web.json_response({"error": _redact_api_error_text(e)}, status=500)
+
+    async def _handle_get_job_output(self, request: "web.Request") -> "web.Response":
+        """GET /api/jobs/{job_id}/output[/{timestamp}] — a saved run's output text."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        cron_err = self._check_jobs_available()
+        if cron_err:
+            return cron_err
+        job_id, id_err = self._check_job_id(request)
+        if id_err:
+            return id_err
+        try:
+            job = _cron_get(job_id)
+            if not job:
+                return web.json_response({"error": "Job not found"}, status=404)
+            timestamp = request.match_info.get("timestamp")
+            output = _cron_read_output(job_id, timestamp)
+            if output is None:
+                return web.json_response({"error": "Output not found"}, status=404)
+            return web.json_response({"output": output})
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -24,6 +24,8 @@ from cron.jobs import (
     heartbeat_run_claim,
     get_due_jobs,
     save_job_output,
+    list_job_outputs,
+    read_job_output,
     _hermes_now,
 )
 
@@ -1016,6 +1018,41 @@ class TestSaveJobOutput:
         assert output_file.exists()
         assert output_file.read_text() == "# Results\nEverything ok."
         assert "test123" in str(output_file)
+
+
+class TestReadJobOutput:
+    @staticmethod
+    def _save_two_runs(monkeypatch):
+        """save_job_output twice with distinct clock ticks (its timestamp is
+        second-resolution, so two same-second saves would collide on one file)."""
+        import cron.jobs as jobs_mod
+        times = iter([
+            datetime(2026, 6, 25, 10, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 6, 25, 10, 0, 1, tzinfo=timezone.utc),
+        ])
+        monkeypatch.setattr(jobs_mod, "_hermes_now", lambda: next(times))
+        save_job_output("test123", "first")
+        save_job_output("test123", "second")
+
+    def test_list_outputs_newest_first(self, tmp_cron_dir, monkeypatch):
+        self._save_two_runs(monkeypatch)
+        timestamps = list_job_outputs("test123")
+        assert len(timestamps) == 2
+        assert read_job_output("test123", timestamps[0]) == "second"
+        assert read_job_output("test123", timestamps[1]) == "first"
+
+    def test_read_without_timestamp_returns_latest(self, tmp_cron_dir, monkeypatch):
+        self._save_two_runs(monkeypatch)
+        assert read_job_output("test123") == "second"
+
+    def test_no_output_returns_none(self, tmp_cron_dir):
+        assert list_job_outputs("test123") == []
+        assert read_job_output("test123") is None
+
+    def test_rejects_path_escape_in_timestamp(self, tmp_cron_dir):
+        save_job_output("test123", "secret")
+        assert read_job_output("test123", "../../etc/passwd") is None
+        assert read_job_output("test123", "not-a-timestamp") is None
 
 
 class TestCronOutputRetention:

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -63,6 +63,9 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/api/jobs/{job_id}/pause", adapter._handle_pause_job)
     app.router.add_post("/api/jobs/{job_id}/resume", adapter._handle_resume_job)
     app.router.add_post("/api/jobs/{job_id}/run", adapter._handle_run_job)
+    app.router.add_get("/api/jobs/{job_id}/executions", adapter._handle_list_job_executions)
+    app.router.add_get("/api/jobs/{job_id}/output", adapter._handle_get_job_output)
+    app.router.add_get("/api/jobs/{job_id}/output/{timestamp}", adapter._handle_get_job_output)
     return app
 
 
@@ -337,6 +340,105 @@ class TestRunJob:
                 data = await resp.json()
                 assert data["job"] == triggered_job
                 mock_trigger.assert_called_once_with(VALID_JOB_ID)
+
+
+# ---------------------------------------------------------------------------
+# 16b. test_list_job_executions / test_get_job_output
+# ---------------------------------------------------------------------------
+
+class TestListJobExecutions:
+    @pytest.mark.asyncio
+    async def test_list_job_executions(self, adapter):
+        """GET /api/jobs/{id}/executions returns the ledger's run history."""
+        app = _create_app(adapter)
+        records = [{"id": "e1", "job_id": VALID_JOB_ID, "status": "completed"}]
+        mock_list_executions = MagicMock(return_value=records)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                f"{_MOD}._CRON_AVAILABLE", True
+            ), patch(
+                f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+            ), patch(
+                f"{_MOD}._cron_list_executions", mock_list_executions
+            ):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/executions?limit=10&before=2026-01-01")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["executions"] == records
+                mock_list_executions.assert_called_once_with(
+                    job_id=VALID_JOB_ID, limit=10, before_claimed_at="2026-01-01",
+                )
+
+    @pytest.mark.asyncio
+    async def test_list_job_executions_job_not_found(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_get", return_value=None
+            ):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/executions")
+                assert resp.status == 404
+
+
+class TestGetJobOutput:
+    @pytest.mark.asyncio
+    async def test_get_latest_output(self, adapter):
+        """GET /api/jobs/{id}/output returns the latest saved run output."""
+        app = _create_app(adapter)
+        mock_read = MagicMock(return_value="# run output")
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                f"{_MOD}._CRON_AVAILABLE", True
+            ), patch(
+                f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+            ), patch(
+                f"{_MOD}._cron_read_output", mock_read
+            ):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/output")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["output"] == "# run output"
+                mock_read.assert_called_once_with(VALID_JOB_ID, None)
+
+    @pytest.mark.asyncio
+    async def test_get_output_by_timestamp(self, adapter):
+        app = _create_app(adapter)
+        mock_read = MagicMock(return_value="# older run")
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                f"{_MOD}._CRON_AVAILABLE", True
+            ), patch(
+                f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+            ), patch(
+                f"{_MOD}._cron_read_output", mock_read
+            ):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/output/2026-01-01_00-00-00")
+                assert resp.status == 200
+                mock_read.assert_called_once_with(VALID_JOB_ID, "2026-01-01_00-00-00")
+
+    @pytest.mark.asyncio
+    async def test_get_output_not_found(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                f"{_MOD}._CRON_AVAILABLE", True
+            ), patch(
+                f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+            ), patch(
+                f"{_MOD}._cron_read_output", return_value=None
+            ):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/output")
+                assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_get_output_job_not_found(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
+                f"{_MOD}._cron_get", return_value=None
+            ):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/output")
+                assert resp.status == 404
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -379,6 +379,57 @@ class TestListJobExecutions:
                 resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/executions")
                 assert resp.status == 404
 
+    @pytest.mark.asyncio
+    async def test_list_job_executions_limit_clamped(self, adapter):
+        """?limit=1000000 is clamped server-side instead of streaming the whole ledger."""
+        app = _create_app(adapter)
+        mock_list_executions = MagicMock(return_value=[])
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                f"{_MOD}._CRON_AVAILABLE", True
+            ), patch(
+                f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+            ), patch(
+                f"{_MOD}._cron_list_executions", mock_list_executions
+            ):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/executions?limit=1000000")
+                assert resp.status == 200
+                mock_list_executions.assert_called_once_with(
+                    job_id=VALID_JOB_ID, limit=500, before_claimed_at=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_list_job_executions_negative_limit_clamped(self, adapter):
+        """A negative limit must not reach list_executions, where SQLite treats it as unbounded."""
+        app = _create_app(adapter)
+        mock_list_executions = MagicMock(return_value=[])
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                f"{_MOD}._CRON_AVAILABLE", True
+            ), patch(
+                f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+            ), patch(
+                f"{_MOD}._cron_list_executions", mock_list_executions
+            ):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/executions?limit=-5")
+                assert resp.status == 200
+                mock_list_executions.assert_called_once_with(
+                    job_id=VALID_JOB_ID, limit=1, before_claimed_at=None,
+                )
+
+    @pytest.mark.asyncio
+    async def test_list_job_executions_malformed_before(self, adapter):
+        """A malformed cursor gets a 400 telling the client, not a generic 500."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch(
+                f"{_MOD}._CRON_AVAILABLE", True
+            ), patch(
+                f"{_MOD}._cron_get", return_value=SAMPLE_JOB
+            ):
+                resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}/executions?before=not-a-timestamp")
+                assert resp.status == 400
+
 
 class TestGetJobOutput:
     @pytest.mark.asyncio

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -530,6 +530,14 @@ Resume a previously paused job.
 
 Trigger the job to run immediately, out of schedule.
 
+### GET /api/jobs/\{job_id\}/executions
+
+Return the job's durable run history (newest first), cursor-paginated with `limit` and `before` query params.
+
+### GET /api/jobs/\{job_id\}/output and GET /api/jobs/\{job_id\}/output/\{timestamp\}
+
+Read the saved output text of the job's latest run, or of a specific run by its timestamp (as returned in the executions history).
+
 ## Sessions API (session control over REST)
 
 External UIs can manage Hermes sessions over REST without standing up the dashboard. All endpoints are gated by `API_SERVER_KEY` and live under `/api/sessions/*`.


### PR DESCRIPTION
## What

Closes #93299.

`cron/executions.py::list_executions(job_id=…, limit=…, before_claimed_at=…)`
already returns indexed, newest-first, cursor-paginated execution history —
verified against `main` — but nothing serves it over HTTP. `GET /api/jobs`
only attaches `latest_execution`, the single newest ledger row
(`cron/jobs.py` around `list_jobs()`).

A run's text output goes to
`HERMES_HOME/cron/output/<job id>/<timestamp>.md`, read back only by
`cron.scheduler` (for `context_from`) or a human with a shell — even
`hermes cron runs <id>` prints the ledger, not the output. For a
`deliver: local` job, the result is invisible to a remote client.

This adds two additive, read-only routes, following the existing
`/api/jobs/*` handler pattern (auth check → cron-availability check →
job-id validation → job lookup):

- `GET /api/jobs/{job_id}/executions?limit=&before=` → what `list_executions`
  already returns.
- `GET /api/jobs/{job_id}/output` (latest run) and
  `GET /api/jobs/{job_id}/output/{timestamp}` (a specific run) → the saved
  output text.

Per the issue's design note, output is served as its own route rather than
attached to execution rows, since the ledger's docstring calls itself an
audit trail and attaching output would change that.

## How

- `cron/jobs.py`: added `list_job_outputs(job_id)` and
  `read_job_output(job_id, timestamp=None)`. Both reuse `_job_output_dir`'s
  existing path-escape guard; `read_job_output` additionally rejects any
  `timestamp` that doesn't match the exact filename stem
  `save_job_output` writes (`YYYY-MM-DD_HH-MM-SS`), so a caller can't walk
  the output directory with a crafted timestamp.
- `gateway/platforms/api_server.py`: registered the two routes and their
  handlers (`_handle_list_job_executions`, `_handle_get_job_output`),
  matching the auth/validation/error shape of the other `/api/jobs/*`
  handlers exactly.
- `website/docs/user-guide/features/api-server.md`: documented the new
  endpoints alongside the existing Jobs API section.

## Test plan

Added tests and confirmed they fail without the fix
(`git stash` the two source files, rerun, restore):

```
$ python3 -m pytest tests/cron/test_jobs.py tests/gateway/test_api_server_jobs.py -q
99 passed, 23 warnings in 3.23s
```

Without the fix (source files reverted, tests kept):

```
tests/cron/test_jobs.py: ImportError: cannot import name 'list_job_outputs' from 'cron.jobs'
tests/gateway/test_api_server_jobs.py: 6 failed — AttributeError: 'APIServerAdapter' object has no attribute '_handle_list_job_executions'
```

Also ran the full `cron/` suite and the `api_server`-related `gateway/`
suite to check for regressions:

```
$ python3 -m pytest tests/cron/ -q
877 passed, 1 skipped in 51.12s

$ python3 -m pytest tests/gateway/ -q -k api_server
253 passed, 2 skipped, 5931 deselected in 27.82s
```

`ruff check` on all changed files passes clean.

## AI assistance disclosure

This PR was written with AI assistance (Claude Code), reviewed and verified
against `main` before submission.
