### PR TITLE
install.ps1 no longer crashes at line 367 under StrictMode (#93017, salvage #93020)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -248,7 +248,10 @@ function ConvertTo-LongPath {
     if ([string]::IsNullOrWhiteSpace($Path)) { return $Path }
     # Only 8.3 short names carry a tilde+digit ("~1"); skip every resolver for
     # ordinary long paths, which is the overwhelmingly common case.
-    if ($Path -notmatch '~\d') { return $Path }
+    if ($Path -notmatch '~\d') {
+        $script:LastResolver = 'skipped-long-path'
+        return $Path
+    }
 
     # 1. kernel32. Compiled on first use only, so a normal profile never pays
     #    the Add-Type cost (this file is re-entered once per install stage).

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -326,6 +326,12 @@ function Set-LongProfileEnvVars {
     return $rewrote
 }
 
+# ConvertTo-LongPath only assigns $script:LastResolver when a ~\d short path
+# actually needs expansion, so an ordinary long profile leaves it unset -- and
+# the ResolvedPathReport below reads it unconditionally, which is fatal under
+# Set-StrictMode before any stage starts. 'none' is the resolver's own value
+# for "nothing ran".
+$script:LastResolver = 'none'
 $script:NormalizedProfilePaths = Set-LongProfileEnvVars
 
 # Re-derive the install paths now that the env vars behind their defaults are

--- a/tests/test_install_ps1_resolver_strictmode.py
+++ b/tests/test_install_ps1_resolver_strictmode.py
@@ -1,0 +1,71 @@
+"""Regression: the ResolvedPathReport must not read an unset resolver.
+
+Issue #93017: fresh Windows installs died at the ``$script:ResolvedPathReport``
+block with ``The variable '$script:LastResolver' cannot be retrieved because
+it has not been set`` — before any install stage ran. The mechanism:
+``ConvertTo-LongPath`` short-circuits at the top for ordinary long paths
+(``-notmatch '~\\d'`` returns early, per the comment "skip every resolver for
+ordinary long paths, which is the overwhelmingly common case"), so
+``$script:LastResolver`` is only ever assigned when a 8.3 short path actually
+needs expansion. The report block read it unconditionally, which is fatal in
+a ``Set-StrictMode`` session (the reporter hit it through three different
+invocation styles, i.e. their host/session enables strict mode).
+
+The fix initializes ``$script:LastResolver = 'none'`` at script scope before
+``Set-LongProfileEnvVars`` can run any resolver — ``'none'`` being the
+resolver's own value for "nothing ran".
+
+install.ps1 only runs on Windows, so these tests lock the contract at the
+source-text level (same style as test_install_ps1_uv_install_fallback.py).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+def _ps1() -> str:
+    return _INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_last_resolver_initialized_at_script_scope():
+    source = _ps1()
+    match = re.search(r"^\$script:LastResolver = 'none'\s*$", source, re.MULTILINE)
+    assert match is not None, (
+        "$script:LastResolver must be initialized at script scope ('none') — "
+        "ConvertTo-LongPath only assigns it when a short path needs expanding, "
+        "so an ordinary long profile leaves it unset (#93017)"
+    )
+
+
+def test_initialization_precedes_resolver_run_and_report_read():
+    source = _ps1()
+    init = re.search(r"^\$script:LastResolver = 'none'\s*$", source, re.MULTILINE)
+    run = re.search(r"^\$script:NormalizedProfilePaths = Set-LongProfileEnvVars", source, re.MULTILINE)
+    read = re.search(r"^\s+resolver\s+= \$script:LastResolver\s*$", source, re.MULTILINE)
+    assert init and run and read, "init / Set-LongProfileEnvVars / report read must all exist"
+    assert init.start() < run.start() < read.start(), (
+        "initialization must come before Set-LongProfileEnvVars can invoke a "
+        "resolver, and before the ResolvedPathReport reads the variable"
+    )
+
+
+def test_convert_to_long_path_still_short_circuits_before_assigning():
+    """Pin the mechanism that leaves the variable unset on normal paths.
+
+    The early return for paths without an 8.3 alias is what makes the
+    initialization load-bearing: if someone removes the short-circuit the
+    resolver always assigns, but the guard is a deliberate performance
+    choice (skip Add-Type for the overwhelmingly common case) and must
+    stay — so the init must stay too.
+    """
+    source = _ps1()
+    start = source.index("function ConvertTo-LongPath")
+    body = source[start : start + 2000]
+    assert re.search(r"-notmatch '~\\d'", body), (
+        "ConvertTo-LongPath must keep its ordinary-long-path short-circuit "
+        "(the reason $script:LastResolver can be unset without an init)"
+    )


### PR DESCRIPTION
## Summary
`install.ps1` no longer crashes at line 367 on fresh Windows installs when the caller's PowerShell session has StrictMode enabled. `$script:LastResolver` was only assigned on the rare 8.3-short-path branch; every ordinary machine reached the resolved-path report with the variable unset → fatal `InvalidOperation` before any install stage ran.

Salvage of #93020 by @liuhao1024 (first-filed, primary credit; authorship preserved) + the `'skipped-long-path'` diagnostics hunk from #93100 (Co-authored-by: @aniruddhaadak80). Closes #93017.

## Changes
- `scripts/install.ps1`: initialize `$script:LastResolver = 'none'` before the report; early long-path return now records `'skipped-long-path'` so the report distinguishes "skipped" from "never ran"
- `tests/test_install_ps1_resolver_strictmode.py`: 3 source-contract tests (init exists, init precedes resolver-run and report-read, early-return pinned)

## Validation
| | Before (main) | After (branch) |
|---|---|---|
| pwsh 7.4.6 StrictMode, `-ShowResolvedPaths` | InvalidOperation at install.ps1:367, exit 1 | clean JSON report, `"resolver":"skipped-long-path"`, exit 0 |
| contract tests vs base install.ps1 | 2 failed, 1 passed | 3 passed |

Live repro on real PowerShell (portable 7.4.6), not simulated.

## Infographic

![Windows install unblocked](https://v3b.fal.media/files/b/0aa78f19/B8pJNuJ0xqYJ32qkK3_FV_uGJHEbwF.png)
