### PR TITLE
perf(bluebubbles): attachment upload no longer blocks the event loop (#93143)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -16,6 +16,7 @@ import re
 import uuid
 from collections import OrderedDict
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -599,7 +600,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         """Send a file attachment via BlueBubbles multipart upload."""
         if not self.client:
             return SendResult(success=False, error="Not connected")
-        if not os.path.isfile(file_path):
+        if not await asyncio.to_thread(os.path.isfile, file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
 
         guid = await self._resolve_chat_guid(chat_id)
@@ -608,23 +609,26 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         fname = filename or os.path.basename(file_path)
         try:
-            with open(file_path, "rb") as f:
-                files = {"attachment": (fname, f, "application/octet-stream")}
-                data: Dict[str, str] = {
-                    "chatGuid": guid,
-                    "name": fname,
-                    "tempGuid": uuid.uuid4().hex,
-                }
-                if is_audio_message:
-                    data["isAudioMessage"] = "true"
-                res = await self.client.post(
-                    self._api_url("/api/v1/message/attachment"),
-                    files=files,
-                    data=data,
-                    timeout=120,
-                )
-                res.raise_for_status()
-                result = res.json()
+            # httpx's async multipart iterator reads file-like objects through
+            # a synchronous chunk generator. Read the file off the event-loop
+            # thread before handing bytes to the client.
+            payload = await asyncio.to_thread(Path(file_path).read_bytes)
+            files = {"attachment": (fname, payload, "application/octet-stream")}
+            data: Dict[str, str] = {
+                "chatGuid": guid,
+                "name": fname,
+                "tempGuid": uuid.uuid4().hex,
+            }
+            if is_audio_message:
+                data["isAudioMessage"] = "true"
+            res = await self.client.post(
+                self._api_url("/api/v1/message/attachment"),
+                files=files,
+                data=data,
+                timeout=120,
+            )
+            res.raise_for_status()
+            result = res.json()
 
             if caption:
                 await self.send(chat_id, caption)

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -274,6 +274,47 @@ class TestBlueBubblesAttachmentDownload:
         assert result == "/tmp/test_image.png"
 
 
+class TestBlueBubblesAttachmentSend:
+    @pytest.mark.asyncio
+    async def test_attachment_payload_is_read_before_async_upload(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+        file_path = tmp_path / "payload.bin"
+        payload = b"attachment-payload"
+        file_path.write_bytes(payload)
+
+        captured = {}
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;+;chat-guid"
+
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"status": 200, "data": {"guid": "message-guid"}}
+
+        class MockClient:
+            async def post(self, url, *, files, data, timeout):
+                captured.update(url=url, files=files, data=data, timeout=timeout)
+                return MockResponse()
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        adapter.client = MockClient()
+
+        result = await adapter._send_attachment(
+            "target", str(file_path), filename="payload.bin"
+        )
+
+        assert result.success is True
+        assert captured["files"]["attachment"] == (
+            "payload.bin",
+            payload,
+            "application/octet-stream",
+        )
+        assert captured["data"]["chatGuid"] == "iMessage;+;chat-guid"
+
+
 # ---------------------------------------------------------------------------
 # Webhook registration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
BlueBubbles attachment uploads no longer block the gateway event loop while the file is read. Previously `_send_attachment()` passed a synchronous `open()` file handle straight to httpx's async multipart POST — httpx iterates file-like inputs through a synchronous chunk generator, so every read chunk executed on the event-loop thread, stalling all other message handling for the duration of the upload. Fixes #93143.

Salvages #93212 by @JoaoMarcos44 (clean cherry-pick, authorship preserved).

## Changes
- `gateway/platforms/bluebubbles.py`: read the file with `await asyncio.to_thread(Path(file_path).read_bytes)` and hand httpx the bytes; the existence check also moves off-loop via `asyncio.to_thread(os.path.isfile, ...)`. Matches house style (`asyncio.to_thread` is the established pattern across signal/discord/telegram/api_server adapters — no `aiofiles` in the tree). All data fields (chatGuid, tempGuid, isAudioMessage), timeout, raise_for_status, and caption handling preserved byte-for-byte.
- `tests/gateway/test_bluebubbles.py`: async regression test asserting the multipart payload is the read bytes (not a file handle), covering all callers that route through `_send_attachment` (send_image/voice/video/document).

## Validation
| | Result |
|---|---|
| `tests/gateway/test_bluebubbles.py` | 19 passed |
| Contract pinned | multipart `attachment` field must be `bytes` — fails against the old file-handle path |

Follow-up noted (separate PR, not folded in): the shared `cache_*_from_bytes` helpers in `gateway/platforms/base.py` do synchronous `write_bytes` on the download path — a cross-adapter issue affecting every platform, worth its own change.

## Infographic

![Attachment upload off the event loop](https://v3b.fal.media/files/b/0aa790fb/Se0Dmp1tT_ps0iS0VwDBs_areDYTw5.png)
