### PR TITLE
feat(desktop): add grouped-by-category view to Skills page

### DIFF
--- a/apps/desktop/src/app/master-detail.tsx
+++ b/apps/desktop/src/app/master-detail.tsx
@@ -404,6 +404,7 @@ export function ListStripButton({
 }) {
   return (
     <button
+      aria-pressed={active}
       className={cn(
         'cursor-pointer text-[0.68rem] font-medium transition-colors disabled:opacity-40',
         active ? 'text-foreground' : 'text-muted-foreground/70 hover:text-foreground'

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -259,6 +259,7 @@ describe('SkillsView toolset management', () => {
     // Flat by default — no category section headings, all three rows visible.
     await screen.findByRole('switch', { name: 'plot-charts' })
     expect(screen.queryByRole('heading', { level: 4 })).toBeNull()
+    expect(screen.getByText('Flat view').getAttribute('aria-pressed')).toBe('false')
 
     await act(async () => {
       fireEvent.click(screen.getByText('Flat view'))
@@ -269,6 +270,13 @@ describe('SkillsView toolset management', () => {
     expect(headers.map(el => el.textContent)).toEqual(['Creative', 'Github'])
     expect(await screen.findByRole('switch', { name: 'gh-pr-review' })).toBeTruthy()
     expect(await screen.findByRole('switch', { name: 'gh-issue-triage' })).toBeTruthy()
+    expect(screen.getByText('By category').getAttribute('aria-pressed')).toBe('true')
+
+    // Filtering to a single category drops the other section's heading entirely.
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Search skills...'), { target: { value: 'plot' } })
+    })
+    await waitFor(() => expect(screen.getAllByRole('heading', { level: 4 }).map(el => el.textContent)).toEqual(['Creative']))
   })
 
   it('shows the FULL skill in the detail pane — frontmatter metadata + body', async () => {

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -97,11 +97,15 @@ beforeEach(() => {
   getProfiles.mockResolvedValue({ profiles: [{ name: 'default', is_default: true }] })
 })
 
-afterEach(() => {
+afterEach(async () => {
   cleanup()
   vi.clearAllMocks()
   // Shared singleton client — drop cached skills/toolsets so each test refetches.
   queryClient.clear()
+  // Persisted view-state atom — reset so a test that flips it doesn't leak
+  // into the next one.
+  const { $skillsGroupedView } = await import('./store')
+  $skillsGroupedView.set(false)
 })
 
 describe('SkillsView toolset management', () => {
@@ -232,6 +236,39 @@ describe('SkillsView toolset management', () => {
       fireEvent.click(sw)
     })
     await waitFor(() => expect(setSkillEnabled).toHaveBeenCalledWith('web-research', false, 'researcher'))
+  })
+
+  it('groups skills by category when the grouped view is toggled on', async () => {
+    getSkills.mockResolvedValue([
+      { name: 'plot-charts', description: 'Charts', category: 'creative', enabled: true, usage: 1 },
+      { name: 'gh-pr-review', description: 'Reviews PRs', category: 'github', enabled: true, usage: 0 },
+      { name: 'gh-issue-triage', description: 'Triages issues', category: 'github', enabled: true, usage: 5 }
+    ])
+
+    const { SkillsView } = await import('./index')
+    await act(async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/skills?tab=skills']}>
+            <SkillsView />
+          </MemoryRouter>
+        </QueryClientProvider>
+      )
+    })
+
+    // Flat by default — no category section headings, all three rows visible.
+    await screen.findByRole('switch', { name: 'plot-charts' })
+    expect(screen.queryByRole('heading', { level: 4 })).toBeNull()
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Flat view'))
+    })
+
+    // Grouped: one heading per category, A–Z, github's two skills sit together.
+    const headers = await screen.findAllByRole('heading', { level: 4 })
+    expect(headers.map(el => el.textContent)).toEqual(['Creative', 'Github'])
+    expect(await screen.findByRole('switch', { name: 'gh-pr-review' })).toBeTruthy()
+    expect(await screen.findByRole('switch', { name: 'gh-issue-triage' })).toBeTruthy()
   })
 
   it('shows the FULL skill in the detail pane — frontmatter metadata + body', async () => {

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -63,7 +63,7 @@ import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
 import { EmbeddedHubPicker } from './embedded-hub-picker'
 import { McpTab } from './mcp-tab'
-import { $skillsSortDesc, $toolsetsSortDesc } from './store'
+import { $skillsGroupedView, $skillsSortDesc, $toolsetsSortDesc } from './store'
 
 // 'hub' is gone as a top-level tab — the Skills Hub browser lives inside the
 // Skills tab now (EmbeddedHubPicker below the installed list). Legacy
@@ -144,6 +144,27 @@ function filteredSkills(skills: SkillInfo[], query: string, desc: boolean): Skil
         !q || includesQuery(skill.name, q) || includesQuery(skill.description, q) || includesQuery(skill.category, q)
     )
     .sort((a, b) => sign * (usageOf(b) - usageOf(a)) || asText(a.name).localeCompare(asText(b.name)))
+}
+
+// Grouped view: bucket by category, preserving each skill's position within
+// its bucket (already sorted by `filteredSkills`), sections ordered A–Z by
+// display name so "General" (uncategorized) falls in with the rest instead
+// of always leading or trailing.
+function groupSkillsByCategory(skills: SkillInfo[]): [string, SkillInfo[]][] {
+  const groups = new Map<string, SkillInfo[]>()
+
+  for (const skill of skills) {
+    const key = categoryFor(skill)
+    const bucket = groups.get(key)
+
+    if (bucket) {
+      bucket.push(skill)
+    } else {
+      groups.set(key, [skill])
+    }
+  }
+
+  return [...groups.entries()].sort(([a], [b]) => prettyName(a).localeCompare(prettyName(b)))
 }
 
 const toolsetCalls = (toolset: ToolsetInfo, toolCalls: Record<string, number>): number =>
@@ -329,6 +350,7 @@ export function SkillsView({
   const toolCallsEpoch = useRef(0)
   const skillsSortDesc = useStore($skillsSortDesc)
   const toolsetsSortDesc = useStore($toolsetsSortDesc)
+  const skillsGroupedView = useStore($skillsGroupedView)
   const [bulkBusy, setBulkBusy] = useState(false)
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null)
   const [selectedToolset, setSelectedToolset] = useState<string | null>(null)
@@ -399,6 +421,13 @@ export function SkillsView({
   const visibleSkills = useMemo(
     () => (skills ? filteredSkills(skills, query, skillsSortDesc) : []),
     [query, skills, skillsSortDesc]
+  )
+
+  // Only computed in grouped mode — searching still filters within groups,
+  // and a category with no matches simply drops out (no empty section shown).
+  const skillGroups = useMemo(
+    () => (skillsGroupedView ? groupSkillsByCategory(visibleSkills) : null),
+    [skillsGroupedView, visibleSkills]
   )
 
   const visibleToolsets = useMemo(
@@ -568,6 +597,12 @@ export function SkillsView({
 
   const sortButton = (desc: boolean, flip: () => void) => (
     <ListStripButton onClick={flip}>{desc ? t.skills.sortMostUsedDesc : t.skills.sortLeastUsedAsc}</ListStripButton>
+  )
+
+  const groupViewButton = (grouped: boolean, flip: () => void) => (
+    <ListStripButton active={grouped} onClick={flip}>
+      {grouped ? t.skills.viewGrouped : t.skills.viewFlat}
+    </ListStripButton>
   )
 
   // Full-bleed empty state, matching the MCP tab (spans both columns, not a
@@ -822,7 +857,13 @@ export function SkillsView({
                   <ListColumn
                     header={
                       <ListStrip
-                        left={sortButton(skillsSortDesc, () => $skillsSortDesc.set(!$skillsSortDesc.get()))}
+                        left={
+                          <>
+                            {sortButton(skillsSortDesc, () => $skillsSortDesc.set(!$skillsSortDesc.get()))}
+                            <span className="text-muted-foreground/30">·</span>
+                            {groupViewButton(skillsGroupedView, () => $skillsGroupedView.set(!skillsGroupedView))}
+                          </>
+                        }
                         right={
                           <ListStripMenu
                             items={[
@@ -839,20 +880,42 @@ export function SkillsView({
                       />
                     }
                   >
-                    {visibleSkills.map(skill => (
-                      <CapRow
-                        active={activeSkill?.name === skill.name}
-                        busy={bulkBusy}
-                        enabled={skill.enabled}
-                        key={skill.name}
-                        meta={usageOf(skill) > 0 ? `×${compactNumber(usageOf(skill))}` : undefined}
-                        onSelect={() => setSelectedSkill(skill.name)}
-                        onToggle={enabled => void handleToggleSkill(skill, enabled)}
-                        subtitle={skillSubtitle(skill)}
-                        title={skill.name}
-                        toggleLabel={skill.name}
-                      />
-                    ))}
+                    {skillGroups
+                      ? skillGroups.map(([category, rows]) => (
+                          <div key={category}>
+                            <h4 className="truncate px-2 pb-1 pt-2 text-[0.65rem] font-medium uppercase tracking-wide text-muted-foreground/60 first:pt-0">
+                              {prettyName(category)}
+                            </h4>
+                            {rows.map(skill => (
+                              <CapRow
+                                active={activeSkill?.name === skill.name}
+                                busy={bulkBusy}
+                                enabled={skill.enabled}
+                                key={skill.name}
+                                meta={usageOf(skill) > 0 ? `×${compactNumber(usageOf(skill))}` : undefined}
+                                onSelect={() => setSelectedSkill(skill.name)}
+                                onToggle={enabled => void handleToggleSkill(skill, enabled)}
+                                subtitle={skillSubtitle(skill)}
+                                title={skill.name}
+                                toggleLabel={skill.name}
+                              />
+                            ))}
+                          </div>
+                        ))
+                      : visibleSkills.map(skill => (
+                          <CapRow
+                            active={activeSkill?.name === skill.name}
+                            busy={bulkBusy}
+                            enabled={skill.enabled}
+                            key={skill.name}
+                            meta={usageOf(skill) > 0 ? `×${compactNumber(usageOf(skill))}` : undefined}
+                            onSelect={() => setSelectedSkill(skill.name)}
+                            onToggle={enabled => void handleToggleSkill(skill, enabled)}
+                            subtitle={skillSubtitle(skill)}
+                            title={skill.name}
+                            toggleLabel={skill.name}
+                          />
+                        ))}
                   </ListColumn>
                   <DetailColumn footer={t.skills.changesApplyNewSessions}>
                     {activeSkill && (

--- a/apps/desktop/src/app/skills/store.ts
+++ b/apps/desktop/src/app/skills/store.ts
@@ -4,3 +4,7 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 // remembers most/least-used across navigations and restarts.
 export const $skillsSortDesc = persistentAtom('hermes.desktop.capabilities.skillsSortDesc', true, Codecs.bool)
 export const $toolsetsSortDesc = persistentAtom('hermes.desktop.capabilities.toolsetsSortDesc', true, Codecs.bool)
+
+// Skills list layout: flat (default) or grouped into category sections.
+// Persisted so a 100+ skill install stays grouped across restarts once set.
+export const $skillsGroupedView = persistentAtom('hermes.desktop.capabilities.skillsGroupedView', false, Codecs.bool)

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1257,6 +1257,8 @@ export const en: Translations = {
     sortAlpha: 'A–Z',
     sortMostUsedDesc: '↓ Most used',
     sortLeastUsedAsc: '↑ Least used',
+    viewFlat: 'Flat view',
+    viewGrouped: 'By category',
     enableAll: 'Enable all',
     disableAll: 'Disable all',
     disableUnused: 'Disable unused',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1166,6 +1166,8 @@ export const ja = defineLocale({
     sortAlpha: 'A–Z',
     sortMostUsedDesc: '↓ 使用頻度順',
     sortLeastUsedAsc: '↑ 使用頻度が低い順',
+    viewFlat: 'フラット表示',
+    viewGrouped: 'カテゴリ別',
     enableAll: 'すべて有効化',
     disableAll: 'すべて無効化',
     disableUnused: '未使用を無効化',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1100,6 +1100,8 @@ export interface Translations {
     sortAlpha: string
     sortMostUsedDesc: string
     sortLeastUsedAsc: string
+    viewFlat: string
+    viewGrouped: string
     enableAll: string
     disableAll: string
     disableUnused: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1126,6 +1126,8 @@ export const zhHant = defineLocale({
     sortAlpha: 'A–Z',
     sortMostUsedDesc: '↓ 最常用',
     sortLeastUsedAsc: '↑ 最少用',
+    viewFlat: '平鋪',
+    viewGrouped: '按分類分組',
     enableAll: '全部啟用',
     disableAll: '全部停用',
     disableUnused: '停用未使用',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1448,6 +1448,8 @@ export const zh: Translations = {
     sortAlpha: 'A–Z',
     sortMostUsedDesc: '↓ 最常用',
     sortLeastUsedAsc: '↑ 最少用',
+    viewFlat: '平铺',
+    viewGrouped: '按分类分组',
     enableAll: '全部启用',
     disableAll: '全部停用',
     disableUnused: '禁用未使用',


### PR DESCRIPTION
Fixes #93435

## Summary

The Desktop app's Skills page rendered installed skills as one flat list, sortable but with category shown only as a small subtitle. With 100+ skills installed there was no way to browse "what's in my creative pack vs my github pack" other than typing the category into search.

Adds an optional grouped-by-category view:

- A view toggle next to the existing sort control (`ListStrip` left side), following the same "current-state label, click flips" convention as the sort button.
- In grouped mode, skills are bucketed by `categoryFor()` into `Map<string, SkillInfo[]>`, sections ordered A–Z by display name, each group's rows keeping the currently active sort (most/least used).
- Uncategorized skills fall under "General" (existing `categoryFor()` default), sitting alongside other sections instead of being special-cased.
- Search still filters before grouping, so a category with no matches simply doesn't render a section.
- Flat view stays the default — existing muscle memory unaffected — and the choice persists across restarts via a new `$skillsGroupedView` atom (`apps/desktop/src/app/skills/store.ts`), mirroring the existing `$skillsSortDesc`/`$toolsetsSortDesc` pattern.

## Changes

- `apps/desktop/src/app/skills/store.ts` — new persisted `$skillsGroupedView` atom (default `false`)
- `apps/desktop/src/app/skills/index.tsx` — `groupSkillsByCategory()`, a `groupViewButton()` toggle, and grouped/flat row rendering (category headers as `<h4>` for accessibility)
- `apps/desktop/src/i18n/types.ts`, `en.ts`, `zh.ts`, `ja.ts`, `zh-hant.ts` — new `viewFlat`/`viewGrouped` strings (`zh.ts` and `types.ts` are exhaustive translation objects so both required the keys; `ja`/`zh-hant` added for completeness, `ar.ts` falls back to English via `defineLocale`)
- `apps/desktop/src/app/skills/index.test.tsx` — new test: toggling the view groups skills into per-category `<h4>` sections; reset the new persisted atom in `afterEach` so it can't leak into other tests in the file

## Test plan

Confirmed the new test fails without the fix (reverted the non-test files to the parent commit, reran):

```
$ git checkout HEAD~1 -- apps/desktop/src/app/skills/index.tsx apps/desktop/src/app/skills/store.ts apps/desktop/src/i18n/*.ts
$ npx vitest run src/app/skills/index.test.tsx
 ❯ src/app/skills/index.test.tsx:264:30
   TestingLibraryElementError: Unable to find an element with the text: Flat view.
 Test Files  1 failed (1)
$ git checkout HEAD -- apps/desktop/src/app/skills/index.tsx apps/desktop/src/app/skills/store.ts apps/desktop/src/i18n/*.ts
```

With the fix restored:

```
$ npx vitest run src/app/skills/index.test.tsx
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Full desktop suite (no regressions):

```
$ npx vitest run
 Test Files  699 passed | 1 skipped (700)
      Tests  7237 passed | 3 skipped (7240)
```

Lint (`npx eslint src/app/skills/index.tsx src/app/skills/index.test.tsx src/app/skills/store.ts src/i18n/*.ts`) — 0 errors (4 pre-existing `no-restricted-globals` warnings in the test file, unrelated to this change, not on lines I touched).

Typecheck (`npx tsc -p . --noEmit`) — clean.

## AI assistance disclosure

Written with AI assistance (Claude Code).
