### PR TITLE
fix: managed-runtime guard no longer false-fails on sdist/build copies

### DIFF
--- a/tests/test_managed_runtime_resolution.py
+++ b/tests/test_managed_runtime_resolution.py
@@ -26,6 +26,7 @@ whose behavior is separately covered by a real test.
 from __future__ import annotations
 
 import ast
+import functools
 from pathlib import Path
 
 import pytest
@@ -125,8 +126,29 @@ def _source_files() -> list[Path]:
         rel = path.relative_to(REPO_ROOT)
         if rel.parts and rel.parts[0] in _EXEMPT_DIRS:
             continue
+        # Skip packaging copies of the source tree (sdist extractions like
+        # hermes_agent-0.20.5/, build/ and *.egg-info dirs). CI jobs that
+        # build the wheel leave one in the workspace; scanning it re-finds
+        # every already-exempted call site under a versioned path prefix
+        # that can never match an _ALLOWED key, failing the guard on code
+        # that was never touched. A dir is a packaging copy iff its top
+        # level carries PKG-INFO (sdist/egg metadata) or it is a build/
+        # dist output directory.
+        if rel.parts and _is_packaging_copy(rel.parts[0]):
+            continue
         files.append(path)
     return files
+
+
+@functools.lru_cache(maxsize=None)
+def _is_packaging_copy(top_level: str) -> bool:
+    """Whether *top_level* (a dir name under REPO_ROOT) is a build artifact."""
+    if top_level in ("build", "dist") or top_level.endswith(".egg-info"):
+        return True
+    candidate = REPO_ROOT / top_level
+    if not candidate.is_dir():
+        return False
+    return (candidate / "PKG-INFO").exists()
 
 
 def _findings() -> list[tuple[str, str, int]]:


### PR DESCRIPTION
## Summary
The managed-runtime guard test (`test_no_unreviewed_bare_managed_runtime_lookups`) no longer false-fails when a wheel-build's sdist extraction is sitting in the CI workspace.

Root cause: the scanner rglobs the repo root, and a leftover `hermes_agent-<version>/` copy re-surfaces every already-exempted `which("node"/"npm"/"uv")` call site under a versioned path prefix that can never match an `_ALLOWED` key. This flaked PR #93420's Python-tests job on code that PR never touched (all flagged paths were inside `hermes_agent-0.20.5/`).

## Changes
- `tests/test_managed_runtime_resolution.py`: `_source_files()` skips `build/`, `dist/`, `*.egg-info`, and any top-level dir carrying `PKG-INFO` (the sdist/egg metadata marker).

## Validation
| Scenario | Before | After |
|---|---|---|
| Fake `hermes_agent-9.9.9/` sdist (with PKG-INFO + a `which("node")` site) planted in the tree | 1 failed | 7 passed |
| Clean tree | 7 passed | 7 passed |

## Infographic

![guard test vs build artifacts](https://v3b.fal.media/files/b/0aa790af/njRvnIdbOQuLHXAYKYPMm_IEZlB1vg.png)
