### PR TITLE
fix(desktop): route remote attachments by connection

### DIFF
--- a/apps/desktop/electron/gateway-file-download-transport.test.ts
+++ b/apps/desktop/electron/gateway-file-download-transport.test.ts
@@ -46,6 +46,15 @@ test('oauth transport streams to disk instead of buffering the whole body', () =
   assert.doesNotMatch(fn, /chunks\.push/)
 })
 
+test('download transports preserve registered connection headers', () => {
+  const token = extract('function downloadViaTokenToFile', '\nfunction ')
+  const oauth = extract('function downloadViaOauthSessionToFile', '\nasync function finalizeGatewayDownload')
+
+  assert.match(token, /\.\.\.\(options\.headers \|\| \{\}\)/)
+  assert.match(oauth, /options\.headers/)
+  assert.match(oauth, /request\.setHeader/)
+})
+
 test('finalizeGatewayDownload prompts a save dialog then streams the response', () => {
   const fn = extract('async function finalizeGatewayDownload', '\nfunction readGatewayErrorText')
 
@@ -61,6 +70,18 @@ test('saveGatewayFile falls back to the data-url route only on 404', () => {
   assert.match(fn, /\/api\/fs\/download\?path=/)
   assert.match(fn, /isNotFoundError\(error\)/)
   assert.match(fn, /saveGatewayFileViaDataUrl\(/)
+})
+
+test('saveGatewayFile pins downloads to a registered connection when supplied', () => {
+  const fn = extract('async function saveGatewayFile', '\nasync function saveGatewayFileViaDataUrl')
+  const fallback = extract('async function saveGatewayFileViaDataUrl', '// Mint a single-use WS ticket')
+
+  assert.match(fn, /payload\.connectionId/)
+  assert.match(fn, /ensureRegistryBackend\(connectionId, profile\)/)
+  assert.match(fn, /pathWithProfileScope/)
+  assert.match(fn, /translateSelfProfileQuery/)
+  assert.match(fn, /headers: connection\.headers/)
+  assert.match(fallback, /headers: connection\.headers/)
 })
 
 test('data-url fallback reads the capped route and decodes it', () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4978,7 +4978,13 @@ function downloadViaTokenToFile(url, token, ctx, options: any = {}) {
       parsed,
       {
         method: 'GET',
-        headers: options.bearer ? { Authorization: `Bearer ${options.bearer}` } : { 'X-Hermes-Session-Token': token }
+        headers: {
+          ...headersForRemoteRequest(url),
+          ...(options.headers || {}),
+          ...(options.bearer
+            ? { Authorization: 'Bearer ' + options.bearer }
+            : { 'X-Hermes-Session-Token': token })
+        }
       },
       res => {
         // Headers arrived — the connection phase is done. Drop the idle timeout
@@ -7384,6 +7390,13 @@ function downloadViaOauthSessionToFile(url, ctx, options: any = {}) {
       redirect: 'follow'
     } as any)
 
+    for (const [name, value] of Object.entries({
+      ...headersForRemoteRequest(url),
+      ...(options.headers || {})
+    })) {
+      request.setHeader(name, String(value))
+    }
+
     let settled = false
 
     const timer = setTimeout(() => {
@@ -7510,16 +7523,24 @@ async function saveGatewayFile(payload: any = {}) {
   }
 
   const profile = payload.profile || null
-  const connection = await ensureBackend(profile)
+  const connectionId = String(payload.connectionId || '').trim()
+
+  const connection = connectionId
+    ? await ensureRegistryBackend(connectionId, profile)
+    : await ensureBackend(profile)
+
   const suggested = String(payload.suggestedName || '').trim()
   const fallbackName = path.basename(filePath) || suggested || 'download'
   const ctx = { suggested, fallbackName }
 
-  const requestPath = pathWithGlobalRemoteProfile(
-    `/api/fs/download?path=${encodeURIComponent(filePath)}`,
-    profile,
-    profileRouteOptions(profile)
-  )
+  const routePath = requestPath =>
+    connectionId
+      ? connection.sharedRemote
+        ? pathWithProfileScope(requestPath, profile)
+        : translateSelfProfileQuery(requestPath, profile, connection.remoteProfile)
+      : pathWithGlobalRemoteProfile(requestPath, profile, profileRouteOptions(profile))
+
+  const requestPath = routePath(`/api/fs/download?path=${encodeURIComponent(filePath)}`)
 
   const url = `${connection.baseUrl}${requestPath}`
 
@@ -7527,20 +7548,23 @@ async function saveGatewayFile(payload: any = {}) {
     const auth = await gatedFileAuth(connection)
 
     if (auth.kind === 'bearer') {
-      return await downloadViaTokenToFile(url, auth.token, ctx, { bearer: auth.token })
+      return await downloadViaTokenToFile(url, auth.token, ctx, {
+        bearer: auth.token,
+        headers: connection.headers
+      })
     }
 
     if (auth.kind === 'cookie') {
-      return await downloadViaOauthSessionToFile(url, ctx)
+      return await downloadViaOauthSessionToFile(url, ctx, { headers: connection.headers })
     }
 
-    return await downloadViaTokenToFile(url, auth.token, ctx)
+    return await downloadViaTokenToFile(url, auth.token, ctx, { headers: connection.headers })
   } catch (error) {
     // Desktop and the remote gateway update independently. A gateway predating
     // /api/fs/download 404s here; fall back (ONLY on 404) to the older capped
     // data-URL route so downloads keep working against older backends.
     if (isNotFoundError(error)) {
-      return await saveGatewayFileViaDataUrl(connection, profile, filePath, ctx)
+      return await saveGatewayFileViaDataUrl(connection, profile, filePath, ctx, routePath)
     }
 
     throw error
@@ -7551,23 +7575,23 @@ async function saveGatewayFile(payload: any = {}) {
 // `/api/fs/read-data-url` route, decode it, and save. Bounded by the gateway's
 // data-URL cap, so it only serves smaller files — enough to keep older gateways
 // working until they gain the streaming route.
-async function saveGatewayFileViaDataUrl(connection, profile, filePath, ctx: any = {}) {
-  const requestPath = pathWithGlobalRemoteProfile(
-    `/api/fs/read-data-url?path=${encodeURIComponent(filePath)}`,
-    profile,
-    profileRouteOptions(profile)
-  )
+async function saveGatewayFileViaDataUrl(connection, profile, filePath, ctx: any = {}, routePath?) {
+  const fallbackPath = `/api/fs/read-data-url?path=${encodeURIComponent(filePath)}`
+
+  const requestPath = routePath
+    ? routePath(fallbackPath)
+    : pathWithGlobalRemoteProfile(fallbackPath, profile, profileRouteOptions(profile))
 
   const url = `${connection.baseUrl}${requestPath}`
   const auth = await gatedFileAuth(connection)
   let json: any
 
   if (auth.kind === 'bearer') {
-    json = await fetchJson(url, null, { bearer: auth.token })
+    json = await fetchJson(url, null, { bearer: auth.token, headers: connection.headers })
   } else if (auth.kind === 'cookie') {
-    json = await fetchJsonViaOauthSession(url)
+    json = await fetchJsonViaOauthSession(url, { headers: connection.headers })
   } else {
-    json = await fetchJson(url, auth.token)
+    json = await fetchJson(url, auth.token, { headers: connection.headers })
   }
 
   const dataUrl = json?.dataUrl

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -220,7 +220,12 @@ declare global {
       }) => Promise<null | string>
       writeClipboard: (text: string) => Promise<boolean>
       readClipboard: () => Promise<string>
-      saveGatewayFile?: (payload: { path: string; profile?: null | string; suggestedName?: string }) => Promise<{
+      saveGatewayFile?: (payload: {
+        connectionId?: string
+        path: string
+        profile?: null | string
+        suggestedName?: string
+      }) => Promise<{
         canceled?: boolean
         path?: string
         saved: boolean

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -144,6 +144,18 @@ describe('desktop filesystem facade', () => {
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: 'remote-docker' })
   })
 
+  it('pins remote preview reads to the active registered connection', async () => {
+    $connection.set({ mode: 'remote', profile: 'opus-manager', connectionId: 'ssh-gateway' } as never)
+
+    await readDesktopFileText('/home/hermes/review.md')
+
+    expect(api).toHaveBeenCalledWith({
+      connectionId: 'ssh-gateway',
+      path: '/api/fs/read-text?path=%2Fhome%2Fhermes%2Freview.md',
+      profile: 'opus-manager'
+    })
+  })
+
   it('keys SSH filesystem caches by stable host identity instead of the forwarded port', () => {
     $connection.set({
       mode: 'remote',
@@ -163,6 +175,32 @@ describe('desktop filesystem facade', () => {
     expect(desktopFsCacheKey()).toBe(first)
     expect(first).toContain('operator@remote-box')
     expect(first).not.toContain('41001')
+  })
+
+  it('separates SSH filesystem caches by registered connection while ignoring forwarded-port churn', () => {
+    const base = {
+      mode: 'remote',
+      remoteKind: 'ssh',
+      remoteHost: 'operator@remote-box',
+      profile: 'opus-manager'
+    }
+
+    const first = desktopFsCacheKey({ ...base, baseUrl: 'http://127.0.0.1:41001', connectionId: 'gateway-a' } as never)
+
+    const reconnected = desktopFsCacheKey({
+      ...base,
+      baseUrl: 'http://127.0.0.1:52002',
+      connectionId: 'gateway-a'
+    } as never)
+
+    const otherConnection = desktopFsCacheKey({
+      ...base,
+      baseUrl: 'http://127.0.0.1:41001',
+      connectionId: 'gateway-b'
+    } as never)
+
+    expect(reconnected).toBe(first)
+    expect(otherConnection).not.toBe(first)
   })
 
   it('separates SSH filesystem caches by ownership and profile', () => {

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -26,7 +26,7 @@ function connectionCacheKey(connection: HermesConnection | null) {
       ? connection.remoteIdentity || connection.remoteHost || ''
       : connection.baseUrl || ''
 
-  return `${connection.mode || 'local'}:${connection.remoteKind || ''}:${connection.profile || ''}:${target}`
+  return `${connection.mode || 'local'}:${connection.remoteKind || ''}:${connection.connectionId || ''}:${connection.profile || ''}:${target}`
 }
 
 export function desktopFsCacheKey(connection: HermesConnection | null = $connection.get()) {
@@ -37,10 +37,15 @@ export function isDesktopFsRemoteMode() {
   return $connection.get()?.mode === 'remote'
 }
 
-// Active profile for FS/git REST calls. Without it the Electron api bridge
-// hits the primary (local) backend even when the user switched to a remote profile.
+// Active profile and registered connection for FS/git REST calls. Without
+// both, Electron can fall back to the legacy profile route and read from a
+// different gateway than the session that produced the path.
 export function desktopFsProfile(): string | undefined {
   return $connection.get()?.profile || undefined
+}
+
+export function desktopFsConnectionId(): string | undefined {
+  return $connection.get()?.connectionId || undefined
 }
 
 function fsPath(endpoint: string, filePath: string) {
@@ -58,9 +63,16 @@ function bridge() {
 }
 
 function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
-  return bridge().api<T>(
-    body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
-  )
+  const connectionId = desktopFsConnectionId()
+  const profile = desktopFsProfile()
+
+  const route = {
+    ...(connectionId ? { connectionId } : {}),
+    path,
+    ...(profile ? { profile } : {})
+  }
+
+  return bridge().api<T>(body ? { ...route, body, method: 'POST' } : route)
 }
 
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -225,7 +225,7 @@ describe('downloadGatewayMediaFile', () => {
   beforeEach(() => {
     saveGatewayFile.mockClear()
     vi.stubGlobal('window', { hermesDesktop: { saveGatewayFile } })
-    $connection.set({ mode: 'remote', profile: 'docker-gw' } as never)
+    $connection.set({ mode: 'remote', profile: 'docker-gw', connectionId: 'ssh-gateway' } as never)
   })
 
   afterEach(() => {
@@ -240,6 +240,7 @@ describe('downloadGatewayMediaFile', () => {
     })
 
     expect(saveGatewayFile).toHaveBeenCalledWith({
+      connectionId: 'ssh-gateway',
       path: '/Users/me/project/a b.md',
       profile: 'docker-gw',
       suggestedName: 'a b.md'

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -208,6 +208,7 @@ export async function downloadGatewayMediaFile(
   }
 
   return window.hermesDesktop.saveGatewayFile({
+    connectionId: conn?.connectionId,
     path: file,
     profile: conn?.profile,
     suggestedName: mediaName(file)


### PR DESCRIPTION
## Summary

Fix remote Hermes Desktop Preview and download requests selecting the wrong backend when multiple registered connections or legacy profile routes exist.

Remote filesystem and attachment requests now preserve both the active registered `connectionId` and profile. Electron resolves the registered backend, applies the same connection/profile translation to streaming downloads and the data-URL compatibility fallback, and preserves registered connection headers. Filesystem caches are isolated by registered connection while remaining stable across SSH forwarded-port churn.

## Root cause

Renderer requests carried the active profile but omitted the registered connection ID. Electron could therefore fall back to a different backend that did not own the remote absolute path, returning a misleading `404 File not found` and rendering “Preview unavailable.”

## Compatibility

- Requests without `connectionId` retain the existing profile-based fallback.
- Shared-remote profile scoping and isolated/SSH profile translation are preserved.
- Streaming and data-URL fallback use the same translated route.
- Token/bearer authentication overrides conflicting custom auth headers.

## Verification

On current upstream `main`:

- Renderer filesystem/media tests: 34 passed
- Electron gateway transport tests: 7 passed
- Focused ESLint: passed
- Renderer, Electron, and E2E TypeScript typecheck: passed
- Electron main/preload bundling: passed
- `git diff --check`: passed
- Independent staged-diff review findings were resolved
- DeepSeek V4 Pro corrective-delta review: APPROVE, zero material findings

A complete Vite production build transformed all 15,135 modules on a 3.8 GiB/no-swap VPS but was OOM-killed during chunk rendering. Hosted CI or a normal build host should perform the complete production build before release.

## Test plan

1. Build and install a macOS Desktop artifact from this branch.
2. Connect to a registered SSH/remote gateway with a non-default profile.
3. Open Markdown/text attachments in chat Preview.
4. Download JSON, patch, and Git bundle attachments.
5. Confirm two registered connections with matching host/profile metadata do not share filesystem cache entries.
6. Confirm gateways requiring registered custom headers work for streaming and data-URL fallback.
