### PR TITLE
fix(telegram): pace degraded sends with polling recovery

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5216,7 +5216,18 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # getattr() — tests build adapters via object.__new__() (no __init__).
         if getattr(self, "_send_path_degraded", False):
-            return SendResult(success=False, error="send_path_degraded", retryable=True)
+            # The reconnect ladder needs up to one full polling-health window
+            # before getUpdates can confirm the replacement transport.  Without
+            # this cadence hint, BasePlatformAdapter burns both generic retries
+            # in ~6 seconds and strands a completed final in the delivery ledger
+            # while the same adapter recovers moments later.
+            return SendResult(
+                success=False,
+                error="send_path_degraded",
+                retryable=True,
+                retry_after=_POLLING_PROGRESS_TIMEOUT,
+                error_kind="transient",
+            )
 
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():

--- a/tests/gateway/test_telegram_polling_health_confirmation.py
+++ b/tests/gateway/test_telegram_polling_health_confirmation.py
@@ -10,8 +10,14 @@ reconnect is a reliable hung-poll signature.
 
 import asyncio
 import logging
+
+import pytest
+
 from gateway.config import Platform  # noqa: E402
-from plugins.platforms.telegram.adapter import TelegramAdapter  # noqa: E402
+from plugins.platforms.telegram.adapter import (  # noqa: E402
+    _POLLING_PROGRESS_TIMEOUT,
+    TelegramAdapter,
+)
 
 
 def _bare_adapter():
@@ -83,3 +89,18 @@ class TestPollingHealthConfirmation:
             rec for rec in caplog.records if "confirmed healthy" in rec.getMessage()
         ]
         assert not a._polling_progress_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_degraded_send_retries_on_polling_health_cadence(self):
+        """A turn-final send must not burn both generic retries before
+        Telegram's bounded reconnect cycle can produce one healthy poll."""
+        a = _bare_adapter()
+        a._bot = object()
+
+        result = await a.send("chat-1", "the answer")
+
+        assert result.success is False
+        assert result.error == "send_path_degraded"
+        assert result.retryable is True
+        assert result.retry_after == _POLLING_PROGRESS_TIMEOUT
+        assert result.error_kind == "transient"


### PR DESCRIPTION
## Summary

- pace Telegram `send_path_degraded` retries against the adapter's polling-health window
- mark the degraded send result as transient
- add regression coverage for the retry cadence contract

## Problem

During a transient Telegram `Bad Gateway` incident, polling entered reconnect recovery and the adapter marked the send path degraded. Final delivery then exhausted both generic retries in roughly six seconds, while Telegram's bounded polling-health check recovered later. The completed response remained failed in the delivery ledger even though the same adapter became healthy shortly afterward.

## Fix

When the Telegram send path is degraded, return `retry_after=_POLLING_PROGRESS_TIMEOUT` and `error_kind="transient"`. This lets the existing platform retry loop wait for one polling-health window instead of immediately burning its retry budget.

## Verification

- `uv run --python venv/bin/python --with pytest==9.1.1 --with pytest-asyncio==1.3.0 python -m pytest tests/gateway/test_telegram_polling_health_confirmation.py tests/gateway/test_send_retry.py tests/gateway/test_telegram_network_reconnect.py -q -o addopts=`
  - 34 passed
- `uv run --python venv/bin/python --with ruff==0.15.10 ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_polling_health_confirmation.py`
  - all checks passed
- `git diff --check origin/main...HEAD`
  - clean

## Review

Independent review found no security, logic, concurrency, or retry-storm blockers. The regression also pins the transient error classification.
