### PR TITLE
fix(gateway): recover later flush files after a single bad pending message

### DIFF
--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -397,16 +397,26 @@ def recover_pending_to_db(
             )
             recovered += 1
             path.unlink(missing_ok=True)
-        except BaseException:
-            # Shutdown cancellation/interrupt must not strand an owned DB.
-            _close_owned_db()
-            raise
         except Exception as exc:
+            # A single bad flush file (corrupt JSON, locked/corrupt DB,
+            # I/O error) must not abort the whole recovery pass: later
+            # files would be silently starved on every subsequent
+            # startup because the loop re-processes in sorted order and
+            # the caller (gateway/run.py) swallows the escape with no
+            # log. Log and leave the file for the next startup retry.
             logger.warning(
                 "Failed to recover pending message from %s: %s",
                 path, exc,
             )
-            # Leave the file for next startup retry.
+            continue
+        except BaseException:
+            # Shutdown cancellation/interrupt must not strand an owned DB.
+            # (Must come after `except Exception` — BaseException is its
+            # superclass, so listing it first made the branch above
+            # unreachable and turned every ordinary error into a hard
+            # abort of the remaining files.)
+            _close_owned_db()
+            raise
 
     _close_owned_db()
 

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -168,3 +168,84 @@ def test_get_flush_dir_uses_get_hermes_home(tmp_path, monkeypatch):
     assert result == tmp_path / "pending_messages"
 
 
+
+
+def test_corrupt_flush_file_does_not_starve_later_files(tmp_path, monkeypatch, caplog):
+    """A single corrupt flush file must not abort the recovery pass.
+
+    Regression: `except BaseException` listed before `except Exception`
+    made every ordinary error (corrupt JSON, DB lock, I/O failure) close
+    the owned DB and re-raise out of the loop — and gateway/run.py
+    swallows that escape silently, so all later flush files were starved
+    on every subsequent startup.
+    """
+    import logging
+
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    good_a = flush_dir / "a_good.json"
+    bad = flush_dir / "b_corrupt.json"
+    good_c = flush_dir / "c_good.json"
+    good_a.write_text(
+        json.dumps(
+            {
+                "session_key": "k1",
+                "data": {"text": "hello", "session_id": "s1"},
+                "ts": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    bad.write_text("{not valid json", encoding="utf-8")
+    good_c.write_text(
+        json.dumps(
+            {
+                "session_key": "k2",
+                "data": {"text": "world", "session_id": "s2"},
+                "ts": 2,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    db = MagicMock()
+    with caplog.at_level(logging.WARNING):
+        recovered = recover_pending_to_db(session_db=db)
+
+    assert recovered == 2
+    assert db.append_message.call_count == 2
+    # The corrupt file is preserved for a later retry, with a warning.
+    assert bad.exists()
+    assert any("b_corrupt.json" in rec.message for rec in caplog.records)
+
+
+def test_base_exception_still_propagates_and_closes_owned_db(
+    tmp_path, monkeypatch
+):
+    """Ctrl-C-style interrupts still abort recovery without stranding a DB."""
+    from unittest.mock import MagicMock, patch
+
+    flush_dir = _make_flush_dir(tmp_path)
+    monkeypatch.setattr(
+        "gateway.shutdown_flush._get_flush_dir", lambda: flush_dir
+    )
+    (flush_dir / "a.json").write_text(
+        json.dumps(
+            {
+                "session_key": "k",
+                "data": {"text": "x", "session_id": "s"},
+                "ts": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    db = MagicMock()
+    db.append_message.side_effect = KeyboardInterrupt()
+    fake_sessiondb = MagicMock(return_value=db)
+    with patch("hermes_state.SessionDB", fake_sessiondb):
+        with pytest.raises(KeyboardInterrupt):
+            recover_pending_to_db()
+    db.close.assert_called_once()


### PR DESCRIPTION
## Bug Description

`recover_pending_to_db()` in `gateway/shutdown_flush.py` listed `except BaseException:` **before** `except Exception as exc:`. Since `BaseException` is the superclass of `Exception`, every ordinary failure while replaying a flush file (corrupt JSON, locked/corrupt DB, I/O error) matched the first clause: it closed the owned SessionDB and re-raised out of the loop — the warning-and-continue branch below it is unreachable dead code.

`gateway/run.py` calls this helper under a bare `except Exception: pass`, so the escape was **silent** (no log at all). Recovery processes files in sorted order, so a single corrupt or unreadable flush file permanently starves every pending message behind it — on every subsequent startup, at the same position.

This contradicts both the inline comment's stated intent ("Leave the file for next startup retry") and #72680's durability goal.

## Repro

```python
# three pending files: good, corrupt, good
recover_pending_to_db(session_db=fake_db)
# → JSONDecodeError escapes; caller swallows silently;
#   recovered=0 for later files, which remain on disk forever
```

## Fix

Reorder the handlers:
- `except Exception` first: log a warning, leave the file for the next startup retry, continue with the remaining files (mirrors the existing `drain_transcript_spool` pattern in the same module).
- `except BaseException` after: close the owned DB and re-raise, so shutdown cancellation/interrupt still aborts recovery without stranding a connection.

Also added two regression tests:
1. A corrupt middle file no longer starves later files (warning logged, file preserved, later messages recovered).
2. A `KeyboardInterrupt` during replay still propagates and closes an owned DB.

Local verification: targeted tests pass (`tests/gateway/test_shutdown_flush.py`: 8 passed), full gateway suite diff vs. clean main shows no new failures.