### PR TITLE
Cron surface no longer crashes on id-keyed jobs.json stores (#92935, salvage #92941)

### DIFF
--- a/contributors/emails/wingkwong.code@gmail.com
+++ b/contributors/emails/wingkwong.code@gmail.com
@@ -1,0 +1,1 @@
+wingkwong

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1319,13 +1319,29 @@ def load_jobs() -> List[Dict[str, Any]]:
             # external tools or hand edits, never by save_jobs(). The public
             # load_jobs() contract and every CRUD/scheduler consumer expect a
             # list; iterating the dict would yield bare id strings and blow up
-            # downstream (e.g. _normalize_job_record -> dict(<str>)). The map
-            # values already carry their own "id", so list(values) is
-            # lossless. (_peek_jobs_unlocked() deliberately does NOT flatten —
+            # downstream (e.g. _normalize_job_record -> dict(<str>)). Flatten
+            # with an id-preserving merge: an inline "id" on the value wins,
+            # otherwise the map key is adopted as the id (external tools often
+            # key by id and omit the inline copy). Non-dict values are junk
+            # (a flattened record would not be a job) — skip them with a
+            # warning instead of crashing downstream.
+            # (_peek_jobs_unlocked() deliberately does NOT flatten —
             # it returns None on a dict-shaped store so the save path never
             # merges against an unrepaired baseline; the flatten lives only
             # here at the load boundary.)
-            jobs = list(jobs.values())
+            skipped = [k for k, v in jobs.items() if not isinstance(v, dict)]
+            if skipped:
+                logger.warning(
+                    "Skipping %d non-dict entr%s in id-keyed jobs map: %s",
+                    len(skipped),
+                    "y" if len(skipped) == 1 else "ies",
+                    ", ".join(map(repr, skipped)),
+                )
+            jobs = [
+                {**v, "id": v.get("id") or k}
+                for k, v in jobs.items()
+                if isinstance(v, dict)
+            ]
             needs_shape_repair = True
         if jobs and (_strict_retry or needs_shape_repair):
             # Rewrite into the canonical {"jobs": [...]} form: either the parse

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1313,12 +1313,30 @@ def load_jobs() -> List[Dict[str, Any]]:
     # down the whole cron subsystem.
     if isinstance(data, dict):
         jobs = data.get("jobs", [])
+        needs_shape_repair = False
         if isinstance(jobs, dict):
+            # ID-keyed map ({"jobs": {"<job_id>": {...}, ...}}) — written by
+            # external tools or hand edits, never by save_jobs(). The public
+            # load_jobs() contract and every CRUD/scheduler consumer expect a
+            # list; iterating the dict would yield bare id strings and blow up
+            # downstream (e.g. _normalize_job_record -> dict(<str>)). The map
+            # values already carry their own "id", so list(values) is
+            # lossless. (_peek_jobs_unlocked() deliberately does NOT flatten —
+            # it returns None on a dict-shaped store so the save path never
+            # merges against an unrepaired baseline; the flatten lives only
+            # here at the load boundary.)
             jobs = list(jobs.values())
-        if _strict_retry and jobs:
-            # Hit control-character corruption — rewrite with proper escaping.
+            needs_shape_repair = True
+        if jobs and (_strict_retry or needs_shape_repair):
+            # Rewrite into the canonical {"jobs": [...]} form: either the parse
+            # hit control-character corruption (_strict_retry) or the store was
+            # an id-keyed map. save_jobs() re-emits the list shape every reader
+            # expects.
             save_jobs(jobs)
-            logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+            if needs_shape_repair:
+                logger.warning("Auto-repaired jobs.json (id-keyed jobs map flattened to list)")
+            else:
+                logger.warning("Auto-repaired jobs.json (had invalid control characters)")
         _record_load_stamp(pre_read_stamp)
         return jobs
     if isinstance(data, list):

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1313,6 +1313,8 @@ def load_jobs() -> List[Dict[str, Any]]:
     # down the whole cron subsystem.
     if isinstance(data, dict):
         jobs = data.get("jobs", [])
+        if isinstance(jobs, dict):
+            jobs = list(jobs.values())
         if _strict_retry and jobs:
             # Hit control-character corruption — rewrite with proper escaping.
             save_jobs(jobs)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1291,6 +1291,99 @@ class TestJobsJsonUtf8Bom:
 
 
 
+# =========================================================================
+# ID-keyed jobs map on jobs.json (external tools / hand edits) — #92935
+# =========================================================================
+
+class TestJobsJsonIdKeyedMap:
+    """load_jobs() must flatten an ID-keyed ``jobs`` map to the list contract.
+
+    A store written as ``{"jobs": {"<job_id>": {...}, ...}}`` (external tool
+    or hand edit — Hermes' own save_jobs() only ever writes a list) made
+    load_jobs() return a dict. Every consumer iterates it as a list, so
+    ``list_jobs()`` → ``_normalize_job_record`` → ``dict(<id-string>)`` raised
+    ``ValueError: dictionary update sequence element #0 has length 1; 2 is
+    required`` and took down ``hermes cron list``, the ``cronjob(action=
+    "list")`` tool, and the Dashboard cron view. The values already carry
+    their own ``id`` matching the map key, so flattening is lossless.
+    """
+
+    _ID_KEYED = {
+        "jobs": {
+            "cron1234abcd": {
+                "id": "cron1234abcd",
+                "name": "Example job",
+                "enabled": True,
+                "prompt": "do a thing",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+            },
+            "cron5678efgh": {
+                "id": "cron5678efgh",
+                "name": "Second job",
+                "enabled": True,
+                "prompt": "do another",
+                "schedule": {"kind": "interval", "minutes": 30, "display": "every 30m"},
+            },
+        },
+        "updated_at": "2026-08-23T10:10:12+08:00",
+    }
+
+    def test_load_jobs_flattens_id_keyed_map(self, tmp_cron_dir):
+        """The pre-fix repro: load_jobs() returns a list, not the raw dict."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(self._ID_KEYED), encoding="utf-8")
+
+        loaded = load_jobs()
+        assert isinstance(loaded, list)
+        assert {j["id"] for j in loaded} == {"cron1234abcd", "cron5678efgh"}
+        assert all(isinstance(j, dict) for j in loaded)
+
+    def test_list_jobs_survives_id_keyed_map(self, tmp_cron_dir):
+        """The reported traceback path (hermes cron list / cronjob list tool)."""
+        import json
+        from cron.jobs import JOBS_FILE, list_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(self._ID_KEYED), encoding="utf-8")
+
+        # Pre-fix this raised ValueError from _normalize_job_record(dict(<str>)).
+        jobs = list_jobs(include_disabled=True)
+        assert {j["id"] for j in jobs} == {"cron1234abcd", "cron5678efgh"}
+
+    def test_id_keyed_map_repaired_to_list_on_disk(self, tmp_cron_dir):
+        """Loading rewrites the store into the canonical {"jobs": [...]} form."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(self._ID_KEYED), encoding="utf-8")
+
+        load_jobs()
+
+        on_disk = json.loads(JOBS_FILE.read_text(encoding="utf-8"))
+        assert isinstance(on_disk["jobs"], list)
+        assert {j["id"] for j in on_disk["jobs"]} == {"cron1234abcd", "cron5678efgh"}
+
+        # A second load reads the repaired list unchanged (idempotent).
+        reloaded = load_jobs()
+        assert {j["id"] for j in reloaded} == {"cron1234abcd", "cron5678efgh"}
+
+    def test_empty_id_keyed_map_returns_empty_list(self, tmp_cron_dir):
+        """An empty ``jobs`` map must not crash and yields no jobs."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps({"jobs": {}}), encoding="utf-8")
+
+        assert load_jobs() == []
+
+
+
+
 class TestAdvanceNextRuns:
     """Tests for advance_next_runs() — the batched due-set advance.
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1189,6 +1189,50 @@ class TestLateEnvRepointScopesStore:
 # UTF-8 BOM on jobs.json (Windows Notepad / PowerShell 5.1)
 # =========================================================================
 
+class TestJobsJsonShapes:
+    def test_load_jobs_normalizes_id_keyed_jobs_mapping(self, tmp_cron_dir):
+        import json
+        from cron.jobs import JOBS_FILE
+
+        job_a = {
+            "id": "cron1234abcd",
+            "name": "daily briefing",
+            "enabled": True,
+            "prompt": "Summarize overnight incidents",
+            "schedule": {"kind": "interval", "minutes": 1440, "display": "every 24h"},
+        }
+        job_b = {
+            "id": "cron5678efgh",
+            "name": "disabled cleanup",
+            "enabled": False,
+            "prompt": "Clean stale scratch files",
+            "schedule": {"kind": "once", "run_at": "2030-01-15T14:00:00+00:00"},
+        }
+        payload = {
+            "jobs": {
+                job_a["id"]: job_a,
+                job_b["id"]: job_b,
+            },
+            "updated_at": "2026-08-23T00:00:00+00:00",
+        }
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(payload), encoding="utf-8")
+
+        loaded = load_jobs()
+        assert isinstance(loaded, list)
+        assert {job["id"] for job in loaded} == {job_a["id"], job_b["id"]}
+
+        listed = {job["id"]: job for job in list_jobs(include_disabled=True)}
+        assert set(listed) == {job_a["id"], job_b["id"]}
+        for expected in (job_a, job_b):
+            actual = listed[expected["id"]]
+            assert actual["id"] == expected["id"]
+            assert actual["name"] == expected["name"]
+            assert actual["prompt"] == expected["prompt"]
+            assert actual["schedule"] == expected["schedule"]
+            assert actual["enabled"] is expected["enabled"]
+
+
 class TestJobsJsonUtf8Bom:
     """jobs.json readers must accept a leading UTF-8 BOM.
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -1381,6 +1381,92 @@ class TestJobsJsonIdKeyedMap:
 
         assert load_jobs() == []
 
+    def test_map_value_without_inline_id_adopts_key(self, tmp_cron_dir):
+        """A value lacking an inline "id" gets the map key as its id."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        payload = {
+            "jobs": {
+                "cronkeyonly1": {
+                    "name": "keyed only",
+                    "enabled": True,
+                    "prompt": "no inline id here",
+                    "schedule": {"kind": "interval", "minutes": 15, "display": "every 15m"},
+                },
+                "cron-ignored-key": {
+                    "id": "croninline99",
+                    "name": "inline id wins",
+                    "enabled": True,
+                    "prompt": "inline id present",
+                    "schedule": {"kind": "interval", "minutes": 5, "display": "every 5m"},
+                },
+            }
+        }
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(payload), encoding="utf-8")
+
+        loaded = {j["id"]: j for j in load_jobs()}
+        # Key adopted when the value has no inline id.
+        assert "cronkeyonly1" in loaded
+        assert loaded["cronkeyonly1"]["name"] == "keyed only"
+        # Inline id wins over a differing map key.
+        assert "croninline99" in loaded
+        assert "cron-ignored-key" not in loaded
+
+        # Self-heal persisted the id-merged records.
+        on_disk = json.loads(JOBS_FILE.read_text(encoding="utf-8"))
+        assert isinstance(on_disk["jobs"], list)
+        assert {j["id"] for j in on_disk["jobs"]} == {"cronkeyonly1", "croninline99"}
+
+    def test_non_dict_map_values_skipped_with_warning(self, tmp_cron_dir, caplog):
+        """Junk (non-dict) values in the map are skipped, never crash."""
+        import json
+        import logging
+        from cron.jobs import JOBS_FILE, list_jobs, load_jobs
+
+        payload = {
+            "jobs": {
+                "goodjob1": {
+                    "name": "survivor",
+                    "enabled": True,
+                    "prompt": "keep me",
+                    "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+                },
+                "junk-string": "i am not a job",
+                "junk-number": 42,
+                "junk-null": None,
+            }
+        }
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(json.dumps(payload), encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            loaded = load_jobs()
+        assert [j["id"] for j in loaded] == ["goodjob1"]
+        assert any("non-dict" in rec.getMessage() for rec in caplog.records)
+
+        # The reported traceback path also survives the junk.
+        jobs = list_jobs(include_disabled=True)
+        assert {j["id"] for j in jobs} == {"goodjob1"}
+
+        # Self-heal wrote only the valid record, canonical list shape.
+        on_disk = json.loads(JOBS_FILE.read_text(encoding="utf-8"))
+        assert isinstance(on_disk["jobs"], list)
+        assert [j["id"] for j in on_disk["jobs"]] == ["goodjob1"]
+
+    def test_all_junk_map_values_yield_empty_list(self, tmp_cron_dir):
+        """A map of only junk values flattens to [] without crashing."""
+        import json
+        from cron.jobs import JOBS_FILE, load_jobs
+
+        JOBS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        JOBS_FILE.write_text(
+            json.dumps({"jobs": {"a": "junk", "b": 1}}), encoding="utf-8"
+        )
+
+        assert load_jobs() == []
+
 
 
 


### PR DESCRIPTION
## Summary
`hermes cron list` (and the whole cron surface) no longer crashes with ValueError when jobs.json was written by an external tool as an id-keyed map (`{"jobs": {id: job}}`). The store is flattened with ids preserved (inline id wins, map key as fallback), non-dict junk entries are skipped with a warning, and the file self-heals on disk to the canonical list shape — matching the existing bare-list auto-repair precedent in the same function.

Salvage stack, earliest submitter first: #92941 by @wingkwong (base fix, primary credit) + #92994 self-heal by @a-yeyang (Co-authored-by; its inaccurate `_peek_jobs_unlocked` comment corrected) + our id-preservation/junk-guard fixup. Closes #92935 (reported by @orangercat). Supersedes #92953.

## Changes
- `cron/jobs.py`: `load_jobs()` flattens dict-shaped stores via `{**v, "id": v.get("id") or k}`; non-dict values skipped with warning; `needs_shape_repair` → `save_jobs()` canonical rewrite
- `tests/cron/test_jobs.py`: shape test (#92941), 4 self-heal/idempotence tests (#92994), 3 id-preservation/junk/all-junk tests (ours)

## Validation
| | Before (main) | After (branch) |
|---|---|---|
| dict-shaped jobs.json, `list_jobs()` | ValueError crash, file untouched | jobs listed; id-less job adopts its map key as id; junk skipped w/ warning |
| on-disk store after first load | still dict (breaks shrink-merge baseline forever) | rewritten to canonical `{"jobs": [...]}`, idempotent reload |
| `tests/cron/test_jobs.py` | — | 80 passed |

## Infographic

![Cron jobs survive hand-edited stores](https://v3b.fal.media/files/b/0aa78f1f/6pobJL1VREZcyvHNHSxno_YuJpKAVN.png)
