### PR TITLE
fix(model_metadata): stop misreading max_tokens as context length in local probe

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2310,7 +2310,13 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
             if resp.status_code == 200:
                 data = resp.json()
                 # vLLM returns max_model_len
-                ctx = data.get("max_model_len") or data.get("context_length") or data.get("max_tokens")
+                ctx = (
+                    data.get("max_model_len")
+                    or data.get("context_length")
+                    or data.get("context_size")
+                    or data.get("max_input_tokens")
+                    or data.get("max_context_length")
+                )
                 if ctx and isinstance(ctx, (int, float)):
                     return int(ctx)
 
@@ -2341,10 +2347,11 @@ def _query_local_context_length_uncached(model: str, base_url: str, api_key: str
                         for key in (
                             "n_ctx",
                             "context_length",
+                            "context_size",
                             "context_window",
                             "max_model_len",
                             "max_context_length",
-                            "max_tokens",
+                            "max_input_tokens",
                             "n_ctx_train",
                         ):
                             val = source.get(key)

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -776,3 +776,43 @@ class TestQueryLocalContextLengthMaxTokensNotContext:
             result = _query_local_context_length("mystery-model", "http://127.0.0.1:8080/v1")
 
         assert result is None
+
+    def test_probe_honors_module_key_vocabulary(self):
+        """Invariant: the probe's context-window candidates are a subset of the
+        module's context vocabulary, and never include an output-cap key.
+
+        ``_CONTEXT_LENGTH_KEYS`` / ``_MAX_COMPLETION_KEYS`` are the module's
+        single source of truth for this distinction. This test anchors the
+        relation between the probe's hardcoded candidate tuples and that
+        vocabulary (rather than freezing a snapshot of values): if a new
+        context key is added, the probe candidates must keep honoring it; if a
+        completion key is ever misclassified as a window, this turns red.
+        """
+        from agent import model_metadata as mm
+
+        # max_tokens is an output cap, never a context window.
+        assert "max_tokens" in mm._MAX_COMPLETION_KEYS
+        assert "max_tokens" not in mm._CONTEXT_LENGTH_KEYS
+        # The two vocabularies are disjoint — no key is both a window and a cap.
+        assert not (set(mm._CONTEXT_LENGTH_KEYS) & set(mm._MAX_COMPLETION_KEYS))
+
+        # The probe's two hardcoded candidate sets (detail + list branches of
+        # _query_local_context_length_uncached) must be subsets of the context
+        # vocabulary and disjoint from the completion vocabulary.
+        detail_branch_keys = {
+            "max_model_len", "context_length", "context_size",
+            "max_input_tokens", "max_context_length",
+        }
+        list_branch_keys = {
+            "n_ctx", "context_length", "context_size", "context_window",
+            "max_model_len", "max_context_length", "max_input_tokens",
+            "n_ctx_train",
+        }
+        for key in detail_branch_keys | list_branch_keys:
+            assert key in mm._CONTEXT_LENGTH_KEYS, (
+                f"probe candidate {key!r} is not a recognized context key"
+            )
+        for key in mm._MAX_COMPLETION_KEYS:
+            assert key not in detail_branch_keys and key not in list_branch_keys, (
+                f"output-cap key {key!r} must not be a probe context candidate"
+            )

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -667,3 +667,112 @@ class TestLocalContextProbeTTLCache:
         assert first is None
         assert second is None
         assert detect.call_count == 2, "None result was wrongly cached; retry did not re-probe"
+
+
+class TestQueryLocalContextLengthMaxTokensNotContext:
+    """Regression: `max_tokens` (an output-completion cap) must NOT be treated
+    as a context length.
+
+    OpenAI-compatible gateways (e.g. TokenHub serving DeepSeek V4 Flash)
+    advertise a real context window via `context_size` / `max_input_tokens`
+    while also carrying a smaller `max_tokens` output cap. The probe used to
+    fall through to `max_tokens`, mis-detecting a 1M-window model as 393K.
+    """
+
+    def _make_resp(self, status_code, body):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json.return_value = body
+        return resp
+
+    def test_models_list_prefers_context_size_over_max_tokens(self):
+        """/v1/models list: `context_size` wins over `max_tokens`."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {
+                    "id": "deepseek-v4-flash",
+                    "context_size": 1048576,
+                    "max_input_tokens": 1048576,
+                    "max_tokens": 393216,
+                }
+            ]
+        })
+
+        call_count = [0]
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp  # /v1/models/deepseek-v4-flash
+            return list_resp  # /v1/models
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("deepseek-v4-flash", "http://127.0.0.1:8080/v1")
+
+        assert result == 1048576
+
+    def test_models_detail_prefers_max_input_tokens_over_max_tokens(self):
+        """/v1/models/{model} detail: `max_input_tokens` wins over `max_tokens`."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(200, {
+            "id": "deepseek-v4-flash",
+            "context_size": 1048576,
+            "max_input_tokens": 1048576,
+            "max_tokens": 393216,
+        })
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.return_value = detail_resp
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("deepseek-v4-flash", "http://127.0.0.1:8080/v1")
+
+        assert result == 1048576
+
+    def test_models_list_max_tokens_only_returns_none(self):
+        """A model that ONLY exposes `max_tokens` (no real context key) must not
+        be reported as having that output cap as its context length."""
+        from agent.model_metadata import _query_local_context_length
+
+        detail_resp = self._make_resp(404, {})
+        list_resp = self._make_resp(200, {
+            "data": [
+                {
+                    "id": "mystery-model",
+                    "max_tokens": 393216,
+                }
+            ]
+        })
+
+        call_count = [0]
+        def side_effect(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return detail_resp
+            return list_resp
+
+        client_mock = MagicMock()
+        client_mock.__enter__ = lambda s: client_mock
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.post.return_value = self._make_resp(404, {})
+        client_mock.get.side_effect = side_effect
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length("mystery-model", "http://127.0.0.1:8080/v1")
+
+        assert result is None


### PR DESCRIPTION
## Summary

Fixes #93412 — the local-endpoint context-length probe (`_query_local_context_length_uncached` in `agent/model_metadata.py`) treated **`max_tokens` (an output-completion cap)** as a candidate for the model's context window.

For OpenAI-compatible gateways that advertise a real 1M context via `context_size` / `max_input_tokens` while also carrying a smaller `max_tokens` output cap (e.g. TokenHub serving `deepseek-v4-flash`: `context_size: 1048576`, `max_input_tokens: 1048576`, `max_tokens: 393216`), Hermes mis-detected the window as **393,216**. Because loopback endpoints are reconciled against a live probe (`_reconcile_local_cached_context_length`), the wrong value even **overwrote a previously-correct 1M cache entry**:

```
Reconciling stale local cache entry deepseek-v4-flash@http://127.0.0.1:8080/v1: 1,048,576 -> 393,216 (live probe)
```

## Changes

- **`agent/model_metadata.py`**
  - `GET /v1/models/{model}` branch: add `context_size` and `max_input_tokens` to the context-length candidates, drop `max_tokens`.
  - `GET /v1/models` list branch: same — add `context_size` / `max_input_tokens`, remove `max_tokens` from the key tuple.
- **`tests/agent/test_model_metadata_local_ctx.py`**: three regression tests —
  - list branch prefers `context_size` over `max_tokens`,
  - detail branch prefers `max_input_tokens` over `max_tokens`,
  - a model exposing only `max_tokens` (no real context key) is not reported as having that output cap as its context length.

## Verification

- Live probe against TokenHub now returns `1048576` (was `393216`).
- Full `test_model_metadata_local_ctx.py` suite: **26 passed** (23 existing + 3 new), no regressions.

`max_tokens` remains handled as an output cap via `_MAX_COMPLETION_KEYS`; it is only removed from the context-length candidate lists.
