### PR TITLE
feat(agent): robust tool choice sanitization

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2066,6 +2066,9 @@ class _AnthropicCompletionsAdapter:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
         tools = kwargs.get("tools")
+        # Anthropic-compatible endpoints reject a tool choice without tools.
+        if not tools:
+            kwargs.pop("tool_choice", None)
         tool_choice = kwargs.get("tool_choice")
         reasoning_config = kwargs.get("_reasoning_config")
         # ZAI's Anthropic-compatible endpoint rejects max_tokens on vision
@@ -2101,6 +2104,8 @@ class _AnthropicCompletionsAdapter:
                 if isinstance(_rc, dict):
                     _reasoning_cfg = _rc
 
+        if not tools:
+            normalized_tool_choice = None
         anthropic_kwargs = build_anthropic_kwargs(
             model=model,
             messages=messages,

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -561,7 +561,14 @@ def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
     return [{"functionDeclarations": declarations}] if declarations else []
 
 
-def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any]]:
+def _translate_tool_choice_to_gemini(
+    tool_choice: Any,
+    *,
+    has_tool_declarations: bool,
+) -> Optional[Dict[str, Any]]:
+    """Translate tool choice only when the request declares callable tools."""
+    if not has_tool_declarations:
+        return None
     if tool_choice is None:
         return None
     if isinstance(tool_choice, str):
@@ -662,7 +669,10 @@ def build_gemini_request(
     if gemini_tools:
         request["tools"] = gemini_tools
 
-    tool_config = _translate_tool_choice_to_gemini(tool_choice)
+    tool_config = _translate_tool_choice_to_gemini(
+        tool_choice,
+        has_tool_declarations=bool(gemini_tools),
+    )
     if tool_config:
         request["toolConfig"] = tool_config
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -660,8 +660,16 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs["include"] = []
 
         request_overrides = params.get("request_overrides")
-        if request_overrides:
+        if isinstance(request_overrides, dict):
             kwargs.update(request_overrides)
+
+        # The OpenAI Responses SDK eagerly iterates ``tools``. A request with
+        # no exposed functions must omit every tool-related field, including
+        # values reintroduced by request_overrides.
+        if not response_tools:
+            kwargs.pop("tools", None)
+            kwargs.pop("tool_choice", None)
+            kwargs.pop("parallel_tool_calls", None)
 
         if "prompt_cache_key" in kwargs:
             bounded_cache_key = _bounded_prompt_cache_key(kwargs["prompt_cache_key"])

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -567,3 +567,37 @@ class TestGemini3ToolCallIds:
         result = translate_gemini_response(resp, model="gemini-2.5-flash")
         tool_calls = result.choices[0].message.tool_calls
         assert tool_calls[0].id.startswith("call_")
+
+def test_tool_choice_is_omitted_without_tool_declarations():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{"role": "user", "content": "hello"}],
+        tools=[],
+        tool_choice="required",
+    )
+
+    assert "tools" not in request
+    assert "toolConfig" not in request
+
+
+def test_required_tool_choice_is_translated_when_tools_are_declared():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    tools = [{
+        "type": "function",
+        "function": {
+            "name": "terminal",
+            "description": "Run a command",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }]
+    request = build_gemini_request(
+        messages=[{"role": "user", "content": "hello"}],
+        tools=tools,
+        tool_choice="required",
+    )
+
+    assert request["tools"]
+    assert request["toolConfig"] == {"functionCallingConfig": {"mode": "ANY"}}
+

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -61,6 +61,48 @@ class TestCodexBuildKwargs:
 
 
 
+    def test_no_tools_strips_tool_overrides_after_request_overrides(self, transport):
+        kwargs = transport.build_kwargs(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=[],
+            request_overrides={
+                "tools": [],
+                "tool_choice": "required",
+                "parallel_tool_calls": True,
+            },
+        )
+
+        assert "tools" not in kwargs
+        assert "tool_choice" not in kwargs
+        assert "parallel_tool_calls" not in kwargs
+
+    def test_tools_keep_default_tool_control_fields(self, transport):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run a command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                },
+            },
+        ]
+
+        kwargs = transport.build_kwargs(
+            model="gpt-5.6",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=tools,
+        )
+
+        assert kwargs["tools"]
+        assert kwargs["tool_choice"] == "auto"
+        assert kwargs["parallel_tool_calls"] is True
+
     def test_cache_key_is_content_addressed_not_session_id(self, transport):
         """prompt_cache_key is content-addressed from the static prefix
         (instructions + tools), not the session_id. This keeps recurring cron


### PR DESCRIPTION
## Summary
- Strip tool-related request overrides from tool-less Codex Responses requests before the OpenAI SDK is called.
- Emit Gemini Native `toolConfig` only when callable tool declarations are present; preserve `auto`, `required`, `none`, and named-function behavior when they are.
- Remove Anthropic-compatible `tool_choice` when no tools are exposed.
- Normalize the touched Python sources to UTF-8 without BOM and LF line endings.

## Tests
- `uv run pytest -q tests/agent/transports/test_codex_transport.py tests/agent/test_gemini_native_adapter.py` — 128 passed
- `uv run pytest -q tests/agent/test_auxiliary_client.py` — 182 passed
- `git diff --check` — passed

## Scope
Only the three request-construction paths and their regression tests are changed.