### PR TITLE
feat(hooks): add pre_compression hook at the context-compression boundary

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3423,6 +3423,27 @@ def _run_summary_phase(
             bypass_cooldown=bypass_cooldown,
         )
         messages_before_compression = copy.deepcopy(messages)
+
+        # Notify plugins before compression discards context, so they can
+        # capture or journal the full pre-compression transcript. Fires AFTER
+        # the memory provider's on_pre_compress and snapshot capture, but BEFORE
+        # compress_fn runs, so `messages` is still the complete, unsummarised history.
+        # Observer-only: return values are ignored.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+            _invoke_hook(
+                "pre_compression",
+                messages=copy.deepcopy(messages_before_compression),
+                session_id=agent.session_id,
+                platform=getattr(agent, "platform", "") or "",
+                compression_count=getattr(
+                    agent.context_compressor, "compression_count", 0
+                ),
+                in_place=in_place,
+            )
+        except Exception as _hook_exc:
+            logger.debug("pre_compression hook failed: %s", _hook_exc)
         _activity_heartbeat = _CompressionActivityHeartbeat(
             agent, commit_fence=commit_fence, emit_client_status=lease.status_emitted,
         ).start()

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -94,6 +94,7 @@ Session hooks describe conversation boundaries and resets:
 | `on_session_end` | A `run_conversation` call ends, including interrupted or incomplete turns. |
 | `on_session_finalize` | CLI or gateway tears down an active session identity. |
 | `on_session_reset` | CLI or gateway moves from an old session identity to a new one. |
+| `pre_compression` | Context compression is about to run and discard/summarize messages. |
 
 Common fields include `session_id`, `completed`, `interrupted`, `reason`,
 `old_session_id`, and `new_session_id` where available.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -124,6 +124,10 @@ VALID_HOOKS: Set[str] = {
     # error_body may be unredacted.
     "transform_api_error_classification", "on_session_start", "on_session_end",
     "on_session_finalize", "on_session_reset",
+    # pre_compression: observer fired immediately before context compression discards
+    # messages (agent/conversation_compression.py compress_context). Kwargs: messages
+    # (snapshot; must not mutate), session_id, platform, compression_count, in_place.
+    "pre_compression",
     # on_skill_lifecycle: successful skill lifecycle facts (local skill name visible to plugins).
     "on_skill_lifecycle", "subagent_start", "subagent_stop",
     # pre_gateway_dispatch: once per incoming MessageEvent, after the internal-event guard, BEFORE

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -2069,3 +2069,66 @@ class TestAbortedRotationDoesNotGrowParent:
 
         assert calls["n"] == 1, "the pre-flush guard never read the parent row"
         assert agent.session_id != parent  # rotation still happened
+
+
+class TestPreCompressionHook:
+    def test_pre_compression_fires_before_compress(self, tmp_path: Path):
+        """pre_compression fires once, before compress(), with the full messages."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_PRE_COMPRESS"
+        db.create_session(parent, source="telegram")
+        agent = _build_agent_with_db(db, parent, platform="telegram")
+
+        msgs = _msgs()
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            agent._compress_context(msgs, "sys", approx_tokens=120_000)
+
+        pre_calls = [
+            c for c in mock_invoke.call_args_list if c.args[0] == "pre_compression"
+        ]
+        assert pre_calls, "pre_compression hook was not fired"
+        assert len(pre_calls) == 1, "pre_compression fired more than once"
+        kwargs = pre_calls[0].kwargs
+        # The hook must receive the complete pre-compression transcript so a
+        # plugin can journal it before compress() summarises it away. The
+        # runner may adopt a durable snapshot (which annotates `_db_persisted`),
+        # so assert on content, not list identity.
+        hooked = kwargs["messages"]
+        assert len(hooked) >= len(msgs)
+        assert [m.get("content") for m in hooked[: len(msgs)]] == [
+            m["content"] for m in msgs
+        ]
+        assert kwargs["session_id"] == parent
+        assert kwargs["platform"] == "telegram"
+        # Pins pre-compression boundary state: reflects compressor.compression_count
+        # as set before the summarizer runs (_build_agent_with_db sets count=1).
+        assert kwargs["compression_count"] == 1
+        assert kwargs["in_place"] is False
+
+    def test_pre_compression_is_a_valid_hook(self):
+        from hermes_cli.plugins import VALID_HOOKS
+
+        assert "pre_compression" in VALID_HOOKS
+
+    def test_pre_compression_hook_messages_mutation_isolation(self, tmp_path: Path):
+        """Mutating the messages list in pre_compression does not corrupt the transcript."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        parent = "PARENT_PRE_COMPRESS_MUTATE"
+        db.create_session(parent, source="telegram")
+        agent = _build_agent_with_db(db, parent, platform="telegram")
+
+        msgs = _msgs()
+        orig_len = len(msgs)
+
+        def mutating_hook(name, **kwargs):
+            if name == "pre_compression":
+                kwargs["messages"].clear()
+                kwargs["messages"].append({"role": "user", "content": "corrupted"})
+
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=mutating_hook):
+            agent._compress_context(msgs, "sys", approx_tokens=120_000)
+
+        agent.context_compressor.compress.assert_called_once()
+        passed_msgs = agent.context_compressor.compress.call_args[0][0]
+        assert len(passed_msgs) == orig_len
+        assert [m.get("content") for m in passed_msgs] == [m["content"] for m in msgs]

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -951,6 +951,7 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
+| [`pre_compression`](/user-guide/features/hooks#pre_compression) | Fired immediately before context compression discards old messages | `messages: list, session_id: str, platform: str, compression_count: int, in_place: bool` | ignored |
 | [`gateway_platform_event`](/user-guide/features/hooks#gateway_platform_event) | An authorized platform-native event is normalized at the gateway boundary (Telegram reactions currently) | `platform: str, event_type: str, payload: dict` | ignored |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -459,6 +459,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_session_end` | Observer | Canonically at each turn finalization; CLI/TUI exits have additional reduced legacy shapes. Return ignored. | Canonical: `session_id`, `task_id`, `turn_id`, `completed`, `failed`, `interrupted`, `turn_exit_reason`, `model`, `platform`; exit paths may add `reason`/`api_request_id` and omit fields. | IDs, model/platform, and outcome; canonical payload has no message body. |
 | `on_session_finalize` | Observer | CLI/TUI/gateway teardown through `finalize_session`; gateway shutdown may finalize without a reset. Return ignored. | Surface-dependent `session_id`, `platform`, optionally `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
 | `on_session_reset` | Observer | CLI/TUI session boundary and gateway after the replacement session exists; return ignored. | CLI: `session_id`, `platform`, `reason`; TUI: `session_id`, `platform`; gateway: those plus `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
+| `pre_compression` | Observer | Immediately before context compression discards old messages, while the full pre-compression transcript is still available; return ignored. | `messages` (snapshot), `session_id`, `platform`, `compression_count`, `in_place` | Full pre-compression transcript snapshot. |
 | `on_skill_lifecycle` | Observer | After an authoritative skill-usage state change; return ignored. | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | Exposes the local skill name and provenance. |
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
@@ -1038,6 +1039,28 @@ def my_callback(session_id: str, platform: str, **kwargs):
 **Return value:** Ignored.
 
 **Use cases:** Reset per-session caches keyed by `session_id`, emit "session rotated" analytics, prime a fresh state bucket.
+
+---
+
+### `pre_compression`
+
+Fires once immediately before context compression discards old messages, while the complete pre-compression transcript is still available. This lets plugins capture, journal, or persist about-to-be-summarized conversation history before compression compacts it.
+
+**Type:** Observer (return value is ignored).
+
+**Payload:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `messages` | `list` | Snapshot of the full pre-compression message history. Must not be mutated by plugins. |
+| `session_id` | `str` | Active session ID. |
+| `platform` | `str` | Messaging platform or CLI/TUI surface. |
+| `compression_count` | `int` | Current compression count for the session. |
+| `in_place` | `bool` | Whether compaction is occurring in-place or via session rotation. |
+
+**Return value:** Ignored.
+
+**Use cases:** Archiving or journaling full transcripts prior to LLM summarization, context-loss auditing, external memory sync.
 
 ---
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -298,7 +298,7 @@ Plugins can register the 26 lifecycle events currently accepted by `hermes_cli.p
 |---|---|
 | **Directive/control** | `pre_tool_call`, `pre_llm_call`, `pre_verify`, `pre_gateway_dispatch` |
 | **Transform** | `transform_tool_result`, `transform_terminal_output`, `transform_llm_output`, `pre_transcription` |
-| **Observer** | `post_tool_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `api_request_error`, `on_stream_start`, `on_stream_delta`, `on_stream_end`, `on_interim_message`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `on_skill_lifecycle`, `subagent_start`, `subagent_stop`, `pre_approval_request`, `post_approval_response`, `pre_command`, `kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked` |
+| **Observer** | `post_tool_call`, `post_llm_call`, `pre_api_request`, `post_api_request`, `api_request_error`, `on_stream_start`, `on_stream_delta`, `on_stream_end`, `on_interim_message`, `on_session_start`, `on_session_end`, `on_session_finalize`, `on_session_reset`, `pre_compression`, `on_skill_lifecycle`, `subagent_start`, `subagent_stop`, `pre_approval_request`, `post_approval_response`, `pre_command`, `kanban_task_claimed`, `kanban_task_completed`, `kanban_task_blocked` |
 
 These categories describe current behavior rather than defining future naming rules. Plugin middleware remains a separate registry/surface.
 ## Plugin types


### PR DESCRIPTION
## What does this PR do?

Adds a `pre_compression` plugin hook to the core hook surface, so plugins can observe — and journal — a session's full transcript *before* context compression discards it.

The compression boundary was already reachable by memory providers (`on_pre_compress`) and by the gateway's separate `session:compress` *event* system — but the event fires *after* the old messages are gone, and neither path is a `ctx.register_hook(...)` plugin hook. A `~/.hermes/plugins/` plugin has no way to capture the about-to-be-summarised transcript today.

## Related Issue

Fixes #93389

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/plugins.py` — add `"pre_compression"` to `VALID_HOOKS` (observer-only; return values ignored).
- `agent/conversation_compression.py` — fire `invoke_hook("pre_compression", ...)` immediately before `compress_fn(...)` runs, after `on_pre_compress`, passing `messages`, `session_id`, `platform`, `compression_count`, `in_place`.
- `tests/agent/test_compression_rotation_state.py` — two tests: the hook fires exactly once with the full pre-compression transcript, and `pre_compression` is a valid hook.

## How to Test

1. `uv run --with pytest python -m pytest tests/agent/test_compression_rotation_state.py -v` — 23 passed (2 new).
2. `uv run --with pytest python -m pytest tests/cli/test_session_boundary_hooks.py tests/gateway/test_gateway_platform_event_hook.py -q` — 39 passed (no regression).

## Motivation / background

We ship an out-of-tree `journal-nudge` plugin that injects a journaling prompt every N turns and at session boundaries. The one trigger point it cannot implement is "right before compaction, prompt to journal, so the session's substance survives compression" — because there is no compression-boundary plugin hook. This PR adds that hook; the plugin consumes it separately (it ships out-of-tree, per the third-party-integration guidance).

One design note: the existing `session:compress` event fires *post*-compaction (old messages already gone), so it cannot satisfy a *pre*-compaction capture. This hook is deliberately observer-only (no return-value contract) to keep it minimal; a plugin that wants to inject into the summary can already reach the memory-provider `on_pre_compress` surface.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 6.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the hook carries a docstring in `VALID_HOOKS` documenting kwargs — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (pure hook registration + a `try/except` invocation on POSIX-independent paths)
