### PR TITLE
prompt_builder/system_prompt tests no longer fail when run together (#93018, salvage #93047)

### DIFF
--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -45,7 +45,12 @@ def _drain_truncation_warnings():
     Truncation warnings ride a ContextVar; under plain ``pytest`` (no
     per-file subprocess isolation) anything this file records leaks into
     later files' contexts and breaks their assertions/ordering.
+
+    Drain on both sides: before, so warnings leaked by earlier files can't
+    pollute this file's assertions, and after, so this file leaves the
+    ContextVar clean for later files.
     """
+    drain_truncation_warnings()
     yield
     drain_truncation_warnings()
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -38,6 +38,18 @@ from agent.prompt_builder import (
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
 
 
+@pytest.fixture(autouse=True)
+def _drain_truncation_warnings():
+    """Leave no truncation warnings in the shared thread context.
+
+    Truncation warnings ride a ContextVar; under plain ``pytest`` (no
+    per-file subprocess isolation) anything this file records leaks into
+    later files' contexts and breaks their assertions/ordering.
+    """
+    yield
+    drain_truncation_warnings()
+
+
 # =========================================================================
 # Guidance constants
 # =========================================================================

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -24,6 +24,11 @@ def _make_agent(**overrides):
         platform="",
         pass_session_id=False,
         session_id="",
+        # build_system_prompt drains pending truncation warnings and
+        # forwards each to this; a warning left in the ContextVar by an
+        # earlier test file (they share one thread's context under plain
+        # pytest) must not make this stub AttributeError.
+        _emit_status=lambda *_args, **_kwargs: None,
     )
     base.update(overrides)
     return SimpleNamespace(**base)


### PR DESCRIPTION
## Summary
`tests/agent/test_prompt_builder.py` and `tests/agent/test_system_prompt.py` now pass together in either order. The former leaked truncation warnings into a shared ContextVar; the latter's agent stub lacked `_emit_status`, so the leaked drain crashed with AttributeError — a phantom red for anyone running both files.

Salvage of #93047 by @aniruddhaadak80 (authorship preserved; BOM stripped from commit message) + our fixup making the drain fire before AND after each test. Closes #93018.

## Changes
- `tests/agent/test_prompt_builder.py`: autouse fixture draining the truncation-warning ContextVar (before + after)
- `tests/agent/test_system_prompt.py`: `_make_agent()` stub gains a no-op `_emit_status`

## Validation
| | Before (main) | After (branch) |
|---|---|---|
| both files, order A | 1 failed (AttributeError at system_prompt.py:927), 104 passed | 105 passed |
| both files, order B | — | 105 passed |

Test-only change.

## Infographic

![Flaky test order fixed](https://v3b.fal.media/files/b/0aa78f13/0jDksEX7oGgN-TIxP9oy4_EbH7ZXwK.png)
