### PR TITLE
fix(plugins): make system prompt section budgets configurable and surface over-budget drops

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -59,7 +59,11 @@ from utils import is_truthy_value
 logger = logging.getLogger(__name__)
 _PLUGIN_SECTION_FRAME_RE = re.compile(
     r"^## Plugin Context: (?P<id>[a-z0-9][a-z0-9._-]{0,127})\n"
-    r"<!-- hermes-plugin-section-chars:(?P<chars>[0-9]{1,4}) -->\n\n",
+    # Up to 9 digits: sections may legitimately exceed 9,999 chars when
+    # plugins.system_prompt_section_max_chars is raised in config.yaml
+    # (#92774). Forged/malformed frames are still rejected by the canonical
+    # re-render equality check in _restore_plugin_prompt_sections.
+    r"<!-- hermes-plugin-section-chars:(?P<chars>[0-9]{1,9}) -->\n\n",
     re.MULTILINE,
 )
 
@@ -222,6 +226,7 @@ def _restore_plugin_prompt_sections(prompt: str) -> tuple:
         PLUGIN_SECTIONS_START,
         RenderedPluginSystemPromptSection,
         format_system_prompt_sections,
+        system_prompt_section_max_chars,
     )
 
     start = prompt.rfind(PLUGIN_SECTIONS_START)
@@ -235,10 +240,16 @@ def _restore_plugin_prompt_sections(prompt: str) -> tuple:
         return ()
     framed = prompt[start:after_end]
 
+    # Honor a raised plugins.system_prompt_section_max_chars: sections that
+    # were legitimately persisted under a larger configured cap must survive
+    # resume. Never restore below the built-in default so lowering the config
+    # afterwards cannot invalidate default-sized persisted prompts.
+    restore_cap = max(MAX_SYSTEM_PROMPT_SECTION_CHARS, system_prompt_section_max_chars())
+
     restored = []
     for match in _PLUGIN_SECTION_FRAME_RE.finditer(framed):
         content_len = int(match.group("chars"))
-        if content_len > MAX_SYSTEM_PROMPT_SECTION_CHARS:
+        if content_len > restore_cap:
             continue
         content_start = match.end()
         content = framed[content_start : content_start + content_len]

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1148,6 +1148,21 @@ platform_toolsets:
   google_chat: [hermes-google_chat]
 
 # =============================================================================
+# Plugin Settings
+# =============================================================================
+# Budgets for plugin system prompt sections (register_system_prompt_section).
+# Sections become always-on prompt bytes charged on every turn of every
+# session, so the defaults are deliberately small. Raise them only for
+# trusted plugins that legitimately pin large always-on context (e.g.
+# user-curated reference files). Over-budget sections are skipped with a
+# warning and reported by /plugins.
+#
+# plugins:
+#   system_prompt_section_max_chars: 4000    # per-section cap
+#   system_prompt_section_total_chars: 8000  # all sections + headings combined
+#   system_prompt_section_max_sections: 32   # section count budget
+
+# =============================================================================
 # Gateway Platform Settings
 # =============================================================================
 # Optional per-platform messaging settings.

--- a/cli.py
+++ b/cli.py
@@ -12249,6 +12249,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         detail = f" ({', '.join(bits)})" if bits else ""
                         label = "" if state == "enabled" else f" [{state}]"
                         error = f" — {info['error']}" if info.get("error") else ""
+                        dropped = info.get("prompt_sections_dropped") or 0
+                        if dropped:
+                            error += (
+                                f" — ⚠ {dropped} prompt section(s) dropped over budget"
+                                " (see plugins.system_prompt_section_* in config.yaml)"
+                            )
                         print(f"  {glyph} {name}{ver}{label}{detail}{error}")
                     if bundled_count:
                         print(f"  (+{bundled_count} bundled — see: hermes plugins list)")

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -497,11 +497,60 @@ def _classify_entrypoint_value_kind(value: str) -> str:
 
 # System-prompt sections are deliberately more constrained than lifecycle
 # hooks. They become high-trust prompt bytes and are charged on every turn.
+# The constants below are the built-in defaults; users who install plugins
+# that legitimately pin large always-on context (#92774) can raise them in
+# config.yaml (mirroring memory.memory_char_limit / memory.user_char_limit):
+#
+#   plugins:
+#     system_prompt_section_max_chars: 16000
+#     system_prompt_section_total_chars: 65536
+#     system_prompt_section_max_sections: 32
 SYSTEM_PROMPT_SECTION_POSITIONS = frozenset({"after_memory"})
 DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS = 4_000
 MAX_SYSTEM_PROMPT_SECTION_CHARS = 4_000
 MAX_SYSTEM_PROMPT_SECTIONS = 32
 MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS = 8_000
+
+
+def _configured_section_limit(key: str, default: int) -> int:
+    """Resolve one ``plugins.<key>`` system-prompt-section limit from config.
+
+    Follows the ``memory.memory_char_limit`` precedent: read the raw user
+    config, accept any positive integer, and fall back to the built-in
+    default on a missing/invalid value. Never raises — a malformed config
+    value must not break plugin loading or prompt construction.
+    """
+    try:
+        raw = cfg_get(load_config_readonly(), "plugins", key, default=None)
+        if raw is None or isinstance(raw, bool):
+            return default
+        value = int(raw)
+        return value if value >= 1 else default
+    except Exception:
+        return default
+
+
+def system_prompt_section_max_chars() -> int:
+    """Effective per-section character cap (config-overridable)."""
+    return _configured_section_limit(
+        "system_prompt_section_max_chars", MAX_SYSTEM_PROMPT_SECTION_CHARS
+    )
+
+
+def system_prompt_section_total_chars() -> int:
+    """Effective aggregate character budget for all sections (config-overridable)."""
+    return _configured_section_limit(
+        "system_prompt_section_total_chars", MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS
+    )
+
+
+def system_prompt_section_max_sections() -> int:
+    """Effective section-count budget (config-overridable)."""
+    return _configured_section_limit(
+        "system_prompt_section_max_sections", MAX_SYSTEM_PROMPT_SECTIONS
+    )
+
+
 _SYSTEM_PROMPT_SECTION_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
 _SYSTEM_PROMPT_SECTION_HEADING_PREFIX = "## Plugin Context: "
 PLUGIN_SECTIONS_START = "<!-- hermes-plugin-sections:start -->"
@@ -3158,13 +3207,17 @@ class PluginContext:
         content: Union[str, Callable[[Mapping[str, Any]], str]],
         *,
         position: str = "after_memory",
-        max_chars: int = DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS,
+        max_chars: Optional[int] = None,
     ) -> PluginRegistration:
         """Register bounded context that is frozen into each new session prompt.
 
         Callables receive a read-only session-info mapping. The rendered full
         system prompt is already persisted by core and restored verbatim, so no
         parallel plugin-section state is needed for process restarts.
+
+        ``max_chars`` defaults to the effective per-section cap —
+        ``plugins.system_prompt_section_max_chars`` in config.yaml, or
+        4,000 characters when unset.
         """
         if not is_valid_system_prompt_section_id(id):
             raise ValueError(
@@ -3178,14 +3231,18 @@ class PluginContext:
                 "system prompt section position must be one of: "
                 + ", ".join(sorted(SYSTEM_PROMPT_SECTION_POSITIONS))
             )
+        section_cap = system_prompt_section_max_chars()
+        if max_chars is None:
+            max_chars = min(DEFAULT_SYSTEM_PROMPT_SECTION_MAX_CHARS, section_cap)
         if (
             isinstance(max_chars, bool)
             or not isinstance(max_chars, int)
-            or not 0 < max_chars <= MAX_SYSTEM_PROMPT_SECTION_CHARS
+            or not 0 < max_chars <= section_cap
         ):
             raise ValueError(
                 "system prompt section max_chars must be between 1 and "
-                f"{MAX_SYSTEM_PROMPT_SECTION_CHARS}"
+                f"{section_cap} (raise plugins.system_prompt_section_max_chars "
+                "in config.yaml for larger sections)"
             )
         existing = self._manager._system_prompt_sections.get(id)
         if existing is not None:
@@ -3425,6 +3482,9 @@ class PluginManager:
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
         self._system_prompt_sections: Dict[str, PluginSystemPromptSection] = {}
+        # Sections dropped by the most recent render, for user-visible
+        # surfacing (``hermes plugins`` / startup) instead of log-only skips.
+        self._dropped_prompt_sections: List[Dict[str, str]] = []
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
         self._gateway_message_injector: tuple[object, Callable] | None = None
@@ -5468,15 +5528,19 @@ class PluginManager:
         """Render all registered sections deterministically and fail open."""
         frozen_info = types.MappingProxyType(dict(session_info))
         rendered: List[RenderedPluginSystemPromptSection] = []
+        self._dropped_prompt_sections = []
+        max_sections = system_prompt_section_max_sections()
+        total_budget = system_prompt_section_total_chars()
         total_chars = len(PLUGIN_SECTIONS_START) + len(PLUGIN_SECTIONS_END) + 2
         for section_id in sorted(self._system_prompt_sections):
             section = self._system_prompt_sections[section_id]
-            if len(rendered) >= MAX_SYSTEM_PROMPT_SECTIONS:
-                logger.warning(
-                    "Plugin system prompt section %s exceeded the section-count "
-                    "budget (%d) and was skipped",
-                    section.id,
-                    MAX_SYSTEM_PROMPT_SECTIONS,
+            if len(rendered) >= max_sections:
+                self._record_dropped_prompt_section(
+                    section,
+                    "Plugin system prompt section %s (%s) exceeded the "
+                    "section-count budget (%d) and was skipped — raise "
+                    "plugins.system_prompt_section_max_sections in config.yaml"
+                    % (section.id, section.plugin, max_sections),
                 )
                 continue
             try:
@@ -5513,25 +5577,23 @@ class PluginManager:
                 )
                 continue
             if len(text) > section.max_chars:
-                logger.warning(
+                self._record_dropped_prompt_section(
+                    section,
                     "Plugin system prompt section %s (%s) exceeded max_chars "
-                    "(%d > %d) and was skipped",
-                    section.id,
-                    section.plugin,
-                    len(text),
-                    section.max_chars,
+                    "(%d > %d) and was skipped"
+                    % (section.id, section.plugin, len(text), section.max_chars),
                 )
                 continue
             rendered_chars = len(format_system_prompt_section(section.id, text))
             if rendered:
                 rendered_chars += 2  # canonical ``\n\n`` separator
-            if total_chars + rendered_chars > MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS:
-                logger.warning(
+            if total_chars + rendered_chars > total_budget:
+                self._record_dropped_prompt_section(
+                    section,
                     "Plugin system prompt section %s (%s) exceeded the aggregate "
-                    "session budget (%d chars) and was skipped",
-                    section.id,
-                    section.plugin,
-                    MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS,
+                    "session budget (%d chars) and was skipped — raise "
+                    "plugins.system_prompt_section_total_chars in config.yaml"
+                    % (section.id, section.plugin, total_budget),
                 )
                 continue
             rendered.append(
@@ -5551,6 +5613,30 @@ class PluginManager:
                 len(text),
             )
         return rendered
+
+    def _record_dropped_prompt_section(
+        self, section: PluginSystemPromptSection, message: str
+    ) -> None:
+        """Log a skipped section AND keep it queryable for user-visible surfacing.
+
+        Silent truncation of high-trust prompt bytes is indistinguishable from
+        a broken plugin (#92774), so every budget/size skip is retained on the
+        manager for ``dropped_prompt_section_reports()`` consumers in addition
+        to the log warning.
+        """
+        logger.warning("%s", message)
+        self._dropped_prompt_sections.append(
+            {"id": section.id, "plugin": section.plugin, "reason": message}
+        )
+
+    def dropped_prompt_section_reports(self) -> List[Dict[str, str]]:
+        """Return sections dropped by the most recent prompt-section render.
+
+        Each entry has ``id``, ``plugin``, and a human-readable ``reason``
+        (including which config.yaml knob would prevent the drop). Empty when
+        the last render kept every registered section.
+        """
+        return list(self._dropped_prompt_sections)
 
     def has_middleware(self, kind: str) -> bool:
         """Return True when at least one callback is registered for middleware."""
@@ -5601,12 +5687,17 @@ class PluginManager:
 
     def list_plugins(self) -> List[Dict[str, Any]]:
         """Return a list of info dicts for all discovered plugins."""
+        drops_by_plugin: Dict[str, int] = {}
+        for report in self._dropped_prompt_sections:
+            plugin_id = report.get("plugin", "")
+            drops_by_plugin[plugin_id] = drops_by_plugin.get(plugin_id, 0) + 1
         result: List[Dict[str, Any]] = []
         for key, loaded in sorted(self._plugins.items()):
+            plugin_key = loaded.manifest.key or loaded.manifest.name
             result.append(
                 {
                     "name": loaded.manifest.name,
-                    "key": loaded.manifest.key or loaded.manifest.name,
+                    "key": plugin_key,
                     "kind": loaded.manifest.kind,
                     "version": loaded.manifest.version,
                     "description": loaded.manifest.description,
@@ -5617,6 +5708,10 @@ class PluginManager:
                     "middleware": len(loaded.middleware_registered),
                     "commands": len(loaded.commands_registered),
                     "error": loaded.error,
+                    "prompt_sections_dropped": (
+                        drops_by_plugin.get(plugin_key, 0)
+                        or drops_by_plugin.get(loaded.manifest.name, 0)
+                    ),
                 }
             )
         return result

--- a/tests/agent/test_plugin_prompt_sections.py
+++ b/tests/agent/test_plugin_prompt_sections.py
@@ -182,3 +182,51 @@ def test_fresh_process_resume_restores_identical_full_prompt_without_callback(tm
     assert b"CHANGED" not in resumed_prompt
     assert outputs[0]["calls"] == outputs[1]["calls"] == 1
     assert outputs[1]["rebuilt_equal"] is True
+
+
+def test_restore_honors_raised_configured_section_cap():
+    """#92774: sections persisted under a raised cap must survive resume."""
+    from pathlib import Path
+
+    from agent.system_prompt import _restore_plugin_prompt_sections
+    from hermes_cli.plugins import (
+        RenderedPluginSystemPromptSection,
+        format_system_prompt_sections,
+    )
+
+    big = RenderedPluginSystemPromptSection(
+        id="example.pinned",
+        content="R" * 43_000,
+        position="after_memory",
+        plugin="persisted-prompt",
+    )
+    framed = format_system_prompt_sections([big])
+    prompt = f"System.\n\n{framed}\n\nConversation started: now"
+
+    # Default caps: an oversized persisted frame is rejected wholesale.
+    assert _restore_plugin_prompt_sections(prompt) == ()
+
+    # With the config knob raised, the same persisted bytes restore intact.
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "plugins:\n  system_prompt_section_max_chars: 65536\n"
+    )
+    restored = _restore_plugin_prompt_sections(prompt)
+    assert [item.id for item in restored] == ["example.pinned"]
+    assert restored[0].content == big.content
+
+    # Lowering the config below the built-in default never rejects
+    # default-sized frames.
+    small = RenderedPluginSystemPromptSection(
+        id="example.small",
+        content="s" * 3_000,
+        position="after_memory",
+        plugin="persisted-prompt",
+    )
+    framed_small = format_system_prompt_sections([small])
+    prompt_small = f"System.\n\n{framed_small}\n\nConversation started: now"
+    (home / "config.yaml").write_text(
+        "plugins:\n  system_prompt_section_max_chars: 100\n"
+    )
+    restored_small = _restore_plugin_prompt_sections(prompt_small)
+    assert [item.id for item in restored_small] == ["example.small"]

--- a/tests/hermes_cli/test_plugin_prompt_sections.py
+++ b/tests/hermes_cli/test_plugin_prompt_sections.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+from pathlib import Path
 from types import MappingProxyType
 
 import pytest
@@ -18,6 +20,14 @@ def _context(manager: PluginManager, name: str = "example-plugin") -> PluginCont
         PluginManifest(name=name, key=name, source="user"),
         manager,
     )
+
+
+def _write_section_limits_config(**limits: int) -> None:
+    """Write plugins.* section limits into this test's isolated HERMES_HOME."""
+    home = Path(os.environ["HERMES_HOME"])
+    lines = ["plugins:"]
+    lines += [f"  {key}: {value}" for key, value in limits.items()]
+    (home / "config.yaml").write_text("\n".join(lines) + "\n")
 
 
 def test_registration_validates_stable_id_position_budget_and_duplicates():
@@ -88,3 +98,113 @@ def test_render_fails_open_for_callback_failure_wrong_type_and_aggregate_budget(
     assert "plugin exploded" in caplog.text
     assert "returned dict, not str" in caplog.text
     assert "aggregate" in caplog.text
+
+
+def test_configured_limits_allow_large_sections_and_aggregate(caplog):
+    """#92774: config.yaml plugins.* knobs raise the hard-coded caps."""
+    _write_section_limits_config(
+        system_prompt_section_max_chars=65536,
+        system_prompt_section_total_chars=131072,
+    )
+    manager = PluginManager()
+    ctx = _context(manager)
+
+    big = "R" * 43_000  # the reporter's pinned-files scale
+    ctx.register_system_prompt_section("example.pinned", big, max_chars=len(big))
+    chunk = "x" * 3_900
+    for i in range(3):
+        ctx.register_system_prompt_section(f"example.ref-{i}", chunk)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+        rendered = manager.render_system_prompt_sections({})
+
+    assert [item.id for item in rendered] == [
+        "example.pinned",
+        "example.ref-0",
+        "example.ref-1",
+        "example.ref-2",
+    ]
+    assert "skipped" not in caplog.text
+    assert manager.dropped_prompt_section_reports() == []
+
+
+def test_configured_max_sections_and_default_max_chars_follow_config():
+    _write_section_limits_config(
+        system_prompt_section_max_chars=10_000,
+        system_prompt_section_total_chars=131072,
+        system_prompt_section_max_sections=2,
+    )
+    manager = PluginManager()
+    ctx = _context(manager)
+
+    # Default max_chars stays at the built-in 4000 even when the ceiling is
+    # raised — larger sections must opt in explicitly.
+    ctx.register_system_prompt_section("example.a", "a" * 4_500, max_chars=5_000)
+    with pytest.raises(ValueError, match="between 1 and 10000"):
+        ctx.register_system_prompt_section("example.too-big", "x", max_chars=10_001)
+
+    ctx.register_system_prompt_section("example.b", "b")
+    ctx.register_system_prompt_section("example.c", "c")
+
+    rendered = manager.render_system_prompt_sections({})
+    assert [item.id for item in rendered] == ["example.a", "example.b"]
+    reports = manager.dropped_prompt_section_reports()
+    assert [r["id"] for r in reports] == ["example.c"]
+    assert "section-count budget" in reports[0]["reason"]
+
+
+def test_invalid_config_values_fall_back_to_defaults():
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        "plugins:\n"
+        "  system_prompt_section_max_chars: not-a-number\n"
+        "  system_prompt_section_total_chars: -5\n"
+        "  system_prompt_section_max_sections: 0\n"
+    )
+    manager = PluginManager()
+    ctx = _context(manager)
+
+    with pytest.raises(ValueError, match="between 1 and 4000"):
+        ctx.register_system_prompt_section("example.big", "x", max_chars=4_001)
+
+    chunk = (MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS // 2) - 200
+    ctx.register_system_prompt_section("example.first", "a" * chunk, max_chars=chunk)
+    ctx.register_system_prompt_section("example.second", "b" * chunk, max_chars=chunk)
+    ctx.register_system_prompt_section("example.zzlast", "c" * 500, max_chars=500)
+
+    rendered = manager.render_system_prompt_sections({})
+    # Default 8000 aggregate + default 32 sections still enforced.
+    assert [item.id for item in rendered] == ["example.first", "example.second"]
+
+
+def test_dropped_sections_are_reported_not_just_logged(caplog):
+    """#92774 ask 3: aggregate overflow must be visible beyond a log line."""
+    manager = PluginManager()
+    ctx = _context(manager)
+    chunk = (MAX_SYSTEM_PROMPT_SECTIONS_TOTAL_CHARS // 2) - 200
+    ctx.register_system_prompt_section("example.first", "a" * chunk, max_chars=chunk)
+    ctx.register_system_prompt_section("example.second", "b" * chunk, max_chars=chunk)
+    ctx.register_system_prompt_section("example.zzlast", "c" * 500, max_chars=500)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+        manager.render_system_prompt_sections({})
+
+    reports = manager.dropped_prompt_section_reports()
+    assert [r["id"] for r in reports] == ["example.zzlast"]
+    assert reports[0]["plugin"] == "example-plugin"
+    assert "system_prompt_section_total_chars" in reports[0]["reason"]
+
+    # And the drop count reaches the plugin-facing introspection surface.
+    from hermes_cli.plugins import LoadedPlugin
+
+    manager._plugins["example-plugin"] = LoadedPlugin(
+        manifest=PluginManifest(name="example-plugin", key="example-plugin", source="user"),
+        enabled=True,
+    )
+    info = manager.list_plugins()[0]
+    assert info["prompt_sections_dropped"] == 1
+
+    # A clean re-render resets the report.
+    manager._system_prompt_sections.pop("example.zzlast")
+    manager.render_system_prompt_sections({})
+    assert manager.dropped_prompt_section_reports() == []

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -418,10 +418,24 @@ The contract is deliberately narrow:
   session**. Its rendered bytes are frozen on compression and recovered from
   the already-persisted full system prompt after a process restart/resume;
   plugin state is not re-read for an existing session.
-- `max_chars` is capped at 4,000 characters. All plugin sections together,
-  including their audit headings, are capped at 8,000 characters and 32
-  sections. Empty, non-string, oversized, aggregate-over-budget, or raising
-  sections are skipped with a warning; prompt construction continues.
+- `max_chars` defaults to 4,000 characters per section. All plugin sections
+  together, including their audit headings, default to 8,000 characters and
+  32 sections. Empty, non-string, oversized, aggregate-over-budget, or raising
+  sections are skipped with a warning; prompt construction continues. Skipped
+  sections are also reported per-plugin by `/plugins` so an over-budget drop
+  is visible without reading logs.
+- Plugins that legitimately pin large always-on context can be given more
+  room in `config.yaml` (the built-in defaults apply when unset):
+
+  ```yaml
+  plugins:
+    system_prompt_section_max_chars: 16000   # per-section cap (default 4000)
+    system_prompt_section_total_chars: 65536 # aggregate budget (default 8000)
+    system_prompt_section_max_sections: 32   # section count (default 32)
+  ```
+
+  Sections persisted under a raised cap survive resume; every extra character
+  is charged on every turn of every session, so raise these deliberately.
 - Every accepted section is named in the prompt and logged at session start
   with its plugin, position, and character count.
 


### PR DESCRIPTION
## What does this PR do?

`register_system_prompt_section()` — the sanctioned path for plugins to inject always-on system-prompt context — enforces three hard-coded module literals (4,000 chars/section, 8,000 chars aggregate, 32 sections in `hermes_cli/plugins.py:501-504`) with no config override, and sections over the aggregate budget are **silently dropped** at render with only a log-line warning. A plugin that legitimately pins large context (e.g. ~43KB of user-curated reference files) cannot use the documented API at all, and its only alternative is masquerading as a `MemoryProvider`, occupying the exclusive `memory.provider` slot.

This PR makes the three limits configurable in `config.yaml` (falling back to the current defaults when unset), following the existing `memory.memory_char_limit` / `memory.user_char_limit` precedent:

```yaml
plugins:
  system_prompt_section_max_chars: 65536
  system_prompt_section_total_chars: 131072
  system_prompt_section_max_sections: 32
```

It also makes over-budget drops visible instead of log-only: every skipped section is recorded on the `PluginManager`, exposed per-plugin via `list_plugins()` (`prompt_sections_dropped`), and printed by `/plugins` with a pointer to the config knob that would prevent the drop.

Design invariants preserved:

- **Bounded by default** — the built-in 4000/8000/32 budgets apply unchanged when no config is set; a plugin's default `max_chars` stays 4,000 even when the ceiling is raised (larger sections must opt in explicitly).
- **Cache-safe** — limits resolve via the cached `load_config_readonly()` at registration/render/restore time (session build only, never mid-conversation), so the system prompt stays byte-stable for the life of a session.
- **Resume-safe** — the persisted-prompt restore path accepts frames up to `max(built-in default, configured cap)`, so sections persisted under a raised cap survive process restart, and lowering the config later can never invalidate default-sized persisted prompts. The frame-length field regex widens from 4 to 9 digits; forged frames are still rejected by the canonical re-render equality check.
- **Fail open** — malformed config values (non-int, zero, negative) fall back to the defaults instead of breaking plugin loading.

## Related Issue

Fixes #92774

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py` — `_configured_section_limit()` + `system_prompt_section_max_chars()/_total_chars()/_max_sections()` resolvers reading `plugins.*` from config with literal fallbacks; registration validates against the configured ceiling (`max_chars` default becomes `None` → resolves to `min(4000, ceiling)`); render loop enforces configured budgets; `_record_dropped_prompt_section()` + `dropped_prompt_section_reports()` retain every skip; `list_plugins()` reports `prompt_sections_dropped` per plugin.
- `agent/system_prompt.py` — restore path caps persisted frames at `max(default, configured)`; `_PLUGIN_SECTION_FRAME_RE` length field widened to `[0-9]{1,9}`.
- `cli.py` — `/plugins` prints a `⚠ N prompt section(s) dropped over budget` line naming the config knobs.
- `cli-config.yaml.example` — documented `plugins:` section-budget block.
- `website/docs/user-guide/features/hooks.md` — documents the new knobs and the drop-visibility behavior.
- `tests/hermes_cli/test_plugin_prompt_sections.py` — configured limits allow a 43KB section + raised aggregate; configured `max_sections`; invalid config values fall back to defaults; dropped sections reported (manager + `list_plugins()`), reset on clean re-render.
- `tests/agent/test_plugin_prompt_sections.py` — restore honors a raised cap (43KB frame round-trips); lowered config never rejects default-sized persisted frames.

## How to Test

1. Register three individually-valid sections of 3,900 chars each from a plugin with **no** config set → render keeps only the first; the drop is now visible via `PluginManager.dropped_prompt_section_reports()` and `/plugins` (previously log-only).
2. Add the `plugins:` block above to `~/.hermes/config.yaml` and register a 43,000-char section with `max_chars=43000` → registration succeeds (previously `ValueError`), the section renders, freezes into the session prompt, and restores intact from the persisted prompt after a process restart.
3. `pytest tests/hermes_cli/test_plugin_prompt_sections.py tests/agent/test_plugin_prompt_sections.py -q` — 10 pass; adjacent suites `tests/hermes_cli/test_plugins.py`, `tests/agent/test_system_prompt.py`, `tests/gateway/test_config.py` — 159 pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python3 validate_fix.py   # temp HERMES_HOME with the plugins: block set
[1] 40970-char section registered OK with raised config cap
[2] rendered: ['pinned-files', 'ref-0', 'ref-1', 'ref-2']
[3] frozen prompt tail: 53029 chars, pinned present: True
[4] restored from persisted prompt bytes: ['pinned-files', 'ref-0', 'ref-1', 'ref-2']
[5] default caps still enforced; dropped reports: [('d-1', ...), ('d-2', ...)]
OVERALL: FIX VALIDATED
```
