### PR TITLE
fix(desktop): clear stale group metadata on disband

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5936,6 +5936,62 @@ function groupMembershipPatch(meta, group, enabled) {
   return { groups, group: groups[0] || null }
 }
 
+/** Build the exact metadata cleanup for a room disband. The rendered member
+ *  list is only a presentation snapshot and can already be empty on a remote
+ *  connection while bot metadata still names the room. Durable room members
+ *  and the full roster recover source-qualified owners; every remaining
+ *  metadata record is still cleared locally, but an unresolved scoped key is
+ *  never guessed into a server route. */
+function groupDisbandMetadataPlan(group, members, room, roster, metaByName) {
+  const owners = new Map()
+  const patches = new Map()
+
+  const rememberOwner = (owner, required = false) => {
+    if (!owner?.name) {
+      return
+    }
+
+    let key
+    try {
+      key = botMetaKey(owner)
+    } catch {
+      return
+    }
+
+    const meta = metaByName?.[key] || botRosterMeta(owner, metaByName) || {}
+    if (!required && !botGroups(meta).includes(group)) {
+      return
+    }
+
+    if (!owners.has(key)) {
+      owners.set(key, owner)
+    }
+    patches.set(key, groupMembershipPatch(meta, group, false))
+  }
+
+  for (const owner of members || []) {
+    rememberOwner(owner, true)
+  }
+  for (const owner of room?.members || []) {
+    rememberOwner(owner, true)
+  }
+  for (const owner of roster || []) {
+    rememberOwner(owner)
+  }
+
+  // Metadata itself is the final source of a metadata-only `0 bots` row.
+  // Clear every record that names the room even when its exact server owner is
+  // temporarily absent from the roster. Known owners still get a routed
+  // profiles.configure write below; unknown scoped records remain local-only.
+  for (const [key, meta] of Object.entries(metaByName || {})) {
+    if (botGroups(meta).includes(group)) {
+      patches.set(key, groupMembershipPatch(meta, group, false))
+    }
+  }
+
+  return { owners, patches }
+}
+
 /** Group chats that should hold a roster row: every group named in bot meta
  *  (local members) plus every room record that still has stored members or
  *  log — cross-connection rooms whose members can't ride bot-meta. */
@@ -6356,6 +6412,26 @@ async function disbandGroupChat(group, members) {
   // the user just discarded.
   const all = { ...$groupChats.get() }
   const prior = all[group] || {}
+  const metaBefore = $botMeta.get()
+  const cleanup = groupDisbandMetadataPlan(group, members, prior, $lastRoster.get(), metaBefore)
+  let metadataPersistence = Promise.resolve()
+
+  if (cleanup.patches.size) {
+    const nextMeta = { ...metaBefore }
+
+    for (const [key, patch] of cleanup.patches) {
+      nextMeta[key] = { ...(nextMeta[key] || {}), ...patch }
+      noteBotMetaWrite(key)
+    }
+
+    // Paint the deletion before any remote write can stall. This also removes
+    // orphaned legacy metadata that cannot safely be routed to a source.
+    $botMeta.set(nextMeta)
+    metadataPersistence = persistBotMetaSnapshot(
+      nextMeta,
+      botMetaV2Active || Object.keys(nextMeta).some(key => key.includes('::'))
+    )
+  }
 
   delete all[group]
   // Keep a runtime-only tombstone while a drive may still be mid-turn; it
@@ -6407,17 +6483,16 @@ async function disbandGroupChat(group, members) {
     /* storage unavailable — the atom reset above still empties the room */
   }
   scheduleGroupChatServerSync($groupChats.get(), { allowEmpty: true, deletedRooms: [group] })
+  await metadataPersistence
 
-  // Remove this membership last. saveBotMeta never throws (local storage +
-  // best-effort profiles.configure per member), so a flaky gateway can't
-  // strand the disband halfway with the room log already gone.
-  for (const member of members) {
-    if (!member?.name) {
-      continue
+  // Persist the cleanup to every exact owner we can prove. saveBotMeta never
+  // throws (local storage + best-effort profiles.configure per owner), so a
+  // flaky gateway cannot strand the local disband halfway.
+  for (const [key, owner] of cleanup.owners) {
+    const patch = cleanup.patches.get(key)
+    if (patch) {
+      await saveBotMeta(owner, patch)
     }
-
-    const meta = botRosterMeta(member, $botMeta.get()) || {}
-    await saveBotMeta(member, groupMembershipPatch(meta, group, false))
   }
 
   // Converge on server truth: the cached roster still carries the pre-disband

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -196,7 +196,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, groupSpeakerLabel, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, groupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, $lastRoster, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -1207,6 +1207,59 @@ test('disband: removes only this membership, room log, workspace, and needs-you 
   assert.ok('Keep' in durable, 'surviving room still persisted')
   assert.equal(durable.Keep.members.length, 1, 'surviving room keeps remote member descriptors')
   assert.equal(durable.Keep.members[0].connectionId, 'remote-1')
+})
+
+test('disband: an empty rendered roster cannot leave a metadata-only group row', async () => {
+  const gc = load(() => '(pass)')
+
+  gc.$botMeta.set({ builder: { groups: ['Remote'], group: 'Remote' } })
+  gc.$groupChats.set({
+    Remote: { log: [], members: [], watermarks: {}, sessions: {}, running: false }
+  })
+
+  await gc.disbandGroupChat('Remote', [])
+
+  assert.equal(gc.$groupChats.get().Remote, undefined, 'room record is deleted')
+  assert.equal(JSON.stringify(gc.$botMeta.get().builder.groups), JSON.stringify([]))
+  assert.equal(gc.$botMeta.get().builder.group, null)
+  assert.equal(
+    JSON.stringify(gc.groupChatNames(gc.$botMeta.get(), gc.$groupChats.get())),
+    JSON.stringify([]),
+    'stale bot metadata cannot reconstruct a deleted zero-member row'
+  )
+})
+
+test('disband: an empty rendered roster recovers the exact source-qualified metadata owner', async () => {
+  const gc = load(() => '(pass)')
+  const remote = {
+    name: 'builder',
+    connectionId: 'remote-1',
+    connectionKind: 'remote',
+    sourceScoped: true,
+    remoteSource: true,
+    route: {
+      connectionId: 'remote-1',
+      mode: 'remote',
+      profile: 'builder',
+      targetProfile: 'builder'
+    }
+  }
+
+  gc.$lastRoster.set([remote])
+  gc.$botMeta.set({
+    builder: { groups: ['Keep'], group: 'Keep' },
+    'remote-1::builder': { groups: ['Remote'], group: 'Remote' }
+  })
+  gc.$groupChats.set({
+    Remote: { log: [], members: [], watermarks: {}, sessions: {}, running: false }
+  })
+
+  await gc.disbandGroupChat('Remote', [])
+
+  assert.equal(JSON.stringify(gc.$botMeta.get()['remote-1::builder'].groups), JSON.stringify([]))
+  assert.equal(gc.$botMeta.get()['remote-1::builder'].group, null)
+  assert.equal(JSON.stringify(gc.$botMeta.get().builder.groups), JSON.stringify(['Keep']))
+  assert.equal(gc.$botMeta.get().builder.group, 'Keep', 'same-named local metadata is untouched')
 })
 
 test('disband: skips source-qualified remote members instead of mutating same-named local metadata', async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes Bot Mode group disbanding when the rendered member list has already collapsed to zero. The room could be removed while stale per-bot group metadata rebuilt a `0 bots` roster row.

The disband path now derives exact cleanup owners from rendered members, durable room members, and the source-qualified roster. It clears local metadata that still names the room immediately, while only routing server writes to owners whose source is known. This preserves legitimate empty or temporarily offline groups and avoids mutating a same-named bot on another source.

## Related Issue

Fixes #93345

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/desktop/src/plugins/hermes-bots/plugin.js` so disband cleanup does not depend on the currently rendered member list.
- Added zero-member deletion and source-qualified same-name regressions in `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs`.

## How to Test

1. Run `node --test apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs apps/desktop/src/plugins/hermes-bots/tests/roster-groups.test.mjs`.
2. Confirm all 98 tests pass.
3. Delete a remotely viewed group after its rendered member list becomes empty and confirm the group row does not return as `0 bots`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run locally; this is a scoped Desktop JavaScript change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows, with the focused Node behavioral tests above

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable. Focused behavioral tests cover the reproduced state transition.