### PR TITLE
fix(cli): treat empty fleet probe as incomplete when gateways were restarted (#93406)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8317,6 +8317,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if print_fleet_version_matrix(_fleet_snapshot):
                 gateway_fleet_restart_incomplete = True
+            elif not _fleet_snapshot and (restarted_services or killed_pids):
+                # Fleet probe returned zero rows even though the restart
+                # phase touched live gateways.  Every failure path inside
+                # collect_fleet_versions() is swallowed via logger.debug(),
+                # so an empty list is indistinguishable from a healthy fleet
+                # in the current output.  Treat it as verification failure
+                # so the receipt records "partial" and the exit code is 1
+                # (#93406).
+                print(
+                    "\n⚠ Fleet version check returned no rows even though"
+                    " gateways were restarted — verification incomplete."
+                )
+                gateway_fleet_restart_incomplete = True
         except Exception as _fleet_exc:
             logger.debug("Fleet version verification failed: %s", _fleet_exc)
 


### PR DESCRIPTION
## Fix: treat empty fleet probe as incomplete when gateways were restarted

Fixes #93406

### Root Cause

`collect_fleet_versions()` swallows every probe exception via `logger.debug()` and returns whatever accumulated — which can be an empty list. `print_fleet_version_matrix([])` returns `False` (no rows to report), so the update exits 0 with "success" even though no gateway was actually verified.

### Reproduction

1. Have a gateway running as a launchd/systemd service
2. Run `hermes gateway restart` (or `hermes update`)
3. If `collect_fleet_versions()` silently fails (socket timeout, import error, etc.), the fleet matrix is empty
4. Update reports "success" with zero fleet-check lines — indistinguishable from a healthy fleet

### Fix

After the restart phase touches live gateways (`restarted_services` or `killed_pids` is truthy), an empty fleet snapshot means verification failed, not that everything is healthy. Treat it as incomplete so the receipt records "partial" and the exit code is 1.

### Changes

- `hermes_cli/update_cmd.py`: Add `elif not _fleet_snapshot and (restarted_services or killed_pids)` guard after `print_fleet_version_matrix()` returns `False`
