### PR TITLE
fix(memory): preserve approval for headless single-query writes

### DIFF
--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -252,6 +252,35 @@ def test_memory_inline_deny_blocks(hermes_home, approval_callback_cleanup):
     assert wa.pending_count("memory") == 0  # denied, not staged
 
 
+def test_single_query_memory_stages_without_inline_prompt(
+    hermes_home, approval_callback_cleanup, monkeypatch
+):
+    """Headless ``hermes chat -q`` runs have no human to answer a callback."""
+    from tools.memory_tool import memory_tool, MemoryStore
+    from tools.terminal_tool import set_approval_callback
+    from tools import write_approval as wa
+
+    _set_approval("memory", True)
+    monkeypatch.setenv("HERMES_SINGLE_QUERY_SESSION", "1")
+
+    calls = []
+
+    def approve_if_prompted(*args, **kwargs):
+        calls.append((args, kwargs))
+        return "once"
+
+    set_approval_callback(approve_if_prompted)
+    store = MemoryStore(); store.load_from_disk()
+
+    r = json.loads(memory_tool("add", "memory", "headless fact", store=store))
+
+    assert calls == []
+    assert r["success"] is True
+    assert r["staged"] is True
+    assert store.memory_entries == []
+    assert wa.pending_count("memory") == 1
+
+
 def test_memory_invalid_params_rejected_before_staging(hermes_home):
     # Param validation must run BEFORE the gate so a broken write is rejected
     # immediately instead of staged and failing at approve time.

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -252,6 +252,39 @@ def test_memory_inline_deny_blocks(hermes_home, approval_callback_cleanup):
     assert wa.pending_count("memory") == 0  # denied, not staged
 
 
+def test_single_query_probe_import_failure_preserves_interactive_callback(
+    approval_callback_cleanup, monkeypatch
+):
+    """A broken headless-context probe must not disable a live CLI callback."""
+    import sys
+
+    from tools import write_approval as wa
+    from tools.terminal_tool import set_approval_callback
+
+    set_approval_callback(lambda *args, **kwargs: "once")
+    monkeypatch.setitem(sys.modules, "tools.approval", None)
+
+    assert wa._interactive_approval_available() is True
+
+
+def test_single_query_probe_exception_fails_safe_to_staging(
+    approval_callback_cleanup, monkeypatch
+):
+    """A broken headless-context probe must not fall through to prompting."""
+    from tools import approval
+    from tools import write_approval as wa
+    from tools.terminal_tool import set_approval_callback
+
+    set_approval_callback(lambda *args, **kwargs: "once")
+    monkeypatch.setattr(
+        approval,
+        "_is_single_query_approval_context",
+        lambda: (_ for _ in ()).throw(RuntimeError("probe failed")),
+    )
+
+    assert wa._interactive_approval_available() is False
+
+
 def test_single_query_memory_stages_without_inline_prompt(
     hermes_home, approval_callback_cleanup, monkeypatch
 ):

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -303,7 +303,8 @@ def test_single_query_memory_stages_without_inline_prompt(
         return "once"
 
     set_approval_callback(approve_if_prompted)
-    store = MemoryStore(); store.load_from_disk()
+    store = MemoryStore()
+    store.load_from_disk()
 
     r = json.loads(memory_tool("add", "memory", "headless fact", store=store))
 

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -185,6 +185,38 @@ def evaluate_gate(subsystem: str, *, inline_summary: str = "", inline_detail: st
     return GateDecision(blocked=True, message="Memory write denied by user. The change was not saved.")
 
 
+def _interactive_approval_available() -> bool:
+    """True when a foreground memory write can be approved inline.
+
+    Inline prompting requires both a live interactive surface and a per-thread
+    approval callback registered by the interactive CLI
+    (``tools.terminal_tool.set_approval_callback``). A callback alone is not
+    sufficient: headless ``hermes chat -q`` / Kanban workers also register one,
+    but have no human available to answer it.
+
+    Every other surface stages instead:
+
+    * **Single-query/Kanban workers** — headless even though a CLI callback is
+      registered; inline prompting would wait until the approval timeout.
+    * **Gateway/API sessions** — the dangerous-command ``/approve`` round-trip
+      lives in the pending-approval queue (``submit_pending`` +
+      ``_await_gateway_decision``), which ``prompt_dangerous_approval`` never
+      reaches; trying to prompt from a gateway session would hit the
+      ``input()`` fallback and silently deny. Staging gives the user a real
+      review affordance (``/memory pending``) instead.
+    * Scripts, cron, and background threads — no user present.
+    """
+    try:
+        from tools.approval import _is_single_query_approval_context
+
+        if _is_single_query_approval_context():
+            return False
+        from tools.terminal_tool import _get_approval_callback
+        return _get_approval_callback() is not None
+    except Exception:
+        return False
+
+
 def _prompt_inline_memory_approval(summary: str, detail: str) -> Optional[bool]:
     """Prompt inline for a memory write: True approved, False denied, None → stage. Uses the per-thread
     CLI approval callback (``tools.terminal_tool.set_approval_callback``) directly, not
@@ -194,6 +226,8 @@ def _prompt_inline_memory_approval(summary: str, detail: str) -> Optional[bool]:
 
     See #15216.
     """
+    if not _interactive_approval_available():
+        return None
     try:
         from tools.terminal_tool import _get_approval_callback
     except Exception:

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -208,10 +208,21 @@ def _interactive_approval_available() -> bool:
     """
     try:
         from tools.approval import _is_single_query_approval_context
-
-        if _is_single_query_approval_context():
+    except ImportError:
+        # Keep the pre-existing callback path available if the optional context
+        # probe cannot be imported during early startup.
+        pass
+    else:
+        try:
+            if _is_single_query_approval_context():
+                return False
+        except Exception:
+            # An unreadable headless-context probe must fail safe to staging.
             return False
+
+    try:
         from tools.terminal_tool import _get_approval_callback
+
         return _get_approval_callback() is not None
     except Exception:
         return False

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -191,13 +191,14 @@ def _interactive_approval_available() -> bool:
     Inline prompting requires both a live interactive surface and a per-thread
     approval callback registered by the interactive CLI
     (``tools.terminal_tool.set_approval_callback``). A callback alone is not
-    sufficient: headless ``hermes chat -q`` / Kanban workers also register one,
-    but have no human available to answer it.
+    sufficient: headless ``hermes chat -q`` runs also register one, but have no
+    human available to answer it. Kanban workers inherit this behavior because
+    the dispatcher launches them through ``hermes chat -q``.
 
     Every other surface stages instead:
 
-    * **Single-query/Kanban workers** — headless even though a CLI callback is
-      registered; inline prompting would wait until the approval timeout.
+    * **Single-query runs (including Kanban workers)** — headless even though a
+      CLI callback is registered; inline prompting would wait until timeout.
     * **Gateway/API sessions** — the dangerous-command ``/approve`` round-trip
       lives in the pending-approval queue (``submit_pending`` +
       ``_await_gateway_decision``), which ``prompt_dangerous_approval`` never


### PR DESCRIPTION
Stage single-query memory writes when running without an interactive approval context instead of silently bypassing approval. Preserve callback behavior if approval-context probing cannot be imported, and document the headless Kanban behavior with regression coverage.