### PR TITLE
fix(gateway): root-qualify native service identity to prevent cross-HERMES_HOME collisions (#93349)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2310,8 +2310,7 @@ def _real_native_hermes_root() -> Path:
     import pwd
 
     try:
-        # windows-footgun: ok — guarded by is_windows() above
-        return Path(pwd.getpwuid(os.getuid()).pw_dir) / ".hermes"
+        return Path(pwd.getpwuid(os.getuid()).pw_dir) / ".hermes"  # windows-footgun: ok — guarded by is_windows() above
     except Exception:
         # Sandboxed/container UID with no matching passwd entry (also hit by
         # tests that stub getuid()/Path without stubbing pwd fully). This is

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3269,6 +3269,8 @@ def launchd_gateway_labels_for_install() -> list[str]:
     from hermes_cli.profiles import list_profiles
     from hermes_constants import get_default_hermes_root
 
+    # All profiles of this install share one root, so one root hash — not
+    # a per-profile one — is folded into every label below.
     root = get_default_hermes_root().resolve()
     root_label: list[str] = []
     profile_labels: list[str] = []

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2326,9 +2326,23 @@ def _native_root_hash(root: Path) -> str:
     Shared by :func:`_native_service_suffix` (current process) and
     :func:`launchd_gateway_labels_for_install` (every profile of an
     install), so both fold the same root identity into their names.
+
+    The pwd-anchored comparison against :func:`_real_native_hermes_root` only
+    runs when ``HERMES_HOME`` is actually set — i.e. there is real evidence
+    of a custom root or profile-mode HOME redirection to correct for. When
+    ``HERMES_HOME`` is unset, *root* is ``get_default_hermes_root()``'s
+    plain ``Path.home()``-based default with nothing Hermes-controlled to
+    redirect it, so it's trusted as canonical outright. Falling through to
+    the pwd check unconditionally would flag a plain default install as
+    "custom" any time ``$HOME`` merely disagrees with the ``/etc/passwd``
+    entry for reasons unrelated to Hermes (containers with a synthetic
+    ``HOME``, restricted-UID pods, ``sudo`` without ``-H``, CI runners) —
+    giving it a spurious hashed identity on every invocation.
     """
     import hashlib
 
+    if not os.environ.get("HERMES_HOME", "").strip():
+        return ""
     resolved = root.resolve()
     if resolved == _real_native_hermes_root().resolve():
         return ""

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2259,6 +2259,15 @@ def _profile_suffix() -> str:
     Returns ``""`` for the default root, the profile name for
     ``<root>/profiles/<name>``, or a short hash for any other path.
     Works correctly in Docker (HERMES_HOME=/opt/data) and standard deployments.
+
+    NOTE: ``""`` here means "the root of *this* HERMES_HOME", not
+    specifically the canonical ``~/.hermes`` root — s6/container dispatch
+    and the multiplexer guard rely on that to treat a single-root container
+    deployment as "the default profile" regardless of where its root lives.
+    Native launchd/systemd identity (label, plist path, unit name) must NOT
+    reuse this value directly for that reason: two independent custom roots
+    would both get ``""`` and collide (#93349). Those call sites go through
+    :func:`_native_service_suffix` instead, which folds in a root hash.
     """
     import hashlib
     import re
@@ -2279,6 +2288,85 @@ def _profile_suffix() -> str:
         pass
     # Fallback: short hash for arbitrary HERMES_HOME paths
     return hashlib.sha256(str(home).encode()).hexdigest()[:8]
+
+
+def _real_native_hermes_root() -> Path:
+    """Canonical Hermes root anchored to the real OS-user account, not ``Path.home()``.
+
+    Profile-mode Hermes often runs subprocesses with ``HOME`` pointed at
+    ``{HERMES_HOME}/home`` for tool-config isolation (see
+    ``hermes_constants.get_subprocess_home``), so ``Path.home()`` — and
+    anything derived from it, like ``get_default_hermes_root()`` — can
+    reflect that redirected profile home rather than the account's real
+    one. Comparing against it directly would make an ordinary canonical
+    profile look "custom" purely because of the caller's HOME, and give it
+    a spurious hash suffix that drifts between subprocess contexts. Mirrors
+    :func:`_launchd_user_home`'s pwd-based resolution for the same reason.
+    """
+    from hermes_constants import _get_platform_default_hermes_home
+
+    if is_windows():
+        return _get_platform_default_hermes_home()
+    import pwd
+
+    try:
+        # windows-footgun: ok — guarded by is_windows() above
+        return Path(pwd.getpwuid(os.getuid()).pw_dir) / ".hermes"
+    except Exception:
+        # Sandboxed/container UID with no matching passwd entry (also hit by
+        # tests that stub getuid()/Path without stubbing pwd fully). This is
+        # a best-effort precision improvement over Path.home() — fall back
+        # to it rather than raising.
+        return _get_platform_default_hermes_home()
+
+
+def _native_root_hash(root: Path) -> str:
+    """Short stable digest of *root*, or ``""`` when it is the canonical root.
+
+    Shared by :func:`_native_service_suffix` (current process) and
+    :func:`launchd_gateway_labels_for_install` (every profile of an
+    install), so both fold the same root identity into their names.
+    """
+    import hashlib
+
+    resolved = root.resolve()
+    if resolved == _real_native_hermes_root().resolve():
+        return ""
+    return hashlib.sha256(str(resolved).encode()).hexdigest()[:12]
+
+
+def _native_suffix_for(profile_suffix: str, root: Path) -> str:
+    """Combine a ``_profile_suffix()``-shaped suffix with *root*'s hash.
+
+    ``_profile_suffix()`` alone collides across distinct custom
+    ``HERMES_HOME`` roots on the same account: two roots that both use the
+    default profile, or both have a same-named profile, produce the same
+    suffix and therefore the same launchd label/plist path or systemd unit
+    name (#93349) — installing the second can overwrite or unlink the
+    first's service. Folding in *root*'s hash (empty for the canonical
+    ``~/.hermes`` root, so its names stay backward compatible) makes every
+    root/profile pair distinct:
+
+      canonical default   -> ``""``
+      canonical ``coder``  -> ``coder``
+      custom root default -> ``<root-hash>``
+      custom root ``coder``-> ``coder-<root-hash>``
+    """
+    root_hash = _native_root_hash(root)
+    if not root_hash:
+        return profile_suffix
+    return f"{profile_suffix}-{root_hash}" if profile_suffix else root_hash
+
+
+def _native_service_suffix() -> str:
+    """Root-qualified service-identity suffix for launchd/systemd naming.
+
+    See :func:`_native_suffix_for` for why this differs from
+    :func:`_profile_suffix`.
+    """
+    from hermes_constants import get_default_hermes_root
+
+    return _native_suffix_for(_profile_suffix(), get_default_hermes_root())
 
 
 def _profile_arg(hermes_home: str | None = None, default_root: str | Path | None = None) -> str:
@@ -2329,9 +2417,10 @@ def get_service_name() -> str:
 
     Default ``~/.hermes`` returns ``hermes-gateway`` (backward compatible).
     Profile ``~/.hermes/profiles/coder`` returns ``hermes-gateway-coder``.
-    Any other HERMES_HOME appends a short hash for uniqueness.
+    A custom HERMES_HOME root appends a root hash for cross-root uniqueness
+    (see :func:`_native_service_suffix`).
     """
-    suffix = _profile_suffix()
+    suffix = _native_service_suffix()
     if not suffix:
         return _SERVICE_BASE
     return f"{_SERVICE_BASE}-{suffix}"
@@ -3138,8 +3227,10 @@ def get_launchd_plist_path() -> Path:
 
     Default ``~/.hermes`` → ``ai.hermes.gateway.plist`` (backward compatible).
     Profile ``~/.hermes/profiles/coder`` → ``ai.hermes.gateway-coder.plist``.
+    A custom HERMES_HOME root appends a root hash for cross-root uniqueness
+    (see :func:`_native_service_suffix`).
     """
-    suffix = _profile_suffix()
+    suffix = _native_service_suffix()
     name = f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
     return _launchd_user_home() / "Library" / "LaunchAgents" / f"{name}.plist"
 
@@ -3163,14 +3254,19 @@ def launchd_gateway_labels_for_install() -> list[str]:
     import re as _re
 
     from hermes_cli.profiles import list_profiles
+    from hermes_constants import get_default_hermes_root
 
+    root = get_default_hermes_root().resolve()
     root_label: list[str] = []
     profile_labels: list[str] = []
     for profile in list_profiles():
         if profile.is_default:
-            root_label.append("ai.hermes.gateway")
+            suffix = _native_suffix_for("", root)
+            root_label.append(f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway")
         elif _re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", profile.name):
-            profile_labels.append(f"ai.hermes.gateway-{profile.name}")
+            profile_labels.append(
+                f"ai.hermes.gateway-{_native_suffix_for(profile.name, root)}"
+            )
     return root_label + sorted(profile_labels)
 
 
@@ -4396,8 +4492,12 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
 
 
 def get_launchd_label() -> str:
-    """Return the launchd service label, scoped per profile."""
-    suffix = _profile_suffix()
+    """Return the launchd service label, scoped per profile and root.
+
+    See :func:`_native_service_suffix` for why this is root-qualified
+    rather than using :func:`_profile_suffix` directly.
+    """
+    suffix = _native_service_suffix()
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1551,6 +1551,24 @@ class TestNativeServiceIdentityRootQualification:
         assert gateway_cli.get_service_name() == "hermes-gateway-coder"
         assert gateway_cli.get_launchd_label() == "ai.hermes.gateway-coder"
 
+    def test_unset_hermes_home_stays_canonical_even_if_home_disagrees_with_passwd(self, tmp_path, monkeypatch):
+        """A plain default install (HERMES_HOME unset) must stay canonical even
+        when $HOME doesn't match the real account's passwd entry — e.g.
+        containers that set HOME via ENV without a matching /etc/passwd row,
+        restricted-UID pods, or sudo without -H. Regression for a review
+        finding on #93349: the root-hash check must not reinterpret
+        "canonical" via pwd.getpwuid unless HERMES_HOME gives it a reason to."""
+        home = tmp_path / "home"
+        home.mkdir()
+        real_passwd_home = tmp_path / "real-passwd-home"
+        real_passwd_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: home)
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir=str(real_passwd_home)))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        assert gateway_cli.get_service_name() == "hermes-gateway"
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway"
+
     def test_distinct_custom_root_defaults_never_collide(self, tmp_path, monkeypatch):
         canonical_home = tmp_path / "home"
         canonical_home.mkdir()

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1509,7 +1509,97 @@ class TestProfileArg:
 
         plist_path = gateway_cli.get_launchd_plist_path()
 
-        assert plist_path == machine_home / "Library" / "LaunchAgents" / "ai.hermes.gateway-orcha.plist"
+        # profile_dir's root (tmp_path/.hermes) is not the real account home
+        # (machine_home/.hermes) here, so it is a "custom root" for identity
+        # purposes and the suffix is root-qualified — see #93349.
+        import hashlib
+
+        root_hash = hashlib.sha256(str((tmp_path / ".hermes").resolve()).encode()).hexdigest()[:12]
+        assert plist_path == (
+            machine_home / "Library" / "LaunchAgents" / f"ai.hermes.gateway-orcha-{root_hash}.plist"
+        )
+        # The real account home is always used for the *directory*, regardless.
+        assert plist_path.parent == machine_home / "Library" / "LaunchAgents"
+
+
+class TestNativeServiceIdentityRootQualification:
+    """Regression for #93349 — service identity must not collide across
+    independent custom HERMES_HOME roots that use the same profile name (or
+    both default), since launchd label / plist path / systemd unit name are
+    all derived from this suffix."""
+
+    @staticmethod
+    def _root_hash(root: Path) -> str:
+        import hashlib
+
+        return hashlib.sha256(str(root.resolve()).encode()).hexdigest()[:12]
+
+    def test_canonical_names_stay_backward_compatible(self, tmp_path, monkeypatch):
+        canonical_home = tmp_path / "home"
+        canonical_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: canonical_home)
+        monkeypatch.setattr(pwd, "getpwuid", lambda uid: SimpleNamespace(pw_dir=str(canonical_home)))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        assert gateway_cli.get_service_name() == "hermes-gateway"
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway"
+
+        coder = canonical_home / ".hermes" / "profiles" / "coder"
+        coder.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(coder))
+
+        assert gateway_cli.get_service_name() == "hermes-gateway-coder"
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway-coder"
+
+    def test_distinct_custom_root_defaults_never_collide(self, tmp_path, monkeypatch):
+        canonical_home = tmp_path / "home"
+        canonical_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: canonical_home)
+
+        root_a = tmp_path / "roots" / "a"
+        root_b = tmp_path / "roots" / "b"
+        root_a.mkdir(parents=True)
+        root_b.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(root_a))
+        name_a = gateway_cli.get_service_name()
+        label_a = gateway_cli.get_launchd_label()
+
+        monkeypatch.setenv("HERMES_HOME", str(root_b))
+        name_b = gateway_cli.get_service_name()
+        label_b = gateway_cli.get_launchd_label()
+
+        # Neither custom root reuses the canonical bare name...
+        assert name_a not in ("hermes-gateway", "hermes-gateway-a", "hermes-gateway-b")
+        assert label_a != "ai.hermes.gateway"
+        # ...and the two custom roots are distinct from EACH OTHER, which is
+        # the actual bug: pre-fix, both resolved to the bare canonical name.
+        assert name_a != name_b
+        assert label_a != label_b
+        assert name_a == f"hermes-gateway-{self._root_hash(root_a)}"
+        assert name_b == f"hermes-gateway-{self._root_hash(root_b)}"
+
+    def test_same_named_profile_on_distinct_custom_roots_never_collides(self, tmp_path, monkeypatch):
+        canonical_home = tmp_path / "home"
+        canonical_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: canonical_home)
+
+        root_a = tmp_path / "roots" / "a"
+        root_b = tmp_path / "roots" / "b"
+        (root_a / "profiles" / "coder").mkdir(parents=True)
+        (root_b / "profiles" / "coder").mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(root_a / "profiles" / "coder"))
+        label_a_coder = gateway_cli.get_launchd_label()
+
+        monkeypatch.setenv("HERMES_HOME", str(root_b / "profiles" / "coder"))
+        label_b_coder = gateway_cli.get_launchd_label()
+
+        assert label_a_coder != label_b_coder
+        assert label_a_coder == f"ai.hermes.gateway-coder-{self._root_hash(root_a)}"
+        assert label_b_coder == f"ai.hermes.gateway-coder-{self._root_hash(root_b)}"
+        # Also distinct from a canonical "coder" profile (no hash at all).
+        assert "coder-" in label_a_coder and label_a_coder != "ai.hermes.gateway-coder"
 
 
 class TestRemapPathForUser:

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -97,10 +97,19 @@ class TestLaunchdGatewayLabelsForInstall:
                 _Profile("Bad Name!"),  # cannot map to a service suffix — skipped
             ],
         )
+        # The hermetic test HERMES_HOME is a tmp dir, not the real ~/.hermes,
+        # so it is a "custom root" for identity purposes and every label is
+        # root-qualified with the same hash (#93349) — this is what keeps a
+        # second, independent custom-root install's identically-named
+        # profiles from colliding with this one's.
+        import hashlib
+        from hermes_constants import get_default_hermes_root
+
+        root_hash = hashlib.sha256(str(get_default_hermes_root().resolve()).encode()).hexdigest()[:12]
         assert launchd_gateway_labels_for_install() == [
-            "ai.hermes.gateway",
-            "ai.hermes.gateway-merit-ops",
-            "ai.hermes.gateway-tfl-wiki",
+            f"ai.hermes.gateway-{root_hash}",
+            f"ai.hermes.gateway-merit-ops-{root_hash}",
+            f"ai.hermes.gateway-tfl-wiki-{root_hash}",
         ]
 
     def test_no_profiles_means_no_fleet(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a service-identity collision reported in #93349: `_profile_suffix()` derives the launchd label / plist path / systemd unit name only from the profile name relative to `get_default_hermes_root()`, ignoring which root produced it. Two independent custom `HERMES_HOME` roots (Docker, `--hermes-home`) that both use the default profile — or both have a same-named profile — resolve to the *same* service identity. Installing the second gateway can overwrite or unlink the first's plist/unit.

`get_service_name()`, `get_launchd_label()`, `get_launchd_plist_path()`, and `launchd_gateway_labels_for_install()` now go through a new `_native_service_suffix()` (built on `_native_root_hash()` / `_native_suffix_for()`) that folds a hash of the resolved root into the suffix. The hash is empty only for the canonical `~/.hermes` root, so existing names for standard installs are unchanged:

- canonical default → `""` (unchanged)
- canonical `coder` → `coder` (unchanged)
- custom root default → `<root-hash>`
- custom root `coder` → `coder-<root-hash>`

The "is this the canonical root" check is anchored to the real OS-user account via `pwd.getpwuid(os.getuid())` (falling back to the existing `Path.home()`-based resolution if that lookup fails), mirroring the reasoning `_launchd_user_home()` already uses for the same file: profile-mode Hermes commonly runs subprocesses with `HOME` pointed at `{HERMES_HOME}/home` for tool-config isolation, and comparing against a possibly-redirected `Path.home()` would make an ordinary canonical profile look "custom" depending on the caller's environment.

**Update after review:** the pwd-anchored check originally ran unconditionally, so a plain default install (`HERMES_HOME` completely unset) got a spurious hashed identity any time `$HOME` merely disagreed with the real account's `/etc/passwd` entry for reasons that have nothing to do with Hermes — containers that set `HOME` via `ENV`/`-e` without a matching passwd row, restricted-UID pods, `sudo` without `-H`, CI runners with a synthetic `HOME`. `_native_root_hash()` now only consults `_real_native_hermes_root()` when `HERMES_HOME` is actually set, i.e. there's real evidence of a custom root or profile-mode redirection to correct for; when it's unset there's nothing Hermes-controlled that could have redirected `HOME`, so the root is trusted as canonical outright, matching pre-fix behavior. Added `test_unset_hermes_home_stays_canonical_even_if_home_disagrees_with_passwd`, which sets `Path.home()` and `pwd.getpwuid` to different values with `HERMES_HOME` unset and asserts the suffix is still `""`.

`_profile_suffix()` itself is intentionally **not** changed — the s6/container dispatcher and the multiplexer guard both rely on its `""` meaning "the root of *this* `HERMES_HOME`" regardless of whether that root is canonical, which is the correct invariant for a single-root container deployment. Only the native launchd/systemd identity call sites needed root-qualification.

## Upgrade note for existing custom-root installs

Flagged in review: a pre-fix custom-`HERMES_HOME` install that used the default profile owned the bare `hermes-gateway` / `ai.hermes.gateway.plist` identity (or an 8-char-hash profile variant); after this fix, the same root computes a *different*, root-qualified identity. The next `gateway install`/`update`/`restart` on such a host will not find a service under the new name and will install a second unit/agent alongside the still-running old one under the old name.

This PR does not add automatic detection/unlink of the old identity — that's a separate, riskier change (identifying and safely tearing down a *different* service definition) than the collision fix itself. Anyone running a custom `HERMES_HOME` in production should, after upgrading, manually check for and remove the pre-upgrade service (`systemctl --user list-units 'hermes-gateway*'` / `launchctl list | grep ai.hermes.gateway` before and after `gateway install`) rather than assuming the update path reconciles it.

## Related Issue

Fixes #93349

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: added `_real_native_hermes_root()`, `_native_root_hash()`, `_native_suffix_for()`, `_native_service_suffix()`; routed `get_service_name()`, `get_launchd_label()`, `get_launchd_plist_path()`, and `launchd_gateway_labels_for_install()` through the new root-qualified suffix. `_native_root_hash()` gates the pwd-anchored comparison on `HERMES_HOME` actually being set (review follow-up). Added a one-line comment in `launchd_gateway_labels_for_install()` noting that all profiles of an install share one root hash (review follow-up).
- `tests/hermes_cli/test_gateway_service.py`: added `TestNativeServiceIdentityRootQualification` (now 4 tests) proving canonical names stay backward compatible, that two distinct custom roots — with default or same-named profiles — never collide, and that an unset `HERMES_HOME` stays canonical even when `Path.home()` and `pwd.getpwuid` disagree (review follow-up). Also updated `test_launchd_plist_path_uses_real_user_home_not_profile_home`, whose scenario (`HERMES_HOME` rooted outside the account home) is exactly the "custom root" case now correctly root-qualified.
- `tests/hermes_cli/test_update_launchd_fleet_restart.py`: updated `test_labels_derive_from_this_installs_profiles` — the hermetic test `HERMES_HOME` is itself a non-canonical root, so its labels are now (correctly) root-qualified too.

## How to Test

1. `HERMES_HOME=/tmp/hermes-a hermes gateway install` then `HERMES_HOME=/tmp/hermes-b hermes gateway install` (same default profile, or same profile name under both roots) — before this fix, the second install reuses/overwrites the first's launchd label and plist.
2. Run `python -m pytest tests/hermes_cli/test_gateway_service.py -k TestNativeServiceIdentityRootQualification -v` — all 3 pass on this branch.
3. Confirm the tests fail without the fix (see "Verification" below).

## Verification

Full affected-area suite (this PR's changed functions and every existing test file that calls them), with the review follow-up fix applied:

```
$ python -m pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_wsl.py \
    tests/hermes_cli/test_gateway_linger.py tests/hermes_cli/test_gateway_s6_dispatch.py \
    tests/hermes_cli/test_gateway_proc_fallback.py tests/hermes_cli/test_gateway_service.py \
    tests/hermes_cli/test_systemd_optional_directives.py tests/hermes_cli/test_update_launchd_restart_verification.py \
    tests/hermes_cli/test_update_wedged_gateway.py tests/hermes_cli/test_update_launchd_fleet_restart.py \
    tests/secret_sources/test_profile_secrets.py tests/gateway/test_multiplex_lifecycle.py -q
...
220 passed, 4 skipped
```

Proof the reviewer's repro is fixed (ran directly against the branch):

```
$ python3 - <<'EOF'
import os, pwd
from pathlib import Path
os.environ.pop("HERMES_HOME", None)
import hermes_cli.gateway as gw
os.environ["HOME"] = "/tmp/fake-home-not-passwd"
print(gw.get_service_name())
print(gw.get_launchd_label())
EOF
hermes-gateway
ai.hermes.gateway
```

Proof the new regression test (`test_unset_hermes_home_stays_canonical_even_if_home_disagrees_with_passwd`) fails without the follow-up fix (`git checkout HEAD~1 -- hermes_cli/gateway.py`, i.e. the version the reviewer blocked, then rerun with only that file reverted):

```
$ python -m pytest tests/hermes_cli/test_gateway_service.py -q -k test_unset_hermes_home_stays_canonical_even_if_home_disagrees_with_passwd
FAILED ...::test_unset_hermes_home_stays_canonical_even_if_home_disagrees_with_passwd
  AssertionError: assert 'hermes-gateway-e2cf5f1ae588' == 'hermes-gateway'
1 failed, 93 deselected
```

(Source restored to the fixed version with `git checkout HEAD -- hermes_cli/gateway.py` afterward; working tree confirmed clean.)

`ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` → `All checks passed!`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (checked #73181, #82773, #19793, #92661 — none touch `_profile_suffix()`/launchd label generation)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected-area test suite and all tests pass (see Verification above; did not run the full ~17k-test suite in this session for time reasons)
- [x] I've added tests for my changes (required for bug fixes)
- [ ] I've tested on my platform: Linux (dev container) — the macOS-only launchd tests in `test_gateway_service.py` were skipped locally and run on the `tests-os` macOS CI lane per the repo's own marker convention

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact: the new `_real_native_hermes_root()` path is POSIX-only (guarded by `is_windows()`, matching the existing `_launchd_user_home()` convention) and falls back safely on lookup failure
- [x] N/A — no tool schemas changed

## AI assistance disclosure

This PR was prepared by an AI coding agent (Claude) operating autonomously against the issue description, with the diff, tests, and verification steps above reviewed for correctness before submission.

