### PR TITLE
fix(gateway): bound clock-rollback chain adjacency by max_gap_seconds

### DIFF
--- a/gateway/restart_loop_guard.py
+++ b/gateway/restart_loop_guard.py
@@ -110,8 +110,15 @@ def _chain_ending_at(boots: List[float], ts: float, gap: float) -> List[float]:
     prev = ts
     for t in sorted(boots, reverse=True):
         if t > ts:
-            # Clock moved backwards (NTP step, restored state file). Treat the
-            # future entry as adjacent rather than dropping the whole chain.
+            # Clock moved backwards (NTP step, restored state file). Treat a
+            # *recent* future entry as adjacent rather than dropping the whole
+            # chain — but bound it by ``gap`` like any other link. Without a
+            # bound here, an arbitrarily old entry (weeks back) chains in
+            # after one large backward step and trips the breaker on
+            # unrelated history, turning the documented fail-open contract
+            # into fail-closed.
+            if t - ts > gap:
+                break
             chain.append(t)
             continue
         if prev - t > gap:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1662,3 +1662,33 @@ class TestLifecycleGuardNeverRaises:
         if os.name != "nt":
             with pytest.raises(GatewayLifecycleBlocked):
                 check_gateway_lifecycle("clean prompt", "/dev/null")
+
+    def test_clock_rollback_does_not_chain_ancient_boots(self):
+        """A large backward clock step (NTP correction, restored RTC) must
+        not pull arbitrarily old boots into the chain: the future-entry
+        adjacency exemption is bounded by max_gap_seconds like every other
+        link. Unbounded, three-week-old restart-interrupted boots would
+        trip the breaker and wedge auto-resume (fail-closed) after one NTP
+        step — violating the module's fail-open contract."""
+        import gateway.restart_loop_guard as rlg
+
+        # Two boots from an episode weeks ago, then a big backward jump.
+        rlg.record_restart_interrupted_boot(60, now=1000.0)
+        rlg.record_restart_interrupted_boot(60, now=1010.0)
+        # now=500.0 — the clock stepped back ~500s; 1000/1010 are >gap away.
+        assert rlg.check_and_record(3, 60, now=500.0) is False
+        assert rlg.is_restart_loop_tripped(3, 60, now=501.0) is False
+
+    def test_clock_rollback_small_step_still_adjacent(self):
+        """A *small* backward step keeps the intended adjacency behavior:
+        a recent boot slightly in the 'future' stays in the chain."""
+        import gateway.restart_loop_guard as rlg
+
+        rlg.record_restart_interrupted_boot(60, now=1100.0)
+        rlg.record_restart_interrupted_boot(60, now=1150.0)
+        # Clock steps back 100s: boot at 1150 is now 50s "in the future",
+        # well within gap — chain intact, next boot trips normally.
+        assert rlg.record_restart_interrupted_boot(60, now=1050.0) == [
+            1100.0, 1150.0, 1050.0,
+        ]
+        assert rlg.is_restart_loop_tripped(3, 60, now=1060.0) is True


### PR DESCRIPTION
## Bug Description

`_chain_ending_at()` in `gateway/restart_loop_guard.py` admitted any boot timestamped **after** `ts` into the chain unconditionally — the "clock moved backwards" adjacency exemption had no magnitude limit:

```python
if t > ts:
    # Treat the future entry as adjacent...
    chain.append(t)
    continue   # skips the gap check entirely
```

After one large backward clock step (NTP correction, restored RTC, manual time change), arbitrarily old restart-interrupted boots chain in. With two boots from an episode weeks ago in `restart_loop.json`, a single backward step plus one new boot trips `len(boots) >= max_restarts(3)` → the auto-resume breaker fires on unrelated history and sessions stay resume-pending until the user manually messages.

This violates the module's own documented fail-open contract ("a broken breaker must never wedge a healthy gateway"): the misjudgment direction here is fail-closed.

## Repro (pre-fix, direct module call)

```python
_chain_ending_at([1000.0, 1010.0], ts=500.0, gap=300)
# → [1000.0, 1010.0]  — 3-week-old boots chained into "now"
```

## Fix

Bound the future-entry adjacency by `gap`, like every other link: an entry more than `max_gap_seconds` ahead of `ts` breaks the chain. Small backward steps (seconds) keep the intended adjacency behavior unchanged.

Added two regression tests:
1. Large rollback: ancient boots no longer trip the breaker.
2. Small rollback: recent future boots remain adjacent and the loop still trips normally.

Verified: `TestRestartLoopGuard` 9 passed; full file shows only one pre-existing environment failure (`croniter` missing locally), identical with and without the patch.