### PR TITLE
feat(petdex): render Kitty images in interactive CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -61,6 +61,7 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.styles import Style as PTStyle
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.application import Application
+from prompt_toolkit.output import ColorDepth
 from prompt_toolkit.layout import Layout, HSplit, Window, FormattedTextControl, ConditionalContainer, WindowAlign
 from prompt_toolkit.layout.processors import Processor, Transformation, PasswordProcessor, ConditionalProcessor
 from prompt_toolkit.filters import Condition
@@ -5552,15 +5553,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._command_running = False
         self._command_blocks_input = False
         self._command_status = ""
-        # Petdex mascot (opt-in via display.pet). The base CLI mirrors the TUI's
-        # PetPane: a half-block sprite above the prompt that reacts to agent
-        # activity. Lazily resolved; an invalidate timer drives the animation.
+        # Petdex mascot (opt-in via display.pet). Kitty-capable terminals use
+        # Unicode placeholders plus out-of-band image transmission; other
+        # terminals use the truecolor half-block fallback.
         self._pet_renderer = None  # agent.pet.render.PetRenderer | None
         self._pet_slug: str = ""
         self._pet_enabled: bool = False
         self._pet_cols: int = 18
         self._pet_scale: float = 0.7
         self._pet_frames_cache: dict = {}  # state -> list[grid]
+        self._pet_kitty_cache: dict = {}  # state -> kitty placeholder payload
+        self._pet_kitty_image_id: int = 0
+        self._pet_kitty_pending: str = ""
         self._pet_frame_idx: int = 0
         self._pet_lock = threading.Lock()
         self._pet_cfg_checked: float = 0.0
@@ -6735,12 +6739,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     # ── Petdex mascot (base-CLI pet pane) ───────────────────────────────
     #
-    # Parity with the TUI: a half-block sprite rendered as a prompt_toolkit
-    # window above the prompt, reacting to agent state and animated by a timer
-    # that calls ``app.invalidate()``. Half-blocks only — the crisp Kitty image
-    # protocol can't coexist with prompt_toolkit's patch_stdout output layer
-    # (raw image escapes get swallowed/mangled), so we use truecolor styled
-    # text, which prompt_toolkit renders natively in any 24-bit terminal.
+    # Parity with the TUI: a sprite rendered as a prompt_toolkit window above
+    # the prompt. Kitty-capable terminals use Unicode placeholders: prompt_toolkit
+    # owns the measurable grid while image bytes are transmitted out-of-band as
+    # a virtual placement (cursor untouched). Other terminals use half-blocks.
 
     _PET_FRAME_INTERVAL = 0.16
     _PET_CFG_INTERVAL = 2.5
@@ -6752,7 +6754,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         the TUI's steady poll. Cheap and fail-open: any problem disables the pet.
         """
         try:
-            from agent.pet import constants, store
+            from agent.pet import constants, render, store
             from agent.pet.render import PetRenderer
             from hermes_cli.config import load_config
 
@@ -6766,12 +6768,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             slug = str(pet_cfg.get("slug", "") or "")
             scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
             cols = constants.resolve_cols(scale, pet_cfg.get("unicode_cols", 0))
+            configured_mode = str(pet_cfg.get("render_mode", "auto") or "auto").lower()
+            detected_mode = render.detect_terminal_graphics() if configured_mode in ("", "auto") else configured_mode
+            # Kitty's virtual Unicode-placeholder placement is grid-safe inside
+            # prompt_toolkit. iTerm and sixel stay on the Unicode fallback.
+            renderer_mode = "kitty" if detected_mode == "kitty" else "unicode"
 
             if not enabled:
                 with self._pet_lock:
                     self._pet_enabled = False
                     self._pet_renderer = None
                     self._pet_frames_cache.clear()
+                    self._pet_kitty_cache.clear()
                 return
 
             pet = store.resolve_active_pet(slug)
@@ -6780,23 +6788,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     self._pet_enabled = False
                     self._pet_renderer = None
                     self._pet_frames_cache.clear()
+                    self._pet_kitty_cache.clear()
                 return
 
             with self._pet_lock:
-                # Rebuild only when the resolved pet or geometry changes.
+                # Rebuild only when the resolved pet, mode, or geometry changes.
                 if (
                     self._pet_renderer is None
                     or self._pet_slug != pet.slug
                     or self._pet_cols != cols
                     or self._pet_scale != scale
+                    or self._pet_renderer.mode != renderer_mode
                 ):
                     self._pet_renderer = PetRenderer(
-                        str(pet.spritesheet), mode="unicode", scale=scale, unicode_cols=cols
+                        str(pet.spritesheet), mode=renderer_mode, scale=scale, unicode_cols=cols
                     )
                     self._pet_slug = pet.slug
                     self._pet_cols = cols
                     self._pet_scale = scale
                     self._pet_frames_cache.clear()
+                    self._pet_kitty_cache.clear()
+                    self._pet_kitty_image_id = render.kitty_image_id(pet.slug)
                     self._pet_frame_idx = 0
                 self._pet_enabled = True
         except Exception:
@@ -6877,12 +6889,63 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._pet_frames_cache[state] = grids
         return grids
 
+    def _pet_kitty_payload_for(self, state: str) -> dict | None:
+        """Return and cache a Kitty virtual-placeholder payload for *state*."""
+        cached = self._pet_kitty_cache.get(state)
+        if cached is not None:
+            return cached
+        renderer = self._pet_renderer
+        if renderer is None or renderer.mode != "kitty":
+            return None
+        try:
+            payload = renderer.kitty_payload(state, image_id=self._pet_kitty_image_id)
+        except Exception:
+            payload = None
+        if payload is not None:
+            self._pet_kitty_cache[state] = payload
+        return payload
+
+    def _pet_queue_kitty_frame(self, state: str) -> None:
+        """Queue one virtual Kitty frame for the next prompt_toolkit render."""
+        payload = self._pet_kitty_payload_for(state)
+        if not payload or not payload.get("frames"):
+            return
+        self._pet_kitty_pending = payload["frames"][self._pet_frame_idx % len(payload["frames"])]
+
+    def _pet_flush_kitty_frame(self, app) -> None:
+        """Write a queued APC after prompt_toolkit has finished its screen diff."""
+        with self._pet_lock:
+            frame = self._pet_kitty_pending
+            self._pet_kitty_pending = ""
+        if not frame:
+            return
+        try:
+            # Serialize protocol output through prompt_toolkit itself. U=1/q=2
+            # leaves the cursor and input stream untouched.
+            app.output.write_raw(frame)
+            app.output.flush()
+        except (OSError, ValueError):
+            pass
+
     def _pet_fragments(self):
         """Return prompt_toolkit FormattedText for the current pet frame, or []."""
         with self._pet_lock:
             if not self._pet_enabled or self._pet_renderer is None:
                 return []
             state = self._derive_pet_state()
+            if self._pet_renderer.mode == "kitty":
+                from agent.pet import render
+
+                payload = self._pet_kitty_payload_for(state)
+                if not payload:
+                    return []
+                color = render.kitty_color_hex(self._pet_kitty_image_id)
+                frags = []
+                for y, row in enumerate(payload["placeholder"]):
+                    if y:
+                        frags.append(("", "\n"))
+                    frags.append((f"fg:{color}", row))
+                return frags
             grids = self._pet_frames_for(state)
             if not grids:
                 return []
@@ -6914,6 +6977,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         with self._pet_lock:
             if not self._pet_enabled or self._pet_renderer is None:
                 return 0
+            if self._pet_renderer.mode == "kitty":
+                payload = self._pet_kitty_payload_for(self._derive_pet_state())
+                return int(payload.get("rows", 0)) if payload else 0
             grids = self._pet_frames_for(self._derive_pet_state())
             if not grids or not grids[0]:
                 return 0
@@ -6934,6 +7000,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 continue
             with self._pet_lock:
                 self._pet_frame_idx += 1
+                state = self._derive_pet_state()
+                if self._pet_renderer is not None and self._pet_renderer.mode == "kitty":
+                    self._pet_queue_kitty_frame(state)
             app = getattr(self, "_app", None)
             if app is not None:
                 try:
@@ -6949,6 +7018,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if self._pet_anim_running:
             return
         self._pet_resolve_config()
+        with self._pet_lock:
+            if self._pet_enabled and self._pet_renderer is not None and self._pet_renderer.mode == "kitty":
+                self._pet_queue_kitty_frame(self._derive_pet_state())
         self._pet_anim_running = True
         self._pet_anim_thread = threading.Thread(target=self._pet_anim_loop, daemon=True)
         self._pet_anim_thread.start()
@@ -19265,10 +19337,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             wrap_lines=True,
         )
 
-        # Petdex mascot — right-aligned half-block sprite above the prompt,
-        # mirroring the TUI's PetPane. Collapses to height 0 when no pet is
-        # enabled, so it's a no-op for everyone else. The _pet_anim_loop thread
-        # advances frames + invalidates; align=RIGHT pins it to the edge.
+        # Petdex mascot — a right-aligned Kitty placeholder or half-block sprite
+        # above the prompt, mirroring the TUI's PetPane. Collapses to height 0
+        # when no pet is enabled. The animation thread transmits virtual Kitty
+        # frames out-of-band while prompt_toolkit owns the placeholder grid.
         self._pet_widget = Window(
             content=FormattedTextControl(self._pet_fragments),
             height=self._pet_widget_height,
@@ -20063,6 +20135,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             full_screen=False,
             mouse_support=False,
             **({"output": _cpr_disabled_output} if _cpr_disabled_output is not None else {}),
+            color_depth=(
+                ColorDepth.DEPTH_24_BIT
+                if os.environ.get("KITTY_WINDOW_ID")
+                or "kitty" in os.environ.get("TERM", "").lower()
+                or "ghostty" in os.environ.get("TERM", "").lower()
+                else None
+            ),
             # Read from display.cli_refresh_interval (default 0 = disabled).
             # When non-zero, prompt_toolkit redraws the UI on this cadence
             # during idle, keeping wall-clock status-bar read-outs ticking.
@@ -20084,6 +20163,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         _disable_prompt_toolkit_cpr_warning(app)
+        app.after_render += self._pet_flush_kitty_frame
         self._app = app  # Store reference for clarify_callback
 
         # ── Fix ghost status-bar lines on terminal resize ──────────────

--- a/cli.py
+++ b/cli.py
@@ -6774,12 +6774,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # prompt_toolkit. iTerm and sixel stay on the Unicode fallback.
             renderer_mode = "kitty" if detected_mode == "kitty" else "unicode"
 
-            if not enabled:
+            if not enabled or detected_mode == "off":
                 with self._pet_lock:
                     self._pet_enabled = False
                     self._pet_renderer = None
                     self._pet_frames_cache.clear()
                     self._pet_kitty_cache.clear()
+                    self._pet_kitty_pending = ""
                 return
 
             pet = store.resolve_active_pet(slug)
@@ -6789,6 +6790,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     self._pet_renderer = None
                     self._pet_frames_cache.clear()
                     self._pet_kitty_cache.clear()
+                    self._pet_kitty_pending = ""
                 return
 
             with self._pet_lock:
@@ -6808,6 +6810,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     self._pet_scale = scale
                     self._pet_frames_cache.clear()
                     self._pet_kitty_cache.clear()
+                    self._pet_kitty_pending = ""
                     self._pet_kitty_image_id = render.kitty_image_id(pet.slug)
                     self._pet_frame_idx = 0
                 self._pet_enabled = True
@@ -6891,18 +6894,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def _pet_kitty_payload_for(self, state: str) -> dict | None:
         """Return and cache a Kitty virtual-placeholder payload for *state*."""
-        cached = self._pet_kitty_cache.get(state)
-        if cached is not None:
-            return cached
-        renderer = self._pet_renderer
-        if renderer is None or renderer.mode != "kitty":
-            return None
+        with self._pet_lock:
+            cached = self._pet_kitty_cache.get(state)
+            if cached is not None:
+                return cached
+            renderer = self._pet_renderer
+            image_id = self._pet_kitty_image_id
+            if renderer is None or renderer.mode != "kitty":
+                return None
         try:
-            payload = renderer.kitty_payload(state, image_id=self._pet_kitty_image_id)
+            # PNG encoding is deliberately outside _pet_lock: this may run the
+            # first time a state appears and must not stall prompt rendering.
+            payload = renderer.kitty_payload(state, image_id=image_id)
         except Exception:
             payload = None
         if payload is not None:
-            self._pet_kitty_cache[state] = payload
+            with self._pet_lock:
+                if self._pet_renderer is renderer and self._pet_kitty_image_id == image_id:
+                    self._pet_kitty_cache[state] = payload
         return payload
 
     def _pet_queue_kitty_frame(self, state: str) -> None:
@@ -6910,7 +6919,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         payload = self._pet_kitty_payload_for(state)
         if not payload or not payload.get("frames"):
             return
-        self._pet_kitty_pending = payload["frames"][self._pet_frame_idx % len(payload["frames"])]
+        with self._pet_lock:
+            if self._pet_renderer is not None and self._pet_renderer.mode == "kitty":
+                self._pet_kitty_pending = payload["frames"][self._pet_frame_idx % len(payload["frames"])]
 
     def _pet_flush_kitty_frame(self, app) -> None:
         """Write a queued APC after prompt_toolkit has finished its screen diff."""
@@ -6933,19 +6944,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if not self._pet_enabled or self._pet_renderer is None:
                 return []
             state = self._derive_pet_state()
-            if self._pet_renderer.mode == "kitty":
-                from agent.pet import render
+            kitty = self._pet_renderer.mode == "kitty"
+            image_id = self._pet_kitty_image_id
+        if kitty:
+            from agent.pet import render
 
-                payload = self._pet_kitty_payload_for(state)
-                if not payload:
-                    return []
-                color = render.kitty_color_hex(self._pet_kitty_image_id)
-                frags = []
-                for y, row in enumerate(payload["placeholder"]):
-                    if y:
-                        frags.append(("", "\n"))
-                    frags.append((f"fg:{color}", row))
-                return frags
+            payload = self._pet_kitty_payload_for(state)
+            if not payload:
+                return []
+            color = render.kitty_color_hex(image_id)
+            frags = []
+            for y, row in enumerate(payload["placeholder"]):
+                if y:
+                    frags.append(("", "\n"))
+                frags.append((f"fg:{color}", row))
+            return frags
+        with self._pet_lock:
             grids = self._pet_frames_for(state)
             if not grids:
                 return []
@@ -6977,10 +6991,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         with self._pet_lock:
             if not self._pet_enabled or self._pet_renderer is None:
                 return 0
-            if self._pet_renderer.mode == "kitty":
-                payload = self._pet_kitty_payload_for(self._derive_pet_state())
-                return int(payload.get("rows", 0)) if payload else 0
-            grids = self._pet_frames_for(self._derive_pet_state())
+            state = self._derive_pet_state()
+            kitty = self._pet_renderer.mode == "kitty"
+        if kitty:
+            payload = self._pet_kitty_payload_for(state)
+            return int(payload.get("rows", 0)) if payload else 0
+        with self._pet_lock:
+            grids = self._pet_frames_for(state)
             if not grids or not grids[0]:
                 return 0
             return len(grids[0])
@@ -7001,8 +7018,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             with self._pet_lock:
                 self._pet_frame_idx += 1
                 state = self._derive_pet_state()
-                if self._pet_renderer is not None and self._pet_renderer.mode == "kitty":
-                    self._pet_queue_kitty_frame(state)
+                kitty = self._pet_renderer is not None and self._pet_renderer.mode == "kitty"
+            if kitty:
+                self._pet_queue_kitty_frame(state)
             app = getattr(self, "_app", None)
             if app is not None:
                 try:
@@ -7019,8 +7037,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return
         self._pet_resolve_config()
         with self._pet_lock:
-            if self._pet_enabled and self._pet_renderer is not None and self._pet_renderer.mode == "kitty":
-                self._pet_queue_kitty_frame(self._derive_pet_state())
+            kitty = self._pet_enabled and self._pet_renderer is not None and self._pet_renderer.mode == "kitty"
+            state = self._derive_pet_state()
+        if kitty:
+            self._pet_queue_kitty_frame(state)
         self._pet_anim_running = True
         self._pet_anim_thread = threading.Thread(target=self._pet_anim_loop, daemon=True)
         self._pet_anim_thread.start()
@@ -20127,6 +20147,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # in _strip_leaked_terminal_responses still guards residual leaks.
         _cpr_disabled_output = _select_classic_cli_pt_output(sys.stdout)
 
+        from agent.pet.render import detect_terminal_graphics
+
         # Create the application
         app = Application(
             layout=layout,
@@ -20137,9 +20159,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             **({"output": _cpr_disabled_output} if _cpr_disabled_output is not None else {}),
             color_depth=(
                 ColorDepth.DEPTH_24_BIT
-                if os.environ.get("KITTY_WINDOW_ID")
-                or "kitty" in os.environ.get("TERM", "").lower()
-                or "ghostty" in os.environ.get("TERM", "").lower()
+                if detect_terminal_graphics() == "kitty"
                 else None
             ),
             # Read from display.cli_refresh_interval (default 0 = disabled).

--- a/cli.py
+++ b/cli.py
@@ -54,6 +54,7 @@ from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 from hermes_cli.cli_billing_mixin import CLIBillingMixin
+from agent.pet import render as pet_render
 from agent.interrupt_compat import request_hard_interrupt
 
 # prompt_toolkit for fixed input area TUI
@@ -6754,7 +6755,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         the TUI's steady poll. Cheap and fail-open: any problem disables the pet.
         """
         try:
-            from agent.pet import constants, render, store
+            from agent.pet import constants, store
             from agent.pet.render import PetRenderer
             from hermes_cli.config import load_config
 
@@ -6769,7 +6770,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
             cols = constants.resolve_cols(scale, pet_cfg.get("unicode_cols", 0))
             configured_mode = str(pet_cfg.get("render_mode", "auto") or "auto").lower()
-            detected_mode = render.detect_terminal_graphics() if configured_mode in ("", "auto") else configured_mode
+            detected_mode = pet_render.detect_terminal_graphics() if configured_mode in ("", "auto") else configured_mode
             # Kitty's virtual Unicode-placeholder placement is grid-safe inside
             # prompt_toolkit. iTerm and sixel stay on the Unicode fallback.
             renderer_mode = "kitty" if detected_mode == "kitty" else "unicode"
@@ -6811,7 +6812,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     self._pet_frames_cache.clear()
                     self._pet_kitty_cache.clear()
                     self._pet_kitty_pending = ""
-                    self._pet_kitty_image_id = render.kitty_image_id(pet.slug)
+                    self._pet_kitty_image_id = pet_render.kitty_image_id(pet.slug)
                     self._pet_frame_idx = 0
                 self._pet_enabled = True
         except Exception:
@@ -6909,6 +6910,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             payload = None
         if payload is not None:
+            payload = {**payload, "image_id": image_id}
             with self._pet_lock:
                 if self._pet_renderer is renderer and self._pet_kitty_image_id == image_id:
                     self._pet_kitty_cache[state] = payload
@@ -6945,14 +6947,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 return []
             state = self._derive_pet_state()
             kitty = self._pet_renderer.mode == "kitty"
-            image_id = self._pet_kitty_image_id
         if kitty:
-            from agent.pet import render
-
             payload = self._pet_kitty_payload_for(state)
             if not payload:
                 return []
-            color = render.kitty_color_hex(image_id)
+            color = pet_render.kitty_color_hex(payload["image_id"])
             frags = []
             for y, row in enumerate(payload["placeholder"]):
                 if y:
@@ -20149,6 +20148,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         from agent.pet.render import detect_terminal_graphics
 
+        # Kitty placeholders encode their image id in exact foreground RGB, so
+        # Kitty-class terminals intentionally use 24-bit color for the whole
+        # prompt_toolkit application; quantizing only that pane is not supported.
         # Create the application
         app = Application(
             layout=layout,

--- a/tests/cli/test_cli_pet_pane.py
+++ b/tests/cli/test_cli_pet_pane.py
@@ -161,6 +161,43 @@ def test_pet_fragments_render_kitty_placeholders(boba_like):
     assert cli_obj._pet_kitty_pending == ""
 
 
+def test_pet_off_clears_pending_kitty_frame(boba_like):
+    from hermes_cli.config import load_config, save_config
+
+    cli_obj = _make_cli()
+    cli_obj._pet_kitty_pending = "stale-apc"
+    cfg = load_config()
+    cfg.setdefault("display", {}).setdefault("pet", {}).update(
+        {"enabled": True, "slug": "boba", "render_mode": "off"}
+    )
+    save_config(cfg)
+
+    cli_obj._pet_resolve_config()
+
+    assert cli_obj._pet_enabled is False
+    assert cli_obj._pet_renderer is None
+    assert cli_obj._pet_kitty_pending == ""
+
+
+def test_pet_resolve_config_detects_wezterm_kitty(boba_like, monkeypatch):
+    from hermes_cli.config import load_config, save_config
+
+    monkeypatch.delenv("KITTY_WINDOW_ID", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.setenv("TERM_PROGRAM", "WezTerm")
+    cli_obj = _make_cli()
+    cfg = load_config()
+    cfg.setdefault("display", {}).setdefault("pet", {}).update(
+        {"enabled": True, "slug": "boba", "render_mode": "auto"}
+    )
+    save_config(cfg)
+
+    cli_obj._pet_resolve_config()
+
+    assert cli_obj._pet_renderer is not None
+    assert cli_obj._pet_renderer.mode == "kitty"
+
+
 def test_pet_resolve_config_enables_and_disables(boba_like, monkeypatch):
     from hermes_cli.config import load_config, save_config
 

--- a/tests/cli/test_cli_pet_pane.py
+++ b/tests/cli/test_cli_pet_pane.py
@@ -53,6 +53,9 @@ def _make_cli():
     cli_obj._pet_cols = 18
     cli_obj._pet_scale = 0.7
     cli_obj._pet_frames_cache = {}
+    cli_obj._pet_kitty_cache = {}
+    cli_obj._pet_kitty_image_id = 0
+    cli_obj._pet_kitty_pending = ""
     cli_obj._pet_frame_idx = 0
     cli_obj._agent_running = False
     # Transient-beat + reasoning state (set by HermesCLI.__init__ in production).
@@ -114,9 +117,55 @@ def test_pet_fragments_render_half_blocks(boba_like):
     assert sum(1 for _, text in frags if text == "\n") == height - 1
 
 
-def test_pet_resolve_config_enables_and_disables(boba_like):
+def test_pet_fragments_render_kitty_placeholders(boba_like):
+    from agent.pet import render
+
+    cli_obj = _make_cli()
+    pet = store.load_pet("boba")
+    assert pet is not None
+    cli_obj._pet_renderer = PetRenderer(
+        str(pet.spritesheet), mode="kitty", scale=0.4
+    )
+    cli_obj._pet_slug = "boba"
+    cli_obj._pet_kitty_image_id = render.kitty_image_id("boba")
+    cli_obj._pet_enabled = True
+
+    frags = cli_obj._pet_fragments()
+    assert frags
+    assert any("\U0010eeee" in text for _, text in frags)
+    color = render.kitty_color_hex(cli_obj._pet_kitty_image_id)
+    assert all(f"fg:{color}" in style for style, text in frags if text != "\n")
+    assert cli_obj._pet_widget_height() > 0
+
+    cli_obj._pet_queue_kitty_frame("idle")
+    assert cli_obj._pet_kitty_pending.startswith("\x1b_G")
+
+    class Output:
+        def __init__(self):
+            self.raw = ""
+            self.flushed = False
+
+        def write_raw(self, text):
+            self.raw += text
+
+        def flush(self):
+            self.flushed = True
+
+    class App:
+        output = Output()
+
+    app = App()
+    cli_obj._pet_flush_kitty_frame(app)
+    assert app.output.raw.startswith("\x1b_G")
+    assert app.output.flushed is True
+    assert cli_obj._pet_kitty_pending == ""
+
+
+def test_pet_resolve_config_enables_and_disables(boba_like, monkeypatch):
     from hermes_cli.config import load_config, save_config
 
+    monkeypatch.setenv("KITTY_WINDOW_ID", "1")
+    monkeypatch.setenv("TERM", "xterm-kitty")
     cli_obj = _make_cli()
 
     cfg = load_config()
@@ -127,6 +176,7 @@ def test_pet_resolve_config_enables_and_disables(boba_like):
     cli_obj._pet_resolve_config()
     assert cli_obj._pet_enabled is True
     assert cli_obj._pet_renderer is not None
+    assert cli_obj._pet_renderer.mode == "kitty"
     assert cli_obj._pet_slug == "boba"
 
     cfg["display"]["pet"]["enabled"] = False

--- a/tests/cli/test_cli_pet_pane.py
+++ b/tests/cli/test_cli_pet_pane.py
@@ -133,7 +133,9 @@ def test_pet_fragments_render_kitty_placeholders(boba_like):
     frags = cli_obj._pet_fragments()
     assert frags
     assert any("\U0010eeee" in text for _, text in frags)
-    color = render.kitty_color_hex(cli_obj._pet_kitty_image_id)
+    payload = cli_obj._pet_kitty_payload_for("idle")
+    assert payload is not None
+    color = render.kitty_color_hex(payload["image_id"])
     assert all(f"fg:{color}" in style for style, text in frags if text != "\n")
     assert cli_obj._pet_widget_height() > 0
 


### PR DESCRIPTION
## Summary

- render Petdex mascots in the interactive `hermes` CLI with Kitty Unicode placeholders when Kitty graphics are available
- transmit virtual-image animation frames through prompt_toolkit’s `after_render` event so terminal protocol writes do not race screen redraws
- force 24-bit color for placeholder image IDs while retaining the Unicode half-block fallback on unsupported terminals

## Motivation

`hermes pets show` already renders crisp Kitty images, but the interactive CLI forced every pet through the low-resolution half-block fallback. The existing pet renderer and Ink TUI already provide Kitty virtual-image payloads and placeholder grids, so this change brings the classic CLI to parity without introducing a second protocol implementation.

Detection honors `KITTY_WINDOW_ID`, which also supports Kitty-hosted environments where an intermediate terminal workspace reports a generic `TERM`.

## Testing

- `uv run --with pytest pytest -q tests/cli/test_cli_pet_pane.py tests/agent/test_pet_engine.py`
- `uv run ruff check cli.py tests/cli/test_cli_pet_pane.py`
- `git diff --check`
- manually verified the crisp animated Petdex sprite in the interactive Hermes CLI under Kitty/Herdr
