### PR TITLE
feat(reasoning): per-skill reasoning effort — skills suggest, config controls

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1104,6 +1104,25 @@ agent:
   #   "claude-opus-4.6": "high"           # bare model name also works
   #   "deepseek/deepseek-v4-pro": "xhigh" # dots and dashes are interchangeable
   reasoning_overrides: {}
+
+  # Per-skill reasoning effort overrides (optional dict)
+  # Key: skill/mode name. Value: effort level (same options as reasoning_effort),
+  #      or "off" to disable a skill's suggestion and fall through to global.
+  # Priority: explicit user value here > (if opted in) the skill's own
+  # frontmatter suggestion > per-model override > global reasoning_effort.
+  # NOTE: skill frontmatter suggestions are INERT unless you either set a value
+  # here for that skill OR enable reasoning_by_skill_optin below.
+  # reasoning_by_skill:
+  #   "plan": "xhigh"
+  #   "brainstorming": "off"
+  reasoning_by_skill: {}
+
+  # Opt-in switch for a skill's own frontmatter reasoning suggestion
+  # (`metadata.hermes.reasoning` in a skill's SKILL.md). When false (default),
+  # a skill's suggestion is treated as inert recommendation data and NEVER
+  # raises effort/spend on its own. Set true to let skill frontmatter
+  # suggestions fire (still overridable per-skill above).
+  reasoning_by_skill_optin: false
   
   # Custom personalities (use with /personality command).
   # Built-ins (helpful, concise, technical, creative, teacher, kawaii, catgirl,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9488,8 +9488,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         active_skill = None
         if task_id:
             try:
-                from tools.skills_tool import active_skill_reasoning
+                from tools.skills_tool import active_skill_reasoning, reset_active_skill_reasoning
                 active_skill = active_skill_reasoning(str(task_id))
+                # Consume-and-clear: skill views recorded during the PREVIOUS
+                # turn are read here (the one-turn lag), then cleared so a
+                # skill viewed once does not stick for every future turn of the
+                # session. Without this the registry never resets and the
+                # suggestion lingers until restart (review comment on #93378).
+                reset_active_skill_reasoning(str(task_id))
             except Exception:
                 active_skill = None
         return resolve_reasoning_config(cfg, model, active_skill=active_skill)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5415,6 +5415,7 @@ class TurnRunner:
             source=ctx.source,
             session_key=ctx.session_key,
             model=model,
+            task_id=ctx.session_id,
         )
         self._runner._reasoning_config = reasoning_config
         self._runner._service_tier = self._runner._resolve_session_service_tier(
@@ -9461,7 +9462,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return getattr(self, "_ephemeral_system_prompt", None) or ""
 
     @staticmethod
-    def _load_reasoning_config(model: str = "") -> dict | None:
+    def _load_reasoning_config(
+        model: str = "", task_id: Optional[str] = None
+    ) -> dict | None:
         """Load reasoning effort from config.yaml, respecting per-model overrides.
 
         Thin wrapper over the shared chokepoint
@@ -9469,13 +9472,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         global ``agent.reasoning_effort``; YAML boolean False = disabled).
         Closes #21256.
 
+        When ``task_id`` is supplied (== session id) and that session has a
+        currently active skill declaring a reasoning suggestion, the skill's
+        suggestion (and any user ``agent.reasoning_by_skill`` override) are
+        honored per the chokepoint's priority.
+
         Args:
             model: The effective model for the calling session. When empty,
                    the config's ``model.default`` is used.
+            task_id: The session's task id (== session id). When set, the
+                     active-skill suggestion is looked up and passed through.
         """
         from hermes_constants import resolve_reasoning_config
         cfg = _load_gateway_runtime_config()
-        return resolve_reasoning_config(cfg, model)
+        active_skill = None
+        if task_id:
+            try:
+                from tools.skills_tool import active_skill_reasoning
+                active_skill = active_skill_reasoning(str(task_id))
+            except Exception:
+                active_skill = None
+        return resolve_reasoning_config(cfg, model, active_skill=active_skill)
 
     @staticmethod
     def _parse_reasoning_command_args(raw_args: str) -> tuple[str, bool]:
@@ -9509,15 +9526,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: Optional[SessionSource] = None,
         session_key: Optional[str] = None,
         model: str = "",
+        task_id: Optional[str] = None,
     ) -> dict | None:
         """Resolve reasoning effort for a session, honoring session overrides.
 
         Priority: session-scoped ``/reasoning --session`` override >
-        per-model override (``agent.reasoning_overrides``) > global
-        ``agent.reasoning_effort``. ``model`` should be the session's
-        *effective* model (session ``/model`` override included) so
-        per-model overrides track what the session actually runs — when
-        empty, the config's ``model.default`` is used.
+        per-skill override/suggestion (``agent.reasoning_by_skill`` + active
+        skill's ``metadata.hermes.reasoning``) > per-model override
+        (``agent.reasoning_overrides``) > global ``agent.reasoning_effort``.
+        ``model`` should be the session's *effective* model (session ``/model``
+        override included) so per-model overrides track what the session
+        actually runs — when empty, the config's ``model.default`` is used.
+        ``task_id`` (== session id) is passed through to look up the active
+        skill's suggestion.
         """
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
@@ -9530,7 +9551,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _r_state = self._peek_session_state(resolved_session_key)
             if _r_state is not None and _r_state.conversation.reasoning_override is not None:
                 return _r_state.conversation.reasoning_override
-        return self._load_reasoning_config(model)
+        return self._load_reasoning_config(model, task_id=task_id)
 
     def _set_session_reasoning_override(
         self,
@@ -23022,7 +23043,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pr = self._provider_routing
             max_iterations = _current_max_iterations()
             reasoning_config = self._resolve_session_reasoning_config(
-                source=source, model=model
+                source=source, model=model, task_id=task_id
             )
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(source=source)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9536,6 +9536,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         active-skill suggestion for this turn, exactly once, at admission —
         before the session-override check — so no precedence rung can leave a
         stale skill record for a later turn (addresses review blocker #3).
+
+        Behavior note (review blocker #1): this is LAST-VIEW-WINS with a
+        one-turn lag. Skills viewed during turn N are recorded; they are
+        consumed at the START of turn N+1 and apply to that turn. The last
+        skill viewed during a turn is the one that applies to the NEXT turn.
+        This is NOT "per-current-skill" attribution — a turn's own effort is
+        decided by what was last viewed in the PREVIOUS turn. This is the
+        documented, intended behavior.
         """
         # Atomic consume-once at turn admission: pop the active-skill record
         # (single locked op) regardless of which precedence rung wins. If a

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9463,7 +9463,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @staticmethod
     def _load_reasoning_config(
-        model: str = "", task_id: Optional[str] = None
+        model: str = "",
+        active_skill: Optional[Tuple[str, Optional[str]]] = None,
     ) -> dict | None:
         """Load reasoning effort from config.yaml, respecting per-model overrides.
 
@@ -9472,32 +9473,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         global ``agent.reasoning_effort``; YAML boolean False = disabled).
         Closes #21256.
 
-        When ``task_id`` is supplied (== session id) and that session has a
-        currently active skill declaring a reasoning suggestion, the skill's
-        suggestion (and any user ``agent.reasoning_by_skill`` override) are
-        honored per the chokepoint's priority.
+        ``active_skill`` is an already-consumed ``(skill_name, reasoning)``
+        pair (or None) for the current turn. It is NOT consumed here — the
+        atomic consume happens exactly once at turn admission in
+        :meth:`_resolve_session_reasoning_config`, regardless of which
+        precedence rung wins (addresses review blocker #3: a session override
+        must not leave an unconsumed skill record to fire stale on a later turn).
 
         Args:
             model: The effective model for the calling session. When empty,
                    the config's ``model.default`` is used.
-            task_id: The session's task id (== session id). When set, the
-                     active-skill suggestion is looked up and passed through.
+            active_skill: Consumed ``(skill_name, reasoning)`` for this turn.
         """
         from hermes_constants import resolve_reasoning_config
         cfg = _load_gateway_runtime_config()
-        active_skill = None
-        if task_id:
-            try:
-                from tools.skills_tool import active_skill_reasoning, reset_active_skill_reasoning
-                active_skill = active_skill_reasoning(str(task_id))
-                # Consume-and-clear: skill views recorded during the PREVIOUS
-                # turn are read here (the one-turn lag), then cleared so a
-                # skill viewed once does not stick for every future turn of the
-                # session. Without this the registry never resets and the
-                # suggestion lingers until restart (review comment on #93378).
-                reset_active_skill_reasoning(str(task_id))
-            except Exception:
-                active_skill = None
         return resolve_reasoning_config(cfg, model, active_skill=active_skill)
 
     @staticmethod
@@ -9543,9 +9532,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``model`` should be the session's *effective* model (session ``/model``
         override included) so per-model overrides track what the session
         actually runs — when empty, the config's ``model.default`` is used.
-        ``task_id`` (== session id) is passed through to look up the active
-        skill's suggestion.
+        ``task_id`` (== session id) is used to atomically consume (pop) the
+        active-skill suggestion for this turn, exactly once, at admission —
+        before the session-override check — so no precedence rung can leave a
+        stale skill record for a later turn (addresses review blocker #3).
         """
+        # Atomic consume-once at turn admission: pop the active-skill record
+        # (single locked op) regardless of which precedence rung wins. If a
+        # session override is present below, the consumed skill is ignored for
+        # THIS turn but still cleared so it cannot fire stale later.
+        active_skill = None
+        if task_id:
+            try:
+                from tools.skills_tool import pop_active_skill_reasoning
+                active_skill = pop_active_skill_reasoning(str(task_id))
+            except Exception:
+                active_skill = None
+
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
             try:
@@ -9557,7 +9560,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _r_state = self._peek_session_state(resolved_session_key)
             if _r_state is not None and _r_state.conversation.reasoning_override is not None:
                 return _r_state.conversation.reasoning_override
-        return self._load_reasoning_config(model, task_id=task_id)
+        return self._load_reasoning_config(model, active_skill=active_skill)
 
     def _set_session_reasoning_override(
         self,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -357,6 +357,13 @@ DEFAULT_CONFIG = {
         # Edit directly in config.yaml (no CLI support due to dots in keys).
         "reasoning_overrides": {},
 
+        # Per-task-mode reasoning effort overrides (skill-suggested).
+        # Dict mapping skill/mode name -> effort level (or off/false to disable
+        # a skill's own suggestion). When the active skill has a suggestion and
+        # its name matches a key here, the user's value wins. Empty by default:
+        # skill frontmatter suggestions pass through unchanged.
+        "reasoning_by_skill": {},
+
         # Per-provider opt-in to preserve assistant ``reasoning_content``
         # when replaying history.  The built-in echo families (DeepSeek,
         # Kimi/Moonshot, Xiaomi MiMo) are auto-detected by provider name

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -361,8 +361,16 @@ DEFAULT_CONFIG = {
         # Dict mapping skill/mode name -> effort level (or off/false to disable
         # a skill's own suggestion). When the active skill has a suggestion and
         # its name matches a key here, the user's value wins. Empty by default:
-        # skill frontmatter suggestions pass through unchanged.
+        # skill frontmatter suggestions are INERT unless the user opts in (see
+        # reasoning_by_skill_optin) or sets an explicit value for the skill.
         "reasoning_by_skill": {},
+
+        # Opt-in switch for a skill's own frontmatter suggestion
+        # (`metadata.hermes.reasoning`). When false (default), a skill's
+        # suggestion is treated as inert recommendation data and NEVER raises
+        # effort/spend on its own — only an explicit `reasoning_by_skill[skill]`
+        # value is honored. Set true to let skill frontmatter suggestions fire.
+        "reasoning_by_skill_optin": False,
 
         # Per-provider opt-in to preserve assistant ``reasoning_content``
         # when replaying history.  The built-in echo families (DeepSeek,

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1427,8 +1427,21 @@ def resolve_reasoning_config(
                     # overrides behave on an unrecognized value.
                     skip_skill = True
 
-    # 2. Active skill's own suggestion (user has not overridden/disabled it).
-    if not skip_skill and active_skill and active_skill[1]:
+    # 2. Active skill's own suggestion — OPT-IN ONLY. A skill's
+    #    `metadata.hermes.reasoning` frontmatter is treated as inert
+    #    recommendation data by default: it never fires unless the user has
+    #    explicitly opted in via `agent.reasoning_by_skill_optin: true` (or
+    #    given an explicit `reasoning_by_skill[skill]` value, handled above).
+    #    This upholds the contract: "nothing changes by default" — installing
+    #    or viewing a third-party skill cannot silently raise model effort,
+    #    latency, or spend without user consent.
+    skill_optin = agent_cfg.get("reasoning_by_skill_optin")
+    if (
+        not skip_skill
+        and skill_optin
+        and active_skill
+        and active_skill[1]
+    ):
         parsed = parse_reasoning_effort(active_skill[1])
         if parsed is not None:
             return parsed

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1338,16 +1338,24 @@ def resolve_per_model_reasoning_effort(model: str, overrides: dict | None) -> di
     return None
 
 
-def resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
+def resolve_reasoning_config(
+    cfg: dict | None,
+    model: str = "",
+    active_skill: tuple[str, str | None] | None = None,
+) -> dict | None:
     """Resolve the effective reasoning config for *model* from a config dict.
 
     Single chokepoint for reasoning-effort resolution, shared by every
     surface (CLI startup, messaging gateway, Desktop/TUI, cron, ``/model``
     switch, fallback activation). Priority:
 
-    1. Per-model override from ``agent.reasoning_overrides``
-       (spelling-tolerant — see :func:`resolve_per_model_reasoning_effort`)
-    2. Global ``agent.reasoning_effort`` — the raw value is passed through
+    1. User override from ``agent.reasoning_by_skill`` for the active skill
+       (if supplied and the skill name matches a key).
+    2. Active skill's own suggestion (``metadata.hermes.reasoning``), when
+       ``active_skill`` carries a non-None effort.
+    3. Per-model override from ``agent.reasoning_overrides``
+       (spelling-tolerant — see :func:`resolve_per_model_reasoning_effort`).
+    4. Global ``agent.reasoning_effort`` — the raw value is passed through
        so a YAML boolean ``False`` (``reasoning_effort: false``/``off``/
        ``no``) means "thinking disabled", never silently re-enabled.
 
@@ -1360,6 +1368,9 @@ def resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
         model: The effective model for this surface/session. When empty,
                it is derived from the config's ``model`` section (string
                form, or a dict's ``default``/``model`` keys).
+        active_skill: Optional ``(skill_name, reasoning_suggestion)`` pair
+               for the currently active skill. ``reasoning_suggestion`` is
+               None when the skill declares none (or was not looked up).
 
     Returns:
         The parsed reasoning config dict, or None when unset/unrecognized
@@ -1381,12 +1392,46 @@ def resolve_reasoning_config(cfg: dict | None, model: str = "") -> dict | None:
         else:
             model = ""
 
+    # 1. User per-skill override (explicitly owns the value).
+    # `off`/`false` for the active skill means "disable THIS skill's
+    # suggestion" — skip the whole skill layer (both the user value and the
+    # skill's own suggestion) and fall through to per-model/global. It does
+    # NOT mean "disable thinking globally" (that is a per-model/global
+    # reasoning_effort concern, not a per-skill one).
+    skip_skill = False
+    _SKILL_OFF = {"off", "false", "no", "none", "0", "disable", "disabled"}
+    if active_skill:
+        skill_name, suggestion = active_skill
+        by_skill = agent_cfg.get("reasoning_by_skill") or {}
+        if isinstance(by_skill, dict) and skill_name:
+            user_val = by_skill.get(skill_name)
+            if user_val is not None:
+                # `off`/`false`/etc. for the active skill = disable THIS
+                # skill's suggestion. The generic parse_reasoning_effort only
+                # treats {"none","false","disabled"} as disabled (global-safe),
+                # but the per-skill map accepts the broader falsey set.
+                if isinstance(user_val, bool) and not user_val:
+                    skip_skill = True
+                elif str(user_val).strip().lower() in _SKILL_OFF:
+                    skip_skill = True
+                else:
+                    parsed = parse_reasoning_effort(user_val)
+                    if parsed is not None and parsed.get("enabled"):
+                        return parsed
+
+    # 2. Active skill's own suggestion (user has not overridden/disabled it).
+    if not skip_skill and active_skill and active_skill[1]:
+        parsed = parse_reasoning_effort(active_skill[1])
+        if parsed is not None:
+            return parsed
+
+    # 3. Per-model override.
     overrides = agent_cfg.get("reasoning_overrides") or {}
     per_model = resolve_per_model_reasoning_effort(model, overrides)
     if per_model is not None:
         return per_model
 
-    # Global fallback — keep the raw value; coercing with ``or ""`` turns a
+    # 4. Global fallback — keep the raw value; coercing with ``or ""`` turns a
     # YAML boolean False into "", silently re-enabling thinking for users
     # who explicitly disabled it.
     effort = agent_cfg.get("reasoning_effort", "")

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1347,20 +1347,25 @@ def resolve_reasoning_config(
 
     Single chokepoint for reasoning-effort resolution, shared by every
     surface (CLI startup, messaging gateway, Desktop/TUI, cron, ``/model``
-    switch, fallback activation). Priority:
+    switch, fallback activation). Full precedence (highest first):
 
+    0. Session-scoped override (gateway ``/reasoning --session``) — resolved by
+       the caller BEFORE this function; it always wins when present. The active
+       skill is still atomically consumed at turn admission regardless, so a
+       session override cannot leave stale skill residue for a later turn.
     1. User override from ``agent.reasoning_by_skill`` for the active skill
-       (if supplied and the skill name matches a key).
-    2. Active skill's own suggestion (``metadata.hermes.reasoning``), when
-       ``active_skill`` carries a non-None effort.
+       (if supplied and the skill name matches a key). ``off``/``false`` here
+       disables the skill layer (fall through); an unrecognized non-off value
+       also falls through rather than activating the skill's suggestion.
+    2. Active skill's own suggestion (``metadata.hermes.reasoning``) — ONLY when
+       the user has opted in via ``agent.reasoning_by_skill_optin: true``. Inert
+       by default so installing/viewing a third-party skill cannot silently
+       raise effort/spend.
     3. Per-model override from ``agent.reasoning_overrides``
        (spelling-tolerant — see :func:`resolve_per_model_reasoning_effort`).
     4. Global ``agent.reasoning_effort`` — the raw value is passed through
        so a YAML boolean ``False`` (``reasoning_effort: false``/``off``/
        ``no``) means "thinking disabled", never silently re-enabled.
-
-    Session-scoped overrides (gateway ``/reasoning --session``) are resolved
-    by the caller BEFORE this function — they always win.
 
     Args:
         cfg: A loaded config dict (any of the three loaders' shapes — only

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1418,6 +1418,14 @@ def resolve_reasoning_config(
                     parsed = parse_reasoning_effort(user_val)
                     if parsed is not None and parsed.get("enabled"):
                         return parsed
+                    # Unrecognized non-off value (e.g. a typo like "turbo"):
+                    # the user said SOMETHING for this skill, so we must NOT
+                    # silently fall through to the skill's own suggestion —
+                    # that would activate the very thing they were trying to
+                    # control. Treat it as "skip the skill layer" and fall
+                    # through to per-model/global, matching how per-model
+                    # overrides behave on an unrecognized value.
+                    skip_skill = True
 
     # 2. Active skill's own suggestion (user has not overridden/disabled it).
     if not skip_skill and active_skill and active_skill[1]:

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -176,6 +176,66 @@ class TestReasoningCommand:
         result = runner._resolve_session_reasoning_config(source=source, task_id=session_key)
         assert result == {"enabled": True, "effort": "medium"}
 
+    def test_last_viewed_skill_in_turn_N_applies_to_turn_N_plus_1(self, tmp_path, monkeypatch):
+        """Lifecycle: a skill viewed during turn N is consumed at the start of
+        the NEXT resolution (turn N+1) and applies to that turn.
+
+        This pins the documented last-viewed-skill → next-turn contract (review
+        blocker #1): the record written during turn N is read exactly once at
+        the next resolution, so it cannot stick for every future turn.
+        """
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "agent:\n  reasoning_effort: medium\n  reasoning_by_skill_optin: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        from tools import skills_tool as st
+
+        runner = _make_runner()
+        source = _make_event("/reasoning").source
+        session_key = runner._session_key_for_source(source)
+
+        # Turn N: a skill is viewed; its record is written.
+        st.record_active_skill(session_key, "plan", "xhigh")
+
+        # The next resolution (turn N+1) consumes the record and applies it.
+        result = runner._resolve_session_reasoning_config(source=source, task_id=session_key)
+        assert result == {"enabled": True, "effort": "xhigh"}
+
+        # Consumed once — a further resolution does NOT re-apply the skill;
+        # it falls back to the global default.
+        result = runner._resolve_session_reasoning_config(source=source, task_id=session_key)
+        assert result == {"enabled": True, "effort": "medium"}
+
+    def test_multiple_skills_viewed_last_one_wins(self, tmp_path, monkeypatch):
+        """Lifecycle: when several skills are viewed in a turn, the LAST one
+        viewed wins the attribution (incidental tool-call order decides).
+        """
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "agent:\n  reasoning_effort: medium\n  reasoning_by_skill_optin: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        from tools import skills_tool as st
+
+        runner = _make_runner()
+        source = _make_event("/reasoning").source
+        session_key = runner._session_key_for_source(source)
+
+        # Two skills viewed in the same turn: first 'plan' (xhigh), then
+        # 'brainstorm' (low). The last one wins for the next turn.
+        st.record_active_skill(session_key, "plan", "xhigh")
+        st.record_active_skill(session_key, "brainstorm", "low")
+
+        result = runner._resolve_session_reasoning_config(source=source, task_id=session_key)
+        assert result == {"enabled": True, "effort": "low"}
+
 
     def test_run_agent_includes_enabled_mcp_servers_in_gateway_toolsets(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -132,6 +132,50 @@ class TestReasoningCommand:
 
         assert runner._resolve_session_reasoning_config(source=source) == {"enabled": True, "effort": "xhigh"}
 
+    def test_session_override_clears_skill_record_no_stale_fire(self, tmp_path, monkeypatch):
+        """Review blocker #3 regression: with a session override active, a
+        skill record viewed during the override period must be consumed
+        (cleared), not left to fire stale once the override is removed.
+
+        Sequence from the review:
+          1. Session override active.
+          2. A turn views a skill; its record is written.
+          3. The override is cleared.
+          4. The next resolution must NOT apply the stale skill from the
+             override period.
+        """
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "agent:\n  reasoning_effort: medium\n  reasoning_by_skill_optin: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        from tools import skills_tool as st
+
+        runner = _make_runner()
+        source = _make_event("/reasoning").source
+        session_key = runner._session_key_for_source(source)
+        # Active session override.
+        runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "xhigh"}
+
+        # A turn views a skill with an xhigh suggestion (the task id = session key).
+        st.record_active_skill(session_key, "plan", "xhigh")
+
+        # Resolve while the override is active: override wins, skill is consumed.
+        result = runner._resolve_session_reasoning_config(source=source, task_id=session_key)
+        assert result == {"enabled": True, "effort": "xhigh"}
+
+        # The skill record must have been consumed (cleared) by the above call.
+        assert st.active_skill_reasoning(session_key) is None
+
+        # Clear the override; the next resolve must fall back to global (medium),
+        # NOT fire the stale plan skill.
+        del runner._session_reasoning_overrides[session_key]
+        result = runner._resolve_session_reasoning_config(source=source, task_id=session_key)
+        assert result == {"enabled": True, "effort": "medium"}
+
 
     def test_run_agent_includes_enabled_mcp_servers_in_gateway_toolsets(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"

--- a/tests/test_active_skill_reasoning.py
+++ b/tests/test_active_skill_reasoning.py
@@ -1,0 +1,47 @@
+"""Tests for the active-skill reasoning registry.
+
+A skill that is viewed during a turn becomes the "active" skill for
+reasoning resolution. This module tests that we record the active skill
+and its optional reasoning suggestion, and that the most-recent view wins.
+"""
+import pytest
+
+from tools import skills_tool as st
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    st.reset_active_skill_reasoning()
+    yield
+    st.reset_active_skill_reasoning()
+
+
+def _record(name, frontmatter):
+    """Simulate a served skill_view recording its reasoning suggestion."""
+    reasoning = st._skill_reasoning_effort(frontmatter)
+    st.record_active_skill("task-1", name, reasoning)
+
+
+def test_records_skill_with_reasoning():
+    _record("plan", {"metadata": {"hermes": {"reasoning": "xhigh"}}})
+    assert st.active_skill_reasoning("task-1") == ("plan", "xhigh")
+
+
+def test_records_skill_without_reasoning():
+    _record("fetch", {"name": "fetch"})
+    assert st.active_skill_reasoning("task-1") == ("fetch", None)
+
+
+def test_no_active_skill_returns_none():
+    assert st.active_skill_reasoning("task-1") is None
+
+
+def test_most_recent_view_wins():
+    _record("plan", {"metadata": {"hermes": {"reasoning": "xhigh"}}})
+    _record("brainstorm", {"metadata": {"hermes": {"reasoning": "high"}}})
+    assert st.active_skill_reasoning("task-1") == ("brainstorm", "high")
+
+
+def test_registry_is_per_task():
+    _record("plan", {"metadata": {"hermes": {"reasoning": "xhigh"}}})
+    assert st.active_skill_reasoning("task-2") is None

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -513,24 +513,39 @@ class TestResolveReasoningConfigWithSkill:
     > per-model override > global agent.reasoning_effort.
     """
 
-    def _cfg(self, effort="medium", overrides=None, by_skill=None):
+    def _cfg(self, effort="medium", overrides=None, by_skill=None, optin=False):
         return {
             "model": {"default": "gpt-5"},
             "agent": {
                 "reasoning_effort": effort,
                 "reasoning_overrides": overrides or {},
                 "reasoning_by_skill": by_skill or {},
+                "reasoning_by_skill_optin": optin,
             },
         }
 
-    def test_skill_suggestion_beats_global(self):
-        """Active skill suggestion (xhigh) wins over global medium."""
+    def test_skill_suggestion_beats_global_when_opted_in(self):
+        """With explicit `reasoning_by_skill_optin: true`, an active skill's
+        suggestion (xhigh) wins over global medium. (Review #93378 blocker #2:
+        the suggestion must NOT fire without opt-in.)"""
         from hermes_constants import resolve_reasoning_config
-        cfg = self._cfg(effort="medium")
+        cfg = self._cfg(effort="medium", optin=True)
         result = resolve_reasoning_config(
             cfg, "gpt-5", active_skill=("plan", "xhigh")
         )
         assert result == {"enabled": True, "effort": "xhigh"}
+
+    def test_skill_suggestion_inert_without_optin(self):
+        """Reviewer blocker #2 regression: with default config
+        (`reasoning_by_skill_optin` false/absent), a skill declaring xhigh must
+        be INERT — the result is the pre-PR global medium. Installing/viewing a
+        third-party skill must never silently raise effort."""
+        from hermes_constants import resolve_reasoning_config
+        cfg = self._cfg(effort="medium")  # optin defaults False
+        result = resolve_reasoning_config(
+            cfg, "gpt-5", active_skill=("plan", "xhigh")
+        )
+        assert result == {"enabled": True, "effort": "medium"}
 
     def test_user_reasoning_by_skill_beats_skill_suggestion(self):
         """User config mapping plan->high beats the skill's xhigh suggestion."""

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -515,7 +515,6 @@ class TestReasoningOverridesDefaultConfig:
         assert "reasoning_overrides" in DEFAULT_CONFIG["agent"]
         assert DEFAULT_CONFIG["agent"]["reasoning_overrides"] == {}
 
-
     def test_spelling_tolerant_lookup_works_with_user_config(self):
         """resolve_per_model_reasoning_effort works with user-added overrides."""
         from hermes_constants import resolve_per_model_reasoning_effort
@@ -532,6 +531,21 @@ class TestReasoningOverridesDefaultConfig:
         # Lookup with provider prefix — should match
         result2 = resolve_per_model_reasoning_effort("openai/gpt-5", overrides2)
         assert result2 == {"enabled": True, "effort": "low"}
+
+
+class TestReasoningBySkillDefaultConfig:
+    """Tests for the agent.reasoning_by_skill default config key.
+
+    Maps skill/mode name -> reasoning effort (or off/false to disable a
+    skill's suggestion). Empty by default: skill frontmatter suggestions
+    pass through unchanged.
+    """
+
+    def test_default_config_has_reasoning_by_skill_key(self):
+        """DEFAULT_CONFIG['agent'] contains 'reasoning_by_skill' as an empty dict."""
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert "reasoning_by_skill" in DEFAULT_CONFIG["agent"]
+        assert DEFAULT_CONFIG["agent"]["reasoning_by_skill"] == {}
 
 
 class TestSecureParentDir:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -506,6 +506,64 @@ class TestResolveReasoningConfig:
         assert resolve_reasoning_config(cfg, "gpt-5") == {"enabled": True, "effort": "medium"}
 
 
+class TestResolveReasoningConfigWithSkill:
+    """Tests for per-skill reasoning resolution (skills suggest, config controls).
+
+    Priority: user reasoning_by_skill[activeSkill] > active skill suggestion
+    > per-model override > global agent.reasoning_effort.
+    """
+
+    def _cfg(self, effort="medium", overrides=None, by_skill=None):
+        return {
+            "model": {"default": "gpt-5"},
+            "agent": {
+                "reasoning_effort": effort,
+                "reasoning_overrides": overrides or {},
+                "reasoning_by_skill": by_skill or {},
+            },
+        }
+
+    def test_skill_suggestion_beats_global(self):
+        """Active skill suggestion (xhigh) wins over global medium."""
+        from hermes_constants import resolve_reasoning_config
+        cfg = self._cfg(effort="medium")
+        result = resolve_reasoning_config(
+            cfg, "gpt-5", active_skill=("plan", "xhigh")
+        )
+        assert result == {"enabled": True, "effort": "xhigh"}
+
+    def test_user_reasoning_by_skill_beats_skill_suggestion(self):
+        """User config mapping plan->high beats the skill's xhigh suggestion."""
+        from hermes_constants import resolve_reasoning_config
+        cfg = self._cfg(by_skill={"plan": "high"})
+        result = resolve_reasoning_config(
+            cfg, "gpt-5", active_skill=("plan", "xhigh")
+        )
+        assert result == {"enabled": True, "effort": "high"}
+
+    def test_user_off_disables_skill_suggestion(self):
+        """plan: off means the skill's xhigh suggestion is ignored -> global."""
+        from hermes_constants import resolve_reasoning_config
+        cfg = self._cfg(effort="medium", by_skill={"plan": "off"})
+        result = resolve_reasoning_config(
+            cfg, "gpt-5", active_skill=("plan", "xhigh")
+        )
+        assert result == {"enabled": True, "effort": "medium"}
+
+    def test_no_active_skill_unchanged(self):
+        """No active skill -> old behavior (per-model > global)."""
+        from hermes_constants import resolve_reasoning_config
+        cfg = self._cfg(effort="medium", overrides={"gpt-5": "high"})
+        assert resolve_reasoning_config(cfg, "gpt-5") == {"enabled": True, "effort": "high"}
+
+    def test_active_skill_without_suggestion_unchanged(self):
+        """An active skill that suggests nothing -> old behavior."""
+        from hermes_constants import resolve_reasoning_config
+        cfg = self._cfg(effort="medium")
+        result = resolve_reasoning_config(cfg, "gpt-5", active_skill=("fetch", None))
+        assert result == {"enabled": True, "effort": "medium"}
+
+
 class TestReasoningOverridesDefaultConfig:
     """Tests for the agent.reasoning_overrides default config key (Task 2)."""
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -563,6 +563,20 @@ class TestResolveReasoningConfigWithSkill:
         result = resolve_reasoning_config(cfg, "gpt-5", active_skill=("fetch", None))
         assert result == {"enabled": True, "effort": "medium"}
 
+    def test_invalid_user_value_skips_skill_suggestion(self):
+        """A typo'd per-skill value must NOT fall through to the skill's
+        suggestion. If the user set plan to something unrecognized, the
+        resolver must skip the skill layer entirely and go to per-model/global
+        — otherwise the typo silently activates the very suggestion the user
+        was trying to override."""
+        from hermes_constants import resolve_reasoning_config
+        cfg = self._cfg(effort="medium", by_skill={"plan": "turbo"})
+        result = resolve_reasoning_config(
+            cfg, "gpt-5", active_skill=("plan", "xhigh")
+        )
+        # Must NOT be xhigh (the skill's suggestion) — must fall through to global medium.
+        assert result == {"enabled": True, "effort": "medium"}
+
 
 class TestReasoningOverridesDefaultConfig:
     """Tests for the agent.reasoning_overrides default config key (Task 2)."""

--- a/tests/test_reasoning_cache_invariant.py
+++ b/tests/test_reasoning_cache_invariant.py
@@ -1,0 +1,63 @@
+"""Cache-invariant proof for per-task reasoning.
+
+The prompt-cache safety of per-skill reasoning effort rests on a single
+claim: changing `reasoning_config` between turns only alters per-request
+request-body fields (``thinking``/``extra_body``), NEVER the `messages` or
+system-prompt prefix that prompt caching keys on. If a future change ever
+starts folding reasoning into the message list, this test fails loudly —
+protecting the "switch reasoning per turn without nuking the cache" contract.
+
+The assertion of record is that `build_anthropic_kwargs` (the Anthropic
+request builder) returns `thinking` as a TOP-LEVEL kwarg and leaves the
+`messages` argument byte-identical to what was passed in.
+"""
+import pytest
+
+from agent.anthropic_adapter import build_anthropic_kwargs
+
+
+def _build(messages, reasoning_config):
+    return build_anthropic_kwargs(
+        model="anthropic/claude-opus-4.6",
+        messages=messages,
+        tools=None,
+        max_tokens=1024,
+        reasoning_config=reasoning_config,
+        tool_choice=None,
+        is_oauth=False,
+        base_url="https://api.anthropic.com",
+    )
+
+
+def test_reasoning_lands_in_top_level_thinking_not_messages():
+    messages = [
+        {"role": "system", "content": "you are a planning agent"},
+        {"role": "user", "content": "write me a plan"},
+    ]
+    kwargs = _build(messages, {"enabled": True, "effort": "xhigh"})
+    # Reasoning is a top-level request-body field, not inside messages.
+    assert kwargs.get("thinking") == {"type": "adaptive", "display": "summarized"}
+    assert "effort" not in kwargs["thinking"]
+
+
+def test_messages_passed_through_unchanged_when_reasoning_changes():
+    """Flipping reasoning effort must not rewrite the cached message prefix."""
+    base = [
+        {"role": "system", "content": "you are a planning agent"},
+        {"role": "user", "content": "go me a plan"},
+    ]
+    # Build with two different reasoning levels.
+    low = _build(base, {"enabled": True, "effort": "low"})
+    xhigh = _build(base, {"enabled": True, "effort": "xhigh"})
+    # The messages list is identical across both — only the per-request
+    # thinking field differs. This is the cache-invariant. (The system role is
+    # hoisted out by the builder into the top-level `system` kwarg — that is a
+    # separate, deterministic transformation of the SAME input; the point is
+    # the message list does not vary with reasoning effort.)
+    assert low["messages"] == xhigh["messages"]
+
+
+def test_no_reasoning_config_keeps_messages_intact():
+    messages = [{"role": "user", "content": "hello"}]
+    out = _build(messages, None)
+    assert out["messages"] == messages

--- a/tests/test_skill_reasoning.py
+++ b/tests/test_skill_reasoning.py
@@ -1,0 +1,47 @@
+"""Tests for per-skill reasoning suggestion extraction.
+
+Covers extracting `metadata.hermes.reasoning` from a skill's frontmatter,
+validating against known effort levels, and the "no suggestion" default.
+"""
+import pytest
+
+from tools.skills_tool import _skill_reasoning_effort
+
+
+def test_extracts_xhigh_from_metadata_hermes():
+    """A skill declaring metadata.hermes.reasoning: xhigh yields 'xhigh'."""
+    frontmatter = {
+        "name": "plan",
+        "metadata": {"hermes": {"reasoning": "xhigh"}},
+    }
+    assert _skill_reasoning_effort(frontmatter) == "xhigh"
+
+
+def test_extracts_medium_from_metadata_hermes():
+    frontmatter = {
+        "name": "brainstorming",
+        "metadata": {"hermes": {"reasoning": "medium"}},
+    }
+    assert _skill_reasoning_effort(frontmatter) == "medium"
+
+
+def test_no_metadata_returns_none():
+    """Skills without the key contribute nothing — default remains."""
+    assert _skill_reasoning_effort({"name": "plan"}) is None
+    assert _skill_reasoning_effort({"name": "plan", "metadata": {}}) is None
+
+
+def test_no_hermes_key_returns_none():
+    assert (
+        _skill_reasoning_effort(
+            {"name": "plan", "metadata": {"tags": ["x"]}}
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("bad", ["turbo", "very-high", "9", ""])
+def test_invalid_effort_returns_none(bad):
+    """Unknown/unsupported levels are ignored, never crash."""
+    frontmatter = {"metadata": {"hermes": {"reasoning": bad}}}
+    assert _skill_reasoning_effort(frontmatter) is None

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1889,6 +1889,7 @@ def skill_view(
             "description": frontmatter.get("description", ""),
             "tags": tags,
             "related_skills": related_skills,
+            "reasoning": _skill_reasoning_effort(frontmatter),
             "content": rendered_content,
             "path": rel_path,
             "skill_dir": str(skill_dir) if skill_dir else None,
@@ -2160,6 +2161,95 @@ def reset_skill_view_dedup(task_id: str | None = None) -> None:
             _skill_view_tracker.pop(str(task_id), None)
 
 
+# ── Active-skill reasoning registry ──────────────────────────────────
+# Records which skill(s) were viewed this turn and the reasoning effort
+# each declares, in view order. The reasoning resolver reads the most
+# recent entry to answer "is the plan skill active right now?". This is
+# deliberately separate from the dedup tracker: a re-view that returns a
+# dedup stub still counts as "the skill is active this turn".
+_active_skill_reasoning: Dict[str, List[Tuple[str, Optional[str]]]] = {}
+_active_skill_reasoning_lock = threading.Lock()
+
+
+def record_active_skill(
+    task_id: str | None, skill_name: str, reasoning: Optional[str]
+) -> None:
+    """Record a skill viewed this turn, with its optional reasoning effort.
+
+    Keeps a per-task list in view order so the resolver can take the most
+    recent. ``reasoning`` is the already-validated effort (None when the
+    skill declares none). Wrapped by :func:`_record_active_skill_from_payload`
+    at the serve site.
+    """
+    if not task_id or not skill_name:
+        return
+    with _active_skill_reasoning_lock:
+        task_list = _active_skill_reasoning.setdefault(str(task_id), [])
+        task_list.append((skill_name, reasoning))
+        # Bound the per-task list (a very long turn could view many skills).
+        if len(task_list) > 200:
+            del task_list[: len(task_list) - 200]
+
+
+def active_skill_reasoning(task_id: str | None) -> Optional[Tuple[str, Optional[str]]]:
+    """Return the most recently viewed (skill_name, reasoning) for a task.
+
+    None when no skill has been viewed this turn (or task_id is unset).
+    """
+    if not task_id:
+        return None
+    with _active_skill_reasoning_lock:
+        task_list = _active_skill_reasoning.get(str(task_id))
+    if not task_list:
+        return None
+    return task_list[-1]
+
+
+def reset_active_skill_reasoning(task_id: str | None = None) -> None:
+    """Clear the active-skill registry (all tasks when task_id is None)."""
+    with _active_skill_reasoning_lock:
+        if task_id is None:
+            _active_skill_reasoning.clear()
+        else:
+            _active_skill_reasoning.pop(str(task_id), None)
+
+
+def _record_active_skill_from_view(task_id, name, parsed_payload: dict) -> None:
+    """Record the active skill + reasoning from a successful skill_view payload."""
+    if not isinstance(parsed_payload, dict) or not parsed_payload.get("success"):
+        return
+    resolved = parsed_payload.get("name") or name
+    if not resolved:
+        return
+    reasoning = parsed_payload.get("reasoning")
+    record_active_skill(task_id, str(resolved), reasoning)
+
+
+def _active_skill_payload_keep_reasoning(
+    task_id: str | None, name: str
+) -> dict:
+    """Return a minimal success payload preserving the last known reasoning.
+
+    Used on the dedup-stub path, where the stub carries no ``reasoning``:
+    look up the effort already recorded for this skill in this task and
+    echo it back so the re-record keeps the correct suggestion instead of
+    clobbering it with None.
+    """
+    if not task_id:
+        return {"success": True, "name": name, "reasoning": None}
+    last = active_skill_reasoning(task_id)
+    if last and str(last[0]) == str(name):
+        reasoning = last[1]
+    else:
+        # Find the latest recorded reasoning for this exact skill name.
+        with _active_skill_reasoning_lock:
+            task_list = list(_active_skill_reasoning.get(str(task_id), []))
+        reasoning = next(
+            (r for s, r in reversed(task_list) if str(s) == str(name)), None
+        )
+    return {"success": True, "name": name, "reasoning": reasoning}
+
+
 def _skill_view_with_bump(args, **kw):
     """Invoke skill_view, then bump view_count on success. Best-effort: a
     telemetry failure never breaks the tool call."""
@@ -2177,6 +2267,12 @@ def _skill_view_with_bump(args, **kw):
     # so a post-compression re-view returns full content again.
     stub = _check_skill_view_dedup(task_id, name, args.get("file_path"))
     if stub is not None:
+        # A dedup re-view still means the skill is active this turn, but the
+        # stub payload carries no `reasoning` — preserve the effort already
+        # recorded for this skill in this task so a re-view can't clobber it.
+        _record_active_skill_from_view(
+            task_id, name, _active_skill_payload_keep_reasoning(task_id, name)
+        )
         return stub
     result = skill_view(
         name, file_path=args.get("file_path"), task_id=task_id
@@ -2185,6 +2281,7 @@ def _skill_view_with_bump(args, **kw):
         parsed = json.loads(result)
         if isinstance(parsed, dict) and parsed.get("success"):
             _record_skill_view(task_id, name, args.get("file_path"), parsed)
+            _record_active_skill_from_view(task_id, name, parsed)
             # Use the resolved skill name from the payload when present —
             # qualified forms ("plugin:skill") return with the canonical name.
             resolved = parsed.get("name") or name

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -2214,6 +2214,27 @@ def reset_active_skill_reasoning(task_id: str | None = None) -> None:
             _active_skill_reasoning.pop(str(task_id), None)
 
 
+def pop_active_skill_reasoning(
+    task_id: str | None,
+) -> Optional[Tuple[str, Optional[str]]]:
+    """Atomically return AND clear the most-recently-viewed skill for a task.
+
+    Single locked ``pop`` so consume-and-reset is one operation — a record
+    arriving between a separate read() and reset() can no longer be discarded.
+    Returns ``(skill_name, reasoning)`` or None when no skill was recorded.
+    (Addresses review blocker #3: the consume must be atomic, not read-then-reset.)
+    """
+    if not task_id:
+        return None
+    with _active_skill_reasoning_lock:
+        task_list = _active_skill_reasoning.get(str(task_id))
+        if not task_list:
+            return None
+        item = task_list[-1]
+        del task_list[:]
+        return item
+
+
 def _record_active_skill_from_view(task_id, name, parsed_payload: dict) -> None:
     """Record the active skill + reasoning from a successful skill_view payload."""
     if not isinstance(parsed_payload, dict) or not parsed_payload.get("success"):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -577,6 +577,33 @@ def _parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     return parse_frontmatter(content)
 
 
+def _skill_reasoning_effort(frontmatter: Dict[str, Any]) -> Optional[str]:
+    """Return the reasoning-effort suggestion a skill declares, or None.
+
+    Reads the optional ``metadata.hermes.reasoning`` frontmatter key
+    (agentskills.io convention, same slot as tags/related_skills). Only
+    recognized effort levels are accepted — anything unknown is ignored
+    so a typo can never crash resolution. Skills that declare nothing
+    contribute None (the reasoning resolver keeps its existing behavior).
+    """
+    if not isinstance(frontmatter, dict):
+        return None
+    metadata = frontmatter.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    hermes_meta = metadata.get("hermes")
+    if not isinstance(hermes_meta, dict):
+        return None
+    effort = hermes_meta.get("reasoning")
+    if not effort:
+        return None
+    from hermes_constants import parse_reasoning_effort
+    parsed = parse_reasoning_effort(effort)
+    if parsed is None or not parsed.get("enabled"):
+        return None
+    return parsed.get("effort")
+
+
 def _get_category_from_path(skill_path: Path) -> Optional[str]:
     """
     Extract category from skill path based on directory structure.

--- a/web/src/components/ReasoningPicker.test.tsx
+++ b/web/src/components/ReasoningPicker.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+/**
+ * Rendered tests for the ReasoningPicker per-skill editor.
+ *
+ * Addresses review #93378 blocker #4 — asserts the exact contract called out:
+ *   "Add a rendered component test that types a multi-character name, selects
+ *    Off, and asserts one saved map of { "plan": "off" } with no empty-string
+ *    key."
+ *
+ * Also covers the other two editor defects from that review:
+ *   - Selecting Off persists the literal "off" sentinel (NOT a delete, which
+ *     would let the skill's frontmatter suggestion fire).
+ *   - addRow() does not persist an empty-string key before a valid name is
+ *     committed.
+ */
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks ---------------------------------------------------------------
+
+const apiMocks = vi.hoisted(() => {
+  const saves: Array<Record<string, unknown>> = [];
+  let cfg: Record<string, unknown> = {};
+  return {
+    savedMaps: () => saves,
+    getConfig: vi.fn(async () => cfg),
+    saveConfig: vi.fn(async (next: Record<string, unknown>) => {
+      cfg = next;
+      saves.push(next);
+      return next;
+    }),
+    reset: () => {
+      saves.length = 0;
+      cfg = {};
+    },
+  };
+});
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getConfig: apiMocks.getConfig,
+    saveConfig: apiMocks.saveConfig,
+  },
+}));
+
+vi.mock("@nous-research/ui/ui/components/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (v: string) => void;
+    children?: ReactNode;
+  }) => {
+    const options = (Array.isArray(children) ? children : []).map((c) =>
+      (c as { props?: { value?: string; children?: ReactNode } })?.props ?? {},
+    );
+    return (
+      <div data-testid="select" data-value={value ?? ""}>
+        {options.map((o) => (
+          <button
+            key={o.value}
+            data-option={o.value}
+            data-label={String(o.children ?? "")}
+            onClick={() => onValueChange?.(o.value ?? "")}
+          >
+            {o.children}
+          </button>
+        ))}
+      </div>
+    );
+  },
+  SelectOption: ({ value, children }: { value?: string; children?: ReactNode }) =>
+    null,
+}));
+
+// --- Render helper --------------------------------------------------------
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(ui: ReactNode) {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root.render(ui));
+}
+
+async function click(selector: string) {
+  const el = container!.querySelector(selector);
+  if (!el) throw new Error(`no element for ${selector}`);
+  await act(async () => (el as HTMLElement).click());
+}
+
+async function type(selector: string, value: string) {
+  const el = container!.querySelector(selector) as HTMLInputElement;
+  if (!el) throw new Error(`no input for ${selector}`);
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )!.set!;
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  apiMocks.reset();
+  apiMocks.getConfig.mockResolvedValueOnce({
+    agent: { reasoning_effort: "medium", reasoning_by_skill: {} },
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+});
+
+// --- Tests ----------------------------------------------------------------
+
+describe("ReasoningPicker per-skill editor", () => {
+  it("persists exactly {'plan':'off'} — no empty-string key — when a name is typed and Off is selected", async () => {
+    const { ReasoningPicker } = await import("./ReasoningPicker");
+    await render(
+      <ReasoningPicker currentModel="gpt-5" />,
+    );
+    // Add a blank row (addRow) — must not persist anything yet.
+    await click("button[data-testid=add-row]");
+    expect(apiMocks.savedMaps()).toHaveLength(0);
+
+    // Type a multi-character skill name.
+    await type("input", "plan");
+
+    // Select Off on that row's effort select (the row's select contains the
+    // Off option button).
+    await click("button[data-option='off']");
+
+    // Commit the name on blur.
+    const input = container!.querySelector("input") as HTMLInputElement;
+    await act(async () => {
+      input.dispatchEvent(new Event("blur", { bubbles: true }));
+    });
+
+    // Every persisted map must have no empty-string key, and the final map
+    // must be exactly { plan: "off" } — no delete that lets the skill's
+    // frontmatter suggestion fire.
+    const saved = apiMocks.savedMaps();
+    expect(saved.length).toBeGreaterThan(0);
+    for (const s of saved) {
+      const map = s.agent.reasoning_by_skill as Record<string, string>;
+      expect(Object.keys(map)).not.toContain("");
+    }
+    const last = saved[saved.length - 1];
+    expect(last.agent.reasoning_by_skill).toEqual({ plan: "off" });
+  });
+});

--- a/web/src/components/ReasoningPicker.tsx
+++ b/web/src/components/ReasoningPicker.tsx
@@ -20,13 +20,14 @@
  */
 
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
-import { Brain } from "lucide-react";
+import { Brain, Plus, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { api } from "@/lib/api";
 import {
   EFFORT_OPTIONS,
   normalizeEffort,
+  normalizeSkillEffort,
   VALID_EFFORTS,
 } from "@/lib/reasoning-effort";
 
@@ -50,6 +51,7 @@ export function ReasoningPicker({
   onChanged,
 }: ReasoningPickerProps) {
   const [effort, setEffort] = useState("medium");
+  const [skillMap, setSkillMap] = useState<Record<string, string>>({});
   const [loaded, setLoaded] = useState(false);
   const [saving, setSaving] = useState(false);
   const lastFetchKeyRef = useRef("");
@@ -63,6 +65,12 @@ export function ReasoningPicker({
       .then((cfg) => {
         const agent = (cfg?.agent as Record<string, unknown> | undefined) ?? {};
         setEffort(normalizeEffort(agent.reasoning_effort));
+        const map = agent.reasoning_by_skill;
+        setSkillMap(
+          map && typeof map === "object"
+            ? (map as Record<string, string>)
+            : {},
+        );
         setLoaded(true);
       })
       .catch(() => {
@@ -71,15 +79,34 @@ export function ReasoningPicker({
       });
   }, [currentModel, profile, refreshKey]);
 
+  const persistSkillMap = useCallback(
+    (nextMap: Record<string, string>) => {
+      setSaving(true);
+      void api
+        .getConfig(profile)
+        .then((cfg) => {
+          const base = (cfg ?? {}) as Record<string, unknown>;
+          const agent =
+            base.agent && typeof base.agent === "object"
+              ? { ...(base.agent as Record<string, unknown>) }
+              : {};
+          agent.reasoning_by_skill = nextMap;
+          return api.saveConfig({ ...base, agent }, profile);
+        })
+        .catch(() => {
+          // Revert on failure is best-effort; keep current state.
+        })
+        .finally(() => setSaving(false));
+    },
+    [profile],
+  );
+
   const onSelect = useCallback(
     (next: string) => {
       if (!VALID_EFFORTS.has(next) || next === effort) return;
       const prev = effort;
       setEffort(next); // optimistic
       setSaving(true);
-      // Read-modify-write the whole config — the dashboard's single-key save
-      // pattern — so we never clobber sibling keys. `saveConfig` PUTs the full
-      // object the agent boots from.
       void api
         .getConfig(profile)
         .then((cfg) => {
@@ -102,24 +129,122 @@ export function ReasoningPicker({
     [effort, onChanged, profile],
   );
 
+  const skillRows = () =>
+    Object.entries(skillMap).map(([skill, eff], i) => ({
+      key: `${skill}::${i}`,
+      skill,
+      effort: eff,
+    }));
+
+  const setRowSkill = (key: string, skill: string) => {
+    const rows = skillRows();
+    const row = rows.find((r) => r.key === key);
+    if (!row) return;
+    const next = { ...skillMap };
+    if (next[row.skill] !== undefined) delete next[row.skill];
+    if (skill.trim()) next[skill.trim()] = row.effort;
+    setSkillMap(next);
+    persistSkillMap(next);
+  };
+
+  const setRowEffort = (key: string, eff: string) => {
+    const rows = skillRows();
+    const row = rows.find((r) => r.key === key);
+    if (!row) return;
+    const next = { ...skillMap };
+    const normalized = normalizeSkillEffort(eff);
+    if (normalized === "off") {
+      delete next[row.skill];
+    } else {
+      next[row.skill] = normalized;
+    }
+    setSkillMap(next);
+    persistSkillMap(next);
+  };
+
+  const addRow = () => {
+    const next = { ...skillMap, "": "xhigh" };
+    setSkillMap(next);
+    persistSkillMap(next);
+  };
+
+  const removeRow = (key: string) => {
+    const rows = skillRows();
+    const row = rows.find((r) => r.key === key);
+    if (!row) return;
+    const next = { ...skillMap };
+    if (next[row.skill] !== undefined) delete next[row.skill];
+    setSkillMap(next);
+    persistSkillMap(next);
+  };
+
   return (
-    <div className="flex items-center gap-2 px-3 py-2 text-xs">
-      <div className="flex items-center gap-1.5 text-text-tertiary">
-        <Brain className="h-3.5 w-3.5" />
-        <span className="text-display tracking-wider">reasoning</span>
+    <div className="px-3 py-2 text-xs">
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5 text-text-tertiary">
+          <Brain className="h-3.5 w-3.5" />
+          <span className="text-display tracking-wider">reasoning</span>
+        </div>
+        <Select
+          className="ml-auto min-w-0"
+          disabled={!loaded || saving}
+          onValueChange={onSelect}
+          value={effort}
+        >
+          {EFFORT_OPTIONS.map((opt) => (
+            <SelectOption key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectOption>
+          ))}
+        </Select>
       </div>
-      <Select
-        className="ml-auto min-w-0"
-        disabled={!loaded || saving}
-        onValueChange={onSelect}
-        value={effort}
-      >
-        {EFFORT_OPTIONS.map((opt) => (
-          <SelectOption key={opt.value} value={opt.value}>
-            {opt.label}
-          </SelectOption>
+
+      <div className="mt-2 flex flex-col gap-1.5 border-t border-line pt-2">
+        <span className="text-display tracking-wider text-text-tertiary">
+          per-skill
+        </span>
+        {skillRows().map((row) => (
+          <div key={row.key} className="flex items-center gap-1.5">
+            <input
+              className="min-w-0 flex-1 rounded border border-line bg-transparent px-1.5 py-1"
+              value={row.skill}
+              disabled={saving}
+              placeholder="skill name (e.g. plan)"
+              onChange={(e) => setRowSkill(row.key, e.target.value)}
+            />
+            <Select
+              className="min-w-0"
+              disabled={saving}
+              onValueChange={(v) => setRowEffort(row.key, v)}
+              value={normalizeSkillEffort(row.effort)}
+            >
+              <SelectOption value="off">Off</SelectOption>
+              {EFFORT_OPTIONS.map((opt) => (
+                <SelectOption key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectOption>
+              ))}
+            </Select>
+            <button
+              className="shrink-0 text-text-tertiary hover:text-danger"
+              disabled={saving}
+              aria-label={`Remove ${row.skill || "skill"} override`}
+              onClick={() => removeRow(row.key)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
         ))}
-      </Select>
+        <button
+          className="flex items-center gap-1 self-start text-text-tertiary hover:text-text-secondary"
+          disabled={saving}
+          onClick={addRow}
+        >
+          <Plus className="h-3 w-3" />
+          Add skill override
+        </button>
+      </div>
     </div>
   );
 }
+

--- a/web/src/components/ReasoningPicker.tsx
+++ b/web/src/components/ReasoningPicker.tsx
@@ -22,6 +22,7 @@
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Brain, Plus, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
 
 import { api } from "@/lib/api";
 import {
@@ -137,6 +138,10 @@ export function ReasoningPicker({
     }));
 
   const setRowSkill = (key: string, skill: string) => {
+    // Update local state only. Persisting here would fire a full config
+    // GET+PUT on EVERY keystroke (e.g. typing "planning" → ~8 writes of
+    // junk intermediates {p:…},{pl:…} that race concurrent writers).
+    // The name is committed to config on blur / Enter via commitRowSkill.
     const rows = skillRows();
     const row = rows.find((r) => r.key === key);
     if (!row) return;
@@ -144,7 +149,14 @@ export function ReasoningPicker({
     if (next[row.skill] !== undefined) delete next[row.skill];
     if (skill.trim()) next[skill.trim()] = row.effort;
     setSkillMap(next);
-    persistSkillMap(next);
+  };
+
+  const commitRowSkill = (key: string) => {
+    const rows = skillRows();
+    const row = rows.find((r) => r.key === key);
+    if (!row) return;
+    if (!row.skill.trim()) return; // empty name — leave the row, don't persist
+    persistSkillMap({ ...skillMap });
   };
 
   const setRowEffort = (key: string, eff: string) => {
@@ -211,6 +223,12 @@ export function ReasoningPicker({
               disabled={saving}
               placeholder="skill name (e.g. plan)"
               onChange={(e) => setRowSkill(row.key, e.target.value)}
+              onBlur={() => commitRowSkill(row.key)}
+              onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+                if (e.key === "Enter") {
+                  e.currentTarget.blur();
+                }
+              }}
             />
             <Select
               className="min-w-0"

--- a/web/src/components/ReasoningPicker.tsx
+++ b/web/src/components/ReasoningPicker.tsx
@@ -17,6 +17,16 @@
  *
  * Profile scoping: the sidebar passes the chat profile explicitly, so this
  * reads/writes the same config the chat PTY was launched from.
+ *
+ * Per-skill row invariants (addressed in review #93378 blocker #4):
+ *   - Row identity is a STABLE local id, NOT the editable skill name, so
+ *     renaming a skill does not remount the row and drop its commit closure.
+ *   - The map is serialized to config ONLY when a valid skill name is
+ *     committed (blur / Enter), never on keystroke or on adding a blank row.
+ *   - Selecting Off persists the literal "off" sentinel (which the resolver
+ *     reads as "skip this skill's suggestion / fall through"), instead of
+ *     deleting the key — deleting would let the skill's own frontmatter
+ *     suggestion run. The trash button is the only delete.
  */
 
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
@@ -45,6 +55,16 @@ interface ReasoningPickerProps {
   onChanged?: (effort: string) => void;
 }
 
+/** A per-skill override row kept in local editor state. `skill` may be an
+ *  in-progress (uncommitted) name; only a non-empty committed name is
+ *  serialized to the config map. `id` is stable across renames so the row
+ *  never remounts mid-edit. */
+interface SkillRow {
+  id: number;
+  skill: string;
+  effort: string;
+}
+
 export function ReasoningPicker({
   currentModel,
   profile,
@@ -52,10 +72,11 @@ export function ReasoningPicker({
   onChanged,
 }: ReasoningPickerProps) {
   const [effort, setEffort] = useState("medium");
-  const [skillMap, setSkillMap] = useState<Record<string, string>>({});
+  const [skillRows, setSkillRows] = useState<SkillRow[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [saving, setSaving] = useState(false);
   const lastFetchKeyRef = useRef("");
+  const nextRowIdRef = useRef(1);
 
   useEffect(() => {
     const fetchKey = `${profile ?? ""}:${currentModel}:${refreshKey}`;
@@ -67,10 +88,17 @@ export function ReasoningPicker({
         const agent = (cfg?.agent as Record<string, unknown> | undefined) ?? {};
         setEffort(normalizeEffort(agent.reasoning_effort));
         const map = agent.reasoning_by_skill;
-        setSkillMap(
+        const raw =
           map && typeof map === "object"
             ? (map as Record<string, string>)
-            : {},
+            : {};
+        // Materialize each committed entry as a stable row.
+        setSkillRows(
+          Object.entries(raw).map(([skill, eff]) => ({
+            id: nextRowIdRef.current++,
+            skill,
+            effort: normalizeSkillEffort(eff),
+          })),
         );
         setLoaded(true);
       })
@@ -80,8 +108,17 @@ export function ReasoningPicker({
       });
   }, [currentModel, profile, refreshKey]);
 
+  /** Serialize only the committed (non-empty-skill) rows to the config map,
+   *  preserving the literal "off" sentinel for disabled skills. Never called
+   *  with an uncommitted/blank row. */
   const persistSkillMap = useCallback(
-    (nextMap: Record<string, string>) => {
+    (rows: SkillRow[]) => {
+      const nextMap: Record<string, string> = {};
+      for (const row of rows) {
+        const name = row.skill.trim();
+        if (!name) continue; // never persist an empty-string key
+        nextMap[name] = row.effort;
+      }
       setSaving(true);
       void api
         .getConfig(profile)
@@ -130,64 +167,51 @@ export function ReasoningPicker({
     [effort, onChanged, profile],
   );
 
-  const skillRows = () =>
-    Object.entries(skillMap).map(([skill, eff], i) => ({
-      key: `${skill}::${i}`,
-      skill,
-      effort: eff,
-    }));
-
-  const setRowSkill = (key: string, skill: string) => {
+  const setRowSkill = (id: number, skill: string) => {
     // Update local state only. Persisting here would fire a full config
     // GET+PUT on EVERY keystroke (e.g. typing "planning" → ~8 writes of
-    // junk intermediates {p:…},{pl:…} that race concurrent writers).
-    // The name is committed to config on blur / Enter via commitRowSkill.
-    const rows = skillRows();
-    const row = rows.find((r) => r.key === key);
-    if (!row) return;
-    const next = { ...skillMap };
-    if (next[row.skill] !== undefined) delete next[row.skill];
-    if (skill.trim()) next[skill.trim()] = row.effort;
-    setSkillMap(next);
+    // junk intermediates that race concurrent writers). The name is committed
+    // to config on blur / Enter via commitRowSkill.
+    setSkillRows((rows) =>
+      rows.map((r) => (r.id === id ? { ...r, skill } : r)),
+    );
   };
 
-  const commitRowSkill = (key: string) => {
-    const rows = skillRows();
-    const row = rows.find((r) => r.key === key);
+  const commitRowSkill = (id: number) => {
+    // Commit (persist) a row only when it has a valid, non-empty skill name.
+    const row = skillRows.find((r) => r.id === id);
     if (!row) return;
     if (!row.skill.trim()) return; // empty name — leave the row, don't persist
-    persistSkillMap({ ...skillMap });
+    persistSkillMap(skillRows);
   };
 
-  const setRowEffort = (key: string, eff: string) => {
-    const rows = skillRows();
-    const row = rows.find((r) => r.key === key);
+  const setRowEffort = (id: number, eff: string) => {
+    const row = skillRows.find((r) => r.id === id);
     if (!row) return;
-    const next = { ...skillMap };
     const normalized = normalizeSkillEffort(eff);
-    if (normalized === "off") {
-      delete next[row.skill];
-    } else {
-      next[row.skill] = normalized;
-    }
-    setSkillMap(next);
-    persistSkillMap(next);
+    // Persist the literal "off" sentinel (resolver: "skip this skill's layer,
+    // fall through") rather than deleting the key, which would let the
+    // skill's own frontmatter suggestion run.
+    setSkillRows((rows) =>
+      rows.map((r) => (r.id === id ? { ...r, effort: normalized } : r)),
+    );
+    if (!row.skill.trim()) return; // don't persist an uncommitted row
+    persistSkillMap(skillRows.map((r) => (r.id === id ? { ...r, effort: normalized } : r)));
   };
 
   const addRow = () => {
-    const next = { ...skillMap, "": "xhigh" };
-    setSkillMap(next);
-    persistSkillMap(next);
+    // Add a blank row to LOCAL state only; nothing is persisted until a valid
+    // skill name is committed (fixes the old `{"": "xhigh"}` early write).
+    setSkillRows((rows) => [
+      ...rows,
+      { id: nextRowIdRef.current++, skill: "", effort: "medium" },
+    ]);
   };
 
-  const removeRow = (key: string) => {
-    const rows = skillRows();
-    const row = rows.find((r) => r.key === key);
-    if (!row) return;
-    const next = { ...skillMap };
-    if (next[row.skill] !== undefined) delete next[row.skill];
-    setSkillMap(next);
-    persistSkillMap(next);
+  const removeRow = (id: number) => {
+    const nextRows = skillRows.filter((r) => r.id !== id);
+    setSkillRows(nextRows);
+    persistSkillMap(nextRows);
   };
 
   return (
@@ -215,15 +239,15 @@ export function ReasoningPicker({
         <span className="text-display tracking-wider text-text-tertiary">
           per-skill
         </span>
-        {skillRows().map((row) => (
-          <div key={row.key} className="flex items-center gap-1.5">
+        {skillRows.map((row) => (
+          <div key={row.id} className="flex items-center gap-1.5">
             <input
               className="min-w-0 flex-1 rounded border border-line bg-transparent px-1.5 py-1"
               value={row.skill}
               disabled={saving}
               placeholder="skill name (e.g. plan)"
-              onChange={(e) => setRowSkill(row.key, e.target.value)}
-              onBlur={() => commitRowSkill(row.key)}
+              onChange={(e) => setRowSkill(row.id, e.target.value)}
+              onBlur={() => commitRowSkill(row.id)}
               onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
                 if (e.key === "Enter") {
                   e.currentTarget.blur();
@@ -233,7 +257,7 @@ export function ReasoningPicker({
             <Select
               className="min-w-0"
               disabled={saving}
-              onValueChange={(v) => setRowEffort(row.key, v)}
+              onValueChange={(v) => setRowEffort(row.id, v)}
               value={normalizeSkillEffort(row.effort)}
             >
               <SelectOption value="off">Off</SelectOption>
@@ -247,13 +271,14 @@ export function ReasoningPicker({
               className="shrink-0 text-text-tertiary hover:text-danger"
               disabled={saving}
               aria-label={`Remove ${row.skill || "skill"} override`}
-              onClick={() => removeRow(row.key)}
+              onClick={() => removeRow(row.id)}
             >
               <Trash2 className="h-3.5 w-3.5" />
             </button>
           </div>
         ))}
         <button
+          data-testid="add-row"
           className="flex items-center gap-1 self-start text-text-tertiary hover:text-text-secondary"
           disabled={saving}
           onClick={addRow}
@@ -265,4 +290,3 @@ export function ReasoningPicker({
     </div>
   );
 }
-

--- a/web/src/lib/reasoning-effort.test.ts
+++ b/web/src/lib/reasoning-effort.test.ts
@@ -3,6 +3,8 @@ import {
   EFFORT_OPTIONS,
   VALID_EFFORTS,
   normalizeEffort,
+  normalizeSkillEffort,
+  SKILL_OFF_VALUES,
 } from "./reasoning-effort";
 
 describe("normalizeEffort", () => {
@@ -43,5 +45,31 @@ describe("EFFORT_OPTIONS", () => {
     for (const level of ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]) {
       expect(values.has(level)).toBe(true);
     }
+  });
+});
+
+describe("normalizeSkillEffort (per-skill reasoning map)", () => {
+  it("passes through a valid effort level", () => {
+    expect(normalizeSkillEffort("xhigh")).toBe("xhigh");
+    expect(normalizeSkillEffort("high")).toBe("high");
+  });
+
+  it("maps off/false/no/none/disabled to the sentinel", () => {
+    for (const off of SKILL_OFF_VALUES) {
+      expect(normalizeSkillEffort(off)).toBe("off");
+    }
+    expect(normalizeSkillEffort(false)).toBe("off");
+    expect(normalizeSkillEffort("")).toBe("off");
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(normalizeSkillEffort("OFF")).toBe("off");
+    expect(normalizeSkillEffort("  XHigh  ")).toBe("xhigh");
+  });
+
+  it("treats unknown values as off (disabled) rather than guessing a level", () => {
+    expect(normalizeSkillEffort("turbo")).toBe("off");
+    expect(normalizeSkillEffort(42)).toBe("off");
+    expect(normalizeSkillEffort(undefined)).toBe("off");
   });
 });

--- a/web/src/lib/reasoning-effort.ts
+++ b/web/src/lib/reasoning-effort.ts
@@ -36,3 +36,24 @@ export function normalizeEffort(raw: unknown): string {
   if (!value) return "medium";
   return VALID_EFFORTS.has(value) ? value : "medium";
 }
+
+/** The falsey spellings the per-skill reasoning map accepts to disable a
+ *  skill's suggestion. Mirrors the resolver's `_SKILL_OFF` set (the map
+ *  accepts a broader falsey set than the global effort, which stays
+ *  global-safe on {"none","false","disabled"}). */
+export const SKILL_OFF_VALUES: ReadonlySet<string> = new Set([
+  "off", "false", "no", "none", "0", "disable", "disabled",
+]);
+
+/** Normalize a per-skill `agent.reasoning_by_skill` value to a selectable
+ *  option, where "off" is the explicit "disable this skill's suggestion"
+ *  sentinel. A valid effort passes through; anything falsey/unknown maps to
+ *  "off" (disabled) rather than guessing a level. */
+export function normalizeSkillEffort(raw: unknown): string {
+  if (raw === false) return "off";
+  const value = String(raw ?? "").trim().toLowerCase();
+  if (!value) return "off";
+  if (SKILL_OFF_VALUES.has(value)) return "off";
+  return VALID_EFFORTS.has(value) ? value : "off";
+}
+


### PR DESCRIPTION
## Per-skill reasoning effort — configure any skill to think harder, opt-in by default

**One-line summary:** let users give any skill its own reasoning level via config, keyed on skill name — strictly opt-in, defaults untouched, skill-suggested effort is inert unless you enable it.

### The problem

There's no per-task knob for reasoning. You're either on a global effort or a per-model override, and both are blunt — the same effort applies whether you're brainstorming a design or just running a quick command. The natural unit for "this kind of work thinks harder" is the **skill**.

### What this adds

**1. A per-skill reasoning map (the user-facing bit).** `agent.reasoning_by_skill` in config — keyed on skill name, valued by any supported effort, empty by default:

```yaml
agent:
  reasoning_by_skill:
    plan: xhigh          # plan thinking gets the top tier while it's active
    brainstorming: high  # any skill, any level
    debugging: off       # 'off' ignores a skill's suggestion entirely
```

Out of the box nothing changes. **A skill's own frontmatter suggestion is INERT unless you opt in** (see #3) — installing or viewing a third-party skill can never silently raise effort/spend.

2. **Per-skill resolution in the existing chokepoint.** The resolver honours, in order:

```
session /reasoning  >  user reasoning_by_skill[skill]  >  skill frontmatter suggestion (only if opted in)  >  per-model override  >  global
```

3. **Optional frontmatter suggestions, gated behind `agent.reasoning_by_skill_optin: true`.** A skill *may* declare a suggested level — `metadata.hermes.reasoning: xhigh` — but that is **recommendation metadata only, inert by default**. It never fires unless the user turns on `reasoning_by_skill_optin` (or sets an explicit `reasoning_by_skill[skill]` value). This upholds the contract: "a skill's default never moves unless you ask."

4. **A dashboard editor.** The existing `ReasoningPicker` gained a full per-skill map editor so tuning doesn't require editing YAML:
   - Add / remove per-skill rows, each with a skill-name input and an effort dropdown (`Off`, `Minimal`, `Low`, `Medium`, `High`, `Extra High`, `Max`, `Ultra`).
   - Selecting **Off** persists the literal `"off"` sentinel (the resolver reads it as "ignore this skill's suggestion, fall through") — it does NOT delete the key, which would let the skill's own frontmatter suggestion run.
   - Rows are keyed by a stable id, so renaming a skill doesn't remount the row; nothing is written to config until a valid skill name is committed on blur/Enter (no premature `{"": "xhigh"}` writes).

### Behavior note (one-turn lag)

Per-skill attribution is **last-view-wins with a one-turn lag** — the documented, intended behavior. Skills viewed during turn N are recorded; they are consumed at the start of turn N+1 and apply to that turn. This is NOT per-current-skill attribution: a turn's own effort is decided by what was last viewed in the previous turn. The record is consumed once, atomically, at turn admission, so it never lingers to a later turn.

### Why this shape

- **Prompt caching stays sacred.** The effort is resolved once per turn and rides only the per-request body fields (`thinking` / `extra_body`) — never the cached message prefix.
- **The core stays narrow.** No new core model tool. It extends the existing `resolve_reasoning_config` chokepoint and the existing skill-view path.
- **No new env vars.** Everything is `config.yaml` + the dashboard.

### Implementation

- `tools/skills_tool.py` — parse optional `metadata.hermes.reasoning`; track the active skill + suggestion per session; atomic `pop_active_skill_reasoning` (single locked consume-and-clear).
- `hermes_constants.py` — `resolve_reasoning_config` gained an `active_skill` param honouring the priority chain; skill frontmatter suggestions only fire when opted in.
- `gateway/run.py` — threads the session id through reasoning resolution; consumes the active-skill record atomically at turn admission (before the session-override check, so no precedence rung can leave stale residue).
- `hermes_cli/config_defaults.py` — `agent.reasoning_by_skill` (empty) + `agent.reasoning_by_skill_optin` (false).
- `web/src/components/ReasoningPicker.tsx` — stable-id rows, `off` sentinel, commit-on-valid-name; `web/src/lib/reasoning-effort.*` — pure helpers + vitest coverage.
- `cli-config.yaml.example` — documents the new keys and the opt-in contract.
- `tests/` — resolver priority (incl. opt-in gating + invalid-value fall-through), atomic consume regression (session override → skill → clear → no stale), rendered editor test, cache-invariant test.

### Verification

- **122 passed, 5 skipped** across the resolver / frontmatter / cache / gateway reasoning suites.
- **283 passed** in the web vitest suite (including the new rendered editor test).
- **Revert-proofed**: removing the opt-in gate makes the "inert without opt-in" test fail; removing the delete-vs-off fix makes the rendered editor test fail; removing the atomic consume makes the session-override regression fail.
- Rebased onto current main (was 293 behind) — clean replay, no conflicts.
