### PR TITLE
fix(feishu): preserve cron topic reply anchors

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2320,11 +2320,17 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     if deliver_value == "origin":
         if origin:
-            return {
+            target = {
                 "platform": origin["platform"],
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": _origin_delivery_thread(origin),
             }
+            if (
+                str(origin["platform"]).lower() == "feishu"
+                and origin.get("message_id")
+            ):
+                target["reply_to_message_id"] = str(origin["message_id"])
+            return target
         # Origin missing (e.g. job created via API/script) — try each
         # platform's home channel as a fallback instead of silently dropping.
         for platform_name in _iter_home_target_platforms():
@@ -2394,11 +2400,14 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                 "chat_id": chat_id,
                 "thread_id": _get_home_target_thread_id(platform_name),
             }
-        return {
+        target = {
             "platform": platform_name,
             "chat_id": str(origin["chat_id"]),
             "thread_id": origin.get("thread_id"),
         }
+        if platform_name.lower() == "feishu" and origin.get("message_id"):
+            target["reply_to_message_id"] = str(origin["message_id"])
+        return target
 
     if not _is_known_delivery_platform(platform_name):
         return None
@@ -2974,6 +2983,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+        reply_to_message_id = target.get("reply_to_message_id")
 
         # bot-chat targets don't ride a gateway adapter: the output becomes a
         # real inbound turn in the target profile's canonical Bot Chat via the
@@ -3250,7 +3260,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {"job_id": job["id"]}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
-                media_metadata = {"thread_id": thread_id} if thread_id else None
+                if reply_to_message_id:
+                    route_metadata["reply_to_message_id"] = str(
+                        reply_to_message_id
+                    )
+                media_metadata = {"thread_id": thread_id} if thread_id else {}
+                if reply_to_message_id:
+                    media_metadata["reply_to_message_id"] = str(
+                        reply_to_message_id
+                    )
+                media_metadata = media_metadata or None
 
             # Relay egress needs a tenant discriminator on the frame: the
             # connector's fail-closed guard resolves the workspace/guild from
@@ -3407,7 +3426,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                 target_errors.append(msg)
                                 adapter_ok = False  # fall through to standalone path
                             elif (
-                                send_raw_response
+                                isinstance(send_raw_response, dict)
                                 and thread_id
                                 and send_raw_response.get("thread_fallback")
                             ):
@@ -3566,7 +3585,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+                reply_to_message_id=reply_to_message_id,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -3595,7 +3622,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(
+                            asyncio.run,
+                            _send_to_platform(
+                                platform,
+                                pconfig,
+                                chat_id,
+                                cleaned_delivery_content,
+                                thread_id=thread_id,
+                                media_files=media_files,
+                                reply_to_message_id=reply_to_message_id,
+                            ),
+                        )
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1945,6 +1945,16 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
+    @staticmethod
+    def _thread_anchor_error(
+        reply_to: Optional[str], metadata: Optional[Dict[str, Any]]
+    ) -> Optional[str]:
+        thread_id = (metadata or {}).get("thread_id")
+        reply_anchor = reply_to or (metadata or {}).get("reply_to_message_id")
+        if thread_id and not reply_anchor:
+            return f"Feishu thread {thread_id} requires reply_to_message_id"
+        return None
+
     async def send(
         self,
         chat_id: str,
@@ -1955,6 +1965,9 @@ class FeishuAdapter(BasePlatformAdapter):
         """Send a Feishu message."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+        thread_error = self._thread_anchor_error(reply_to, metadata)
+        if thread_error:
+            return SendResult(success=False, error=thread_error)
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -2306,6 +2319,9 @@ class FeishuAdapter(BasePlatformAdapter):
         """Send a local image file to Feishu."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+        thread_error = self._thread_anchor_error(reply_to, metadata)
+        if thread_error:
+            return SendResult(success=False, error=thread_error)
         if not os.path.exists(image_path):
             return SendResult(success=False, error=f"Image file not found: {image_path}")
 
@@ -4705,6 +4721,9 @@ class FeishuAdapter(BasePlatformAdapter):
     ) -> SendResult:
         if not self._client:
             return SendResult(success=False, error="Not connected")
+        thread_error = self._thread_anchor_error(reply_to, metadata)
+        if thread_error:
+            return SendResult(success=False, error=thread_error)
         if not os.path.exists(file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
 
@@ -4755,62 +4774,10 @@ class FeishuAdapter(BasePlatformAdapter):
                     reply_to=reply_to,
                     metadata=metadata,
                 )
-                # Audio messages may fail with 99992402 when using thread_id routing.
-                # Try replying to the last message in the thread, then fall back to chat_id.
-                if (not self._response_succeeded(message_response)
-                        and getattr(message_response, "code", None) == 99992402
-                        and resolved_message_type == "audio"
-                        and (metadata or {}).get("thread_id")):
-                    # Try reply API with thread_id as reply anchor
-                    thread_msg_id = (metadata or {}).get("reply_to_message_id")
-                    if not thread_msg_id:
-                        thread_msg_id = await self._fetch_last_message_in_thread(
-                            (metadata or {}).get("thread_id")
-                        )
-                    if thread_msg_id:
-                        logger.info("[Feishu] Audio: retrying via reply API in thread")
-                        message_response = await self._feishu_send_with_retry(
-                            chat_id=chat_id,
-                            msg_type=resolved_message_type,
-                            payload=json.dumps({"file_key": file_key}, ensure_ascii=False),
-                            reply_to=thread_msg_id,
-                            metadata=metadata,
-                        )
-                    if not self._response_succeeded(message_response):
-                        logger.warning("[Feishu] Audio send failed in thread, retrying with chat_id")
-                        message_response = await self._feishu_send_with_retry(
-                            chat_id=chat_id,
-                            msg_type=resolved_message_type,
-                            payload=json.dumps({"file_key": file_key}, ensure_ascii=False),
-                            reply_to=None,
-                            metadata=None,
-                        )
             return self._finalize_send_result(message_response, "file send failed")
         except Exception as exc:
             logger.error("[Feishu] Failed to send file %s: %s", file_path, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
-
-    async def _fetch_last_message_in_thread(self, thread_id: str) -> Optional[str]:
-        """Fetch the last message_id in a thread for reply-based routing."""
-        if not self._client or not thread_id:
-            return None
-        try:
-            from lark_oapi.api.im.v1 import ListMessageRequest
-            request = (
-                ListMessageRequest.builder()
-                .container_id_type("thread")
-                .container_id(thread_id)
-                .page_size(1)
-                .build()
-            )
-            response = await asyncio.to_thread(self._client.im.v1.message.list, request)
-            if response and getattr(response, "success", lambda: False)():
-                items = getattr(getattr(response, "data", None), "items", None)
-                if items and len(items) > 0:
-                    return getattr(items[0], "message_id", None)
-        except Exception as exc:
-            logger.debug("[Feishu] Failed to fetch last message in thread %s: %s", thread_id, exc)
-        return None
 
     async def _send_raw_message(
         self,
@@ -4821,6 +4788,10 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
+        thread_error = self._thread_anchor_error(reply_to, metadata)
+        if thread_error:
+            raise ValueError(thread_error)
+
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
@@ -4835,34 +4806,21 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await self._run_blocking(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
-        _thread_id = (metadata or {}).get("thread_id")
-        if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+        )
+        request = self._build_create_message_request(receive_id_type, body)
         return await self._run_blocking(self._client.im.v1.message.create, request)
 
     @staticmethod
@@ -5616,6 +5574,7 @@ async def _standalone_send(
     message,
     *,
     thread_id=None,
+    reply_to_message_id=None,
     media_files=None,
     force_document=False,
 ):
@@ -5635,7 +5594,12 @@ async def _standalone_send(
         domain_name = getattr(adapter, "_domain_name", "feishu")
         domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
         adapter._client = adapter._build_lark_client(domain)
-        metadata = {"thread_id": thread_id} if thread_id else None
+        metadata = {}
+        if thread_id:
+            metadata["thread_id"] = thread_id
+        if reply_to_message_id:
+            metadata["reply_to_message_id"] = reply_to_message_id
+        metadata = metadata or None
 
         last_result = None
         if message.strip():

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -196,6 +196,24 @@ class TestResolveDeliveryTarget:
             "thread_id": "17585",
         }
 
+    def test_feishu_origin_delivery_preserves_reply_anchor(self):
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "feishu",
+                "chat_id": "oc_chat",
+                "thread_id": "omt_topic",
+                "message_id": "om_trigger",
+            },
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "feishu",
+            "chat_id": "oc_chat",
+            "thread_id": "omt_topic",
+            "reply_to_message_id": "om_trigger",
+        }
+
 
     def test_bare_platform_delivery_uses_home_root_instead_of_origin_thread(self, monkeypatch):
         monkeypatch.setenv("DISCORD_HOME_CHANNEL", "home-parent")
@@ -375,6 +393,116 @@ class TestDeliverResultWrapping:
         assert "-------------" in sent_content
         assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content
+
+    def test_feishu_standalone_delivery_forwards_reply_anchor(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.FEISHU: pconfig}
+        job = {
+            "id": "feishu-topic-job",
+            "deliver": "origin",
+            "origin": {
+                "platform": "feishu",
+                "chat_id": "oc_chat",
+                "thread_id": "omt_topic",
+                "message_id": "om_trigger",
+            },
+        }
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=mock_cfg),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+            patch(
+                "tools.send_message_tool._send_to_platform",
+                new=AsyncMock(return_value={"success": True}),
+            ) as send_mock,
+        ):
+            result = _deliver_result(job, "hello")
+
+        assert result is None
+        send_mock.assert_awaited_once()
+        assert send_mock.call_args.kwargs["thread_id"] == "omt_topic"
+        assert send_mock.call_args.kwargs["reply_to_message_id"] == "om_trigger"
+
+    def test_feishu_live_text_and_media_use_anchor_without_sdk_dict_access(
+        self, tmp_path, monkeypatch,
+    ):
+        from concurrent.futures import Future
+        from types import SimpleNamespace
+
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "report.pdf")
+        adapter = AsyncMock()
+        adapter.send.return_value = SendResult(
+            success=True,
+            message_id="om_delivery",
+            raw_response=SimpleNamespace(code=0),
+        )
+        adapter.send_document.return_value = SendResult(
+            success=True,
+            message_id="om_media",
+            raw_response=SimpleNamespace(code=0),
+        )
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.FEISHU: pconfig}
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        job = {
+            "id": "feishu-live-topic-job",
+            "deliver": "origin",
+            "origin": {
+                "platform": "feishu",
+                "chat_id": "oc_chat",
+                "thread_id": "omt_topic",
+                "message_id": "om_trigger",
+            },
+        }
+
+        def fake_run_coro(coro, _loop):
+            import asyncio as _asyncio
+
+            future = Future()
+            try:
+                future.set_result(_asyncio.run(coro))
+            except BaseException as exc:  # noqa: BLE001
+                future.set_exception(exc)
+            return future
+
+        standalone_send = AsyncMock(return_value={"success": True})
+        with (
+            patch("gateway.config.load_gateway_config", return_value=mock_cfg),
+            patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro),
+            patch("tools.send_message_tool._send_to_platform", new=standalone_send),
+        ):
+            result = _deliver_result(
+                job,
+                f"status update\nMEDIA:{media_path}",
+                adapters={Platform.FEISHU: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        standalone_send.assert_not_awaited()
+        adapter.send.assert_awaited_once()
+        assert adapter.send.await_args.kwargs["metadata"] == {
+            "job_id": "feishu-live-topic-job",
+            "thread_id": "omt_topic",
+            "reply_to_message_id": "om_trigger",
+        }
+        adapter.send_document.assert_awaited_once()
+        assert adapter.send_document.await_args.kwargs["metadata"] == {
+            "thread_id": "omt_topic",
+            "reply_to_message_id": "om_trigger",
+        }
 
 
     def test_relay_fronted_home_uses_relay_config_and_live_adapter(self, monkeypatch, tmp_path):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1246,6 +1246,223 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_explicit_reply_anchor_precedes_metadata_anchor_in_thread(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _MessageAPI:
+            def reply(self, request):
+                calls.append(("reply", request))
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+            def create(self, request):
+                calls.append(("create", request))
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="thread reply",
+                    reply_to="om_explicit",
+                    metadata={
+                        "thread_id": "omt_topic",
+                        "reply_to_message_id": "om_metadata",
+                    },
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual([kind for kind, _request in calls], ["reply"])
+        request = calls[0][1]
+        self.assertEqual(request.message_id, "om_explicit")
+        self.assertTrue(request.request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_thread_without_reply_anchor_fails_closed_without_message_api_calls(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _MessageAPI:
+            def list(self, request):
+                calls.append("list")
+                return SimpleNamespace(success=lambda: False)
+
+            def reply(self, request):
+                calls.append("reply")
+                return SimpleNamespace(success=lambda: True)
+
+            def create(self, request):
+                calls.append("create")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_wrong_lane"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="thread reply",
+                    metadata={"thread_id": "omt_topic"},
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("requires reply_to_message_id", result.error)
+        self.assertEqual(calls, [])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_anchorless_thread_media_fails_without_message_calls(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _FileAPI:
+            def create(self, request):
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_key"),
+                )
+
+        class _MessageAPI:
+            def list(self, request):
+                calls.append("message.list")
+                return SimpleNamespace(success=lambda: False)
+
+            def reply(self, request):
+                calls.append("message.reply")
+                return SimpleNamespace(success=lambda: True)
+
+            def create(self, request):
+                calls.append("message.create")
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(file=_FileAPI(), message=_MessageAPI())
+            )
+        )
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".ogg") as temp_file:
+            result = asyncio.run(
+                adapter.send_voice(
+                    chat_id="oc_chat",
+                    audio_path=temp_file.name,
+                    metadata={"thread_id": "omt_topic"},
+                )
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("requires reply_to_message_id", result.error)
+        self.assertEqual(calls, [])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_non_thread_create_routing_remains_unchanged(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        requests = []
+
+        class _MessageAPI:
+            def create(self, request):
+                requests.append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_created"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        cases = (
+            ("oc_chat", "chat_id", "oc_chat"),
+            ("feishu_user_id:u_123", "user_id", "u_123"),
+            ("ou_123", "open_id", "ou_123"),
+        )
+        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+            for chat_id, expected_type, expected_id in cases:
+                with self.subTest(chat_id=chat_id):
+                    requests.clear()
+                    result = asyncio.run(adapter.send(chat_id, "ordinary message"))
+                    self.assertTrue(result.success)
+                    self.assertEqual(len(requests), 1)
+                    self.assertEqual(requests[0].receive_id_type, expected_type)
+                    self.assertEqual(requests[0].request_body.receive_id, expected_id)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_standalone_text_and_media_preserve_cron_topic_anchor(self):
+        from plugins.platforms.feishu import adapter as feishu_module
+
+        adapter = Mock()
+        adapter._domain_name = "feishu"
+        adapter._build_lark_client.return_value = Mock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="om_text")
+        )
+        adapter.send_document = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="om_media")
+        )
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".pdf") as temp_file:
+            with (
+                patch.object(feishu_module, "_load_lark_oapi", return_value=True),
+                patch.object(feishu_module, "FeishuAdapter", return_value=adapter),
+            ):
+                result = asyncio.run(
+                    feishu_module._standalone_send(
+                        Mock(),
+                        "oc_chat",
+                        "scheduled report",
+                        thread_id="omt_topic",
+                        reply_to_message_id="om_trigger",
+                        media_files=[(temp_file.name, False)],
+                    )
+                )
+
+        expected_metadata = {
+            "thread_id": "omt_topic",
+            "reply_to_message_id": "om_trigger",
+        }
+        self.assertTrue(result["success"])
+        adapter.send.assert_awaited_once_with(
+            "oc_chat", "scheduled report", metadata=expected_metadata,
+        )
+        adapter.send_document.assert_awaited_once_with(
+            "oc_chat", temp_file.name, metadata=expected_metadata,
+        )
+
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_every_chunk_of_multi_chunk_markdown(self):
@@ -2465,5 +2682,4 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
 

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -491,6 +491,53 @@ class TestLocalDeliveryNotice:
         assert "local-only cron job" not in created["message"]
 
 
+class TestOriginFromEnv:
+    def test_feishu_origin_captures_triggering_message_anchor(self):
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.cronjob_tools import _origin_from_env
+
+        tokens = set_session_vars(
+            platform="feishu",
+            chat_id="oc_chat",
+            thread_id="omt_topic",
+            message_id="om_trigger",
+        )
+        try:
+            assert _origin_from_env() == {
+                "platform": "feishu",
+                "chat_id": "oc_chat",
+                "chat_name": None,
+                "thread_id": "omt_topic",
+                "user_id": None,
+                "scope_id": None,
+                "message_id": "om_trigger",
+            }
+        finally:
+            clear_session_vars(tokens)
+
+    def test_non_feishu_origin_shape_is_unchanged(self):
+        from gateway.session_context import clear_session_vars, set_session_vars
+        from tools.cronjob_tools import _origin_from_env
+
+        tokens = set_session_vars(
+            platform="telegram",
+            chat_id="-1001",
+            thread_id="42",
+            message_id="999",
+        )
+        try:
+            assert _origin_from_env() == {
+                "platform": "telegram",
+                "chat_id": "-1001",
+                "chat_name": None,
+                "thread_id": "42",
+                "user_id": None,
+                "scope_id": None,
+            }
+        finally:
+            clear_session_vars(tokens)
+
+
 class TestValidateCronBaseUrl:
     """The cron base_url guard must not let a NAMED custom provider's stored
     credential be sent to an off-host endpoint (CWE-200/CWE-522)."""

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -717,6 +717,67 @@ class TestSendToPlatformWhatsapp:
         assert _call.args[2] == "hello from hermes"
 
 
+class TestSendToPlatformFeishuCronAnchor:
+    @pytest.mark.parametrize(
+        ("message", "media_files"),
+        [
+            ("scheduled text", []),
+            ("scheduled report", [("/tmp/report.pdf", False)]),
+        ],
+    )
+    def test_feishu_text_and_media_propagate_keyword_only_reply_anchor(
+        self, message, media_files,
+    ):
+        import inspect
+
+        from gateway.platform_registry import platform_registry
+        from hermes_cli.plugins import discover_plugins
+        from tools.send_message_tool import _registry_standalone_send
+
+        discover_plugins()
+        entry = platform_registry.get("feishu")
+        original_sender = entry.standalone_sender_fn
+        sender = AsyncMock(
+            return_value={
+                "success": True,
+                "platform": "feishu",
+                "message_id": "om_delivery",
+            }
+        )
+        entry.standalone_sender_fn = sender
+        try:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    SimpleNamespace(enabled=True, token=None, extra={}),
+                    "oc_chat",
+                    message,
+                    thread_id="omt_topic",
+                    media_files=media_files,
+                    reply_to_message_id="om_trigger",
+                )
+            )
+        finally:
+            entry.standalone_sender_fn = original_sender
+
+        assert result["success"] is True
+        sender.assert_awaited_once()
+        assert sender.await_args.kwargs["thread_id"] == "omt_topic"
+        assert sender.await_args.kwargs["reply_to_message_id"] == "om_trigger"
+        assert (
+            inspect.signature(_send_to_platform)
+            .parameters["reply_to_message_id"]
+            .kind
+            is inspect.Parameter.KEYWORD_ONLY
+        )
+        assert (
+            inspect.signature(_registry_standalone_send)
+            .parameters["reply_to_message_id"]
+            .kind
+            is inspect.Parameter.KEYWORD_ONLY
+        )
+
+
 class TestSendTelegramHtmlDetection:
     """Verify that messages containing HTML tags are sent with parse_mode=HTML
     and that plain / markdown messages use MarkdownV2."""

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -341,7 +341,7 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
                 "Cron origin captured thread_id=%s for %s:%s",
                 thread_id, origin_platform, origin_chat_id,
             )
-        return {
+        origin = {
             "platform": origin_platform,
             "chat_id": origin_chat_id,
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
@@ -363,6 +363,13 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             # snapshots; None for platforms without scope.
             "scope_id": get_session_env("HERMES_SESSION_SCOPE_ID") or None,
         }
+        if origin_platform.lower() == "feishu":
+            # Feishu topic delivery requires replying to an om_* message;
+            # omt_* is routing context, not a valid create-message recipient.
+            origin["message_id"] = (
+                get_session_env("HERMES_SESSION_MESSAGE_ID") or None
+            )
+        return origin
     return None
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -922,7 +922,18 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    args=None,
+    *,
+    reply_to_message_id=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1123,6 +1134,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chunk,
                 media_files=media_files if is_last else None,
                 thread_id=thread_id,
+                reply_to_message_id=reply_to_message_id,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -1275,7 +1287,14 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _registry_standalone_send("dingtalk", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.FEISHU:
-            result = await _registry_standalone_send("feishu", pconfig, chat_id, chunk, thread_id)
+            result = await _registry_standalone_send(
+                "feishu",
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id,
+                reply_to_message_id=reply_to_message_id,
+            )
         elif platform == Platform.WECOM:
             result = await _registry_standalone_send("wecom", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.BLUEBUBBLES:
@@ -1655,7 +1674,15 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 # (plugins/platforms/slack/adapter.py), wired via standalone_sender_fn. #41112.
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(
+    platform_name,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    *,
+    reply_to_message_id=None,
+):
     """Dispatch a one-shot send through a migrated platform plugin's
     standalone_sender_fn (registry hook).  Used for platforms whose adapter
     moved out of gateway/platforms/ into plugins/platforms/<name>/ (#41112):
@@ -1668,7 +1695,10 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
     entry = platform_registry.get(platform_name)
     if entry is None or entry.standalone_sender_fn is None:
         return {"error": f"{platform_name} plugin not registered or missing standalone_sender_fn"}
-    return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
+    kwargs = {"thread_id": thread_id}
+    if reply_to_message_id is not None:
+        kwargs["reply_to_message_id"] = reply_to_message_id
+    return await entry.standalone_sender_fn(pconfig, chat_id, message, **kwargs)
 
 
 # _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,


### PR DESCRIPTION
## Summary

Feishu topic delivery requires `message.reply(message_id, reply_in_thread=true)`. A topic ID (`omt_*`) is routing context, not a valid `message.create` recipient.

This patch fixes delayed Cron origin delivery end to end:

- persist the triggering Feishu `om_*` message anchor when a Cron job is created;
- propagate that anchor through target resolution, live adapter delivery, standalone text delivery, and standalone media delivery;
- use the reply API with `reply_in_thread=true`;
- fail closed when a topic has no message anchor, instead of using the unsupported `receive_id_type="thread_id"` or silently falling back to the parent chat;
- stop treating Feishu SDK response objects as dictionaries in the thread-fallback check.

## Why this PR

This is the safety-complete combination of two existing directions:

- #65520 carries the Cron reply anchor end to end, but permits parent-chat fallback when the anchor is unavailable.
- #61383 applies fail-closed topic delivery, but does not cover Cron origin persistence and standalone delivery.

This PR applies both requirements on current `main`, without adding configuration, dependencies, permissions, or migrations.

## Root cause

`HERMES_SESSION_MESSAGE_ID` was available when the Cron job was created but was not persisted in the Feishu origin. By delivery time, Hermes retained only the `omt_*` thread ID and attempted an unsupported create/list routing path, producing Feishu error `99992402` or risking delivery outside the originating topic.

## Verification

Regression proof before source changes:

- `TestOriginFromEnv`: **1 failed, 1 passed** because the Feishu origin omitted `message_id="om_trigger"`.

After the patch, rebased onto current `main`:

```text
HOME=/root scripts/run_tests.sh \
  tests/tools/test_cronjob_tools.py \
  tests/cron/test_scheduler.py \
  tests/tools/test_send_message_tool.py \
  tests/gateway/test_feishu.py

4 files, 307 tests passed, 0 failed
```

`git diff --check` also passes.

Focused coverage includes:

- Feishu-only origin anchor capture, with non-Feishu origin shape unchanged;
- live and standalone text/media anchor propagation;
- explicit `reply_to` precedence;
- `reply_in_thread=true` routing;
- anchorless topic fail-closed behavior with no reply/create API call;
- unchanged non-topic `chat_id`, `user_id`, and `open_id` create routing.

## Risk and scope

- No user-facing configuration or schema change.
- No new dependency or Feishu permission.
- No live Feishu message was sent during verification; tests are isolated and mock-backed.
- Intentional behavior change: an anchorless topic delivery now returns an explicit failure instead of failing with `99992402` or appearing in the parent chat.

Fixes #78975
