### PR TITLE
fix: wait()/read_log() must not swallow notify_on_complete notifications

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -204,8 +204,16 @@ class TestCodeExecutionBlocked:
 class TestCompletionConsumed:
     """Test that wait/log consume completion notifications while poll stays read-only."""
 
-    def test_wait_marks_completion_consumed(self, registry):
-        """wait() returning exited status marks session as consumed."""
+    def test_wait_preserves_notify_completion(self, registry):
+        """wait() on a notify_on_complete process must NOT mark it consumed.
+
+        The synchronous wait() result is the agent's own copy of the outcome.
+        Marking _completion_consumed here would also suppress the user-facing
+        autonomous delivery (the desktop/tui poller and gateway watcher both
+        gate on is_completion_consumed), so the user never learns the long
+        task finished. notify_on_complete is an explicit promise to surface a
+        notification on exit — wait() must not silently break it.
+        """
         s = _make_session(sid="proc_wait", notify_on_complete=True, output="done")
         s.exited = True
         s.exit_code = 0
@@ -221,8 +229,9 @@ class TestCompletionConsumed:
         result = registry.wait("proc_wait", timeout=1)
         assert result["status"] == "exited"
 
-        # Now the completion is marked as consumed
-        assert registry.is_completion_consumed("proc_wait")
+        # notify_on_complete survives wait(): the user-facing notification is
+        # still deliverable (the desktop/tui poller checks is_completion_consumed).
+        assert not registry.is_completion_consumed("proc_wait")
 
 
     def test_poll_observed_does_not_suppress_gateway_watcher(self, registry):
@@ -248,9 +257,10 @@ class TestCompletionConsumed:
         registry.poll("proc_run2")
         assert "proc_run2" not in registry._poll_observed
 
-    def test_wait_and_log_still_skip_cli_drain(self, registry):
-        """wait()/read_log() consume the output, so the CLI drain skips their
-        completions via _completion_consumed (the original #8228 contract)."""
+    def test_wait_and_log_preserve_notify_delivery(self, registry):
+        """wait()/read_log() consume the agent's own copy of the result, but a
+        notify_on_complete process keeps its user-facing completion queued so the
+        autonomous delivery (desktop/tui poller, gateway watcher) still fires."""
         for sid, action in (("proc_w", "wait"), ("proc_l", "log")):
             s = _make_session(sid=sid, notify_on_complete=True, output="done")
             s.exited = True
@@ -262,8 +272,9 @@ class TestCompletionConsumed:
                 registry.wait(sid, timeout=1)
             else:
                 registry.read_log(sid)
-            assert registry.is_completion_consumed(sid)
-        assert registry.drain_notifications() == []
+            assert not registry.is_completion_consumed(sid)
+        # The completion events remain deliverable — not drained as consumed.
+        assert len(registry.drain_notifications()) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2072,7 +2072,7 @@ class ProcessRegistry:
             "total_lines": total_lines,
             "showing": f"{len(selected)} lines",
         }
-        if session.exited and observed_completion_output:
+        if session.exited and observed_completion_output and not session.notify_on_complete:
             self._completion_consumed.add(session_id)
         return result
 
@@ -2134,7 +2134,17 @@ class ProcessRegistry:
             # child has already exited (issue #17327).
             self._reconcile_local_exit(session)
             if session.exited:
-                self._completion_consumed.add(session_id)
+                # A process started with notify_on_complete=True made an explicit
+                # promise to surface a completion notification on exit. The
+                # synchronous wait() result is the *agent's* copy of that outcome;
+                # marking it _completion_consumed here would ALSO suppress the
+                # autonomous user-facing delivery (the desktop/tui poller checks
+                # only is_completion_consumed, not _drain_should_skip), so the
+                # user never learns the long task finished. Honour the flag: only
+                # suppress the autonomous turn when the caller did NOT ask to be
+                # notified on completion.
+                if not session.notify_on_complete:
+                    self._completion_consumed.add(session_id)
                 result = {
                     "status": "exited",
                     "command": session.command,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -568,6 +568,12 @@ class ProcessRegistry:
                         # Promote to notify_on_complete so the agent still gets
                         # exactly one notification when the process actually ends.
                         session.notify_on_complete = True
+                        # Undo any consume-mark wait()/read_log() may already have
+                        # applied while the flag was still False — a promoted
+                        # notify_on_complete must still deliver even if the agent
+                        # consumed a completion under the old flag (AI review on
+                        # #93368, point 1).
+                        self._completion_consumed.discard(session.id)
                         should_disable = True
                 return_early = True
             else:


### PR DESCRIPTION
## Summary

`wait()` and `read_log()` marked the session `_completion_consumed` on exit, which silently suppressed the user-facing autonomous completion delivery — the desktop/TUI poller and the gateway watcher both gate their autonomous delivery turn on `is_completion_consumed`, not on `_drain_should_skip`.

A background task started with `notify_on_complete=True` makes an explicit promise to surface a completion notification on exit. But if the agent **also** waited synchronously (or read the log), that `wait()`/`read_log()` call would consume the signal, and the user never learned the long task finished.

## Fix

Honour the `notify_on_complete` flag: `wait()`/`read_log()` now leave the completion deliverable (only mark `_completion_consumed` when the caller did **not** ask to be notified), so the autonomous turn still fires.

- `tools/process_registry.py`: guard both the `wait()` and `read_log()` consumed-mark sites with `and not session.notify_on_complete`.
- `tools/process_registry.py`: the watch-strike promotion that force-sets `notify_on_complete = True` now also discards the session from `_completion_consumed`, so a completion consumed under the old flag cannot defeat the promoted delivery.
- `tests/tools/test_notify_on_complete.py`: update the two tests that had pinned the buggy "wait marks consumed" behaviour.

## Intentional trade-off: double delivery

Honouring `notify_on_complete` means an agent that also calls `wait()` (or `read_log()`) on the process will surface the outcome **twice** — once in its own reply, and again as the autonomous completion notification. This is deliberate: it trades away part of the original #8228 duplicate-suppression in exchange for flag fidelity, so the user-facing promise is never broken. Please do not "fix" the duplicate back.

## Context

This is the second half of #92196, split out into its own focused PR per maintainer request. The first half — the gateway lifecycle-guard fix — was already merged via #93267.
