### PR TITLE
feat(desktop): show $/Mtok pricing in the model catalog menu

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -106,3 +106,33 @@ describe('the catalog owns model curation', () => {
     expect($modelVisibilityOpen.get()).toBe(true)
   })
 })
+
+// #93360 — the picker in model-picker.tsx already shows $/Mtok pricing; the
+// catalog menu (the composer's model pill, a different surface reachable
+// while typing) had no pricing at all, so a price-sensitive pick meant
+// switching to the settings picker just to compare cost.
+describe('pricing', () => {
+  it('shows $/Mtok pricing on a row when the catalog carries it', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          models: ['gemini-3.1-pro', 'gemini-2.5-flash'],
+          name: 'Google',
+          pricing: { 'gemini-3.1-pro': { cache: null, free: false, input: '$3.00', output: '$15.00' } },
+          slug: 'google'
+        }
+      ]
+    })
+
+    renderMenu()
+
+    await screen.findByText(/\$3\.00 in \/ \$15\.00 out per Mtok/)
+  })
+
+  it('renders no price text for a model with no pricing data', async () => {
+    renderMenu()
+
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+    expect(screen.queryByText(/per Mtok/)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -404,6 +404,7 @@ export function ModelCatalogMenu({
                     const isCurrent = activeId !== null
                     const name = modelDisplayParts(family.id).name
                     const caps = group.provider.capabilities?.[family.id]
+                    const price = group.provider.pricing?.[family.id]
 
                     // Effective settings for this row: the live choice when it's
                     // the active model, otherwise its remembered preset. Row
@@ -419,9 +420,19 @@ export function ModelCatalogMenu({
                       effFast
                     )
 
+                    // $/Mtok pricing, same data + copy shape as the settings model
+                    // picker (model-picker.tsx) and onboarding — surfaced here too
+                    // so it's visible from wherever a model gets picked (#93360).
+                    const priceLabel = price?.free
+                      ? copy.free
+                      : price && (price.input || price.output)
+                        ? copy.price(price.input || '?', price.output || '?')
+                        : null
+
                     const meta = [
                       fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
-                      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort || defaultEffort) : null
+                      (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort || defaultEffort) : null,
+                      priceLabel
                     ]
                       .filter(Boolean)
                       .join(' ')

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2200,7 +2200,9 @@ export const ar = defineLocale({
       noModels: 'لا توجد نماذج',
       editModels: 'تحرير النماذج',
       refreshModels: 'تحديث النماذج',
-      fast: 'سريع'
+      fast: 'سريع',
+      free: 'مجاني',
+      price: (input, output) => `${input} إدخال / ${output} إخراج لكل مليون رمز`
     },
     modelOptions: {
       noOptions: 'لا توجد خيارات لهذا النموذج',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2785,7 +2785,9 @@ export const en: Translations = {
       noModels: 'No models found',
       editModels: 'Edit Models…',
       refreshModels: 'Refresh Models',
-      fast: 'Fast'
+      fast: 'Fast',
+      free: 'Free',
+      price: (input, output) => `${input} in / ${output} out per Mtok`
     },
     modelOptions: {
       noOptions: 'No options for this model',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2453,7 +2453,9 @@ export const ja = defineLocale({
       noModels: 'モデルが見つかりません',
       editModels: 'モデルを編集…',
       refreshModels: 'モデルを更新',
-      fast: '高速'
+      fast: '高速',
+      free: '無料',
+      price: (input, output) => `${input} 入力 / ${output} 出力 per Mtok`
     },
     modelOptions: {
       noOptions: 'このモデルにはオプションがありません',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2353,6 +2353,8 @@ export interface Translations {
       editModels: string
       refreshModels: string
       fast: string
+      free: string
+      price: (input: string, output: string) => string
     }
     modelOptions: {
       noOptions: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2365,7 +2365,9 @@ export const zhHant = defineLocale({
       noModels: '找不到模型',
       editModels: '編輯模型…',
       refreshModels: '重新整理模型',
-      fast: '快速'
+      fast: '快速',
+      free: '免費',
+      price: (input, output) => `${input} 輸入 / ${output} 輸出 每 Mtok`
     },
     modelOptions: {
       noOptions: '此模型沒有可用選項',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2950,7 +2950,9 @@ export const zh: Translations = {
       noModels: '未找到模型',
       editModels: '编辑模型…',
       refreshModels: '刷新模型',
-      fast: '快速'
+      fast: '快速',
+      free: '免费',
+      price: (input, output) => `${input} 输入 / ${output} 输出每 Mtok`
     },
     modelOptions: {
       noOptions: '此模型没有可用选项',


### PR DESCRIPTION
## What does this PR do?

Adds current model pricing ($/Mtok) to the desktop app's model catalog
menu — the floating model-selection dropdown reachable from the
composer's model pill, which is also where the reasoning-effort
submenu lives.

The data was already there: `provider.pricing` comes back on the same
`model.options` response this menu already queries, and it's already
rendered elsewhere (the settings model picker in `model-picker.tsx`,
and the onboarding confirm screen in `onboarding/flow.tsx`). The
catalog menu was the one surface that fetched it but never displayed
it, so comparing model cost meant opening a *different* picker.

This reuses the existing pricing data and copy shape (`free` / `price(input, output)`
strings, same as onboarding) rather than inventing a new format or a
new data source — no new network calls, no design decision about
where pricing numbers come from.

## Related Issue

Fixes #93360

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/app/shell/model-catalog-menu.tsx`: read `group.provider.pricing?.[family.id]`
  per row and append a formatted price (or "Free") to the row's meta
  label, alongside the existing Fast/reasoning-effort labels.
- `apps/desktop/src/i18n/{en,zh,zh-hant,ja,ar}.ts` + `types.ts`: add
  `modelMenu.free` / `modelMenu.price(input, output)` copy, mirroring
  the existing `onboarding.free` / `onboarding.price` strings.
- `apps/desktop/src/app/shell/model-catalog-menu.test.tsx`: new tests —
  a row shows the formatted price when the catalog carries pricing
  data, and shows nothing extra when it doesn't.

## How to Test

1. `npm install --workspace apps/desktop`
2. `cd apps/desktop && npx vitest run src/app/shell/model-catalog-menu.test.tsx`

Test output (after the fix, all 5 pass):

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Verified the new test actually exercises the fix — reverted just the
source changes (`git checkout HEAD~1 -- apps/desktop/src/app/shell/model-catalog-menu.tsx apps/desktop/src/i18n/*`)
and reran with only the test file changed:

```
 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
 ❯ pricing > shows $/Mtok pricing on a row when the catalog carries it
   Unable to find an element with the text: /\$3\.00 in \/ \$15\.00 out per Mtok/.
```

Then restored the fix and confirmed all 5 pass again.

Also ran, both clean:

```
npx tsc -p . --noEmit
npx eslint src/app/shell/model-catalog-menu.tsx src/app/shell/model-catalog-menu.test.tsx src/i18n/*.ts
npx vitest run src/app/shell   # 72 passed
npx vitest run src/i18n        # 28 passed
```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've added tests for my changes
- [ ] I've tested on my platform — no desktop app runtime available in this environment; verified via `tsc`, `eslint`, and `vitest` only, not a manual click-through.

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed.

## AI assistance disclosure

This change (analysis, implementation, and tests) was produced by an
AI coding agent (Claude/Anthropic) operating autonomously against this
repository, with test and type-check output verified as shown above.
