### PR TITLE
fix(agent): max-iteration warning no longer contaminates -Q/oneshot stdout (salvages #26155)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2848,8 +2848,21 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
-    agent._safe_print(
-        f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary..."
+    warning = f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary..."
+    if getattr(agent, "suppress_status_output", False):
+        # Strict machine-readable mode (hermes chat -Q, oneshot, background
+        # review): keep diagnostics out of stdout so wrappers receive only
+        # the final assistant content (#93220 class). Note: plain quiet_mode
+        # is NOT the right gate — the interactive CLI runs quiet_mode=True by
+        # default and should still see this warning.
+        logger.warning(warning)
+    else:
+        agent._safe_print(warning)
+
+    summary_request = (
+        "You've reached the maximum number of tool-calling iterations allowed. "
+        "Please provide a final response summarizing what you've found and accomplished so far, "
+        "without calling any more tools."
     )
 
     summary_api_request_id = f"iteration-summary:{uuid.uuid4()}"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2689,6 +2689,42 @@ class TestHandleMaxIterations:
             outcome="success",
         )
 
+    def test_suppress_status_output_keeps_iteration_warning_off_stdout(self, agent, capsys):
+        """Machine-readable mode (-Q/oneshot) must not contaminate stdout (#26155)."""
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        agent.suppress_status_output = True
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            1,
+        )
+
+        captured = capsys.readouterr()
+        assert result == "Summary"
+        assert "Reached maximum iterations" not in captured.out
+
+    def test_plain_quiet_mode_still_prints_iteration_warning(self, agent, capsys):
+        """Interactive CLI runs quiet_mode=True by default — the warning must
+        still show there; only suppress_status_output gates it (#26155)."""
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        agent.quiet_mode = True
+        agent.suppress_status_output = False
+        printed = []
+        agent._print_fn = lambda *a, **k: printed.append(" ".join(str(x) for x in a))
+
+        result = agent._handle_max_iterations(
+            [{"role": "user", "content": "do stuff"}],
+            1,
+        )
+
+        assert result == "Summary"
+        combined = "\n".join(printed) + capsys.readouterr().out
+        assert "Reached maximum iterations" in combined
+
     def test_api_failure_returns_error(self, agent):
         agent.client.chat.completions.create.side_effect = Exception("API down")
         agent._cached_system_prompt = "You are helpful."


### PR DESCRIPTION
## Summary
A `-Q`/oneshot run that hits the iteration cap no longer prints "⚠️ Reached maximum iterations…" into machine-readable stdout — the warning routes to the log in strict mode and stays visible everywhere else. Salvages #26155 by @honor2030 (authorship preserved).

Follow-up to #93325, which fixed the same leak class (reasoning box, tool diffs, spinner lines) but left this one site: `handle_max_iterations()` prints via `agent._safe_print`, which is not gated by `suppress_status_output` (only `_vprint` is).

## Changes
- `agent/chat_completion_helpers.py`: gate the warning on `suppress_status_output` (not `quiet_mode` as the original PR did — the interactive CLI runs `quiet_mode=True` by default and must keep seeing the warning; strict mode is `-Q`, oneshot, and background-review forks).
- `tests/run_agent/test_run_agent.py`: positive + negative tests — strict mode keeps stdout clean, plain quiet mode still shows the warning.

## Validation
| | Result |
|---|---|
| `TestHandleMaxIterations` (14 tests incl. 2 new) | pass |
| Sabotage run (gate removed) | new test fails as expected |

## Infographic

![Quiet stdout keeps its promise](https://v3b.fal.media/files/b/0aa78ebe/EZt3RlTQ8Y_2a8PULYn-P_HDfedOzq.png)
