### PR TITLE
fix(desktop): remote gateways stay connected instead of snapping back to a local backend

### DIFF
--- a/apps/desktop/electron/connection-config-apply.test.ts
+++ b/apps/desktop/electron/connection-config-apply.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { applyConnectionConfigAtomically } from './connection-config-apply'
+
+describe('applyConnectionConfigAtomically', () => {
+  it('commits legacy and registry state before activation', async () => {
+    const events: string[] = []
+
+    await applyConnectionConfigAtomically({
+      previousConfig: 'old-config',
+      previousRegistry: 'old-registry',
+      nextConfig: 'remote-config',
+      nextRegistry: 'remote-registry',
+      writeConfig: value => events.push(`config:${value}`),
+      writeRegistry: value => events.push(`registry:${value}`),
+      apply: async () => {
+        events.push('activate')
+      }
+    })
+
+    expect(events).toEqual(['config:remote-config', 'registry:remote-registry', 'activate'])
+  })
+
+  it('rolls both stores back when activation fails', async () => {
+    const writeConfig = vi.fn()
+    const writeRegistry = vi.fn()
+
+    await expect(
+      applyConnectionConfigAtomically({
+        previousConfig: 'local-config',
+        previousRegistry: 'local-registry',
+        nextConfig: 'remote-config',
+        nextRegistry: 'remote-registry',
+        writeConfig,
+        writeRegistry,
+        apply: async () => {
+          throw new Error('activation failed')
+        }
+      })
+    ).rejects.toThrow('activation failed')
+
+    expect(writeConfig.mock.calls).toEqual([['remote-config'], ['local-config']])
+    expect(writeRegistry.mock.calls).toEqual([['remote-registry'], ['local-registry']])
+  })
+
+  it('rolls legacy state back when the registry write fails', async () => {
+    const writes: string[] = []
+    let registryWrites = 0
+
+    await expect(
+      applyConnectionConfigAtomically({
+        previousConfig: 'local-config',
+        previousRegistry: 'local-registry',
+        nextConfig: 'remote-config',
+        nextRegistry: 'remote-registry',
+        writeConfig: value => writes.push(`config:${value}`),
+        writeRegistry: value => {
+          registryWrites += 1
+
+          if (registryWrites === 1) {
+            throw new Error('disk full')
+          }
+
+          writes.push(`registry:${value}`)
+        },
+        apply: vi.fn()
+      })
+    ).rejects.toThrow('disk full')
+
+    expect(writes).toEqual(['config:remote-config', 'config:local-config', 'registry:local-registry'])
+  })
+})

--- a/apps/desktop/electron/connection-config-apply.test.ts
+++ b/apps/desktop/electron/connection-config-apply.test.ts
@@ -69,4 +69,50 @@ describe('applyConnectionConfigAtomically', () => {
 
     expect(writes).toEqual(['config:remote-config', 'config:local-config', 'registry:local-registry'])
   })
+
+  it('preflights before writing either store', async () => {
+    const events: string[] = []
+
+    await applyConnectionConfigAtomically({
+      previousConfig: 'local-config',
+      previousRegistry: 'local-registry',
+      nextConfig: 'remote-config',
+      nextRegistry: 'remote-registry',
+      preflight: async () => {
+        events.push('preflight')
+      },
+      writeConfig: value => events.push(`config:${value}`),
+      writeRegistry: value => events.push(`registry:${value}`),
+      apply: async () => {
+        events.push('activate')
+      }
+    })
+
+    expect(events).toEqual(['preflight', 'config:remote-config', 'registry:remote-registry', 'activate'])
+  })
+
+  it('leaves both stores untouched when the preflight rejects', async () => {
+    const writeConfig = vi.fn()
+    const writeRegistry = vi.fn()
+    const apply = vi.fn()
+
+    await expect(
+      applyConnectionConfigAtomically({
+        previousConfig: 'local-config',
+        previousRegistry: 'local-registry',
+        nextConfig: 'remote-config',
+        nextRegistry: 'remote-registry',
+        preflight: async () => {
+          throw new Error('gateway unreachable')
+        },
+        writeConfig,
+        writeRegistry,
+        apply
+      })
+    ).rejects.toThrow('gateway unreachable')
+
+    expect(writeConfig).not.toHaveBeenCalled()
+    expect(writeRegistry).not.toHaveBeenCalled()
+    expect(apply).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/electron/connection-config-apply.ts
+++ b/apps/desktop/electron/connection-config-apply.ts
@@ -2,6 +2,13 @@ interface ApplyConnectionConfigAtomicallyOptions<TConfig, TRegistry> {
   apply: () => Promise<void>
   nextConfig: TConfig
   nextRegistry: TRegistry
+  /**
+   * Optional reachability check (authenticated REST + a real WebSocket leg).
+   * Runs BEFORE either file is written, so a rejected OAuth session or a
+   * blocked /api/ws leaves the previous primary/current connection intact
+   * rather than committing a gateway the app cannot actually reach.
+   */
+  preflight?: () => Promise<unknown>
   previousConfig: TConfig
   previousRegistry: TRegistry
   writeConfig: (config: TConfig) => void
@@ -17,11 +24,16 @@ export async function applyConnectionConfigAtomically<TConfig, TRegistry>({
   apply,
   nextConfig,
   nextRegistry,
+  preflight,
   previousConfig,
   previousRegistry,
   writeConfig,
   writeRegistry
 }: ApplyConnectionConfigAtomicallyOptions<TConfig, TRegistry>): Promise<void> {
+  // Outside the try: a preflight failure has written nothing, so there is
+  // nothing to roll back and no reason to touch either store.
+  await preflight?.()
+
   try {
     writeConfig(nextConfig)
     writeRegistry(nextRegistry)

--- a/apps/desktop/electron/connection-config-apply.ts
+++ b/apps/desktop/electron/connection-config-apply.ts
@@ -1,0 +1,41 @@
+interface ApplyConnectionConfigAtomicallyOptions<TConfig, TRegistry> {
+  apply: () => Promise<void>
+  nextConfig: TConfig
+  nextRegistry: TRegistry
+  previousConfig: TConfig
+  previousRegistry: TRegistry
+  writeConfig: (config: TConfig) => void
+  writeRegistry: (registry: TRegistry) => void
+}
+
+/**
+ * Commit the legacy config and v2 registry as one recoverable Apply boundary.
+ * File replacement itself is atomic per file; this wrapper restores both
+ * previous snapshots when the second write or synchronous re-home fails.
+ */
+export async function applyConnectionConfigAtomically<TConfig, TRegistry>({
+  apply,
+  nextConfig,
+  nextRegistry,
+  previousConfig,
+  previousRegistry,
+  writeConfig,
+  writeRegistry
+}: ApplyConnectionConfigAtomicallyOptions<TConfig, TRegistry>): Promise<void> {
+  try {
+    writeConfig(nextConfig)
+    writeRegistry(nextRegistry)
+    await apply()
+  } catch (error) {
+    try {
+      writeConfig(previousConfig)
+      writeRegistry(previousRegistry)
+    } catch {
+      // Preserve the original activation/write failure. Both storage writers
+      // are atomic replacements, so a rollback failure cannot be repaired by
+      // retrying one side blindly here.
+    }
+
+    throw error
+  }
+}

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -26,6 +26,7 @@ import {
   normalizeRegistry,
   parseRemoteProfileListing,
   reconcileAppliedGlobalConnection,
+  reconcileRegistryDrift,
   REGISTRY_VERSION,
   rememberSshEnumeration,
   removeConnection,
@@ -1232,7 +1233,9 @@ test('Apply remote inserts into an existing local-only registry and becomes prim
   assert.equal(registry.lastUsed, remote.id)
   assert.equal(
     resolvedConnectionId(registry, {
+      authMode: 'oauth',
       baseUrl: 'https://gateway.example.com',
+      headers: {},
       mode: 'remote',
       remoteKind: 'url'
     }),
@@ -1301,6 +1304,112 @@ test('Apply between two remotes keeps each real registration once and activates 
   assert.equal(new Set(remotes.map(connection => connection.id)).size, 2)
   assert.equal(second.primary, remotes.find(connection => connection.url === 'https://two.example.com')?.id)
   assert.equal(second.lastUsed, second.primary)
+})
+
+// --- reconcileRegistryDrift (v1 ↔ v2 healing) ---
+
+test('drift heal registers a v1 remote the registry never learned about and makes it primary', () => {
+  // The exact shape users keep reporting: registry migrated while local-only,
+  // then Settings → Gateway pointed v1 at a remote. connections.json still
+  // says primary 'local', so every launch force-switches off the live remote.
+  const drifted = reconcileRegistryDrift(emptyRegistry(), {
+    mode: 'remote',
+    remote: { url: 'https://agent.example.com:4443', authMode: 'oauth' }
+  })
+
+  assert.equal(drifted.changed, true)
+
+  const remote = drifted.registry.connections.find(connection => connection.kind === 'remote')
+
+  assert.ok(remote)
+  assert.equal(drifted.registry.primary, remote.id)
+  assert.equal(drifted.registry.lastUsed, remote.id)
+  // The whole point: the live v1 descriptor can now be named, so the boot pick
+  // resolves to the remote instead of re-homing to 'local'. Descriptor shape
+  // matches what buildRemoteConnection emits for an oauth remote.
+  assert.equal(
+    resolvedConnectionId(drifted.registry, {
+      authMode: 'oauth',
+      baseUrl: 'https://agent.example.com:4443',
+      headers: {},
+      mode: 'remote',
+      remoteKind: 'url'
+    }),
+    remote.id
+  )
+})
+
+test('drift heal leaves a registry that already knows the v1 route untouched', () => {
+  const registered = reconcileAppliedGlobalConnection(emptyRegistry(), {
+    mode: 'remote',
+    remote: { url: 'https://agent.example.com', authMode: 'oauth' }
+  })
+
+  const drifted = reconcileRegistryDrift(registered, {
+    mode: 'remote',
+    remote: { url: 'https://AGENT.example.com/', authMode: 'oauth' }
+  })
+
+  assert.equal(drifted.changed, false)
+  assert.equal(drifted.registry, registered)
+})
+
+test('drift heal respects a deliberate primary pick on a registered route', () => {
+  // Route IS registered, but the user chose This device in the Connections
+  // panel. That is a choice, not drift — never override it.
+  let registry = reconcileAppliedGlobalConnection(emptyRegistry(), {
+    mode: 'remote',
+    remote: { url: 'https://agent.example.com', authMode: 'oauth' }
+  })
+
+  registry = setPrimaryConnection(registry, LOCAL_CONNECTION_ID)
+
+  const drifted = reconcileRegistryDrift(registry, {
+    mode: 'remote',
+    remote: { url: 'https://agent.example.com', authMode: 'oauth' }
+  })
+
+  assert.equal(drifted.changed, false)
+  assert.equal(drifted.registry.primary, LOCAL_CONNECTION_ID)
+})
+
+test('drift heal ignores local, ssh, and unparseable v1 routes', () => {
+  const registry = emptyRegistry()
+
+  for (const v1 of [
+    { mode: 'local', remote: {} },
+    { mode: 'ssh', remote: { host: 'box' } },
+    { mode: 'remote', remote: { url: 'not a url' } },
+    { mode: 'remote', remote: {} },
+    null
+  ]) {
+    const drifted = reconcileRegistryDrift(registry, v1)
+
+    assert.equal(drifted.changed, false, `expected no heal for ${JSON.stringify(v1)}`)
+    assert.equal(drifted.registry, registry)
+  }
+})
+
+test('drift heal adds the missing remote without disturbing other registered sources', () => {
+  let registry = emptyRegistry()
+
+  registry = upsertConnection(registry, {
+    id: 'homelab',
+    kind: 'remote',
+    label: 'Homelab',
+    url: 'https://homelab.example.com',
+    authMode: 'token',
+    token: { keep: true }
+  })
+
+  const drifted = reconcileRegistryDrift(registry, {
+    mode: 'remote',
+    remote: { url: 'https://agent.example.com:4443', authMode: 'oauth' }
+  })
+
+  assert.equal(drifted.changed, true)
+  assert.equal(drifted.registry.connections.filter(connection => connection.kind === 'remote').length, 2)
+  assert.ok(drifted.registry.connections.some(connection => connection.id === 'homelab'))
 })
 
 // --- connectionDialFieldsChanged (edit → recycle decision) ---

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -25,6 +25,7 @@ import {
   normalizeConnectionInput,
   normalizeRegistry,
   parseRemoteProfileListing,
+  reconcileAppliedGlobalConnection,
   REGISTRY_VERSION,
   rememberSshEnumeration,
   removeConnection,
@@ -1216,6 +1217,90 @@ test('upsertConnection replaces by id and appends new ids', () => {
 
   assert.equal(registry.connections.filter(c => c.id === a.id).length, 1)
   assert.equal(registry.connections.find(c => c.id === a.id)?.url, 'http://a:2')
+})
+
+test('Apply remote inserts into an existing local-only registry and becomes primary/current', () => {
+  const registry = reconcileAppliedGlobalConnection(emptyRegistry(), {
+    mode: 'remote',
+    remote: { url: 'https://gateway.example.com/', authMode: 'oauth' }
+  })
+
+  const remote = registry.connections.find(connection => connection.kind === 'remote')
+
+  assert.ok(remote)
+  assert.equal(registry.primary, remote.id)
+  assert.equal(registry.lastUsed, remote.id)
+  assert.equal(
+    resolvedConnectionId(registry, {
+      baseUrl: 'https://gateway.example.com',
+      mode: 'remote',
+      remoteKind: 'url'
+    }),
+    remote.id
+  )
+})
+
+test('Apply remote preserves an existing URL identity and label without duplicates', () => {
+  let registry = emptyRegistry()
+
+  registry = upsertConnection(registry, {
+    id: 'hermes-alex',
+    kind: 'remote',
+    label: 'Existing gateway',
+    url: 'https://gateway.example.com',
+    authMode: 'token',
+    token: { old: true }
+  })
+
+  const applied = reconcileAppliedGlobalConnection(registry, {
+    mode: 'remote',
+    remote: { url: 'https://GATEWAY.example.com/', authMode: 'oauth' }
+  })
+
+  const matches = applied.connections.filter(connection => connection.url === 'https://gateway.example.com')
+
+  assert.equal(matches.length, 1)
+  assert.equal(matches[0].id, 'hermes-alex')
+  assert.equal(matches[0].label, 'Existing gateway')
+  assert.equal(matches[0].authMode, 'oauth')
+  assert.equal(applied.primary, 'hermes-alex')
+  assert.equal(applied.lastUsed, 'hermes-alex')
+})
+
+test('Apply local moves primary/current to This device without deleting registered remotes', () => {
+  const remoteRegistry = reconcileAppliedGlobalConnection(emptyRegistry(), {
+    mode: 'remote',
+    remote: { url: 'https://one.example.com', authMode: 'oauth' }
+  })
+
+  const localRegistry = reconcileAppliedGlobalConnection(remoteRegistry, { mode: 'local', remote: {} })
+
+  assert.equal(localRegistry.primary, LOCAL_CONNECTION_ID)
+  assert.equal(localRegistry.lastUsed, LOCAL_CONNECTION_ID)
+  assert.equal(localRegistry.connections.filter(connection => connection.kind === 'remote').length, 1)
+  assert.equal(resolvedConnectionId(localRegistry, { mode: 'local' }), LOCAL_CONNECTION_ID)
+})
+
+test('Apply between two remotes keeps each real registration once and activates the latest', () => {
+  const first = reconcileAppliedGlobalConnection(emptyRegistry(), {
+    mode: 'remote',
+    remote: { url: 'https://one.example.com', authMode: 'oauth' }
+  })
+
+  const second = reconcileAppliedGlobalConnection(first, {
+    mode: 'remote',
+    remote: { url: 'https://two.example.com/', authMode: 'oauth' }
+  })
+
+  const remotes = second.connections.filter(connection => connection.kind === 'remote')
+
+  assert.deepEqual(
+    remotes.map(connection => connection.url).sort(),
+    ['https://one.example.com', 'https://two.example.com']
+  )
+  assert.equal(new Set(remotes.map(connection => connection.id)).size, 2)
+  assert.equal(second.primary, remotes.find(connection => connection.url === 'https://two.example.com')?.id)
+  assert.equal(second.lastUsed, second.primary)
 })
 
 // --- connectionDialFieldsChanged (edit → recycle decision) ---

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -1280,6 +1280,69 @@ export function reconcileAppliedGlobalConnection(
   }
 }
 
+/**
+ * Heal an already-created registry that never learned about the v1 route it is
+ * supposed to be serving.
+ *
+ * `migrateV1ToRegistry` runs exactly once — only when connections.json does not
+ * exist. A user who was local at that moment and configured a remote gateway
+ * afterwards (Settings -> Gateway writes connection.json alone) ends up with a
+ * live remote that the registry cannot name: `resolvedConnectionId` returns
+ * null, `primary` still says `local`, and every launch force-switches the
+ * window onto a fresh local backend seconds after boot. Deleting
+ * connections.json by hand is the only recovery today.
+ *
+ * Deliberately narrow: heal ONLY when the v1 global route has no matching
+ * registry entry at all. That is the drift state and nothing else. If the
+ * route is already registered but `primary` names another source, the user
+ * chose that in the Connections panel and we leave it alone.
+ */
+export function reconcileRegistryDrift(
+  registry: ConnectionRegistry,
+  v1: unknown
+): { changed: boolean; registry: ConnectionRegistry } {
+  const config = v1 && typeof v1 === 'object' ? (v1 as Record<string, any>) : {}
+  const unchanged = { changed: false, registry }
+
+  if (!modeIsRemoteLike(config.mode)) {
+    return unchanged
+  }
+
+  const block = config.remote && typeof config.remote === 'object' ? config.remote : {}
+
+  let url = ''
+
+  try {
+    url = normalizeRemoteBaseUrl(block.url)
+  } catch {
+    // An unparseable v1 URL is not a route we can register. The v1 path keeps
+    // failing the way it already does; do not corrupt the registry over it.
+    return unchanged
+  }
+
+  if (!url) {
+    return unchanged
+  }
+
+  const alreadyRegistered = registry.connections.some(connection => {
+    if (connection.kind !== 'remote' && connection.kind !== 'cloud') {
+      return false
+    }
+
+    try {
+      return normalizeRemoteBaseUrl(connection.url) === url
+    } catch {
+      return false
+    }
+  })
+
+  if (alreadyRegistered) {
+    return unchanged
+  }
+
+  return { changed: true, registry: reconcileAppliedGlobalConnection(registry, config) }
+}
+
 /** Choose whether launch restores the explicit primary or the last-used source. */
 export function setConnectionLaunchMode(registry: ConnectionRegistry, launchMode: string): ConnectionRegistry {
   if (launchMode !== 'last-used' && launchMode !== 'primary') {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -1207,6 +1207,79 @@ export function setLastUsedConnection(registry: ConnectionRegistry, id: string):
   return { ...registry, lastUsed: id }
 }
 
+/**
+ * Reconcile a successfully-coerced global v1 connection config into the v2
+ * registry. Settings still writes connection.json for compatibility, but an
+ * Apply must publish the same primary identity to connections.json in the
+ * same transaction or the live remote descriptor has no connectionId.
+ *
+ * Remote-shaped entries are matched by normalized URL across remote/cloud so
+ * changing provenance never duplicates a gateway. Existing identity and
+ * user-chosen label win; a new entry derives both from the host. Switching to
+ * local keeps registered remotes available while moving primary/last-used
+ * back to This device.
+ */
+export function reconcileAppliedGlobalConnection(
+  registry: ConnectionRegistry,
+  config: Record<string, any>
+): ConnectionRegistry {
+  const mode = config?.mode
+
+  if (!modeIsRemoteLike(mode)) {
+    if (mode === 'local') {
+      return { ...registry, primary: LOCAL_CONNECTION_ID, lastUsed: LOCAL_CONNECTION_ID }
+    }
+
+    // SSH registry identity is managed by its existing registry editor and
+    // migration path. Do not reinterpret or delete it here.
+    return registry
+  }
+
+  const block = config.remote && typeof config.remote === 'object' ? config.remote : {}
+  const url = normalizeRemoteBaseUrl(block.url)
+
+  const existing = registry.connections.find(connection => {
+    if (connection.kind !== 'remote' && connection.kind !== 'cloud') {
+      return false
+    }
+
+    try {
+      return normalizeRemoteBaseUrl(connection.url) === url
+    } catch {
+      return false
+    }
+  })
+
+  const kind: ConnectionKind = mode === 'cloud' ? 'cloud' : 'remote'
+
+  const label =
+    existing?.label ||
+    uniqueLabel(
+      hostLabelFromBaseUrl(url) || (kind === 'cloud' ? 'Hermes Cloud' : 'Remote gateway'),
+      registry.connections.map(connection => connection.label)
+    )
+
+  const entry = normalizeConnectionInput(
+    {
+      id: existing?.id,
+      kind,
+      label,
+      url,
+      authMode: block.authMode,
+      token: block.token,
+      headers: block.headers,
+      org: block.org
+    },
+    registry
+  )
+
+  return {
+    ...upsertConnection(registry, entry),
+    primary: entry.id,
+    lastUsed: entry.id
+  }
+}
+
 /** Choose whether launch restores the explicit primary or the last-used source. */
 export function setConnectionLaunchMode(registry: ConnectionRegistry, launchMode: string): ConnectionRegistry {
   if (launchMode !== 'last-used' && launchMode !== 'primary') {

--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -938,30 +938,6 @@ test('registry JSON helpers retain native OAuth bearer authentication', () => {
   assert.doesNotMatch(helpers, /fetchJsonViaOauthSession/)
 })
 
-test('connection tests authenticate protected OAuth status probes', () => {
-  const source = readMain()
-  const helperStart = source.indexOf('async function fetchConnectionStatus(')
-  const helperEnd = source.indexOf('\nfunction ', helperStart + 1)
-  const helper = source.slice(helperStart, helperEnd === -1 ? undefined : helperEnd)
-
-  assert.notEqual(helperStart, -1)
-  assert.match(helper, /ensureNativeAccessToken\(baseUrl\)/)
-  assert.match(helper, /fetchJsonViaOauthSession\(url/)
-  assert.match(helper, /bearer: nativeAt/)
-})
-
-test('global remote Apply preflights before the atomic persistence boundary', () => {
-  const source = readMain()
-  const handlerStart = source.indexOf("ipcMain.handle('hermes:connection-config:apply'")
-  const handlerEnd = source.indexOf("ipcMain.handle('hermes:profile:get'", handlerStart)
-  const handler = source.slice(handlerStart, handlerEnd)
-  const preflight = handler.indexOf('await testDesktopConnectionConfig(payload)')
-  const commit = handler.indexOf('await applyConnectionConfigAtomically({')
-
-  assert.notEqual(handlerStart, -1)
-  assert.ok(preflight >= 0 && preflight < commit, 'remote REST+WS validation must happen before either config is committed')
-})
-
 test('coerceDesktopConnectionConfig routes token persistence through resolvePersistedRemoteToken', () => {
   const source = readMain()
   const fnStart = source.indexOf('function coerceDesktopConnectionConfig(')

--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -938,6 +938,30 @@ test('registry JSON helpers retain native OAuth bearer authentication', () => {
   assert.doesNotMatch(helpers, /fetchJsonViaOauthSession/)
 })
 
+test('connection tests authenticate protected OAuth status probes', () => {
+  const source = readMain()
+  const helperStart = source.indexOf('async function fetchConnectionStatus(')
+  const helperEnd = source.indexOf('\nfunction ', helperStart + 1)
+  const helper = source.slice(helperStart, helperEnd === -1 ? undefined : helperEnd)
+
+  assert.notEqual(helperStart, -1)
+  assert.match(helper, /ensureNativeAccessToken\(baseUrl\)/)
+  assert.match(helper, /fetchJsonViaOauthSession\(url/)
+  assert.match(helper, /bearer: nativeAt/)
+})
+
+test('global remote Apply preflights before the atomic persistence boundary', () => {
+  const source = readMain()
+  const handlerStart = source.indexOf("ipcMain.handle('hermes:connection-config:apply'")
+  const handlerEnd = source.indexOf("ipcMain.handle('hermes:profile:get'", handlerStart)
+  const handler = source.slice(handlerStart, handlerEnd)
+  const preflight = handler.indexOf('await testDesktopConnectionConfig(payload)')
+  const commit = handler.indexOf('await applyConnectionConfigAtomically({')
+
+  assert.notEqual(handlerStart, -1)
+  assert.ok(preflight >= 0 && preflight < commit, 'remote REST+WS validation must happen before either config is committed')
+})
+
 test('coerceDesktopConnectionConfig routes token persistence through resolvePersistedRemoteToken', () => {
   const source = readMain()
   const fnStart = source.indexOf('function coerceDesktopConnectionConfig(')
@@ -974,7 +998,7 @@ test('connection-config save and apply IPC handlers route payloads through coerc
     const handlerBody = source.slice(handlerStart, handlerStart + 400)
     assert.match(
       handlerBody,
-      /coerceDesktopConnectionConfig\(payload\)/,
+      /coerceDesktopConnectionConfig\(payload(?:, previousConfig)?\)/,
       `${channel} must coerce its payload (the propagation seam) before persisting`
     )
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -102,6 +102,7 @@ import {
   translateSelfProfileQuery,
   withTransientRetries
 } from './connection-config'
+import { applyConnectionConfigAtomically } from './connection-config-apply'
 import {
   backendScopeKey,
   backendScopePrefix,
@@ -111,6 +112,7 @@ import {
   migrateV1ToRegistry,
   normalizeConnectionInput,
   normalizeRegistry,
+  reconcileAppliedGlobalConnection,
   rememberSshEnumeration,
   removeConnection,
   resolvedConnectionId,
@@ -9717,10 +9719,11 @@ async function testDesktopConnectionConfig(input: any = {}) {
   const wantRemote =
     modeIsRemoteLike(block?.mode) || (!key && modeIsRemoteLike(config.mode)) || (modeIsRemoteLike(input.mode) && block)
 
-  // ``/api/status`` is public on every gateway (no creds needed), so a
-  // reachability test works for local, token, and oauth modes alike — we only
-  // need a base URL. For a remote config we normalize the URL from the input;
-  // for local we fall back to the resolved/started backend.
+  // Test ``/api/status`` through the connection's real auth path. Self-hosted
+  // gateways may protect it, and an anonymous success/failure would not prove
+  // that the OAuth cookie/native bearer or configured token is reusable. For
+  // a remote config we normalize the URL from the input; for local we fall
+  // back to the resolved/started backend.
   let baseUrl
   let token = null
   let authMode = 'token'
@@ -9742,7 +9745,7 @@ async function testDesktopConnectionConfig(input: any = {}) {
     testHeaders = remote.headers || {}
   }
 
-  const status = (await fetchJson(`${baseUrl}/api/status`, token, { timeoutMs: 8_000, headers: testHeaders })) as any
+  const status = (await fetchConnectionStatus(baseUrl, authMode, token, testHeaders)) as any
 
   // The HTTP status check above proves the backend is reachable, but the chat
   // surface only works once the renderer's live WebSocket to ``/api/ws``
@@ -9774,6 +9777,22 @@ async function testDesktopConnectionConfig(input: any = {}) {
     baseUrl,
     version: status?.version || null
   }
+}
+
+async function fetchConnectionStatus(baseUrl, authMode, token, headers = {}) {
+  const url = `${baseUrl}/api/status`
+
+  if (authMode === 'oauth') {
+    const nativeAt = await ensureNativeAccessToken(baseUrl).catch(() => null)
+
+    if (nativeAt) {
+      return fetchJson(url, null, { timeoutMs: 8_000, bearer: nativeAt, headers })
+    }
+
+    return fetchJsonViaOauthSession(url, { timeoutMs: 8_000, headers })
+  }
+
+  return fetchJson(url, token, { timeoutMs: 8_000, headers })
 }
 
 function resetBootProgressForReconnect() {
@@ -12809,7 +12828,7 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
     }
   }
 
-  const status = (await fetchJson(`${baseUrl}/api/status`, token, { timeoutMs: 8_000, headers: testHeaders })) as any
+  const status = (await fetchConnectionStatus(baseUrl, authMode, token, testHeaders)) as any
 
   // The Test button is the cheapest moment to (re)learn this backend's stable
   // identity for the same-backend roster collapse + Settings hint.
@@ -13322,32 +13341,50 @@ ipcMain.handle('hermes:connection-config:save', async (_event, payload) => {
   return sanitizeDesktopConnectionConfig(config, payload?.profile)
 })
 ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
-  const config = coerceDesktopConnectionConfig(payload)
-  writeDesktopConnectionConfig(config)
+  const previousConfig = readDesktopConnectionConfig()
+  const previousRegistry = readDesktopConnectionsRegistry()
+  const config = coerceDesktopConnectionConfig(payload, previousConfig)
 
   const key = connectionScopeKey(payload?.profile)
   const scope = key || ''
+  const nextRegistry = key ? previousRegistry : reconcileAppliedGlobalConnection(previousRegistry, config)
 
-  await applyConnectionChange({
-    cancelAndWait: value => sshBootstrapCoordinator.cancelAndWait(value),
-    isPrimary: !key || key === primaryProfileKey(),
-    rehomePrimary: () =>
-      rehomePrimaryConnection({
-        clearLocalBootstrapFailure: () => {
-          // A remote connection bypasses local runtime/bootstrap failures. Clear
-          // the local-install latch so unsupported/failure escape paths can re-home.
-          bootstrapFailure = null
-        },
-        mode: config.mode,
-        notifyConnectionApplied: sendConnectionApplied,
-        resumeFirstRunRemote: abandonFirstRunSetupChoiceForRemoteApply,
-        teardownPrimaryBackend: teardownPrimaryBackendAndWait
-      }),
-    scope,
-    sendApplied: sendConnectionApplied,
-    stopPool: stopPoolBackend,
-    teardownPrimary: () => teardownPrimaryBackendAndWait({ soft: true }),
-    teardownSsh: value => teardownSshConnection(value || null)
+  // Exercise the same authenticated REST + real WebSocket legs before either
+  // config file changes. A rejected OAuth session or blocked /api/ws leaves
+  // the previous primary/current connection intact.
+  if (!key && modeIsRemoteLike(config.mode)) {
+    await testDesktopConnectionConfig(payload)
+  }
+
+  await applyConnectionConfigAtomically({
+    previousConfig,
+    previousRegistry,
+    nextConfig: config,
+    nextRegistry,
+    writeConfig: writeDesktopConnectionConfig,
+    writeRegistry: writeDesktopConnectionsRegistry,
+    apply: () =>
+      applyConnectionChange({
+        cancelAndWait: value => sshBootstrapCoordinator.cancelAndWait(value),
+        isPrimary: !key || key === primaryProfileKey(),
+        rehomePrimary: () =>
+          rehomePrimaryConnection({
+            clearLocalBootstrapFailure: () => {
+              // A remote connection bypasses local runtime/bootstrap failures. Clear
+              // the local-install latch so unsupported/failure escape paths can re-home.
+              bootstrapFailure = null
+            },
+            mode: config.mode,
+            notifyConnectionApplied: sendConnectionApplied,
+            resumeFirstRunRemote: abandonFirstRunSetupChoiceForRemoteApply,
+            teardownPrimaryBackend: teardownPrimaryBackendAndWait
+          }),
+        scope,
+        sendApplied: sendConnectionApplied,
+        stopPool: stopPoolBackend,
+        teardownPrimary: () => teardownPrimaryBackendAndWait({ soft: true }),
+        teardownSsh: value => teardownSshConnection(value || null)
+      })
   })
 
   return sanitizeDesktopConnectionConfig(config, payload?.profile)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -113,6 +113,7 @@ import {
   normalizeConnectionInput,
   normalizeRegistry,
   reconcileAppliedGlobalConnection,
+  reconcileRegistryDrift,
   rememberSshEnumeration,
   removeConnection,
   resolvedConnectionId,
@@ -8533,6 +8534,11 @@ function writeDesktopConnectionConfig(config) {
  * connections.json does not exist yet). Same mtime-cache + tighten-mode
  * discipline as readDesktopConnectionConfig; a corrupt registry degrades to
  * local-only via normalizeRegistry rather than throwing at boot.
+ *
+ * An EXISTING registry is additionally reconciled against v1 when the two have
+ * drifted — see reconcileRegistryDrift. The one-shot migration cannot cover a
+ * user who registered nothing and then pointed Settings -> Gateway at a remote,
+ * and until that heals, every launch re-homes them onto a local backend.
  */
 function readDesktopConnectionsRegistry() {
   let mtime = null
@@ -8577,6 +8583,28 @@ function readDesktopConnectionsRegistry() {
     registry = normalizeRegistry(JSON.parse(fs.readFileSync(DESKTOP_CONNECTIONS_REGISTRY_PATH, 'utf8')))
   } catch {
     registry = normalizeRegistry(null)
+  }
+
+  // Heal v1 -> v2 drift: the v1 global route names a remote this registry has
+  // never heard of, so the live descriptor resolves to no connectionId and the
+  // launch pick sends the window somewhere else. Persist so the repair is a
+  // one-time event rather than a recomputation on every read; a failed write
+  // still returns the healed registry for this session.
+  const reconciled = reconcileRegistryDrift(registry, readDesktopConnectionConfig())
+
+  if (reconciled.changed) {
+    registry = reconciled.registry
+
+    try {
+      writeDesktopConnectionsRegistry(registry)
+
+      return connectionRegistryCache
+    } catch {
+      connectionRegistryCache = registry
+      connectionRegistryCacheMtime = null
+
+      return registry
+    }
   }
 
   connectionRegistryCache = registry

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9783,6 +9783,12 @@ async function fetchConnectionStatus(baseUrl, authMode, token, headers = {}) {
   const url = `${baseUrl}/api/status`
 
   if (authMode === 'oauth') {
+    // Native PKCE bearer first, OAuth session cookies second — the same two
+    // credentials real traffic uses, in the same order. A refresh failure is
+    // NOT a silent downgrade to an anonymous probe: the cookie path is still
+    // an authenticated request, and if neither credential works the probe
+    // fails, which is the correct answer for a gateway we cannot reach with
+    // the credentials we hold.
     const nativeAt = await ensureNativeAccessToken(baseUrl).catch(() => null)
 
     if (nativeAt) {
@@ -13349,18 +13355,15 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
   const scope = key || ''
   const nextRegistry = key ? previousRegistry : reconcileAppliedGlobalConnection(previousRegistry, config)
 
-  // Exercise the same authenticated REST + real WebSocket legs before either
-  // config file changes. A rejected OAuth session or blocked /api/ws leaves
-  // the previous primary/current connection intact.
-  if (!key && modeIsRemoteLike(config.mode)) {
-    await testDesktopConnectionConfig(payload)
-  }
-
   await applyConnectionConfigAtomically({
     previousConfig,
     previousRegistry,
     nextConfig: config,
     nextRegistry,
+    // Exercise the same authenticated REST + real WebSocket legs before either
+    // config file changes. A rejected OAuth session or blocked /api/ws leaves
+    // the previous primary/current connection intact.
+    preflight: !key && modeIsRemoteLike(config.mode) ? () => testDesktopConnectionConfig(payload) : undefined,
     writeConfig: writeDesktopConnectionConfig,
     writeRegistry: writeDesktopConnectionsRegistry,
     apply: () =>

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12335,7 +12335,7 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
         connectionPromise,
         currentConnectionPromise: () => backendConnectionState.getPromise(),
         log: rememberLog,
-        probe: fetchPublicJson,
+        probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
         resetConnection: () => resetHermesConnection({ soft: true }),
         tracker: remoteLiveness
       }),
@@ -12366,7 +12366,7 @@ function revalidatePool() {
   return revalidatePooledRemoteBackends({
     entries: backendPool.entries(),
     log: rememberLog,
-    probe: fetchPublicJson,
+    probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
     stopBackend: stopPoolBackend,
     tracker: remoteLiveness
   })

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -179,9 +179,13 @@ describe('revalidateRemoteConnection', () => {
     const test = harness()
 
     await expect(revalidateRemoteConnection(test.options)).resolves.toEqual({ ok: true, rebuilt: false })
-    expect(test.probe).toHaveBeenCalledWith('https://gateway.example.com/api/status', {
-      timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS
-    })
+    expect(test.probe).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: 'https://gateway.example.com/' }),
+      '/api/status',
+      {
+        timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS
+      }
+    )
     expect(test.resetConnection).not.toHaveBeenCalled()
   })
 
@@ -254,13 +258,34 @@ describe('revalidateRemoteConnection', () => {
 })
 
 describe('revalidatePooledRemoteBackends', () => {
-  const harness = (entries: Array<[string, { process?: unknown; remoteBaseUrl?: null | string }]>) => {
+  interface TestRemoteConnection {
+    authMode?: string
+    baseUrl: string
+    process?: unknown
+    remoteBaseUrl?: null | string
+  }
+
+  const harness = (
+    rawEntries: Array<[string, { process?: unknown; remoteBaseUrl?: null | string; authMode?: string }]>
+  ) => {
+    const entries: Array<[
+      string,
+      TestRemoteConnection & { connectionPromise: Promise<TestRemoteConnection> }
+    ]> = rawEntries.map(([profile, entry]) => {
+      const connection = { ...entry, baseUrl: String(entry.remoteBaseUrl || '') }
+
+      return [
+        profile,
+        { ...connection, connectionPromise: Promise.resolve(connection) }
+      ]
+    })
+
     const unreachable = new Set<string>()
     const log = vi.fn()
     const stopBackend = vi.fn()
 
-    const probe = vi.fn(async (url: string) => {
-      if ([...unreachable].some(base => url.startsWith(base))) {
+    const probe = vi.fn(async (connection: TestRemoteConnection) => {
+      if ([...unreachable].some(base => connection.remoteBaseUrl?.startsWith(base))) {
         throw new Error('unreachable')
       }
 
@@ -291,7 +316,26 @@ describe('revalidatePooledRemoteBackends', () => {
     await pool.run(new RemoteLivenessTracker())
 
     expect(pool.probe).toHaveBeenCalledTimes(1)
-    expect(pool.probe).toHaveBeenCalledWith('https://remote.example.com/api/status', {
+    expect(pool.probe).toHaveBeenCalledWith(
+      expect.objectContaining({ remoteBaseUrl: 'https://remote.example.com' }),
+      '/api/status',
+      { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS }
+    )
+    expect(pool.stopBackend).not.toHaveBeenCalled()
+  })
+
+  it('passes the authenticated OAuth descriptor to the liveness probe', async () => {
+    const remote = {
+      process: null,
+      remoteBaseUrl: 'https://remote.example.com',
+      authMode: 'oauth'
+    }
+
+    const pool = harness([['oauth', remote]])
+
+    await pool.run(new RemoteLivenessTracker())
+
+    expect(pool.probe).toHaveBeenCalledWith(expect.objectContaining({ authMode: 'oauth' }), '/api/status', {
       timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS
     })
     expect(pool.stopBackend).not.toHaveBeenCalled()

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -19,7 +19,7 @@ export interface RevalidateRemoteConnectionOptions<TConnection extends RemoteCon
   connectionPromise: Promise<TConnection>
   currentConnectionPromise: () => null | Promise<TConnection>
   log: (message: string) => void
-  probe: (url: string, options: { timeoutMs: number }) => Promise<unknown>
+  probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
   resetConnection: () => void
   tracker: RemoteLivenessTracker
 }
@@ -117,15 +117,16 @@ export class RemoteLivenessTracker {
   }
 }
 
-export interface PooledRemoteEntry {
+export interface PooledRemoteEntry<TConnection extends RemoteConnectionDescriptor = RemoteConnectionDescriptor> {
+  connectionPromise?: null | Promise<TConnection>
   process?: unknown
   remoteBaseUrl?: null | string
 }
 
-export interface RevalidatePooledRemoteBackendsOptions {
-  entries: Iterable<[string, PooledRemoteEntry]>
+export interface RevalidatePooledRemoteBackendsOptions<TConnection extends RemoteConnectionDescriptor> {
+  entries: Iterable<[string, PooledRemoteEntry<TConnection>]>
   log: (message: string) => void
-  probe: (url: string, options: { timeoutMs: number }) => Promise<unknown>
+  probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
   stopBackend: (profile: string) => void
   tracker: RemoteLivenessTracker
 }
@@ -141,13 +142,13 @@ export interface RevalidatePooledRemoteBackendsOptions {
  * Entries share the primary's failure policy, keyed per base URL, so a profile
  * pointing at the same host as another does not burn the streak twice as fast.
  */
-export async function revalidatePooledRemoteBackends({
+export async function revalidatePooledRemoteBackends<TConnection extends RemoteConnectionDescriptor>({
   entries,
   log,
   probe,
   stopBackend,
   tracker
-}: RevalidatePooledRemoteBackendsOptions): Promise<{ dropped: string[] }> {
+}: RevalidatePooledRemoteBackendsOptions<TConnection>): Promise<{ dropped: string[] }> {
   const remotes = [...entries].filter(([, entry]) => !entry.process && entry.remoteBaseUrl)
   const dropped: string[] = []
 
@@ -156,7 +157,12 @@ export async function revalidatePooledRemoteBackends({
       const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
 
       try {
-        await probe(`${baseUrl}/api/status`, { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
+        if (!entry.connectionPromise) {
+          throw new Error('Remote backend descriptor is unavailable.')
+        }
+
+        const connection = await entry.connectionPromise
+        await probe(connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
         tracker.recordSuccess(baseUrl)
       } catch {
         const failure = tracker.recordFailure(baseUrl)
@@ -212,7 +218,7 @@ export async function revalidateRemoteConnection<TConnection extends RemoteConne
   const baseUrl = connection.baseUrl.replace(/\/+$/, '')
 
   try {
-    await probe(`${baseUrl}/api/status`, { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
+    await probe(connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
 
     if (currentConnectionPromise() !== connectionPromise) {
       return { ok: true, rebuilt: false }

--- a/apps/desktop/src/app/settings/connections-registry.test.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.test.tsx
@@ -161,13 +161,16 @@ describe('ConnectionsRegistrySection', () => {
     await waitFor(() => expect(setLaunchMode).toHaveBeenCalledWith('last-used'))
   })
 
-  it('keeps the launch preference out of the way for a single source', async () => {
+  it('offers the launch preference even for a single source', async () => {
+    // A local-only registry is the drift state from #90174, and the launch
+    // toggle is the control that lets a user out of it. Hiding it there left
+    // hand-editing connections.json as the only recourse.
     list.mockResolvedValueOnce({ ...registry, connections: [registry.connections[0]] })
 
     render(<ConnectionsRegistrySection />)
 
     await waitFor(() => expect(list).toHaveBeenCalledTimes(1))
-    expect(screen.queryByText('At startup, return to Sessions on the last-used gateway')).toBeNull()
+    expect(screen.getByText('At startup, return to Sessions on the last-used gateway')).toBeTruthy()
   })
 
   it('keeps search out of the way for a small registry', async () => {

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -989,7 +989,11 @@ export function ConnectionsRegistrySection() {
         </div>
       )}
 
-      {!loading && registry && registry.connections.length > 1 && (
+      {/* Not gated on connections.length > 1: a registry that drifted down to
+          local-only is exactly the state where a user needs to see and change
+          the launch behavior, and hiding the control there left hand-editing
+          connections.json as the only recourse (#90174). */}
+      {!loading && registry && (
         <div className="mt-6 border-t border-border/60 pt-4">
           <ToggleRow
             checked={registry.launchMode === 'last-used'}

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -276,4 +276,19 @@ describe('selectConnection', () => {
     expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
     expect($showAllProfiles.get()).toBe(false)
   })
+
+  it('never re-homes a live connection the registry cannot name', async () => {
+    // A window connected through the legacy v1 route carries an unqualified
+    // descriptor, so resolvedConnectionId — and therefore $activeConnectionId
+    // — is null. Restoring the registry primary over it would re-home a
+    // working remote onto local a few seconds after boot.
+    list.mockResolvedValueOnce({ ...registry, launchMode: 'primary', primary: 'local' })
+    $connection.set({ mode: 'remote', profile: 'default', registryScoped: false })
+
+    await initializeConnectionsRegistry()
+
+    expect(ensureGatewayAgent).not.toHaveBeenCalled()
+    expect(wipeSessionListsForGatewaySwitch).not.toHaveBeenCalled()
+    expect($connection.get()?.mode).toBe('remote')
+  })
 })

--- a/apps/desktop/src/store/connections.test.ts
+++ b/apps/desktop/src/store/connections.test.ts
@@ -253,4 +253,27 @@ describe('selectConnection', () => {
     expect($pendingConnectionId.get()).toBeNull()
     expect(setLastUsed).not.toHaveBeenCalled()
   })
+
+  it('boot-time restore leaves "All profiles" browse mode on (#93197)', async () => {
+    // Fresh boot: nothing active yet, registry restores last-used. The
+    // persisted showAllProfiles=true must survive the silent restore.
+    list.mockResolvedValueOnce({ ...registry, lastUsed: 'homelab', launchMode: 'last-used' })
+    $showAllProfiles.set(true)
+
+    await initializeConnectionsRegistry()
+
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect($showAllProfiles.get()).toBe(true)
+  })
+
+  it('a user-initiated source switch still collapses "All profiles"', async () => {
+    setConnectionsRegistry(registry)
+    $connection.set({ connectionId: 'local', mode: 'local' })
+    $showAllProfiles.set(true)
+
+    await selectConnection('homelab')
+
+    expect(ensureGatewayAgent).toHaveBeenCalledWith('homelab', 'default')
+    expect($showAllProfiles.get()).toBe(false)
+  })
 })

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -126,6 +126,17 @@ export async function initializeConnectionsRegistry(): Promise<DesktopConnection
 
   restoreAttempted = true
 
+  // Residual drift: a window can be live on a source the registry cannot name
+  // (a v1-configured remote that reconciliation has not repaired yet, e.g. a
+  // read-only userData that rejected the healed write). $activeConnectionId is
+  // null there, so the preferred-id guard below would miss and "restore" the
+  // registry primary over a connection that is already up and painting —
+  // re-homing the user onto a different backend seconds after boot. The
+  // registry has no claim on a source it does not know; leave the live one be.
+  if ($connection.get() && $activeConnectionId.get() === null) {
+    return registry
+  }
+
   const lastUsed = registry.connections.some(connection => connection.id === registry.lastUsed)
     ? registry.lastUsed
     : registry.primary

--- a/apps/desktop/src/store/connections.ts
+++ b/apps/desktop/src/store/connections.ts
@@ -158,6 +158,12 @@ export async function selectConnection(connectionId: string): Promise<void> {
     return
   }
 
+  // A user-initiated source switch collapses "All profiles" browse mode: the
+  // picker is a concrete-source action. The silent boot-time restore (below,
+  // from initializeConnectionsRegistry) is not — it must leave the persisted
+  // browse-mode preference alone so it survives restart (#93197).
+  const restoreOnBoot = pendingTarget === null && $activeConnectionId.get() === null
+
   const currentConnectionId = $activeConnectionId.get()
   const currentProfile = normalizeProfileKey($activeGatewayProfile.get())
   const targetProfile = normalizeProfileKey($lastProfileByConnection.get()[connectionId] ?? 'default')
@@ -207,7 +213,11 @@ export async function selectConnection(connectionId: string): Promise<void> {
     if (revision === switchRevision) {
       await rememberConnection(connectionId)
       wipeSessionListsForGatewaySwitch()
-      $showAllProfiles.set(false)
+
+      if (!restoreOnBoot) {
+        $showAllProfiles.set(false)
+      }
+
       $newChatProfile.set(targetProfile)
       requestFreshSession()
       await refreshActiveProfile()


### PR DESCRIPTION
Hermes Desktop connects to a remote gateway, paints its sessions, and then a
few seconds later re-homes itself onto a fresh local backend — greying out the
session list and popping the setup wizard, while the remote sits there healthy.
This consolidates the fixes for that and for the two other symptoms the same
drift produces.

## What breaks

`migrateV1ToRegistry` imports the legacy `connection.json` into the v2
`connections.json` registry exactly once, only when the registry file does not
exist. Settings → Gateway (`hermes:connection-config:apply`) writes only the v1
file. So anyone who was local when the registry was born and pointed Settings at
a remote afterwards ends up with two stores that disagree, permanently, with
nothing to reconcile them.

From there:

1. Boot dials the remote through the v1 route. It works — sessions paint.
2. The descriptor is unqualified, so `resolvedConnectionId` returns null and
   `$activeConnectionId` is null.
3. Boot completes, `initializeConnectionsRegistry` restores `registry.primary`
   (`local`). The `=== preferredId` guard misses on null, so
   `selectConnection('local')` runs and `wipeSessionListsForGatewaySwitch()`
   clears the list.
4. The forced-local backend has no inference provider, so onboarding opens as a
   blocking overlay.

The same force-switch is what duplicates every MCP server (#91564) and what
clobbers the persisted "Show all profiles" preference (#93197). Users have been
trading a hand-edit of `connections.json` as the workaround.

## The fix

**Heal the drift at its source.** When the v1 global route names a remote the
registry has never heard of, register it and adopt it as primary/last-used, then
persist so the repair happens once. This is what the manual JSON edit was doing.
It is deliberately narrow: an already-registered route is left alone even when
`primary` names something else, because that is a real pick in the Connections
panel, not drift.

**Stop creating new drift.** Apply now reconciles the v2 registry in the same
transaction as the v1 write, so `Save and reconnect` publishes one identity to
both stores. Both writes plus the re-home roll back together, and an
authenticated REST + WebSocket preflight runs before either file changes.

**Authenticate liveness probes.** Primary and pooled remote checks went out
anonymously, so a gateway that protects `/api/status` returned 401 and the
tracker condemned a perfectly healthy connection. They now use the same
credentials as real traffic (native bearer, then OAuth session).

**Two guards behind that.** The boot restore returns early when a connection is
live but unnameable — the registry has no claim on a source it does not know.
And the launch-source toggle is no longer hidden when only one connection is
registered, which was exactly the state the drift produces.

## Testing

Bug-class coverage: drift heals a v1 remote into a local-only registry and the
live descriptor resolves to it; an already-registered route is untouched; a
deliberate local primary is never overridden; local/ssh/unparseable v1 routes
are ignored; other registered sources survive the heal; boot restore leaves a
live unnameable connection alone; preflight runs before either store is written
and a rejected preflight leaves both untouched.

Electron suite 1620 passed / 3 skipped, renderer suite green, all three
typecheck projects and eslint clean.

Two salvaged tests asserted against `main.ts` source text (regex for
`ensureNativeAccessToken(baseUrl)`, index arithmetic for preflight ordering).
Replaced with behavior tests: `preflight` is now a real option on
`applyConnectionConfigAtomically`, so its ordering is observable through the
seam instead of inferred from source layout.

## Credit

Root cause analysis and reproduction by @ExManubis (#90174), with independent
confirmations from @TheAirick (Arch), @greetingsyi (Windows + remote gateway,
with the log timeline pinning the regression to the 8/17 build) and @iosmand,
whose **fresh-install** reproduction showed this is not only stale upgrade data
and whose "delete `connections.json`" recovery is what the reconciliation
automates. @Hemir95 reported the duplicated-MCP symptom (#91564) and @TVD7678
the browse-mode reset (#93197).

Co-authored-by: Alessandro Levantini <176400450+Allecpu@users.noreply.github.com>
Co-authored-by: ClintonEmok <54935030+ClintonEmok@users.noreply.github.com>

Supersedes #92274, #93279
Closes #90174, #91564, #93197
