### PR TITLE
fix(desktop): scope remote filesystem requests

### DIFF
--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestConnection } from '@/api/client'
 import { $connection } from '@/store/session'
 
 import {
@@ -66,12 +67,14 @@ describe('desktop filesystem facade', () => {
   beforeEach(() => {
     stubBridge()
     $connection.set(null)
+    setApiRequestConnection(null)
   })
 
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.clearAllMocks()
     $connection.set(null)
+    setApiRequestConnection(null)
     setDesktopFsRemotePicker(null)
   })
 
@@ -142,6 +145,19 @@ describe('desktop filesystem facade', () => {
 
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/list?path=%2Fsrv%2Fproject', profile: 'remote-docker' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: 'remote-docker' })
+  })
+
+  it('pins remote filesystem reads to the active registry connection', async () => {
+    $connection.set({ mode: 'remote', profile: 'default' } as never)
+    setApiRequestConnection('homelab-ssh')
+
+    await readDesktopFileText('/home/luke/inventory.md')
+
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'homelab-ssh',
+      path: '/api/fs/read-text?path=%2Fhome%2Fluke%2Finventory.md',
+      profile: 'default'
+    })
   })
 
   it('keys SSH filesystem caches by stable host identity instead of the forwarded port', () => {

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -149,13 +149,13 @@ describe('desktop filesystem facade', () => {
 
   it('pins remote filesystem reads to the active registry connection', async () => {
     $connection.set({ mode: 'remote', profile: 'default' } as never)
-    setApiRequestConnection('homelab-ssh')
+    setApiRequestConnection('remote-workstation')
 
-    await readDesktopFileText('/home/luke/inventory.md')
+    await readDesktopFileText('/srv/project/inventory.md')
 
     expect(api).toHaveBeenCalledWith({
-      connectionId: 'homelab-ssh',
-      path: '/api/fs/read-text?path=%2Fhome%2Fluke%2Finventory.md',
+      connectionId: 'remote-workstation',
+      path: '/api/fs/read-text?path=%2Fsrv%2Fproject%2Finventory.md',
       profile: 'default'
     })
   })

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -1,3 +1,4 @@
+import { hermesApi } from '@/api/client'
 import type {
   HermesConnection,
   HermesReadDirResult,
@@ -58,7 +59,7 @@ function bridge() {
 }
 
 function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
-  return bridge().api<T>(
+  return hermesApi<T>(
     body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
   )
 }


### PR DESCRIPTION
## Summary
- route remote Desktop filesystem requests through the connection-scoped `hermesApi` helper
- preserve the existing profile scope while adding the active registry `connectionId`
- add a regression test for file reads on a registered SSH connection

## Root cause
The Desktop filesystem facade called the preload API bridge directly with only a profile. In the multi-connection registry, omitting `connectionId` made Electron use the legacy/local backend. Remote file previews then returned 404 even though the active SSH backend could read the path.

## Test plan
- [x] `npx vitest run --project ui src/lib/desktop-fs.test.ts` (12 passed)
- [x] `npm run typecheck`
- [x] `npx eslint src/lib/desktop-fs.ts src/lib/desktop-fs.test.ts`
