### PR TITLE
fix(bot-mode): disband clears stale group metadata even with zero live members

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6420,6 +6420,17 @@ async function disbandGroupChat(group, members) {
     await saveBotMeta(member, groupMembershipPatch(meta, group, false))
   }
 
+  // A remote-resolved rendered row can carry zero members (member resolution
+  // already fell to zero) while durable Bot Mode metadata still names this
+  // group — the loop above then performs no writes and groupChatNames()
+  // reconstructs a metadata-only roster row. Clear the group from every
+  // meta entry that still names it, independent of what was rendered.
+  for (const [key, entry] of Object.entries($botMeta.get())) {
+    if (botGroups(entry).includes(group)) {
+      await saveBotMeta(key, groupMembershipPatch(entry, group, false))
+    }
+  }
+
   // Converge on server truth: the cached roster still carries the pre-disband
   // ui_meta (the write-fence in mergeServerMeta keeps it from resurrecting
   // the membership, but a fresh snapshot is what makes every surface agree).

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -6426,9 +6426,22 @@ async function disbandGroupChat(group, members) {
   // reconstructs a metadata-only roster row. Clear the group from every
   // meta entry that still names it, independent of what was rendered.
   for (const [key, entry] of Object.entries($botMeta.get())) {
-    if (botGroups(entry).includes(group)) {
-      await saveBotMeta(key, groupMembershipPatch(entry, group, false))
+    if (!botGroups(entry).includes(group)) {
+      continue
     }
+
+    // A route-keyed entry (`connectionId::profile`) is not itself a valid
+    // saveBotMeta owner — botOwner's string path only resolves migrated
+    // LOCAL routes, so passing the raw key would send profiles.configure
+    // to the default connection with the garbled composite as `name`.
+    // Reconstruct the source-scoped owner so the write reaches the bot's
+    // actual connection.
+    const { connectionId, name } = parseRosterKey(key)
+    const owner = connectionId
+      ? { name, sourceScoped: true, route: { connectionId, profile: name, targetProfile: name } }
+      : key
+
+    await saveBotMeta(owner, groupMembershipPatch(entry, group, false))
   }
 
   // Converge on server truth: the cached roster still carries the pre-disband

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -196,7 +196,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, groupChatNames, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -1220,6 +1220,26 @@ test('disband: skips source-qualified remote members instead of mutating same-na
   assert.equal(JSON.stringify(gc.$botMeta.get().builder.groups), JSON.stringify(['Keep']))
   assert.equal(gc.$botMeta.get().builder.group, 'Keep')
   assert.equal(gc.$botMeta.get()['[object Object]'], undefined)
+})
+
+test('disband: a zero-member remote row still clears stale bot-meta so the room does not reappear as 0-bots (#93345)', async () => {
+  const gc = load(() => '(pass)')
+
+  gc.$botMeta.set({ builder: { groups: ['앱데브팀'], group: '앱데브팀' } })
+  gc.$groupChats.set({
+    '앱데브팀': { log: [], members: [], watermarks: {}, sessions: {}, running: false }
+  })
+
+  // Remote symptom: member resolution already fell to zero, so Delete Group
+  // receives an empty member array and cannot clear the stale membership.
+  await gc.disbandGroupChat('앱데브팀', [])
+
+  assert.equal(gc.$groupChats.get()['앱데브팀'], undefined, 'room record is deleted')
+  assert.equal(
+    JSON.stringify(gc.groupChatNames(gc.$botMeta.get(), gc.$groupChats.get())),
+    JSON.stringify([]),
+    'deleted room must not be reconstructed from stale bot metadata'
+  )
 })
 
 test('disband: a running room leaves an epoch-bumped empty tombstone so in-flight turns bail', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -1209,6 +1209,38 @@ test('disband: removes only this membership, room log, workspace, and needs-you 
   assert.equal(durable.Keep.members[0].connectionId, 'remote-1')
 })
 
+test('disband: a route-keyed stale entry clears via the bot\'s own connection, not the default gateway (#93345)', async () => {
+  const gc = load(() => '(pass)')
+  const remoteRequests = []
+  gc.host.requestProfile = async (route, method, params) => {
+    remoteRequests.push({ connectionId: route.connectionId, profile: route.profile, method, params })
+    if (method === 'profiles.configure') {
+      return { applied: { ui_meta: true, ui_meta_revisions: {} } }
+    }
+    return {}
+  }
+
+  gc.$botMeta.set({ 'gw-42::builder': { groups: ['Ghost'], group: 'Ghost' } })
+  gc.$groupChats.set({
+    Ghost: { log: [], members: [], watermarks: {}, sessions: {}, running: false }
+  })
+
+  await gc.disbandGroupChat('Ghost', [])
+
+  assert.equal(JSON.stringify(gc.$botMeta.get()['gw-42::builder'].groups), JSON.stringify([]))
+  assert.equal(gc.$botMeta.get()['gw-42::builder'].group, null)
+
+  const routed = remoteRequests.filter(call => call.method === 'profiles.configure')
+  assert.equal(routed.length, 1, 'the server-side clear is sent to the bot\'s own connection')
+  assert.equal(routed[0].connectionId, 'gw-42')
+  assert.equal(routed[0].params.name, 'builder', 'name must not be the garbled composite key')
+
+  const defaultBotMetaCalls = gc.requests.filter(
+    call => call.method === 'profiles.configure' && 'hermes-bots' in (call.params.ui_meta || {})
+  )
+  assert.equal(defaultBotMetaCalls.length, 0, 'the bot-meta write must not go to the default connection')
+})
+
 test('disband: skips source-qualified remote members instead of mutating same-named local metadata', async () => {
   const gc = load(() => '(pass)')
   gc.$botMeta.set({ builder: { groups: ['Keep'], group: 'Keep' } })


### PR DESCRIPTION
## What changed

`disbandGroupChat(group, members)` only cleared the group from the bot-meta
of the passed-in `members` list. When remote member resolution has already
fallen to zero (Desktop Bot Mode, remote gateway view), that list arrives
empty: the room record is still deleted, but the cleanup loop performs no
metadata writes. `knownGroups($botMeta)` still names the group, so
`groupChatNames()` reconstructs a metadata-only roster row — the observed
`<name> · 0 bots` ghost entry.

Fix: after clearing membership for the rendered `members`, also clear the
group from every `$botMeta` entry that still names it, independent of what
was rendered for this call. This keeps the existing source-qualified/remote
skip behavior intact (that path only ever touches meta keys resolved via
`botRosterMeta`), while making deletion authoritative even when the live
member list resolved to nothing.

## Follow-up fix (review feedback)

The first version of that second loop passed the raw `$botMeta` string key
straight to `saveBotMeta(key, ...)`. That's correct for a local bot's plain
name, but a source-scoped/remote bot's key is a `connectionId::profile`
composite (see `botRouteKey`/`botMetaKey`). `saveBotMeta`'s string-owner path
(`botOwner`) only resolves migrated **local** routes from a bare name, so a
composite key fell through: `route` resolved to `null` and the server-side
write went to `host.request` on the **default** connection with `name`
literally set to the garbled composite string — never reaching the bot's
actual connection. The local atom looked fixed, but the real server-side
`ui_meta` for that remote profile was never cleared, so the next roster poll
re-merged the stale membership and resurrected the ghost row — for remote
bots specifically, the exact scenario the issue is about.

Fixed by reconstructing a source-scoped owner object from the key (parsing
`connectionId::profile` the same way `parseRosterKey` already does elsewhere
in this file) before calling `saveBotMeta`, so routed entries go through
`requestForBot` → `host.requestProfile` with the correct connection and the
un-garbled profile name as `name`.

## Why not the other suggested direction

The issue also suggested a durable deletion marker that suppresses stale
metadata until reconciliation completes. That's more machinery for the same
outcome — clearing the stale metadata directly is the minimal fix and keeps
`groupChatNames()` untouched.

## Testing

Added a regression test reproducing the issue's exact repro (zero-member
remote disband of a room named `앱데브팀` with stale bot-meta) to
`apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs`, and exposed
`groupChatNames` in that test file's harness so the test can assert on the
roster projection directly, matching the issue's suggested repro.

Added a second regression test for the composite-key routing bug found in
review: seeds `$botMeta` with a `gw-42::builder` route-keyed entry, mocks
`host.requestProfile`, and asserts the server-side clear is sent to
connection `gw-42` with `name: 'builder'` (not the garbled composite), and
that the default connection never receives this particular write.

Confirmed both new tests fail without their respective fixes:

```
$ git checkout HEAD~2 -- apps/desktop/src/plugins/hermes-bots/plugin.js
$ node --test --test-name-pattern="93345" apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
not ok - disband: a zero-member remote row still clears stale bot-meta ...
  '["앱데브팀"]' !== '[]'

$ git checkout HEAD~1 -- apps/desktop/src/plugins/hermes-bots/plugin.js
$ node --test --test-name-pattern="93345" apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
not ok - disband: a route-keyed stale entry clears via the bot's own connection ...
  the server-side clear is sent to the bot's own connection
  0 !== 1

$ git checkout HEAD -- apps/desktop/src/plugins/hermes-bots/plugin.js
```

And passes with the fix applied, along with the full existing suite:

```
$ node --test apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
# tests 87
# pass 87
# fail 0

$ cd apps/desktop && npm run check:test:plugins
# tests 528
# pass 528
# fail 0
```

`npm run lint` still isn't clean-runnable in this environment (the shared
eslint config fails to resolve `@eslint/js` regardless of this change); the
plugin test suite above (`check:test:plugins`, the repo's own plugin test
command) covers this file.

## AI assistance disclosure

This PR was prepared by an autonomous coding agent (Claude, via Claude Code).
