### PR TITLE
fix(gateway): fresh Bot Chats no longer feed the orphan reaper after reconnect (live-E2E follow-up to #93361)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5376,6 +5376,76 @@ def test_superseded_by_resume_is_recoverable_end_reason():
     assert "superseded_by_resume" not in server._RECLAIM_END_REASONS
 
 
+def test_lazy_unpersisted_resume_rebinds_transport_and_cancels_reap(monkeypatch):
+    """The lazy/unpersisted resume branch (no state.db row yet — every fresh
+    Bot Chat) must ALSO rebind the transport and cancel the pending reap when
+    it hands back a sentinel-parked live record. Found by live WS E2E after
+    the #93361 merge: the unit-covered paths (_live_session_payload,
+    _reuse_live_response, _claim_or_reuse_live) all cancelled, but this branch
+    returned the record while leaving it on the drop sentinel with the reap
+    Timer armed — the storm survived for unpersisted sessions (storm killer,
+    part 3)."""
+    cancelled = []
+
+    class _Timer:
+        def __init__(self, _delay, fn):
+            self.fn = fn
+
+        def start(self):
+            return None
+
+        def cancel(self):
+            cancelled.append(self)
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    live_transport = _LiveTransport()
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server, "current_transport", lambda: live_transport)
+    # get_session/get_session_by_title miss -> forces the unpersisted branch
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: types.SimpleNamespace(
+            get_session=lambda _t: None,
+            get_session_by_title=lambda _t: None,
+        ),
+    )
+
+    session = _session(
+        session_key="stored-lazy",
+        transport=server._detached_ws_transport,
+        running=False,
+        history=[],
+        profile_home=None,
+    )
+    server._sessions["lazy-sid"] = session
+
+    try:
+        server._schedule_ws_orphan_reap("lazy-sid")
+        assert "lazy-sid" in server._pending_ws_reaps
+
+        resp = _dispatch_sync(
+            {
+                "id": "lz1",
+                "method": "session.resume",
+                "params": {"session_id": "stored-lazy", "omit_messages": True},
+            },
+            transport=live_transport,
+        )
+
+        assert resp is not None and resp["result"]["session_id"] == "lazy-sid"
+        assert session["transport"] is live_transport
+        assert "lazy-sid" not in server._pending_ws_reaps
+        assert len(cancelled) == 1
+    finally:
+        server._sessions.pop("lazy-sid", None)
+        server._pending_ws_reaps.pop("lazy-sid", None)
+
+
 def test_ws_orphan_reap_still_fires_when_never_resumed(monkeypatch):
     """Nobody re-resumes: the reap fires normally and unregisters its Timer."""
     callbacks = []

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -456,6 +456,18 @@ def _(rid, params: dict) -> dict:
                         with contextlib.suppress(Exception):
                             db.close()
                     live["last_active"] = time.time()
+                    # This resume reattaches the live record. A lazy session
+                    # (no state.db row yet — every fresh Bot Chat) that was
+                    # sentinel-parked by a WS drop MUST be rebound here, or it
+                    # keeps the drop sentinel and the armed orphan-reap Timer
+                    # fires against a client that is attached right now — the
+                    # unpersisted sibling of the storm-killer paths (#91276).
+                    transport = current_transport()
+                    if transport is not None:
+                        with live.setdefault("history_lock", threading.Lock()):
+                            live["transport"] = transport
+                            live.setdefault("viewers", {})[transport] = time.time()
+                    _cancel_ws_orphan_reap(live_sid)
                     history = live.get("history") or []
                     return _ok(
                         rid,


### PR DESCRIPTION
# Live E2E follow-up to #93361

## Summary
The last surviving reap-storm path is closed: a lazy/unpersisted session (every fresh Bot Chat before its first message) that was sentinel-parked by a WS drop now rebinds its transport and cancels the armed orphan-reap Timer when re-resumed — instead of being handed back live while the reaper still fires against it.

Found by live wire testing after #93361 merged: a real web_server + tui_gateway over real WebSockets (isolated HERMES_HOME, 2 s configured grace) still produced a `ws_orphan_reap` reclaim on the drop→re-resume sequence. Root cause: the unpersisted-resume branch in `methods_session.py` returns the live record directly and bypassed all three unit-covered cancel sites (`_live_session_payload`, `_reuse_live_response`, `_claim_or_reuse_live`) — precisely the Bot Mode sessions the cluster targeted.

## Changes
- `tui_gateway/methods_session.py`: the lazy/unpersisted resume branch rebinds `current_transport()` (registering it as a viewer) and calls `_cancel_ws_orphan_reap` before returning the record.
- `tests/test_tui_gateway_server.py`: regression test drives the real `session.resume` RPC against a sentinel-parked unpersisted record — sabotage-verified (fails with the fix stashed, passes with it applied).

## Validation
| | Result |
|---|---|
| Live WS E2E (real uvicorn + WS clients, all scenarios) | 10/10 — storm killer, quiet supersede, normal reap preserved, 4× drop/resume loop with 0 reclaims, config grace honored live, approval 4001 negative |
| tests/test_tui_gateway_server.py (full file) | 605 passed |
| Sabotage run (fix stashed) | new test FAILS — load-bearing |
| ruff on changed files | clean |

## Infographic

![Lazy resume storm gap closed](https://v3b.fal.media/files/b/0aa78f5f/N1HxDYjRzWkmdn8--_-j5_FabxGh3G.png)
