### PR TITLE
fix(desktop): preserve remote session routing

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -9,6 +9,7 @@ import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
+import { requestGatewayForAgent } from '@/store/gateway'
 import { $goalsBySession, setSessionGoal } from '@/store/goals'
 import { $hudMode } from '@/store/hud'
 import { $notifications, clearNotifications } from '@/store/notifications'
@@ -47,6 +48,11 @@ vi.mock('@/hermes', () => ({
   PROMPT_SUBMIT_REQUEST_TIMEOUT_MS: 1_800_000,
   setApiRequestProfile: vi.fn(),
   transcribeAudio: vi.fn()
+}))
+
+vi.mock('@/store/gateway', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  requestGatewayForAgent: vi.fn()
 }))
 
 // The active id the desktop holds is the *runtime* session id from
@@ -1767,7 +1773,39 @@ describe('usePromptActions desktop slash pickers', () => {
 describe('usePromptActions submit / queue drain semantics', () => {
   afterEach(() => {
     cleanup()
+    $connection.set(null)
+    vi.mocked(requestGatewayForAgent).mockReset()
     vi.restoreAllMocks()
+  })
+
+  it('pins prompt.submit to the active registry connection when the remote session row is untagged', async () => {
+    $connection.set({ connectionId: 'hermes01', mode: 'remote' } as never)
+    setSessions([sessionInfo({ id: 'stored-remote', profile: 'default' })])
+
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    vi.mocked(requestGatewayForAgent).mockResolvedValue({} as never)
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId="runtime-remote"
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={ambientRequest}
+        runtimeIdByStoredSessionIdRef={{ current: new Map([['stored-remote', 'runtime-remote']]) }}
+        storedSessionId="stored-remote"
+      />
+    )
+
+    expect(await handle!.submitText('continue remotely')).toBe(true)
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'hermes01',
+      'default',
+      'prompt.submit',
+      { session_id: 'runtime-remote', text: 'continue remotely' },
+      1_800_000
+    )
+    expect(ambientRequest).not.toHaveBeenCalled()
   })
 
   it('clears a leftover interrupted flag on a fresh submit (so the new turn streams)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -22,6 +22,7 @@ import {
   updateComposerAttachment
 } from '@/store/composer'
 import { resetSessionBackground } from '@/store/composer-status'
+import { requestGatewayForAgent } from '@/store/gateway'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
@@ -31,6 +32,7 @@ import {
   $currentCwd,
   $messages,
   $terminalBackend,
+  getSessionOwnerHint,
   setActiveSessionId,
   setAwaitingResponse,
   setBusy,
@@ -483,6 +485,30 @@ export function usePromptActions({
     }
   }, [activeSessionId, composerAttachments, eagerlyUploadAttachment])
 
+  // Session resume can be routed through a registry connection while the
+  // render-time requestGateway still points at the local default socket. Keep
+  // every follow-up session RPC on the same composite owner; otherwise resume
+  // succeeds on HERMES01 and prompt.submit immediately fails locally with
+  // "session not found".
+  const requestForPromptSession = useCallback<GatewayRequest>(
+    (method, params = {}, timeoutMs) => {
+      const storedSessionId = selectedStoredSessionIdRef.current
+      const owner = storedSessionId ? getSessionOwnerHint(storedSessionId) : undefined
+      const ambientConnection = $connection.get()
+
+      const connectionId =
+        owner?.connectionId ||
+        (ambientConnection?.mode === 'remote' ? ambientConnection.connectionId?.trim() || '' : '')
+
+      if (connectionId) {
+        return requestGatewayForAgent(connectionId, owner?.profile || 'default', method, params, timeoutMs)
+      }
+
+      return timeoutMs === undefined ? requestGateway(method, params) : requestGateway(method, params, timeoutMs)
+    },
+    [requestGateway, selectedStoredSessionIdRef]
+  )
+
   const submitPromptText = useSubmitPrompt({
     activeSessionIdRef,
     busyRef,
@@ -491,7 +517,7 @@ export function usePromptActions({
     getRoutedStoredSessionId,
     getRuntimeIdForStoredSession,
     getRouteToken,
-    requestGateway,
+    requestGateway: requestForPromptSession,
     runtimeIdByStoredSessionIdRef,
     resumeStoredSession,
     selectedStoredSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
-import { requestGatewayForAgent } from '@/store/gateway'
+import { requestGatewayForAgent, requestGatewayForProfile } from '@/store/gateway'
 import { $activeGatewayProfile, $newChatProfile, $newChatRoute, ensureGatewayProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
 import {
@@ -36,6 +36,7 @@ import {
   setActiveSessionStoredIdRotation,
   setAwaitingResponse,
   setBusy,
+  setConnection,
   setCurrentCwd,
   setCurrentFastMode,
   setCurrentModel,
@@ -78,7 +79,8 @@ vi.mock('@/store/profile', async importOriginal => ({
 
 vi.mock('@/store/gateway', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  requestGatewayForAgent: vi.fn()
+  requestGatewayForAgent: vi.fn(),
+  requestGatewayForProfile: vi.fn()
 }))
 
 vi.mock('@/components/pane-shell/tree/store', async importOriginal => ({
@@ -1795,7 +1797,43 @@ describe('resumeSession warm-cache mapping integrity', () => {
       .mockReset()
       .mockResolvedValue({ messages: [] } as never)
     vi.mocked(requestGatewayForAgent).mockReset()
+    vi.mocked(requestGatewayForProfile).mockReset()
+    setConnection(null)
     vi.restoreAllMocks()
+  })
+
+  it('pins an untagged row to the active registry connection instead of the same-named local profile', async () => {
+    setConnection({ connectionId: 'hermes01', mode: 'remote' } as never)
+    setSessions([storedSession({ id: 'remote-stored', profile: 'default' })])
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({ messages: [], session_id: 'remote-stored' } as never)
+    vi.mocked(requestGatewayForAgent).mockResolvedValue({
+      info: {},
+      messages: [],
+      resumed: 'remote-stored',
+      session_id: 'remote-runtime'
+    } as never)
+    vi.mocked(requestGatewayForProfile).mockResolvedValue({
+      info: {},
+      messages: [],
+      resumed: 'remote-stored',
+      session_id: 'wrong-local-runtime'
+    } as never)
+
+    const ambientRequest = vi.fn(async () => ({}) as never)
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+
+    render(<ResumeHarness onReady={ready => (resume = ready)} requestGateway={ambientRequest} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('remote-stored', true)
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'hermes01',
+      'default',
+      'session.resume',
+      expect.objectContaining({ session_id: 'remote-stored' })
+    )
+    expect(requestGatewayForProfile).not.toHaveBeenCalled()
+    expect(ambientRequest).not.toHaveBeenCalled()
   })
 
   it('pins metadata, transcript, resume, activate, and usage to the captured connection', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -39,6 +39,7 @@ import {
 import { setApprovalRequest } from '@/store/prompts'
 import {
   $activeSessionStoredIdRotation,
+  $connection,
   $currentCwd,
   $currentFastMode,
   $currentModel,
@@ -792,6 +793,17 @@ export function useSessionActions({
       // resolveStoredSession finds the row by id (cheap), so an uncached pasted
       // id loads as fast as a sidebar click instead of hanging on a list scan.
       const ownerRoute = capturedOwner || getSessionOwnerHint(storedSessionId)
+      // A connection switch clears/reloads the session rows before this path
+      // runs, so an untagged row belongs to the connection that supplied the
+      // current list. Capture that source before the async metadata lookup. If
+      // we reduce it to the profile string `default`, requestForSessionProfile
+      // resolves the local default socket and sends an SSH session id to the
+      // wrong machine ("resume failed: session not found").
+      const ambientConnection = $connection.get()
+
+      const ambientConnectionId =
+        ambientConnection?.mode === 'remote' ? ambientConnection.connectionId?.trim() || '' : ''
+
       const storedForProfile = await resolveStoredSession(storedSessionId, ownerRoute)
       const sessionProfile = storedForProfile?.profile
 
@@ -799,14 +811,17 @@ export function useSessionActions({
         return
       }
 
+      const resolvedConnectionId = ownerRoute?.connectionId || storedForProfile?.connection_id || ambientConnectionId
+
       // A row spliced from a CONNECTED registry gateway (#88880) carries its
-      // owning connection — activate THAT gateway, not a same-named local
-      // profile. Rows without the tag keep the legacy profile path.
-      const sessionOwner: SessionOwnerScope =
-        ownerRoute ||
-        (storedForProfile?.connection_id
+      // owning connection. A row fetched directly after activating a registry
+      // gateway can be untagged, so retain the captured ambient connection too.
+      // Either way, route by the composite (connection, profile), never by a
+      // same-named profile alone.
+      const sessionOwner: SessionOwnerScope = ownerRoute ||
+        (resolvedConnectionId
           ? {
-              connectionId: storedForProfile.connection_id,
+              connectionId: resolvedConnectionId,
               profile: sessionProfile || 'default'
             }
           : sessionProfile)
@@ -814,19 +829,13 @@ export function useSessionActions({
       // All-profiles / plugin navigation must not steal chrome API-home:
       // dial the owning backend without moving $activeGatewayProfile.
       if ($showAllProfiles.get()) {
-        if (ownerRoute?.connectionId || storedForProfile?.connection_id) {
-          await openGatewayForAgent(
-            ownerRoute?.connectionId || storedForProfile?.connection_id || null,
-            ownerRoute?.profile || sessionProfile || 'default'
-          )
+        if (resolvedConnectionId) {
+          await openGatewayForAgent(resolvedConnectionId, ownerRoute?.profile || sessionProfile || 'default')
         } else if (sessionProfile) {
           await openGatewayForProfile(normalizeProfileKey(sessionProfile))
         }
-      } else if (ownerRoute?.connectionId || storedForProfile?.connection_id) {
-        await ensureGatewayAgent(
-          ownerRoute?.connectionId || storedForProfile?.connection_id || null,
-          ownerRoute?.profile || sessionProfile || 'default'
-        )
+      } else if (resolvedConnectionId) {
+        await ensureGatewayAgent(resolvedConnectionId, ownerRoute?.profile || sessionProfile || 'default')
       } else {
         await ensureGatewayProfile(sessionProfile)
       }
@@ -846,10 +855,10 @@ export function useSessionActions({
       const requestForSession = <T>(method: string, params: Record<string, unknown> = {}): Promise<T> =>
         requestForSessionProfile<T>(sessionOwner, requestGateway, method, params)
 
-      const sessionRestScope = ownerRoute
+      const sessionRestScope = resolvedConnectionId
         ? {
-            connectionId: ownerRoute.connectionId,
-            profile: ownerRoute.targetProfile || ownerRoute.profile
+            connectionId: resolvedConnectionId,
+            profile: ownerRoute?.targetProfile || ownerRoute?.profile || sessionProfile || 'default'
           }
         : sessionProfile
 


### PR DESCRIPTION
## Summary

- preserve the active registry connection as the owner fallback when a remote session row has no `connection_id`
- keep stored-session reads, `session.resume`, and follow-up `prompt.submit` on that same `(connection, profile)` route
- add regression coverage for both opening an untagged remote row and sending the next prompt

## Problem

The unified Sessions list normally tags registry-owned rows with `connection_id`, but a direct connection switch can reload rows without that tag. In a multi-gateway setup, an untagged remote row whose profile is `default` can then be resolved as only `default`.

That profile name is not globally unique: both the local gateway and an SSH/remote gateway can own a `default` profile. The renderer consequently falls back to the ambient/local dispatcher. The remote session still exists, but `session.resume` reaches the local backend and fails with `resume failed, session not found`. Even after a successful resume, the prompt pipeline had its own ambient dispatcher and could fail the next message with `session not found` for the same reason.

This can affect other users with multiple registered gateways and legacy/untagged session rows, particularly local + SSH/remote configurations where both sides use the default profile name.

The behavior became reachable when the unified cross-gateway Sessions list was introduced in d354af5e1290c5860369d108de1346deb17e4ad0 (`feat(desktop): unified Sessions list shows every connected gateway's chats (#88880)`, Aug 18, 2026). Later profile-routing fixes covered explicit owner metadata, but not this connection-less fallback or the separate prompt submission path.

## Fix

For an untagged row, use the active registry connection as an ambient owner only when the current connection is remote. Explicit owner hints and persisted `connection_id` values continue to take precedence, and local mode is unchanged.

The resolved connection is then used consistently for:

- stored-session REST scope
- `session.resume` / `session.activate` / `session.usage`
- follow-up `prompt.submit`

## Test plan

- [x] `npx vitest run src/app/session/hooks/use-prompt-actions/index.test.tsx src/app/session/hooks/use-session-actions.test.tsx` (183 passed)
- [x] `npm run typecheck`
- [x] ESLint on all four modified Desktop files (no errors; one pre-existing exhaustive-deps warning in the prompt test harness)
- [x] `git diff --check`
- [x] `npm run pack`
- [x] Live local + SSH gateway verification: reopened the original affected remote session, submitted a follow-up prompt, and confirmed both the prompt and response were persisted in the remote gateway's state database
