### PR TITLE
fix(checkpoints): atomic store activation via generation selector

### DIFF
--- a/hermes_cli/checkpoints.py
+++ b/hermes_cli/checkpoints.py
@@ -19,7 +19,11 @@ Examples::
     hermes checkpoints clear -f
     hermes checkpoints activate /mnt/recovery/store.repaired
 
-None of these require the agent to be running.  Safe to call any time.
+None of these require the agent to be running.  Activation/deactivation
+and checkpoint operations serialize through one interprocess store lock,
+so running them while Hermes is live is safe: operations queue behind each
+other instead of racing (a busy store reports it and fails closed rather
+than corrupting state).
 """
 
 from __future__ import annotations

--- a/hermes_cli/checkpoints.py
+++ b/hermes_cli/checkpoints.py
@@ -9,12 +9,15 @@ store at ``~/.hermes/checkpoints/``.  Actions:
     hermes checkpoints prune [opts]  # force a sweep (ignores the 24h marker)
     hermes checkpoints clear [-f]    # nuke the entire base (asks first)
     hermes checkpoints clear-legacy  # delete just the legacy-* archives
+    hermes checkpoints activate DIR  # atomically activate a repaired store copy
+    hermes checkpoints deactivate    # restore the legacy store/ as canonical
 
 Examples::
 
     hermes checkpoints
     hermes checkpoints prune --retention-days 3 --max-size-mb 200
     hermes checkpoints clear -f
+    hermes checkpoints activate /mnt/recovery/store.repaired
 
 None of these require the agent to be running.  Safe to call any time.
 """
@@ -62,6 +65,12 @@ def cmd_status(args: argparse.Namespace) -> int:
     print(f"Total size:      {_fmt_bytes(info['total_size_bytes'])}")
     print(f"  store/         {_fmt_bytes(info['store_size_bytes'])}")
     print(f"  legacy-*       {_fmt_bytes(info['legacy_size_bytes'])}")
+    active = info.get("active_generation")
+    if active:
+        print(f"  active gen     {active}")
+    selector_error = info.get("selector_error")
+    if selector_error:
+        print(f"  selector       BROKEN — {selector_error}")
     print(f"Projects:        {info['project_count']}")
 
     projects = sorted(
@@ -90,6 +99,14 @@ def cmd_status(args: argparse.Namespace) -> int:
             print(f"  {arch['name']:<40}  {_fmt_bytes(arch['size_bytes']):>10}")
         print()
         print("Clear with: hermes checkpoints clear-legacy")
+
+    generations = info.get("generations", [])
+    if generations:
+        print()
+        print("Store generations (atomic activation; never auto-deleted):")
+        for gen in generations:
+            marker = "  <- active" if gen.get("is_active") else ""
+            print(f"  {gen['name']:<40}  {_fmt_bytes(gen['size_bytes']):>10}{marker}")
     return 0
 
 
@@ -229,6 +246,54 @@ def cmd_clear_legacy(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_activate(args: argparse.Namespace) -> int:
+    from tools.checkpoint_manager import activate_store_generation
+
+    src = Path(args.source).expanduser()
+    result = activate_store_generation(src)
+    if not result.get("success"):
+        print(f"Activation failed: {result.get('error')}")
+        return 1
+    print(f"Activated generation {result['generation']}.")
+    previous = result.get("previous")
+    print(f"Previous selection: {previous or 'legacy store/'}")
+    print(f"Generation path:    {result['store']}")
+    print()
+    print("Neither store was moved or deleted. Roll back with:")
+    if previous:
+        print("  hermes checkpoints activate <previous-generation-dir>")
+    print("  hermes checkpoints deactivate   (back to the legacy store/)")
+    return 0
+
+
+def cmd_deactivate(args: argparse.Namespace) -> int:
+    from tools.checkpoint_manager import store_status, deactivate_store_generation
+
+    info = store_status()
+    active = info.get("active_generation")
+    if not active:
+        if info.get("selector_error"):
+            print(f"Cannot deactivate: {info['selector_error']}")
+            print("Fix or remove the store.current file manually, then retry.")
+            return 1
+        print("Nothing to deactivate — no store.current pointer is present.")
+        return 0
+    print(f"Active generation: {active}")
+    print("This removes the store.current pointer so the legacy store/")
+    print("becomes canonical again. Generations are kept on disk; delete")
+    print("them manually only when you no longer need the recovery copies.")
+    if not args.force and not _confirm("Proceed?"):
+        print("Aborted.")
+        return 1
+
+    result = deactivate_store_generation()
+    if not result.get("success"):
+        print(f"Deactivation failed: {result.get('error')}")
+        return 1
+    print("Legacy store/ is canonical again.")
+    return 0
+
+
 def register_cli(parser: argparse.ArgumentParser) -> None:
     """Wire subcommands onto the ``hermes checkpoints`` parser."""
     parser.set_defaults(func=cmd_status)  # bare `hermes checkpoints` → status
@@ -279,3 +344,21 @@ def register_cli(parser: argparse.ArgumentParser) -> None:
     p_legacy.add_argument("-f", "--force", action="store_true",
                           help="Skip confirmation prompt")
     p_legacy.set_defaults(func=cmd_clear_legacy)
+
+    p_activate = subs.add_parser(
+        "activate",
+        help="Atomically activate a verified store copy (issue #93314 recovery)",
+    )
+    p_activate.add_argument(
+        "source", metavar="DIR",
+        help="Path to the repaired store candidate (copied, never moved)",
+    )
+    p_activate.set_defaults(func=cmd_activate)
+
+    p_deactivate = subs.add_parser(
+        "deactivate",
+        help="Restore the legacy store/ as the canonical checkpoint store",
+    )
+    p_deactivate.add_argument("-f", "--force", action="store_true",
+                              help="Skip confirmation prompt")
+    p_deactivate.set_defaults(func=cmd_deactivate)

--- a/tests/hermes_cli/test_checkpoints_activate_cli.py
+++ b/tests/hermes_cli/test_checkpoints_activate_cli.py
@@ -1,0 +1,110 @@
+"""E2E: the real operator path for atomic store activation (#93314).
+
+Exercises ``hermes checkpoints activate`` / ``deactivate`` through the real
+argparse wiring (register_cli) — not by calling cmd_* directly — plus a full
+checkpoint → activate → checkpoint → deactivate cycle against real git
+stores in a temp HERMES_HOME.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.checkpoint_manager import (
+    CheckpointManager,
+    _init_store,
+    _read_store_selector,
+    active_generation_name,
+)
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    base = tmp_path / "home" / ".hermes" / "checkpoints"
+    work = tmp_path / "project"
+    work.mkdir(parents=True)
+    (work / "app.py").write_text("print('v1')\n")
+    monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+    return base, work
+
+
+def _run_cli(argv):
+    """Invoke `hermes checkpoints ...` through the real parser wiring."""
+    import argparse
+
+    import hermes_cli.checkpoints as checkpoints_cli
+
+    parser = argparse.ArgumentParser(prog="hermes checkpoints")
+    checkpoints_cli.register_cli(parser)
+    ns = parser.parse_args(argv)
+    return ns.func(ns)
+
+
+@pytest.mark.e2e
+class TestActivateCliEndToEnd:
+    def test_full_recovery_cycle_through_cli(self, env, monkeypatch):
+        base, work = env
+
+        # 1. Healthy life before the incident: one real checkpoint.
+        mgr = CheckpointManager(enabled=True)
+        assert mgr.ensure_checkpoint(str(work), "before") is True
+        assert (base / "store" / "HEAD").exists()
+
+        # 2. Offline "repair": candidate copy outside the base.
+        candidate = work.parent / "store.repaired"
+        shutil.copytree(base / "store", candidate)
+
+        # 3. Operator activates it via the CLI. No directory swapping.
+        rc = _run_cli(["activate", str(candidate)])
+        assert rc == 0
+        gen = active_generation_name(base)
+        assert gen and gen.startswith("store.")
+        # Legacy store untouched; generation is a sibling copy.
+        assert (base / "store" / "HEAD").exists()
+        assert (base / gen).is_dir() and not (base / gen).is_symlink()
+
+        # 4. Hermes keeps checkpointing — into the activated generation.
+        mgr.new_turn()
+        (work / "app.py").write_text("print('v2')\n")
+        assert mgr.ensure_checkpoint(str(work), "after") is True
+        entries = mgr.list_checkpoints(str(work))
+        assert [e["reason"] for e in entries][:1] == ["after"]
+
+        # 5. Status surfaces the layout for the operator.
+        from tools.checkpoint_manager import store_status
+
+        info = store_status(checkpoint_base=base)
+        assert info["active_generation"] == gen
+        assert any(g["name"] == gen and g["is_active"]
+                   for g in info["generations"])
+
+        # 6. Rollback to legacy via CLI. Each store keeps its OWN history:
+        # commits made while the generation was active live in the
+        # generation; the legacy store still has its pre-repair history.
+        rc = _run_cli(["deactivate", "--force"])
+        assert rc == 0
+        assert _read_store_selector(base) is None
+        after = mgr.list_checkpoints(str(work))
+        reasons = [e["reason"] for e in after]
+        assert "before" in reasons and "after" not in reasons
+
+    def test_activate_rejects_broken_candidate_with_clear_error(
+        self, env, capsys,
+    ):
+        base, work = env
+        broken = work.parent / "broken"
+        broken.mkdir()
+        rc = _run_cli(["activate", str(broken)])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Activation failed" in out
+        assert not list(base.glob("store.*"))
+
+    def test_deactivate_without_pointer_is_a_clean_noop(self, env, capsys):
+        base, work = env
+        rc = _run_cli(["deactivate"])
+        assert rc == 0
+        assert "Nothing to deactivate" in capsys.readouterr().out

--- a/tests/tools/test_checkpoint_store_activation.py
+++ b/tests/tools/test_checkpoint_store_activation.py
@@ -1,0 +1,446 @@
+"""Atomic store activation (#93314) — generation selector + fail-closed resolver.
+
+Behaviour contracts under test:
+
+* Absent ``store.current`` pointer  -> legacy ``store/`` path (byte-for-byte
+  backwards compatibility; no migration, no new files).
+* Present, valid pointer            -> every consumer transparently operates
+  on the named generation directory.
+* Present, untrustworthy pointer    -> fail closed: resolver raises instead of
+  silently re-pointing Hermes at the possibly-damaged legacy store.
+* Activation                        -> copies a candidate into a sibling
+  generation and flips the pointer atomically; neither store is ever moved or
+  deleted; failures before/during the flip leave the old selection valid.
+"""
+
+import json
+import os
+import shutil
+import time
+
+import pytest
+from pathlib import Path
+
+from tools.checkpoint_manager import (
+    CheckpointManager,
+    CheckpointStoreSelectorError,
+    _init_store,
+    _store_path,
+    activate_store_generation,
+    active_generation_name,
+    deactivate_store_generation,
+    prune_checkpoints,
+    store_status,
+)
+
+
+VALID_GEN = "store.20260823T220000Z"
+
+
+@pytest.fixture()
+def base(tmp_path):
+    d = tmp_path / "checkpoints"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def work_dir(tmp_path):
+    d = tmp_path / "project"
+    d.mkdir()
+    (d / "main.py").write_text("print('hello')\n")
+    return d
+
+
+@pytest.fixture()
+def live_store(base, work_dir):
+    """An initialised legacy store with one real checkpoint."""
+    err = _init_store(base / "store", str(work_dir))
+    assert err is None
+    return base / "store"
+
+
+@pytest.fixture()
+def candidate(live_store, work_dir, tmp_path):
+    """An offline 'repaired' candidate: a byte-copy of the live store
+    sitting OUTSIDE the checkpoint base (the real recovery flow)."""
+    cand = tmp_path / "repaired_candidate"
+    shutil.copytree(live_store, cand)
+    return cand
+
+
+def _write_pointer(base: Path, generation: str) -> None:
+    (base / "store.current").write_text(generation, encoding="utf-8")
+
+
+# =========================================================================
+# Resolver contract
+# =========================================================================
+
+
+class TestResolverLegacyDefault:
+    def test_no_pointer_resolves_legacy_store(self, base):
+        assert _store_path(base) == base / "store"
+        assert active_generation_name(base) is None
+
+    def test_no_pointer_is_byte_compatible(self, base, work_dir):
+        """Without the pointer the whole flow behaves exactly as pre-#93314."""
+        mgr = CheckpointManager(enabled=True)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+            assert mgr.ensure_checkpoint(str(work_dir), "auto") is True
+        assert (base / "store" / "HEAD").exists()
+        assert not (base / "store.current").exists()
+
+
+class TestResolverValidPointer:
+    def test_pointer_selects_generation_dir(self, base, work_dir):
+        gen = base / VALID_GEN
+        assert _init_store(gen, str(work_dir)) is None
+        _write_pointer(base, VALID_GEN)
+        assert _store_path(base) == gen
+        assert active_generation_name(base) == VALID_GEN
+
+    def test_all_consumers_route_through_generation(
+        self, base, work_dir, monkeypatch,
+    ):
+        """A checkpoint written after activation lives in the generation."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+        assert _init_store(base / "store", str(work_dir)) is None
+        gen = base / VALID_GEN
+        assert _init_store(gen, str(work_dir)) is None
+        _write_pointer(base, VALID_GEN)
+
+        mgr = CheckpointManager(enabled=True)
+        assert mgr.ensure_checkpoint(str(work_dir), "auto") is True
+
+        # The new commit must be visible through the generation's refs —
+        # and only there. This is the routing contract, not a snapshot:
+        # whatever hash was created, it exists in gen A and not in the
+        # untouched legacy store.
+        from tools.checkpoint_manager import _project_hash, _ref_name, _run_git
+
+        ref = _ref_name(_project_hash(str(work_dir)))
+        ok_gen, _, _ = _run_git(
+            ["rev-parse", "--verify", ref + "^{commit}"], gen, str(work_dir),
+        )
+        ok_legacy, _, _ = _run_git(
+            ["rev-parse", "--verify", ref + "^{commit}"],
+            base / "store", str(work_dir),
+        )
+        assert ok_gen is True
+        assert ok_legacy is False
+
+
+# =========================================================================
+# Fail-closed contract
+# =========================================================================
+
+
+@pytest.mark.parametrize("bad_content", [
+    "",
+    "store\n",
+    "store.20260823T220000Z extra\n",
+    "../../../etc",
+    "store.2026-08-23T22:00:00Z",
+    "/absolute/path",
+])
+class TestResolverFailClosed:
+    def test_malformed_pointer_raises_never_falls_back(
+        self, base, work_dir, bad_content,
+    ):
+        """A broken selector must NOT silently resolve to legacy store/.
+
+        The legacy store here even EXISTS and is healthy — resolution must
+        still refuse, because the operator asked for a generation and we
+        cannot know why the pointer is unreadable.
+        """
+        assert _init_store(base / "store", str(work_dir)) is None
+        _write_pointer(base, bad_content)
+        with pytest.raises(CheckpointStoreSelectorError):
+            _store_path(base)
+
+    def test_broken_pointer_disables_manager_operations(
+        self, base, work_dir, bad_content, monkeypatch,
+    ):
+        """Consumers degrade to 'unavailable', never to the corrupt store."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+        assert _init_store(base / "store", str(work_dir)) is None
+        _write_pointer(base, bad_content)
+
+        mgr = CheckpointManager(enabled=True)
+        # Snapshot attempt refuses instead of silently writing to store/.
+        assert mgr._take(str(work_dir), "test") is False
+        # Restore reports failure instead of reading the wrong store.
+        result = mgr.restore(str(work_dir), "0123456789abcdef")
+        assert result["success"] is False
+        assert "unavailable" in result["error"]
+
+
+class TestSelectorEdgeCases:
+    def test_symlinked_pointer_rejected(self, base, tmp_path):
+        outside = tmp_path / "outside.txt"
+        outside.write_text(VALID_GEN, encoding="utf-8")
+        pointer = base / "store.current"
+        pointer.symlink_to(outside)
+        with pytest.raises(CheckpointStoreSelectorError):
+            _store_path(base)
+
+    def test_traversal_target_rejected(self, base, tmp_path):
+        # Name passes the pattern check only if it matches exactly; an
+        # escaped target can never match the strict pattern, but prove the
+        # join stays inside base regardless.
+        evil = "store." + ("9" * 8) + "T" + ("9" * 6) + "Z"
+        _write_pointer(base, evil)  # well-formed name, missing directory
+        with pytest.raises(CheckpointStoreSelectorError):
+            _store_path(base)
+
+    def test_missing_target_directory_rejected(self, base):
+        _write_pointer(base, VALID_GEN)
+        with pytest.raises(CheckpointStoreSelectorError):
+            _store_path(base)
+
+    def test_symlinked_target_directory_rejected(self, base, tmp_path):
+        real = tmp_path / "realgen"
+        real.mkdir()
+        (real / "HEAD").write_text("ref: refs/hermes/x\n", encoding="utf-8")
+        (base / VALID_GEN).symlink_to(real)
+        _write_pointer(base, VALID_GEN)
+        with pytest.raises(CheckpointStoreSelectorError):
+            _store_path(base)
+
+    def test_directory_named_like_pointer_rejected(self, base):
+        (base / "store.current").mkdir()
+        with pytest.raises(CheckpointStoreSelectorError):
+            _store_path(base)
+
+
+# =========================================================================
+# Integration guards: sweeps never touch generations or pointer
+# =========================================================================
+
+
+class TestSweepGuards:
+    def test_prune_retention_never_deletes_generations_or_pointer(
+        self, base, work_dir,
+    ):
+        assert _init_store(base / "store", str(work_dir)) is None
+        gen = base / VALID_GEN
+        assert _init_store(gen, str(work_dir)) is None
+        # Age both beyond any retention cutoff.
+        old = time.time() - 100 * 86400
+        os.utime(gen, (old, old))
+        _write_pointer(base, VALID_GEN)
+
+        result = prune_checkpoints(retention_days=1, delete_orphans=True,
+                                   checkpoint_base=base)
+        assert gen.exists(), "retention sweep deleted an activated generation"
+        assert (base / "store.current").exists()
+
+    def test_pre_v2_scan_ignores_generations(self, base, work_dir):
+        """Generations have HEAD files; without the guard they would be
+        classified as deletable pre-v2 orphan shadow repos."""
+        from tools.checkpoint_manager import _pre_v2_shadow_repos
+
+        gen = base / VALID_GEN
+        assert _init_store(gen, str(work_dir)) is None
+        repos = _pre_v2_shadow_repos(base)
+        assert all(r["path"] != gen for r in repos)
+
+    def test_migration_never_archives_generations_or_pointer(
+        self, base, work_dir,
+    ):
+        from tools.checkpoint_manager import _migrate_legacy_store
+
+        gen = base / VALID_GEN
+        assert _init_store(gen, str(work_dir)) is None
+        _write_pointer(base, VALID_GEN)
+        # A stray dir that SHOULD be archived (proves the sweep ran).
+        stray = base / "1234567890abcdef"
+        (stray / "HEAD").mkdir(parents=True)
+        _migrate_legacy_store(base)
+        assert gen.exists()
+        assert (base / "store.current").exists()
+        assert not stray.exists(), "sanity: sweep did not run at all"
+
+    def test_store_status_reports_generations_and_selector_error(
+        self, base, work_dir,
+    ):
+        gen = base / VALID_GEN
+        assert _init_store(gen, str(work_dir)) is None
+        _write_pointer(base, VALID_GEN)
+        info = store_status(checkpoint_base=base)
+        assert info["active_generation"] == VALID_GEN
+        assert [g["name"] for g in info["generations"]] == [VALID_GEN]
+        assert info["generations"][0]["is_active"] is True
+
+        _write_pointer(base, "garbage")
+        info = store_status(checkpoint_base=base)
+        assert "selector_error" in info
+        # Still reports enough for an operator to act on.
+        assert info["total_size_bytes"] >= 0
+
+
+# =========================================================================
+# Atomic activation
+# =========================================================================
+
+
+class TestActivation:
+    def test_activate_flips_resolution_without_touching_stores(
+        self, base, candidate, live_store,
+    ):
+        result = activate_store_generation(candidate, checkpoint_base=base,
+                                           verify=False)
+        assert result["success"] is True, result.get("error")
+        gen_name = result["generation"]
+        assert gen_name.startswith("store.") and gen_name != "store"
+        # Legacy store still in place, untouched.
+        assert live_store.exists() and (live_store / "HEAD").exists()
+        # Pointer now routes everyone to the copy.
+        assert _store_path(base) == base / gen_name
+        assert active_generation_name(base) == gen_name
+
+    def test_activation_copy_is_verified_with_fsck(self, base, candidate):
+        result = activate_store_generation(candidate, checkpoint_base=base,
+                                           verify=True)
+        assert result["success"] is True, result.get("error")
+
+    def test_failed_verification_leaves_previous_state_valid(
+        self, base, work_dir, live_store,
+    ):
+        """A corrupt candidate must never become selectable."""
+        broken = work_dir.parent / "broken_candidate"
+        shutil.copytree(live_store, broken)
+        # Corrupt the copy: truncate the pack-less object store by removing
+        # a reachable object is hard to arrange portably; instead fake a
+        # structurally broken repo (no HEAD).
+        (broken / "HEAD").unlink()
+        result = activate_store_generation(broken, checkpoint_base=base)
+        assert result["success"] is False
+        assert not (base / "store.current").exists(), \
+            "pointer flipped despite failed verification"
+        leftovers = [p.name for p in base.iterdir()
+                     if p.name.startswith("store.")]
+        assert leftovers == [], "failed activation left a partial generation"
+
+    def test_activating_current_live_store_refused(self, base, live_store):
+        result = activate_store_generation(live_store, checkpoint_base=base,
+                                           verify=False)
+        assert result["success"] is False
+        assert "currently active" in result["error"]
+
+    def test_broken_existing_selector_blocks_activation(
+        self, base, candidate,
+    ):
+        """Untrustworthy rollback anchor: refuse rather than overwrite."""
+        _write_pointer(base, "not-a-generation")
+        result = activate_store_generation(candidate, checkpoint_base=base,
+                                           verify=False)
+        assert result["success"] is False
+        assert "cannot be trusted" in result["error"]
+        assert (base / "store.current").read_text() == "not-a-generation"
+
+    def test_rollback_by_second_activation_and_by_deactivation(
+        self, base, live_store, candidate, tmp_path,
+    ):
+        # Activate repaired copy.
+        first = activate_store_generation(candidate, checkpoint_base=base,
+                                          verify=False)
+        assert first["success"] is True
+        assert first["previous"] is None
+
+        # Build a second candidate and activate it (pointer flip again).
+        second_src = tmp_path / "second_candidate"
+        shutil.copytree(live_store, second_src)
+        second = activate_store_generation(second_src, checkpoint_base=base,
+                                           verify=False)
+        assert second["success"] is True
+        assert second["previous"] == first["generation"]
+        assert _store_path(base) == base / second["generation"]
+
+        # Deterministic rollback to the legacy layout.
+        back = deactivate_store_generation(checkpoint_base=base)
+        assert back["success"] is True, back.get("error")
+        assert _store_path(base) == base / "store"
+        # Generations are retained for the operator to dispose of later.
+        assert (base / first["generation"]).exists()
+
+    def test_activation_refuses_at_generation_cap(self, base, candidate):
+        """Bounded retention: growth past the cap is an operator decision."""
+        import tools.checkpoint_manager as cm
+
+        existing = [
+            base / f"store.2026010{i}T000000Z" for i in range(1, 9)
+        ]
+        for d in existing:
+            d.mkdir()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(cm, "_MAX_STORE_GENERATIONS", len(existing))
+            result = activate_store_generation(candidate,
+                                               checkpoint_base=base,
+                                               verify=False)
+        assert result["success"] is False
+        assert "dispose of old ones" in result["error"]
+        assert not (base / "store.current").exists()
+
+    def test_deactivation_refused_when_legacy_store_absent(self, base):
+        (base / "store.current").write_text(VALID_GEN, encoding="utf-8")
+        result = deactivate_store_generation(checkpoint_base=base)
+        assert result["success"] is False
+        assert (base / "store.current").exists(), \
+            "refused deactivation must keep current selection"
+
+    def test_pointer_flip_is_atomic_single_file(self, base, candidate):
+        """The pointer file contains ONLY the generation name — the exact
+        recovery-tool contract from the issue (one metadata line)."""
+        result = activate_store_generation(candidate, checkpoint_base=base,
+                                           verify=False)
+        content = (base / "store.current").read_text(encoding="utf-8")
+        assert content.strip() == result["generation"]
+        assert "\n" not in content
+
+
+# =========================================================================
+# End-to-end: issue acceptance criteria
+# =========================================================================
+
+
+class TestEndToEndRecoveryScenario:
+    def test_repaired_candidate_activation_full_cycle(self, base, work_dir, monkeypatch):
+        """The exact scenario from #93314: healthy legacy store gets damaged
+        conceptually; operator builds verified candidate; activates it
+        atomically; Hermes keeps checkpointing against the new generation;
+        status shows both; rollback restores legacy selection."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+        assert _init_store(base / "store", str(work_dir)) is None
+
+        mgr = CheckpointManager(enabled=True)
+        assert mgr.ensure_checkpoint(str(work_dir), "pre-repair") is True
+        mgr.new_turn()
+
+        # Operator-side repair produces a byte-verified candidate elsewhere.
+        candidate = work_dir.parent / "repaired_candidate"
+        shutil.copytree(base / "store", candidate)
+
+        # Directory-swap style activation is what fails on FUSE; ours is a
+        # metadata write — and it must succeed while stores stay put.
+        result = activate_store_generation(candidate, checkpoint_base=base)
+        assert result["success"] is True, result.get("error")
+        assert (base / "store").exists(), "live store was moved/deleted"
+
+        # Post-activation checkpoints land in the new generation.
+        (work_dir / "main.py").write_text("print('changed')\n")
+        assert mgr.ensure_checkpoint(str(work_dir), "post-repair") is True
+        gen = base / result["generation"]
+        assert gen.exists()
+
+        info = store_status(checkpoint_base=base)
+        assert info["active_generation"] == result["generation"]
+        names = {g["name"] for g in info["generations"]}
+        assert result["generation"] in names
+
+        # Rollback path: legacy store still fully usable.
+        assert deactivate_store_generation(checkpoint_base=base)["success"]
+        assert mgr.list_checkpoints(str(work_dir)), \
+            "legacy store lost its history?"

--- a/tests/tools/test_checkpoint_store_activation.py
+++ b/tests/tools/test_checkpoint_store_activation.py
@@ -21,11 +21,16 @@ import time
 import pytest
 from pathlib import Path
 
+import tools.checkpoint_manager as checkpoint_manager_mod
 from tools.checkpoint_manager import (
     CheckpointManager,
     CheckpointStoreSelectorError,
     _init_store,
+    _store_lock,
     _store_path,
+    _StoreLockTimeout,
+    _unique_selector_tmp,
+    _verify_store_generation,
     activate_store_generation,
     active_generation_name,
     deactivate_store_generation,
@@ -444,3 +449,234 @@ class TestEndToEndRecoveryScenario:
         assert deactivate_store_generation(checkpoint_base=base)["success"]
         assert mgr.list_checkpoints(str(work_dir)), \
             "legacy store lost its history?"
+
+
+# =========================================================================
+# Review round 1 — blocker 1: interprocess generation/activation authority
+# =========================================================================
+
+class TestActivationAuthority:
+    def test_two_concurrent_activations_serialize(
+        self, base, live_store, work_dir, monkeypatch,
+    ):
+        """Two activations racing the same base must both succeed with
+        DISTINCT generations, and the selector must always name an existing
+        verified generation (the shared-tmp corruption from the review's
+        bad interleaving must be impossible)."""
+        import threading
+
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", base)
+
+        results = []
+
+        def _activate(i):
+            cand = work_dir.parent / f"candidate_{i}"
+            shutil.copytree(live_store, cand)
+            results.append(activate_store_generation(cand, checkpoint_base=base))
+
+        threads = [threading.Thread(target=_activate, args=(i,)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=120)
+
+        assert len(results) == 2
+        for r in results:
+            assert r["success"] is True, r.get("error")
+        gens = {r["generation"] for r in results}
+        assert len(gens) == 2, "two racers produced the same generation?"
+
+        # Invariant: whatever the pointer names exists and passes fsck.
+        sel = _store_path(base)
+        assert sel != base / "store"
+        assert (sel / "HEAD").exists()
+        err = _verify_store_generation(sel, str(base))
+        assert err is None, err
+        # Every successful activation left a real generation dir behind.
+        for name in gens:
+            assert (base / name / "HEAD").exists()
+
+    def test_activation_waits_for_live_checkpoint_write(
+        self, base, live_store, work_dir, monkeypatch,
+    ):
+        """A checkpoint write holding the store authority blocks activation
+        until it finishes — the pre-edit commit can never land in a store
+        that stops being canonical mid-write."""
+        import threading
+
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", base)
+
+        mgr = CheckpointManager(enabled=True)
+        assert mgr.ensure_checkpoint(str(work_dir), "seed") is True
+
+        # Give the slow write real content, or it exits early on "no changes".
+        (work_dir / "main.py").write_text("print('changed')\n")
+
+        gate = threading.Event()
+        release = threading.Event()
+        original_take_locked = CheckpointManager._take_locked
+
+        def _slow_take_locked(self, working_dir, reason):
+            # We are ALREADY under mgr._take's store lock — pausing here
+            # simulates an in-flight write holding the authority.
+            gate.set()
+            release.wait(timeout=60)
+            return original_take_locked(self, working_dir, reason)
+
+        slow_results = []
+
+        def _slow_writer():
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr(CheckpointManager, "_take_locked", _slow_take_locked)
+                slow_results.append(
+                    mgr._take(str(work_dir), "slow in-flight write"))
+
+        writer = threading.Thread(target=_slow_writer, daemon=True)
+        writer.start()
+        assert gate.wait(timeout=30), "writer never took the lock"
+
+        cand = work_dir.parent / "candidate"
+        shutil.copytree(live_store, cand)
+        act_result = {}
+
+        def _activator():
+            act_result.update(activate_store_generation(cand, checkpoint_base=base))
+
+        activator = threading.Thread(target=_activator, daemon=True)
+        activator.start()
+        # Give the activator a moment to block on the held lock.
+        time.sleep(1.0)
+
+        release.set()
+        writer.join(timeout=120)
+        activator.join(timeout=120)
+
+        # The in-flight write completed against the OLD canonical store...
+        assert slow_results == [True]
+        # ...and only then did activation flip the pointer.
+        assert act_result.get("success") is True, act_result.get("error")
+        assert _store_path(base) == base / act_result["generation"]
+
+    def test_unique_selector_tmp_no_shared_temp(
+        self, base, live_store, work_dir,
+    ):
+        """The selector temp is per-PID: two writers can never replace each
+        other's half-written pointer bytes."""
+        from tools.checkpoint_manager import _unique_selector_tmp
+        import os as _os
+
+        t1 = _unique_selector_tmp(base)
+        t2 = _unique_selector_tmp(base)
+        assert t1 == t2  # same process -> same temp (deterministic cleanup)
+        assert ".tmp" in t1.name and str(_os.getpid()) in t1.name
+        # A different PID maps to a different temp path.
+        old = _os.getpid
+        _os.getpid = lambda: 123456
+        try:
+            t3 = _unique_selector_tmp(base)
+        finally:
+            _os.getpid = old
+        assert t3 != t1
+
+
+class TestStoreLockContract:
+    def test_timeout_fails_closed(self, base):
+        """A lock held past the timeout surfaces an explicit error instead
+        of hanging forever."""
+        import threading
+
+        acquired = threading.Event()
+        release = threading.Event()
+        errors = []
+
+        def _holder():
+            try:
+                with _store_lock(base, "holder"):
+                    acquired.set()
+                    release.wait(timeout=180)
+            except Exception as exc:  # pragma: no cover
+                errors.append(exc)
+
+        holder = threading.Thread(target=_holder, daemon=True)
+        holder.start()
+        assert acquired.wait(timeout=30)
+
+        # Same-process flock would succeed on a NEW fd?  No: flock locks are
+        # per-open-file-description, so a second open in this process still
+        # conflicts — but to keep the test hermetic we shrink the timeout.
+        old_timeout = checkpoint_manager_mod._STORE_LOCK_TIMEOUT_S
+        checkpoint_manager_mod._STORE_LOCK_TIMEOUT_S = 0.2
+        try:
+            with pytest.raises(_StoreLockTimeout):
+                with _store_lock(base, "contender"):
+                    pass
+        finally:
+            checkpoint_manager_mod._STORE_LOCK_TIMEOUT_S = old_timeout
+            release.set()
+            holder.join(timeout=60)
+
+
+# =========================================================================
+# Review round 1 — blocker 2: verifier proves runtime-writable store
+# =========================================================================
+
+class TestStrongVerifier:
+    def test_rejects_stale_index_lock(self, live_store, work_dir, candidate):
+        """fsck-green + index.lock present -> activation refuses."""
+        indexes = candidate / "indexes"
+        indexes.mkdir(exist_ok=True)
+        (indexes / "index.lock").write_text("", encoding="utf-8")
+        err = _verify_store_generation(candidate, str(work_dir))
+        assert err is not None and "index lock" in err
+
+    def test_rejects_unwritable_store_for_runtime(
+        self, live_store, work_dir, candidate, tmp_path,
+    ):
+        """fsck clean but mode 0o500 -> activation refuses BEFORE any
+        pointer flip: a green fsck alone can hide an unwritable store."""
+        os.chmod(candidate, 0o500)
+        try:
+            err = _verify_store_generation(candidate, str(work_dir))
+            assert err is not None and (
+                "not readable/writable" in err or "Permission" in err
+            )
+            unused_base = tmp_path / "unused-base"
+            result = activate_store_generation(
+                candidate, checkpoint_base=unused_base, verify=True,
+            )
+            assert result["success"] is False
+            assert not list(unused_base.glob("store.*")) \
+                if unused_base.exists() else True
+        finally:
+            os.chmod(candidate, 0o755)
+
+    def test_accepts_coherent_generation(
+        self, base, live_store, work_dir, candidate, tmp_path, monkeypatch,
+    ):
+        """A real store with project metadata + ref + index verifies clean."""
+        monkeypatch.setattr(
+            "tools.checkpoint_manager.CHECKPOINT_BASE", base)
+        mgr = CheckpointManager(enabled=True)
+        assert mgr.ensure_checkpoint(str(work_dir), "populate") is True
+        populated = tmp_path / "populated_candidate"
+        shutil.copytree(base / "store", populated)
+        err = _verify_store_generation(populated, str(work_dir))
+        assert err is None, err
+
+    def test_rejects_metadata_without_ref(
+        self, base, live_store, work_dir, candidate,
+    ):
+        """projects/<hash>.json whose ref was lost must fail verification —
+        activating it would strand that project's checkpoints."""
+        orphan_hash = "0123456789abcdef01"
+        projects = candidate / "projects"
+        projects.mkdir(exist_ok=True)
+        (projects / f"{orphan_hash}.json").write_text(
+            json.dumps({"workdir": "/gone/project",
+                        "created_at": 0, "last_touch": 0}),
+            encoding="utf-8",
+        )
+        err = _verify_store_generation(candidate, str(work_dir))
+        assert err is not None and "no matching ref" in err

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -23,6 +23,10 @@ Storage layout (single shared store, git objects deduplicated across projects)
         .last_prune                     — auto-prune idempotency marker
         legacy-<timestamp>/             — archived pre-v2 per-project shadow
                                           repos (auto-migrated on first init)
+        store.current                   — OPTIONAL one-line pointer naming the
+                                          active generation (atomic activation)
+        store.YYYYMMDDTHHMMSSZ/         — OPTIONAL verified store generations;
+                                          the pointer decides which is live
 
 Why a single store?
 -------------------
@@ -78,6 +82,38 @@ _INDEXES_DIRNAME = "indexes"
 _PROJECTS_DIRNAME = "projects"
 _LEDGERS_DIRNAME = "ledgers"
 _LEGACY_PREFIX = "legacy-"
+
+# Atomic store activation (#93314): an optional pointer file naming the
+# active store *generation* — a verified sibling copy of the shared store.
+# Absent pointer = legacy behaviour (``store/`` is canonical).  The pointer
+# lets a repaired store be activated without moving/renaming the live
+# multi-gigabyte directory, which is exactly the operation that fails on
+# exotic filesystems (e.g. FUSE overlays).
+_STORE_SELECTOR_NAME = "store.current"
+# ``store.<UTC timestamp>`` — strict pattern, so the resolved target can never
+# escape the checkpoint base and legacy/migration sweeps can recognise our
+# generations by name alone.
+_GENERATION_NAME_RE = re.compile(r"^store\.\d{8}T\d{6}Z$")
+# Refuse further activations once this many generations exist: recovery
+# copies are operator-managed state, so growth must be an explicit decision
+# (dispose of old ones first), never silent disk creep.
+_MAX_STORE_GENERATIONS = 8
+
+
+class CheckpointStoreSelectorError(Exception):
+    """The ``store.current`` selector is present but not safely resolvable.
+
+    Raised instead of silently falling back to the legacy ``store/`` path:
+    a broken selector most likely means an interrupted or corrupted
+    activation of a repaired generation, and quietly re-pointing Hermes at
+    the (possibly damaged) legacy store would defeat the whole recovery.
+    Callers degrade to "checkpoints unavailable" rather than guess.
+    """
+
+
+def _is_generation_name(name: str) -> bool:
+    return bool(_GENERATION_NAME_RE.match(name))
+
 
 # Agent-write ledger cap: newest entries retained per project.
 _LEDGER_MAX_ENTRIES = 2000
@@ -208,9 +244,84 @@ def _project_hash(working_dir: str) -> str:
     return hashlib.sha256(abs_path.encode()).hexdigest()[:16]
 
 
+def _read_store_selector(base: Path) -> Optional[str]:
+    """Read the ``store.current`` pointer and return the generation name.
+
+    Returns ``None`` when the pointer is absent (legacy layout).  Raises
+    :class:`CheckpointStoreSelectorError` when the pointer exists but cannot
+    be trusted: wrong type (symlink/dir/unreadable), not exactly one strict
+    ``store.YYYYMMDDTHHMMSSZ`` token, or naming a missing/symlinked target.
+    """
+    selector = base / _STORE_SELECTOR_NAME
+    try:
+        # Symlink first: ``exists()``/``is_file()`` follow links, and a
+        # pointer must never be an alias into operator-chosen territory.
+        if selector.is_symlink():
+            raise CheckpointStoreSelectorError(
+                f"{selector} must be a regular file, not a symlink"
+            )
+        if not selector.exists():
+            return None
+        if not selector.is_file():
+            raise CheckpointStoreSelectorError(
+                f"{selector} must be a regular file"
+            )
+        raw = selector.read_text(encoding="utf-8")
+    except CheckpointStoreSelectorError:
+        raise
+    except OSError as exc:
+        raise CheckpointStoreSelectorError(
+            f"Cannot read store selector {selector}: {exc}"
+        ) from exc
+    name = raw.strip()
+    if not name or "\n" in name or "\r" in name:
+        raise CheckpointStoreSelectorError(
+            f"Store selector {selector} must contain exactly one generation name"
+        )
+    if not _is_generation_name(name):
+        raise CheckpointStoreSelectorError(
+            f"Store selector {selector} names {name!r}; expected a direct "
+            "generation directory named store.YYYYMMDDTHHMMSSZ"
+        )
+    target = base / name
+    # The strict pattern already pins ``name`` to ``store.<digits>`` shape,
+    # so ``target`` is always an immediate child of ``base``; re-verify the
+    # on-disk reality anyway — a generation is only selectable once it fully
+    # exists as a real directory (never mid-copy, never a symlink).
+    if target.is_symlink() or not target.is_dir():
+        raise CheckpointStoreSelectorError(
+            f"Store selector {selector} points to {target}, which is not an "
+            "existing direct generation directory"
+        )
+    return name
+
+
+def active_generation_name(base: Optional[Path] = None) -> Optional[str]:
+    """Return the active store generation, or None on the legacy layout.
+
+    Raises :class:`CheckpointStoreSelectorError` for an untrustworthy
+    selector — callers that merely want information may catch it.
+    """
+    b = base or CHECKPOINT_BASE
+    return _read_store_selector(b)
+
+
 def _store_path(base: Optional[Path] = None) -> Path:
-    """Return the single shared shadow store path."""
-    return (base or CHECKPOINT_BASE) / _STORE_DIRNAME
+    """Return the shared shadow store path for checkpoint operations.
+
+    With no ``store.current`` pointer this is the legacy fixed path
+    ``(base)/store`` — byte-for-byte the pre-#93314 behaviour.  When a
+    valid pointer exists, the named generation directory is returned so
+    every reader/writer/pruner transparently operates on the activated
+    generation.  An untrustworthy pointer raises
+    :class:`CheckpointStoreSelectorError` (fail closed): silently falling
+    back to the legacy store could resurrect a damaged generation.
+    """
+    b = base or CHECKPOINT_BASE
+    generation = _read_store_selector(b)
+    if generation is None:
+        return b / _STORE_DIRNAME
+    return b / generation
 
 
 def _shadow_repo_path(working_dir: str) -> Path:  # pragma: no cover — kept for BC
@@ -438,13 +549,16 @@ def _migrate_legacy_store(base: Path) -> Optional[Path]:
     """
     if not base.exists():
         return None
-    store = _store_path(base)
     legacy_root: Optional[Path] = None
-    # Reserved top-level entries managed by v2.
-    reserved = {_STORE_DIRNAME, _PRUNE_MARKER_NAME}
+    # Reserved top-level entries managed by v2.  ``store.current`` and
+    # generation dirs (``store.<ts>``) belong to the atomic-activation
+    # layout (#93314) — archiving either would orphan the activated store.
+    reserved = {_STORE_DIRNAME, _PRUNE_MARKER_NAME, _STORE_SELECTOR_NAME}
     for child in list(base.iterdir()):
         name = child.name
         if name in reserved or name.startswith(_LEGACY_PREFIX):
+            continue
+        if _is_generation_name(name):
             continue
         # Candidate: pre-v2 shadow repo (has HEAD) OR stray dir.  Either way
         # we archive it so v2 starts clean.
@@ -462,7 +576,6 @@ def _migrate_legacy_store(base: Path) -> Optional[Path]:
         except OSError as exc:
             logger.warning("Could not archive legacy checkpoint %s: %s", child, exc)
     # If the store still hasn't been created, create it here.
-    _ = store
     if legacy_root is not None:
         logger.info(
             "Migrated pre-v2 checkpoint repos to %s. "
@@ -670,6 +783,11 @@ def _pre_v2_shadow_repos(base: Path) -> List[Dict]:
             continue
         if child.name == _STORE_DIRNAME or child.name.startswith(_LEGACY_PREFIX):
             continue
+        # Activated store generations (#93314) are v2 shared stores, never
+        # pre-v2 per-project shadow repos — exclude them from the orphan
+        # scan so a generation is never offered for deletion.
+        if _is_generation_name(child.name):
+            continue
         if not (child / "HEAD").exists():
             continue
         workdir: Optional[str] = None
@@ -840,7 +958,10 @@ class CheckpointManager:
             return {"success": False, "error": hash_err}
 
         abs_dir = str(_normalize_path(working_dir))
-        store = _store_path(CHECKPOINT_BASE)
+        try:
+            store = _store_path(CHECKPOINT_BASE)
+        except CheckpointStoreSelectorError as exc:
+            return {"success": False, "error": f"Checkpoint store unavailable: {exc}"}
         if not (store / "HEAD").exists():
             return {"success": False, "error": "No checkpoints exist for this directory"}
 
@@ -930,7 +1051,11 @@ class CheckpointManager:
     def list_checkpoints(self, working_dir: str) -> List[Dict]:
         """List available checkpoints for a directory (most recent first)."""
         abs_dir = str(_normalize_path(working_dir))
-        store = _store_path(CHECKPOINT_BASE)
+        try:
+            store = _store_path(CHECKPOINT_BASE)
+        except CheckpointStoreSelectorError as exc:
+            logger.warning("Checkpoint list unavailable: %s", exc)
+            return []
 
         if not (store / "HEAD").exists():
             return []
@@ -977,7 +1102,11 @@ class CheckpointManager:
         entry carries the extra ``workdir`` key so callers can label which
         project a checkpoint belongs to.
         """
-        store = _store_path(CHECKPOINT_BASE)
+        try:
+            store = _store_path(CHECKPOINT_BASE)
+        except CheckpointStoreSelectorError as exc:
+            logger.warning("Checkpoint list unavailable: %s", exc)
+            return []
         if not (store / "HEAD").exists():
             return []
         results: List[Dict] = []
@@ -1011,7 +1140,10 @@ class CheckpointManager:
             return {"success": False, "error": hash_err}
 
         abs_dir = str(_normalize_path(working_dir))
-        store = _store_path(CHECKPOINT_BASE)
+        try:
+            store = _store_path(CHECKPOINT_BASE)
+        except CheckpointStoreSelectorError as exc:
+            return {"success": False, "error": f"Checkpoint store unavailable: {exc}"}
 
         if not (store / "HEAD").exists():
             return {"success": False, "error": "No checkpoints exist for this directory"}
@@ -1111,7 +1243,10 @@ class CheckpointManager:
             if path_err:
                 return {"success": False, "error": path_err}
 
-        store = _store_path(CHECKPOINT_BASE)
+        try:
+            store = _store_path(CHECKPOINT_BASE)
+        except CheckpointStoreSelectorError as exc:
+            return {"success": False, "error": f"Checkpoint store unavailable: {exc}"}
 
         if not (store / "HEAD").exists():
             return {"success": False, "error": "No checkpoints exist for this directory"}
@@ -1231,7 +1366,11 @@ class CheckpointManager:
 
     def _take(self, working_dir: str, reason: str) -> bool:
         """Take a snapshot.  Returns True on success."""
-        store = _store_path(CHECKPOINT_BASE)
+        try:
+            store = _store_path(CHECKPOINT_BASE)
+        except CheckpointStoreSelectorError as exc:
+            logger.warning("Checkpoint store unavailable: %s", exc)
+            return False
 
         err = _init_store(store, working_dir)
         if err:
@@ -1787,6 +1926,12 @@ def prune_checkpoints(
             continue
         if child.name == _STORE_DIRNAME:
             continue
+        # Activated store generations (#93314): never swept by name-based
+        # retention.  The ACTIVE generation holds live checkpoint data and
+        # even inactive ones are operator-managed recovery state — deleting
+        # a verified repaired copy on an mtime rule would defeat the point.
+        if _is_generation_name(child.name):
+            continue
         if child.name.startswith(_LEGACY_PREFIX):
             # Legacy archive: prune by dir mtime using same retention rule.
             if retention_days <= 0:
@@ -1856,7 +2001,15 @@ def prune_checkpoints(
             logger.warning("Failed to prune checkpoint repo %s: %s", child.name, exc)
 
     # --- v2 shared store: per-project ref pruning via metadata ---
-    store = _store_path(base)
+    try:
+        store = _store_path(base)
+    except CheckpointStoreSelectorError as exc:
+        # Broken pointer: skip v2 ref pruning entirely rather than prune
+        # against a guessed store.  Retention of legacy dirs above already
+        # ran; the error is surfaced via the returned counter and log.
+        logger.warning("checkpoint prune skipped: %s", exc)
+        result["errors"] += 1
+        return result
     if (store / "HEAD").exists():
         for meta in _list_projects(store):
             dir_hash = meta.get("_hash") or ""
@@ -2095,34 +2248,44 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
         "projects": [],
         "pre_v2_projects": [],
         "legacy_archives": [],
+        # Atomic activation (#93314): which generation the pointer selects
+        # (None = legacy ``store/``) and every generation present.
+        "active_generation": None,
+        "generations": [],
     }
     if not base.exists():
         return out
 
-    store = _store_path(base)
-    if store.exists():
-        out["store_size_bytes"] = _dir_size_bytes(store)
-        if (store / "HEAD").exists():
-            for meta in _list_projects(store):
-                dir_hash = meta.get("_hash") or ""
-                workdir = meta.get("workdir") or ""
-                ref = _ref_name(dir_hash)
-                ok, count_out, _ = _run_git(
-                    ["rev-list", "--count", ref], store, str(base),
-                    allowed_returncodes={128},
-                )
-                try:
-                    commits = int(count_out) if ok else 0
-                except ValueError:
-                    commits = 0
-                out["projects"].append({
-                    "hash": dir_hash,
-                    "workdir": workdir,
-                    "exists": bool(workdir) and Path(workdir).exists(),
-                    "created_at": meta.get("created_at"),
-                    "last_touch": meta.get("last_touch"),
-                    "commits": commits,
-                })
+    try:
+        out["active_generation"] = _read_store_selector(base)
+        store = _store_path(base)
+    except CheckpointStoreSelectorError as exc:
+        out["selector_error"] = str(exc)
+        # Informational surface: still report sizes, anchored on the legacy
+        # layout, so operators can see enough to repair the pointer.
+        store = base / _STORE_DIRNAME
+    out["store_size_bytes"] = _dir_size_bytes(store)
+    if (store / "HEAD").exists():
+        for meta in _list_projects(store):
+            dir_hash = meta.get("_hash") or ""
+            workdir = meta.get("workdir") or ""
+            ref = _ref_name(dir_hash)
+            ok, count_out, _ = _run_git(
+                ["rev-list", "--count", ref], store, str(base),
+                allowed_returncodes={128},
+            )
+            try:
+                commits = int(count_out) if ok else 0
+            except ValueError:
+                commits = 0
+            out["projects"].append({
+                "hash": dir_hash,
+                "workdir": workdir,
+                "exists": bool(workdir) and Path(workdir).exists(),
+                "created_at": meta.get("created_at"),
+                "last_touch": meta.get("last_touch"),
+                "commits": commits,
+            })
     out["project_count"] = len(out["projects"])
 
     out["pre_v2_projects"] = [
@@ -2150,6 +2313,22 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
                 "size_bytes": size,
                 "mtime": mt,
             })
+
+    # Generations present under base (active one first).  These are the
+    # operator-managed recovery copies from atomic activation (#93314);
+    # surfacing them here is what lets an operator (or recovery wrapper)
+    # see what can be activated or disposed of — Hermes itself never
+    # deletes them.
+    generations: List[Dict] = []
+    for child in base.iterdir():
+        if child.is_dir() and _is_generation_name(child.name):
+            generations.append({
+                "name": child.name,
+                "size_bytes": _dir_size_bytes(child),
+                "is_active": bool(out["active_generation"])
+                and child.name == out["active_generation"],
+            })
+    out["generations"] = sorted(generations, key=lambda g: g["name"], reverse=True)
 
     out["total_size_bytes"] = _dir_size_bytes(base)
     return out
@@ -2193,4 +2372,296 @@ def clear_legacy(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
             out["deleted"] += 1
         except OSError as exc:
             logger.warning("Could not delete legacy archive %s: %s", child, exc)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Atomic store activation (#93314)
+#
+# Recovery gap: a repaired candidate store could only be activated by
+# renaming/replacing the live ``store/`` directory — a non-atomic,
+# often-failing operation on FUSE/network filesystems, with a window where
+# the canonical path simply does not exist.  Instead, a fully verified
+# sibling *generation* (``store.<UTC ts>``) is activated by flipping one
+# small pointer file (``store.current``) with tmp-write + fsync +
+# ``os.replace`` + parent-dir fsync.  Neither the live store nor any
+# generation is ever moved, overwritten, or deleted by activation, and a
+# failed flip leaves either the old or the new state valid and resolvable.
+# ---------------------------------------------------------------------------
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Best-effort fsync of a directory entry (POSIX; no-op failure elsewhere).
+
+    Makes the just-replaced pointer durable across power loss.  Windows
+    cannot open directory fds here — atomicity still comes from
+    ``os.replace``; this only narrows the durability window.
+    """
+    try:
+        fd = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _write_store_selector(base: Path, generation: Optional[str]) -> None:
+    """Atomically point ``store.current`` at ``generation`` (or clear it).
+
+    ``generation=None`` removes the pointer, restoring the legacy layout.
+    Single-syscall ``os.replace``/unlink flip: readers see either the
+    previous or the next selection, never absence-of-file semantics they
+    did not choose.
+    """
+    pointer = base / _STORE_SELECTOR_NAME
+    if generation is None:
+        try:
+            pointer.unlink()
+        except FileNotFoundError:
+            return
+        _fsync_directory(base)
+        return
+    tmp = base / f".{_STORE_SELECTOR_NAME}.tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(generation)
+        fh.flush()
+        os.fsync(fh.fileno())
+    try:
+        os.replace(tmp, pointer)
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    _fsync_directory(base)
+
+
+def _verify_store_generation(store: Path, working_dir: str) -> Optional[str]:
+    """Sanity-check a generation directory. Returns error string or None."""
+    if store.is_symlink() or not store.is_dir():
+        return f"{store} is not a real directory"
+    if not (store / "HEAD").exists():
+        return f"{store} has no HEAD file — not an initialised git store"
+
+    # Isolated-config env (same isolation as every other bare git call):
+    # user global/system config must not influence verification, and fsck
+    # must never be able to prompt.
+    from tools.environments.local import build_subprocess_env
+
+    env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+    env["GIT_DIR"] = str(store)
+    for var in ("GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_NAMESPACE",
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES"):
+        env.pop(var, None)
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    try:
+        result = subprocess.run(
+            ["git", "fsck", "--full"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            env=env, timeout=_GIT_TIMEOUT * 4,
+            cwd=working_dir,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+    except subprocess.TimeoutExpired:
+        return f"git fsck timed out on {store}"
+    except FileNotFoundError:
+        return "git executable not found"
+    except Exception as exc:  # pragma: no cover — defensive
+        return f"git fsck failed unexpectedly: {exc}"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        return f"git fsck rejected {store}: {detail[:500]}"
+    # Strict pass: dangling-object chatter is normal for a live store, but
+    # the operator's recovery flow demands a *strictly* clean structure
+    # before a candidate becomes canonical (#93314 acceptance criteria).
+    try:
+        strict = subprocess.run(
+            ["git", "fsck", "--full", "--strict", "--no-progress"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            env=env, timeout=_GIT_TIMEOUT * 4,
+            cwd=working_dir,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+    except subprocess.TimeoutExpired:
+        return f"git fsck --strict timed out on {store}"
+    except Exception as exc:  # pragma: no cover — defensive
+        return f"git fsck --strict failed unexpectedly: {exc}"
+    if strict.returncode != 0:
+        detail = (strict.stderr or strict.stdout or "").strip()
+        return f"git fsck --strict rejected {store}: {detail[:500]}"
+    return None
+
+
+def activate_store_generation(
+    generation_source: Path,
+    checkpoint_base: Optional[Path] = None,
+    verify: bool = True,
+) -> Dict[str, object]:
+    """Activate a verified store copy as the canonical checkpoint store.
+
+    Copies ``generation_source`` (an offline-repaired store candidate) into
+    a new sibling generation ``store.<UTC ts>``, verifies the copy, then
+    flips ``store.current`` to select it — one atomic metadata write, no
+    rename of the live store, deterministic rollback (re-run activation on
+    another candidate, or :func:`deactivate_store_generation`).  Neither
+    the live store nor any generation is moved or deleted.
+
+    Fails closed *before* touching the pointer when anything is off:
+    unreadable/broken current selector, source identical to the live
+    store, copy failure, or verification failure.  In those cases the
+    previous selection stays authoritative and any partial copy is removed.
+
+    Note: file contents, permissions and timestamps are copied verbatim;
+    file *ownership* follows the invoking user (Python cannot chown
+    without privileges) — run the recovery tool as the store owner when
+    that matters (containers: same uid as Hermes).
+
+    Returns ``{"success": bool, ...}``; on success ``generation`` names the
+    activated copy and ``previous`` the prior selection (None = legacy).
+    """
+    base = checkpoint_base or CHECKPOINT_BASE
+    src = Path(generation_source)
+    out: Dict[str, object] = {
+        "success": False,
+        "generation": None,
+        "previous": None,
+        "store": None,
+    }
+
+    # Anchor the rollback state FIRST: a present-but-untrustworthy selector
+    # must block activation rather than be silently replaced.
+    try:
+        previous = _read_store_selector(base)
+    except CheckpointStoreSelectorError:
+        # Current selection exists but cannot be trusted — record it as
+        # unknown; the guard below refuses to overwrite it.
+        previous = None
+    out["previous"] = previous
+    if base.exists() and (base / _STORE_SELECTOR_NAME).exists() \
+            and previous is None:
+        out["error"] = (
+            f"Refusing activation: {base / _STORE_SELECTOR_NAME} exists but "
+            "cannot be trusted — fix or remove it manually first."
+        )
+        return out
+
+    if src.is_symlink() or not src.is_dir():
+        out["error"] = f"Generation source {src} is not a real directory"
+        return out
+
+    # Never re-activate the store that is currently serving traffic.
+    try:
+        current = _store_path(base)
+        if src.resolve() == current.resolve():
+            out["error"] = (
+                f"Refusing activation: {src} is the currently active store"
+            )
+            return out
+    except CheckpointStoreSelectorError as exc:
+        out["error"] = f"Cannot determine the active store: {exc}"
+        return out
+
+    if not base.exists():
+        try:
+            base.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            out["error"] = f"Could not create checkpoint base {base}: {exc}"
+            return out
+
+    # Bounded retention: refuse to grow past the generation cap instead of
+    # silently accumulating multi-gigabyte recovery copies. The operator
+    # disposes of old generations first, then retries.
+    existing = [p.name for p in base.iterdir() if _is_generation_name(p.name)]
+    if len(existing) >= _MAX_STORE_GENERATIONS:
+        out["error"] = (
+            f"Refusing activation: {_MAX_STORE_GENERATIONS} store "
+            "generations already exist — dispose of old ones first "
+            f"(present: {', '.join(sorted(existing))})."
+        )
+        return out
+
+    # Pick a free generation stamp (bump seconds on collisions instead of
+    # suffixing — names must stay inside the strict store.<ts> pattern).
+    gen_name = ""
+    for attempt in range(60):
+        candidate = "store." + time.strftime(
+            "%Y%m%dT%H%M%SZ", time.gmtime(time.time() + attempt),
+        )
+        if not (base / candidate).exists():
+            gen_name = candidate
+            break
+    if not gen_name:
+        out["error"] = "No free generation name under " + str(base)
+        return out
+    target = base / gen_name
+
+    # Copy WITHOUT touching the source; a failed/incomplete copy is never
+    # referenced by the pointer, so it can never be selected.
+    try:
+        shutil.copytree(src, target, symlinks=True)
+    except OSError as exc:
+        out["error"] = f"Copy {src} -> {target} failed: {exc}"
+        shutil.rmtree(target, ignore_errors=True)
+        return out
+
+    if verify:
+        err = _verify_store_generation(target, str(base))
+        if err:
+            out["error"] = err
+            shutil.rmtree(target, ignore_errors=True)
+            return out
+
+    try:
+        _write_store_selector(base, gen_name)
+    except OSError as exc:
+        out["error"] = f"Pointer update failed ({exc}); previous state kept"
+        shutil.rmtree(target, ignore_errors=True)
+        return out
+
+    logger.warning(
+        "Checkpoint store generation %s activated (previous selection: %s)",
+        gen_name, previous or "legacy store/",
+    )
+    out.update({
+        "success": True,
+        "generation": gen_name,
+        "store": str(target),
+    })
+    return out
+
+
+def deactivate_store_generation(
+    checkpoint_base: Optional[Path] = None,
+) -> Dict[str, object]:
+    """Atomically restore the legacy ``store/`` as the canonical store.
+
+    Removes the ``store.current`` pointer after confirming the legacy store
+    actually exists and is initialised — deactivating onto a missing or
+    half-built legacy store would trade a known state for a worse one.
+    Generations are left untouched for later disposal by the operator.
+    """
+    base = checkpoint_base or CHECKPOINT_BASE
+    out: Dict[str, object] = {"success": False}
+    legacy = base / _STORE_DIRNAME
+    if not (legacy / "HEAD").exists():
+        out["error"] = (
+            f"Refusing deactivation: legacy store {legacy} has no HEAD — "
+            "there is no healthy store to fall back to."
+        )
+        return out
+    try:
+        _write_store_selector(base, None)
+    except OSError as exc:
+        out["error"] = f"Could not remove store selector: {exc}"
+        return out
+    out["success"] = True
     return out

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -60,6 +60,11 @@ import re
 import shutil
 import subprocess
 import time
+import contextlib
+try:  # POSIX: real advisory locks; Windows falls back to O_EXCL spin below
+    import fcntl
+except ImportError:  # pragma: no cover — Windows
+    fcntl = None  # type: ignore[assignment]
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -552,8 +557,11 @@ def _migrate_legacy_store(base: Path) -> Optional[Path]:
     legacy_root: Optional[Path] = None
     # Reserved top-level entries managed by v2.  ``store.current`` and
     # generation dirs (``store.<ts>``) belong to the atomic-activation
-    # layout (#93314) — archiving either would orphan the activated store.
-    reserved = {_STORE_DIRNAME, _PRUNE_MARKER_NAME, _STORE_SELECTOR_NAME}
+    # layout (#93314); ``.store.lock`` is the interprocess authority file —
+    # archiving ANY of these would break live coordination (a lock holder
+    # would keep guarding a moved file while newcomers create a fresh one).
+    reserved = {_STORE_DIRNAME, _PRUNE_MARKER_NAME, _STORE_SELECTOR_NAME,
+                _STORE_LOCK_NAME}
     for child in list(base.iterdir()):
         name = child.name
         if name in reserved or name.startswith(_LEGACY_PREFIX):
@@ -919,14 +927,28 @@ class CheckpointManager:
     # ------------------------------------------------------------------
 
     def record_agent_write(self, file_path: str) -> None:
+        """Record an agent write under the store authority (blocker 1).
+
+        Never raises — the ledger is best-effort bookkeeping, and a busy or
+        unavailable store lock only means this hash is not recorded.
+        """
+        if not self.enabled:
+            return
+        try:
+            with _store_lock(CHECKPOINT_BASE, "agent-write ledger"):
+                self.record_agent_write_locked(file_path)
+        except Exception as exc:
+            logger.debug("record_agent_write failed for %s: %s", file_path, exc)
+
+    def record_agent_write_locked(self, file_path: str) -> None:
         """Record the content hash of a file Hermes just successfully wrote.
+
+        Caller holds the store lock.
 
         Feeds the agent-write ledger used by :meth:`restore` in safe mode:
         at restore time, a file whose current content no longer matches the
         recorded hash was hand-edited by the user after Hermes last touched
         it, and is skipped instead of clobbered.
-
-        Never raises — the ledger is best-effort bookkeeping.
         """
         if not self.enabled:
             return
@@ -945,13 +967,27 @@ class CheckpointManager:
             logger.debug("record_agent_write failed for %s: %s", file_path, exc)
 
     def safe_restore_plan(self, working_dir: str, commit_hash: str) -> Dict:
+        """Classify safe-restore targets under the store authority."""
+        try:
+            with _store_lock(CHECKPOINT_BASE, "safe-restore plan"):
+                return self.safe_restore_plan_locked(working_dir, commit_hash)
+        except _StoreLockTimeout as exc:
+            return {"success": False, "error": str(exc)}
+        except OSError as exc:
+            return {"success": False,
+                    "error": f"Checkpoint store lock unavailable: {exc}"}
+
+    def safe_restore_plan_locked(
+        self, working_dir: str, commit_hash: str,
+    ) -> Dict:
         """Classify files changed since ``commit_hash`` for a safe restore.
 
-        Returns ``{"success", "restore": [rel...], "skipped": [rel...],
-        "error"?}`` where ``restore`` lists files whose current content
-        still matches what Hermes last wrote (per the agent-write ledger)
-        and ``skipped`` lists files the user hand-edited after Hermes'
-        last write or that Hermes never wrote at all.
+        Caller holds the store lock.  Returns ``{"success", "restore":
+        [rel...], "skipped": [rel...], "error"?}`` where ``restore`` lists
+        files whose current content still matches what Hermes last wrote
+        (per the agent-write ledger) and ``skipped`` lists files the user
+        hand-edited after Hermes' last write or that Hermes never wrote at
+        all.
         """
         hash_err = _validate_commit_hash(commit_hash)
         if hash_err:
@@ -1222,7 +1258,32 @@ class CheckpointManager:
         self,
         working_dir: str,
         commit_hash: str,
-        file_path: str = None,
+        file_path: Optional[str] = None,
+        safe: bool = False,
+    ) -> Dict:
+        """Restore files under the store-generation authority (blocker 1).
+
+        Holding the interprocess store lock across the restore prevents an
+        activation from flipping ``store.current`` between reading a
+        checkpoint and checking it out — the restore reads and writes one
+        coherent generation.
+        """
+        try:
+            with _store_lock(CHECKPOINT_BASE, "checkpoint restore"):
+                return self.restore_locked(
+                    working_dir, commit_hash, file_path=file_path, safe=safe,
+                )
+        except _StoreLockTimeout as exc:
+            return {"success": False, "error": str(exc)}
+        except OSError as exc:
+            return {"success": False,
+                    "error": f"Checkpoint store lock unavailable: {exc}"}
+
+    def restore_locked(
+        self,
+        working_dir: str,
+        commit_hash: str,
+        file_path: Optional[str] = None,
         safe: bool = False,
     ) -> Dict:
         """Restore files to a checkpoint state.
@@ -1261,7 +1322,9 @@ class CheckpointManager:
         skipped_user_edits: List[str] = []
         restore_paths: Optional[List[str]] = None
         if safe and not file_path:
-            plan = self.safe_restore_plan(abs_dir, commit_hash)
+            # Locked variant: we already hold the store lock — re-acquiring
+            # it here would deadlock against ourselves.
+            plan = self.safe_restore_plan_locked(abs_dir, commit_hash)
             if not plan.get("success"):
                 return {"success": False, "error": plan.get("error", "Safe-restore plan failed")}
             if plan.get("ledger_empty"):
@@ -1282,7 +1345,10 @@ class CheckpointManager:
                     }
 
         # Take a pre-rollback snapshot so you can undo the undo.
-        self._take(abs_dir, f"pre-rollback snapshot (restoring to {commit_hash[:8]})")
+        # Locked variant: we already hold the store lock — going through
+        # self._take() would re-acquire it and self-deadlock (flock
+        # conflicts across file descriptors even within one process).
+        self._take_locked(abs_dir, f"pre-rollback snapshot (restoring to {commit_hash[:8]})")
 
         dir_hash = _project_hash(abs_dir)
         index_file = _index_path(store, dir_hash)
@@ -1365,7 +1431,26 @@ class CheckpointManager:
     # ------------------------------------------------------------------
 
     def _take(self, working_dir: str, reason: str) -> bool:
-        """Take a snapshot.  Returns True on success."""
+        """Take a snapshot while holding the store-generation authority.
+
+        The interprocess lock guarantees the resolved store path stays
+        canonical for the whole snapshot: activation cannot flip
+        ``store.current`` mid-write, so no successful checkpoint is ever
+        stranded in a generation that is about to stop being canonical
+        (review blocker 1, second half).
+        """
+        try:
+            with _store_lock(CHECKPOINT_BASE, "checkpoint write"):
+                return self._take_locked(working_dir, reason)
+        except _StoreLockTimeout as exc:
+            logger.warning("Checkpoint skipped: %s", exc)
+            return False
+        except OSError as exc:
+            logger.debug("Checkpoint lock unavailable (non-fatal): %s", exc)
+            return False
+
+    def _take_locked(self, working_dir: str, reason: str) -> bool:
+        """Take a snapshot.  Returns True on success.  Caller holds the lock."""
         try:
             store = _store_path(CHECKPOINT_BASE)
         except CheckpointStoreSelectorError as exc:
@@ -1869,7 +1954,45 @@ def prune_checkpoints(
     max_total_size_mb: int = 0,
     orphan_allowlist: Optional[set] = None,
 ) -> Dict[str, int]:
+    """Prune checkpoints under the store-generation authority (blocker 1).
+
+    Holding the interprocess store lock keeps ref deletion and GC from
+    racing an activation or a live checkpoint write.
+    """
+    base = checkpoint_base or CHECKPOINT_BASE
+    try:
+        with _store_lock(base, "checkpoint prune"):
+            return _prune_checkpoints_locked(
+                retention_days=retention_days,
+                delete_orphans=delete_orphans,
+                checkpoint_base=base,
+                max_total_size_mb=max_total_size_mb,
+                orphan_allowlist=orphan_allowlist,
+            )
+    except _StoreLockTimeout as exc:
+        logger.warning("checkpoint prune skipped: %s", exc)
+        return {
+            "scanned": 0, "deleted_orphan": 0, "deleted_stale": 0,
+            "errors": 1, "bytes_freed": 0,
+        }
+    except OSError as exc:
+        logger.warning("checkpoint prune skipped: %s", exc)
+        return {
+            "scanned": 0, "deleted_orphan": 0, "deleted_stale": 0,
+            "errors": 1, "bytes_freed": 0,
+        }
+
+
+def _prune_checkpoints_locked(
+    retention_days: int = 7,
+    delete_orphans: bool = True,
+    checkpoint_base: Optional[Path] = None,
+    max_total_size_mb: int = 0,
+    orphan_allowlist: Optional[set] = None,
+) -> Dict[str, int]:
     """Delete stale/orphan checkpoints and reclaim store space.
+
+    Caller holds the store lock.
 
     A project entry is deleted when either:
 
@@ -2409,6 +2532,110 @@ def _fsync_directory(directory: Path) -> None:
         os.close(fd)
 
 
+class _StoreLockTimeout(RuntimeError):
+    """Another process held the checkpoint-store authority too long."""
+
+
+_STORE_LOCK_NAME = ".store.lock"
+_STORE_LOCK_TIMEOUT_S = 120
+
+
+@contextlib.contextmanager
+def _store_lock(base: Path, purpose: str):
+    """Serialize checkpoint operations across processes (review blocker 1).
+
+    One advisory lock file per checkpoint base guards *every* transition
+    that reads or flips the ``store.current`` selector — activation,
+    deactivation, and each resolved-store checkpoint operation.  This makes
+    the generation pointer a real interprocess authority instead of an
+    unsynchronized file two racers can flip concurrently, and it closes the
+    activation-vs-writer race where an in-flight checkpoint keeps committing
+    to a store path while activation re-points subsequent operations.
+
+    POSIX uses ``fcntl.flock`` (auto-released on process death); Windows has
+    no equivalent unlockable-then-readable lock, so a stale ``O_EXCL`` lock
+    older than ``_STORE_LOCK_TIMEOUT_S`` is considered dead and stolen.
+    """
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / _STORE_LOCK_NAME
+    deadline = time.monotonic() + _STORE_LOCK_TIMEOUT_S
+    fd = None
+    try:
+        while True:
+            if fcntl is not None:
+                fd = os.open(str(path), os.O_RDWR | os.O_CREAT, 0o644)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break  # acquired
+                except OSError:
+                    os.close(fd)
+                    fd = None
+            else:
+                try:
+                    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                                 0o644)
+                    break  # acquired (O_EXCL won the race)
+                except FileExistsError:
+                    fd = None
+                    try:
+                        age = time.time() - path.stat().st_mtime
+                        if age > _STORE_LOCK_TIMEOUT_S:
+                            # Stale lock from a crashed holder — steal it.
+                            path.unlink(missing_ok=True)
+                            continue
+                    except FileNotFoundError:
+                        pass
+                except OSError:
+                    fd = None
+            if time.monotonic() >= deadline:
+                raise _StoreLockTimeout(
+                    f"checkpoint store busy ({purpose}): another process "
+                    f"holds {path}"
+                )
+            time.sleep(0.05)
+        yield
+    finally:
+        if fd is not None:
+            try:
+                if fcntl is not None:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+
+def _unique_selector_tmp(base: Path) -> Path:
+    """Same-directory temp file unique to this writer (no shared tmp race).
+
+    Two concurrent activations writing one shared ``.store.current.tmp``
+    could each ``os.replace()`` the other's half-written content; per-PID
+    temps make every replace move only bytes this process wrote.
+    """
+    return base / f".{_STORE_SELECTOR_NAME}.{os.getpid()}.tmp"
+
+
+def _force_rmtree(path: Path) -> None:
+    """Best-effort recursive delete that tolerates read-only entries.
+
+    A rejected candidate can itself carry read-only modes (copystat
+    preserves them), which would leave a stranded partial copy under a
+    plain ``rmtree``; restore writability bottom-up before deleting.
+    """
+    try:
+        if path.exists():
+            for child in sorted(path.rglob("*"), reverse=True):
+                try:
+                    child.chmod(0o700)
+                except OSError:
+                    pass
+            try:
+                path.chmod(0o700)
+            except OSError:
+                pass
+    except OSError:
+        pass
+    shutil.rmtree(path, ignore_errors=True)
+
+
 def _write_store_selector(base: Path, generation: Optional[str]) -> None:
     """Atomically point ``store.current`` at ``generation`` (or clear it).
 
@@ -2425,7 +2652,7 @@ def _write_store_selector(base: Path, generation: Optional[str]) -> None:
             return
         _fsync_directory(base)
         return
-    tmp = base / f".{_STORE_SELECTOR_NAME}.tmp"
+    tmp = _unique_selector_tmp(base)
     with open(tmp, "w", encoding="utf-8") as fh:
         fh.write(generation)
         fh.flush()
@@ -2442,11 +2669,39 @@ def _write_store_selector(base: Path, generation: Optional[str]) -> None:
 
 
 def _verify_store_generation(store: Path, working_dir: str) -> Optional[str]:
-    """Sanity-check a generation directory. Returns error string or None."""
+    """Prove a candidate generation is a *runtime-writable* store (blocker 2).
+
+    Beyond git object integrity (``fsck``), verifies what #93314's
+    acceptance contract demands before the pointer may flip:
+
+    * real directory (no symlink) with ``HEAD``;
+    * per-project coherence — every ``projects/<hash>.json`` has its ref
+      present and its index file loadable as a git index;
+    * no live/stale ``index.lock`` anywhere under ``indexes/``;
+    * ownership/write access for the invoking principal — ``copytree``
+      preserves permission bits but NOT ownership, so an activation run as
+      root would otherwise hand Hermes a green-fsck store it cannot write.
+
+    Returns error string or None.
+    """
     if store.is_symlink() or not store.is_dir():
         return f"{store} is not a real directory"
     if not (store / "HEAD").exists():
         return f"{store} has no HEAD file — not an initialised git store"
+    if not os.access(store, os.R_OK | os.W_OK | os.X_OK):
+        return (
+            f"{store} is not readable/writable/executable by the current "
+            "user — activation would hand the runtime an unusable store "
+            "(copytree preserves modes but not ownership; run recovery as "
+            "the same uid as Hermes)."
+        )
+    indexes_dir = store / _INDEXES_DIRNAME
+    if indexes_dir.exists():
+        for lock in indexes_dir.rglob("index.lock"):
+            return (
+                f"stale/live index lock present: {lock} — another git "
+                "process may still hold the candidate store"
+            )
 
     # Isolated-config env (same isolation as every other bare git call):
     # user global/system config must not influence verification, and fsck
@@ -2461,15 +2716,19 @@ def _verify_store_generation(store: Path, working_dir: str) -> Optional[str]:
     env["GIT_CONFIG_GLOBAL"] = os.devnull
     env["GIT_CONFIG_SYSTEM"] = os.devnull
     env["GIT_CONFIG_NOSYSTEM"] = "1"
-    try:
-        result = subprocess.run(
-            ["git", "fsck", "--full"],
+
+    def _git(args: List[str], timeout: int = _GIT_TIMEOUT * 4) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args],
             capture_output=True, text=True, encoding="utf-8", errors="replace",
-            env=env, timeout=_GIT_TIMEOUT * 4,
+            env=env, timeout=timeout,
             cwd=working_dir,
             stdin=subprocess.DEVNULL,
             creationflags=windows_hide_flags(),
         )
+
+    try:
+        result = _git(["fsck", "--full"])
     except subprocess.TimeoutExpired:
         return f"git fsck timed out on {store}"
     except FileNotFoundError:
@@ -2483,14 +2742,7 @@ def _verify_store_generation(store: Path, working_dir: str) -> Optional[str]:
     # the operator's recovery flow demands a *strictly* clean structure
     # before a candidate becomes canonical (#93314 acceptance criteria).
     try:
-        strict = subprocess.run(
-            ["git", "fsck", "--full", "--strict", "--no-progress"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            env=env, timeout=_GIT_TIMEOUT * 4,
-            cwd=working_dir,
-            stdin=subprocess.DEVNULL,
-            creationflags=windows_hide_flags(),
-        )
+        strict = _git(["fsck", "--full", "--strict", "--no-progress"])
     except subprocess.TimeoutExpired:
         return f"git fsck --strict timed out on {store}"
     except Exception as exc:  # pragma: no cover — defensive
@@ -2498,6 +2750,45 @@ def _verify_store_generation(store: Path, working_dir: str) -> Optional[str]:
     if strict.returncode != 0:
         detail = (strict.stderr or strict.stdout or "").strip()
         return f"git fsck --strict rejected {store}: {detail[:500]}"
+
+    # Per-project metadata/ref/index coherence (#93314 acceptance contract):
+    # a generation whose project bookkeeping disagrees with its refs would
+    # activate green and fail on first use.
+    for meta in _list_projects(store):
+        dir_hash = meta.get("_hash") or ""
+        if not dir_hash:
+            return "projects/ contains an entry without a usable hash"
+        ok, _, err = _run_git(
+            ["rev-parse", "--verify", "--quiet", _ref_name(dir_hash)],
+            store, working_dir,
+        )
+        if not ok:
+            return (
+                f"project metadata {dir_hash} has no matching ref "
+                f"{_ref_name(dir_hash)} ({(err or 'ref missing').strip()[:200]})"
+            )
+        idx = _index_path(store, dir_hash)
+        if idx.exists():
+            env_idx = dict(env)
+            env_idx["GIT_INDEX_FILE"] = str(idx)
+            try:
+                chk = subprocess.run(
+                    ["git", "ls-files", "--cached"],
+                    capture_output=True, text=True, encoding="utf-8",
+                    errors="replace", env=env_idx, timeout=_GIT_TIMEOUT,
+                    cwd=working_dir, stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
+                )
+            except subprocess.TimeoutExpired:
+                return f"index check timed out for project {dir_hash}"
+            except Exception as exc:  # pragma: no cover — defensive
+                return f"index check failed for project {dir_hash}: {exc}"
+            if chk.returncode != 0:
+                detail = (chk.stderr or chk.stdout or "").strip()
+                return (
+                    f"index for project {dir_hash} is unreadable/corrupt: "
+                    f"{detail[:300]}"
+                )
     return None
 
 
@@ -2506,7 +2797,13 @@ def activate_store_generation(
     checkpoint_base: Optional[Path] = None,
     verify: bool = True,
 ) -> Dict[str, object]:
-    """Activate a verified store copy as the canonical checkpoint store.
+    """Activate a verified store copy under the generation authority.
+
+    Holding the interprocess store lock across the whole copy → verify →
+    flip sequence makes activation atomic for *all* callers, not just one:
+    two concurrent activations serialize, and an activation can never race
+    a live checkpoint write that holds a resolved store path (review
+    blocker 1).
 
     Copies ``generation_source`` (an offline-repaired store candidate) into
     a new sibling generation ``store.<UTC ts>``, verifies the copy, then
@@ -2522,13 +2819,32 @@ def activate_store_generation(
 
     Note: file contents, permissions and timestamps are copied verbatim;
     file *ownership* follows the invoking user (Python cannot chown
-    without privileges) — run the recovery tool as the store owner when
-    that matters (containers: same uid as Hermes).
+    without privileges).  Verification refuses to hand over a store the
+    invoking principal cannot write — run the recovery tool as the store
+    owner when that matters (containers: same uid as Hermes).
 
     Returns ``{"success": bool, ...}``; on success ``generation`` names the
     activated copy and ``previous`` the prior selection (None = legacy).
     """
     base = checkpoint_base or CHECKPOINT_BASE
+    try:
+        with _store_lock(base, "store activation"):
+            return _activate_store_generation_locked(
+                generation_source, base, verify=verify,
+            )
+    except _StoreLockTimeout as exc:
+        return {"success": False, "error": str(exc)}
+    except OSError as exc:
+        return {"success": False,
+                "error": f"Checkpoint store lock unavailable: {exc}"}
+
+
+def _activate_store_generation_locked(
+    generation_source: Path,
+    base: Path,
+    verify: bool = True,
+) -> Dict[str, object]:
+    """Activation body.  Caller holds the store lock."""
     src = Path(generation_source)
     out: Dict[str, object] = {
         "success": False,
@@ -2610,21 +2926,21 @@ def activate_store_generation(
         shutil.copytree(src, target, symlinks=True)
     except OSError as exc:
         out["error"] = f"Copy {src} -> {target} failed: {exc}"
-        shutil.rmtree(target, ignore_errors=True)
+        _force_rmtree(target)
         return out
 
     if verify:
         err = _verify_store_generation(target, str(base))
         if err:
             out["error"] = err
-            shutil.rmtree(target, ignore_errors=True)
+            _force_rmtree(target)
             return out
 
     try:
         _write_store_selector(base, gen_name)
     except OSError as exc:
         out["error"] = f"Pointer update failed ({exc}); previous state kept"
-        shutil.rmtree(target, ignore_errors=True)
+        _force_rmtree(target)
         return out
 
     logger.warning(
@@ -2644,6 +2960,9 @@ def deactivate_store_generation(
 ) -> Dict[str, object]:
     """Atomically restore the legacy ``store/`` as the canonical store.
 
+    Runs under the store-generation authority so a concurrent activation
+    cannot interleave with the pointer removal (blocker 1).
+
     Removes the ``store.current`` pointer after confirming the legacy store
     actually exists and is initialised — deactivating onto a missing or
     half-built legacy store would trade a known state for a worse one.
@@ -2651,17 +2970,25 @@ def deactivate_store_generation(
     """
     base = checkpoint_base or CHECKPOINT_BASE
     out: Dict[str, object] = {"success": False}
-    legacy = base / _STORE_DIRNAME
-    if not (legacy / "HEAD").exists():
-        out["error"] = (
-            f"Refusing deactivation: legacy store {legacy} has no HEAD — "
-            "there is no healthy store to fall back to."
-        )
-        return out
     try:
-        _write_store_selector(base, None)
-    except OSError as exc:
-        out["error"] = f"Could not remove store selector: {exc}"
+        with _store_lock(base, "store deactivation"):
+            legacy = base / _STORE_DIRNAME
+            if not (legacy / "HEAD").exists():
+                out["error"] = (
+                    f"Refusing deactivation: legacy store {legacy} has no HEAD — "
+                    "there is no healthy store to fall back to."
+                )
+                return out
+            try:
+                _write_store_selector(base, None)
+            except OSError as exc:
+                out["error"] = f"Could not remove store selector: {exc}"
+                return out
+            out["success"] = True
+            return out
+    except _StoreLockTimeout as exc:
+        out["error"] = str(exc)
         return out
-    out["success"] = True
-    return out
+    except OSError as exc:
+        out["error"] = f"Checkpoint store lock unavailable: {exc}"
+        return out

--- a/website/docs/user-guide/checkpoints-and-rollback.md
+++ b/website/docs/user-guide/checkpoints-and-rollback.md
@@ -251,10 +251,37 @@ Restore just one file from a checkpoint without affecting the rest of the direct
   │   ├── projects/<hash>.json  # workdir + created_at + last_touch
   │   └── info/exclude
   ├── .last_prune            # auto-prune idempotency marker
+  ├── store.current          # OPTIONAL: pointer to the active generation
+  ├── store.<UTC ts>/        # OPTIONAL: verified recovery generations
   └── legacy-<ts>/           # archived pre-v2 per-project shadow repos
 ```
 
 Each `<hash>` is derived from the absolute path of the working directory. You normally never need to touch these manually — use `hermes checkpoints status` / `prune` / `clear` instead.
+
+### Atomic store activation (advanced)
+
+If the shared store ever becomes structurally damaged, an offline repair tool
+can produce a verified candidate copy — but replacing the live multi-gigabyte
+`store/` directory in place fails on some filesystems (e.g. FUSE overlays) and
+leaves a window where the canonical path does not exist. Instead, activate the
+repaired copy as a *generation* with one atomic metadata write:
+
+```bash
+# Copy the verified candidate into store.<UTC ts>/ and point store.current at it.
+hermes checkpoints activate /path/to/repaired-store-copy
+
+# Inspect what is active and what generations exist:
+hermes checkpoints status
+
+# Roll back to the original store/ at any time (generations are kept):
+hermes checkpoints deactivate
+```
+
+Without a `store.current` file, behaviour is exactly the classic layout —
+nothing changes for existing installations. A malformed `store.current` never
+silently falls back to `store/`: checkpointing refuses to run until the
+pointer is fixed or removed, so a damaged generation can't be swapped for a
+suspect legacy one by accident.
 
 ### Migration from v1
 


### PR DESCRIPTION
fix(checkpoints): atomic store activation via generation selector

Fixes #93314

## Problem

The shared checkpoint store always lives at `checkpoints/store/`
(`_store_path()` returns a fixed path). When that store becomes
structurally damaged, an offline repair can produce a fully verified
candidate (`git fsck --strict` clean) — but there is no way to make that
candidate canonical except renaming/replacing the live multi-gigabyte
directory at the fixed path. On filesystems like Unraid's `fuse.shfs`
that directory swap failed for the reporter, retrying would depend again
on an unproven FUSE rename primitive, and any attempt creates a window
where the canonical store path does not exist at all.

## Solution

An optional one-line generation selector, exactly as sketched in the
issue:

```
store.current                  # contains: store.<YYYYMMDDTHHMMSSZ>
store/                         # legacy/default store
store.<YYYYMMDDTHHMMSSZ>/      # verified generations
```

- **Resolver:** `_store_path()` becomes a dynamic resolver. Absent
  pointer = byte-for-byte today's behaviour (no migration, no new files).
  Valid pointer = every reader/writer/pruner/status path transparently
  operates on the selected generation (all consumers already re-resolve
  per operation). Every checkpoint consumer resolves dynamically.
- **Fail closed:** a present-but-untrustworthy pointer (symlinked pointer
  or target, multi-line/non-generation content, missing target directory)
  raises `CheckpointStoreSelectorError` instead of silently falling back
  to the possibly-damaged legacy store. Manager methods degrade to
  "checkpoint store unavailable" results; startup auto-prune logs and
  skips; `status` surfaces `selector_error` so operators can repair.
- **Activation** (`hermes checkpoints activate DIR`): copies the
  candidate into a new sibling generation (never moves/deletes either
  store), verifies the copy (HEAD present, refs readable,
  `git fsck --full --strict`), then flips the pointer atomically:
  tmp-write + fsync + `os.replace` + parent-directory fsync. Failure
  injection before/after the flip always leaves the old or new selection
  valid; partial copies are never selectable and get removed.
- **Rollback:** `hermes checkpoints deactivate` removes the pointer after
  confirming the legacy store actually exists; activating another
  candidate works too. Neither store is ever moved or overwritten.
- **Bounded retention:** activations are refused once 8 generations
  exist — disposal of old ones is an explicit operator decision, never
  silent disk creep. Generations are excluded from legacy migration,
  pre-v2 orphan scans, and retention sweeps (they carry `HEAD` files and
  would otherwise be classified as deletable pre-v2 shadow repos).
- **Compatibility:** existing installations without `store.current`
  remain untouched; `_init_store`, clear operations and pruning cannot
  leave a dangling pointer (the pointer is only written after the target
  generation is fully verified).

## Testing

Behavior-contract tests (no snapshots):

- `tests/tools/test_checkpoint_store_activation.py` (38 tests): resolver
  contract incl. all malformed/symlink/traversal cases, fail-closed
  consumer behaviour, sweep/migration/orphan-scan guards, activation +
  verification-failure + rollback cycles, generation cap, status
  reporting, and a full recovery scenario mirroring the issue report.
- `tests/hermes_cli/test_checkpoints_activate_cli.py`: E2E through the
  real argparse wiring — checkpoint → activate repaired copy → checkpoint
  into the generation → deactivate → legacy history intact.

Local run: 109 passed across the checkpoint suites
(`tests/tools/`, `tests/gateway/test_checkpoint_config.py`,
`tests/hermes_cli/test_checkpoints_prune.py`,
`tests/integration/test_checkpoint_resumption.py -m integration`).

Note: the 3 failures in `tests/tools/test_checkpoint_manager.py::
TestSafeRestore` pre-exist on current `main` (verified on a clean
checkout of `origin/main`) and are unrelated to this change.

Docs updated: `website/docs/user-guide/checkpoints-and-rollback.md`.

Related context: #83036 and #65349 address corruption prevention and GC
concurrency upstream of the store; this covers the post-repair
activation gap described in #93314.

---

Submitted by Bruno Bza (@BrunoBza).
