### PR TITLE
fix(dashboard): log auth rejections on /api/ws like /api/pty does

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17418,7 +17418,13 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
+    peer = ws.client.host if ws.client else "?"
+    auth_reason, cred = _ws_auth_reason(ws)
+    if auth_reason is not None:
+        _log.warning(
+            "ws auth rejected reason=%s mode=%s cred=%s peer=%s",
+            auth_reason, _ws_auth_mode(), cred, peer,
+        )
         await ws.close(code=4401)
         return
 

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -318,6 +318,9 @@ class TestGatewayWsAuthRejectionLogging:
             "ws auth rejected" in record.message and "reason=no_credential" in record.message
             for record in caplog.records
         )
+
+
+class TestWsRequestIsAllowedGated:
     """Bug fix: in gated mode, the WS peer-IP loopback check must be
     bypassed.
 

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -290,7 +290,34 @@ class TestWsAuthOkGated:
             assert "ws_ticket_rejected" in content
 
 
-class TestWsRequestIsAllowedGated:
+class TestGatewayWsAuthRejectionLogging:
+    """`/api/ws` must log an auth rejection the same way `/api/pty` does.
+
+    Before this fix, `gateway_ws` called the boolean `_ws_auth_ok` and
+    discarded the rejection reason, so a bad/missing credential on
+    `/api/ws` closed the socket with no log line at all (see #93235:
+    "`/api/ws` auth rejections are invisible in the logs").
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_credential_is_logged_before_close(self, loopback_app, caplog):
+        ws = _fake_ws(query={}, path="/api/ws")
+
+        closed = {}
+
+        async def fake_close(code=None, reason=None):
+            closed["code"] = code
+
+        ws.close = fake_close
+
+        with caplog.at_level("WARNING", logger="hermes_cli.web_server"):
+            await web_server.gateway_ws(ws)
+
+        assert closed["code"] == 4401
+        assert any(
+            "ws auth rejected" in record.message and "reason=no_credential" in record.message
+            for record in caplog.records
+        )
     """Bug fix: in gated mode, the WS peer-IP loopback check must be
     bypassed.
 

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -319,6 +319,41 @@ class TestGatewayWsAuthRejectionLogging:
             for record in caplog.records
         )
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "fixture_name, query, expected_reason",
+        [
+            ("loopback_app", {"token": "wrong-token"}, "token_mismatch"),
+            ("gated_app", {"ticket": "never-minted"}, "ticket_invalid"),
+            ("gated_app", {"internal": "never-minted"}, "internal_invalid"),
+        ],
+    )
+    async def test_other_rejection_reasons_are_logged_before_close(
+        self, request, fixture_name, query, expected_reason, caplog
+    ):
+        """Pin the remaining three machine-parseable reasons (see
+        _ws_auth_reason's docstring) through the same gateway_ws log line
+        exercised above for no_credential."""
+        request.getfixturevalue(fixture_name)
+        ws = _fake_ws(query=query, path="/api/ws")
+
+        closed = {}
+
+        async def fake_close(code=None, reason=None):
+            closed["code"] = code
+
+        ws.close = fake_close
+
+        with caplog.at_level("WARNING", logger="hermes_cli.web_server"):
+            await web_server.gateway_ws(ws)
+
+        assert closed["code"] == 4401
+        assert any(
+            "ws auth rejected" in record.message
+            and f"reason={expected_reason}" in record.message
+            for record in caplog.records
+        )
+
 
 class TestWsRequestIsAllowedGated:
     """Bug fix: in gated mode, the WS peer-IP loopback check must be


### PR DESCRIPTION
## What

`/api/ws`'s auth gate (`gateway_ws` in `hermes_cli/web_server.py`) called
the boolean `_ws_auth_ok(ws)` and threw away the rejection reason, so a
missing or invalid credential on that endpoint closed the socket with
**no log line at all**. `/api/pty` (`pty_ws`) already calls
`_ws_auth_reason(ws)` and logs `reason`/`mode`/`cred`/`peer` on every
rejection before closing with 4401. This PR makes `gateway_ws` do the
same.

This addresses one specific, self-contained item called out in #93235:

> `/api/ws` auth rejections are invisible in the logs.

It does **not** address the issue's main root cause (the duplicate v1 /
registry SSH backend lane and the resulting silent `Send` no-op) — that
requires an architectural decision (how a registry entry should reuse an
identity-equal v1 primary, retiring the legacy config, adding an
idle-TTL to request-scoped gateway secondaries, and deciding how
`submit.ts`'s abort paths should surface an error to the user). Those are
maintainer-level design calls spanning the Electron main process, session
routing, and UX, not something a minimal, single-purpose PR should
attempt to also fix. This PR only closes the logging blind spot so an
operator debugging "the chat WS keeps closing" on `/api/ws` gets the same
signal they'd already get on `/api/pty`.

## Change

- `hermes_cli/web_server.py`: `gateway_ws` now calls `_ws_auth_reason(ws)`
  (same helper `pty_ws` already uses) instead of the boolean
  `_ws_auth_ok(ws)`, and logs `_log.warning("ws auth rejected reason=%s
  mode=%s cred=%s peer=%s", ...)` before closing with 4401 when the
  credential is rejected.

## Test

Added `TestGatewayWsAuthRejectionLogging.test_missing_credential_is_logged_before_close`
in `tests/hermes_cli/test_dashboard_auth_ws_auth.py`, which drives
`gateway_ws` directly with a synthetic WS object carrying no credential
and asserts both that the socket is closed with 4401 **and** that a
`"ws auth rejected reason=no_credential"` warning is emitted.

Confirmed the test fails without the fix (reverted just
`hermes_cli/web_server.py` to `HEAD`, i.e. the pre-fix state, then ran
the test):

```
$ git stash push -- hermes_cli/web_server.py
$ scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_ws_auth.py -k TestGatewayWsAuthRejectionLogging -v
...
tests/hermes_cli/test_dashboard_auth_ws_auth.py::TestGatewayWsAuthRejectionLogging::test_missing_credential_is_logged_before_close FAILED
...
E       assert False
E        +  where False = any(<generator object ...> at 0x...)
=================================== FAILURES ===================================
    assert closed["code"] == 4401
>   assert any(
        "ws auth rejected" in record.message and "reason=no_credential" in record.message
        for record in caplog.records
    )
================== 1 failed, 4 passed, 15 deselected in 0.84s ==================
$ git stash pop
```

With the fix restored, the full file passes:

```
$ scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_ws_auth.py -v
[100.0% |    20/~20 | ✓20 | ✗ 0] ✓ tests/hermes_cli/test_dashboard_auth_ws_auth.py (20✓, 1.3s)
=== Summary: 1 files, 20 tests passed, 0 failed (100% complete) in 1.3s (8 workers) ===
```

Also re-ran the adjacent WS-endpoint suites to check for regressions:

```
$ scripts/run_tests.sh tests/test_pty_keepalive_ws.py tests/hermes_cli/test_web_server_console_ws.py tests/test_tui_gateway_ws.py -v
=== Summary: 3 files, 12 tests passed, 0 failed (100% complete) in 2.4s (8 workers) ===
```

`ruff check hermes_cli/web_server.py tests/hermes_cli/test_dashboard_auth_ws_auth.py` — all checks passed.

**Follow-up fix:** the first version of this diff had a botched hunk that
deleted the `class TestWsRequestIsAllowedGated:` declaration line while
leaving its docstring and four (unrelated, pre-existing) test methods in
place — they silently got folded into the new
`TestGatewayWsAuthRejectionLogging` class, and the orphaned docstring
became a dead statement. Pytest and ruff both stayed green through that
(a method's containing class doesn't affect collection, and a stray
string literal is legal Python), so it wasn't caught by CI. A second
commit restores the `TestWsRequestIsAllowedGated` class boundary verbatim
so those four peer-IP/loopback-guard tests are back in their own class,
untouched, with `TestGatewayWsAuthRejectionLogging` now a genuinely
separate, additive class ahead of it. Re-verified: `git diff` against the
pre-#93235 test file shows only the new class inserted, no other class
boundaries clipped; full suite still 20/20; ruff clean.

## Related

- #93235

---
Authorship: investigated and written with Claude (Sonnet 5) under human direction; test output above is from a real run against this checkout.
