### PR TITLE
fix(desktop): hold clarify panel until same-turn text, keep it on dead turns

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -68,7 +68,10 @@ describe('clarify.request stream hydration', () => {
 
     clarifyRequest({ choices: ['yes', 'no'], question: 'Ship it?', request_id: 'req-reveal' })
 
-    expect(scrollToBottom).toHaveBeenCalledOnce()
+    expect(scrollToBottom).not.toHaveBeenCalled()
+    expect($clarifyRequests.get()[SID]?.requestId).toBe('req-reveal')
+    expect(clarifyParts()).toHaveLength(1)
+    expect(stream.state().needsInput).toBe(true)
   })
 
   it('does not move the active thread for a background session clarify', () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -4,7 +4,6 @@ import { $gateway } from '@/store/gateway'
 import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
-import { requestScrollToBottom } from '@/store/thread-scroll'
 
 import type { GatewayEventContext } from './types'
 
@@ -13,7 +12,7 @@ import type { GatewayEventContext } from './types'
  *  each of these must be parked per-session and surfaced. */
 export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
   const { deps, event, payload, sessionId, occurredAt } = ctx
-  const { activeSessionIdRef, updateSessionState, upsertToolCall } = deps
+  const { updateSessionState, upsertToolCall } = deps
 
   if (event.type === 'clarify.request') {
     // Surface the clarify tool's overlay. The Python side is blocked on
@@ -78,10 +77,6 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
           occurredAt
         )
         updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
-
-        if (sessionId === activeSessionIdRef.current) {
-          requestScrollToBottom()
-        }
       }
 
       dispatchNativeNotification({
@@ -128,11 +123,10 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         // it's working). Flag the session so the sidebar shows a persistent
         // "needs input" indicator on its row — works for the active session
         // too, and survives alt-tab / window blur (unlike a toast).
+        // Deliberately NO requestScrollToBottom() here: yanking the viewport
+        // to the bottom is what users experienced as the panel "covering the
+        // conversation". Scrolling stays with the thread's own stick-to-bottom.
         updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
-
-        if (sessionId === activeSessionIdRef.current) {
-          requestScrollToBottom()
-        }
       }
 
       dispatchNativeNotification({

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.test.tsx
@@ -1,27 +1,34 @@
 import type { ToolCallMessagePartProps } from '@assistant-ui/react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { I18nProvider } from '@/i18n'
+import type { ChatMessage } from '@/lib/chat-messages'
 import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
-import { $activeSessionId } from '@/store/session'
+import { $activeSessionId, $messages } from '@/store/session'
 
 import { ClarifyTool, readClarifyBatchResult, readClarifyResult } from './clarify-tool'
 
-// The live pending card only renders while its message is running. Force that so
-// keyboard-navigation tests can exercise ClarifyToolPending directly.
+const { messageRunningMock } = vi.hoisted(() => ({
+  messageRunningMock: { current: true }
+}))
+
+// Live pending card reads useAuiState(selectMessageRunning). Tests flip this
+// to cover the dead-turn keep-alive path without remounting the tree.
 vi.mock('@assistant-ui/react', () => ({
-  useAuiState: () => true
+  useAuiState: () => messageRunningMock.current
 }))
 
 afterEach(() => {
   cleanup()
   clearClarifyRequest()
   $activeSessionId.set(null)
+  $messages.set([])
   $gateway.set(null)
+  messageRunningMock.current = true
   vi.clearAllMocks()
 })
 
@@ -629,5 +636,127 @@ describe('ClarifyTool batch card', () => {
     expect(screen.getByText('red')).toBeTruthy()
     expect(screen.getByText('Name?')).toBeTruthy()
     expect(screen.getByText('Skipped')).toBeTruthy()
+  })
+})
+
+const CLARIFY_TEXT_WAIT_MS = 1500
+
+function streamingAssistant(text: string): ChatMessage {
+  return {
+    id: 'asst-live',
+    parts: [{ type: 'text', text }],
+    role: 'assistant'
+  }
+}
+
+function queryPendingChoices() {
+  return screen.queryByRole('button', { name: /staging/ })
+}
+
+function queryFallbackRow() {
+  return document.querySelector('[data-tool-row]')
+}
+
+describe('ClarifyTool visibility gate', () => {
+  beforeEach(() => {
+    messageRunningMock.current = true
+    $messages.set([])
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    messageRunningMock.current = true
+    // Note: $messages is reset by the file-level afterEach AFTER cleanup(),
+    // once the store subscription is gone — resetting it here would re-render
+    // a still-mounted tree outside act().
+  })
+
+  it('R1: keeps the pending panel when the turn is dead but the request is still answerable', () => {
+    messageRunningMock.current = false
+    renderLiveClarify()
+
+    expect(queryPendingChoices()).toBeTruthy()
+    expect(queryFallbackRow()).toBeNull()
+  })
+
+  it('R4: falls back when the turn is dead and no request is parked', () => {
+    messageRunningMock.current = false
+    $activeSessionId.set('session-1')
+    renderClarify(<ClarifyTool {...liveClarifyProps()} />)
+
+    expect(queryPendingChoices()).toBeNull()
+    expect(queryFallbackRow()).toBeTruthy()
+  })
+
+  it('R3a: with a streaming assistant turn, waits the fallback window and never renders ToolFallback', () => {
+    $messages.set([streamingAssistant('Hello')])
+    renderLiveClarify()
+
+    expect(queryPendingChoices()).toBeNull()
+    expect(queryFallbackRow()).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(CLARIFY_TEXT_WAIT_MS - 1)
+    })
+    expect(queryPendingChoices()).toBeNull()
+    expect(queryFallbackRow()).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(queryPendingChoices()).toBeTruthy()
+    expect(queryFallbackRow()).toBeNull()
+  })
+
+  it('R3b: a mid-window text increment releases immediately and does not remount', () => {
+    $messages.set([streamingAssistant('Hello')])
+    renderLiveClarify()
+
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+    expect(queryPendingChoices()).toBeNull()
+
+    act(() => {
+      $messages.set([streamingAssistant('Hello world')])
+    })
+    expect(queryPendingChoices()).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /staging/ }))
+    expect(screen.getByRole('button', { name: /staging/ }).getAttribute('aria-pressed')).toBe('true')
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(screen.getByRole('button', { name: /staging/ }).getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('keeps staged choices across a messageRunning falling edge (same Pending instance)', () => {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest({
+      choices: ['staging', 'production'],
+      multiSelect: false,
+      question: 'Which deployment target?',
+      requestId: 'request-1',
+      sessionId: 'session-1'
+    })
+    const props = liveClarifyProps()
+    const view = renderClarify(<ClarifyTool {...props} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /staging/ }))
+    expect(screen.getByRole('button', { name: /staging/ }).getAttribute('aria-pressed')).toBe('true')
+
+    messageRunningMock.current = false
+    view.rerender(
+      <I18nProvider configClient={null} initialLocale="en">
+        <ClarifyTool {...props} />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('button', { name: /staging/ }).getAttribute('aria-pressed')).toBe('true')
+    expect(queryFallbackRow()).toBeNull()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -22,6 +22,7 @@ import { Kbd } from '@/components/ui/kbd'
 import { Textarea } from '@/components/ui/textarea'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
+import type { ChatMessage } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
 import { CircleLetterA, Loader2, MessageQuestion } from '@/lib/icons'
 import { cn } from '@/lib/utils'
@@ -37,6 +38,7 @@ import {
 } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
+import { $activeSessionId, $messages } from '@/store/session'
 
 import { selectMessageRunning } from './tool/fallback-model'
 import { parseMaybeObject } from './tool/fallback-model/format'
@@ -289,12 +291,110 @@ export const ClarifyTool = (props: ToolCallMessagePartProps) => {
   return <ClarifyToolLive {...props} />
 }
 
+/** Fallback window for the visibility gate: when the turn is still streaming
+ *  and no prose increment has been observed yet, hold the panel this long so
+ *  it appears *after* the same-turn conversation text instead of jumping ahead
+ *  of it. Named constant — the tests drive it with fake timers. */
+const CLARIFY_TEXT_WAIT_MS = 1500
+
+/** Character count of the text parts on the last assistant message, or `null`
+ *  when there is no assistant message at all (nothing being painted). */
+function lastAssistantTextChars(messages: ChatMessage[]): number | null {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i]
+
+    if (message.role !== 'assistant') {
+      continue
+    }
+
+    return message.parts.reduce((sum, part) => (part.type === 'text' ? sum + part.text.length : sum), 0)
+  }
+
+  return null
+}
+
+/** Visibility gate for a pending clarify panel.
+ *
+ *  While the turn is running and a request is parked, the panel must not pop
+ *  ahead of the same-turn conversation text. The gate watches the last
+ *  assistant message's text length on `$messages`: any increment past the
+ *  zero point (request arrived + tool row mounted) releases immediately; with
+ *  no increment it releases after CLARIFY_TEXT_WAIT_MS. When there is no
+ *  assistant message to wait for (and on a session-identity mismatch, e.g.
+ *  session tiles), there is nothing the panel could overtake, so it releases
+ *  without waiting. The gate is a pure boolean — ClarifyToolPending mounts at
+ *  the ClarifyToolLive top level, never inside the gate, so release / running
+ *  transitions never remount the panel or drop its staged choices. */
+function useClarifyTextGate({ sessionId, active }: { sessionId: string | null; active: boolean }): boolean {
+  const activeSessionId = useStore($activeSessionId)
+  const messages = useStore($messages)
+  const [released, setReleased] = useState(false)
+  const zeroChars = useRef<number | null>(null)
+
+  const sameSession = sessionId != null && activeSessionId === sessionId
+  const textChars = useMemo(() => (sameSession ? lastAssistantTextChars(messages) : null), [messages, sameSession])
+
+  useEffect(() => {
+    if (!active) {
+      // Not gating (no parked request / dead turn): reset so the next request
+      // starts a fresh zero point instead of inheriting a stale release.
+      zeroChars.current = null
+      setReleased(false)
+
+      return
+    }
+
+    if (released) {
+      return
+    }
+
+    if (textChars === null) {
+      // No assistant turn to wait for — nothing precedes the panel.
+      setReleased(true)
+
+      return
+    }
+
+    if (zeroChars.current === null) {
+      zeroChars.current = textChars
+    }
+
+    if (textChars > zeroChars.current) {
+      setReleased(true)
+
+      return
+    }
+
+    const timer = window.setTimeout(() => setReleased(true), CLARIFY_TEXT_WAIT_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [active, released, textChars])
+
+  return released
+}
+
 function ClarifyToolLive(props: ToolCallMessagePartProps) {
   const messageRunning = useAuiState(selectMessageRunning)
+  const sessionId = useStore(useSessionView().$runtimeId)
+  const $request = useMemo(() => sessionClarifyRequest(sessionId), [sessionId])
+  const request = useStore($request)
+  const gateReleased = useClarifyTextGate({ active: messageRunning && request != null, sessionId })
 
-  // Stopped mid-prompt with no result — don't leave a dead interactive panel.
+  // Keep-alive condition is "the request is still answerable", NOT the turn
+  // still running: a dead turn with a parked request keeps the panel live.
+  if (request != null && !messageRunning) {
+    return <ClarifyToolPending {...props} />
+  }
+
   if (!messageRunning) {
+    // Dead turn with nothing parked — don't leave a dead interactive panel.
     return <ToolFallback {...props} />
+  }
+
+  if (request != null && !gateReleased) {
+    // Hold the panel until the same-turn text has painted (or the fallback
+    // window lapses). Render nothing meanwhile — no fallback row, no stub.
+    return null
   }
 
   return <ClarifyToolPending {...props} />


### PR DESCRIPTION
<!-- GateGuard
importers: none — human-only PR body for `gh pr create --body-file`; not imported by runtime.
API: none — markdown document, no functions / config keys.
schema: none — no data store.
verbatim: 释放提上游
-->
## Summary

Desktop's inline clarify card had three related bugs:

1. **Scroll yank** — `clarify.request` called `requestScrollToBottom()`, so answering a prompt while reading history jumped the viewport to the bottom.
2. **Flash / disappear** — `ClarifyToolLive` collapsed to `ToolFallback` whenever `messageRunning` went false, even if the parked request was still answerable.
3. **Paint before prose** — the card rendered as soon as the tool part arrived, often ahead of the same-turn assistant text.

This PR keeps the panel inline (no overlay / z-index change) and:

- Drops both `requestScrollToBottom()` calls on the `clarify.request` path. Parking, tool-row upsert, `needsInput`, and the native notification stay.
- Keeps `ClarifyToolPending` mounted when a request is parked and the turn is dead (skip the wait gate).
- Adds a visibility gate that watches `$messages` for a same-session last-assistant text increment, with a 1500ms fallback. No assistant message / session-identity mismatch releases immediately. The gate is a boolean; the pending panel is a sibling, so a running→dead edge does not remount or drop staged two-step choices.
- Does **not** change two-step confirm, `timeout<=0`, multi-select, or selectable choice text.

## Test plan

- [x] New visibility-gate cases: dead-turn keep-alive (R1), dead-turn fallback (R4), 1500ms hold without `ToolFallback` (R3a), mid-window text increment releases immediately (R3b), staged choices survive `messageRunning` falling edge
- [x] Hydration: active-session `clarify.request` must **not** call `scrollToBottom`, but still parks the request, upserts the tool row, and sets `needsInput`
- [x] Existing two-step / skip / multi-select / `select-text` cases left in place
- Neighbor-tree note: this worktree has no Desktop toolchain. Equivalent four-file change `9a93ab496` passed 40/40 on `hermes-agent-wt-release-verify`. CI on this branch is the source of truth.

## Out of scope

- One-shot / skip-button preference defaults (see #71297)
- Selectable-text PR (#69425)
- Backend / gateway / `config.yaml`
