### PR TITLE
fix(tools): gated SSH-config writes no longer crash with TypeError (#93201, salvages #87735 + #93215)

### DIFF
--- a/contributors/emails/kwang@Kangs-Mac-mini.local
+++ b/contributors/emails/kwang@Kangs-Mac-mini.local
@@ -1,0 +1,1 @@
+acewong7

--- a/contributors/emails/thenabbu@users.noreply.github.com
+++ b/contributors/emails/thenabbu@users.noreply.github.com
@@ -1,0 +1,1 @@
+thenabbu

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -1000,3 +1000,36 @@ class TestNotFoundCache:
         assert _check_not_found_cache("read", "/tmp/never-exists-notify", tid) is None, (
             "notify_other_tool_call must clear cached misses"
         )
+
+
+class TestSSHConfigWriteGateSingleQuery:
+    """Regression: the ssh-config write guard must pass
+    single_query_deny_message to _run_approval_gate (required kwarg since
+    1596148ff). Missing it raises TypeError instead of routing through the
+    approval flow — see issue #93201."""
+
+    def test_gate_call_passes_single_query_deny_message(self):
+        import inspect as _inspect
+        import re as _re
+        import tools.file_tools as ft
+
+        src = _inspect.getsource(ft)
+        idx = src.find("_approval._run_approval_gate(")
+        assert idx != -1, "ssh_config_write gate call not found"
+        block = src[idx:idx + 900]
+        assert "pattern_key=\"ssh_config_write\"" in block
+
+        from tools.approval import _run_approval_gate
+        required = [
+            name for name, param in _inspect.signature(
+                _run_approval_gate).parameters.items()
+            if param.kind == _inspect.Parameter.KEYWORD_ONLY
+            and param.default is _inspect.Parameter.empty
+        ]
+        missing = [k for k in required if not _re.search(
+            rf"\b{k}\s*=", block)]
+        assert missing == [], (
+            f"_run_approval_gate call at ssh_config_write gate is missing "
+            f"required kwargs {missing}; it would raise TypeError instead "
+            f"of showing an approval prompt"
+        )

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1009,6 +1009,9 @@ def _check_approval_required_write(paths: list[str],
         display_target=f"<write to {display_targets}>",
         cron_deny_message=blocked.format(
             why="requires approval but this cron session denies it."),
+        single_query_deny_message=blocked.format(
+            why="requires approval but single-query mode (-q) runs without "
+                "a user present to approve it."),
         autoapprove_log_prefix="ssh_config_write",
         fail_closed_when_no_human=True,
         no_human_block_message=blocked.format(

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1010,8 +1010,10 @@ def _check_approval_required_write(paths: list[str],
         cron_deny_message=blocked.format(
             why="requires approval but this cron session denies it."),
         single_query_deny_message=blocked.format(
-            why="requires approval but single-query mode (-q) runs without "
-                "a user present to approve it."),
+            why="requires approval but single-query (-q) sessions run "
+                "without a user present to approve it. To allow flagged "
+                "actions in single-query mode, set approvals.single_query_mode: "
+                "approve in config.yaml."),
         autoapprove_log_prefix="ssh_config_write",
         fail_closed_when_no_human=True,
         no_human_block_message=blocked.format(


### PR DESCRIPTION
## Summary
Gated SSH-config writes route through the approval flow again instead of crashing — commit 1596148ff added the required `single_query_deny_message` kwarg to `_run_approval_gate()` and updated its two in-file callers, but missed the third caller in `tools/file_tools.py` (`pattern_key="ssh_config_write"`), so every gated SSH-config write raised `TypeError` since. Fixes #93201.

Salvages #87735 by @acewong7 (earliest fix, Aug 16 — authorship preserved) and #93215 by @thenabbu (issue reporter; his commit carries the deny-message config hint plus a signature-driven regression test that fails on ANY future required kwarg the gate call misses, not just this one).

## Changes
- `tools/file_tools.py`: pass `single_query_deny_message` at the ssh_config_write gate call (message includes the `approvals.single_query_mode` config hint, matching the sibling callers in `tools/approval.py`).
- `tests/tools/test_file_tools.py`: regression test introspects `_run_approval_gate`'s required keyword-only params and asserts the gate call passes every one — future signature growth can't silently break this caller again.

## Validation
| | Before | After |
|---|---|---|
| Live repro (`_check_approval_required_write` on `~/.ssh/config`, isolated HERMES_HOME) | `TypeError: missing 1 required keyword-only argument` | fail-closed deny message, no crash |
| `tests/tools/test_file_tools.py` | — | 46 passed, 2 skipped |

## Infographic

![Approval gate: link restored](https://v3b.fal.media/files/b/0aa78ee6/Ij7sHVl15nbcwMCloyrCP_i1ziSuAB.png)
