### PR TITLE
fix(build): use import.meta.dirname in vite configs for native configLoader

### DIFF
--- a/apps/bootstrap-installer/vite.config.ts
+++ b/apps/bootstrap-installer/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src')
+      '@': path.resolve(import.meta.dirname, './src')
     }
   },
   clearScreen: false,

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -31,9 +31,9 @@ const real = (p: string): string | null => {
 const fsAllow = [
   ...new Set(
     [
-      path.resolve(__dirname, '../..'),
-      real(path.resolve(__dirname, 'node_modules')),
-      real(path.resolve(__dirname, '../../node_modules'))
+      path.resolve(import.meta.dirname, '../..'),
+      real(path.resolve(import.meta.dirname, 'node_modules')),
+      real(path.resolve(import.meta.dirname, '../../node_modules'))
     ].filter((p): p is string => p !== null)
   )
 ]
@@ -48,7 +48,7 @@ const fsAllow = [
 // warns. Resolving from this workspace instead of a hardcoded root path yields
 // the versions declared here — npm nests a copy under the workspace exactly
 // when the hoisted one differs, so the pair can only ever match.
-const requireFromApp = createRequire(path.join(__dirname, 'vite.config.ts'))
+const requireFromApp = createRequire(path.join(import.meta.dirname, 'vite.config.ts'))
 const reactDir = path.dirname(requireFromApp.resolve('react/package.json'))
 const reactDomDir = path.dirname(requireFromApp.resolve('react-dom/package.json'))
 
@@ -60,16 +60,16 @@ const reactDomDir = path.dirname(requireFromApp.resolve('react-dom/package.json'
 // the perf harness opts a production build back in with VITE_PERF_PROBE=1.
 const debugEntry = (command: string, env: Record<string, string>) =>
   command === 'serve' || env.VITE_PERF_PROBE === '1'
-    ? path.resolve(__dirname, './src/debug/dev-only.ts')
-    : path.resolve(__dirname, './src/debug/dev-only.noop.ts')
+    ? path.resolve(import.meta.dirname, './src/debug/dev-only.ts')
+    : path.resolve(import.meta.dirname, './src/debug/dev-only.noop.ts')
 
 // The emoji picker (frimousse) fetches `<emojibaseUrl>/<locale>/data.json` at
 // runtime. Its default is a CDN; Electron must work offline, so serve the
 // bundled emojibase-data package at a stable local path instead — middleware
 // in dev, emitted assets in the build. Only the files a locale actually needs.
 const emojibaseDir =
-  real(path.resolve(__dirname, 'node_modules/emojibase-data')) ??
-  real(path.resolve(__dirname, '../../node_modules/emojibase-data'))
+  real(path.resolve(import.meta.dirname, 'node_modules/emojibase-data')) ??
+  real(path.resolve(import.meta.dirname, '../../node_modules/emojibase-data'))
 
 const EMOJIBASE_PATH = /^[a-z-]+\/(data|messages|shortcodes\/emojibase)\.json$/
 
@@ -186,10 +186,10 @@ export default defineConfig(({ command }) => ({
   resolve: {
     alias: {
       '@/debug/dev-only': debugEntry(command, process.env as Record<string, string>),
-      '@': path.resolve(__dirname, './src'),
-      '@hermes/plugin-sdk': path.resolve(__dirname, './src/sdk/index.ts'),
-      '@hermes/shared/billing': path.resolve(__dirname, '../shared/src/billing-types.ts'),
-      '@hermes/shared': path.resolve(__dirname, '../shared/src'),
+      '@': path.resolve(import.meta.dirname, './src'),
+      '@hermes/plugin-sdk': path.resolve(import.meta.dirname, './src/sdk/index.ts'),
+      '@hermes/shared/billing': path.resolve(import.meta.dirname, '../shared/src/billing-types.ts'),
+      '@hermes/shared': path.resolve(import.meta.dirname, '../shared/src'),
       // The tour tool's preview surface injects driver.js's prebuilt IIFE into
       // the pane's guest page as raw source; the package's exports map doesn't
       // expose that dist file (nor ./package.json), so resolve the main entry

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -77,8 +77,8 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@hermes/shared": path.resolve(__dirname, "../apps/shared/src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
+      "@hermes/shared": path.resolve(import.meta.dirname, "../apps/shared/src"),
     },
     // When @nous-research/ui is symlinked via `file:../../design-language`,
     // Node's module resolution would pick up shared deps from


### PR DESCRIPTION
## What does this PR do?

Fixes the Vite 8.x deprecation warning shown during `web` production builds:

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.ts:80:25). Use `import.meta.dirname` instead
```

Vite's `configLoader: 'native'` loads config files as native ESM, where the CommonJS `__dirname` global does not exist. The current configs still work today (the native loader is opt-in), but once it becomes the default in a future Vite major version these configs will fail to load at build time.

The fix replaces every `__dirname` usage in the three Vite configs with `import.meta.dirname` (available since Node 20.11; the repo requires `node >=22.22.0`). This is a pure build-config change with zero runtime impact — both resolve to the same absolute directory at config-load time.

## Related Issue

No existing issue found; this surfaces as a build warning after the Vite 8.x bump. Happy to file one if maintainers prefer.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `web/vite.config.ts` — 2 occurrences: `@` and `@hermes/shared` aliases
- `apps/desktop/vite.config.ts` — 12 occurrences: `fs.allow` whitelist, `createRequire` path, `debugEntry` paths, `emojibaseDir` paths, and all alias entries
- `apps/bootstrap-installer/vite.config.ts` — 1 occurrence: `@` alias

All are `path.resolve(__dirname, ...)` / `path.join(__dirname, ...)` → `path.resolve(import.meta.dirname, ...)` / `path.join(import.meta.dirname, ...)`; the `createRequire(path.join(__dirname, 'vite.config.ts'))` call likewise becomes `createRequire(path.join(import.meta.dirname, 'vite.config.ts'))`.

## How to Test

1. `cd web && npx tsc -b && npx vite build` — build succeeds, and the `configLoader: 'native'` / `__dirname` warning no longer appears
2. `cd apps/desktop && npx tsc -b && npx vite build` — build succeeds (an unrelated pre-existing `advancedChunks` deprecation notice remains; it is not touched by this PR)
3. `cd apps/bootstrap-installer && npx tsc -b && npx vite build` — build succeeds

All three verified locally on macOS (Node v22.22.2, Vite v8.2.0): `tsc -b` exit 0 everywhere; all builds exit 0; the `__dirname` warning is gone from the `web` build output.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (JS-only change; JS test suite not run)
- [ ] I've added tests for my changes (build-config only; covered by the tsc/vite build steps above)
- [x] I've tested on my platform: macOS (Apple Silicon, Node v22.22.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `import.meta.dirname` requires Node ≥20.11, satisfied by the repo's `engines` floor of 22.22.0
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (web build, Vite 8.2.0):

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.ts:80:25). Use `import.meta.dirname` instead
```

After (web build, Vite 8.2.0):

```
vite v8.2.0 building client environment for production...
✓ built in 2.15s
```

