### PR TITLE
fix: dot-sourced and NUL-padded scripts no longer bypass the gateway lifecycle guard (#77925 #77927, salvage #77926 #77928)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -641,7 +641,11 @@ def _iter_referenced_shell_scripts(
         executable = segment[index]
         executable_name = Path(executable).name
 
-        if executable_name in {".", "source"}:
+        # Compare the RAW token as well as the basename: `Path(".").name` is the
+        # empty string, so a basename-only test silently misses the dot operator
+        # while still catching `source`. `. ./restart.sh` is exactly equivalent
+        # to `source ./restart.sh`, so both must reach the referenced-script scan.
+        if executable in {".", "source"} or executable_name == "source":
             if len(segment) > index + 1:
                 resolved = _resolve_terminal_script_path(segment[index + 1], cwd)
                 if resolved is not None:

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -791,12 +791,15 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
                 return None, False
             return None, True
         # Sniff a small prefix first: files that are clearly compiled
-        # binaries (executable magic, or NUL bytes in the head) are never
-        # shell scripts, so skip them WITHOUT reading the rest — reading a
-        # megabyte of machine code just to discard it wastes the guard's
-        # budget and (pre-#77703) fed decoded garbage into the recursion.
+        # binaries (executable magic) are never shell scripts, so skip them
+        # WITHOUT reading the rest — reading a megabyte of machine code just
+        # to discard it wastes the guard's budget and (pre-#77703) fed
+        # decoded garbage into the recursion. Deliberately NOT keyed on the
+        # mere presence of a NUL byte (#77927): bash executes a text script
+        # straight past an embedded NUL, so NUL-bearing text must fall
+        # through to the magic-number check + NUL-strip below.
         data = os.read(descriptor, _BINARY_SNIFF_BYTES)
-        if data.startswith(_BINARY_MAGIC_PREFIXES) or b"\x00" in data:
+        if data.startswith(_BINARY_MAGIC_PREFIXES):
             return None, False
         # Read the remainder (bounded). Loop because os.read may return
         # short for non-regular-file-backed descriptors.

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -714,6 +714,38 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
     return None
 
 
+_BINARY_MAGICS = (
+    b"\x7fELF",              # ELF — Linux/BSD executables and shared objects
+    b"\xfe\xed\xfa\xce",     # Mach-O 32-bit
+    b"\xfe\xed\xfa\xcf",     # Mach-O 64-bit
+    b"\xce\xfa\xed\xfe",     # Mach-O 32-bit, byte-swapped
+    b"\xcf\xfa\xed\xfe",     # Mach-O 64-bit, byte-swapped
+    b"\xca\xfe\xba\xbe",     # Mach-O universal ("fat") binary
+    b"MZ",                   # PE/COFF — Windows .exe/.dll
+    b"!<arch>",              # static archive (.a)
+    b"\x1f\x8b",             # gzip
+    b"PK\x03\x04",           # zip (also .jar/.whl/.egg)
+)
+
+
+def _has_binary_magic(data: bytes) -> bool:
+    """Return True when *data* starts with a known compiled-binary signature.
+
+    Deliberately narrower than "contains a NUL byte": a shell script that
+    happens to hold a NUL is still executed by ``bash``, so treating every
+    NUL-bearing file as an unscannable binary lets a padded script bypass the
+    lifecycle scan entirely.
+
+    A shebang always wins — an interpreted script is never a binary, however
+    odd its payload. File extensions are deliberately *not* consulted: a
+    suffixless shell script must still be scanned (and, if oversized, still
+    fail closed).
+    """
+    if data.startswith(b"#!"):
+        return False
+    return data.startswith(_BINARY_MAGICS)
+
+
 def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     """Return ``(text, unsafe)`` using bounded, regular-file-only reads.
 
@@ -779,16 +811,25 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     finally:
         os.close(descriptor)
-    # A NUL byte in the first chunk means this is a binary (ELF/Mach-O/
-    # PE), not a shell script — scanning its decoded contents would
-    # tokenize machine code and feed junk paths into the recursion
-    # (including a `ValueError: embedded null byte` from Path.resolve,
-    # #76762). Treat it as "nothing to scan" rather than unsafe: a binary
-    # executed by the user is not a referenced *shell script*.
-    if b"\x00" in data:
+    # Identify binaries by MAGIC NUMBER, not by the mere presence of a NUL.
+    #
+    # "contains a NUL" and "is a compiled binary" are different questions, and
+    # the gap between them is a guard bypass: `bash` executes a *text* script
+    # straight past an embedded NUL, so a single pad byte in a shell script made
+    # the scan skip a file that still runs its lifecycle command. Match on the
+    # signature instead (ELF/Mach-O/PE/static archive/compressed), and treat a
+    # NUL-bearing *text* file as a script whose NULs are stripped before
+    # scanning — stripping can only splice tokens together, never apart, so it
+    # fails closed.
+    if _has_binary_magic(data):
         return None, False
+    # Check the size BEFORE stripping: stripping shrinks the buffer, so doing it
+    # first would let an oversized file slip under the threshold and skip this
+    # fail-closed branch.
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
+    if b"\x00" in data:
+        data = data.replace(b"\x00", b"")
     return data.decode("utf-8", errors="replace"), False
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -879,6 +879,24 @@ class TestLifecycleGuardModule:
             is True
         )
 
+    def test_nul_padded_script_is_still_scanned(self, tmp_path):
+        """A NUL byte in a *text* script must not disable the scan.
+
+        The #76762 binary check treated any NUL in the first chunk as "compiled
+        binary, nothing to scan" — but ``bash`` executes a text script straight
+        past an embedded NUL, so one pad byte bypassed the guard entirely while
+        the script still ran its lifecycle command.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "padded.sh"
+        script.write_bytes(b"#!/bin/bash\n# pad\x00\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"bash {script}")
+            is True
+        )
+
     def test_source_builtin_sourced_script_is_scanned(self, tmp_path):
         """The `source` spelling must stay blocked (it already was)."""
         from cron.lifecycle_guard import (
@@ -901,6 +919,84 @@ class TestLifecycleGuardModule:
         script.write_text("#!/bin/bash\nexport PATH=/usr/bin:$PATH\n")
         assert (
             contains_gateway_lifecycle_command_or_referenced_script(f". {script}")
+            is False
+        )
+
+    def test_nul_padded_script_without_shebang_is_scanned(self, tmp_path):
+        """Same bypass without a shebang — bash still runs it, so still scan.
+
+        Keying the fix on a leading ``#!`` alone is insufficient: a shebang-less
+        file with a NUL on any line but the first executes normally.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "padded_noshebang.sh"
+        script.write_bytes(b"# ok\n# pad\x00\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"bash {script}")
+            is True
+        )
+
+    def test_elf_binary_is_not_scanned_as_script(self, tmp_path):
+        """#76762 must stay fixed: a real binary is nothing-to-scan, no crash.
+
+        Its decoded machine code must never be tokenized as shell text, and the
+        guard must not fail closed on an innocent interpreter invocation.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        binary = tmp_path / "tool"
+        binary.write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 64 + b"/usr/bin/x\x00")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"{binary} --version")
+            is False
+        )
+
+    def test_macho_binary_is_not_scanned_as_script(self, tmp_path):
+        """Same for Mach-O, including the universal/fat signature (macOS)."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        for name, magic in (
+            ("macho64", b"\xcf\xfa\xed\xfe"),
+            ("machofat", b"\xca\xfe\xba\xbe"),
+        ):
+            binary = tmp_path / name
+            binary.write_bytes(magic + b"\x00" * 64)
+            assert (
+                contains_gateway_lifecycle_command_or_referenced_script(
+                    f"{binary} --version"
+                )
+                is False
+            )
+
+    def test_oversized_nul_bearing_text_still_fails_closed(self, tmp_path):
+        """An oversized *text* script must keep failing closed.
+
+        Stripping NULs must not let a too-large file skip the size guard — the
+        binary check runs first, the size check still applies afterwards.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "huge.sh"
+        script.write_bytes(b"#!/bin/bash\n# \x00" + b"x" * (1024 * 1024 + 64) + b"\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"bash {script}")
+            is True
+        )
+
+    def test_clean_script_without_lifecycle_command_not_blocked(self, tmp_path):
+        """Sanity: the change must not false-block innocent scripts."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "safe.sh"
+        script.write_bytes(b"#!/bin/bash\necho hello\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"bash {script}")
             is False
         )
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -861,6 +861,49 @@ class TestTerminalToolGatewayLifecycleGuard:
 class TestLifecycleGuardModule:
     """Direct tests for cron.lifecycle_guard.check_gateway_lifecycle."""
 
+    def test_dot_operator_sourced_script_is_scanned(self, tmp_path):
+        """`. ./script.sh` must reach the referenced-script scan.
+
+        The dot operator and `source` are the same POSIX builtin, but the
+        executable test compared only `Path(executable).name` — and
+        `Path(".").name` is the empty string, so `source` was caught while a
+        bare `.` slipped through and the sourced script was never scanned.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f". {script}")
+            is True
+        )
+
+    def test_source_builtin_sourced_script_is_scanned(self, tmp_path):
+        """The `source` spelling must stay blocked (it already was)."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"source {script}")
+            is True
+        )
+
+    def test_dot_operator_clean_script_not_blocked(self, tmp_path):
+        """Widening the dot check must not false-block an innocent sourced
+        script — e.g. sourcing a venv activate or an env file."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "activate.sh"
+        script.write_text("#!/bin/bash\nexport PATH=/usr/bin:$PATH\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f". {script}")
+            is False
+        )
+
     def test_prompt_with_command_raises(self):
         from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
         with pytest.raises(GatewayLifecycleBlocked) as exc:


### PR DESCRIPTION
## Summary

Two remaining lifecycle-guard bypass shapes are closed. (1) `. script.sh` — the POSIX dot operator — was never scanned: `_iter_referenced_shell_scripts` keyed the sourced-script branch on `Path(token).name`, and `Path(".").name` is the empty string, so the same file blocked via `source` sailed through via `.`. (2) A single NUL byte in a *text* script disabled the entire scan: the #76762 crash fix treated "contains a NUL" as "is a compiled binary, nothing to scan", but bash executes text straight past an embedded NUL, so one pad byte silently laundered a lifecycle command (this shape WAS blocked before #76762 — the crash fix traded a loud failure for a silent one).

Salvages PRs #77926 and #77928 by @Mengchee118 (earliest submitter on both — Aug 3). Closes #77925 and #77927.

## Changes

- `cron/lifecycle_guard.py` (@Mengchee118): dot-operator tokens reach the sourced-script branch; binaries identified by MAGIC NUMBER (ELF/Mach-O incl. fat/PE/archive/gzip/zip) instead of NUL presence — NUL-bearing text is scanned with NULs stripped (splices tokens together, never apart → fails closed), size checked BEFORE stripping
- follow-up commit: the newer main-side sniff fast-path also keyed on NUL-in-head and short-circuited before the magic check — re-keyed on executable magic only so the salvaged fix actually engages
- Tests (@Mengchee118): dot/source parity, NUL-padded (with and without shebang), oversized-NUL fail-closed, ELF/Mach-O still skipped, clean-script negatives

## Validation

| Case | Before | After |
|---|---|---|
| `. restart.sh` (lifecycle command inside) | passed guard | blocked |
| `source restart.sh` | blocked | still blocked |
| NUL-padded text script via `bash` | passed (post-#76762 regression) | blocked |
| shebang-less NUL-padded script | passed | blocked |
| real ELF/Mach-O full-path invocation | skipped, no crash | still skipped, no crash |
| `. activate.sh` (innocent venv activate) | allowed | still allowed |

All shapes live-verified against the real guard; 204/204 targeted tests.

## Infographic

![Two doors left open, now shut](https://v3b.fal.media/files/b/0aa78f89/Oa8niN-2QrhFUycFJ41mQ_2QJriXqV.png)
