### PR TITLE
fix(agent): run init-time fallback for ANY exhausted primary provider

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1358,14 +1358,71 @@ def init_agent(
                 if _routed_headers:
                     client_kwargs["default_headers"] = dict(_routed_headers)
             else:
-                # When the user explicitly chose a non-OpenRouter provider
-                # but no credentials were found, fail fast with a clear
-                # message instead of silently routing through OpenRouter.
+                # No credentials resolved for the configured provider.  Give
+                # the user-configured fallback chain a chance BEFORE failing
+                # (#17929) — regardless of WHICH provider failed.  An
+                # exhausted single-entry pool (typically ``openrouter``
+                # under free-tier daily quotas) must still reach the chain
+                # instead of dying at init with a misleading "No LLM
+                # provider configured" error.  Only providers explicitly
+                # chosen by name keep the dedicated missing-key diagnostic.
                 _explicit = (agent.provider or "").strip().lower()
-                if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
-                    # Look up the actual env var name from the provider
-                    # config — some providers use non-standard names
-                    # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
+                # --- Init-time fallback (#17929) ---
+                _fb_entries = []
+                if isinstance(fallback_model, list):
+                    _fb_entries = [
+                        f for f in fallback_model
+                        if isinstance(f, dict) and f.get("provider") and f.get("model")
+                    ]
+                elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
+                    _fb_entries = [fallback_model]
+                _fb_resolved = False
+                for _fb in _fb_entries:
+                    try:
+                        from hermes_cli.fallback_config import resolve_entry_api_key
+                        _fb_explicit_key = resolve_entry_api_key(_fb)
+                        _fb_client, _fb_model = resolve_provider_client(
+                            _fb["provider"], model=_fb["model"], raw_codex=True,
+                            explicit_base_url=_fb.get("base_url"),
+                            explicit_api_key=_fb_explicit_key,
+                        )
+                    except Exception as _fb_exc:
+                        logger.debug(
+                            "Init-time fallback entry %s failed: %s",
+                            _fb.get("provider"), _fb_exc,
+                        )
+                        continue
+                    if _fb_client is not None:
+                        agent.provider = _fb["provider"]
+                        agent.model = _fb_model or _fb["model"]
+                        agent._fallback_activated = True
+                        client_kwargs = {
+                            "api_key": _fb_client.api_key,
+                            "base_url": str(_fb_client.base_url),
+                        }
+                        if _provider_timeout is not None:
+                            client_kwargs["timeout"] = _provider_timeout
+                        _fb_headers = getattr(_fb_client, "_custom_headers", None)
+                        if not _fb_headers:
+                            _fb_headers = getattr(_fb_client, "default_headers", None)
+                        if not _fb_headers:
+                            _fb_headers = getattr(_fb_client, "_default_headers", None)
+                        if _fb_headers:
+                            client_kwargs["default_headers"] = dict(_fb_headers)
+                        _fb_resolved = True
+                        break
+                if (
+                    not _fb_resolved
+                    and _explicit
+                    and _explicit not in {"auto", "openrouter", "custom"}
+                ):
+                    # Explicitly chosen non-OpenRouter provider with neither
+                    # credentials nor a usable fallback: fail fast with a
+                    # clear message instead of silently routing through
+                    # OpenRouter.  Look up the actual env var name from the
+                    # provider config — some providers use non-standard
+                    # names (e.g. alibaba → DASHSCOPE_API_KEY, not
+                    # ALIBABA_API_KEY).
                     _env_hint = f"{_explicit.upper()}_API_KEY"
                     try:
                         from hermes_cli.auth import PROVIDER_REGISTRY
@@ -1374,56 +1431,11 @@ def init_agent(
                             _env_hint = _pcfg.api_key_env_vars[0]
                     except Exception:
                         pass
-                    # --- Init-time fallback (#17929) ---
-                    _fb_entries = []
-                    if isinstance(fallback_model, list):
-                        _fb_entries = [
-                            f for f in fallback_model
-                            if isinstance(f, dict) and f.get("provider") and f.get("model")
-                        ]
-                    elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-                        _fb_entries = [fallback_model]
-                    _fb_resolved = False
-                    for _fb in _fb_entries:
-                        try:
-                            from hermes_cli.fallback_config import resolve_entry_api_key
-                            _fb_explicit_key = resolve_entry_api_key(_fb)
-                            _fb_client, _fb_model = resolve_provider_client(
-                                _fb["provider"], model=_fb["model"], raw_codex=True,
-                                explicit_base_url=_fb.get("base_url"),
-                                explicit_api_key=_fb_explicit_key,
-                            )
-                        except Exception as _fb_exc:
-                            logger.debug(
-                                "Init-time fallback entry %s failed: %s",
-                                _fb.get("provider"), _fb_exc,
-                            )
-                            continue
-                        if _fb_client is not None:
-                            agent.provider = _fb["provider"]
-                            agent.model = _fb_model or _fb["model"]
-                            agent._fallback_activated = True
-                            client_kwargs = {
-                                "api_key": _fb_client.api_key,
-                                "base_url": str(_fb_client.base_url),
-                            }
-                            if _provider_timeout is not None:
-                                client_kwargs["timeout"] = _provider_timeout
-                            _fb_headers = getattr(_fb_client, "_custom_headers", None)
-                            if not _fb_headers:
-                                _fb_headers = getattr(_fb_client, "default_headers", None)
-                            if not _fb_headers:
-                                _fb_headers = getattr(_fb_client, "_default_headers", None)
-                            if _fb_headers:
-                                client_kwargs["default_headers"] = dict(_fb_headers)
-                            _fb_resolved = True
-                            break
-                    if not _fb_resolved:
-                        raise RuntimeError(
-                            f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_env_hint} environment "
-                            f"variable, or switch to a different provider with `hermes model`."
-                        )
+                    raise RuntimeError(
+                        f"Provider '{_explicit}' is set in config.yaml but no API key "
+                        f"was found. Set the {_env_hint} environment "
+                        f"variable, or switch to a different provider with `hermes model`."
+                    )
                 if not getattr(agent, "_fallback_activated", False):
                     # No provider configured — reject with a clear message.
                     raise RuntimeError(

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -67,3 +67,67 @@ def test_init_raises_when_no_fallback_configured():
                 skip_memory=True,
                 fallback_model=None,
             )
+
+
+def test_init_tries_fallback_when_openrouter_pool_exhausted():
+    """Regression: an exhausted ``openrouter`` pool (single credential entry
+    in 429-cooldown) must still reach fallback_providers at init.
+
+    Before the fix, the init-time fallback block was nested inside the
+    ``_explicit not in {auto, openrouter, custom}`` guard, so the default
+    openrouter setup skipped the chain entirely and raised the misleading
+    "No LLM provider configured" RuntimeError (2026-08-23 outage).
+    """
+    fb = _mock_client(api_key="local-key-1234567890",
+                      base_url="http://127.0.0.1:11434/v1")
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                     explicit_base_url=None, explicit_api_key=None):
+        if provider == "custom" and explicit_base_url:
+            return fb, "qwen3.5:4b"
+        return None, None  # openrouter pool exhausted
+
+    with patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve), \
+         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI", return_value=MagicMock()):
+
+        agent = AIAgent(
+            provider="openrouter",
+            model="z-ai/glm-5.2:free",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[
+                {"provider": "openrouter", "model": "poolside/laguna-s-2.1:free"},
+                {"provider": "custom", "model": "qwen3.5:4b",
+                 "base_url": "http://127.0.0.1:11434/v1"},
+            ],
+        )
+        assert agent.provider == "custom"
+        assert agent.model == "qwen3.5:4b"
+        assert agent._fallback_activated is True
+
+
+def test_init_openrouter_exhausted_without_chain_keeps_generic_error():
+    """openrouter exhausted + no usable fallback keeps the generic
+    'No LLM provider configured' error (not the named-provider one)."""
+    with patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)), \
+         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI", return_value=MagicMock()):
+
+        with pytest.raises(RuntimeError, match="No LLM provider configured"):
+            AIAgent(
+                provider="openrouter",
+                model="z-ai/glm-5.2:free",
+                api_key=None,
+                base_url=None,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=[{"provider": "openrouter",
+                                 "model": "poolside/laguna-s-2.1:free"}],
+            )


### PR DESCRIPTION
## Summary

The #17929 init-time fallback block in `agent/agent_init.py` was nested inside the `_explicit not in {"auto", "openrouter", "custom"}` guard. Consequence: when the **primary provider is `openrouter`** (the default for most users) and its credential pool is exhausted, `AIAgent.__init__` raises `RuntimeError: No LLM provider configured` **without ever trying `fallback_providers`** — even when the chain contains a perfectly healthy entry.

The guard was clearly meant to pick the *error message*, not to gate *whether the chain runs*: it only fires the dedicated missing-key diagnostic for explicitly named non-OpenRouter providers.

## Real-world impact

2026-08-23 outage on a production gateway (~22:09–23:50, 60 logged occurrences, including a scheduled cron job): a single-entry OpenRouter pool hit the free-tier daily quota; every messaging turn and cron spawn died at init with the misleading error. The configured chain had a healthy local Ollama fallback (`custom/qwen3.5:4b`) that was never attempted — verified live E2E before/after.

## Fix

Un-nest the block so the chain runs for **any** provider without usable credentials:

- Chain resolution now happens before any failure decision.
- Explicitly chosen providers (not `auto`/`openrouter`/`custom`) keep the dedicated "Provider X ... no API key" diagnostic when both primary AND chain fail — no behavior change there.
- `openrouter`/`auto`/`custom` primaries keep the generic "No LLM provider configured" error when nothing resolves.

## Testing

- Extended `tests/run_agent/test_init_fallback_on_exhausted_pool.py`: existing tests pass unchanged; two new regressions cover openrouter-primary exhausted **with** a usable chain entry (activates local custom provider) and **without** one (keeps the generic error). `4 passed` via `scripts/run_tests.sh` and against current `origin/main` + this patch.
- Live E2E with real imports, empty credential env, temp `HERMES_HOME`, and a real HTTP round-trip to a local OpenAI-compatible server: agent initializes on the chain's last entry and serves a completion instead of raising.