### PR TITLE
Cron scripts no longer fail to find hermes under service-manager PATH (#92998, salvage #93082)

### DIFF
--- a/contributors/emails/pushand@foxmail.com
+++ b/contributors/emails/pushand@foxmail.com
@@ -1,0 +1,1 @@
+UniversePeak

--- a/tests/computer_use/test_cua_cli_fallback_env.py
+++ b/tests/computer_use/test_cua_cli_fallback_env.py
@@ -53,6 +53,8 @@ def test_cli_fallback_strips_provider_secret_from_subprocess_env(monkeypatch):
     assert captured["env"] is not None, "subprocess.run must receive an explicit env="
     assert "ANTHROPIC_API_KEY" not in captured["env"]
     # Sanitization filters secrets, not everything — an ordinary var survives.
-    assert captured["env"].get("PATH") == "/usr/bin:/bin"
+    # Original PATH entries are preserved; the hermes console-script dir may
+    # be prepended (see _sanitize_subprocess_env, issue #92998).
+    assert captured["env"].get("PATH", "").endswith("/usr/bin:/bin")
 
 

--- a/tests/computer_use/test_cua_spawn_env_sanitization.py
+++ b/tests/computer_use/test_cua_spawn_env_sanitization.py
@@ -14,6 +14,7 @@ full parent environment (provider API keys included):
 """
 
 import json
+import os
 from unittest.mock import MagicMock
 
 SECRET = "sk-super-secret-should-not-leak"
@@ -42,9 +43,22 @@ def _assert_sanitized(captured):
     assert env is not None, "subprocess must receive an explicit env="
     assert "ANTHROPIC_API_KEY" not in env
     # Sanitization filters secrets, not everything — ordinary vars survive.
-    assert env.get("PATH") == "/usr/bin:/bin"
+    _assert_path_preserved(env)
     # Confirms the telemetry helper still ran (default: telemetry disabled).
     assert env.get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"
+
+
+def _assert_path_preserved(env):
+    """Original PATH entries survive sanitization; the hermes console-script
+    dir may be prepended (see _sanitize_subprocess_env, issue #92998) so we
+    assert the contract, not byte equality."""
+    from tools.environments.local import _resolve_hermes_bin_dir
+
+    path_val = env.get("PATH", "")
+    assert path_val.endswith("/usr/bin:/bin"), path_val
+    hermes_bin = _resolve_hermes_bin_dir()
+    if hermes_bin and path_val != "/usr/bin:/bin":
+        assert path_val.startswith(hermes_bin + os.pathsep), path_val
 
 
 def _patch_windows_hide_flags(monkeypatch, module):
@@ -211,7 +225,7 @@ def test_doctor_sanitized_env_helper(monkeypatch):
 
     env = doctor._sanitized_cua_env()
     assert "ANTHROPIC_API_KEY" not in env
-    assert env.get("PATH") == "/usr/bin:/bin"
+    _assert_path_preserved(env)
     assert env.get("CUA_DRIVER_RS_TELEMETRY_ENABLED") == "0"
 
     # The Popen spawn site must actually use the sanitized helper.

--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -97,3 +97,46 @@ def test_e2e_no_scrub_child_keeps_planted_secret(tmp_path, monkeypatch):
         env=env, capture_output=True, text=True, timeout=60, check=True,
     )
     assert out.stdout.strip() == "sk-FAKE-planted"
+
+
+# ---------------------------------------------------------------------------
+# E2E regression (#93082): cron/no_agent children keep bare `hermes` on PATH
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_scrubbed_env_resolves_bare_hermes_under_minimal_parent_path(monkeypatch):
+    """Regression for #92998/#93082: a gateway launched by systemd/cron with a
+    minimal PATH (no hermes console-script dir) must still hand cron job
+    children an env whose PATH resolves bare ``hermes``.
+
+    Exercises the REAL factory and the REAL bin-dir resolver — no mocks of the
+    helpers. cron/scheduler._run_job_script builds its child env via exactly
+    this call (``build_subprocess_env()`` with scrub on).
+    """
+    import shutil
+
+    from tools.environments import local as local_mod
+
+    bin_dir = local_mod._resolve_hermes_bin_dir()
+    if not bin_dir or not os.path.isfile(
+        os.path.join(bin_dir, "hermes.exe" if os.name == "nt" else "hermes")
+    ):
+        pytest.skip("no real hermes console-script install available")
+
+    # Simulate the service-manager minimal PATH: hermes dir absent.
+    minimal_path = os.pathsep.join(["/usr/bin", "/bin"])
+    monkeypatch.setenv("PATH", minimal_path)
+    assert shutil.which("hermes", path=minimal_path) is None
+
+    env = build_subprocess_env(scrub_secrets=True)  # cron _run_job_script path
+
+    resolved = shutil.which("hermes", path=env.get("PATH", ""))
+    assert resolved is not None, (
+        f"bare 'hermes' must resolve from the child PATH {env.get('PATH')!r}"
+    )
+    assert os.path.dirname(resolved) == bin_dir
+    assert env["PATH"].split(os.pathsep)[0] == bin_dir
+    # Idempotent: running the parent env through the factory again must not
+    # duplicate the entry.
+    env2 = build_subprocess_env(env, scrub_secrets=True)
+    assert env2["PATH"].split(os.pathsep).count(bin_dir) == 1

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -240,6 +240,41 @@ class TestProviderEnvBlocklist:
         assert "USER" in result_env
         assert "PATH" in result_env
 
+    def test_bare_hermes_resolves_from_sanitized_subprocess_path(self):
+        """Cron children can resolve Hermes even when the gateway PATH cannot."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        with patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value="/home/user/.local/bin",
+        ):
+            result = _sanitize_subprocess_env(
+                {
+                    "PATH": os.pathsep.join(["/usr/bin", "/bin"]),
+                    "HOME": "/home/user",
+                }
+            )
+
+        assert result["PATH"] == os.pathsep.join(
+            ["/home/user/.local/bin", "/usr/bin", "/bin"]
+        )
+
+    def test_bare_hermes_path_does_not_duplicate_existing_install_dir(self):
+        """The PATH repair is idempotent for already-correct environments."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        with patch(
+            "tools.environments.local._resolve_hermes_bin_dir",
+            return_value="/home/user/.local/bin",
+        ):
+            result = _sanitize_subprocess_env(
+                {"PATH": os.pathsep.join(["/home/user/.local/bin", "/usr/bin"])}
+            )
+
+        assert result["PATH"] == os.pathsep.join(
+            ["/home/user/.local/bin", "/usr/bin"]
+        )
+
     def test_self_env_blocked_vars_also_stripped(self):
         """Blocked vars in self.env are stripped; non-blocked vars pass through."""
         result_env = _run_with_env(self_env={

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -523,6 +523,14 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # against the repo layout before trusting it.
     _strip_hermes_owned_pythonpath_and_runtime_markers(sanitized)
 
+    # Keep bare ``hermes`` invocations available to child jobs even when the
+    # gateway was launched by a service manager or cron without the console
+    # script's directory on PATH.  The terminal environment already applies
+    # this invariant; Cron scripts use this sanitizer directly (#92998).
+    path_key = _path_env_key(sanitized)
+    if path_key is not None:
+        sanitized[path_key] = _prepend_hermes_bin_dir(sanitized.get(path_key, ""))
+
     _apply_windows_msys_bash_env_defaults(sanitized)
 
     sanitized = _scrub_delegated_child_kanban_env(sanitized)


### PR DESCRIPTION
## Summary
Cron `no_agent` scripts (and all other sanitized-env children: process registry, ddgs, computer-use) can now call `hermes` by bare name even when the gateway was launched by a service manager with a minimal PATH. Previously bare-name calls failed with exit 127 because `_sanitize_subprocess_env` passed the parent's PATH through untouched.

Salvage of #93082 by @UniversePeak (authorship preserved) + our e2e regression test. Closes #92998. Supersedes #70490 (same root cause diagnosed earlier by @RKelln — credit to him; his sane-PATH append idea is a possible follow-up).

## Changes
- `tools/environments/local.py`: `_sanitize_subprocess_env` prepends the hermes console-script dir via the existing `_prepend_hermes_bin_dir`/`_path_env_key` helpers (one predicate owner, idempotent)
- `tests/tools/test_build_subprocess_env.py`: contributor's 2 unit tests + our e2e test (real `build_subprocess_env`, minimal parent PATH, real resolution — no helper mocks)

## Validation
| | Before (main) | After (branch) |
|---|---|---|
| child PATH under `/usr/bin:/bin` parent | `/usr/bin:/bin` — `hermes: not found (127)` | venv bin prepended — `Hermes Agent v0.20.5`, rc=0 |
| targeted tests | — | 85 passed, 3 skipped |

Real-subprocess A/B via the exact call cron's `_run_job_script` uses (`cron/scheduler.py:4057`).

## Infographic

![Cron finds hermes again](https://v3b.fal.media/files/b/0aa78f2d/5SQzEhrDG26KkTjMAAuj3_PRMwXWTj.png)
